### PR TITLE
feat: support ?role= query param for non-gateway backends

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -603,13 +603,19 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		// Triggered when there's no explicit X-Warden-Token but an auth path
 		// is configured on the namespace. The Authorization: Bearer value is
 		// treated as a JWT credential, not a Warden token.
+		// Auth role precedence: ?role= query param > X-Warden-Role header > auth method default_role.
 		if req.HTTPRequest != nil && req.HTTPRequest.Header.Get("X-Warden-Token") == "" {
 			var authPath string
 			if ns, _ := namespace.FromContext(ctx); ns != nil {
 				authPath = ns.CustomMetadata["auto_auth_path"]
 			}
 			if authPath != "" {
-				authRole := req.HTTPRequest.Header.Get("X-Warden-Role")
+				var authRole string
+			if role, ok := req.Data["role"].(string); ok {
+				authRole = role
+			} else {
+				authRole = req.HTTPRequest.Header.Get("X-Warden-Role")
+			}
 				if err := c.performImplicitAuth(ctx, req, authPath, authRole); err != nil {
 					c.logger.Warn("transparent operations auth failed",
 						logger.Err(err),
@@ -1063,7 +1069,7 @@ func (c *Core) isTransparentRequest(req *logical.Request, backend logical.Backen
 	}
 
 	// Extract auth role from path (may return default auth role or empty string)
-	authRole := tmp.GetAuthRole(relativePath)
+	authRole := tmp.GetAuthRole(relativePath, req)
 
 	// Fallback: extract role from protocol-specific request headers.
 	// Used by SigV4-compatible providers (AWS, Alibaba Cloud, Scaleway) where

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -790,7 +790,7 @@ func (m *mockTransparentModeProvider) GetAutoAuthPath() string {
 	return m.autoAuthPath
 }
 
-func (m *mockTransparentModeProvider) GetAuthRole(path string) string {
+func (m *mockTransparentModeProvider) GetAuthRole(path string, _ *logical.Request) string {
 	// Simple pattern matching for testing: role/{role}/gateway...
 	if strings.HasPrefix(path, "role/") {
 		parts := strings.Split(path, "/")
@@ -1534,6 +1534,85 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 
 		_, _, _ = core.handleNonLoginRequest(nsCtx, req)
 		assert.True(t, req.Transparent)
+	})
+
+	t.Run("role query param takes precedence over X-Warden-Role header", func(t *testing.T) {
+		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJwcmVjLXVzZXIifQ.prec-sig"
+
+		// Pre-create cached tokens for both roles
+		for _, roleName := range []string{"from-query", "from-header"} {
+			authData := &AuthData{
+				TokenValue:     sampleJWT,
+				RoleName:       roleName,
+				PrincipalID:    "prec-user",
+				ExpireAt:       time.Now().Add(24 * time.Hour),
+				Policies:       []string{"default"},
+				CredentialSpec: "test-spec",
+			}
+			_, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, authData)
+			require.NoError(t, err)
+		}
+
+		ns := &namespace.Namespace{
+			ID:   "test-ns-prec",
+			Path: "prec/",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/jwt/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources?role=from-query", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)
+		httpReq.Header.Set("X-Warden-Role", "from-header")
+		req := &logical.Request{
+			Path:        "sys/cred/sources",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		_, _, _ = core.handleNonLoginRequest(nsCtx, req)
+		assert.True(t, req.Transparent)
+		require.NotNil(t, req.TokenEntry())
+		assert.Equal(t, "from-query", req.TokenEntry().RoleName)
+	})
+
+	t.Run("X-Warden-Role header used when no role query param", func(t *testing.T) {
+		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWxsYmFjay11c2VyIn0.fallback-sig"
+
+		authData := &AuthData{
+			TokenValue:     sampleJWT,
+			RoleName:       "from-header",
+			PrincipalID:    "fallback-user",
+			ExpireAt:       time.Now().Add(24 * time.Hour),
+			Policies:       []string{"default"},
+			CredentialSpec: "test-spec",
+		}
+		_, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, authData)
+		require.NoError(t, err)
+
+		ns := &namespace.Namespace{
+			ID:   "test-ns-fallback",
+			Path: "fallback/",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/jwt/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)
+		httpReq.Header.Set("X-Warden-Role", "from-header")
+		req := &logical.Request{
+			Path:        "sys/cred/sources",
+			Operation:   logical.ReadOperation,
+			HTTPRequest: httpReq,
+		}
+
+		_, _, _ = core.handleNonLoginRequest(nsCtx, req)
+		assert.True(t, req.Transparent)
+		require.NotNil(t, req.TokenEntry())
+		assert.Equal(t, "from-header", req.TokenEntry().RoleName)
 	})
 }
 

--- a/framework/access_backend.go
+++ b/framework/access_backend.go
@@ -70,9 +70,14 @@ func (b *AccessBackend) GetAutoAuthPath() string {
 	return b.cfg.AutoAuthPath
 }
 
-// GetAuthRole returns empty string — auth role resolution is the auth
-// method's responsibility (via X-Warden-Role header or auth method's default_role).
-func (b *AccessBackend) GetAuthRole(path string) string {
+// GetAuthRole extracts the auth role from the ?role= query parameter.
+// Falls back to empty string (auth method's default_role provides the fallback).
+func (b *AccessBackend) GetAuthRole(_ string, req *logical.Request) string {
+	if req != nil {
+		if role, ok := req.Data["role"].(string); ok {
+			return role
+		}
+	}
 	return ""
 }
 

--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -505,7 +505,7 @@ func (b *StreamingBackend) GetAutoAuthPath() string {
 }
 
 // GetAuthRole extracts the auth role name from the request path for implicit login.
-func (b *StreamingBackend) GetAuthRole(path string) string {
+func (b *StreamingBackend) GetAuthRole(path string, _ *logical.Request) string {
 	if b.TransparentConfig == nil {
 		return ""
 	}

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -116,10 +116,11 @@ type TransparentModeProvider interface {
 	// GetAutoAuthPath returns the auth mount path for implicit authentication (e.g., "auth/jwt/")
 	GetAutoAuthPath() string
 
-	// GetAuthRole extracts the auth role name from the request path for implicit login.
-	// For path pattern /role/{role}/gateway/*, returns the auth role.
-	// Returns empty string if path doesn't match transparent pattern.
-	GetAuthRole(path string) string
+	// GetAuthRole extracts the auth role name for implicit login.
+	// Streaming backends extract the role from the path (e.g., /role/{role}/gateway/*).
+	// Access backends read the "role" query parameter from req.Data.
+	// Returns empty string if no role is found.
+	GetAuthRole(path string, req *Request) string
 
 	// IsUnauthenticatedPath checks if a path can be accessed without authentication.
 	// Used for read-only endpoints that clients may access

--- a/provider/rds/README.md
+++ b/provider/rds/README.md
@@ -180,7 +180,7 @@ warden write auth/jwt/role/db-user \
     user_claim=sub
 ```
 
-Setting `default_role=db-user` means workloads don't need to pass `X-Warden-Role` — the auth method uses this role automatically during authentication.
+Setting `default_role=db-user` means workloads don't need to pass `?role=` — the auth method uses this role automatically during authentication.
 
 > **Advanced: Dynamic Policy Mapping with `groups_claim`**
 >
@@ -362,12 +362,11 @@ curl -s -H "Authorization: Bearer $JWT_TOKEN" \
   "${WARDEN_ADDR}/v1/rds/access/readonly" | jq
 ```
 
-The auth method's `default_role` determines which policies apply. To use a specific auth role, pass `X-Warden-Role`:
+The auth method's `default_role` determines which policies apply. To use a specific auth role, pass the `role` query parameter:
 
 ```bash
 curl -s -H "Authorization: Bearer $JWT_TOKEN" \
-  -H "X-Warden-Role: data-team" \
-  "${WARDEN_ADDR}/v1/rds/access/readonly" | jq
+  "${WARDEN_ADDR}/v1/rds/access/readonly?role=data-team" | jq
 ```
 
 Response:

--- a/provider/rds/provider_test.go
+++ b/provider/rds/provider_test.go
@@ -149,7 +149,7 @@ func TestTransparentModeProvider(t *testing.T) {
 	t.Run("disabled by default", func(t *testing.T) {
 		assert.False(t, b.IsTransparentMode())
 		assert.Equal(t, "", b.GetAutoAuthPath())
-		assert.Equal(t, "", b.GetAuthRole("access/readonly"))
+		assert.Equal(t, "", b.GetAuthRole("access/readonly", nil))
 	})
 
 	t.Run("enabled after config with auto_auth_path", func(t *testing.T) {
@@ -160,7 +160,21 @@ func TestTransparentModeProvider(t *testing.T) {
 
 		assert.True(t, b.IsTransparentMode())
 		assert.Equal(t, "auth/jwt/", b.GetAutoAuthPath())
-		assert.Equal(t, "", b.GetAuthRole("access/readonly"))
+		assert.Equal(t, "", b.GetAuthRole("access/readonly", nil))
+	})
+
+	t.Run("extracts role from query parameter", func(t *testing.T) {
+		req := &logical.Request{
+			Data: map[string]any{"role": "data-team"},
+		}
+		assert.Equal(t, "data-team", b.GetAuthRole("access/readonly", req))
+	})
+
+	t.Run("returns empty when no role in request", func(t *testing.T) {
+		req := &logical.Request{
+			Data: map[string]any{},
+		}
+		assert.Equal(t, "", b.GetAuthRole("access/readonly", req))
 	})
 
 	t.Run("IsUnauthenticatedPath always false", func(t *testing.T) {

--- a/provider/vault/provider_test.go
+++ b/provider/vault/provider_test.go
@@ -90,7 +90,7 @@ func TestGetAuthRole_ViaStreamingBackend(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sb.GetAuthRole(tt.path)
+			result := sb.GetAuthRole(tt.path, nil)
 			assert.Equal(t, tt.expectedRole, result)
 		})
 	}
@@ -105,12 +105,12 @@ func TestGetAuthRole_NoDefaultAuthRole(t *testing.T) {
 	}
 
 	t.Run("returns empty for non-matching path without default", func(t *testing.T) {
-		result := sb.GetAuthRole("gateway/v1/secret/data/foo")
+		result := sb.GetAuthRole("gateway/v1/secret/data/foo", nil)
 		assert.Empty(t, result)
 	})
 
 	t.Run("still extracts role from matching path", func(t *testing.T) {
-		result := sb.GetAuthRole("role/terraform/gateway/v1/secret")
+		result := sb.GetAuthRole("role/terraform/gateway/v1/secret", nil)
 		assert.Equal(t, "terraform", result)
 	})
 }
@@ -227,7 +227,7 @@ func TestSetTransparentConfig(t *testing.T) {
 	// Now should be enabled
 	assert.True(t, sb.IsTransparentMode())
 	assert.Equal(t, "auth/oidc/", sb.GetAutoAuthPath())
-	assert.Equal(t, "admin", sb.GetAuthRole("config"))
+	assert.Equal(t, "admin", sb.GetAuthRole("config", nil))
 }
 
 func TestExtractToken(t *testing.T) {


### PR DESCRIPTION
Add ?role= query parameter as the primary way to specify an auth role for non-gateway backends (access and system). Falls back to X-Warden-Role header when query param is not present.

Change GetAuthRole interface to accept (path, *Request), allowing access backends to also read the role from req.Data. Streaming/gateway backends are unchanged — they extract the role from the URL path.