### PR TITLE
feat: fix Director LB forwarding and add IP binding e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: bash e2e/setup.sh
 
       - name: Run E2E tests
-        run: go test -tags e2e -v -count=1 -p 1 -timeout 45m ./e2e/cluster/ ./e2e/provider/ ./e2e/ha/ ./e2e/namespace/ ./e2e/forwarding/ ./e2e/credential/ ./e2e/rotation/ ./e2e/auth/ ./e2e/audit/ ./e2e/seal/ ./e2e/concurrency/ ./e2e/loadbalancer/
+        run: go test -tags e2e -v -count=1 -p 1 -timeout 45m ./e2e/...
 
       - name: Teardown E2E cluster
         if: always()

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1084,6 +1084,13 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 	// Mark request as transparent mode
 	req.Transparent = true
 
+	// Inject client IP into context so validateIPBinding can read it
+	// during cached token lookups. Without this, transparent mode tokens
+	// bypass IP binding because the context has no client IP.
+	if req.ClientIP != "" {
+		ctx = context.WithValue(ctx, logical.ClientIPKey, req.ClientIP)
+	}
+
 	// Detect credential type: client certificate or JWT bearer token
 	var singleflightKey string
 	var lookupFunc func() (*TokenEntry, error)
@@ -1141,12 +1148,22 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		return nil
 	}
 
+	// IP binding violation means the token exists but the client IP doesn't match.
+	// Return the error immediately — don't fall through and create a new token.
+	if err == ErrOriginViolation {
+		return err
+	}
+
 	// Step 2: Token not found — perform implicit auth with singleflight
 	result, err, shared := c.transparentAuthGroup.Do(singleflightKey, func() (interface{}, error) {
 		// Double-check: another goroutine may have just created the token
 		checkTE, lookupErr := lookupFunc()
 		if lookupErr == nil && checkTE != nil {
 			return checkTE, nil
+		}
+		// Same as above: IP binding violation should not trigger re-login
+		if lookupErr == ErrOriginViolation {
+			return nil, lookupErr
 		}
 
 		// Build login request to the auto-auth path (e.g., auth/jwt/login or auth/cert/login)

--- a/e2e/auth/ip_binding_test.go
+++ b/e2e/auth/ip_binding_test.go
@@ -1,0 +1,149 @@
+//go:build e2e
+
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// spoofedIP is a trusted proxy IP (in 172.16.0.0/12 from node configs)
+// used to simulate a different client IP. It must be in trusted_proxies
+// so that certForwardingMiddleware preserves X-SSL-Client-Cert headers.
+const spoofedIP = "172.16.0.1"
+
+// TestIPBinding verifies IP binding enforcement across auth methods and gateway modes.
+// Tests are grouped by policy to minimize cluster restarts.
+func TestIPBinding(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// --- Set up cert auth environment (used by cert subtests in both policies) ---
+	caCertPEM, caKey := h.SetupCertVaultEnv(t, port)
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, "agent-ip-test")
+	defer h.TeardownCertVaultEnv(t, port)
+
+	t.Run("Optional", func(t *testing.T) {
+		h.SetIPBindingPolicy(t, "optional")
+		port := h.GetLeaderPort(t) // leader may change after restart
+
+		runIPBindingSubtests(t, port, clientCertPEM)
+	})
+
+	t.Run("Required", func(t *testing.T) {
+		h.SetIPBindingPolicy(t, "required")
+		port := h.GetLeaderPort(t)
+
+		runIPBindingSubtests(t, port, clientCertPEM)
+	})
+
+	// Restore disabled policy for other tests
+	h.RestoreIPBindingPolicy(t)
+}
+
+// runIPBindingSubtests runs all 8 subtests (2 auth methods × 2 modes × 2 IP scenarios).
+// Non-transparent denial returns 403 (ErrPermissionDenied from ResolveToken).
+// Transparent denial returns 401 (ErrUnauthorized from performImplicitAuth).
+func runIPBindingSubtests(t *testing.T, port int, clientCertPEM string) {
+	t.Helper()
+
+	// --- JWT Non-Transparent ---
+	t.Run("JWT_NT_SameIP_Allowed", func(t *testing.T) {
+		token := h.GetNTWardenToken(t, port)
+		status, _ := h.VaultNTRequest(t, "GET", "secret/data/e2e/app-config", port, token)
+		if status != 200 {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	})
+
+	t.Run("JWT_NT_DifferentIP_Denied", func(t *testing.T) {
+		token := h.GetNTWardenToken(t, port)
+		u := fmt.Sprintf("%s/v1/vault-nt/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+		headers := map[string]string{
+			"X-Warden-Token":  token,
+			"X-Forwarded-For": spoofedIP,
+		}
+		status, _ := h.DoRequest(t, "GET", u, headers, "")
+		if status != 403 {
+			t.Fatalf("expected 403, got %d", status)
+		}
+	})
+
+	// --- JWT Transparent ---
+	t.Run("JWT_T_SameIP_Allowed", func(t *testing.T) {
+		jwt := h.GetDefaultJWT(t)
+		status, _ := h.VaultTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-reader", port, jwt)
+		if status != 200 {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	})
+
+	t.Run("JWT_T_DifferentIP_Denied", func(t *testing.T) {
+		jwt := h.GetDefaultJWT(t)
+		// First request creates the cached token with CreatedByIP=127.0.0.1
+		status, _ := h.VaultTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-reader", port, jwt)
+		if status != 200 {
+			t.Fatalf("setup: expected 200, got %d", status)
+		}
+		// Second request with different IP should be denied (401 for transparent)
+		u := fmt.Sprintf("%s/v1/vault/role/e2e-reader/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+		headers := map[string]string{
+			"Authorization":   "Bearer " + jwt,
+			"X-Forwarded-For": spoofedIP,
+		}
+		status, _ = h.DoRequest(t, "GET", u, headers, "")
+		if status != 401 {
+			t.Fatalf("expected 401, got %d", status)
+		}
+	})
+
+	// --- Cert Non-Transparent ---
+	t.Run("Cert_NT_SameIP_Allowed", func(t *testing.T) {
+		token := h.GetCertNTWardenToken(t, port, "e2e-cert-nt-reader", clientCertPEM)
+		status, _ := h.VaultNTRequest(t, "GET", "secret/data/e2e/app-config", port, token)
+		if status != 200 {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	})
+
+	t.Run("Cert_NT_DifferentIP_Denied", func(t *testing.T) {
+		token := h.GetCertNTWardenToken(t, port, "e2e-cert-nt-reader", clientCertPEM)
+		u := fmt.Sprintf("%s/v1/vault-nt/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+		headers := map[string]string{
+			"X-Warden-Token":  token,
+			"X-Forwarded-For": spoofedIP,
+		}
+		status, _ := h.DoRequest(t, "GET", u, headers, "")
+		if status != 403 {
+			t.Fatalf("expected 403, got %d", status)
+		}
+	})
+
+	// --- Cert Transparent ---
+	t.Run("Cert_T_SameIP_Allowed", func(t *testing.T) {
+		status, _ := h.VaultCertTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM)
+		if status != 200 {
+			t.Fatalf("expected 200, got %d", status)
+		}
+	})
+
+	t.Run("Cert_T_DifferentIP_Denied", func(t *testing.T) {
+		// First request creates cached token with CreatedByIP=127.0.0.1
+		status, _ := h.VaultCertTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-cert-reader", port, clientCertPEM)
+		if status != 200 {
+			t.Fatalf("setup: expected 200, got %d", status)
+		}
+		// Second request with different IP — must use trusted proxy IP so
+		// certForwardingMiddleware preserves the X-SSL-Client-Cert header.
+		u := fmt.Sprintf("%s/v1/vault-cert/role/e2e-cert-reader/gateway/v1/secret/data/e2e/app-config", h.NodeURL(port))
+		headers := map[string]string{
+			"X-SSL-Client-Cert": h.URLEncodePEM(clientCertPEM),
+			"X-Forwarded-For":   spoofedIP,
+		}
+		status, _ = h.DoRequest(t, "GET", u, headers, "")
+		if status != 401 {
+			t.Fatalf("expected 401, got %d", status)
+		}
+	})
+}

--- a/e2e/helpers/ip_binding_helpers.go
+++ b/e2e/helpers/ip_binding_helpers.go
@@ -1,0 +1,52 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// --- IP Binding Policy Helpers ---
+
+var ipBindingRe = regexp.MustCompile(`ip_binding_policy\s*=\s*"[^"]*"`)
+
+// SetIPBindingPolicy modifies all 3 node configs to use the given policy,
+// restarts the cluster, and waits for it to become healthy.
+func SetIPBindingPolicy(t *testing.T, policy string) {
+	t.Helper()
+	replacement := fmt.Sprintf(`ip_binding_policy = "%s"`, policy)
+	configsDir := filepath.Join(E2EDir(), "configs")
+
+	for i := 1; i <= 3; i++ {
+		cfgPath := filepath.Join(configsDir, fmt.Sprintf("node%d.hcl", i))
+		data, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", cfgPath, err)
+		}
+		updated := ipBindingRe.ReplaceAll(data, []byte(replacement))
+		if err := os.WriteFile(cfgPath, updated, 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", cfgPath, err)
+		}
+	}
+
+	// Restart all nodes with new config
+	for i := 1; i <= 3; i++ {
+		KillNode(t, i, "TERM")
+	}
+	time.Sleep(2 * time.Second)
+	for i := 1; i <= 3; i++ {
+		RestartNode(t, i)
+	}
+	WaitForCluster(t, 30, 2*time.Second)
+}
+
+// RestoreIPBindingPolicy resets all node configs to "disabled" and restarts.
+func RestoreIPBindingPolicy(t *testing.T) {
+	t.Helper()
+	SetIPBindingPolicy(t, "disabled")
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -201,7 +201,14 @@ func (f *standbyForwarder) getProxy(clusterAddr, redirectAddr string) *httputil.
 			// Set forwarding headers from the direct client connection.
 			// Append to X-Forwarded-For to preserve the chain from
 			// upstream proxies (load balancers, etc.).
-			if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+			clientIP, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				// RemoteAddr may be a bare IP (no port) after middleware.RealIP
+				if ip := net.ParseIP(req.RemoteAddr); ip != nil {
+					clientIP = req.RemoteAddr
+				}
+			}
+			if clientIP != "" {
 				if prior := req.Header.Get("X-Forwarded-For"); prior != "" {
 					req.Header.Set("X-Forwarded-For", prior+", "+clientIP)
 				} else {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -526,3 +526,77 @@ func TestProxyDirectorSetsForwardingHeaders(t *testing.T) {
 	assert.Contains(t, receivedXFF, "192.168.1.100")
 	assert.Equal(t, "http", receivedXFP)
 }
+
+// TestProxyDirectorHandlesBareIPRemoteAddr verifies that the Director correctly
+// sets X-Forwarded-For when RemoteAddr is a bare IP (no port), as happens after
+// middleware.RealIP rewrites RemoteAddr from X-Forwarded-For headers.
+func TestProxyDirectorHandlesBareIPRemoteAddr(t *testing.T) {
+	var receivedXFF string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedXFF = r.Header.Get("X-Forwarded-For")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = backendURL.Scheme
+			req.URL.Host = backendURL.Host
+
+			// Replicate the fixed Director logic from handler.go
+			clientIP, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				if ip := net.ParseIP(req.RemoteAddr); ip != nil {
+					clientIP = req.RemoteAddr
+				}
+			}
+			if clientIP != "" {
+				if prior := req.Header.Get("X-Forwarded-For"); prior != "" {
+					req.Header.Set("X-Forwarded-For", prior+", "+clientIP)
+				} else {
+					req.Header.Set("X-Forwarded-For", clientIP)
+				}
+			}
+		},
+	}
+
+	t.Run("bare_IPv4", func(t *testing.T) {
+		// Simulate middleware.RealIP stripping the port
+		req := httptest.NewRequest(http.MethodGet, "/v1/test", nil)
+		req.RemoteAddr = "192.168.1.100" // no port
+		w := httptest.NewRecorder()
+
+		proxy.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, receivedXFF, "192.168.1.100")
+	})
+
+	t.Run("bare_IPv4_with_prior_XFF", func(t *testing.T) {
+		// LB already set X-Forwarded-For, RealIP stripped port
+		req := httptest.NewRequest(http.MethodGet, "/v1/test", nil)
+		req.RemoteAddr = "10.0.0.50"
+		req.Header.Set("X-Forwarded-For", "203.0.113.10")
+		w := httptest.NewRecorder()
+
+		proxy.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, receivedXFF, "203.0.113.10")
+		assert.Contains(t, receivedXFF, "10.0.0.50")
+	})
+
+	t.Run("with_port_still_works", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/test", nil)
+		req.RemoteAddr = "192.168.1.100:54321"
+		w := httptest.NewRecorder()
+
+		proxy.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, receivedXFF, "192.168.1.100")
+	})
+}


### PR DESCRIPTION
Fix standby Director to handle port-less RemoteAddr (bare IP after middleware.RealIP) by falling back to net.ParseIP when SplitHostPort fails. Previously the X-Forwarded-For header was silently not set.

Fix transparent mode IP binding by injecting ClientIP into context in performImplicitAuth, and returning ErrOriginViolation immediately instead of falling through to create a new token.

Add 16 e2e subtests covering IP binding enforcement across optional and required policies, JWT and cert auth, transparent and non-transparent modes.

Simplify CI e2e test command to use ./e2e/... instead of listing individual packages.