### PR TITLE
feat: add Mistral AI provider with API key credential rotation

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stephnangue/warden/provider/gcp"
 	"github.com/stephnangue/warden/provider/github"
 	"github.com/stephnangue/warden/provider/gitlab"
+	"github.com/stephnangue/warden/provider/mistral"
 	"github.com/stephnangue/warden/provider/vault"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -86,12 +87,13 @@ Usage: warden server [options]
 	}
 
 	providers = map[string]wardenlogical.Factory{
-		"aws":    aws.Factory,
-		"azure":  azure.Factory,
-		"gcp":    gcp.Factory,
-		"github": github.Factory,
-		"gitlab": gitlab.Factory,
-		"vault":  vault.Factory,
+		"aws":     aws.Factory,
+		"azure":   azure.Factory,
+		"gcp":     gcp.Factory,
+		"github":  github.Factory,
+		"gitlab":  gitlab.Factory,
+		"mistral": mistral.Factory,
+		"vault":   vault.Factory,
 	}
 
 	authMethods = map[string]wardenlogical.Factory{

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -14,6 +14,7 @@ const (
 	TypeGCPAccessToken    = "gcp_access_token"
 	TypeGitLabAccessToken = "gitlab_access_token"
 	TypeGitHubToken       = "github_token"
+	TypeAIAPIKey          = "ai_api_key"
 )
 
 // Source type constants
@@ -23,8 +24,9 @@ const (
 	SourceTypeAWS    = "aws"
 	SourceTypeAzure  = "azure"
 	SourceTypeGCP    = "gcp"
-	SourceTypeGitLab  = "gitlab"
-	SourceTypeGitHub  = "github"
+	SourceTypeGitLab   = "gitlab"
+	SourceTypeGitHub   = "github"
+	SourceTypeMistral  = "mistral"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -39,5 +39,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register Mistral driver factory
+	if err := registry.RegisterFactory(&MistralDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/mistral_driver.go
+++ b/credential/drivers/mistral_driver.go
@@ -1,0 +1,181 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// mistralMaxResponseBodySize limits response body reads to prevent OOM
+const mistralMaxResponseBodySize = 1 << 20 // 1MB
+
+// mistralMaxRetryAttempts for retryable API operations
+const mistralMaxRetryAttempts = 3
+
+// DefaultMistralAPIURL is the default Mistral API base URL
+const DefaultMistralAPIURL = "https://api.mistral.ai"
+
+// Compile-time interface assertions
+// Note: MistralDriver does not implement credential.Rotatable.
+// Mistral does not expose REST API endpoints for programmatic key management.
+var _ credential.SourceDriver = (*MistralDriver)(nil)
+var _ credential.SpecVerifier = (*MistralDriver)(nil)
+
+// MistralDriver provides API key credentials for Mistral AI.
+//
+// The source config holds only connection info (api_url). Auth credentials
+// (api_key) live in the credential spec config and are read at MintCredential
+// time. This allows multiple specs with different API keys to share one source.
+//
+// Key rotation must be performed manually:
+//  1. Create a new API key in the Mistral console
+//  2. Update the spec config via Warden API
+//  3. The old key continues to work until deleted from the console
+type MistralDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// MistralDriverFactory creates MistralDriver instances
+type MistralDriverFactory struct{}
+
+// Type returns the driver type
+func (f *MistralDriverFactory) Type() string {
+	return credential.SourceTypeMistral
+}
+
+// ValidateConfig validates Mistral source configuration using declarative schema.
+// The source only holds connection info (api_url). Auth credentials are
+// validated at spec level by AIAPIKeyCredType.ValidateConfig.
+func (f *MistralDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("api_url").
+			Custom(validateMistralURL).
+			Describe("Mistral API base URL (default: https://api.mistral.ai)").
+			Example("https://api.mistral.ai"),
+	)
+}
+
+// SensitiveConfigFields returns the list of source config keys that should be masked.
+// No secrets are stored on the source — they live in the spec config.
+func (f *MistralDriverFactory) SensitiveConfigFields() []string {
+	return nil
+}
+
+// Create instantiates a new MistralDriver.
+// The driver only needs the api_url from source config. Auth credentials
+// are provided per-spec at MintCredential time.
+func (f *MistralDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(credential.SourceTypeMistral),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	return driver, nil
+}
+
+// getAPIURL returns the Mistral API base URL from source config
+func (d *MistralDriver) getAPIURL() string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, "api_url", DefaultMistralAPIURL), "/")
+}
+
+// MintCredential returns the Mistral API key from spec config.
+// The key is static — no TTL, no lease.
+func (d *MistralDriver) MintCredential(_ context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	apiKey := credential.GetString(spec.Config, "api_key", "")
+	if apiKey == "" {
+		return nil, 0, "", fmt.Errorf("no Mistral API key configured in spec")
+	}
+
+	rawData := map[string]interface{}{
+		"api_key": apiKey,
+	}
+
+	// Copy optional metadata from spec config
+	if orgID := credential.GetString(spec.Config, "organization_id", ""); orgID != "" {
+		rawData["organization_id"] = orgID
+	}
+
+	return rawData, 0, "", nil // Static — no TTL, no lease
+}
+
+// Revoke is a no-op for static API keys.
+func (d *MistralDriver) Revoke(_ context.Context, leaseID string) error {
+	if d.logger != nil {
+		d.logger.Debug("Mistral API keys are static, skipping revocation",
+			logger.String("lease_id", leaseID),
+		)
+	}
+	return nil
+}
+
+// Type returns the driver type
+func (d *MistralDriver) Type() string {
+	return credential.SourceTypeMistral
+}
+
+// Cleanup releases resources
+func (d *MistralDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates that the spec's API key is functional by calling
+// GET /v1/models, a lightweight read-only endpoint.
+func (d *MistralDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	apiKey := credential.GetString(spec.Config, "api_key", "")
+	if apiKey == "" {
+		return fmt.Errorf("no Mistral API key configured in spec")
+	}
+
+	apiURL := d.getAPIURL() + "/v1/models"
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       mistralMaxRetryAttempts,
+		MaxBodySize:       mistralMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500}, // 429 and all 5xx
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodGet,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + apiKey,
+			"Accept":        "application/json",
+		},
+	}
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("Mistral API key verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateMistralURL validates that the api_url is a well-formed HTTPS URL
+func validateMistralURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid api_url: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("api_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("api_url must include a host")
+	}
+	return nil
+}

--- a/credential/drivers/mistral_driver_test.go
+++ b/credential/drivers/mistral_driver_test.go
@@ -1,0 +1,332 @@
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMistralDriverFactory_Type(t *testing.T) {
+	factory := &MistralDriverFactory{}
+	assert.Equal(t, credential.SourceTypeMistral, factory.Type())
+}
+
+func TestMistralDriverFactory_SensitiveConfigFields(t *testing.T) {
+	factory := &MistralDriverFactory{}
+	fields := factory.SensitiveConfigFields()
+	assert.Nil(t, fields, "source has no secrets — they live in the spec")
+}
+
+func TestMistralDriverFactory_ValidateConfig(t *testing.T) {
+	factory := &MistralDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid empty config (uses default api_url)",
+			config:  map[string]string{},
+			wantErr: false,
+		},
+		{
+			name:    "valid explicit api_url",
+			config:  map[string]string{"api_url": "https://api.mistral.ai"},
+			wantErr: false,
+		},
+		{
+			name:    "valid custom api_url",
+			config:  map[string]string{"api_url": "https://mistral.example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid api_url scheme",
+			config:  map[string]string{"api_url": "http://api.mistral.ai"},
+			wantErr: true,
+			errMsg:  "must use https://",
+		},
+		{
+			name:    "invalid api_url no host",
+			config:  map[string]string{"api_url": "https://"},
+			wantErr: true,
+			errMsg:  "must include a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMistralDriverFactory_Create(t *testing.T) {
+	factory := &MistralDriverFactory{}
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	driver, err := factory.Create(map[string]string{
+		"api_url": "https://api.mistral.ai",
+	}, log)
+	require.NoError(t, err)
+	assert.NotNil(t, driver)
+	assert.Equal(t, credential.SourceTypeMistral, driver.Type())
+}
+
+func TestMistralDriver_Type(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, credential.SourceTypeMistral, driver.Type())
+}
+
+func TestMistralDriver_Cleanup(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+		httpClient: &http.Client{},
+	}
+	err := driver.Cleanup(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestMistralDriver_Revoke_NoOp(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+	}
+	// Mistral API keys are static — revoke is a no-op
+	err := driver.Revoke(context.Background(), "any-lease-id")
+	assert.NoError(t, err)
+
+	err = driver.Revoke(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestMistralDriver_NotRotatable(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+	}
+	// MistralDriver should not implement Rotatable
+	var sd credential.SourceDriver = driver
+	_, ok := sd.(credential.Rotatable)
+	assert.False(t, ok, "MistralDriver should not implement credential.Rotatable")
+}
+
+func TestMistralDriver_MintCredential(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{"api_url": "https://api.mistral.ai"},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-mistral",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "sk-test-key-123",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Equal(t, "", leaseID)
+}
+
+func TestMistralDriver_MintCredential_EmptyKey(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-mistral",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Mistral API key configured")
+}
+
+func TestMistralDriver_MintCredential_WithOrganizationID(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-mistral",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key":         "sk-test-key-123",
+			"organization_id": "org-456",
+		},
+	}
+
+	rawData, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
+	assert.Equal(t, "org-456", rawData["organization_id"])
+}
+
+func TestMistralDriver_VerifySpec(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/models", r.URL.Path)
+		assert.Equal(t, "Bearer sk-valid-key", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer server.Close()
+
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{"api_url": server.URL},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-verify",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "sk-valid-key",
+		},
+	}
+
+	err := driver.VerifySpec(context.Background(), spec)
+	assert.NoError(t, err)
+}
+
+func TestMistralDriver_VerifySpec_InvalidKey(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{"api_url": server.URL},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-verify",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "sk-invalid-key",
+		},
+	}
+
+	err := driver.VerifySpec(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verification failed")
+}
+
+func TestMistralDriver_VerifySpec_EmptyKey(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-verify",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "",
+		},
+	}
+
+	err := driver.VerifySpec(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Mistral API key configured")
+}
+
+func TestMistralDriver_GetAPIURL(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{"api_url": "https://api.mistral.ai/"},
+		},
+	}
+	// getAPIURL trims trailing slash
+	assert.Equal(t, "https://api.mistral.ai", driver.getAPIURL())
+}
+
+func TestMistralDriver_GetAPIURL_Default(t *testing.T) {
+	driver := &MistralDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeMistral,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, DefaultMistralAPIURL, driver.getAPIURL())
+}
+
+func TestValidateMistralURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{"https://api.mistral.ai", false, ""},
+		{"https://mistral.example.com", false, ""},
+		{"http://api.mistral.ai", true, "must use https://"},
+		{"ftp://api.mistral.ai", true, "must use https://"},
+		{"https://", true, "must include a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateMistralURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/credential/types/ai_api_key.go
+++ b/credential/types/ai_api_key.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/stephnangue/warden/credential"
+)
+
+// AIAPIKeyCredType handles AI provider API keys (Mistral, OpenAI, Anthropic, etc.)
+type AIAPIKeyCredType struct {
+	*BaseTokenType
+}
+
+// NewAIAPIKeyCredType creates a new AI API key credential type
+func NewAIAPIKeyCredType() *AIAPIKeyCredType {
+	return &AIAPIKeyCredType{
+		BaseTokenType: &BaseTokenType{
+			TypeMetadata: credential.TypeMetadata{
+				Name:        credential.TypeAIAPIKey,
+				Category:    credential.CategoryAPI,
+				Description: "API key for AI provider authentication (Mistral, OpenAI, Anthropic, etc.)",
+				DefaultTTL:  0, // Static API keys have no default TTL
+			},
+			FieldConfig: TokenFieldConfig{
+				PrimaryField:      "api_key",
+				AlternativeFields: []string{},
+				OptionalFields:    []string{"key_id", "key_name", "organization_id"},
+				FieldSchemas: map[string]*credential.CredentialFieldSchema{
+					"api_key": {
+						Description: "AI provider API key for authentication",
+						Sensitive:   true,
+					},
+					"key_id": {
+						Description: "Key identifier (if available from provider)",
+						Sensitive:   false,
+					},
+					"key_name": {
+						Description: "Human-readable key name",
+						Sensitive:   false,
+					},
+					"organization_id": {
+						Description: "Organization identifier",
+						Sensitive:   false,
+					},
+				},
+			},
+			Revocable: false, // Static API keys are not revocable via lease
+		},
+	}
+}
+
+// ConfigSchema returns the declarative schema for AI API key credential config.
+// The API key is stored at the spec level (like GitHub PATs), not on the source.
+func (t *AIAPIKeyCredType) ConfigSchema() []*credential.FieldValidator {
+	return []*credential.FieldValidator{
+		credential.StringField("api_key").
+			Describe("AI provider API key").
+			Example("sk-xxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("organization_id").
+			Describe("Organization ID for the AI provider (optional)").
+			Example("org-xxxxxxxxxxxx"),
+	}
+}
+
+// ValidateConfig validates the Config for an AI API key credential spec.
+// The API key is stored at the spec level (like GitHub PATs). The source only
+// holds connection info (api_url). This allows multiple specs with different
+// API keys to share one source.
+func (t *AIAPIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	// Step 1: Validate source type compatibility
+	switch sourceType {
+	case credential.SourceTypeMistral, credential.SourceTypeLocal:
+		// Supported
+	default:
+		return fmt.Errorf("ai_api_key credentials require a mistral or local source, got: %s", sourceType)
+	}
+
+	// Step 2: Validate config against schema
+	schema := t.ConfigSchema()
+	if err := credential.ValidateSchema(config, schema...); err != nil {
+		return err
+	}
+
+	// Step 3: api_key is required for all source types
+	if config["api_key"] == "" {
+		return fmt.Errorf("'api_key' is required")
+	}
+
+	return nil
+}
+
+// RequiresSpecRotation returns false — API keys live in source config, not spec.
+func (t *AIAPIKeyCredType) RequiresSpecRotation() bool {
+	return false
+}
+
+// SensitiveConfigFields returns spec config keys that should be masked in output
+func (t *AIAPIKeyCredType) SensitiveConfigFields() []string {
+	return []string{"api_key"}
+}

--- a/credential/types/ai_api_key_test.go
+++ b/credential/types/ai_api_key_test.go
@@ -1,0 +1,316 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIAPIKeyCredType_Metadata(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+	metadata := ct.Metadata()
+
+	assert.Equal(t, credential.TypeAIAPIKey, metadata.Name)
+	assert.Equal(t, credential.CategoryAPI, metadata.Category)
+	assert.Contains(t, metadata.Description, "AI provider")
+	assert.Equal(t, time.Duration(0), metadata.DefaultTTL)
+}
+
+func TestAIAPIKeyCredType_ValidateConfig(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+
+	tests := []struct {
+		name       string
+		config     map[string]string
+		sourceType string
+		wantErr    bool
+		errMsg     string
+	}{
+		// --- Mistral source ---
+		{
+			name: "mistral source - valid config",
+			config: map[string]string{
+				"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
+			},
+			sourceType: credential.SourceTypeMistral,
+			wantErr:    false,
+		},
+		{
+			name: "mistral source - with organization_id",
+			config: map[string]string{
+				"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
+				"organization_id": "org-123",
+			},
+			sourceType: credential.SourceTypeMistral,
+			wantErr:    false,
+		},
+		{
+			name:       "mistral source - missing api_key",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeMistral,
+			wantErr:    true,
+			errMsg:     "api_key",
+		},
+		// --- Local source ---
+		{
+			name: "local source - valid config",
+			config: map[string]string{
+				"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
+			},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    false,
+		},
+		{
+			name: "local source - with optional fields",
+			config: map[string]string{
+				"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
+				"organization_id": "org-123",
+			},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    false,
+		},
+		{
+			name:       "local source - missing api_key",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    true,
+			errMsg:     "api_key",
+		},
+		{
+			name: "local source - empty api_key",
+			config: map[string]string{
+				"api_key": "",
+			},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    true,
+			errMsg:     "api_key",
+		},
+		// --- Unsupported source types ---
+		{
+			name: "unsupported source type - aws",
+			config: map[string]string{
+				"api_key": "sk-test",
+			},
+			sourceType: "aws",
+			wantErr:    true,
+			errMsg:     "require a mistral or local source",
+		},
+		{
+			name: "unsupported source type - vault",
+			config: map[string]string{
+				"api_key": "sk-test",
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "require a mistral or local source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, tt.sourceType)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAIAPIKeyCredType_Parse(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+
+	tests := []struct {
+		name     string
+		rawData  map[string]interface{}
+		leaseTTL time.Duration
+		leaseID  string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "valid api_key",
+			rawData: map[string]interface{}{
+				"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
+			},
+			leaseTTL: 0,
+			leaseID:  "",
+			wantErr:  false,
+		},
+		{
+			name: "valid api_key with optional fields",
+			rawData: map[string]interface{}{
+				"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
+				"key_id":          "key-123",
+				"key_name":        "production-key",
+				"organization_id": "org-456",
+			},
+			leaseTTL: 0,
+			leaseID:  "",
+			wantErr:  false,
+		},
+		{
+			name:     "missing api_key",
+			rawData:  map[string]interface{}{},
+			leaseTTL: 0,
+			leaseID:  "",
+			wantErr:  true,
+			errMsg:   "missing or invalid api_key",
+		},
+		{
+			name: "empty api_key",
+			rawData: map[string]interface{}{
+				"api_key": "",
+			},
+			leaseTTL: 0,
+			leaseID:  "",
+			wantErr:  true,
+			errMsg:   "missing or invalid api_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, cred)
+				assert.Equal(t, credential.TypeAIAPIKey, cred.Type)
+				assert.Equal(t, credential.CategoryAPI, cred.Category)
+				assert.Equal(t, tt.leaseTTL, cred.LeaseTTL)
+				assert.Equal(t, tt.leaseID, cred.LeaseID)
+				assert.NotEmpty(t, cred.Data["api_key"])
+				// Static keys are never revocable
+				assert.False(t, cred.Revocable)
+			}
+		})
+	}
+}
+
+func TestAIAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+
+	rawData := map[string]interface{}{
+		"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
+		"key_id":          "key-123",
+		"key_name":        "production-key",
+		"organization_id": "org-456",
+	}
+
+	cred, err := ct.Parse(rawData, 0, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "sk-xxxxxxxxxxxxxxxxxxxx", cred.Data["api_key"])
+	assert.Equal(t, "key-123", cred.Data["key_id"])
+	assert.Equal(t, "production-key", cred.Data["key_name"])
+	assert.Equal(t, "org-456", cred.Data["organization_id"])
+}
+
+func TestAIAPIKeyCredType_Validate(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+
+	tests := []struct {
+		name    string
+		cred    *credential.Credential
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid credential",
+			cred: &credential.Credential{
+				Type: credential.TypeAIAPIKey,
+				Data: map[string]string{
+					"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong type",
+			cred: &credential.Credential{
+				Type: credential.TypeVaultToken,
+				Data: map[string]string{
+					"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected type ai_api_key",
+		},
+		{
+			name: "missing api_key",
+			cred: &credential.Credential{
+				Type: credential.TypeAIAPIKey,
+				Data: map[string]string{},
+			},
+			wantErr: true,
+			errMsg:  "missing api_key",
+		},
+		{
+			name: "empty api_key",
+			cred: &credential.Credential{
+				Type: credential.TypeAIAPIKey,
+				Data: map[string]string{
+					"api_key": "",
+				},
+			},
+			wantErr: true,
+			errMsg:  "missing api_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.Validate(tt.cred)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAIAPIKeyCredType_RequiresSpecRotation(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+	assert.False(t, ct.RequiresSpecRotation())
+}
+
+func TestAIAPIKeyCredType_SensitiveConfigFields(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+	fields := ct.SensitiveConfigFields()
+	assert.Len(t, fields, 1)
+	assert.Contains(t, fields, "api_key")
+}
+
+func TestAIAPIKeyCredType_FieldSchemas(t *testing.T) {
+	ct := NewAIAPIKeyCredType()
+	schemas := ct.FieldSchemas()
+
+	assert.Contains(t, schemas, "api_key")
+	assert.True(t, schemas["api_key"].Sensitive)
+	assert.NotEmpty(t, schemas["api_key"].Description)
+
+	assert.Contains(t, schemas, "key_id")
+	assert.False(t, schemas["key_id"].Sensitive)
+
+	assert.Contains(t, schemas, "key_name")
+	assert.False(t, schemas["key_name"].Sensitive)
+
+	assert.Contains(t, schemas, "organization_id")
+	assert.False(t, schemas["organization_id"].Sensitive)
+}

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -34,5 +34,10 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
+	// Register AI API key type
+	if err := registry.Register(NewAIAPIKeyCredType()); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -1,0 +1,347 @@
+# Mistral AI Provider
+
+The Mistral provider enables proxied access to the Mistral AI API through Warden. It streams requests to Mistral endpoints (chat completions, embeddings, models) with automatic API key injection and policy evaluation on AI request fields.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Mount the Mistral Provider](#step-1-mount-the-mistral-provider)
+- [Step 2: Configure the Provider](#step-2-configure-the-provider)
+- [Step 3: Create a Credential Source](#step-3-create-a-credential-source)
+- [Step 4: Create a Credential Spec](#step-4-create-a-credential-spec)
+- [Step 5: Create a Policy](#step-5-create-a-policy)
+- [Step 6: Configure JWT Auth and Create a Role](#step-6-configure-jwt-auth-and-create-a-role)
+- [Step 7: Get a JWT](#step-7-get-a-jwt)
+- [Step 8: Make Requests Through the Gateway](#step-8-make-requests-through-the-gateway)
+- [Policy Evaluation on AI Requests](#policy-evaluation-on-ai-requests)
+- [Configuration Reference](#configuration-reference)
+- [Key Management](#key-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- A **Mistral AI API key** from [console.mistral.ai](https://console.mistral.ai)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 6–7:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Start the Warden server** in dev mode:
+> ```bash
+> ./warden server --dev
+> ```
+>
+> **4. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="<your-token>"
+> ```
+
+## Step 1: Mount the Mistral Provider
+
+Enable the Mistral provider at a path of your choice:
+
+```bash
+warden provider enable --type=mistral
+```
+
+To mount at a custom path:
+
+```bash
+warden provider enable --type=mistral mistral-prod
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+## Step 2: Configure the Provider
+
+Configure the provider with transparent mode enabled. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write mistral/config <<EOF
+{
+  "mistral_url": "https://api.mistral.ai",
+  "transparent_mode": true,
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "120s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read mistral/config
+```
+
+## Step 3: Create a Credential Source
+
+The credential source holds only connection info (`api_url`). The API key is stored on the credential spec (Step 4), allowing multiple specs with different keys to share one source.
+
+```bash
+warden cred source create mistral-src \
+  --type=mistral \
+  --rotation-period=0 \
+  --config=api_url=https://api.mistral.ai
+```
+
+Verify the source was created:
+
+```bash
+warden cred source read mistral-src
+```
+
+## Step 4: Create a Credential Spec
+
+Create a credential spec that references the credential source. The spec carries the API key and gets associated with tokens at login time.
+
+```bash
+warden cred spec create mistral-ops \
+  --type ai_api_key \
+  --source mistral-src \
+  --config api_key=<your-mistral-api-key>
+```
+
+Optionally include an organization ID:
+
+```bash
+warden cred spec create mistral-ops \
+  --type ai_api_key \
+  --source mistral-src \
+  --config api_key=<your-mistral-api-key> \
+  --config organization_id=<your-org-id>
+```
+
+The API key is validated at creation time via a `GET /v1/models` call to the Mistral API (SpecVerifier). If the key is invalid, spec creation will fail.
+
+Verify:
+
+```bash
+warden cred spec read mistral-ops
+```
+
+## Step 5: Create a Policy
+
+Create a policy that grants access to the Mistral provider gateway:
+
+```bash
+warden policy write mistral-access - <<EOF
+path "mistral/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For fine-grained cost control, restrict access based on AI request fields:
+
+```bash
+warden policy write mistral-restricted - <<EOF
+path "mistral/role/+/gateway/v1/chat/completions" {
+  capabilities = ["create"]
+  allowed_parameters = {
+    "model" = ["mistral-small-latest", "mistral-medium-latest"]
+    "stream" = ["true"]
+    "*"      = []
+  }
+}
+EOF
+```
+
+Verify:
+
+```bash
+warden policy read mistral-access
+```
+
+## Step 6: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. With transparent mode, clients authenticate directly with their JWT — no separate login step is needed.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/mistral-user \
+    token_type=jwt_role \
+    token_policies="mistral-access" \
+    user_claim=sub \
+    cred_spec_name=mistral-ops \
+    token_ttl=1h
+```
+
+## Step 7: Get a JWT
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+## Step 8: Make Requests Through the Gateway
+
+With transparent mode, requests use role-based paths. Warden performs implicit JWT authentication and injects the Mistral API key automatically.
+
+The URL pattern is: `/v1/mistral/role/{role}/gateway/{mistral-api-path}`
+
+Export MISTRAL_ENDPOINT as environment variable:
+```bash
+export MISTRAL_ENDPOINT="${WARDEN_ADDR}/v1/mistral/role/mistral-user/gateway"
+```
+
+### Chat Completions
+
+```bash
+curl -X POST "${MISTRAL_ENDPOINT}/v1/chat/completions" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [
+      {"role": "user", "content": "Hello, how are you?"}
+    ]
+  }'
+```
+
+### Streaming Chat Completions
+
+```bash
+curl -X POST "${MISTRAL_ENDPOINT}/v1/chat/completions" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -N \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [
+      {"role": "user", "content": "Write a short poem about the ocean."}
+    ],
+    "stream": true
+  }'
+```
+
+### Embeddings
+
+```bash
+curl -X POST "${MISTRAL_ENDPOINT}/v1/embeddings" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-embed",
+    "input": ["Hello world"]
+  }'
+```
+
+### List Models
+
+```bash
+curl "${MISTRAL_ENDPOINT}/v1/models" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
+
+## Policy Evaluation on AI Requests
+
+The Mistral provider has request body parsing enabled (`ParseStreamBody: true`), which means Warden can evaluate policies against fields in the AI request body. This enables fine-grained cost control and usage policies.
+
+Evaluable fields include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Model to use (e.g., `mistral-small-latest`, `mistral-large-latest`) |
+| `max_tokens` | integer | Maximum tokens to generate |
+| `temperature` | float | Sampling temperature |
+| `stream` | boolean | Whether to stream the response |
+| `top_p` | float | Nucleus sampling parameter |
+
+This allows operators to enforce policies such as:
+- Restrict which models users can access
+- Enforce maximum token limits
+- Require streaming mode for cost visibility
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mistral_url` | string | `https://api.mistral.ai` | Mistral API base URL (must be HTTPS) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `120s` | Request timeout — set high for AI inference |
+| `transparent_mode` | bool | `false` | Enable implicit JWT authentication |
+| `auto_auth_path` | string | — | JWT auth mount path (required when `transparent_mode` is true) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Credential Source Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_url` | string | `https://api.mistral.ai` | Mistral API base URL (must be HTTPS) |
+
+### Credential Spec Config
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | Mistral AI API key (sensitive — masked in output) |
+| `organization_id` | string | No | Organization identifier |
+
+## Key Management
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | API key is stored on the credential spec (not the source) |
+| **Validation** | Key is verified at spec creation via `GET /v1/models` |
+| **Rotation** | Manual — Mistral does not expose key management APIs |
+| **Lifetime** | Static — no expiration or auto-refresh |
+
+**To rotate an API key:**
+
+1. Create a new API key in the [Mistral console](https://console.mistral.ai)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update mistral-ops \
+     --config api_key=<new-api-key>
+   ```
+3. Delete the old key from the Mistral console

--- a/provider/mistral/config.go
+++ b/provider/mistral/config.go
@@ -1,0 +1,205 @@
+package mistral
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+)
+
+// DefaultMistralURL is the default Mistral API base URL
+const DefaultMistralURL = "https://api.mistral.ai"
+
+// DefaultMistralTimeout is the default request timeout for AI inference
+const DefaultMistralTimeout = 120 * time.Second
+
+// ProviderConfig holds parsed configuration for the Mistral provider
+type ProviderConfig struct {
+	MistralURL      string
+	MaxBodySize     int64
+	Timeout         time.Duration
+	TransparentMode bool
+	AutoAuthPath    string
+	DefaultRole     string
+}
+
+// parseConfig parses configuration from mount config (map[string]any from JSON)
+func parseConfig(conf map[string]any) ProviderConfig {
+	config := ProviderConfig{
+		MistralURL:  DefaultMistralURL,
+		MaxBodySize: framework.DefaultMaxBodySize,
+		Timeout:     DefaultMistralTimeout,
+	}
+
+	if addr, ok := conf["mistral_url"].(string); ok && addr != "" {
+		config.MistralURL = addr
+	}
+
+	// Parse max_body_size — handle various JSON number types
+	if maxSize, ok := conf["max_body_size"]; ok {
+		switch v := maxSize.(type) {
+		case int:
+			if v > 0 {
+				config.MaxBodySize = int64(v)
+			}
+		case int64:
+			if v > 0 {
+				config.MaxBodySize = v
+			}
+		case float64:
+			if v > 0 {
+				config.MaxBodySize = int64(v)
+			}
+		case json.Number:
+			if parsed, err := v.Int64(); err == nil && parsed > 0 {
+				config.MaxBodySize = parsed
+			}
+		case string:
+			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
+				config.MaxBodySize = parsed
+			}
+		}
+	}
+
+	// Parse timeout — handle duration string or number
+	if timeout, ok := conf["timeout"]; ok {
+		switch v := timeout.(type) {
+		case string:
+			if parsed, err := time.ParseDuration(v); err == nil {
+				config.Timeout = parsed
+			}
+		case int:
+			if v > 0 {
+				config.Timeout = time.Duration(v) * time.Second
+			}
+		case float64:
+			if v > 0 {
+				config.Timeout = time.Duration(v) * time.Second
+			}
+		}
+	}
+
+	// Parse transparent mode settings
+	if tm, ok := conf["transparent_mode"].(bool); ok {
+		config.TransparentMode = tm
+	}
+	if aap, ok := conf["auto_auth_path"].(string); ok {
+		config.AutoAuthPath = aap
+	}
+	if dr, ok := conf["default_role"].(string); ok {
+		config.DefaultRole = dr
+	}
+
+	return config
+}
+
+// ValidateConfig validates provider-level configuration
+func ValidateConfig(conf map[string]any) error {
+	// mistral_url is optional (defaults to api.mistral.ai), but if provided must be valid
+	if addr, ok := conf["mistral_url"].(string); ok && addr != "" {
+		if err := validateMistralAddress(addr); err != nil {
+			return err
+		}
+	}
+
+	// Validate max_body_size if provided
+	if maxSize, ok := conf["max_body_size"]; ok {
+		var size int64
+		switch v := maxSize.(type) {
+		case int:
+			size = int64(v)
+		case int64:
+			size = v
+		case float64:
+			size = int64(v)
+		case json.Number:
+			parsed, err := v.Int64()
+			if err != nil {
+				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
+			}
+			size = parsed
+		case string:
+			parsed, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
+			}
+			size = parsed
+		default:
+			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
+		}
+		if size < 0 {
+			return fmt.Errorf("max_body_size must be greater than 0")
+		}
+		if size > 104857600 { // 100MB
+			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
+		}
+	}
+
+	// Validate timeout if provided
+	if timeout, ok := conf["timeout"]; ok {
+		switch v := timeout.(type) {
+		case string:
+			if _, err := time.ParseDuration(v); err != nil {
+				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
+			}
+		case int:
+			if v < 0 {
+				return fmt.Errorf("timeout must be greater than 0 seconds")
+			}
+		case float64:
+			if v < 0 {
+				return fmt.Errorf("timeout must be greater than 0 seconds")
+			}
+		default:
+			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
+		}
+	}
+
+	// Validate transparent_mode
+	if tm, ok := conf["transparent_mode"]; ok {
+		if _, ok := tm.(bool); !ok {
+			return fmt.Errorf("transparent_mode must be a boolean")
+		}
+	}
+
+	// Validate auto_auth_path
+	if aap, ok := conf["auto_auth_path"]; ok {
+		if _, ok := aap.(string); !ok {
+			return fmt.Errorf("auto_auth_path must be a string")
+		}
+	}
+
+	// Validate default_role
+	if dr, ok := conf["default_role"]; ok {
+		if _, ok := dr.(string); !ok {
+			return fmt.Errorf("default_role must be a string")
+		}
+	}
+
+	return nil
+}
+
+// validateMistralAddress validates that the mistral_url is a well-formed HTTPS URL
+func validateMistralAddress(addr string) error {
+	if addr == "" {
+		return nil // Empty means use default
+	}
+
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("invalid mistral_url: %w", err)
+	}
+
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("mistral_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("mistral_url must include a host")
+	}
+
+	return nil
+}

--- a/provider/mistral/path_config.go
+++ b/provider/mistral/path_config.go
@@ -1,0 +1,163 @@
+package mistral
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathConfig returns the config path definition for the Mistral provider
+func (b *mistralBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"mistral_url": {
+				Type:        framework.TypeString,
+				Description: "The Mistral API base URL (default: https://api.mistral.ai)",
+				Default:     DefaultMistralURL,
+			},
+			"max_body_size": {
+				Type:        framework.TypeInt64,
+				Description: "Maximum request body size in bytes (default: 10MB, max: 100MB)",
+				Default:     framework.DefaultMaxBodySize,
+			},
+			"timeout": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Request timeout duration (e.g., '120s', '5m')",
+				Default:     "120s",
+			},
+			"transparent_mode": {
+				Type:        framework.TypeBool,
+				Description: "Enable transparent mode for implicit JWT authentication",
+				Default:     false,
+			},
+			"auto_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Path to JWT auth mount for transparent mode (e.g., 'auth/jwt/')",
+			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default role to use when not specified in URL path",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read Mistral provider configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure Mistral provider settings",
+			},
+		},
+		HelpSynopsis:    "Configure Mistral provider",
+		HelpDescription: "This endpoint configures the Mistral provider settings including API URL, body size limits, and timeouts.",
+	}
+}
+
+// handleConfigRead handles reading the Mistral provider configuration
+func (b *mistralBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"mistral_url":      b.mistralURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		},
+	}, nil
+}
+
+// handleConfigWrite handles writing the Mistral provider configuration
+func (b *mistralBackend) handleConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if val, ok := d.GetOk("mistral_url"); ok {
+		addr := val.(string)
+		if addr != "" {
+			addr = strings.TrimRight(addr, "/")
+			if err := validateMistralAddress(addr); err != nil {
+				return &logical.Response{
+					StatusCode: http.StatusBadRequest,
+					Err:        logical.ErrBadRequest(err.Error()),
+				}, nil
+			}
+			b.mistralURL = addr
+		}
+	}
+
+	if val, ok := d.GetOk("max_body_size"); ok {
+		b.MaxBodySize = val.(int64)
+	} else if b.MaxBodySize == 0 {
+		b.MaxBodySize = framework.DefaultMaxBodySize
+	}
+
+	if val, ok := d.GetOk("timeout"); ok {
+		b.Timeout = time.Duration(val.(int)) * time.Second
+	} else if b.Timeout == 0 {
+		b.Timeout = DefaultMistralTimeout
+	}
+
+	// Transparent mode settings
+	tc := &framework.TransparentConfig{
+		Enabled:      b.TransparentConfig.Enabled,
+		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
+		DefaultRole:  b.TransparentConfig.DefaultRole,
+	}
+	if val, ok := d.GetOk("transparent_mode"); ok {
+		tc.Enabled = val.(bool)
+	}
+	if val, ok := d.GetOk("auto_auth_path"); ok {
+		tc.AutoAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("default_role"); ok {
+		tc.DefaultRole = val.(string)
+	}
+
+	if tc.Enabled && tc.AutoAuthPath == "" {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest("auto_auth_path is required when transparent_mode is enabled"),
+		}, nil
+	}
+
+	b.StreamingBackend.SetTransparentConfig(tc)
+
+	// Persist config to storage
+	if b.StorageView != nil {
+		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"mistral_url":      b.mistralURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		})
+		if err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+		if err := b.StorageView.Put(ctx, entry); err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"message": "configuration updated",
+		},
+	}, nil
+}

--- a/provider/mistral/path_gateway.go
+++ b/provider/mistral/path_gateway.go
@@ -1,0 +1,167 @@
+package mistral
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// Headers to remove before proxying
+var headersToRemove = []string{
+	// Security headers (will be replaced with Mistral API key)
+	"Authorization",
+	"X-Warden-Token",
+	// Hop-by-hop headers
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+	// Proxy headers
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Port",
+	"X-Real-Ip",
+	"Forwarded",
+}
+
+func (b *mistralBackend) handleGateway(ctx context.Context, req *logical.Request) {
+	// Apply timeout if configured
+	if b.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		defer cancel()
+		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	}
+
+	// Enforce max body size
+	maxBody := b.MaxBodySize
+	if maxBody <= 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+	req.HTTPRequest.Body = http.MaxBytesReader(req.ResponseWriter, req.HTTPRequest.Body, maxBody)
+
+	// Get Mistral API key from credential
+	apiKey, err := b.getMistralAPIKey(req)
+	if err != nil {
+		b.Logger.Warn("Failed to get Mistral API key", logger.Err(err))
+		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Build target URL
+	targetURL, err := b.buildTargetURL(req.HTTPRequest.URL.Path, req.HTTPRequest.URL.RawQuery)
+	if err != nil {
+		b.Logger.Error("Failed to build target URL", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Prepare request for proxying
+	r := req.HTTPRequest
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		b.Logger.Error("Failed to parse target URL", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	r.URL = parsedURL
+	r.Host = parsedURL.Host
+	r.RequestURI = "" // Required for outgoing requests
+
+	// Clean headers and inject Mistral API key
+	b.prepareHeaders(r, apiKey)
+
+	b.Logger.Trace("Proxying Mistral request",
+		logger.String("path", r.URL.Path),
+		logger.String("method", r.Method),
+		logger.Bool("has_key", apiKey != ""),
+	)
+
+	// Forward the request (body streams through without buffering)
+	b.Proxy.ServeHTTP(req.ResponseWriter, r)
+}
+
+// getMistralAPIKey extracts the Mistral API key from the credential
+func (b *mistralBackend) getMistralAPIKey(req *logical.Request) (string, error) {
+	if req.Credential == nil {
+		return "", fmt.Errorf("no credential available")
+	}
+
+	if req.Credential.Type != credential.TypeAIAPIKey {
+		return "", fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+	}
+
+	apiKey := req.Credential.Data["api_key"]
+	if apiKey == "" {
+		return "", fmt.Errorf("credential missing api_key field")
+	}
+
+	return apiKey, nil
+}
+
+// buildTargetURL constructs the target Mistral API URL from the gateway path
+func (b *mistralBackend) buildTargetURL(path, rawQuery string) (string, error) {
+	// Find gateway path marker
+	gatewayIdx := strings.Index(path, "/gateway")
+	if gatewayIdx == -1 {
+		return "", fmt.Errorf("invalid gateway path: %s", path)
+	}
+
+	// Extract path after "/gateway"
+	mistralPath := path[gatewayIdx+8:] // len("/gateway") = 8
+	if mistralPath == "" || mistralPath == "/" {
+		mistralPath = "/"
+	}
+
+	if rawQuery != "" {
+		return b.mistralURL + mistralPath + "?" + rawQuery, nil
+	}
+	return b.mistralURL + mistralPath, nil
+}
+
+// prepareHeaders removes unwanted headers and injects the Mistral API key
+func (b *mistralBackend) prepareHeaders(r *http.Request, apiKey string) {
+	// Read Connection header before removing it
+	conn := r.Header.Get("Connection")
+
+	// Remove headers in single pass
+	for _, h := range headersToRemove {
+		r.Header.Del(h)
+	}
+
+	// Handle Connection header's listed headers
+	if conn != "" {
+		for _, h := range strings.Split(conn, ",") {
+			if h = strings.TrimSpace(h); h != "" {
+				r.Header.Del(h)
+			}
+		}
+	}
+
+	// Inject the Mistral API key using Bearer format
+	if apiKey != "" {
+		r.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	// Set Accept header if not already set
+	if r.Header.Get("Accept") == "" {
+		r.Header.Set("Accept", "application/json")
+	}
+
+	// Set User-Agent if not already set
+	if r.Header.Get("User-Agent") == "" {
+		r.Header.Set("User-Agent", "warden-mistral-proxy")
+	}
+}

--- a/provider/mistral/path_gateway_test.go
+++ b/provider/mistral/path_gateway_test.go
@@ -1,0 +1,160 @@
+package mistral
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTargetURL(t *testing.T) {
+	b := &mistralBackend{
+		mistralURL: "https://api.mistral.ai",
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		query    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "chat completions",
+			path:     "/mistral/gateway/v1/chat/completions",
+			expected: "https://api.mistral.ai/v1/chat/completions",
+		},
+		{
+			name:     "embeddings",
+			path:     "/mistral/gateway/v1/embeddings",
+			expected: "https://api.mistral.ai/v1/embeddings",
+		},
+		{
+			name:     "models",
+			path:     "/mistral/gateway/v1/models",
+			expected: "https://api.mistral.ai/v1/models",
+		},
+		{
+			name:     "path with query",
+			path:     "/mistral/gateway/v1/models",
+			query:    "page=1&per_page=10",
+			expected: "https://api.mistral.ai/v1/models?page=1&per_page=10",
+		},
+		{
+			name:     "bare gateway",
+			path:     "/mistral/gateway",
+			expected: "https://api.mistral.ai/",
+		},
+		{
+			name:     "gateway with trailing slash",
+			path:     "/mistral/gateway/",
+			expected: "https://api.mistral.ai/",
+		},
+		{
+			name:    "no gateway marker",
+			path:    "/mistral/v1/chat/completions",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := b.buildTargetURL(tc.path, tc.query)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildTargetURL_CustomURL(t *testing.T) {
+	b := &mistralBackend{
+		mistralURL: "https://mistral.example.com",
+	}
+
+	result, err := b.buildTargetURL("/custom/gateway/v1/chat/completions", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://mistral.example.com/v1/chat/completions", result)
+}
+
+func TestPrepareHeaders(t *testing.T) {
+	b := &mistralBackend{}
+
+	t.Run("removes security headers and injects API key", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+		req.Header.Set("Authorization", "Bearer warden-token")
+		req.Header.Set("X-Warden-Token", "warden-token")
+		req.Header.Set("X-Custom", "keep-me")
+
+		b.prepareHeaders(req, "sk-test-key")
+
+		assert.Equal(t, "Bearer sk-test-key", req.Header.Get("Authorization"))
+		assert.Equal(t, "", req.Header.Get("X-Warden-Token"))
+		assert.Equal(t, "keep-me", req.Header.Get("X-Custom"))
+	})
+
+	t.Run("injects default headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "sk-test-key")
+
+		assert.Equal(t, "application/json", req.Header.Get("Accept"))
+		assert.Equal(t, "warden-mistral-proxy", req.Header.Get("User-Agent"))
+	})
+
+	t.Run("preserves client-set Accept header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+		req.Header.Set("Accept", "text/event-stream")
+
+		b.prepareHeaders(req, "sk-test-key")
+
+		assert.Equal(t, "text/event-stream", req.Header.Get("Accept"))
+	})
+
+	t.Run("removes hop-by-hop headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+		req.Header.Set("Connection", "keep-alive")
+		req.Header.Set("Transfer-Encoding", "chunked")
+		req.Header.Set("Proxy-Authorization", "Basic abc")
+
+		b.prepareHeaders(req, "sk-test-key")
+
+		assert.Equal(t, "", req.Header.Get("Connection"))
+		assert.Equal(t, "", req.Header.Get("Transfer-Encoding"))
+		assert.Equal(t, "", req.Header.Get("Proxy-Authorization"))
+	})
+
+	t.Run("removes Connection-listed headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+		req.Header.Set("Connection", "X-Custom-Hop")
+		req.Header.Set("X-Custom-Hop", "should-be-removed")
+
+		b.prepareHeaders(req, "sk-test-key")
+
+		assert.Equal(t, "", req.Header.Get("X-Custom-Hop"))
+	})
+
+	t.Run("removes proxy headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+		req.Header.Set("X-Forwarded-For", "10.0.0.1")
+		req.Header.Set("X-Real-Ip", "10.0.0.1")
+		req.Header.Set("Forwarded", "for=10.0.0.1")
+
+		b.prepareHeaders(req, "sk-test-key")
+
+		assert.Equal(t, "", req.Header.Get("X-Forwarded-For"))
+		assert.Equal(t, "", req.Header.Get("X-Real-Ip"))
+		assert.Equal(t, "", req.Header.Get("Forwarded"))
+	})
+
+	t.Run("empty API key does not set Authorization", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.mistral.ai/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "")
+
+		assert.Equal(t, "", req.Header.Get("Authorization"))
+	})
+}

--- a/provider/mistral/provider.go
+++ b/provider/mistral/provider.go
@@ -1,0 +1,256 @@
+package mistral
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// mistralBackend is the streaming backend for Mistral provider operations
+type mistralBackend struct {
+	*framework.StreamingBackend
+	mistralURL string // e.g., "https://api.mistral.ai"
+}
+
+// extractToken extracts Warden token from Authorization: Bearer or X-Warden-Token headers
+func extractToken(r *http.Request) string {
+	// First, check X-Warden-Token header (explicit Warden token)
+	if token := r.Header.Get("X-Warden-Token"); token != "" {
+		return token
+	}
+
+	// Then check Authorization header for Bearer token
+	authHeader := r.Header.Get("Authorization")
+	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
+		return authHeader[7:]
+	}
+
+	return ""
+}
+
+// Factory creates a new Mistral provider backend using the logical.Factory pattern
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &mistralBackend{}
+
+	// Create the streaming backend with gateway path for streaming
+	b.StreamingBackend = &framework.StreamingBackend{
+		StreamingPaths: []*framework.StreamingPath{
+			{
+				Pattern:         "gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Mistral AI Gateway proxy",
+				HelpDescription: "Proxies requests to Mistral AI API with API key injection",
+			},
+			{
+				Pattern:         "gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Mistral AI Gateway proxy",
+				HelpDescription: "Proxies requests to Mistral AI API with API key injection",
+			},
+			// Transparent mode: role-based gateway paths
+			{
+				Pattern:         "role/[^/]+/gateway",
+				Handler:         b.handleTransparentGatewayStreaming,
+				HelpSynopsis:    "Mistral AI Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to Mistral AI API with implicit JWT authentication",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway/.*",
+				Handler:         b.handleTransparentGatewayStreaming,
+				HelpSynopsis:    "Mistral AI Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to Mistral AI API with implicit JWT authentication",
+			},
+		},
+		ParseStreamBody: true, // Enable policy evaluation on model, max_tokens, etc.
+		TransparentConfig: &framework.TransparentConfig{
+			Enabled:      false,
+			AutoAuthPath: "",
+			DefaultRole:  "",
+		},
+		Backend: &framework.Backend{
+			Help:           mistralBackendHelp,
+			BackendType:    "mistral",
+			BackendClass:   logical.ClassProvider,
+			TokenExtractor: extractToken,
+			Paths:          b.paths(),
+		},
+	}
+
+	// Set common fields
+	b.Logger = conf.Logger.WithSubsystem("mistral")
+	b.StorageView = conf.StorageView
+
+	// Initialize reverse proxy with Mistral transport
+	b.StreamingBackend.InitProxy(sharedTransport)
+
+	// Register transport shutdown hook for process-level cleanup
+	if conf.RegisterShutdownHook != nil {
+		conf.RegisterShutdownHook("mistral-transport", ShutdownHTTPTransport)
+	}
+
+	// Set defaults
+	b.MaxBodySize = framework.DefaultMaxBodySize
+	b.Timeout = DefaultMistralTimeout
+	b.mistralURL = DefaultMistralURL
+
+	// Apply configuration if provided
+	if len(conf.Config) > 0 {
+		if err := ValidateConfig(conf.Config); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+		parsedConfig := parseConfig(conf.Config)
+		b.mistralURL = strings.TrimRight(parsedConfig.MistralURL, "/")
+		b.MaxBodySize = parsedConfig.MaxBodySize
+		b.Timeout = parsedConfig.Timeout
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			Enabled:      parsedConfig.TransparentMode,
+			AutoAuthPath: parsedConfig.AutoAuthPath,
+			DefaultRole:  parsedConfig.DefaultRole,
+		})
+	}
+
+	return b, nil
+}
+
+// Initialize loads persisted config from storage
+func (b *mistralBackend) Initialize(ctx context.Context) error {
+	if b.StorageView == nil {
+		return nil
+	}
+
+	entry, err := b.StorageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry != nil {
+		var config struct {
+			MistralURL      string `json:"mistral_url"`
+			MaxBodySize     int64  `json:"max_body_size"`
+			Timeout         string `json:"timeout"`
+			TransparentMode bool   `json:"transparent_mode"`
+			AutoAuthPath    string `json:"auto_auth_path"`
+			DefaultRole     string `json:"default_role"`
+		}
+		if err := entry.DecodeJSON(&config); err != nil {
+			return fmt.Errorf("failed to decode config: %w", err)
+		}
+		if config.MistralURL != "" {
+			b.mistralURL = strings.TrimRight(config.MistralURL, "/")
+		}
+		b.MaxBodySize = config.MaxBodySize
+		if config.Timeout != "" {
+			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
+				b.Timeout = timeout
+			}
+		}
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			Enabled:      config.TransparentMode,
+			AutoAuthPath: config.AutoAuthPath,
+			DefaultRole:  config.DefaultRole,
+		})
+	} else {
+		// No persisted config — persist defaults
+		tc := b.TransparentConfig
+		defaultEntry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"mistral_url":      b.mistralURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create default config entry: %w", err)
+		}
+		if err := b.StorageView.Put(ctx, defaultEntry); err != nil {
+			return fmt.Errorf("failed to persist default config: %w", err)
+		}
+		b.Logger.Info("persisted default configuration for new Mistral provider")
+	}
+	return nil
+}
+
+// paths returns the configuration paths for the Mistral provider
+func (b *mistralBackend) paths() []*framework.Path {
+	return []*framework.Path{
+		b.pathConfig(),
+	}
+}
+
+// handleGatewayStreaming handles streaming gateway requests
+func (b *mistralBackend) handleGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// handleTransparentGatewayStreaming handles transparent mode gateway requests.
+// The implicit auth has already been performed by the core request handler.
+func (b *mistralBackend) handleTransparentGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	if !b.StreamingBackend.IsTransparentMode() {
+		http.Error(req.ResponseWriter, "Transparent mode not enabled", http.StatusForbidden)
+		return nil
+	}
+
+	// Rewrite the path: /role/{role}/gateway/... -> /gateway/...
+	req.Path = b.StreamingBackend.RewriteTransparentPath(req.Path)
+
+	// Also update the HTTP request URL path for the proxy
+	if req.HTTPRequest != nil && req.HTTPRequest.URL != nil {
+		req.HTTPRequest.URL.Path = b.StreamingBackend.RewriteTransparentPath(req.HTTPRequest.URL.Path)
+	}
+
+	// Delegate to standard gateway handler
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// SensitiveConfigFields returns the list of config fields that should be masked in output
+func (b *mistralBackend) SensitiveConfigFields() []string {
+	return []string{}
+}
+
+const mistralBackendHelp = `
+The Mistral provider enables proxying requests to the Mistral AI API with
+automatic credential management and API key injection.
+
+Clients authenticate to Warden with a session token (via X-Warden-Token or
+Authorization: Bearer header). The provider obtains a Mistral API key from
+the credential manager and injects it into the proxied request's Authorization
+header. This allows Warden to broker Mistral AI access without exposing API
+keys to clients.
+
+The gateway path format is:
+  /mistral/gateway/{api-path}
+
+Examples:
+  /mistral/gateway/v1/chat/completions
+  /mistral/gateway/v1/embeddings
+  /mistral/gateway/v1/models
+
+Request body parsing is enabled, allowing policies to evaluate AI request
+fields such as model, max_tokens, temperature, and stream. This enables
+fine-grained cost control and usage policies.
+
+Transparent mode allows implicit JWT authentication via role-based paths,
+eliminating the need for clients to perform an explicit Warden login:
+  /mistral/role/{role}/gateway/{api-path}
+
+The core extracts the role from the URL, performs implicit JWT auth against
+the configured auth mount, and issues a short-lived token for the request.
+
+Configuration:
+- mistral_url: Mistral API base URL (default: https://api.mistral.ai)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 120s for AI inference)
+- transparent_mode: Enable implicit JWT authentication (default: false)
+- auto_auth_path: JWT auth mount path for transparent mode (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`

--- a/provider/mistral/provider_test.go
+++ b/provider/mistral/provider_test.go
@@ -1,0 +1,170 @@
+package mistral
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected string
+	}{
+		{
+			name:     "X-Warden-Token header",
+			headers:  map[string]string{"X-Warden-Token": "warden-token-123"},
+			expected: "warden-token-123",
+		},
+		{
+			name:     "Bearer token",
+			headers:  map[string]string{"Authorization": "Bearer my-bearer-token"},
+			expected: "my-bearer-token",
+		},
+		{
+			name:     "X-Warden-Token takes priority over Bearer",
+			headers:  map[string]string{"X-Warden-Token": "warden-token", "Authorization": "Bearer bearer-token"},
+			expected: "warden-token",
+		},
+		{
+			name:     "No token",
+			headers:  map[string]string{},
+			expected: "",
+		},
+		{
+			name:     "Non-Bearer auth header ignored",
+			headers:  map[string]string{"Authorization": "token ghp_abc123"},
+			expected: "",
+		},
+		{
+			name:     "Case insensitive Bearer",
+			headers:  map[string]string{"Authorization": "bearer my-token"},
+			expected: "my-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			result := extractToken(req)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseConfig(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		config := parseConfig(map[string]any{})
+		assert.Equal(t, DefaultMistralURL, config.MistralURL)
+		assert.Greater(t, config.MaxBodySize, int64(0))
+		assert.Equal(t, DefaultMistralTimeout, config.Timeout)
+	})
+
+	t.Run("custom values", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"mistral_url": "https://mistral.example.com",
+			"timeout":     "60s",
+		})
+		assert.Equal(t, "https://mistral.example.com", config.MistralURL)
+		assert.Equal(t, 60.0, config.Timeout.Seconds())
+	})
+
+	t.Run("integer timeout", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"timeout": 45,
+		})
+		assert.Equal(t, 45.0, config.Timeout.Seconds())
+	})
+
+	t.Run("transparent mode settings", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"transparent_mode": true,
+			"auto_auth_path":   "auth/jwt/",
+			"default_role":     "reader",
+		})
+		assert.True(t, config.TransparentMode)
+		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
+		assert.Equal(t, "reader", config.DefaultRole)
+	})
+}
+
+func TestValidateConfig(t *testing.T) {
+	t.Run("empty config is valid", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid mistral_url", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"mistral_url": "https://api.mistral.ai",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-HTTPS mistral_url rejected", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"mistral_url": "http://api.mistral.ai",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "https://")
+	})
+
+	t.Run("invalid timeout format", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"timeout": "not-a-duration",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("negative max_body_size", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"max_body_size": -1,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("oversized max_body_size", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"max_body_size": 200000000, // 200MB
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid transparent_mode type", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"transparent_mode": "yes",
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateMistralAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr bool
+	}{
+		{"empty is valid", "", false},
+		{"valid HTTPS", "https://api.mistral.ai", false},
+		{"valid custom", "https://mistral.example.com", false},
+		{"HTTP rejected", "http://api.mistral.ai", true},
+		{"no scheme", "api.mistral.ai", true},
+		{"no host", "https://", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMistralAddress(tc.addr)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/provider/mistral/transport.go
+++ b/provider/mistral/transport.go
@@ -1,0 +1,88 @@
+package mistral
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+var (
+	sharedTransport        *http.Transport
+	transportCleanupCtx    context.Context
+	transportCleanupCancel context.CancelFunc
+)
+
+func init() {
+	sharedTransport = newMistralTransport()
+
+	// Start background cleanup with proper lifecycle management
+	transportCleanupCtx, transportCleanupCancel = context.WithCancel(context.Background())
+	go cleanupIdleConnections(transportCleanupCtx, sharedTransport)
+}
+
+// newMistralTransport creates an HTTP transport optimized for Mistral AI API workloads
+func newMistralTransport() *http.Transport {
+	transport := &http.Transport{
+		// Connection pool settings
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 50,
+		MaxConnsPerHost:     0, // Unlimited outbound connections
+		IdleConnTimeout:     90 * time.Second,
+
+		// TLS configuration
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ClientSessionCache: tls.NewLRUClientSessionCache(100),
+		},
+
+		// Dialer settings
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+
+		// Timeout settings — higher for AI inference (streaming responses can be slow)
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 120 * time.Second,
+
+		// HTTP/2 optimization
+		ForceAttemptHTTP2: true,
+	}
+
+	if err := http2.ConfigureTransport(transport); err != nil {
+		log.Printf("Failed to configure HTTP/2 for Mistral transport: %v", err)
+	}
+
+	return transport
+}
+
+// cleanupIdleConnections periodically closes idle connections
+func cleanupIdleConnections(ctx context.Context, transport *http.Transport) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			transport.CloseIdleConnections()
+		}
+	}
+}
+
+// ShutdownHTTPTransport should be called during application shutdown
+func ShutdownHTTPTransport() {
+	if transportCleanupCancel != nil {
+		transportCleanupCancel()
+	}
+	if sharedTransport != nil {
+		sharedTransport.CloseIdleConnections()
+	}
+}


### PR DESCRIPTION
Add a new Mistral AI provider that supports API key management and rotation via the Warden gateway, along with the corresponding AI API key credential type and Mistral driver.