### PR TITLE
feat: add runtime conditions for CBP policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Warden are documented in this file.
 
+## [v0.3.0] — 2026-03-05
+
+### New Features
+
+- **Runtime Conditions for CBP Policies** — Policies now support a `conditions` block that restricts access based on runtime context, even when capabilities match. Supported condition types: `source_ip` (CIDR ranges or bare IPs, IPv4/IPv6), `time_window` (time-of-day windows with timezone, including midnight-spanning ranges), and `day_of_week` (3-letter abbreviations). Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Conditions are validated at policy parse time, not per-request. Paths without conditions work as before. When multiple policies apply to the same path, OR semantics apply: if any policy has no conditions, access is unconditional.
+
+### Documentation
+
+- **Provider README updates** — All 8 provider READMEs (AWS, Azure, GCP, GitHub, GitLab, Vault, Mistral, OpenAI) now include runtime conditions examples showing how to protect destructive or costly operations on specific paths.
+
+### Infrastructure
+
+- **CI release gating** — Release workflow now requires unit and e2e tests to pass before publishing. (#56)
+
 ## [v0.2.1] — 2026-03-05
 
 ### Improvements
@@ -71,6 +85,7 @@ Initial release. See the [v0.1.0 release notes](https://github.com/stephnangue/w
 - Docker image published to `ghcr.io/stephnangue/warden`
 - Pre-built binaries for Linux, macOS, and Windows
 
+[v0.3.0]: https://github.com/stephnangue/warden/compare/v0.2.1...v0.3.0
 [v0.2.1]: https://github.com/stephnangue/warden/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/stephnangue/warden/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/stephnangue/warden/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Warden constrains what an agent can do by controlling which APIs it can reach, w
 
 A Mistral API key grants access to every model. Warden can restrict an agent to `mistral-small-latest` only, enforce max_tokens limits, and require streaming mode — cost control that API key scoping alone cannot provide. A GitHub fine-grained PAT with `contents: read` lets the holder read *every file* in a repo. Warden can restrict an agent to `src/` while blocking `.github/workflows/` and `.env` — something GitHub simply cannot express. For AWS, destructive operations can be blocked at the gateway regardless of what the underlying IAM role permits.
 
+Policies also support **runtime conditions** — source IP restrictions, time-of-day windows, and day-of-week constraints — that deny requests even when capabilities match. This enables scenarios like restricting production deployments to office hours from trusted networks only.
+
 ### AI Request Governance
 
 Warden parses AI request bodies and evaluates policies against inference parameters. This enables cost control and usage governance at the gateway layer:
@@ -193,7 +195,7 @@ Explicit mode is **required for AWS** (SigV4 request signing means Warden must h
 |---|---|---|---|
 | Credential isolation | Credentials never leave Warden | Virtual keys stored in Portkey vault | Credentials pass through edge component |
 | Audit granularity | Every API request logged | Logs + cost analytics (Enterprise) | Access grant logged |
-| Policy enforcement | HTTP path + method + AI parameters | Guardrails (PII, jailbreak) | Workload-to-service level |
+| Policy enforcement | HTTP path + method + AI parameters + runtime conditions (IP, time, day) | Guardrails (PII, jailbreak) | Workload-to-service level |
 | AI inference governance | Model, token, and parameter policies | Guardrails + rate limiting | N/A |
 | Cloud provider support | AWS, Azure, GCP, GitHub, GitLab, Vault | N/A — AI providers only | Per-provider integration |
 | Client modification | Change base URL | Portkey SDK or Universal API | Deploy sidecar agents |
@@ -328,7 +330,7 @@ Warden uses HCL configuration files. See `warden.local.hcl` for a full example c
 
 **Observability** — Structured audit log export (OpenTelemetry, SIEM), new audit device types, Prometheus metrics, distributed tracing
 
-**Security** — Rate limiting per identity, mTLS to upstream providers, audit log tamper detection
+**Security** — Rate limiting per identity, mTLS to upstream providers, audit log tamper detection, additional policy conditions (max request rate, required headers)
 
 **Operations** — Helm chart, Docker Compose quick start, Terraform module
 

--- a/core/policy.go
+++ b/core/policy.go
@@ -118,6 +118,7 @@ type PathRules struct {
 	RequiredParametersHCL     []string         `hcl:"required_parameters"`
 	PaginationLimitHCL        int              `hcl:"pagination_limit"`
 	ResponseKeysFilterPathHCL string           `hcl:"list_scan_response_keys_filter_path"`
+	ConditionsHCL             map[string][]string `hcl:"conditions"`
 }
 
 type CBPPermissions struct {
@@ -128,6 +129,11 @@ type CBPPermissions struct {
 	PaginationLimit        int
 	GrantingPoliciesMap    map[uint32][]sdklogical.PolicyInfo
 	ResponseKeysFilterPath string
+	// ConditionSets holds condition sets from all merged policies for this path.
+	// nil means unconditional access (at least one policy had no conditions).
+	// Non-nil: each entry is one policy's conditions; request must satisfy at
+	// least one set (OR between sets, AND within each set's types).
+	ConditionSets []*PolicyConditions
 }
 
 func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
@@ -172,6 +178,17 @@ func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
 			return nil, err
 		}
 		ret.GrantingPoliciesMap = clonedGrantingPoliciesMap.(map[uint32][]sdklogical.PolicyInfo)
+	}
+
+	switch {
+	case p.ConditionSets == nil:
+	case len(p.ConditionSets) == 0:
+		ret.ConditionSets = make([]*PolicyConditions, 0)
+	default:
+		ret.ConditionSets = make([]*PolicyConditions, len(p.ConditionSets))
+		for i, cs := range p.ConditionSets {
+			ret.ConditionSets[i] = cs.Clone()
+		}
 	}
 
 	return ret, nil
@@ -266,6 +283,7 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			"pagination_limit",
 			"expiration",
 			"list_scan_response_keys_filter_path",
+			"conditions",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
@@ -395,6 +413,14 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 		}
 
 		pc.Permissions.PaginationLimit = pc.PaginationLimitHCL
+
+		if len(pc.ConditionsHCL) > 0 {
+			conditions, err := parseAndValidateConditions(pc.ConditionsHCL)
+			if err != nil {
+				return fmt.Errorf("path %q: %w", key, err)
+			}
+			pc.Permissions.ConditionSets = []*PolicyConditions{conditions}
+		}
 	PathFinished:
 		paths = append(paths, &pc)
 	}

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -240,6 +240,21 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 				existingPerms.ResponseKeysFilterPath = pc.Permissions.ResponseKeysFilterPath
 			}
 
+			// Conditions merging: OR semantics across policies.
+			// If existing is already unconditional (nil), it stays nil.
+			// If the new policy has no conditions, clear to nil (unconditional wins).
+			// If both have conditions, append new conditions (OR across sets).
+			if existingPerms.ConditionSets != nil {
+				if pc.Permissions.ConditionSets == nil {
+					existingPerms.ConditionSets = nil
+				} else {
+					existingPerms.ConditionSets = append(
+						existingPerms.ConditionSets,
+						pc.Permissions.ConditionSets...,
+					)
+				}
+			}
+
 		INSERT:
 			switch {
 			case pc.HasSegmentWildcards:
@@ -429,6 +444,21 @@ CHECK:
 
 	if !operationAllowed {
 		return ret
+	}
+
+	// Check conditions before parameter validation. Conditions restrict
+	// access at the path+operation level, independent of parameters.
+	if permissions.ConditionSets != nil {
+		conditionsMet := false
+		for _, conds := range permissions.ConditionSets {
+			if conds.Evaluate(req.ClientIP, time.Now()) {
+				conditionsMet = true
+				break
+			}
+		}
+		if !conditionsMet {
+			return ret
+		}
 	}
 
 	ret.GrantingPolicies = grantingPolicies

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -1326,3 +1326,246 @@ func TestCBPPermissions_CloneEmptyMaps(t *testing.T) {
 	assert.Len(t, cloned.AllowedParameters, 0)
 	assert.Len(t, cloned.DeniedParameters, 0)
 }
+
+// =============================================================================
+// Conditions Integration Tests
+// =============================================================================
+
+func TestCBP_ConditionsSourceIP_Allowed(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "10.1.2.3",
+	}
+
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.True(t, result.Allowed)
+}
+
+func TestCBP_ConditionsSourceIP_Denied(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "192.168.1.1",
+	}
+
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.False(t, result.Allowed)
+}
+
+func TestCBP_ConditionsCapCheckOnly_SkipsConditions(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "192.168.1.1", // Does NOT match, but capCheckOnly should skip
+	}
+
+	result := cbp.AllowOperation(ctx, req, true)
+	assert.True(t, result.CapabilitiesBitmap&ReadCapabilityInt > 0)
+}
+
+func TestCBP_ConditionsWithParameters(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["create"]
+			allowed_parameters {
+				"key" = []
+			}
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	// Good IP, valid parameter → allowed
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "10.1.2.3",
+		Data:      map[string]any{"key": "value"},
+	}
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.True(t, result.Allowed)
+
+	// Bad IP, valid parameter → denied by conditions
+	req.ClientIP = "192.168.1.1"
+	result = cbp.AllowOperation(ctx, req, false)
+	assert.False(t, result.Allowed)
+}
+
+func TestCBP_ConditionsEmpty_NoEffect(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "anything",
+	}
+
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.True(t, result.Allowed)
+}
+
+func TestCBP_MergeConditions_OneUnconditional(t *testing.T) {
+	ctx := testContext()
+
+	policyA := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	policyB := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policyA, policyB})
+	require.NoError(t, err)
+
+	// Request from IP outside policyA's range should still succeed
+	// because policyB is unconditional
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "192.168.1.1",
+	}
+
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.True(t, result.Allowed)
+}
+
+func TestCBP_MergeConditions_BothConditional_OR(t *testing.T) {
+	ctx := testContext()
+
+	policyA := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	policyB := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["192.168.0.0/16"]
+			}
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policyA, policyB})
+	require.NoError(t, err)
+
+	// Matches policyA's conditions
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "10.1.2.3",
+	}
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.True(t, result.Allowed)
+
+	// Matches policyB's conditions
+	req.ClientIP = "192.168.1.1"
+	result = cbp.AllowOperation(ctx, req, false)
+	assert.True(t, result.Allowed)
+
+	// Matches neither
+	req.ClientIP = "172.16.0.1"
+	result = cbp.AllowOperation(ctx, req, false)
+	assert.False(t, result.Allowed)
+}
+
+func TestCBP_MergeConditions_DenyOverrides(t *testing.T) {
+	ctx := testContext()
+
+	policyAllow := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["10.0.0.0/8"]
+			}
+		}
+	`)
+
+	policyDeny := testParsePolicy(t, `
+		path "secret/data/*" {
+			capabilities = ["deny"]
+		}
+	`)
+
+	cbp, err := NewCBP(ctx, []*Policy{policyAllow, policyDeny})
+	require.NoError(t, err)
+
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "secret/data/foo",
+		ClientIP:  "10.1.2.3",
+	}
+
+	result := cbp.AllowOperation(ctx, req, false)
+	assert.False(t, result.Allowed)
+}

--- a/core/policy_conditions.go
+++ b/core/policy_conditions.go
@@ -1,0 +1,277 @@
+package core
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// PolicyConditions holds the parsed and validated conditions for a path rule.
+// All specified condition types must be satisfied (AND semantics between types).
+// Within each type's list, at least one entry must match (OR semantics).
+type PolicyConditions struct {
+	SourceCIDRs []*net.IPNet   // Parsed CIDR networks from source_ip
+	TimeWindows []TimeWindow   // Parsed time window specifications
+	DaysOfWeek  []time.Weekday // Parsed day-of-week values
+}
+
+// TimeWindow represents a parsed time-of-day window with timezone.
+type TimeWindow struct {
+	StartHour   int
+	StartMinute int
+	EndHour     int
+	EndMinute   int
+	Location    *time.Location
+}
+
+// validConditionKeys defines the recognized condition type names.
+var validConditionKeys = map[string]bool{
+	"source_ip":   true,
+	"time_window": true,
+	"day_of_week": true,
+}
+
+// dayAbbrevToWeekday maps 3-letter abbreviations to time.Weekday.
+var dayAbbrevToWeekday = map[string]time.Weekday{
+	"Sun": time.Sunday,
+	"Mon": time.Monday,
+	"Tue": time.Tuesday,
+	"Wed": time.Wednesday,
+	"Thu": time.Thursday,
+	"Fri": time.Friday,
+	"Sat": time.Saturday,
+}
+
+// parseAndValidateConditions converts the raw HCL conditions map into a
+// validated PolicyConditions struct. Returns an error if any condition
+// type is unknown or any value is malformed.
+func parseAndValidateConditions(raw map[string][]string) (*PolicyConditions, error) {
+	for key := range raw {
+		if !validConditionKeys[key] {
+			return nil, fmt.Errorf("unknown condition type %q", key)
+		}
+	}
+
+	cond := &PolicyConditions{}
+
+	if cidrs, ok := raw["source_ip"]; ok {
+		if len(cidrs) == 0 {
+			return nil, fmt.Errorf("source_ip condition requires at least one CIDR")
+		}
+		for _, cidrStr := range cidrs {
+			_, ipNet, err := net.ParseCIDR(cidrStr)
+			if err != nil {
+				// Try as a bare IP (no prefix length)
+				ip := net.ParseIP(cidrStr)
+				if ip == nil {
+					return nil, fmt.Errorf("invalid source_ip %q: %w", cidrStr, err)
+				}
+				bits := 32
+				if ip.To4() == nil {
+					bits = 128
+				}
+				ipNet = &net.IPNet{
+					IP:   ip,
+					Mask: net.CIDRMask(bits, bits),
+				}
+			}
+			cond.SourceCIDRs = append(cond.SourceCIDRs, ipNet)
+		}
+	}
+
+	if windows, ok := raw["time_window"]; ok {
+		if len(windows) == 0 {
+			return nil, fmt.Errorf("time_window condition requires at least one window")
+		}
+		for _, winStr := range windows {
+			tw, err := parseTimeWindow(winStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid time_window %q: %w", winStr, err)
+			}
+			cond.TimeWindows = append(cond.TimeWindows, tw)
+		}
+	}
+
+	if days, ok := raw["day_of_week"]; ok {
+		if len(days) == 0 {
+			return nil, fmt.Errorf("day_of_week condition requires at least one day")
+		}
+		for _, dayStr := range days {
+			day, ok := dayAbbrevToWeekday[dayStr]
+			if !ok {
+				return nil, fmt.Errorf("invalid day_of_week %q (use Sun, Mon, Tue, Wed, Thu, Fri, Sat)", dayStr)
+			}
+			cond.DaysOfWeek = append(cond.DaysOfWeek, day)
+		}
+	}
+
+	return cond, nil
+}
+
+// parseTimeWindow parses a time window string like "08:00-18:00 UTC"
+// or "22:00-06:00 America/New_York" (midnight-spanning).
+func parseTimeWindow(s string) (TimeWindow, error) {
+	parts := strings.Fields(s)
+	if len(parts) != 2 {
+		return TimeWindow{}, fmt.Errorf("expected format 'HH:MM-HH:MM TZ', got %q", s)
+	}
+
+	timeRange := parts[0]
+	tzStr := parts[1]
+
+	loc, err := time.LoadLocation(tzStr)
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("invalid timezone %q: %w", tzStr, err)
+	}
+
+	rangeParts := strings.SplitN(timeRange, "-", 2)
+	if len(rangeParts) != 2 {
+		return TimeWindow{}, fmt.Errorf("expected HH:MM-HH:MM, got %q", timeRange)
+	}
+
+	startH, startM, err := parseHHMM(rangeParts[0])
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("invalid start time: %w", err)
+	}
+
+	endH, endM, err := parseHHMM(rangeParts[1])
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("invalid end time: %w", err)
+	}
+
+	return TimeWindow{
+		StartHour:   startH,
+		StartMinute: startM,
+		EndHour:     endH,
+		EndMinute:   endM,
+		Location:    loc,
+	}, nil
+}
+
+// parseHHMM parses "HH:MM" into hour and minute integers.
+func parseHHMM(s string) (int, int, error) {
+	var h, m int
+	n, err := fmt.Sscanf(s, "%d:%d", &h, &m)
+	if err != nil || n != 2 {
+		return 0, 0, fmt.Errorf("expected HH:MM, got %q", s)
+	}
+	if h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, 0, fmt.Errorf("time out of range: %q", s)
+	}
+	return h, m, nil
+}
+
+// Evaluate checks whether the request satisfies all conditions.
+// Returns true if all condition types are met, false otherwise.
+// A nil PolicyConditions always returns true (unconditional).
+func (c *PolicyConditions) Evaluate(clientIP string, now time.Time) bool {
+	if c == nil {
+		return true
+	}
+
+	if len(c.SourceCIDRs) > 0 {
+		if !c.evaluateSourceIP(clientIP) {
+			return false
+		}
+	}
+
+	if len(c.TimeWindows) > 0 {
+		if !c.evaluateTimeWindows(now) {
+			return false
+		}
+	}
+
+	if len(c.DaysOfWeek) > 0 {
+		if !c.evaluateDayOfWeek(now) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *PolicyConditions) evaluateSourceIP(clientIP string) bool {
+	if clientIP == "" {
+		return false
+	}
+
+	ip := net.ParseIP(clientIP)
+	if ip == nil {
+		return false
+	}
+
+	for _, cidr := range c.SourceCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *PolicyConditions) evaluateTimeWindows(now time.Time) bool {
+	for i := range c.TimeWindows {
+		if c.TimeWindows[i].Contains(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// Contains checks if a time falls within the window. Handles midnight-spanning
+// windows (e.g., 22:00-06:00) by checking if the time is NOT in the
+// complement range. End time is exclusive.
+func (tw *TimeWindow) Contains(t time.Time) bool {
+	locTime := t.In(tw.Location)
+	minuteOfDay := locTime.Hour()*60 + locTime.Minute()
+	start := tw.StartHour*60 + tw.StartMinute
+	end := tw.EndHour*60 + tw.EndMinute
+
+	if start <= end {
+		// Normal window: e.g., 08:00-18:00
+		return minuteOfDay >= start && minuteOfDay < end
+	}
+	// Midnight-spanning window: e.g., 22:00-06:00
+	return minuteOfDay >= start || minuteOfDay < end
+}
+
+func (c *PolicyConditions) evaluateDayOfWeek(now time.Time) bool {
+	currentDay := now.UTC().Weekday()
+	for _, day := range c.DaysOfWeek {
+		if currentDay == day {
+			return true
+		}
+	}
+	return false
+}
+
+// Clone returns a deep copy of the PolicyConditions.
+func (c *PolicyConditions) Clone() *PolicyConditions {
+	if c == nil {
+		return nil
+	}
+	clone := &PolicyConditions{}
+
+	if c.SourceCIDRs != nil {
+		clone.SourceCIDRs = make([]*net.IPNet, len(c.SourceCIDRs))
+		for i, cidr := range c.SourceCIDRs {
+			ipCopy := make(net.IP, len(cidr.IP))
+			copy(ipCopy, cidr.IP)
+			maskCopy := make(net.IPMask, len(cidr.Mask))
+			copy(maskCopy, cidr.Mask)
+			clone.SourceCIDRs[i] = &net.IPNet{IP: ipCopy, Mask: maskCopy}
+		}
+	}
+
+	if c.TimeWindows != nil {
+		clone.TimeWindows = make([]TimeWindow, len(c.TimeWindows))
+		copy(clone.TimeWindows, c.TimeWindows)
+	}
+
+	if c.DaysOfWeek != nil {
+		clone.DaysOfWeek = make([]time.Weekday, len(c.DaysOfWeek))
+		copy(clone.DaysOfWeek, c.DaysOfWeek)
+	}
+
+	return clone
+}

--- a/core/policy_conditions_test.go
+++ b/core/policy_conditions_test.go
@@ -1,0 +1,604 @@
+package core
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Parsing and Validation Tests
+// =============================================================================
+
+func TestParseConditions_ValidSourceIP_IPv4CIDR(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {"10.0.0.0/8"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.SourceCIDRs, 1)
+	assert.Equal(t, "10.0.0.0/8", cond.SourceCIDRs[0].String())
+}
+
+func TestParseConditions_ValidSourceIP_MultipleCIDRs(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {"10.0.0.0/8", "192.168.0.0/16"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.SourceCIDRs, 2)
+}
+
+func TestParseConditions_ValidSourceIP_IPv6CIDR(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {"2001:db8::/32"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.SourceCIDRs, 1)
+	assert.Equal(t, "2001:db8::/32", cond.SourceCIDRs[0].String())
+}
+
+func TestParseConditions_ValidSourceIP_BareIPv4(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {"192.168.1.1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.SourceCIDRs, 1)
+	ones, bits := cond.SourceCIDRs[0].Mask.Size()
+	assert.Equal(t, 32, ones)
+	assert.Equal(t, 32, bits)
+}
+
+func TestParseConditions_ValidSourceIP_BareIPv6(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {"::1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.SourceCIDRs, 1)
+	ones, bits := cond.SourceCIDRs[0].Mask.Size()
+	assert.Equal(t, 128, ones)
+	assert.Equal(t, 128, bits)
+}
+
+func TestParseConditions_InvalidSourceIP(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {"not-a-cidr"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid source_ip")
+}
+
+func TestParseConditions_EmptySourceIPList(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"source_ip": {},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least one")
+}
+
+func TestParseConditions_ValidTimeWindow(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"08:00-18:00 UTC"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.TimeWindows, 1)
+	assert.Equal(t, 8, cond.TimeWindows[0].StartHour)
+	assert.Equal(t, 0, cond.TimeWindows[0].StartMinute)
+	assert.Equal(t, 18, cond.TimeWindows[0].EndHour)
+	assert.Equal(t, 0, cond.TimeWindows[0].EndMinute)
+	assert.Equal(t, time.UTC, cond.TimeWindows[0].Location)
+}
+
+func TestParseConditions_ValidTimeWindow_MidnightSpan(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"22:00-06:00 UTC"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.TimeWindows, 1)
+	assert.Equal(t, 22, cond.TimeWindows[0].StartHour)
+	assert.Equal(t, 6, cond.TimeWindows[0].EndHour)
+}
+
+func TestParseConditions_ValidTimeWindow_WithMinutes(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"08:30-17:45 UTC"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 8, cond.TimeWindows[0].StartHour)
+	assert.Equal(t, 30, cond.TimeWindows[0].StartMinute)
+	assert.Equal(t, 17, cond.TimeWindows[0].EndHour)
+	assert.Equal(t, 45, cond.TimeWindows[0].EndMinute)
+}
+
+func TestParseConditions_InvalidTimeWindow_BadFormat(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"8am-6pm"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid time_window")
+}
+
+func TestParseConditions_InvalidTimeWindow_BadTimezone(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"08:00-18:00 Mars/Olympus"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid timezone")
+}
+
+func TestParseConditions_InvalidTimeWindow_OutOfRange(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"25:00-18:00 UTC"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestParseConditions_InvalidTimeWindow_BadMinute(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {"08:60-18:00 UTC"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestParseConditions_EmptyTimeWindowList(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"time_window": {},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least one")
+}
+
+func TestParseConditions_ValidDayOfWeek(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"day_of_week": {"Mon", "Fri"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.DaysOfWeek, 2)
+	assert.Equal(t, time.Monday, cond.DaysOfWeek[0])
+	assert.Equal(t, time.Friday, cond.DaysOfWeek[1])
+}
+
+func TestParseConditions_ValidDayOfWeek_AllDays(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"day_of_week": {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cond.DaysOfWeek, 7)
+}
+
+func TestParseConditions_InvalidDayOfWeek_FullName(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"day_of_week": {"Monday"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid day_of_week")
+}
+
+func TestParseConditions_InvalidDayOfWeek_Lowercase(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"day_of_week": {"mon"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid day_of_week")
+}
+
+func TestParseConditions_EmptyDayOfWeekList(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"day_of_week": {},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least one")
+}
+
+func TestParseConditions_UnknownConditionType(t *testing.T) {
+	_, err := parseAndValidateConditions(map[string][]string{
+		"hostname": {"foo.example.com"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown condition type")
+}
+
+func TestParseConditions_MultipleTypes(t *testing.T) {
+	cond, err := parseAndValidateConditions(map[string][]string{
+		"source_ip":   {"10.0.0.0/8"},
+		"time_window": {"08:00-18:00 UTC"},
+		"day_of_week": {"Mon", "Tue", "Wed", "Thu", "Fri"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, cond.SourceCIDRs, 1)
+	assert.Len(t, cond.TimeWindows, 1)
+	assert.Len(t, cond.DaysOfWeek, 5)
+}
+
+// =============================================================================
+// Source IP Evaluation Tests
+// =============================================================================
+
+func TestEvaluateSourceIP_Match(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+	}
+	assert.True(t, cond.Evaluate("10.1.2.3", time.Now()))
+}
+
+func TestEvaluateSourceIP_NoMatch(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+	}
+	assert.False(t, cond.Evaluate("192.168.1.1", time.Now()))
+}
+
+func TestEvaluateSourceIP_MultipleCIDRs_SecondMatches(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8", "192.168.0.0/16"),
+	}
+	assert.True(t, cond.Evaluate("192.168.1.1", time.Now()))
+}
+
+func TestEvaluateSourceIP_EmptyClientIP(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+	}
+	assert.False(t, cond.Evaluate("", time.Now()))
+}
+
+func TestEvaluateSourceIP_UnparseableClientIP(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+	}
+	assert.False(t, cond.Evaluate("not-an-ip", time.Now()))
+}
+
+func TestEvaluateSourceIP_IPv6Match(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "2001:db8::/32"),
+	}
+	assert.True(t, cond.Evaluate("2001:db8::1", time.Now()))
+}
+
+func TestEvaluateSourceIP_IPv6NoMatch(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "2001:db8::/32"),
+	}
+	assert.False(t, cond.Evaluate("2001:db9::1", time.Now()))
+}
+
+func TestEvaluateSourceIP_Loopback(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "127.0.0.0/8"),
+	}
+	assert.True(t, cond.Evaluate("127.0.0.1", time.Now()))
+}
+
+// =============================================================================
+// Time Window Evaluation Tests
+// =============================================================================
+
+func TestEvaluateTimeWindow_WithinRange(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, StartMinute: 0,
+			EndHour: 18, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_OutsideRange(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, StartMinute: 0,
+			EndHour: 18, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 20, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_AtStart(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, StartMinute: 0,
+			EndHour: 18, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 8, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_AtEnd_Excluded(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, StartMinute: 0,
+			EndHour: 18, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 18, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_MidnightSpan_Late(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 22, StartMinute: 0,
+			EndHour: 6, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 23, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_MidnightSpan_Early(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 22, StartMinute: 0,
+			EndHour: 6, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 3, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_MidnightSpan_Outside(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 22, StartMinute: 0,
+			EndHour: 6, EndMinute: 0,
+			Location: time.UTC,
+		}},
+	}
+	at := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_TimezoneConversion(t *testing.T) {
+	est, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, StartMinute: 0,
+			EndHour: 18, EndMinute: 0,
+			Location: est,
+		}},
+	}
+	// 15:00 UTC = 10:00 EST → within 08:00-18:00 EST
+	at := time.Date(2026, 3, 5, 15, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+
+	// 01:00 UTC = 20:00 EST previous day → outside 08:00-18:00 EST
+	at = time.Date(2026, 3, 5, 1, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateTimeWindow_MultipleWindows_SecondMatches(t *testing.T) {
+	cond := &PolicyConditions{
+		TimeWindows: []TimeWindow{
+			{StartHour: 8, EndHour: 12, Location: time.UTC},
+			{StartHour: 14, EndHour: 18, Location: time.UTC},
+		},
+	}
+	at := time.Date(2026, 3, 5, 15, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+// =============================================================================
+// Day of Week Evaluation Tests
+// =============================================================================
+
+func TestEvaluateDayOfWeek_Match(t *testing.T) {
+	cond := &PolicyConditions{
+		DaysOfWeek: []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+	}
+	// 2026-03-02 is a Monday (UTC)
+	at := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateDayOfWeek_NoMatch(t *testing.T) {
+	cond := &PolicyConditions{
+		DaysOfWeek: []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday},
+	}
+	// 2026-03-07 is a Saturday (UTC)
+	at := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("", at))
+}
+
+func TestEvaluateDayOfWeek_Sunday(t *testing.T) {
+	cond := &PolicyConditions{
+		DaysOfWeek: []time.Weekday{time.Sunday},
+	}
+	// 2026-03-08 is a Sunday (UTC)
+	at := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("", at))
+}
+
+// =============================================================================
+// Combined Conditions (AND Semantics) Tests
+// =============================================================================
+
+func TestEvaluateConditions_AllTypesMustMatch_AllPass(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, EndHour: 18, Location: time.UTC,
+		}},
+		DaysOfWeek: []time.Weekday{time.Thursday},
+	}
+	// 2026-03-05 is a Thursday
+	at := time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC)
+	assert.True(t, cond.Evaluate("10.1.2.3", at))
+}
+
+func TestEvaluateConditions_IPFails_OthersPass(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, EndHour: 18, Location: time.UTC,
+		}},
+		DaysOfWeek: []time.Weekday{time.Thursday},
+	}
+	at := time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("192.168.1.1", at))
+}
+
+func TestEvaluateConditions_TimeFails_OthersPass(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, EndHour: 18, Location: time.UTC,
+		}},
+		DaysOfWeek: []time.Weekday{time.Thursday},
+	}
+	at := time.Date(2026, 3, 5, 20, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("10.1.2.3", at))
+}
+
+func TestEvaluateConditions_DayFails_OthersPass(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, EndHour: 18, Location: time.UTC,
+		}},
+		DaysOfWeek: []time.Weekday{time.Monday},
+	}
+	// 2026-03-05 is a Thursday, not Monday
+	at := time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC)
+	assert.False(t, cond.Evaluate("10.1.2.3", at))
+}
+
+func TestEvaluateConditions_NilConditions(t *testing.T) {
+	var cond *PolicyConditions
+	assert.True(t, cond.Evaluate("anything", time.Now()))
+}
+
+// =============================================================================
+// Clone Tests
+// =============================================================================
+
+func TestClone_NilConditions(t *testing.T) {
+	var cond *PolicyConditions
+	assert.Nil(t, cond.Clone())
+}
+
+func TestClone_DeepCopy(t *testing.T) {
+	cond := &PolicyConditions{
+		SourceCIDRs: parseCIDRs(t, "10.0.0.0/8"),
+		TimeWindows: []TimeWindow{{
+			StartHour: 8, EndHour: 18, Location: time.UTC,
+		}},
+		DaysOfWeek: []time.Weekday{time.Monday},
+	}
+
+	clone := cond.Clone()
+	require.NotNil(t, clone)
+
+	// Verify values match
+	assert.Equal(t, len(cond.SourceCIDRs), len(clone.SourceCIDRs))
+	assert.Equal(t, cond.SourceCIDRs[0].String(), clone.SourceCIDRs[0].String())
+	assert.Equal(t, cond.TimeWindows[0].StartHour, clone.TimeWindows[0].StartHour)
+	assert.Equal(t, cond.DaysOfWeek[0], clone.DaysOfWeek[0])
+
+	// Verify independence — mutating clone doesn't affect original
+	clone.SourceCIDRs[0].IP[0] = 99
+	assert.NotEqual(t, cond.SourceCIDRs[0].IP[0], clone.SourceCIDRs[0].IP[0])
+}
+
+// =============================================================================
+// HCL Policy Parsing Integration Tests
+// =============================================================================
+
+func TestParseCBPPolicy_WithConditions(t *testing.T) {
+	policy := testParsePolicy(t, `
+		path "aws/sts/prod-*" {
+			capabilities = ["create"]
+			conditions {
+				source_ip = ["10.0.0.0/8", "172.16.0.0/12"]
+			}
+		}
+	`)
+	require.Len(t, policy.Paths, 1)
+	require.NotNil(t, policy.Paths[0].Permissions.ConditionSets)
+	require.Len(t, policy.Paths[0].Permissions.ConditionSets, 1)
+	assert.Len(t, policy.Paths[0].Permissions.ConditionSets[0].SourceCIDRs, 2)
+}
+
+func TestParseCBPPolicy_WithAllConditionTypes(t *testing.T) {
+	policy := testParsePolicy(t, `
+		path "secret/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip   = ["10.0.0.0/8"]
+				time_window = ["08:00-18:00 UTC"]
+				day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+			}
+		}
+	`)
+	require.Len(t, policy.Paths, 1)
+	conds := policy.Paths[0].Permissions.ConditionSets[0]
+	assert.Len(t, conds.SourceCIDRs, 1)
+	assert.Len(t, conds.TimeWindows, 1)
+	assert.Len(t, conds.DaysOfWeek, 5)
+}
+
+func TestParseCBPPolicy_WithoutConditions(t *testing.T) {
+	policy := testParsePolicy(t, `
+		path "secret/*" {
+			capabilities = ["read"]
+		}
+	`)
+	require.Len(t, policy.Paths, 1)
+	assert.Nil(t, policy.Paths[0].Permissions.ConditionSets)
+}
+
+func TestParseCBPPolicy_InvalidCondition(t *testing.T) {
+	_, err := ParseCBPPolicy(namespace.RootNamespace, `
+		path "secret/*" {
+			capabilities = ["read"]
+			conditions {
+				source_ip = ["not-a-cidr"]
+			}
+		}
+	`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid source_ip")
+}
+
+func TestParseCBPPolicy_UnknownConditionType(t *testing.T) {
+	_, err := ParseCBPPolicy(namespace.RootNamespace, `
+		path "secret/*" {
+			capabilities = ["read"]
+			conditions {
+				hostname = ["foo.example.com"]
+			}
+		}
+	`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown condition type")
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+func parseCIDRs(t *testing.T, cidrs ...string) []*net.IPNet {
+	t.Helper()
+	var result []*net.IPNet
+	for _, cidrStr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidrStr)
+		require.NoError(t, err)
+		result = append(result, ipNet)
+	}
+	return result
+}

--- a/e2e/auth/auth_test.go
+++ b/e2e/auth/auth_test.go
@@ -220,3 +220,110 @@ func TestTokenTTLDecrement(t *testing.T) {
 		t.Fatalf("expected non-empty token")
 	}
 }
+
+// TestConditionsSourceIPAllowed verifies that a policy with source_ip condition
+// matching the request IP (127.0.0.1 for localhost) allows the request (T-069).
+func TestConditionsSourceIPAllowed(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-allow", port,
+		`{"policy":"path \"vault-nt/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n  conditions {\n    source_ip = [\"127.0.0.0/8\"]\n  }\n}"}`)
+	h.APIRequest(t, "POST", "auth/jwt/role/e2e-cond-allow-test", port,
+		`{"token_policies":["e2e-cond-allow"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":300}`)
+
+	jwt := h.GetDefaultJWT(t)
+	loginStatus, token := h.LoginJWT(t, jwt, "e2e-cond-allow-test", port)
+	if loginStatus != 200 && loginStatus != 201 {
+		t.Fatalf("expected 200 or 201 on login, got %d", loginStatus)
+	}
+
+	status, _ := h.VaultNTRequest(t, "GET", "secret/data/e2e/app-config", port, token)
+	if status != 200 {
+		t.Fatalf("expected 200 with matching source_ip condition, got %d", status)
+	}
+
+	h.APIRequest(t, "DELETE", "auth/jwt/role/e2e-cond-allow-test", port, "")
+	h.APIRequest(t, "DELETE", "sys/policies/cbp/e2e-cond-allow", port, "")
+}
+
+// TestConditionsSourceIPDenied verifies that a policy with source_ip condition
+// NOT matching the request IP denies even with correct capabilities (T-070).
+func TestConditionsSourceIPDenied(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-deny", port,
+		`{"policy":"path \"vault-nt/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n  conditions {\n    source_ip = [\"10.0.0.0/8\"]\n  }\n}"}`)
+	h.APIRequest(t, "POST", "auth/jwt/role/e2e-cond-deny-test", port,
+		`{"token_policies":["e2e-cond-deny"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":300}`)
+
+	jwt := h.GetDefaultJWT(t)
+	loginStatus, token := h.LoginJWT(t, jwt, "e2e-cond-deny-test", port)
+	if loginStatus != 200 && loginStatus != 201 {
+		t.Fatalf("expected 200 or 201 on login, got %d", loginStatus)
+	}
+
+	status, _ := h.VaultNTRequest(t, "GET", "secret/data/e2e/app-config", port, token)
+	if status != 403 {
+		t.Fatalf("expected 403 with non-matching source_ip condition, got %d", status)
+	}
+
+	h.APIRequest(t, "DELETE", "auth/jwt/role/e2e-cond-deny-test", port, "")
+	h.APIRequest(t, "DELETE", "sys/policies/cbp/e2e-cond-deny", port, "")
+}
+
+// TestConditionsInvalidCIDRRejected verifies that creating a policy with an
+// invalid CIDR in source_ip conditions is rejected at parse time (T-071).
+func TestConditionsInvalidCIDRRejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	status, _ := h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-bad-cidr", port,
+		`{"policy":"path \"secret/*\" {\n  capabilities = [\"read\"]\n  conditions {\n    source_ip = [\"not-a-cidr\"]\n  }\n}"}`)
+	if status != 400 {
+		t.Fatalf("expected 400 for invalid CIDR, got %d", status)
+	}
+}
+
+// TestConditionsUnknownTypeRejected verifies that creating a policy with an
+// unknown condition type is rejected at parse time (T-072).
+func TestConditionsUnknownTypeRejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	status, _ := h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-bad-type", port,
+		`{"policy":"path \"secret/*\" {\n  capabilities = [\"read\"]\n  conditions {\n    hostname = [\"foo.example.com\"]\n  }\n}"}`)
+	if status != 400 {
+		t.Fatalf("expected 400 for unknown condition type, got %d", status)
+	}
+}
+
+// TestConditionsMergeWithUnconditional verifies that when a role has both a
+// conditional and an unconditional policy for the same path, the unconditional
+// policy wins (OR semantics) and access is granted (T-073).
+func TestConditionsMergeWithUnconditional(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Conditional policy: source_ip does NOT match loopback
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-restricted", port,
+		`{"policy":"path \"vault-nt/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n  conditions {\n    source_ip = [\"10.0.0.0/8\"]\n  }\n}"}`)
+	// Unconditional policy for same path
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-unrestricted", port,
+		`{"policy":"path \"vault-nt/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n}"}`)
+	// Role with both policies
+	h.APIRequest(t, "POST", "auth/jwt/role/e2e-cond-merge-test", port,
+		`{"token_policies":["e2e-cond-restricted","e2e-cond-unrestricted"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":300}`)
+
+	jwt := h.GetDefaultJWT(t)
+	loginStatus, token := h.LoginJWT(t, jwt, "e2e-cond-merge-test", port)
+	if loginStatus != 200 && loginStatus != 201 {
+		t.Fatalf("expected 200 or 201 on login, got %d", loginStatus)
+	}
+
+	// Unconditional policy wins: access granted despite source_ip mismatch
+	status, _ := h.VaultNTRequest(t, "GET", "secret/data/e2e/app-config", port, token)
+	if status != 200 {
+		t.Fatalf("expected 200 when unconditional policy overrides conditions, got %d", status)
+	}
+
+	h.APIRequest(t, "DELETE", "auth/jwt/role/e2e-cond-merge-test", port, "")
+	h.APIRequest(t, "DELETE", "sys/policies/cbp/e2e-cond-restricted", port, "")
+	h.APIRequest(t, "DELETE", "sys/policies/cbp/e2e-cond-unrestricted", port, "")
+}

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -262,6 +262,27 @@ path "aws/gateway*" {
 EOF
 ```
 
+For tighter control, add runtime conditions to protect destructive operations on specific paths. For example, restrict S3 object deletion to trusted networks during business hours while leaving read access unconditional:
+
+```bash
+warden policy write aws-prod-restricted - <<EOF
+path "aws/gateway*" {
+  capabilities = ["delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "aws/gateway*" {
+  capabilities = ["read", "create", "update", "patch"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -217,6 +217,27 @@ path "azure/role/+/gateway*" {
 EOF
 ```
 
+For tighter control, add runtime conditions to protect destructive operations on specific paths. For example, restrict resource group deletion to trusted networks during business hours while leaving read access unconditional:
+
+```bash
+warden policy write azure-prod-restricted - <<EOF
+path "azure/role/+/gateway/management.azure.com/subscriptions/+/resourcegroups/*" {
+  capabilities = ["delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "azure/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "patch"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -183,6 +183,27 @@ path "gcp/role/+/gateway*" {
 EOF
 ```
 
+For tighter control, add runtime conditions to protect destructive operations on specific paths. For example, restrict Compute Engine instance deletion to trusted networks during business hours while leaving read access unconditional:
+
+```bash
+warden policy write gcp-prod-restricted - <<EOF
+path "gcp/role/+/gateway/compute.googleapis.com/compute/v1/projects/+/zones/+/instances/*" {
+  capabilities = ["delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "gcp/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "patch"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -167,6 +167,27 @@ path "github/role/+/gateway*" {
 EOF
 ```
 
+For tighter control, add runtime conditions to protect destructive operations on specific paths. For example, restrict repository deletion to trusted networks during business hours while leaving read and create access unconditional:
+
+```bash
+warden policy write github-prod-restricted - <<EOF
+path "github/role/+/gateway/repos/+/*" {
+  capabilities = ["delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "github/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "patch"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -194,6 +194,27 @@ path "gitlab/role/+/gateway*" {
 EOF
 ```
 
+For tighter control, add runtime conditions to protect destructive operations on specific paths. For example, restrict project deletion to trusted networks during business hours while leaving read and create access unconditional:
+
+```bash
+warden policy write gitlab-prod-restricted - <<EOF
+path "gitlab/role/+/gateway/api/v4/projects/*" {
+  capabilities = ["delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "gitlab/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "patch"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -172,6 +172,32 @@ path "mistral/role/+/gateway/v1/chat/completions" {
 EOF
 ```
 
+You can also combine parameter restrictions with runtime conditions to protect costly inference endpoints. For example, restrict chat completions to specific models and trusted networks during business hours:
+
+```bash
+warden policy write mistral-prod-restricted - <<EOF
+path "mistral/role/+/gateway/v1/chat/completions" {
+  capabilities = ["create"]
+  allowed_parameters = {
+    "model" = ["mistral-small-latest"]
+    "stream" = ["true"]
+    "*"      = []
+  }
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "mistral/role/+/gateway/v1/models" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -173,6 +173,32 @@ path "openai/role/+/gateway/v1/chat/completions" {
 EOF
 ```
 
+You can also combine parameter restrictions with runtime conditions to protect costly inference endpoints. For example, restrict chat completions to specific models and trusted networks during business hours:
+
+```bash
+warden policy write openai-prod-restricted - <<EOF
+path "openai/role/+/gateway/v1/chat/completions" {
+  capabilities = ["create"]
+  allowed_parameters = {
+    "model" = ["gpt-4o", "gpt-4o-mini"]
+    "stream" = ["true"]
+    "*"      = []
+  }
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "openai/role/+/gateway/v1/models" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -269,6 +269,27 @@ path "vault/role/+/gateway*" {
 EOF
 ```
 
+For tighter control, add runtime conditions to protect sensitive Vault paths. For example, restrict secret deletion to trusted networks during business hours while leaving read access unconditional:
+
+```bash
+warden policy write vault-prod-restricted - <<EOF
+path "vault/gateway/secret/data/*" {
+  capabilities = ["delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "vault/gateway*" {
+  capabilities = ["read", "create", "update", "patch"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
 Verify:
 
 ```bash


### PR DESCRIPTION
Add source_ip, time_window, and day_of_week conditions to policy path rules. Conditions are validated at parse time and evaluated per-request after capability checks. AND semantics between condition types, OR within each type's values. When merging policies, unconditional wins (OR across policies). Includes unit tests, CBP integration tests, e2e tests, and documentation across all provider READMEs.