### PR TITLE
ci: gate release on unit + e2e tests passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
-  test:
+  unit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +27,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [unit]
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,12 @@ permissions:
   packages: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   release:
     runs-on: ubuntu-latest
+    needs: [ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
- Rename CI job from "test" to "unit" for clarity
- Add workflow_call trigger to ci.yml so it can be reused
- Update release.yml to call ci.yml; GoReleaser only runs after both unit and e2e jobs pass