### PR TITLE
docs: use custom root token in quickstart instructions

### DIFF
--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -50,14 +50,14 @@ The Anthropic provider enables proxied access to the Anthropic API through Warde
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ## Step 1: Configure JWT Auth and Create a Role

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -54,14 +54,14 @@ The AWS provider enables proxied access to AWS services through Warden. It inter
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ### Create the IAM User

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -51,14 +51,14 @@ The Azure provider enables proxied access to Azure APIs through Warden. It manag
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ### Creating an Azure AD App Registration

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -50,14 +50,14 @@ The GCP provider enables proxied access to Google Cloud Platform APIs through Wa
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ### Creating a Service Account Key

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -52,14 +52,14 @@ The GitHub provider enables proxied access to the GitHub REST API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ## Step 1: Configure JWT Auth and Create a Role

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -54,14 +54,14 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ## Step 1: Configure JWT Auth and Create a Role

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -50,14 +50,14 @@ The Mistral provider enables proxied access to the Mistral AI API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ## Step 1: Configure JWT Auth and Create a Role

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -50,14 +50,14 @@ The OpenAI provider enables proxied access to the OpenAI API through Warden. It 
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ## Step 1: Configure JWT Auth and Create a Role

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -55,14 +55,14 @@ The Vault provider enables proxied access to HashiCorp Vault (or OpenBao) throug
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev
+> warden server --dev --dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
 > ```bash
 > export PATH="$PWD:$PATH"
 > export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="<your-token>"
+> export WARDEN_TOKEN="root"
 > ```
 
 ## Step 1: Create an AppRole in Vault


### PR DESCRIPTION
Pass --dev-root-token=root to the dev server so users can use a known token value instead of copying it from the server output.