### PR TITLE
fix: make --type flag optional on cred spec create, add hvault docs t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Warden are documented in this file.
 
+## [v0.9.1] — 2026-04-06
+
+### Bug Fixes
+
+- **`--type` flag no longer required on `cred spec create`** — The CLI enforced `--type` as required even though the server can infer the credential type from the source driver. The flag is now optional, matching the server-side behavior documented since v0.7.0. (#111)
+
+### Documentation
+
+- **AWS Provider README** — Added Vault/OpenBao credential source section with `static_aws` and `dynamic_aws` mint method examples and configuration reference tables.
+- **Quickstart paths** — Fixed docker-compose quickstart file path in all provider READMEs (`deploy/docker-compose.quickstart.yml` → `docker-compose.quickstart.yml`).
+
+### Infrastructure
+
+- **Vault init script** — Added `secret/data/*` read/list capabilities to the Vault policy, enabling KV v2 secret access for the `static_apikey` and `static_aws` mint methods.
+
 ## [v0.9.0] — 2026-04-06
 
 ### Breaking Changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,14 @@
-## Warden v0.9.0
+## Warden v0.9.1
 
 Warden is an identity-based access layer for cloud APIs, SaaS platforms, databases, and AI providers. It eliminates static credentials from your workloads entirely. Your workload authenticates to Warden with its own identity — a JWT from your identity provider or a TLS certificate. Warden verifies who is calling, evaluates fine-grained capability-based policies, and issues ephemeral request-scoped access: forwarding API requests with short-lived credentials injected, returning database auth tokens, or vending pre-signed URLs. Credentials are minted on demand, scoped to the request, and never exposed to the caller. Every API call is logged with caller identity, target service, and full request context. No secrets ever reach your applications.
 
 ### What's New
 
-**Vault/OpenBao as a universal credential source.** Any provider that uses API keys or OAuth2 tokens can now fetch credentials from Vault/OpenBao instead of storing them directly in Warden. Store your API keys in a KV v2 secret engine, mint GCP tokens through the Vault GCP engine, or fetch OAuth2 tokens through the openbao-plugin-secrets-oauthapp plugin — all using a single `hvault` credential source.
+**`--type` flag is now truly optional on `cred spec create`.** The CLI previously enforced `--type` as required, even though the server has been able to infer the credential type from the source driver since v0.7.0. The flag is now optional — when omitted, the type is inferred automatically.
 
-**New Vault mint methods:**
+**AWS provider: Vault/OpenBao credential source.** The AWS provider README now documents how to use `hvault` as a credential source with `static_aws` (static credentials from KV v2) and `dynamic_aws` (temporary credentials from the Vault AWS secrets engine) mint methods.
 
-| Mint Method | Credential Type | Description |
-|---|---|---|
-| `static_aws` | `aws_access_keys` | Fetch static AWS credentials from KV v2 (replaces `kv2_static`) |
-| `static_apikey` | `api_key` | Fetch static API keys from KV v2 |
-| `dynamic_gcp` | `gcp_access_token` | Mint GCP tokens via Vault GCP secret engine |
-| `oauth2` | `oauth_bearer_token` | Fetch OAuth2 tokens via Vault OAuth2 plugin |
+**Quickstart path fix.** All provider READMEs now reference the correct docker-compose quickstart file path.
 
 ### Providers
 
@@ -35,12 +30,6 @@ Warden is an identity-based access layer for cloud APIs, SaaS platforms, databas
 
 - **Streaming providers** proxy requests through Warden, injecting credentials in-flight.
 - **Access providers** vend credentials directly (database auth tokens, pre-signed URLs).
-
-### Breaking Changes
-
-- **`kv2_static` removed** — Replaced by `static_aws`. Update existing specs: `mint_method=kv2_static` becomes `mint_method=static_aws`. Config fields `kv2_mount` and `secret_path` are unchanged.
-
-- **`dynamic_database` removed** — The Vault database engine mint method has been removed.
 
 ### Getting Started
 

--- a/cmd/cred/spec/create.go
+++ b/cmd/cred/spec/create.go
@@ -29,14 +29,13 @@ var (
 )
 
 func init() {
-	CreateCmd.Flags().StringVar(&createType, "type", "", "Credential type (required)")
+	CreateCmd.Flags().StringVar(&createType, "type", "", "Credential type (optional — inferred from source when omitted)")
 	CreateCmd.Flags().StringVar(&createSource, "source", "", "Source name (required)")
 	CreateCmd.Flags().StringToStringVar(&createConfig, "config", nil, "Type-specific configuration (key=value)")
 	CreateCmd.Flags().StringVar(&createMinTTL, "min-ttl", "1h", "Minimum TTL")
 	CreateCmd.Flags().StringVar(&createMaxTTL, "max-ttl", "24h", "Maximum TTL")
 	CreateCmd.Flags().StringVar(&createRotationPeriod, "rotation-period", "", "Rotation period for credentials stored in the spec (e.g., '24h', '7d'). Empty means no rotation")
 
-	CreateCmd.MarkFlagRequired("type")
 	CreateCmd.MarkFlagRequired("source")
 }
 

--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -23,9 +23,9 @@ The Anthropic provider enables proxied access to the Anthropic API through Warde
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -391,7 +391,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -27,9 +27,9 @@ The AWS provider enables proxied access to AWS services through Warden. Clients 
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -266,6 +266,56 @@ warden cred spec create operator \
 
 Each spec points to a different `role_arn`, so the IAM user's `AssumeRoles` policy must allow assuming all of them (the `devops-*` wildcard in the [AssumeRoles policy](#attach-iam-policies) covers this).
 
+### Alternative: Vault/OpenBao as Credential Source
+
+Instead of storing AWS credentials directly in Warden, you can store them in a Vault/OpenBao instance and have Warden fetch them at runtime. This supports two mint methods: `static_aws` (static credentials from KV v2) and `dynamic_aws` (temporary credentials from the Vault AWS secrets engine).
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- An AppRole configured for Warden access
+- Either a KV v2 mount containing AWS credentials, or an AWS secrets engine with configured roles
+
+```bash
+# Create a Vault credential source
+warden cred source create aws-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=<role-id> \
+  --config=secret_id=<secret-id> \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+```
+
+#### static_aws — fetch static credentials from KV v2
+
+The KV v2 secret must contain `access_key_id` and `secret_access_key` fields.
+
+```bash
+warden cred spec create developer \
+  --source aws-vault-src \
+  --config mint_method=static_aws \
+  --config kv2_mount=secret \
+  --config secret_path=aws/creds \
+  --min-ttl 600s \
+  --max-ttl 2h
+```
+
+#### dynamic_aws — generate credentials via Vault AWS secrets engine
+
+Vault generates temporary AWS credentials using its [AWS secrets engine](https://developer.hashicorp.com/vault/docs/secrets/aws). The role must already be configured in Vault.
+
+```bash
+warden cred spec create developer \
+  --source aws-vault-src \
+  --config mint_method=dynamic_aws \
+  --config aws_mount=aws \
+  --config role_name=my-vault-aws-role \
+  --config ttl=1h \
+  --min-ttl 600s \
+  --max-ttl 2h
+```
+
 ## Step 4: Create a Policy
 
 Create a policy that grants access to the AWS provider gateway. Note that this policy is intentionally coarse-grained for simplicity, but it can be made much more fine-grained to restrict access to specific paths or capabilities as needed:
@@ -409,7 +459,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
@@ -575,6 +625,25 @@ For HTTPS, you'll need a **wildcard SSL certificate** (`*.warden.yourdomain.com`
 | `mint_method` | string | Yes | Must be `secrets_manager` |
 | `secret_id` | string | Yes | Secret ID or ARN in Secrets Manager |
 | `version_stage` | string | No | Version stage to retrieve (default: `AWSCURRENT`) |
+
+### Credential Spec Config — static_aws (via hvault)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_aws` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to secret (must contain `access_key_id` and `secret_access_key`) |
+
+### Credential Spec Config — dynamic_aws (via hvault)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `dynamic_aws` |
+| `aws_mount` | string | Yes | Vault AWS secrets engine mount path |
+| `role_name` | string | Yes | AWS role name configured in Vault |
+| `role_arn` | string | No | ARN of the role to assume (for STS) |
+| `role_session_name` | string | No | Session name for STS assumption |
+| `ttl` | duration | No | Credential TTL (clamped to spec min/max bounds) |
 
 ### TTL Bounds
 

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -24,9 +24,9 @@ The Azure provider enables proxied access to Azure APIs through Warden. It manag
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -325,7 +325,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -23,9 +23,9 @@ The GCP provider enables proxied access to Google Cloud Platform APIs through Wa
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -334,7 +334,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -25,9 +25,9 @@ The GitHub provider enables proxied access to the GitHub REST API through Warden
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -316,7 +316,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -27,9 +27,9 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -319,7 +319,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -23,9 +23,9 @@ The Mistral provider enables proxied access to the Mistral AI API through Warden
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -330,7 +330,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -23,9 +23,9 @@ The OpenAI provider enables proxied access to the OpenAI API through Warden. It 
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -343,7 +343,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/pagerduty/README.md
+++ b/provider/pagerduty/README.md
@@ -24,9 +24,9 @@ The PagerDuty provider enables proxied access to the PagerDuty REST API v2 throu
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -343,7 +343,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/servicenow/README.md
+++ b/provider/servicenow/README.md
@@ -25,9 +25,9 @@ The ServiceNow provider enables proxied access to a ServiceNow instance REST API
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -352,7 +352,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/slack/README.md
+++ b/provider/slack/README.md
@@ -23,9 +23,9 @@ The Slack provider enables proxied access to the Slack Web API through Warden. I
 >
 > **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 >
 > **2. Download the latest Warden binary:**
@@ -354,7 +354,7 @@ To stop Warden and the identity provider:
 # Stop Warden (Ctrl+C in the terminal where it's running)
 
 # Stop and remove the identity provider containers
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -537,9 +537,9 @@ Steps 2 and 6 above use TLS certificate authentication. Alternatively, you can a
 
 > **Prerequisite:** JWT authentication requires an identity provider that issues JWTs. The quickstart uses [Ory Hydra](https://www.ory.sh/hydra/) via Docker Compose:
 > ```bash
-> curl -fsSL -o deploy/docker-compose.quickstart.yml \
+> curl -fsSL -o docker-compose.quickstart.yml \
 >   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f deploy/docker-compose.quickstart.yml up -d
+> docker compose -f docker-compose.quickstart.yml up -d
 > ```
 
 Steps 1, 3-5 (provider setup) are identical. Replace Steps 2 and 6 with the following.
@@ -609,7 +609,7 @@ vault kv list secret/
 To stop the identity provider containers:
 
 ```bash
-docker compose -f deploy/docker-compose.quickstart.yml down -v
+docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 ## Configuration Reference

--- a/scripts/init-vault.sh
+++ b/scripts/init-vault.sh
@@ -82,6 +82,10 @@ path "auth/token/create/*" {
 path "auth/token/revoke-accessor" {
   capabilities = ["update"]
 }
+
+path "secret/data/*" {
+  capabilities = ["read","list"]
+}
 EOF
 
 echo ""


### PR DESCRIPTION
…o AWS provider

The CLI enforced --type as required even though the server infers the credential type from the source driver since v0.7.0. Also adds Vault/OpenBao credential source documentation to the AWS provider README, fixes quickstart paths across all provider READMEs, and adds KV v2 read policy to the Vault init script.