### PR TITLE
fix: harden HA cluster resilience with configurable timeouts and corr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to Warden are documented in this file.
 
+## [v0.2.1] — 2026-03-05
+
+### Improvements
+
+- **Configurable HA cluster tuning** — All HA cluster timeouts and intervals are now configurable via HCL: `goroutine_shutdown_timeout`, `lock_acquisition_timeout`, `leader_cleanup_interval`, `step_down_state_lock_timeout`, `leader_lookup_timeout`, `clock_skew_grace`, `cluster_listener_read_timeout`, `cluster_listener_write_timeout`, `forwarding_timeout`. Sensible defaults are provided via `DefaultClusterConfig()`.
+- **Parallel goroutine shutdown** — Background goroutines (key upgrade checker, leader refresh, leader cleanup) now shut down in parallel during step-down with a configurable timeout, preventing sequential hangs.
+- **Lock acquisition timeout** — HA lock acquisition can now be bounded with `lock_acquisition_timeout` to prevent indefinite blocking when the lock backend is unresponsive.
+- **Leader lookup timeout** — Barrier reads in `Leader()` are now bounded by `leader_lookup_timeout` to prevent standby nodes from hanging on slow storage.
+- **Step-down state lock timeout** — Step-down no longer blocks indefinitely waiting for the state lock; falls back to forced teardown after `step_down_state_lock_timeout`.
+- **Leader advertisement failure aborts leadership** — If the active node fails to write its leader advertisement, it immediately steps down instead of running invisibly to standbys.
+- **Forwarding metrics** — Added `ha.forward.{success,error,redirect,duration}` metrics for observability into standby-to-active request forwarding.
+- **X-Forwarded-For chain preservation** — Standby forwarding now appends to existing `X-Forwarded-For` headers instead of overwriting them, preserving the full proxy chain.
+- **Narrower connection error detection** — `isConnectionError` now only matches `dial`, `read`, and `write` operations, excluding DNS and TLS errors from connection-error handling.
+- **Fresh leader lookup on forwarding errors** — Non-connection forwarding errors (e.g., TLS handshake failures) now trigger a fresh leader lookup before redirecting, avoiding stale addresses.
+- **Idle connection cleanup on proxy invalidation** — Old transport connections are closed when the reverse proxy is recreated due to leader changes.
+- **Configurable clock skew grace** — Cluster certificate `NotBefore` offset is now configurable via `clock_skew_grace` (default: 60s, was 30s).
+- **Reduced leader cleanup interval** — Default leader advertisement cleanup interval reduced from 24h to 1h.
+
+### Infrastructure
+
+- **Sequential E2E tests** — E2E test packages now run sequentially (`-p 1`) to prevent HA chaos tests from destabilizing subsequent test suites.
+
 ## [v0.2.0] — 2026-03-04
 
 ### New Features
@@ -49,6 +71,7 @@ Initial release. See the [v0.1.0 release notes](https://github.com/stephnangue/w
 - Docker image published to `ghcr.io/stephnangue/warden`
 - Pre-built binaries for Linux, macOS, and Windows
 
+[v0.2.1]: https://github.com/stephnangue/warden/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/stephnangue/warden/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/stephnangue/warden/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/stephnangue/warden/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-e2e-setup:
 # Run all e2e tests (starts cluster, runs tests, tears down)
 test-e2e: test-e2e-setup
 	@echo "Running e2e tests..."
-	@go test -tags e2e -v ./e2e/... || (bash e2e/teardown.sh && exit 1)
+	@go test -tags e2e -v -p 1 ./e2e/... || (bash e2e/teardown.sh && exit 1)
 	@bash e2e/teardown.sh
 	@echo "✓ E2E tests passed"
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -264,9 +264,10 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Create HTTP handler from core
 	httpHandler := wardenhttp.Handler(&wardenhttp.HandlerProperties{
-		Core:                newCore,
-		Logger:              logger,
+		Core:                 newCore,
+		Logger:               logger,
 		ClusterTLSConfigFunc: newCore.ClusterTLSConfig,
+		ForwardingTimeout:    newCore.ClusterConfig().ForwardingTimeout,
 	})
 
 	// init the listeners
@@ -506,11 +507,14 @@ func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, 
 			return nil, fmt.Errorf("error parsing cluster_addr %q: %w", conf.ClusterAddr, err)
 		}
 
+		cc := c.ClusterConfig()
 		clusterLn, err := clusterlistener.NewClusterListener(clusterlistener.ClusterListenerConfig{
 			Logger:        logger.WithSystem("cluster"),
 			Address:       clusterAddr,
 			Handler:       httpHandler,
 			TLSConfigFunc: c.ClusterTLSConfig,
+			ReadTimeout:   cc.ClusterListenerReadTimeout,
+			WriteTimeout:  cc.ClusterListenerWriteTimeout,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error initializing cluster listener: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,19 @@ type Config struct {
 	// Valid values: "disabled", "optional", "required"
 	// Defaults to "optional" if not specified.
 	IPBindingPolicy string `hcl:"ip_binding_policy,optional"`
+
+	// HA cluster tuning — all values are Go duration strings (e.g., "30s", "1h").
+	// Omitted values use built-in defaults from core.DefaultClusterConfig().
+
+	GoroutineShutdownTimeout    string `hcl:"goroutine_shutdown_timeout,optional"`
+	LockAcquisitionTimeout      string `hcl:"lock_acquisition_timeout,optional"`
+	LeaderCleanupInterval       string `hcl:"leader_cleanup_interval,optional"`
+	StepDownStateLockTimeout    string `hcl:"step_down_state_lock_timeout,optional"`
+	LeaderLookupTimeout         string `hcl:"leader_lookup_timeout,optional"`
+	ClockSkewGrace              string `hcl:"clock_skew_grace,optional"`
+	ClusterListenerReadTimeout  string `hcl:"cluster_listener_read_timeout,optional"`
+	ClusterListenerWriteTimeout string `hcl:"cluster_listener_write_timeout,optional"`
+	ForwardingTimeout           string `hcl:"forwarding_timeout,optional"`
 }
 
 type KMS struct {
@@ -478,6 +491,34 @@ func LoadConfig(configFile string) (*Config, error) {
 	for i, ln := range config.Listeners {
 		if ln.TLSEnabled && (ln.TLSCertFile == "" || ln.TLSKeyFile == "") {
 			return nil, fmt.Errorf("listener[%d]: tls_enabled requires both tls_cert_file and tls_key_file", i)
+		}
+	}
+
+	// Validate cluster tuning durations if set
+	clusterDurationFields := []struct {
+		name  string
+		value string
+	}{
+		{"goroutine_shutdown_timeout", config.GoroutineShutdownTimeout},
+		{"lock_acquisition_timeout", config.LockAcquisitionTimeout},
+		{"leader_cleanup_interval", config.LeaderCleanupInterval},
+		{"step_down_state_lock_timeout", config.StepDownStateLockTimeout},
+		{"leader_lookup_timeout", config.LeaderLookupTimeout},
+		{"clock_skew_grace", config.ClockSkewGrace},
+		{"cluster_listener_read_timeout", config.ClusterListenerReadTimeout},
+		{"cluster_listener_write_timeout", config.ClusterListenerWriteTimeout},
+		{"forwarding_timeout", config.ForwardingTimeout},
+	}
+	for _, f := range clusterDurationFields {
+		if f.value == "" {
+			continue
+		}
+		d, err := time.ParseDuration(f.value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s %q: %w", f.name, f.value, err)
+		}
+		if d < 0 {
+			return nil, fmt.Errorf("%s must not be negative, got %s", f.name, d)
 		}
 	}
 

--- a/core/cluster.go
+++ b/core/cluster.go
@@ -76,7 +76,7 @@ func (c *Core) setupCluster(ctx context.Context) error {
 		},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageCertSign,
 		SerialNumber:          serial,
-		NotBefore:             time.Now().Add(-30 * time.Second),  // clock skew grace
+		NotBefore:             time.Now().Add(-c.clusterConfig.ClockSkewGrace), // clock skew grace
 		NotAfter:              time.Now().Add(262980 * time.Hour), // ~30 years
 		BasicConstraintsValid: true,
 		IsCA:                  true,

--- a/core/cluster_config.go
+++ b/core/cluster_config.go
@@ -1,0 +1,59 @@
+package core
+
+import "time"
+
+// ClusterConfig holds tunable parameters for HA clustering behavior.
+// All fields have sensible defaults via DefaultClusterConfig().
+type ClusterConfig struct {
+	// GoroutineShutdownTimeout is how long to wait for background goroutines
+	// (key upgrade checker, leader refresh, leader cleanup) to exit during
+	// step-down before giving up.
+	GoroutineShutdownTimeout time.Duration
+
+	// LockAcquisitionTimeout is the maximum time to wait when acquiring the
+	// HA lock. Zero means wait indefinitely (the default).
+	LockAcquisitionTimeout time.Duration
+
+	// LeaderCleanupInterval is how often the active node removes stale
+	// leader advertisements from barrier storage.
+	LeaderCleanupInterval time.Duration
+
+	// StepDownStateLockTimeout is how long to wait to acquire the state lock
+	// during step-down before forcing teardown without the lock.
+	StepDownStateLockTimeout time.Duration
+
+	// LeaderLookupTimeout is the deadline for barrier reads when looking up
+	// the leader advertisement in Leader()/LeaderLocked().
+	LeaderLookupTimeout time.Duration
+
+	// ClockSkewGrace is the backwards offset applied to the cluster
+	// certificate's NotBefore time to tolerate clock drift between nodes.
+	ClockSkewGrace time.Duration
+
+	// ClusterListenerReadTimeout is the HTTP read timeout for the cluster
+	// listener that handles forwarded requests from standby nodes.
+	ClusterListenerReadTimeout time.Duration
+
+	// ClusterListenerWriteTimeout is the HTTP write timeout for the cluster
+	// listener.
+	ClusterListenerWriteTimeout time.Duration
+
+	// ForwardingTimeout is the maximum time for a forwarded request from a
+	// standby node to the active node before timing out.
+	ForwardingTimeout time.Duration
+}
+
+// DefaultClusterConfig returns a ClusterConfig with production-ready defaults.
+func DefaultClusterConfig() ClusterConfig {
+	return ClusterConfig{
+		GoroutineShutdownTimeout:    30 * time.Second,
+		LockAcquisitionTimeout:      0, // indefinite
+		LeaderCleanupInterval:       1 * time.Hour,
+		StepDownStateLockTimeout:    30 * time.Second,
+		LeaderLookupTimeout:         10 * time.Second,
+		ClockSkewGrace:              60 * time.Second,
+		ClusterListenerReadTimeout:  30 * time.Second,
+		ClusterListenerWriteTimeout: 60 * time.Second,
+		ForwardingTimeout:           60 * time.Second,
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -317,6 +317,9 @@ type Core struct {
 	// transparentAuthGroup ensures only one implicit auth per JWT to prevent
 	// duplicate token creation when concurrent requests arrive with the same JWT
 	transparentAuthGroup singleflight.Group
+
+	// clusterConfig holds tunable HA cluster parameters (timeouts, intervals).
+	clusterConfig ClusterConfig
 }
 
 type CoreConfig struct {
@@ -499,6 +502,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 	c.shutdownDoneCh.Store(make(chan struct{}))
 
 	c.SetConfig(conf.RawConfig)
+	c.clusterConfig = parseClusterConfig(conf.RawConfig)
 
 	// Load seal information.
 	if c.seal == nil {
@@ -786,6 +790,41 @@ func (c *Core) runShutdownHooks() {
 // SetConfig sets core's config object to the newly provided config.
 func (c *Core) SetConfig(conf *config.Config) {
 	c.rawConfig.Store(conf)
+}
+
+// ClusterConfig returns the resolved cluster configuration.
+func (c *Core) ClusterConfig() ClusterConfig {
+	return c.clusterConfig
+}
+
+// parseClusterConfig builds a ClusterConfig from the raw Config, falling back
+// to defaults for any field not explicitly set.
+func parseClusterConfig(conf *config.Config) ClusterConfig {
+	cc := DefaultClusterConfig()
+	if conf == nil {
+		return cc
+	}
+
+	applyDuration := func(src string, dst *time.Duration) {
+		if src == "" {
+			return
+		}
+		if d, err := time.ParseDuration(src); err == nil {
+			*dst = d
+		}
+	}
+
+	applyDuration(conf.GoroutineShutdownTimeout, &cc.GoroutineShutdownTimeout)
+	applyDuration(conf.LockAcquisitionTimeout, &cc.LockAcquisitionTimeout)
+	applyDuration(conf.LeaderCleanupInterval, &cc.LeaderCleanupInterval)
+	applyDuration(conf.StepDownStateLockTimeout, &cc.StepDownStateLockTimeout)
+	applyDuration(conf.LeaderLookupTimeout, &cc.LeaderLookupTimeout)
+	applyDuration(conf.ClockSkewGrace, &cc.ClockSkewGrace)
+	applyDuration(conf.ClusterListenerReadTimeout, &cc.ClusterListenerReadTimeout)
+	applyDuration(conf.ClusterListenerWriteTimeout, &cc.ClusterListenerWriteTimeout)
+	applyDuration(conf.ForwardingTimeout, &cc.ForwardingTimeout)
+
+	return cc
 }
 
 // CredSourceRotationPeriodBounds returns the configured min and max rotation

--- a/core/ha.go
+++ b/core/ha.go
@@ -78,8 +78,11 @@ func (c *Core) LeaderLocked() (isLeader bool, leaderAddr, clusterAddr string, er
 		return false, "", "", nil
 	}
 
-	// Read the leader advertisement from barrier storage.
-	adv, err := c.readLeaderAdvertisement(context.Background(), leaderUUID)
+	// Read the leader advertisement from barrier storage with a timeout
+	// to prevent indefinite hangs if the barrier is slow or unresponsive.
+	lookupCtx, lookupCancel := context.WithTimeout(context.Background(), c.clusterConfig.LeaderLookupTimeout)
+	defer lookupCancel()
+	adv, err := c.readLeaderAdvertisement(lookupCtx, leaderUUID)
 	if err != nil {
 		c.logger.Warn("failed to read leader advertisement from barrier",
 			logger.Err(err), logger.String("leader_uuid", leaderUUID))

--- a/core/ha_leader.go
+++ b/core/ha_leader.go
@@ -14,10 +14,6 @@ import (
 const (
 	// leaderPrefix is the barrier storage prefix for leader advertisements.
 	leaderPrefix = "core/leader/"
-
-	// leaderCleanupInterval is how often the background cleaner removes
-	// stale leader advertisements from barrier storage.
-	leaderCleanupInterval = 24 * time.Hour
 )
 
 // activeAdvertisement is stored in the barrier under core/leader/{uuid}
@@ -103,7 +99,7 @@ func (c *Core) cleanLeaderPrefix(ctx context.Context, activeUUID string, doneCh,
 	// Run once immediately on startup
 	cleanup()
 
-	ticker := time.NewTicker(leaderCleanupInterval)
+	ticker := time.NewTicker(c.clusterConfig.LeaderCleanupInterval)
 	defer ticker.Stop()
 
 	for {

--- a/core/ha_standby.go
+++ b/core/ha_standby.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	metrics "github.com/hashicorp/go-metrics/compat"
@@ -99,9 +100,29 @@ func (c *Core) runStandbyOnce(manualStepDownCh chan struct{}, stopCh chan struct
 		}
 
 		// Attempt to acquire the lock. This blocks until the lock is
-		// acquired or stopCh is closed.
+		// acquired, stopCh is closed, or the acquisition timeout fires.
+		lockStopCh := stopCh
+		var lockTimer *time.Timer
+		if timeout := c.clusterConfig.LockAcquisitionTimeout; timeout > 0 {
+			lockStopCh = make(chan struct{})
+			lockTimer = time.NewTimer(timeout)
+			go func() {
+				select {
+				case <-stopCh:
+					close(lockStopCh)
+				case <-lockTimer.C:
+					close(lockStopCh)
+				}
+			}()
+		}
+
 		lockAcquireStart := time.Now()
-		leaderLostCh, err := lock.Lock(stopCh)
+		leaderLostCh, err := lock.Lock(lockStopCh)
+
+		if lockTimer != nil {
+			lockTimer.Stop()
+		}
+
 		if err != nil {
 			c.logger.Error("failed to acquire HA lock", logger.Err(err))
 			metrics.IncrCounter([]string{"ha", "lock", "acquire", "error"}, 1)
@@ -113,9 +134,24 @@ func (c *Core) runStandbyOnce(manualStepDownCh chan struct{}, stopCh chan struct
 			}
 		}
 
-		// If Lock returned nil, the stopCh was closed
+		// If Lock returned nil, either stopCh was closed or the
+		// acquisition timeout fired. Check stopCh to distinguish.
 		if leaderLostCh == nil {
-			return false
+			select {
+			case <-stopCh:
+				return false
+			default:
+				// Acquisition timeout — retry after interval.
+				c.logger.Warn("HA lock acquisition timed out, retrying",
+					logger.Duration("timeout", c.clusterConfig.LockAcquisitionTimeout))
+				metrics.IncrCounter([]string{"ha", "lock", "acquire", "timeout"}, 1)
+				select {
+				case <-time.After(lockRetryInterval):
+					continue
+				case <-stopCh:
+					return false
+				}
+			}
 		}
 
 		// We acquired the lock — become active
@@ -211,15 +247,19 @@ func (c *Core) becomeActive(leaderUUID string, leaderLostCh <-chan struct{}, man
 
 	// Write leader advertisement AFTER postUnseal succeeds so standby
 	// nodes never discover and forward to a node that isn't fully active.
-	leaderInfo := &clusterLeaderParams{
+	// If the advertisement fails, step down — an active node that can't
+	// advertise is invisible to standbys and unusable.
+	if err := c.advertiseLeader(activeCtx, leaderUUID); err != nil {
+		c.logger.Error("failed to write leader advertisement, stepping down", logger.Err(err))
+		c.stateLock.Unlock()
+		activeCtxCancel()
+		return false, fmt.Errorf("leader advertisement failed: %w", err)
+	}
+	c.leaderParams.Store(&clusterLeaderParams{
 		LeaderUUID:   leaderUUID,
 		RedirectAddr: c.redirectAddr,
 		ClusterAddr:  c.clusterAddrValue(),
-	}
-	if err := c.advertiseLeader(activeCtx, leaderUUID); err != nil {
-		c.logger.Warn("failed to write leader advertisement", logger.Err(err))
-	}
-	c.leaderParams.Store(leaderInfo)
+	})
 
 	metrics.MeasureSince([]string{"ha", "post_unseal", "duration"}, postUnsealStart)
 	metrics.IncrCounter([]string{"ha", "transition", "standby_to_active"}, 1)
@@ -275,18 +315,41 @@ func (c *Core) becomeActive(leaderUUID string, leaderLostCh <-chan struct{}, man
 		}
 	}()
 
-	// Stop background goroutines
-	close(keyUpgradeStop)
-	<-keyUpgradeDone
+	// Stop background goroutines in parallel with a timeout.
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() { defer wg.Done(); close(keyUpgradeStop); <-keyUpgradeDone }()
+		go func() { defer wg.Done(); close(leaderRefreshStop); <-leaderRefreshDone }()
+		go func() { defer wg.Done(); close(leaderCleanupStop); <-leaderCleanupDone }()
+		wg.Wait()
+	}()
+	select {
+	case <-shutdownDone:
+	case <-time.After(c.clusterConfig.GoroutineShutdownTimeout):
+		c.logger.Warn("timed out waiting for background goroutines during step-down",
+			logger.Duration("timeout", c.clusterConfig.GoroutineShutdownTimeout))
+	}
 
-	close(leaderRefreshStop)
-	<-leaderRefreshDone
-
-	close(leaderCleanupStop)
-	<-leaderCleanupDone
-
-	// Transition back to standby
-	if grabLockOrStop(c.stateLock.Lock, c.stateLock.Unlock, stopCh) {
+	// Transition back to standby. Use a combined stop channel that fires
+	// on either shutdown or a timeout, so we don't block indefinitely if
+	// the state lock is held by a long-running seal operation.
+	stepDownStop := make(chan struct{})
+	stepDownTimer := time.NewTimer(c.clusterConfig.StepDownStateLockTimeout)
+	go func() {
+		select {
+		case <-stopCh:
+			close(stepDownStop)
+		case <-stepDownTimer.C:
+			c.logger.Warn("timed out waiting for state lock during step-down",
+				logger.Duration("timeout", c.clusterConfig.StepDownStateLockTimeout))
+			close(stepDownStop)
+		}
+	}()
+	if grabLockOrStop(c.stateLock.Lock, c.stateLock.Unlock, stepDownStop) {
+		stepDownTimer.Stop()
 		// Stopped while acquiring lock for step-down teardown.
 		// Still run preSeal to properly shut down subsystems (expiration
 		// manager, rotation manager, mounts, etc.) rather than leaving
@@ -304,6 +367,7 @@ func (c *Core) becomeActive(leaderUUID string, leaderLostCh <-chan struct{}, man
 		}
 		return manualStepDown, nil
 	}
+	stepDownTimer.Stop()
 	defer c.stateLock.Unlock()
 
 	c.standby.Store(true)

--- a/http/handler.go
+++ b/http/handler.go
@@ -13,14 +13,15 @@ import (
 	"syscall"
 	"time"
 
+	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/stephnangue/warden/core"
 	"github.com/stephnangue/warden/logger"
 )
 
 const (
-	// forwardingTimeout is the maximum time for a forwarded request to
-	// the active node before timing out.
-	forwardingTimeout = 60 * time.Second
+	// defaultForwardingTimeout is the maximum time for a forwarded request to
+	// the active node before timing out, when not explicitly configured.
+	defaultForwardingTimeout = 60 * time.Second
 )
 
 // HandlerProperties contains configuration for the HTTP handler
@@ -32,6 +33,10 @@ type HandlerProperties struct {
 	// forwarding requests from standby to active. When nil, forwarding
 	// uses plain HTTP (backward compatible).
 	ClusterTLSConfigFunc func() *tls.Config
+
+	// ForwardingTimeout overrides the default forwarding timeout.
+	// Zero means use the default (60s).
+	ForwardingTimeout time.Duration
 }
 
 // Handler creates and returns the main HTTP handler for Warden.
@@ -43,7 +48,11 @@ func Handler(props *HandlerProperties) http.Handler {
 	// Create a shared forwarder for standby-to-active request forwarding.
 	// Used both by the generic handler (pre-check) and the logical handler
 	// (mid-request standby transition race).
-	forwarder := newStandbyForwarder(log, props.ClusterTLSConfigFunc)
+	fwdTimeout := props.ForwardingTimeout
+	if fwdTimeout == 0 {
+		fwdTimeout = defaultForwardingTimeout
+	}
+	forwarder := newStandbyForwarder(log, props.ClusterTLSConfigFunc, fwdTimeout)
 	forwarder.core = core
 
 	// HA endpoints — must work on standby and sealed nodes.
@@ -85,15 +94,16 @@ var standbyAllowedPaths = map[string]bool{
 type standbyForwarder struct {
 	mu                sync.RWMutex
 	proxy             *httputil.ReverseProxy
-	cachedClusterAddr string // cluster address of the last-known leader; used to detect leader changes and invalidate the cached proxy
-	cachedServerName  string // cert CN of the last-known leader; used to detect cert rotation across leadership terms
+	cachedClusterAddr string         // cluster address of the last-known leader; used to detect leader changes and invalidate the cached proxy
+	cachedServerName  string         // cert CN of the last-known leader; used to detect cert rotation across leadership terms
 	logger            *logger.GatedLogger
 	tlsConfigFunc     func() *tls.Config // returns cluster mTLS config; nil = plain HTTP
 	core              *core.Core         // used for fresh leader lookups in ErrorHandler
+	forwardingTimeout time.Duration      // max time for a forwarded request
 }
 
-func newStandbyForwarder(log *logger.GatedLogger, tlsConfigFunc func() *tls.Config) *standbyForwarder {
-	return &standbyForwarder{logger: log, tlsConfigFunc: tlsConfigFunc}
+func newStandbyForwarder(log *logger.GatedLogger, tlsConfigFunc func() *tls.Config, forwardingTimeout time.Duration) *standbyForwarder {
+	return &standbyForwarder{logger: log, tlsConfigFunc: tlsConfigFunc, forwardingTimeout: forwardingTimeout}
 }
 
 // getProxy returns a reverse proxy targeting the current leader's cluster
@@ -134,7 +144,7 @@ func (f *standbyForwarder) getProxy(clusterAddr, redirectAddr string) *httputil.
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: forwardingTimeout,
+		ResponseHeaderTimeout: f.forwardingTimeout,
 		IdleConnTimeout:       30 * time.Second,
 		MaxIdleConns:          100,
 		MaxIdleConnsPerHost:   10,
@@ -165,6 +175,14 @@ func (f *standbyForwarder) getProxy(clusterAddr, redirectAddr string) *httputil.
 		ServerName:   serverName,
 	}
 
+	// Close idle connections from the old proxy's transport to prevent
+	// leaking connections to a previous leader.
+	if f.proxy != nil {
+		if t, ok := f.proxy.Transport.(*http.Transport); ok {
+			t.CloseIdleConnections()
+		}
+	}
+
 	f.proxy = &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = target.Scheme
@@ -178,11 +196,15 @@ func (f *standbyForwarder) getProxy(clusterAddr, redirectAddr string) *httputil.
 			// Standard proxy header: original Host for backend awareness.
 			req.Header.Set("X-Forwarded-Host", req.Host)
 
-			// Set forwarding headers from the direct client connection.Ò
-			// Overwrite (not append) X-Forwarded-For to prevent spoofing
-			// from untrusted clients injecting arbitrary IPs.
+			// Set forwarding headers from the direct client connection.
+			// Append to X-Forwarded-For to preserve the chain from
+			// upstream proxies (load balancers, etc.).
 			if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
-				req.Header.Set("X-Forwarded-For", clientIP)
+				if prior := req.Header.Get("X-Forwarded-For"); prior != "" {
+					req.Header.Set("X-Forwarded-For", prior+", "+clientIP)
+				} else {
+					req.Header.Set("X-Forwarded-For", clientIP)
+				}
 			}
 			if req.TLS != nil {
 				req.Header.Set("X-Forwarded-Proto", "https")
@@ -219,7 +241,15 @@ func (f *standbyForwarder) getProxy(clusterAddr, redirectAddr string) *httputil.
 				return
 			}
 
-			// For non-connection errors (e.g., TLS handshake), fall back to redirect
+			// For non-connection errors (e.g., TLS handshake), do a fresh
+			// leader lookup before redirecting to avoid stale addresses.
+			if f.core != nil {
+				_, freshLeaderAddr, _, leaderErr := f.core.Leader()
+				if leaderErr == nil && freshLeaderAddr != "" {
+					respondStandby(w, r, freshLeaderAddr)
+					return
+				}
+			}
 			respondStandby(w, r, redirectAddr)
 		},
 	}
@@ -270,8 +300,10 @@ func wrapGenericHandler(c *core.Core, handler http.Handler, log *logger.GatedLog
 // forwardToActive forwards a request to the active node via the shared
 // reverse proxy. Falls back to a 307 redirect if the proxy is unavailable.
 func forwardToActive(c *core.Core, forwarder *standbyForwarder, w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
 	_, leaderAddr, clusterAddr, err := c.Leader()
 	if err != nil || leaderAddr == "" {
+		metrics.IncrCounter([]string{"ha", "forward", "error"}, 1)
 		respondError(w, http.StatusServiceUnavailable, "node is standby and no active node found")
 		return
 	}
@@ -279,10 +311,13 @@ func forwardToActive(c *core.Core, forwarder *standbyForwarder, w http.ResponseW
 	if clusterAddr != "" {
 		if proxy := forwarder.getProxy(clusterAddr, leaderAddr); proxy != nil {
 			proxy.ServeHTTP(w, r)
+			metrics.MeasureSince([]string{"ha", "forward", "duration"}, start)
+			metrics.IncrCounter([]string{"ha", "forward", "success"}, 1)
 			return
 		}
 	}
 
+	metrics.IncrCounter([]string{"ha", "forward", "redirect"}, 1)
 	respondStandby(w, r, leaderAddr)
 }
 
@@ -315,7 +350,9 @@ func isConnectionError(err error) bool {
 	}
 	var netErr *net.OpError
 	if errors.As(err, &netErr) {
-		return true
+		// Only match dial errors (connection refused/timeout) and
+		// read/write errors (connection reset). Exclude DNS, TLS, etc.
+		return netErr.Op == "dial" || netErr.Op == "read" || netErr.Op == "write"
 	}
 	return false
 }

--- a/listener/cluster/listener.go
+++ b/listener/cluster/listener.go
@@ -33,6 +33,11 @@ type ClusterListenerConfig struct {
 	// at handshake time so that leadership transitions (which generate
 	// new certs) take effect without restarting the listener.
 	TLSConfigFunc func() *tls.Config
+
+	// ReadTimeout and WriteTimeout override the defaults for the HTTP server.
+	// Zero means use the built-in defaults (30s read, 60s write).
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
 }
 
 // NewClusterListener creates a new cluster listener that serves the
@@ -43,11 +48,20 @@ func NewClusterListener(cfg ClusterListenerConfig) (*ClusterListener, error) {
 		return nil, errors.New("cluster listener requires a TLS config function")
 	}
 
+	readTimeout := cfg.ReadTimeout
+	if readTimeout == 0 {
+		readTimeout = 30 * time.Second
+	}
+	writeTimeout := cfg.WriteTimeout
+	if writeTimeout == 0 {
+		writeTimeout = 60 * time.Second
+	}
+
 	server := &http.Server{
 		Handler:      cfg.Handler,
 		IdleTimeout:  time.Minute,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			// Use GetConfigForClient to dynamically return the TLS config

--- a/warden.hcl
+++ b/warden.hcl
@@ -29,3 +29,34 @@ listener "tcp" {
 #   - "optional": Check only if both creation and request IPs are present (default)
 #   - "required": Reject tokens without IP binding or requests without client IP
 # ip_binding_policy = "optional"
+
+# HA cluster tuning
+# All values are Go duration strings (e.g., "30s", "5m", "1h").
+# Omitted values use built-in defaults.
+
+# Max time to wait for background goroutines to exit during step-down.
+# goroutine_shutdown_timeout = "30s"
+
+# Max time to wait when acquiring the HA lock. "0" means wait indefinitely.
+# lock_acquisition_timeout = "0"
+
+# How often the active node cleans stale leader advertisements from storage.
+# leader_cleanup_interval = "1h"
+
+# Max time to acquire the state lock during step-down before forcing teardown.
+# step_down_state_lock_timeout = "30s"
+
+# Deadline for barrier reads when looking up the leader advertisement.
+# leader_lookup_timeout = "10s"
+
+# Backwards offset on cluster certificate NotBefore to tolerate clock drift.
+# clock_skew_grace = "1m"
+
+# HTTP read timeout for the cluster listener (inter-node forwarding).
+# cluster_listener_read_timeout = "30s"
+
+# HTTP write timeout for the cluster listener.
+# cluster_listener_write_timeout = "1m"
+
+# Max time for a forwarded request from standby to active node.
+# forwarding_timeout = "1m"


### PR DESCRIPTION
…ectness fixes

Address 14 identified weaknesses in the HA cluster code:

- Add ClusterConfig with 9 configurable duration parameters (timeouts, intervals, grace periods) with sensible defaults
- Parallel goroutine shutdown with timeout during step-down
- Bounded lock acquisition, leader lookup, and step-down state lock
- Abort leadership when advertisement write fails
- Add forwarding metrics (success/error/redirect/duration)
- Preserve X-Forwarded-For chain, narrow isConnectionError scope
- Fresh leader lookup on non-connection forwarding errors
- Close idle connections on proxy invalidation
- Configurable clock skew grace (default 60s) and listener timeouts
- Reduce leader cleanup interval from 24h to 1h
- Run E2E tests sequentially to prevent cross-suite interference