### PR TITLE
docs: add PATH export to the second terminal window step

### DIFF
--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -55,6 +55,7 @@ The Anthropic provider enables proxied access to the Anthropic API through Warde
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -59,6 +59,7 @@ The AWS provider enables proxied access to AWS services through Warden. It inter
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -56,6 +56,7 @@ The Azure provider enables proxied access to Azure APIs through Warden. It manag
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -55,6 +55,7 @@ The GCP provider enables proxied access to Google Cloud Platform APIs through Wa
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -57,6 +57,7 @@ The GitHub provider enables proxied access to the GitHub REST API through Warden
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -59,6 +59,7 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -55,6 +55,7 @@ The Mistral provider enables proxied access to the Mistral AI API through Warden
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -55,6 +55,7 @@ The OpenAI provider enables proxied access to the OpenAI API through Warden. It 
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -60,6 +60,7 @@ The Vault provider enables proxied access to HashiCorp Vault (or OpenBao) throug
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
+> export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
 > export WARDEN_TOKEN="<your-token>"
 > ```


### PR DESCRIPTION
The new terminal in step 5 does not inherit the PATH from step 3, so warden commands would still fail without it.