### PR TITLE
feat: remove X-Warden-Auth-Path header and add default_role to auth m…

### DIFF
--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -26,6 +26,7 @@ type CertAuthConfig struct {
 	RevocationMode string        `json:"revocation_mode,omitempty"`    // "none" (default), "crl", "ocsp", "best_effort"
 	CRLCacheTTL    string        `json:"crl_cache_ttl,omitempty"`      // CRL cache TTL (default: "1h")
 	OCSPTimeout    string        `json:"ocsp_timeout,omitempty"`       // OCSP request timeout (default: "5s")
+	DefaultRole    string        `json:"default_role,omitempty"`       // Default role for transparent operations
 
 	// Internal — parsed CA pool
 	caPool *x509.CertPool `json:"-"`

--- a/auth/method/cert/path_config.go
+++ b/auth/method/cert/path_config.go
@@ -50,6 +50,10 @@ func (b *certAuthBackend) pathConfig() *framework.Path {
 				Description: "OCSP request timeout (default: 5s). Example: 3s, 10s",
 				Default:     "5s",
 			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default role for transparent operations when no role is specified",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -97,6 +101,7 @@ func (b *certAuthBackend) handleConfigRead(ctx context.Context, req *logical.Req
 			"revocation_mode":  b.config.RevocationMode,
 			"crl_cache_ttl":    b.config.CRLCacheTTL,
 			"ocsp_timeout":     b.config.OCSPTimeout,
+			"default_role":     b.config.DefaultRole,
 			"trusted_ca_count": certCount,
 		},
 	}, nil
@@ -116,6 +121,7 @@ func (b *certAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 		conf["revocation_mode"] = b.config.RevocationMode
 		conf["crl_cache_ttl"] = b.config.CRLCacheTTL
 		conf["ocsp_timeout"] = b.config.OCSPTimeout
+		conf["default_role"] = b.config.DefaultRole
 	}
 
 	// Apply new values from request

--- a/auth/method/cert/path_login.go
+++ b/auth/method/cert/path_login.go
@@ -26,8 +26,7 @@ func (b *certAuthBackend) pathLogin() *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"role": {
 				Type:        framework.TypeString,
-				Description: "Role to assume after authentication",
-				Required:    true,
+				Description: "Role to assume after authentication (falls back to default_role if configured)",
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -56,8 +55,11 @@ func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse(logical.ErrBadRequest("no client certificate provided")), nil
 	}
 
-	// Get role name
+	// Get role name — fall back to default_role if configured
 	roleName := d.Get("role").(string)
+	if roleName == "" && b.config != nil && b.config.DefaultRole != "" {
+		roleName = b.config.DefaultRole
+	}
 	if roleName == "" {
 		return logical.ErrorResponse(logical.ErrBadRequest("missing role")), nil
 	}

--- a/auth/method/cert/path_login_test.go
+++ b/auth/method/cert/path_login_test.go
@@ -1,17 +1,95 @@
 package cert
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"io"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/listener"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
 )
+
+// testLogger creates a logger for tests that discards output
+func testLogger() *logger.GatedLogger {
+	config := &logger.Config{
+		Level:   logger.ErrorLevel,
+		Format:  logger.JSONFormat,
+		Outputs: []io.Writer{io.Discard},
+	}
+	gateConfig := logger.GatedWriterConfig{
+		Underlying: io.Discard,
+	}
+	gl, _ := logger.NewGatedLogger(config, gateConfig)
+	return gl
+}
+
+// inmemStorage implements sdklogical.Storage for testing
+type inmemStorage struct {
+	mu   sync.RWMutex
+	data map[string]*sdklogical.StorageEntry
+}
+
+func newInmemStorage() *inmemStorage {
+	return &inmemStorage{
+		data: make(map[string]*sdklogical.StorageEntry),
+	}
+}
+
+func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			keys = append(keys, k[len(prefix):])
+		}
+	}
+	return keys, nil
+}
+
+func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key], nil
+}
+
+func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[entry.Key] = entry
+	return nil
+}
+
+func (s *inmemStorage) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *inmemStorage) ListPage(_ context.Context, prefix string, _ string, _ int) ([]string, error) {
+	return s.List(context.Background(), prefix)
+}
+
+var _ sdklogical.Storage = (*inmemStorage)(nil)
 
 // testCA generates a test CA certificate and key.
 func testCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, string) {
@@ -326,4 +404,94 @@ func TestCertFingerprint(t *testing.T) {
 	if fp1 == fp3 {
 		t.Fatal("different certs should have different fingerprints")
 	}
+}
+
+// =============================================================================
+// Default Role Fallback Tests
+// =============================================================================
+
+func TestHandleLogin_DefaultRoleFallback(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	clientCert := testClientCert(t, caCert, caKey, "test-agent")
+
+	t.Run("uses default_role when role is empty", func(t *testing.T) {
+		storage := newInmemStorage()
+		conf := &logical.BackendConfig{
+			Logger:          testLogger(),
+			StorageView:     storage,
+			ValidTokenTypes: []string{"warden_token"},
+		}
+		backend, err := Factory(context.Background(), conf)
+		require.NoError(t, err)
+		b := backend.(*certAuthBackend)
+		b.config = &CertAuthConfig{
+			TrustedCAPEM:   caPEM,
+			PrincipalClaim: "cn",
+			TokenTTL:       time.Hour,
+			DefaultRole:    "fallback-role",
+		}
+		b.config.caPool, _ = buildCAPool(caPEM)
+
+		req := &logical.Request{
+			HTTPRequest: newCertHTTPRequest(t, clientCert),
+		}
+		d := &framework.FieldData{
+			Raw: map[string]any{
+				"role": "",
+			},
+			Schema: b.pathLogin().Fields,
+		}
+
+		resp, err := b.handleLogin(context.Background(), req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Should NOT get "missing role" — should proceed past role check
+		if resp.Err != nil {
+			assert.NotContains(t, resp.Err.Error(), "missing role")
+		}
+	})
+
+	t.Run("missing role with no default_role returns error", func(t *testing.T) {
+		storage := newInmemStorage()
+		conf := &logical.BackendConfig{
+			Logger:          testLogger(),
+			StorageView:     storage,
+			ValidTokenTypes: []string{"warden_token"},
+		}
+		backend, err := Factory(context.Background(), conf)
+		require.NoError(t, err)
+		b := backend.(*certAuthBackend)
+		b.config = &CertAuthConfig{
+			TrustedCAPEM:   caPEM,
+			PrincipalClaim: "cn",
+			TokenTTL:       time.Hour,
+			DefaultRole:    "",
+		}
+
+		req := &logical.Request{
+			HTTPRequest: newCertHTTPRequest(t, clientCert),
+		}
+		d := &framework.FieldData{
+			Raw: map[string]any{
+				"role": "",
+			},
+			Schema: b.pathLogin().Fields,
+		}
+
+		resp, err := b.handleLogin(context.Background(), req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "missing role")
+	})
+}
+
+// newCertHTTPRequest creates an HTTP request with a client certificate in the
+// X-SSL-Client-Cert forwarded header context (simulating LB forwarding).
+func newCertHTTPRequest(t *testing.T, cert *x509.Certificate) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/cert/login", nil)
+	// Store the cert in the context via the cert forwarding middleware's context key
+	ctx := listener.WithForwardedClientCert(req.Context(), cert)
+	return req.WithContext(ctx)
 }

--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -44,6 +44,9 @@ type JWTAuthConfig struct {
 	TokenTTL  time.Duration `json:"token_ttl" default:"1h"`
 	TokenType string        `json:"token_type,omitempty"`
 
+	// Default role for transparent operations when no role is specified
+	DefaultRole string `json:"default_role,omitempty"`
+
 	// Internal
 	validator *jwt.Validator `json:"-"`
 	keySet    jwt.KeySet     `json:"-"`

--- a/auth/method/jwt/path_config.go
+++ b/auth/method/jwt/path_config.go
@@ -80,6 +80,10 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 				Default:       "warden_token",
 				AllowedValues: b.allowedTokenTypeValues(),
 			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default role for transparent operations when no role is specified",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -134,6 +138,7 @@ func (b *jwtAuthBackend) handleConfigRead(ctx context.Context, req *logical.Requ
 			"groups_claim": b.config.GroupsClaim,
 			"token_ttl":    b.config.TokenTTL.String(),
 			"token_type":   b.config.TokenType,
+			"default_role": b.config.DefaultRole,
 		},
 	}, nil
 }
@@ -160,6 +165,7 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 		conf["groups_claim"] = b.config.GroupsClaim
 		conf["token_ttl"] = b.config.TokenTTL
 		conf["token_type"] = b.config.TokenType
+		conf["default_role"] = b.config.DefaultRole
 	}
 
 	// Apply new values from request

--- a/auth/method/jwt/path_login.go
+++ b/auth/method/jwt/path_login.go
@@ -25,8 +25,7 @@ func (b *jwtAuthBackend) pathLogin() *framework.Path {
 			},
 			"role": {
 				Type:        framework.TypeString,
-				Description: "Role to assume after authentication",
-				Required:    true,
+				Description: "Role to assume after authentication (falls back to default_role if configured)",
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -55,8 +54,11 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse(logical.ErrBadRequest("missing jwt token")), nil
 	}
 
-	// Get role name
+	// Get role name — fall back to default_role if configured
 	roleName := d.Get("role").(string)
+	if roleName == "" && b.config != nil && b.config.DefaultRole != "" {
+		roleName = b.config.DefaultRole
+	}
 	if roleName == "" {
 		return logical.ErrorResponse(logical.ErrBadRequest("missing role")), nil
 	}

--- a/auth/method/jwt/path_login_test.go
+++ b/auth/method/jwt/path_login_test.go
@@ -152,7 +152,7 @@ func TestPathLogin_Fields(t *testing.T) {
 
 	// Check required flags
 	assert.True(t, jwtField.Required, "jwt field should be required")
-	assert.True(t, roleField.Required, "role field should be required")
+	assert.False(t, roleField.Required, "role field should not be required (falls back to default_role)")
 }
 
 func TestPathLogin_Operations(t *testing.T) {
@@ -517,4 +517,102 @@ func TestHandleLogin_RoleNotFound(t *testing.T) {
 	// Should fail because backend is not configured (validator is nil)
 	// This is the expected behavior - role check happens after config validation
 	assert.NotNil(t, resp.Err)
+}
+
+// =============================================================================
+// Default Role Fallback Tests
+// =============================================================================
+
+func TestHandleLogin_DefaultRoleFallback(t *testing.T) {
+	t.Run("uses default_role when role is empty", func(t *testing.T) {
+		ctx := context.Background()
+		conf := &logical.BackendConfig{
+			Logger: testLoggerLogin(),
+		}
+		backend, err := Factory(ctx, conf)
+		require.NoError(t, err)
+
+		b := backend.(*jwtAuthBackend)
+		b.config = &JWTAuthConfig{
+			DefaultRole: "fallback-role",
+		}
+
+		req := &logical.Request{}
+		d := &framework.FieldData{
+			Raw: map[string]any{
+				"jwt":  "some.jwt.token",
+				"role": "",
+			},
+			Schema: b.pathLogin().Fields,
+		}
+
+		resp, err := b.handleLogin(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Should NOT get "missing role" error — should proceed past role check
+		// and fail on config validation instead (validator is nil)
+		if resp.Err != nil {
+			assert.NotContains(t, resp.Err.Error(), "missing role")
+		}
+	})
+
+	t.Run("explicit role overrides default_role", func(t *testing.T) {
+		ctx := context.Background()
+		conf := &logical.BackendConfig{
+			Logger: testLoggerLogin(),
+		}
+		backend, err := Factory(ctx, conf)
+		require.NoError(t, err)
+
+		b := backend.(*jwtAuthBackend)
+		b.config = &JWTAuthConfig{
+			DefaultRole: "fallback-role",
+		}
+
+		req := &logical.Request{}
+		d := &framework.FieldData{
+			Raw: map[string]any{
+				"jwt":  "some.jwt.token",
+				"role": "explicit-role",
+			},
+			Schema: b.pathLogin().Fields,
+		}
+
+		resp, err := b.handleLogin(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Should fail on config validation (validator nil), not missing role
+		if resp.Err != nil {
+			assert.NotContains(t, resp.Err.Error(), "missing role")
+		}
+	})
+
+	t.Run("missing role with no default_role returns error", func(t *testing.T) {
+		ctx := context.Background()
+		conf := &logical.BackendConfig{
+			Logger: testLoggerLogin(),
+		}
+		backend, err := Factory(ctx, conf)
+		require.NoError(t, err)
+
+		b := backend.(*jwtAuthBackend)
+		b.config = &JWTAuthConfig{
+			DefaultRole: "", // no default
+		}
+
+		req := &logical.Request{}
+		d := &framework.FieldData{
+			Raw: map[string]any{
+				"jwt":  "some.jwt.token",
+				"role": "",
+			},
+			Schema: b.pathLogin().Fields,
+		}
+
+		resp, err := b.handleLogin(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "missing role")
+	})
 }

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -586,6 +586,28 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
 		}
 		req.ClientToken = extractToken(req.HTTPRequest)
+
+		// Transparent operations: implicit auth on non-gateway endpoints.
+		// Triggered when there's no explicit X-Warden-Token but an auth path
+		// is configured on the namespace. The Authorization: Bearer value is
+		// treated as a JWT credential, not a Warden token.
+		if req.HTTPRequest != nil && req.HTTPRequest.Header.Get("X-Warden-Token") == "" {
+			var authPath string
+			if ns, _ := namespace.FromContext(ctx); ns != nil {
+				authPath = ns.CustomMetadata["auto_auth_path"]
+			}
+			if authPath != "" {
+				role := req.HTTPRequest.Header.Get("X-Warden-Role")
+				if err := c.performImplicitAuth(ctx, req, authPath, role); err != nil {
+					c.logger.Warn("transparent operations auth failed",
+						logger.Err(err),
+						logger.String("path", req.Path),
+						logger.String("auth_path", authPath),
+					)
+					return logical.ErrorResponse(logical.ErrUnauthorized(err.Error())), nil, nil
+				}
+			}
+		}
 	} else {
 		req.Streamed = true
 
@@ -1024,31 +1046,50 @@ func (c *Core) isTransparentRequest(req *logical.Request, backend logical.Backen
 	return true, role
 }
 
-// handleTransparentAuth performs implicit authentication for transparent mode requests.
-// It detects the credential type (JWT bearer token or TLS client certificate) and
-// performs lookup/implicit auth accordingly.
+// handleTransparentAuth performs implicit authentication for transparent mode (gateway) requests.
+// It delegates to performImplicitAuth for credential detection and login.
+// The role may be empty — the auth method's default_role config provides the fallback.
+func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, backend logical.Backend, role string) error {
+	tmp := backend.(logical.TransparentModeProvider)
+	return c.performImplicitAuth(ctx, req, tmp.GetAutoAuthPath(), role)
+}
+
+// performImplicitAuth performs implicit authentication by detecting the credential type
+// (JWT bearer token or TLS client certificate), looking up cached tokens, and performing
+// login if needed. Used by both gateway transparent mode and transparent operations.
+//
+// Transparent mode precedence rules:
+//
+//	Credential (first match wins):
+//	  1. X-Warden-Token header → explicit auth, transparent mode skipped entirely
+//	  2. TLS client certificate (via X-SSL-Client-Cert) → implicit cert auth
+//	  3. Authorization: Bearer eyJ... → implicit JWT auth
+//
+//	Auth path (config only, no per-request override):
+//	  - Gateway: provider auto_auth_path config
+//	  - Operations: namespace auto_auth_path metadata
+//
+//	Role (first match wins):
+//	  1. URL path /role/{name}/gateway/... (gateway only)
+//	  2. X-Warden-Role header
+//	  3. Provider default_role config (gateway only)
+//	  4. Auth method default_role config (login-time fallback)
+//
 // Uses singleflight to prevent duplicate token creation when concurrent requests
 // arrive with the same credential+role combination.
 //
 // IMPORTANT: The role is validated when reusing cached tokens. A token created for
 // credential+Role1 cannot be reused for credential+Role2, as they may have different policies.
-func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, backend logical.Backend, role string) error {
-	// Mark request as transparent mode - credentials will be cache-only
+func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, autoAuthPath, role string) error {
+	// Mark request as transparent mode
 	req.Transparent = true
-
-	tmp := backend.(logical.TransparentModeProvider)
-	autoAuthPath := tmp.GetAutoAuthPath()
-
-	// Check if role is available (either from URL or default_role config)
-	if role == "" {
-		return fmt.Errorf("transparent mode requires a role: use /role/{role}/gateway/... path, X-Warden-Role header, or configure default_role")
-	}
 
 	// Detect credential type: client certificate or JWT bearer token
 	var singleflightKey string
 	var lookupFunc func() (*TokenEntry, error)
 	var loginData map[string]any
-	var postLoginLookup func() (*TokenEntry, error)
+	var credType string  // "cert" or "jwt" — used for post-login lookup with resolved role
+	var credKey string   // fingerprint or JWT — used for post-login lookup with resolved role
 
 	// Check for client certificate first (forwarded from LB or direct TLS)
 	clientCert := extractTransparentClientCert(req)
@@ -1061,10 +1102,11 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 		sfHash := sha256.Sum256([]byte("cert:" + fingerprint + ":" + role))
 		singleflightKey = hex.EncodeToString(sfHash[:])
 		loginData = map[string]any{"role": role}
+		credType = "cert"
+		credKey = fingerprint
 		lookupFunc = func() (*TokenEntry, error) {
 			return c.LookupCertTokenWithRole(ctx, fingerprint, role)
 		}
-		postLoginLookup = lookupFunc
 
 	case strings.HasPrefix(req.ClientToken, "eyJ"):
 		// JWT-based transparent auth
@@ -1072,13 +1114,14 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 		jwtHash := sha256.Sum256([]byte(clientToken + ":" + role))
 		singleflightKey = hex.EncodeToString(jwtHash[:])
 		loginData = map[string]any{"jwt": clientToken, "role": role}
+		credType = "jwt"
+		credKey = clientToken
 		lookupFunc = func() (*TokenEntry, error) {
 			return c.LookupJWTTokenWithRole(ctx, clientToken, role)
 		}
-		postLoginLookup = lookupFunc
 
 	default:
-		return fmt.Errorf("no valid credential for transparent mode (need JWT bearer token or TLS client certificate)")
+		return fmt.Errorf("no valid credential for implicit auth (need JWT bearer token or TLS client certificate)")
 	}
 
 	// Step 1: Try cached lookup
@@ -1090,9 +1133,8 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 	te, err := lookupFunc()
 	if err == nil && te != nil {
 		req.SetTokenEntry(te)
-		// For cert transparent auth, ClientToken is empty since the client only
-		// sends a certificate. Set it to the token ID so the downstream policy
-		// check in fetchCBPAndTokenEntry doesn't reject it.
+		// For cert auth, ClientToken is empty since the client only sends a certificate.
+		// Set it to the token ID so downstream policy checks don't reject it.
 		if req.ClientToken == "" {
 			req.ClientToken = te.ID
 		}
@@ -1132,10 +1174,20 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 			return nil, fmt.Errorf("implicit auth returned no auth data")
 		}
 
-		// Lookup the newly created token
-		newTE, lookupErr := postLoginLookup()
-		if lookupErr != nil {
-			return nil, fmt.Errorf("failed to lookup created token: %w", lookupErr)
+		// Lookup the newly created token using the resolved role from the login response.
+		// This handles default_role fallback: the original role may be empty, but the
+		// auth method resolves it to default_role. The token is stored with the resolved role.
+		resolvedRole := loginResp.Auth.RoleName
+		var newTE *TokenEntry
+		var postErr error
+		switch credType {
+		case "cert":
+			newTE, postErr = c.LookupCertTokenWithRole(ctx, credKey, resolvedRole)
+		case "jwt":
+			newTE, postErr = c.LookupJWTTokenWithRole(ctx, credKey, resolvedRole)
+		}
+		if postErr != nil {
+			return nil, fmt.Errorf("failed to lookup created token: %w", postErr)
 		}
 
 		return newTE, nil

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1362,6 +1362,178 @@ func TestHandleRequest_ConcurrentWithRootToken(t *testing.T) {
 	}
 }
 
+// TestTransparentOps_NonStreamingPath tests transparent operations on non-gateway endpoints
+func TestTransparentOps_NonStreamingPath(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	t.Run("X-Warden-Token skips transparent ops", func(t *testing.T) {
+		// When X-Warden-Token is set, transparent ops should be skipped entirely,
+		// even if namespace has auto_auth_path configured.
+		rootToken, err := core.tokenStore.GenerateRootToken()
+		require.NoError(t, err)
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/providers?warden-list=true", nil)
+		httpReq.Header.Set("X-Warden-Token", rootToken)
+		httpReq.Header.Set("X-Warden-Role", "operator")
+		req := &logical.Request{
+			Path:        "sys/providers",
+			Operation:   logical.ListOperation,
+			HTTPRequest: httpReq,
+		}
+
+		resp, _, err := core.handleNonLoginRequest(ctx, req)
+		// Should succeed with root token — transparent ops was skipped
+		assert.Nil(t, err)
+		if resp != nil {
+			assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+		}
+		// Transparent flag should NOT be set
+		assert.False(t, req.Transparent)
+	})
+
+	t.Run("no auth path means normal flow - Bearer treated as Warden token", func(t *testing.T) {
+		// No X-Warden-Token, no namespace auto_auth_path.
+		// Authorization: Bearer should be treated as a Warden token (normal flow).
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/providers", nil)
+		httpReq.Header.Set("Authorization", "Bearer some-warden-token")
+		req := &logical.Request{
+			Path:        "sys/providers",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+		// Should NOT be marked transparent
+		assert.False(t, req.Transparent)
+		// ClientToken should be the Bearer value (extracted by extractToken)
+		assert.Equal(t, "some-warden-token", req.ClientToken)
+	})
+
+	t.Run("JWT transparent ops with namespace auto_auth_path triggers implicit auth", func(t *testing.T) {
+		// Sends Authorization: Bearer <JWT> with namespace auto_auth_path configured.
+		// Since the auth backend isn't actually mounted, this will fail — but it
+		// proves transparent ops was triggered (req.Transparent is set).
+		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.test-sig-ops"
+
+		ns := &namespace.Namespace{
+			ID:   "test-ns-trigger",
+			Path: "trigger/",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/jwt/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)
+		httpReq.Header.Set("X-Warden-Role", "operator")
+		req := &logical.Request{
+			Path:        "sys/cred/sources",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		resp, _, _ := core.handleNonLoginRequest(nsCtx, req)
+		// Should fail because auth backend is not mounted, but transparent flag is set
+		require.NotNil(t, resp)
+		assert.True(t, req.Transparent, "request should be marked as transparent")
+	})
+
+	t.Run("JWT transparent ops with cached token succeeds", func(t *testing.T) {
+		// Pre-create a cached token in root namespace, then verify transparent ops finds it.
+		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjYWNoZWQtdXNlciJ9.cached-sig"
+
+		authData := &AuthData{
+			TokenValue:     sampleJWT,
+			RoleName:       "ops-reader",
+			PrincipalID:    "cached-user",
+			ExpireAt:       time.Now().Add(24 * time.Hour),
+			Policies:       []string{"default"},
+			CredentialSpec: "test-spec",
+		}
+		te, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, authData)
+		require.NoError(t, err)
+		require.NotNil(t, te)
+
+		// Use root namespace with auto_auth_path to trigger transparent ops
+		rootWithAuth := &namespace.Namespace{
+			ID:   namespace.RootNamespaceID,
+			Path: "",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/jwt/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), rootWithAuth)
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)
+		httpReq.Header.Set("X-Warden-Role", "ops-reader")
+		req := &logical.Request{
+			Path:        "sys/cred/sources",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		_, _, _ = core.handleNonLoginRequest(nsCtx, req)
+		assert.True(t, req.Transparent)
+		assert.NotNil(t, req.TokenEntry())
+		assert.Equal(t, te.ID, req.TokenEntry().ID)
+	})
+
+	t.Run("no credential with auto_auth_path returns auth error", func(t *testing.T) {
+		// No JWT, no cert — namespace has auto_auth_path but no credential
+		ns := &namespace.Namespace{
+			ID:   "test-ns-nocred",
+			Path: "nocred/",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/cert/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
+		httpReq.Header.Set("X-Warden-Role", "agent")
+		req := &logical.Request{
+			Path:        "sys/cred/sources",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		resp, _, _ := core.handleNonLoginRequest(nsCtx, req)
+		require.NotNil(t, resp)
+		assert.True(t, req.Transparent)
+		assert.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "no valid credential")
+	})
+
+	t.Run("namespace auto_auth_path triggers transparent ops", func(t *testing.T) {
+		// Create a namespace with auto_auth_path in custom_metadata
+		ns := &namespace.Namespace{
+			ID:   "test-ns-id",
+			Path: "team-a/",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/jwt/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+
+		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJucy11c2VyIn0.ns-sig"
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)
+		httpReq.Header.Set("X-Warden-Role", "operator")
+		req := &logical.Request{
+			Path:        "sys/cred/sources",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		_, _, _ = core.handleNonLoginRequest(nsCtx, req)
+		assert.True(t, req.Transparent)
+	})
+}
+
 // TestHandleNonLoginRequest_StreamingWithoutBodyParsing tests that backends without
 // StreamBodyParser do not get body parsing on streaming requests
 func TestHandleNonLoginRequest_StreamingWithoutBodyParsing(t *testing.T) {

--- a/e2e/auth/transparent_ops_test.go
+++ b/e2e/auth/transparent_ops_test.go
@@ -1,0 +1,338 @@
+//go:build e2e
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// =============================================================================
+// JWT Transparent Operations Tests
+// =============================================================================
+
+// TestTransparentOps_JWTGatewayAccess verifies that JWT transparent ops work for
+// gateway endpoints using X-Warden-Role header (T-TO01).
+// Auth path comes from the provider's auto_auth_path config.
+func TestTransparentOps_JWTGatewayAccess(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	// Use transparent ops to access vault gateway
+	status, body := h.TransparentOpsRequest(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		port, jwt, "e2e-reader")
+
+	if status != 200 {
+		t.Fatalf("T-TO01: expected 200, got %d: %s", status, string(body))
+	}
+
+	// Verify response contains expected secret data (Vault KV v2 nests under data.data)
+	data := h.ParseJSON(t, body)
+	apiKey := h.JSONPath(data, "data.data.api_key")
+	if apiKey == nil || apiKey == "" {
+		t.Fatalf("T-TO01: expected api_key in response, got: %s", string(body))
+	}
+}
+
+// TestTransparentOps_JWTDefaultRole verifies that JWT transparent ops work
+// when no X-Warden-Role is specified, falling back to default_role (T-TO03).
+func TestTransparentOps_JWTDefaultRole(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	// Configure default_role on JWT auth method
+	status, body := h.APIRequest(t, "PUT", "auth/jwt/config", port,
+		`{"default_role":"e2e-reader"}`)
+	if status != 200 && status != 204 {
+		t.Fatalf("T-TO03: failed to set default_role (status %d): %s", status, string(body))
+	}
+	// Clean up: remove default_role after test
+	defer h.APIRequest(t, "PUT", "auth/jwt/config", port,
+		`{"default_role":""}`)
+
+	// Request without X-Warden-Role — should fall back to default_role
+	status, body = h.TransparentOpsRequestNoRole(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		port, jwt)
+
+	if status != 200 {
+		t.Fatalf("T-TO03: expected 200 with default_role, got %d: %s", status, string(body))
+	}
+}
+
+// TestTransparentOps_JWTNoRoleNoDefault verifies that JWT transparent ops fail
+// when no role is specified and no default_role is configured (T-TO03b).
+func TestTransparentOps_JWTNoRoleNoDefault(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	// Ensure no default_role is configured
+	h.APIRequest(t, "PUT", "auth/jwt/config", port, `{"default_role":""}`)
+
+	// Request without X-Warden-Role and no default_role
+	status, _ := h.TransparentOpsRequestNoRole(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		port, jwt)
+
+	if status != 401 && status != 403 && status != 400 {
+		t.Fatalf("T-TO03b: expected 401/403/400 without role, got %d", status)
+	}
+}
+
+// =============================================================================
+// Certificate Transparent Operations Tests
+// =============================================================================
+
+// TestTransparentOps_CertGatewayAccess verifies that cert transparent ops work for
+// gateway endpoints using X-Warden-Role + X-SSL-Client-Cert (T-TO04).
+// Auth path comes from the provider's auto_auth_path config.
+func TestTransparentOps_CertGatewayAccess(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Setup cert auth and vault-cert provider
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	// Generate client cert
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-1")
+
+	// Use transparent ops with cert auth
+	status, body := h.CertTransparentOpsRequest(t, "GET",
+		"vault-cert/gateway/v1/secret/data/e2e/app-config",
+		port, clientCertPEM, "e2e-cert-reader")
+
+	if status != 200 {
+		t.Fatalf("T-TO04: expected 200, got %d: %s", status, string(body))
+	}
+}
+
+// TestTransparentOps_CertDefaultRole verifies that cert transparent ops work
+// when no X-Warden-Role is specified, falling back to default_role (T-TO05).
+func TestTransparentOps_CertDefaultRole(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Setup cert auth and vault-cert provider
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	// Configure default_role on cert auth method
+	status, body := h.APIRequest(t, "PUT", "auth/cert/config", port,
+		`{"default_role":"e2e-cert-reader"}`)
+	if status != 200 && status != 204 {
+		t.Fatalf("T-TO05: failed to set default_role (status %d): %s", status, string(body))
+	}
+
+	// Generate client cert
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-1")
+
+	// Request without X-Warden-Role — should fall back to default_role
+	status, body = h.CertTransparentOpsRequestNoRole(t, "GET",
+		"vault-cert/gateway/v1/secret/data/e2e/app-config",
+		port, clientCertPEM)
+
+	if status != 200 {
+		t.Fatalf("T-TO05: expected 200 with default_role, got %d: %s", status, string(body))
+	}
+}
+
+// =============================================================================
+// Precedence and Error Tests
+// =============================================================================
+
+// TestTransparentOps_WardenTokenPrecedence verifies that X-Warden-Token takes
+// precedence — normal auth flow is used, transparent ops skipped (T-TO06).
+func TestTransparentOps_WardenTokenPrecedence(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Get a regular warden token via normal login
+	token := h.GetNTWardenToken(t, port)
+
+	// Send request with X-Warden-Token — transparent ops should be skipped
+	u := fmt.Sprintf("%s/v1/vault-nt/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+	headers := map[string]string{
+		"X-Warden-Token": token,
+		"X-Warden-Role":  "e2e-reader",
+	}
+	status, _ := h.DoRequest(t, "GET", u, headers, "")
+
+	// Should succeed via normal Warden token flow (transparent ops skipped)
+	if status != 200 {
+		t.Fatalf("T-TO06: expected 200 with Warden token precedence, got %d", status)
+	}
+}
+
+// TestTransparentOps_NoCredentialReturnsError verifies that transparent ops with
+// auto_auth_path configured but no credential (no JWT, no cert) returns 401 (T-TO07).
+func TestTransparentOps_NoCredentialReturnsError(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Request with NO Authorization header or cert on a transparent mode gateway
+	u := fmt.Sprintf("%s/v1/vault/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+	headers := map[string]string{
+		"X-Warden-Role": "e2e-reader",
+	}
+	status, _ := h.DoRequest(t, "GET", u, headers, "")
+
+	if status != 401 && status != 403 {
+		t.Fatalf("T-TO07: expected 401 or 403 without credential, got %d", status)
+	}
+}
+
+// TestTransparentOps_InvalidAuthPath verifies that transparent ops with an invalid
+// auto_auth_path on the namespace returns an error (T-TO08).
+func TestTransparentOps_InvalidAuthPath(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	// Create namespace with invalid auto_auth_path, then attempt transparent ops.
+	// Since namespace creation requires server-side config that e2e may not support
+	// for arbitrary namespaces, we test via the gateway path which uses the provider's
+	// auto_auth_path. A misconfigured provider would fail at config write time.
+	// This test verifies the gateway rejects requests when auth fails.
+	u := fmt.Sprintf("%s/v1/vault/gateway/v1/secret/data/e2e/nonexistent-path", h.NodeURL(port))
+	headers := map[string]string{
+		"Authorization": "Bearer " + jwt,
+		"X-Warden-Role": "nonexistent-role",
+	}
+	status, _ := h.DoRequest(t, "GET", u, headers, "")
+
+	if status != 401 && status != 403 && status != 404 && status != 400 {
+		t.Fatalf("T-TO08: expected error status for bad role, got %d", status)
+	}
+}
+
+// TestTransparentOps_CachedToken verifies that a second transparent ops request
+// reuses the cached token from the first request (T-TO09).
+func TestTransparentOps_CachedToken(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	// First request — creates token
+	status1, body1 := h.TransparentOpsRequest(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		port, jwt, "e2e-reader")
+	if status1 != 200 {
+		t.Fatalf("T-TO09: first request expected 200, got %d: %s", status1, string(body1))
+	}
+
+	// Second request — should reuse cached token
+	status2, body2 := h.TransparentOpsRequest(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		port, jwt, "e2e-reader")
+	if status2 != 200 {
+		t.Fatalf("T-TO09: second request expected 200, got %d: %s", status2, string(body2))
+	}
+}
+
+// TestTransparentOps_StandbyForwarding verifies that transparent ops work through
+// standby nodes (T-TO10).
+func TestTransparentOps_StandbyForwarding(t *testing.T) {
+	standby := h.GetStandbyPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	status, body := h.TransparentOpsRequest(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		standby, jwt, "e2e-reader")
+
+	if status != 200 {
+		t.Fatalf("T-TO10: standby expected 200, got %d: %s", status, string(body))
+	}
+}
+
+// TestTransparentOps_DefaultRoleConfigReadback verifies that default_role config
+// is persisted and can be read back (T-TO11).
+func TestTransparentOps_DefaultRoleConfigReadback(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Set default_role on JWT auth
+	status, body := h.APIRequest(t, "PUT", "auth/jwt/config", port,
+		`{"default_role":"e2e-reader"}`)
+	if status != 200 && status != 204 {
+		t.Fatalf("T-TO11: failed to set default_role (status %d): %s", status, string(body))
+	}
+	defer h.APIRequest(t, "PUT", "auth/jwt/config", port, `{"default_role":""}`)
+
+	// Read config back
+	status, body = h.APIRequest(t, "GET", "auth/jwt/config", port, "")
+	if status != 200 {
+		t.Fatalf("T-TO11: failed to read config (status %d): %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	defaultRole := h.JSONPath(data, "data.default_role")
+	if defaultRole != "e2e-reader" {
+		t.Fatalf("T-TO11: expected default_role=e2e-reader, got %v", defaultRole)
+	}
+}
+
+// TestTransparentOps_ExpiredJWTRejected verifies that an expired JWT is rejected
+// in transparent ops mode (T-TO12).
+func TestTransparentOps_ExpiredJWTRejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Get an ephemeral JWT (2s TTL)
+	jwt := h.GetJWT(t, "e2e-ephemeral", "ephemeral-secret")
+	time.Sleep(3 * time.Second)
+
+	status, _ := h.TransparentOpsRequest(t, "GET",
+		"vault/gateway/v1/secret/data/e2e/app-config",
+		port, jwt, "e2e-reader")
+
+	if status != 401 && status != 403 && status != 400 {
+		t.Fatalf("T-TO12: expected 401/403/400 for expired JWT, got %d", status)
+	}
+}
+
+// TestTransparentOps_CertWrongCN verifies that a certificate with non-matching CN
+// is rejected in transparent ops mode (T-TO13).
+func TestTransparentOps_CertWrongCN(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Setup cert auth and vault-cert provider
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	// Generate cert with CN that doesn't match "agent-*" pattern
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "server-1")
+
+	// Should be rejected — CN doesn't match allowed pattern
+	status, _ := h.CertTransparentOpsRequest(t, "GET",
+		"vault-cert/gateway/v1/secret/data/e2e/app-config",
+		port, clientCertPEM, "e2e-cert-reader")
+
+	if status != 401 && status != 403 {
+		t.Fatalf("T-TO13: expected 401 or 403 for wrong CN, got %d", status)
+	}
+}
+
+// TestTransparentOps_NoAuthPathNormalFlow verifies that without namespace
+// auto_auth_path configured, the Authorization header is treated as a
+// normal Warden token (not transparent ops) (T-TO15).
+func TestTransparentOps_NoAuthPathNormalFlow(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Send a request with Authorization: Bearer <random-value> on a non-transparent provider.
+	// This should NOT trigger transparent ops — the bearer value is treated as a Warden token
+	u := fmt.Sprintf("%s/v1/vault-nt/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+	headers := map[string]string{
+		"Authorization": "Bearer not-a-real-warden-token",
+	}
+	status, body := h.DoRequest(t, "GET", u, headers, "")
+
+	// Should fail with 401/403 because "not-a-real-warden-token" is not a valid Warden token
+	if status == 200 {
+		t.Fatalf("T-TO15: expected non-200 for invalid Warden token, got 200: %s", string(body))
+	}
+	if status != 401 && status != 403 {
+		// Some configurations may return 400 for malformed tokens
+		if status != 400 {
+			t.Logf("T-TO15: got status %d (expected 401/403), response: %s",
+				status, strings.TrimSpace(string(body)))
+		}
+	}
+}

--- a/e2e/helpers/cert_helpers.go
+++ b/e2e/helpers/cert_helpers.go
@@ -451,3 +451,29 @@ func SetupCertVaultEnvWithCA(t *testing.T, port int, caCertPEM string) {
 	APIRequest(t, "POST", "auth/cert/role/e2e-cert-nt-reader", port,
 		`{"allowed_common_names":["agent-*"],"token_policies":["vault-nt-gateway-access"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
 }
+
+// --- Cert Transparent Operations Helpers ---
+
+// CertTransparentOpsRequest makes a transparent operations request using cert implicit auth.
+// Sends client cert via X-SSL-Client-Cert header (simulating LB forwarding).
+// The namespace must have auto_auth_path configured.
+func CertTransparentOpsRequest(t *testing.T, method, path string, port int, clientCertPEM, role string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/%s", NodeURL(port), path)
+	headers := map[string]string{
+		"X-SSL-Client-Cert": URLEncodePEM(clientCertPEM),
+		"X-Warden-Role":     role,
+	}
+	return DoRequest(t, method, u, headers, "")
+}
+
+// CertTransparentOpsRequestNoRole makes a transparent operations request using cert implicit auth
+// without specifying a role (relies on default_role configured on the auth method).
+func CertTransparentOpsRequestNoRole(t *testing.T, method, path string, port int, clientCertPEM string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/%s", NodeURL(port), path)
+	headers := map[string]string{
+		"X-SSL-Client-Cert": URLEncodePEM(clientCertPEM),
+	}
+	return DoRequest(t, method, u, headers, "")
+}

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -802,3 +802,28 @@ func CertLoginRequestViaLB(t *testing.T, role, clientCertPEM, clientKeyPEM strin
 	body := fmt.Sprintf(`{"role":"%s"}`, role)
 	return DoLBRequest(t, "POST", u, headers, body, &cert)
 }
+
+// --- Transparent Operations Helpers ---
+
+// TransparentOpsRequest makes a transparent operations request using JWT implicit auth.
+// The namespace must have auto_auth_path configured. Uses X-Warden-Role header.
+func TransparentOpsRequest(t *testing.T, method, path string, port int, jwt, role string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/%s", NodeURL(port), path)
+	headers := map[string]string{
+		"Authorization": "Bearer " + jwt,
+		"X-Warden-Role": role,
+	}
+	return DoRequest(t, method, u, headers, "")
+}
+
+// TransparentOpsRequestNoRole makes a transparent operations request using JWT implicit auth
+// without specifying a role (relies on default_role configured on the auth method).
+func TransparentOpsRequestNoRole(t *testing.T, method, path string, port int, jwt string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/%s", NodeURL(port), path)
+	headers := map[string]string{
+		"Authorization": "Bearer " + jwt,
+	}
+	return DoRequest(t, method, u, headers, "")
+}

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -20,7 +20,7 @@ var headersToRemove = []string{
 	"X-Vault-Token",   // Will be replaced with real Vault token
 	"X-Vault-Request", // Internal Vault header
 	"X-Warden-Token",  // Warden-specific auth header
-	"X-Warden-Role",   // Warden transparent mode role header
+	"X-Warden-Role", // Warden transparent mode role header
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",


### PR DESCRIPTION
…ethods

Auth path is now config-only (provider auto_auth_path for gateway, namespace auto_auth_path for operations), eliminating a per-request security concern where clients could downgrade auth methods.

Add default_role config to JWT and cert auth methods for transparent mode fallback. Document full role precedence: URL path > X-Warden-Role header > provider default_role > auth method default_role.