### PR TITLE
feat: add opt-in request body parsing for streaming requests

### DIFF
--- a/framework/streaming_backend_test.go
+++ b/framework/streaming_backend_test.go
@@ -454,3 +454,20 @@ func BenchmarkIsUnauthenticatedPath_NoMatch(b *testing.B) {
 		backend.IsUnauthenticatedPath("role/provisionner/gateway/v1/secret/data/mykey")
 	}
 }
+
+func TestShouldParseStreamBody(t *testing.T) {
+	t.Run("returns false by default", func(t *testing.T) {
+		b := &StreamingBackend{
+			Backend: &Backend{BackendType: "test"},
+		}
+		assert.False(t, b.ShouldParseStreamBody())
+	})
+
+	t.Run("returns true when enabled", func(t *testing.T) {
+		b := &StreamingBackend{
+			ParseStreamBody: true,
+			Backend:         &Backend{BackendType: "test"},
+		}
+		assert.True(t, b.ShouldParseStreamBody())
+	})
+}

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -128,3 +128,16 @@ type TransparentModeProvider interface {
 	// without sending tokens (e.g., PKI certificate PEM files).
 	IsUnauthenticatedPath(path string) bool
 }
+
+// StreamBodyParser can be implemented by streaming backends that want the core
+// to parse the request body into req.Data before policy evaluation, even for
+// streaming requests. By default, streaming requests skip body parsing to avoid
+// buffering large payloads. Backends that need req.Data for ACL/policy checks
+// (e.g., Vault) should implement this interface and return true.
+//
+// When enabled, the core parses application/json and application/x-www-form-urlencoded
+// bodies (up to maxRequestBodySize), restores the body for the provider to re-read,
+// and populates req.Data before CheckToken runs.
+type StreamBodyParser interface {
+	ShouldParseStreamBody() bool
+}

--- a/logical/paths.go
+++ b/logical/paths.go
@@ -14,9 +14,12 @@ type Paths struct {
     Unauthenticated []string
 
 	// Stream is a list of paths that handle streaming requests.
-	// For these paths, the core does two things during processing :
-	// 	1) does NOT parse request body into req.Data
-	// 	2) mints and injects credential into logical request
+	// For these paths, the core does two things during processing:
+	//  1) does NOT parse request body into req.Data, unless the backend
+	//     implements StreamBodyParser and returns true from ShouldParseStreamBody().
+	//     In that case, JSON and form-urlencoded bodies are parsed and restored
+	//     for the streaming handler to re-read.
+	//  2) mints and injects credential into logical request
 	// The path syntax is the same as Root and Unauthenticated:
 	// exact match, or prefix match if ends with '*'.
 	Stream []string

--- a/provider/vault/provider.go
+++ b/provider/vault/provider.go
@@ -95,6 +95,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			},
 		},
 		UnauthenticatedPaths: vaultUnauthenticatedPaths,
+		ParseStreamBody:      true,
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      false, // Updated via config write or Initialize
 			AutoAuthPath: "",


### PR DESCRIPTION
Enable backends to declare whether the core should parse request bodies for streaming requests, allowing policy evaluation (AllowedParameters, DeniedParameters, RequiredParameters) on streaming paths.

- Add StreamBodyParser interface for per-backend opt-in
- Add parseFormBody for application/x-www-form-urlencoded support
- Add parseBody content-type dispatcher (JSON, form-urlencoded, skip others)
- Flatten nested JSON into dot-separated keys for deep policy matching
- Vault provider opts in; AWS and others remain raw (SigV4 compatibility)