### PR TITLE
feat: add warden_crypto_token self-contained token type

### DIFF
--- a/auth/helper/token_type.go
+++ b/auth/helper/token_type.go
@@ -20,7 +20,7 @@ func ResolveTokenType(backend, alias string) string {
 	case "aws":
 		return "aws_access_keys"
 	case "warden":
-		return "warden_token"
+		return "warden_crypto_token"
 	case "transparent":
 		if backend == BackendCert {
 			return "cert_role"
@@ -37,7 +37,7 @@ func DisplayTokenType(internal string) string {
 	switch internal {
 	case "aws_access_keys":
 		return "aws"
-	case "warden_token":
+	case "warden_crypto_token":
 		return "warden"
 	case "jwt_role", "cert_role":
 		return "transparent"

--- a/auth/method/cert/path_login_test.go
+++ b/auth/method/cert/path_login_test.go
@@ -419,7 +419,7 @@ func TestHandleLogin_DefaultRoleFallback(t *testing.T) {
 		conf := &logical.BackendConfig{
 			Logger:          testLogger(),
 			StorageView:     storage,
-			ValidTokenTypes: []string{"warden_token"},
+			ValidTokenTypes: []string{"warden_token", "warden_crypto_token"},
 		}
 		backend, err := Factory(context.Background(), conf)
 		require.NoError(t, err)
@@ -456,7 +456,7 @@ func TestHandleLogin_DefaultRoleFallback(t *testing.T) {
 		conf := &logical.BackendConfig{
 			Logger:          testLogger(),
 			StorageView:     storage,
-			ValidTokenTypes: []string{"warden_token"},
+			ValidTokenTypes: []string{"warden_token", "warden_crypto_token"},
 		}
 		backend, err := Factory(context.Background(), conf)
 		require.NoError(t, err)

--- a/auth/method/cert/path_role_test.go
+++ b/auth/method/cert/path_role_test.go
@@ -24,7 +24,7 @@ func createTestBackendWithAllTokenTypes(t *testing.T) (*certAuthBackend, context
 	conf := &logical.BackendConfig{
 		Logger:          testLogger(),
 		StorageView:     storage,
-		ValidTokenTypes: []string{"service", "batch", "user_pass", "aws_access_keys", "warden_token", "jwt_role", "cert_role"},
+		ValidTokenTypes: []string{"service", "batch", "user_pass", "aws_access_keys", "warden_token", "warden_crypto_token", "jwt_role", "cert_role"},
 	}
 	backend, err := Factory(ctx, conf)
 	require.NoError(t, err)

--- a/auth/method/jwt/path_login_test.go
+++ b/auth/method/jwt/path_login_test.go
@@ -98,7 +98,7 @@ func createTestBackendWithStorage(t *testing.T) (*jwtAuthBackend, context.Contex
 	conf := &logical.BackendConfig{
 		Logger:          testLoggerLogin(),
 		StorageView:     storage,
-		ValidTokenTypes: []string{"service", "batch", "user_pass", "aws_access_keys", "warden_token"},
+		ValidTokenTypes: []string{"service", "batch", "user_pass", "aws_access_keys", "warden_token", "warden_crypto_token"},
 	}
 
 	backend, err := Factory(ctx, conf)

--- a/auth/method/jwt/path_role_test.go
+++ b/auth/method/jwt/path_role_test.go
@@ -519,7 +519,7 @@ func createTestBackendWithAllTokenTypes(t *testing.T) (*jwtAuthBackend, context.
 	conf := &logical.BackendConfig{
 		Logger:          testLoggerLogin(),
 		StorageView:     storage,
-		ValidTokenTypes: []string{"service", "batch", "user_pass", "aws_access_keys", "warden_token", "jwt_role", "cert_role"},
+		ValidTokenTypes: []string{"service", "batch", "user_pass", "aws_access_keys", "warden_token", "warden_crypto_token", "jwt_role", "cert_role"},
 	}
 	backend, err := Factory(ctx, conf)
 	require.NoError(t, err)

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openbao/openbao/helper/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/pathmanager"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	authhelper "github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -551,18 +552,23 @@ func (c *Core) LoginCreateToken(ctx context.Context, resp *logical.Response) (*l
 	}
 
 	data := map[string]any{
-		"token_type":     tokenValue.Type,
+		"token_type":     authhelper.DisplayTokenType(tokenValue.Type),
 		"expire_at":      tokenValue.ExpireAt,
 		"bound_ip":       tokenValue.CreatedByIP,
 		"token_id":       tokenValue.ID,
 		"token_assessor": tokenValue.Accessor,
 		"namespace":      tokenValue.NamespacePath,
+		"principal_id":   tokenValue.PrincipalID,
 		"role":           tokenValue.RoleName,
 		"data":           tokenValue.Data,
 		"policies":       tokenValue.Policies,
 	}
 
 	maps.Copy(resp.Data, data)
+
+	// Remove internal fields that were needed for token generation
+	// but should not be exposed to the client.
+	delete(resp.Data, "fingerprint")
 
 	resp.StatusCode = http.StatusCreated
 

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1110,7 +1110,7 @@ func TestHandleTransparentAuth_JWTDifferentRoles(t *testing.T) {
 			ExpireAt:    time.Now().Add(1 * time.Hour),
 			Policies:    []string{"policy1"},
 		}
-		_, err := jwtType.Generate(authData1, entry1)
+		_, err := jwtType.Generate(context.Background(), authData1, entry1)
 		require.NoError(t, err)
 		id1 := jwtType.ComputeID(entry1.Data["jwt"])
 
@@ -1125,7 +1125,7 @@ func TestHandleTransparentAuth_JWTDifferentRoles(t *testing.T) {
 			ExpireAt:    time.Now().Add(1 * time.Hour),
 			Policies:    []string{"policy2"},
 		}
-		_, err = jwtType.Generate(authData2, entry2)
+		_, err = jwtType.Generate(context.Background(), authData2, entry2)
 		require.NoError(t, err)
 		id2 := jwtType.ComputeID(entry2.Data["jwt"])
 
@@ -1153,7 +1153,7 @@ func TestHandleTransparentAuth_JWTDifferentRoles(t *testing.T) {
 			Data: map[string]string{},
 		}
 		authData := &AuthData{TokenValue: sampleJWT, RoleName: "terraform"}
-		jwtType.Generate(authData, entry)
+		jwtType.Generate(context.Background(), authData, entry)
 
 		// Verify the stored value is a hash of JWT+role (not raw value)
 		expectedHash := sha256.Sum256([]byte(sampleJWT + ":terraform"))

--- a/core/token_store.go
+++ b/core/token_store.go
@@ -20,11 +20,12 @@ import (
 )
 
 const (
-	TypeUserPass      = "user_pass"
-	TypeAWSAccessKeys = "aws_access_keys"
-	TypeWardenToken   = "warden_token"
-	TypeJWTRole       = "jwt_role"
-	TypeCertRole      = "cert_role"
+	TypeUserPass          = "user_pass"
+	TypeAWSAccessKeys     = "aws_access_keys"
+	TypeWardenToken       = "warden_token"
+	TypeWardenCryptoToken = "warden_crypto_token"
+	TypeJWTRole           = "jwt_role"
+	TypeCertRole          = "cert_role"
 )
 
 // Storage path constants for token store organization
@@ -310,6 +311,7 @@ func (s *TokenStore) registerBuiltinTypes() error {
 		&UserPassTokenType{},
 		&AWSAccessKeysTokenType{},
 		&WardenTokenType{},
+		&WardenCryptoTokenType{encryptor: s.core.barrier},
 		&JWTRoleTokenType{},
 		&CertRoleTokenType{},
 	}
@@ -400,7 +402,7 @@ func (s *TokenStore) generateWithCollisionDetection(
 		entry.Accessor = accessor
 
 		// Let the token type generate its values
-		clientData, err := tokenType.Generate(authData, entry)
+		clientData, err := tokenType.Generate(ctx, authData, entry)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate token: %w", err)
 		}
@@ -455,9 +457,10 @@ func (s *TokenStore) generateWithCollisionDetection(
 		}
 
 		// Register token with expiration manager for timer-based TTL enforcement
-		// JWT and cert role tokens are cache-only, so don't persist their expiration entries
+		// Self-contained tokens (JWT, cert) are cache-only, so don't persist their expiration entries,
+		// Do not also register warden crypto token for expiration
 		if expMgr := s.core.GetExpirationManager(); expMgr != nil && ttl > 0 {
-			persist := entry.Type != TypeJWTRole && entry.Type != TypeCertRole
+			persist := entry.Type != TypeJWTRole && entry.Type != TypeCertRole && entry.Type != TypeWardenCryptoToken
 			if err := expMgr.RegisterToken(ctx, entry.ID, ttl, persist); err != nil {
 				s.logger.Warn("failed to register token with expiration manager",
 					logger.String("token_id", entry.ID),
@@ -514,6 +517,11 @@ func (s *TokenStore) ResolveToken(ctx context.Context, tokenValue string) (strin
 		}
 	} else {
 		tokenID = tokenType.ComputeID(tokenValue)
+	}
+
+	// Self-contained crypto tokens: decrypt and validate inline, no cache/storage lookup
+	if cryptoType, ok := tokenType.(*WardenCryptoTokenType); ok {
+		return s.resolveCryptoToken(ctx, tokenValue, cryptoType, ns)
 	}
 
 	// Lookup token in cache
@@ -1018,8 +1026,8 @@ func (s *TokenStore) ReplaceRootTokenValue(customToken string) error {
 // Uses a transaction to ensure atomicity: both token and accessor are stored together
 // or neither is stored if any operation fails
 func (s *TokenStore) persistToken(entry *TokenEntry) error {
-	// Skip persistence for jwt_role and cert_role tokens - they are cache-only
-	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole {
+	// Skip persistence for self-contained tokens - they are cache-only
+	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole || entry.Type == TypeWardenCryptoToken {
 		return nil
 	}
 
@@ -1285,8 +1293,8 @@ func (s *TokenStore) loadTokenByAccessor(accessor string) (*TokenEntry, error) {
 // Uses a transaction to ensure atomicity: both token and accessor are deleted together
 // or neither is deleted if any operation fails
 func (s *TokenStore) deleteToken(entry *TokenEntry) error {
-	// Skip storage operations for jwt_role and cert_role tokens - they are cache-only
-	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole {
+	// Skip storage operations for self-contained tokens - they are cache-only
+	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole || entry.Type == TypeWardenCryptoToken {
 		return nil
 	}
 
@@ -1390,6 +1398,11 @@ func (c *Core) LookupToken(ctx context.Context, tokenValue string) (*TokenEntry,
 		}
 	} else {
 		tokenID = tokenType.ComputeID(tokenValue)
+	}
+
+	// Self-contained crypto tokens: decrypt and validate inline, no cache/storage lookup
+	if cryptoType, ok := tokenType.(*WardenCryptoTokenType); ok {
+		return s.lookupCryptoToken(ctx, tokenValue, cryptoType, ns)
 	}
 
 	// Lookup token in cache
@@ -1809,6 +1822,111 @@ func (s *TokenStore) validateIPBinding(ctx context.Context, tokenID string, entr
 	}
 
 	return nil
+}
+
+// resolveCryptoToken validates a self-contained crypto token by decrypting its
+// embedded claims and checking expiration, namespace, and IP binding.
+// validateCryptoTokenClaims validates expiration and namespace binding for
+// decrypted crypto token claims. Shared by resolveCryptoToken and lookupCryptoToken.
+func (s *TokenStore) validateCryptoTokenClaims(
+	ctx context.Context,
+	claims *CryptoTokenClaims,
+	ns *namespace.Namespace,
+) error {
+	// Validate expiration
+	if claims.ExpireAt > 0 && time.Now().Unix() > claims.ExpireAt {
+		if s.config.EnableMetrics {
+			s.metrics.IncrementTokensExpired()
+		}
+		return ErrTokenExpired
+	}
+
+	// Validate namespace binding with hierarchical access
+	tokenNs, err := s.core.namespaceStore.GetNamespaceByAccessor(ctx, claims.NamespaceID)
+	if err != nil || tokenNs == nil {
+		return ErrTokenNamespaceMismatch
+	}
+	if ns.UUID != tokenNs.UUID && !ns.HasParent(tokenNs) {
+		if s.config.EnableMetrics {
+			s.metrics.IncrementNamespaceMismatches()
+		}
+		return ErrTokenNamespaceMismatch
+	}
+
+	return nil
+}
+
+func (s *TokenStore) resolveCryptoToken(
+	ctx context.Context,
+	tokenValue string,
+	cryptoType *WardenCryptoTokenType,
+	ns *namespace.Namespace,
+) (string, string, error) {
+	claims, err := cryptoType.DecryptToken(ctx, tokenValue)
+	if err != nil {
+		return "", "", ErrTokenNotFound
+	}
+
+	if err := s.validateCryptoTokenClaims(ctx, claims, ns); err != nil {
+		return "", "", err
+	}
+
+	// Validate IP binding using a temporary entry for the shared validation logic
+	tempEntry := &TokenEntry{
+		ID:          cryptoType.ComputeID(tokenValue),
+		CreatedByIP: claims.CreatedByIP,
+	}
+	if err := s.validateIPBinding(ctx, tempEntry.ID, tempEntry); err != nil {
+		return "", "", err
+	}
+
+	if s.config.EnableMetrics {
+		s.metrics.IncrementTokensResolved()
+	}
+
+	return claims.PrincipalID, claims.RoleName, nil
+}
+
+// lookupCryptoToken decrypts a self-contained crypto token and reconstructs
+// a TokenEntry from its embedded claims.
+func (s *TokenStore) lookupCryptoToken(
+	ctx context.Context,
+	tokenValue string,
+	cryptoType *WardenCryptoTokenType,
+	ns *namespace.Namespace,
+) (*TokenEntry, error) {
+	claims, err := cryptoType.DecryptToken(ctx, tokenValue)
+	if err != nil {
+		return nil, ErrTokenNotFound
+	}
+
+	if err := s.validateCryptoTokenClaims(ctx, claims, ns); err != nil {
+		return nil, err
+	}
+
+	// Reconstruct TokenEntry from claims
+	entry := &TokenEntry{
+		ID:             cryptoType.ComputeID(tokenValue),
+		Accessor:       claims.Accessor,
+		Type:           TypeWardenCryptoToken,
+		NamespaceID:    claims.NamespaceID,
+		NamespacePath:  claims.NamespacePath,
+		CreatedAt:      time.Unix(claims.CreatedAt, 0),
+		CreatedByIP:    claims.CreatedByIP,
+		PrincipalID:    claims.PrincipalID,
+		RoleName:       claims.RoleName,
+		ExpireAt:       time.Unix(claims.ExpireAt, 0),
+		Data:           map[string]string{"token": tokenValue},
+		Policies:       claims.Policies,
+		CredentialSpec: claims.CredentialSpec,
+	}
+
+	// Validate IP binding
+	if err := s.validateIPBinding(ctx, entry.ID, entry); err != nil {
+		return nil, err
+	}
+
+	return entry, nil
 }
 
 // computeCacheTTL calculates the cache TTL for a token entry.

--- a/core/token_type.go
+++ b/core/token_type.go
@@ -1,6 +1,9 @@
 package core
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // TokenTypeMetadata describes a token type's characteristics
 type TokenTypeMetadata struct {
@@ -32,7 +35,7 @@ type TokenType interface {
 	// 1. Generate cryptographically secure random values
 	// 2. Populate entry.Data with all necessary fields
 	// 3. Return the client-facing values (e.g., {"username": "...", "password": "..."})
-	Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error)
+	Generate(ctx context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error)
 
 	// ValidateValue checks if a token value matches the expected format
 	ValidateValue(tokenValue string) bool

--- a/core/token_type_aws.go
+++ b/core/token_type_aws.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -22,7 +23,7 @@ func (t *AWSAccessKeysTokenType) Metadata() TokenTypeMetadata {
 	}
 }
 
-func (t *AWSAccessKeysTokenType) Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+func (t *AWSAccessKeysTokenType) Generate(_ context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
 	accessKeyID := helper.GenerateAWSAccessKeyID()
 	secretAccessKey := helper.GenerateAWSSecretAccessKey()
 

--- a/core/token_type_cert.go
+++ b/core/token_type_cert.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"time"
@@ -23,7 +24,7 @@ func (t *CertRoleTokenType) Metadata() TokenTypeMetadata {
 	}
 }
 
-func (t *CertRoleTokenType) Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+func (t *CertRoleTokenType) Generate(_ context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
 	// For cert tokens, the certificate comes from the TLS connection.
 	// authData.TokenValue contains the cert fingerprint (SHA-256 of DER bytes).
 	//

--- a/core/token_type_cert_test.go
+++ b/core/token_type_cert_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 )
 
@@ -100,7 +101,7 @@ func TestCertRoleTokenType_Generate(t *testing.T) {
 		RoleName:   "agent",
 	}
 
-	result, err := ct.Generate(authData, entry)
+	result, err := ct.Generate(context.Background(), authData, entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestCertRoleTokenType_Generate(t *testing.T) {
 
 	// Without authData
 	entry2 := &TokenEntry{Data: map[string]string{"existing": "data"}}
-	result2, err := ct.Generate(nil, entry2)
+	result2, err := ct.Generate(context.Background(), nil, entry2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -132,7 +133,7 @@ func TestCertRoleTokenType_Generate(t *testing.T) {
 	// With empty TokenValue
 	entry3 := &TokenEntry{Data: make(map[string]string)}
 	authData3 := &AuthData{TokenValue: "", RoleName: "agent"}
-	result3, err := ct.Generate(authData3, entry3)
+	result3, err := ct.Generate(context.Background(), authData3, entry3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/core/token_type_crypto.go
+++ b/core/token_type_crypto.go
@@ -1,0 +1,174 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	cryptoTokenEncryptionKey = "crypto-token"
+
+	// CryptoTokenClaimsVersion is incremented when the claims schema changes.
+	// Old tokens with a lower version will still decrypt but can be handled differently.
+	CryptoTokenClaimsVersion = 1
+
+	// MaxCryptoTokenPlaintextSize is the maximum allowed size of the JSON claims
+	// before encryption. Prevents oversized tokens that would exceed HTTP header limits.
+	// 6KB plaintext ≈ ~8KB base64 encoded, within typical HTTP header limits.
+	MaxCryptoTokenPlaintextSize = 6 * 1024
+
+	// MaxCryptoTokenValueSize is the maximum allowed size of the full token value
+	// (prefix + base64 encoded ciphertext). Rejects oversized tokens early before decryption.
+	MaxCryptoTokenValueSize = 10 * 1024
+)
+
+// CryptoTokenClaims holds the claims embedded in a crypto token's encrypted blob.
+// Field names are abbreviated to minimize token size.
+//
+// Note: policies are baked in at issuance. If a role's policies change after
+// the token is issued, the token still carries the old policies until it expires.
+// This is an inherent trade-off of self-contained tokens (same as Vault batch tokens).
+type CryptoTokenClaims struct {
+	Version        int      `json:"v"`
+	PrincipalID    string   `json:"pid"`
+	RoleName       string   `json:"rn"`
+	Policies       []string `json:"pol"`
+	NamespaceID    string   `json:"nid"`
+	NamespacePath  string   `json:"np"`
+	ExpireAt       int64    `json:"exp"`
+	CreatedAt      int64    `json:"iat"`
+	CreatedByIP    string   `json:"cip"`
+	CredentialSpec string   `json:"cs,omitempty"`
+	Accessor       string   `json:"acc"`
+}
+
+// WardenCryptoTokenType implements a self-contained token type where the token
+// value itself is a barrier-encrypted blob carrying all claims. No server-side
+// storage or cache lookup is needed for validation — just decrypt and verify.
+//
+// Trade-offs vs reference tokens (warden_token):
+//   - No individual revocation — tokens are valid until they expire
+//   - Policies are frozen at issuance — role policy changes don't affect existing tokens
+//   - Larger token size (~500-800 bytes vs 68 chars)
+//   - Requires barrier to be unsealed for both generation and validation
+type WardenCryptoTokenType struct {
+	encryptor BarrierEncryptor
+}
+
+func (t *WardenCryptoTokenType) Metadata() TokenTypeMetadata {
+	return TokenTypeMetadata{
+		Name:        "warden_crypto_token",
+		IDPrefix:    "wcrt_",
+		ValuePrefix: "cwc.",
+		Description: "Self-contained barrier-encrypted token",
+		DefaultTTL:  1 * time.Hour,
+	}
+}
+
+func (t *WardenCryptoTokenType) Generate(ctx context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+	if authData == nil {
+		return nil, errors.New("authData required for crypto token generation")
+	}
+
+	// Crypto tokens must have a finite expiration — they cannot be revoked
+	if entry.ExpireAt.IsZero() {
+		return nil, errors.New("crypto tokens require a finite expiration (cannot be non-expiring)")
+	}
+
+	claims := CryptoTokenClaims{
+		Version:        CryptoTokenClaimsVersion,
+		PrincipalID:    authData.PrincipalID,
+		RoleName:       authData.RoleName,
+		Policies:       authData.Policies,
+		NamespaceID:    entry.NamespaceID,
+		NamespacePath:  entry.NamespacePath,
+		ExpireAt:       entry.ExpireAt.Unix(),
+		CreatedAt:      entry.CreatedAt.Unix(),
+		CreatedByIP:    authData.ClientIP,
+		CredentialSpec: authData.CredentialSpec,
+		Accessor:       entry.Accessor,
+	}
+
+	plaintext, err := json.Marshal(claims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal crypto token claims: %w", err)
+	}
+
+	if len(plaintext) > MaxCryptoTokenPlaintextSize {
+		return nil, fmt.Errorf("crypto token claims too large (%d bytes, max %d)", len(plaintext), MaxCryptoTokenPlaintextSize)
+	}
+
+	ciphertext, err := t.encryptor.Encrypt(ctx, cryptoTokenEncryptionKey, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt crypto token: %w", err)
+	}
+
+	tokenValue := "cwc." + base64.RawURLEncoding.EncodeToString(ciphertext)
+
+	entry.Data = map[string]string{
+		"token": tokenValue,
+	}
+
+	return map[string]string{
+		"token": tokenValue,
+	}, nil
+}
+
+func (t *WardenCryptoTokenType) ValidateValue(tokenValue string) bool {
+	if !strings.HasPrefix(tokenValue, "cwc.") {
+		return false
+	}
+	if len(tokenValue) > MaxCryptoTokenValueSize {
+		return false
+	}
+	payload := tokenValue[4:]
+	_, err := base64.RawURLEncoding.DecodeString(payload)
+	return err == nil && len(payload) > 0
+}
+
+func (t *WardenCryptoTokenType) ComputeID(lookupValue string) string {
+	h := sha256.New()
+	h.Write([]byte(lookupValue))
+	hash := hex.EncodeToString(h.Sum(nil))[:32]
+	return t.Metadata().IDPrefix + hash
+}
+
+func (t *WardenCryptoTokenType) LookupKey() string {
+	return "token"
+}
+
+// DecryptToken decrypts a crypto token value and returns the embedded claims.
+// Rejects tokens exceeding MaxCryptoTokenValueSize before attempting decryption.
+func (t *WardenCryptoTokenType) DecryptToken(ctx context.Context, tokenValue string) (*CryptoTokenClaims, error) {
+	if !strings.HasPrefix(tokenValue, "cwc.") {
+		return nil, errors.New("invalid crypto token prefix")
+	}
+
+	if len(tokenValue) > MaxCryptoTokenValueSize {
+		return nil, errors.New("crypto token value exceeds maximum size")
+	}
+
+	ciphertext, err := base64.RawURLEncoding.DecodeString(tokenValue[4:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode crypto token: %w", err)
+	}
+
+	plaintext, err := t.encryptor.Decrypt(ctx, cryptoTokenEncryptionKey, ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt crypto token: %w", err)
+	}
+
+	var claims CryptoTokenClaims
+	if err := json.Unmarshal(plaintext, &claims); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal crypto token claims: %w", err)
+	}
+
+	return &claims, nil
+}

--- a/core/token_type_crypto_test.go
+++ b/core/token_type_crypto_test.go
@@ -1,0 +1,215 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbao/openbao/helper/namespace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCryptoTokenType_Metadata(t *testing.T) {
+	ct := &WardenCryptoTokenType{}
+	meta := ct.Metadata()
+
+	assert.Equal(t, "warden_crypto_token", meta.Name)
+	assert.Equal(t, "wcrt_", meta.IDPrefix)
+	assert.Equal(t, "cwc.", meta.ValuePrefix)
+	assert.Equal(t, 1*time.Hour, meta.DefaultTTL)
+}
+
+func TestCryptoTokenType_Generate(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID:    "test-user",
+		RoleName:       "test-role",
+		ExpireAt:       time.Now().Add(1 * time.Hour),
+		Policies:       []string{"default", "admin"},
+		ClientIP:       "10.0.0.1",
+		CredentialSpec: "my-spec",
+	}
+
+	entry, err := core.tokenStore.GenerateToken(ctx, TypeWardenCryptoToken, authData)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+
+	assert.Equal(t, TypeWardenCryptoToken, entry.Type)
+	assert.True(t, strings.HasPrefix(entry.Data["token"], "cwc."))
+	assert.True(t, strings.HasPrefix(entry.ID, "wcrt_"))
+	assert.Equal(t, "test-user", entry.PrincipalID)
+	assert.Equal(t, "test-role", entry.RoleName)
+}
+
+func TestCryptoTokenType_RoundTrip(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID:    "roundtrip-user",
+		RoleName:       "roundtrip-role",
+		ExpireAt:       time.Now().Add(1 * time.Hour),
+		Policies:       []string{"policy-a", "policy-b"},
+		ClientIP:       "10.0.0.2",
+		CredentialSpec: "spec-1",
+	}
+
+	entry, err := core.tokenStore.GenerateToken(ctx, TypeWardenCryptoToken, authData)
+	require.NoError(t, err)
+
+	// Decrypt and verify claims
+	cryptoType := &WardenCryptoTokenType{encryptor: core.barrier}
+	claims, err := cryptoType.DecryptToken(ctx, entry.Data["token"])
+	require.NoError(t, err)
+
+	assert.Equal(t, "roundtrip-user", claims.PrincipalID)
+	assert.Equal(t, "roundtrip-role", claims.RoleName)
+	assert.Equal(t, []string{"policy-a", "policy-b"}, claims.Policies)
+	assert.Equal(t, "10.0.0.2", claims.CreatedByIP)
+	assert.Equal(t, "spec-1", claims.CredentialSpec)
+	assert.Equal(t, namespace.RootNamespaceID, claims.NamespaceID)
+	assert.NotEmpty(t, claims.Accessor)
+	assert.True(t, claims.ExpireAt > 0)
+	assert.True(t, claims.CreatedAt > 0)
+}
+
+func TestCryptoTokenType_ValidateValue(t *testing.T) {
+	ct := &WardenCryptoTokenType{}
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{"valid prefix", "cwc.dGVzdA", true},
+		{"empty payload", "cwc.", false},
+		{"wrong prefix", "cws.dGVzdA", false},
+		{"no prefix", "dGVzdA", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.valid, ct.ValidateValue(tt.value))
+		})
+	}
+}
+
+func TestCryptoTokenType_ResolveToken(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID: "resolve-user",
+		RoleName:    "resolve-role",
+		ExpireAt:    time.Now().Add(1 * time.Hour),
+		Policies:    []string{"default"},
+	}
+
+	entry, err := core.tokenStore.GenerateToken(ctx, TypeWardenCryptoToken, authData)
+	require.NoError(t, err)
+
+	// ResolveToken should decrypt inline without cache lookup
+	principalID, roleName, err := core.tokenStore.ResolveToken(ctx, entry.Data["token"])
+	require.NoError(t, err)
+	assert.Equal(t, "resolve-user", principalID)
+	assert.Equal(t, "resolve-role", roleName)
+}
+
+func TestCryptoTokenType_LookupToken(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID:    "lookup-user",
+		RoleName:       "lookup-role",
+		ExpireAt:       time.Now().Add(1 * time.Hour),
+		Policies:       []string{"default", "reader"},
+		CredentialSpec: "lookup-spec",
+	}
+
+	entry, err := core.tokenStore.GenerateToken(ctx, TypeWardenCryptoToken, authData)
+	require.NoError(t, err)
+
+	// LookupToken should reconstruct a full TokenEntry from claims
+	looked, err := core.LookupToken(ctx, entry.Data["token"])
+	require.NoError(t, err)
+	require.NotNil(t, looked)
+
+	assert.Equal(t, TypeWardenCryptoToken, looked.Type)
+	assert.Equal(t, "lookup-user", looked.PrincipalID)
+	assert.Equal(t, "lookup-role", looked.RoleName)
+	assert.Equal(t, []string{"default", "reader"}, looked.Policies)
+	assert.Equal(t, "lookup-spec", looked.CredentialSpec)
+	assert.Equal(t, namespace.RootNamespaceID, looked.NamespaceID)
+}
+
+func TestCryptoTokenType_ExpiredToken(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID: "expired-user",
+		RoleName:    "expired-role",
+		ExpireAt:    time.Now().Add(-1 * time.Hour), // already expired
+		Policies:    []string{"default"},
+	}
+
+	// GenerateToken rejects already-expired tokens
+	_, err := core.tokenStore.GenerateToken(ctx, TypeWardenCryptoToken, authData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token already expired")
+}
+
+func TestCryptoTokenType_NoPersistence(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID: "no-persist-user",
+		RoleName:    "no-persist-role",
+		ExpireAt:    time.Now().Add(1 * time.Hour),
+		Policies:    []string{"default"},
+	}
+
+	entry, err := core.tokenStore.GenerateToken(ctx, TypeWardenCryptoToken, authData)
+	require.NoError(t, err)
+
+	// Clear cache — crypto tokens should NOT be in persistent storage
+	core.tokenStore.byID.Clear()
+	core.tokenStore.byID.Wait()
+
+	// ResolveToken should still work (decrypts from the token value itself)
+	principalID, roleName, err := core.tokenStore.ResolveToken(ctx, entry.Data["token"])
+	require.NoError(t, err)
+	assert.Equal(t, "no-persist-user", principalID)
+	assert.Equal(t, "no-persist-role", roleName)
+}
+
+func TestCryptoTokenType_DecryptInvalidToken(t *testing.T) {
+	core := createTestCore(t)
+
+	cryptoType := &WardenCryptoTokenType{encryptor: core.barrier}
+
+	_, err := cryptoType.DecryptToken(context.Background(), "cwc.invalidciphertext")
+	require.Error(t, err)
+
+	_, err = cryptoType.DecryptToken(context.Background(), "wrong.prefix")
+	require.Error(t, err)
+}

--- a/core/token_type_jwt.go
+++ b/core/token_type_jwt.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -24,7 +25,7 @@ func (t *JWTRoleTokenType) Metadata() TokenTypeMetadata {
 	}
 }
 
-func (t *JWTRoleTokenType) Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+func (t *JWTRoleTokenType) Generate(_ context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
 	// For JWT tokens, we don't generate - the JWT comes from an external IdP.
 	// The JWT is passed via authData.TokenValue for transparent mode.
 	//

--- a/core/token_type_jwt_test.go
+++ b/core/token_type_jwt_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -123,7 +124,7 @@ func TestJWTRoleTokenType_Generate(t *testing.T) {
 			Data: map[string]string{},
 		}
 
-		result, err := jwtType.Generate(nil, entry)
+		result, err := jwtType.Generate(context.Background(), nil, entry)
 		require.NoError(t, err)
 		assert.Empty(t, result["jwt"])
 	})
@@ -134,7 +135,7 @@ func TestJWTRoleTokenType_Generate(t *testing.T) {
 		}
 
 		authData := &AuthData{TokenValue: "", RoleName: "terraform"}
-		result, err := jwtType.Generate(authData, entry)
+		result, err := jwtType.Generate(context.Background(), authData, entry)
 		require.NoError(t, err)
 		assert.Empty(t, result["jwt"])
 	})
@@ -145,7 +146,7 @@ func TestJWTRoleTokenType_Generate(t *testing.T) {
 		}
 
 		authData := &AuthData{TokenValue: sampleJWT, RoleName: ""}
-		result, err := jwtType.Generate(authData, entry)
+		result, err := jwtType.Generate(context.Background(), authData, entry)
 		require.NoError(t, err)
 		// JWT should be stored as hash (not raw value) for security
 		expectedHash := sha256.Sum256([]byte(sampleJWT))
@@ -158,7 +159,7 @@ func TestJWTRoleTokenType_Generate(t *testing.T) {
 		}
 
 		authData := &AuthData{TokenValue: sampleJWT, RoleName: "terraform"}
-		result, err := jwtType.Generate(authData, entry)
+		result, err := jwtType.Generate(context.Background(), authData, entry)
 		require.NoError(t, err)
 		// JWT+role composite should be stored as hash for security
 		expectedHash := sha256.Sum256([]byte(sampleJWT + ":terraform"))
@@ -196,7 +197,7 @@ func TestJWTRoleTokenType_ComputeData(t *testing.T) {
 			Data: map[string]string{},
 		}
 		authData := &AuthData{TokenValue: sampleJWT, RoleName: "myapp"}
-		jwtType.Generate(authData, entry)
+		jwtType.Generate(context.Background(), authData, entry)
 
 		// The stored hash should match ComputeData
 		expectedHash := jwtType.ComputeData(sampleJWT, "myapp")

--- a/core/token_type_userpass.go
+++ b/core/token_type_userpass.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -22,7 +23,7 @@ func (t *UserPassTokenType) Metadata() TokenTypeMetadata {
 	}
 }
 
-func (t *UserPassTokenType) Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+func (t *UserPassTokenType) Generate(_ context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
 	username := "usr-" + helper.GenerateRandomString(26)
 	password := helper.GenerateRandomString(40)
 

--- a/core/token_type_warden.go
+++ b/core/token_type_warden.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
@@ -22,7 +23,7 @@ func (t *WardenTokenType) Metadata() TokenTypeMetadata {
 	}
 }
 
-func (t *WardenTokenType) Generate(authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+func (t *WardenTokenType) Generate(_ context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
 	tokenValue := "cws." + helper.GenerateRandomString(64)
 
 	entry.Data = map[string]string{

--- a/e2e/auth/cert_auth_test.go
+++ b/e2e/auth/cert_auth_test.go
@@ -758,13 +758,13 @@ func TestCertAuthLogin_CertReplacement(t *testing.T) {
 		t.Fatalf("cert2 login failed (status %d): %s", status2, string(body2))
 	}
 
-	// They should have different fingerprints (different key pairs → different cert bytes)
+	// They should have different token IDs (different key pairs → different cert bytes → different fingerprints)
 	data1 := h.ParseJSON(t, body1)
 	data2 := h.ParseJSON(t, body2)
-	fp1 := h.JSONPath(data1, "data.fingerprint")
-	fp2 := h.JSONPath(data2, "data.fingerprint")
-	if fp1 == fp2 {
-		t.Fatalf("expected different fingerprints for different certs with same CN, got %v", fp1)
+	tid1 := h.JSONPath(data1, "data.token_id")
+	tid2 := h.JSONPath(data2, "data.token_id")
+	if tid1 == tid2 {
+		t.Fatalf("expected different token_ids for different certs with same CN, got %v", tid1)
 	}
 
 	// Both should have the same principal_id (same CN)


### PR DESCRIPTION
Add a Vault-style batch token alternative where the token value itself is a barrier-encrypted blob carrying all claims (principal, policies, TTL, namespace). This eliminates server-side storage for validation — just decrypt and verify.

Key changes:
- New WardenCryptoTokenType with cwc. prefix and wcrt_ ID prefix
- Claims versioning, max size limits, expiration enforcement
- No persistence (skip persistToken/deleteToken/expiration registration)
- Inline decrypt fast path in ResolveToken and LookupToken
- Shared validateCryptoTokenClaims helper for DRY validation
- Add context.Context to TokenType.Generate interface
- Map "warden" alias to warden_crypto_token in auth helper
- Use DisplayTokenType for user-facing token_type in login response
- Remove internal fingerprint field from login response
- Update all token type implementations, tests, and e2e tests

Trade-offs (by design): no individual revocation, policies frozen at issuance, larger token size (~500-800 bytes vs 68 chars).