### PR TITLE
Fix/aws sigv4 content length issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Warden are documented in this file.
 
+## [v0.4.1] — 2026-03-13
+
+### Bug Fixes
+
+- **AWS SigV4 Content-Length Signature Mismatch** — Fixed AWS gateway signature verification failing on all POST requests (EC2, DynamoDB, etc.). The AWS SDK v4 signer automatically includes `content-length` in canonical headers when `ContentLength > 0`, but most AWS clients (including the AWS CLI) do not sign `content-length`. The server now respects the client's `SignedHeaders` list and only includes `content-length` in the canonical request when the client actually signed it.
+
 ## [v0.4.0] — 2026-03-12
 
 ### New Features
@@ -131,6 +137,7 @@ Initial release. See the [v0.1.0 release notes](https://github.com/stephnangue/w
 - Docker image published to `ghcr.io/stephnangue/warden`
 - Pre-built binaries for Linux, macOS, and Windows
 
+[v0.4.1]: https://github.com/stephnangue/warden/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/stephnangue/warden/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/stephnangue/warden/compare/v0.2.1...v0.3.0
 [v0.2.1]: https://github.com/stephnangue/warden/compare/v0.2.0...v0.2.1

--- a/provider/aws/signature.go
+++ b/provider/aws/signature.go
@@ -184,7 +184,23 @@ func (b *awsBackend) verifyIncomingSignature(
 	// Restore body in the cloned request
 	if len(bodyBytes) > 0 {
 		testReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	// Only set ContentLength if the client signed the content-length header.
+	// The AWS SDK v4 signer automatically includes content-length in canonical
+	// headers when ContentLength > 0, which causes a signature mismatch if the
+	// client didn't sign it. Setting -1 tells the signer to omit it.
+	contentLengthSigned := false
+	for _, sh := range signedHeadersList {
+		if strings.ToLower(strings.TrimSpace(sh)) == "content-length" {
+			contentLengthSigned = true
+			break
+		}
+	}
+	if contentLengthSigned {
 		testReq.ContentLength = int64(len(bodyBytes))
+	} else {
+		testReq.ContentLength = -1
 	}
 
 	// Compute payload hash


### PR DESCRIPTION
- Fixed AWS gateway signature verification failing on all POST requests (EC2, DynamoDB, etc.) via aws CLI
- The AWS SDK v4 signer automatically includes `content-length` in canonical headers when `ContentLength > 0`, but most AWS clients do not sign it
- The server now respects the client's `SignedHeaders` list and only includes `content-length` when the client actually signed it
- GET requests (e.g., Lambda) were unaffected since they have no body
