### PR TITLE
feat: add access backend framework and RDS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,143 +23,109 @@
 
 # Warden
 
-Warden is an identity-aware egress gateway that replaces cloud credentials with zero-trust access.
+**Every team that ships code has credentials it shouldn't have.**
+ 
+**Developers with AWS keys on their laptops. Data pipelines with Snowflake passwords in config files. AI agents with ambient cloud access and no policy. CI pipelines with secrets that never rotate.**
+ 
+**Warden is the single layer that eliminates all of it.**
+ 
+---
 
-Instead of trusting every workload to handle credentials responsibly, Warden removes that burden entirely. Workloads authenticate to Warden using their own identity (JWT, TLS certificate, or SPIFFE SVID). Warden then mints short-lived credentials, injects them into outbound requests, and forwards them. Workloads never handle cloud credentials directly. The attack surface shrinks to a single, fully audited and tightly controlled component.
+Your workload authenticates to Warden with its identity. Warden verifies who is calling, checks the policy, and issues ephemeral request-scoped access — either by forwarding the request with access token injected, returning a database auth token, or returning a pre-signed URL. Your workload has no secrets to leak.
 
 ```
 ┌──────────────┐                    ┌──────────────┐                     ┌──────────────┐
 │  Developer   │      Identity      │              │    Scoped Access    │ AWS, Azure   │
 │  K8s pod     │───────────────────▶│    Warden    │───────────────────▶ │ GitHub, GCP  │
 │  Pipeline    │   no credentials   │              │  real credentials   │ Anthropic    │
-│  AI agent    │                    │              │                     │ Mistral ...  │
+│  AI agent    │                    │              │                     │ Mistral      │
+│              │                    │              │                     │ RDS, S3...   │
 └──────────────┘                    └──────────────┘                     └──────────────┘
                                     • Auth ✓
                                     • Policy ✓
                                     • Audit ✓
 ```
 
+## The problem
+ 
+Exposed credentials are the root cause of most cloud security incidents:
+ 
+- An AI agent with ambient cloud credentials — no policy on what it can call, no audit trail of what it did
+- A `DATABASE_URL` in a `.env` — one accidental commit away from being in your repository forever
+- A developer laptop with a `~/.aws/credentials` — production access on a device that gets lost, stolen, or compromised
+- An AWS key in a Lambda environment variable — visible in plaintext to anyone with console access or a logging misconfiguration
+- A GitHub PAT in a CI environment variable — a bearer token any compromised runner can extract and use from any IP
+ 
+The common thread: **the credential exists somewhere it shouldn't, with more scope than needed, for longer than necessary.**
+ 
+Warden eliminates the credential from the equation entirely. Your workloads authenticate with their identity. Warden handles the credential.
+
+## Quickstart
+
+Follow a provider guide to configure your first endpoint:
+
+- [AWS](provider/aws/README.md)
+- [Azure](provider/azure/README.md)
+- [GCP](provider/gcp/README.md)
+- [GitHub](provider/github/README.md)
+- [GitLab](provider/gitlab/README.md)
+- [Vault / OpenBao](provider/vault/README.md)
+- [Anthropic](provider/anthropic/README.md)
+- [Mistral](provider/mistral/README.md)
+- [OpenAI](provider/openai/README.md)
+- [AWS RDS / Aurora](provider/rds/README.md)
+
+## What Warden covers
+ 
+| Your workload needs | Warden handles |
+|---|---|
+| Call cloud APIs (AWS, GCP, Azure, GitHub, GitLab...) | Request forwarding, with injected ephemeral credentials |
+| Connect to a database (RDS, Cloud SQL, Redshift, Azure SQL, Snowflake...) | Ephemeral database auth tokens — replacing static passwords entirely |
+| Read and write files (S3, GCS, Azure Blob...) | Pre-signed URLs, scoped to exactly one object and operation |
+
+One binary. One policy model. One audit log. Across your entire stack.
+
 ## Supported Providers
 
-### Cloud & SaaS Providers
-
-| Provider | Status | Credential Source |
-|----------|--------|-------------------|
-| **AWS** | ✅ GA | Direct from AWS STS or via Vault AWS secrets engine |
-| **Azure** | ✅ GA | Service principal credentials |
-| **GCP** | ✅ GA | Service account credentials |
-| **GitHub** | ✅ GA | PATs, GitHub App tokens |
-| **GitLab** | ✅ GA | PATs, Deploy tokens |
-| **Vault / OpenBao** | ✅ GA | Token-based |
-
-### AI Providers
-
-| Provider | Status | Credential Source |
-|----------|--------|-------------------|
-| **Anthropic** | ✅ GA | API key |
-| **Mistral** | ✅ GA | API key |
-| **OpenAI** | ✅ GA | API key |
-| Cohere | Planned | — |
-
-The roadmap targets 100+ cloud and SaaS providers and all major AI providers.
-
-## Why Warden?
-
-### Zero Credential Exposure
-
-Your workloads never see API keys or cloud credentials. Warden intercepts requests, injects credentials on the fly, and forwards them to providers. No secrets in environment variables, no keys in config files, no credential leaks — even if a workload is compromised, there are no credentials to exfiltrate.
-
-### Request-Level Audit Trail
-
-Warden doesn't just log who received credentials — it logs what they did with them. Every API call — whether an AI inference or a cloud operation — produces a structured audit entry capturing identity, policy result, credential used, request details, and response status.
-
-```
-# Typical:  "pipeline-X was granted AWS credentials at 14:32"
-# Warden:   "pipeline-X (role: deploy-ops) called PUT .../resourcegroups/my-rg → 201, using
-#           credential: azure-source/azure-cred-spec (ttl: 3599s)"
-#
-# Warden:   "agent-Y (role: mistral-ops) called POST /v1/chat/completions
-#           (model: mistral-large, max_tokens: 4096) → 200, using
-#           credential: mistral-src/mistral-ops"
-```
-
-### Fine-Grained Policy Enforcement
-
-Warden constrains what a workload can do by controlling which APIs it can reach, which operations it can perform, and — for AI providers — which models and parameters it can use.
-
-A GitHub fine-grained PAT with `contents: read` lets the holder read *every file* in a repo. Warden can restrict a pipeline to `src/` while blocking `.github/workflows/` and `.env` — something GitHub simply cannot express. For AWS, destructive operations can be blocked at the gateway regardless of what the underlying IAM role permits. A Mistral API key grants access to every model. Warden can restrict an agent to `mistral-small-latest` only, enforce max_tokens limits, and require streaming mode — cost control that API key scoping alone cannot provide.
-
-Policies also support **runtime conditions** — source IP restrictions, time-of-day windows, and day-of-week constraints — that deny requests even when capabilities match. This enables scenarios like restricting production deployments to office hours from trusted networks only.
-
-### AI Request Governance
-
-Warden parses AI request bodies and evaluates policies against inference parameters. This enables cost control and usage governance at the gateway layer:
-
-- **Model access control** — restrict which models each agent identity can use
-- **Token budgets** — enforce max_tokens limits per role
-- **Streaming requirements** — require streaming mode for real-time cost visibility
-- **Full inference audit** — every completion request is logged with model, parameters, and response status
-
-### Zero Client Modification
-
-Point your existing tools at Warden's endpoint instead of the provider's. The AWS CLI, Terraform, GitHub CLI, Anthropic SDK, Mistral SDK, OpenAI SDK, or any HTTP client — if it supports a custom base URL or endpoint override, it works with Warden. No code changes, no special libraries, no proxy configuration.
-
-### Identity-Based Access
-
-Every request is tied to a verified identity — via JWT, TLS client certificate, or SPIFFE SVID. Whether it's a developer authenticating with a client certificate from their laptop, a Kubernetes pod identified by its SPIFFE SVID, a CI/CD pipeline deploying to AWS, or an AI agent calling Anthropic, Warden knows exactly who is making each API call and applies policies accordingly.
-
-### Unified Identity Across Providers
-
-Every provider has its own identity system — AWS IAM, Azure Entra ID, GitHub Apps, Anthropic API keys. Multi-provider means multi-identity: different auth flows, different credential formats, different rotation strategies. Warden collapses all of that behind a single identity layer. Your workloads authenticate once — with a JWT or a client certificate — and Warden translates to each provider's native auth on the fly. One identity plane, regardless of how many providers sit behind it.
-
-```
-                                     ┌─── AWS (SigV4)
-                                     │
-                                     ├─── Azure (Bearer + Entra ID)
-                                     │
-  Workload ── JWT / cert ──▶ Warden ─┼─── GitHub (Installation token)
-                                     │
-                                     ├─── Anthropic (x-api-key)
-                                     │
-                                     ├─── Mistral (Bearer + API key)
-                                     │
-                                     └─── OpenAI (Bearer + API key)
-```
+| Provider | Warden does | Status |
+|---|---|---|
+| AWS | Injects credentials | ✅ |
+| GCP | Injects credentials | ✅ |
+| Azure | Injects credentials | ✅ |
+| GitHub | Injects credentials | ✅ |
+| GitLab | Injects credentials | ✅ |
+| Anthropic | Injects credentials | ✅ |
+| Mistral | Injects credentials | ✅ |
+| OpenAI | Injects credentials | ✅ |
+| HashiCorp Vault / OpenBao | Injects credentials | ✅ |
+| AWS RDS / Aurora | Issues database auth token | 🔜 |
+| AWS Redshift | Issues database auth token | 🔜 |
+| GCP Cloud SQL | Issues database auth token | 🔜 |
+| Azure SQL | Issues database auth token | 🔜 |
+| Snowflake | Issues database auth token | 🔜 |
+| AWS S3 | Issues pre-signed URL | 🔜 |
+| GCP Cloud Storage | Issues pre-signed URL | 🔜 |
+| Azure Blob Storage | Issues pre-signed URL | 🔜 |
+ 
 
 ## Use Cases
+ 
+**AI agents** — agents authenticate with their identity and can only reach the APIs your policy allows. Every file read, every API call, every database query is logged with the agent's identity. Prompt injection can't exfiltrate credentials that don't exist in the agent's environment.
+ 
+**CI/CD pipelines** — pipelines authenticate with their OIDC token (GitHub Actions, GitLab CI, Kubernetes). No credentials stored as CI secrets. Per-job audit trail across every cloud and SaaS API the pipeline touches.
+ 
+**Data pipelines** — dbt, Airflow, Spark, and custom ELT jobs touch more external services per run than almost any other workload. With Warden, each pipeline run authenticates with its job identity and gets scoped, ephemeral credentials for every source database, data warehouse, and staging bucket it needs. No shared Snowflake passwords in `profiles.yml`. No Redshift user shared across 30 DAGs. Full per-run audit trail of every query and file operation.
+ 
+**Developer machines** — developers authenticate with a mTLS certificate or short-lived JWT. No static keys on disk. Full per-developer audit trail in production-like environments.
+ 
+**Microservices** — each service authenticates with its Kubernetes service account JWT or SPIFFE SVID. Gets exactly the credentials it needs. Credential sprawl — one IAM user per service — is eliminated at the architecture level.
+ 
+**Database access** — no static password in your `DATABASE_URL`. Your workload asks Warden for a database auth token when it needs one. It expires in 15 minutes. Nothing to leak, nothing to rotate, nothing to store.
+ 
+**Storage access** — no AWS credentials in your Lambda to generate pre-signed URLs. Your backend calls Warden with the object path and gets a pre-signed URL valid for 5 minutes, scoped to exactly that object and operation.
+ 
+**Multi-provider workloads** — a single service that calls AWS for storage, GCP for ML inference, GitHub for source access, and Anthropic for LLM completions has four separate credential problems today. With Warden, it has one: authenticate once with its identity, and let Warden handle every provider behind a single policy layer and a single audit log.
 
-### Terraform / Infrastructure as Code
-
-No more AWS credentials on the machine running `terraform apply`. Terraform points at Warden, authenticates with a JWT or TLS certificate, and Warden signs requests with just-in-time credentials scoped to the pipeline's identity. Full audit trail of every API call Terraform makes.
-
-### CI/CD Pipelines
-
-Pipelines store credentials as CI secrets — each one a potential leak, each one painful to rotate. With Warden, pipelines authenticate with their workload identity (Kubernetes SA, OIDC token) and access cloud and SaaS APIs through the gateway. No secrets to distribute, no credentials to rotate.
-
-### Kubernetes & Service Mesh
-
-Pods authenticate to Warden using their SPIFFE identity — either an X.509-SVID via certificate auth or a JWT-SVID via JWT auth. No sidecar agents, no mounted secrets, no token distributors. Warden validates the SVID, extracts the SPIFFE ID, and grants scoped access to upstream APIs. A pod in the `payment` namespace can reach the payment secrets in Vault, and nothing else.
-
-### AI Agents — Inference Governance
-
-AI agents call AI providers autonomously — choosing models, setting token limits, running completions. Without Warden, an API key grants unlimited access to every model. With Warden, each agent identity has scoped model access, enforced token limits, and every inference call is audited with full request parameters.
-
-```bash
-# Agent can only use claude-sonnet-4-20250514, max_tokens capped, streaming required
-curl -X POST https://warden.internal/v1/anthropic/role/agent-role/gateway/v1/messages \
-  -H "Authorization: Bearer <jwt>" \
-  -d '{"model": "claude-sonnet-4-20250514", "max_tokens": 1024, "messages": [...], "stream": true}'
-```
-
-### AI Agents — Tool Use Governance
-
-When agents call cloud APIs — reading GitHub repos, writing to S3, deploying to Azure — Warden governs every tool action. Full audit trail of every file read, every PR created, every cloud resource touched.
-
-> *Marc Brooker, AWS Principal Engineer, [argues](https://brooker.co.za/blog/2026/01/12/agent-box.html) that agent safety requires a deterministic gateway outside the agent that enforces policy on every tool call. Warden is that gateway.*
-
-### Multi-Provider Workloads
-
-A workload that reads from GitHub, writes to S3, deploys to Azure, and calls Anthropic for inference needs four different credential types, four different auth flows, four different rotation strategies. Without Warden, each integration is its own identity problem. With Warden, the workload gets one JWT and one endpoint pattern. It doesn't matter whether the target is AWS, GitHub, or Anthropic — the auth flow is identical. Add a new provider and existing workloads gain access without changing a single line of code.
 
 ## Authentication Methods
 
@@ -172,157 +138,33 @@ Warden supports multiple methods for verifying caller identity.
 
 SPIFFE is supported in both methods — JWT-SVIDs via JWT auth and X.509-SVIDs via certificate auth. Both methods produce the same internal session. Once authenticated, the caller interacts with Warden identically regardless of how they proved their identity.
 
-## Authentication Modes
+## How workloads interact with Warden
 
-Warden supports two modes for how callers interact with the gateway. The availability of each mode depends on the provider.
+**Transparent mode** — your tool points at Warden's endpoint and makes a normal HTTP request with a JWT in the `Authorization` header, or via mTLS. Warden authenticates, injects credentials, and either forwards the request to the provider or returns an access grant (database auth token, pre-signed URL) directly. No code changes beyond changing the base URL.
 
-### Transparent Mode
+**Explicit mode** — your workload first authenticates to Warden and receives an IP-bound session token pair, then uses it for subsequent API calls. Required for AWS (SigV4 request signing), optional for all other providers.
 
-The caller sends a request with a JWT in the `Authorization` header (or authenticates via TLS client certificate) and includes the target role in the URL. Warden authenticates the caller, mints an IP-bound session on the first request, and injects provider credentials — all in a single round trip. The session persists until JWT expiry and is bound to the caller's IP (requests from a different IP are denied, not re-authenticated).
-
-```bash
-# Single request — caller authenticates and reaches GitHub in one round trip
-curl -H "Authorization: Bearer <your-jwt>" \
-  https://warden.internal/github/role/my-role/gateway/repos/acme/frontend/contents/README.md
-
-# What happens behind the scenes:
-#   1. Warden verifies the caller's identity and checks policies for role "my-role"
-#   2. Mints a short-lived GitHub token scoped to that role
-#   3. Forwards the request to https://api.github.com/repos/acme/frontend/contents/README.md
-```
-
-Transparent mode works with any provider that uses bearer tokens or API keys: **Anthropic, Azure, GCP, GitHub, GitLab, Vault, Mistral, OpenAI**. It's the simplest integration path — no code changes, no token exchange, one HTTP call.
-
-### Explicit Mode
-
-The caller first authenticates to Warden and receives an IP-bound session token pair, then uses it for subsequent API calls. The token pair mimics AWS credential format so standard AWS tools work out of the box, but the keys are only valid through Warden's gateway, bound to the caller's IP, and expire with the JWT. This two-step flow is required for providers where Warden needs to sign the request itself rather than inject a bearer token.
-
-```bash
-# Step 1: Authenticate and get an IP-bound session token pair from Warden
-CREDS=$(curl -s -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"jwt": "<your-jwt>", "role": "my-role"}' \
-  https://warden.internal/v1/auth/jwt/login)
-
-export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r '.data.data.access_key_id')
-export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r '.data.data.secret_access_key')
-
-# Step 2: Point AWS tools at Warden — Warden verifies the session and re-signs with real credentials
-export AWS_ENDPOINT_URL=https://warden.internal/v1/aws/gateway
-aws s3 ls s3://my-bucket
-```
-
-Explicit mode is **required for AWS** (SigV4 request signing means Warden must hold credentials and sign the entire request). It's also available as an option for all other providers.
-
-| Provider | Transparent | Explicit |
-|----------|:-----------:|:--------:|
-| **AWS** | — | ✅ |
-| **Azure** | ✅ | ✅ |
-| **GCP** | ✅ | ✅ |
-| **GitHub** | ✅ | ✅ |
-| **GitLab** | ✅ | ✅ |
-| **Vault / OpenBao** | ✅ | ✅ |
-| **Anthropic** | ✅ | ✅ |
-| **Mistral** | ✅ | ✅ |
-| **OpenAI** | ✅ | ✅ |
-
-## How It Compares
-
-|  | **Warden** | **Portkey** | **Aembit** |
-|---|---|---|---|
-| Credential isolation | Credentials never leave Warden | Virtual keys stored in Portkey vault | Credentials pass through edge component |
-| Audit granularity | Every API request logged | Logs + cost analytics (Enterprise) | Access grant logged |
-| Policy enforcement | HTTP path + method + runtime conditions (IP, time, day) + AI parameters | Guardrails (PII, jailbreak) | Workload-to-service level |
-| Cloud provider support | AWS, Azure, GCP, GitHub, GitLab, Vault | N/A — AI providers only | Per-provider integration |
-| AI provider support | Anthropic, Mistral, OpenAI | Multiple AI providers | N/A |
-| AI inference governance | Model, token, and parameter policies | Guardrails + rate limiting | N/A |
-| Client modification | Change base URL | Portkey SDK or Universal API | Deploy sidecar agents |
-| Data residency | Fully self-hosted, your infrastructure | SaaS or airgapped (Enterprise) | SaaS only |
-| Deployment | Single self-hosted gateway | SaaS, hybrid, or airgapped | SaaS + edge agents |
-| Open source | Yes (MPL-2.0) | Gateway only (MIT) | No |
-| Credential rotation | Two-stage async (prepare → activate) | N/A — virtual keys only | Automated via SaaS |
-| Streaming support | Full HTTP streaming (SSE, chunked) | Yes | N/A |
-| High availability | Active/standby with automatic failover | SaaS-managed | SaaS-managed |
-| Identity model | JWT, TLS certificate, or SPIFFE SVID for all providers | RBAC + SSO (Enterprise) | Per-provider identity mapping |
+## Why not just use the cloud provider's native tooling?
+ 
+AWS IRSA, GCP Workload Identity, and Azure Managed Identity each solve this within their own cloud. None of them:
+ 
+- Work across multiple cloud providers from a single policy layer
+- Cover databases and storage with the same identity and audit model
+- Give you request-level audit tied to the specific workload identity — not just the IAM role shared by many workloads
+- Work for GitHub, GitLab, or any SaaS API
+- Can be deployed on-premises or in air-gapped environments
+ 
+Warden is the layer that makes workload identity work everywhere, for every credential type, from a single control plane you own.
 
 ## Architecture
 
-Warden is a reverse proxy written in Go. Each provider is registered as a streaming backend with its own credential source driver, authentication flow, and policy rules.
+Warden is a Go service that sits between workloads and providers. Providers are registered as either streaming backends (which proxy traffic to upstream services) or access backends (which vend credentials directly without proxying). Each backend has its own credential source driver, authentication flow, and policy rules.
 
 **Key design decisions:**
-
-- **Inline proxy over credential vending** — Vault hands credentials to the caller. Warden sits in the request path, injecting credentials on the fly. This costs latency and infrastructure, but is what makes per-request audit and per-request policy enforcement possible.
-- **IP-bound sessions** — Sessions are tied to the caller's IP. A stolen session token is useless from a different machine.
-- **Two-stage credential rotation** — Rotation is split into PREPARE (mint new credentials while old ones remain valid) and ACTIVATE (commit new credentials, destroy old ones). For eventually-consistent providers like AWS and Azure, Warden defers activation by a configurable propagation delay, eliminating the polling loops that cloud SDKs typically require.
 - **Seal/unseal model** — Like Vault, Warden protects secrets at rest using envelope encryption. Supports dev mode (in-memory) and production mode with multiple seal types (Shamir, Transit, AWS KMS, GCP KMS, Azure Key Vault, OCI KMS, PKCS11, KMIP) and PostgreSQL storage.
-- **Active/standby HA** — Multiple Warden nodes share a storage backend and use lock-based leader election. One node is active; the rest are hot standbys that forward requests and automatically promote on leader failure. Sealed nodes are prevented from acquiring the leadership lock, eliminating cluster stalls.
+- **Active/standby HA** — See [High Availability](#high-availability) below.
+- **Access grants over proxying for databases** — For providers like RDS where Warden doesn't need to sit in the data path, access backends return ready-to-use connection strings with short-lived tokens. This avoids the latency and complexity of proxying database traffic while preserving identity-based access control and audit attribution.
 - **Namespace isolation** — Every credential source, policy, and mount point is scoped to a namespace with hard boundaries. Policies cannot leak across namespaces.
-
-## Getting Started
-
-### Quick Start (Dev Mode)
-
-Dev mode runs Warden entirely in-memory with automatic initialization and unsealing. No external dependencies — perfect for exploring and testing.
-
-**1. Download the latest release:**
-
-```bash
-# macOS (Apple Silicon)
-curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
-
-# macOS (Intel)
-curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
-
-# Linux (x86_64)
-curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
-
-# Linux (ARM64)
-curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-```
-
-**2. Start the server:**
-
-```bash
-# Using the binary
-./warden server --dev
-
-# Or using Docker
-docker run --rm -p 8400:8400 ghcr.io/stephnangue/warden:latest server --dev
-```
-
-**3. In another terminal, use the Warden client:**
-
-```bash
-export WARDEN_ADDR="http://127.0.0.1:8400"
-export WARDEN_TOKEN="<root-token-from-output>"
-
-./warden --help
-```
-
-Once Warden is running, follow a provider guide to configure your first endpoint:
-
-**Cloud & SaaS Providers:**
-- [AWS](provider/aws/README.md)
-- [Azure](provider/azure/README.md)
-- [GCP](provider/gcp/README.md)
-- [GitHub](provider/github/README.md)
-- [GitLab](provider/gitlab/README.md)
-- [Vault / OpenBao](provider/vault/README.md)
-
-**AI Providers:**
-- [Anthropic](provider/anthropic/README.md)
-- [Mistral](provider/mistral/README.md)
-- [OpenAI](provider/openai/README.md)
-
-> **Warning**: Dev mode stores all data in-memory. Everything is lost on restart. Do not use in production.
-
-### Production Setup
-
-Production mode requires a configuration file and external dependencies (PostgreSQL for storage, and a seal that suits your need).
-
-```bash
-./warden server --config=./warden.hcl
-```
 
 ### High Availability
 
@@ -357,37 +199,9 @@ listener "tcp" {
 
 Warden uses HCL configuration files. See `warden.local.hcl` for a full example covering storage backend, listener, providers, and auth methods.
 
-## Roadmap
-
-**Cloud & SaaS Providers** — Enterprise cloud (Oracle, IBM, Alibaba), specialized cloud (DigitalOcean, Hetzner, OVH), government cloud (GovCloud, Azure Gov), AI/GPU cloud (CoreWeave, Lambda, RunPod), DevOps SaaS (Terraform Cloud, Datadog, Cloudflare), data SaaS (Snowflake, Databricks, MongoDB Atlas), productivity SaaS (Slack, Jira, Notion)
-
-**AI Providers** — Cohere, Google AI (Gemini), xAI, Replicate, Hugging Face, Together AI
-
-**AI Governance** — Per-model cost budgets, token usage tracking, prompt/response audit, rate limiting per agent per model
-
-**Auth** — Kubernetes, cloud machine identities (AWS IAM, Azure MI, GCP SA), OIDC, LDAP, SAML
-
-**Observability** — Structured audit log export (OpenTelemetry, SIEM), new audit device types, Prometheus metrics, distributed tracing
-
-**Security** — Rate limiting per identity, mTLS to upstream providers, audit log tamper detection, additional policy conditions (max request rate, required headers)
-
-**Operations** — Helm chart, Docker Compose quick start, Terraform module
-
-**Developer experience** — Web UI, Swagger/OpenAPI spec, MCP server for AI agent frameworks, SDKs (Go, Python, TypeScript)
-
 ## Contributing
 
 We welcome contributions! See the [contributing guide](CONTRIBUTING.md) for setup instructions, build commands, testing conventions, and submission guidelines.
-
-**Quick reference:**
-
-```bash
-make deps-up          # Start development dependencies
-make brd-fast         # Build and run (skip tests)
-make dev-watch        # Hot reload for development
-make test-unit        # Run unit tests with race detection
-make test-e2e         # Run e2e tests (3-node HA cluster)
-```
 
 ## License
 

--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -39,7 +39,8 @@ type JWTAuthConfig struct {
 	BoundClaims    map[string]any    `json:"bound_claims,omitempty"`
 	ClaimMappings  map[string]string `json:"claim_mappings,omitempty"`
 	UserClaim      string            `json:"user_claim,omitempty" default:"sub"`
-	GroupsClaim    string            `json:"groups_claim,omitempty" default:"groups"`
+	GroupsClaim       string            `json:"groups_claim,omitempty"`
+	GroupPolicyPrefix string            `json:"group_policy_prefix,omitempty"`
 
 	// Token settings
 	TokenTTL  time.Duration `json:"token_ttl" default:"1h"`

--- a/auth/method/jwt/helper.go
+++ b/auth/method/jwt/helper.go
@@ -100,3 +100,41 @@ func extractClaim(claims map[string]interface{}, claimName string) string {
 	}
 	return ""
 }
+
+// extractGroupsClaim extracts a string slice from a JWT claim.
+// Handles: []interface{} (standard JSON array), string (single group),
+// and comma-separated string.
+func extractGroupsClaim(claims map[string]interface{}, claimName string) []string {
+	value, ok := claims[claimName]
+	if !ok {
+		return nil
+	}
+
+	switch v := value.(type) {
+	case []interface{}:
+		groups := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				groups = append(groups, s)
+			}
+		}
+		return groups
+	case string:
+		if v == "" {
+			return nil
+		}
+		if strings.Contains(v, ",") {
+			parts := strings.Split(v, ",")
+			groups := make([]string, 0, len(parts))
+			for _, p := range parts {
+				if s := strings.TrimSpace(p); s != "" {
+					groups = append(groups, s)
+				}
+			}
+			return groups
+		}
+		return []string{v}
+	default:
+		return nil
+	}
+}

--- a/auth/method/jwt/helper_test.go
+++ b/auth/method/jwt/helper_test.go
@@ -461,3 +461,74 @@ func TestExtractClaim_TableDriven(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractGroupsClaim(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   map[string]interface{}
+		claim    string
+		expected []string
+	}{
+		{
+			name:     "string array",
+			claims:   map[string]interface{}{"groups": []interface{}{"db-read", "monitoring"}},
+			claim:    "groups",
+			expected: []string{"db-read", "monitoring"},
+		},
+		{
+			name:     "single string",
+			claims:   map[string]interface{}{"role": "admin"},
+			claim:    "role",
+			expected: []string{"admin"},
+		},
+		{
+			name:     "comma-separated string",
+			claims:   map[string]interface{}{"groups": "db-read,monitoring, admin"},
+			claim:    "groups",
+			expected: []string{"db-read", "monitoring", "admin"},
+		},
+		{
+			name:     "missing claim",
+			claims:   map[string]interface{}{"sub": "user1"},
+			claim:    "groups",
+			expected: nil,
+		},
+		{
+			name:     "empty string",
+			claims:   map[string]interface{}{"groups": ""},
+			claim:    "groups",
+			expected: nil,
+		},
+		{
+			name:     "empty array",
+			claims:   map[string]interface{}{"groups": []interface{}{}},
+			claim:    "groups",
+			expected: []string{},
+		},
+		{
+			name:     "array with non-string elements skipped",
+			claims:   map[string]interface{}{"groups": []interface{}{"admin", 42, "reader"}},
+			claim:    "groups",
+			expected: []string{"admin", "reader"},
+		},
+		{
+			name:     "non-string non-array type returns nil",
+			claims:   map[string]interface{}{"groups": 42},
+			claim:    "groups",
+			expected: nil,
+		},
+		{
+			name:     "cognito:groups nested claim name",
+			claims:   map[string]interface{}{"cognito:groups": []interface{}{"db-read"}},
+			claim:    "cognito:groups",
+			expected: []string{"db-read"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractGroupsClaim(tc.claims, tc.claim)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/auth/method/jwt/path_config.go
+++ b/auth/method/jwt/path_config.go
@@ -68,8 +68,12 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 			},
 			"groups_claim": {
 				Type:        framework.TypeString,
-				Description: "Claim to use for groups (default: groups)",
-				Default:     "groups",
+				Description: "JWT claim containing group names for dynamic policy mapping. Empty disables group-based policies.",
+			},
+			"group_policy_prefix": {
+				Type:        framework.TypeString,
+				Description: "Prefix prepended to each group name to form the policy name (default: group-)",
+				Default:     "group-",
 			},
 			"token_ttl": {
 				Type:        framework.TypeDurationSecond,
@@ -136,8 +140,9 @@ func (b *jwtAuthBackend) handleConfigRead(ctx context.Context, req *logical.Requ
 			"bound_claims":           b.config.BoundClaims,
 			"claim_mappings":         b.config.ClaimMappings,
 			"user_claim":   b.config.UserClaim,
-			"groups_claim": b.config.GroupsClaim,
-			"token_ttl":    b.config.TokenTTL.String(),
+			"groups_claim":        b.config.GroupsClaim,
+			"group_policy_prefix": b.config.GroupPolicyPrefix,
+			"token_ttl":           b.config.TokenTTL.String(),
 			"token_type":   helper.DisplayTokenType(b.config.TokenType),
 			"default_role": b.config.DefaultRole,
 		},
@@ -165,6 +170,7 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 		conf["claim_mappings"] = b.config.ClaimMappings
 		conf["user_claim"] = b.config.UserClaim
 		conf["groups_claim"] = b.config.GroupsClaim
+		conf["group_policy_prefix"] = b.config.GroupPolicyPrefix
 		conf["token_ttl"] = b.config.TokenTTL
 		conf["token_type"] = b.config.TokenType
 		conf["default_role"] = b.config.DefaultRole
@@ -210,6 +216,7 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 			"claim_mappings":         b.config.ClaimMappings,
 			"user_claim":             b.config.UserClaim,
 			"groups_claim":           b.config.GroupsClaim,
+			"group_policy_prefix":   b.config.GroupPolicyPrefix,
 			"token_ttl":              b.config.TokenTTL.String(),
 			"token_type":             b.config.TokenType,
 			"default_role": b.config.DefaultRole,

--- a/auth/method/jwt/path_config_test.go
+++ b/auth/method/jwt/path_config_test.go
@@ -137,7 +137,10 @@ func TestPathConfig_DefaultValues(t *testing.T) {
 	assert.Equal(t, "sub", userClaimField.Default)
 
 	groupsClaimField := path.Fields["groups_claim"]
-	assert.Equal(t, "groups", groupsClaimField.Default)
+	assert.Nil(t, groupsClaimField.Default) // empty = disabled
+
+	groupPolicyPrefixField := path.Fields["group_policy_prefix"]
+	assert.Equal(t, "group-", groupPolicyPrefixField.Default)
 }
 
 func TestPathConfig_Operations(t *testing.T) {

--- a/auth/method/jwt/path_login.go
+++ b/auth/method/jwt/path_login.go
@@ -250,6 +250,30 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 		effectiveTTL = roleTTL
 	}
 
+	// Resolve group-based policies from JWT claims
+	policies := role.TokenPolicies
+	groupsClaim := role.GroupsClaim
+	if groupsClaim == "" {
+		groupsClaim = config.GroupsClaim
+	}
+	if groupsClaim != "" {
+		groups := extractGroupsClaim(claims, groupsClaim)
+		if len(groups) > 0 {
+			prefix := role.GroupPolicyPrefix
+			if prefix == "" {
+				prefix = config.GroupPolicyPrefix
+			}
+			if prefix == "" {
+				prefix = "group-"
+			}
+			groupPolicies := make([]string, len(groups))
+			for i, group := range groups {
+				groupPolicies[i] = prefix + group
+			}
+			policies = append(append([]string{}, policies...), groupPolicies...)
+		}
+	}
+
 	// Return auth response using role configuration.
 	// ClientToken carries the raw JWT so that LoginCreateToken can pass it to
 	// JWTRoleTokenType.Generate(), which hashes jwt+role to compute the
@@ -259,7 +283,7 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 		Auth: &logical.Auth{
 			PrincipalID:    principalID,
 			RoleName:       roleName,
-			Policies:       role.TokenPolicies,
+			Policies:       policies,
 			CredentialSpec: role.CredSpecName,
 			TokenType:      role.TokenType,
 			TokenTTL:       effectiveTTL,

--- a/auth/method/jwt/path_role.go
+++ b/auth/method/jwt/path_role.go
@@ -69,6 +69,14 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Credential spec name",
 			},
+			"groups_claim": {
+				Type:        framework.TypeString,
+				Description: "Override global groups_claim for this role",
+			},
+			"group_policy_prefix": {
+				Type:        framework.TypeString,
+				Description: "Override global group_policy_prefix for this role",
+			},
 			"max_age": {
 				Type:        framework.TypeString,
 				Description: "Maximum elapsed time since JWT was issued (iat). Rejects JWTs older than this. Example: 30m, 1h",
@@ -177,8 +185,10 @@ func (b *jwtAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reques
 			"token_ttl":          role.TokenTTL,
 			"token_type":         helper.DisplayTokenType(role.TokenType),
 			"user_claim":         role.UserClaim,
-			"cred_spec_name":     role.CredSpecName,
-			"max_age":            role.MaxAge,
+			"cred_spec_name":      role.CredSpecName,
+			"groups_claim":        role.GroupsClaim,
+			"group_policy_prefix": role.GroupPolicyPrefix,
+			"max_age":             role.MaxAge,
 		},
 	}, nil
 }
@@ -226,6 +236,12 @@ func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Requ
 		}
 		if v, ok := d.GetOk("cred_spec_name"); ok {
 			role.CredSpecName = v.(string)
+		}
+		if v, ok := d.GetOk("groups_claim"); ok {
+			role.GroupsClaim = v.(string)
+		}
+		if v, ok := d.GetOk("group_policy_prefix"); ok {
+			role.GroupPolicyPrefix = v.(string)
 		}
 		if v, ok := d.GetOk("max_age"); ok {
 			role.MaxAge = v.(string)
@@ -388,6 +404,12 @@ func (b *jwtAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldD
 	}
 	if v, ok := d.GetOk("cred_spec_name"); ok {
 		role.CredSpecName = v.(string)
+	}
+	if v, ok := d.GetOk("groups_claim"); ok {
+		role.GroupsClaim = v.(string)
+	}
+	if v, ok := d.GetOk("group_policy_prefix"); ok {
+		role.GroupPolicyPrefix = v.(string)
 	}
 	if v, ok := d.GetOk("max_age"); ok {
 		role.MaxAge = v.(string)

--- a/auth/method/jwt/role.go
+++ b/auth/method/jwt/role.go
@@ -17,8 +17,10 @@ type JWTRole struct {
 	TokenTTL         string         `json:"token_ttl"`
 	TokenType        string         `json:"token_type,omitempty"`
 	UserClaim        string         `json:"user_claim,omitempty"`
-	CredSpecName     string         `json:"cred_spec_name,omitempty"`
-	MaxAge           string         `json:"max_age,omitempty"`            // Max time since iat (e.g. "30m", "1h"). Empty = no check.
+	CredSpecName      string         `json:"cred_spec_name,omitempty"`
+	GroupsClaim       string         `json:"groups_claim,omitempty"`       // Override global groups_claim for this role
+	GroupPolicyPrefix string         `json:"group_policy_prefix,omitempty"` // Override global group_policy_prefix for this role
+	MaxAge            string         `json:"max_age,omitempty"`            // Max time since iat (e.g. "30m", "1h"). Empty = no check.
 }
 
 // ParseTokenTTL parses the TokenTTL string to a time.Duration.

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/stephnangue/warden/provider/gitlab"
 	"github.com/stephnangue/warden/provider/mistral"
 	"github.com/stephnangue/warden/provider/openai"
+	"github.com/stephnangue/warden/provider/rds"
 	"github.com/stephnangue/warden/provider/vault"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -107,6 +108,7 @@ Usage: warden server [options]
 		"mistral": mistral.Factory,
 		"openai":  openai.Factory,
 		"vault":   vault.Factory,
+		"rds":     rds.Factory,
 	}
 
 	authMethods = map[string]wardenlogical.Factory{

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
-	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/openbao/openbao/sdk/v2/helper/pathmanager"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	authhelper "github.com/stephnangue/warden/auth/helper"
+	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -609,8 +609,8 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 				authPath = ns.CustomMetadata["auto_auth_path"]
 			}
 			if authPath != "" {
-				role := req.HTTPRequest.Header.Get("X-Warden-Role")
-				if err := c.performImplicitAuth(ctx, req, authPath, role); err != nil {
+				authRole := req.HTTPRequest.Header.Get("X-Warden-Role")
+				if err := c.performImplicitAuth(ctx, req, authPath, authRole); err != nil {
 					c.logger.Warn("transparent operations auth failed",
 						logger.Err(err),
 						logger.String("path", req.Path),
@@ -789,6 +789,24 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		return nil, auth, retErr
 	}
 
+	// Access backend returned AccessData → mint credential + let backend format response
+	if resp != nil && resp.AccessData != nil {
+		ad := resp.AccessData
+		if te == nil {
+			c.logger.Error("AccessData returned but no token entry", logger.String("path", req.Path))
+			retErr = multierror.Append(retErr, ErrInternalError)
+			return nil, auth, retErr
+		}
+		te.CredentialSpec = ad.CredentialSpec
+		if err := c.mintCredentialForRequest(ctx, req, te); err != nil {
+			c.logger.Error("failed to mint credential for access request",
+				logger.Err(err), logger.String("path", req.Path))
+			return logical.ErrorResponse(err), auth, nil
+		}
+		resp.Data = ad.ResponseBuilder(req.Credential)
+		resp.AccessData = nil
+	}
+
 	// Return the response and error
 	if routeErr != nil {
 		retErr = multierror.Append(retErr, routeErr)
@@ -949,7 +967,7 @@ func (c *Core) parseFormBody(req *logical.Request) error {
 	return nil
 }
 
-// mintCredentialForRequest mints credentials for streaming requests using the credential manager
+// mintCredentialForRequest mints credentials for requests using the credential manager
 func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Request, te *logical.TokenEntry) error {
 	if te == nil {
 		return logical.ErrInternal("cannot mint credential since token entry is nil")
@@ -1038,33 +1056,33 @@ func (c *Core) isTransparentRequest(req *logical.Request, backend logical.Backen
 		relativePath = strings.TrimPrefix(req.Path, req.MountPoint)
 	}
 
-	// Check if this is a gateway path (transparent mode applies to gateway requests)
-	// Gateway paths are: "gateway", "gateway/...", "role/X/gateway", "role/X/gateway/..."
-	if !strings.HasPrefix(relativePath, "gateway") && !strings.Contains(relativePath, "/gateway") {
+	// Check if this path should trigger transparent auth (delegated to the backend).
+	// Streaming backends match gateway paths; access backends match access/ paths.
+	if !tmp.IsTransparentPath(relativePath) {
 		return false, ""
 	}
 
-	// Extract role from path (may return default role or empty string)
-	role := tmp.GetTransparentRole(relativePath)
+	// Extract auth role from path (may return default auth role or empty string)
+	authRole := tmp.GetAuthRole(relativePath)
 
-	// X-Warden-Role header takes priority over DefaultRole but not over URL-embedded role.
-	// If the path doesn't start with "role/", any role value came from DefaultRole, not the URL.
+	// X-Warden-Role header takes priority over DefaultAuthRole but not over URL-embedded role.
+	// If the path doesn't start with "role/", any role value came from DefaultAuthRole, not the URL.
 	if !strings.HasPrefix(relativePath, "role/") && req.HTTPRequest != nil {
 		if headerRole := req.HTTPRequest.Header.Get("X-Warden-Role"); headerRole != "" {
-			role = headerRole
+			authRole = headerRole
 		}
 	}
 
-	return true, role
+	return true, authRole
 }
 
 // handleTransparentAuth performs implicit authentication for transparent mode (gateway) requests.
 // It delegates to performImplicitAuth for credential detection and login.
-// The role may be empty — the auth method's default_role config provides the fallback.
-func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, backend logical.Backend, role string) error {
+// The authRole may be empty — the auth method's default_role config provides the fallback.
+func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, backend logical.Backend, authRole string) error {
 	tmp := backend.(logical.TransparentModeProvider)
 	autoAuthPath := tmp.GetAutoAuthPath()
-	return c.performImplicitAuth(ctx, req, autoAuthPath, role)
+	return c.performImplicitAuth(ctx, req, autoAuthPath, authRole)
 }
 
 // performImplicitAuth performs implicit authentication by detecting the credential type
@@ -1082,18 +1100,18 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 //	  - Gateway: provider auto_auth_path config
 //	  - Operations: namespace auto_auth_path metadata
 //
-//	Role (first match wins):
+//	Auth role (first match wins):
 //	  1. URL path /role/{name}/gateway/... (gateway only)
 //	  2. X-Warden-Role header
 //	  3. Provider default_role config (gateway only)
 //	  4. Auth method default_role config (login-time fallback)
 //
 // Uses singleflight to prevent duplicate token creation when concurrent requests
-// arrive with the same credential+role combination.
+// arrive with the same credential+authRole combination.
 //
-// IMPORTANT: The role is validated when reusing cached tokens. A token created for
+// IMPORTANT: The auth role is validated when reusing cached tokens. A token created for
 // credential+Role1 cannot be reused for credential+Role2, as they may have different policies.
-func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, autoAuthPath, role string) error {
+func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, autoAuthPath, authRole string) error {
 	// Mark request as transparent mode
 	req.Transparent = true
 
@@ -1119,25 +1137,25 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		// Certificate-based transparent auth
 		hash := sha256.Sum256(clientCert.Raw)
 		fingerprint := hex.EncodeToString(hash[:])
-		sfHash := sha256.Sum256([]byte("cert:" + fingerprint + ":" + role))
+		sfHash := sha256.Sum256([]byte("cert:" + fingerprint + ":" + authRole))
 		singleflightKey = hex.EncodeToString(sfHash[:])
-		loginData = map[string]any{"role": role}
+		loginData = map[string]any{"role": authRole}
 		credType = "cert"
 		credKey = fingerprint
 		lookupFunc = func() (*TokenEntry, error) {
-			return c.LookupCertTokenWithRole(ctx, fingerprint, role)
+			return c.LookupCertTokenWithRole(ctx, fingerprint, authRole)
 		}
 
 	case strings.HasPrefix(req.ClientToken, "eyJ"):
 		// JWT-based transparent auth
 		clientToken := req.ClientToken
-		jwtHash := sha256.Sum256([]byte(clientToken + ":" + role))
+		jwtHash := sha256.Sum256([]byte(clientToken + ":" + authRole))
 		singleflightKey = hex.EncodeToString(jwtHash[:])
-		loginData = map[string]any{"jwt": clientToken, "role": role}
+		loginData = map[string]any{"jwt": clientToken, "role": authRole}
 		credType = "jwt"
 		credKey = clientToken
 		lookupFunc = func() (*TokenEntry, error) {
-			return c.LookupJWTTokenWithRole(ctx, clientToken, role)
+			return c.LookupJWTTokenWithRole(ctx, clientToken, authRole)
 		}
 
 	default:

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -779,7 +779,7 @@ type mockTransparentModeProvider struct {
 	mockProvider
 	transparentMode bool
 	autoAuthPath    string
-	defaultRole     string
+	defaultAuthRole     string
 }
 
 func (m *mockTransparentModeProvider) IsTransparentMode() bool {
@@ -790,7 +790,7 @@ func (m *mockTransparentModeProvider) GetAutoAuthPath() string {
 	return m.autoAuthPath
 }
 
-func (m *mockTransparentModeProvider) GetTransparentRole(path string) string {
+func (m *mockTransparentModeProvider) GetAuthRole(path string) string {
 	// Simple pattern matching for testing: role/{role}/gateway...
 	if strings.HasPrefix(path, "role/") {
 		parts := strings.Split(path, "/")
@@ -798,11 +798,14 @@ func (m *mockTransparentModeProvider) GetTransparentRole(path string) string {
 			return parts[1]
 		}
 	}
-	return m.defaultRole
+	return m.defaultAuthRole
+}
+
+func (m *mockTransparentModeProvider) IsTransparentPath(path string) bool {
+	return strings.HasPrefix(path, "gateway") || strings.Contains(path, "/gateway")
 }
 
 func (m *mockTransparentModeProvider) IsUnauthenticatedPath(path string) bool {
-	// Default to requiring auth for tests
 	return false
 }
 
@@ -832,7 +835,7 @@ func TestIsTransparentRequest(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: false,
 			autoAuthPath:    "auth/jwt/",
-			defaultRole:     "default",
+			defaultAuthRole:     "default",
 		}
 		req := &logical.Request{Path: "role/terraform/gateway/v1/secret"}
 
@@ -845,7 +848,7 @@ func TestIsTransparentRequest(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: true,
 			autoAuthPath:    "auth/jwt/",
-			defaultRole:     "", // No default role
+			defaultAuthRole:     "", // No default role
 		}
 		req := &logical.Request{Path: "config"}
 
@@ -870,7 +873,7 @@ func TestIsTransparentRequest(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: true,
 			autoAuthPath:    "auth/jwt/",
-			defaultRole:     "default-role",
+			defaultAuthRole:     "default-role",
 		}
 		req := &logical.Request{Path: "gateway/v1/secret"}
 
@@ -917,7 +920,7 @@ func TestIsTransparentRequest(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: true,
 			autoAuthPath:    "auth/jwt/",
-			defaultRole:     "fallback",
+			defaultAuthRole:     "fallback",
 		}
 		httpReq := httptest.NewRequest(http.MethodGet, "/v1/vault/gateway/v1/secret", nil)
 		httpReq.Header.Set("X-Warden-Role", "terraform")

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -15,6 +15,7 @@ const (
 	TypeGitLabAccessToken = "gitlab_access_token"
 	TypeGitHubToken       = "github_token"
 	TypeAIAPIKey          = "ai_api_key"
+	TypeDBAuthToken       = "db_auth_token"
 )
 
 // Source type constants

--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	rdsauth "github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -231,8 +232,10 @@ func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 		return d.mintViaSTSAssumeRole(ctx, spec)
 	case "secrets_manager":
 		return d.mintViaSecretsManager(ctx, spec)
+	case "rds_iam_token":
+		return d.mintViaRDSIAMToken(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role' or 'secrets_manager'", mintMethod)
+		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role', 'secrets_manager', or 'rds_iam_token'", mintMethod)
 	}
 }
 
@@ -370,6 +373,53 @@ func applyKeyMap(data map[string]interface{}, keyMapStr string) map[string]inter
 		}
 	}
 	return result
+}
+
+// mintViaRDSIAMToken generates a short-lived IAM authentication token for RDS.
+// The token is a pre-signed STS GetCallerIdentity URL that RDS accepts as a password.
+// This is a local SigV4 signing operation — no network call to RDS.
+func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	dbEndpoint, err := credential.GetStringRequired(spec.Config, "db_endpoint")
+	if err != nil {
+		return nil, 0, "", err
+	}
+	dbUser, err := credential.GetStringRequired(spec.Config, "db_user")
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	dbEngine := credential.GetString(spec.Config, "db_engine", "postgres")
+	dbPort := credential.GetString(spec.Config, "db_port", defaultPortForEngine(dbEngine))
+	region := credential.GetString(spec.Config, "region", d.region)
+
+	endpoint := fmt.Sprintf("%s:%s", dbEndpoint, dbPort)
+
+	token, err := rdsauth.BuildAuthToken(ctx, endpoint, region, dbUser, d.baseCreds)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to build RDS IAM auth token: %w", err)
+	}
+
+	rawData := map[string]interface{}{
+		"auth_token": token,
+		"db_host":    dbEndpoint,
+		"db_port":    dbPort,
+		"db_user":    dbUser,
+		"db_engine":  dbEngine,
+		"region":     region,
+		"token_type": "rds_iam",
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("generated RDS IAM auth token",
+			logger.String("spec", spec.Name),
+			logger.String("endpoint", endpoint),
+			logger.String("db_user", dbUser),
+			logger.String("region", region),
+		)
+	}
+
+	// RDS IAM tokens are valid for 15 minutes
+	return rawData, 15 * time.Minute, "", nil
 }
 
 // Revoke attempts to revoke a credential (best-effort)

--- a/credential/drivers/db_helpers.go
+++ b/credential/drivers/db_helpers.go
@@ -1,0 +1,13 @@
+package drivers
+
+// defaultPortForEngine returns the standard port for common database engines.
+func defaultPortForEngine(engine string) string {
+	switch engine {
+	case "mysql":
+		return "3306"
+	case "sqlserver":
+		return "1433"
+	default: // postgres
+		return "5432"
+	}
+}

--- a/credential/drivers/db_helpers_test.go
+++ b/credential/drivers/db_helpers_test.go
@@ -1,0 +1,15 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultPortForEngine(t *testing.T) {
+	assert.Equal(t, "5432", defaultPortForEngine("postgres"))
+	assert.Equal(t, "3306", defaultPortForEngine("mysql"))
+	assert.Equal(t, "1433", defaultPortForEngine("sqlserver"))
+	assert.Equal(t, "5432", defaultPortForEngine(""))
+	assert.Equal(t, "5432", defaultPortForEngine("unknown"))
+}

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -139,8 +139,9 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 		return nil, fmt.Errorf("failed to get namespace from context: %w", err)
 	}
 
-	// Build namespace-aware cache key: {namespace-uuid}:{tokenID}
-	cacheKey := fmt.Sprintf("%s:%s", ns.ID, tokenID)
+	// Build namespace-aware cache key: {namespace-uuid}:{tokenID}:{specName}
+	// Including specName allows access backends to mint different specs for the same token.
+	cacheKey := fmt.Sprintf("%s:%s:%s", ns.ID, tokenID, specName)
 
 	// Check cache first
 	if cred, found := m.cache.Get(cacheKey); found {

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -36,7 +36,7 @@ func (t *AWSIAMAccessKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 		// Common field for vault and aws sources
 		credential.StringField("mint_method").
-			OneOf("kv2_static", "dynamic_aws", "sts_assume_role", "secrets_manager").
+			OneOf("kv2_static", "dynamic_aws", "sts_assume_role", "secrets_manager", "rds_iam_token").
 			Describe("Method for minting AWS credentials").
 			Example("sts_assume_role"),
 

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -39,5 +39,10 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
+	// Register database auth token type
+	if err := registry.Register(NewDBAuthTokenCredType()); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/types/db_auth_token.go
+++ b/credential/types/db_auth_token.go
@@ -1,0 +1,171 @@
+package types
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+)
+
+// DBAuthTokenCredType handles database IAM authentication tokens for cloud-native databases.
+// Supports RDS IAM auth (AWS), Cloud SQL IAM auth (GCP), and Azure AD database auth.
+type DBAuthTokenCredType struct {
+	*BaseTokenType
+}
+
+// NewDBAuthTokenCredType creates a new database auth token credential type
+func NewDBAuthTokenCredType() *DBAuthTokenCredType {
+	return &DBAuthTokenCredType{
+		BaseTokenType: &BaseTokenType{
+			TypeMetadata: credential.TypeMetadata{
+				Name:        credential.TypeDBAuthToken,
+				Category:    credential.CategoryDatabase,
+				Description: "Database IAM authentication token for cloud-native databases",
+				DefaultTTL:  15 * time.Minute, // RDS tokens valid for 15 min; GCP/Azure ~1 hour
+			},
+			FieldConfig: TokenFieldConfig{
+				PrimaryField:      "auth_token",
+				AlternativeFields: []string{},
+				OptionalFields: []string{
+					"db_host", "db_port", "db_user", "db_engine",
+					"token_type", "region", "instance_connection_name",
+				},
+				FieldSchemas: map[string]*credential.CredentialFieldSchema{
+					"auth_token": {
+						Description: "Database IAM auth token (used as password)",
+						Sensitive:   true,
+					},
+					"db_host": {
+						Description: "Database hostname",
+						Sensitive:   false,
+					},
+					"db_port": {
+						Description: "Database port",
+						Sensitive:   false,
+					},
+					"db_user": {
+						Description: "Database user",
+						Sensitive:   false,
+					},
+					"db_engine": {
+						Description: "Database engine (postgres, mysql, sqlserver)",
+						Sensitive:   false,
+					},
+					"token_type": {
+						Description: "Token type (rds_iam, gcp_oauth2, azure_ad)",
+						Sensitive:   false,
+					},
+					"region": {
+						Description: "Cloud region",
+						Sensitive:   false,
+					},
+					"instance_connection_name": {
+						Description: "Cloud SQL instance connection name",
+						Sensitive:   false,
+					},
+				},
+			},
+			Revocable: false, // All DB IAM tokens expire naturally
+		},
+	}
+}
+
+// ConfigSchema returns the declarative schema for database auth token credential config
+func (t *DBAuthTokenCredType) ConfigSchema() []*credential.FieldValidator {
+	return []*credential.FieldValidator{
+		credential.StringField("mint_method").
+			OneOf("rds_iam_token", "cloud_sql_iam_token", "azure_db_iam_token").
+			Describe("Method for minting database IAM auth tokens").
+			Example("rds_iam_token"),
+
+		credential.StringField("db_user").
+			Required().
+			Describe("Database user to authenticate as").
+			Example("app_readonly"),
+
+		credential.StringField("db_endpoint").
+			Describe("Database endpoint hostname (required for rds_iam_token)").
+			Example("mydb.abc123.us-east-1.rds.amazonaws.com"),
+
+		credential.StringField("db_host").
+			Describe("Database hostname (required for azure_db_iam_token)").
+			Example("mydb.postgres.database.azure.com"),
+
+		credential.StringField("db_port").
+			Describe("Database port (defaults based on engine: postgres=5432, mysql=3306, sqlserver=1433)").
+			Example("5432"),
+
+		credential.StringField("db_engine").
+			OneOf("postgres", "mysql", "sqlserver").
+			Describe("Database engine type").
+			Example("postgres"),
+
+		credential.StringField("region").
+			Describe("Cloud region (defaults to source region for AWS)").
+			Example("us-east-1"),
+
+		credential.StringField("role_arn").
+			Describe("AWS IAM role ARN for cross-account access (rds_iam_token)").
+			Example("arn:aws:iam::123456789:role/db-access"),
+
+		credential.StringField("target_service_account").
+			Describe("GCP service account to impersonate (required for cloud_sql_iam_token)").
+			Example("db-reader@myproject.iam.gserviceaccount.com"),
+
+		credential.StringField("instance_connection_name").
+			Describe("Cloud SQL instance connection name (optional metadata for cloud_sql_iam_token)").
+			Example("myproject:us-central1:mydb"),
+
+		credential.StringField("resource_uri").
+			Describe("Azure AD resource URI override (azure_db_iam_token)").
+			Example("https://ossrdbms-aad.database.windows.net/"),
+	}
+}
+
+// ValidateConfig validates the config for a database auth token credential spec.
+// Cross-validates mint_method against source type and required fields.
+func (t *DBAuthTokenCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	schema := t.ConfigSchema()
+	if err := credential.ValidateSchema(config, schema...); err != nil {
+		return err
+	}
+
+	mintMethod := config["mint_method"]
+	switch mintMethod {
+	case "rds_iam_token":
+		if sourceType != credential.SourceTypeAWS {
+			return fmt.Errorf("rds_iam_token requires an aws source, got: %s", sourceType)
+		}
+		if config["db_endpoint"] == "" {
+			return fmt.Errorf("rds_iam_token requires db_endpoint")
+		}
+	case "cloud_sql_iam_token":
+		if sourceType != credential.SourceTypeGCP {
+			return fmt.Errorf("cloud_sql_iam_token requires a gcp source, got: %s", sourceType)
+		}
+		if config["target_service_account"] == "" {
+			return fmt.Errorf("cloud_sql_iam_token requires target_service_account")
+		}
+	case "azure_db_iam_token":
+		if sourceType != credential.SourceTypeAzure {
+			return fmt.Errorf("azure_db_iam_token requires an azure source, got: %s", sourceType)
+		}
+		if config["db_host"] == "" {
+			return fmt.Errorf("azure_db_iam_token requires db_host")
+		}
+	default:
+		return fmt.Errorf("unsupported mint_method: %s", mintMethod)
+	}
+
+	return nil
+}
+
+// RequiresSpecRotation returns false — DB auth tokens are short-lived and don't need spec rotation.
+func (t *DBAuthTokenCredType) RequiresSpecRotation() bool {
+	return false
+}
+
+// SensitiveConfigFields returns spec config keys that should be masked in output
+func (t *DBAuthTokenCredType) SensitiveConfigFields() []string {
+	return nil
+}

--- a/credential/types/db_auth_token_test.go
+++ b/credential/types/db_auth_token_test.go
@@ -1,0 +1,164 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBAuthTokenCredType_Metadata(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+	meta := ct.Metadata()
+	assert.Equal(t, credential.TypeDBAuthToken, meta.Name)
+	assert.Equal(t, credential.CategoryDatabase, meta.Category)
+	assert.Equal(t, 15*time.Minute, meta.DefaultTTL)
+}
+
+func TestDBAuthTokenCredType_Parse(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	rawData := map[string]interface{}{
+		"auth_token": "my-iam-token-xyz",
+		"db_host":    "mydb.abc123.us-east-1.rds.amazonaws.com",
+		"db_port":    "5432",
+		"db_user":    "app_readonly",
+		"db_engine":  "postgres",
+		"token_type": "rds_iam",
+		"region":     "us-east-1",
+	}
+
+	cred, err := ct.Parse(rawData, 15*time.Minute, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, credential.TypeDBAuthToken, cred.Type)
+	assert.Equal(t, credential.CategoryDatabase, cred.Category)
+	assert.Equal(t, 15*time.Minute, cred.LeaseTTL)
+	assert.False(t, cred.Revocable)
+	assert.Equal(t, "my-iam-token-xyz", cred.Data["auth_token"])
+	assert.Equal(t, "mydb.abc123.us-east-1.rds.amazonaws.com", cred.Data["db_host"])
+	assert.Equal(t, "5432", cred.Data["db_port"])
+	assert.Equal(t, "app_readonly", cred.Data["db_user"])
+	assert.Equal(t, "postgres", cred.Data["db_engine"])
+	assert.Equal(t, "rds_iam", cred.Data["token_type"])
+	assert.Equal(t, "us-east-1", cred.Data["region"])
+}
+
+func TestDBAuthTokenCredType_Parse_MissingToken(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	rawData := map[string]interface{}{
+		"db_host": "mydb.rds.amazonaws.com",
+	}
+
+	_, err := ct.Parse(rawData, 15*time.Minute, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "auth_token")
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_RDS(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method": "rds_iam_token",
+		"db_user":     "app_readonly",
+		"db_endpoint": "mydb.abc123.us-east-1.rds.amazonaws.com",
+		"db_engine":   "postgres",
+		"region":      "us-east-1",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeAWS)
+	assert.NoError(t, err)
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_RDS_WrongSource(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method": "rds_iam_token",
+		"db_user":     "app_readonly",
+		"db_endpoint": "mydb.rds.amazonaws.com",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeGCP)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "aws source")
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_RDS_MissingEndpoint(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method": "rds_iam_token",
+		"db_user":     "app_readonly",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeAWS)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db_endpoint")
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_CloudSQL(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method":            "cloud_sql_iam_token",
+		"db_user":               "db-reader@myproject.iam",
+		"target_service_account": "db-reader@myproject.iam.gserviceaccount.com",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeGCP)
+	assert.NoError(t, err)
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_CloudSQL_WrongSource(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method":            "cloud_sql_iam_token",
+		"db_user":               "db-reader",
+		"target_service_account": "sa@proj.iam.gserviceaccount.com",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeAWS)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "gcp source")
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_Azure(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method": "azure_db_iam_token",
+		"db_user":     "app-identity@mydb",
+		"db_host":     "mydb.postgres.database.azure.com",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeAzure)
+	assert.NoError(t, err)
+}
+
+func TestDBAuthTokenCredType_ValidateConfig_Azure_MissingHost(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+
+	config := map[string]string{
+		"mint_method": "azure_db_iam_token",
+		"db_user":     "app-identity",
+	}
+
+	err := ct.ValidateConfig(config, credential.SourceTypeAzure)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db_host")
+}
+
+func TestDBAuthTokenCredType_RequiresSpecRotation(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+	assert.False(t, ct.RequiresSpecRotation())
+}
+
+func TestDBAuthTokenCredType_SensitiveConfigFields(t *testing.T) {
+	ct := NewDBAuthTokenCredType()
+	assert.Nil(t, ct.SensitiveConfigFields())
+}

--- a/framework/access_backend.go
+++ b/framework/access_backend.go
@@ -1,0 +1,192 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// AccessConfig holds the transparent mode configuration for access backends.
+type AccessConfig struct {
+	TransparentMode bool   `json:"transparent_mode"`
+	AutoAuthPath    string `json:"auto_auth_path"`
+}
+
+// AccessBackend implements logical.Backend for access backends that vend access grants
+// (connection strings, presigned URLs, etc.) without proxying traffic.
+// It provides transparent mode support and storage access, paralleling StreamingBackend
+// for proxy providers.
+type AccessBackend struct {
+	*Backend
+
+	// Logger is the provider's scoped logger.
+	Logger *logger.GatedLogger
+
+	// StorageView is the provider's storage backend for persisting configuration.
+	StorageView sdklogical.Storage
+
+	// AccessPathPrefix is the path prefix that triggers transparent auth.
+	// Defaults to "access/" if empty.
+	AccessPathPrefix string
+
+	// cfg holds the persisted transparent mode configuration.
+	cfg *AccessConfig
+}
+
+// Compile-time interface assertions
+var _ logical.Backend = (*AccessBackend)(nil)
+var _ logical.TransparentModeProvider = (*AccessBackend)(nil)
+
+// Setup initializes the access backend with the provided configuration.
+// It loads persisted config from storage.
+func (b *AccessBackend) Setup(ctx context.Context, conf *logical.BackendConfig) error {
+	b.StorageView = conf.StorageView
+	if b.Logger == nil {
+		b.Logger = conf.Logger
+	}
+	if err := b.Backend.Setup(ctx, conf); err != nil {
+		return err
+	}
+	b.cfg = &AccessConfig{}
+	b.loadConfig(ctx)
+	return nil
+}
+
+// --- TransparentModeProvider implementation ---
+
+// IsTransparentMode returns whether transparent mode is enabled.
+func (b *AccessBackend) IsTransparentMode() bool {
+	return b.cfg != nil && b.cfg.TransparentMode
+}
+
+// GetAutoAuthPath returns the auth mount path for implicit authentication.
+func (b *AccessBackend) GetAutoAuthPath() string {
+	if b.cfg == nil {
+		return ""
+	}
+	return b.cfg.AutoAuthPath
+}
+
+// GetAuthRole returns empty string — auth role resolution is the auth
+// method's responsibility (via X-Warden-Role header or auth method's default_role).
+func (b *AccessBackend) GetAuthRole(path string) string {
+	return ""
+}
+
+// IsTransparentPath checks if the given path should trigger transparent authentication.
+// Matches paths starting with the configured access path prefix (default "access/").
+func (b *AccessBackend) IsTransparentPath(path string) bool {
+	prefix := b.AccessPathPrefix
+	if prefix == "" {
+		prefix = "access/"
+	}
+	return strings.HasPrefix(path, prefix)
+}
+
+// IsUnauthenticatedPath returns false — all access paths require authentication.
+func (b *AccessBackend) IsUnauthenticatedPath(path string) bool {
+	return false
+}
+
+// --- Config persistence ---
+
+// GetAccessConfig returns the current access configuration.
+func (b *AccessBackend) GetAccessConfig() *AccessConfig {
+	if b.cfg == nil {
+		return &AccessConfig{}
+	}
+	return b.cfg
+}
+
+// SetAccessConfig updates and persists the access configuration.
+func (b *AccessBackend) SetAccessConfig(ctx context.Context, cfg *AccessConfig) error {
+	b.cfg = cfg
+	entry, err := sdklogical.StorageEntryJSON("access_config", cfg)
+	if err != nil {
+		return err
+	}
+	return b.StorageView.Put(ctx, entry)
+}
+
+// loadConfig loads persisted access configuration from storage.
+func (b *AccessBackend) loadConfig(ctx context.Context) {
+	if b.StorageView == nil {
+		return
+	}
+	entry, err := b.StorageView.Get(ctx, "access_config")
+	if err != nil || entry == nil {
+		return
+	}
+	var cfg AccessConfig
+	if err := json.Unmarshal(entry.Value, &cfg); err != nil {
+		return
+	}
+	b.cfg = &cfg
+}
+
+// PathAccessConfig returns a standard config path for access backends.
+// Providers can include this in their paths() to get config CRUD for free.
+func (b *AccessBackend) PathAccessConfig() *Path {
+	return &Path{
+		Pattern: "config",
+		Fields: map[string]*FieldSchema{
+			"transparent_mode": {
+				Type:        TypeBool,
+				Description: "Enable transparent mode for implicit JWT authentication",
+				Default:     false,
+			},
+			"auto_auth_path": {
+				Type:        TypeString,
+				Description: "Auth mount path for implicit authentication (e.g., auth/jwt/)",
+			},
+		},
+		Operations: map[logical.Operation]OperationHandler{
+			logical.ReadOperation: &PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read access backend configuration",
+			},
+			logical.UpdateOperation: &PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure access backend",
+			},
+		},
+		HelpSynopsis:    "Configure access backend",
+		HelpDescription: "Configure transparent mode and authentication settings.",
+	}
+}
+
+func (b *AccessBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *FieldData) (*logical.Response, error) {
+	cfg := b.GetAccessConfig()
+	return &logical.Response{
+		StatusCode: 200,
+		Data: map[string]any{
+			"transparent_mode": cfg.TransparentMode,
+			"auto_auth_path":   cfg.AutoAuthPath,
+		},
+	}, nil
+}
+
+func (b *AccessBackend) handleConfigWrite(ctx context.Context, _ *logical.Request, d *FieldData) (*logical.Response, error) {
+	cfg := b.GetAccessConfig()
+
+	if v, ok := d.GetOk("transparent_mode"); ok {
+		cfg.TransparentMode = v.(bool)
+	}
+	if v, ok := d.GetOk("auto_auth_path"); ok {
+		cfg.AutoAuthPath = v.(string)
+	}
+
+	if cfg.TransparentMode && cfg.AutoAuthPath == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("auto_auth_path is required when transparent_mode is enabled")), nil
+	}
+
+	if err := b.SetAccessConfig(ctx, cfg); err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{StatusCode: 204}, nil
+}

--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -28,14 +28,14 @@ const (
 	DefaultTimeout     = 30 * time.Second
 )
 
-// DefaultTransparentRolePattern is the default pattern for extracting role from transparent paths.
-// Matches: role/{role}/gateway... and extracts the role name.
-var DefaultTransparentRolePattern = regexp.MustCompile(`^role/([^/]+)/gateway`)
+// DefaultAuthRolePattern is the default pattern for extracting the auth role from transparent paths.
+// Matches: role/{role}/gateway... and extracts the auth role name.
+var DefaultAuthRolePattern = regexp.MustCompile(`^role/([^/]+)/gateway`)
 
 // DefaultPathRewriter rewrites transparent paths to standard paths.
 // Converts: role/X/gateway/... -> gateway/...
 func DefaultPathRewriter(path string) string {
-	return DefaultTransparentRolePattern.ReplaceAllString(path, "gateway")
+	return DefaultAuthRolePattern.ReplaceAllString(path, "gateway")
 }
 
 // TransparentConfig holds declarative transparent mode configuration.
@@ -48,13 +48,13 @@ type TransparentConfig struct {
 	// AutoAuthPath is the auth mount path for implicit authentication (e.g., "auth/jwt/")
 	AutoAuthPath string
 
-	// DefaultRole is the role to use when not specified in URL path
-	DefaultRole string
+	// DefaultAuthRole is the auth role to use when not specified in URL path
+	DefaultAuthRole string
 
-	// RolePattern is the regex pattern to extract role from path (optional)
-	// If nil, uses DefaultTransparentRolePattern: `^role/([^/]+)/gateway`
-	// First capture group is used as the role name
-	RolePattern *regexp.Regexp
+	// AuthRolePattern is the regex pattern to extract the auth role from path (optional)
+	// If nil, uses DefaultAuthRolePattern: `^role/([^/]+)/gateway`
+	// First capture group is used as the auth role name
+	AuthRolePattern *regexp.Regexp
 
 	// PathRewriter converts transparent paths to standard paths (optional)
 	// If nil, uses DefaultPathRewriter: role/X/gateway/... -> gateway/...
@@ -507,23 +507,23 @@ func (b *StreamingBackend) GetAutoAuthPath() string {
 	return b.TransparentConfig.AutoAuthPath
 }
 
-// GetTransparentRole extracts the role name from the request path
-func (b *StreamingBackend) GetTransparentRole(path string) string {
+// GetAuthRole extracts the auth role name from the request path for implicit login.
+func (b *StreamingBackend) GetAuthRole(path string) string {
 	if b.TransparentConfig == nil {
 		return ""
 	}
 
 	// Use custom pattern or default
-	pattern := b.TransparentConfig.RolePattern
+	pattern := b.TransparentConfig.AuthRolePattern
 	if pattern == nil {
-		pattern = DefaultTransparentRolePattern
+		pattern = DefaultAuthRolePattern
 	}
 
 	matches := pattern.FindStringSubmatch(path)
 	if len(matches) > 1 {
-		return matches[1] // First capture group is the role
+		return matches[1] // First capture group is the auth role
 	}
-	return b.TransparentConfig.DefaultRole
+	return b.TransparentConfig.DefaultAuthRole
 }
 
 // RewriteTransparentPath rewrites a transparent path to standard path
@@ -604,6 +604,13 @@ func (b *StreamingBackend) initUnauthPaths() {
 		paths:         tree,
 		wildcardPaths: wildcards,
 	}
+}
+
+// IsTransparentPath checks if the given path should trigger transparent authentication.
+// For streaming backends, this matches gateway paths: "gateway", "gateway/...",
+// "role/X/gateway", "role/X/gateway/...".
+func (b *StreamingBackend) IsTransparentPath(path string) bool {
+	return strings.HasPrefix(path, "gateway") || strings.Contains(path, "/gateway")
 }
 
 // IsUnauthenticatedPath checks if the path matches an unauthenticated pattern.

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1h
 github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.12 h1:oqtA6v+y5fZg//tcTWahyN9PEn5eDU/Wpvc2+kJ4aY8=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.12/go.mod h1:U3R1RtSHx6NB0DvEQFGyf/0sbrpJrluENHdPy1j/3TE=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.20 h1:nBtAkfvLanKNwKfmsxfpLqYAjKpTAO9yRfuXAKconUY=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.20/go.mod h1:wtCkeFPPKHdxFPrZGkdT5tKR4boa3GvW54sYdGNWPHg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -119,15 +119,20 @@ type TransparentModeProvider interface {
 	// GetAutoAuthPath returns the auth mount path for implicit authentication (e.g., "auth/jwt/")
 	GetAutoAuthPath() string
 
-	// GetTransparentRole extracts the role name from the request path
-	// For path pattern /role/{role}/gateway/*, returns the role
-	// Returns empty string if path doesn't match transparent pattern
-	GetTransparentRole(path string) string
+	// GetAuthRole extracts the auth role name from the request path for implicit login.
+	// For path pattern /role/{role}/gateway/*, returns the auth role.
+	// Returns empty string if path doesn't match transparent pattern.
+	GetAuthRole(path string) string
 
 	// IsUnauthenticatedPath checks if a path can be accessed without authentication
 	// in transparent mode. Used for read-only endpoints that clients may access
 	// without sending tokens (e.g., PKI certificate PEM files).
 	IsUnauthenticatedPath(path string) bool
+
+	// IsTransparentPath checks if the given path (relative to mount) should trigger
+	// transparent authentication. Streaming backends match gateway paths;
+	// access backends match access/ paths.
+	IsTransparentPath(path string) bool
 }
 
 // StreamBodyParser can be implemented by streaming backends that want the core

--- a/logical/response.go
+++ b/logical/response.go
@@ -2,6 +2,8 @@ package logical
 
 import (
 	"net/http"
+
+	"github.com/stephnangue/warden/credential"
 )
 
 // Response is a struct that holds the response from a logical backend.
@@ -11,6 +13,11 @@ type Response struct {
 	// Auth, if not nil, contains the authentication information for
 	// this response.
 	Auth *Auth `json:"auth" structs:"auth" mapstructure:"auth"`
+
+	// AccessData, if not nil, signals the core to mint a credential and let
+	// the backend format the response. Mirrors Auth: the backend declares what
+	// it needs, the core handles minting. Cleared before the HTTP response.
+	AccessData *AccessData `json:"-"`
 
 	// StatusCode is the HTTP status code for the response.
 	StatusCode int
@@ -36,6 +43,20 @@ type Response struct {
 
 	// Warnings contains any warnings generated during processing
 	Warnings []string
+}
+
+// AccessData is returned by access backends to request credential minting.
+// Mirrors Auth: the backend declares what it needs, the core handles minting.
+// ResponseBuilder lets each backend own its response format (connection string,
+// presigned URL, raw credentials, etc.) — the core never interprets the output.
+type AccessData struct {
+	// CredentialSpec is the name of the credential spec to mint.
+	CredentialSpec string
+
+	// ResponseBuilder formats the minted credential into the final response data.
+	// The backend closes over its role config and produces whatever fields make sense
+	// for the access type (e.g., "connection_string" for databases, "presigned_url" for S3).
+	ResponseBuilder func(cred *credential.Credential) map[string]interface{}
 }
 
 // NewResponse creates a new Response with default values.

--- a/provider/anthropic/config.go
+++ b/provider/anthropic/config.go
@@ -23,7 +23,7 @@ type ProviderConfig struct {
 	Timeout         time.Duration
 	TransparentMode bool
 	AutoAuthPath    string
-	DefaultRole     string
+	DefaultAuthRole string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
@@ -90,7 +90,7 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		config.AutoAuthPath = aap
 	}
 	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultRole = dr
+		config.DefaultAuthRole = dr
 	}
 
 	return config

--- a/provider/anthropic/path_config.go
+++ b/provider/anthropic/path_config.go
@@ -72,7 +72,7 @@ func (b *anthropicBackend) handleConfigRead(_ context.Context, _ *logical.Reques
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -109,7 +109,7 @@ func (b *anthropicBackend) handleConfigWrite(ctx context.Context, _ *logical.Req
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -118,7 +118,7 @@ func (b *anthropicBackend) handleConfigWrite(ctx context.Context, _ *logical.Req
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 	if tc.Enabled && tc.AutoAuthPath == "" {
@@ -138,7 +138,7 @@ func (b *anthropicBackend) handleConfigWrite(ctx context.Context, _ *logical.Req
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/anthropic/provider.go
+++ b/provider/anthropic/provider.go
@@ -77,7 +77,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      false,
 			AutoAuthPath: "",
-			DefaultRole:  "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           anthropicBackendHelp,
@@ -122,7 +122,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      parsedConfig.TransparentMode,
 			AutoAuthPath: parsedConfig.AutoAuthPath,
-			DefaultRole:  parsedConfig.DefaultRole,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
 
@@ -146,7 +146,7 @@ func (b *anthropicBackend) Initialize(ctx context.Context) error {
 			Timeout         string `json:"timeout"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -164,7 +164,7 @@ func (b *anthropicBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
 		// No persisted config — persist defaults
@@ -175,7 +175,7 @@ func (b *anthropicBackend) Initialize(ctx context.Context) error {
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)

--- a/provider/anthropic/provider_test.go
+++ b/provider/anthropic/provider_test.go
@@ -104,7 +104,7 @@ func TestParseConfig(t *testing.T) {
 		})
 		assert.True(t, config.TransparentMode)
 		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
-		assert.Equal(t, "reader", config.DefaultRole)
+		assert.Equal(t, "reader", config.DefaultAuthRole)
 	})
 }
 

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -14,7 +14,7 @@ type ProviderConfig struct {
 	Timeout         time.Duration
 	TransparentMode bool
 	AutoAuthPath    string
-	DefaultRole     string
+	DefaultAuthRole string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
@@ -85,7 +85,7 @@ func parseConfig(conf map[string]any) ProviderConfig {
 
 	// Parse default_role
 	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultRole = dr
+		config.DefaultAuthRole = dr
 	}
 
 	return config

--- a/provider/azure/path_config.go
+++ b/provider/azure/path_config.go
@@ -65,7 +65,7 @@ func (b *azureBackend) handleConfigRead(ctx context.Context, req *logical.Reques
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -91,7 +91,7 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -100,7 +100,7 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 
@@ -121,7 +121,7 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/azure/provider.go
+++ b/provider/azure/provider.go
@@ -69,9 +69,9 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			},
 		},
 		TransparentConfig: &framework.TransparentConfig{
-			Enabled:      false, // Updated via config write or Initialize
-			AutoAuthPath: "",
-			DefaultRole:  "",
+			Enabled:         false, // Updated via config write or Initialize
+			AutoAuthPath:    "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           azureBackendHelp,
@@ -114,7 +114,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      parsedConfig.TransparentMode,
 			AutoAuthPath: parsedConfig.AutoAuthPath,
-			DefaultRole:  parsedConfig.DefaultRole,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
 
@@ -138,7 +138,7 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 			Timeout         string `json:"timeout"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -153,7 +153,7 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
 		// No persisted config — persist the defaults so a newly enabled
@@ -164,7 +164,7 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)

--- a/provider/azure/provider_test.go
+++ b/provider/azure/provider_test.go
@@ -194,7 +194,7 @@ func TestParseConfig(t *testing.T) {
 		assert.Equal(t, 60*time.Second, config.Timeout)
 		assert.True(t, config.TransparentMode)
 		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
-		assert.Equal(t, "my-role", config.DefaultRole)
+		assert.Equal(t, "my-role", config.DefaultAuthRole)
 	})
 
 	t.Run("timeout as integer seconds", func(t *testing.T) {

--- a/provider/gcp/config.go
+++ b/provider/gcp/config.go
@@ -14,7 +14,7 @@ type ProviderConfig struct {
 	Timeout         time.Duration
 	TransparentMode bool
 	AutoAuthPath    string
-	DefaultRole     string
+	DefaultAuthRole string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
@@ -85,7 +85,7 @@ func parseConfig(conf map[string]any) ProviderConfig {
 
 	// Parse default_role
 	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultRole = dr
+		config.DefaultAuthRole = dr
 	}
 
 	return config

--- a/provider/gcp/path_config.go
+++ b/provider/gcp/path_config.go
@@ -65,7 +65,7 @@ func (b *gcpBackend) handleConfigRead(ctx context.Context, req *logical.Request,
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -91,7 +91,7 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -100,7 +100,7 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 
@@ -121,7 +121,7 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/gcp/provider.go
+++ b/provider/gcp/provider.go
@@ -69,9 +69,9 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			},
 		},
 		TransparentConfig: &framework.TransparentConfig{
-			Enabled:      false, // Updated via config write or Initialize
-			AutoAuthPath: "",
-			DefaultRole:  "",
+			Enabled:         false, // Updated via config write or Initialize
+			AutoAuthPath:    "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           gcpBackendHelp,
@@ -114,7 +114,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      parsedConfig.TransparentMode,
 			AutoAuthPath: parsedConfig.AutoAuthPath,
-			DefaultRole:  parsedConfig.DefaultRole,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
 
@@ -138,7 +138,7 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 			Timeout         string `json:"timeout"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -153,7 +153,7 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
 		// No persisted config — persist the defaults so a newly enabled
@@ -164,7 +164,7 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)

--- a/provider/gcp/provider_test.go
+++ b/provider/gcp/provider_test.go
@@ -200,7 +200,7 @@ func TestParseConfig(t *testing.T) {
 		assert.Equal(t, 60*time.Second, config.Timeout)
 		assert.True(t, config.TransparentMode)
 		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
-		assert.Equal(t, "my-role", config.DefaultRole)
+		assert.Equal(t, "my-role", config.DefaultAuthRole)
 	})
 
 	t.Run("timeout as integer seconds", func(t *testing.T) {

--- a/provider/github/config.go
+++ b/provider/github/config.go
@@ -24,7 +24,7 @@ type ProviderConfig struct {
 	APIVersion      string
 	TransparentMode bool
 	AutoAuthPath    string
-	DefaultRole     string
+	DefaultAuthRole string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
@@ -96,7 +96,7 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		config.AutoAuthPath = aap
 	}
 	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultRole = dr
+		config.DefaultAuthRole = dr
 	}
 
 	return config

--- a/provider/github/path_config.go
+++ b/provider/github/path_config.go
@@ -78,7 +78,7 @@ func (b *githubBackend) handleConfigRead(_ context.Context, _ *logical.Request, 
 			"api_version":      b.apiVersion,
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -122,7 +122,7 @@ func (b *githubBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -131,7 +131,7 @@ func (b *githubBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 	if tc.Enabled && tc.AutoAuthPath == "" {
@@ -152,7 +152,7 @@ func (b *githubBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 			"api_version":      b.apiVersion,
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/github/provider.go
+++ b/provider/github/provider.go
@@ -69,9 +69,9 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			},
 		},
 		TransparentConfig: &framework.TransparentConfig{
-			Enabled:      false,
-			AutoAuthPath: "",
-			DefaultRole:  "",
+			Enabled:         false,
+			AutoAuthPath:    "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           githubBackendHelp,
@@ -118,7 +118,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      parsedConfig.TransparentMode,
 			AutoAuthPath: parsedConfig.AutoAuthPath,
-			DefaultRole:  parsedConfig.DefaultRole,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
 
@@ -143,7 +143,7 @@ func (b *githubBackend) Initialize(ctx context.Context) error {
 			APIVersion      string `json:"api_version"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -164,7 +164,7 @@ func (b *githubBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
 		// No persisted config — persist defaults
@@ -176,7 +176,7 @@ func (b *githubBackend) Initialize(ctx context.Context) error {
 			"api_version":      b.apiVersion,
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)

--- a/provider/github/provider_test.go
+++ b/provider/github/provider_test.go
@@ -92,7 +92,7 @@ func TestParseConfig(t *testing.T) {
 		})
 		assert.True(t, config.TransparentMode)
 		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
-		assert.Equal(t, "reader", config.DefaultRole)
+		assert.Equal(t, "reader", config.DefaultAuthRole)
 	})
 }
 

--- a/provider/gitlab/path_config.go
+++ b/provider/gitlab/path_config.go
@@ -71,7 +71,7 @@ func (b *gitlabBackend) handleConfigRead(_ context.Context, _ *logical.Request, 
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -105,7 +105,7 @@ func (b *gitlabBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -114,7 +114,7 @@ func (b *gitlabBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 	if tc.Enabled && tc.AutoAuthPath == "" {
@@ -134,7 +134,7 @@ func (b *gitlabBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/gitlab/provider.go
+++ b/provider/gitlab/provider.go
@@ -69,9 +69,9 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			},
 		},
 		TransparentConfig: &framework.TransparentConfig{
-			Enabled:      false,
-			AutoAuthPath: "",
-			DefaultRole:  "",
+			Enabled:         false,
+			AutoAuthPath:    "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           gitlabBackendHelp,
@@ -133,7 +133,7 @@ func (b *gitlabBackend) Initialize(ctx context.Context) error {
 			Timeout         string `json:"timeout"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -149,7 +149,7 @@ func (b *gitlabBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	}
 	return nil

--- a/provider/mistral/config.go
+++ b/provider/mistral/config.go
@@ -23,7 +23,7 @@ type ProviderConfig struct {
 	Timeout         time.Duration
 	TransparentMode bool
 	AutoAuthPath    string
-	DefaultRole     string
+	DefaultAuthRole string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
@@ -90,7 +90,7 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		config.AutoAuthPath = aap
 	}
 	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultRole = dr
+		config.DefaultAuthRole = dr
 	}
 
 	return config

--- a/provider/mistral/path_config.go
+++ b/provider/mistral/path_config.go
@@ -72,7 +72,7 @@ func (b *mistralBackend) handleConfigRead(_ context.Context, _ *logical.Request,
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -109,7 +109,7 @@ func (b *mistralBackend) handleConfigWrite(ctx context.Context, _ *logical.Reque
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -118,7 +118,7 @@ func (b *mistralBackend) handleConfigWrite(ctx context.Context, _ *logical.Reque
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 	if tc.Enabled && tc.AutoAuthPath == "" {
@@ -138,7 +138,7 @@ func (b *mistralBackend) handleConfigWrite(ctx context.Context, _ *logical.Reque
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/mistral/provider.go
+++ b/provider/mistral/provider.go
@@ -71,7 +71,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      false,
 			AutoAuthPath: "",
-			DefaultRole:  "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           mistralBackendHelp,
@@ -116,7 +116,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      parsedConfig.TransparentMode,
 			AutoAuthPath: parsedConfig.AutoAuthPath,
-			DefaultRole:  parsedConfig.DefaultRole,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
 
@@ -140,7 +140,7 @@ func (b *mistralBackend) Initialize(ctx context.Context) error {
 			Timeout         string `json:"timeout"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -158,7 +158,7 @@ func (b *mistralBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
 		// No persisted config — persist defaults
@@ -169,7 +169,7 @@ func (b *mistralBackend) Initialize(ctx context.Context) error {
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)

--- a/provider/mistral/provider_test.go
+++ b/provider/mistral/provider_test.go
@@ -89,7 +89,7 @@ func TestParseConfig(t *testing.T) {
 		})
 		assert.True(t, config.TransparentMode)
 		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
-		assert.Equal(t, "reader", config.DefaultRole)
+		assert.Equal(t, "reader", config.DefaultAuthRole)
 	})
 }
 

--- a/provider/openai/config.go
+++ b/provider/openai/config.go
@@ -23,7 +23,7 @@ type ProviderConfig struct {
 	Timeout         time.Duration
 	TransparentMode bool
 	AutoAuthPath    string
-	DefaultRole     string
+	DefaultAuthRole string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
@@ -90,7 +90,7 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		config.AutoAuthPath = aap
 	}
 	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultRole = dr
+		config.DefaultAuthRole = dr
 	}
 
 	return config

--- a/provider/openai/path_config.go
+++ b/provider/openai/path_config.go
@@ -72,7 +72,7 @@ func (b *openaiBackend) handleConfigRead(_ context.Context, _ *logical.Request, 
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -109,7 +109,7 @@ func (b *openaiBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -118,7 +118,7 @@ func (b *openaiBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 	if tc.Enabled && tc.AutoAuthPath == "" {
@@ -138,7 +138,7 @@ func (b *openaiBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/openai/provider.go
+++ b/provider/openai/provider.go
@@ -71,7 +71,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      false,
 			AutoAuthPath: "",
-			DefaultRole:  "",
+			DefaultAuthRole: "",
 		},
 		Backend: &framework.Backend{
 			Help:           openaiBackendHelp,
@@ -116,7 +116,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      parsedConfig.TransparentMode,
 			AutoAuthPath: parsedConfig.AutoAuthPath,
-			DefaultRole:  parsedConfig.DefaultRole,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
 
@@ -140,7 +140,7 @@ func (b *openaiBackend) Initialize(ctx context.Context) error {
 			Timeout         string `json:"timeout"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -158,7 +158,7 @@ func (b *openaiBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
 		// No persisted config — persist defaults
@@ -169,7 +169,7 @@ func (b *openaiBackend) Initialize(ctx context.Context) error {
 			"timeout":          b.Timeout.String(),
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)

--- a/provider/openai/provider_test.go
+++ b/provider/openai/provider_test.go
@@ -89,7 +89,7 @@ func TestParseConfig(t *testing.T) {
 		})
 		assert.True(t, config.TransparentMode)
 		assert.Equal(t, "auth/jwt/", config.AutoAuthPath)
-		assert.Equal(t, "reader", config.DefaultRole)
+		assert.Equal(t, "reader", config.DefaultAuthRole)
 	})
 }
 

--- a/provider/rds/README.md
+++ b/provider/rds/README.md
@@ -1,0 +1,477 @@
+# RDS Provider
+
+The RDS provider is an **access backend** that vends ready-to-use database connection strings with short-lived IAM authentication tokens. It does not proxy database traffic — workloads use the returned connection string to connect to RDS directly.
+
+Supports PostgreSQL, MySQL, and SQL Server on Amazon RDS and Aurora. Both use the same IAM authentication mechanism — the only difference is the endpoint hostname.
+
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the RDS Provider](#step-2-mount-and-configure-the-rds-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create Grants on the Provider](#step-4-create-grants-on-the-provider)
+- [Step 5: Create a Policy](#step-5-create-a-policy)
+- [Step 6: Get a Connection String](#step-6-get-a-connection-string)
+- [Attribution](#attribution)
+- [Configuration Reference](#configuration-reference)
+
+## How It Works
+
+```
+Workload ──GET /rds/access/readonly──> Warden ──IAM SigV4 signing──> (no network call)
+                                         │
+                                         ├── 1. Resolve grant → credential spec
+                                         ├── 2. Mint RDS IAM auth token (local SigV4)
+                                         ├── 3. Build connection string with attribution
+                                         └── 4. Return connection string + lease_duration
+                                         │
+Workload <── { "connection_string": "host=... password=<token> ...", "lease_duration": 900 }
+   │
+   └── sql.Open("postgres", connStr)  ──> RDS (IAM-authenticated)
+```
+
+Unlike Vault's database secrets engine, which creates SQL users via an admin connection, the RDS provider generates IAM auth tokens — a pure identity-plane operation. No admin credentials or database connections are needed on the Warden side.
+
+RDS IAM tokens are valid for **15 minutes** and are generated locally via SigV4 signing (no network call to AWS).
+
+## Prerequisites
+
+### 1. Warden server
+
+A running Warden server. See the [Anthropic provider README](../anthropic/README.md) for quickstart instructions (download binary, start dev server, set env vars).
+
+### 2. AWS IAM credentials
+
+Two IAM identities are recommended — a **service user** (whose access keys Warden holds and rotates) and a **database role** (with only `rds-db:connect`, assumed via STS). This separation ensures the database-scoped identity cannot manage IAM keys.
+
+**Service IAM user** (`warden-svc`) — holds access keys, can assume the database role and rotate its own keys:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeDBRole",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::<account-id>:role/warden-rds-connect"
+    },
+    {
+      "Sid": "KeyRotation",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:ListAccessKeys"
+      ],
+      "Resource": "arn:aws:iam::<account-id>:user/warden-svc"
+    }
+  ]
+}
+```
+
+**Database IAM role** (`warden-rds-connect`) — scoped to RDS IAM auth only:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RDSIAMAuth",
+      "Effect": "Allow",
+      "Action": "rds-db:connect",
+      "Resource": "arn:aws:rds-db:<region>:<account-id>:dbuser:<dbi-resource-id>/*"
+    }
+  ]
+}
+```
+
+The role's trust policy must allow the service user to assume it:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::<account-id>:user/warden-svc" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+Replace `<region>`, `<account-id>`, and `<dbi-resource-id>` (from the RDS console → Configuration → Resource ID) with your values.
+
+> **Simpler alternative:** For non-production environments, you can use a single IAM user with both `rds-db:connect` and `iam:*AccessKey` permissions, and omit `role_arn` from the credential spec. The trade-off is that the same identity that connects to the database can also manage its own keys.
+
+### 3. RDS instance with IAM authentication enabled
+
+Enable IAM authentication on your RDS or Aurora instance:
+
+- **Console**: RDS → Databases → Modify → IAM DB authentication → Enable
+- **CLI**: `aws rds modify-db-instance --db-instance-identifier mydb --enable-iam-database-authentication --apply-immediately`
+- **Aurora**: `aws rds modify-db-cluster --db-cluster-identifier mycluster --enable-iam-database-authentication --apply-immediately`
+
+### 4. Database user mapped to IAM
+
+Create a database user that authenticates via IAM instead of a password:
+
+**PostgreSQL:**
+```sql
+-- Read-only user
+CREATE USER app_readonly WITH LOGIN;
+GRANT rds_iam TO app_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO app_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO app_readonly;
+
+-- Read-write user
+CREATE USER app_readwrite WITH LOGIN;
+GRANT rds_iam TO app_readwrite;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_readwrite;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_readwrite;
+```
+
+**MySQL:**
+```sql
+-- Read-only user
+CREATE USER 'app_readonly'@'%' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+GRANT SELECT ON myapp.* TO 'app_readonly'@'%';
+
+-- Read-write user
+CREATE USER 'app_readwrite'@'%' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+GRANT SELECT, INSERT, UPDATE, DELETE ON myapp.* TO 'app_readwrite'@'%';
+```
+
+**SQL Server:**
+```sql
+-- Read-only user (requires RDS with Kerberos/Windows auth or IAM integration)
+CREATE LOGIN [app_readonly] FROM EXTERNAL PROVIDER;
+CREATE USER [app_readonly] FOR LOGIN [app_readonly];
+ALTER ROLE db_datareader ADD MEMBER [app_readonly];
+
+-- Read-write user
+CREATE LOGIN [app_readwrite] FROM EXTERNAL PROVIDER;
+CREATE USER [app_readwrite] FOR LOGIN [app_readwrite];
+ALTER ROLE db_datareader ADD MEMBER [app_readwrite];
+ALTER ROLE db_datawriter ADD MEMBER [app_readwrite];
+```
+
+> **Note:** RDS for SQL Server IAM authentication requires Active Directory integration. See [AWS docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for setup.
+
+Each database user name must match the `db_user` in its corresponding credential spec (Step 3). Warden controls which workload gets which user — the database controls what that user can do.
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up JWT auth for workload authentication. The auth role does **not** need a `cred_spec_name` — the RDS provider resolves credentials via path-based provider grants instead.
+
+```bash
+warden auth enable --type=jwt
+
+warden write auth/jwt/config \
+    mode=jwt \
+    jwks_url=http://localhost:4444/.well-known/jwks.json \
+    default_role=db-user
+
+warden write auth/jwt/role/db-user \
+    token_policies="rds-access" \
+    user_claim=sub \
+    token_ttl=1h
+```
+
+Setting `default_role=db-user` means workloads don't need to pass `X-Warden-Role` — the auth method uses this role automatically during transparent authentication.
+
+> **Advanced: Dynamic Policy Mapping with `groups_claim`**
+>
+> If your identity provider includes group claims in JWTs (e.g., Keycloak, Auth0, Azure AD), you can map groups directly to Warden policies instead of creating multiple auth roles:
+>
+> ```bash
+> warden write auth/jwt/config \
+>     mode=jwt \
+>     jwks_url=http://localhost:4444/.well-known/jwks.json \
+>     default_role=db-user \
+>     groups_claim=groups \
+>     group_policy_prefix=group-
+>
+> warden write auth/jwt/role/db-user \
+>     token_policies="base-access" \
+>     user_claim=sub \
+>     token_ttl=1h
+>
+> # Create policies matching group names
+> warden policy write group-db-read - <<EOF
+> path "rds/access/readonly" { capabilities = ["read"] }
+> EOF
+>
+> warden policy write group-db-write - <<EOF
+> path "rds/access/readwrite" { capabilities = ["read"] }
+> EOF
+> ```
+>
+> A workload with JWT `{"groups": ["db-read"]}` gets policies `["base-access", "group-db-read"]` — access to `rds/access/readonly` but not `rds/access/readwrite`. The group-to-policy mapping is automatic: each group name is prefixed with `group_policy_prefix` (default `group-`) to form the policy name.
+>
+> This requires an identity provider that supports custom claims. Hydra (used in the quickstart) needs a [token hook](https://www.ory.sh/docs/hydra/guides/claims-at-refresh) for custom claims. Keycloak, Auth0, and Azure AD support this natively.
+
+## Step 2: Mount and Configure the RDS Provider
+
+```bash
+warden provider enable --type=rds
+```
+
+Enable transparent mode so workloads can authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write rds/config \
+    transparent_mode=true \
+    auto_auth_path=auth/jwt/
+```
+
+Verify:
+
+```bash
+warden provider list
+warden read rds/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+Create an AWS credential source with the service user's access keys and automatic rotation. The rotation period controls how often Warden rotates the source IAM access keys (creates a new key, waits for propagation, activates, deletes the old key):
+
+```bash
+warden cred source create aws-prod \
+  --type=aws \
+  --rotation-period=24h \
+  --config access_key_id=<SERVICE_USER_ACCESS_KEY_ID> \
+  --config secret_access_key=<SERVICE_USER_SECRET_ACCESS_KEY> \
+  --config region=us-east-1
+```
+
+> Set `--rotation-period=0` to disable rotation (not recommended for production). The IAM permissions for rotation are included in the prerequisite policy on the service user.
+
+Create credential specs for each database user / permission level. The `role_arn` points to the database IAM role from the prerequisites:
+
+```bash
+# Read-only spec
+warden cred spec create rds-readonly \
+  --type db_auth_token \
+  --source aws-prod \
+  --config mint_method=rds_iam_token \
+  --config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
+  --config db_user=app_readonly \
+  --config db_engine=postgres \
+  --config region=us-east-1 \
+  --config role_arn=arn:aws:iam::123456789:role/warden-rds-connect
+
+# Read-write spec
+warden cred spec create rds-readwrite \
+  --type db_auth_token \
+  --source aws-prod \
+  --config mint_method=rds_iam_token \
+  --config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
+  --config db_user=app_readwrite \
+  --config db_engine=postgres \
+  --config region=us-east-1 \
+  --config role_arn=arn:aws:iam::123456789:role/warden-rds-connect
+```
+
+For Aurora, use the cluster or reader endpoint:
+
+```bash
+warden cred spec create aurora-readonly \
+  --type db_auth_token \
+  --source aws-prod \
+  --config mint_method=rds_iam_token \
+  --config db_endpoint=mydb.cluster-ro-abc123.us-east-1.rds.amazonaws.com \
+  --config db_user=app_readonly \
+  --config db_engine=postgres \
+  --config region=us-east-1
+```
+
+For cross-account access, add `role_arn`:
+
+```bash
+warden cred spec create rds-cross-account \
+  --type db_auth_token \
+  --source aws-prod \
+  --config mint_method=rds_iam_token \
+  --config db_endpoint=mydb.xyz789.eu-west-1.rds.amazonaws.com \
+  --config db_user=app_readonly \
+  --config db_engine=postgres \
+  --config region=eu-west-1 \
+  --config role_arn=arn:aws:iam::987654321:role/rds-cross-account
+```
+
+## Step 4: Create Grants on the Provider
+
+Grants map access paths to credential specs and include the database name in the connection string:
+
+```bash
+warden write rds/grants/readonly \
+    credential_spec=rds-readonly \
+    db_name=myapp \
+    db_engine=postgres
+
+warden write rds/grants/readwrite \
+    credential_spec=rds-readwrite \
+    db_name=myapp \
+    db_engine=postgres
+```
+
+Verify:
+
+```bash
+warden read rds/grants/readonly
+```
+
+## Step 5: Create a Policy
+
+Control which grants each token can access:
+
+```bash
+warden policy write rds-access - <<EOF
+path "rds/access/readonly" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+For broader access:
+
+```bash
+warden policy write rds-full-access - <<EOF
+path "rds/access/*" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+## Step 6: Get a Connection String
+
+Get a JWT from your identity provider:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+With transparent mode enabled, pass the JWT directly — no login step needed:
+
+```bash
+curl -s -H "Authorization: Bearer $JWT_TOKEN" \
+  "${WARDEN_ADDR}/v1/rds/access/readonly" | jq
+```
+
+The auth method's `default_role` determines which policies apply. To use a specific auth role, pass `X-Warden-Role`:
+
+```bash
+curl -s -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "X-Warden-Role: data-team" \
+  "${WARDEN_ADDR}/v1/rds/access/readonly" | jq
+```
+
+Response:
+
+```json
+{
+  "connection_string": "host=mydb.abc123.us-east-1.rds.amazonaws.com port=5432 dbname=myapp user=app_readonly password=<iam-token> sslmode=require application_name=workload-a",
+  "lease_duration": 900
+}
+```
+
+### Using the connection string
+
+The connection string is ready-to-use — no assembly required:
+
+**psql:**
+```bash
+psql "$(curl -s -H "Authorization: Bearer $JWT_TOKEN" \
+  "${WARDEN_ADDR}/v1/rds/access/readonly" | jq -r .connection_string)"
+```
+
+**Go:**
+```go
+req, _ := http.NewRequest("GET", wardenAddr+"/v1/rds/access/readonly", nil)
+req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+resp, _ := http.DefaultClient.Do(req)
+var result map[string]interface{}
+json.NewDecoder(resp.Body).Decode(&result)
+
+db, err := sql.Open("postgres", result["connection_string"].(string))
+```
+
+**Python:**
+```python
+import psycopg2, requests
+
+resp = requests.get(
+    f"{WARDEN_ADDR}/v1/rds/access/readonly",
+    headers={"Authorization": f"Bearer {jwt_token}"},
+).json()
+
+conn = psycopg2.connect(resp["connection_string"])
+```
+
+**Node.js:**
+```javascript
+const { Client } = require('pg');
+const resp = await fetch(`${WARDEN_ADDR}/v1/rds/access/readonly`, {
+  headers: { 'Authorization': `Bearer ${jwtToken}` },
+}).then(r => r.json());
+
+const client = new Client({ connectionString: resp.connection_string });
+await client.connect();
+```
+
+## Attribution
+
+Warden injects the requesting principal's identity into the connection string for database audit attribution:
+
+| Engine | Parameter | Visible In |
+|--------|-----------|------------|
+| PostgreSQL | `application_name=<principal>` | `pg_stat_activity`, server logs |
+| MySQL | `connectionAttributes=program_name:<principal>` | `performance_schema.session_connect_attrs` |
+| SQL Server | `app name=<principal>` | `sys.dm_exec_sessions` |
+
+This means database audit logs show both the shared IAM user and which Warden workload opened the connection — without requiring per-workload database users.
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `transparent_mode` | bool | `false` | Enable implicit JWT authentication |
+| `auto_auth_path` | string | — | Auth mount path for implicit authentication (required when `transparent_mode` is true) |
+
+### Credential Spec Config (`db_auth_token` type)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `rds_iam_token` |
+| `db_endpoint` | string | Yes | RDS endpoint hostname |
+| `db_user` | string | Yes | Database user mapped to IAM identity |
+| `db_engine` | string | No | `postgres` (default), `mysql`, or `sqlserver` |
+| `db_port` | string | No | Defaults based on engine (5432, 3306, 1433) |
+| `region` | string | No | AWS region (defaults to source region) |
+| `role_arn` | string | No | IAM role ARN for cross-account access |
+
+### Provider Grant Config
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `credential_spec` | string | Yes | Name of the credential spec to mint |
+| `db_name` | string | No | Database name to include in connection string |
+| `db_engine` | string | No | Overrides engine from credential spec |
+| `description` | string | No | Human-readable description |
+
+### Response Format
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `connection_string` | string | Ready-to-use DSN for `sql.Open()` or equivalent |
+| `lease_duration` | int | Token validity in seconds (900 for RDS IAM) |

--- a/provider/rds/provider.go
+++ b/provider/rds/provider.go
@@ -1,0 +1,247 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// rdsBackend is an access backend that vends database connection strings
+// using RDS IAM authentication tokens.
+type rdsBackend struct {
+	*framework.AccessBackend
+}
+
+// rdsGrant maps a grant name to a credential spec and database configuration.
+type rdsGrant struct {
+	CredentialSpec string `json:"credential_spec"`
+	DBName         string `json:"db_name"`
+	DBEngine       string `json:"db_engine"`
+	Description    string `json:"description,omitempty"`
+}
+
+// Factory creates a new RDS access backend.
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &rdsBackend{}
+	b.AccessBackend = &framework.AccessBackend{
+		Backend: &framework.Backend{
+			BackendType:  "rds",
+			BackendClass: logical.ClassProvider,
+		},
+		Logger: conf.Logger.WithSubsystem("rds"),
+	}
+	b.Backend.Paths = b.paths()
+	if err := b.AccessBackend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (b *rdsBackend) paths() []*framework.Path {
+	return []*framework.Path{
+		b.PathAccessConfig(),
+		b.pathGrants(),
+		b.pathAccess(),
+	}
+}
+
+// --- Grants CRUD ---
+
+func (b *rdsBackend) pathGrants() *framework.Path {
+	return &framework.Path{
+		Pattern: "grants/(?P<name>[^/]+)",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Grant name",
+			},
+			"credential_spec": {
+				Type:        framework.TypeString,
+				Description: "Credential spec name to mint for this grant",
+			},
+			"db_name": {
+				Type:        framework.TypeString,
+				Description: "Database name to include in the connection string",
+			},
+			"db_engine": {
+				Type:        framework.TypeString,
+				Description: "Database engine (postgres, mysql, sqlserver). Overrides the spec value if set.",
+			},
+			"description": {
+				Type:        framework.TypeString,
+				Description: "Human-readable description of this grant",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleGrantRead,
+				Summary:  "Read a grant",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleGrantWrite,
+				Summary:  "Create or update a grant",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.handleGrantDelete,
+				Summary:  "Delete a grant",
+			},
+		},
+		HelpSynopsis:    "Manage RDS access grants",
+		HelpDescription: "Grants map a name to a credential spec and database configuration.",
+	}
+}
+
+func (b *rdsBackend) handleGrantRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	grant, err := b.getGrant(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if grant == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", name)), nil
+	}
+	return &logical.Response{
+		StatusCode: 200,
+		Data: map[string]any{
+			"credential_spec": grant.CredentialSpec,
+			"db_name":         grant.DBName,
+			"db_engine":       grant.DBEngine,
+			"description":     grant.Description,
+		},
+	}, nil
+}
+
+func (b *rdsBackend) handleGrantWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	credSpec, _ := d.Get("credential_spec").(string)
+	if credSpec == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("credential_spec is required")), nil
+	}
+
+	grant := &rdsGrant{
+		CredentialSpec: credSpec,
+		DBName:         d.Get("db_name").(string),
+		DBEngine:       d.Get("db_engine").(string),
+		Description:    d.Get("description").(string),
+	}
+
+	if err := b.putGrant(ctx, name, grant); err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{StatusCode: 204}, nil
+}
+
+func (b *rdsBackend) handleGrantDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if err := b.StorageView.Delete(ctx, "grants/"+name); err != nil {
+		return nil, err
+	}
+	return &logical.Response{StatusCode: 204}, nil
+}
+
+func (b *rdsBackend) getGrant(ctx context.Context, name string) (*rdsGrant, error) {
+	entry, err := b.StorageView.Get(ctx, "grants/"+name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var grant rdsGrant
+	if err := json.Unmarshal(entry.Value, &grant); err != nil {
+		return nil, fmt.Errorf("failed to decode grant %q: %w", name, err)
+	}
+	return &grant, nil
+}
+
+func (b *rdsBackend) putGrant(ctx context.Context, name string, grant *rdsGrant) error {
+	entry, err := sdklogical.StorageEntryJSON("grants/"+name, grant)
+	if err != nil {
+		return err
+	}
+	return b.StorageView.Put(ctx, entry)
+}
+
+// --- Access endpoint ---
+
+func (b *rdsBackend) pathAccess() *framework.Path {
+	return &framework.Path{
+		Pattern: "access/(?P<name>[^/]+)",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Grant name",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleGetAccess,
+				Summary:  "Get a database connection string for the given grant",
+			},
+		},
+		HelpSynopsis:    "Get database access",
+		HelpDescription: "Returns a ready-to-use connection string with IAM authentication.",
+	}
+}
+
+func (b *rdsBackend) handleGetAccess(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	grantName := d.Get("name").(string)
+	grant, err := b.getGrant(ctx, grantName)
+	if err != nil {
+		return nil, err
+	}
+	if grant == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", grantName)), nil
+	}
+
+	principal := ""
+	if te := req.TokenEntry(); te != nil {
+		principal = te.PrincipalID
+	}
+
+	return &logical.Response{
+		AccessData: &logical.AccessData{
+			CredentialSpec: grant.CredentialSpec,
+			ResponseBuilder: func(cred *credential.Credential) map[string]interface{} {
+				return map[string]interface{}{
+					"connection_string": formatConnectionString(cred, grant, principal),
+					"lease_duration":    int(cred.LeaseTTL.Seconds()),
+				}
+			},
+		},
+	}, nil
+}
+
+// formatConnectionString builds a ready-to-use DSN from the minted credential,
+// grant config, and the requesting principal (for attribution).
+func formatConnectionString(cred *credential.Credential, grant *rdsGrant, principal string) string {
+	host := cred.Data["db_host"]
+	port := cred.Data["db_port"]
+	user := cred.Data["db_user"]
+	token := cred.Data["auth_token"]
+	dbName := grant.DBName
+	engine := grant.DBEngine
+	if engine == "" {
+		engine = cred.Data["db_engine"]
+	}
+
+	switch engine {
+	case "mysql":
+		return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?tls=true&connectionAttributes=program_name:%s",
+			user, url.QueryEscape(token), host, port, dbName, principal)
+	case "sqlserver":
+		return fmt.Sprintf("sqlserver://%s:%s@%s:%s?database=%s&encrypt=true&app+name=%s",
+			url.QueryEscape(user), url.QueryEscape(token), host, port, dbName, principal)
+	default: // postgres
+		return fmt.Sprintf("host=%s port=%s dbname=%s user=%s password=%s sslmode=require application_name=%s",
+			host, port, dbName, user, token, principal)
+	}
+}

--- a/provider/rds/provider_test.go
+++ b/provider/rds/provider_test.go
@@ -1,0 +1,417 @@
+package rds
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+type inmemStorage struct {
+	mu   sync.RWMutex
+	data map[string]*sdklogical.StorageEntry
+}
+
+func newInmemStorage() *inmemStorage {
+	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
+}
+
+func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			keys = append(keys, k[len(prefix):])
+		}
+	}
+	return keys, nil
+}
+
+func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key], nil
+}
+
+func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[entry.Key] = entry
+	return nil
+}
+
+func (s *inmemStorage) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *inmemStorage) ListPage(_ context.Context, prefix string, _ string, _ int) ([]string, error) {
+	return s.List(context.Background(), prefix)
+}
+
+func testLogger() *logger.GatedLogger {
+	config := &logger.Config{Level: logger.TraceLevel, Format: logger.DefaultFormat}
+	gateConfig := logger.GatedWriterConfig{InitialState: logger.GateOpen}
+	gl, _ := logger.NewGatedLogger(config, gateConfig)
+	return gl
+}
+
+func setupBackend(t *testing.T) *rdsBackend {
+	t.Helper()
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      testLogger(),
+	}
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+	return b.(*rdsBackend)
+}
+
+func makeFieldData(path *framework.Path, raw map[string]interface{}) *framework.FieldData {
+	return &framework.FieldData{
+		Raw:    raw,
+		Schema: path.Fields,
+	}
+}
+
+// --- Factory tests ---
+
+func TestFactory(t *testing.T) {
+	b := setupBackend(t)
+	assert.Equal(t, "rds", b.Type())
+	assert.Equal(t, logical.ClassProvider, b.Class())
+}
+
+// --- Config tests ---
+
+func TestConfigCRUD(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+
+	t.Run("default config", func(t *testing.T) {
+		cfg := b.GetAccessConfig()
+		assert.False(t, cfg.TransparentMode)
+		assert.Equal(t, "", cfg.AutoAuthPath)
+	})
+
+	t.Run("set and get config", func(t *testing.T) {
+		err := b.SetAccessConfig(ctx, &framework.AccessConfig{
+			TransparentMode: true,
+			AutoAuthPath:    "auth/jwt/",
+		})
+		require.NoError(t, err)
+
+		cfg := b.GetAccessConfig()
+		assert.True(t, cfg.TransparentMode)
+		assert.Equal(t, "auth/jwt/", cfg.AutoAuthPath)
+	})
+
+	t.Run("config persists via HandleRequest", func(t *testing.T) {
+		// Write config via HandleRequest
+		resp, err := b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "config",
+			Data: map[string]any{
+				"transparent_mode": true,
+				"auto_auth_path":   "auth/cert/",
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 204, resp.StatusCode)
+
+		// Read config via HandleRequest
+		resp, err = b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "config",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, true, resp.Data["transparent_mode"])
+		assert.Equal(t, "auth/cert/", resp.Data["auto_auth_path"])
+	})
+
+	t.Run("transparent_mode without auto_auth_path fails", func(t *testing.T) {
+		resp, err := b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "config",
+			Data: map[string]any{
+				"transparent_mode": true,
+				"auto_auth_path":   "",
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+}
+
+// --- TransparentModeProvider tests ---
+
+func TestTransparentModeProvider(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		assert.False(t, b.IsTransparentMode())
+		assert.Equal(t, "", b.GetAutoAuthPath())
+		assert.Equal(t, "", b.GetAuthRole("access/readonly"))
+	})
+
+	t.Run("enabled after config", func(t *testing.T) {
+		err := b.SetAccessConfig(ctx, &framework.AccessConfig{
+			TransparentMode: true,
+			AutoAuthPath:    "auth/jwt/",
+		})
+		require.NoError(t, err)
+
+		assert.True(t, b.IsTransparentMode())
+		assert.Equal(t, "auth/jwt/", b.GetAutoAuthPath())
+		assert.Equal(t, "", b.GetAuthRole("access/readonly"))
+	})
+
+	t.Run("IsUnauthenticatedPath always false", func(t *testing.T) {
+		assert.False(t, b.IsUnauthenticatedPath("access/readonly"))
+		assert.False(t, b.IsUnauthenticatedPath("config"))
+	})
+}
+
+func TestIsTransparentPath(t *testing.T) {
+	b := setupBackend(t)
+
+	assert.True(t, b.IsTransparentPath("access/readonly"))
+	assert.True(t, b.IsTransparentPath("access/readwrite"))
+	assert.False(t, b.IsTransparentPath("grants/readonly"))
+	assert.False(t, b.IsTransparentPath("config"))
+	assert.False(t, b.IsTransparentPath(""))
+}
+
+// --- Grant CRUD tests ---
+
+func TestGrantCRUD(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+	req := &logical.Request{}
+	grantsPath := b.pathGrants()
+
+	t.Run("read nonexistent grant returns error", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{"name": "nonexistent"})
+		resp, err := b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("write grant", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{
+			"name":            "readonly",
+			"credential_spec": "rds-readonly",
+			"db_name":         "myapp",
+			"db_engine":       "postgres",
+			"description":     "Read-only access",
+		})
+		resp, err := b.handleGrantWrite(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, 204, resp.StatusCode)
+	})
+
+	t.Run("read grant", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, "rds-readonly", resp.Data["credential_spec"])
+		assert.Equal(t, "myapp", resp.Data["db_name"])
+		assert.Equal(t, "postgres", resp.Data["db_engine"])
+		assert.Equal(t, "Read-only access", resp.Data["description"])
+	})
+
+	t.Run("write grant without credential_spec fails", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{
+			"name":    "bad-grant",
+			"db_name": "myapp",
+		})
+		resp, err := b.handleGrantWrite(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("delete grant", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGrantDelete(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, 204, resp.StatusCode)
+
+		resp, err = b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+}
+
+// --- Access endpoint tests ---
+
+func TestHandleGetAccess(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+	grantsPath := b.pathGrants()
+	accessPath := b.pathAccess()
+
+	// Create a grant first
+	d := makeFieldData(grantsPath, map[string]interface{}{
+		"name":            "readonly",
+		"credential_spec": "rds-readonly",
+		"db_name":         "myapp",
+		"db_engine":       "postgres",
+	})
+	_, err := b.handleGrantWrite(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+
+	t.Run("nonexistent grant returns error", func(t *testing.T) {
+		req := &logical.Request{}
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "nonexistent"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("returns AccessData with correct spec", func(t *testing.T) {
+		req := &logical.Request{}
+		te := &logical.TokenEntry{PrincipalID: "workload-a"}
+		req.SetTokenEntry(te)
+
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+		assert.Equal(t, "rds-readonly", resp.AccessData.CredentialSpec)
+	})
+
+	t.Run("ResponseBuilder produces correct connection string", func(t *testing.T) {
+		req := &logical.Request{}
+		te := &logical.TokenEntry{PrincipalID: "workload-a"}
+		req.SetTokenEntry(te)
+
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+
+		cred := &credential.Credential{
+			LeaseTTL: 15 * time.Minute,
+			Data: map[string]string{
+				"auth_token": "iam-token-xyz",
+				"db_host":    "mydb.rds.amazonaws.com",
+				"db_port":    "5432",
+				"db_user":    "app_readonly",
+				"db_engine":  "postgres",
+			},
+		}
+
+		result := resp.AccessData.ResponseBuilder(cred)
+		connStr := result["connection_string"].(string)
+		assert.Contains(t, connStr, "host=mydb.rds.amazonaws.com")
+		assert.Contains(t, connStr, "port=5432")
+		assert.Contains(t, connStr, "dbname=myapp")
+		assert.Contains(t, connStr, "user=app_readonly")
+		assert.Contains(t, connStr, "password=iam-token-xyz")
+		assert.Contains(t, connStr, "sslmode=require")
+		assert.Contains(t, connStr, "application_name=workload-a")
+		assert.Equal(t, 900, result["lease_duration"])
+	})
+
+	t.Run("no token entry still works with empty principal", func(t *testing.T) {
+		req := &logical.Request{}
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+
+		cred := &credential.Credential{
+			LeaseTTL: 15 * time.Minute,
+			Data: map[string]string{
+				"auth_token": "token",
+				"db_host":    "h",
+				"db_port":    "5432",
+				"db_user":    "u",
+				"db_engine":  "postgres",
+			},
+		}
+		result := resp.AccessData.ResponseBuilder(cred)
+		connStr := result["connection_string"].(string)
+		assert.Contains(t, connStr, "application_name=")
+	})
+}
+
+// --- formatConnectionString tests ---
+
+func TestFormatConnectionString(t *testing.T) {
+	cred := &credential.Credential{
+		Data: map[string]string{
+			"auth_token": "my-token",
+			"db_host":    "mydb.rds.amazonaws.com",
+			"db_port":    "5432",
+			"db_user":    "app_user",
+			"db_engine":  "postgres",
+		},
+	}
+
+	t.Run("postgres", func(t *testing.T) {
+		grant := &rdsGrant{DBName: "myapp", DBEngine: "postgres"}
+		result := formatConnectionString(cred, grant, "workload-a")
+		assert.Equal(t,
+			"host=mydb.rds.amazonaws.com port=5432 dbname=myapp user=app_user password=my-token sslmode=require application_name=workload-a",
+			result,
+		)
+	})
+
+	t.Run("mysql", func(t *testing.T) {
+		grant := &rdsGrant{DBName: "myapp", DBEngine: "mysql"}
+		result := formatConnectionString(cred, grant, "workload-b")
+		assert.Equal(t,
+			"app_user:my-token@tcp(mydb.rds.amazonaws.com:5432)/myapp?tls=true&connectionAttributes=program_name:workload-b",
+			result,
+		)
+	})
+
+	t.Run("sqlserver", func(t *testing.T) {
+		grant := &rdsGrant{DBName: "myapp", DBEngine: "sqlserver"}
+		result := formatConnectionString(cred, grant, "workload-c")
+		assert.Equal(t,
+			"sqlserver://app_user:my-token@mydb.rds.amazonaws.com:5432?database=myapp&encrypt=true&app+name=workload-c",
+			result,
+		)
+	})
+
+	t.Run("engine fallback from credential", func(t *testing.T) {
+		grant := &rdsGrant{DBName: "myapp", DBEngine: ""}
+		result := formatConnectionString(cred, grant, "workload-d")
+		assert.Contains(t, result, "host=")
+		assert.Contains(t, result, "sslmode=require")
+	})
+
+	t.Run("token with special characters is escaped in mysql", func(t *testing.T) {
+		specialCred := &credential.Credential{
+			Data: map[string]string{
+				"auth_token": "token/with+special=chars&more",
+				"db_host":    "h",
+				"db_port":    "3306",
+				"db_user":    "u",
+				"db_engine":  "mysql",
+			},
+		}
+		grant := &rdsGrant{DBName: "db", DBEngine: "mysql"}
+		result := formatConnectionString(specialCred, grant, "w")
+		assert.NotContains(t, result, "token/with+special")
+		assert.Contains(t, result, "token%2Fwith%2Bspecial%3Dchars%26more")
+	})
+}

--- a/provider/vault/path_config.go
+++ b/provider/vault/path_config.go
@@ -77,7 +77,7 @@ func (b *vaultBackend) handleConfigRead(ctx context.Context, req *logical.Reques
 			"tls_skip_verify":  b.tlsSkipVerify,
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		},
 	}, nil
 }
@@ -127,7 +127,7 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	tc := &framework.TransparentConfig{
 		Enabled:      b.TransparentConfig.Enabled,
 		AutoAuthPath: b.TransparentConfig.AutoAuthPath,
-		DefaultRole:  b.TransparentConfig.DefaultRole,
+		DefaultAuthRole:  b.TransparentConfig.DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("transparent_mode"); ok {
 		tc.Enabled = val.(bool)
@@ -136,7 +136,7 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 		tc.AutoAuthPath = val.(string)
 	}
 	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultRole = val.(string)
+		tc.DefaultAuthRole = val.(string)
 	}
 
 
@@ -159,7 +159,7 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 			"tls_skip_verify":  b.tlsSkipVerify,
 			"transparent_mode": tc.Enabled,
 			"auto_auth_path":   tc.AutoAuthPath,
-			"default_role":     tc.DefaultRole,
+			"default_role":     tc.DefaultAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/vault/provider.go
+++ b/provider/vault/provider.go
@@ -101,7 +101,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      false, // Updated via config write or Initialize
 			AutoAuthPath: "",
-			DefaultRole:  "",
+			DefaultAuthRole:  "",
 		},
 		Backend: &framework.Backend{
 			Help:           vaultBackendHelp,
@@ -168,7 +168,7 @@ func (b *vaultBackend) Initialize(ctx context.Context) error {
 			TLSSkipVerify   bool   `json:"tls_skip_verify"`
 			TransparentMode bool   `json:"transparent_mode"`
 			AutoAuthPath    string `json:"auto_auth_path"`
-			DefaultRole     string `json:"default_role"`
+			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
@@ -190,7 +190,7 @@ func (b *vaultBackend) Initialize(ctx context.Context) error {
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			Enabled:      config.TransparentMode,
 			AutoAuthPath: config.AutoAuthPath,
-			DefaultRole:  config.DefaultRole,
+			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	}
 	return nil

--- a/provider/vault/provider_test.go
+++ b/provider/vault/provider_test.go
@@ -14,7 +14,7 @@ func TestTransparentModeProvider_ViaStreamingBackend(t *testing.T) {
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      true,
 			AutoAuthPath: "auth/jwt/",
-			DefaultRole:  "default-role",
+			DefaultAuthRole:  "default-role",
 		},
 	}
 
@@ -48,12 +48,12 @@ func TestTransparentModeProvider_ViaStreamingBackend(t *testing.T) {
 	})
 }
 
-func TestGetTransparentRole_ViaStreamingBackend(t *testing.T) {
+func TestGetAuthRole_ViaStreamingBackend(t *testing.T) {
 	sb := &framework.StreamingBackend{
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      true,
 			AutoAuthPath: "auth/jwt/",
-			DefaultRole:  "default-role",
+			DefaultAuthRole:  "default-role",
 		},
 	}
 
@@ -101,28 +101,28 @@ func TestGetTransparentRole_ViaStreamingBackend(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sb.GetTransparentRole(tt.path)
+			result := sb.GetAuthRole(tt.path)
 			assert.Equal(t, tt.expectedRole, result)
 		})
 	}
 }
 
-func TestGetTransparentRole_NoDefaultRole(t *testing.T) {
+func TestGetAuthRole_NoDefaultAuthRole(t *testing.T) {
 	sb := &framework.StreamingBackend{
 		TransparentConfig: &framework.TransparentConfig{
 			Enabled:      true,
 			AutoAuthPath: "auth/jwt/",
-			DefaultRole:  "", // No default role
+			DefaultAuthRole:  "", // No default role
 		},
 	}
 
 	t.Run("returns empty for non-matching path without default", func(t *testing.T) {
-		result := sb.GetTransparentRole("gateway/v1/secret/data/foo")
+		result := sb.GetAuthRole("gateway/v1/secret/data/foo")
 		assert.Empty(t, result)
 	})
 
 	t.Run("still extracts role from matching path", func(t *testing.T) {
-		result := sb.GetTransparentRole("role/terraform/gateway/v1/secret")
+		result := sb.GetAuthRole("role/terraform/gateway/v1/secret")
 		assert.Equal(t, "terraform", result)
 	})
 }
@@ -174,7 +174,7 @@ func TestRewriteTransparentPath_ViaStreamingBackend(t *testing.T) {
 	}
 }
 
-func TestDefaultTransparentRolePattern(t *testing.T) {
+func TestDefaultAuthRolePattern(t *testing.T) {
 	tests := []struct {
 		name         string
 		path         string
@@ -212,7 +212,7 @@ func TestDefaultTransparentRolePattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matches := framework.DefaultTransparentRolePattern.FindStringSubmatch(tt.path)
+			matches := framework.DefaultAuthRolePattern.FindStringSubmatch(tt.path)
 			if tt.shouldMatch {
 				assert.NotNil(t, matches, "expected path to match: %s", tt.path)
 				if len(matches) > 1 {
@@ -236,13 +236,13 @@ func TestSetTransparentConfig(t *testing.T) {
 	sb.SetTransparentConfig(&framework.TransparentConfig{
 		Enabled:      true,
 		AutoAuthPath: "auth/oidc/",
-		DefaultRole:  "admin",
+		DefaultAuthRole:  "admin",
 	})
 
 	// Now should be enabled
 	assert.True(t, sb.IsTransparentMode())
 	assert.Equal(t, "auth/oidc/", sb.GetAutoAuthPath())
-	assert.Equal(t, "admin", sb.GetTransparentRole("config"))
+	assert.Equal(t, "admin", sb.GetAuthRole("config"))
 }
 
 func TestExtractToken(t *testing.T) {


### PR DESCRIPTION
Introduce access backends — a new provider type that vends credentials directly (database auth tokens, pre-signed URLs) instead of proxying traffic. Add the RDS provider as the first access backend, issuing short-lived IAM auth connection strings for PostgreSQL, MySQL, and SQL Server on RDS/Aurora. Rewrite README to reflect the expanded scope.