### PR TITLE
docs: add PATH export step to provider README quickstart instructions

### DIFF
--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -43,12 +43,17 @@ The Anthropic provider enables proxied access to the Anthropic API through Warde
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -47,12 +47,17 @@ The AWS provider enables proxied access to AWS services through Warden. It inter
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -44,12 +44,17 @@ The Azure provider enables proxied access to Azure APIs through Warden. It manag
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -43,12 +43,17 @@ The GCP provider enables proxied access to Google Cloud Platform APIs through Wa
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -45,12 +45,17 @@ The GitHub provider enables proxied access to the GitHub REST API through Warden
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -47,12 +47,17 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -43,12 +43,17 @@ The Mistral provider enables proxied access to the Mistral AI API through Warden
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -43,12 +43,17 @@ The OpenAI provider enables proxied access to the OpenAI API through Warden. It 
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -48,12 +48,17 @@ The Vault provider enables proxied access to HashiCorp Vault (or OpenBao) throug
 > curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
 > ```
 >
-> **3. Start the Warden server** in dev mode:
+> **3. Add the binary to your PATH:**
 > ```bash
-> ./warden server --dev
+> export PATH="$PWD:$PATH"
 > ```
 >
-> **4. In another terminal window**, export the environment variables for the CLI:
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"


### PR DESCRIPTION
The downloaded binary is not on PATH by default, so bare `warden` commands fail. Add an explicit `export PATH` step after downloading and renumber subsequent steps.