### PR TITLE
feat: add TLS PeerCertificates fallback for cert auth without LB term…

### DIFF
--- a/auth/method/cert/cert_extract.go
+++ b/auth/method/cert/cert_extract.go
@@ -8,11 +8,13 @@ import (
 )
 
 // extractClientCert extracts the client certificate from the request.
-// Warden always sits behind a load balancer — client certs arrive exclusively
-// via the X-SSL-Client-Cert header, parsed by the cert forwarding middleware
-// and stored in the request context. On cluster-forwarded requests (standby →
-// leader), the header is re-forwarded and re-parsed, so ForwardedClientCert
-// works correctly for both direct and forwarded paths.
+// The cert forwarding middleware stores it in the request context after
+// extracting it from either a forwarding header (X-SSL-Client-Cert or
+// X-Forwarded-Client-Cert from a trusted proxy) or the TLS connection
+// state (r.TLS.PeerCertificates for direct mTLS / LB passthrough).
+// On cluster-forwarded requests (standby → leader), the header is
+// re-forwarded and re-parsed, so ForwardedClientCert works correctly
+// for all paths.
 func extractClientCert(req *logical.Request) *x509.Certificate {
 	if req.HTTPRequest == nil {
 		return nil

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1213,11 +1213,13 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 }
 
 // extractTransparentClientCert extracts the client certificate from a request.
-// Warden always sits behind a load balancer — client certs arrive exclusively
-// via the X-SSL-Client-Cert header, parsed by the cert forwarding middleware
-// and stored in the request context. On cluster-forwarded requests (standby →
-// leader), the header is re-forwarded and re-parsed, so ForwardedClientCert
-// works correctly for both direct and forwarded paths.
+// The cert forwarding middleware stores it in the request context after
+// extracting it from either a forwarding header (X-SSL-Client-Cert or
+// X-Forwarded-Client-Cert from a trusted proxy) or the TLS connection
+// state (r.TLS.PeerCertificates for direct mTLS / LB passthrough).
+// On cluster-forwarded requests (standby → leader), the header is
+// re-forwarded and re-parsed, so ForwardedClientCert works correctly
+// for all paths.
 func extractTransparentClientCert(req *logical.Request) *x509.Certificate {
 	if req.HTTPRequest == nil {
 		return nil

--- a/e2e/configs/node1.hcl
+++ b/e2e/configs/node1.hcl
@@ -6,7 +6,7 @@ min_cred_spec_rotation_period   = "5m"
 
 ip_binding_policy = "disabled"
 
-api_addr     = "http://127.0.0.1:8500"
+api_addr     = "https://127.0.0.1:8500"
 cluster_addr = "https://127.0.0.1:8501"
 
 seal "static" {
@@ -22,7 +22,11 @@ storage "postgres" {
 }
 
 listener "tcp" {
-    address         = "0.0.0.0:8500"
-    tls_enabled     = false
-    trusted_proxies = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
+    address                 = "0.0.0.0:8500"
+    tls_enabled             = true
+    tls_cert_file           = "../.certs/server.crt"
+    tls_key_file            = "../.certs/server.key"
+    tls_client_ca_file      = "../.certs/client-ca.crt"
+    tls_require_client_cert = false
+    trusted_proxies         = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
 }

--- a/e2e/configs/node2.hcl
+++ b/e2e/configs/node2.hcl
@@ -6,7 +6,7 @@ min_cred_spec_rotation_period   = "5m"
 
 ip_binding_policy = "disabled"
 
-api_addr     = "http://127.0.0.1:8510"
+api_addr     = "https://127.0.0.1:8510"
 cluster_addr = "https://127.0.0.1:8511"
 
 seal "static" {
@@ -22,7 +22,11 @@ storage "postgres" {
 }
 
 listener "tcp" {
-    address         = "0.0.0.0:8510"
-    tls_enabled     = false
-    trusted_proxies = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
+    address                 = "0.0.0.0:8510"
+    tls_enabled             = true
+    tls_cert_file           = "../.certs/server.crt"
+    tls_key_file            = "../.certs/server.key"
+    tls_client_ca_file      = "../.certs/client-ca.crt"
+    tls_require_client_cert = false
+    trusted_proxies         = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
 }

--- a/e2e/configs/node3.hcl
+++ b/e2e/configs/node3.hcl
@@ -6,7 +6,7 @@ min_cred_spec_rotation_period   = "5m"
 
 ip_binding_policy = "disabled"
 
-api_addr     = "http://127.0.0.1:8520"
+api_addr     = "https://127.0.0.1:8520"
 cluster_addr = "https://127.0.0.1:8521"
 
 seal "static" {
@@ -22,7 +22,11 @@ storage "postgres" {
 }
 
 listener "tcp" {
-    address         = "0.0.0.0:8520"
-    tls_enabled     = false
-    trusted_proxies = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
+    address                 = "0.0.0.0:8520"
+    tls_enabled             = true
+    tls_cert_file           = "../.certs/server.crt"
+    tls_key_file            = "../.certs/server.key"
+    tls_client_ca_file      = "../.certs/client-ca.crt"
+    tls_require_client_cert = false
+    trusted_proxies         = ["127.0.0.1/32", "172.16.0.0/12", "192.168.0.0/16"]
 }

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -104,14 +104,17 @@ services:
     restart: unless-stopped
     command: serve all --dev
 
-  # Nginx load balancer in front of the 3-node Warden cluster (TLS termination)
+  # Nginx load balancer in front of the 3-node Warden cluster
+  # Port 8000: TLS termination (nginx terminates TLS, forwards cert via header)
+  # Port 8001: TLS passthrough (raw TLS stream forwarded to Warden)
   nginx:
     image: nginx:alpine
     container_name: e2e-nginx
     ports:
       - "8000:8000"
+      - "8001:8001"
     volumes:
-      - ./loadbalancer/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./loadbalancer/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./loadbalancer/certs:/etc/nginx/certs:ro
     networks:
       - e2e-network

--- a/e2e/forwarding/forwarding_test.go
+++ b/e2e/forwarding/forwarding_test.go
@@ -3,6 +3,7 @@
 package forwarding
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -137,7 +138,12 @@ func TestStandbyForwardTimeoutHandling(t *testing.T) {
 
 	h.SignalNode(t, leaderNode, syscall.SIGSTOP)
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	token := h.RootToken(t)
 	reqURL := fmt.Sprintf("%s/v1/sys/namespaces?warden-list=true", h.NodeURL(standby))
 

--- a/e2e/forwarding/sigv4_test.go
+++ b/e2e/forwarding/sigv4_test.go
@@ -5,6 +5,7 @@ package forwarding
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -158,7 +159,12 @@ func TestSigV4ThroughStandbyForwarding(t *testing.T) {
 	standbyURL := fmt.Sprintf("%s/v1/aws/gateway", h.NodeURL(standby))
 	req := signSTSRequest(t, standbyURL, accessKeyID, secretAccessKey)
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("request through standby failed: %v", err)
@@ -234,7 +240,12 @@ func signSigV4Request(t *testing.T, method, targetURL, body, contentType, access
 func sendSigV4AndAssert(t *testing.T, req *http.Request, label string) int {
 	t.Helper()
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		// Transport errors (EOF, connection reset) mean signature verification
@@ -276,7 +287,12 @@ func TestConcurrentSigV4ThroughStandby(t *testing.T) {
 			defer wg.Done()
 
 			req := signSTSRequest(t, standbyURL, accessKeyID, secretAccessKey)
-			client := &http.Client{Timeout: 30 * time.Second}
+			client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 			resp, err := client.Do(req)
 			if err != nil {
 				// Transport error = SigV4 passed
@@ -329,7 +345,12 @@ func TestSigV4DuringLeaderStepDown(t *testing.T) {
 			time.Sleep(time.Duration(i) * 200 * time.Millisecond)
 
 			req := signSTSRequest(t, standbyURL, accessKeyID, secretAccessKey)
-			client := &http.Client{Timeout: 30 * time.Second}
+			client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 			resp, err := client.Do(req)
 
 			mu.Lock()
@@ -469,7 +490,12 @@ func TestSigV4PolicyDenialThroughStandby(t *testing.T) {
 	standbyURL := fmt.Sprintf("%s/v1/aws/gateway", h.NodeURL(standby))
 	req := signSTSRequest(t, standbyURL, accessKeyID, secretAccessKey)
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("request through standby failed: %v", err)

--- a/e2e/helpers/cert_helpers.go
+++ b/e2e/helpers/cert_helpers.go
@@ -452,6 +452,164 @@ func SetupCertVaultEnvWithCA(t *testing.T, port int, caCertPEM string) {
 		`{"allowed_common_names":["agent-*"],"token_policies":["vault-nt-gateway-access"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
 }
 
+// --- mTLS Client CA Helpers ---
+
+// LoadMTLSClientCA loads the pre-generated mTLS client CA certificate and key
+// from e2e/.certs/. This CA is configured as the tls_client_ca_file on all
+// Warden nodes, so mTLS client certs must be signed by this CA.
+func LoadMTLSClientCA(t *testing.T) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	certPath := filepath.Join(E2EDir(), ".certs", "client-ca.crt")
+	keyPath := filepath.Join(E2EDir(), ".certs", "client-ca.key")
+
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to load mTLS client CA cert: %v", err)
+	}
+
+	keyData, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("failed to load mTLS client CA key: %v", err)
+	}
+
+	block, _ := pem.Decode(keyData)
+	if block == nil {
+		t.Fatal("failed to decode mTLS client CA key PEM")
+	}
+
+	switch block.Type {
+	case "PRIVATE KEY":
+		parsed, parseErr := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if parseErr != nil {
+			t.Fatalf("failed to parse mTLS client CA PKCS8 key: %v", parseErr)
+		}
+		var ok bool
+		caKey, ok = parsed.(*ecdsa.PrivateKey)
+		if !ok {
+			t.Fatalf("mTLS client CA key is not ECDSA: %T", parsed)
+		}
+	default:
+		caKey, err = x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse mTLS client CA key: %v", err)
+		}
+	}
+
+	return string(certData), caKey
+}
+
+// --- mTLS Request Helpers ---
+
+// CertLoginRequestViaMTLS performs a cert auth login via direct mTLS connection.
+// The client cert is presented during the TLS handshake (not via headers).
+// Warden extracts it from r.TLS.PeerCertificates via the TLS fallback.
+func CertLoginRequestViaMTLS(t *testing.T, port int, role, clientCertPEM, clientKeyPEM string) (int, []byte) {
+	t.Helper()
+	cert := parseTLSCert(t, clientCertPEM, clientKeyPEM)
+	u := fmt.Sprintf("%s/v1/auth/cert/login", NodeURL(port))
+	headers := map[string]string{"Content-Type": "application/json"}
+	body := fmt.Sprintf(`{"role":"%s"}`, role)
+	return DoMTLSRequest(t, "POST", u, headers, body, cert)
+}
+
+// CertLoginRequestViaLBPassthrough performs a cert auth login through the nginx
+// TLS passthrough port. The TLS handshake goes end-to-end to Warden, so
+// r.TLS.PeerCertificates contains the client cert.
+func CertLoginRequestViaLBPassthrough(t *testing.T, role, clientCertPEM, clientKeyPEM string) (int, []byte) {
+	t.Helper()
+	cert := parseTLSCert(t, clientCertPEM, clientKeyPEM)
+	u := fmt.Sprintf("%s/v1/auth/cert/login", LBPassthroughURL())
+	headers := map[string]string{"Content-Type": "application/json"}
+	body := fmt.Sprintf(`{"role":"%s"}`, role)
+	return DoMTLSRequest(t, "POST", u, headers, body, cert)
+}
+
+// VaultCertTransparentRequestViaMTLS makes a transparent vault gateway request
+// via direct mTLS connection. The client cert is presented during the TLS
+// handshake and extracted by Warden's TLS fallback.
+func VaultCertTransparentRequestViaMTLS(t *testing.T, method, vaultPath, role string, port int, clientCertPEM, clientKeyPEM string) (int, []byte) {
+	t.Helper()
+	cert := parseTLSCert(t, clientCertPEM, clientKeyPEM)
+	u := fmt.Sprintf("%s/v1/vault-cert/role/%s/gateway/v1/%s", NodeURL(port), role, vaultPath)
+	return DoMTLSRequest(t, method, u, nil, "", cert)
+}
+
+// VaultCertTransparentRequestViaLBPassthrough makes a transparent vault gateway
+// request through the nginx TLS passthrough port via mTLS.
+func VaultCertTransparentRequestViaLBPassthrough(t *testing.T, method, vaultPath, role, clientCertPEM, clientKeyPEM string) (int, []byte) {
+	t.Helper()
+	cert := parseTLSCert(t, clientCertPEM, clientKeyPEM)
+	u := fmt.Sprintf("%s/v1/vault-cert/role/%s/gateway/v1/%s", LBPassthroughURL(), role, vaultPath)
+	return DoMTLSRequest(t, method, u, nil, "", cert)
+}
+
+// LoginJWTViaLBPassthrough logs in with a JWT through the LB passthrough port.
+// No client cert — just HTTPS with InsecureSkipVerify.
+func LoginJWTViaLBPassthrough(t *testing.T, jwt, role string) (int, string) {
+	t.Helper()
+	loginBody := fmt.Sprintf(`{"jwt":"%s","role":"%s"}`, jwt, role)
+	// Use doLBHTTP (which has InsecureSkipVerify) with no client cert
+	status, body := DoLBRequest(t, "POST",
+		fmt.Sprintf("%s/v1/auth/jwt/login", LBPassthroughURL()),
+		map[string]string{"Content-Type": "application/json"},
+		loginBody, nil,
+	)
+	if status != 200 && status != 201 {
+		return status, ""
+	}
+	data := ParseJSON(t, body)
+	token, _ := JSONPath(data, "data.data.token").(string)
+	if token == "" {
+		token, _ = JSONPath(data, "data.token_id").(string)
+	}
+	return status, token
+}
+
+// VaultTransparentRequestViaLBPassthrough makes a JWT transparent vault gateway
+// request through the nginx TLS passthrough port. No client cert.
+func VaultTransparentRequestViaLBPassthrough(t *testing.T, method, vaultPath, role, jwt string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/vault/role/%s/gateway/v1/%s", LBPassthroughURL(), role, vaultPath)
+	headers := map[string]string{"Authorization": "Bearer " + jwt}
+	return DoLBRequest(t, method, u, headers, "", nil)
+}
+
+// SetupCertVaultEnvWithMTLSCA sets up a vault provider with cert-based transparent
+// mode using the mTLS client CA. Use this for mTLS tests where clients present
+// their cert during the TLS handshake instead of via headers.
+func SetupCertVaultEnvWithMTLSCA(t *testing.T, port int) {
+	t.Helper()
+	caCertPEM, _ := LoadMTLSClientCA(t)
+
+	// Mount vault-cert provider
+	APIRequest(t, "POST", "sys/providers/vault-cert", port, `{"type":"vault"}`)
+	time.Sleep(1 * time.Second)
+
+	// Configure vault-cert provider
+	APIRequest(t, "PUT", "vault-cert/config", port,
+		`{"vault_address":"http://127.0.0.1:8200","tls_skip_verify":true,"timeout":"30s"}`)
+
+	// Enable transparent mode with cert auth path
+	APIRequest(t, "POST", "vault-cert/config", port,
+		`{"transparent_mode":true,"auto_auth_path":"auth/cert/"}`)
+
+	// Mount cert auth with mTLS client CA
+	SetupCertAuthWithCA(t, port, caCertPEM)
+
+	// Policy for vault-cert gateway access
+	APIRequest(t, "POST", "sys/policies/cbp/vault-cert-gateway-access", port,
+		`{"policy":"path \"vault-cert/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\npath \"vault-cert/role/+/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}"}`)
+
+	// Cert role for transparent mode (cert_role token type)
+	APIRequest(t, "POST", "auth/cert/role/e2e-cert-reader", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-cert-gateway-access"],"token_type":"cert_role","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
+
+	// Cert role for non-transparent mode (warden_token token type)
+	APIRequest(t, "POST", "auth/cert/role/e2e-cert-nt-reader", port,
+		`{"allowed_common_names":["agent-*"],"token_policies":["vault-nt-gateway-access"],"token_type":"warden_token","cred_spec_name":"vault-token-reader","token_ttl":3600}`)
+}
+
 // --- Cert Transparent Operations Helpers ---
 
 // CertTransparentOpsRequest makes a transparent operations request using cert implicit auth.

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -50,9 +50,9 @@ func RootToken(t *testing.T) string {
 	return strings.TrimSpace(string(data))
 }
 
-// NodeURL returns the base URL for a given port.
+// NodeURL returns the base URL for a given port (HTTPS, self-signed cert).
 func NodeURL(port int) string {
-	return fmt.Sprintf("http://127.0.0.1:%d", port)
+	return fmt.Sprintf("https://127.0.0.1:%d", port)
 }
 
 // --- HTTP Helpers ---
@@ -92,7 +92,12 @@ func doHTTP(method, rawURL string, headers map[string]string, body string) (int,
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed e2e cert
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -801,6 +806,86 @@ func CertLoginRequestViaLB(t *testing.T, role, clientCertPEM, clientKeyPEM strin
 	headers := map[string]string{"Content-Type": "application/json"}
 	body := fmt.Sprintf(`{"role":"%s"}`, role)
 	return DoLBRequest(t, "POST", u, headers, body, &cert)
+}
+
+// --- LB Passthrough Helpers ---
+
+// LBPassthroughPort is the nginx TLS passthrough port.
+const LBPassthroughPort = 8001
+
+// LBPassthroughURL returns the base URL for the nginx TLS passthrough port.
+func LBPassthroughURL() string {
+	return fmt.Sprintf("https://127.0.0.1:%d", LBPassthroughPort)
+}
+
+// LBPassthroughAvailable checks if the nginx TLS passthrough port can proxy to
+// the Warden cluster. Uses InsecureSkipVerify since the TLS handshake goes
+// end-to-end to Warden's self-signed cert.
+func LBPassthroughAvailable() bool {
+	status, _, _ := doLBHTTP("GET", LBPassthroughURL()+"/v1/sys/health", nil, "", nil)
+	return status == 200 || status == 429
+}
+
+// SkipWithoutLBPassthrough skips the test if the LB passthrough port is not available.
+func SkipWithoutLBPassthrough(t *testing.T) {
+	t.Helper()
+	if !LBPassthroughAvailable() {
+		t.Skip("nginx LB passthrough port not available (skipping passthrough test)")
+	}
+}
+
+// --- mTLS Helpers ---
+
+// doMTLSHTTP makes an HTTPS request with a TLS client certificate.
+// InsecureSkipVerify is used because Warden uses self-signed certs in e2e.
+func doMTLSHTTP(method, rawURL string, headers map[string]string, body string, clientCert tls.Certificate) (int, []byte, error) {
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	if err != nil {
+		return 0, nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if body != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // self-signed e2e cert
+		Certificates:       []tls.Certificate{clientCert},
+	}
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+// DoMTLSRequest makes an HTTPS request with a TLS client certificate.
+// Fatals on connection errors.
+func DoMTLSRequest(t *testing.T, method, rawURL string, headers map[string]string, body string, clientCert tls.Certificate) (int, []byte) {
+	t.Helper()
+	status, respBody, err := doMTLSHTTP(method, rawURL, headers, body, clientCert)
+	if err != nil {
+		t.Fatalf("mTLS request failed: %v", err)
+	}
+	return status, respBody
 }
 
 // --- Transparent Operations Helpers ---

--- a/e2e/loadbalancer/nginx.conf
+++ b/e2e/loadbalancer/nginx.conf
@@ -1,45 +1,67 @@
-upstream warden_cluster {
-    server host.docker.internal:8500;
-    server host.docker.internal:8510;
-    server host.docker.internal:8520;
-}
+worker_processes auto;
+events { worker_connections 1024; }
 
-server {
-    listen 8000 ssl;
-
-    ssl_certificate     /etc/nginx/certs/server.crt;
-    ssl_certificate_key /etc/nginx/certs/server.key;
-
-    # Validate client certificates against the trusted CA.
-    # "optional" means: accept connections without a client cert (for JWT
-    # requests), but verify the cert against the CA if one is presented.
-    ssl_client_certificate /etc/nginx/certs/ca.crt;
-    ssl_verify_client      optional;
-
-    location = /nginx-health {
-        return 200 "ok";
-        add_header Content-Type text/plain;
+http {
+    upstream warden_cluster {
+        server host.docker.internal:8500;
+        server host.docker.internal:8510;
+        server host.docker.internal:8520;
     }
 
-    location / {
-        proxy_pass http://warden_cluster;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+    server {
+        listen 8000 ssl;
 
-        # Forward the verified TLS client certificate to the backend
-        # (URL-encoded PEM). Overwrites any client-provided header to
-        # prevent spoofing.
-        proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
 
-        # Strip XFCC header to prevent spoofing
-        proxy_set_header X-Forwarded-Client-Cert "";
+        # Validate client certificates against the trusted CA.
+        # "optional" means: accept connections without a client cert (for JWT
+        # requests), but verify the cert against the CA if one is presented.
+        ssl_client_certificate /etc/nginx/certs/ca.crt;
+        ssl_verify_client      optional;
 
-        proxy_pass_request_headers on;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 30s;
-        proxy_read_timeout 30s;
-        proxy_buffering off;
+        location = /nginx-health {
+            return 200 "ok";
+            add_header Content-Type text/plain;
+        }
+
+        location / {
+            proxy_pass https://warden_cluster;
+            proxy_ssl_verify off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Forward the verified TLS client certificate to the backend
+            # (URL-encoded PEM). Overwrites any client-provided header to
+            # prevent spoofing.
+            proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
+
+            # Strip XFCC header to prevent spoofing
+            proxy_set_header X-Forwarded-Client-Cert "";
+
+            proxy_pass_request_headers on;
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+            proxy_buffering off;
+        }
+    }
+}
+
+# TLS passthrough — raw TLS stream forwarded to Warden without termination.
+# Client TLS handshake goes directly to Warden, so r.TLS.PeerCertificates
+# contains the client cert. No X-SSL-Client-Cert header is injected.
+stream {
+    upstream warden_passthrough {
+        server host.docker.internal:8500;
+        server host.docker.internal:8510;
+        server host.docker.internal:8520;
+    }
+
+    server {
+        listen 8001;
+        proxy_pass warden_passthrough;
     }
 }

--- a/e2e/mtls/mtls_test.go
+++ b/e2e/mtls/mtls_test.go
@@ -1,0 +1,184 @@
+//go:build e2e
+
+package mtls
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// --- Direct mTLS tests (connect directly to Warden nodes) ---
+
+// TestMTLSCertLogin verifies cert auth login via direct mTLS connection to the
+// leader. The TLS fallback in certForwardingMiddleware extracts the client cert
+// from r.TLS.PeerCertificates.
+func TestMTLSCertLogin(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	h.SetupCertVaultEnvWithMTLSCA(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	caCertPEM, caKey := h.LoadMTLSClientCA(t)
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-mtls-login")
+
+	status, body := h.CertLoginRequestViaMTLS(t, port, "e2e-cert-reader", clientCertPEM, clientKeyPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("mTLS cert login failed (status %d): %s", status, string(body))
+	}
+
+	// Verify we got a valid token/token_id back
+	data := h.ParseJSON(t, body)
+	tokenID, _ := h.JSONPath(data, "data.token_id").(string)
+	if tokenID == "" {
+		t.Fatalf("no token_id in mTLS cert login response: %s", string(body))
+	}
+}
+
+// TestMTLSCertLoginViaStandby verifies mTLS cert login via a standby node.
+// Exercises the full forwarding chain:
+// client → standby (TLS fallback → context) → standby forwarder (context → header)
+// → leader cluster listener (header → context) → cert auth backend (context → login)
+func TestMTLSCertLoginViaStandby(t *testing.T) {
+	leaderPort := h.GetLeaderPort(t)
+	standbyPort := h.GetStandbyPort(t)
+
+	h.SetupCertVaultEnvWithMTLSCA(t, leaderPort)
+	defer h.TeardownCertVaultEnv(t, leaderPort)
+
+	caCertPEM, caKey := h.LoadMTLSClientCA(t)
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-mtls-standby")
+
+	status, body := h.CertLoginRequestViaMTLS(t, standbyPort, "e2e-cert-reader", clientCertPEM, clientKeyPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("mTLS cert login via standby failed (status %d): %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	tokenID, _ := h.JSONPath(data, "data.token_id").(string)
+	if tokenID == "" {
+		t.Fatalf("no token_id in mTLS cert login via standby response: %s", string(body))
+	}
+}
+
+// TestMTLSCertTransparentRead verifies transparent vault read via direct mTLS.
+// Path: client → Warden (TLS fallback) → cert auth → mint Vault token → proxy to Vault.
+func TestMTLSCertTransparentRead(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	h.SetupCertVaultEnvWithMTLSCA(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	caCertPEM, caKey := h.LoadMTLSClientCA(t)
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-mtls-transparent")
+
+	status, body := h.VaultCertTransparentRequestViaMTLS(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM, clientKeyPEM)
+	if status != 200 {
+		t.Fatalf("mTLS transparent read failed (status %d): %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in mTLS transparent read response")
+	}
+}
+
+// TestMTLSCertNonTransparentRead verifies: mTLS login → warden_token → non-transparent gateway.
+// The login uses direct mTLS; the gateway request uses the resulting warden_token.
+func TestMTLSCertNonTransparentRead(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	h.SetupCertVaultEnvWithMTLSCA(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	caCertPEM, caKey := h.LoadMTLSClientCA(t)
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-mtls-nt")
+
+	// Login via mTLS with warden_token role
+	loginStatus, loginBody := h.CertLoginRequestViaMTLS(t, port, "e2e-cert-nt-reader", clientCertPEM, clientKeyPEM)
+	if loginStatus != 200 && loginStatus != 201 {
+		t.Fatalf("mTLS cert login for NT failed (status %d): %s", loginStatus, string(loginBody))
+	}
+	wardenToken := h.JSONString(t, loginBody, "data.data.token")
+
+	// Use warden_token for non-transparent gateway request
+	status, body := h.VaultNTRequest(t, "GET", "secret/data/e2e/app-config", port, wardenToken)
+	if status != 200 {
+		t.Fatalf("non-transparent read with mTLS-obtained token failed (status %d): %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in NT read response")
+	}
+}
+
+// --- LB passthrough tests (connect via nginx port 8001, TLS not terminated) ---
+
+// TestLBPassthroughCertLogin verifies mTLS cert login through the nginx TLS
+// passthrough port. The client TLS handshake goes end-to-end to Warden (nginx
+// does NOT terminate TLS). Exercises the exact "LB doesn't terminate TLS" scenario.
+func TestLBPassthroughCertLogin(t *testing.T) {
+	h.SkipWithoutLBPassthrough(t)
+
+	port := h.GetLeaderPort(t)
+	h.SetupCertVaultEnvWithMTLSCA(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	caCertPEM, caKey := h.LoadMTLSClientCA(t)
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-passthrough-login")
+
+	status, body := h.CertLoginRequestViaLBPassthrough(t, "e2e-cert-reader", clientCertPEM, clientKeyPEM)
+	if status != 200 && status != 201 {
+		t.Fatalf("LB passthrough cert login failed (status %d): %s", status, string(body))
+	}
+
+	data := h.ParseJSON(t, body)
+	tokenID, _ := h.JSONPath(data, "data.token_id").(string)
+	if tokenID == "" {
+		t.Fatalf("no token_id in LB passthrough cert login response: %s", string(body))
+	}
+}
+
+// TestLBPassthroughCertTransparentRead verifies transparent vault read via LB
+// TLS passthrough + mTLS. Full path:
+// client → nginx:8001 (passthrough) → Warden TLS fallback → cert auth → gateway → Vault
+func TestLBPassthroughCertTransparentRead(t *testing.T) {
+	h.SkipWithoutLBPassthrough(t)
+
+	port := h.GetLeaderPort(t)
+	h.SetupCertVaultEnvWithMTLSCA(t, port)
+	defer h.TeardownCertVaultEnv(t, port)
+
+	caCertPEM, caKey := h.LoadMTLSClientCA(t)
+	clientCertPEM, clientKeyPEM := h.GenerateClientCert(t, caCertPEM, caKey, "agent-passthrough-transparent")
+
+	status, body := h.VaultCertTransparentRequestViaLBPassthrough(t, "GET",
+		"secret/data/e2e/app-config", "e2e-cert-reader", clientCertPEM, clientKeyPEM)
+	if status != 200 {
+		t.Fatalf("LB passthrough transparent read failed (status %d): %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in LB passthrough transparent read response")
+	}
+}
+
+// TestLBPassthroughJWTTransparentRead verifies JWT auth through the TLS
+// passthrough port (no client cert). This confirms the TLS fallback is a no-op
+// when r.TLS.PeerCertificates is empty — JWT auth works normally over TLS
+// without interference from the cert fallback logic.
+func TestLBPassthroughJWTTransparentRead(t *testing.T) {
+	h.SkipWithoutLBPassthrough(t)
+
+	jwt := h.GetDefaultJWT(t)
+	status, body := h.VaultTransparentRequestViaLBPassthrough(t, "GET",
+		"secret/data/e2e/app-config", "e2e-reader", jwt)
+	if status != 200 {
+		t.Fatalf("JWT transparent read via LB passthrough failed (status %d): %s", status, string(body))
+	}
+
+	apiKey := h.JSONString(t, body, "data.data.api_key")
+	if apiKey == "" {
+		t.Fatal("expected api_key in JWT passthrough response")
+	}
+}

--- a/e2e/provider/gateway_test.go
+++ b/e2e/provider/gateway_test.go
@@ -3,6 +3,7 @@
 package provider
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -172,7 +173,12 @@ func TestGatewayResponseContentType(t *testing.T) {
 	}
 	req.Header.Set("Authorization", "Bearer "+jwt)
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -30,7 +30,29 @@ HYDRA_ADMIN="http://localhost:4445"
 echo "=== Warden E2E Cluster Setup ==="
 echo ""
 
-# Step 0: Generate TLS certificates for nginx load balancer
+# Step 0a: Generate TLS certificates for Warden API listeners (mTLS support)
+WARDEN_CERT_DIR="$SCRIPT_DIR/.certs"
+mkdir -p "$WARDEN_CERT_DIR"
+
+if [ ! -f "$WARDEN_CERT_DIR/server.crt" ]; then
+  echo "Generating Warden API server certificate..."
+  openssl ecparam -genkey -name prime256v1 -noout -out "$WARDEN_CERT_DIR/server.key" 2>/dev/null
+  openssl req -new -key "$WARDEN_CERT_DIR/server.key" -out "$WARDEN_CERT_DIR/server.csr" \
+    -subj "/CN=warden-e2e/O=Warden E2E" 2>/dev/null
+  openssl x509 -req -in "$WARDEN_CERT_DIR/server.csr" -signkey "$WARDEN_CERT_DIR/server.key" \
+    -out "$WARDEN_CERT_DIR/server.crt" -days 365 \
+    -extfile <(printf "subjectAltName=IP:127.0.0.1,DNS:localhost") 2>/dev/null
+  rm -f "$WARDEN_CERT_DIR/server.csr"
+fi
+
+if [ ! -f "$WARDEN_CERT_DIR/client-ca.crt" ]; then
+  echo "Generating mTLS client CA certificate..."
+  openssl ecparam -genkey -name prime256v1 -noout -out "$WARDEN_CERT_DIR/client-ca.key" 2>/dev/null
+  openssl req -x509 -new -key "$WARDEN_CERT_DIR/client-ca.key" -out "$WARDEN_CERT_DIR/client-ca.crt" \
+    -days 365 -subj "/CN=E2E mTLS Client CA/O=Warden E2E" 2>/dev/null
+fi
+
+# Step 0b: Generate TLS certificates for nginx load balancer
 NGINX_CERT_DIR="$SCRIPT_DIR/loadbalancer/certs"
 mkdir -p "$NGINX_CERT_DIR"
 
@@ -150,12 +172,13 @@ done
 echo ""
 echo "[5/10] Checking initialization status..."
 
-export WARDEN_ADDR="http://127.0.0.1:8500"
+export WARDEN_ADDR="https://127.0.0.1:8500"
+export WARDEN_SKIP_VERIFY="true"
 
 # Wait for at least one node to respond (not 000/unreachable)
 echo "  Waiting for a node to become reachable..."
 for attempt in $(seq 1 30); do
-  HEALTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:8500/v1/sys/health" 2>/dev/null || true)
+  HEALTH_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "https://127.0.0.1:8500/v1/sys/health" 2>/dev/null || true)
   if [ -n "$HEALTH_CODE" ] && [ "$HEALTH_CODE" != "000" ]; then
     break
   fi
@@ -206,7 +229,7 @@ for attempt in $(seq 1 10); do
   LEADER_COUNT=0
   STANDBY_COUNT=0
   for port in 8500 8510 8520; do
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${port}/v1/sys/health" 2>/dev/null || echo "000")
+    HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "https://127.0.0.1:${port}/v1/sys/health" 2>/dev/null || echo "000")
     case "$HTTP_CODE" in
       200) LEADER_COUNT=$((LEADER_COUNT + 1)) ;;
       429) STANDBY_COUNT=$((STANDBY_COUNT + 1)) ;;
@@ -245,7 +268,7 @@ fi
 # Helper: make authenticated Warden API request
 warden_api() {
   local method="$1" path="$2" body="${3:-}"
-  local args=(-s -X "$method" "http://127.0.0.1:8500/v1/${path}" -H "X-Warden-Token: $WARDEN_TOKEN")
+  local args=(-sk -X "$method" "https://127.0.0.1:8500/v1/${path}" -H "X-Warden-Token: $WARDEN_TOKEN")
   if [ -n "$body" ]; then
     args+=(-H "Content-Type: application/json" -d "$body")
   fi
@@ -428,7 +451,7 @@ warden_api POST "auth/jwt/role/e2e-nt-reader" \
 echo "  Obtaining Warden token for non-transparent testing..."
 NT_JWT=$(bash "$SCRIPT_DIR/tools/get_jwt.sh" 2>/dev/null || echo "")
 if [ -n "$NT_JWT" ]; then
-  NT_LOGIN=$(curl -s -X POST "http://127.0.0.1:8500/v1/auth/jwt/login" \
+  NT_LOGIN=$(curl -sk -X POST "https://127.0.0.1:8500/v1/auth/jwt/login" \
     -H "Content-Type: application/json" \
     -d "{\"jwt\":\"$NT_JWT\",\"role\":\"e2e-nt-reader\"}" 2>/dev/null)
   NT_WARDEN_TOKEN=$(echo "$NT_LOGIN" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['data']['token'])" 2>/dev/null || echo "")
@@ -449,8 +472,8 @@ echo "[10/10] Verifying Vault integration..."
 # 10a. Non-transparent mode: read secret through vault-nt gateway with Warden token
 echo "  Testing non-transparent mode (Warden token -> vault-nt/gateway -> Vault)..."
 if [ -n "$NT_WARDEN_TOKEN" ]; then
-  NT_RESULT=$(curl -s -o /dev/null -w "%{http_code}" \
-    "http://127.0.0.1:8500/v1/vault-nt/gateway/v1/secret/data/e2e/app-config" \
+  NT_RESULT=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "https://127.0.0.1:8500/v1/vault-nt/gateway/v1/secret/data/e2e/app-config" \
     -H "X-Warden-Token: $NT_WARDEN_TOKEN" 2>/dev/null)
   if [ "$NT_RESULT" = "200" ]; then
     echo "  Non-transparent mode: OK (HTTP $NT_RESULT)"
@@ -465,8 +488,8 @@ fi
 echo "  Testing transparent mode (JWT -> vault/gateway -> Vault)..."
 TEST_JWT=$(bash "$SCRIPT_DIR/tools/get_jwt.sh" 2>/dev/null || echo "")
 if [ -n "$TEST_JWT" ]; then
-  T_RESULT=$(curl -s -o /dev/null -w "%{http_code}" \
-    "http://127.0.0.1:8500/v1/vault/role/e2e-reader/gateway/v1/secret/data/e2e/app-config" \
+  T_RESULT=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "https://127.0.0.1:8500/v1/vault/role/e2e-reader/gateway/v1/secret/data/e2e/app-config" \
     -H "Authorization: Bearer $TEST_JWT" 2>/dev/null)
   if [ "$T_RESULT" = "200" ]; then
     echo "  Transparent mode: OK (HTTP $T_RESULT)"
@@ -482,7 +505,7 @@ echo ""
 echo "=== CLUSTER READY ==="
 echo ""
 for port in 8500 8510 8520; do
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${port}/v1/sys/health" 2>/dev/null)
+  HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "https://127.0.0.1:${port}/v1/sys/health" 2>/dev/null)
   case "$HTTP_CODE" in
     200) echo "  Node :${port} — ACTIVE (200)" ;;
     429) echo "  Node :${port} — STANDBY (429)" ;;
@@ -495,8 +518,8 @@ echo "  Vault:  $VAULT_ADDR (token: $VAULT_TOKEN)"
 echo "  Hydra:  $HYDRA_PUBLIC (OIDC) / $HYDRA_ADMIN (admin)"
 echo ""
 echo "Vault integration:"
-echo "  Non-transparent: curl -H 'X-Warden-Token: <token>' http://127.0.0.1:8500/v1/vault-nt/gateway/v1/secret/data/e2e/app-config"
-echo "  Transparent:     curl -H 'Authorization: Bearer <jwt>' http://127.0.0.1:8500/v1/vault/role/e2e-reader/gateway/v1/secret/data/e2e/app-config"
+echo "  Non-transparent: curl -k -H 'X-Warden-Token: <token>' https://127.0.0.1:8500/v1/vault-nt/gateway/v1/secret/data/e2e/app-config"
+echo "  Transparent:     curl -k -H 'Authorization: Bearer <jwt>' https://127.0.0.1:8500/v1/vault/role/e2e-reader/gateway/v1/secret/data/e2e/app-config"
 echo "  Get JWT:         bash e2e/tools/get_jwt.sh"
 echo ""
 echo "To start chaos testing:"

--- a/e2e/teardown.sh
+++ b/e2e/teardown.sh
@@ -46,6 +46,7 @@ rm -f "$SCRIPT_DIR/configs/warden-audit.log"
 rm -f "$SCRIPT_DIR/.root_token"
 rm -f "$SCRIPT_DIR/.logs"/*.log
 rm -rf "$SCRIPT_DIR/loadbalancer/certs"
+rm -rf "$SCRIPT_DIR/.certs"
 
 echo ""
 echo "Teardown complete."

--- a/e2e/tools/api_request.sh
+++ b/e2e/tools/api_request.sh
@@ -15,7 +15,7 @@ BODY="${4:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TOKEN=$(cat "$SCRIPT_DIR/.root_token" 2>/dev/null || echo "")
 
-ARGS=(-s -X "$METHOD" "http://127.0.0.1:${PORT}/v1/${PATH_}" -w "\nHTTP_STATUS:%{http_code}\n")
+ARGS=(-sk -X "$METHOD" "https://127.0.0.1:${PORT}/v1/${PATH_}" -w "\nHTTP_STATUS:%{http_code}\n")
 if [ -n "$TOKEN" ]; then
   ARGS+=(-H "X-Warden-Token: $TOKEN")
 fi

--- a/e2e/tools/assert_cluster_healthy.sh
+++ b/e2e/tools/assert_cluster_healthy.sh
@@ -12,7 +12,7 @@ STANDBY_COUNT=0
 UNREACHABLE=0
 
 for port in 8500 8510 8520; do
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${port}/v1/sys/health" 2>/dev/null || echo "000")
+  HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "https://127.0.0.1:${port}/v1/sys/health" 2>/dev/null || echo "000")
   case "$HTTP_CODE" in
     200)
       LEADER_COUNT=$((LEADER_COUNT + 1))

--- a/e2e/tools/concurrent_requests.sh
+++ b/e2e/tools/concurrent_requests.sh
@@ -17,7 +17,7 @@ echo "Firing $COUNT concurrent $METHOD requests to /v1/$PATH_ on port $PORT..."
 
 for i in $(seq 1 "$COUNT"); do
   (
-    ARGS=(-s -X "$METHOD" "http://127.0.0.1:${PORT}/v1/${PATH_}" -w "%{http_code}" -o "$TMPDIR/body_${i}.json")
+    ARGS=(-sk -X "$METHOD" "https://127.0.0.1:${PORT}/v1/${PATH_}" -w "%{http_code}" -o "$TMPDIR/body_${i}.json")
     if [ -n "$TOKEN" ]; then
       ARGS+=(-H "X-Warden-Token: $TOKEN")
     fi

--- a/e2e/tools/get_leader.sh
+++ b/e2e/tools/get_leader.sh
@@ -3,7 +3,7 @@
 # Usage: get_leader.sh
 
 for port in 8500 8510 8520; do
-  RESULT=$(curl -s "http://127.0.0.1:${port}/v1/sys/leader" 2>/dev/null)
+  RESULT=$(curl -sk "https://127.0.0.1:${port}/v1/sys/leader" 2>/dev/null)
   IS_SELF=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('is_self', False))" 2>/dev/null)
   if [ "$IS_SELF" = "True" ]; then
     echo "Leader: node on port $port"

--- a/e2e/tools/health_check.sh
+++ b/e2e/tools/health_check.sh
@@ -6,8 +6,8 @@
 PORTS="${1:-8500 8510 8520}"
 for port in $PORTS; do
   echo "=== Node :${port} ==="
-  BODY=$(curl -s "http://127.0.0.1:${port}/v1/sys/health" 2>/dev/null)
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${port}/v1/sys/health" 2>/dev/null || echo "000")
+  BODY=$(curl -sk "https://127.0.0.1:${port}/v1/sys/health" 2>/dev/null)
+  HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" "https://127.0.0.1:${port}/v1/sys/health" 2>/dev/null || echo "000")
   echo "  HTTP: $HTTP_CODE"
   if [ -n "$BODY" ]; then
     echo "$BODY" | python3 -m json.tool 2>/dev/null || echo "  $BODY"

--- a/e2e/tools/step_down.sh
+++ b/e2e/tools/step_down.sh
@@ -11,7 +11,7 @@ if [ -z "$TOKEN" ]; then
   exit 1
 fi
 
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-  -X PUT "http://127.0.0.1:${PORT}/v1/sys/step-down" \
+HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" \
+  -X PUT "https://127.0.0.1:${PORT}/v1/sys/step-down" \
   -H "X-Warden-Token: $TOKEN")
 echo "Step-down on port $PORT: HTTP $HTTP_CODE"

--- a/e2e/tools/vault_gateway_request.sh
+++ b/e2e/tools/vault_gateway_request.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # The root token does NOT have a credential spec and cannot be used for gateway requests.
 JWT=$(bash "$SCRIPT_DIR/tools/get_jwt.sh" 2>/dev/null || echo "")
 if [ -n "$JWT" ]; then
-  LOGIN=$(curl -s -X POST "http://127.0.0.1:${PORT}/v1/auth/jwt/login" \
+  LOGIN=$(curl -sk -X POST "https://127.0.0.1:${PORT}/v1/auth/jwt/login" \
     -H "Content-Type: application/json" \
     -d "{\"jwt\":\"$JWT\",\"role\":\"e2e-nt-reader\"}" 2>/dev/null)
   TOKEN=$(echo "$LOGIN" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['data']['token'])" 2>/dev/null || echo "")
@@ -32,9 +32,9 @@ if [ -z "$TOKEN" ]; then
 fi
 
 # Build gateway URL: /v1/vault-nt/gateway/v1/<vault_path> (non-transparent mount)
-URL="http://127.0.0.1:${PORT}/v1/vault-nt/gateway/v1/${VAULT_PATH}"
+URL="https://127.0.0.1:${PORT}/v1/vault-nt/gateway/v1/${VAULT_PATH}"
 
-ARGS=(-s -X "$METHOD" "$URL" -w "\nHTTP_STATUS:%{http_code}\n")
+ARGS=(-sk -X "$METHOD" "$URL" -w "\nHTTP_STATUS:%{http_code}\n")
 ARGS+=(-H "X-Warden-Token: $TOKEN")
 if [ -n "$BODY" ]; then
   ARGS+=(-H "Content-Type: application/json" -d "$BODY")

--- a/e2e/tools/vault_transparent_request.sh
+++ b/e2e/tools/vault_transparent_request.sh
@@ -30,9 +30,9 @@ if [ -z "$JWT" ]; then
 fi
 
 # Build transparent gateway URL: /v1/vault/role/<role>/gateway/v1/<vault_path>
-URL="http://127.0.0.1:${PORT}/v1/vault/role/${ROLE}/gateway/v1/${VAULT_PATH}"
+URL="https://127.0.0.1:${PORT}/v1/vault/role/${ROLE}/gateway/v1/${VAULT_PATH}"
 
-ARGS=(-s -X "$METHOD" "$URL" -w "\nHTTP_STATUS:%{http_code}\n")
+ARGS=(-sk -X "$METHOD" "$URL" -w "\nHTTP_STATUS:%{http_code}\n")
 ARGS+=(-H "Authorization: Bearer $JWT")
 if [ -n "$BODY" ]; then
   ARGS+=(-H "Content-Type: application/json" -d "$BODY")

--- a/listener/api/cert_forwarding.go
+++ b/listener/api/cert_forwarding.go
@@ -9,48 +9,52 @@ import (
 )
 
 // certForwardingMiddleware returns middleware that extracts client certificates
-// from forwarding headers sent by trusted proxies. It must run BEFORE
-// middleware.RealIP which overwrites r.RemoteAddr.
+// from the request. It must run BEFORE middleware.RealIP which overwrites
+// r.RemoteAddr.
 //
-// When the request comes from a trusted proxy IP:
-//   - Parses X-Forwarded-Client-Cert (XFCC, Envoy/Istio) or
-//     X-SSL-Client-Cert (NGINX/HAProxy) headers
-//   - Stores the parsed certificate in the request context
-//   - Strips the forwarding headers to prevent downstream leakage
+// Certificate extraction follows a two-tier priority:
 //
-// When the request comes from an untrusted IP:
-//   - Deletes any forwarding headers to prevent spoofing
+//  1. Forwarding headers from trusted proxies (X-Forwarded-Client-Cert or
+//     X-SSL-Client-Cert). Headers from untrusted sources are stripped.
+//  2. TLS peer certificates from the direct connection (r.TLS.PeerCertificates).
+//     Used as a fallback when no forwarded cert is found — covers direct mTLS
+//     connections and load balancers operating in TLS passthrough mode.
+//
+// The TLS fallback is safe because r.TLS.PeerCertificates is populated by
+// Go's TLS stack from the actual handshake and cannot be spoofed via headers.
+// This fallback is NOT applied on the cluster listener (which has its own
+// handler), so standby-to-leader forwarding never picks up the wrong cert.
 func certForwardingMiddleware(trustedProxies []string) func(http.Handler) http.Handler {
 	// Pre-parse CIDR networks at startup
 	networks := parseCIDRs(trustedProxies)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// If no trusted proxies configured, strip headers and pass through
-			if len(networks) == 0 {
+			// --- Header-based extraction ---
+			if len(networks) > 0 {
+				remoteIP := extractRemoteIP(r.RemoteAddr)
+				if remoteIP != nil && isTrustedProxy(remoteIP, networks) {
+					// Trusted proxy — extract cert from forwarding headers
+					cert := listener.ParseForwardedCert(r)
+					if cert != nil {
+						ctx := listener.WithForwardedClientCert(r.Context(), cert)
+						r = r.WithContext(ctx)
+					}
+				} else {
+					listener.StripCertHeaders(r)
+				}
+			} else {
 				listener.StripCertHeaders(r)
-				next.ServeHTTP(w, r)
-				return
 			}
 
-			remoteIP := extractRemoteIP(r.RemoteAddr)
-			if remoteIP == nil {
-				listener.StripCertHeaders(r)
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			if !isTrustedProxy(remoteIP, networks) {
-				listener.StripCertHeaders(r)
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			// Trusted proxy — extract cert from forwarding headers
-			cert := listener.ParseForwardedCert(r)
-
-			if cert != nil {
-				ctx := listener.WithForwardedClientCert(r.Context(), cert)
+			// --- TLS fallback: direct mTLS or LB passthrough ---
+			// When no cert was extracted from headers, check the TLS
+			// connection state. This covers two scenarios:
+			//   - Direct mTLS connections (no load balancer)
+			//   - Load balancers in TLS passthrough mode (no header injection)
+			if listener.ForwardedClientCert(r.Context()) == nil &&
+				r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+				ctx := listener.WithForwardedClientCert(r.Context(), r.TLS.PeerCertificates[0])
 				r = r.WithContext(ctx)
 			}
 

--- a/listener/api/cert_forwarding_test.go
+++ b/listener/api/cert_forwarding_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -256,6 +257,169 @@ func TestExtractRemoteIP(t *testing.T) {
 				t.Fatalf("expected %q, got %q", tc.expected, ip.String())
 			}
 		})
+	}
+}
+
+// --- TLS fallback tests ---
+
+func TestCertForwardingMiddleware_TLSFallback_NoProxies(t *testing.T) {
+	_, tlsCert := generateTestCert(t, "direct-tls-client")
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware(nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{tlsCert},
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert == nil {
+		t.Fatal("expected cert from TLS fallback, got nil")
+	}
+	if extractedCert.Subject.CommonName != "direct-tls-client" {
+		t.Fatalf("expected CN %q, got %q", "direct-tls-client", extractedCert.Subject.CommonName)
+	}
+}
+
+func TestCertForwardingMiddleware_TLSFallback_TrustedProxyNoHeaders(t *testing.T) {
+	_, tlsCert := generateTestCert(t, "passthrough-client")
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"127.0.0.1/32"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	// No cert headers — simulates LB passthrough
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{tlsCert},
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert == nil {
+		t.Fatal("expected cert from TLS fallback in passthrough scenario, got nil")
+	}
+	if extractedCert.Subject.CommonName != "passthrough-client" {
+		t.Fatalf("expected CN %q, got %q", "passthrough-client", extractedCert.Subject.CommonName)
+	}
+}
+
+func TestCertForwardingMiddleware_HeaderWinsOverTLS(t *testing.T) {
+	headerCertPEM, _ := generateTestCert(t, "header-cert")
+	_, tlsCert := generateTestCert(t, "tls-cert")
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"127.0.0.1/32"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-SSL-Client-Cert", url.QueryEscape(headerCertPEM))
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{tlsCert},
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert == nil {
+		t.Fatal("expected cert, got nil")
+	}
+	if extractedCert.Subject.CommonName != "header-cert" {
+		t.Fatalf("expected header cert (CN %q) to win over TLS cert, got CN %q", "header-cert", extractedCert.Subject.CommonName)
+	}
+}
+
+func TestCertForwardingMiddleware_TLSFallback_UntrustedProxyWithTLS(t *testing.T) {
+	_, tlsCert := generateTestCert(t, "untrusted-tls-client")
+
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"10.0.0.0/8"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "192.168.1.1:12345" // Not in trusted range
+	req.Header.Set("X-SSL-Client-Cert", "spoofed-value")
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{tlsCert},
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// Headers should be stripped, but TLS cert should be used
+	if extractedCert == nil {
+		t.Fatal("expected cert from TLS fallback after header stripping, got nil")
+	}
+	if extractedCert.Subject.CommonName != "untrusted-tls-client" {
+		t.Fatalf("expected CN %q, got %q", "untrusted-tls-client", extractedCert.Subject.CommonName)
+	}
+}
+
+func TestCertForwardingMiddleware_NoCertAnywhere(t *testing.T) {
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware([]string{"127.0.0.1/32"})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	// No headers, no TLS
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert != nil {
+		t.Fatal("expected nil cert when no headers and no TLS, got one")
+	}
+}
+
+func TestCertForwardingMiddleware_TLSWithEmptyPeerCerts(t *testing.T) {
+	var extractedCert *x509.Certificate
+	handler := certForwardingMiddleware(nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			extractedCert = listener.ForwardedClientCert(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{}, // TLS but no client cert
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if extractedCert != nil {
+		t.Fatal("expected nil cert when TLS has empty PeerCertificates")
 	}
 }
 

--- a/listener/cert_forwarding.go
+++ b/listener/cert_forwarding.go
@@ -16,9 +16,10 @@ type contextKey string
 
 const ctxForwardedClientCert contextKey = "forwarded_client_cert"
 
-// ForwardedClientCert retrieves a client certificate that was forwarded by a
-// trusted proxy (load balancer) or re-injected by the cluster listener from
-// forwarding headers.
+// ForwardedClientCert retrieves the client certificate stored in the context
+// by the cert forwarding middleware. The cert may originate from a forwarding
+// header (trusted proxy / LB), the TLS connection state (direct mTLS / LB
+// passthrough), or re-injection by the cluster listener on forwarded requests.
 func ForwardedClientCert(ctx context.Context) *x509.Certificate {
 	cert, _ := ctx.Value(ctxForwardedClientCert).(*x509.Certificate)
 	return cert


### PR DESCRIPTION
…ination

When a load balancer does not terminate TLS (passthrough mode) or when clients connect directly to Warden, cert auth previously failed silently because only forwarding headers were checked. This adds a fallback in the API listener middleware that reads r.TLS.PeerCertificates when no cert was found in headers, enabling mTLS cert auth in both scenarios.

Priority: (1) forwarding headers from trusted proxy, (2) TLS fallback. The cluster listener is NOT modified — standby node cluster certs are never incorrectly used as client certs.

E2E infrastructure updated: TLS enabled on all nodes, nginx TLS passthrough on port 8001, all scripts/helpers updated for HTTPS, 7 new mTLS e2e tests covering direct mTLS, standby forwarding, and LB passthrough scenarios.