### PR TITLE
fix: correct ServiceNow provider docs against official API documentation

### DIFF
--- a/provider/servicenow/README.md
+++ b/provider/servicenow/README.md
@@ -19,7 +19,7 @@ The ServiceNow provider enables proxied access to a ServiceNow instance REST API
 
 - Docker and Docker Compose installed and running
 - A **ServiceNow instance** with REST API access enabled
-- A **ServiceNow API token** (from System OAuth > Application Registry) **or** a **ServiceNow OAuth2 App** (client_id and client_secret from System OAuth > Application Registry)
+- A **ServiceNow user account** with REST API access (for Basic Auth via the `apikey` source type) **or** a **ServiceNow OAuth2 App** (client_id and client_secret from System OAuth > Application Registry)
 
 > **New to Warden?** Follow these steps to get a local dev environment running:
 >
@@ -478,13 +478,13 @@ curl --cert client.pem --key client-key.pem \
 
 **To rotate a static API token:**
 
-1. Generate a new API token in ServiceNow (System OAuth > Application Registry)
+1. Generate new credentials in ServiceNow
 2. Update the credential spec:
    ```bash
    warden cred spec update servicenow-ops \
      --config api_key=your-new-api-token
    ```
-3. Revoke the old token in ServiceNow
+3. Revoke the old credentials in ServiceNow
 
 ### OAuth2 Client Credentials
 

--- a/provider/servicenow/provider.go
+++ b/provider/servicenow/provider.go
@@ -90,10 +90,11 @@ the URL path:
   /servicenow/role/{role}/gateway/{api-path}
 
 Two credential source types are supported:
-- apikey: Static API token (stored in spec config as api_key)
+- apikey: Static bearer token (stored in spec config as api_key)
 - oauth2: OAuth2 client credentials flow (client_id/client_secret/token_url
   on source, scope on spec; token_url is typically
-  https://{instance}.service-now.com/oauth_token.do)
+  https://{instance}.service-now.com/oauth_token.do; default scope
+  is "useraccount")
 
 Configuration:
 - servicenow_url: ServiceNow instance URL (required, e.g., "https://mycompany.service-now.com")


### PR DESCRIPTION
Clarify that ServiceNow uses Basic Auth or OAuth2 (not traditional API keys), add default OAuth2 scope (useraccount), and remove incorrect references to System OAuth > Application Registry for static tokens.