### PR TITLE
feat: add static_apikey, dynamic_gcp, and oauth2 Vault mint methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Warden are documented in this file.
 
+## [v0.9.0] — 2026-04-06
+
+### Breaking Changes
+
+- **`kv2_static` mint method removed** — Replaced by `static_aws`. Existing credential specs using `mint_method=kv2_static` must be updated to `mint_method=static_aws`. The `kv2_mount` and `secret_path` config fields are unchanged.
+
+- **`dynamic_database` mint method removed** — The Vault database engine mint method has been removed from the Vault driver. Credential specs using `mint_method=dynamic_database` will no longer work.
+
+### New Features
+
+- **`static_apikey` mint method** — Fetch static API keys from Vault/OpenBao KV v2 and infer the `api_key` credential type. Allows any provider that uses API keys (OpenAI, Anthropic, Mistral, Slack, PagerDuty, ServiceNow) to store secrets in Vault instead of directly in Warden.
+
+- **`dynamic_gcp` mint method** — Generate GCP OAuth2 access tokens via the Vault GCP secret engine. Supports both `roleset` and `static-account` role types. No service account key needs to be stored in Warden.
+
+- **`oauth2` mint method** — Fetch OAuth2 bearer tokens via a Vault/OpenBao OAuth2 secret engine plugin (compatible with openbao-plugin-secrets-oauthapp). Infers the `oauth_bearer_token` credential type. TTL is computed from the plugin's `expire_time` response field.
+
+- **Vault as universal credential source** — The `api_key`, `gcp_access_token`, and `oauth_bearer_token` credential types now accept `hvault` as a valid source type, in addition to their native source types. This enables centralized secret management through Vault/OpenBao for all providers.
+
+### Documentation
+
+- **Provider READMEs** — Added Vault/OpenBao credential source examples and configuration reference tables to PagerDuty, ServiceNow, OpenAI, Anthropic, Mistral, Slack, and GCP provider READMEs.
+- **Vault Provider README** — Updated mint methods table with all new methods (`static_aws`, `static_apikey`, `dynamic_gcp`, `oauth2`) and added configuration reference sections.
+
 ## [v0.8.0] — 2026-04-04
 
 ### Breaking Changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,19 @@
-## Warden v0.8.0
+## Warden v0.9.0
 
 Warden is an identity-based access layer for cloud APIs, SaaS platforms, databases, and AI providers. It eliminates static credentials from your workloads entirely. Your workload authenticates to Warden with its own identity — a JWT from your identity provider or a TLS certificate. Warden verifies who is calling, evaluates fine-grained capability-based policies, and issues ephemeral request-scoped access: forwarding API requests with short-lived credentials injected, returning database auth tokens, or vending pre-signed URLs. Credentials are minted on demand, scoped to the request, and never exposed to the caller. Every API call is logged with caller identity, target service, and full request context. No secrets ever reach your applications.
 
 ### What's New
 
-**Generic credential source drivers.** The `apikey` and `oauth2` driver types replace all per-provider credential source types. Adding a new API key or OAuth2 provider no longer requires code changes — configure everything at source creation time.
+**Vault/OpenBao as a universal credential source.** Any provider that uses API keys or OAuth2 tokens can now fetch credentials from Vault/OpenBao instead of storing them directly in Warden. Store your API keys in a KV v2 secret engine, mint GCP tokens through the Vault GCP engine, or fetch OAuth2 tokens through the openbao-plugin-secrets-oauthapp plugin — all using a single `hvault` credential source.
+
+**New Vault mint methods:**
+
+| Mint Method | Credential Type | Description |
+|---|---|---|
+| `static_aws` | `aws_access_keys` | Fetch static AWS credentials from KV v2 (replaces `kv2_static`) |
+| `static_apikey` | `api_key` | Fetch static API keys from KV v2 |
+| `dynamic_gcp` | `gcp_access_token` | Mint GCP tokens via Vault GCP secret engine |
+| `oauth2` | `oauth_bearer_token` | Fetch OAuth2 tokens via Vault OAuth2 plugin |
 
 ### Providers
 
@@ -12,15 +21,16 @@ Warden is an identity-based access layer for cloud APIs, SaaS platforms, databas
 |----------|:---:|---|
 | AWS | Streaming (SigV4) | Access keys via STS or static |
 | Azure | Streaming | OAuth2 tokens |
-| GCP | Streaming | OAuth2 tokens |
+| GCP | Streaming | OAuth2 tokens (native or via Vault) |
 | GitHub | Streaming | Installation tokens |
 | GitLab | Streaming | Project/group tokens |
 | Vault / OpenBao | Streaming | Dynamic Vault tokens |
-| Anthropic | Streaming | API keys |
-| OpenAI | Streaming | API keys |
-| Mistral | Streaming | API keys |
-| Slack | Streaming | API keys |
-| PagerDuty | Streaming | API keys / OAuth2 bearer tokens |
+| Anthropic | Streaming | API keys (native or via Vault) |
+| OpenAI | Streaming | API keys (native or via Vault) |
+| Mistral | Streaming | API keys (native or via Vault) |
+| Slack | Streaming | API keys (native or via Vault) |
+| PagerDuty | Streaming | API keys / OAuth2 (native or via Vault) |
+| ServiceNow | Streaming | API keys / OAuth2 (native or via Vault) |
 | RDS | Access | IAM auth tokens |
 
 - **Streaming providers** proxy requests through Warden, injecting credentials in-flight.
@@ -28,15 +38,9 @@ Warden is an identity-based access layer for cloud APIs, SaaS platforms, databas
 
 ### Breaking Changes
 
-- **`apikey` replaces per-provider source types** — The source types `anthropic`, `openai`, `mistral`, `slack`, and `pagerduty` have been replaced by a single `apikey` type. Existing sources must be recreated with `--type=apikey` and explicit config fields (`api_url`, `verify_endpoint`, `auth_header_type`, etc.).
+- **`kv2_static` removed** — Replaced by `static_aws`. Update existing specs: `mint_method=kv2_static` becomes `mint_method=static_aws`. Config fields `kv2_mount` and `secret_path` are unchanged.
 
-- **`oauth2` replaces `pagerduty_oauth2`** — The `pagerduty_oauth2` source type has been replaced by a generic `oauth2` type. Existing OAuth2 sources must be recreated with `--type=oauth2` and explicit `token_url`.
-
-### New Features
-
-- **Generic API Key Driver (`apikey`)** — Single config-driven driver replaces five per-provider API key drivers. Supports configurable auth header injection (`bearer`, `token`, `custom_header`), extra static headers (e.g., `anthropic-version:2023-06-01`), optional metadata field forwarding, and configurable verification endpoints.
-
-- **Generic OAuth2 Driver (`oauth2`)** — Single config-driven driver for any OAuth2 client credentials provider. All provider-specific config (token URL, verification endpoint, auth header type, scopes) is set at source creation time.
+- **`dynamic_database` removed** — The Vault database engine mint method has been removed.
 
 ### Getting Started
 

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -176,8 +176,14 @@ func (f *VaultDriverFactory) SensitiveConfigFields() []string {
 func (f *VaultDriverFactory) InferCredentialType(specConfig map[string]string) (string, error) {
 	mintMethod := specConfig["mint_method"]
 	switch mintMethod {
-	case "dynamic_aws", "kv2_static":
+	case "static_aws", "dynamic_aws":
 		return credential.TypeAWSAccessKeys, nil
+	case "static_apikey":
+		return credential.TypeAPIKey, nil
+	case "dynamic_gcp":
+		return credential.TypeGCPAccessToken, nil
+	case "oauth2":
+		return credential.TypeOAuthBearerToken, nil
 	case "vault_token", "":
 		return credential.TypeVaultToken, nil
 	default:
@@ -269,16 +275,18 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
-	case "kv2_static":
+	case "static_aws", "static_apikey":
 		return d.fetchStaticKVSecret(ctx, spec)
-	case "dynamic_database":
-		return d.fetchDynamicDatabaseCreds(ctx, spec)
 	case "dynamic_aws":
 		return d.fetchDynamicAWSCreds(ctx, spec)
+	case "dynamic_gcp":
+		return d.fetchDynamicGCPCreds(ctx, spec)
 	case "vault_token":
 		return d.fetchDynamicVaultToken(ctx, spec)
+	case "oauth2":
+		return d.fetchOAuth2Creds(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; use 'kv2_static', 'dynamic_database', 'dynamic_aws', or 'vault_token'", mintMethod)
+		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'dynamic_aws', 'dynamic_gcp', 'vault_token', 'oauth2'", mintMethod)
 	}
 }
 
@@ -310,56 +318,6 @@ func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, spec *credential.
 
 	// Return raw data (static, no lease)
 	return secret.Data, 0, "", nil
-}
-
-// fetchDynamicDatabaseCreds fetches dynamic database credentials from Vault database engine
-func (d *VaultDriver) fetchDynamicDatabaseCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
-	dbMount := credential.GetString(spec.Config, "database_mount", "")
-	roleName := credential.GetString(spec.Config, "role_name", "")
-
-	if dbMount == "" || roleName == "" {
-		return nil, 0, "", fmt.Errorf("database_mount and role_name are required for dynamic database credentials")
-	}
-
-	// Read credentials
-	path := fmt.Sprintf("%s/creds/%s", dbMount, roleName)
-	secret, err := d.vault.Logical().ReadWithContext(ctx, path)
-	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to generate database credentials: %w", err)
-	}
-
-	if secret == nil || secret.Data == nil {
-		return nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, dbMount)
-	}
-
-	leaseTTL := time.Duration(secret.LeaseDuration) * time.Second
-
-	// Validate lease TTL is positive
-	if leaseTTL <= 0 {
-		return nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for database credentials on mount '%s'", dbMount)
-	}
-
-	// Add optional database name if provided in config
-	rawData := make(map[string]interface{})
-	for k, v := range secret.Data {
-		rawData[k] = v
-	}
-	database := credential.GetString(spec.Config, "database", "")
-	if database != "" {
-		rawData["database"] = database
-	}
-
-	if d.logger != nil {
-		d.logger.Trace("generated dynamic database credentials from Vault",
-			logger.String("spec", spec.Name),
-			logger.String("mount", dbMount),
-			logger.String("vault_role", roleName),
-			logger.String("lease_id", secret.LeaseID),
-			logger.String("lease_ttl", leaseTTL.String()),
-		)
-	}
-
-	return rawData, leaseTTL, secret.LeaseID, nil
 }
 
 // fetchDynamicAWSCreds fetches dynamic AWS credentials from Vault AWS engine
@@ -442,6 +400,117 @@ func (d *VaultDriver) fetchDynamicAWSCreds(ctx context.Context, spec *credential
 			logger.String("mount", awsMount),
 			logger.String("vault_role", roleName),
 			logger.String("lease_id", secret.LeaseID),
+			logger.String("lease_ttl", leaseTTL.String()),
+		)
+	}
+
+	return rawData, leaseTTL, secret.LeaseID, nil
+}
+
+// fetchDynamicGCPCreds fetches dynamic GCP credentials from Vault GCP secret engine
+func (d *VaultDriver) fetchDynamicGCPCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	gcpMount := credential.GetString(spec.Config, "gcp_mount", "")
+	roleName := credential.GetString(spec.Config, "role_name", "")
+
+	if gcpMount == "" || roleName == "" {
+		return nil, 0, "", fmt.Errorf("gcp_mount and role_name are required for dynamic GCP credentials")
+	}
+
+	// Build path based on role_type (roleset or static-account)
+	roleType := credential.GetString(spec.Config, "role_type", "roleset")
+	var path string
+	switch roleType {
+	case "roleset":
+		path = fmt.Sprintf("%s/roleset/%s/token", gcpMount, roleName)
+	case "static-account":
+		path = fmt.Sprintf("%s/static-account/%s/token", gcpMount, roleName)
+	default:
+		return nil, 0, "", fmt.Errorf("unsupported role_type '%s'; use 'roleset' or 'static-account'", roleType)
+	}
+
+	secret, err := d.vault.Logical().ReadWithContext(ctx, path)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to generate GCP credentials: %w", err)
+	}
+
+	if secret == nil || secret.Data == nil {
+		return nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, gcpMount)
+	}
+
+	leaseTTL := time.Duration(secret.LeaseDuration) * time.Second
+
+	// GCP tokens may have zero lease duration; use token_ttl from response if available
+	if leaseTTL <= 0 {
+		if ttlStr, ok := secret.Data["token_ttl"].(string); ok && ttlStr != "" {
+			if parsed, err := time.ParseDuration(ttlStr); err == nil {
+				leaseTTL = parsed
+			}
+		}
+		// Default to 1 hour if still zero (GCP access tokens expire in ~1h)
+		if leaseTTL <= 0 {
+			leaseTTL = 1 * time.Hour
+		}
+	}
+
+	rawData := make(map[string]interface{})
+	for k, v := range secret.Data {
+		rawData[k] = v
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("generated dynamic GCP credentials from Vault",
+			logger.String("spec", spec.Name),
+			logger.String("mount", gcpMount),
+			logger.String("vault_role", roleName),
+			logger.String("role_type", roleType),
+			logger.String("lease_ttl", leaseTTL.String()),
+		)
+	}
+
+	return rawData, leaseTTL, secret.LeaseID, nil
+}
+
+// fetchOAuth2Creds fetches OAuth2 credentials from an OpenBao/Vault OAuth2 secret engine
+// (compatible with openbao-plugin-secrets-oauthapp)
+func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	oauth2Mount := credential.GetString(spec.Config, "oauth2_mount", "")
+	credentialName := credential.GetString(spec.Config, "credential_name", "")
+
+	if oauth2Mount == "" || credentialName == "" {
+		return nil, 0, "", fmt.Errorf("oauth2_mount and credential_name are required for oauth2 credentials")
+	}
+
+	path := fmt.Sprintf("%s/creds/%s", oauth2Mount, credentialName)
+	secret, err := d.vault.Logical().ReadWithContext(ctx, path)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to fetch OAuth2 credentials: %w", err)
+	}
+
+	if secret == nil || secret.Data == nil {
+		return nil, 0, "", fmt.Errorf("no credentials returned for '%s' on mount '%s'", credentialName, oauth2Mount)
+	}
+
+	// Compute TTL from expire_time if available (RFC3339 timestamp from oauthapp plugin)
+	leaseTTL := time.Duration(secret.LeaseDuration) * time.Second
+	if expireTime, ok := secret.Data["expire_time"].(string); ok && expireTime != "" {
+		if parsed, err := time.Parse(time.RFC3339, expireTime); err == nil {
+			remaining := time.Until(parsed)
+			if remaining > 0 {
+				leaseTTL = remaining
+			}
+		}
+	}
+
+	rawData := make(map[string]interface{})
+	for k, v := range secret.Data {
+		rawData[k] = v
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("fetched OAuth2 credentials from Vault",
+			logger.String("spec", spec.Name),
+			logger.String("mount", oauth2Mount),
+			logger.String("credential_name", credentialName),
 			logger.String("lease_ttl", leaseTTL.String()),
 		)
 	}

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -281,7 +281,7 @@ func TestVaultDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported mint_method 'invalid'")
 }
 
-func TestVaultDriver_MintCredential_DatabaseRouting(t *testing.T) {
+func TestVaultDriver_MintCredential_StaticRouting(t *testing.T) {
 	driver := &VaultDriver{
 		credSource: &credential.CredSource{
 			Type: credential.SourceTypeVault,
@@ -291,30 +291,29 @@ func TestVaultDriver_MintCredential_DatabaseRouting(t *testing.T) {
 		},
 	}
 
-	// kv2_static without kv2_mount should fail on missing fields
+	// static_aws without kv2_mount should fail on missing fields
 	spec := &credential.CredSpec{
-		Name: "test-db",
-		Type: credential.TypeVaultToken,
+		Name: "test-static-aws",
+		Type: credential.TypeAWSAccessKeys,
 		Config: map[string]string{
-			"mint_method": "kv2_static",
+			"mint_method": "static_aws",
 		},
 	}
 	_, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kv2_mount and secret_path are required")
 
-	// dynamic_database without role_name should fail on missing fields
+	// static_apikey without kv2_mount should fail on missing fields
 	spec2 := &credential.CredSpec{
-		Name: "test-db-dynamic",
-		Type: credential.TypeVaultToken,
+		Name: "test-static-apikey",
+		Type: credential.TypeAPIKey,
 		Config: map[string]string{
-			"mint_method":    "dynamic_database",
-			"database_mount": "database",
+			"mint_method": "static_apikey",
 		},
 	}
 	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "database_mount and role_name are required")
+	assert.Contains(t, err.Error(), "kv2_mount and secret_path are required")
 }
 
 func TestVaultDriver_MintCredential_AWSRouting(t *testing.T) {
@@ -327,12 +326,12 @@ func TestVaultDriver_MintCredential_AWSRouting(t *testing.T) {
 		},
 	}
 
-	// kv2_static without kv2_mount should fail on missing fields
+	// static_aws without kv2_mount should fail on missing fields
 	spec := &credential.CredSpec{
 		Name: "test-aws",
 		Type: credential.TypeAWSAccessKeys,
 		Config: map[string]string{
-			"mint_method": "kv2_static",
+			"mint_method": "static_aws",
 		},
 	}
 	_, _, _, err := driver.MintCredential(context.TODO(), spec)
@@ -374,6 +373,99 @@ func TestVaultDriver_MintCredential_VaultTokenRouting(t *testing.T) {
 	_, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token_role is required")
+}
+
+func TestVaultDriver_MintCredential_DynamicGCPRouting(t *testing.T) {
+	driver := &VaultDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeVault,
+			Config: map[string]string{
+				"vault_address": "http://127.0.0.1:8200",
+			},
+		},
+	}
+
+	// dynamic_gcp without gcp_mount should fail
+	spec := &credential.CredSpec{
+		Name: "test-gcp",
+		Type: credential.TypeGCPAccessToken,
+		Config: map[string]string{
+			"mint_method": "dynamic_gcp",
+		},
+	}
+	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gcp_mount and role_name are required")
+
+	// dynamic_gcp with invalid role_type should fail
+	spec2 := &credential.CredSpec{
+		Name: "test-gcp-bad-type",
+		Type: credential.TypeGCPAccessToken,
+		Config: map[string]string{
+			"mint_method": "dynamic_gcp",
+			"gcp_mount":   "gcp",
+			"role_name":   "my-role",
+			"role_type":   "invalid",
+		},
+	}
+	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported role_type")
+}
+
+func TestVaultDriver_MintCredential_OAuth2Routing(t *testing.T) {
+	driver := &VaultDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeVault,
+			Config: map[string]string{
+				"vault_address": "http://127.0.0.1:8200",
+			},
+		},
+	}
+
+	// oauth2 without oauth2_mount should fail
+	spec := &credential.CredSpec{
+		Name: "test-oauth2",
+		Type: credential.TypeOAuthBearerToken,
+		Config: map[string]string{
+			"mint_method": "oauth2",
+		},
+	}
+	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "oauth2_mount and credential_name are required")
+}
+
+func TestVaultDriverFactory_InferCredentialType(t *testing.T) {
+	factory := &VaultDriverFactory{}
+
+	tests := []struct {
+		name       string
+		mintMethod string
+		wantType   string
+		wantErr    bool
+	}{
+		{"static_aws", "static_aws", credential.TypeAWSAccessKeys, false},
+		{"dynamic_aws", "dynamic_aws", credential.TypeAWSAccessKeys, false},
+		{"static_apikey", "static_apikey", credential.TypeAPIKey, false},
+		{"dynamic_gcp", "dynamic_gcp", credential.TypeGCPAccessToken, false},
+		{"oauth2", "oauth2", credential.TypeOAuthBearerToken, false},
+		{"vault_token", "vault_token", credential.TypeVaultToken, false},
+		{"empty defaults to vault_token", "", credential.TypeVaultToken, false},
+		{"unsupported", "invalid", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credType, err := factory.InferCredentialType(map[string]string{"mint_method": tt.mintMethod})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantType, credType)
+			}
+		})
+	}
 }
 
 func TestVaultDriver_FetchDynamicAWSCreds_InvalidTTL(t *testing.T) {

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -68,6 +68,20 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("project_id").
 			Describe("Project ID (optional)").
 			Example("proj-xxxxxxxxxxxx"),
+
+		// Vault source - static_apikey fields
+		credential.StringField("mint_method").
+			OneOf("static_apikey").
+			Describe("Mint method (required for vault source)").
+			Example("static_apikey"),
+
+		credential.StringField("kv2_mount").
+			Describe("Vault KV2 mount path (required for static_apikey)").
+			Example("secret"),
+
+		credential.StringField("secret_path").
+			Describe("Path to secret in KV2 (required for static_apikey)").
+			Example("apikeys/my-service"),
 	}
 }
 
@@ -78,10 +92,10 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	// Step 1: Validate source type compatibility
 	switch sourceType {
-	case credential.SourceTypeAPIKey, credential.SourceTypeLocal:
+	case credential.SourceTypeAPIKey, credential.SourceTypeLocal, credential.SourceTypeVault:
 		// Supported
 	default:
-		return fmt.Errorf("api_key credentials require an apikey or local source, got: %s", sourceType)
+		return fmt.Errorf("api_key credentials require an apikey, local, or vault source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema
@@ -90,9 +104,22 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 		return err
 	}
 
-	// Step 3: api_key is required for all source types
-	if config["api_key"] == "" {
-		return fmt.Errorf("'api_key' is required")
+	// Step 3: Source-specific validation
+	switch sourceType {
+	case credential.SourceTypeVault:
+		if config["mint_method"] != "static_apikey" {
+			return fmt.Errorf("'mint_method' must be 'static_apikey' for vault source, got: %s", config["mint_method"])
+		}
+		if config["kv2_mount"] == "" {
+			return fmt.Errorf("'kv2_mount' is required when mint_method is static_apikey")
+		}
+		if config["secret_path"] == "" {
+			return fmt.Errorf("'secret_path' is required when mint_method is static_apikey")
+		}
+	default:
+		if config["api_key"] == "" {
+			return fmt.Errorf("'api_key' is required")
+		}
 	}
 
 	return nil

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -106,16 +106,48 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: "aws",
 			wantErr:    true,
-			errMsg:     "require an apikey or local source",
+			errMsg:     "require an apikey, local, or vault source",
+		},
+		// --- Vault source ---
+		{
+			name: "vault source - valid static_apikey config",
+			config: map[string]string{
+				"mint_method": "static_apikey",
+				"kv2_mount":   "secret",
+				"secret_path": "apikeys/my-service",
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
 		},
 		{
-			name: "unsupported source type - vault",
+			name: "vault source - missing mint_method",
 			config: map[string]string{
-				"api_key": "sk-test",
+				"kv2_mount":   "secret",
+				"secret_path": "apikeys/my-service",
 			},
 			sourceType: credential.SourceTypeVault,
 			wantErr:    true,
-			errMsg:     "require an apikey or local source",
+			errMsg:     "'mint_method' must be 'static_apikey'",
+		},
+		{
+			name: "vault source - missing kv2_mount",
+			config: map[string]string{
+				"mint_method": "static_apikey",
+				"secret_path": "apikeys/my-service",
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "'kv2_mount' is required",
+		},
+		{
+			name: "vault source - missing secret_path",
+			config: map[string]string{
+				"mint_method": "static_apikey",
+				"kv2_mount":   "secret",
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "'secret_path' is required",
 		},
 	}
 

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -36,17 +36,17 @@ func (t *AWSIAMAccessKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 		// Common field for vault and aws sources
 		credential.StringField("mint_method").
-			OneOf("kv2_static", "dynamic_aws", "sts_assume_role", "secrets_manager", "rds_iam_token").
+			OneOf("static_aws", "dynamic_aws", "sts_assume_role", "secrets_manager", "rds_iam_token").
 			Describe("Method for minting AWS credentials").
 			Example("sts_assume_role"),
 
 		// Vault source - KV2 static fields
 		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for kv2_static)").
+			Describe("Vault KV2 mount path (required for static_aws)").
 			Example("secret"),
 
 		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for kv2_static)").
+			Describe("Path to secret in KV2 (required for static_aws)").
 			Example("aws/prod/keys"),
 
 		// Vault source - Dynamic AWS fields
@@ -159,12 +159,12 @@ func (t *AWSIAMAccessKeysCredType) validateVaultConfig(config map[string]string)
 	}
 
 	switch mintMethod {
-	case "kv2_static":
+	case "static_aws":
 		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is kv2_static")
+			return fmt.Errorf("'kv2_mount' is required when mint_method is static_aws")
 		}
 		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is kv2_static")
+			return fmt.Errorf("'secret_path' is required when mint_method is static_aws")
 		}
 	case "dynamic_aws":
 		if config["aws_mount"] == "" {

--- a/credential/types/aws_iam_keys_test.go
+++ b/credential/types/aws_iam_keys_test.go
@@ -110,9 +110,9 @@ func TestAWSIAMAccessKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "valid kv2_static config",
+			name: "valid static_aws config",
 			config: map[string]string{
-				"mint_method": "kv2_static",
+				"mint_method": "static_aws",
 				"kv2_mount":   "secret",
 				"secret_path": "aws-creds/myapp",
 			},
@@ -146,9 +146,9 @@ func TestAWSIAMAccessKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
 			errMsg:     "role_name",
 		},
 		{
-			name: "kv2_static without secret_path",
+			name: "static_aws without secret_path",
 			config: map[string]string{
-				"mint_method": "kv2_static",
+				"mint_method": "static_aws",
 				"kv2_mount":   "secret",
 			},
 			sourceType: credential.SourceTypeVault,

--- a/credential/types/gcp_access_token.go
+++ b/credential/types/gcp_access_token.go
@@ -58,7 +58,7 @@ func NewGCPAccessTokenCredType() *GCPAccessTokenCredType {
 func (t *GCPAccessTokenCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("mint_method").
-			OneOf("access_token", "impersonated_access_token").
+			OneOf("access_token", "impersonated_access_token", "dynamic_gcp").
 			Describe("Method for minting GCP access tokens").
 			Example("access_token"),
 
@@ -77,16 +77,34 @@ func (t *GCPAccessTokenCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("lifetime").
 			Describe("Requested token lifetime (max 3600s for impersonated tokens)").
 			Example("3600s"),
+
+		// Vault source - dynamic GCP fields
+		credential.StringField("gcp_mount").
+			Describe("Vault GCP secrets engine mount (required for dynamic_gcp)").
+			Example("gcp"),
+
+		credential.StringField("role_name").
+			Describe("Vault GCP role name (required for dynamic_gcp)").
+			Example("my-gcp-roleset"),
+
+		credential.StringField("role_type").
+			OneOf("roleset", "static-account").
+			Describe("Vault GCP role type (defaults to roleset)").
+			Example("roleset"),
 	}
 }
 
 // ValidateConfig validates the Config for a GCP access token credential spec
 // sourceType determines the validation rules:
 // - "gcp": requires service account configuration for token minting
+// - "hvault": requires Vault GCP engine configuration for dynamic_gcp
 func (t *GCPAccessTokenCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	// Step 1: Validate source type compatibility
-	if sourceType != credential.SourceTypeGCP {
-		return fmt.Errorf("gcp_access_token credentials require a gcp source, got: %s", sourceType)
+	switch sourceType {
+	case credential.SourceTypeGCP, credential.SourceTypeVault:
+		// Supported
+	default:
+		return fmt.Errorf("gcp_access_token credentials require a gcp or vault source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema
@@ -95,11 +113,25 @@ func (t *GCPAccessTokenCredType) ValidateConfig(config map[string]string, source
 		return err
 	}
 
-	// Step 3: Conditional validation based on mint_method
-	mintMethod := credential.GetString(config, "mint_method", "access_token")
-	if mintMethod == "impersonated_access_token" {
-		if config["target_service_account"] == "" {
-			return fmt.Errorf("'target_service_account' is required when mint_method is impersonated_access_token")
+	// Step 3: Conditional validation based on source type and mint_method
+	switch sourceType {
+	case credential.SourceTypeGCP:
+		mintMethod := credential.GetString(config, "mint_method", "access_token")
+		if mintMethod == "impersonated_access_token" {
+			if config["target_service_account"] == "" {
+				return fmt.Errorf("'target_service_account' is required when mint_method is impersonated_access_token")
+			}
+		}
+	case credential.SourceTypeVault:
+		mintMethod := config["mint_method"]
+		if mintMethod != "dynamic_gcp" {
+			return fmt.Errorf("'mint_method' must be 'dynamic_gcp' for vault source, got: %s", mintMethod)
+		}
+		if config["gcp_mount"] == "" {
+			return fmt.Errorf("'gcp_mount' is required when mint_method is dynamic_gcp")
+		}
+		if config["role_name"] == "" {
+			return fmt.Errorf("'role_name' is required when mint_method is dynamic_gcp")
 		}
 	}
 

--- a/credential/types/gcp_access_token_test.go
+++ b/credential/types/gcp_access_token_test.go
@@ -62,7 +62,44 @@ func TestGCPAccessTokenCredType_ValidateConfig(t *testing.T) {
 	t.Run("unsupported source type", func(t *testing.T) {
 		err := ct.ValidateConfig(map[string]string{}, "azure")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "require a gcp source")
+		assert.Contains(t, err.Error(), "require a gcp or vault source")
+	})
+
+	t.Run("vault source - valid dynamic_gcp config", func(t *testing.T) {
+		err := ct.ValidateConfig(map[string]string{
+			"mint_method": "dynamic_gcp",
+			"gcp_mount":   "gcp",
+			"role_name":   "my-roleset",
+		}, credential.SourceTypeVault)
+		require.NoError(t, err)
+	})
+
+	t.Run("vault source - wrong mint_method", func(t *testing.T) {
+		err := ct.ValidateConfig(map[string]string{
+			"mint_method": "access_token",
+			"gcp_mount":   "gcp",
+			"role_name":   "my-roleset",
+		}, credential.SourceTypeVault)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'mint_method' must be 'dynamic_gcp'")
+	})
+
+	t.Run("vault source - missing gcp_mount", func(t *testing.T) {
+		err := ct.ValidateConfig(map[string]string{
+			"mint_method": "dynamic_gcp",
+			"role_name":   "my-roleset",
+		}, credential.SourceTypeVault)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'gcp_mount' is required")
+	})
+
+	t.Run("vault source - missing role_name", func(t *testing.T) {
+		err := ct.ValidateConfig(map[string]string{
+			"mint_method": "dynamic_gcp",
+			"gcp_mount":   "gcp",
+		}, credential.SourceTypeVault)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'role_name' is required")
 	})
 }
 

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -53,21 +53,48 @@ func (t *OAuthBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("scope").
 			Describe("OAuth2 scope to request").
 			Example("read write"),
+
+		// Vault source - OAuth2 plugin fields
+		credential.StringField("mint_method").
+			OneOf("oauth2").
+			Describe("Mint method (required for vault source)").
+			Example("oauth2"),
+
+		credential.StringField("oauth2_mount").
+			Describe("Vault OAuth2 secrets engine mount (required for oauth2 mint_method)").
+			Example("oauth2"),
+
+		credential.StringField("credential_name").
+			Describe("Credential name in the OAuth2 plugin (required for oauth2 mint_method)").
+			Example("my-oauth-cred"),
 	}
 }
 
 // ValidateConfig validates the Config for an OAuth bearer token credential spec.
 func (t *OAuthBearerTokenCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	switch sourceType {
-	case credential.SourceTypeOAuth2:
-		// Supported OAuth2 source types
+	case credential.SourceTypeOAuth2, credential.SourceTypeVault:
+		// Supported
 	default:
-		return fmt.Errorf("oauth_bearer_token credentials require an OAuth2 source, got: %s", sourceType)
+		return fmt.Errorf("oauth_bearer_token credentials require an oauth2 or vault source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
 	if err := credential.ValidateSchema(config, schema...); err != nil {
 		return err
+	}
+
+	// Vault source requires oauth2 mint_method with mount and credential_name
+	if sourceType == credential.SourceTypeVault {
+		if config["mint_method"] != "oauth2" {
+			return fmt.Errorf("'mint_method' must be 'oauth2' for vault source, got: %s", config["mint_method"])
+		}
+		if config["oauth2_mount"] == "" {
+			return fmt.Errorf("'oauth2_mount' is required when mint_method is oauth2")
+		}
+		if config["credential_name"] == "" {
+			return fmt.Errorf("'credential_name' is required when mint_method is oauth2")
+		}
 	}
 
 	return nil

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -46,21 +46,21 @@ func TestOAuthBearerTokenCredType_ValidateConfig(t *testing.T) {
 			config:     map[string]string{},
 			sourceType: credential.SourceTypeLocal,
 			wantErr:    true,
-			errMsg:     "require an OAuth2 source",
+			errMsg:     "require an oauth2 or vault source",
 		},
 		{
 			name:       "unsupported source type - aws",
 			config:     map[string]string{},
 			sourceType: credential.SourceTypeAWS,
 			wantErr:    true,
-			errMsg:     "require an OAuth2 source",
+			errMsg:     "require an oauth2 or vault source",
 		},
 		{
 			name:       "unsupported source type - static apikey",
 			config:     map[string]string{},
 			sourceType: credential.SourceTypeAPIKey,
 			wantErr:    true,
-			errMsg:     "require an OAuth2 source",
+			errMsg:     "require an oauth2 or vault source",
 		},
 	}
 

--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -157,6 +157,36 @@ Verify:
 warden cred spec read anthropic-ops
 ```
 
+### Alternative: Vault/OpenBao as Credential Source
+
+Instead of storing the API key directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your Anthropic API key (e.g., at `secret/anthropic/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create anthropic-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+
+# Create a credential spec using the static_apikey mint method
+warden cred spec create anthropic-ops \
+  --source anthropic-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=anthropic/ops
+```
+
+The KV v2 secret at `secret/anthropic/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+
 ## Step 4: Create a Policy
 
 Create a policy that grants access to the Anthropic provider gateway:
@@ -482,6 +512,14 @@ curl --cert client.pem --key client-key.pem \
 |-------|------|----------|-------------|
 | `api_key` | string | Yes | Anthropic API key (sensitive — masked in output) |
 | `organization_id` | string | No | Organization identifier |
+
+### Credential Spec Config (Vault — static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Key Management
 

--- a/provider/aws/e2e_test/README.md
+++ b/provider/aws/e2e_test/README.md
@@ -65,7 +65,7 @@ EOF
 ./warden -n PROD/SEC cred spec create aws_static \
   --type aws_access_keys \
   --source vault \
-  --config mint_method=kv2_static \
+  --config mint_method=static_aws \
   --config kv2_mount=kv_static_secret \
   --config secret_path=aws/prod
 

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -181,6 +181,42 @@ warden cred spec create gcp-impersonated \
   --config=lifetime=3600s
 ```
 
+### Option C: Vault/OpenBao GCP Secret Engine
+
+Instead of storing a service account key in Warden, you can use the Vault GCP secret engine to dynamically mint access tokens. Vault manages the service account lifecycle.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- The GCP secret engine mounted and configured with a roleset or static account
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create gcp-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+
+# Create a credential spec using the dynamic_gcp mint method (roleset)
+warden cred spec create gcp-cloud-platform \
+  --source gcp-vault-src \
+  --config mint_method=dynamic_gcp \
+  --config gcp_mount=gcp \
+  --config role_name=my-roleset
+
+# Or using a static account instead of a roleset
+warden cred spec create gcp-static \
+  --source gcp-vault-src \
+  --config mint_method=dynamic_gcp \
+  --config gcp_mount=gcp \
+  --config role_name=my-static-account \
+  --config role_type=static-account
+```
+
 Verify:
 
 ```bash
@@ -309,8 +345,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 |--------|-------------|----------------|----------|
 | `access_token` | OAuth2 token from source SA key | ~1 hour (auto-refreshed) | Direct access with source SA permissions |
 | `impersonated_access_token` | Token minted on behalf of another SA | Configurable via `lifetime` (default: 1h) | Least-privilege delegation without sharing target SA keys |
+| `dynamic_gcp` | Token from Vault GCP secret engine | ~1 hour | Vault-managed service accounts — no SA key in Warden |
 
-Both methods return tokens that expire naturally and cannot be revoked.
+Both `access_token` and `impersonated_access_token` return tokens that expire naturally and cannot be revoked. `dynamic_gcp` delegates token minting to the Vault GCP engine.
 
 ### Returned Credential Data
 
@@ -436,3 +473,12 @@ curl --cert client.pem --key client-key.pem \
 | `target_service_account` | string | Yes | Email of the service account to impersonate |
 | `scopes` | string | No | Comma-separated OAuth2 scopes (default: `https://www.googleapis.com/auth/cloud-platform`) |
 | `lifetime` | string | No | Token lifetime (default: `3600s`, max: `43200s` / 12 hours) |
+
+### Credential Spec Config (Vault — dynamic_gcp)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `dynamic_gcp` |
+| `gcp_mount` | string | Yes | Vault GCP secrets engine mount path |
+| `role_name` | string | Yes | GCP roleset or static account name in Vault |
+| `role_type` | string | No | `roleset` (default) or `static-account` |

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -164,6 +164,36 @@ Verify:
 warden cred spec read mistral-ops
 ```
 
+### Alternative: Vault/OpenBao as Credential Source
+
+Instead of storing the API key directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your Mistral API key (e.g., at `secret/mistral/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create mistral-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+
+# Create a credential spec using the static_apikey mint method
+warden cred spec create mistral-ops \
+  --source mistral-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=mistral/ops
+```
+
+The KV v2 secret at `secret/mistral/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+
 ## Step 4: Create a Policy
 
 Create a policy that grants access to the Mistral provider gateway:
@@ -416,6 +446,14 @@ curl --cert client.pem --key client-key.pem \
 |-------|------|----------|-------------|
 | `api_key` | string | Yes | Mistral AI API key (sensitive — masked in output) |
 | `organization_id` | string | No | Organization identifier |
+
+### Credential Spec Config (Vault — static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Key Management
 

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -165,6 +165,36 @@ Verify:
 warden cred spec read openai-ops
 ```
 
+### Alternative: Vault/OpenBao as Credential Source
+
+Instead of storing the API key directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your OpenAI API key (e.g., at `secret/openai/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create openai-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+
+# Create a credential spec using the static_apikey mint method
+warden cred spec create openai-ops \
+  --source openai-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=openai/ops
+```
+
+The KV v2 secret at `secret/openai/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+
 ## Step 4: Create a Policy
 
 Create a policy that grants access to the OpenAI provider gateway:
@@ -431,6 +461,14 @@ curl --cert client.pem --key client-key.pem \
 | `api_key` | string | Yes | OpenAI API key (sensitive — masked in output) |
 | `organization_id` | string | No | Organization identifier (injected as `OpenAI-Organization` header) |
 | `project_id` | string | No | Project identifier (injected as `OpenAI-Project` header) |
+
+### Credential Spec Config (Vault — static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Key Management
 

--- a/provider/pagerduty/README.md
+++ b/provider/pagerduty/README.md
@@ -149,6 +149,49 @@ The API token is validated at creation time via a `GET /users/me` call to the Pa
 
 See [OAuth2 Client Credentials Mode](#oauth2-client-credentials-mode) below for setup with `client_id` and `client_secret`.
 
+### Option C: Vault/OpenBao as Credential Source
+
+Instead of storing the API token directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your PagerDuty API token (e.g., at `secret/pagerduty/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create pagerduty-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+```
+
+Create a credential spec using the `static_apikey` mint method:
+
+```bash
+warden cred spec create pagerduty-ops \
+  --source pagerduty-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=pagerduty/ops
+```
+
+The KV v2 secret at `secret/pagerduty/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+
+You can also use the `oauth2` mint method if you have an OAuth2 plugin (openbao-plugin-secrets-oauthapp) configured in Vault:
+
+```bash
+warden cred spec create pagerduty-ops \
+  --source pagerduty-vault-src \
+  --config mint_method=oauth2 \
+  --config oauth2_mount=oauth2 \
+  --config credential_name=pagerduty
+```
+
 Verify:
 
 ```bash
@@ -455,6 +498,34 @@ curl --cert client.pem --key client-key.pem \
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `scope` | string | No | OAuth2 scope to request |
+
+### Credential Source Config (Vault/OpenBao)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
+| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
+| `auth_method` | string | No | Authentication method (`approle`) |
+| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
+| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
+| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
+| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
+
+### Credential Spec Config (Vault — static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
+
+### Credential Spec Config (Vault — oauth2)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `oauth2` |
+| `oauth2_mount` | string | Yes | Vault OAuth2 secrets engine mount path |
+| `credential_name` | string | Yes | Credential name configured in the OAuth2 plugin |
 
 ## Token Management
 

--- a/provider/servicenow/README.md
+++ b/provider/servicenow/README.md
@@ -150,6 +150,49 @@ The API token is validated at creation time via a `GET /api/now/table/sys_user?s
 
 See [OAuth2 Client Credentials Mode](#oauth2-client-credentials-mode) below for setup with `client_id` and `client_secret`.
 
+### Option C: Vault/OpenBao as Credential Source
+
+Instead of storing the API token directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your ServiceNow API token (e.g., at `secret/servicenow/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create servicenow-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+```
+
+Create a credential spec using the `static_apikey` mint method:
+
+```bash
+warden cred spec create servicenow-ops \
+  --source servicenow-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=servicenow/ops
+```
+
+The KV v2 secret at `secret/servicenow/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+
+You can also use the `oauth2` mint method if you have an OAuth2 plugin (openbao-plugin-secrets-oauthapp) configured in Vault:
+
+```bash
+warden cred spec create servicenow-ops \
+  --source servicenow-vault-src \
+  --config mint_method=oauth2 \
+  --config oauth2_mount=oauth2 \
+  --config credential_name=servicenow
+```
+
 Verify:
 
 ```bash
@@ -464,6 +507,34 @@ curl --cert client.pem --key client-key.pem \
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `scope` | string | No | OAuth2 scope to request (e.g., `useraccount`) |
+
+### Credential Source Config (Vault/OpenBao)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
+| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
+| `auth_method` | string | No | Authentication method (`approle`) |
+| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
+| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
+| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
+| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
+
+### Credential Spec Config (Vault — static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
+
+### Credential Spec Config (Vault — oauth2)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `oauth2` |
+| `oauth2_mount` | string | Yes | Vault OAuth2 secrets engine mount path |
+| `credential_name` | string | Yes | Credential name configured in the OAuth2 plugin |
 
 ## Token Management
 

--- a/provider/slack/README.md
+++ b/provider/slack/README.md
@@ -155,6 +155,36 @@ Verify:
 warden cred spec read slack-ops
 ```
 
+### Alternative: Vault/OpenBao as Credential Source
+
+Instead of storing the bot token directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your Slack bot token (e.g., at `secret/slack/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create slack-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+
+# Create a credential spec using the static_apikey mint method
+warden cred spec create slack-ops \
+  --source slack-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=slack/ops
+```
+
+The KV v2 secret at `secret/slack/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+
 ## Step 4: Create a Policy
 
 Create a policy that grants access to the Slack provider gateway:
@@ -447,6 +477,14 @@ curl --cert client.pem --key client-key.pem \
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `api_key` | string | Yes | Slack bot token (sensitive — masked in output) |
+
+### Credential Spec Config (Vault — static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Token Management
 

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -524,9 +524,12 @@ If cleanup fails, it is retried daily for up to 7 days. Rotation requires `auth_
 
 | Mint Method | Credential Type | Description |
 |-------------|-----------------|-------------|
-| `kv2_static` | `aws_access_keys` | Fetch static secrets from Vault KV v2 |
+| `static_aws` | `aws_access_keys` | Fetch static AWS credentials from Vault KV v2 |
+| `static_apikey` | `api_key` | Fetch static API keys from Vault KV v2 |
 | `dynamic_aws` | `aws_access_keys` | Generate temporary AWS credentials via Vault AWS engine |
+| `dynamic_gcp` | `gcp_access_token` | Generate GCP access tokens via Vault GCP engine |
 | `vault_token` | `vault_token` | Create a child Vault token via token roles |
+| `oauth2` | `oauth_bearer_token` | Fetch OAuth2 tokens via Vault OAuth2 plugin (openbao-plugin-secrets-oauthapp) |
 
 ## JWT Authentication
 
@@ -645,22 +648,21 @@ docker compose -f deploy/docker-compose.quickstart.yml down -v
 | `display_name` | string | No | User-friendly name attached to the token |
 | `meta` | string | No | Metadata attached to the token |
 
-### Credential Spec Config — kv2_static
+### Credential Spec Config — static_aws
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `kv2_static` |
+| `mint_method` | string | Yes | Must be `static_aws` |
 | `kv2_mount` | string | Yes | KV v2 mount path in Vault |
 | `secret_path` | string | Yes | Path to the secret within the mount |
 
-### Credential Spec Config — dynamic_database
+### Credential Spec Config — static_apikey
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_database` |
-| `database_mount` | string | Yes | Vault database engine mount path |
-| `role_name` | string | Yes | Database role name configured in Vault |
-| `database` | string | No | Database name (passed through to credential data) |
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ### Credential Spec Config — dynamic_aws
 
@@ -672,6 +674,23 @@ docker compose -f deploy/docker-compose.quickstart.yml down -v
 | `role_arn` | string | No | ARN of the role to assume (for STS) |
 | `role_session_name` | string | No | Session name for the STS assumption |
 | `ttl` | duration | No | Credential TTL (clamped to min/max bounds) |
+
+### Credential Spec Config — dynamic_gcp
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `dynamic_gcp` |
+| `gcp_mount` | string | Yes | Vault GCP secrets engine mount path |
+| `role_name` | string | Yes | GCP roleset or static account name |
+| `role_type` | string | No | `roleset` (default) or `static-account` |
+
+### Credential Spec Config — oauth2
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `oauth2` |
+| `oauth2_mount` | string | Yes | Vault OAuth2 secrets engine mount path |
+| `credential_name` | string | Yes | Credential name configured in the OAuth2 plugin |
 
 ### TTL Bounds
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -118,7 +118,7 @@ EOF
 ./warden cred spec create aws_static \
   --type aws_access_keys \
   --source vault \
-  --config mint_method=kv2_static \
+  --config mint_method=static_aws \
   --config kv2_mount=kv_static_secret \
   --config secret_path=aws/prod
 ./warden cred spec create aws_dynamic \
@@ -233,7 +233,7 @@ EOF
 ./warden -n PROD/SEC cred spec create aws_static \
   --type aws_access_keys \
   --source vault \
-  --config mint_method=kv2_static \
+  --config mint_method=static_aws \
   --config kv2_mount=kv_static_secret \
   --config secret_path=aws/prod
 ./warden -n PROD/SEC cred spec create aws_dynamic \
@@ -442,7 +442,7 @@ export VAULT_ADDR=http://localhost:8400/v1/PROD/DEV/vault-auto/role/provisionner
 ./warden -n PROD/DEV cred spec create aws_static \
   --type aws_access_keys \
   --source vault \
-  --config mint_method=kv2_static \
+  --config mint_method=static_aws \
   --config kv2_mount=kv_static_secret \
   --config secret_path=aws/prod
 


### PR DESCRIPTION
Replace kv2_static with static_aws, remove dynamic_database, and add three new mint methods to the Vault driver: static_apikey (KV v2 API keys), dynamic_gcp (Vault GCP engine tokens), and oauth2 (OpenBao oauthapp plugin). Update credential type validators to accept Vault as a source for api_key, gcp_access_token, and oauth_bearer_token types. Add Vault credential source documentation to all relevant provider READMEs.