### PR TITLE
feat: add @file support to write command and document cert auth TLS p…

### DIFF
--- a/cmd/basic/write.go
+++ b/cmd/basic/write.go
@@ -39,6 +39,10 @@ Usage: warden write PATH [DATA]
   Write configuration using key=value format:
 
       $ warden write aws/config token_ttl=1h proxy_domains='["localhost","warden"]'
+
+  Use @file to read a value from a file (useful for PEM certificates, large payloads, etc.):
+
+      $ warden write auth/cert/config trusted_ca_pem=@/path/to/ca.pem default_role=my-role
 `,
 		Args: cobra.MinimumNArgs(1),
 		RunE: runWrite,
@@ -89,6 +93,16 @@ func runWrite(cmd *cobra.Command, args []string) error {
 				}
 				key := parts[0]
 				value := parts[1]
+
+				// Check for @file reference — read file contents as string
+				if strings.HasPrefix(value, "@") {
+					fileData, err := os.ReadFile(value[1:])
+					if err != nil {
+						return fmt.Errorf("failed to read file for key %q: %w", key, err)
+					}
+					data[key] = string(fileData)
+					continue
+				}
 
 				// Try to infer the type of the value
 				data[key] = inferType(value)

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -481,6 +481,8 @@ For HTTPS, you'll need a **wildcard SSL certificate** (`*.warden.yourdomain.com`
 
 Steps 1 and 5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 2–4 (provider setup) are identical. Replace Steps 1 and 5 with the following.
 
 ### Enable Cert Auth

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -369,6 +369,8 @@ Warden supports automatic rotation of Azure service principal credentials via th
 
 Steps 4–5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -340,6 +340,8 @@ When the source key rotates, all credential specs sharing that source automatica
 
 Steps 4–5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -336,6 +336,8 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4–5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -361,6 +361,8 @@ The default activation delay is **1 minute** (configurable via `activation_delay
 
 Steps 4–5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -323,6 +323,8 @@ This allows operators to enforce policies such as:
 
 Steps 4–5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -337,6 +337,8 @@ This allows operators to enforce policies such as:
 
 Steps 4–5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -573,6 +573,8 @@ Certain read-only PKI endpoints are forwarded without authentication, matching V
 
 Steps 2 and 6 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
 Steps 1, 3–5 (provider setup) are identical. Replace Steps 2 and 6 with the following.
 
 ### Enable Cert Auth


### PR DESCRIPTION
…rerequisite

Add @file syntax to `warden write` for reading values from files (e.g. trusted_ca_pem=@/path/to/ca.pem). Add TLS prerequisite note to the cert auth section of all 8 provider READMEs.