### PR TITLE
feat: enable ParseStreamBody for GitHub, GitLab, and PagerDuty providers

### DIFF
--- a/provider/github/provider.go
+++ b/provider/github/provider.go
@@ -38,7 +38,7 @@ var Spec = &httpproxy.ProviderSpec{
 	DefaultURL:         DefaultGitHubURL,
 	URLConfigKey:       "github_url",
 	DefaultTimeout:     framework.DefaultTimeout,
-	ParseStreamBody:    false,
+	ParseStreamBody:    true,
 	UserAgent:          "warden-github-proxy",
 	HelpText:           githubBackendHelp,
 	ExtractCredentials: httpproxy.TypedTokenExtractor(credential.TypeGitHubToken, "token", "Authorization", "token "),

--- a/provider/gitlab/provider.go
+++ b/provider/gitlab/provider.go
@@ -56,7 +56,7 @@ var Spec = &httpproxy.ProviderSpec{
 	DefaultURL:           "", // GitLab requires explicit address
 	URLConfigKey:         "gitlab_address",
 	DefaultTimeout:       framework.DefaultTimeout,
-	ParseStreamBody:      false,
+	ParseStreamBody:      true,
 	UserAgent:            "warden-gitlab-proxy",
 	HelpText:             gitlabBackendHelp,
 	ExtractCredentials:   httpproxy.TypedTokenExtractor(credential.TypeGitLabAccessToken, "access_token", "Authorization", "Bearer "),

--- a/provider/pagerduty/provider.go
+++ b/provider/pagerduty/provider.go
@@ -23,7 +23,7 @@ var Spec = &httpproxy.ProviderSpec{
 	DefaultURL:         DefaultPagerDutyURL,
 	URLConfigKey:       "pagerduty_url",
 	DefaultTimeout:     DefaultPagerDutyTimeout,
-	ParseStreamBody:    false,
+	ParseStreamBody:    true,
 	UserAgent:          "warden-pagerduty-proxy",
 	HelpText:           pagerdutyBackendHelp,
 	ExtractCredentials: httpproxy.BearerAPIKeyExtractor,


### PR DESCRIPTION
Allow request body parsing for policy evaluation on these providers, making req.Data available for fine-grained access control policies.