### PR TITLE
feat: add OpenAI AI provider (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Warden sits in the request path between AI agents and the services they call —
 | Provider | Status | Credential Source |
 |----------|--------|-------------------|
 | **Mistral** | ✅ GA | API key |
-| OpenAI | Planned | — |
+| **OpenAI** | ✅ GA | API key |
 | Anthropic | Planned | — |
 | Cohere | Planned | — |
 
@@ -153,7 +153,7 @@ curl -H "Authorization: Bearer <your-jwt>" \
 #   3. Forwards the request to https://api.github.com/repos/acme/frontend/contents/README.md
 ```
 
-Transparent mode works with any provider that uses bearer tokens: **Mistral, Azure, GCP, GitHub, GitLab, Vault**. It's the simplest integration path — no code changes, no token exchange, one HTTP call.
+Transparent mode works with any provider that uses bearer tokens: **Mistral, OpenAI, Azure, GCP, GitHub, GitLab, Vault**. It's the simplest integration path — no code changes, no token exchange, one HTTP call.
 
 ### Explicit Mode
 
@@ -179,6 +179,7 @@ Explicit mode is **required for AWS** (SigV4 request signing means Warden must h
 | Provider | Transparent | Explicit |
 |----------|:-----------:|:--------:|
 | **Mistral** | ✅ | ✅ |
+| **OpenAI** | ✅ | ✅ |
 | **AWS** | — | ✅ |
 | **Azure** | ✅ | ✅ |
 | **GCP** | ✅ | ✅ |
@@ -260,6 +261,7 @@ Once Warden is running, follow a provider guide to configure your first endpoint
 
 **AI Providers:**
 - [Mistral](provider/mistral/README.md)
+- [OpenAI](provider/openai/README.md)
 
 **Cloud & SaaS Providers:**
 - [AWS](provider/aws/README.md)
@@ -285,7 +287,7 @@ Warden uses HCL configuration files. See `warden.local.hcl` for a full example c
 
 ## Roadmap
 
-**AI Providers** — OpenAI, Anthropic, Cohere, Google AI (Gemini), xAI, Replicate, Hugging Face, Together AI
+**AI Providers** — Anthropic, Cohere, Google AI (Gemini), xAI, Replicate, Hugging Face, Together AI
 
 **AI Governance** — Per-model cost budgets, token usage tracking, prompt/response audit, rate limiting per agent per model
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stephnangue/warden/provider/github"
 	"github.com/stephnangue/warden/provider/gitlab"
 	"github.com/stephnangue/warden/provider/mistral"
+	"github.com/stephnangue/warden/provider/openai"
 	"github.com/stephnangue/warden/provider/vault"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -93,6 +94,7 @@ Usage: warden server [options]
 		"github":  github.Factory,
 		"gitlab":  gitlab.Factory,
 		"mistral": mistral.Factory,
+		"openai":  openai.Factory,
 		"vault":   vault.Factory,
 	}
 

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -27,6 +27,7 @@ const (
 	SourceTypeGitLab   = "gitlab"
 	SourceTypeGitHub   = "github"
 	SourceTypeMistral  = "mistral"
+	SourceTypeOpenAI   = "openai"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -44,5 +44,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register OpenAI driver factory
+	if err := registry.RegisterFactory(&OpenAIDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/openai_driver.go
+++ b/credential/drivers/openai_driver.go
@@ -1,0 +1,184 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// openaiMaxResponseBodySize limits response body reads to prevent OOM
+const openaiMaxResponseBodySize = 1 << 20 // 1MB
+
+// openaiMaxRetryAttempts for retryable API operations
+const openaiMaxRetryAttempts = 3
+
+// DefaultOpenAIAPIURL is the default OpenAI API base URL
+const DefaultOpenAIAPIURL = "https://api.openai.com"
+
+// Compile-time interface assertions
+// Note: OpenAIDriver does not implement credential.Rotatable.
+// OpenAI does not expose REST API endpoints for programmatic key management.
+var _ credential.SourceDriver = (*OpenAIDriver)(nil)
+var _ credential.SpecVerifier = (*OpenAIDriver)(nil)
+
+// OpenAIDriver provides API key credentials for OpenAI.
+//
+// The source config holds only connection info (api_url). Auth credentials
+// (api_key) live in the credential spec config and are read at MintCredential
+// time. This allows multiple specs with different API keys to share one source.
+//
+// Key rotation must be performed manually:
+//  1. Create a new API key in the OpenAI dashboard
+//  2. Update the spec config via Warden API
+//  3. The old key continues to work until deleted from the dashboard
+type OpenAIDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// OpenAIDriverFactory creates OpenAIDriver instances
+type OpenAIDriverFactory struct{}
+
+// Type returns the driver type
+func (f *OpenAIDriverFactory) Type() string {
+	return credential.SourceTypeOpenAI
+}
+
+// ValidateConfig validates OpenAI source configuration using declarative schema.
+// The source only holds connection info (api_url). Auth credentials are
+// validated at spec level by AIAPIKeyCredType.ValidateConfig.
+func (f *OpenAIDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("api_url").
+			Custom(validateOpenAIURL).
+			Describe("OpenAI API base URL (default: https://api.openai.com)").
+			Example("https://api.openai.com"),
+	)
+}
+
+// SensitiveConfigFields returns the list of source config keys that should be masked.
+// No secrets are stored on the source — they live in the spec config.
+func (f *OpenAIDriverFactory) SensitiveConfigFields() []string {
+	return nil
+}
+
+// Create instantiates a new OpenAIDriver.
+// The driver only needs the api_url from source config. Auth credentials
+// are provided per-spec at MintCredential time.
+func (f *OpenAIDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(credential.SourceTypeOpenAI),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	return driver, nil
+}
+
+// getAPIURL returns the OpenAI API base URL from source config
+func (d *OpenAIDriver) getAPIURL() string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, "api_url", DefaultOpenAIAPIURL), "/")
+}
+
+// MintCredential returns the OpenAI API key from spec config.
+// The key is static — no TTL, no lease.
+func (d *OpenAIDriver) MintCredential(_ context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	apiKey := credential.GetString(spec.Config, "api_key", "")
+	if apiKey == "" {
+		return nil, 0, "", fmt.Errorf("no OpenAI API key configured in spec")
+	}
+
+	rawData := map[string]interface{}{
+		"api_key": apiKey,
+	}
+
+	// Copy optional metadata from spec config
+	if orgID := credential.GetString(spec.Config, "organization_id", ""); orgID != "" {
+		rawData["organization_id"] = orgID
+	}
+	if projectID := credential.GetString(spec.Config, "project_id", ""); projectID != "" {
+		rawData["project_id"] = projectID
+	}
+
+	return rawData, 0, "", nil // Static — no TTL, no lease
+}
+
+// Revoke is a no-op for static API keys.
+func (d *OpenAIDriver) Revoke(_ context.Context, leaseID string) error {
+	if d.logger != nil {
+		d.logger.Debug("OpenAI API keys are static, skipping revocation",
+			logger.String("lease_id", leaseID),
+		)
+	}
+	return nil
+}
+
+// Type returns the driver type
+func (d *OpenAIDriver) Type() string {
+	return credential.SourceTypeOpenAI
+}
+
+// Cleanup releases resources
+func (d *OpenAIDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates that the spec's API key is functional by calling
+// GET /v1/models, a lightweight read-only endpoint.
+func (d *OpenAIDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	apiKey := credential.GetString(spec.Config, "api_key", "")
+	if apiKey == "" {
+		return fmt.Errorf("no OpenAI API key configured in spec")
+	}
+
+	apiURL := d.getAPIURL() + "/v1/models"
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       openaiMaxRetryAttempts,
+		MaxBodySize:       openaiMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500}, // 429 and all 5xx
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodGet,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + apiKey,
+			"Accept":        "application/json",
+		},
+	}
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("OpenAI API key verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateOpenAIURL validates that the api_url is a well-formed HTTPS URL
+func validateOpenAIURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid api_url: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("api_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("api_url must include a host")
+	}
+	return nil
+}

--- a/credential/drivers/openai_driver_test.go
+++ b/credential/drivers/openai_driver_test.go
@@ -1,0 +1,380 @@
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIDriverFactory_Type(t *testing.T) {
+	factory := &OpenAIDriverFactory{}
+	assert.Equal(t, credential.SourceTypeOpenAI, factory.Type())
+}
+
+func TestOpenAIDriverFactory_SensitiveConfigFields(t *testing.T) {
+	factory := &OpenAIDriverFactory{}
+	fields := factory.SensitiveConfigFields()
+	assert.Nil(t, fields, "source has no secrets — they live in the spec")
+}
+
+func TestOpenAIDriverFactory_ValidateConfig(t *testing.T) {
+	factory := &OpenAIDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid empty config (uses default api_url)",
+			config:  map[string]string{},
+			wantErr: false,
+		},
+		{
+			name:    "valid explicit api_url",
+			config:  map[string]string{"api_url": "https://api.openai.com"},
+			wantErr: false,
+		},
+		{
+			name:    "valid custom api_url",
+			config:  map[string]string{"api_url": "https://openai.example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid api_url scheme",
+			config:  map[string]string{"api_url": "http://api.openai.com"},
+			wantErr: true,
+			errMsg:  "must use https://",
+		},
+		{
+			name:    "invalid api_url no host",
+			config:  map[string]string{"api_url": "https://"},
+			wantErr: true,
+			errMsg:  "must include a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOpenAIDriverFactory_Create(t *testing.T) {
+	factory := &OpenAIDriverFactory{}
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	driver, err := factory.Create(map[string]string{
+		"api_url": "https://api.openai.com",
+	}, log)
+	require.NoError(t, err)
+	assert.NotNil(t, driver)
+	assert.Equal(t, credential.SourceTypeOpenAI, driver.Type())
+}
+
+func TestOpenAIDriver_Type(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, credential.SourceTypeOpenAI, driver.Type())
+}
+
+func TestOpenAIDriver_Cleanup(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+		httpClient: &http.Client{},
+	}
+	err := driver.Cleanup(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestOpenAIDriver_Revoke_NoOp(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+	// OpenAI API keys are static — revoke is a no-op
+	err := driver.Revoke(context.Background(), "any-lease-id")
+	assert.NoError(t, err)
+
+	err = driver.Revoke(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestOpenAIDriver_NotRotatable(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+	// OpenAIDriver should not implement Rotatable
+	var sd credential.SourceDriver = driver
+	_, ok := sd.(credential.Rotatable)
+	assert.False(t, ok, "OpenAIDriver should not implement credential.Rotatable")
+}
+
+func TestOpenAIDriver_MintCredential(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{"api_url": "https://api.openai.com"},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-openai",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "sk-test-key-123",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Equal(t, "", leaseID)
+}
+
+func TestOpenAIDriver_MintCredential_EmptyKey(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-openai",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no OpenAI API key configured")
+}
+
+func TestOpenAIDriver_MintCredential_WithOrganizationID(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-openai",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key":         "sk-test-key-123",
+			"organization_id": "org-456",
+		},
+	}
+
+	rawData, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
+	assert.Equal(t, "org-456", rawData["organization_id"])
+}
+
+func TestOpenAIDriver_MintCredential_WithProjectID(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-openai",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key":    "sk-test-key-123",
+			"project_id": "proj-789",
+		},
+	}
+
+	rawData, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
+	assert.Equal(t, "proj-789", rawData["project_id"])
+}
+
+func TestOpenAIDriver_MintCredential_WithAllOptionalFields(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-openai",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key":         "sk-test-key-123",
+			"organization_id": "org-456",
+			"project_id":      "proj-789",
+		},
+	}
+
+	rawData, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
+	assert.Equal(t, "org-456", rawData["organization_id"])
+	assert.Equal(t, "proj-789", rawData["project_id"])
+}
+
+func TestOpenAIDriver_VerifySpec(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/models", r.URL.Path)
+		assert.Equal(t, "Bearer sk-valid-key", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer server.Close()
+
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{"api_url": server.URL},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-verify",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "sk-valid-key",
+		},
+	}
+
+	err := driver.VerifySpec(context.Background(), spec)
+	assert.NoError(t, err)
+}
+
+func TestOpenAIDriver_VerifySpec_InvalidKey(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"Incorrect API key provided","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{"api_url": server.URL},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-verify",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "sk-invalid-key",
+		},
+	}
+
+	err := driver.VerifySpec(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verification failed")
+}
+
+func TestOpenAIDriver_VerifySpec_EmptyKey(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-verify",
+		Type: credential.TypeAIAPIKey,
+		Config: map[string]string{
+			"api_key": "",
+		},
+	}
+
+	err := driver.VerifySpec(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no OpenAI API key configured")
+}
+
+func TestOpenAIDriver_GetAPIURL(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{"api_url": "https://api.openai.com/"},
+		},
+	}
+	// getAPIURL trims trailing slash
+	assert.Equal(t, "https://api.openai.com", driver.getAPIURL())
+}
+
+func TestOpenAIDriver_GetAPIURL_Default(t *testing.T) {
+	driver := &OpenAIDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOpenAI,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, DefaultOpenAIAPIURL, driver.getAPIURL())
+}
+
+func TestValidateOpenAIURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{"https://api.openai.com", false, ""},
+		{"https://openai.example.com", false, ""},
+		{"http://api.openai.com", true, "must use https://"},
+		{"ftp://api.openai.com", true, "must use https://"},
+		{"https://", true, "must include a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateOpenAIURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/credential/types/ai_api_key.go
+++ b/credential/types/ai_api_key.go
@@ -24,7 +24,7 @@ func NewAIAPIKeyCredType() *AIAPIKeyCredType {
 			FieldConfig: TokenFieldConfig{
 				PrimaryField:      "api_key",
 				AlternativeFields: []string{},
-				OptionalFields:    []string{"key_id", "key_name", "organization_id"},
+				OptionalFields:    []string{"key_id", "key_name", "organization_id", "project_id"},
 				FieldSchemas: map[string]*credential.CredentialFieldSchema{
 					"api_key": {
 						Description: "AI provider API key for authentication",
@@ -40,6 +40,10 @@ func NewAIAPIKeyCredType() *AIAPIKeyCredType {
 					},
 					"organization_id": {
 						Description: "Organization identifier",
+						Sensitive:   false,
+					},
+					"project_id": {
+						Description: "Project identifier",
 						Sensitive:   false,
 					},
 				},
@@ -60,6 +64,10 @@ func (t *AIAPIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("organization_id").
 			Describe("Organization ID for the AI provider (optional)").
 			Example("org-xxxxxxxxxxxx"),
+
+		credential.StringField("project_id").
+			Describe("Project ID for the AI provider (optional)").
+			Example("proj-xxxxxxxxxxxx"),
 	}
 }
 
@@ -70,10 +78,10 @@ func (t *AIAPIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 func (t *AIAPIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	// Step 1: Validate source type compatibility
 	switch sourceType {
-	case credential.SourceTypeMistral, credential.SourceTypeLocal:
+	case credential.SourceTypeMistral, credential.SourceTypeOpenAI, credential.SourceTypeLocal:
 		// Supported
 	default:
-		return fmt.Errorf("ai_api_key credentials require a mistral or local source, got: %s", sourceType)
+		return fmt.Errorf("ai_api_key credentials require a mistral, openai, or local source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema

--- a/credential/types/ai_api_key_test.go
+++ b/credential/types/ai_api_key_test.go
@@ -88,6 +88,32 @@ func TestAIAPIKeyCredType_ValidateConfig(t *testing.T) {
 			wantErr:    true,
 			errMsg:     "api_key",
 		},
+		// --- OpenAI source ---
+		{
+			name: "openai source - valid config",
+			config: map[string]string{
+				"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
+			},
+			sourceType: credential.SourceTypeOpenAI,
+			wantErr:    false,
+		},
+		{
+			name: "openai source - with organization_id and project_id",
+			config: map[string]string{
+				"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
+				"organization_id": "org-123",
+				"project_id":      "proj-456",
+			},
+			sourceType: credential.SourceTypeOpenAI,
+			wantErr:    false,
+		},
+		{
+			name:       "openai source - missing api_key",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeOpenAI,
+			wantErr:    true,
+			errMsg:     "api_key",
+		},
 		// --- Unsupported source types ---
 		{
 			name: "unsupported source type - aws",
@@ -96,7 +122,7 @@ func TestAIAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: "aws",
 			wantErr:    true,
-			errMsg:     "require a mistral or local source",
+			errMsg:     "require a mistral, openai, or local source",
 		},
 		{
 			name: "unsupported source type - vault",
@@ -105,7 +131,7 @@ func TestAIAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: credential.SourceTypeVault,
 			wantErr:    true,
-			errMsg:     "require a mistral or local source",
+			errMsg:     "require a mistral, openai, or local source",
 		},
 	}
 
@@ -207,6 +233,7 @@ func TestAIAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
 		"key_id":          "key-123",
 		"key_name":        "production-key",
 		"organization_id": "org-456",
+		"project_id":      "proj-789",
 	}
 
 	cred, err := ct.Parse(rawData, 0, "")
@@ -216,6 +243,7 @@ func TestAIAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
 	assert.Equal(t, "key-123", cred.Data["key_id"])
 	assert.Equal(t, "production-key", cred.Data["key_name"])
 	assert.Equal(t, "org-456", cred.Data["organization_id"])
+	assert.Equal(t, "proj-789", cred.Data["project_id"])
 }
 
 func TestAIAPIKeyCredType_Validate(t *testing.T) {
@@ -313,4 +341,7 @@ func TestAIAPIKeyCredType_FieldSchemas(t *testing.T) {
 
 	assert.Contains(t, schemas, "organization_id")
 	assert.False(t, schemas["organization_id"].Sensitive)
+
+	assert.Contains(t, schemas, "project_id")
+	assert.False(t, schemas["project_id"].Sensitive)
 }

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -1,0 +1,362 @@
+# OpenAI Provider
+
+The OpenAI provider enables proxied access to the OpenAI API through Warden. It streams requests to OpenAI endpoints (chat completions, responses, embeddings, images, models) with automatic API key injection and policy evaluation on AI request fields.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Mount the OpenAI Provider](#step-1-mount-the-openai-provider)
+- [Step 2: Configure the Provider](#step-2-configure-the-provider)
+- [Step 3: Create a Credential Source](#step-3-create-a-credential-source)
+- [Step 4: Create a Credential Spec](#step-4-create-a-credential-spec)
+- [Step 5: Create a Policy](#step-5-create-a-policy)
+- [Step 6: Configure JWT Auth and Create a Role](#step-6-configure-jwt-auth-and-create-a-role)
+- [Step 7: Get a JWT](#step-7-get-a-jwt)
+- [Step 8: Make Requests Through the Gateway](#step-8-make-requests-through-the-gateway)
+- [Policy Evaluation on AI Requests](#policy-evaluation-on-ai-requests)
+- [Configuration Reference](#configuration-reference)
+- [Key Management](#key-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- An **OpenAI API key** from [platform.openai.com](https://platform.openai.com)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 6-7:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Start the Warden server** in dev mode:
+> ```bash
+> ./warden server --dev
+> ```
+>
+> **4. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="<your-token>"
+> ```
+
+## Step 1: Mount the OpenAI Provider
+
+Enable the OpenAI provider at a path of your choice:
+
+```bash
+warden provider enable --type=openai
+```
+
+To mount at a custom path:
+
+```bash
+warden provider enable --type=openai openai-prod
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+## Step 2: Configure the Provider
+
+Configure the provider with transparent mode enabled. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write openai/config <<EOF
+{
+  "openai_url": "https://api.openai.com",
+  "transparent_mode": true,
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "120s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read openai/config
+```
+
+## Step 3: Create a Credential Source
+
+The credential source holds only connection info (`api_url`). The API key is stored on the credential spec (Step 4), allowing multiple specs with different keys to share one source.
+
+```bash
+warden cred source create openai-src \
+  --type=openai \
+  --rotation-period=0 \
+  --config=api_url=https://api.openai.com
+```
+
+Verify the source was created:
+
+```bash
+warden cred source read openai-src
+```
+
+## Step 4: Create a Credential Spec
+
+Create a credential spec that references the credential source. The spec carries the API key and gets associated with tokens at login time.
+
+```bash
+warden cred spec create openai-ops \
+  --type ai_api_key \
+  --source openai-src \
+  --config api_key=<your-openai-api-key>
+```
+
+Optionally include an organization ID and/or project ID:
+
+```bash
+warden cred spec create openai-ops \
+  --type ai_api_key \
+  --source openai-src \
+  --config api_key=<your-openai-api-key> \
+  --config organization_id=<your-org-id> \
+  --config project_id=<your-project-id>
+```
+
+The API key is validated at creation time via a `GET /v1/models` call to the OpenAI API (SpecVerifier). If the key is invalid, spec creation will fail.
+
+Verify:
+
+```bash
+warden cred spec read openai-ops
+```
+
+## Step 5: Create a Policy
+
+Create a policy that grants access to the OpenAI provider gateway:
+
+```bash
+warden policy write openai-access - <<EOF
+path "openai/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For fine-grained cost control, restrict access based on AI request fields:
+
+```bash
+warden policy write openai-restricted - <<EOF
+path "openai/role/+/gateway/v1/chat/completions" {
+  capabilities = ["create"]
+  allowed_parameters = {
+    "model" = ["gpt-4o", "gpt-4o-mini"]
+    "stream" = ["true"]
+    "*"      = []
+  }
+}
+EOF
+```
+
+Verify:
+
+```bash
+warden policy read openai-access
+```
+
+## Step 6: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. With transparent mode, clients authenticate directly with their JWT — no separate login step is needed.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/openai-user \
+    token_type=jwt_role \
+    token_policies="openai-access" \
+    user_claim=sub \
+    cred_spec_name=openai-ops \
+    token_ttl=1h
+```
+
+## Step 7: Get a JWT
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+## Step 8: Make Requests Through the Gateway
+
+With transparent mode, requests use role-based paths. Warden performs implicit JWT authentication and injects the OpenAI API key automatically.
+
+The URL pattern is: `/v1/openai/role/{role}/gateway/{openai-api-path}`
+
+Export OPENAI_ENDPOINT as environment variable:
+```bash
+export OPENAI_ENDPOINT="${WARDEN_ADDR}/v1/openai/role/openai-user/gateway"
+```
+
+### Chat Completions
+
+```bash
+curl -X POST "${OPENAI_ENDPOINT}/v1/chat/completions" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "Hello, how are you?"}
+    ]
+  }'
+```
+
+### Streaming Chat Completions
+
+```bash
+curl -X POST "${OPENAI_ENDPOINT}/v1/chat/completions" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -N \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "Write a short poem about the ocean."}
+    ],
+    "stream": true
+  }'
+```
+
+### Responses API
+
+```bash
+curl -X POST "${OPENAI_ENDPOINT}/v1/responses" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "input": "Tell me a joke."
+  }'
+```
+
+### Embeddings
+
+```bash
+curl -X POST "${OPENAI_ENDPOINT}/v1/embeddings" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "text-embedding-3-small",
+    "input": ["Hello world"]
+  }'
+```
+
+### List Models
+
+```bash
+curl "${OPENAI_ENDPOINT}/v1/models" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
+
+## Policy Evaluation on AI Requests
+
+The OpenAI provider has request body parsing enabled (`ParseStreamBody: true`), which means Warden can evaluate policies against fields in the AI request body. This enables fine-grained cost control and usage policies.
+
+Evaluable fields include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Model to use (e.g., `gpt-4o`, `gpt-4o-mini`, `o3-mini`) |
+| `max_tokens` | integer | Maximum tokens to generate |
+| `max_completion_tokens` | integer | Maximum completion tokens (newer API parameter) |
+| `temperature` | float | Sampling temperature |
+| `stream` | boolean | Whether to stream the response |
+| `top_p` | float | Nucleus sampling parameter |
+
+This allows operators to enforce policies such as:
+- Restrict which models users can access
+- Enforce maximum token limits
+- Require streaming mode for cost visibility
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `openai_url` | string | `https://api.openai.com` | OpenAI API base URL (must be HTTPS) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `120s` | Request timeout — set high for AI inference |
+| `transparent_mode` | bool | `false` | Enable implicit JWT authentication |
+| `auto_auth_path` | string | — | JWT auth mount path (required when `transparent_mode` is true) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Credential Source Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_url` | string | `https://api.openai.com` | OpenAI API base URL (must be HTTPS) |
+
+### Credential Spec Config
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | OpenAI API key (sensitive — masked in output) |
+| `organization_id` | string | No | Organization identifier (injected as `OpenAI-Organization` header) |
+| `project_id` | string | No | Project identifier (injected as `OpenAI-Project` header) |
+
+## Key Management
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | API key is stored on the credential spec (not the source) |
+| **Validation** | Key is verified at spec creation via `GET /v1/models` |
+| **Rotation** | Manual — OpenAI does not expose key management APIs |
+| **Lifetime** | Static — no expiration or auto-refresh |
+
+**To rotate an API key:**
+
+1. Create a new API key in the [OpenAI dashboard](https://platform.openai.com/api-keys)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update openai-ops \
+     --config api_key=<new-api-key>
+   ```
+3. Delete the old key from the OpenAI dashboard

--- a/provider/openai/config.go
+++ b/provider/openai/config.go
@@ -1,0 +1,205 @@
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+)
+
+// DefaultOpenAIURL is the default OpenAI API base URL
+const DefaultOpenAIURL = "https://api.openai.com"
+
+// DefaultOpenAITimeout is the default request timeout for AI inference
+const DefaultOpenAITimeout = 120 * time.Second
+
+// ProviderConfig holds parsed configuration for the OpenAI provider
+type ProviderConfig struct {
+	OpenAIURL       string
+	MaxBodySize     int64
+	Timeout         time.Duration
+	TransparentMode bool
+	AutoAuthPath    string
+	DefaultRole     string
+}
+
+// parseConfig parses configuration from mount config (map[string]any from JSON)
+func parseConfig(conf map[string]any) ProviderConfig {
+	config := ProviderConfig{
+		OpenAIURL:   DefaultOpenAIURL,
+		MaxBodySize: framework.DefaultMaxBodySize,
+		Timeout:     DefaultOpenAITimeout,
+	}
+
+	if addr, ok := conf["openai_url"].(string); ok && addr != "" {
+		config.OpenAIURL = addr
+	}
+
+	// Parse max_body_size — handle various JSON number types
+	if maxSize, ok := conf["max_body_size"]; ok {
+		switch v := maxSize.(type) {
+		case int:
+			if v > 0 {
+				config.MaxBodySize = int64(v)
+			}
+		case int64:
+			if v > 0 {
+				config.MaxBodySize = v
+			}
+		case float64:
+			if v > 0 {
+				config.MaxBodySize = int64(v)
+			}
+		case json.Number:
+			if parsed, err := v.Int64(); err == nil && parsed > 0 {
+				config.MaxBodySize = parsed
+			}
+		case string:
+			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
+				config.MaxBodySize = parsed
+			}
+		}
+	}
+
+	// Parse timeout — handle duration string or number
+	if timeout, ok := conf["timeout"]; ok {
+		switch v := timeout.(type) {
+		case string:
+			if parsed, err := time.ParseDuration(v); err == nil {
+				config.Timeout = parsed
+			}
+		case int:
+			if v > 0 {
+				config.Timeout = time.Duration(v) * time.Second
+			}
+		case float64:
+			if v > 0 {
+				config.Timeout = time.Duration(v) * time.Second
+			}
+		}
+	}
+
+	// Parse transparent mode settings
+	if tm, ok := conf["transparent_mode"].(bool); ok {
+		config.TransparentMode = tm
+	}
+	if aap, ok := conf["auto_auth_path"].(string); ok {
+		config.AutoAuthPath = aap
+	}
+	if dr, ok := conf["default_role"].(string); ok {
+		config.DefaultRole = dr
+	}
+
+	return config
+}
+
+// ValidateConfig validates provider-level configuration
+func ValidateConfig(conf map[string]any) error {
+	// openai_url is optional (defaults to api.openai.com), but if provided must be valid
+	if addr, ok := conf["openai_url"].(string); ok && addr != "" {
+		if err := validateOpenAIAddress(addr); err != nil {
+			return err
+		}
+	}
+
+	// Validate max_body_size if provided
+	if maxSize, ok := conf["max_body_size"]; ok {
+		var size int64
+		switch v := maxSize.(type) {
+		case int:
+			size = int64(v)
+		case int64:
+			size = v
+		case float64:
+			size = int64(v)
+		case json.Number:
+			parsed, err := v.Int64()
+			if err != nil {
+				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
+			}
+			size = parsed
+		case string:
+			parsed, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
+			}
+			size = parsed
+		default:
+			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
+		}
+		if size < 0 {
+			return fmt.Errorf("max_body_size must be greater than 0")
+		}
+		if size > 104857600 { // 100MB
+			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
+		}
+	}
+
+	// Validate timeout if provided
+	if timeout, ok := conf["timeout"]; ok {
+		switch v := timeout.(type) {
+		case string:
+			if _, err := time.ParseDuration(v); err != nil {
+				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
+			}
+		case int:
+			if v < 0 {
+				return fmt.Errorf("timeout must be greater than 0 seconds")
+			}
+		case float64:
+			if v < 0 {
+				return fmt.Errorf("timeout must be greater than 0 seconds")
+			}
+		default:
+			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
+		}
+	}
+
+	// Validate transparent_mode
+	if tm, ok := conf["transparent_mode"]; ok {
+		if _, ok := tm.(bool); !ok {
+			return fmt.Errorf("transparent_mode must be a boolean")
+		}
+	}
+
+	// Validate auto_auth_path
+	if aap, ok := conf["auto_auth_path"]; ok {
+		if _, ok := aap.(string); !ok {
+			return fmt.Errorf("auto_auth_path must be a string")
+		}
+	}
+
+	// Validate default_role
+	if dr, ok := conf["default_role"]; ok {
+		if _, ok := dr.(string); !ok {
+			return fmt.Errorf("default_role must be a string")
+		}
+	}
+
+	return nil
+}
+
+// validateOpenAIAddress validates that the openai_url is a well-formed HTTPS URL
+func validateOpenAIAddress(addr string) error {
+	if addr == "" {
+		return nil // Empty means use default
+	}
+
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("invalid openai_url: %w", err)
+	}
+
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("openai_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("openai_url must include a host")
+	}
+
+	return nil
+}

--- a/provider/openai/path_config.go
+++ b/provider/openai/path_config.go
@@ -1,0 +1,163 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathConfig returns the config path definition for the OpenAI provider
+func (b *openaiBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"openai_url": {
+				Type:        framework.TypeString,
+				Description: "The OpenAI API base URL (default: https://api.openai.com)",
+				Default:     DefaultOpenAIURL,
+			},
+			"max_body_size": {
+				Type:        framework.TypeInt64,
+				Description: "Maximum request body size in bytes (default: 10MB, max: 100MB)",
+				Default:     framework.DefaultMaxBodySize,
+			},
+			"timeout": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Request timeout duration (e.g., '120s', '5m')",
+				Default:     "120s",
+			},
+			"transparent_mode": {
+				Type:        framework.TypeBool,
+				Description: "Enable transparent mode for implicit JWT authentication",
+				Default:     false,
+			},
+			"auto_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Path to JWT auth mount for transparent mode (e.g., 'auth/jwt/')",
+			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default role to use when not specified in URL path",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read OpenAI provider configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure OpenAI provider settings",
+			},
+		},
+		HelpSynopsis:    "Configure OpenAI provider",
+		HelpDescription: "This endpoint configures the OpenAI provider settings including API URL, body size limits, and timeouts.",
+	}
+}
+
+// handleConfigRead handles reading the OpenAI provider configuration
+func (b *openaiBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"openai_url":       b.openaiURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		},
+	}, nil
+}
+
+// handleConfigWrite handles writing the OpenAI provider configuration
+func (b *openaiBackend) handleConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if val, ok := d.GetOk("openai_url"); ok {
+		addr := val.(string)
+		if addr != "" {
+			addr = strings.TrimRight(addr, "/")
+			if err := validateOpenAIAddress(addr); err != nil {
+				return &logical.Response{
+					StatusCode: http.StatusBadRequest,
+					Err:        logical.ErrBadRequest(err.Error()),
+				}, nil
+			}
+			b.openaiURL = addr
+		}
+	}
+
+	if val, ok := d.GetOk("max_body_size"); ok {
+		b.MaxBodySize = val.(int64)
+	} else if b.MaxBodySize == 0 {
+		b.MaxBodySize = framework.DefaultMaxBodySize
+	}
+
+	if val, ok := d.GetOk("timeout"); ok {
+		b.Timeout = time.Duration(val.(int)) * time.Second
+	} else if b.Timeout == 0 {
+		b.Timeout = DefaultOpenAITimeout
+	}
+
+	// Transparent mode settings
+	tc := &framework.TransparentConfig{
+		Enabled:      b.TransparentConfig.Enabled,
+		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
+		DefaultRole:  b.TransparentConfig.DefaultRole,
+	}
+	if val, ok := d.GetOk("transparent_mode"); ok {
+		tc.Enabled = val.(bool)
+	}
+	if val, ok := d.GetOk("auto_auth_path"); ok {
+		tc.AutoAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("default_role"); ok {
+		tc.DefaultRole = val.(string)
+	}
+
+	if tc.Enabled && tc.AutoAuthPath == "" {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest("auto_auth_path is required when transparent_mode is enabled"),
+		}, nil
+	}
+
+	b.StreamingBackend.SetTransparentConfig(tc)
+
+	// Persist config to storage
+	if b.StorageView != nil {
+		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"openai_url":       b.openaiURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		})
+		if err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+		if err := b.StorageView.Put(ctx, entry); err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"message": "configuration updated",
+		},
+	}, nil
+}

--- a/provider/openai/path_gateway.go
+++ b/provider/openai/path_gateway.go
@@ -1,0 +1,183 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// Headers to remove before proxying
+var headersToRemove = []string{
+	// Security headers (will be replaced with OpenAI API key)
+	"Authorization",
+	"X-Warden-Token",
+	// OpenAI-specific headers (will be injected from credential data)
+	"OpenAI-Organization",
+	"OpenAI-Project",
+	// Hop-by-hop headers
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+	// Proxy headers
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Port",
+	"X-Real-Ip",
+	"Forwarded",
+}
+
+func (b *openaiBackend) handleGateway(ctx context.Context, req *logical.Request) {
+	// Apply timeout if configured
+	if b.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		defer cancel()
+		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	}
+
+	// Enforce max body size
+	maxBody := b.MaxBodySize
+	if maxBody <= 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+	req.HTTPRequest.Body = http.MaxBytesReader(req.ResponseWriter, req.HTTPRequest.Body, maxBody)
+
+	// Get OpenAI credential (API key + optional org/project)
+	apiKey, orgID, projectID, err := b.getOpenAICredential(req)
+	if err != nil {
+		b.Logger.Warn("Failed to get OpenAI API key", logger.Err(err))
+		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Build target URL
+	targetURL, err := b.buildTargetURL(req.HTTPRequest.URL.Path, req.HTTPRequest.URL.RawQuery)
+	if err != nil {
+		b.Logger.Error("Failed to build target URL", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Prepare request for proxying
+	r := req.HTTPRequest
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		b.Logger.Error("Failed to parse target URL", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	r.URL = parsedURL
+	r.Host = parsedURL.Host
+	r.RequestURI = "" // Required for outgoing requests
+
+	// Clean headers and inject OpenAI credentials
+	b.prepareHeaders(r, apiKey, orgID, projectID)
+
+	b.Logger.Trace("Proxying OpenAI request",
+		logger.String("path", r.URL.Path),
+		logger.String("method", r.Method),
+		logger.Bool("has_key", apiKey != ""),
+	)
+
+	// Forward the request (body streams through without buffering)
+	b.Proxy.ServeHTTP(req.ResponseWriter, r)
+}
+
+// getOpenAICredential extracts the OpenAI API key and optional org/project from the credential
+func (b *openaiBackend) getOpenAICredential(req *logical.Request) (apiKey, orgID, projectID string, err error) {
+	if req.Credential == nil {
+		return "", "", "", fmt.Errorf("no credential available")
+	}
+
+	if req.Credential.Type != credential.TypeAIAPIKey {
+		return "", "", "", fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+	}
+
+	apiKey = req.Credential.Data["api_key"]
+	if apiKey == "" {
+		return "", "", "", fmt.Errorf("credential missing api_key field")
+	}
+
+	orgID = req.Credential.Data["organization_id"]
+	projectID = req.Credential.Data["project_id"]
+
+	return apiKey, orgID, projectID, nil
+}
+
+// buildTargetURL constructs the target OpenAI API URL from the gateway path
+func (b *openaiBackend) buildTargetURL(path, rawQuery string) (string, error) {
+	// Find gateway path marker
+	gatewayIdx := strings.Index(path, "/gateway")
+	if gatewayIdx == -1 {
+		return "", fmt.Errorf("invalid gateway path: %s", path)
+	}
+
+	// Extract path after "/gateway"
+	openaiPath := path[gatewayIdx+8:] // len("/gateway") = 8
+	if openaiPath == "" || openaiPath == "/" {
+		openaiPath = "/"
+	}
+
+	if rawQuery != "" {
+		return b.openaiURL + openaiPath + "?" + rawQuery, nil
+	}
+	return b.openaiURL + openaiPath, nil
+}
+
+// prepareHeaders removes unwanted headers and injects the OpenAI credentials
+func (b *openaiBackend) prepareHeaders(r *http.Request, apiKey, orgID, projectID string) {
+	// Read Connection header before removing it
+	conn := r.Header.Get("Connection")
+
+	// Remove headers in single pass
+	for _, h := range headersToRemove {
+		r.Header.Del(h)
+	}
+
+	// Handle Connection header's listed headers
+	if conn != "" {
+		for _, h := range strings.Split(conn, ",") {
+			if h = strings.TrimSpace(h); h != "" {
+				r.Header.Del(h)
+			}
+		}
+	}
+
+	// Inject the OpenAI API key using Bearer format
+	if apiKey != "" {
+		r.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	// Inject optional OpenAI organization header
+	if orgID != "" {
+		r.Header.Set("OpenAI-Organization", orgID)
+	}
+
+	// Inject optional OpenAI project header
+	if projectID != "" {
+		r.Header.Set("OpenAI-Project", projectID)
+	}
+
+	// Set Accept header if not already set
+	if r.Header.Get("Accept") == "" {
+		r.Header.Set("Accept", "application/json")
+	}
+
+	// Set User-Agent if not already set
+	if r.Header.Get("User-Agent") == "" {
+		r.Header.Set("User-Agent", "warden-openai-proxy")
+	}
+}

--- a/provider/openai/path_gateway_test.go
+++ b/provider/openai/path_gateway_test.go
@@ -1,0 +1,213 @@
+package openai
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTargetURL(t *testing.T) {
+	b := &openaiBackend{
+		openaiURL: "https://api.openai.com",
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		query    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "chat completions",
+			path:     "/openai/gateway/v1/chat/completions",
+			expected: "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:     "responses",
+			path:     "/openai/gateway/v1/responses",
+			expected: "https://api.openai.com/v1/responses",
+		},
+		{
+			name:     "embeddings",
+			path:     "/openai/gateway/v1/embeddings",
+			expected: "https://api.openai.com/v1/embeddings",
+		},
+		{
+			name:     "models",
+			path:     "/openai/gateway/v1/models",
+			expected: "https://api.openai.com/v1/models",
+		},
+		{
+			name:     "path with query",
+			path:     "/openai/gateway/v1/models",
+			query:    "page=1&per_page=10",
+			expected: "https://api.openai.com/v1/models?page=1&per_page=10",
+		},
+		{
+			name:     "bare gateway",
+			path:     "/openai/gateway",
+			expected: "https://api.openai.com/",
+		},
+		{
+			name:     "gateway with trailing slash",
+			path:     "/openai/gateway/",
+			expected: "https://api.openai.com/",
+		},
+		{
+			name:    "no gateway marker",
+			path:    "/openai/v1/chat/completions",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := b.buildTargetURL(tc.path, tc.query)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildTargetURL_CustomURL(t *testing.T) {
+	b := &openaiBackend{
+		openaiURL: "https://openai.example.com",
+	}
+
+	result, err := b.buildTargetURL("/custom/gateway/v1/chat/completions", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://openai.example.com/v1/chat/completions", result)
+}
+
+func TestPrepareHeaders(t *testing.T) {
+	b := &openaiBackend{}
+
+	t.Run("removes security headers and injects API key", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+		req.Header.Set("Authorization", "Bearer warden-token")
+		req.Header.Set("X-Warden-Token", "warden-token")
+		req.Header.Set("X-Custom", "keep-me")
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "Bearer sk-test-key", req.Header.Get("Authorization"))
+		assert.Equal(t, "", req.Header.Get("X-Warden-Token"))
+		assert.Equal(t, "keep-me", req.Header.Get("X-Custom"))
+	})
+
+	t.Run("injects default headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "application/json", req.Header.Get("Accept"))
+		assert.Equal(t, "warden-openai-proxy", req.Header.Get("User-Agent"))
+	})
+
+	t.Run("preserves client-set Accept header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+		req.Header.Set("Accept", "text/event-stream")
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "text/event-stream", req.Header.Get("Accept"))
+	})
+
+	t.Run("removes hop-by-hop headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+		req.Header.Set("Connection", "keep-alive")
+		req.Header.Set("Transfer-Encoding", "chunked")
+		req.Header.Set("Proxy-Authorization", "Basic abc")
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "", req.Header.Get("Connection"))
+		assert.Equal(t, "", req.Header.Get("Transfer-Encoding"))
+		assert.Equal(t, "", req.Header.Get("Proxy-Authorization"))
+	})
+
+	t.Run("removes Connection-listed headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+		req.Header.Set("Connection", "X-Custom-Hop")
+		req.Header.Set("X-Custom-Hop", "should-be-removed")
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "", req.Header.Get("X-Custom-Hop"))
+	})
+
+	t.Run("removes proxy headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+		req.Header.Set("X-Forwarded-For", "10.0.0.1")
+		req.Header.Set("X-Real-Ip", "10.0.0.1")
+		req.Header.Set("Forwarded", "for=10.0.0.1")
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "", req.Header.Get("X-Forwarded-For"))
+		assert.Equal(t, "", req.Header.Get("X-Real-Ip"))
+		assert.Equal(t, "", req.Header.Get("Forwarded"))
+	})
+
+	t.Run("empty API key does not set Authorization", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "", "", "")
+
+		assert.Equal(t, "", req.Header.Get("Authorization"))
+	})
+
+	t.Run("injects OpenAI-Organization header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "sk-test-key", "org-123", "")
+
+		assert.Equal(t, "org-123", req.Header.Get("OpenAI-Organization"))
+		assert.Equal(t, "", req.Header.Get("OpenAI-Project"))
+	})
+
+	t.Run("injects OpenAI-Project header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "sk-test-key", "", "proj-456")
+
+		assert.Equal(t, "", req.Header.Get("OpenAI-Organization"))
+		assert.Equal(t, "proj-456", req.Header.Get("OpenAI-Project"))
+	})
+
+	t.Run("injects both OpenAI-Organization and OpenAI-Project headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "sk-test-key", "org-123", "proj-456")
+
+		assert.Equal(t, "org-123", req.Header.Get("OpenAI-Organization"))
+		assert.Equal(t, "proj-456", req.Header.Get("OpenAI-Project"))
+	})
+
+	t.Run("does not inject empty organization or project", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		assert.Equal(t, "", req.Header.Get("OpenAI-Organization"))
+		assert.Equal(t, "", req.Header.Get("OpenAI-Project"))
+	})
+
+	t.Run("removes client-sent OpenAI-Organization and OpenAI-Project", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+		req.Header.Set("OpenAI-Organization", "spoofed-org")
+		req.Header.Set("OpenAI-Project", "spoofed-proj")
+
+		b.prepareHeaders(req, "sk-test-key", "", "")
+
+		// Client-sent headers should be removed (not re-injected since orgID/projectID are empty)
+		assert.Equal(t, "", req.Header.Get("OpenAI-Organization"))
+		assert.Equal(t, "", req.Header.Get("OpenAI-Project"))
+	})
+}

--- a/provider/openai/provider.go
+++ b/provider/openai/provider.go
@@ -1,0 +1,257 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// openaiBackend is the streaming backend for OpenAI provider operations
+type openaiBackend struct {
+	*framework.StreamingBackend
+	openaiURL string // e.g., "https://api.openai.com"
+}
+
+// extractToken extracts Warden token from Authorization: Bearer or X-Warden-Token headers
+func extractToken(r *http.Request) string {
+	// First, check X-Warden-Token header (explicit Warden token)
+	if token := r.Header.Get("X-Warden-Token"); token != "" {
+		return token
+	}
+
+	// Then check Authorization header for Bearer token
+	authHeader := r.Header.Get("Authorization")
+	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
+		return authHeader[7:]
+	}
+
+	return ""
+}
+
+// Factory creates a new OpenAI provider backend using the logical.Factory pattern
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &openaiBackend{}
+
+	// Create the streaming backend with gateway path for streaming
+	b.StreamingBackend = &framework.StreamingBackend{
+		StreamingPaths: []*framework.StreamingPath{
+			{
+				Pattern:         "gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "OpenAI Gateway proxy",
+				HelpDescription: "Proxies requests to OpenAI API with API key injection",
+			},
+			{
+				Pattern:         "gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "OpenAI Gateway proxy",
+				HelpDescription: "Proxies requests to OpenAI API with API key injection",
+			},
+			// Transparent mode: role-based gateway paths
+			{
+				Pattern:         "role/[^/]+/gateway",
+				Handler:         b.handleTransparentGatewayStreaming,
+				HelpSynopsis:    "OpenAI Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to OpenAI API with implicit JWT authentication",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway/.*",
+				Handler:         b.handleTransparentGatewayStreaming,
+				HelpSynopsis:    "OpenAI Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to OpenAI API with implicit JWT authentication",
+			},
+		},
+		ParseStreamBody: true, // Enable policy evaluation on model, max_tokens, etc.
+		TransparentConfig: &framework.TransparentConfig{
+			Enabled:      false,
+			AutoAuthPath: "",
+			DefaultRole:  "",
+		},
+		Backend: &framework.Backend{
+			Help:           openaiBackendHelp,
+			BackendType:    "openai",
+			BackendClass:   logical.ClassProvider,
+			TokenExtractor: extractToken,
+			Paths:          b.paths(),
+		},
+	}
+
+	// Set common fields
+	b.Logger = conf.Logger.WithSubsystem("openai")
+	b.StorageView = conf.StorageView
+
+	// Initialize reverse proxy with OpenAI transport
+	b.StreamingBackend.InitProxy(sharedTransport)
+
+	// Register transport shutdown hook for process-level cleanup
+	if conf.RegisterShutdownHook != nil {
+		conf.RegisterShutdownHook("openai-transport", ShutdownHTTPTransport)
+	}
+
+	// Set defaults
+	b.MaxBodySize = framework.DefaultMaxBodySize
+	b.Timeout = DefaultOpenAITimeout
+	b.openaiURL = DefaultOpenAIURL
+
+	// Apply configuration if provided
+	if len(conf.Config) > 0 {
+		if err := ValidateConfig(conf.Config); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+		parsedConfig := parseConfig(conf.Config)
+		b.openaiURL = strings.TrimRight(parsedConfig.OpenAIURL, "/")
+		b.MaxBodySize = parsedConfig.MaxBodySize
+		b.Timeout = parsedConfig.Timeout
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			Enabled:      parsedConfig.TransparentMode,
+			AutoAuthPath: parsedConfig.AutoAuthPath,
+			DefaultRole:  parsedConfig.DefaultRole,
+		})
+	}
+
+	return b, nil
+}
+
+// Initialize loads persisted config from storage
+func (b *openaiBackend) Initialize(ctx context.Context) error {
+	if b.StorageView == nil {
+		return nil
+	}
+
+	entry, err := b.StorageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry != nil {
+		var config struct {
+			OpenAIURL       string `json:"openai_url"`
+			MaxBodySize     int64  `json:"max_body_size"`
+			Timeout         string `json:"timeout"`
+			TransparentMode bool   `json:"transparent_mode"`
+			AutoAuthPath    string `json:"auto_auth_path"`
+			DefaultRole     string `json:"default_role"`
+		}
+		if err := entry.DecodeJSON(&config); err != nil {
+			return fmt.Errorf("failed to decode config: %w", err)
+		}
+		if config.OpenAIURL != "" {
+			b.openaiURL = strings.TrimRight(config.OpenAIURL, "/")
+		}
+		b.MaxBodySize = config.MaxBodySize
+		if config.Timeout != "" {
+			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
+				b.Timeout = timeout
+			}
+		}
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			Enabled:      config.TransparentMode,
+			AutoAuthPath: config.AutoAuthPath,
+			DefaultRole:  config.DefaultRole,
+		})
+	} else {
+		// No persisted config — persist defaults
+		tc := b.TransparentConfig
+		defaultEntry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"openai_url":       b.openaiURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create default config entry: %w", err)
+		}
+		if err := b.StorageView.Put(ctx, defaultEntry); err != nil {
+			return fmt.Errorf("failed to persist default config: %w", err)
+		}
+		b.Logger.Info("persisted default configuration for new OpenAI provider")
+	}
+	return nil
+}
+
+// paths returns the configuration paths for the OpenAI provider
+func (b *openaiBackend) paths() []*framework.Path {
+	return []*framework.Path{
+		b.pathConfig(),
+	}
+}
+
+// handleGatewayStreaming handles streaming gateway requests
+func (b *openaiBackend) handleGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// handleTransparentGatewayStreaming handles transparent mode gateway requests.
+// The implicit auth has already been performed by the core request handler.
+func (b *openaiBackend) handleTransparentGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	if !b.StreamingBackend.IsTransparentMode() {
+		http.Error(req.ResponseWriter, "Transparent mode not enabled", http.StatusForbidden)
+		return nil
+	}
+
+	// Rewrite the path: /role/{role}/gateway/... -> /gateway/...
+	req.Path = b.StreamingBackend.RewriteTransparentPath(req.Path)
+
+	// Also update the HTTP request URL path for the proxy
+	if req.HTTPRequest != nil && req.HTTPRequest.URL != nil {
+		req.HTTPRequest.URL.Path = b.StreamingBackend.RewriteTransparentPath(req.HTTPRequest.URL.Path)
+	}
+
+	// Delegate to standard gateway handler
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// SensitiveConfigFields returns the list of config fields that should be masked in output
+func (b *openaiBackend) SensitiveConfigFields() []string {
+	return []string{}
+}
+
+const openaiBackendHelp = `
+The OpenAI provider enables proxying requests to the OpenAI API with
+automatic credential management and API key injection.
+
+Clients authenticate to Warden with a session token (via X-Warden-Token or
+Authorization: Bearer header). The provider obtains an OpenAI API key from
+the credential manager and injects it into the proxied request's Authorization
+header. This allows Warden to broker OpenAI access without exposing API
+keys to clients.
+
+The gateway path format is:
+  /openai/gateway/{api-path}
+
+Examples:
+  /openai/gateway/v1/chat/completions
+  /openai/gateway/v1/responses
+  /openai/gateway/v1/embeddings
+  /openai/gateway/v1/models
+
+Request body parsing is enabled, allowing policies to evaluate AI request
+fields such as model, max_tokens, temperature, and stream. This enables
+fine-grained cost control and usage policies.
+
+Transparent mode allows implicit JWT authentication via role-based paths,
+eliminating the need for clients to perform an explicit Warden login:
+  /openai/role/{role}/gateway/{api-path}
+
+The core extracts the role from the URL, performs implicit JWT auth against
+the configured auth mount, and issues a short-lived token for the request.
+
+Configuration:
+- openai_url: OpenAI API base URL (default: https://api.openai.com)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 120s for AI inference)
+- transparent_mode: Enable implicit JWT authentication (default: false)
+- auto_auth_path: JWT auth mount path for transparent mode (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`

--- a/provider/openai/provider_test.go
+++ b/provider/openai/provider_test.go
@@ -1,0 +1,170 @@
+package openai
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected string
+	}{
+		{
+			name:     "X-Warden-Token header",
+			headers:  map[string]string{"X-Warden-Token": "warden-token-123"},
+			expected: "warden-token-123",
+		},
+		{
+			name:     "Bearer token",
+			headers:  map[string]string{"Authorization": "Bearer my-bearer-token"},
+			expected: "my-bearer-token",
+		},
+		{
+			name:     "X-Warden-Token takes priority over Bearer",
+			headers:  map[string]string{"X-Warden-Token": "warden-token", "Authorization": "Bearer bearer-token"},
+			expected: "warden-token",
+		},
+		{
+			name:     "No token",
+			headers:  map[string]string{},
+			expected: "",
+		},
+		{
+			name:     "Non-Bearer auth header ignored",
+			headers:  map[string]string{"Authorization": "token ghp_abc123"},
+			expected: "",
+		},
+		{
+			name:     "Case insensitive Bearer",
+			headers:  map[string]string{"Authorization": "bearer my-token"},
+			expected: "my-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			result := extractToken(req)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseConfig(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		config := parseConfig(map[string]any{})
+		assert.Equal(t, DefaultOpenAIURL, config.OpenAIURL)
+		assert.Greater(t, config.MaxBodySize, int64(0))
+		assert.Equal(t, DefaultOpenAITimeout, config.Timeout)
+	})
+
+	t.Run("custom values", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"openai_url": "https://openai.example.com",
+			"timeout":    "60s",
+		})
+		assert.Equal(t, "https://openai.example.com", config.OpenAIURL)
+		assert.Equal(t, 60.0, config.Timeout.Seconds())
+	})
+
+	t.Run("integer timeout", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"timeout": 45,
+		})
+		assert.Equal(t, 45.0, config.Timeout.Seconds())
+	})
+
+	t.Run("transparent mode settings", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"transparent_mode": true,
+			"auto_auth_path":   "auth/jwt/",
+			"default_role":     "reader",
+		})
+		assert.True(t, config.TransparentMode)
+		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
+		assert.Equal(t, "reader", config.DefaultRole)
+	})
+}
+
+func TestValidateConfig(t *testing.T) {
+	t.Run("empty config is valid", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid openai_url", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"openai_url": "https://api.openai.com",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-HTTPS openai_url rejected", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"openai_url": "http://api.openai.com",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "https://")
+	})
+
+	t.Run("invalid timeout format", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"timeout": "not-a-duration",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("negative max_body_size", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"max_body_size": -1,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("oversized max_body_size", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"max_body_size": 200000000, // 200MB
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid transparent_mode type", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"transparent_mode": "yes",
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateOpenAIAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr bool
+	}{
+		{"empty is valid", "", false},
+		{"valid HTTPS", "https://api.openai.com", false},
+		{"valid custom", "https://openai.example.com", false},
+		{"HTTP rejected", "http://api.openai.com", true},
+		{"no scheme", "api.openai.com", true},
+		{"no host", "https://", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOpenAIAddress(tc.addr)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/provider/openai/transport.go
+++ b/provider/openai/transport.go
@@ -1,0 +1,88 @@
+package openai
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+var (
+	sharedTransport        *http.Transport
+	transportCleanupCtx    context.Context
+	transportCleanupCancel context.CancelFunc
+)
+
+func init() {
+	sharedTransport = newOpenAITransport()
+
+	// Start background cleanup with proper lifecycle management
+	transportCleanupCtx, transportCleanupCancel = context.WithCancel(context.Background())
+	go cleanupIdleConnections(transportCleanupCtx, sharedTransport)
+}
+
+// newOpenAITransport creates an HTTP transport optimized for OpenAI API workloads
+func newOpenAITransport() *http.Transport {
+	transport := &http.Transport{
+		// Connection pool settings
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 50,
+		MaxConnsPerHost:     0, // Unlimited outbound connections
+		IdleConnTimeout:     90 * time.Second,
+
+		// TLS configuration
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ClientSessionCache: tls.NewLRUClientSessionCache(100),
+		},
+
+		// Dialer settings
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+
+		// Timeout settings — higher for AI inference (streaming responses can be slow)
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 120 * time.Second,
+
+		// HTTP/2 optimization
+		ForceAttemptHTTP2: true,
+	}
+
+	if err := http2.ConfigureTransport(transport); err != nil {
+		log.Printf("Failed to configure HTTP/2 for OpenAI transport: %v", err)
+	}
+
+	return transport
+}
+
+// cleanupIdleConnections periodically closes idle connections
+func cleanupIdleConnections(ctx context.Context, transport *http.Transport) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			transport.CloseIdleConnections()
+		}
+	}
+}
+
+// ShutdownHTTPTransport should be called during application shutdown
+func ShutdownHTTPTransport() {
+	if transportCleanupCancel != nil {
+		transportCleanupCancel()
+	}
+	if sharedTransport != nil {
+		sharedTransport.CloseIdleConnections()
+	}
+}


### PR DESCRIPTION
Add OpenAI as the second AI provider, following the same streaming proxy architecture as Mistral. The provider proxies requests to the OpenAI API with automatic API key injection, policy evaluation on AI request fields, and transparent mode support.

OpenAI-specific additions beyond the Mistral template:
- OpenAI-Organization and OpenAI-Project header injection from credential data (stripped from client requests to prevent spoofing)
- project_id added as optional field to the shared ai_api_key credential type