### PR TITLE
feat: add TLS certificate auth method with SPIFFE support and securit…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: bash e2e/setup.sh
 
       - name: Run E2E tests
-        run: go test -tags e2e -v -count=1 -p 1 -timeout 45m ./e2e/cluster/ ./e2e/provider/ ./e2e/ha/ ./e2e/namespace/ ./e2e/forwarding/ ./e2e/credential/ ./e2e/rotation/ ./e2e/auth/ ./e2e/audit/ ./e2e/seal/ ./e2e/concurrency/
+        run: go test -tags e2e -v -count=1 -p 1 -timeout 45m ./e2e/cluster/ ./e2e/provider/ ./e2e/ha/ ./e2e/namespace/ ./e2e/forwarding/ ./e2e/credential/ ./e2e/rotation/ ./e2e/auth/ ./e2e/audit/ ./e2e/seal/ ./e2e/concurrency/ ./e2e/loadbalancer/
 
       - name: Teardown E2E cluster
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ temp/
 .terraform.lock.hcl
 
 test.sh
+
+# E2E generated certs
+e2e/loadbalancer/certs/

--- a/auth/helper/match.go
+++ b/auth/helper/match.go
@@ -1,0 +1,116 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MatchPattern checks whether a value matches a segment-aware wildcard pattern.
+//
+// Both value and pattern are split by "/" into segments and compared segment
+// by segment. If both contain "://", the scheme must match exactly and segment
+// matching applies to the portion after "://". If neither contains "://",
+// the full strings are compared as segments. A mismatch in scheme presence
+// (one has "://", the other does not) always returns false.
+//
+// Wildcard syntax (mirrors CBP policy segment wildcards):
+//   - "+"  matches exactly one segment
+//   - "*"  as the last segment matches one or more remaining segments
+//   - "+*" is forbidden
+//   - all other segments require an exact match
+//
+// Examples:
+//
+//	MatchPattern("spiffe://example.com/dept/svc", "spiffe://+/dept/svc")             // true
+//	MatchPattern("spiffe://example.com/dept/team/svc", "spiffe://example.com/dept/*") // true
+//	MatchPattern("spiffe://anything/any/path", "spiffe://*")                          // true
+//	MatchPattern("example.com/dept/svc", "+/dept/svc")                                // true
+//	MatchPattern("example.com/dept/team/svc", "example.com/dept/*")                   // true
+func MatchPattern(value, pattern string) bool {
+	valScheme, valBody := parseScheme(value)
+	patScheme, patBody := parseScheme(pattern)
+
+	if valScheme != patScheme {
+		return false
+	}
+
+	// "scheme://*" or bare "*" — matches everything with the same scheme
+	if patBody == "*" {
+		return true
+	}
+
+	return matchSegments(strings.Split(valBody, "/"), strings.Split(patBody, "/"))
+}
+
+// matchSegments compares value segments against pattern segments using
+// "+" (single-segment wildcard) and trailing "*" (prefix wildcard).
+func matchSegments(valParts, patParts []string) bool {
+	isPrefix := len(patParts) > 0 && patParts[len(patParts)-1] == "*"
+	if isPrefix {
+		patParts = patParts[:len(patParts)-1]
+	}
+
+	if !isPrefix && len(valParts) != len(patParts) {
+		return false
+	}
+	// With prefix (*): value must have strictly more segments than the
+	// pattern prefix — the wildcard matches one or more segments.
+	if isPrefix && len(valParts) <= len(patParts) {
+		return false
+	}
+
+	for i, pp := range patParts {
+		if pp != "+" && pp != valParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchAny checks whether a value matches any of the given patterns.
+func MatchAny(value string, patterns []string) bool {
+	for _, p := range patterns {
+		if MatchPattern(value, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidatePattern checks that a pattern is well-formed for use with MatchPattern.
+func ValidatePattern(pattern string) error {
+	if strings.Contains(pattern, "+*") {
+		return fmt.Errorf("pattern %q: '+*' is forbidden", pattern)
+	}
+
+	_, body := parseScheme(pattern)
+	if body == "" {
+		return fmt.Errorf("pattern %q: empty body", pattern)
+	}
+
+	// "scheme://*" or bare "*" — valid catch-all
+	if body == "*" {
+		return nil
+	}
+
+	parts := strings.Split(body, "/")
+	for i, p := range parts {
+		if p == "" {
+			return fmt.Errorf("pattern %q: empty segment at position %d", pattern, i)
+		}
+		if p == "*" && i != len(parts)-1 {
+			return fmt.Errorf("pattern %q: '*' is only allowed as the last segment", pattern)
+		}
+	}
+	return nil
+}
+
+// parseScheme splits a string at "://". If the separator is absent, scheme is
+// empty and body is the full string — this lets callers treat scheme-less
+// values and patterns uniformly (both yield empty scheme, so they compare equal).
+func parseScheme(s string) (scheme, body string) {
+	if idx := strings.Index(s, "://"); idx >= 0 {
+		return s[:idx], s[idx+3:]
+	}
+	return "", s
+}

--- a/auth/helper/match_test.go
+++ b/auth/helper/match_test.go
@@ -1,0 +1,135 @@
+package helper
+
+import "testing"
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		pattern string
+		want    bool
+	}{
+		// --- Exact match ---
+		{"exact spiffe", "spiffe://example.com/web", "spiffe://example.com/web", true},
+		{"exact mismatch path", "spiffe://example.com/web", "spiffe://example.com/api", false},
+		{"exact mismatch domain", "spiffe://example.com/web", "spiffe://other.com/web", false},
+
+		// --- Single-segment wildcard (+) ---
+		{"plus trust domain", "spiffe://example.com/dept/svc", "spiffe://+/dept/svc", true},
+		{"plus middle", "spiffe://example.com/dept/svc", "spiffe://example.com/+/svc", true},
+		{"plus last", "spiffe://example.com/dept/svc", "spiffe://example.com/dept/+", true},
+		{"plus multiple", "spiffe://example.com/path/to/dept/subject", "spiffe://+/path/+/+/subject", true},
+		{"plus all", "spiffe://a/b/c", "spiffe://+/+/+", true},
+		{"plus mismatch fixed", "spiffe://example.com/other/svc", "spiffe://+/dept/svc", false},
+		{"plus too few segments", "spiffe://example.com/svc", "spiffe://+/dept/svc", false},
+		{"plus too many segments", "spiffe://example.com/dept/team/svc", "spiffe://+/dept/svc", false},
+
+		// --- Trailing * (prefix match) ---
+		{"star matches rest", "spiffe://domain/dept/team/svc", "spiffe://domain/dept/*", true},
+		{"star matches one", "spiffe://domain/dept/svc", "spiffe://domain/dept/*", true},
+		{"star matches many", "spiffe://domain/dept/a/b/c/d", "spiffe://domain/dept/*", true},
+		{"star mismatch prefix", "spiffe://domain/other/svc", "spiffe://domain/dept/*", false},
+		{"star mismatch domain", "spiffe://other/dept/svc", "spiffe://domain/dept/*", false},
+		{"star needs at least one after", "spiffe://domain/dept", "spiffe://domain/dept/*", false},
+
+		// --- scheme://* (catch-all for scheme) ---
+		{"scheme star", "spiffe://anything/any/path", "spiffe://*", true},
+		{"scheme star single segment", "spiffe://domain", "spiffe://*", true},
+		{"scheme star mismatch scheme", "https://example.com/path", "spiffe://*", false},
+
+		// --- Combined + and * ---
+		{"plus and star", "spiffe://example.com/dept/team/svc", "spiffe://+/dept/*", true},
+		{"plus and star mismatch", "spiffe://example.com/other/team/svc", "spiffe://+/dept/*", false},
+
+		// --- Scheme mismatch ---
+		{"different schemes", "https://example.com/path", "spiffe://example.com/path", false},
+
+		// --- Non-SPIFFE URIs ---
+		{"https exact", "https://example.com/callback", "https://example.com/callback", true},
+		{"https plus", "https://example.com/callback", "https://+/callback", true},
+		{"https star", "https://example.com/api/v1/users", "https://example.com/api/*", true},
+
+		// --- No scheme (bare segments) ---
+		{"bare exact", "example.com/dept/svc", "example.com/dept/svc", true},
+		{"bare plus", "example.com/dept/svc", "+/dept/svc", true},
+		{"bare star", "example.com/dept/team/svc", "example.com/dept/*", true},
+		{"bare mismatch", "example.com/other/svc", "+/dept/svc", false},
+		{"bare catch-all", "anything/here", "*", true},
+
+		// --- Scheme presence mismatch ---
+		{"scheme vs bare", "spiffe://example.com/path", "example.com/path", false},
+		{"bare vs scheme", "example.com/path", "spiffe://example.com/path", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchPattern(tc.value, tc.pattern)
+			if got != tc.want {
+				t.Errorf("MatchPattern(%q, %q) = %v, want %v", tc.value, tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchAny(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		patterns []string
+		want     bool
+	}{
+		{"matches first", "spiffe://example.com/web", []string{"spiffe://example.com/web", "spiffe://other.com/web"}, true},
+		{"matches second", "spiffe://other.com/web", []string{"spiffe://example.com/web", "spiffe://other.com/web"}, true},
+		{"matches none", "spiffe://third.com/web", []string{"spiffe://example.com/web", "spiffe://other.com/web"}, false},
+		{"empty patterns", "spiffe://example.com/web", []string{}, false},
+		{"wildcard in list", "spiffe://any.com/svc", []string{"spiffe://example.com/web", "spiffe://*"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchAny(tc.value, tc.patterns)
+			if got != tc.want {
+				t.Errorf("MatchAny(%q, %v) = %v, want %v", tc.value, tc.patterns, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidatePattern(t *testing.T) {
+	valid := []string{
+		"spiffe://example.com/web",
+		"spiffe://+/dept/svc",
+		"spiffe://+/path/+/+/subject",
+		"spiffe://domain/dept/*",
+		"spiffe://*",
+		"https://+/callback",
+		"https://example.com/api/*",
+		"+/dept/svc",
+		"example.com/dept/*",
+		"*",
+	}
+	for _, p := range valid {
+		t.Run("valid/"+p, func(t *testing.T) {
+			if err := ValidatePattern(p); err != nil {
+				t.Errorf("ValidatePattern(%q) unexpected error: %v", p, err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		pattern string
+		desc    string
+	}{
+		{"spiffe://", "empty body after scheme"},
+		{"spiffe://domain/+*/svc", "+* forbidden"},
+		{"spiffe://domain/*/svc", "* not last segment"},
+		{"spiffe://domain//svc", "empty segment"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.desc, func(t *testing.T) {
+			if err := ValidatePattern(tc.pattern); err == nil {
+				t.Errorf("ValidatePattern(%q) expected error for %s, got nil", tc.pattern, tc.desc)
+			}
+		})
+	}
+}

--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -1,0 +1,268 @@
+package cert
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"sync"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// CertAuthConfig represents certificate authentication configuration
+type CertAuthConfig struct {
+	TrustedCAPEM   string        `json:"trusted_ca_pem"`              // PEM-encoded trusted CA certs
+	PrincipalClaim string        `json:"principal_claim,omitempty"`    // "cn" (default), "dns_san", "email_san", "uri_san", "serial"
+	TokenTTL       time.Duration `json:"token_ttl" default:"1h"`      // Default token TTL
+	TokenType      string        `json:"token_type,omitempty"`         // Default token type
+	RevocationMode string        `json:"revocation_mode,omitempty"`    // "none" (default), "crl", "ocsp", "best_effort"
+	CRLCacheTTL    string        `json:"crl_cache_ttl,omitempty"`      // CRL cache TTL (default: "1h")
+	OCSPTimeout    string        `json:"ocsp_timeout,omitempty"`       // OCSP request timeout (default: "5s")
+
+	// Internal — parsed CA pool
+	caPool *x509.CertPool `json:"-"`
+}
+
+type certAuthBackend struct {
+	*framework.Backend
+	config             *CertAuthConfig
+	configMu           sync.RWMutex
+	logger             *logger.GatedLogger
+	storageView        sdklogical.Storage
+	validTokenTypes    []string
+	revocationChecker  *revocationChecker
+}
+
+// Factory creates a new certificate auth backend
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &certAuthBackend{
+		logger:          conf.Logger,
+		storageView:     conf.StorageView,
+		validTokenTypes: conf.ValidTokenTypes,
+	}
+
+	b.Backend = &framework.Backend{
+		Help:         certAuthHelp,
+		BackendType:  "cert",
+		BackendClass: logical.ClassAuth,
+		PathsSpecial: &logical.Paths{
+			Unauthenticated: []string{
+				"login",
+			},
+		},
+		Paths: []*framework.Path{
+			b.pathLogin(),
+			b.pathConfig(),
+			b.pathRole(),
+			b.pathRoleList(),
+		},
+	}
+
+	if err := b.Backend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	if len(conf.Config) > 0 {
+		if err := b.setupCertConfig(ctx, conf.Config); err != nil {
+			return nil, fmt.Errorf("failed to setup cert config: %w", err)
+		}
+	}
+
+	return b, nil
+}
+
+// validRevocationModes lists the allowed values for revocation_mode.
+var validRevocationModes = []string{"", "none", "crl", "ocsp", "best_effort"}
+
+// validPrincipalClaims lists the allowed values for principal_claim.
+var validPrincipalClaims = []string{"cn", "dns_san", "email_san", "uri_san", "spiffe_id", "serial"}
+
+func (b *certAuthBackend) setupCertConfig(_ context.Context, conf map[string]any) error {
+	config, err := mapToCertAuthConfig(conf)
+	if err != nil {
+		return err
+	}
+
+	if config.TokenTTL == 0 {
+		config.TokenTTL = time.Hour
+	}
+	if config.PrincipalClaim == "" {
+		config.PrincipalClaim = "cn"
+	}
+	if !isValidPrincipalClaim(config.PrincipalClaim) {
+		return fmt.Errorf("invalid principal_claim %q; must be one of: %v", config.PrincipalClaim, validPrincipalClaims)
+	}
+
+	// Validate revocation mode
+	if !isValidRevocationMode(config.RevocationMode) {
+		return fmt.Errorf("invalid revocation_mode %q; must be one of: none, crl, ocsp, best_effort", config.RevocationMode)
+	}
+
+	// Parse and validate CRL cache TTL
+	crlCacheTTL := time.Hour // default
+	if config.CRLCacheTTL != "" {
+		d, err := time.ParseDuration(config.CRLCacheTTL)
+		if err != nil {
+			return fmt.Errorf("invalid crl_cache_ttl: %w", err)
+		}
+		crlCacheTTL = d
+	}
+
+	// Parse and validate OCSP timeout
+	ocspTimeout := 5 * time.Second // default
+	if config.OCSPTimeout != "" {
+		d, err := time.ParseDuration(config.OCSPTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid ocsp_timeout: %w", err)
+		}
+		ocspTimeout = d
+	}
+
+	// Parse trusted CA certificates
+	if config.TrustedCAPEM != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(config.TrustedCAPEM)) {
+			return fmt.Errorf("trusted_ca_pem contains no valid certificates")
+		}
+		config.caPool = pool
+	}
+
+	// Initialize revocation checker if revocation is enabled
+	mode := config.RevocationMode
+	if mode != "" && mode != "none" {
+		b.revocationChecker = newRevocationChecker(crlCacheTTL, ocspTimeout)
+	} else {
+		b.revocationChecker = nil
+	}
+
+	b.configMu.Lock()
+	b.config = config
+	b.configMu.Unlock()
+	return nil
+}
+
+func isValidRevocationMode(mode string) bool {
+	for _, valid := range validRevocationModes {
+		if mode == valid {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidPrincipalClaim(claim string) bool {
+	for _, valid := range validPrincipalClaims {
+		if claim == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// Initialize loads persisted config from storage
+func (b *certAuthBackend) Initialize(ctx context.Context) error {
+	if b.storageView == nil {
+		return nil
+	}
+
+	entry, err := b.storageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry != nil {
+		var configMap map[string]any
+		if err := entry.DecodeJSON(&configMap); err != nil {
+			return fmt.Errorf("failed to decode config: %w", err)
+		}
+		if err := b.setupCertConfig(ctx, configMap); err != nil {
+			return fmt.Errorf("failed to setup cert config from storage: %w", err)
+		}
+	}
+	return nil
+}
+
+// SensitiveConfigFields returns the list of config fields that should be masked
+func (b *certAuthBackend) SensitiveConfigFields() []string {
+	return []string{
+		"trusted_ca_pem",
+	}
+}
+
+// principalClaimAllowedValues converts validPrincipalClaims to []interface{} for FieldSchema.AllowedValues
+func principalClaimAllowedValues() []interface{} {
+	values := make([]interface{}, len(validPrincipalClaims))
+	for i, v := range validPrincipalClaims {
+		values[i] = v
+	}
+	return values
+}
+
+// allowedTokenTypeValues converts validTokenTypes to []interface{} for FieldSchema.AllowedValues
+func (b *certAuthBackend) allowedTokenTypeValues() []interface{} {
+	values := make([]interface{}, len(b.validTokenTypes))
+	for i, t := range b.validTokenTypes {
+		values[i] = t
+	}
+	return values
+}
+
+// buildCAPool builds an x509.CertPool from the given PEM string.
+// Used for role-specific CAs that override the global trusted CAs.
+func buildCAPool(caPEM string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(caPEM)) {
+		return nil, fmt.Errorf("certificate PEM contains no valid certificates")
+	}
+	return pool, nil
+}
+
+// certFingerprint returns the hex-encoded SHA-256 fingerprint of a certificate's raw DER bytes.
+func certFingerprint(cert *x509.Certificate) string {
+	hash := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(hash[:])
+}
+
+const certAuthHelp = `
+The certificate auth method authenticates clients using TLS client certificates.
+
+Clients present a certificate during the TLS handshake (direct mTLS) or via
+a forwarding header from a trusted load balancer (X-Forwarded-Client-Cert or
+X-SSL-Client-Cert).
+
+The certificate is validated against trusted CAs configured globally or per-role.
+Role constraints (allowed CNs, SANs, OUs, Organizations) further restrict which
+certificates are accepted.
+
+Configuration:
+  POST /auth/{mount}/config      - Configure trusted CAs and defaults
+  GET  /auth/{mount}/config      - Read current configuration
+  POST /auth/{mount}/role/:name  - Create roles with certificate constraints
+  POST /auth/{mount}/login       - Authenticate with a client certificate
+`
+
+// parsePEMCertificates returns the number of valid certificates in a PEM bundle
+func parsePEMCertificates(pemData string) int {
+	count := 0
+	rest := []byte(pemData)
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			if _, err := x509.ParseCertificate(block.Bytes); err == nil {
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/auth/method/cert/cert_extract.go
+++ b/auth/method/cert/cert_extract.go
@@ -1,0 +1,22 @@
+package cert
+
+import (
+	"crypto/x509"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stephnangue/warden/logical"
+)
+
+// extractClientCert extracts the client certificate from the request.
+// Warden always sits behind a load balancer — client certs arrive exclusively
+// via the X-SSL-Client-Cert header, parsed by the cert forwarding middleware
+// and stored in the request context. On cluster-forwarded requests (standby →
+// leader), the header is re-forwarded and re-parsed, so ForwardedClientCert
+// works correctly for both direct and forwarded paths.
+func extractClientCert(req *logical.Request) *x509.Certificate {
+	if req.HTTPRequest == nil {
+		return nil
+	}
+
+	return listener.ForwardedClientCert(req.HTTPRequest.Context())
+}

--- a/auth/method/cert/parser.go
+++ b/auth/method/cert/parser.go
@@ -1,0 +1,52 @@
+package cert
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func mapToCertAuthConfig(data map[string]any) (*CertAuthConfig, error) {
+	dataCopy := make(map[string]any)
+	for k, v := range data {
+		dataCopy[k] = v
+	}
+
+	// Handle token_ttl duration conversion from various source types
+	switch ttl := dataCopy["token_ttl"].(type) {
+	case string:
+		if d, err := time.ParseDuration(ttl); err == nil {
+			dataCopy["token_ttl"] = d
+		}
+	case int:
+		dataCopy["token_ttl"] = time.Duration(ttl) * time.Second
+	case float64:
+		dataCopy["token_ttl"] = time.Duration(int64(ttl)) * time.Second
+	case time.Duration:
+		// Already a duration, keep as-is
+	}
+
+	jsonData, err := json.Marshal(dataCopy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal map: %w", err)
+	}
+
+	var config CertAuthConfig
+	if err := json.Unmarshal(jsonData, &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal to CertAuthConfig: %w", err)
+	}
+
+	if config.PrincipalClaim == "" {
+		config.PrincipalClaim = "cn"
+	}
+
+	if config.TokenTTL == 0 {
+		config.TokenTTL = time.Hour
+	}
+
+	if config.TokenType == "" {
+		config.TokenType = "warden_token"
+	}
+
+	return &config, nil
+}

--- a/auth/method/cert/path_config.go
+++ b/auth/method/cert/path_config.go
@@ -1,0 +1,159 @@
+package cert
+
+import (
+	"context"
+	"net/http"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathConfig returns the config path definition
+func (b *certAuthBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"trusted_ca_pem": {
+				Type:        framework.TypeString,
+				Description: "PEM-encoded trusted CA certificates",
+			},
+			"principal_claim": {
+				Type:          framework.TypeString,
+				Description:   "Identity source from certificate: cn (default), spiffe_id, dns_san, email_san, uri_san, serial",
+				Default:       "cn",
+				AllowedValues: principalClaimAllowedValues(),
+			},
+			"token_ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Default token TTL (default: 1h)",
+			},
+			"token_type": {
+				Type:          framework.TypeString,
+				Description:   "Default token type for roles that don't specify one (default: warden_token)",
+				Default:       "warden_token",
+				AllowedValues: b.allowedTokenTypeValues(),
+			},
+			"revocation_mode": {
+				Type:        framework.TypeString,
+				Description: "Certificate revocation checking mode: none (default), crl, ocsp, best_effort",
+				Default:     "none",
+			},
+			"crl_cache_ttl": {
+				Type:        framework.TypeString,
+				Description: "CRL cache TTL (default: 1h). Example: 30m, 2h",
+				Default:     "1h",
+			},
+			"ocsp_timeout": {
+				Type:        framework.TypeString,
+				Description: "OCSP request timeout (default: 5s). Example: 3s, 10s",
+				Default:     "5s",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read certificate auth configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure certificate authentication",
+			},
+		},
+		HelpSynopsis: "Configure certificate authentication",
+		HelpDescription: `This endpoint configures the certificate authentication method.
+
+Set 'trusted_ca_pem' to PEM-encoded CA certificates that sign client certificates.
+Use 'principal_claim' to control which certificate field identifies the principal
+(cn, dns_san, email_san, uri_san, or serial).`,
+	}
+}
+
+// handleConfigRead handles reading the configuration
+func (b *certAuthBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.configMu.RLock()
+	defer b.configMu.RUnlock()
+
+	if b.config == nil {
+		return &logical.Response{
+			StatusCode: http.StatusOK,
+			Data:       map[string]any{},
+		}, nil
+	}
+
+	certCount := 0
+	if b.config.TrustedCAPEM != "" {
+		certCount = parsePEMCertificates(b.config.TrustedCAPEM)
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"trusted_ca_pem":   b.config.TrustedCAPEM,
+			"principal_claim":  b.config.PrincipalClaim,
+			"token_ttl":        b.config.TokenTTL.String(),
+			"token_type":       b.config.TokenType,
+			"revocation_mode":  b.config.RevocationMode,
+			"crl_cache_ttl":    b.config.CRLCacheTTL,
+			"ocsp_timeout":     b.config.OCSPTimeout,
+			"trusted_ca_count": certCount,
+		},
+	}, nil
+}
+
+// handleConfigWrite handles writing the configuration
+func (b *certAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Build config map from field data
+	conf := make(map[string]any)
+
+	// Copy existing config if present
+	if b.config != nil {
+		conf["trusted_ca_pem"] = b.config.TrustedCAPEM
+		conf["principal_claim"] = b.config.PrincipalClaim
+		conf["token_ttl"] = b.config.TokenTTL
+		conf["token_type"] = b.config.TokenType
+		conf["revocation_mode"] = b.config.RevocationMode
+		conf["crl_cache_ttl"] = b.config.CRLCacheTTL
+		conf["ocsp_timeout"] = b.config.OCSPTimeout
+	}
+
+	// Apply new values from request
+	for key := range d.Schema {
+		if val, ok := d.GetOk(key); ok {
+			conf[key] = val
+		}
+	}
+
+	// Setup new config
+	if err := b.setupCertConfig(ctx, conf); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        err,
+		}, nil
+	}
+
+	// Persist config to storage
+	if b.storageView != nil {
+		entry, err := sdklogical.StorageEntryJSON("config", conf)
+		if err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+		if err := b.storageView.Put(ctx, entry); err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"message": "configuration updated",
+		},
+	}, nil
+}

--- a/auth/method/cert/path_login.go
+++ b/auth/method/cert/path_login.go
@@ -1,0 +1,331 @@
+package cert
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/auth/helper"
+	"github.com/stephnangue/warden/framework"
+	lgr "github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// errCertAuthFailed is a generic error returned for all certificate authentication
+// failures to prevent information leakage about which specific check failed.
+var errCertAuthFailed = fmt.Errorf("authentication failed")
+
+// pathLogin returns the login path definition
+func (b *certAuthBackend) pathLogin() *framework.Path {
+	return &framework.Path{
+		Pattern: "login",
+		Fields: map[string]*framework.FieldSchema{
+			"role": {
+				Type:        framework.TypeString,
+				Description: "Role to assume after authentication",
+				Required:    true,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleLogin,
+				Summary:  "Authenticate using a TLS client certificate",
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.handleLogin,
+				Summary:  "Authenticate using a TLS client certificate",
+			},
+		},
+		HelpSynopsis:    "Authenticate using a TLS client certificate",
+		HelpDescription: "This endpoint authenticates using a client certificate presented via TLS or forwarded by a trusted load balancer.",
+	}
+}
+
+// handleLogin handles the certificate login operation
+func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	b.configMu.RLock()
+	defer b.configMu.RUnlock()
+
+	// Extract client certificate from TLS connection or forwarded header
+	cert := extractClientCert(req)
+	if cert == nil {
+		return logical.ErrorResponse(logical.ErrBadRequest("no client certificate provided")), nil
+	}
+
+	// Get role name
+	roleName := d.Get("role").(string)
+	if roleName == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("missing role")), nil
+	}
+
+	// Look up the role
+	role, err := b.getRole(ctx, roleName)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if role == nil {
+		b.logger.Warn("login failed: role not found", lgr.String("role", roleName))
+		return &logical.Response{
+			StatusCode: http.StatusUnauthorized,
+			Err:        errCertAuthFailed,
+		}, nil
+	}
+
+	// Build CA pool: role-specific overrides global
+	caPool, err := b.getCAPool(role)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if caPool == nil {
+		return &logical.Response{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("no trusted CA certificates configured"),
+		}, nil
+	}
+
+	// Verify certificate chain
+	verifyOpts := x509.VerifyOptions{
+		Roots:     caPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	verifiedChains, err := cert.Verify(verifyOpts)
+	if err != nil {
+		b.logger.Warn("login failed: certificate verification error", lgr.Err(err), lgr.String("role", roleName))
+		return &logical.Response{
+			StatusCode: http.StatusUnauthorized,
+			Err:        errCertAuthFailed,
+		}, nil
+	}
+
+	// Check certificate revocation status if configured
+	if b.revocationChecker != nil && b.config != nil &&
+		b.config.RevocationMode != "" && b.config.RevocationMode != "none" {
+		if err := b.revocationChecker.checkRevocation(cert, verifiedChains, b.config.RevocationMode); err != nil {
+			b.logger.Warn("login failed: certificate revocation check", lgr.Err(err), lgr.String("role", roleName))
+			return &logical.Response{
+				StatusCode: http.StatusUnauthorized,
+				Err:        errCertAuthFailed,
+			}, nil
+		}
+	}
+
+	// Validate role constraints
+	if err := validateCertConstraints(cert, role); err != nil {
+		b.logger.Warn("login failed: certificate constraint check", lgr.Err(err), lgr.String("role", roleName))
+		return &logical.Response{
+			StatusCode: http.StatusUnauthorized,
+			Err:        errCertAuthFailed,
+		}, nil
+	}
+
+	// Determine principal claim source: role overrides global config
+	principalClaim := role.PrincipalClaim
+	if principalClaim == "" && b.config != nil {
+		principalClaim = b.config.PrincipalClaim
+	}
+	if principalClaim == "" {
+		principalClaim = "cn"
+	}
+
+	// Extract principal identity from the certificate
+	principalID := extractPrincipal(cert, principalClaim)
+	if principalID == "" {
+		b.logger.Warn("login failed: no principal identity in certificate",
+			lgr.String("principal_claim", principalClaim), lgr.String("role", roleName))
+		return &logical.Response{
+			StatusCode: http.StatusUnauthorized,
+			Err:        errCertAuthFailed,
+		}, nil
+	}
+
+	// Calculate effective TTL
+	effectiveTTL := b.calculateTTL(cert, role)
+
+	// Determine token type: role overrides global config
+	tokenType := role.TokenType
+	if tokenType == "" && b.config != nil {
+		tokenType = b.config.TokenType
+	}
+
+	// Certificate fingerprint for token caching in transparent mode
+	fingerprint := certFingerprint(cert)
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Auth: &logical.Auth{
+			PrincipalID:    principalID,
+			RoleName:       roleName,
+			Policies:       role.TokenPolicies,
+			CredentialSpec: role.CredSpecName,
+			TokenType:      tokenType,
+			TokenTTL:       effectiveTTL,
+			ClientIP:       req.ClientIP,
+			ClientToken:    fingerprint, // Cert fingerprint for token type caching
+		},
+		Data: map[string]any{
+			"principal_id": principalID,
+			"role":         roleName,
+			"fingerprint":  fingerprint,
+		},
+	}, nil
+}
+
+// getCAPool returns the CA pool to use for cert verification.
+// Role-specific CA overrides the global trusted CAs.
+func (b *certAuthBackend) getCAPool(role *CertRole) (*x509.CertPool, error) {
+	if role.Certificate != "" {
+		return buildCAPool(role.Certificate)
+	}
+	if b.config != nil && b.config.caPool != nil {
+		return b.config.caPool, nil
+	}
+	return nil, nil
+}
+
+// calculateTTL returns the effective TTL, capped by the certificate's NotAfter.
+func (b *certAuthBackend) calculateTTL(cert *x509.Certificate, role *CertRole) time.Duration {
+	// Start with the certificate's remaining validity
+	certTTL := time.Until(cert.NotAfter)
+	if certTTL <= 0 {
+		return 0
+	}
+
+	// Role TTL
+	roleTTL, err := role.ParseTokenTTL()
+	if err != nil {
+		roleTTL = time.Hour
+	}
+
+	// Global config TTL
+	var configTTL time.Duration
+	if b.config != nil {
+		configTTL = b.config.TokenTTL
+	}
+
+	// Pick the smallest positive TTL among: certTTL, roleTTL, configTTL
+	effectiveTTL := certTTL
+	if roleTTL > 0 && roleTTL < effectiveTTL {
+		effectiveTTL = roleTTL
+	}
+	if configTTL > 0 && configTTL < effectiveTTL {
+		effectiveTTL = configTTL
+	}
+
+	return effectiveTTL
+}
+
+// validateCertConstraints checks whether the certificate satisfies the role constraints.
+// If a constraint list is empty, it is not enforced.
+func validateCertConstraints(cert *x509.Certificate, role *CertRole) error {
+	if len(role.AllowedCommonNames) > 0 {
+		if !matchesGlob(cert.Subject.CommonName, role.AllowedCommonNames) {
+			return fmt.Errorf("certificate CN %q not allowed by role", cert.Subject.CommonName)
+		}
+	}
+
+	if len(role.AllowedDNSSANs) > 0 {
+		if !matchesAnyGlob(cert.DNSNames, role.AllowedDNSSANs) {
+			return fmt.Errorf("certificate DNS SANs not allowed by role")
+		}
+	}
+
+	if len(role.AllowedEmailSANs) > 0 {
+		if !matchesAnyGlob(cert.EmailAddresses, role.AllowedEmailSANs) {
+			return fmt.Errorf("certificate email SANs not allowed by role")
+		}
+	}
+
+	if len(role.AllowedURISANs) > 0 {
+		matched := false
+		for _, u := range cert.URIs {
+			if helper.MatchAny(u.String(), role.AllowedURISANs) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("certificate URI SANs not allowed by role")
+		}
+	}
+
+	if len(role.AllowedOrganizationalUnits) > 0 {
+		if !matchesAnyExact(cert.Subject.OrganizationalUnit, role.AllowedOrganizationalUnits) {
+			return fmt.Errorf("certificate OU not allowed by role")
+		}
+	}
+
+	if len(role.AllowedOrganizations) > 0 {
+		if !matchesAnyExact(cert.Subject.Organization, role.AllowedOrganizations) {
+			return fmt.Errorf("certificate organization not allowed by role")
+		}
+	}
+
+	return nil
+}
+
+// extractPrincipal extracts the principal identity from the certificate based on the claim type.
+func extractPrincipal(cert *x509.Certificate, claim string) string {
+	switch claim {
+	case "cn":
+		return cert.Subject.CommonName
+	case "dns_san":
+		if len(cert.DNSNames) > 0 {
+			return cert.DNSNames[0]
+		}
+	case "email_san":
+		if len(cert.EmailAddresses) > 0 {
+			return cert.EmailAddresses[0]
+		}
+	case "uri_san":
+		if len(cert.URIs) > 0 {
+			return cert.URIs[0].String()
+		}
+	case "spiffe_id":
+		for _, u := range cert.URIs {
+			if strings.HasPrefix(u.String(), "spiffe://") {
+				return u.String()
+			}
+		}
+	case "serial":
+		return cert.SerialNumber.String()
+	}
+	return ""
+}
+
+// matchesGlob checks if a value matches any of the glob patterns.
+func matchesGlob(value string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if matched, _ := path.Match(pattern, value); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAnyGlob checks if any of the values matches any of the glob patterns.
+func matchesAnyGlob(values []string, patterns []string) bool {
+	for _, v := range values {
+		if matchesGlob(v, patterns) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAnyExact checks if any of the values matches any of the allowed values exactly.
+func matchesAnyExact(values []string, allowed []string) bool {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		allowedSet[a] = struct{}{}
+	}
+	for _, v := range values {
+		if _, ok := allowedSet[v]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/auth/method/cert/path_login_test.go
+++ b/auth/method/cert/path_login_test.go
@@ -1,0 +1,329 @@
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// testCA generates a test CA certificate and key.
+func testCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "Test CA",
+			Organization: []string{"Test Org"},
+		},
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	cert, _ := x509.ParseCertificate(certDER)
+
+	// PEM encode
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	return cert, key, string(pemBytes)
+}
+
+// testClientCert generates a client certificate signed by the given CA.
+func testClientCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, opts ...func(*x509.Certificate)) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Minute),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	for _, opt := range opts {
+		opt(template)
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create client cert: %v", err)
+	}
+
+	cert, _ := x509.ParseCertificate(certDER)
+	return cert
+}
+
+func TestValidateCertConstraints_AllowedCommonNames(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent-1")
+
+	// Matching glob pattern
+	role := &CertRole{AllowedCommonNames: []string{"agent-*"}}
+	if err := validateCertConstraints(cert, role); err != nil {
+		t.Fatalf("expected no error for matching CN, got: %v", err)
+	}
+
+	// Non-matching glob pattern
+	role = &CertRole{AllowedCommonNames: []string{"server-*"}}
+	if err := validateCertConstraints(cert, role); err == nil {
+		t.Fatal("expected error for non-matching CN")
+	}
+
+	// Empty constraint (should pass)
+	role = &CertRole{}
+	if err := validateCertConstraints(cert, role); err != nil {
+		t.Fatalf("expected no error for empty constraints, got: %v", err)
+	}
+}
+
+func TestValidateCertConstraints_AllowedDNSSANs(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent", func(tmpl *x509.Certificate) {
+		tmpl.DNSNames = []string{"agent.example.com"}
+	})
+
+	// Matching glob
+	role := &CertRole{AllowedDNSSANs: []string{"*.example.com"}}
+	if err := validateCertConstraints(cert, role); err != nil {
+		t.Fatalf("expected no error for matching DNS SAN, got: %v", err)
+	}
+
+	// Non-matching
+	role = &CertRole{AllowedDNSSANs: []string{"*.other.com"}}
+	if err := validateCertConstraints(cert, role); err == nil {
+		t.Fatal("expected error for non-matching DNS SAN")
+	}
+}
+
+func TestValidateCertConstraints_AllowedEmailSANs(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent", func(tmpl *x509.Certificate) {
+		tmpl.EmailAddresses = []string{"agent@example.com"}
+	})
+
+	role := &CertRole{AllowedEmailSANs: []string{"*@example.com"}}
+	if err := validateCertConstraints(cert, role); err != nil {
+		t.Fatalf("expected no error for matching email SAN, got: %v", err)
+	}
+
+	role = &CertRole{AllowedEmailSANs: []string{"*@other.com"}}
+	if err := validateCertConstraints(cert, role); err == nil {
+		t.Fatal("expected error for non-matching email SAN")
+	}
+}
+
+func TestValidateCertConstraints_AllowedURISANs(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent", func(tmpl *x509.Certificate) {
+		u, _ := url.Parse("spiffe://example.com/dept/team/agent")
+		tmpl.URIs = append(tmpl.URIs, u)
+	})
+
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		// Prefix wildcard
+		{"prefix match", "spiffe://example.com/dept/*", false},
+		{"prefix mismatch domain", "spiffe://other.com/dept/*", true},
+		{"prefix mismatch path", "spiffe://example.com/other/*", true},
+
+		// Segment wildcard (+)
+		{"plus trust domain", "spiffe://+/dept/team/agent", false},
+		{"plus middle segment", "spiffe://example.com/+/team/agent", false},
+		{"plus multiple", "spiffe://+/+/+/agent", false},
+		{"plus mismatch", "spiffe://+/other/team/agent", true},
+
+		// Catch-all
+		{"scheme catch-all", "spiffe://*", false},
+		{"scheme catch-all wrong scheme", "https://*", true},
+
+		// Exact match
+		{"exact match", "spiffe://example.com/dept/team/agent", false},
+		{"exact mismatch", "spiffe://example.com/dept/team/other", true},
+
+		// Combined + and *
+		{"plus and star", "spiffe://+/dept/*", false},
+		{"plus and star mismatch", "spiffe://+/other/*", true},
+
+		// Empty constraint (should pass)
+		{"empty constraint", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var role *CertRole
+			if tc.pattern == "" {
+				role = &CertRole{}
+			} else {
+				role = &CertRole{AllowedURISANs: []string{tc.pattern}}
+			}
+			err := validateCertConstraints(cert, role)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for pattern %q, got nil", tc.pattern)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for pattern %q, got: %v", tc.pattern, err)
+			}
+		})
+	}
+}
+
+func TestValidateCertConstraints_AllowedOrganizationalUnits(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent", func(tmpl *x509.Certificate) {
+		tmpl.Subject.OrganizationalUnit = []string{"Engineering"}
+	})
+
+	role := &CertRole{AllowedOrganizationalUnits: []string{"Engineering"}}
+	if err := validateCertConstraints(cert, role); err != nil {
+		t.Fatalf("expected no error for matching OU, got: %v", err)
+	}
+
+	role = &CertRole{AllowedOrganizationalUnits: []string{"Marketing"}}
+	if err := validateCertConstraints(cert, role); err == nil {
+		t.Fatal("expected error for non-matching OU")
+	}
+}
+
+func TestValidateCertConstraints_AllowedOrganizations(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent", func(tmpl *x509.Certificate) {
+		tmpl.Subject.Organization = []string{"Acme Corp"}
+	})
+
+	role := &CertRole{AllowedOrganizations: []string{"Acme Corp"}}
+	if err := validateCertConstraints(cert, role); err != nil {
+		t.Fatalf("expected no error for matching org, got: %v", err)
+	}
+
+	role = &CertRole{AllowedOrganizations: []string{"Other Corp"}}
+	if err := validateCertConstraints(cert, role); err == nil {
+		t.Fatal("expected error for non-matching org")
+	}
+}
+
+func TestExtractPrincipal(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+
+	cert := testClientCert(t, caCert, caKey, "my-agent", func(tmpl *x509.Certificate) {
+		tmpl.DNSNames = []string{"agent.example.com"}
+		tmpl.EmailAddresses = []string{"agent@example.com"}
+		u, _ := url.Parse("spiffe://example.com/agent")
+		tmpl.URIs = append(tmpl.URIs, u)
+	})
+
+	tests := []struct {
+		claim    string
+		expected string
+	}{
+		{"cn", "my-agent"},
+		{"dns_san", "agent.example.com"},
+		{"email_san", "agent@example.com"},
+		{"uri_san", "spiffe://example.com/agent"},
+		{"spiffe_id", "spiffe://example.com/agent"},
+		{"serial", cert.SerialNumber.String()},
+		{"unknown", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.claim, func(t *testing.T) {
+			result := extractPrincipal(cert, tc.claim)
+			if result != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestMatchesGlob(t *testing.T) {
+	tests := []struct {
+		value    string
+		patterns []string
+		expected bool
+	}{
+		{"agent-1", []string{"agent-*"}, true},
+		{"agent-1", []string{"server-*"}, false},
+		{"agent-1", []string{"server-*", "agent-*"}, true},
+		{"exact-match", []string{"exact-match"}, true},
+		{"foo", []string{}, false},
+	}
+
+	for _, tc := range tests {
+		result := matchesGlob(tc.value, tc.patterns)
+		if result != tc.expected {
+			t.Fatalf("matchesGlob(%q, %v) = %v, want %v", tc.value, tc.patterns, result, tc.expected)
+		}
+	}
+}
+
+func TestMatchesAnyExact(t *testing.T) {
+	tests := []struct {
+		values   []string
+		allowed  []string
+		expected bool
+	}{
+		{[]string{"Engineering"}, []string{"Engineering", "Sales"}, true},
+		{[]string{"Marketing"}, []string{"Engineering", "Sales"}, false},
+		{[]string{"A", "B"}, []string{"B"}, true},
+		{[]string{}, []string{"A"}, false},
+	}
+
+	for _, tc := range tests {
+		result := matchesAnyExact(tc.values, tc.allowed)
+		if result != tc.expected {
+			t.Fatalf("matchesAnyExact(%v, %v) = %v, want %v", tc.values, tc.allowed, result, tc.expected)
+		}
+	}
+}
+
+func TestCertFingerprint(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "fingerprint-test")
+
+	fp1 := certFingerprint(cert)
+	fp2 := certFingerprint(cert)
+
+	if fp1 == "" {
+		t.Fatal("expected non-empty fingerprint")
+	}
+	if fp1 != fp2 {
+		t.Fatal("fingerprint should be deterministic")
+	}
+
+	// Different cert → different fingerprint
+	cert2 := testClientCert(t, caCert, caKey, "fingerprint-test-2")
+	fp3 := certFingerprint(cert2)
+	if fp1 == fp3 {
+		t.Fatal("different certs should have different fingerprints")
+	}
+}

--- a/auth/method/cert/path_role.go
+++ b/auth/method/cert/path_role.go
@@ -1,4 +1,4 @@
-package jwt
+package cert
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 const rolePrefix = "role/"
 
 // pathRole returns the role CRUD path definition
-func (b *jwtAuthBackend) pathRole() *framework.Path {
+func (b *certAuthBackend) pathRole() *framework.Path {
 	return &framework.Path{
 		Pattern: "role/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
@@ -25,25 +25,33 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 				Description: "Name of the role",
 				Required:    true,
 			},
-			"bound_audiences": {
+			"allowed_common_names": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: "List of audiences that are valid for this role",
+				Description: "Glob patterns for allowed certificate common names",
 			},
-			"bound_subject": {
-				Type:        framework.TypeString,
-				Description: "Subject claim that must match for this role",
-			},
-			"bound_claims": {
-				Type:        framework.TypeMap,
-				Description: "Map of claims that must match for this role",
-			},
-			"bound_uri_patterns": {
+			"allowed_dns_sans": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: "Segment-aware URI patterns to match against uri_claim (e.g. spiffe://+/dept/*, spiffe://*)",
+				Description: "Glob patterns for allowed DNS SANs",
 			},
-			"uri_claim": {
+			"allowed_email_sans": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "Glob patterns for allowed email SANs",
+			},
+			"allowed_uri_sans": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "Glob patterns for allowed URI SANs",
+			},
+			"allowed_organizational_units": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "Allowed organizational units",
+			},
+			"allowed_organizations": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "Allowed organizations",
+			},
+			"certificate": {
 				Type:        framework.TypeString,
-				Description: "JWT claim to validate against bound_uri_patterns (default: sub)",
+				Description: "Role-specific CA PEM (overrides global trusted CAs)",
 			},
 			"token_policies": {
 				Type:        framework.TypeCommaStringSlice,
@@ -51,7 +59,7 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 			},
 			"token_ttl": {
 				Type:        framework.TypeDurationSecond,
-				Description: "Token TTL",
+				Description: "Token TTL (default: 1h)",
 				Default:     3600,
 			},
 			"token_type": {
@@ -60,18 +68,14 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 				Required:      true,
 				AllowedValues: b.allowedTokenTypeValues(),
 			},
-			"user_claim": {
-				Type:        framework.TypeString,
-				Description: "Claim to use as the principal identity",
-				Default:     "sub",
-			},
 			"cred_spec_name": {
 				Type:        framework.TypeString,
 				Description: "Credential spec name",
 			},
-			"max_age": {
-				Type:        framework.TypeString,
-				Description: "Maximum elapsed time since JWT was issued (iat). Rejects JWTs older than this. Example: 30m, 1h",
+			"principal_claim": {
+				Type:          framework.TypeString,
+				Description:   "Identity source from certificate (overrides global config): cn, dns_san, email_san, uri_san, spiffe_id, serial",
+				AllowedValues: principalClaimAllowedValues(),
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -92,13 +96,13 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 				Summary:  "Delete a role",
 			},
 		},
-		HelpSynopsis:    "Manage JWT auth roles",
-		HelpDescription: "Create, read, update, and delete roles for JWT authentication.",
+		HelpSynopsis:    "Manage certificate auth roles",
+		HelpDescription: "Create, read, update, and delete roles for certificate authentication.",
 	}
 }
 
 // pathRoleList returns the role list path definition
-func (b *jwtAuthBackend) pathRoleList() *framework.Path {
+func (b *certAuthBackend) pathRoleList() *framework.Path {
 	return &framework.Path{
 		Pattern: "role/?$",
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -107,18 +111,18 @@ func (b *jwtAuthBackend) pathRoleList() *framework.Path {
 				Summary:  "List all roles",
 			},
 		},
-		HelpSynopsis:    "List JWT auth roles",
-		HelpDescription: "List all configured roles for JWT authentication.",
+		HelpSynopsis:    "List certificate auth roles",
+		HelpDescription: "List all configured roles for certificate authentication.",
 	}
 }
 
 // isValidTokenType checks if the given token type is valid
-func (b *jwtAuthBackend) isValidTokenType(tokenType string) bool {
+func (b *certAuthBackend) isValidTokenType(tokenType string) bool {
 	return slices.Contains(b.validTokenTypes, tokenType)
 }
 
 // handleRoleCreate creates a new role
-func (b *jwtAuthBackend) handleRoleCreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+func (b *certAuthBackend) handleRoleCreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
 	// Check if role already exists
@@ -153,7 +157,7 @@ func (b *jwtAuthBackend) handleRoleCreate(ctx context.Context, req *logical.Requ
 }
 
 // handleRoleRead reads a role configuration
-func (b *jwtAuthBackend) handleRoleRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+func (b *certAuthBackend) handleRoleRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
 	role, err := b.getRole(ctx, name)
@@ -167,24 +171,25 @@ func (b *jwtAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reques
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
-			"name":               role.Name,
-			"bound_audiences":    role.BoundAudiences,
-			"bound_subject":      role.BoundSubject,
-			"bound_claims":       role.BoundClaims,
-			"bound_uri_patterns": role.BoundURIPatterns,
-			"uri_claim":          role.URIClaim,
-			"token_policies":     role.TokenPolicies,
-			"token_ttl":          role.TokenTTL,
-			"token_type":         role.TokenType,
-			"user_claim":         role.UserClaim,
-			"cred_spec_name":     role.CredSpecName,
-			"max_age":            role.MaxAge,
+			"name":                         role.Name,
+			"allowed_common_names":         role.AllowedCommonNames,
+			"allowed_dns_sans":             role.AllowedDNSSANs,
+			"allowed_email_sans":           role.AllowedEmailSANs,
+			"allowed_uri_sans":             role.AllowedURISANs,
+			"allowed_organizational_units": role.AllowedOrganizationalUnits,
+			"allowed_organizations":        role.AllowedOrganizations,
+			"certificate":                  role.Certificate,
+			"token_policies":               role.TokenPolicies,
+			"token_ttl":                    role.TokenTTL,
+			"token_type":                   role.TokenType,
+			"cred_spec_name":               role.CredSpecName,
+			"principal_claim":              role.PrincipalClaim,
 		},
 	}, nil
 }
 
 // handleRoleUpdate updates an existing role or creates it if it doesn't exist (upsert pattern).
-func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+func (b *certAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
 	role, err := b.getRole(ctx, name)
@@ -197,20 +202,26 @@ func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Requ
 		role = b.buildRoleFromFieldData(name, d)
 	} else {
 		// Update existing role — only update fields that are provided
-		if v, ok := d.GetOk("bound_audiences"); ok {
-			role.BoundAudiences = v.([]string)
+		if v, ok := d.GetOk("allowed_common_names"); ok {
+			role.AllowedCommonNames = v.([]string)
 		}
-		if v, ok := d.GetOk("bound_subject"); ok {
-			role.BoundSubject = v.(string)
+		if v, ok := d.GetOk("allowed_dns_sans"); ok {
+			role.AllowedDNSSANs = v.([]string)
 		}
-		if v, ok := d.GetOk("bound_claims"); ok {
-			role.BoundClaims = v.(map[string]any)
+		if v, ok := d.GetOk("allowed_email_sans"); ok {
+			role.AllowedEmailSANs = v.([]string)
 		}
-		if v, ok := d.GetOk("bound_uri_patterns"); ok {
-			role.BoundURIPatterns = v.([]string)
+		if v, ok := d.GetOk("allowed_uri_sans"); ok {
+			role.AllowedURISANs = v.([]string)
 		}
-		if v, ok := d.GetOk("uri_claim"); ok {
-			role.URIClaim = v.(string)
+		if v, ok := d.GetOk("allowed_organizational_units"); ok {
+			role.AllowedOrganizationalUnits = v.([]string)
+		}
+		if v, ok := d.GetOk("allowed_organizations"); ok {
+			role.AllowedOrganizations = v.([]string)
+		}
+		if v, ok := d.GetOk("certificate"); ok {
+			role.Certificate = v.(string)
 		}
 		if v, ok := d.GetOk("token_policies"); ok {
 			role.TokenPolicies = v.([]string)
@@ -221,14 +232,11 @@ func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Requ
 		if v, ok := d.GetOk("token_type"); ok {
 			role.TokenType = v.(string)
 		}
-		if v, ok := d.GetOk("user_claim"); ok {
-			role.UserClaim = v.(string)
-		}
 		if v, ok := d.GetOk("cred_spec_name"); ok {
 			role.CredSpecName = v.(string)
 		}
-		if v, ok := d.GetOk("max_age"); ok {
-			role.MaxAge = v.(string)
+		if v, ok := d.GetOk("principal_claim"); ok {
+			role.PrincipalClaim = v.(string)
 		}
 	}
 
@@ -259,7 +267,7 @@ func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Requ
 }
 
 // handleRoleDelete deletes a role
-func (b *jwtAuthBackend) handleRoleDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+func (b *certAuthBackend) handleRoleDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
 	if err := b.deleteRole(ctx, name); err != nil {
@@ -275,7 +283,7 @@ func (b *jwtAuthBackend) handleRoleDelete(ctx context.Context, req *logical.Requ
 }
 
 // handleRoleList lists all roles
-func (b *jwtAuthBackend) handleRoleList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+func (b *certAuthBackend) handleRoleList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	roles, err := b.listRoles(ctx)
 	if err != nil {
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
@@ -290,12 +298,7 @@ func (b *jwtAuthBackend) handleRoleList(ctx context.Context, req *logical.Reques
 }
 
 // validateRole validates role fields and sets defaults
-func (b *jwtAuthBackend) validateRole(role *JWTRole) error {
-	// Default user claim
-	if role.UserClaim == "" {
-		role.UserClaim = "sub"
-	}
-
+func (b *certAuthBackend) validateRole(role *CertRole) error {
 	// Default token type from config
 	if role.TokenType == "" && b.config != nil && b.config.TokenType != "" {
 		role.TokenType = b.config.TokenType
@@ -311,56 +314,70 @@ func (b *jwtAuthBackend) validateRole(role *JWTRole) error {
 	if role.TokenTTL == "" {
 		role.TokenTTL = time.Hour.String()
 	}
+	// Validate the TTL parses
 	if _, err := role.ParseTokenTTL(); err != nil {
 		return logical.ErrBadRequestf("invalid token_ttl: %v", err)
 	}
 
-	// Validate URI patterns
-	for _, p := range role.BoundURIPatterns {
+	// Require at least one certificate constraint to prevent overly permissive roles
+	// that would accept any certificate signed by a trusted CA.
+	if len(role.AllowedCommonNames) == 0 &&
+		len(role.AllowedDNSSANs) == 0 &&
+		len(role.AllowedEmailSANs) == 0 &&
+		len(role.AllowedURISANs) == 0 &&
+		len(role.AllowedOrganizationalUnits) == 0 &&
+		len(role.AllowedOrganizations) == 0 {
+		return logical.ErrBadRequest("at least one certificate constraint is required (allowed_common_names, allowed_dns_sans, allowed_email_sans, allowed_uri_sans, allowed_organizational_units, or allowed_organizations)")
+	}
+
+	// Validate URI SAN patterns
+	for _, p := range role.AllowedURISANs {
 		if err := helper.ValidatePattern(p); err != nil {
-			return logical.ErrBadRequestf("invalid bound_uri_patterns pattern: %v", err)
+			return logical.ErrBadRequestf("invalid allowed_uri_sans pattern: %v", err)
 		}
 	}
 
-	// Default URI claim to "sub" when patterns are configured
-	if len(role.BoundURIPatterns) > 0 && role.URIClaim == "" {
-		role.URIClaim = "sub"
+	// Validate principal_claim if provided
+	if role.PrincipalClaim != "" && !isValidPrincipalClaim(role.PrincipalClaim) {
+		return logical.ErrBadRequestf("invalid principal_claim %q; must be one of: %v", role.PrincipalClaim, validPrincipalClaims)
 	}
 
-	// Validate max_age if provided
-	if role.MaxAge != "" {
-		maxAge, err := role.ParseMaxAge()
-		if err != nil {
-			return logical.ErrBadRequestf("invalid max_age: %v", err)
-		}
-		if maxAge <= 0 {
-			return logical.ErrBadRequest("max_age must be a positive duration")
+	// Validate role-specific CA PEM if provided
+	if role.Certificate != "" {
+		if _, err := buildCAPool(role.Certificate); err != nil {
+			return logical.ErrBadRequestf("invalid certificate PEM: %v", err)
 		}
 	}
 
 	return nil
 }
 
-// buildRoleFromFieldData creates a JWTRole from request field data
-func (b *jwtAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldData) *JWTRole {
-	role := &JWTRole{
+// buildRoleFromFieldData creates a CertRole from request field data
+func (b *certAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldData) *CertRole {
+	role := &CertRole{
 		Name: name,
 	}
 
-	if v, ok := d.GetOk("bound_audiences"); ok {
-		role.BoundAudiences = v.([]string)
+	if v, ok := d.GetOk("allowed_common_names"); ok {
+		role.AllowedCommonNames = v.([]string)
 	}
-	if v, ok := d.GetOk("bound_subject"); ok {
-		role.BoundSubject = v.(string)
+	if v, ok := d.GetOk("allowed_dns_sans"); ok {
+		role.AllowedDNSSANs = v.([]string)
 	}
-	if v, ok := d.GetOk("bound_claims"); ok {
-		role.BoundClaims = v.(map[string]any)
+	if v, ok := d.GetOk("allowed_email_sans"); ok {
+		role.AllowedEmailSANs = v.([]string)
 	}
-	if v, ok := d.GetOk("bound_uri_patterns"); ok {
-		role.BoundURIPatterns = v.([]string)
+	if v, ok := d.GetOk("allowed_uri_sans"); ok {
+		role.AllowedURISANs = v.([]string)
 	}
-	if v, ok := d.GetOk("uri_claim"); ok {
-		role.URIClaim = v.(string)
+	if v, ok := d.GetOk("allowed_organizational_units"); ok {
+		role.AllowedOrganizationalUnits = v.([]string)
+	}
+	if v, ok := d.GetOk("allowed_organizations"); ok {
+		role.AllowedOrganizations = v.([]string)
+	}
+	if v, ok := d.GetOk("certificate"); ok {
+		role.Certificate = v.(string)
 	}
 	if v, ok := d.GetOk("token_policies"); ok {
 		role.TokenPolicies = v.([]string)
@@ -371,14 +388,11 @@ func (b *jwtAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldD
 	if v, ok := d.GetOk("token_type"); ok {
 		role.TokenType = v.(string)
 	}
-	if v, ok := d.GetOk("user_claim"); ok {
-		role.UserClaim = v.(string)
-	}
 	if v, ok := d.GetOk("cred_spec_name"); ok {
 		role.CredSpecName = v.(string)
 	}
-	if v, ok := d.GetOk("max_age"); ok {
-		role.MaxAge = v.(string)
+	if v, ok := d.GetOk("principal_claim"); ok {
+		role.PrincipalClaim = v.(string)
 	}
 
 	return role
@@ -386,7 +400,7 @@ func (b *jwtAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldD
 
 // Storage helper methods
 
-func (b *jwtAuthBackend) getRole(ctx context.Context, name string) (*JWTRole, error) {
+func (b *certAuthBackend) getRole(ctx context.Context, name string) (*CertRole, error) {
 	entry, err := b.storageView.Get(ctx, rolePrefix+name)
 	if err != nil {
 		return nil, err
@@ -395,7 +409,7 @@ func (b *jwtAuthBackend) getRole(ctx context.Context, name string) (*JWTRole, er
 		return nil, nil
 	}
 
-	var role JWTRole
+	var role CertRole
 	if err := entry.DecodeJSON(&role); err != nil {
 		return nil, err
 	}
@@ -403,7 +417,7 @@ func (b *jwtAuthBackend) getRole(ctx context.Context, name string) (*JWTRole, er
 	return &role, nil
 }
 
-func (b *jwtAuthBackend) setRole(ctx context.Context, role *JWTRole) error {
+func (b *certAuthBackend) setRole(ctx context.Context, role *CertRole) error {
 	entry, err := sdklogical.StorageEntryJSON(rolePrefix+role.Name, role)
 	if err != nil {
 		return err
@@ -412,11 +426,11 @@ func (b *jwtAuthBackend) setRole(ctx context.Context, role *JWTRole) error {
 	return b.storageView.Put(ctx, entry)
 }
 
-func (b *jwtAuthBackend) deleteRole(ctx context.Context, name string) error {
+func (b *certAuthBackend) deleteRole(ctx context.Context, name string) error {
 	return b.storageView.Delete(ctx, rolePrefix+name)
 }
 
-func (b *jwtAuthBackend) listRoles(ctx context.Context) ([]string, error) {
+func (b *certAuthBackend) listRoles(ctx context.Context) ([]string, error) {
 	entries, err := b.storageView.List(ctx, rolePrefix)
 	if err != nil {
 		return nil, err

--- a/auth/method/cert/revocation.go
+++ b/auth/method/cert/revocation.go
@@ -1,0 +1,200 @@
+package cert
+
+import (
+	"bytes"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ocsp"
+)
+
+// revocationChecker handles CRL and OCSP certificate revocation checks.
+type revocationChecker struct {
+	crlCache    sync.Map // URL → *crlEntry
+	crlCacheTTL time.Duration
+	ocspTimeout time.Duration
+	httpClient  *http.Client
+}
+
+type crlEntry struct {
+	crl       *x509.RevocationList
+	fetchedAt time.Time
+}
+
+func newRevocationChecker(crlCacheTTL, ocspTimeout time.Duration) *revocationChecker {
+	return &revocationChecker{
+		crlCacheTTL: crlCacheTTL,
+		ocspTimeout: ocspTimeout,
+		httpClient: &http.Client{
+			Timeout: ocspTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse // Do not follow redirects
+			},
+		},
+	}
+}
+
+// checkRevocation verifies the certificate has not been revoked.
+// mode: "crl", "ocsp", or "best_effort".
+// verifiedChains comes from cert.Verify() — the first chain is used to find the issuer.
+func (rc *revocationChecker) checkRevocation(cert *x509.Certificate, verifiedChains [][]*x509.Certificate, mode string) error {
+	// Find the issuer certificate from the verified chain
+	var issuer *x509.Certificate
+	if len(verifiedChains) > 0 && len(verifiedChains[0]) > 1 {
+		issuer = verifiedChains[0][1]
+	}
+
+	// Try OCSP first (faster, more current), then CRL
+	ocspErr := rc.checkOCSP(cert, issuer)
+	if ocspErr == nil {
+		return nil // OCSP says good
+	}
+	if isRevoked(ocspErr) {
+		return ocspErr // Definitively revoked
+	}
+
+	// OCSP inconclusive — try CRL
+	crlErr := rc.checkCRL(cert, issuer)
+	if crlErr == nil {
+		return nil // CRL says not revoked
+	}
+	if isRevoked(crlErr) {
+		return crlErr // Definitively revoked
+	}
+
+	// Both checks inconclusive
+	if mode == "best_effort" {
+		return nil // Allow on best_effort
+	}
+	// Strict mode — fail if we can't verify
+	if ocspErr != nil {
+		return fmt.Errorf("revocation check failed: %w", ocspErr)
+	}
+	return fmt.Errorf("revocation check failed: %w", crlErr)
+}
+
+// errRevoked is a sentinel error indicating a certificate has been revoked.
+var errRevoked = fmt.Errorf("certificate has been revoked")
+
+func isRevoked(err error) bool {
+	return err == errRevoked
+}
+
+// checkOCSP queries the OCSP responder for the certificate's revocation status.
+func (rc *revocationChecker) checkOCSP(cert *x509.Certificate, issuer *x509.Certificate) error {
+	if len(cert.OCSPServer) == 0 {
+		return fmt.Errorf("no OCSP responder URL in certificate")
+	}
+	if issuer == nil {
+		return fmt.Errorf("issuer certificate not available for OCSP")
+	}
+
+	ocspReq, err := ocsp.CreateRequest(cert, issuer, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create OCSP request: %w", err)
+	}
+
+	for _, responderURL := range cert.OCSPServer {
+		resp, err := rc.httpClient.Post(responderURL, "application/ocsp-request", bytes.NewReader(ocspReq))
+		if err != nil {
+			continue // Try next responder
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
+		resp.Body.Close()
+		if err != nil {
+			continue
+		}
+
+		ocspResp, err := ocsp.ParseResponseForCert(body, cert, issuer)
+		if err != nil {
+			continue
+		}
+
+		switch ocspResp.Status {
+		case ocsp.Good:
+			return nil
+		case ocsp.Revoked:
+			return errRevoked
+		default:
+			continue // Unknown or other status — try next
+		}
+	}
+
+	return fmt.Errorf("no OCSP responder returned a definitive answer")
+}
+
+// checkCRL downloads and checks the CRL distribution points.
+// The issuer is used to verify the CRL signature when available.
+func (rc *revocationChecker) checkCRL(cert *x509.Certificate, issuer *x509.Certificate) error {
+	if len(cert.CRLDistributionPoints) == 0 {
+		return fmt.Errorf("no CRL distribution points in certificate")
+	}
+
+	for _, crlURL := range cert.CRLDistributionPoints {
+		crl, err := rc.fetchCRL(crlURL, issuer)
+		if err != nil {
+			continue // Try next distribution point
+		}
+
+		for _, revoked := range crl.RevokedCertificateEntries {
+			if revoked.SerialNumber.Cmp(cert.SerialNumber) == 0 {
+				return errRevoked
+			}
+		}
+		// Found a valid CRL that doesn't list this cert — it's good
+		return nil
+	}
+
+	return fmt.Errorf("no CRL distribution point returned a usable CRL")
+}
+
+// fetchCRL retrieves a CRL from the given URL, using cached data when available.
+// The issuer is used to verify the CRL signature; unsigned/forged CRLs are rejected.
+func (rc *revocationChecker) fetchCRL(url string, issuer *x509.Certificate) (*x509.RevocationList, error) {
+	// Check cache
+	if cached, ok := rc.crlCache.Load(url); ok {
+		entry := cached.(*crlEntry)
+		if time.Since(entry.fetchedAt) < rc.crlCacheTTL {
+			return entry.crl, nil
+		}
+	}
+
+	resp, err := rc.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch CRL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CRL endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10MB limit
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CRL response: %w", err)
+	}
+
+	crl, err := x509.ParseRevocationList(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CRL: %w", err)
+	}
+
+	// Verify the CRL was signed by the issuer to prevent forged CRLs
+	if issuer != nil {
+		if err := crl.CheckSignatureFrom(issuer); err != nil {
+			return nil, fmt.Errorf("CRL signature verification failed: %w", err)
+		}
+	}
+
+	rc.crlCache.Store(url, &crlEntry{
+		crl:       crl,
+		fetchedAt: time.Now(),
+	})
+
+	return crl, nil
+}

--- a/auth/method/cert/revocation_test.go
+++ b/auth/method/cert/revocation_test.go
@@ -1,0 +1,189 @@
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRevocationChecker_CheckCRL_NotRevoked(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	clientCert := testClientCert(t, caCert, caKey, "good-client")
+
+	// Create an empty CRL (no revoked certs)
+	crlTemplate := &x509.RevocationList{
+		Number:     big.NewInt(1),
+		ThisUpdate: time.Now(),
+		NextUpdate: time.Now().Add(1 * time.Hour),
+	}
+	crlDER, err := x509.CreateRevocationList(rand.Reader, crlTemplate, caCert, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CRL: %v", err)
+	}
+
+	// Serve CRL via HTTP
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pkix-crl")
+		w.Write(crlDER)
+	}))
+	defer srv.Close()
+
+	// Create cert with CRL distribution point
+	clientCert.CRLDistributionPoints = []string{srv.URL}
+
+	rc := newRevocationChecker(time.Hour, 5*time.Second)
+	err = rc.checkCRL(clientCert, caCert)
+	if err != nil {
+		t.Fatalf("expected no error for non-revoked cert, got: %v", err)
+	}
+}
+
+func TestRevocationChecker_CheckCRL_Revoked(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	clientCert := testClientCert(t, caCert, caKey, "revoked-client")
+
+	// Create a CRL listing the client cert as revoked
+	crlTemplate := &x509.RevocationList{
+		Number:     big.NewInt(1),
+		ThisUpdate: time.Now(),
+		NextUpdate: time.Now().Add(1 * time.Hour),
+		RevokedCertificateEntries: []x509.RevocationListEntry{
+			{
+				SerialNumber:   clientCert.SerialNumber,
+				RevocationTime: time.Now().Add(-10 * time.Minute),
+			},
+		},
+	}
+	crlDER, err := x509.CreateRevocationList(rand.Reader, crlTemplate, caCert, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CRL: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pkix-crl")
+		w.Write(crlDER)
+	}))
+	defer srv.Close()
+
+	clientCert.CRLDistributionPoints = []string{srv.URL}
+
+	rc := newRevocationChecker(time.Hour, 5*time.Second)
+	err = rc.checkCRL(clientCert, caCert)
+	if !isRevoked(err) {
+		t.Fatalf("expected revoked error, got: %v", err)
+	}
+}
+
+func TestRevocationChecker_CheckCRL_NoCRLDistributionPoints(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	clientCert := testClientCert(t, caCert, caKey, "no-cdp-client")
+	// No CRL distribution points set
+
+	rc := newRevocationChecker(time.Hour, 5*time.Second)
+	err := rc.checkCRL(clientCert, caCert)
+	if err == nil {
+		t.Fatal("expected error for cert with no CRL distribution points")
+	}
+}
+
+func TestRevocationChecker_CheckCRL_CachesResults(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	clientCert := testClientCert(t, caCert, caKey, "cache-test-client")
+
+	requestCount := 0
+	crlTemplate := &x509.RevocationList{
+		Number:     big.NewInt(1),
+		ThisUpdate: time.Now(),
+		NextUpdate: time.Now().Add(1 * time.Hour),
+	}
+	crlDER, _ := x509.CreateRevocationList(rand.Reader, crlTemplate, caCert, caKey)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Write(crlDER)
+	}))
+	defer srv.Close()
+
+	clientCert.CRLDistributionPoints = []string{srv.URL}
+
+	rc := newRevocationChecker(time.Hour, 5*time.Second)
+
+	// First request fetches
+	_ = rc.checkCRL(clientCert, caCert)
+	if requestCount != 1 {
+		t.Fatalf("expected 1 request, got %d", requestCount)
+	}
+
+	// Second request uses cache
+	_ = rc.checkCRL(clientCert, caCert)
+	if requestCount != 1 {
+		t.Fatalf("expected 1 request (cached), got %d", requestCount)
+	}
+}
+
+func TestRevocationChecker_CheckRevocation_BestEffort(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	clientCert := testClientCert(t, caCert, caKey, "best-effort-client")
+	// No CRL or OCSP endpoints — both checks will be inconclusive
+
+	chains := [][]*x509.Certificate{{clientCert, caCert}}
+	rc := newRevocationChecker(time.Hour, 5*time.Second)
+
+	// best_effort mode should allow the cert through
+	err := rc.checkRevocation(clientCert, chains, "best_effort")
+	if err != nil {
+		t.Fatalf("expected no error in best_effort mode, got: %v", err)
+	}
+
+	// strict modes should reject
+	err = rc.checkRevocation(clientCert, chains, "crl")
+	if err == nil {
+		t.Fatal("expected error in strict crl mode with no endpoints")
+	}
+}
+
+func TestRevocationChecker_CheckOCSP_NoServers(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+
+	cert := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "test"},
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
+	parsedCert, _ := x509.ParseCertificate(certDER)
+
+	rc := newRevocationChecker(time.Hour, 5*time.Second)
+	err := rc.checkOCSP(parsedCert, nil)
+	if err == nil {
+		t.Fatal("expected error when no OCSP servers configured")
+	}
+}
+
+func TestIsValidRevocationMode(t *testing.T) {
+	tests := []struct {
+		mode  string
+		valid bool
+	}{
+		{"", true},
+		{"none", true},
+		{"crl", true},
+		{"ocsp", true},
+		{"best_effort", true},
+		{"invalid", false},
+		{"NONE", false},
+	}
+
+	for _, tc := range tests {
+		if isValidRevocationMode(tc.mode) != tc.valid {
+			t.Fatalf("isValidRevocationMode(%q) = %v, want %v", tc.mode, !tc.valid, tc.valid)
+		}
+	}
+}

--- a/auth/method/cert/role.go
+++ b/auth/method/cert/role.go
@@ -1,0 +1,29 @@
+package cert
+
+import "time"
+
+// CertRole represents a role configuration for certificate authentication.
+// Used for both runtime and storage (TokenTTL stored as string for JSON readability).
+type CertRole struct {
+	Name                       string   `json:"name"`
+	AllowedCommonNames         []string `json:"allowed_common_names,omitempty"`
+	AllowedDNSSANs             []string `json:"allowed_dns_sans,omitempty"`
+	AllowedEmailSANs           []string `json:"allowed_email_sans,omitempty"`
+	AllowedURISANs             []string `json:"allowed_uri_sans,omitempty"`
+	AllowedOrganizationalUnits []string `json:"allowed_organizational_units,omitempty"`
+	AllowedOrganizations       []string `json:"allowed_organizations,omitempty"`
+	Certificate                string   `json:"certificate,omitempty"` // Role-specific CA PEM (overrides global)
+	TokenPolicies              []string `json:"token_policies"`
+	TokenTTL                   string   `json:"token_ttl"`
+	TokenType                  string   `json:"token_type,omitempty"`
+	CredSpecName               string   `json:"cred_spec_name,omitempty"`
+	PrincipalClaim             string   `json:"principal_claim,omitempty"`
+}
+
+// ParseTokenTTL parses the TokenTTL string to a time.Duration.
+func (r *CertRole) ParseTokenTTL() (time.Duration, error) {
+	if r.TokenTTL == "" {
+		return time.Hour, nil
+	}
+	return time.ParseDuration(r.TokenTTL)
+}

--- a/auth/method/jwt/helper.go
+++ b/auth/method/jwt/helper.go
@@ -5,20 +5,65 @@ import (
 	"strings"
 )
 
-// validateBoundClaims validates that JWT claims match the bound claims
+// errAuthFailed is a generic error returned for all authentication failures
+// to prevent information leakage about which specific check failed.
+var errAuthFailed = fmt.Errorf("authentication failed")
+
+// validateBoundClaims validates that JWT claims match the bound claims.
+// Returns a descriptive error for server-side logging; callers should return
+// errAuthFailed to clients instead.
 func validateBoundClaims(claims map[string]interface{}, boundClaims map[string]any) error {
 	for key, expectedValue := range boundClaims {
 		actualValue, exists := claims[key]
 		if !exists {
-			return fmt.Errorf("required claim '%s' not found in JWT", key)
+			return fmt.Errorf("required claim %q not found in JWT", key)
 		}
 
-		// Simple equality check - in production you'd want more sophisticated matching
-		if fmt.Sprintf("%v", actualValue) != fmt.Sprintf("%v", expectedValue) {
-			return fmt.Errorf("claim '%s' does not match expected value", key)
+		if !claimValuesEqual(actualValue, expectedValue) {
+			return fmt.Errorf("claim %q value mismatch", key)
 		}
 	}
 	return nil
+}
+
+// claimValuesEqual performs type-aware comparison of claim values.
+// Values must be the same type and equal. No cross-type coercion is allowed
+// (e.g., int 1 does NOT match string "1").
+func claimValuesEqual(actual, expected interface{}) bool {
+	switch e := expected.(type) {
+	case string:
+		a, ok := actual.(string)
+		return ok && a == e
+	case float64:
+		// JSON numbers decode as float64
+		switch a := actual.(type) {
+		case float64:
+			return a == e
+		case int:
+			return float64(a) == e
+		case int64:
+			return float64(a) == e
+		default:
+			return false
+		}
+	case int:
+		switch a := actual.(type) {
+		case int:
+			return a == e
+		case int64:
+			return a == int64(e)
+		case float64:
+			return a == float64(e)
+		default:
+			return false
+		}
+	case bool:
+		a, ok := actual.(bool)
+		return ok && a == e
+	default:
+		// Reject unknown types — no implicit coercion
+		return false
+	}
 }
 
 // buildJWTMetadata extracts metadata from JWT claims

--- a/auth/method/jwt/helper_test.go
+++ b/auth/method/jwt/helper_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/auth/helper"
 )
 
 // =============================================================================
@@ -73,7 +75,7 @@ func TestValidateBoundClaims_MissingClaim(t *testing.T) {
 
 	err := validateBoundClaims(claims, boundClaims)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "required claim 'tenant' not found")
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestValidateBoundClaims_MismatchedValue(t *testing.T) {
@@ -87,16 +89,16 @@ func TestValidateBoundClaims_MismatchedValue(t *testing.T) {
 
 	err := validateBoundClaims(claims, boundClaims)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "claim 'tenant' does not match")
+	assert.Contains(t, err.Error(), "mismatch")
 }
 
 func TestValidateBoundClaims_NumericClaim(t *testing.T) {
 	claims := map[string]interface{}{
 		"sub":   "user123",
-		"level": 5,
+		"level": float64(5), // JSON numbers decode as float64
 	}
 	boundClaims := map[string]any{
-		"level": 5,
+		"level": float64(5),
 	}
 
 	err := validateBoundClaims(claims, boundClaims)
@@ -105,7 +107,7 @@ func TestValidateBoundClaims_NumericClaim(t *testing.T) {
 
 func TestValidateBoundClaims_BooleanClaim(t *testing.T) {
 	claims := map[string]interface{}{
-		"sub":     "user123",
+		"sub":      "user123",
 		"is_admin": true,
 	}
 	boundClaims := map[string]any{
@@ -114,6 +116,51 @@ func TestValidateBoundClaims_BooleanClaim(t *testing.T) {
 
 	err := validateBoundClaims(claims, boundClaims)
 	assert.NoError(t, err)
+}
+
+// =============================================================================
+// claimValuesEqual Type Safety Tests (Phase 4: M1)
+// =============================================================================
+
+func TestClaimValuesEqual_TypeSafety(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   interface{}
+		expected interface{}
+		want     bool
+	}{
+		// Same-type matches
+		{"string match", "hello", "hello", true},
+		{"string mismatch", "hello", "world", false},
+		{"float64 match", float64(42), float64(42), true},
+		{"float64 mismatch", float64(42), float64(99), false},
+		{"int match", 5, 5, true},
+		{"int mismatch", 5, 6, false},
+		{"bool true match", true, true, true},
+		{"bool false match", false, false, true},
+		{"bool mismatch", true, false, false},
+
+		// Cross-type numeric (allowed: JSON numbers are float64)
+		{"float64 actual vs int expected", float64(5), 5, true},
+		{"int actual vs float64 expected", 5, float64(5), true},
+		{"int64 actual vs float64 expected", int64(5), float64(5), true},
+
+		// Cross-type rejection (no coercion between unrelated types)
+		{"int vs string rejected", 1, "1", false},
+		{"string vs int rejected", "1", 1, false},
+		{"bool vs string rejected", true, "true", false},
+		{"string vs bool rejected", "true", true, false},
+		{"float vs string rejected", float64(1.0), "1", false},
+		{"string vs float rejected", "1", float64(1.0), false},
+		{"bool vs int rejected", true, 1, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := claimValuesEqual(tc.actual, tc.expected)
+			assert.Equal(t, tc.want, got, "claimValuesEqual(%v [%T], %v [%T])", tc.actual, tc.actual, tc.expected, tc.expected)
+		})
+	}
 }
 
 // =============================================================================
@@ -386,7 +433,7 @@ func TestValidateBoundClaims_TableDriven(t *testing.T) {
 			claims:      map[string]interface{}{"sub": "user", "iss": "wrong"},
 			boundClaims: map[string]any{"iss": "expected"},
 			expectError: true,
-			errorMsg:    "does not match",
+			errorMsg:    "mismatch",
 		},
 		{
 			name:        "Multiple matching claims",
@@ -405,6 +452,57 @@ func TestValidateBoundClaims_TableDriven(t *testing.T) {
 				assert.Contains(t, err.Error(), tc.errorMsg)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// validateBoundURIPatterns Tests (via helper.MatchAny)
+// =============================================================================
+
+func TestBoundURIPatterns_Validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		claimValue string
+		patterns   []string
+		wantMatch  bool
+	}{
+		// SPIFFE ID patterns
+		{"exact spiffe match", "spiffe://example.com/dept/svc", []string{"spiffe://example.com/dept/svc"}, true},
+		{"plus trust domain", "spiffe://example.com/dept/svc", []string{"spiffe://+/dept/svc"}, true},
+		{"prefix wildcard", "spiffe://example.com/dept/team/svc", []string{"spiffe://example.com/dept/*"}, true},
+		{"scheme catch-all", "spiffe://anything/any/path", []string{"spiffe://*"}, true},
+		{"combined plus and star", "spiffe://example.com/dept/team/svc", []string{"spiffe://+/dept/*"}, true},
+		{"mismatch domain", "spiffe://other.com/dept/svc", []string{"spiffe://example.com/dept/svc"}, false},
+		{"mismatch path", "spiffe://example.com/other/svc", []string{"spiffe://+/dept/svc"}, false},
+		{"wrong scheme", "https://example.com/path", []string{"spiffe://*"}, false},
+
+		// Multiple patterns (OR semantics)
+		{"matches second pattern", "spiffe://other.com/web", []string{"spiffe://example.com/web", "spiffe://other.com/web"}, true},
+		{"matches none", "spiffe://third.com/web", []string{"spiffe://example.com/web", "spiffe://other.com/web"}, false},
+
+		// Empty claim
+		{"empty claim value", "", []string{"spiffe://*"}, false},
+		{"empty patterns", "spiffe://example.com/svc", []string{}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := map[string]interface{}{
+				"sub": tc.claimValue,
+			}
+
+			claimValue := extractClaim(claims, "sub")
+			var matched bool
+			if claimValue != "" && len(tc.patterns) > 0 {
+				matched = helper.MatchAny(claimValue, tc.patterns)
+			}
+
+			if tc.wantMatch {
+				assert.True(t, matched, "expected claim %q to match patterns %v", tc.claimValue, tc.patterns)
+			} else {
+				assert.False(t, matched, "expected claim %q NOT to match patterns %v", tc.claimValue, tc.patterns)
 			}
 		})
 	}

--- a/auth/method/jwt/path_login.go
+++ b/auth/method/jwt/path_login.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/cap/jwt"
+	"github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/framework"
+	lgr "github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
 
@@ -73,7 +75,11 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
 	}
 	if role == nil {
-		return logical.ErrorResponse(logical.ErrNotFoundf("role %q not found", roleName)), nil
+		b.logger.Warn("login failed: role not found", lgr.String("role", roleName))
+		return &logical.Response{
+			StatusCode: http.StatusUnauthorized,
+			Err:        errAuthFailed,
+		}, nil
 	}
 
 	// Build expected claims - merge global config with role-specific
@@ -102,26 +108,45 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 
 	claims, err := b.config.validator.Validate(ctx, jwtToken, expected)
 	if err != nil {
+		b.logger.Warn("login failed: JWT validation error", lgr.Err(err), lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        err,
+			Err:        errAuthFailed,
 		}, nil
 	}
 
 	// Validate bound claims from config
 	if err := validateBoundClaims(claims, b.config.BoundClaims); err != nil {
+		b.logger.Warn("login failed: config bound claims check", lgr.Err(err), lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        err,
+			Err:        errAuthFailed,
 		}, nil
 	}
 
 	// Validate bound claims from role
 	if err := validateBoundClaims(claims, role.BoundClaims); err != nil {
+		b.logger.Warn("login failed: role bound claims check", lgr.Err(err), lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        err,
+			Err:        errAuthFailed,
 		}, nil
+	}
+
+	// Validate bound URI patterns against the configured claim
+	if len(role.BoundURIPatterns) > 0 {
+		uriClaim := role.URIClaim
+		if uriClaim == "" {
+			uriClaim = "sub"
+		}
+		claimValue := extractClaim(claims, uriClaim)
+		if claimValue == "" || !helper.MatchAny(claimValue, role.BoundURIPatterns) {
+			b.logger.Warn("login failed: URI pattern mismatch", lgr.String("claim", uriClaim), lgr.String("role", roleName))
+			return &logical.Response{
+				StatusCode: http.StatusUnauthorized,
+				Err:        errAuthFailed,
+			}, nil
+		}
 	}
 
 	// Extract principal identity - use role's user_claim or fallback to config
@@ -131,18 +156,20 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 	}
 	principalID := extractClaim(claims, userClaim)
 	if principalID == "" {
+		b.logger.Warn("login failed: no principal identity in JWT", lgr.String("user_claim", userClaim), lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        fmt.Errorf("no principal identity found in jwt"),
+			Err:        errAuthFailed,
 		}, nil
 	}
 
 	// Extract expiration time
 	expValue, ok := claims["exp"]
 	if !ok {
+		b.logger.Warn("login failed: no exp claim in JWT", lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        fmt.Errorf("no exp found in jwt"),
+			Err:        errAuthFailed,
 		}, nil
 	}
 
@@ -156,9 +183,10 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 	case int:
 		expTimestamp = int64(v)
 	default:
+		b.logger.Warn("login failed: invalid exp format in JWT", lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        fmt.Errorf("invalid exp format in jwt"),
+			Err:        errAuthFailed,
 		}, nil
 	}
 
@@ -166,17 +194,68 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 	jwtTTL := time.Until(jwtExpiration)
 
 	if jwtTTL <= 0 {
+		b.logger.Warn("login failed: JWT has expired", lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
-			Err:        fmt.Errorf("jwt has expired"),
+			Err:        errAuthFailed,
 		}, nil
+	}
+
+	// Validate max_age (iat freshness) if configured on the role
+	if role.MaxAge != "" {
+		maxAge, err := role.ParseMaxAge()
+		if err != nil {
+			b.logger.Warn("login failed: corrupt max_age in role config", lgr.String("role", roleName), lgr.Err(err))
+			return &logical.Response{
+				StatusCode: http.StatusUnauthorized,
+				Err:        errAuthFailed,
+			}, nil
+		}
+		iatValue, ok := claims["iat"]
+		if !ok {
+			b.logger.Warn("login failed: iat claim required when max_age is set", lgr.String("role", roleName))
+			return &logical.Response{
+				StatusCode: http.StatusUnauthorized,
+				Err:        errAuthFailed,
+			}, nil
+		}
+		var iatTimestamp int64
+		switch v := iatValue.(type) {
+		case float64:
+			iatTimestamp = int64(v)
+		case int64:
+			iatTimestamp = v
+		case int:
+			iatTimestamp = int64(v)
+		default:
+			b.logger.Warn("login failed: invalid iat format in JWT", lgr.String("role", roleName))
+			return &logical.Response{
+				StatusCode: http.StatusUnauthorized,
+				Err:        errAuthFailed,
+			}, nil
+		}
+		age := time.Since(time.Unix(iatTimestamp, 0))
+		if age > maxAge {
+			b.logger.Warn("login failed: JWT exceeds max_age",
+				lgr.String("role", roleName),
+				lgr.String("age", age.String()),
+				lgr.String("max_age", maxAge.String()))
+			return &logical.Response{
+				StatusCode: http.StatusUnauthorized,
+				Err:        errAuthFailed,
+			}, nil
+		}
 	}
 
 	// Calculate effective TTL: min(role.TokenTTL, jwtTTL)
 	// The token should never outlive the JWT's actual expiration
 	effectiveTTL := jwtTTL
-	if role.TokenTTL > 0 && role.TokenTTL < jwtTTL {
-		effectiveTTL = role.TokenTTL
+	roleTTL, err := role.ParseTokenTTL()
+	if err != nil {
+		b.logger.Warn("corrupt token_ttl in role config, using JWT TTL", lgr.String("role", roleName), lgr.Err(err))
+	}
+	if roleTTL > 0 && roleTTL < jwtTTL {
+		effectiveTTL = roleTTL
 	}
 
 	// Return auth response using role configuration

--- a/auth/method/jwt/path_role_test.go
+++ b/auth/method/jwt/path_role_test.go
@@ -24,24 +24,24 @@ func TestPathRole_Create(t *testing.T) {
 
 	fieldData := &framework.FieldData{
 		Raw: map[string]any{
-			"name":                "test-role",
-			"bound_audiences":     []string{"aud1", "aud2"},
-			"bound_subject":       "test-subject",
-			"token_policies":      []string{"policy1", "policy2"},
-			"token_ttl":           3600,
-			"token_type":          "service",
-			"user_claim":          "email",
-			"cred_spec_name":      "aws-dev",
+			"name":            "test-role",
+			"bound_audiences": []string{"aud1", "aud2"},
+			"bound_subject":   "test-subject",
+			"token_policies":  []string{"policy1", "policy2"},
+			"token_ttl":       3600,
+			"token_type":      "service",
+			"user_claim":      "email",
+			"cred_spec_name":  "aws-dev",
 		},
 		Schema: map[string]*framework.FieldSchema{
-			"name":                {Type: framework.TypeString},
-			"bound_audiences":     {Type: framework.TypeCommaStringSlice},
-			"bound_subject":       {Type: framework.TypeString},
-			"token_policies":      {Type: framework.TypeCommaStringSlice},
-			"token_ttl":           {Type: framework.TypeDurationSecond, Default: 3600},
-			"token_type":          {Type: framework.TypeString, Default: "service"},
-			"user_claim":          {Type: framework.TypeString, Default: "sub"},
-			"cred_spec_name":      {Type: framework.TypeString},
+			"name":            {Type: framework.TypeString},
+			"bound_audiences": {Type: framework.TypeCommaStringSlice},
+			"bound_subject":   {Type: framework.TypeString},
+			"token_policies":  {Type: framework.TypeCommaStringSlice},
+			"token_ttl":       {Type: framework.TypeDurationSecond, Default: 3600},
+			"token_type":      {Type: framework.TypeString, Default: "service"},
+			"user_claim":      {Type: framework.TypeString, Default: "sub"},
+			"cred_spec_name":  {Type: framework.TypeString},
 		},
 	}
 
@@ -57,7 +57,7 @@ func TestPathRole_Create(t *testing.T) {
 	assert.Equal(t, []string{"aud1", "aud2"}, role.BoundAudiences)
 	assert.Equal(t, "test-subject", role.BoundSubject)
 	assert.Equal(t, []string{"policy1", "policy2"}, role.TokenPolicies)
-	assert.Equal(t, time.Hour, role.TokenTTL)
+	assert.Equal(t, time.Hour.String(), role.TokenTTL)
 	assert.Equal(t, "service", role.TokenType)
 	assert.Equal(t, "email", role.UserClaim)
 	assert.Equal(t, "aws-dev", role.CredSpecName)
@@ -70,7 +70,7 @@ func TestPathRole_CreateDuplicate(t *testing.T) {
 	role := &JWTRole{
 		Name:          "existing-role",
 		TokenPolicies: []string{"policy1"},
-		TokenTTL:      time.Hour,
+		TokenTTL:      time.Hour.String(),
 	}
 	err := b.setRole(ctx, role)
 	require.NoError(t, err)
@@ -81,14 +81,14 @@ func TestPathRole_CreateDuplicate(t *testing.T) {
 			"name": "existing-role",
 		},
 		Schema: map[string]*framework.FieldSchema{
-			"name":                {Type: framework.TypeString},
-			"bound_audiences":     {Type: framework.TypeCommaStringSlice},
-			"bound_subject":       {Type: framework.TypeString},
-			"token_policies":      {Type: framework.TypeCommaStringSlice},
-			"token_ttl":           {Type: framework.TypeDurationSecond, Default: 3600},
-			"token_type":          {Type: framework.TypeString, Default: "service"},
-			"user_claim":          {Type: framework.TypeString, Default: "sub"},
-			"cred_spec_name":      {Type: framework.TypeString},
+			"name":            {Type: framework.TypeString},
+			"bound_audiences": {Type: framework.TypeCommaStringSlice},
+			"bound_subject":   {Type: framework.TypeString},
+			"token_policies":  {Type: framework.TypeCommaStringSlice},
+			"token_ttl":       {Type: framework.TypeDurationSecond, Default: 3600},
+			"token_type":      {Type: framework.TypeString, Default: "service"},
+			"user_claim":      {Type: framework.TypeString, Default: "sub"},
+			"cred_spec_name":  {Type: framework.TypeString},
 		},
 	}
 
@@ -102,14 +102,14 @@ func TestPathRole_Read(t *testing.T) {
 
 	// Create role
 	role := &JWTRole{
-		Name:              "read-test-role",
-		BoundAudiences:    []string{"aud1"},
-		BoundSubject:      "sub1",
-		TokenPolicies:     []string{"policy1"},
-		TokenTTL:          2 * time.Hour,
-		TokenType:         "batch",
-		UserClaim:         "preferred_username",
-		CredSpecName:      "aws-prod",
+		Name:           "read-test-role",
+		BoundAudiences: []string{"aud1"},
+		BoundSubject:   "sub1",
+		TokenPolicies:  []string{"policy1"},
+		TokenTTL:       (2 * time.Hour).String(),
+		TokenType:      "batch",
+		UserClaim:      "preferred_username",
+		CredSpecName:   "aws-prod",
 	}
 	err := b.setRole(ctx, role)
 	require.NoError(t, err)
@@ -155,12 +155,12 @@ func TestPathRole_Update(t *testing.T) {
 
 	// Create initial role
 	role := &JWTRole{
-		Name:              "update-test-role",
-		BoundAudiences:    []string{"aud1"},
-		TokenPolicies:     []string{"policy1"},
-		TokenTTL:          time.Hour,
-		TokenType:         "service",
-		UserClaim:         "sub",
+		Name:           "update-test-role",
+		BoundAudiences: []string{"aud1"},
+		TokenPolicies:  []string{"policy1"},
+		TokenTTL:       time.Hour.String(),
+		TokenType:      "service",
+		UserClaim:      "sub",
 	}
 	err := b.setRole(ctx, role)
 	require.NoError(t, err)
@@ -174,14 +174,14 @@ func TestPathRole_Update(t *testing.T) {
 			"cred_spec_name": "new-aws-spec",
 		},
 		Schema: map[string]*framework.FieldSchema{
-			"name":                {Type: framework.TypeString},
-			"bound_audiences":     {Type: framework.TypeCommaStringSlice},
-			"bound_subject":       {Type: framework.TypeString},
-			"token_policies":      {Type: framework.TypeCommaStringSlice},
-			"token_ttl":           {Type: framework.TypeDurationSecond},
-			"token_type":          {Type: framework.TypeString},
-			"user_claim":          {Type: framework.TypeString},
-			"cred_spec_name":      {Type: framework.TypeString},
+			"name":            {Type: framework.TypeString},
+			"bound_audiences": {Type: framework.TypeCommaStringSlice},
+			"bound_subject":   {Type: framework.TypeString},
+			"token_policies":  {Type: framework.TypeCommaStringSlice},
+			"token_ttl":       {Type: framework.TypeDurationSecond},
+			"token_type":      {Type: framework.TypeString},
+			"user_claim":      {Type: framework.TypeString},
+			"cred_spec_name":  {Type: framework.TypeString},
 		},
 	}
 
@@ -193,7 +193,7 @@ func TestPathRole_Update(t *testing.T) {
 	updatedRole, err := b.getRole(ctx, "update-test-role")
 	require.NoError(t, err)
 	assert.Len(t, updatedRole.TokenPolicies, 3)
-	assert.Equal(t, 2*time.Hour, updatedRole.TokenTTL)
+	assert.Equal(t, (2 * time.Hour).String(), updatedRole.TokenTTL)
 	assert.Equal(t, "new-aws-spec", updatedRole.CredSpecName)
 	// Verify unchanged fields
 	assert.Len(t, updatedRole.BoundAudiences, 1)
@@ -228,7 +228,7 @@ func TestPathRole_UpdateCreatesIfNotExists(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, createdRole)
 	assert.Equal(t, "new-role-via-update", createdRole.Name)
-	assert.Equal(t, time.Hour, createdRole.TokenTTL)
+	assert.Equal(t, time.Hour.String(), createdRole.TokenTTL)
 	assert.Equal(t, "service", createdRole.TokenType)
 	// Verify defaults were applied
 	assert.Equal(t, "sub", createdRole.UserClaim)
@@ -241,7 +241,7 @@ func TestPathRole_Delete(t *testing.T) {
 	role := &JWTRole{
 		Name:          "delete-test-role",
 		TokenPolicies: []string{"policy1"},
-		TokenTTL:      time.Hour,
+		TokenTTL:      time.Hour.String(),
 	}
 	err := b.setRole(ctx, role)
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestPathRole_List(t *testing.T) {
 		role := &JWTRole{
 			Name:          name,
 			TokenPolicies: []string{"policy1"},
-			TokenTTL:      time.Hour,
+			TokenTTL:      time.Hour.String(),
 		}
 		err := b.setRole(ctx, role)
 		require.NoError(t, err)
@@ -318,14 +318,14 @@ func TestRole_StorageRoundTrip(t *testing.T) {
 	b, ctx := createTestBackendWithStorage(t)
 
 	original := &JWTRole{
-		Name:              "roundtrip-role",
-		BoundAudiences:    []string{"aud1", "aud2"},
-		BoundSubject:      "test-subject",
-		TokenPolicies:     []string{"policy1", "policy2"},
-		TokenTTL:          2*time.Hour + 30*time.Minute,
-		TokenType:         "batch",
-		UserClaim:         "preferred_username",
-		CredSpecName:      "aws-test-spec",
+		Name:           "roundtrip-role",
+		BoundAudiences: []string{"aud1", "aud2"},
+		BoundSubject:   "test-subject",
+		TokenPolicies:  []string{"policy1", "policy2"},
+		TokenTTL:       (2*time.Hour + 30*time.Minute).String(),
+		TokenType:      "batch",
+		UserClaim:      "preferred_username",
+		CredSpecName:   "aws-test-spec",
 	}
 
 	// Store
@@ -356,14 +356,14 @@ func TestRole_Defaults(t *testing.T) {
 			"token_type": "warden_token", // Required field
 		},
 		Schema: map[string]*framework.FieldSchema{
-			"name":                {Type: framework.TypeString},
-			"bound_audiences":     {Type: framework.TypeCommaStringSlice},
-			"bound_subject":       {Type: framework.TypeString},
-			"token_policies":      {Type: framework.TypeCommaStringSlice},
-			"token_ttl":           {Type: framework.TypeDurationSecond, Default: 3600},
-			"token_type":          {Type: framework.TypeString, Required: true},
-			"user_claim":          {Type: framework.TypeString, Default: "sub"},
-			"cred_spec_name":      {Type: framework.TypeString},
+			"name":            {Type: framework.TypeString},
+			"bound_audiences": {Type: framework.TypeCommaStringSlice},
+			"bound_subject":   {Type: framework.TypeString},
+			"token_policies":  {Type: framework.TypeCommaStringSlice},
+			"token_ttl":       {Type: framework.TypeDurationSecond, Default: 3600},
+			"token_type":      {Type: framework.TypeString, Required: true},
+			"user_claim":      {Type: framework.TypeString, Default: "sub"},
+			"cred_spec_name":  {Type: framework.TypeString},
 		},
 	}
 
@@ -375,7 +375,7 @@ func TestRole_Defaults(t *testing.T) {
 
 	// Verify defaults were applied
 	assert.Equal(t, "sub", role.UserClaim)
-	assert.Equal(t, time.Hour, role.TokenTTL)
+	assert.Equal(t, time.Hour.String(), role.TokenTTL)
 }
 
 // =============================================================================
@@ -395,8 +395,10 @@ func TestPathRole_Fields(t *testing.T) {
 
 	// Check all expected fields exist
 	expectedFields := []string{
-		"name", "bound_audiences", "bound_subject", "token_policies",
+		"name", "bound_audiences", "bound_subject", "bound_claims",
+		"bound_uri_patterns", "uri_claim", "token_policies",
 		"token_ttl", "token_type", "user_claim", "cred_spec_name",
+		"max_age",
 	}
 
 	for _, field := range expectedFields {
@@ -434,4 +436,75 @@ func TestPathRoleList_Operations(t *testing.T) {
 
 	_, hasList := path.Operations[logical.ListOperation]
 	assert.True(t, hasList, "Should have list operation")
+}
+
+func TestPathRole_MaxAgeValidation(t *testing.T) {
+	b, ctx := createTestBackendWithStorage(t)
+
+	tests := []struct {
+		name      string
+		maxAge    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{"valid 30m", "30m", false, ""},
+		{"valid 1h", "1h", false, ""},
+		{"valid 24h", "24h", false, ""},
+		{"invalid format", "not-a-duration", true, "invalid max_age"},
+		{"negative", "-5m", true, "must be a positive"},
+		{"zero", "0s", true, "must be a positive"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldData := &framework.FieldData{
+				Raw: map[string]any{
+					"name":       "max-age-test-" + tc.name,
+					"token_type": "service",
+					"max_age":    tc.maxAge,
+				},
+				Schema: map[string]*framework.FieldSchema{
+					"name":       {Type: framework.TypeString},
+					"token_type": {Type: framework.TypeString},
+					"max_age":    {Type: framework.TypeString},
+					"token_ttl":  {Type: framework.TypeDurationSecond, Default: 3600},
+					"user_claim": {Type: framework.TypeString, Default: "sub"},
+				},
+			}
+
+			resp, err := b.handleRoleCreate(ctx, &logical.Request{}, fieldData)
+			require.NoError(t, err)
+			if tc.wantErr {
+				assert.NotNil(t, resp.Err, "expected error for max_age=%q", tc.maxAge)
+				if tc.errSubstr != "" {
+					assert.Contains(t, resp.Err.Error(), tc.errSubstr)
+				}
+			} else {
+				assert.Nil(t, resp.Err, "expected no error for max_age=%q", tc.maxAge)
+				assert.Equal(t, http.StatusCreated, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestPathRole_MaxAgeRoundTrip(t *testing.T) {
+	b, ctx := createTestBackendWithStorage(t)
+
+	role := &JWTRole{
+		Name:      "max-age-roundtrip",
+		TokenTTL:  time.Hour.String(),
+		TokenType: "service",
+		UserClaim: "sub",
+		MaxAge:    "30m",
+	}
+	err := b.setRole(ctx, role)
+	require.NoError(t, err)
+
+	retrieved, err := b.getRole(ctx, "max-age-roundtrip")
+	require.NoError(t, err)
+	assert.Equal(t, "30m", retrieved.MaxAge)
+
+	maxAge, err := retrieved.ParseMaxAge()
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, maxAge)
 }

--- a/auth/method/jwt/role.go
+++ b/auth/method/jwt/role.go
@@ -4,28 +4,36 @@ import (
 	"time"
 )
 
-// JWTRole represents a role configuration for JWT authentication
+// JWTRole represents a role configuration for JWT authentication.
+// Used for both runtime and storage (TokenTTL stored as string for JSON readability).
 type JWTRole struct {
-	Name           string         `json:"name"`
-	BoundAudiences []string       `json:"bound_audiences,omitempty"`
-	BoundSubject   string         `json:"bound_subject,omitempty"`
-	BoundClaims    map[string]any `json:"bound_claims,omitempty"`
-	TokenPolicies  []string       `json:"token_policies"`
-	TokenTTL       time.Duration  `json:"token_ttl"`
-	TokenType      string         `json:"token_type,omitempty"`
-	UserClaim      string         `json:"user_claim,omitempty"`
-	CredSpecName   string         `json:"cred_spec_name,omitempty"`
+	Name             string         `json:"name"`
+	BoundAudiences   []string       `json:"bound_audiences,omitempty"`
+	BoundSubject     string         `json:"bound_subject,omitempty"`
+	BoundClaims      map[string]any `json:"bound_claims,omitempty"`
+	BoundURIPatterns []string       `json:"bound_uri_patterns,omitempty"` // Segment-aware URI patterns (e.g. spiffe://+/dept/*)
+	URIClaim         string         `json:"uri_claim,omitempty"`          // Claim to match against URI patterns (default: "sub")
+	TokenPolicies    []string       `json:"token_policies"`
+	TokenTTL         string         `json:"token_ttl"`
+	TokenType        string         `json:"token_type,omitempty"`
+	UserClaim        string         `json:"user_claim,omitempty"`
+	CredSpecName     string         `json:"cred_spec_name,omitempty"`
+	MaxAge           string         `json:"max_age,omitempty"`            // Max time since iat (e.g. "30m", "1h"). Empty = no check.
 }
 
-// StoredRole is the JSON-serializable format for storage
-type StoredRole struct {
-	Name           string         `json:"name"`
-	BoundAudiences []string       `json:"bound_audiences,omitempty"`
-	BoundSubject   string         `json:"bound_subject,omitempty"`
-	BoundClaims    map[string]any `json:"bound_claims,omitempty"`
-	TokenPolicies  []string       `json:"token_policies"`
-	TokenTTL       string         `json:"token_ttl"`
-	TokenType      string         `json:"token_type,omitempty"`
-	UserClaim      string         `json:"user_claim,omitempty"`
-	CredSpecName   string         `json:"cred_spec_name,omitempty"`
+// ParseTokenTTL parses the TokenTTL string to a time.Duration.
+func (r *JWTRole) ParseTokenTTL() (time.Duration, error) {
+	if r.TokenTTL == "" {
+		return time.Hour, nil
+	}
+	return time.ParseDuration(r.TokenTTL)
+}
+
+// ParseMaxAge parses the MaxAge string to a time.Duration.
+// Returns 0 if MaxAge is not set.
+func (r *JWTRole) ParseMaxAge() (time.Duration, error) {
+	if r.MaxAge == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(r.MaxAge)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	wardenapi "github.com/stephnangue/warden/api"
 	"github.com/stephnangue/warden/audit"
+	"github.com/stephnangue/warden/auth/method/cert"
 	"github.com/stephnangue/warden/auth/method/jwt"
 	"github.com/stephnangue/warden/config"
 	"github.com/stephnangue/warden/core"
@@ -101,7 +102,8 @@ Usage: warden server [options]
 	}
 
 	authMethods = map[string]wardenlogical.Factory{
-		"jwt": jwt.Factory,
+		"jwt":  jwt.Factory,
+		"cert": cert.Factory,
 	}
 
 	storageBackends = map[string]physical.Factory{
@@ -482,12 +484,14 @@ func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, 
 		case listenerTypeTCP, listenerTypeUnix:
 			// construct api listener using shared HTTP handler
 			ln, err := api.NewApiListener(api.ApiListenerConfig{
-				Logger:          logger.WithSystem(subsystemListener),
-				Address:         lnConfig.Address,
-				TLSCertFile:     lnConfig.TLSCertFile,
-				TLSKeyFile:      lnConfig.TLSKeyFile,
-				TLSClientCAFile: lnConfig.TLSClientCAFile,
-				TLSEnabled:      lnConfig.TLSEnabled,
+				Logger:               logger.WithSystem(subsystemListener),
+				Address:              lnConfig.Address,
+				TLSCertFile:          lnConfig.TLSCertFile,
+				TLSKeyFile:           lnConfig.TLSKeyFile,
+				TLSClientCAFile:      lnConfig.TLSClientCAFile,
+				TLSEnabled:           lnConfig.TLSEnabled,
+				TLSRequireClientCert: lnConfig.TLSRequireClientCert,
+				TrustedProxies:       lnConfig.TrustedProxies,
 			}, httpHandler)
 			if err != nil {
 				return nil, fmt.Errorf("error initializing listener of type %s: %s", lnConfig.Type, err)

--- a/config/config.go
+++ b/config/config.go
@@ -412,12 +412,14 @@ func (s *StorageBlock) Config() map[string]string {
 }
 
 type ListenerBlock struct {
-	Type            string `hcl:"type,label"` // "tcp", "unix", etc.
-	Address         string `hcl:"address"`
-	TLSCertFile     string `hcl:"tls_cert_file,optional"`
-	TLSKeyFile      string `hcl:"tls_key_file,optional"`
-	TLSClientCAFile string `hcl:"tls_client_ca_file,optional"`
-	TLSEnabled      bool   `hcl:"tls_enabled,optional"`
+	Type                  string   `hcl:"type,label"` // "tcp", "unix", etc.
+	Address               string   `hcl:"address"`
+	TLSCertFile           string   `hcl:"tls_cert_file,optional"`
+	TLSKeyFile            string   `hcl:"tls_key_file,optional"`
+	TLSClientCAFile       string   `hcl:"tls_client_ca_file,optional"`
+	TLSEnabled            bool     `hcl:"tls_enabled,optional"`
+	TLSRequireClientCert  *bool    `hcl:"tls_require_client_cert,optional"` // nil = default (true when tls_client_ca_file set)
+	TrustedProxies        []string `hcl:"trusted_proxies,optional"`         // CIDR ranges for LB cert forwarding
 }
 
 func LoadConfig(configFile string) (*Config, error) {

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,7 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/pathmanager"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
@@ -1014,75 +1016,97 @@ func (c *Core) isTransparentRequest(req *logical.Request, backend logical.Backen
 }
 
 // handleTransparentAuth performs implicit authentication for transparent mode requests.
-// It first tries to lookup the token (which may be a JWT) using the existing token store.
-// If not found, it performs implicit auth via the configured auto-auth path.
+// It detects the credential type (JWT bearer token or TLS client certificate) and
+// performs lookup/implicit auth accordingly.
 // Uses singleflight to prevent duplicate token creation when concurrent requests
-// arrive with the same JWT+role combination.
+// arrive with the same credential+role combination.
 //
 // IMPORTANT: The role is validated when reusing cached tokens. A token created for
-// JWT+Role1 cannot be reused for JWT+Role2, as they may have different policies.
+// credential+Role1 cannot be reused for credential+Role2, as they may have different policies.
 func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, backend logical.Backend, role string) error {
 	// Mark request as transparent mode - credentials will be cache-only
 	req.Transparent = true
 
 	tmp := backend.(logical.TransparentModeProvider)
 	autoAuthPath := tmp.GetAutoAuthPath()
-	clientToken := req.ClientToken
-
-	// Unauthenticated paths are handled earlier in handleNonLoginRequest
-	// (before we even enter handleTransparentAuth), so if we get here with
-	// no token, it's an error.
-	if clientToken == "" {
-		return fmt.Errorf("no token provided for transparent mode request")
-	}
 
 	// Check if role is available (either from URL or default_role config)
 	if role == "" {
 		return fmt.Errorf("transparent mode requires a role: use /role/{role}/gateway/... path or configure default_role")
 	}
 
-	// Transparent mode only supports JWT tokens
-	if !strings.HasPrefix(clientToken, "eyJ") {
-		return fmt.Errorf("transparent mode requires a JWT token (expected eyJ prefix)")
+	// Detect credential type: client certificate or JWT bearer token
+	var singleflightKey string
+	var lookupFunc func() (*TokenEntry, error)
+	var loginData map[string]any
+	var postLoginLookup func() (*TokenEntry, error)
+
+	// Check for client certificate first (forwarded from LB or direct TLS)
+	clientCert := extractTransparentClientCert(req)
+
+	switch {
+	case clientCert != nil:
+		// Certificate-based transparent auth
+		hash := sha256.Sum256(clientCert.Raw)
+		fingerprint := hex.EncodeToString(hash[:])
+		sfHash := sha256.Sum256([]byte("cert:" + fingerprint + ":" + role))
+		singleflightKey = hex.EncodeToString(sfHash[:])
+		loginData = map[string]any{"role": role}
+		lookupFunc = func() (*TokenEntry, error) {
+			return c.LookupCertTokenWithRole(ctx, fingerprint, role)
+		}
+		postLoginLookup = lookupFunc
+
+	case strings.HasPrefix(req.ClientToken, "eyJ"):
+		// JWT-based transparent auth
+		clientToken := req.ClientToken
+		jwtHash := sha256.Sum256([]byte(clientToken + ":" + role))
+		singleflightKey = hex.EncodeToString(jwtHash[:])
+		loginData = map[string]any{"jwt": clientToken, "role": role}
+		lookupFunc = func() (*TokenEntry, error) {
+			return c.LookupJWTTokenWithRole(ctx, clientToken, role)
+		}
+		postLoginLookup = lookupFunc
+
+	default:
+		return fmt.Errorf("no valid credential for transparent mode (need JWT bearer token or TLS client certificate)")
 	}
 
-	// Step 1: Try to lookup the token using JWT+role for proper ID computation
-	te, err := c.LookupJWTTokenWithRole(ctx, clientToken, role)
+	// Step 1: Try cached lookup
+	// Note: cached tokens are returned without re-checking certificate revocation.
+	// This is an accepted design trade-off — revocation is a best-effort signal and
+	// the token TTL (default 1h) bounds the exposure window. Explicit login requests
+	// always perform full revocation checks. To reduce exposure for revoked certs,
+	// configure a shorter token_ttl on cert roles.
+	te, err := lookupFunc()
 	if err == nil && te != nil {
-		// Token found with correct role
 		req.SetTokenEntry(te)
+		// For cert transparent auth, ClientToken is empty since the client only
+		// sends a certificate. Set it to the token ID so the downstream policy
+		// check in fetchCBPAndTokenEntry doesn't reject it.
+		if req.ClientToken == "" {
+			req.ClientToken = te.ID
+		}
 		return nil
 	}
 
-	// Step 2: Token not found - perform implicit auth with singleflight
-	// Use hash of JWT+role as the key to:
-	// 1. Reduce memory overhead (JWTs can be 1-2KB+)
-	// 2. Avoid storing sensitive JWT in singleflight map keys
-	// 3. Ensure fast fixed-size key comparison
-	jwtHash := sha256.Sum256([]byte(clientToken + ":" + role))
-	singleflightKey := hex.EncodeToString(jwtHash[:])
-
-	// Use singleflight to ensure only one implicit auth per JWT+role combination
-	// This prevents duplicate token creation when concurrent requests arrive
+	// Step 2: Token not found — perform implicit auth with singleflight
 	result, err, shared := c.transparentAuthGroup.Do(singleflightKey, func() (interface{}, error) {
-		// Double-check: another goroutine may have just created the token for this role
-		checkTE, lookupErr := c.LookupJWTTokenWithRole(ctx, clientToken, role)
+		// Double-check: another goroutine may have just created the token
+		checkTE, lookupErr := lookupFunc()
 		if lookupErr == nil && checkTE != nil {
 			return checkTE, nil
 		}
 
-		// Build login request to the auto-auth path (e.g., auth/jwt/login)
+		// Build login request to the auto-auth path (e.g., auth/jwt/login or auth/cert/login)
 		loginPath := strings.TrimSuffix(autoAuthPath, "/") + "/login"
 		loginReq := &logical.Request{
 			Operation:   logical.UpdateOperation,
 			Path:        loginPath,
-			HTTPRequest: req.HTTPRequest,
-			Data: map[string]any{
-				"jwt":  clientToken,
-				"role": role,
-			},
-			ClientIP:  req.ClientIP,
-			RequestID: req.RequestID,
+			HTTPRequest: req.HTTPRequest, // Carries TLS info and forwarded cert context
+			Data:        loginData,
+			ClientIP:    req.ClientIP,
+			RequestID:   req.RequestID,
 		}
 
 		// Perform the login request
@@ -1091,7 +1115,6 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 			return nil, loginErr
 		}
 
-		// Check for authentication errors (e.g., expired JWT, invalid token)
 		if loginResp != nil && loginResp.Err != nil {
 			return nil, loginResp.Err
 		}
@@ -1100,9 +1123,8 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 			return nil, fmt.Errorf("implicit auth returned no auth data")
 		}
 
-		// Lookup the newly created token using JWT+role
-		// The token was created with the JWT as its lookup value, so we can find it directly
-		newTE, lookupErr := c.LookupJWTTokenWithRole(ctx, clientToken, role)
+		// Lookup the newly created token
+		newTE, lookupErr := postLoginLookup()
 		if lookupErr != nil {
 			return nil, fmt.Errorf("failed to lookup created token: %w", lookupErr)
 		}
@@ -1111,16 +1133,34 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 	})
 
 	if err != nil {
-		// Don't cache errors - allow next request to retry
 		c.transparentAuthGroup.Forget(singleflightKey)
 		return err
 	}
 
 	te = result.(*TokenEntry)
-	_ = shared // suppress unused variable warning
+	_ = shared
 
-	// Set the token entry on the request
 	req.SetTokenEntry(te)
-
+	// Ensure ClientToken is set so downstream policy checks (fetchCBPAndTokenEntry)
+	// don't short-circuit on the empty-token guard. For JWT transparent auth the
+	// JWT string is already in ClientToken, but for cert transparent auth there is
+	// no token in the request — only a certificate.
+	if req.ClientToken == "" {
+		req.ClientToken = te.ID
+	}
 	return nil
+}
+
+// extractTransparentClientCert extracts the client certificate from a request.
+// Warden always sits behind a load balancer — client certs arrive exclusively
+// via the X-SSL-Client-Cert header, parsed by the cert forwarding middleware
+// and stored in the request context. On cluster-forwarded requests (standby →
+// leader), the header is re-forwarded and re-parsed, so ForwardedClientCert
+// works correctly for both direct and forwarded paths.
+func extractTransparentClientCert(req *logical.Request) *x509.Certificate {
+	if req.HTTPRequest == nil {
+		return nil
+	}
+
+	return listener.ForwardedClientCert(req.HTTPRequest.Context())
 }

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -885,7 +885,7 @@ func TestHandleTransparentAuth(t *testing.T) {
 	core := createTestCore(t)
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
-	t.Run("returns error when no token provided", func(t *testing.T) {
+	t.Run("returns error when no credential provided", func(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: true,
 			autoAuthPath:    "auth/jwt/",
@@ -896,10 +896,10 @@ func TestHandleTransparentAuth(t *testing.T) {
 
 		err := core.handleTransparentAuth(ctx, req, backend, "terraform")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no token provided")
+		assert.Contains(t, err.Error(), "no valid credential")
 	})
 
-	t.Run("returns error for non-JWT token", func(t *testing.T) {
+	t.Run("returns error for non-JWT non-cert token", func(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: true,
 			autoAuthPath:    "auth/jwt/",
@@ -910,7 +910,7 @@ func TestHandleTransparentAuth(t *testing.T) {
 
 		err := core.handleTransparentAuth(ctx, req, backend, "terraform")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "transparent mode requires a JWT token")
+		assert.Contains(t, err.Error(), "no valid credential")
 	})
 
 	t.Run("uses existing JWT token when found in cache", func(t *testing.T) {

--- a/core/token_store.go
+++ b/core/token_store.go
@@ -24,6 +24,7 @@ const (
 	TypeAWSAccessKeys = "aws_access_keys"
 	TypeWardenToken   = "warden_token"
 	TypeJWTRole       = "jwt_role"
+	TypeCertRole      = "cert_role"
 )
 
 // Storage path constants for token store organization
@@ -310,6 +311,7 @@ func (s *TokenStore) registerBuiltinTypes() error {
 		&AWSAccessKeysTokenType{},
 		&WardenTokenType{},
 		&JWTRoleTokenType{},
+		&CertRoleTokenType{},
 	}
 
 	for _, tokenType := range builtinTypes {
@@ -409,10 +411,10 @@ func (s *TokenStore) generateWithCollisionDetection(
 
 		// Check for existing token with same ID
 		if existingEntry, found := s.byID.Get(entry.ID); found {
-			// For JWT tokens, the ID is deterministic (based on jwt:role hash).
-			// Finding an existing token means this JWT+role already has a valid token.
+			// For JWT and cert tokens, the ID is deterministic (based on credential:role hash).
+			// Finding an existing token means this credential+role already has a valid token.
 			// Return the existing token instead of treating it as a collision.
-			if meta.Name == TypeJWTRole {
+			if meta.Name == TypeJWTRole || meta.Name == TypeCertRole {
 				return existingEntry, nil
 			}
 
@@ -453,9 +455,9 @@ func (s *TokenStore) generateWithCollisionDetection(
 		}
 
 		// Register token with expiration manager for timer-based TTL enforcement
-		// JWT role tokens are cache-only, so don't persist their expiration entries
+		// JWT and cert role tokens are cache-only, so don't persist their expiration entries
 		if expMgr := s.core.GetExpirationManager(); expMgr != nil && ttl > 0 {
-			persist := entry.Type != TypeJWTRole
+			persist := entry.Type != TypeJWTRole && entry.Type != TypeCertRole
 			if err := expMgr.RegisterToken(ctx, entry.ID, ttl, persist); err != nil {
 				s.logger.Warn("failed to register token with expiration manager",
 					logger.String("token_id", entry.ID),
@@ -1016,8 +1018,8 @@ func (s *TokenStore) ReplaceRootTokenValue(customToken string) error {
 // Uses a transaction to ensure atomicity: both token and accessor are stored together
 // or neither is stored if any operation fails
 func (s *TokenStore) persistToken(entry *TokenEntry) error {
-	// Skip persistence for jwt_role tokens - they are cache-only
-	if entry.Type == TypeJWTRole {
+	// Skip persistence for jwt_role and cert_role tokens - they are cache-only
+	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole {
 		return nil
 	}
 
@@ -1283,8 +1285,8 @@ func (s *TokenStore) loadTokenByAccessor(accessor string) (*TokenEntry, error) {
 // Uses a transaction to ensure atomicity: both token and accessor are deleted together
 // or neither is deleted if any operation fails
 func (s *TokenStore) deleteToken(entry *TokenEntry) error {
-	// Skip storage operations for jwt_role tokens - they are cache-only
-	if entry.Type == TypeJWTRole {
+	// Skip storage operations for jwt_role and cert_role tokens - they are cache-only
+	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole {
 		return nil
 	}
 
@@ -1564,6 +1566,112 @@ func (c *Core) LookupJWTTokenWithRole(ctx context.Context, jwt string, role stri
 	// to prevent timing attacks
 	if subtle.ConstantTimeCompare([]byte(expectedHash), []byte(jwtHash)) != 1 {
 		s.logger.Error("JWT token value mismatch",
+			logger.String("token_id", tokenID),
+			logger.String("lookup_key", lookupKey))
+		return nil, ErrTokenNotFound
+	}
+
+	// Validate expiration
+	if !entry.ExpireAt.IsZero() && time.Now().After(entry.ExpireAt) {
+		if s.config.EnableMetrics {
+			s.metrics.IncrementTokensExpired()
+		}
+		return nil, ErrTokenExpired
+	}
+
+	// Validate same-origin policy (IP binding)
+	if err := s.validateIPBinding(ctx, tokenID, entry); err != nil {
+		return nil, err
+	}
+
+	if s.config.EnableMetrics {
+		s.metrics.IncrementTokensResolved()
+	}
+
+	entryCopy := *entry
+	return &entryCopy, nil
+}
+
+// LookupCertTokenWithRole looks up a cert token using both the fingerprint and role.
+// This is used for transparent mode where the same cert with different roles
+// should produce different tokens. The composite "fingerprint:role" value is used
+// for ID computation and validation.
+func (c *Core) LookupCertTokenWithRole(ctx context.Context, certFingerprint string, role string) (*TokenEntry, error) {
+	if c.Sealed() {
+		return nil, fmt.Errorf("the core is sealed")
+	}
+
+	if c.tokenStore == nil {
+		return nil, nil
+	}
+
+	s := c.tokenStore
+
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, ErrStoreClosed
+	}
+	s.mu.RUnlock()
+
+	// Extract namespace from context
+	ns, err := namespace.FromContext(ctx)
+	if err != nil || ns == nil {
+		return nil, errors.New("namespace not found in context")
+	}
+
+	certType := &CertRoleTokenType{}
+
+	// Compute hash of "fingerprint:role" - this matches what's stored in entry.Data["cert_fingerprint"]
+	certHash := certType.ComputeData(certFingerprint, role)
+	// Token ID is computed from the hash
+	tokenID := certType.ComputeID(certHash)
+
+	// Lookup token in cache only - cert tokens are not persisted to storage
+	entry, found := s.byID.Get(tokenID)
+	if !found {
+		if s.config.EnableMetrics {
+			s.metrics.IncrementCacheMisses()
+		}
+		return nil, ErrTokenNotFound
+	}
+
+	if s.config.EnableMetrics {
+		s.metrics.IncrementCacheHits()
+	}
+
+	// Validate namespace binding
+	tokenNs, err := c.namespaceStore.GetNamespaceByAccessor(ctx, entry.NamespaceID)
+	if err != nil || tokenNs == nil {
+		s.logger.Warn("cert token namespace not found",
+			logger.String("token_id", tokenID),
+			logger.String("token_namespace_id", entry.NamespaceID))
+		return nil, ErrTokenNamespaceMismatch
+	}
+
+	isValidNamespace := ns.UUID == tokenNs.UUID || ns.HasParent(tokenNs)
+	if !isValidNamespace {
+		if s.config.EnableMetrics {
+			s.metrics.IncrementNamespaceMismatches()
+		}
+		s.logger.Warn("cert token namespace mismatch",
+			logger.String("token_id", tokenID),
+			logger.String("token_namespace", tokenNs.Path),
+			logger.String("request_namespace", ns.Path))
+		return nil, ErrTokenNamespaceMismatch
+	}
+
+	// Validate token value matches (comparing hashes, not raw fingerprint)
+	lookupKey := certType.LookupKey()
+	expectedHash, ok := entry.Data[lookupKey]
+	if !ok {
+		s.logger.Error("cert token lookup key not found",
+			logger.String("token_id", tokenID),
+			logger.String("lookup_key", lookupKey))
+		return nil, ErrTokenNotFound
+	}
+	if subtle.ConstantTimeCompare([]byte(expectedHash), []byte(certHash)) != 1 {
+		s.logger.Error("cert token value mismatch",
 			logger.String("token_id", tokenID),
 			logger.String("lookup_key", lookupKey))
 		return nil, ErrTokenNotFound

--- a/core/token_type_cert.go
+++ b/core/token_type_cert.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
+
+// CertRoleTokenType implements certificate-based token handling with role binding.
+// This token type is used when providers operate in transparent mode, where clients
+// present TLS client certificates and Warden performs implicit authentication.
+// The cert fingerprint + role combination is used as the lookup value, and its hash
+// becomes the token ID.
+type CertRoleTokenType struct{}
+
+func (t *CertRoleTokenType) Metadata() TokenTypeMetadata {
+	return TokenTypeMetadata{
+		Name:        "cert_role",
+		IDPrefix:    "cert_",
+		ValuePrefix: "", // No bearer prefix — certs are in TLS, not headers
+		Description: "TLS client certificate with role binding",
+		DefaultTTL:  1 * time.Hour,
+	}
+}
+
+func (t *CertRoleTokenType) Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+	// For cert tokens, the certificate comes from the TLS connection.
+	// authData.TokenValue contains the cert fingerprint (SHA-256 of DER bytes).
+	//
+	// We store a hash of the composite "fingerprint:role" value for:
+	// - ID computation: ComputeID() uses this to derive the token ID
+	// - Validation: LookupCertTokenWithRole compares hashes
+	// The role is included because:
+	// - Same cert with different roles should produce different tokens
+	// - Each role may have different policies and credential specs
+	if authData == nil {
+		return entry.Data, nil
+	}
+
+	fingerprint := authData.TokenValue
+	if fingerprint == "" {
+		return entry.Data, nil
+	}
+
+	// Store hash of composite "fingerprint:role" value
+	entry.Data["cert_fingerprint"] = t.ComputeData(fingerprint, authData.RoleName)
+
+	return entry.Data, nil
+}
+
+func (t *CertRoleTokenType) ValidateValue(tokenValue string) bool {
+	// Cert tokens have no bearer value to validate — the cert is in the TLS connection
+	return true
+}
+
+func (t *CertRoleTokenType) ComputeID(lookupValue string) string {
+	h := sha256.New()
+	h.Write([]byte(lookupValue))
+	hash := hex.EncodeToString(h.Sum(nil))[:32]
+	return t.Metadata().IDPrefix + hash
+}
+
+func (t *CertRoleTokenType) LookupKey() string {
+	return "cert_fingerprint"
+}
+
+// ComputeData computes a SHA-256 hash of the composite "fingerprint:role" value.
+// This hash is stored in entry.Data["cert_fingerprint"] and used for both ID
+// computation and validation.
+func (t *CertRoleTokenType) ComputeData(fingerprint, role string) string {
+	lookupValue := fingerprint
+	if role != "" {
+		lookupValue = fingerprint + ":" + role
+	}
+	h := sha256.Sum256([]byte(lookupValue))
+	return hex.EncodeToString(h[:])
+}

--- a/core/token_type_cert_test.go
+++ b/core/token_type_cert_test.go
@@ -1,0 +1,184 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestCertRoleTokenType_Metadata(t *testing.T) {
+	ct := &CertRoleTokenType{}
+	meta := ct.Metadata()
+
+	if meta.Name != "cert_role" {
+		t.Fatalf("expected name 'cert_role', got %q", meta.Name)
+	}
+	if meta.IDPrefix != "cert_" {
+		t.Fatalf("expected IDPrefix 'cert_', got %q", meta.IDPrefix)
+	}
+	if meta.ValuePrefix != "" {
+		t.Fatalf("expected empty ValuePrefix, got %q", meta.ValuePrefix)
+	}
+}
+
+func TestCertRoleTokenType_ComputeData(t *testing.T) {
+	ct := &CertRoleTokenType{}
+
+	// With role
+	hash1 := ct.ComputeData("fingerprint123", "admin")
+	hash2 := ct.ComputeData("fingerprint123", "admin")
+	if hash1 != hash2 {
+		t.Fatal("ComputeData should be deterministic")
+	}
+
+	// Different roles should produce different hashes
+	hash3 := ct.ComputeData("fingerprint123", "reader")
+	if hash1 == hash3 {
+		t.Fatal("different roles should produce different hashes")
+	}
+
+	// Different fingerprints should produce different hashes
+	hash4 := ct.ComputeData("fingerprint456", "admin")
+	if hash1 == hash4 {
+		t.Fatal("different fingerprints should produce different hashes")
+	}
+
+	// Without role
+	hash5 := ct.ComputeData("fingerprint123", "")
+	if hash5 == hash1 {
+		t.Fatal("empty role should produce different hash from non-empty role")
+	}
+}
+
+func TestCertRoleTokenType_ComputeID(t *testing.T) {
+	ct := &CertRoleTokenType{}
+
+	id := ct.ComputeID("somehash")
+	if len(id) == 0 {
+		t.Fatal("ComputeID should return non-empty ID")
+	}
+	if id[:5] != "cert_" {
+		t.Fatalf("expected 'cert_' prefix, got %q", id[:5])
+	}
+
+	// Deterministic
+	id2 := ct.ComputeID("somehash")
+	if id != id2 {
+		t.Fatal("ComputeID should be deterministic")
+	}
+
+	// Different input → different ID
+	id3 := ct.ComputeID("differenthash")
+	if id == id3 {
+		t.Fatal("different inputs should produce different IDs")
+	}
+}
+
+func TestCertRoleTokenType_LookupKey(t *testing.T) {
+	ct := &CertRoleTokenType{}
+	if ct.LookupKey() != "cert_fingerprint" {
+		t.Fatalf("expected 'cert_fingerprint', got %q", ct.LookupKey())
+	}
+}
+
+func TestCertRoleTokenType_ValidateValue(t *testing.T) {
+	ct := &CertRoleTokenType{}
+	// Cert tokens always pass validation (no bearer token to check)
+	if !ct.ValidateValue("anything") {
+		t.Fatal("ValidateValue should always return true for cert tokens")
+	}
+	if !ct.ValidateValue("") {
+		t.Fatal("ValidateValue should return true even for empty string")
+	}
+}
+
+func TestCertRoleTokenType_Generate(t *testing.T) {
+	ct := &CertRoleTokenType{}
+
+	// With authData
+	entry := &TokenEntry{Data: make(map[string]string)}
+	authData := &AuthData{
+		TokenValue: "abc123fingerprint",
+		RoleName:   "agent",
+	}
+
+	result, err := ct.Generate(authData, entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fingerprint, ok := result["cert_fingerprint"]
+	if !ok {
+		t.Fatal("expected cert_fingerprint in result")
+	}
+	if fingerprint == "" {
+		t.Fatal("expected non-empty cert_fingerprint")
+	}
+
+	// Verify it matches ComputeData
+	expected := ct.ComputeData("abc123fingerprint", "agent")
+	if fingerprint != expected {
+		t.Fatalf("expected %q, got %q", expected, fingerprint)
+	}
+
+	// Without authData
+	entry2 := &TokenEntry{Data: map[string]string{"existing": "data"}}
+	result2, err := ct.Generate(nil, entry2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result2["cert_fingerprint"]; ok {
+		t.Fatal("should not set cert_fingerprint when authData is nil")
+	}
+
+	// With empty TokenValue
+	entry3 := &TokenEntry{Data: make(map[string]string)}
+	authData3 := &AuthData{TokenValue: "", RoleName: "agent"}
+	result3, err := ct.Generate(authData3, entry3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result3["cert_fingerprint"]; ok {
+		t.Fatal("should not set cert_fingerprint when TokenValue is empty")
+	}
+}
+
+func TestCertRoleTokenType_RegisteredInRegistry(t *testing.T) {
+	registry := NewTokenTypeRegistry()
+	err := registry.Register(&CertRoleTokenType{})
+	if err != nil {
+		t.Fatalf("failed to register cert_role type: %v", err)
+	}
+
+	tokenType, err := registry.GetByName("cert_role")
+	if err != nil {
+		t.Fatalf("failed to look up cert_role type: %v", err)
+	}
+
+	if tokenType.Metadata().Name != "cert_role" {
+		t.Fatalf("expected name 'cert_role', got %q", tokenType.Metadata().Name)
+	}
+
+	// cert_role has no ValuePrefix, so DetectType won't find it
+	_, err = registry.DetectType("some-value")
+	if err == nil {
+		t.Fatal("expected error from DetectType with no matching prefix")
+	}
+}
+
+func TestCertRoleTokenType_EndToEndIDComputation(t *testing.T) {
+	ct := &CertRoleTokenType{}
+
+	fingerprint := "a1b2c3d4e5f6"
+	role := "agent"
+
+	// This simulates the full flow: Generate stores hash, ComputeID creates the ID
+	hash := ct.ComputeData(fingerprint, role)
+	tokenID := ct.ComputeID(hash)
+
+	// Verify the same computation in LookupCertTokenWithRole would produce the same ID
+	hash2 := ct.ComputeData(fingerprint, role)
+	tokenID2 := ct.ComputeID(hash2)
+
+	if tokenID != tokenID2 {
+		t.Fatalf("ID computation should be deterministic: %q != %q", tokenID, tokenID2)
+	}
+}

--- a/e2e/auth/cert_auth_test.go
+++ b/e2e/auth/cert_auth_test.go
@@ -1,0 +1,749 @@
+//go:build e2e
+
+package auth
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// setupCertAuthEnv mounts cert auth, configures it, and creates a test role.
+// Returns the CA cert PEM and key for generating client certs.
+func setupCertAuthEnv(t *testing.T, port int) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+	certPEM, key := h.SetupCertAuth(t, port)
+
+	// Create role with CN glob pattern
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+
+	return certPEM, key
+}
+
+func teardownCertAuthEnv(t *testing.T, port int) {
+	t.Helper()
+	h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+	h.TeardownCertAuth(t, port)
+}
+
+// T-C01: Cert auth login with valid cert and matching CN
+func TestCertAuthLogin_ValidCertMatchingCN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-1")
+
+	status, body := h.CertLoginRequest(t, port, "agent", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	// Verify we got a token back
+	data := h.ParseJSON(t, body)
+	principalID := h.JSONPath(data, "data.principal_id")
+	if principalID == nil || principalID == "" {
+		t.Fatalf("expected principal_id in response, got: %s", string(body))
+	}
+}
+
+// T-C02: Cert auth login rejected - wrong CN
+func TestCertAuthLogin_WrongCN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+
+	// Generate cert with CN that doesn't match
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "unauthorized-user")
+
+	status, _ := h.CertLoginRequest(t, port, "agent", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for wrong CN, got %d", status)
+	}
+}
+
+// T-C03: Cert auth login rejected - untrusted CA
+func TestCertAuthLogin_UntrustedCA(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	_, _ = h.SetupCertAuth(t, port) // setup with CA1
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+
+	// Generate a completely different CA and client cert
+	otherCACertPEM, otherCAKey := h.GenerateTestCA(t)
+	clientCertPEM, _ := h.GenerateClientCert(t, otherCACertPEM, otherCAKey, "agent-1")
+
+	status, _ := h.CertLoginRequest(t, port, "agent", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for untrusted CA, got %d", status)
+	}
+}
+
+// T-C04: Cert auth login with DNS SAN matching
+func TestCertAuthLogin_DNSSANMatching(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/dns-role", port,
+		`{"allowed_dns_sans":["*.example.com"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/dns-role", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent", h.WithDNSSANs("agent.example.com"))
+
+	status, body := h.CertLoginRequest(t, port, "dns-role", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for DNS SAN match, got %d: %s", status, string(body))
+	}
+}
+
+// T-C05: Cert auth login rejected - no cert forwarded
+func TestCertAuthLogin_NoCert(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	_, _ = h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+
+	// Login without any cert header
+	u := fmt.Sprintf("%s/v1/auth/cert/login", h.NodeURL(port))
+	status, _ := h.DoRequest(t, "POST", u,
+		map[string]string{"Content-Type": "application/json"},
+		`{"role":"agent"}`)
+
+	if status != 400 {
+		t.Fatalf("expected 400 for missing cert, got %d", status)
+	}
+}
+
+// T-C07: Cert auth via XFCC header format
+func TestCertAuthLogin_XFCCHeaderFormat(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-xfcc")
+
+	status, body := h.CertLoginRequestWithXFCC(t, port, "agent", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for XFCC login, got %d: %s", status, string(body))
+	}
+}
+
+// T-C09: Cert auth forwarding through standby
+func TestCertAuthLogin_ThroughStandby(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/agent", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/agent", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-standby")
+
+	// Login via standby node
+	standbyPort := h.GetStandbyPort(t)
+	status, body := h.CertLoginRequest(t, standbyPort, "agent", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 through standby, got %d: %s", status, string(body))
+	}
+}
+
+// T-C10: Cert auth config and role CRUD
+func TestCertAuthConfigAndRoleCRUD(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	_, _ = h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	// Read config
+	status, body := h.APIRequest(t, "GET", "auth/cert/config", port, "")
+	if status != 200 {
+		t.Fatalf("expected 200 for config read, got %d: %s", status, string(body))
+	}
+
+	// Create role
+	h.APIRequest(t, "POST", "auth/cert/role/test-crud", port,
+		`{"allowed_common_names":["test-*"],"token_policies":["default"],"token_type":"warden_token","token_ttl":7200}`)
+
+	// Read role
+	status, body = h.APIRequest(t, "GET", "auth/cert/role/test-crud", port, "")
+	if status != 200 {
+		t.Fatalf("expected 200 for role read, got %d: %s", status, string(body))
+	}
+	data := h.ParseJSON(t, body)
+	tokenTTL := h.JSONPath(data, "data.token_ttl")
+	if tokenTTL == nil {
+		t.Fatal("expected token_ttl in role read response")
+	}
+
+	// Update role
+	status, _ = h.APIRequest(t, "PUT", "auth/cert/role/test-crud", port,
+		`{"token_ttl":1800}`)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for role update, got %d", status)
+	}
+
+	// List roles
+	status, body = h.APIRequest(t, "GET", "auth/cert/role/", port, "")
+	// LIST might also be via GET to role/?list=true, or the backend may respond to GET on role/
+	if status != 200 && status != 405 {
+		t.Logf("role list returned status %d (may need LIST operation)", status)
+	}
+
+	// Delete role
+	status, _ = h.APIRequest(t, "DELETE", "auth/cert/role/test-crud", port, "")
+	if status != 200 && status != 204 {
+		t.Fatalf("expected 200 or 204 for role delete, got %d", status)
+	}
+
+	// Verify deletion
+	status, _ = h.APIRequest(t, "GET", "auth/cert/role/test-crud", port, "")
+	if status != 404 {
+		t.Fatalf("expected 404 for deleted role, got %d", status)
+	}
+}
+
+// T-C11: Multiple certs, multiple roles
+func TestCertAuthLogin_MultipleRoles(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	// Create two roles with different CN patterns
+	h.APIRequest(t, "POST", "auth/cert/role/web-role", port,
+		`{"allowed_common_names":["web-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/web-role", port, "")
+
+	h.APIRequest(t, "POST", "auth/cert/role/api-role", port,
+		`{"allowed_common_names":["api-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":7200}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/api-role", port, "")
+
+	// Login with web cert to web-role
+	webCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "web-server-1")
+	status, _ := h.CertLoginRequest(t, port, "web-role", webCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for web-role login, got %d", status)
+	}
+
+	// Login with api cert to api-role
+	apiCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "api-service-1")
+	status, _ = h.CertLoginRequest(t, port, "api-role", apiCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for api-role login, got %d", status)
+	}
+
+	// web cert should NOT match api-role
+	status, _ = h.CertLoginRequest(t, port, "api-role", webCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for web cert on api-role, got %d", status)
+	}
+}
+
+// T-C12: Cert auth login rejected - expired certificate
+func TestCertAuthLogin_ExpiredCert(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := setupCertAuthEnv(t, port)
+	defer teardownCertAuthEnv(t, port)
+
+	// Generate a cert that expired 1 hour ago (NotBefore 3h ago, NotAfter 1h ago)
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-expired",
+		h.WithNotBefore(time.Now().Add(-3*time.Hour)),
+		h.WithExpiry(-1*time.Hour))
+
+	status, _ := h.CertLoginRequest(t, port, "agent", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for expired cert, got %d", status)
+	}
+}
+
+// T-C13: Cert auth login rejected - not-yet-valid certificate
+func TestCertAuthLogin_NotYetValidCert(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := setupCertAuthEnv(t, port)
+	defer teardownCertAuthEnv(t, port)
+
+	// Generate a cert that won't be valid for another hour
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-future",
+		h.WithNotBefore(time.Now().Add(1*time.Hour)),
+		h.WithExpiry(2*time.Hour))
+
+	status, _ := h.CertLoginRequest(t, port, "agent", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for not-yet-valid cert, got %d", status)
+	}
+}
+
+// T-C14: Cert auth login with email SAN matching
+func TestCertAuthLogin_EmailSANMatching(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/email-role", port,
+		`{"allowed_email_sans":["*@example.com"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/email-role", port, "")
+
+	// Matching email SAN
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-email",
+		h.WithEmailSANs("user@example.com"))
+	status, body := h.CertLoginRequest(t, port, "email-role", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for matching email SAN, got %d: %s", status, string(body))
+	}
+}
+
+// T-C15: Cert auth login rejected - wrong email SAN
+func TestCertAuthLogin_EmailSANRejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/email-role", port,
+		`{"allowed_email_sans":["*@example.com"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/email-role", port, "")
+
+	// Non-matching email SAN
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-email-bad",
+		h.WithEmailSANs("user@other.com"))
+	status, _ := h.CertLoginRequest(t, port, "email-role", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for non-matching email SAN, got %d", status)
+	}
+}
+
+// T-C16: Cert auth login with URI SAN matching (SPIFFE pattern)
+func TestCertAuthLogin_URISANMatching(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/uri-role", port,
+		`{"allowed_uri_sans":["spiffe://cluster.local/*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/uri-role", port, "")
+
+	// Matching URI SAN
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-uri",
+		h.WithURISANs("spiffe://cluster.local/service-a"))
+	status, body := h.CertLoginRequest(t, port, "uri-role", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for matching URI SAN, got %d: %s", status, string(body))
+	}
+}
+
+// T-C17: Cert auth login rejected - wrong URI SAN
+func TestCertAuthLogin_URISANRejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/uri-role", port,
+		`{"allowed_uri_sans":["spiffe://cluster.local/*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/uri-role", port, "")
+
+	// Non-matching URI SAN
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-uri-bad",
+		h.WithURISANs("spiffe://other.domain/service-a"))
+	status, _ := h.CertLoginRequest(t, port, "uri-role", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for non-matching URI SAN, got %d", status)
+	}
+}
+
+// T-C18: Cert auth login with organizational unit matching
+func TestCertAuthLogin_OUMatching(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/ou-role", port,
+		`{"allowed_organizational_units":["Engineering"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/ou-role", port, "")
+
+	// Matching OU
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-ou",
+		h.WithOUs("Engineering"))
+	status, body := h.CertLoginRequest(t, port, "ou-role", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for matching OU, got %d: %s", status, string(body))
+	}
+}
+
+// T-C19: Cert auth login rejected - wrong OU
+func TestCertAuthLogin_OURejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/ou-role", port,
+		`{"allowed_organizational_units":["Engineering"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/ou-role", port, "")
+
+	// Non-matching OU
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-ou-bad",
+		h.WithOUs("Marketing"))
+	status, _ := h.CertLoginRequest(t, port, "ou-role", clientCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for non-matching OU, got %d", status)
+	}
+}
+
+// T-C20: Cert auth login with role-specific CA override
+func TestCertAuthLogin_RoleSpecificCA(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	_, _ = h.SetupCertAuth(t, port) // Global CA
+	defer h.TeardownCertAuth(t, port)
+
+	// Generate a second CA for the role-specific override
+	roleCA, roleCAKey := h.GenerateTestCA(t)
+
+	// Create role with role-specific CA — this CA overrides the global trusted CA
+	escapedPEM := strings.ReplaceAll(roleCA, "\n", "\\n")
+	roleBody := fmt.Sprintf(`{"allowed_common_names":["role-agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600,"certificate":"%s"}`, escapedPEM)
+	h.APIRequest(t, "POST", "auth/cert/role/role-ca", port, roleBody)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/role-ca", port, "")
+
+	// Client cert signed by role CA should succeed
+	clientCertPEM, _ := h.GenerateClientCert(t, roleCA, roleCAKey, "role-agent-1")
+	status, body := h.CertLoginRequest(t, port, "role-ca", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for role-CA cert, got %d: %s", status, string(body))
+	}
+
+	// Client cert signed by global CA should be rejected (role CA overrides global)
+	globalCA, globalCAKey := h.GenerateTestCA(t)
+	_ = globalCA // same structure as the one in SetupCertAuth
+	globalCertPEM, _ := h.GenerateClientCert(t, globalCA, globalCAKey, "role-agent-2")
+	status, _ = h.CertLoginRequest(t, port, "role-ca", globalCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for cert signed by wrong CA, got %d", status)
+	}
+}
+
+// T-C21: Principal claim - dns_san
+func TestCertAuthLogin_PrincipalClaimDNSSAN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/dns-principal", port,
+		`{"allowed_dns_sans":["*.example.com"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600,"principal_claim":"dns_san"}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/dns-principal", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-dns",
+		h.WithDNSSANs("myservice.example.com"))
+
+	status, body := h.CertLoginRequest(t, port, "dns-principal", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	principalID := h.JSONPath(data, "data.principal_id")
+	if principalID != "myservice.example.com" {
+		t.Fatalf("expected principal_id 'myservice.example.com', got %v", principalID)
+	}
+}
+
+// T-C22: Principal claim - email_san
+func TestCertAuthLogin_PrincipalClaimEmailSAN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/email-principal", port,
+		`{"allowed_email_sans":["*@corp.example.com"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600,"principal_claim":"email_san"}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/email-principal", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-email-p",
+		h.WithEmailSANs("alice@corp.example.com"))
+
+	status, body := h.CertLoginRequest(t, port, "email-principal", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	principalID := h.JSONPath(data, "data.principal_id")
+	if principalID != "alice@corp.example.com" {
+		t.Fatalf("expected principal_id 'alice@corp.example.com', got %v", principalID)
+	}
+}
+
+// T-C23: Principal claim - uri_san
+func TestCertAuthLogin_PrincipalClaimURISAN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/uri-principal", port,
+		`{"allowed_uri_sans":["https://service.example.com/*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600,"principal_claim":"uri_san"}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/uri-principal", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-uri-p",
+		h.WithURISANs("https://service.example.com/api"))
+
+	status, body := h.CertLoginRequest(t, port, "uri-principal", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	principalID := h.JSONPath(data, "data.principal_id")
+	if principalID != "https://service.example.com/api" {
+		t.Fatalf("expected principal_id 'https://service.example.com/api', got %v", principalID)
+	}
+}
+
+// T-C24: Principal claim - spiffe_id
+func TestCertAuthLogin_PrincipalClaimSPIFFEID(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	h.APIRequest(t, "POST", "auth/cert/role/spiffe-principal", port,
+		`{"allowed_uri_sans":["spiffe://prod.example.com/*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600,"principal_claim":"spiffe_id"}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/spiffe-principal", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-spiffe",
+		h.WithURISANs("spiffe://prod.example.com/ns/default/sa/api-server"))
+
+	status, body := h.CertLoginRequest(t, port, "spiffe-principal", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	principalID := h.JSONPath(data, "data.principal_id")
+	if principalID != "spiffe://prod.example.com/ns/default/sa/api-server" {
+		t.Fatalf("expected SPIFFE ID principal, got %v", principalID)
+	}
+}
+
+// T-C25: Principal claim - serial
+func TestCertAuthLogin_PrincipalClaimSerial(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	// Serial-based principal: use CN constraint for authorization, serial for identity
+	h.APIRequest(t, "POST", "auth/cert/role/serial-principal", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600,"principal_claim":"serial"}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/serial-principal", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-serial")
+
+	status, body := h.CertLoginRequest(t, port, "serial-principal", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	principalID := h.JSONPath(data, "data.principal_id")
+	if principalID == nil || principalID == "" {
+		t.Fatal("expected non-empty serial number as principal_id")
+	}
+	// Serial should be a numeric string, not a CN
+	if principalID == "agent-serial" {
+		t.Fatal("principal_id should be serial number, not CN")
+	}
+}
+
+// T-C26: Config API read and update
+func TestCertAuthConfigReadUpdate(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	_, _ = h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	// Read initial config
+	status, body := h.APIRequest(t, "GET", "auth/cert/config", port, "")
+	if status != 200 {
+		t.Fatalf("expected 200 for config read, got %d: %s", status, string(body))
+	}
+	data := h.ParseJSON(t, body)
+	principalClaim := h.JSONPath(data, "data.principal_claim")
+	if principalClaim != "cn" {
+		t.Fatalf("expected default principal_claim 'cn', got %v", principalClaim)
+	}
+
+	// Update principal_claim to dns_san
+	status, body = h.APIRequest(t, "PUT", "auth/cert/config", port,
+		`{"principal_claim":"dns_san"}`)
+	if status != 200 && status != 204 {
+		t.Fatalf("expected 200 for config update, got %d: %s", status, string(body))
+	}
+
+	// Read updated config
+	status, body = h.APIRequest(t, "GET", "auth/cert/config", port, "")
+	if status != 200 {
+		t.Fatalf("expected 200 for config read, got %d: %s", status, string(body))
+	}
+	data = h.ParseJSON(t, body)
+	principalClaim = h.JSONPath(data, "data.principal_claim")
+	if principalClaim != "dns_san" {
+		t.Fatalf("expected updated principal_claim 'dns_san', got %v", principalClaim)
+	}
+
+	// Verify the config change takes effect: role without principal_claim inherits from config
+	caCertPEM, caKey := h.GenerateTestCA(t)
+	escapedPEM := strings.ReplaceAll(caCertPEM, "\n", "\\n")
+	h.APIRequest(t, "PUT", "auth/cert/config", port,
+		fmt.Sprintf(`{"trusted_ca_pem":"%s","principal_claim":"dns_san"}`, escapedPEM))
+
+	h.APIRequest(t, "POST", "auth/cert/role/config-test", port,
+		`{"allowed_dns_sans":["*.test.com"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/config-test", port, "")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-config",
+		h.WithDNSSANs("app.test.com"))
+
+	status, body = h.CertLoginRequest(t, port, "config-test", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201, got %d: %s", status, string(body))
+	}
+
+	data = h.ParseJSON(t, body)
+	pid := h.JSONPath(data, "data.principal_id")
+	if pid != "app.test.com" {
+		t.Fatalf("expected principal_id 'app.test.com' (inherited from config), got %v", pid)
+	}
+}
+
+// T-C27: Multiple constraints on same role (CN + OU)
+func TestCertAuthLogin_MultipleConstraints(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	defer h.TeardownCertAuth(t, port)
+
+	// Role requires BOTH CN match AND OU match
+	h.APIRequest(t, "POST", "auth/cert/role/multi-constraint", port,
+		`{"allowed_common_names":["agent-*"],"allowed_organizational_units":["Engineering"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/multi-constraint", port, "")
+
+	// Cert matching both CN and OU → should succeed
+	goodCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-multi",
+		h.WithOUs("Engineering"))
+	status, body := h.CertLoginRequest(t, port, "multi-constraint", goodCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for matching CN+OU, got %d: %s", status, string(body))
+	}
+
+	// Cert matching CN but wrong OU → should fail
+	badOUCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-multi-ou",
+		h.WithOUs("Marketing"))
+	status, _ = h.CertLoginRequest(t, port, "multi-constraint", badOUCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for wrong OU, got %d", status)
+	}
+
+	// Cert matching OU but wrong CN → should fail
+	badCNCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "bad-multi",
+		h.WithOUs("Engineering"))
+	status, _ = h.CertLoginRequest(t, port, "multi-constraint", badCNCertPEM)
+	if status != 401 && status != 403 {
+		t.Fatalf("expected 401 or 403 for wrong CN, got %d", status)
+	}
+}
+
+// T-C28: Certificate chain with intermediate CA
+func TestCertAuthLogin_IntermediateCA(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Generate root CA → intermediate CA → client cert
+	rootCertPEM, rootKey := h.GenerateTestCA(t)
+	intermediateCertPEM, intermediateKey := h.GenerateIntermediateCA(t, rootCertPEM, rootKey)
+
+	// Mount cert auth with both root + intermediate in trusted CAs
+	chainPEM := rootCertPEM + intermediateCertPEM
+	escapedPEM := strings.ReplaceAll(chainPEM, "\n", "\\n")
+
+	status, body := h.APIRequest(t, "POST", "sys/auth/cert", port, `{"type":"cert"}`)
+	if status != 200 && status != 201 && status != 204 {
+		t.Fatalf("failed to mount cert auth (status %d): %s", status, string(body))
+	}
+	defer h.TeardownCertAuth(t, port)
+
+	configBody := fmt.Sprintf(`{"trusted_ca_pem":"%s"}`, escapedPEM)
+	status, body = h.APIRequest(t, "PUT", "auth/cert/config", port, configBody)
+	if status != 200 && status != 204 {
+		t.Fatalf("failed to configure cert auth (status %d): %s", status, string(body))
+	}
+
+	h.APIRequest(t, "POST", "auth/cert/role/chain-role", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-gateway-access"],"token_type":"warden_token","token_ttl":3600}`)
+	defer h.APIRequest(t, "DELETE", "auth/cert/role/chain-role", port, "")
+
+	// Client cert signed by intermediate CA → should succeed
+	clientCertPEM, _ := h.GenerateClientCert(t, intermediateCertPEM, intermediateKey, "agent-chain")
+	status, body = h.CertLoginRequest(t, port, "chain-role", clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for intermediate-signed cert, got %d: %s", status, string(body))
+	}
+
+	// Client cert signed directly by root CA → should also succeed
+	rootClientCertPEM, _ := h.GenerateClientCert(t, rootCertPEM, rootKey, "agent-root")
+	status, body = h.CertLoginRequest(t, port, "chain-role", rootClientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("expected 200 or 201 for root-signed cert, got %d: %s", status, string(body))
+	}
+}
+
+// T-C29: Cert replacement - new cert with same CN produces different fingerprint
+func TestCertAuthLogin_CertReplacement(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := setupCertAuthEnv(t, port)
+	defer teardownCertAuthEnv(t, port)
+
+	// Generate two different certs with the same CN
+	cert1PEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-replace")
+	cert2PEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-replace")
+
+	// Both should authenticate successfully
+	status1, body1 := h.CertLoginRequest(t, port, "agent", cert1PEM)
+	if status1 != 200 && status1 != 201 {
+		t.Fatalf("cert1 login failed (status %d): %s", status1, string(body1))
+	}
+
+	status2, body2 := h.CertLoginRequest(t, port, "agent", cert2PEM)
+	if status2 != 200 && status2 != 201 {
+		t.Fatalf("cert2 login failed (status %d): %s", status2, string(body2))
+	}
+
+	// They should have different fingerprints (different key pairs → different cert bytes)
+	data1 := h.ParseJSON(t, body1)
+	data2 := h.ParseJSON(t, body2)
+	fp1 := h.JSONPath(data1, "data.fingerprint")
+	fp2 := h.JSONPath(data2, "data.fingerprint")
+	if fp1 == fp2 {
+		t.Fatalf("expected different fingerprints for different certs with same CN, got %v", fp1)
+	}
+
+	// Both should have the same principal_id (same CN)
+	pid1 := h.JSONPath(data1, "data.principal_id")
+	pid2 := h.JSONPath(data2, "data.principal_id")
+	if pid1 != pid2 {
+		t.Fatalf("expected same principal_id for same CN, got %v vs %v", pid1, pid2)
+	}
+}

--- a/e2e/configs/node1.hcl
+++ b/e2e/configs/node1.hcl
@@ -22,6 +22,7 @@ storage "postgres" {
 }
 
 listener "tcp" {
-    address     = "127.0.0.1:8500"
-    tls_enabled = false
+    address         = "0.0.0.0:8500"
+    tls_enabled     = false
+    trusted_proxies = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
 }

--- a/e2e/configs/node2.hcl
+++ b/e2e/configs/node2.hcl
@@ -22,6 +22,7 @@ storage "postgres" {
 }
 
 listener "tcp" {
-    address     = "127.0.0.1:8510"
-    tls_enabled = false
+    address         = "0.0.0.0:8510"
+    tls_enabled     = false
+    trusted_proxies = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
 }

--- a/e2e/configs/node3.hcl
+++ b/e2e/configs/node3.hcl
@@ -22,6 +22,7 @@ storage "postgres" {
 }
 
 listener "tcp" {
-    address     = "127.0.0.1:8520"
-    tls_enabled = false
+    address         = "0.0.0.0:8520"
+    tls_enabled     = false
+    trusted_proxies = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
 }

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -104,6 +104,25 @@ services:
     restart: unless-stopped
     command: serve all --dev
 
+  # Nginx load balancer in front of the 3-node Warden cluster (TLS termination)
+  nginx:
+    image: nginx:alpine
+    container_name: e2e-nginx
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./loadbalancer/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./loadbalancer/certs:/etc/nginx/certs:ro
+    networks:
+      - e2e-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "--no-check-certificate", "https://localhost:8000/nginx-health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
 networks:
   e2e-network:
     driver: bridge

--- a/e2e/helpers/cert_helpers.go
+++ b/e2e/helpers/cert_helpers.go
@@ -1,0 +1,453 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// CertOption configures optional fields on a generated client certificate.
+type CertOption func(*x509.Certificate)
+
+// WithDNSSANs adds DNS SANs to the certificate.
+func WithDNSSANs(names ...string) CertOption {
+	return func(tmpl *x509.Certificate) {
+		tmpl.DNSNames = names
+	}
+}
+
+// WithEmailSANs adds email SANs to the certificate.
+func WithEmailSANs(emails ...string) CertOption {
+	return func(tmpl *x509.Certificate) {
+		tmpl.EmailAddresses = emails
+	}
+}
+
+// WithURISANs adds URI SANs to the certificate.
+func WithURISANs(uris ...string) CertOption {
+	return func(tmpl *x509.Certificate) {
+		for _, u := range uris {
+			parsed, err := url.Parse(u)
+			if err == nil {
+				tmpl.URIs = append(tmpl.URIs, parsed)
+			}
+		}
+	}
+}
+
+// WithOUs sets the organizational units.
+func WithOUs(ous ...string) CertOption {
+	return func(tmpl *x509.Certificate) {
+		tmpl.Subject.OrganizationalUnit = ous
+	}
+}
+
+// WithOrganizations sets the organizations.
+func WithOrganizations(orgs ...string) CertOption {
+	return func(tmpl *x509.Certificate) {
+		tmpl.Subject.Organization = orgs
+	}
+}
+
+// WithExpiry sets a custom validity duration.
+func WithExpiry(d time.Duration) CertOption {
+	return func(tmpl *x509.Certificate) {
+		tmpl.NotAfter = time.Now().Add(d)
+	}
+}
+
+// WithNotBefore sets the certificate's NotBefore field.
+func WithNotBefore(t time.Time) CertOption {
+	return func(tmpl *x509.Certificate) {
+		tmpl.NotBefore = t
+	}
+}
+
+// GenerateTestCA creates a self-signed CA certificate and private key for testing.
+func GenerateTestCA(t *testing.T) (certPEM string, key *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+
+	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "Test CA",
+			Organization: []string{"Warden E2E Tests"},
+		},
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            1,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+	return certPEM, key
+}
+
+// GenerateIntermediateCA creates an intermediate CA signed by the given root CA.
+func GenerateIntermediateCA(t *testing.T, rootCertPEM string, rootKey *ecdsa.PrivateKey) (certPEM string, key *ecdsa.PrivateKey) {
+	t.Helper()
+
+	// Parse root CA cert
+	block, _ := pem.Decode([]byte(rootCertPEM))
+	if block == nil {
+		t.Fatal("failed to decode root CA cert PEM")
+	}
+	rootCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse root CA certificate: %v", err)
+	}
+
+	key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate intermediate CA key: %v", err)
+	}
+
+	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "Test Intermediate CA",
+			Organization: []string{"Warden E2E Tests"},
+		},
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, rootCert, &key.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("failed to create intermediate CA certificate: %v", err)
+	}
+
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+	return certPEM, key
+}
+
+// GenerateClientCert creates a client certificate signed by the given CA.
+func GenerateClientCert(t *testing.T, caCertPEM string, caKey *ecdsa.PrivateKey, cn string, opts ...CertOption) (certPEM string, keyPEM string) {
+	t.Helper()
+
+	// Parse CA cert
+	block, _ := pem.Decode([]byte(caCertPEM))
+	if block == nil {
+		t.Fatal("failed to decode CA cert PEM")
+	}
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+
+	// Generate client key
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+
+	serialNumber, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		NotBefore:   time.Now().Add(-1 * time.Minute),
+		NotAfter:    time.Now().Add(8 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	for _, opt := range opts {
+		opt(template)
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create client certificate: %v", err)
+	}
+
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+
+	keyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("failed to marshal client key: %v", err)
+	}
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+
+	return certPEM, keyPEM
+}
+
+// URLEncodePEM URL-encodes a PEM string for use in X-SSL-Client-Cert header.
+func URLEncodePEM(pemStr string) string {
+	return url.QueryEscape(pemStr)
+}
+
+// BuildXFCCHeader builds an X-Forwarded-Client-Cert header value with the Cert field.
+func BuildXFCCHeader(certPEM string) string {
+	encoded := url.QueryEscape(certPEM)
+	return fmt.Sprintf("Cert=%s", encoded)
+}
+
+// CertLoginRequest performs a cert auth login request with a forwarded client cert.
+func CertLoginRequest(t *testing.T, port int, role string, clientCertPEM string) (int, []byte) {
+	t.Helper()
+	token := RootToken(t)
+	u := fmt.Sprintf("%s/v1/auth/cert/login", NodeURL(port))
+	headers := map[string]string{
+		"Content-Type":       "application/json",
+		"X-SSL-Client-Cert":  URLEncodePEM(clientCertPEM),
+		"X-Warden-Token":     token, // Not used for auth, but needed for routing
+	}
+	body := fmt.Sprintf(`{"role":"%s"}`, role)
+
+	// For login, we don't need the warden token since login is unauthenticated.
+	// Remove it and use a plain request.
+	delete(headers, "X-Warden-Token")
+
+	return DoRequest(t, "POST", u, headers, body)
+}
+
+// CertLoginRequestWithXFCC performs a cert auth login using XFCC header format.
+func CertLoginRequestWithXFCC(t *testing.T, port int, role string, clientCertPEM string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/auth/cert/login", NodeURL(port))
+	headers := map[string]string{
+		"Content-Type":               "application/json",
+		"X-Forwarded-Client-Cert":    BuildXFCCHeader(clientCertPEM),
+	}
+	body := fmt.Sprintf(`{"role":"%s"}`, role)
+	return DoRequest(t, "POST", u, headers, body)
+}
+
+// SetupCertAuth mounts cert auth, configures trusted CA, and returns the CA cert/key.
+func SetupCertAuth(t *testing.T, port int) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+	caCertPEM, caKey = GenerateTestCA(t)
+
+	// Mount cert auth
+	status, body := APIRequest(t, "POST", "sys/auth/cert", port, `{"type":"cert"}`)
+	if status != 200 && status != 201 && status != 204 {
+		t.Fatalf("failed to mount cert auth (status %d): %s", status, string(body))
+	}
+
+	// Configure trusted CA — escape the PEM for JSON
+	escapedPEM := strings.ReplaceAll(caCertPEM, "\n", "\\n")
+	configBody := fmt.Sprintf(`{"trusted_ca_pem":"%s"}`, escapedPEM)
+	status, body = APIRequest(t, "PUT", "auth/cert/config", port, configBody)
+	if status != 200 && status != 204 {
+		t.Fatalf("failed to configure cert auth (status %d): %s", status, string(body))
+	}
+
+	return caCertPEM, caKey
+}
+
+// TeardownCertAuth unmounts cert auth.
+func TeardownCertAuth(t *testing.T, port int) {
+	t.Helper()
+	APIRequest(t, "DELETE", "sys/auth/cert", port, "")
+}
+
+// VaultCertTransparentRequest makes a transparent vault gateway request using
+// a client certificate in the X-SSL-Client-Cert header.
+func VaultCertTransparentRequest(t *testing.T, method, vaultPath, role string, port int, clientCertPEM string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/vault-cert/role/%s/gateway/v1/%s", NodeURL(port), role, vaultPath)
+	headers := map[string]string{
+		"X-SSL-Client-Cert": URLEncodePEM(clientCertPEM),
+	}
+	return DoRequest(t, method, u, headers, "")
+}
+
+// GetCertNTWardenToken logs in via cert auth and returns a warden_token for
+// non-transparent gateway access.
+func GetCertNTWardenToken(t *testing.T, port int, role string, clientCertPEM string) string {
+	t.Helper()
+	status, body := CertLoginRequest(t, port, role, clientCertPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("cert login failed (status %d): %s", status, string(body))
+	}
+	token := JSONString(t, body, "data.data.token")
+	if token == "" {
+		t.Fatalf("no token in cert login response: %s", string(body))
+	}
+	return token
+}
+
+// SetupCertVaultEnv sets up a vault provider with cert-based transparent mode.
+// Returns the CA cert and key for generating client certificates.
+func SetupCertVaultEnv(t *testing.T, port int) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	// Mount vault-cert provider
+	APIRequest(t, "POST", "sys/providers/vault-cert", port, `{"type":"vault"}`)
+	time.Sleep(1 * time.Second)
+
+	// Configure vault-cert provider
+	APIRequest(t, "PUT", "vault-cert/config", port,
+		`{"vault_address":"http://127.0.0.1:8200","tls_skip_verify":true,"timeout":"30s"}`)
+
+	// Enable transparent mode with cert auth path
+	APIRequest(t, "POST", "vault-cert/config", port,
+		`{"transparent_mode":true,"auto_auth_path":"auth/cert/"}`)
+
+	// Mount cert auth method with CA
+	caCertPEM, caKey = SetupCertAuth(t, port)
+
+	// Policy for vault-cert gateway access
+	APIRequest(t, "POST", "sys/policies/cbp/vault-cert-gateway-access", port,
+		`{"policy":"path \"vault-cert/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\npath \"vault-cert/role/+/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}"}`)
+
+	// Cert role for transparent mode (cert_role token type)
+	APIRequest(t, "POST", "auth/cert/role/e2e-cert-reader", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-cert-gateway-access"],"token_type":"cert_role","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
+
+	// Cert role for non-transparent mode (warden_token token type)
+	APIRequest(t, "POST", "auth/cert/role/e2e-cert-nt-reader", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-nt-gateway-access"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
+
+	return caCertPEM, caKey
+}
+
+// TeardownCertVaultEnv removes all resources created by SetupCertVaultEnv.
+func TeardownCertVaultEnv(t *testing.T, port int) {
+	t.Helper()
+	APIRequest(t, "DELETE", "auth/cert/role/e2e-cert-reader", port, "")
+	APIRequest(t, "DELETE", "auth/cert/role/e2e-cert-nt-reader", port, "")
+	TeardownCertAuth(t, port)
+	APIRequest(t, "DELETE", "sys/policies/cbp/vault-cert-gateway-access", port, "")
+	APIRequest(t, "DELETE", "sys/providers/vault-cert", port, "")
+	time.Sleep(1 * time.Second)
+}
+
+// --- Load Balancer CA Helpers ---
+
+// LoadLBCA loads the pre-generated LB CA certificate and key from
+// e2e/loadbalancer/certs/. This CA is used by nginx to validate client
+// certificates, so LB cert tests must generate client certs from this CA.
+func LoadLBCA(t *testing.T) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	certPath := filepath.Join(E2EDir(), "loadbalancer", "certs", "ca.crt")
+	keyPath := filepath.Join(E2EDir(), "loadbalancer", "certs", "ca.key")
+
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to load LB CA cert: %v", err)
+	}
+
+	keyData, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("failed to load LB CA key: %v", err)
+	}
+
+	block, _ := pem.Decode(keyData)
+	if block == nil {
+		t.Fatal("failed to decode LB CA key PEM")
+	}
+
+	// Handle both PKCS8 ("PRIVATE KEY" from genpkey) and SEC1 ("EC PRIVATE KEY")
+	switch block.Type {
+	case "PRIVATE KEY":
+		parsed, parseErr := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if parseErr != nil {
+			t.Fatalf("failed to parse LB CA PKCS8 key: %v", parseErr)
+		}
+		var ok bool
+		caKey, ok = parsed.(*ecdsa.PrivateKey)
+		if !ok {
+			t.Fatalf("LB CA key is not ECDSA: %T", parsed)
+		}
+	default:
+		caKey, err = x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse LB CA key: %v", err)
+		}
+	}
+
+	return string(certData), caKey
+}
+
+// SetupCertAuthWithCA mounts cert auth and configures it with the given CA
+// (instead of generating a new one). Use this when the CA must match what
+// an external component (like the LB) trusts.
+func SetupCertAuthWithCA(t *testing.T, port int, caCertPEM string) {
+	t.Helper()
+
+	status, body := APIRequest(t, "POST", "sys/auth/cert", port, `{"type":"cert"}`)
+	if status != 200 && status != 201 && status != 204 {
+		t.Fatalf("failed to mount cert auth (status %d): %s", status, string(body))
+	}
+
+	escapedPEM := strings.ReplaceAll(caCertPEM, "\n", "\\n")
+	configBody := fmt.Sprintf(`{"trusted_ca_pem":"%s"}`, escapedPEM)
+	status, body = APIRequest(t, "PUT", "auth/cert/config", port, configBody)
+	if status != 200 && status != 204 {
+		t.Fatalf("failed to configure cert auth (status %d): %s", status, string(body))
+	}
+}
+
+// SetupCertVaultEnvWithCA sets up a vault provider with cert-based transparent
+// mode using the given CA. Use this with LoadLBCA for LB tests so that nginx
+// and Warden trust the same CA.
+func SetupCertVaultEnvWithCA(t *testing.T, port int, caCertPEM string) {
+	t.Helper()
+
+	// Mount vault-cert provider
+	APIRequest(t, "POST", "sys/providers/vault-cert", port, `{"type":"vault"}`)
+	time.Sleep(1 * time.Second)
+
+	// Configure vault-cert provider
+	APIRequest(t, "PUT", "vault-cert/config", port,
+		`{"vault_address":"http://127.0.0.1:8200","tls_skip_verify":true,"timeout":"30s"}`)
+
+	// Enable transparent mode with cert auth path
+	APIRequest(t, "POST", "vault-cert/config", port,
+		`{"transparent_mode":true,"auto_auth_path":"auth/cert/"}`)
+
+	// Mount cert auth with the provided CA
+	SetupCertAuthWithCA(t, port, caCertPEM)
+
+	// Policy for vault-cert gateway access
+	APIRequest(t, "POST", "sys/policies/cbp/vault-cert-gateway-access", port,
+		`{"policy":"path \"vault-cert/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\npath \"vault-cert/role/+/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}"}`)
+
+	// Cert role for transparent mode (cert_role token type)
+	APIRequest(t, "POST", "auth/cert/role/e2e-cert-reader", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-cert-gateway-access"],"token_type":"cert_role","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
+
+	// Cert role for non-transparent mode (warden_token token type)
+	APIRequest(t, "POST", "auth/cert/role/e2e-cert-nt-reader", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-nt-gateway-access"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
+}

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -4,6 +4,7 @@
 package helpers
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -640,4 +641,151 @@ func JSONFloat(t *testing.T, body []byte, path string) float64 {
 		t.Fatalf("JSON path %q is not a number: %v", path, val)
 	}
 	return f
+}
+
+// --- Load Balancer Helpers ---
+
+// LBPort is the nginx load balancer port (HTTPS).
+const LBPort = 8000
+
+// LBNodeURL returns the base URL for the nginx load balancer.
+func LBNodeURL() string {
+	return fmt.Sprintf("https://127.0.0.1:%d", LBPort)
+}
+
+// LBAvailable checks if the nginx load balancer can actually proxy to the
+// Warden cluster. We probe /v1/sys/health through the LB rather than the
+// nginx-only /nginx-health endpoint, because nginx may be healthy while
+// unable to reach the backend nodes (e.g., on Linux CI where nodes bind
+// to 127.0.0.1 and host.docker.internal maps to the Docker bridge gateway).
+func LBAvailable() bool {
+	status, _, _ := doLBHTTP("GET", LBNodeURL()+"/v1/sys/health", nil, "", nil)
+	// 200 = active leader, 429 = standby — both mean proxying works
+	return status == 200 || status == 429
+}
+
+// SkipWithoutLB skips the test if the load balancer is not available.
+func SkipWithoutLB(t *testing.T) {
+	t.Helper()
+	if !LBAvailable() {
+		t.Skip("nginx load balancer not available (skipping LB test)")
+	}
+}
+
+// doLBHTTP makes an HTTPS request through the LB with optional TLS client cert.
+func doLBHTTP(method, rawURL string, headers map[string]string, body string, clientCert *tls.Certificate) (int, []byte, error) {
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	if err != nil {
+		return 0, nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if body != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // self-signed e2e cert
+	if clientCert != nil {
+		tlsConfig.Certificates = []tls.Certificate{*clientCert}
+	}
+
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+// DoLBRequest makes an HTTPS request through the LB. Fatals on connection errors.
+func DoLBRequest(t *testing.T, method, rawURL string, headers map[string]string, body string, clientCert *tls.Certificate) (int, []byte) {
+	t.Helper()
+	status, respBody, err := doLBHTTP(method, rawURL, headers, body, clientCert)
+	if err != nil {
+		t.Fatalf("LB request failed: %v", err)
+	}
+	return status, respBody
+}
+
+// parseTLSCert parses PEM-encoded cert+key into a tls.Certificate.
+func parseTLSCert(t *testing.T, certPEM, keyPEM string) tls.Certificate {
+	t.Helper()
+	cert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		t.Fatalf("failed to parse TLS client cert: %v", err)
+	}
+	return cert
+}
+
+// VaultTransparentRequestViaLB makes a JWT transparent vault gateway request through the LB.
+func VaultTransparentRequestViaLB(t *testing.T, method, vaultPath, role, jwt string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/vault/role/%s/gateway/v1/%s", LBNodeURL(), role, vaultPath)
+	headers := map[string]string{"Authorization": "Bearer " + jwt}
+	return DoLBRequest(t, method, u, headers, "", nil)
+}
+
+// VaultCertTransparentRequestViaLB makes a cert transparent vault gateway request
+// through the LB. The client presents its TLS certificate to nginx, which
+// validates it against the LB CA and forwards it via X-SSL-Client-Cert.
+func VaultCertTransparentRequestViaLB(t *testing.T, method, vaultPath, role, clientCertPEM, clientKeyPEM string) (int, []byte) {
+	t.Helper()
+	cert := parseTLSCert(t, clientCertPEM, clientKeyPEM)
+	u := fmt.Sprintf("%s/v1/vault-cert/role/%s/gateway/v1/%s", LBNodeURL(), role, vaultPath)
+	return DoLBRequest(t, method, u, nil, "", &cert)
+}
+
+// VaultNTRequestViaLB makes a non-transparent vault gateway request through the LB.
+func VaultNTRequestViaLB(t *testing.T, method, vaultPath, wardenToken string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/vault-nt/gateway/v1/%s", LBNodeURL(), vaultPath)
+	headers := map[string]string{"X-Warden-Token": wardenToken}
+	return DoLBRequest(t, method, u, headers, "", nil)
+}
+
+// LoginJWTViaLB logs in with a JWT and role through the load balancer.
+func LoginJWTViaLB(t *testing.T, jwt, role string) (int, string) {
+	t.Helper()
+	loginBody := fmt.Sprintf(`{"jwt":"%s","role":"%s"}`, jwt, role)
+	status, body := DoLBRequest(t, "POST",
+		fmt.Sprintf("%s/v1/auth/jwt/login", LBNodeURL()),
+		map[string]string{"Content-Type": "application/json"},
+		loginBody, nil,
+	)
+	if status != 200 && status != 201 {
+		return status, ""
+	}
+	data := ParseJSON(t, body)
+	token, _ := JSONPath(data, "data.data.token").(string)
+	if token == "" {
+		token, _ = JSONPath(data, "data.token_id").(string)
+	}
+	return status, token
+}
+
+// CertLoginRequestViaLB performs a cert auth login through the load balancer.
+// The client presents its TLS certificate to nginx for forwarding.
+func CertLoginRequestViaLB(t *testing.T, role, clientCertPEM, clientKeyPEM string) (int, []byte) {
+	t.Helper()
+	cert := parseTLSCert(t, clientCertPEM, clientKeyPEM)
+	u := fmt.Sprintf("%s/v1/auth/cert/login", LBNodeURL())
+	headers := map[string]string{"Content-Type": "application/json"}
+	body := fmt.Sprintf(`{"role":"%s"}`, role)
+	return DoLBRequest(t, "POST", u, headers, body, &cert)
 }

--- a/e2e/loadbalancer/lb_test.go
+++ b/e2e/loadbalancer/lb_test.go
@@ -1,0 +1,187 @@
+//go:build e2e
+
+package loadbalancer
+
+import (
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// TestLBJWTTransparentRead verifies JWT transparent vault read through the
+// nginx load balancer (HTTPS, no client cert).
+func TestLBJWTTransparentRead(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	jwt := h.GetDefaultJWT(t)
+	status, body := h.VaultTransparentRequestViaLB(t, "GET",
+		"secret/data/e2e/app-config", "e2e-reader", jwt)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in response")
+	}
+}
+
+// TestLBJWTNonTransparentRead verifies JWT login + warden_token gateway read
+// through the load balancer.
+func TestLBJWTNonTransparentRead(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	jwt := h.GetDefaultJWT(t)
+	loginStatus, wardenToken := h.LoginJWTViaLB(t, jwt, "e2e-nt-reader")
+	if loginStatus != 200 && loginStatus != 201 {
+		t.Fatalf("JWT login via LB failed: status %d", loginStatus)
+	}
+	if wardenToken == "" {
+		t.Fatal("no warden token from JWT login via LB")
+	}
+
+	status, body := h.VaultNTRequestViaLB(t, "GET",
+		"secret/data/e2e/app-config", wardenToken)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %s", status, string(body))
+	}
+}
+
+// TestLBCertTransparentRead verifies cert transparent vault read through the
+// load balancer. The client presents a TLS certificate to nginx, which
+// validates it against the LB CA and forwards it via X-SSL-Client-Cert.
+func TestLBCertTransparentRead(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.LoadLBCA(t)
+	h.SetupCertVaultEnvWithCA(t, port, caCertPEM)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-lb")
+
+	status, body := h.VaultCertTransparentRequestViaLB(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", clientCertPEM, clientKeyPEM)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in response")
+	}
+}
+
+// TestLBCertNonTransparentRead verifies cert login + warden_token gateway read
+// through the load balancer. The TLS client cert is validated by nginx and
+// forwarded to Warden for authentication.
+func TestLBCertNonTransparentRead(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.LoadLBCA(t)
+	h.SetupCertVaultEnvWithCA(t, port, caCertPEM)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-lb-nt")
+
+	// Login via cert through LB to get a warden token
+	loginStatus, loginBody := h.CertLoginRequestViaLB(t, "e2e-cert-nt-reader", clientCertPEM, clientKeyPEM)
+	if loginStatus != 200 && loginStatus != 201 {
+		t.Fatalf("cert login via LB failed (status %d): %s", loginStatus, string(loginBody))
+	}
+	wardenToken := h.JSONString(t, loginBody, "data.data.token")
+	if wardenToken == "" {
+		t.Fatalf("no token in cert login response: %s", string(loginBody))
+	}
+
+	// Use the warden token for non-transparent gateway access through LB
+	status, body := h.VaultNTRequestViaLB(t, "GET",
+		"secret/data/e2e/app-config", wardenToken)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %s", status, string(body))
+	}
+}
+
+// TestLBCertHeaderForwarding verifies that TLS client certificates presented
+// to the LB are properly forwarded to Warden. The end-to-end path is:
+// client TLS cert -> nginx validates against CA -> X-SSL-Client-Cert header
+// -> Warden trusted_proxies allows Docker bridge CIDR -> cert auth login.
+func TestLBCertHeaderForwarding(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.LoadLBCA(t)
+	h.SetupCertVaultEnvWithCA(t, port, caCertPEM)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-lb-fwd")
+
+	// Cert login through LB — exercises the full trusted_proxies + TLS forwarding path
+	status, body := h.CertLoginRequestViaLB(t, "e2e-cert-reader", clientCertPEM, clientKeyPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("cert login through LB failed (status %d): %s — "+
+			"this may indicate trusted_proxies doesn't include Docker bridge CIDR",
+			status, string(body))
+	}
+}
+
+// TestLBConcurrentJWTTransparent verifies that multiple concurrent JWT
+// transparent requests through the load balancer all succeed.
+func TestLBConcurrentJWTTransparent(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	jwt := h.GetDefaultJWT(t)
+
+	const n = 10
+	var wg sync.WaitGroup
+	results := make([]int, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			status, _ := h.VaultTransparentRequestViaLB(t, "GET",
+				"secret/data/e2e/app-config", "e2e-reader", jwt)
+			results[idx] = status
+		}(i)
+	}
+	wg.Wait()
+
+	for i, status := range results {
+		if status != 200 {
+			t.Fatalf("request %d: expected 200, got %d", i, status)
+		}
+	}
+}
+
+// TestLBHealthRouting verifies that the LB routes to healthy nodes even when
+// one node is temporarily unreachable. We test this by killing a standby node,
+// sending requests through the LB, and verifying they still succeed (routed to
+// remaining healthy nodes).
+func TestLBHealthRouting(t *testing.T) {
+	h.SkipWithoutLB(t)
+
+	// Find a standby to kill
+	standbyPort := h.GetStandbyPort(t)
+	nodeNum := h.NodeNumberForPort(standbyPort)
+
+	// Kill the standby
+	h.KillNode(t, nodeNum, "TERM")
+	defer func() {
+		h.RestartNode(t, nodeNum)
+		h.WaitForCluster(t, 30, 1e9) // 1s delay
+	}()
+
+	// Wait a moment for the node to go down
+	h.WaitForNodeStatus(t, standbyPort, 0, 10, 500e6) // expect unreachable (status 0)
+
+	// Requests through LB should still succeed (routed to healthy nodes)
+	jwt := h.GetDefaultJWT(t)
+	status, body := h.VaultTransparentRequestViaLB(t, "GET",
+		"secret/data/e2e/app-config", "e2e-reader", jwt)
+	if status != 200 {
+		t.Fatalf("expected 200 through LB with one node down, got %d: %s", status, string(body))
+	}
+}

--- a/e2e/loadbalancer/nginx.conf
+++ b/e2e/loadbalancer/nginx.conf
@@ -1,0 +1,45 @@
+upstream warden_cluster {
+    server host.docker.internal:8500;
+    server host.docker.internal:8510;
+    server host.docker.internal:8520;
+}
+
+server {
+    listen 8000 ssl;
+
+    ssl_certificate     /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+
+    # Validate client certificates against the trusted CA.
+    # "optional" means: accept connections without a client cert (for JWT
+    # requests), but verify the cert against the CA if one is presented.
+    ssl_client_certificate /etc/nginx/certs/ca.crt;
+    ssl_verify_client      optional;
+
+    location = /nginx-health {
+        return 200 "ok";
+        add_header Content-Type text/plain;
+    }
+
+    location / {
+        proxy_pass http://warden_cluster;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Forward the verified TLS client certificate to the backend
+        # (URL-encoded PEM). Overwrites any client-provided header to
+        # prevent spoofing.
+        proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
+
+        # Strip XFCC header to prevent spoofing
+        proxy_set_header X-Forwarded-Client-Cert "";
+
+        proxy_pass_request_headers on;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+        proxy_buffering off;
+    }
+}

--- a/e2e/provider/cert_gateway_test.go
+++ b/e2e/provider/cert_gateway_test.go
@@ -1,0 +1,161 @@
+//go:build e2e
+
+package provider
+
+import (
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// TestCertTransparentReadKVSecret verifies cert-based transparent mode
+// reads a vault secret on the leader.
+func TestCertTransparentReadKVSecret(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-1")
+
+	status, body := h.VaultCertTransparentRequest(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in response")
+	}
+}
+
+// TestCertNonTransparentReadKVSecret verifies cert login produces a
+// warden_token that can be used for non-transparent vault gateway access.
+func TestCertNonTransparentReadKVSecret(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-2")
+	wardenToken := h.GetCertNTWardenToken(t, port, "e2e-cert-nt-reader", clientCertPEM)
+
+	status, body := h.VaultNTRequest(t, "GET",
+		"secret/data/e2e/app-config", port, wardenToken)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d: %s", status, string(body))
+	}
+}
+
+// TestCertTransparentThroughStandby verifies cert-based transparent mode
+// works when the request arrives at a standby node and is forwarded to the leader.
+func TestCertTransparentThroughStandby(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-standby")
+
+	standbyPort := h.GetStandbyPort(t)
+	status, body := h.VaultCertTransparentRequest(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", standbyPort, clientCertPEM)
+	if status != 200 {
+		t.Fatalf("expected 200 through standby, got %d: %s", status, string(body))
+	}
+}
+
+// TestCertNonTransparentThroughStandby verifies that a warden_token obtained
+// via cert login on the leader works for gateway requests through a standby.
+func TestCertNonTransparentThroughStandby(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-nt-standby")
+	wardenToken := h.GetCertNTWardenToken(t, port, "e2e-cert-nt-reader", clientCertPEM)
+
+	standbyPort := h.GetStandbyPort(t)
+	status, body := h.VaultNTRequest(t, "GET",
+		"secret/data/e2e/app-config", standbyPort, wardenToken)
+	if status != 200 {
+		t.Fatalf("expected 200 through standby, got %d: %s", status, string(body))
+	}
+}
+
+// TestCertTransparentTokenReuse verifies that concurrent transparent requests
+// with the same certificate reuse the same token via singleflight.
+func TestCertTransparentTokenReuse(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-reuse")
+
+	const n = 10
+	var wg sync.WaitGroup
+	results := make([]int, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			status, _ := h.VaultCertTransparentRequest(t, "GET",
+				"secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM)
+			results[idx] = status
+		}(i)
+	}
+	wg.Wait()
+
+	for i, status := range results {
+		if status != 200 {
+			t.Fatalf("request %d: expected 200, got %d", i, status)
+		}
+	}
+}
+
+// TestCertTransparentWrongCN verifies that a certificate with a CN that
+// doesn't match the role's allowed_common_names is rejected.
+func TestCertTransparentWrongCN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "unauthorized-user")
+
+	status, _ := h.VaultCertTransparentRequest(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM)
+	if status == 200 {
+		t.Fatal("expected non-200 for cert with non-matching CN")
+	}
+}
+
+// TestCertTransparentAndJWTTransparentSameVault verifies that both cert and
+// JWT transparent modes can access the same underlying vault secret.
+func TestCertTransparentAndJWTTransparentSameVault(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	// Read via cert transparent mode
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-cert-cross")
+	certStatus, certBody := h.VaultCertTransparentRequest(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM)
+	if certStatus != 200 {
+		t.Fatalf("cert transparent: expected 200, got %d: %s", certStatus, string(certBody))
+	}
+
+	// Read via JWT transparent mode (uses existing vault provider + jwt auth)
+	jwt := h.GetDefaultJWT(t)
+	jwtStatus, jwtBody := h.VaultTransparentRequest(t, "GET",
+		"secret/data/e2e/app-config", "e2e-reader", port, jwt)
+	if jwtStatus != 200 {
+		t.Fatalf("JWT transparent: expected 200, got %d: %s", jwtStatus, string(jwtBody))
+	}
+
+	// Both should return the same secret
+	certAPIKey := h.JSONString(t, certBody, "data.data.api_key")
+	jwtAPIKey := h.JSONString(t, jwtBody, "data.data.api_key")
+	if certAPIKey != jwtAPIKey {
+		t.Fatalf("expected same api_key from both modes, got cert=%q jwt=%q", certAPIKey, jwtAPIKey)
+	}
+}

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -30,9 +30,37 @@ HYDRA_ADMIN="http://localhost:4445"
 echo "=== Warden E2E Cluster Setup ==="
 echo ""
 
-# Step 1: Start infrastructure (PostgreSQL + Vault + Hydra)
-echo "[1/10] Starting infrastructure (PostgreSQL + Vault + Hydra)..."
-$DOCKER_COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" up -d
+# Step 0: Generate TLS certificates for nginx load balancer
+NGINX_CERT_DIR="$SCRIPT_DIR/loadbalancer/certs"
+mkdir -p "$NGINX_CERT_DIR"
+
+if [ ! -f "$NGINX_CERT_DIR/ca.crt" ]; then
+  echo "Generating LB CA certificate..."
+  openssl ecparam -genkey -name prime256v1 -noout -out "$NGINX_CERT_DIR/ca.key" 2>/dev/null
+  openssl req -x509 -new -key "$NGINX_CERT_DIR/ca.key" -out "$NGINX_CERT_DIR/ca.crt" \
+    -days 365 -subj "/CN=E2E LB CA/O=Warden E2E" 2>/dev/null
+fi
+
+if [ ! -f "$NGINX_CERT_DIR/server.crt" ]; then
+  echo "Generating nginx server certificate..."
+  openssl ecparam -genkey -name prime256v1 -noout -out "$NGINX_CERT_DIR/server.key" 2>/dev/null
+  openssl req -x509 -new -key "$NGINX_CERT_DIR/server.key" -out "$NGINX_CERT_DIR/server.crt" \
+    -days 365 -subj "/CN=e2e-nginx-lb" 2>/dev/null
+fi
+
+# Step 1: Start infrastructure (PostgreSQL + Vault + Hydra + Nginx)
+echo "[1/10] Starting infrastructure (PostgreSQL + Vault + Hydra + Nginx)..."
+for pull_attempt in 1 2 3; do
+  if $DOCKER_COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" up -d 2>&1; then
+    break
+  fi
+  if [ "$pull_attempt" -eq 3 ]; then
+    echo "ERROR: docker compose up failed after 3 attempts"
+    exit 1
+  fi
+  echo "  Retrying docker compose up (attempt $((pull_attempt + 1))/3)..."
+  sleep 5
+done
 
 echo "Waiting for PostgreSQL to be ready..."
 until docker exec e2e-postgres-warden pg_isready -U warden -q 2>/dev/null; do
@@ -65,6 +93,20 @@ for attempt in $(seq 1 60); do
   sleep 2
 done
 echo "Hydra is ready."
+
+echo "Waiting for Nginx LB to be ready..."
+for attempt in $(seq 1 30); do
+  if curl -sk "https://127.0.0.1:8000/nginx-health" >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$attempt" -eq 30 ]; then
+    echo "  WARNING: Nginx LB not ready after 30 attempts (LB tests will skip)"
+  fi
+  sleep 1
+done
+if curl -sk "https://127.0.0.1:8000/nginx-health" >/dev/null 2>&1; then
+  echo "Nginx LB is ready."
+fi
 
 # Step 2: Reset E2E tables (clean state)
 echo ""

--- a/e2e/teardown.sh
+++ b/e2e/teardown.sh
@@ -45,6 +45,7 @@ rm -f "$SCRIPT_DIR/configs/seal.key"
 rm -f "$SCRIPT_DIR/configs/warden-audit.log"
 rm -f "$SCRIPT_DIR/.root_token"
 rm -f "$SCRIPT_DIR/.logs"/*.log
+rm -rf "$SCRIPT_DIR/loadbalancer/certs"
 
 echo ""
 echo "Teardown complete."

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/crypto v0.48.0
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.50.0
 	golang.org/x/sync v0.19.0

--- a/http/handler.go
+++ b/http/handler.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"crypto/tls"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net"
@@ -15,6 +16,7 @@ import (
 
 	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/stephnangue/warden/core"
+	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -210,6 +212,17 @@ func (f *standbyForwarder) getProxy(clusterAddr, redirectAddr string) *httputil.
 				req.Header.Set("X-Forwarded-Proto", "https")
 			} else if req.Header.Get("X-Forwarded-Proto") == "" {
 				req.Header.Set("X-Forwarded-Proto", "http")
+			}
+
+			// Re-inject any forwarded client certificate that the API
+			// middleware extracted and stripped. The cluster listener
+			// needs it as a header to pass the cert to the leader.
+			if cert := listener.ForwardedClientCert(req.Context()); cert != nil {
+				pemBytes := pem.EncodeToMemory(&pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: cert.Raw,
+				})
+				req.Header.Set("X-SSL-Client-Cert", url.QueryEscape(string(pemBytes)))
 			}
 		},
 		Transport: transport,

--- a/listener/api/cert_forwarding.go
+++ b/listener/api/cert_forwarding.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// certForwardingMiddleware returns middleware that extracts client certificates
+// from forwarding headers sent by trusted proxies. It must run BEFORE
+// middleware.RealIP which overwrites r.RemoteAddr.
+//
+// When the request comes from a trusted proxy IP:
+//   - Parses X-Forwarded-Client-Cert (XFCC, Envoy/Istio) or
+//     X-SSL-Client-Cert (NGINX/HAProxy) headers
+//   - Stores the parsed certificate in the request context
+//   - Strips the forwarding headers to prevent downstream leakage
+//
+// When the request comes from an untrusted IP:
+//   - Deletes any forwarding headers to prevent spoofing
+func certForwardingMiddleware(trustedProxies []string) func(http.Handler) http.Handler {
+	// Pre-parse CIDR networks at startup
+	networks := parseCIDRs(trustedProxies)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// If no trusted proxies configured, strip headers and pass through
+			if len(networks) == 0 {
+				listener.StripCertHeaders(r)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			remoteIP := extractRemoteIP(r.RemoteAddr)
+			if remoteIP == nil {
+				listener.StripCertHeaders(r)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !isTrustedProxy(remoteIP, networks) {
+				listener.StripCertHeaders(r)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Trusted proxy — extract cert from forwarding headers
+			cert := listener.ParseForwardedCert(r)
+
+			if cert != nil {
+				ctx := listener.WithForwardedClientCert(r.Context(), cert)
+				r = r.WithContext(ctx)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func extractRemoteIP(remoteAddr string) net.IP {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		// Try parsing as bare IP
+		return net.ParseIP(remoteAddr)
+	}
+	return net.ParseIP(host)
+}
+
+func isTrustedProxy(ip net.IP, networks []*net.IPNet) bool {
+	for _, network := range networks {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateCIDRs checks that all entries are valid CIDR notations or bare IPs.
+// Returns an error listing any unparseable entries, so misconfigurations are
+// caught at startup rather than silently ignored.
+func ValidateCIDRs(cidrs []string) error {
+	var invalid []string
+	for _, cidr := range cidrs {
+		_, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			// Allow bare IPs (they get /32 or /128 in parseCIDRs)
+			if net.ParseIP(cidr) == nil {
+				invalid = append(invalid, cidr)
+			}
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid trusted_proxies entries: %v", invalid)
+	}
+	return nil
+}
+
+func parseCIDRs(cidrs []string) []*net.IPNet {
+	networks := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			// Try as single IP (add /32 or /128)
+			ip := net.ParseIP(cidr)
+			if ip != nil {
+				if ip.To4() != nil {
+					_, network, _ = net.ParseCIDR(cidr + "/32")
+				} else {
+					_, network, _ = net.ParseCIDR(cidr + "/128")
+				}
+				if network != nil {
+					networks = append(networks, network)
+				}
+			}
+			continue
+		}
+		networks = append(networks, network)
+	}
+	return networks
+}

--- a/listener/api/cert_forwarding_test.go
+++ b/listener/api/cert_forwarding_test.go
@@ -1,0 +1,329 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// generateTestCert creates a self-signed certificate for testing.
+func generateTestCert(t *testing.T, cn string) (certPEM string, cert *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Minute),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	cert, _ = x509.ParseCertificate(certDER)
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+	return certPEM, cert
+}
+
+func TestCertForwardingMiddleware_TrustedProxyWithXSSLClientCert(t *testing.T) {
+	certPEM, expectedCert := generateTestCert(t, "test-client")
+	encodedPEM := url.QueryEscape(certPEM)
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"127.0.0.1/32"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-SSL-Client-Cert", encodedPEM)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert == nil {
+		t.Fatal("expected certificate in context, got nil")
+	}
+	if extractedCert.Subject.CommonName != expectedCert.Subject.CommonName {
+		t.Fatalf("expected CN %q, got %q", expectedCert.Subject.CommonName, extractedCert.Subject.CommonName)
+	}
+
+	// Header should be stripped
+	if req.Header.Get("X-SSL-Client-Cert") != "" {
+		t.Fatal("X-SSL-Client-Cert header should have been stripped")
+	}
+}
+
+func TestCertForwardingMiddleware_TrustedProxyWithXFCC(t *testing.T) {
+	certPEM, expectedCert := generateTestCert(t, "xfcc-client")
+	encodedPEM := url.QueryEscape(certPEM)
+	certHash := fmt.Sprintf("%x", sha256.Sum256(expectedCert.Raw))
+	xfcc := "Hash=" + certHash + ";Cert=" + encodedPEM + ";Subject=\"CN=xfcc-client\""
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"10.0.0.0/8"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.1.2.3:9999"
+	req.Header.Set("X-Forwarded-Client-Cert", xfcc)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert == nil {
+		t.Fatal("expected certificate in context from XFCC header, got nil")
+	}
+	if extractedCert.Subject.CommonName != expectedCert.Subject.CommonName {
+		t.Fatalf("expected CN %q, got %q", expectedCert.Subject.CommonName, extractedCert.Subject.CommonName)
+	}
+}
+
+func TestCertForwardingMiddleware_UntrustedProxyStripsHeaders(t *testing.T) {
+	certPEM, _ := generateTestCert(t, "spoofed-client")
+	encodedPEM := url.QueryEscape(certPEM)
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"10.0.0.0/8"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.1:12345" // Not in trusted range
+	req.Header.Set("X-SSL-Client-Cert", encodedPEM)
+	req.Header.Set("X-Forwarded-Client-Cert", "Hash=abc;Cert="+encodedPEM)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert != nil {
+		t.Fatal("expected no certificate from untrusted proxy, got one")
+	}
+	// Headers should be stripped
+	if req.Header.Get("X-SSL-Client-Cert") != "" {
+		t.Fatal("X-SSL-Client-Cert header should have been stripped from untrusted request")
+	}
+	if req.Header.Get("X-Forwarded-Client-Cert") != "" {
+		t.Fatal("X-Forwarded-Client-Cert header should have been stripped from untrusted request")
+	}
+}
+
+func TestCertForwardingMiddleware_NoTrustedProxies(t *testing.T) {
+	certPEM, _ := generateTestCert(t, "no-proxy-client")
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware(nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-SSL-Client-Cert", url.QueryEscape(certPEM))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert != nil {
+		t.Fatal("expected no cert when no trusted proxies configured")
+	}
+}
+
+func TestCertForwardingMiddleware_TrustedProxyNoCertHeader(t *testing.T) {
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"127.0.0.1/32"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	// No cert headers set
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert != nil {
+		t.Fatal("expected no cert when no header present, got one")
+	}
+}
+
+func TestParseCIDRs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected int
+	}{
+		{"single CIDR", []string{"10.0.0.0/8"}, 1},
+		{"multiple CIDRs", []string{"10.0.0.0/8", "172.16.0.0/12"}, 2},
+		{"bare IP converted to /32", []string{"192.168.1.1"}, 1},
+		{"empty", nil, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseCIDRs(tc.input)
+			if len(result) != tc.expected {
+				t.Fatalf("expected %d networks, got %d", tc.expected, len(result))
+			}
+		})
+	}
+}
+
+func TestValidateCIDRs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		wantErr bool
+	}{
+		{"valid CIDR", []string{"10.0.0.0/8"}, false},
+		{"valid bare IP", []string{"192.168.1.1"}, false},
+		{"valid mixed", []string{"10.0.0.0/8", "127.0.0.1"}, false},
+		{"empty", nil, false},
+		{"invalid entry", []string{"not-a-cidr"}, true},
+		{"mixed valid and invalid", []string{"10.0.0.0/8", "garbage", "127.0.0.1"}, true},
+		{"multiple invalid", []string{"foo", "bar"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCIDRs(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestExtractRemoteIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		addr     string
+		expected string
+	}{
+		{"host:port", "127.0.0.1:8080", "127.0.0.1"},
+		{"bare IP", "192.168.1.1", "192.168.1.1"},
+		{"IPv6 with port", "[::1]:8080", "::1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := extractRemoteIP(tc.addr)
+			if ip == nil {
+				t.Fatalf("expected IP, got nil for %q", tc.addr)
+			}
+			if ip.String() != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, ip.String())
+			}
+		})
+	}
+}
+
+func TestParseXFCCHeader(t *testing.T) {
+	certPEM, expectedCert := generateTestCert(t, "xfcc-parse-test")
+	encodedPEM := url.QueryEscape(certPEM)
+	correctHash := fmt.Sprintf("%x", sha256.Sum256(expectedCert.Raw))
+
+	// Standard format with correct hash
+	cert := listener.ParseXFCCHeader("Hash=" + correctHash + ";Cert=" + encodedPEM + ";Subject=\"CN=test\"")
+	if cert == nil {
+		t.Fatal("expected cert from XFCC header with correct hash")
+	}
+	if cert.Subject.CommonName != expectedCert.Subject.CommonName {
+		t.Fatalf("expected CN %q, got %q", expectedCert.Subject.CommonName, cert.Subject.CommonName)
+	}
+
+	// With quoted value and no hash (should pass — hash is optional)
+	cert = listener.ParseXFCCHeader("Cert=\"" + encodedPEM + "\"")
+	if cert == nil {
+		t.Fatal("expected cert from quoted XFCC header without hash")
+	}
+
+	// No Cert field
+	cert = listener.ParseXFCCHeader("Hash=abc;Subject=\"CN=test\"")
+	if cert != nil {
+		t.Fatal("expected nil cert when no Cert field in XFCC")
+	}
+
+	// Invalid cert data
+	cert = listener.ParseXFCCHeader("Cert=not-a-cert")
+	if cert != nil {
+		t.Fatal("expected nil cert for invalid data")
+	}
+
+	// Mismatched hash — cert should be rejected
+	cert = listener.ParseXFCCHeader("Hash=0000000000000000000000000000000000000000000000000000000000000000;Cert=" + encodedPEM)
+	if cert != nil {
+		t.Fatal("expected nil cert when hash does not match certificate")
+	}
+
+	// Invalid (non-hex) hash — cert should be rejected
+	cert = listener.ParseXFCCHeader("Hash=not-a-valid-hash;Cert=" + encodedPEM)
+	if cert != nil {
+		t.Fatal("expected nil cert when hash is not valid hex")
+	}
+}
+
+func TestParseSSLClientCertHeader(t *testing.T) {
+	certPEM, expectedCert := generateTestCert(t, "ssl-cert-test")
+
+	cert := listener.ParseSSLClientCertHeader(url.QueryEscape(certPEM))
+	if cert == nil {
+		t.Fatal("expected cert from X-SSL-Client-Cert header")
+	}
+	if cert.Subject.CommonName != expectedCert.Subject.CommonName {
+		t.Fatalf("expected CN %q, got %q", expectedCert.Subject.CommonName, cert.Subject.CommonName)
+	}
+
+	// Invalid URL encoding
+	cert = listener.ParseSSLClientCertHeader("%zz-invalid")
+	if cert != nil {
+		t.Fatal("expected nil for invalid URL encoding")
+	}
+
+	// Valid URL encoding but not a cert
+	cert = listener.ParseSSLClientCertHeader(url.QueryEscape("not a certificate"))
+	if cert != nil {
+		t.Fatal("expected nil for non-PEM data")
+	}
+}

--- a/listener/api/listener.go
+++ b/listener/api/listener.go
@@ -25,17 +25,24 @@ type ApiListener struct {
 }
 
 type ApiListenerConfig struct {
-	Logger          *logger.GatedLogger
-	Address         string
-	TLSCertFile     string
-	TLSKeyFile      string
-	TLSClientCAFile string
-	TLSEnabled      bool
+	Logger               *logger.GatedLogger
+	Address              string
+	TLSCertFile          string
+	TLSKeyFile           string
+	TLSClientCAFile      string
+	TLSEnabled           bool
+	TLSRequireClientCert *bool    // nil = default (true when TLSClientCAFile set)
+	TrustedProxies       []string // CIDR ranges for LB cert forwarding
 }
 
 func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListener, error) {
+	// Validate trusted proxy CIDRs at startup to catch misconfigurations early
+	if err := ValidateCIDRs(cfg.TrustedProxies); err != nil {
+		return nil, fmt.Errorf("listener config: %w", err)
+	}
 
 	var handler http.Handler = httpHandler
+	handler = certForwardingMiddleware(cfg.TrustedProxies)(handler)
 	handler = middleware.RealIP(handler)
 	handler = middleware.RequestID(handler)
 	handler = middleware.Recoverer(handler)
@@ -67,7 +74,12 @@ func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListen
 				return nil, fmt.Errorf("tls_client_ca_file %q contains no valid certificates", cfg.TLSClientCAFile)
 			}
 			tlsCfg.ClientCAs = caPool
-			tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+			requireClientCert := cfg.TLSRequireClientCert == nil || *cfg.TLSRequireClientCert
+			if requireClientCert {
+				tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+			} else {
+				tlsCfg.ClientAuth = tls.VerifyClientCertIfGiven
+			}
 		}
 
 		server.TLSConfig = tlsCfg

--- a/listener/cert_forwarding.go
+++ b/listener/cert_forwarding.go
@@ -1,0 +1,148 @@
+package listener
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type contextKey string
+
+const ctxForwardedClientCert contextKey = "forwarded_client_cert"
+
+// ForwardedClientCert retrieves a client certificate that was forwarded by a
+// trusted proxy (load balancer) or re-injected by the cluster listener from
+// forwarding headers.
+func ForwardedClientCert(ctx context.Context) *x509.Certificate {
+	cert, _ := ctx.Value(ctxForwardedClientCert).(*x509.Certificate)
+	return cert
+}
+
+// WithForwardedClientCert returns a new context with the forwarded client cert set.
+func WithForwardedClientCert(ctx context.Context, cert *x509.Certificate) context.Context {
+	return context.WithValue(ctx, ctxForwardedClientCert, cert)
+}
+
+// ParseForwardedCert extracts a client certificate from forwarding headers
+// (X-Forwarded-Client-Cert or X-SSL-Client-Cert) and strips the headers.
+func ParseForwardedCert(r *http.Request) *x509.Certificate {
+	cert := ParseCertFromHeaders(r)
+	StripCertHeaders(r)
+	return cert
+}
+
+// ParseCertFromHeaders tries to extract a client certificate from forwarding headers.
+// Checks X-Forwarded-Client-Cert (XFCC) first, then X-SSL-Client-Cert.
+func ParseCertFromHeaders(r *http.Request) *x509.Certificate {
+	if xfcc := r.Header.Get("X-Forwarded-Client-Cert"); xfcc != "" {
+		if cert := ParseXFCCHeader(xfcc); cert != nil {
+			return cert
+		}
+	}
+
+	if sslCert := r.Header.Get("X-SSL-Client-Cert"); sslCert != "" {
+		if cert := ParseSSLClientCertHeader(sslCert); cert != nil {
+			return cert
+		}
+	}
+
+	return nil
+}
+
+// ParseXFCCHeader parses the X-Forwarded-Client-Cert header (Envoy/Istio format).
+// Format: Hash=<hex-encoded SHA-256>;Cert="<URL-encoded PEM>";Subject="..."
+//
+// When a Hash field is present, it is validated against the SHA-256 fingerprint
+// of the extracted certificate. A mismatch returns nil (cert rejected).
+func ParseXFCCHeader(xfcc string) *x509.Certificate {
+	var certValue, hashValue string
+
+	for _, part := range strings.Split(xfcc, ";") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(part, "Cert="):
+			certValue = strings.TrimPrefix(part, "Cert=")
+			certValue = strings.Trim(certValue, "\"")
+		case strings.HasPrefix(part, "Hash="):
+			hashValue = strings.TrimPrefix(part, "Hash=")
+			hashValue = strings.Trim(hashValue, "\"")
+		}
+	}
+
+	if certValue == "" {
+		return nil
+	}
+
+	decoded, err := url.QueryUnescape(certValue)
+	if err != nil {
+		return nil
+	}
+	cert := ParsePEMCertificate(decoded)
+	if cert == nil {
+		return nil
+	}
+
+	if hashValue != "" {
+		fingerprint := fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
+		normalizedHash := strings.ToLower(strings.ReplaceAll(hashValue, ":", ""))
+		if normalizedHash != fingerprint {
+			if decoded, err := hex.DecodeString(normalizedHash); err == nil {
+				expected := sha256.Sum256(cert.Raw)
+				if !shaEqual(decoded, expected[:]) {
+					return nil
+				}
+			} else {
+				return nil
+			}
+		}
+	}
+
+	return cert
+}
+
+func shaEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ParseSSLClientCertHeader parses the X-SSL-Client-Cert header (NGINX/HAProxy format).
+// The value is a URL-encoded PEM certificate.
+func ParseSSLClientCertHeader(value string) *x509.Certificate {
+	decoded, err := url.QueryUnescape(value)
+	if err != nil {
+		return nil
+	}
+	return ParsePEMCertificate(decoded)
+}
+
+// ParsePEMCertificate parses a PEM-encoded certificate string.
+func ParsePEMCertificate(pemData string) *x509.Certificate {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil
+	}
+	return cert
+}
+
+// StripCertHeaders removes cert forwarding headers from the request.
+func StripCertHeaders(r *http.Request) {
+	r.Header.Del("X-Forwarded-Client-Cert")
+	r.Header.Del("X-SSL-Client-Cert")
+}

--- a/listener/cluster/listener.go
+++ b/listener/cluster/listener.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -57,8 +58,21 @@ func NewClusterListener(cfg ClusterListenerConfig) (*ClusterListener, error) {
 		writeTimeout = 60 * time.Second
 	}
 
+	// Wrap the handler to re-parse any cert forwarding headers from the
+	// original request. ParseForwardedCert re-extracts the original client
+	// cert from headers (X-SSL-Client-Cert / XFCC) that the standby's
+	// reverse proxy preserved. This is safe because the cluster listener
+	// enforces mTLS — only authenticated cluster nodes can send requests here.
+	clusterHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if cert := listener.ParseForwardedCert(r); cert != nil {
+			ctx = listener.WithForwardedClientCert(ctx, cert)
+		}
+		cfg.Handler.ServeHTTP(w, r.WithContext(ctx))
+	})
+
 	server := &http.Server{
-		Handler:      cfg.Handler,
+		Handler:      clusterHandler,
 		IdleTimeout:  time.Minute,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,


### PR DESCRIPTION
…y hardening

Add a new certificate-based authentication method supporting direct mTLS, forwarded client certificates (XFCC/X-SSL-Client-Cert), and SPIFFE X.509 SVIDs alongside JWT-SVID support in the JWT auth method.

Certificate auth capabilities:
- Certificate chain validation against trusted CAs (global or per-role)
- CRL and OCSP revocation checking with configurable modes
- Role-based constraints (CN, DNS/Email/URI SANs, OU, Org)
- Principal identity extraction from multiple cert fields
- Transparent auth mode with cert fingerprint-based token caching

SPIFFE support (both auth methods):
- Cert auth: dedicated spiffe_id principal claim extracts SPIFFE URI from X.509 SVID certificates; allowed_uri_sans constrains trust domains/paths
- JWT auth: bound_uri_patterns with segment-aware wildcards (+, *) validate SPIFFE IDs in JWT-SVIDs (e.g. spiffe://+/dept/*)
- Shared helper (auth/helper/match.go) provides consistent segment-aware URI pattern matching across both methods

Security hardening across both auth methods:
- Generic error messages to prevent information leakage
- Mandatory role constraints to prevent overly permissive cert roles
- XFCC hash validation against extracted certificate
- Type-aware bound claims comparison, no implicit coercion
- CIDR validation at config time instead of silent drop
- JWT max_age/iat freshness validation per role
- CRL signature verification against issuer certificate
- HTTP status checks and redirect prevention on CRL/OCSP fetches
- Principal claim whitelist validation at config/role time
- Defensive parse error handling for role config fields