### PR TITLE
feat: add Anthropic provider with credential driver and gateway proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Instead of trusting every workload to handle credentials responsibly, Warden rem
 ┌──────────────┐                    ┌──────────────┐                     ┌──────────────┐
 │  Developer   │      Identity      │              │    Scoped Access    │ AWS, Azure   │
 │  K8s pod     │───────────────────▶│    Warden    │───────────────────▶ │ GitHub, GCP  │
-│  Pipeline    │   no credentials   │              │  real credentials   │ Mistral      │
-│  AI agent    │                    │              │                     │ OpenAI  ...  │
+│  Pipeline    │   no credentials   │              │  real credentials   │ Anthropic    │
+│  AI agent    │                    │              │                     │ Mistral ...  │
 └──────────────┘                    └──────────────┘                     └──────────────┘
                                     • Auth ✓
                                     • Policy ✓
@@ -56,9 +56,9 @@ Instead of trusting every workload to handle credentials responsibly, Warden rem
 
 | Provider | Status | Credential Source |
 |----------|--------|-------------------|
+| **Anthropic** | ✅ GA | API key |
 | **Mistral** | ✅ GA | API key |
 | **OpenAI** | ✅ GA | API key |
-| Anthropic | Planned | — |
 | Cohere | Planned | — |
 
 The roadmap targets 100+ cloud and SaaS providers and all major AI providers.
@@ -102,15 +102,15 @@ Warden parses AI request bodies and evaluates policies against inference paramet
 
 ### Zero Client Modification
 
-Point your existing tools at Warden's endpoint instead of the provider's. The AWS CLI, Terraform, GitHub CLI, Mistral SDK, OpenAI SDK, or any HTTP client — if it supports a custom base URL or endpoint override, it works with Warden. No code changes, no special libraries, no proxy configuration.
+Point your existing tools at Warden's endpoint instead of the provider's. The AWS CLI, Terraform, GitHub CLI, Anthropic SDK, Mistral SDK, OpenAI SDK, or any HTTP client — if it supports a custom base URL or endpoint override, it works with Warden. No code changes, no special libraries, no proxy configuration.
 
 ### Identity-Based Access
 
-Every request is tied to a verified identity — via JWT, TLS client certificate, or SPIFFE SVID. Whether it's a developer authenticating with a client certificate from their laptop, a Kubernetes pod identified by its SPIFFE SVID, a CI/CD pipeline deploying to AWS, or an AI agent calling Mistral, Warden knows exactly who is making each API call and applies policies accordingly.
+Every request is tied to a verified identity — via JWT, TLS client certificate, or SPIFFE SVID. Whether it's a developer authenticating with a client certificate from their laptop, a Kubernetes pod identified by its SPIFFE SVID, a CI/CD pipeline deploying to AWS, or an AI agent calling Anthropic, Warden knows exactly who is making each API call and applies policies accordingly.
 
 ### Unified Identity Across Providers
 
-Every provider has its own identity system — AWS IAM, Azure Entra ID, GitHub Apps, Mistral API keys. Multi-provider means multi-identity: different auth flows, different credential formats, different rotation strategies. Warden collapses all of that behind a single identity layer. Your workloads authenticate once — with a JWT or a client certificate — and Warden translates to each provider's native auth on the fly. One identity plane, regardless of how many providers sit behind it.
+Every provider has its own identity system — AWS IAM, Azure Entra ID, GitHub Apps, Anthropic API keys. Multi-provider means multi-identity: different auth flows, different credential formats, different rotation strategies. Warden collapses all of that behind a single identity layer. Your workloads authenticate once — with a JWT or a client certificate — and Warden translates to each provider's native auth on the fly. One identity plane, regardless of how many providers sit behind it.
 
 ```
                                      ┌─── AWS (SigV4)
@@ -118,6 +118,8 @@ Every provider has its own identity system — AWS IAM, Azure Entra ID, GitHub A
                                      ├─── Azure (Bearer + Entra ID)
                                      │
   Workload ── JWT / cert ──▶ Warden ─┼─── GitHub (Installation token)
+                                     │
+                                     ├─── Anthropic (x-api-key)
                                      │
                                      ├─── Mistral (Bearer + API key)
                                      │
@@ -143,10 +145,10 @@ Pods authenticate to Warden using their SPIFFE identity — either an X.509-SVID
 AI agents call AI providers autonomously — choosing models, setting token limits, running completions. Without Warden, an API key grants unlimited access to every model. With Warden, each agent identity has scoped model access, enforced token limits, and every inference call is audited with full request parameters.
 
 ```bash
-# Agent can only use mistral-small-latest, max_tokens capped, streaming required
-curl -X POST https://warden.internal/v1/mistral/role/agent-role/gateway/v1/chat/completions \
+# Agent can only use claude-sonnet-4-20250514, max_tokens capped, streaming required
+curl -X POST https://warden.internal/v1/anthropic/role/agent-role/gateway/v1/messages \
   -H "Authorization: Bearer <jwt>" \
-  -d '{"model": "mistral-small-latest", "messages": [...], "stream": true}'
+  -d '{"model": "claude-sonnet-4-20250514", "max_tokens": 1024, "messages": [...], "stream": true}'
 ```
 
 ### AI Agents — Tool Use Governance
@@ -157,7 +159,7 @@ When agents call cloud APIs — reading GitHub repos, writing to S3, deploying t
 
 ### Multi-Provider Workloads
 
-A workload that reads from GitHub, writes to S3, deploys to Azure, and calls Mistral for inference needs four different credential types, four different auth flows, four different rotation strategies. Without Warden, each integration is its own identity problem. With Warden, the workload gets one JWT and one endpoint pattern. It doesn't matter whether the target is AWS, GitHub, or Mistral — the auth flow is identical. Add a new provider and existing workloads gain access without changing a single line of code.
+A workload that reads from GitHub, writes to S3, deploys to Azure, and calls Anthropic for inference needs four different credential types, four different auth flows, four different rotation strategies. Without Warden, each integration is its own identity problem. With Warden, the workload gets one JWT and one endpoint pattern. It doesn't matter whether the target is AWS, GitHub, or Anthropic — the auth flow is identical. Add a new provider and existing workloads gain access without changing a single line of code.
 
 ## Authentication Methods
 
@@ -189,7 +191,7 @@ curl -H "Authorization: Bearer <your-jwt>" \
 #   3. Forwards the request to https://api.github.com/repos/acme/frontend/contents/README.md
 ```
 
-Transparent mode works with any provider that uses bearer tokens: **Azure, GCP, GitHub, GitLab, Vault, Mistral, OpenAI**. It's the simplest integration path — no code changes, no token exchange, one HTTP call.
+Transparent mode works with any provider that uses bearer tokens or API keys: **Anthropic, Azure, GCP, GitHub, GitLab, Vault, Mistral, OpenAI**. It's the simplest integration path — no code changes, no token exchange, one HTTP call.
 
 ### Explicit Mode
 
@@ -220,6 +222,7 @@ Explicit mode is **required for AWS** (SigV4 request signing means Warden must h
 | **GitHub** | ✅ | ✅ |
 | **GitLab** | ✅ | ✅ |
 | **Vault / OpenBao** | ✅ | ✅ |
+| **Anthropic** | ✅ | ✅ |
 | **Mistral** | ✅ | ✅ |
 | **OpenAI** | ✅ | ✅ |
 
@@ -231,6 +234,7 @@ Explicit mode is **required for AWS** (SigV4 request signing means Warden must h
 | Audit granularity | Every API request logged | Logs + cost analytics (Enterprise) | Access grant logged |
 | Policy enforcement | HTTP path + method + runtime conditions (IP, time, day) + AI parameters | Guardrails (PII, jailbreak) | Workload-to-service level |
 | Cloud provider support | AWS, Azure, GCP, GitHub, GitLab, Vault | N/A — AI providers only | Per-provider integration |
+| AI provider support | Anthropic, Mistral, OpenAI | Multiple AI providers | N/A |
 | AI inference governance | Model, token, and parameter policies | Guardrails + rate limiting | N/A |
 | Client modification | Change base URL | Portkey SDK or Universal API | Deploy sidecar agents |
 | Data residency | Fully self-hosted, your infrastructure | SaaS or airgapped (Enterprise) | SaaS only |
@@ -306,6 +310,7 @@ Once Warden is running, follow a provider guide to configure your first endpoint
 - [Vault / OpenBao](provider/vault/README.md)
 
 **AI Providers:**
+- [Anthropic](provider/anthropic/README.md)
 - [Mistral](provider/mistral/README.md)
 - [OpenAI](provider/openai/README.md)
 
@@ -356,7 +361,7 @@ Warden uses HCL configuration files. See `warden.local.hcl` for a full example c
 
 **Cloud & SaaS Providers** — Enterprise cloud (Oracle, IBM, Alibaba), specialized cloud (DigitalOcean, Hetzner, OVH), government cloud (GovCloud, Azure Gov), AI/GPU cloud (CoreWeave, Lambda, RunPod), DevOps SaaS (Terraform Cloud, Datadog, Cloudflare), data SaaS (Snowflake, Databricks, MongoDB Atlas), productivity SaaS (Slack, Jira, Notion)
 
-**AI Providers** — Anthropic, Cohere, Google AI (Gemini), xAI, Replicate, Hugging Face, Together AI
+**AI Providers** — Cohere, Google AI (Gemini), xAI, Replicate, Hugging Face, Together AI
 
 **AI Governance** — Per-model cost budgets, token usage tracking, prompt/response audit, rate limiting per agent per model
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -38,6 +38,7 @@ import (
 	log "github.com/stephnangue/warden/logger"
 	wardenlogical "github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/physical"
+	"github.com/stephnangue/warden/provider/anthropic"
 	"github.com/stephnangue/warden/provider/aws"
 	"github.com/stephnangue/warden/provider/azure"
 	"github.com/stephnangue/warden/provider/gcp"
@@ -91,7 +92,8 @@ Usage: warden server [options]
 	}
 
 	providers = map[string]wardenlogical.Factory{
-		"aws":     aws.Factory,
+		"anthropic": anthropic.Factory,
+		"aws":       aws.Factory,
 		"azure":   azure.Factory,
 		"gcp":     gcp.Factory,
 		"github":  github.Factory,

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -26,8 +26,9 @@ const (
 	SourceTypeGCP    = "gcp"
 	SourceTypeGitLab   = "gitlab"
 	SourceTypeGitHub   = "github"
-	SourceTypeMistral  = "mistral"
-	SourceTypeOpenAI   = "openai"
+	SourceTypeMistral    = "mistral"
+	SourceTypeOpenAI     = "openai"
+	SourceTypeAnthropic  = "anthropic"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/anthropic_driver.go
+++ b/credential/drivers/anthropic_driver.go
@@ -1,0 +1,185 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// anthropicMaxResponseBodySize limits response body reads to prevent OOM
+const anthropicMaxResponseBodySize = 1 << 20 // 1MB
+
+// anthropicMaxRetryAttempts for retryable API operations
+const anthropicMaxRetryAttempts = 3
+
+// DefaultAnthropicAPIURL is the default Anthropic API base URL
+const DefaultAnthropicAPIURL = "https://api.anthropic.com"
+
+// anthropicAPIVersion is the required Anthropic API version header value
+const anthropicAPIVersion = "2023-06-01"
+
+// Compile-time interface assertions
+// Note: AnthropicDriver does not implement credential.Rotatable.
+// Anthropic does not expose REST API endpoints for programmatic key management.
+var _ credential.SourceDriver = (*AnthropicDriver)(nil)
+var _ credential.SpecVerifier = (*AnthropicDriver)(nil)
+
+// AnthropicDriver provides API key credentials for Anthropic.
+//
+// The source config holds only connection info (api_url). Auth credentials
+// (api_key) live in the credential spec config and are read at MintCredential
+// time. This allows multiple specs with different API keys to share one source.
+//
+// Key rotation must be performed manually:
+//  1. Create a new API key in the Anthropic console
+//  2. Update the spec config via Warden API
+//  3. The old key continues to work until deleted from the console
+type AnthropicDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// AnthropicDriverFactory creates AnthropicDriver instances
+type AnthropicDriverFactory struct{}
+
+// Type returns the driver type
+func (f *AnthropicDriverFactory) Type() string {
+	return credential.SourceTypeAnthropic
+}
+
+// ValidateConfig validates Anthropic source configuration using declarative schema.
+// The source only holds connection info (api_url). Auth credentials are
+// validated at spec level by AIAPIKeyCredType.ValidateConfig.
+func (f *AnthropicDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("api_url").
+			Custom(validateAnthropicURL).
+			Describe("Anthropic API base URL (default: https://api.anthropic.com)").
+			Example("https://api.anthropic.com"),
+	)
+}
+
+// SensitiveConfigFields returns the list of source config keys that should be masked.
+// No secrets are stored on the source — they live in the spec config.
+func (f *AnthropicDriverFactory) SensitiveConfigFields() []string {
+	return nil
+}
+
+// Create instantiates a new AnthropicDriver.
+// The driver only needs the api_url from source config. Auth credentials
+// are provided per-spec at MintCredential time.
+func (f *AnthropicDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &AnthropicDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeAnthropic,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(credential.SourceTypeAnthropic),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	return driver, nil
+}
+
+// getAPIURL returns the Anthropic API base URL from source config
+func (d *AnthropicDriver) getAPIURL() string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, "api_url", DefaultAnthropicAPIURL), "/")
+}
+
+// MintCredential returns the Anthropic API key from spec config.
+// The key is static — no TTL, no lease.
+func (d *AnthropicDriver) MintCredential(_ context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	apiKey := credential.GetString(spec.Config, "api_key", "")
+	if apiKey == "" {
+		return nil, 0, "", fmt.Errorf("no Anthropic API key configured in spec")
+	}
+
+	rawData := map[string]interface{}{
+		"api_key": apiKey,
+	}
+
+	// Copy optional metadata from spec config
+	if orgID := credential.GetString(spec.Config, "organization_id", ""); orgID != "" {
+		rawData["organization_id"] = orgID
+	}
+
+	return rawData, 0, "", nil // Static — no TTL, no lease
+}
+
+// Revoke is a no-op for static API keys.
+func (d *AnthropicDriver) Revoke(_ context.Context, leaseID string) error {
+	if d.logger != nil {
+		d.logger.Debug("Anthropic API keys are static, skipping revocation",
+			logger.String("lease_id", leaseID),
+		)
+	}
+	return nil
+}
+
+// Type returns the driver type
+func (d *AnthropicDriver) Type() string {
+	return credential.SourceTypeAnthropic
+}
+
+// Cleanup releases resources
+func (d *AnthropicDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates that the spec's API key is functional by calling
+// GET /v1/models, a lightweight read-only endpoint.
+func (d *AnthropicDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	apiKey := credential.GetString(spec.Config, "api_key", "")
+	if apiKey == "" {
+		return fmt.Errorf("no Anthropic API key configured in spec")
+	}
+
+	apiURL := d.getAPIURL() + "/v1/models"
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       anthropicMaxRetryAttempts,
+		MaxBodySize:       anthropicMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500}, // 429 and all 5xx
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodGet,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"x-api-key":         apiKey,
+			"anthropic-version": anthropicAPIVersion,
+			"Accept":            "application/json",
+		},
+	}
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("Anthropic API key verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateAnthropicURL validates that the api_url is a well-formed HTTPS URL
+func validateAnthropicURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid api_url: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("api_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("api_url must include a host")
+	}
+	return nil
+}

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -49,5 +49,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register Anthropic driver factory
+	if err := registry.RegisterFactory(&AnthropicDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/types/ai_api_key.go
+++ b/credential/types/ai_api_key.go
@@ -78,10 +78,10 @@ func (t *AIAPIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 func (t *AIAPIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	// Step 1: Validate source type compatibility
 	switch sourceType {
-	case credential.SourceTypeMistral, credential.SourceTypeOpenAI, credential.SourceTypeLocal:
+	case credential.SourceTypeMistral, credential.SourceTypeOpenAI, credential.SourceTypeAnthropic, credential.SourceTypeLocal:
 		// Supported
 	default:
-		return fmt.Errorf("ai_api_key credentials require a mistral, openai, or local source, got: %s", sourceType)
+		return fmt.Errorf("ai_api_key credentials require a mistral, openai, anthropic, or local source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema

--- a/credential/types/ai_api_key_test.go
+++ b/credential/types/ai_api_key_test.go
@@ -122,7 +122,7 @@ func TestAIAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: "aws",
 			wantErr:    true,
-			errMsg:     "require a mistral, openai, or local source",
+			errMsg:     "require a mistral, openai, anthropic, or local source",
 		},
 		{
 			name: "unsupported source type - vault",
@@ -131,7 +131,7 @@ func TestAIAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: credential.SourceTypeVault,
 			wantErr:    true,
-			errMsg:     "require a mistral, openai, or local source",
+			errMsg:     "require a mistral, openai, anthropic, or local source",
 		},
 	}
 

--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -1,0 +1,517 @@
+# Anthropic Provider
+
+The Anthropic provider enables proxied access to the Anthropic API through Warden. It streams requests to Anthropic endpoints (messages, models) with automatic API key injection and policy evaluation on AI request fields.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [Policy Evaluation on AI Requests](#policy-evaluation-on-ai-requests)
+- [Configuration Reference](#configuration-reference)
+- [Key Management](#key-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- An **Anthropic API key** from [console.anthropic.com](https://console.anthropic.com)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Start the Warden server** in dev mode:
+> ```bash
+> ./warden server --dev
+> ```
+>
+> **4. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="<your-token>"
+> ```
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. With transparent mode, clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/anthropic-user \
+    token_policies="anthropic-access" \
+    user_claim=sub \
+    cred_spec_name=anthropic-ops \
+    token_ttl=1h
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the Anthropic provider at a path of your choice:
+
+```bash
+warden provider enable --type=anthropic
+```
+
+To mount at a custom path:
+
+```bash
+warden provider enable --type=anthropic anthropic-prod
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider with transparent mode enabled. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write anthropic/config <<EOF
+{
+  "anthropic_url": "https://api.anthropic.com",
+  "transparent_mode": true,
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "120s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read anthropic/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+The credential source holds only connection info (`api_url`). The API key is stored on the credential spec below, allowing multiple specs with different keys to share one source.
+
+```bash
+warden cred source create anthropic-src \
+  --type=anthropic \
+  --rotation-period=0 \
+  --config=api_url=https://api.anthropic.com
+```
+
+Verify the source was created:
+
+```bash
+warden cred source read anthropic-src
+```
+
+Create a credential spec that references the credential source. The spec carries the API key and gets associated with tokens at login time.
+
+```bash
+warden cred spec create anthropic-ops \
+  --type ai_api_key \
+  --source anthropic-src \
+  --config api_key=<your-anthropic-api-key>
+```
+
+The API key is validated at creation time via a `GET /v1/models` call to the Anthropic API (SpecVerifier). If the key is invalid, spec creation will fail.
+
+Verify:
+
+```bash
+warden cred spec read anthropic-ops
+```
+
+## Step 4: Create a Policy
+
+Create a policy that grants access to the Anthropic provider gateway:
+
+```bash
+warden policy write anthropic-access - <<EOF
+path "anthropic/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For fine-grained cost control, restrict access based on AI request fields:
+
+```bash
+warden policy write anthropic-restricted - <<EOF
+path "anthropic/role/+/gateway/v1/messages" {
+  capabilities = ["create"]
+  allowed_parameters = {
+    "model" = ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"]
+    "stream" = ["true"]
+    "*"      = []
+  }
+}
+EOF
+```
+
+You can also combine parameter restrictions with runtime conditions to protect costly inference endpoints. For example, restrict messages to specific models and trusted networks during business hours:
+
+```bash
+warden policy write anthropic-prod-restricted - <<EOF
+path "anthropic/role/+/gateway/v1/messages" {
+  capabilities = ["create"]
+  allowed_parameters = {
+    "model" = ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"]
+    "stream" = ["true"]
+    "*"      = []
+  }
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+
+path "anthropic/role/+/gateway/v1/models" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+Condition types are AND-ed (all must be satisfied), values within each type are OR-ed (at least one must match). Supported types: `source_ip` (CIDR or bare IP), `time_window` (`HH:MM-HH:MM TZ`, supports midnight-spanning), `day_of_week` (3-letter abbreviations).
+
+Verify:
+
+```bash
+warden policy read anthropic-access
+```
+
+## Step 5: Get a JWT and Make Requests
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+With transparent mode, requests use role-based paths. Warden performs implicit JWT authentication and injects the Anthropic API key (via `x-api-key` header) and `anthropic-version` header automatically.
+
+The URL pattern is: `/v1/anthropic/role/{role}/gateway/{anthropic-api-path}`
+
+Export ANTHROPIC_ENDPOINT as environment variable:
+```bash
+export ANTHROPIC_ENDPOINT="${WARDEN_ADDR}/v1/anthropic/role/anthropic-user/gateway"
+```
+
+### Messages
+
+```bash
+curl -X POST "${ANTHROPIC_ENDPOINT}/v1/messages" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "Hello, how are you?"}
+    ]
+  }'
+```
+
+### Streaming Messages
+
+```bash
+curl -X POST "${ANTHROPIC_ENDPOINT}/v1/messages" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -N \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "Write a short poem about the ocean."}
+    ],
+    "stream": true
+  }'
+```
+
+### Using the Anthropic SDK
+
+The Anthropic SDK uses the `x-api-key` header by default. Warden's Anthropic provider accepts this header as a Warden token, so the SDK works with minimal configuration:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(
+    api_key="<your-warden-jwt-or-token>",
+    base_url="http://127.0.0.1:8400/v1/anthropic/role/anthropic-user/gateway",
+)
+
+message = client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "Hello, Claude!"}
+    ],
+)
+print(message.content[0].text)
+```
+
+### Using Claude Code
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) uses the `x-api-key` header natively. Set `ANTHROPIC_BASE_URL` to route all Claude Code traffic through Warden:
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:8400/v1/anthropic/role/anthropic-user/gateway"
+export ANTHROPIC_API_KEY="<your-warden-jwt-or-token>"
+
+claude
+```
+
+Or persist it in your Claude Code settings (`~/.claude/settings.json`):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8400/v1/anthropic/role/anthropic-user/gateway"
+  }
+}
+```
+
+For TLS-enabled Warden deployments with certificate authentication:
+
+```bash
+export ANTHROPIC_BASE_URL="https://warden.internal/v1/anthropic/role/anthropic-user/gateway"
+export NODE_EXTRA_CA_CERTS="/path/to/warden-ca.pem"
+export CLAUDE_CODE_CLIENT_CERT="/path/to/client.pem"
+export CLAUDE_CODE_CLIENT_KEY="/path/to/client-key.pem"
+
+claude
+```
+
+For dynamic token refresh (e.g., short-lived JWTs), use an API key helper script:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8400/v1/anthropic/role/anthropic-user/gateway"
+  },
+  "apiKeyHelper": "~/bin/get-warden-jwt.sh"
+}
+```
+
+Where `get-warden-jwt.sh` fetches a fresh JWT from your identity provider.
+
+### Using Claude Desktop
+
+Set environment variables before launching Claude Desktop to route traffic through Warden:
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:8400/v1/anthropic/role/anthropic-user/gateway"
+export ANTHROPIC_API_KEY="<your-warden-jwt-or-token>"
+
+open -a "Claude"
+```
+
+### List Models
+
+```bash
+curl "${ANTHROPIC_ENDPOINT}/v1/models" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
+
+## Policy Evaluation on AI Requests
+
+The Anthropic provider has request body parsing enabled (`ParseStreamBody: true`), which means Warden can evaluate policies against fields in the AI request body. This enables fine-grained cost control and usage policies.
+
+Evaluable fields include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Model to use (e.g., `claude-sonnet-4-20250514`, `claude-haiku-4-20250414`, `claude-opus-4-20250514`) |
+| `max_tokens` | integer | Maximum tokens to generate (required by Anthropic API) |
+| `temperature` | float | Sampling temperature |
+| `stream` | boolean | Whether to stream the response |
+| `top_p` | float | Nucleus sampling parameter |
+| `top_k` | integer | Top-k sampling parameter |
+
+This allows operators to enforce policies such as:
+- Restrict which models users can access
+- Enforce maximum token limits
+- Require streaming mode for cost visibility
+
+## TLS Certificate Authentication
+
+Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). It does not work in dev mode, which uses plain HTTP. Start Warden with a TLS listener, or place it behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable --type=cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=anthropic-user
+```
+
+### Create a Cert Role
+
+Create a role that binds allowed certificate identities to a credential spec and policy:
+
+```bash
+warden write auth/cert/role/anthropic-user \
+    allowed_common_names="agent-*" \
+    token_policies="anthropic-access" \
+    cred_spec_name=anthropic-ops \
+    token_ttl=1h
+```
+
+The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+
+### Configure Provider for Cert Auth
+
+Update the provider config to use cert auth for transparent mode:
+
+```bash
+warden write anthropic/config <<EOF
+{
+  "anthropic_url": "https://api.anthropic.com",
+  "transparent_mode": true,
+  "auto_auth_path": "auth/cert/",
+  "timeout": "120s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -X POST "https://warden.internal/v1/anthropic/role/anthropic-user/gateway/v1/messages" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "claude-sonnet-4-20250514",
+      "max_tokens": 1024,
+      "messages": [{"role": "user", "content": "Hello"}]
+    }'
+```
+
+### Explicit Login with Certificates
+
+To use cert auth for explicit login (without transparent mode):
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    token_type=warden \
+    default_role=anthropic-user
+
+warden write auth/cert/role/anthropic-user \
+    allowed_common_names="agent-*" \
+    token_type=warden \
+    token_policies="anthropic-access" \
+    cred_spec_name=anthropic-ops \
+    token_ttl=1h
+```
+
+Then authenticate with the CLI:
+
+```bash
+warden login --method=cert --role=anthropic-user \
+    --cert=./client.pem --key=./client-key.pem
+```
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `anthropic_url` | string | `https://api.anthropic.com` | Anthropic API base URL (must be HTTPS) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `120s` | Request timeout — set high for AI inference |
+| `transparent_mode` | bool | `false` | Enable implicit authentication (JWT or TLS certificate) |
+| `auto_auth_path` | string | — | JWT auth mount path (required when `transparent_mode` is true) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Credential Source Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_url` | string | `https://api.anthropic.com` | Anthropic API base URL (must be HTTPS) |
+
+### Credential Spec Config
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | Anthropic API key (sensitive — masked in output) |
+| `organization_id` | string | No | Organization identifier |
+
+## Key Management
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | API key is stored on the credential spec (not the source) |
+| **Validation** | Key is verified at spec creation via `GET /v1/models` |
+| **Rotation** | Manual — Anthropic does not expose key management APIs |
+| **Lifetime** | Static — no expiration or auto-refresh |
+
+**To rotate an API key:**
+
+1. Create a new API key in the [Anthropic console](https://console.anthropic.com)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update anthropic-ops \
+     --config api_key=<new-api-key>
+   ```
+3. Delete the old key from the Anthropic console

--- a/provider/anthropic/config.go
+++ b/provider/anthropic/config.go
@@ -1,0 +1,205 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+)
+
+// DefaultAnthropicURL is the default Anthropic API base URL
+const DefaultAnthropicURL = "https://api.anthropic.com"
+
+// DefaultAnthropicTimeout is the default request timeout for AI inference
+const DefaultAnthropicTimeout = 120 * time.Second
+
+// ProviderConfig holds parsed configuration for the Anthropic provider
+type ProviderConfig struct {
+	AnthropicURL    string
+	MaxBodySize     int64
+	Timeout         time.Duration
+	TransparentMode bool
+	AutoAuthPath    string
+	DefaultRole     string
+}
+
+// parseConfig parses configuration from mount config (map[string]any from JSON)
+func parseConfig(conf map[string]any) ProviderConfig {
+	config := ProviderConfig{
+		AnthropicURL: DefaultAnthropicURL,
+		MaxBodySize:  framework.DefaultMaxBodySize,
+		Timeout:      DefaultAnthropicTimeout,
+	}
+
+	if addr, ok := conf["anthropic_url"].(string); ok && addr != "" {
+		config.AnthropicURL = addr
+	}
+
+	// Parse max_body_size — handle various JSON number types
+	if maxSize, ok := conf["max_body_size"]; ok {
+		switch v := maxSize.(type) {
+		case int:
+			if v > 0 {
+				config.MaxBodySize = int64(v)
+			}
+		case int64:
+			if v > 0 {
+				config.MaxBodySize = v
+			}
+		case float64:
+			if v > 0 {
+				config.MaxBodySize = int64(v)
+			}
+		case json.Number:
+			if parsed, err := v.Int64(); err == nil && parsed > 0 {
+				config.MaxBodySize = parsed
+			}
+		case string:
+			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
+				config.MaxBodySize = parsed
+			}
+		}
+	}
+
+	// Parse timeout — handle duration string or number
+	if timeout, ok := conf["timeout"]; ok {
+		switch v := timeout.(type) {
+		case string:
+			if parsed, err := time.ParseDuration(v); err == nil {
+				config.Timeout = parsed
+			}
+		case int:
+			if v > 0 {
+				config.Timeout = time.Duration(v) * time.Second
+			}
+		case float64:
+			if v > 0 {
+				config.Timeout = time.Duration(v) * time.Second
+			}
+		}
+	}
+
+	// Parse transparent mode settings
+	if tm, ok := conf["transparent_mode"].(bool); ok {
+		config.TransparentMode = tm
+	}
+	if aap, ok := conf["auto_auth_path"].(string); ok {
+		config.AutoAuthPath = aap
+	}
+	if dr, ok := conf["default_role"].(string); ok {
+		config.DefaultRole = dr
+	}
+
+	return config
+}
+
+// ValidateConfig validates provider-level configuration
+func ValidateConfig(conf map[string]any) error {
+	// anthropic_url is optional (defaults to api.anthropic.com), but if provided must be valid
+	if addr, ok := conf["anthropic_url"].(string); ok && addr != "" {
+		if err := validateAnthropicAddress(addr); err != nil {
+			return err
+		}
+	}
+
+	// Validate max_body_size if provided
+	if maxSize, ok := conf["max_body_size"]; ok {
+		var size int64
+		switch v := maxSize.(type) {
+		case int:
+			size = int64(v)
+		case int64:
+			size = v
+		case float64:
+			size = int64(v)
+		case json.Number:
+			parsed, err := v.Int64()
+			if err != nil {
+				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
+			}
+			size = parsed
+		case string:
+			parsed, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
+			}
+			size = parsed
+		default:
+			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
+		}
+		if size < 0 {
+			return fmt.Errorf("max_body_size must be greater than 0")
+		}
+		if size > 104857600 { // 100MB
+			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
+		}
+	}
+
+	// Validate timeout if provided
+	if timeout, ok := conf["timeout"]; ok {
+		switch v := timeout.(type) {
+		case string:
+			if _, err := time.ParseDuration(v); err != nil {
+				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
+			}
+		case int:
+			if v < 0 {
+				return fmt.Errorf("timeout must be greater than 0 seconds")
+			}
+		case float64:
+			if v < 0 {
+				return fmt.Errorf("timeout must be greater than 0 seconds")
+			}
+		default:
+			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
+		}
+	}
+
+	// Validate transparent_mode
+	if tm, ok := conf["transparent_mode"]; ok {
+		if _, ok := tm.(bool); !ok {
+			return fmt.Errorf("transparent_mode must be a boolean")
+		}
+	}
+
+	// Validate auto_auth_path
+	if aap, ok := conf["auto_auth_path"]; ok {
+		if _, ok := aap.(string); !ok {
+			return fmt.Errorf("auto_auth_path must be a string")
+		}
+	}
+
+	// Validate default_role
+	if dr, ok := conf["default_role"]; ok {
+		if _, ok := dr.(string); !ok {
+			return fmt.Errorf("default_role must be a string")
+		}
+	}
+
+	return nil
+}
+
+// validateAnthropicAddress validates that the anthropic_url is a well-formed HTTPS URL
+func validateAnthropicAddress(addr string) error {
+	if addr == "" {
+		return nil // Empty means use default
+	}
+
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("invalid anthropic_url: %w", err)
+	}
+
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("anthropic_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("anthropic_url must include a host")
+	}
+
+	return nil
+}

--- a/provider/anthropic/path_config.go
+++ b/provider/anthropic/path_config.go
@@ -1,0 +1,163 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathConfig returns the config path definition for the Anthropic provider
+func (b *anthropicBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"anthropic_url": {
+				Type:        framework.TypeString,
+				Description: "The Anthropic API base URL (default: https://api.anthropic.com)",
+				Default:     DefaultAnthropicURL,
+			},
+			"max_body_size": {
+				Type:        framework.TypeInt64,
+				Description: "Maximum request body size in bytes (default: 10MB, max: 100MB)",
+				Default:     framework.DefaultMaxBodySize,
+			},
+			"timeout": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Request timeout duration (e.g., '120s', '5m')",
+				Default:     "120s",
+			},
+			"transparent_mode": {
+				Type:        framework.TypeBool,
+				Description: "Enable transparent mode for implicit JWT authentication",
+				Default:     false,
+			},
+			"auto_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Path to JWT auth mount for transparent mode (e.g., 'auth/jwt/')",
+			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default role to use when not specified in URL path",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read Anthropic provider configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure Anthropic provider settings",
+			},
+		},
+		HelpSynopsis:    "Configure Anthropic provider",
+		HelpDescription: "This endpoint configures the Anthropic provider settings including API URL, body size limits, and timeouts.",
+	}
+}
+
+// handleConfigRead handles reading the Anthropic provider configuration
+func (b *anthropicBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"anthropic_url":    b.anthropicURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		},
+	}, nil
+}
+
+// handleConfigWrite handles writing the Anthropic provider configuration
+func (b *anthropicBackend) handleConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if val, ok := d.GetOk("anthropic_url"); ok {
+		addr := val.(string)
+		if addr != "" {
+			addr = strings.TrimRight(addr, "/")
+			if err := validateAnthropicAddress(addr); err != nil {
+				return &logical.Response{
+					StatusCode: http.StatusBadRequest,
+					Err:        logical.ErrBadRequest(err.Error()),
+				}, nil
+			}
+			b.anthropicURL = addr
+		}
+	}
+
+	if val, ok := d.GetOk("max_body_size"); ok {
+		b.MaxBodySize = val.(int64)
+	} else if b.MaxBodySize == 0 {
+		b.MaxBodySize = framework.DefaultMaxBodySize
+	}
+
+	if val, ok := d.GetOk("timeout"); ok {
+		b.Timeout = time.Duration(val.(int)) * time.Second
+	} else if b.Timeout == 0 {
+		b.Timeout = DefaultAnthropicTimeout
+	}
+
+	// Transparent mode settings
+	tc := &framework.TransparentConfig{
+		Enabled:      b.TransparentConfig.Enabled,
+		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
+		DefaultRole:  b.TransparentConfig.DefaultRole,
+	}
+	if val, ok := d.GetOk("transparent_mode"); ok {
+		tc.Enabled = val.(bool)
+	}
+	if val, ok := d.GetOk("auto_auth_path"); ok {
+		tc.AutoAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("default_role"); ok {
+		tc.DefaultRole = val.(string)
+	}
+
+	if tc.Enabled && tc.AutoAuthPath == "" {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest("auto_auth_path is required when transparent_mode is enabled"),
+		}, nil
+	}
+
+	b.StreamingBackend.SetTransparentConfig(tc)
+
+	// Persist config to storage
+	if b.StorageView != nil {
+		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"anthropic_url":    b.anthropicURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		})
+		if err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+		if err := b.StorageView.Put(ctx, entry); err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"message": "configuration updated",
+		},
+	}, nil
+}

--- a/provider/anthropic/path_gateway.go
+++ b/provider/anthropic/path_gateway.go
@@ -1,0 +1,182 @@
+package anthropic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// anthropicAPIVersionHeader is the required Anthropic API version
+const anthropicAPIVersionHeader = "2023-06-01"
+
+// Headers to remove before proxying
+var headersToRemove = []string{
+	// Security headers (will be replaced with Anthropic API key)
+	"Authorization",
+	"X-Warden-Token",
+	"X-Warden-Role",
+	// Anthropic-specific headers (will be injected from credential data)
+	"x-api-key",
+	"anthropic-version",
+	// Hop-by-hop headers
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+	// Proxy headers
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Port",
+	"X-Real-Ip",
+	"Forwarded",
+}
+
+func (b *anthropicBackend) handleGateway(ctx context.Context, req *logical.Request) {
+	// Apply timeout if configured
+	if b.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		defer cancel()
+		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	}
+
+	// Enforce max body size
+	maxBody := b.MaxBodySize
+	if maxBody <= 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+	req.HTTPRequest.Body = http.MaxBytesReader(req.ResponseWriter, req.HTTPRequest.Body, maxBody)
+
+	// Get Anthropic credential (API key)
+	apiKey, err := b.getAnthropicCredential(req)
+	if err != nil {
+		b.Logger.Warn("Failed to get Anthropic API key", logger.Err(err))
+		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Build target URL
+	targetURL, err := b.buildTargetURL(req.HTTPRequest.URL.Path, req.HTTPRequest.URL.RawQuery)
+	if err != nil {
+		b.Logger.Error("Failed to build target URL", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Prepare request for proxying
+	r := req.HTTPRequest
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		b.Logger.Error("Failed to parse target URL", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	r.URL = parsedURL
+	r.Host = parsedURL.Host
+	r.RequestURI = "" // Required for outgoing requests
+
+	// Clean headers and inject Anthropic credentials
+	b.prepareHeaders(r, apiKey)
+
+	b.Logger.Trace("Proxying Anthropic request",
+		logger.String("path", r.URL.Path),
+		logger.String("method", r.Method),
+		logger.Bool("has_key", apiKey != ""),
+	)
+
+	// Forward the request (body streams through without buffering)
+	b.Proxy.ServeHTTP(req.ResponseWriter, r)
+}
+
+// getAnthropicCredential extracts the Anthropic API key from the credential
+func (b *anthropicBackend) getAnthropicCredential(req *logical.Request) (apiKey string, err error) {
+	if req.Credential == nil {
+		return "", fmt.Errorf("no credential available")
+	}
+
+	if req.Credential.Type != credential.TypeAIAPIKey {
+		return "", fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+	}
+
+	apiKey = req.Credential.Data["api_key"]
+	if apiKey == "" {
+		return "", fmt.Errorf("credential missing api_key field")
+	}
+
+	return apiKey, nil
+}
+
+// buildTargetURL constructs the target Anthropic API URL from the gateway path
+func (b *anthropicBackend) buildTargetURL(path, rawQuery string) (string, error) {
+	// Find gateway path marker
+	gatewayIdx := strings.Index(path, "/gateway")
+	if gatewayIdx == -1 {
+		return "", fmt.Errorf("invalid gateway path: %s", path)
+	}
+
+	// Extract path after "/gateway"
+	anthropicPath := path[gatewayIdx+8:] // len("/gateway") = 8
+	if anthropicPath == "" || anthropicPath == "/" {
+		anthropicPath = "/"
+	}
+
+	if rawQuery != "" {
+		return b.anthropicURL + anthropicPath + "?" + rawQuery, nil
+	}
+	return b.anthropicURL + anthropicPath, nil
+}
+
+// prepareHeaders removes unwanted headers and injects the Anthropic credentials
+func (b *anthropicBackend) prepareHeaders(r *http.Request, apiKey string) {
+	// Read Connection header before removing it
+	conn := r.Header.Get("Connection")
+
+	// Remove headers in single pass
+	for _, h := range headersToRemove {
+		r.Header.Del(h)
+	}
+
+	// Handle Connection header's listed headers
+	if conn != "" {
+		for _, h := range strings.Split(conn, ",") {
+			if h = strings.TrimSpace(h); h != "" {
+				r.Header.Del(h)
+			}
+		}
+	}
+
+	// Inject the Anthropic API key using x-api-key header
+	if apiKey != "" {
+		r.Header.Set("x-api-key", apiKey)
+	}
+
+	// Inject the required anthropic-version header
+	r.Header.Set("anthropic-version", anthropicAPIVersionHeader)
+
+	// Set Accept header if not already set
+	if r.Header.Get("Accept") == "" {
+		r.Header.Set("Accept", "application/json")
+	}
+
+	// Set Content-Type if not already set (Anthropic requires JSON)
+	if r.Header.Get("Content-Type") == "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+
+	// Set User-Agent if not already set
+	if r.Header.Get("User-Agent") == "" {
+		r.Header.Set("User-Agent", "warden-anthropic-proxy")
+	}
+}

--- a/provider/anthropic/path_gateway_test.go
+++ b/provider/anthropic/path_gateway_test.go
@@ -1,0 +1,181 @@
+package anthropic
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTargetURL(t *testing.T) {
+	b := &anthropicBackend{
+		anthropicURL: "https://api.anthropic.com",
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		query    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "messages",
+			path:     "/anthropic/gateway/v1/messages",
+			expected: "https://api.anthropic.com/v1/messages",
+		},
+		{
+			name:     "models",
+			path:     "/anthropic/gateway/v1/models",
+			expected: "https://api.anthropic.com/v1/models",
+		},
+		{
+			name:     "path with query",
+			path:     "/anthropic/gateway/v1/models",
+			query:    "page=1&per_page=10",
+			expected: "https://api.anthropic.com/v1/models?page=1&per_page=10",
+		},
+		{
+			name:     "bare gateway",
+			path:     "/anthropic/gateway",
+			expected: "https://api.anthropic.com/",
+		},
+		{
+			name:     "gateway with trailing slash",
+			path:     "/anthropic/gateway/",
+			expected: "https://api.anthropic.com/",
+		},
+		{
+			name:    "no gateway marker",
+			path:    "/anthropic/v1/messages",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := b.buildTargetURL(tc.path, tc.query)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildTargetURL_CustomURL(t *testing.T) {
+	b := &anthropicBackend{
+		anthropicURL: "https://anthropic.example.com",
+	}
+
+	result, err := b.buildTargetURL("/custom/gateway/v1/messages", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://anthropic.example.com/v1/messages", result)
+}
+
+func TestPrepareHeaders(t *testing.T) {
+	b := &anthropicBackend{}
+
+	t.Run("removes security headers and injects API key", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("Authorization", "Bearer warden-token")
+		req.Header.Set("X-Warden-Token", "warden-token")
+		req.Header.Set("X-Custom", "keep-me")
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "sk-ant-test-key", req.Header.Get("x-api-key"))
+		assert.Equal(t, anthropicAPIVersionHeader, req.Header.Get("anthropic-version"))
+		assert.Equal(t, "", req.Header.Get("Authorization"))
+		assert.Equal(t, "", req.Header.Get("X-Warden-Token"))
+		assert.Equal(t, "keep-me", req.Header.Get("X-Custom"))
+	})
+
+	t.Run("injects default headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "application/json", req.Header.Get("Accept"))
+		assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		assert.Equal(t, "warden-anthropic-proxy", req.Header.Get("User-Agent"))
+	})
+
+	t.Run("preserves client-set Accept header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("Accept", "text/event-stream")
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "text/event-stream", req.Header.Get("Accept"))
+	})
+
+	t.Run("preserves client-set Content-Type header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("Content-Type", "multipart/form-data")
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "multipart/form-data", req.Header.Get("Content-Type"))
+	})
+
+	t.Run("removes hop-by-hop headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("Connection", "keep-alive")
+		req.Header.Set("Transfer-Encoding", "chunked")
+		req.Header.Set("Proxy-Authorization", "Basic abc")
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "", req.Header.Get("Connection"))
+		assert.Equal(t, "", req.Header.Get("Transfer-Encoding"))
+		assert.Equal(t, "", req.Header.Get("Proxy-Authorization"))
+	})
+
+	t.Run("removes Connection-listed headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("Connection", "X-Custom-Hop")
+		req.Header.Set("X-Custom-Hop", "should-be-removed")
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "", req.Header.Get("X-Custom-Hop"))
+	})
+
+	t.Run("removes proxy headers", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("X-Forwarded-For", "10.0.0.1")
+		req.Header.Set("X-Real-Ip", "10.0.0.1")
+		req.Header.Set("Forwarded", "for=10.0.0.1")
+
+		b.prepareHeaders(req, "sk-ant-test-key")
+
+		assert.Equal(t, "", req.Header.Get("X-Forwarded-For"))
+		assert.Equal(t, "", req.Header.Get("X-Real-Ip"))
+		assert.Equal(t, "", req.Header.Get("Forwarded"))
+	})
+
+	t.Run("empty API key does not set x-api-key", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+
+		b.prepareHeaders(req, "")
+
+		assert.Equal(t, "", req.Header.Get("x-api-key"))
+		// anthropic-version should still be set
+		assert.Equal(t, anthropicAPIVersionHeader, req.Header.Get("anthropic-version"))
+	})
+
+	t.Run("removes client-sent x-api-key and anthropic-version", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+		req.Header.Set("x-api-key", "spoofed-key")
+		req.Header.Set("anthropic-version", "spoofed-version")
+
+		b.prepareHeaders(req, "sk-ant-real-key")
+
+		// Client-sent headers should be replaced with correct values
+		assert.Equal(t, "sk-ant-real-key", req.Header.Get("x-api-key"))
+		assert.Equal(t, anthropicAPIVersionHeader, req.Header.Get("anthropic-version"))
+	})
+}

--- a/provider/anthropic/provider.go
+++ b/provider/anthropic/provider.go
@@ -1,0 +1,265 @@
+package anthropic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// anthropicBackend is the streaming backend for Anthropic provider operations
+type anthropicBackend struct {
+	*framework.StreamingBackend
+	anthropicURL string // e.g., "https://api.anthropic.com"
+}
+
+// extractToken extracts Warden token from X-Warden-Token, x-api-key, or Authorization: Bearer headers.
+// Anthropic clients typically send credentials via x-api-key, so we accept that as a Warden token source.
+func extractToken(r *http.Request) string {
+	// First, check X-Warden-Token header (explicit Warden token)
+	if token := r.Header.Get("X-Warden-Token"); token != "" {
+		return token
+	}
+
+	// Then check x-api-key header (Anthropic SDK default)
+	if token := r.Header.Get("x-api-key"); token != "" {
+		return token
+	}
+
+	// Then check Authorization header for Bearer token
+	authHeader := r.Header.Get("Authorization")
+	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
+		return authHeader[7:]
+	}
+
+	return ""
+}
+
+// Factory creates a new Anthropic provider backend using the logical.Factory pattern
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &anthropicBackend{}
+
+	// Create the streaming backend with gateway path for streaming
+	b.StreamingBackend = &framework.StreamingBackend{
+		StreamingPaths: []*framework.StreamingPath{
+			{
+				Pattern:         "gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Anthropic Gateway proxy",
+				HelpDescription: "Proxies requests to Anthropic API with API key injection",
+			},
+			{
+				Pattern:         "gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Anthropic Gateway proxy",
+				HelpDescription: "Proxies requests to Anthropic API with API key injection",
+			},
+			// Transparent mode: role-based gateway paths
+			{
+				Pattern:         "role/[^/]+/gateway",
+				Handler:         b.handleTransparentGatewayStreaming,
+				HelpSynopsis:    "Anthropic Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to Anthropic API with implicit JWT authentication",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway/.*",
+				Handler:         b.handleTransparentGatewayStreaming,
+				HelpSynopsis:    "Anthropic Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to Anthropic API with implicit JWT authentication",
+			},
+		},
+		ParseStreamBody: true, // Enable policy evaluation on model, max_tokens, etc.
+		TransparentConfig: &framework.TransparentConfig{
+			Enabled:      false,
+			AutoAuthPath: "",
+			DefaultRole:  "",
+		},
+		Backend: &framework.Backend{
+			Help:           anthropicBackendHelp,
+			BackendType:    "anthropic",
+			BackendClass:   logical.ClassProvider,
+			TokenExtractor: extractToken,
+			Paths:          b.paths(),
+		},
+	}
+
+	// Set common fields
+	b.Logger = conf.Logger.WithSubsystem("anthropic")
+	b.StorageView = conf.StorageView
+
+	// Initialize reverse proxy with Anthropic transport
+	b.StreamingBackend.InitProxy(sharedTransport)
+
+	// Register transport shutdown hook for process-level cleanup
+	if conf.RegisterShutdownHook != nil {
+		conf.RegisterShutdownHook("anthropic-transport", ShutdownHTTPTransport)
+	}
+
+	if err := b.StreamingBackend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	// Set defaults
+	b.MaxBodySize = framework.DefaultMaxBodySize
+	b.Timeout = DefaultAnthropicTimeout
+	b.anthropicURL = DefaultAnthropicURL
+
+	// Apply configuration if provided
+	if len(conf.Config) > 0 {
+		if err := ValidateConfig(conf.Config); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+		parsedConfig := parseConfig(conf.Config)
+		b.anthropicURL = strings.TrimRight(parsedConfig.AnthropicURL, "/")
+		b.MaxBodySize = parsedConfig.MaxBodySize
+		b.Timeout = parsedConfig.Timeout
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			Enabled:      parsedConfig.TransparentMode,
+			AutoAuthPath: parsedConfig.AutoAuthPath,
+			DefaultRole:  parsedConfig.DefaultRole,
+		})
+	}
+
+	return b, nil
+}
+
+// Initialize loads persisted config from storage
+func (b *anthropicBackend) Initialize(ctx context.Context) error {
+	if b.StorageView == nil {
+		return nil
+	}
+
+	entry, err := b.StorageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry != nil {
+		var config struct {
+			AnthropicURL    string `json:"anthropic_url"`
+			MaxBodySize     int64  `json:"max_body_size"`
+			Timeout         string `json:"timeout"`
+			TransparentMode bool   `json:"transparent_mode"`
+			AutoAuthPath    string `json:"auto_auth_path"`
+			DefaultRole     string `json:"default_role"`
+		}
+		if err := entry.DecodeJSON(&config); err != nil {
+			return fmt.Errorf("failed to decode config: %w", err)
+		}
+		if config.AnthropicURL != "" {
+			b.anthropicURL = strings.TrimRight(config.AnthropicURL, "/")
+		}
+		b.MaxBodySize = config.MaxBodySize
+		if config.Timeout != "" {
+			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
+				b.Timeout = timeout
+			}
+		}
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			Enabled:      config.TransparentMode,
+			AutoAuthPath: config.AutoAuthPath,
+			DefaultRole:  config.DefaultRole,
+		})
+	} else {
+		// No persisted config — persist defaults
+		tc := b.TransparentConfig
+		defaultEntry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"anthropic_url":    b.anthropicURL,
+			"max_body_size":    b.MaxBodySize,
+			"timeout":          b.Timeout.String(),
+			"transparent_mode": tc.Enabled,
+			"auto_auth_path":   tc.AutoAuthPath,
+			"default_role":     tc.DefaultRole,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create default config entry: %w", err)
+		}
+		if err := b.StorageView.Put(ctx, defaultEntry); err != nil {
+			return fmt.Errorf("failed to persist default config: %w", err)
+		}
+		b.Logger.Info("persisted default configuration for new Anthropic provider")
+	}
+	return nil
+}
+
+// paths returns the configuration paths for the Anthropic provider
+func (b *anthropicBackend) paths() []*framework.Path {
+	return []*framework.Path{
+		b.pathConfig(),
+	}
+}
+
+// handleGatewayStreaming handles streaming gateway requests
+func (b *anthropicBackend) handleGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// handleTransparentGatewayStreaming handles transparent mode gateway requests.
+// The implicit auth has already been performed by the core request handler.
+func (b *anthropicBackend) handleTransparentGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	if !b.StreamingBackend.IsTransparentMode() {
+		http.Error(req.ResponseWriter, "Transparent mode not enabled", http.StatusForbidden)
+		return nil
+	}
+
+	// Rewrite the path: /role/{role}/gateway/... -> /gateway/...
+	req.Path = b.StreamingBackend.RewriteTransparentPath(req.Path)
+
+	// Also update the HTTP request URL path for the proxy
+	if req.HTTPRequest != nil && req.HTTPRequest.URL != nil {
+		req.HTTPRequest.URL.Path = b.StreamingBackend.RewriteTransparentPath(req.HTTPRequest.URL.Path)
+	}
+
+	// Delegate to standard gateway handler
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// SensitiveConfigFields returns the list of config fields that should be masked in output
+func (b *anthropicBackend) SensitiveConfigFields() []string {
+	return []string{}
+}
+
+const anthropicBackendHelp = `
+The Anthropic provider enables proxying requests to the Anthropic API with
+automatic credential management and API key injection.
+
+Clients authenticate to Warden with a session token (via X-Warden-Token or
+Authorization: Bearer header). The provider obtains an Anthropic API key from
+the credential manager and injects it into the proxied request's x-api-key
+header. This allows Warden to broker Anthropic access without exposing API
+keys to clients.
+
+The gateway path format is:
+  /anthropic/gateway/{api-path}
+
+Examples:
+  /anthropic/gateway/v1/messages
+  /anthropic/gateway/v1/models
+
+Request body parsing is enabled, allowing policies to evaluate AI request
+fields such as model, max_tokens, temperature, and stream. This enables
+fine-grained cost control and usage policies.
+
+Transparent mode allows implicit JWT authentication via role-based paths,
+eliminating the need for clients to perform an explicit Warden login:
+  /anthropic/role/{role}/gateway/{api-path}
+
+The core extracts the role from the URL, performs implicit JWT auth against
+the configured auth mount, and issues a short-lived token for the request.
+
+Configuration:
+- anthropic_url: Anthropic API base URL (default: https://api.anthropic.com)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 120s for AI inference)
+- transparent_mode: Enable implicit JWT authentication (default: false)
+- auto_auth_path: JWT auth mount path for transparent mode (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`

--- a/provider/anthropic/provider_test.go
+++ b/provider/anthropic/provider_test.go
@@ -1,0 +1,185 @@
+package anthropic
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected string
+	}{
+		{
+			name:     "X-Warden-Token header",
+			headers:  map[string]string{"X-Warden-Token": "warden-token-123"},
+			expected: "warden-token-123",
+		},
+		{
+			name:     "Bearer token",
+			headers:  map[string]string{"Authorization": "Bearer my-bearer-token"},
+			expected: "my-bearer-token",
+		},
+		{
+			name:     "x-api-key header",
+			headers:  map[string]string{"x-api-key": "sk-ant-api-key"},
+			expected: "sk-ant-api-key",
+		},
+		{
+			name:     "X-Warden-Token takes priority over x-api-key",
+			headers:  map[string]string{"X-Warden-Token": "warden-token", "x-api-key": "sk-ant-api-key"},
+			expected: "warden-token",
+		},
+		{
+			name:     "x-api-key takes priority over Bearer",
+			headers:  map[string]string{"x-api-key": "sk-ant-api-key", "Authorization": "Bearer bearer-token"},
+			expected: "sk-ant-api-key",
+		},
+		{
+			name:     "X-Warden-Token takes priority over Bearer",
+			headers:  map[string]string{"X-Warden-Token": "warden-token", "Authorization": "Bearer bearer-token"},
+			expected: "warden-token",
+		},
+		{
+			name:     "No token",
+			headers:  map[string]string{},
+			expected: "",
+		},
+		{
+			name:     "Non-Bearer auth header ignored",
+			headers:  map[string]string{"Authorization": "token ghp_abc123"},
+			expected: "",
+		},
+		{
+			name:     "Case insensitive Bearer",
+			headers:  map[string]string{"Authorization": "bearer my-token"},
+			expected: "my-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			result := extractToken(req)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseConfig(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		config := parseConfig(map[string]any{})
+		assert.Equal(t, DefaultAnthropicURL, config.AnthropicURL)
+		assert.Greater(t, config.MaxBodySize, int64(0))
+		assert.Equal(t, DefaultAnthropicTimeout, config.Timeout)
+	})
+
+	t.Run("custom values", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"anthropic_url": "https://anthropic.example.com",
+			"timeout":       "60s",
+		})
+		assert.Equal(t, "https://anthropic.example.com", config.AnthropicURL)
+		assert.Equal(t, 60.0, config.Timeout.Seconds())
+	})
+
+	t.Run("integer timeout", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"timeout": 45,
+		})
+		assert.Equal(t, 45.0, config.Timeout.Seconds())
+	})
+
+	t.Run("transparent mode settings", func(t *testing.T) {
+		config := parseConfig(map[string]any{
+			"transparent_mode": true,
+			"auto_auth_path":   "auth/jwt/",
+			"default_role":     "reader",
+		})
+		assert.True(t, config.TransparentMode)
+		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
+		assert.Equal(t, "reader", config.DefaultRole)
+	})
+}
+
+func TestValidateConfig(t *testing.T) {
+	t.Run("empty config is valid", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid anthropic_url", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"anthropic_url": "https://api.anthropic.com",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-HTTPS anthropic_url rejected", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"anthropic_url": "http://api.anthropic.com",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "https://")
+	})
+
+	t.Run("invalid timeout format", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"timeout": "not-a-duration",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("negative max_body_size", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"max_body_size": -1,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("oversized max_body_size", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"max_body_size": 200000000, // 200MB
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid transparent_mode type", func(t *testing.T) {
+		err := ValidateConfig(map[string]any{
+			"transparent_mode": "yes",
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateAnthropicAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr bool
+	}{
+		{"empty is valid", "", false},
+		{"valid HTTPS", "https://api.anthropic.com", false},
+		{"valid custom", "https://anthropic.example.com", false},
+		{"HTTP rejected", "http://api.anthropic.com", true},
+		{"no scheme", "api.anthropic.com", true},
+		{"no host", "https://", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAnthropicAddress(tc.addr)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/provider/anthropic/transport.go
+++ b/provider/anthropic/transport.go
@@ -1,0 +1,88 @@
+package anthropic
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+var (
+	sharedTransport        *http.Transport
+	transportCleanupCtx    context.Context
+	transportCleanupCancel context.CancelFunc
+)
+
+func init() {
+	sharedTransport = newAnthropicTransport()
+
+	// Start background cleanup with proper lifecycle management
+	transportCleanupCtx, transportCleanupCancel = context.WithCancel(context.Background())
+	go cleanupIdleConnections(transportCleanupCtx, sharedTransport)
+}
+
+// newAnthropicTransport creates an HTTP transport optimized for Anthropic API workloads
+func newAnthropicTransport() *http.Transport {
+	transport := &http.Transport{
+		// Connection pool settings
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 50,
+		MaxConnsPerHost:     0, // Unlimited outbound connections
+		IdleConnTimeout:     90 * time.Second,
+
+		// TLS configuration
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ClientSessionCache: tls.NewLRUClientSessionCache(100),
+		},
+
+		// Dialer settings
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+
+		// Timeout settings — higher for AI inference (streaming responses can be slow)
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 120 * time.Second,
+
+		// HTTP/2 optimization
+		ForceAttemptHTTP2: true,
+	}
+
+	if err := http2.ConfigureTransport(transport); err != nil {
+		log.Printf("Failed to configure HTTP/2 for Anthropic transport: %v", err)
+	}
+
+	return transport
+}
+
+// cleanupIdleConnections periodically closes idle connections
+func cleanupIdleConnections(ctx context.Context, transport *http.Transport) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			transport.CloseIdleConnections()
+		}
+	}
+}
+
+// ShutdownHTTPTransport should be called during application shutdown
+func ShutdownHTTPTransport() {
+	if transportCleanupCancel != nil {
+		transportCleanupCancel()
+	}
+	if sharedTransport != nil {
+		sharedTransport.CloseIdleConnections()
+	}
+}


### PR DESCRIPTION
Add full Anthropic AI provider support including:
- Credential driver (anthropic_driver.go) with API key management and SpecVerifier using GET /v1/models
- Streaming gateway proxy injecting x-api-key and anthropic-version headers (differs from OpenAI/Mistral Bearer auth)
- Token extraction supporting X-Warden-Token, x-api-key, and Bearer for native Anthropic SDK compatibility
- Provider config with transparent mode, timeout, and body size limits
- Policy evaluation on AI request fields (model, max_tokens, stream)
- Provider README with quickstart, SDK, Claude Code, and Claude Desktop usage examples
- Updated main README: Anthropic moved from Planned to GA