### PR TITLE
feat: add PagerDuty provider with static API key and OAuth2 client cr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to Warden are documented in this file.
 
+## [v0.7.0] — 2026-04-03
+
+### New Features
+
+- **PagerDuty Provider** — New streaming gateway provider for the PagerDuty REST API v2. Proxies requests to incidents, services, users, schedules, and escalation policies with automatic credential injection. Supports two credential modes: static API tokens and OAuth2 client credentials.
+
+- **Generic OAuth2 Client Credentials Driver** — New reusable credential driver that exchanges `client_id`/`client_secret` for bearer tokens via the standard OAuth2 client credentials grant (RFC 6749). Parameterized by an `OAuth2ProviderConfig` struct — adding a new OAuth2 provider requires only a config definition, no custom driver code. PagerDuty is the first provider to use it; future OAuth2 providers (Datadog, Twilio, etc.) can reuse it directly.
+
+- **OAuth Bearer Token Credential Type** — New `oauth_bearer_token` credential type for OAuth2-minted bearer tokens. Tokens have a TTL from the provider's `expires_in` response and are minted on demand when leases expire. Primary field is `api_key` for compatibility with `BearerAPIKeyExtractor`.
+
+- **HTTP Proxy Framework** — Extracted a generic `httpproxy` framework from the provider implementations. All streaming providers (Anthropic, GitHub, GitLab, Mistral, OpenAI, PagerDuty, Slack) now share a single `ProviderSpec`-based implementation, reducing per-provider code from ~500 lines to ~30 lines. (#114)
+
+- **Credential Type Inference** — The `--type` flag on `warden cred spec create` is now optional. When omitted, the credential type is inferred from the source driver via `InferCredentialType`. All provider READMEs updated to omit the flag. (#111)
+
+- **Slack Provider** — New streaming gateway provider for the Slack Web API with body parsing for policy evaluation on request fields (channel, text, user). (#97)
+
+- **`?role=` Query Parameter** — Non-gateway backends now accept a `?role=` query parameter as an alternative to the `X-Warden-Role` header or URL path segment. (#108)
+
+### Improvements
+
+- **Unified Static API Key Driver** — Replaced four separate API key drivers (Anthropic, OpenAI, Mistral, Slack) with a single `StaticAPIKeyDriver` parameterized by `APIKeyProviderConfig`. (#111)
+
+### Bug Fixes
+
+- **SQL Server Removal** — Removed SQL Server physical storage backend. (#92)
+- **CI Permissions** — Added explicit permissions block to CI workflow. (#99)
+
+### Infrastructure
+
+- **Test Coverage** — Increased test coverage across all packages. (#110)
+- **Badges** — Added pkg.go.dev and Codecov badges. (#109)
+- **Dependency Updates** — Bumped Go minor/patch dependencies. (#98)
+
+### Documentation
+
+- **Provider READMEs** — Removed `--type` from all `cred spec create` examples (now inferred). Added PagerDuty provider README with full quickstart for both static API token and OAuth2 client credentials modes.
+
 ## [v0.6.0] — 2026-03-27
 
 ### Breaking Changes
@@ -199,6 +236,8 @@ Initial release. See the [v0.1.0 release notes](https://github.com/stephnangue/w
 - Docker image published to `ghcr.io/stephnangue/warden`
 - Pre-built binaries for Linux, macOS, and Windows
 
+[v0.7.0]: https://github.com/stephnangue/warden/compare/v0.6.0...v0.7.0
+[v0.6.0]: https://github.com/stephnangue/warden/compare/v0.5.0...v0.6.0
 [v0.5.0]: https://github.com/stephnangue/warden/compare/v0.4.1...v0.5.0
 [v0.4.1]: https://github.com/stephnangue/warden/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/stephnangue/warden/compare/v0.3.0...v0.4.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,14 @@
-## Warden v0.6.0
+## Warden v0.7.0
 
 Warden is an identity-based access layer for cloud APIs, SaaS platforms, databases, and AI providers. It eliminates static credentials from your workloads entirely. Your workload authenticates to Warden with its own identity — a JWT from your identity provider or a TLS certificate. Warden verifies who is calling, evaluates fine-grained capability-based policies, and issues ephemeral request-scoped access: forwarding API requests with short-lived credentials injected, returning database auth tokens, or vending pre-signed URLs. Credentials are minted on demand, scoped to the request, and never exposed to the caller. Every API call is logged with caller identity, target service, and full request context. No secrets ever reach your applications.
 
 ### What's New
 
-**Transparent mode is the only mode.** There is no longer a separate "explicit login" flow. Clients pass their JWT or certificate directly to the gateway endpoint — Warden handles authentication implicitly on every request.
+**PagerDuty provider with dual credential modes.** The new PagerDuty provider proxies requests to the PagerDuty REST API v2 with automatic credential injection. Two credential modes are supported: static API tokens (for simple setups) and OAuth2 client credentials (for production deployments with auto-refreshing bearer tokens).
+
+**Generic HTTP proxy framework.** All streaming providers now share a single `httpproxy.ProviderSpec`-based implementation. Adding a new provider requires ~30 lines of configuration instead of ~500 lines of boilerplate.
+
+**Credential type inference.** The `--type` flag on `warden cred spec create` is now optional — the type is inferred from the source driver automatically.
 
 ### Providers
 
@@ -19,23 +23,22 @@ Warden is an identity-based access layer for cloud APIs, SaaS platforms, databas
 | Anthropic | Streaming | API keys |
 | OpenAI | Streaming | API keys |
 | Mistral | Streaming | API keys |
-| **RDS** *(new)* | **Access** | **IAM auth tokens** |
+| Slack | Streaming | API keys |
+| **PagerDuty** *(new)* | **Streaming** | **API keys / OAuth2 bearer tokens** |
+| RDS | Access | IAM auth tokens |
 
 - **Streaming providers** proxy requests through Warden, injecting credentials in-flight.
 - **Access providers** vend credentials directly (database auth tokens, pre-signed URLs).
 
-### Breaking Changes
-
-- **`token_type` removed** — The `token_type` field on auth method configs and roles no longer exists. All roles use the transparent type (`jwt_role` or `cert_role`) automatically.
-- **Explicit login blocked** — `/auth/jwt/login` and `/auth/cert/login` return `400`. Use the gateway endpoint directly.
-- **`transparent_mode` config removed** — Remove `"transparent_mode": true` from provider configs. The `auto_auth_path` field (required) controls authentication.
-- **`warden_crypto_token` removed** — Self-contained encrypted tokens are no longer supported.
-
 ### New Features
 
-- **AWS Transparent Mode** — AWS SDK clients authenticate via JWT or TLS certificate. Warden intercepts SigV4-signed requests, verifies the client signature, then re-signs with real AWS credentials. Supports `aws-chunked` streaming uploads.
-- **RDS Provider** — Issues short-lived IAM authentication tokens for PostgreSQL and MySQL on RDS/Aurora.
-- **TLS in Dev Mode** — `--dev-tls` generates a self-signed certificate at startup for HTTPS development.
+- **PagerDuty Provider** — Streaming gateway for PagerDuty REST API v2. Supports static API tokens (`pagerduty` source) and OAuth2 client credentials (`pagerduty_oauth2` source) with automatic token minting and refresh.
+- **Slack Provider** — Streaming gateway for Slack Web API with policy evaluation on request fields (channel, text, user).
+- **Generic OAuth2 Client Credentials Driver** — Reusable credential driver for any OAuth2 provider using the client credentials grant. PagerDuty is the first consumer; future OAuth2 providers can reuse it with config only.
+- **OAuth Bearer Token Credential Type** — New `oauth_bearer_token` type for dynamically minted OAuth2 bearer tokens with TTL-based lifecycle.
+- **HTTP Proxy Framework** — Shared `httpproxy.ProviderSpec` eliminates per-provider boilerplate across all streaming providers.
+- **Credential Type Inference** — `--type` on `warden cred spec create` is now optional; inferred from the source driver.
+- **`?role=` Query Parameter** — Non-gateway backends accept `?role=` as an alternative to `X-Warden-Role` header.
 
 ### Getting Started
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/stephnangue/warden/provider/gitlab"
 	"github.com/stephnangue/warden/provider/mistral"
 	"github.com/stephnangue/warden/provider/openai"
+	"github.com/stephnangue/warden/provider/pagerduty"
 	"github.com/stephnangue/warden/provider/rds"
 	"github.com/stephnangue/warden/provider/slack"
 	"github.com/stephnangue/warden/provider/vault"
@@ -108,6 +109,7 @@ Usage: warden server [options]
 		"gitlab":    gitlab.Factory,
 		"mistral":   mistral.Factory,
 		"openai":    openai.Factory,
+		"pagerduty": pagerduty.Factory,
 		"slack":     slack.Factory,
 		"vault":     vault.Factory,
 		"rds":       rds.Factory,

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -16,21 +16,24 @@ const (
 	TypeGitHubToken       = "github_token"
 	TypeAPIKey            = "api_key"
 	TypeDBAuthToken       = "db_auth_token"
+	TypeOAuthBearerToken  = "oauth_bearer_token"
 )
 
 // Source type constants
 const (
-	SourceTypeLocal     = "local"
-	SourceTypeVault     = "hvault"
-	SourceTypeAWS       = "aws"
-	SourceTypeAzure     = "azure"
-	SourceTypeGCP       = "gcp"
-	SourceTypeGitLab    = "gitlab"
-	SourceTypeGitHub    = "github"
-	SourceTypeMistral   = "mistral"
-	SourceTypeOpenAI    = "openai"
-	SourceTypeAnthropic = "anthropic"
-	SourceTypeSlack     = "slack"
+	SourceTypeLocal          = "local"
+	SourceTypeVault          = "hvault"
+	SourceTypeAWS            = "aws"
+	SourceTypeAzure          = "azure"
+	SourceTypeGCP            = "gcp"
+	SourceTypeGitLab         = "gitlab"
+	SourceTypeGitHub         = "github"
+	SourceTypeMistral        = "mistral"
+	SourceTypeOpenAI         = "openai"
+	SourceTypeAnthropic      = "anthropic"
+	SourceTypeSlack          = "slack"
+	SourceTypePagerDuty      = "pagerduty"
+	SourceTypePagerDutyOAuth = "pagerduty_oauth2"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -39,11 +39,20 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
-	// Register static API key driver factories (Anthropic, OpenAI, Mistral, Slack)
+	// Register static API key driver factories (Anthropic, OpenAI, Mistral, Slack, PagerDuty)
 	for _, provider := range []APIKeyProviderConfig{
-		AnthropicProvider, OpenAIProvider, MistralProvider, SlackProvider,
+		AnthropicProvider, OpenAIProvider, MistralProvider, SlackProvider, PagerDutyProvider,
 	} {
 		if err := registry.RegisterFactory(NewStaticAPIKeyDriverFactory(provider)); err != nil {
+			return err
+		}
+	}
+
+	// Register OAuth2 client credentials driver factories
+	for _, provider := range []OAuth2ProviderConfig{
+		PagerDutyOAuth2Provider,
+	} {
+		if err := registry.RegisterFactory(NewOAuth2DriverFactory(provider)); err != nil {
 			return err
 		}
 	}

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -1,0 +1,293 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// oauth2MaxRetryAttempts for retryable token endpoint calls
+const oauth2MaxRetryAttempts = 3
+
+// OAuth2ProviderConfig holds the per-provider differences that parameterize
+// the OAuth2 client credentials driver. Each OAuth2 provider (PagerDuty, etc.)
+// is defined as a config instance rather than a separate driver type.
+type OAuth2ProviderConfig struct {
+	SourceType       string         // e.g. credential.SourceTypePagerDutyOAuth
+	DisplayName      string         // e.g. "PagerDuty" (for error messages, logs)
+	DefaultTokenURL  string         // e.g. "https://identity.pagerduty.com/oauth/token"
+	DefaultScopes    string         // default OAuth2 scopes (space-separated)
+	VerifyURL        string         // optional endpoint to verify minted tokens
+	VerifyMethod     string         // HTTP method for verify (default GET)
+	BuildAuthHeaders AuthHeaderFunc // how to attach token for verification
+}
+
+// PagerDutyOAuth2Provider defines the PagerDuty OAuth2 provider configuration.
+var PagerDutyOAuth2Provider = OAuth2ProviderConfig{
+	SourceType:      credential.SourceTypePagerDutyOAuth,
+	DisplayName:     "PagerDuty",
+	DefaultTokenURL: "https://identity.pagerduty.com/oauth/token",
+	DefaultScopes:   "",
+	VerifyURL:       "https://api.pagerduty.com/users/me",
+	VerifyMethod:    http.MethodGet,
+	BuildAuthHeaders: func(apiKey string) map[string]string {
+		return map[string]string{
+			"Authorization": "Bearer " + apiKey,
+			"Accept":        "application/json",
+		}
+	},
+}
+
+// Compile-time interface assertions
+var _ credential.SourceDriver = (*OAuth2Driver)(nil)
+var _ credential.SpecVerifier = (*OAuth2Driver)(nil)
+
+// OAuth2Driver exchanges OAuth2 client credentials for bearer tokens.
+//
+// The source config holds client_id, client_secret, and optionally token_url.
+// The spec config holds an optional scope override. The driver POSTs to the
+// token endpoint using the client_credentials grant type and returns the
+// resulting access_token as an api_key field (for BearerAPIKeyExtractor
+// compatibility).
+type OAuth2Driver struct {
+	provider   OAuth2ProviderConfig
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// OAuth2DriverFactory creates OAuth2Driver instances.
+// One factory instance is registered per provider, each with a different config.
+type OAuth2DriverFactory struct {
+	provider OAuth2ProviderConfig
+}
+
+// NewOAuth2DriverFactory creates a factory for the given provider config.
+func NewOAuth2DriverFactory(provider OAuth2ProviderConfig) *OAuth2DriverFactory {
+	return &OAuth2DriverFactory{provider: provider}
+}
+
+// Type returns the driver type identifier for this provider.
+func (f *OAuth2DriverFactory) Type() string {
+	return f.provider.SourceType
+}
+
+// ValidateConfig validates source configuration.
+// Requires client_id and client_secret; token_url is optional.
+func (f *OAuth2DriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("client_id").
+			Required().
+			Describe(fmt.Sprintf("%s OAuth2 client ID", f.provider.DisplayName)).
+			Example("your-client-id"),
+
+		credential.StringField("client_secret").
+			Required().
+			Describe(fmt.Sprintf("%s OAuth2 client secret", f.provider.DisplayName)).
+			Example("your-client-secret"),
+
+		credential.StringField("token_url").
+			Custom(validateOAuth2TokenURL).
+			Describe(fmt.Sprintf("OAuth2 token endpoint (default: %s)", f.provider.DefaultTokenURL)).
+			Example(f.provider.DefaultTokenURL),
+	)
+}
+
+// SensitiveConfigFields returns the list of source config keys that should be masked.
+func (f *OAuth2DriverFactory) SensitiveConfigFields() []string {
+	return []string{"client_secret"}
+}
+
+// InferCredentialType returns the credential type for OAuth2 providers.
+func (f *OAuth2DriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeOAuthBearerToken, nil
+}
+
+// Create instantiates a new OAuth2Driver.
+func (f *OAuth2DriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &OAuth2Driver{
+		provider: f.provider,
+		credSource: &credential.CredSource{
+			Type:   f.provider.SourceType,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(f.provider.SourceType),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	return driver, nil
+}
+
+// Type returns the driver type.
+func (d *OAuth2Driver) Type() string {
+	return d.provider.SourceType
+}
+
+// getTokenURL returns the token endpoint URL from source config or default.
+func (d *OAuth2Driver) getTokenURL() string {
+	return credential.GetString(d.credSource.Config, "token_url", d.provider.DefaultTokenURL)
+}
+
+// oauth2TokenResponse is the standard OAuth2 token endpoint response.
+type oauth2TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+// MintCredential exchanges client credentials for a bearer token.
+func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	clientID := credential.GetString(d.credSource.Config, "client_id", "")
+	clientSecret := credential.GetString(d.credSource.Config, "client_secret", "")
+
+	if clientID == "" || clientSecret == "" {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 source missing client_id or client_secret", d.provider.DisplayName)
+	}
+
+	scope := credential.GetString(spec.Config, "scope", d.provider.DefaultScopes)
+
+	// Build token request body
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       oauth2MaxRetryAttempts,
+		MaxBodySize:       DefaultMaxBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodPost,
+		URL:    d.getTokenURL(),
+		Body:   []byte(form.Encode()),
+		Headers: map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept":       "application/json",
+		},
+	}
+
+	body, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", d.provider.DisplayName, err)
+	}
+
+	var tokenResp oauth2TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, 0, "", fmt.Errorf("failed to decode %s OAuth2 token response: %w", d.provider.DisplayName, err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 token response missing access_token", d.provider.DisplayName)
+	}
+
+	rawData := map[string]interface{}{
+		"api_key": tokenResp.AccessToken,
+	}
+	if tokenResp.Scope != "" {
+		rawData["scope"] = tokenResp.Scope
+	}
+	if tokenResp.TokenType != "" {
+		rawData["token_type"] = tokenResp.TokenType
+	}
+
+	var ttl time.Duration
+	if tokenResp.ExpiresIn > 0 {
+		ttl = time.Duration(tokenResp.ExpiresIn) * time.Second
+	}
+
+	return rawData, ttl, "", nil
+}
+
+// Revoke is a no-op for OAuth2 bearer tokens — they expire naturally.
+func (d *OAuth2Driver) Revoke(_ context.Context, leaseID string) error {
+	if d.logger != nil {
+		d.logger.Debug(fmt.Sprintf("%s OAuth2 bearer tokens expire naturally, skipping revocation", d.provider.DisplayName),
+			logger.String("lease_id", leaseID),
+		)
+	}
+	return nil
+}
+
+// Cleanup releases resources.
+func (d *OAuth2Driver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates the spec by minting a token and optionally calling
+// the provider's verification endpoint.
+func (d *OAuth2Driver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	rawData, _, _, err := d.MintCredential(ctx, spec)
+	if err != nil {
+		return fmt.Errorf("%s OAuth2 spec verification failed: %w", d.provider.DisplayName, err)
+	}
+
+	if d.provider.VerifyURL == "" {
+		return nil
+	}
+
+	token, _ := rawData["api_key"].(string)
+
+	headers := map[string]string{
+		"Authorization": "Bearer " + token,
+		"Accept":        "application/json",
+	}
+	if d.provider.BuildAuthHeaders != nil {
+		headers = d.provider.BuildAuthHeaders(token)
+	}
+
+	method := d.provider.VerifyMethod
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       oauth2MaxRetryAttempts,
+		MaxBodySize:       DefaultMaxBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method:  method,
+		URL:     d.provider.VerifyURL,
+		Headers: headers,
+	}
+
+	_, _, err = ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("%s OAuth2 token verification failed: %w", d.provider.DisplayName, err)
+	}
+
+	return nil
+}
+
+// validateOAuth2TokenURL validates that the token_url is a well-formed HTTPS URL.
+func validateOAuth2TokenURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid token_url: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("token_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("token_url must include a host")
+	}
+	return nil
+}

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -1,0 +1,561 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Factory Tests
+// =============================================================================
+
+func TestOAuth2DriverFactory_Type(t *testing.T) {
+	f := NewOAuth2DriverFactory(PagerDutyOAuth2Provider)
+	assert.Equal(t, credential.SourceTypePagerDutyOAuth, f.Type())
+}
+
+func TestOAuth2DriverFactory_SensitiveConfigFields(t *testing.T) {
+	f := NewOAuth2DriverFactory(PagerDutyOAuth2Provider)
+	fields := f.SensitiveConfigFields()
+	assert.Equal(t, []string{"client_secret"}, fields)
+}
+
+func TestOAuth2DriverFactory_InferCredentialType(t *testing.T) {
+	f := NewOAuth2DriverFactory(PagerDutyOAuth2Provider)
+	ct, err := f.InferCredentialType(map[string]string{})
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeOAuthBearerToken, ct)
+}
+
+func TestOAuth2DriverFactory_ValidateConfig(t *testing.T) {
+	f := NewOAuth2DriverFactory(PagerDutyOAuth2Provider)
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config",
+			config: map[string]string{
+				"client_id":     "test-client-id",
+				"client_secret": "test-client-secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with custom token_url",
+			config: map[string]string{
+				"client_id":     "test-client-id",
+				"client_secret": "test-client-secret",
+				"token_url":     "https://custom.example.com/oauth/token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing client_id",
+			config: map[string]string{
+				"client_secret": "test-client-secret",
+			},
+			wantErr: true,
+			errMsg:  "client_id",
+		},
+		{
+			name: "missing client_secret",
+			config: map[string]string{
+				"client_id": "test-client-id",
+			},
+			wantErr: true,
+			errMsg:  "client_secret",
+		},
+		{
+			name:    "missing both",
+			config:  map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "invalid token_url - http scheme",
+			config: map[string]string{
+				"client_id":     "test-client-id",
+				"client_secret": "test-client-secret",
+				"token_url":     "http://example.com/token",
+			},
+			wantErr: true,
+			errMsg:  "must use https://",
+		},
+		{
+			name: "invalid token_url - no host",
+			config: map[string]string{
+				"client_id":     "test-client-id",
+				"client_secret": "test-client-secret",
+				"token_url":     "https://",
+			},
+			wantErr: true,
+			errMsg:  "must include a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := f.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOAuth2DriverFactory_Create(t *testing.T) {
+	f := NewOAuth2DriverFactory(PagerDutyOAuth2Provider)
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	driver, err := f.Create(map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+	}, log)
+	require.NoError(t, err)
+	require.NotNil(t, driver)
+	assert.Equal(t, credential.SourceTypePagerDutyOAuth, driver.Type())
+}
+
+// =============================================================================
+// Driver Tests
+// =============================================================================
+
+func createTestOAuth2Driver(t *testing.T, config map[string]string) *OAuth2Driver {
+	t.Helper()
+	f := NewOAuth2DriverFactory(PagerDutyOAuth2Provider)
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	driver, err := f.Create(config, log)
+	require.NoError(t, err)
+	return driver.(*OAuth2Driver)
+}
+
+func TestOAuth2Driver_Type(t *testing.T) {
+	d := createTestOAuth2Driver(t, map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+	})
+	assert.Equal(t, credential.SourceTypePagerDutyOAuth, d.Type())
+}
+
+func TestOAuth2Driver_Cleanup(t *testing.T) {
+	d := createTestOAuth2Driver(t, map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+	})
+	assert.NoError(t, d.Cleanup(context.Background()))
+}
+
+func TestOAuth2Driver_Revoke_NoOp(t *testing.T) {
+	d := createTestOAuth2Driver(t, map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+	})
+	assert.NoError(t, d.Revoke(context.Background(), "any-lease-id"))
+	assert.NoError(t, d.Revoke(context.Background(), ""))
+}
+
+func TestOAuth2Driver_NotRotatable(t *testing.T) {
+	d := createTestOAuth2Driver(t, map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+	})
+	var sd credential.SourceDriver = d
+	_, ok := sd.(credential.Rotatable)
+	assert.False(t, ok, "OAuth2Driver should not implement credential.Rotatable")
+}
+
+func TestOAuth2Driver_MintCredential(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		err := r.ParseForm()
+		require.NoError(t, err)
+		assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
+		assert.Equal(t, "test-client-id", r.Form.Get("client_id"))
+		assert.Equal(t, "test-client-secret", r.Form.Get("client_secret"))
+		assert.Equal(t, "read write", r.Form.Get("scope"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "eyJ-test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"scope":        "read write",
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-client-id",
+				"client_secret": "test-client-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Type:   credential.TypeOAuthBearerToken,
+		Config: map[string]string{"scope": "read write"},
+	}
+
+	rawData, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJ-test-access-token", rawData["api_key"])
+	assert.Equal(t, "Bearer", rawData["token_type"])
+	assert.Equal(t, "read write", rawData["scope"])
+	assert.Equal(t, 3600*time.Second, ttl)
+	assert.Empty(t, leaseID)
+}
+
+func TestOAuth2Driver_MintCredential_DefaultScope(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		require.NoError(t, err)
+		// Default scope for PagerDuty is empty, so scope param should not be set
+		assert.Empty(t, r.Form.Get("scope"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   1800,
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Type:   credential.TypeOAuthBearerToken,
+		Config: map[string]string{},
+	}
+
+	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "test-token", rawData["api_key"])
+	assert.Equal(t, 1800*time.Second, ttl)
+}
+
+func TestOAuth2Driver_MintCredential_NoExpiresIn(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{},
+	}
+
+	_, ttl, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), ttl)
+}
+
+func TestOAuth2Driver_MintCredential_MissingCredentials(t *testing.T) {
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing client_id or client_secret")
+}
+
+func TestOAuth2Driver_MintCredential_TokenEndpointError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid_client"}`))
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "bad-id",
+				"client_secret": "bad-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token exchange failed")
+}
+
+func TestOAuth2Driver_MintCredential_EmptyAccessToken(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "",
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing access_token")
+}
+
+func TestOAuth2Driver_MintCredential_MalformedJSON(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not-json`))
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+// =============================================================================
+// VerifySpec Tests
+// =============================================================================
+
+func TestOAuth2Driver_VerifySpec(t *testing.T) {
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "verify-test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	verifyServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "Bearer verify-test-token", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"user":{"id":"PUSER123"}}`))
+	}))
+	defer verifyServer.Close()
+
+	provider := OAuth2ProviderConfig{
+		SourceType:      credential.SourceTypePagerDutyOAuth,
+		DisplayName:     "PagerDuty",
+		DefaultTokenURL: tokenServer.URL,
+		VerifyURL:       verifyServer.URL,
+		VerifyMethod:    http.MethodGet,
+		BuildAuthHeaders: func(apiKey string) map[string]string {
+			return map[string]string{
+				"Authorization": "Bearer " + apiKey,
+				"Accept":        "application/json",
+			}
+		},
+	}
+
+	d := &OAuth2Driver{
+		provider: provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     tokenServer.URL,
+			},
+		},
+		httpClient: tokenServer.Client(),
+	}
+	// Use the same TLS client for both servers
+	d.httpClient.Transport = tokenServer.Client().Transport
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	err := d.VerifySpec(context.Background(), spec)
+	assert.NoError(t, err)
+}
+
+func TestOAuth2Driver_VerifySpec_NoVerifyURL(t *testing.T) {
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	provider := OAuth2ProviderConfig{
+		SourceType:      credential.SourceTypePagerDutyOAuth,
+		DisplayName:     "PagerDuty",
+		DefaultTokenURL: tokenServer.URL,
+		VerifyURL:       "", // No verification endpoint
+	}
+
+	d := &OAuth2Driver{
+		provider: provider,
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     tokenServer.URL,
+			},
+		},
+		httpClient: tokenServer.Client(),
+	}
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	err := d.VerifySpec(context.Background(), spec)
+	assert.NoError(t, err)
+}
+
+func TestOAuth2Driver_VerifySpec_MintFails(t *testing.T) {
+	d := &OAuth2Driver{
+		provider: PagerDutyOAuth2Provider,
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypePagerDutyOAuth,
+			Config: map[string]string{}, // Missing credentials
+		},
+	}
+
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+	err := d.VerifySpec(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec verification failed")
+}
+
+// =============================================================================
+// GetTokenURL Tests
+// =============================================================================
+
+func TestOAuth2Driver_GetTokenURL_Default(t *testing.T) {
+	d := createTestOAuth2Driver(t, map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+	})
+	assert.Equal(t, PagerDutyOAuth2Provider.DefaultTokenURL, d.getTokenURL())
+}
+
+func TestOAuth2Driver_GetTokenURL_Custom(t *testing.T) {
+	d := createTestOAuth2Driver(t, map[string]string{
+		"client_id":     "test-id",
+		"client_secret": "test-secret",
+		"token_url":     "https://custom.example.com/oauth/token",
+	})
+	assert.Equal(t, "https://custom.example.com/oauth/token", d.getTokenURL())
+}
+
+// =============================================================================
+// URL Validator Tests
+// =============================================================================
+
+func TestValidateOAuth2TokenURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{"https://identity.pagerduty.com/oauth/token", false, ""},
+		{"https://custom.example.com/token", false, ""},
+		{"http://example.com/token", true, "must use https://"},
+		{"ftp://example.com/token", true, "must use https://"},
+		{"https://", true, "must include a host"},
+		{"not-a-url", true, "must use https://"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateOAuth2TokenURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/credential/drivers/static_apikey_driver_test.go
+++ b/credential/drivers/static_apikey_driver_test.go
@@ -16,7 +16,7 @@ import (
 // allAPIKeyProviders returns the 4 built-in API key provider configs for table-driven tests.
 func allAPIKeyProviders() []APIKeyProviderConfig {
 	return []APIKeyProviderConfig{
-		AnthropicProvider, OpenAIProvider, MistralProvider, SlackProvider,
+		AnthropicProvider, OpenAIProvider, MistralProvider, SlackProvider, PagerDutyProvider,
 	}
 }
 
@@ -312,6 +312,16 @@ func TestStaticAPIKeyDriver_VerifySpec(t *testing.T) {
 			expectedPath:   "/auth.test",
 			checkHeaders: func(t *testing.T, r *http.Request) {
 				assert.Equal(t, "Bearer sk-valid-key", r.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			},
+		},
+		{
+			provider:       PagerDutyProvider,
+			expectedMethod: http.MethodGet,
+			expectedPath:   "/users/me",
+			checkHeaders: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "Bearer sk-valid-key", r.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 			},
 		},

--- a/credential/drivers/static_apikey_providers.go
+++ b/credential/drivers/static_apikey_providers.go
@@ -10,6 +10,7 @@ const (
 	DefaultOpenAIAPIURL    = "https://api.openai.com"
 	DefaultMistralAPIURL   = "https://api.mistral.ai"
 	DefaultSlackAPIURL     = "https://slack.com/api"
+	DefaultPagerDutyAPIURL = "https://api.pagerduty.com"
 )
 
 // AnthropicProvider defines the Anthropic API key provider configuration.
@@ -59,6 +60,23 @@ var MistralProvider = APIKeyProviderConfig{
 		}
 	},
 	OptionalMetadata: []string{"organization_id"},
+}
+
+// PagerDutyProvider defines the PagerDuty API key provider configuration.
+var PagerDutyProvider = APIKeyProviderConfig{
+	SourceType:     credential.SourceTypePagerDuty,
+	DisplayName:    "PagerDuty",
+	DefaultAPIURL:  DefaultPagerDutyAPIURL,
+	VerifyEndpoint: "/users/me",
+	VerifyMethod:   http.MethodGet,
+	BuildAuthHeaders: func(apiKey string) map[string]string {
+		return map[string]string{
+			"Authorization": "Bearer " + apiKey,
+			"Accept":        "application/json",
+			"Content-Type":  "application/json",
+		}
+	},
+	OptionalMetadata: nil,
 }
 
 // SlackProvider defines the Slack API key provider configuration.

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -78,10 +78,10 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	// Step 1: Validate source type compatibility
 	switch sourceType {
-	case credential.SourceTypeMistral, credential.SourceTypeOpenAI, credential.SourceTypeAnthropic, credential.SourceTypeSlack, credential.SourceTypeLocal:
+	case credential.SourceTypeMistral, credential.SourceTypeOpenAI, credential.SourceTypeAnthropic, credential.SourceTypeSlack, credential.SourceTypePagerDuty, credential.SourceTypeLocal:
 		// Supported
 	default:
-		return fmt.Errorf("api_key credentials require a mistral, openai, anthropic, slack, or local source, got: %s", sourceType)
+		return fmt.Errorf("api_key credentials require a mistral, openai, anthropic, slack, pagerduty, or local source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -138,7 +138,7 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: "aws",
 			wantErr:    true,
-			errMsg:     "require a mistral, openai, anthropic, slack, or local source",
+			errMsg:     "require a mistral, openai, anthropic, slack, pagerduty, or local source",
 		},
 		{
 			name: "unsupported source type - vault",
@@ -147,7 +147,7 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: credential.SourceTypeVault,
 			wantErr:    true,
-			errMsg:     "require a mistral, openai, anthropic, slack, or local source",
+			errMsg:     "require a mistral, openai, anthropic, slack, pagerduty, or local source",
 		},
 	}
 

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -39,6 +39,11 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
+	// Register OAuth bearer token type
+	if err := registry.Register(NewOAuthBearerTokenCredType()); err != nil {
+		return err
+	}
+
 	// Register database auth token type
 	if err := registry.Register(NewDBAuthTokenCredType()); err != nil {
 		return err

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+)
+
+// OAuthBearerTokenCredType handles OAuth2 bearer tokens minted via client credentials flow.
+type OAuthBearerTokenCredType struct {
+	*BaseTokenType
+}
+
+// NewOAuthBearerTokenCredType creates a new OAuth bearer token credential type.
+func NewOAuthBearerTokenCredType() *OAuthBearerTokenCredType {
+	return &OAuthBearerTokenCredType{
+		BaseTokenType: &BaseTokenType{
+			TypeMetadata: credential.TypeMetadata{
+				Name:        credential.TypeOAuthBearerToken,
+				Category:    credential.CategoryOAuth,
+				Description: "OAuth2 bearer token for provider authentication",
+				DefaultTTL:  1 * time.Hour,
+			},
+			FieldConfig: TokenFieldConfig{
+				PrimaryField:      "api_key",
+				AlternativeFields: []string{"access_token"},
+				OptionalFields:    []string{"scope", "token_type"},
+				FieldSchemas: map[string]*credential.CredentialFieldSchema{
+					"api_key": {
+						Description: "OAuth2 bearer token for authentication",
+						Sensitive:   true,
+					},
+					"scope": {
+						Description: "OAuth2 scope granted",
+						Sensitive:   false,
+					},
+					"token_type": {
+						Description: "Token type (typically Bearer)",
+						Sensitive:   false,
+					},
+				},
+			},
+			Revocable: false,
+		},
+	}
+}
+
+// ConfigSchema returns the declarative schema for OAuth bearer token spec config.
+// The spec holds only the scope — the driver mints the token dynamically.
+func (t *OAuthBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
+	return []*credential.FieldValidator{
+		credential.StringField("scope").
+			Describe("OAuth2 scope to request").
+			Example("read write"),
+	}
+}
+
+// ValidateConfig validates the Config for an OAuth bearer token credential spec.
+func (t *OAuthBearerTokenCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	switch sourceType {
+	case credential.SourceTypePagerDutyOAuth:
+		// Supported OAuth2 source types
+	default:
+		return fmt.Errorf("oauth_bearer_token credentials require an OAuth2 source, got: %s", sourceType)
+	}
+
+	schema := t.ConfigSchema()
+	if err := credential.ValidateSchema(config, schema...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RequiresSpecRotation returns false — the driver mints fresh tokens, no
+// credentials are embedded in the spec.
+func (t *OAuthBearerTokenCredType) RequiresSpecRotation() bool {
+	return false
+}
+
+// SensitiveConfigFields returns spec config keys that should be masked in output.
+func (t *OAuthBearerTokenCredType) SensitiveConfigFields() []string {
+	return nil
+}

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -1,0 +1,271 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuthBearerTokenCredType_Metadata(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+	metadata := ct.Metadata()
+
+	assert.Equal(t, credential.TypeOAuthBearerToken, metadata.Name)
+	assert.Equal(t, credential.CategoryOAuth, metadata.Category)
+	assert.Contains(t, metadata.Description, "OAuth2 bearer token")
+	assert.Equal(t, 1*time.Hour, metadata.DefaultTTL)
+}
+
+func TestOAuthBearerTokenCredType_ValidateConfig(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+
+	tests := []struct {
+		name       string
+		config     map[string]string
+		sourceType string
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:       "pagerduty_oauth2 source - empty config (scope optional)",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypePagerDutyOAuth,
+			wantErr:    false,
+		},
+		{
+			name:       "pagerduty_oauth2 source - with scope",
+			config:     map[string]string{"scope": "read write"},
+			sourceType: credential.SourceTypePagerDutyOAuth,
+			wantErr:    false,
+		},
+		{
+			name:       "unsupported source type - local",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    true,
+			errMsg:     "require an OAuth2 source",
+		},
+		{
+			name:       "unsupported source type - aws",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "require an OAuth2 source",
+		},
+		{
+			name:       "unsupported source type - static pagerduty",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypePagerDuty,
+			wantErr:    true,
+			errMsg:     "require an OAuth2 source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, tt.sourceType)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOAuthBearerTokenCredType_Parse(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+
+	tests := []struct {
+		name     string
+		rawData  map[string]interface{}
+		leaseTTL time.Duration
+		leaseID  string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "valid api_key field",
+			rawData: map[string]interface{}{
+				"api_key": "eyJhbGciOiJSUzI1NiJ9.test-token",
+			},
+			leaseTTL: 1 * time.Hour,
+			leaseID:  "",
+			wantErr:  false,
+		},
+		{
+			name: "valid access_token alternative field",
+			rawData: map[string]interface{}{
+				"access_token": "eyJhbGciOiJSUzI1NiJ9.test-token",
+			},
+			leaseTTL: 30 * time.Minute,
+			leaseID:  "",
+			wantErr:  false,
+		},
+		{
+			name: "valid with optional fields",
+			rawData: map[string]interface{}{
+				"api_key":    "test-token",
+				"scope":      "read write",
+				"token_type": "Bearer",
+			},
+			leaseTTL: 1 * time.Hour,
+			leaseID:  "",
+			wantErr:  false,
+		},
+		{
+			name:     "missing token",
+			rawData:  map[string]interface{}{},
+			leaseTTL: 0,
+			leaseID:  "",
+			wantErr:  true,
+			errMsg:   "missing or invalid api_key",
+		},
+		{
+			name: "empty token",
+			rawData: map[string]interface{}{
+				"api_key": "",
+			},
+			leaseTTL: 0,
+			leaseID:  "",
+			wantErr:  true,
+			errMsg:   "missing or invalid api_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, cred)
+				assert.Equal(t, credential.TypeOAuthBearerToken, cred.Type)
+				assert.Equal(t, credential.CategoryOAuth, cred.Category)
+				assert.Equal(t, tt.leaseTTL, cred.LeaseTTL)
+				assert.NotEmpty(t, cred.Data["api_key"])
+				// OAuth tokens are not revocable
+				assert.False(t, cred.Revocable)
+			}
+		})
+	}
+}
+
+func TestOAuthBearerTokenCredType_Parse_OptionalFields(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+
+	rawData := map[string]interface{}{
+		"api_key":    "test-token",
+		"scope":      "read write",
+		"token_type": "Bearer",
+	}
+
+	cred, err := ct.Parse(rawData, 1*time.Hour, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-token", cred.Data["api_key"])
+	assert.Equal(t, "read write", cred.Data["scope"])
+	assert.Equal(t, "Bearer", cred.Data["token_type"])
+}
+
+func TestOAuthBearerTokenCredType_Validate(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+
+	tests := []struct {
+		name    string
+		cred    *credential.Credential
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid credential",
+			cred: &credential.Credential{
+				Type: credential.TypeOAuthBearerToken,
+				Data: map[string]string{
+					"api_key": "test-token",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong type",
+			cred: &credential.Credential{
+				Type: credential.TypeAPIKey,
+				Data: map[string]string{
+					"api_key": "test-token",
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected type oauth_bearer_token",
+		},
+		{
+			name: "missing api_key",
+			cred: &credential.Credential{
+				Type: credential.TypeOAuthBearerToken,
+				Data: map[string]string{},
+			},
+			wantErr: true,
+			errMsg:  "missing api_key",
+		},
+		{
+			name: "empty api_key",
+			cred: &credential.Credential{
+				Type: credential.TypeOAuthBearerToken,
+				Data: map[string]string{
+					"api_key": "",
+				},
+			},
+			wantErr: true,
+			errMsg:  "missing api_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.Validate(tt.cred)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOAuthBearerTokenCredType_RequiresSpecRotation(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+	assert.False(t, ct.RequiresSpecRotation())
+}
+
+func TestOAuthBearerTokenCredType_SensitiveConfigFields(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+	assert.Nil(t, ct.SensitiveConfigFields())
+}
+
+func TestOAuthBearerTokenCredType_FieldSchemas(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+	schemas := ct.FieldSchemas()
+
+	assert.Contains(t, schemas, "api_key")
+	assert.True(t, schemas["api_key"].Sensitive)
+	assert.NotEmpty(t, schemas["api_key"].Description)
+
+	assert.Contains(t, schemas, "scope")
+	assert.False(t, schemas["scope"].Sensitive)
+
+	assert.Contains(t, schemas, "token_type")
+	assert.False(t, schemas["token_type"].Sensitive)
+}

--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -139,7 +139,6 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create anthropic-ops \
-  --type api_key \
   --source anthropic-src \
   --config api_key=<your-anthropic-api-key>
 ```

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -238,7 +238,6 @@ A credential spec defines what temporary credentials Warden mints for consumers.
 ```bash
 # Spec for developers — read-only access, short TTL
 warden cred spec create developer \
-  --type aws_access_keys \
   --source my-aws-source \
   --config mint_method=sts_assume_role \
   --config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-readonly-role \
@@ -248,7 +247,6 @@ warden cred spec create developer \
 
 # Spec for CI/CD pipelines — deploy permissions
 warden cred spec create deployer \
-  --type aws_access_keys \
   --source my-aws-source \
   --config mint_method=sts_assume_role \
   --config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-deploy-role \
@@ -258,7 +256,6 @@ warden cred spec create deployer \
 
 # Spec for operators — full access, longer TTL
 warden cred spec create operator \
-  --type aws_access_keys \
   --source my-aws-source \
   --config mint_method=sts_assume_role \
   --config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-operator-role \

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -194,7 +194,6 @@ Mints an Azure AD Bearer token using the client credentials flow:
 
 ```bash
 warden cred spec create azure-ops \
-  --type azure_bearer_token \
   --source azure-src \
   --config auth_method=bearer_token \
   --config client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
@@ -208,7 +207,6 @@ Fetches a secret directly from Azure Key Vault:
 
 ```bash
 warden cred spec create azure-kv \
-  --type azure_bearer_token \
   --source azure-src \
   --config auth_method=key_vault_secret \
   --config client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -159,7 +159,6 @@ Mint OAuth2 access tokens using the source service account directly:
 
 ```bash
 warden cred spec create gcp-cloud-platform \
-  --type=gcp_access_token \
   --source=gcp-sa \
   --min-ttl=5m \
   --max-ttl=1h \
@@ -173,7 +172,6 @@ Mint tokens on behalf of another service account:
 
 ```bash
 warden cred spec create gcp-impersonated \
-  --type=gcp_access_token \
   --source=gcp-sa \
   --min-ttl=5m \
   --max-ttl=1h \

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -149,7 +149,6 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create github-ops \
-  --type github_token \
   --source github-src \
   --config auth_method=app \
   --config app_id=<your-app-id> \
@@ -161,7 +160,6 @@ warden cred spec create github-ops \
 
 ```bash
 warden cred spec create github-ops \
-  --type github_token \
   --source github-src \
   --config auth_method=pat \
   --config token=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -168,7 +168,6 @@ Create a credential spec that references the credential source. The spec defines
 
 ```bash
 warden cred spec create gitlab-project-token \
-  --type=gitlab_access_token \
   --source=gitlab-pat \
   --min-ttl=1h \
   --max-ttl=24h \
@@ -183,7 +182,6 @@ warden cred spec create gitlab-project-token \
 
 ```bash
 warden cred spec create gitlab-group-token \
-  --type=gitlab_access_token \
   --source=gitlab-pat \
   --min-ttl=1h \
   --max-ttl=24h \

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -140,7 +140,6 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create mistral-ops \
-  --type api_key \
   --source mistral-src \
   --config api_key=<your-mistral-api-key>
 ```
@@ -149,7 +148,6 @@ Optionally include an organization ID:
 
 ```bash
 warden cred spec create mistral-ops \
-  --type api_key \
   --source mistral-src \
   --config api_key=<your-mistral-api-key> \
   --config organization_id=<your-org-id>

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -140,7 +140,6 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create openai-ops \
-  --type api_key \
   --source openai-src \
   --config api_key=<your-openai-api-key>
 ```
@@ -149,7 +148,6 @@ Optionally include an organization ID and/or project ID:
 
 ```bash
 warden cred spec create openai-ops \
-  --type api_key \
   --source openai-src \
   --config api_key=<your-openai-api-key> \
   --config organization_id=<your-org-id> \

--- a/provider/pagerduty/README.md
+++ b/provider/pagerduty/README.md
@@ -1,0 +1,498 @@
+# PagerDuty Provider
+
+The PagerDuty provider enables proxied access to the PagerDuty REST API v2 through Warden. It forwards requests to PagerDuty endpoints (incidents, services, users, schedules, etc.) with automatic credential injection and policy evaluation. Two credential modes are supported: static API tokens and OAuth2 client credentials.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [OAuth2 Client Credentials Mode](#oauth2-client-credentials-mode)
+- [TLS Certificate Authentication](#tls-certificate-authentication)
+- [Configuration Reference](#configuration-reference)
+- [Token Management](#token-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- A **PagerDuty API Token** (from PagerDuty > Integrations > API Access Keys) **or** a **PagerDuty OAuth2 App** (client_id and client_secret from PagerDuty > Integrations > App Registration)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Add the binary to your PATH:**
+> ```bash
+> export PATH="$PWD:$PATH"
+> ```
+>
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev --dev-root-token=root
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export PATH="$PWD:$PATH"
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="root"
+> ```
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/pagerduty-user \
+    token_policies="pagerduty-access" \
+    user_claim=sub \
+    cred_spec_name=pagerduty-ops
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the PagerDuty provider at a path of your choice:
+
+```bash
+warden provider enable --type=pagerduty
+```
+
+To mount at a custom path:
+
+```bash
+warden provider enable --type=pagerduty pagerduty-prod
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider with `auto_auth_path`. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write pagerduty/config <<EOF
+{
+  "pagerduty_url": "https://api.pagerduty.com",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read pagerduty/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+### Option A: Static API Token
+
+The credential source holds only connection info (`api_url`). The API token is stored on the credential spec below, allowing multiple specs with different tokens to share one source.
+
+```bash
+warden cred source create pagerduty-src \
+  --type=pagerduty \
+  --rotation-period=0 \
+  --config=api_url=https://api.pagerduty.com
+```
+
+Create a credential spec that references the credential source. The spec carries the API token and gets associated with tokens at login time.
+
+```bash
+warden cred spec create pagerduty-ops \
+  --source pagerduty-src \
+  --config api_key=your-pagerduty-api-token
+```
+
+The API token is validated at creation time via a `GET /users/me` call to the PagerDuty API (SpecVerifier). If the token is invalid, spec creation will fail.
+
+### Option B: OAuth2 Client Credentials
+
+See [OAuth2 Client Credentials Mode](#oauth2-client-credentials-mode) below for setup with `client_id` and `client_secret`.
+
+Verify:
+
+```bash
+warden cred spec read pagerduty-ops
+```
+
+## Step 4: Create a Policy
+
+Create a policy that grants access to the PagerDuty provider gateway:
+
+```bash
+warden policy write pagerduty-access - <<EOF
+path "pagerduty/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For fine-grained access control, restrict which PagerDuty resources and actions a role can use:
+
+```bash
+warden policy write pagerduty-readonly - <<EOF
+path "pagerduty/role/+/gateway/incidents" {
+  capabilities = ["read"]
+}
+
+path "pagerduty/role/+/gateway/services" {
+  capabilities = ["read"]
+}
+
+path "pagerduty/role/+/gateway/users" {
+  capabilities = ["read"]
+}
+
+path "pagerduty/role/+/gateway/schedules" {
+  capabilities = ["read"]
+}
+
+path "pagerduty/role/+/gateway/escalation_policies" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+Verify:
+
+```bash
+warden policy read pagerduty-access
+```
+
+## Step 5: Get a JWT and Make Requests
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+Requests use role-based paths. Warden performs implicit JWT authentication and injects the PagerDuty token automatically.
+
+The URL pattern is: `/v1/pagerduty/role/{role}/gateway/{api-path}`
+
+Export PD_ENDPOINT as environment variable:
+```bash
+export PD_ENDPOINT="${WARDEN_ADDR}/v1/pagerduty/role/pagerduty-user/gateway"
+```
+
+### List Incidents
+
+```bash
+curl -s "${PD_ENDPOINT}/incidents" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### Get Current User
+
+```bash
+curl -s "${PD_ENDPOINT}/users/me" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Services
+
+```bash
+curl -s "${PD_ENDPOINT}/services" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List On-Call Schedules
+
+```bash
+curl -s "${PD_ENDPOINT}/schedules" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Escalation Policies
+
+```bash
+curl -s "${PD_ENDPOINT}/escalation_policies" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### Create an Incident
+
+```bash
+curl -s -X POST "${PD_ENDPOINT}/incidents" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "incident": {
+      "type": "incident",
+      "title": "Server unreachable",
+      "service": {
+        "id": "PSERVICE1",
+        "type": "service_reference"
+      },
+      "urgency": "high"
+    }
+  }'
+```
+
+### Acknowledge an Incident
+
+```bash
+curl -s -X PUT "${PD_ENDPOINT}/incidents/PINCIDENT1" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "incident": {
+      "type": "incident_reference",
+      "status": "acknowledged"
+    }
+  }'
+```
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
+
+## OAuth2 Client Credentials Mode
+
+Instead of a static API token, you can use OAuth2 client credentials to have Warden mint short-lived bearer tokens automatically. This is recommended for production deployments.
+
+### Create an OAuth2 Credential Source
+
+The source holds the OAuth2 app credentials (`client_id`, `client_secret`). Tokens are minted dynamically on each credential request.
+
+```bash
+warden cred source create pagerduty-oauth-src \
+  --type=pagerduty_oauth2 \
+  --rotation-period=0 \
+  --config=client_id=your-client-id \
+  --config=client_secret=your-client-secret
+```
+
+Optionally, override the default token endpoint:
+
+```bash
+warden cred source create pagerduty-oauth-src \
+  --type=pagerduty_oauth2 \
+  --rotation-period=0 \
+  --config=client_id=your-client-id \
+  --config=client_secret=your-client-secret \
+  --config=token_url=https://identity.pagerduty.com/oauth/token
+```
+
+### Create an OAuth2 Credential Spec
+
+The spec optionally specifies the OAuth2 scope. If omitted, the default scope from the provider configuration is used.
+
+```bash
+warden cred spec create pagerduty-ops \
+  --source pagerduty-oauth-src \
+  --config scope="read write"
+```
+
+The spec is validated at creation time: Warden mints a test token and verifies it by calling `GET /users/me` on the PagerDuty API. If the credentials are invalid, spec creation will fail.
+
+### Update the JWT Role
+
+Make sure the JWT role references the OAuth2 spec:
+
+```bash
+warden write auth/jwt/role/pagerduty-user \
+    token_policies="pagerduty-access" \
+    user_claim=sub \
+    cred_spec_name=pagerduty-ops
+```
+
+All gateway requests work identically — Warden transparently injects the minted bearer token.
+
+## TLS Certificate Authentication
+
+Steps 1-3 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 1-3 (provider setup) are identical. Replace Steps 1 and 5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable --type=cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=pagerduty-user
+```
+
+### Create a Cert Role
+
+Create a role that binds allowed certificate identities to a credential spec and policy:
+
+```bash
+warden write auth/cert/role/pagerduty-user \
+    allowed_common_names="agent-*" \
+    token_policies="pagerduty-access" \
+    cred_spec_name=pagerduty-ops
+```
+
+The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+
+### Configure Provider for Cert Auth
+
+Update the provider config to use cert auth:
+
+```bash
+warden write pagerduty/config <<EOF
+{
+  "pagerduty_url": "https://api.pagerduty.com",
+  "auto_auth_path": "auth/cert/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -s "https://warden.internal/v1/pagerduty/role/pagerduty-user/gateway/incidents" \
+    -H "Content-Type: application/json"
+```
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pagerduty_url` | string | `https://api.pagerduty.com` | PagerDuty API base URL (must be HTTPS) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `30s` | Request timeout |
+| `auto_auth_path` | string | — | Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Credential Source Config (Static API Token)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_url` | string | `https://api.pagerduty.com` | PagerDuty API base URL (must be HTTPS) |
+
+### Credential Source Config (OAuth2 Client Credentials)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `client_id` | string | Yes | PagerDuty OAuth2 application client ID |
+| `client_secret` | string | Yes | PagerDuty OAuth2 application client secret (sensitive — masked in output) |
+| `token_url` | string | No | OAuth2 token endpoint (default: `https://identity.pagerduty.com/oauth/token`) |
+
+### Credential Spec Config (Static API Token)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | PagerDuty API token (sensitive — masked in output) |
+
+### Credential Spec Config (OAuth2 Client Credentials)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scope` | string | No | OAuth2 scope to request |
+
+## Token Management
+
+### Static API Token
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | API token is stored on the credential spec (not the source) |
+| **Validation** | Token is verified at spec creation via `GET /users/me` |
+| **Rotation** | Manual — regenerate in PagerDuty and update the spec |
+| **Lifetime** | Static — no expiration or auto-refresh |
+
+**To rotate a static API token:**
+
+1. Generate a new API token in PagerDuty (Integrations > API Access Keys)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update pagerduty-ops \
+     --config api_key=your-new-api-token
+   ```
+3. Revoke the old token in PagerDuty
+
+### OAuth2 Client Credentials
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Client credentials are stored on the credential source |
+| **Validation** | Spec is verified at creation by minting a test token and calling `GET /users/me` |
+| **Rotation** | Client credentials are managed in PagerDuty; bearer tokens are minted automatically |
+| **Lifetime** | Bearer tokens have a TTL set by PagerDuty's `expires_in` response field |
+
+Bearer tokens are minted on demand and cached for their TTL. When a token expires, Warden automatically mints a new one using the stored client credentials.
+
+**To rotate OAuth2 client credentials:**
+
+1. Generate new credentials in PagerDuty (Integrations > App Registration)
+2. Update the credential source:
+   ```bash
+   warden cred source update pagerduty-oauth-src \
+     --config=client_id=new-client-id \
+     --config=client_secret=new-client-secret
+   ```
+3. Revoke the old credentials in PagerDuty

--- a/provider/pagerduty/provider.go
+++ b/provider/pagerduty/provider.go
@@ -1,0 +1,73 @@
+package pagerduty
+
+import (
+	"time"
+
+	"github.com/stephnangue/warden/provider/httpproxy"
+)
+
+// DefaultPagerDutyURL is the default PagerDuty API base URL
+const DefaultPagerDutyURL = "https://api.pagerduty.com"
+
+// DefaultPagerDutyTimeout is the default request timeout for PagerDuty API calls
+const DefaultPagerDutyTimeout = 30 * time.Second
+
+var (
+	sharedTransport        = httpproxy.NewTransport()
+	transportCleanupCancel = httpproxy.StartCleanup(sharedTransport)
+)
+
+// Spec defines the PagerDuty provider configuration for the httpproxy framework.
+var Spec = &httpproxy.ProviderSpec{
+	Name:               "pagerduty",
+	DefaultURL:         DefaultPagerDutyURL,
+	URLConfigKey:       "pagerduty_url",
+	DefaultTimeout:     DefaultPagerDutyTimeout,
+	ParseStreamBody:    false,
+	UserAgent:          "warden-pagerduty-proxy",
+	HelpText:           pagerdutyBackendHelp,
+	ExtractCredentials: httpproxy.BearerAPIKeyExtractor,
+	Transport:          sharedTransport,
+	ShutdownTransport: func() {
+		httpproxy.ShutdownTransport(sharedTransport, transportCleanupCancel)
+	},
+}
+
+// Factory creates a new PagerDuty provider backend.
+var Factory = httpproxy.NewFactory(Spec)
+
+const pagerdutyBackendHelp = `
+The PagerDuty provider enables proxying requests to the PagerDuty REST API v2
+with automatic credential management and token injection.
+
+Warden performs implicit authentication on every request and obtains a
+PagerDuty API token or OAuth2 bearer token from the credential manager,
+injecting it into the proxied request's Authorization header. This allows
+Warden to broker PagerDuty access without exposing tokens to clients.
+
+The gateway path format is:
+  /pagerduty/gateway/{api-path}
+
+Examples:
+  /pagerduty/gateway/incidents
+  /pagerduty/gateway/services
+  /pagerduty/gateway/users/me
+  /pagerduty/gateway/schedules
+  /pagerduty/gateway/escalation_policies
+
+The role can be provided via the X-Warden-Role header, or embedded in
+the URL path:
+  /pagerduty/role/{role}/gateway/{api-path}
+
+Two credential source types are supported:
+- pagerduty: Static API token (stored in spec config as api_key)
+- pagerduty_oauth2: OAuth2 client credentials flow (client_id/client_secret
+  on source, scope on spec; tokens are minted dynamically)
+
+Configuration:
+- pagerduty_url: PagerDuty API base URL (default: https://api.pagerduty.com)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 30s)
+- auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`

--- a/provider/rds/README.md
+++ b/provider/rds/README.md
@@ -236,7 +236,6 @@ Create credential specs for each database user / permission level. The `role_arn
 ```bash
 # Read-only spec
 warden cred spec create rds-readonly \
-  --type db_auth_token \
   --source aws-prod \
   --config mint_method=rds_iam_token \
   --config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
@@ -247,7 +246,6 @@ warden cred spec create rds-readonly \
 
 # Read-write spec
 warden cred spec create rds-readwrite \
-  --type db_auth_token \
   --source aws-prod \
   --config mint_method=rds_iam_token \
   --config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
@@ -261,7 +259,6 @@ For Aurora, use the cluster or reader endpoint:
 
 ```bash
 warden cred spec create aurora-readonly \
-  --type db_auth_token \
   --source aws-prod \
   --config mint_method=rds_iam_token \
   --config db_endpoint=mydb.cluster-ro-abc123.us-east-1.rds.amazonaws.com \
@@ -274,7 +271,6 @@ For cross-account access, add `role_arn`:
 
 ```bash
 warden cred spec create rds-cross-account \
-  --type db_auth_token \
   --source aws-prod \
   --config mint_method=rds_iam_token \
   --config db_endpoint=mydb.xyz789.eu-west-1.rds.amazonaws.com \

--- a/provider/slack/README.md
+++ b/provider/slack/README.md
@@ -140,7 +140,6 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create slack-ops \
-  --type api_key \
   --source slack-src \
   --config api_key=xoxb-your-bot-token
 ```

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -303,7 +303,6 @@ The Vault provider gateway requires a credential spec of type `vault_token`. War
 ```bash
 # Read-only Vault token
 warden cred spec create vault-reader \
-  --type vault_token \
   --source vault-prod \
   --config mint_method=vault_token \
   --config token_role=reader \
@@ -312,7 +311,6 @@ warden cred spec create vault-reader \
 
 # Admin Vault token with custom TTL
 warden cred spec create vault-admin \
-  --type vault_token \
   --source vault-prod \
   --config mint_method=vault_token \
   --config token_role=admin \


### PR DESCRIPTION
…edentials support

- New PagerDuty streaming gateway provider using httpproxy framework
- Generic OAuth2ClientCredentialsDriver for RFC 6749 client credentials flow
- OAuthBearerTokenCredType for dynamically minted OAuth2 bearer tokens
- PagerDuty static API key support via StaticAPIKeyDriver
- Remove --type from cred spec create in all provider READMEs (now inferred)
- Update CHANGELOG and RELEASE_NOTES for v0.7.0