### PR TITLE
fix: add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restrict GITHUB_TOKEN to contents:read to resolve CodeQL warning about missing permissions.