### PR TITLE
deps: upgrade Go from 1.25.1 to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stephnangue/warden
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/ProtonMail/go-crypto v1.3.0
@@ -164,8 +164,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgraph-io/ristretto/v2 v2.4.0
-	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary
- Bumps `go.mod` from `go 1.25.1` to `go 1.26.0`, aligning with the Dockerfile (already on `golang:1.26.0-alpine`)
- CI workflows read the version from `go.mod` via `go-version-file`, so they pick this up automatically
- All tests pass locally with `-race`

## Test plan
- [x] CI status checks pass (build + test)
- [x] Verify Docker build still works