### PR TITLE
feat: add IBM Cloud credential driver with IAM token exchange and key…

### DIFF
--- a/credential/credential.go
+++ b/credential/credential.go
@@ -30,6 +30,7 @@ const (
 	SourceTypeGitHub = "github"
 	SourceTypeAPIKey = "apikey"
 	SourceTypeOAuth2 = "oauth2"
+	SourceTypeIBM    = "ibm"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -49,5 +49,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register IBM Cloud driver factory
+	if err := registry.RegisterFactory(&IBMDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -1,0 +1,585 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// DefaultIBMActivationDelay is the default wait period for IBM Cloud API key propagation.
+// IBM Cloud IAM key propagation is typically fast (seconds), but a 2-minute default
+// provides a safe buffer for eventual consistency. Configurable via activation_delay.
+const DefaultIBMActivationDelay = 2 * time.Minute
+
+// ibmMaxResponseBodySize limits response body reads to prevent OOM
+const ibmMaxResponseBodySize = 1 << 20 // 1MB
+
+// defaultIBMIAMEndpoint is the default IBM Cloud IAM endpoint
+const defaultIBMIAMEndpoint = "https://iam.cloud.ibm.com"
+
+// Compile-time interface assertions
+var _ credential.SourceDriver = (*IBMDriver)(nil)
+var _ credential.Rotatable = (*IBMDriver)(nil)
+var _ credential.SpecVerifier = (*IBMDriver)(nil)
+
+// IBMDriver mints credentials from IBM Cloud services.
+// It exchanges an IBM Cloud API key for IAM bearer tokens.
+//
+// The driver's source credentials (API key) are used for:
+// - Minting IAM bearer tokens via the IAM token endpoint
+// - Rotating the source API key via the IAM Identity Services API
+type IBMDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+
+	// Token cache for IAM bearer tokens
+	tokenCache *TokenCache
+
+	// HTTP client for IBM Cloud API calls
+	httpClient *http.Client
+
+	// authMu protects iamID, apiKeyID, and credSource.Config writes during rotation.
+	// These fields are read by SupportsRotation/PrepareRotation and written by
+	// CommitRotation/discoverAPIKeyDetails concurrently.
+	authMu sync.Mutex
+
+	// iamID is the IAM identity associated with the source API key
+	// Discovered at creation time, required for rotation
+	// Protected by authMu
+	iamID string
+
+	// apiKeyID is the unique ID of the current source API key
+	// Used for cleanup during rotation
+	// Protected by authMu
+	apiKeyID string
+}
+
+// IBMDriverFactory creates IBMDriver instances
+type IBMDriverFactory struct{}
+
+// Type returns the driver type
+func (f *IBMDriverFactory) Type() string {
+	return credential.SourceTypeIBM
+}
+
+// ValidateConfig validates IBM Cloud driver configuration using declarative schema
+func (f *IBMDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("api_key").
+			Required().
+			Describe("IBM Cloud API key").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("account_id").
+			Describe("IBM Cloud account ID (optional, discovered from API key if omitted)").
+			Example("abcdef1234567890abcdef1234567890"),
+
+		credential.StringField("iam_endpoint").
+			Custom(func(v string) error {
+				if !strings.HasPrefix(v, "https://") {
+					return fmt.Errorf("iam_endpoint must use https scheme, got: %s", v)
+				}
+				if _, err := url.Parse(v); err != nil {
+					return fmt.Errorf("iam_endpoint is not a valid URL: %w", err)
+				}
+				return nil
+			}).
+			Describe("IBM Cloud IAM endpoint (optional, defaults to https://iam.cloud.ibm.com)").
+			Example("https://iam.cloud.ibm.com"),
+	)
+}
+
+// SensitiveConfigFields returns the list of config keys that should be masked in output
+func (f *IBMDriverFactory) SensitiveConfigFields() []string {
+	return []string{"api_key"}
+}
+
+// InferCredentialType infers the credential type from the spec's mint_method.
+func (f *IBMDriverFactory) InferCredentialType(specConfig map[string]string) (string, error) {
+	mintMethod := specConfig["mint_method"]
+	switch mintMethod {
+	case "iam_token", "":
+		return credential.TypeOAuthBearerToken, nil
+	default:
+		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
+	}
+}
+
+// Create instantiates a new IBMDriver
+func (f *IBMDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeIBM,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(credential.SourceTypeIBM),
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+
+	// Validate source credentials by acquiring a token
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, _, err := driver.acquireIAMToken(ctx); err != nil {
+		return nil, fmt.Errorf("IBM Cloud authentication failed: %w", err)
+	}
+
+	// Discover API key details for rotation support
+	if err := driver.discoverAPIKeyDetails(ctx); err != nil {
+		// Non-fatal: rotation won't be available but minting still works
+		if driver.logger != nil {
+			driver.logger.Warn("failed to discover API key details, rotation will be disabled",
+				logger.Err(err),
+			)
+		}
+	}
+
+	return driver, nil
+}
+
+// ============================================================================
+// SourceDriver Interface Implementation
+// ============================================================================
+
+// MintCredential mints credentials based on the spec's mint_method.
+func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token")
+
+	switch mintMethod {
+	case "iam_token":
+		return d.mintIAMToken(ctx, spec)
+	default:
+		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for IBM driver; use 'iam_token'", mintMethod)
+	}
+}
+
+// mintIAMToken exchanges the source API key for an IAM bearer token
+func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	token, expiry, err := d.getIAMToken(ctx)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
+	}
+
+	ttl := time.Until(expiry)
+	rawData := map[string]interface{}{
+		"api_key":      token,
+		"access_token": token,
+		"token_type":   "Bearer",
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("minted IBM IAM bearer token",
+			logger.String("spec", spec.Name),
+			logger.String("ttl", ttl.String()),
+		)
+	}
+
+	// No leaseID — IAM tokens expire naturally and cannot be revoked
+	return rawData, ttl, "", nil
+}
+
+// Revoke is a no-op for IBM credentials (IAM tokens expire naturally)
+func (d *IBMDriver) Revoke(ctx context.Context, leaseID string) error {
+	if d.logger != nil {
+		d.logger.Debug("IBM IAM tokens expire naturally, skipping revocation",
+			logger.String("lease_id", leaseID),
+		)
+	}
+	return nil
+}
+
+// Type returns the driver type
+func (d *IBMDriver) Type() string {
+	return credential.SourceTypeIBM
+}
+
+// Cleanup releases resources
+func (d *IBMDriver) Cleanup(ctx context.Context) error {
+	return nil
+}
+
+// VerifySpec validates that an IBM spec's configuration is functional by performing
+// a lightweight IAM token exchange. Called during spec creation/update only.
+func (d *IBMDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token")
+	if mintMethod != "iam_token" {
+		return nil
+	}
+
+	// Verify the source API key can mint an IAM token
+	_, _, err := d.getIAMToken(ctx)
+	if err != nil {
+		return fmt.Errorf("IBM spec verification failed: %w", err)
+	}
+	return nil
+}
+
+// ============================================================================
+// Rotatable Interface Implementation (Source API Key Rotation)
+// ============================================================================
+
+// SupportsRotation returns true if this driver can rotate its source API key.
+// Rotation requires the API key's IAM identity to have permission to create/delete API keys.
+func (d *IBMDriver) SupportsRotation() bool {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	return d.iamID != ""
+}
+
+// PrepareRotation creates a new API key for the same IAM identity.
+// Returns activateAfter to allow time for IBM Cloud propagation.
+func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+
+	if d.iamID == "" {
+		return nil, nil, 0, fmt.Errorf("cannot rotate: IAM identity not discovered")
+	}
+
+	// Get IAM token using current API key
+	iamToken, _, err := d.getIAMToken(ctx)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to get IAM token for rotation: %w", err)
+	}
+
+	// Create new API key for the same IAM identity
+	newAPIKey, newAPIKeyID, err := d.createAPIKey(ctx, iamToken)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	oldAPIKeyID := d.apiKeyID
+
+	// Build new config
+	newConfig := make(map[string]string)
+	for k, v := range d.credSource.Config {
+		newConfig[k] = v
+	}
+	newConfig["api_key"] = newAPIKey
+
+	cleanupConfig := map[string]string{
+		"api_key_id": oldAPIKeyID,
+	}
+
+	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultIBMActivationDelay)
+
+	if d.logger != nil {
+		d.logger.Debug("prepared source API key rotation",
+			logger.String("old_key_id", truncateID(oldAPIKeyID, 8)),
+			logger.String("new_key_id", truncateID(newAPIKeyID, 8)),
+			logger.String("activate_after", activateAfter.String()),
+		)
+	}
+
+	return newConfig, cleanupConfig, activateAfter, nil
+}
+
+// CommitRotation activates new credentials in the driver.
+//
+// Thread-safety: authMu protects credSource.Config writes and iamID/apiKeyID updates.
+// The rotated field (api_key) is only read by acquireIAMToken, which is always called
+// either under authMu or during initial creation (single-threaded).
+func (d *IBMDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+
+	// Save old config for rollback on failure
+	oldConfig := d.credSource.Config
+
+	// Update config
+	d.credSource.Config = newConfig
+
+	// Invalidate all cached tokens from previous generation
+	d.tokenCache.InvalidateGeneration()
+
+	// Verify new credentials work
+	if _, _, err := d.acquireIAMToken(ctx); err != nil {
+		d.credSource.Config = oldConfig
+		d.tokenCache.InvalidateGeneration()
+		return fmt.Errorf("failed to authenticate with new API key: %w", err)
+	}
+
+	// Re-discover API key details with new key
+	if err := d.discoverAPIKeyDetailsLocked(ctx); err != nil {
+		d.credSource.Config = oldConfig
+		d.tokenCache.InvalidateGeneration()
+		return fmt.Errorf("failed to discover new API key details: %w", err)
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("committed source API key rotation",
+			logger.String("new_key_id", truncateID(d.apiKeyID, 8)),
+		)
+	}
+
+	return nil
+}
+
+// CleanupRotation deletes the old API key
+func (d *IBMDriver) CleanupRotation(ctx context.Context, cleanupConfig map[string]string) error {
+	oldAPIKeyID := cleanupConfig["api_key_id"]
+	if oldAPIKeyID == "" {
+		return nil
+	}
+
+	// Get IAM token using current (new) API key
+	iamToken, _, err := d.getIAMToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get IAM token for cleanup: %w", err)
+	}
+
+	if err := d.deleteAPIKey(ctx, iamToken, oldAPIKeyID); err != nil {
+		return fmt.Errorf("failed to delete old API key: %w", err)
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("cleaned up old API key",
+			logger.String("old_key_id", truncateID(oldAPIKeyID, 8)),
+		)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Token Acquisition
+// ============================================================================
+
+// getIAMToken returns a cached or freshly acquired IAM bearer token.
+// Thread-safe via TokenCache.
+func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) {
+	// Check cache (with 30s refresh buffer)
+	if token, expiry, ok := d.tokenCache.Get("iam", 30*time.Second); ok {
+		return token, expiry, nil
+	}
+
+	// Acquire fresh token
+	token, expiry, err := d.acquireIAMToken(ctx)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	// Cache it
+	d.tokenCache.Set("iam", token, expiry)
+
+	return token, expiry, nil
+}
+
+// acquireIAMToken exchanges the source API key for an IAM bearer token.
+func (d *IBMDriver) acquireIAMToken(ctx context.Context) (string, time.Time, error) {
+	apiKey := credential.GetString(d.credSource.Config, "api_key", "")
+	if apiKey == "" {
+		return "", time.Time{}, fmt.Errorf("api_key is empty")
+	}
+
+	iamEndpoint := d.getIAMEndpoint()
+
+	form := url.Values{
+		"grant_type": {"urn:ibm:params:oauth:grant-type:apikey"},
+		"apikey":     {apiKey},
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+		Method: "POST",
+		URL:    iamEndpoint + "/identity/token",
+		Body:   []byte(form.Encode()),
+		Headers: map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept":       "application/json",
+		},
+	}, defaultIBMRetryConfig())
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("IBM IAM token request failed: %w", err)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int64  `json:"expires_in"`
+		Expiration  int64  `json:"expiration"` // Unix timestamp
+	}
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to decode IAM token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", time.Time{}, fmt.Errorf("IAM token response missing access_token")
+	}
+
+	// Compute expiry from either expiration (Unix timestamp) or expires_in (seconds)
+	var expiry time.Time
+	if tokenResp.Expiration > 0 {
+		expiry = time.Unix(tokenResp.Expiration, 0)
+	} else if tokenResp.ExpiresIn > 0 {
+		expiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	} else {
+		expiry = time.Now().Add(1 * time.Hour) // fallback
+	}
+
+	return tokenResp.AccessToken, expiry, nil
+}
+
+// ============================================================================
+// IAM Identity Services API Helpers
+// ============================================================================
+
+// discoverAPIKeyDetails fetches the IAM identity and key ID for the source API key.
+// Acquires authMu internally.
+func (d *IBMDriver) discoverAPIKeyDetails(ctx context.Context) error {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	return d.discoverAPIKeyDetailsLocked(ctx)
+}
+
+// discoverAPIKeyDetailsLocked is the lock-free implementation of discoverAPIKeyDetails.
+// Caller must hold authMu.
+func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
+	iamToken, _, err := d.getIAMToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get IAM token: %w", err)
+	}
+
+	iamEndpoint := d.getIAMEndpoint()
+	apiKey := credential.GetString(d.credSource.Config, "api_key", "")
+
+	// Use POST with API key in request body (more secure than GET with IAM-Apikey header)
+	reqBody, err := json.Marshal(map[string]string{
+		"apikey": apiKey,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal API key details request: %w", err)
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+		Method: "POST",
+		URL:    iamEndpoint + "/v1/apikeys/details",
+		Body:   reqBody,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + iamToken,
+			"Content-Type":  "application/json",
+			"Accept":        "application/json",
+		},
+	}, defaultIBMRetryConfig())
+	if err != nil {
+		return fmt.Errorf("failed to get API key details: %w", err)
+	}
+
+	var detailsResp struct {
+		ID        string `json:"id"`
+		IamID     string `json:"iam_id"`
+		AccountID string `json:"account_id"`
+		Name      string `json:"name"`
+	}
+	if err := json.Unmarshal(respBody, &detailsResp); err != nil {
+		return fmt.Errorf("failed to decode API key details: %w", err)
+	}
+
+	if detailsResp.IamID == "" {
+		return fmt.Errorf("API key details response missing iam_id")
+	}
+
+	d.iamID = detailsResp.IamID
+	d.apiKeyID = detailsResp.ID
+
+	// Set account_id from discovery if not already configured
+	if credential.GetString(d.credSource.Config, "account_id", "") == "" && detailsResp.AccountID != "" {
+		d.credSource.Config["account_id"] = detailsResp.AccountID
+	}
+
+	if d.logger != nil {
+		d.logger.Trace("discovered IBM API key details",
+			logger.String("api_key_id", truncateID(d.apiKeyID, 8)),
+			logger.String("iam_id", d.iamID),
+		)
+	}
+
+	return nil
+}
+
+// createAPIKey creates a new API key for the same IAM identity
+func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, string, error) {
+	iamEndpoint := d.getIAMEndpoint()
+	accountID := credential.GetString(d.credSource.Config, "account_id", "")
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"name":        fmt.Sprintf("warden-rotated-%d", time.Now().Unix()),
+		"description": "Managed by Warden credential rotation",
+		"iam_id":      d.iamID,
+		"account_id":  accountID,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal create API key request: %w", err)
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+		Method: "POST",
+		URL:    iamEndpoint + "/v1/apikeys",
+		Body:   reqBody,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + iamToken,
+			"Content-Type":  "application/json",
+			"Accept":        "application/json",
+		},
+	}, defaultIBMRetryConfig())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create new API key: %w", err)
+	}
+
+	var createResp struct {
+		ID     string `json:"id"`
+		Apikey string `json:"apikey"`
+	}
+	if err := json.Unmarshal(respBody, &createResp); err != nil {
+		return "", "", fmt.Errorf("failed to decode create API key response: %w", err)
+	}
+
+	if createResp.Apikey == "" || createResp.ID == "" {
+		return "", "", fmt.Errorf("create API key response missing apikey or id")
+	}
+
+	return createResp.Apikey, createResp.ID, nil
+}
+
+// deleteAPIKey deletes an API key by ID
+func (d *IBMDriver) deleteAPIKey(ctx context.Context, iamToken, apiKeyID string) error {
+	iamEndpoint := d.getIAMEndpoint()
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+		Method: "DELETE",
+		URL:    fmt.Sprintf("%s/v1/apikeys/%s", iamEndpoint, url.PathEscape(apiKeyID)),
+		Headers: map[string]string{
+			"Authorization": "Bearer " + iamToken,
+		},
+		OKStatuses: []int{http.StatusNoContent, http.StatusOK},
+	}, defaultIBMRetryConfig())
+	return err
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// getIAMEndpoint returns the configured IAM endpoint or the default
+func (d *IBMDriver) getIAMEndpoint() string {
+	return credential.GetString(d.credSource.Config, "iam_endpoint", defaultIBMIAMEndpoint)
+}
+
+// defaultIBMRetryConfig returns the standard retry configuration for IBM Cloud API calls.
+func defaultIBMRetryConfig() HTTPRetryConfig {
+	return HTTPRetryConfig{
+		MaxAttempts:       3,
+		MaxBodySize:       ibmMaxResponseBodySize,
+		RetryableStatuses: []int{429, 500}, // 500 = wildcard for all 5xx (see ExecuteWithRetry)
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+}

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -1,0 +1,530 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Factory Tests
+// ============================================================================
+
+func TestIBMDriverFactory_Type(t *testing.T) {
+	f := &IBMDriverFactory{}
+	assert.Equal(t, credential.SourceTypeIBM, f.Type())
+}
+
+func TestIBMDriverFactory_SensitiveConfigFields(t *testing.T) {
+	f := &IBMDriverFactory{}
+	fields := f.SensitiveConfigFields()
+	assert.Contains(t, fields, "api_key")
+}
+
+func TestIBMDriverFactory_ValidateConfig(t *testing.T) {
+	f := &IBMDriverFactory{}
+
+	t.Run("missing api_key", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api_key")
+	})
+
+	t.Run("valid minimal config", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"api_key": "test-api-key",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"api_key":      "test-api-key",
+			"account_id":   "abc123",
+			"iam_endpoint": "https://iam.test.cloud.ibm.com",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("iam_endpoint rejects http scheme", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"api_key":      "test-api-key",
+			"iam_endpoint": "http://iam.cloud.ibm.com",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "https")
+	})
+}
+
+func TestIBMDriverFactory_InferCredentialType(t *testing.T) {
+	f := &IBMDriverFactory{}
+
+	t.Run("iam_token", func(t *testing.T) {
+		ct, err := f.InferCredentialType(map[string]string{"mint_method": "iam_token"})
+		require.NoError(t, err)
+		assert.Equal(t, credential.TypeOAuthBearerToken, ct)
+	})
+
+	t.Run("empty defaults to oauth bearer token", func(t *testing.T) {
+		ct, err := f.InferCredentialType(map[string]string{})
+		require.NoError(t, err)
+		assert.Equal(t, credential.TypeOAuthBearerToken, ct)
+	})
+
+	t.Run("unsupported mint method", func(t *testing.T) {
+		_, err := f.InferCredentialType(map[string]string{"mint_method": "invalid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot infer credential type")
+	})
+}
+
+// ============================================================================
+// Driver Unit Tests
+// ============================================================================
+
+func TestIBMDriver_Type(t *testing.T) {
+	d := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeIBM,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, credential.SourceTypeIBM, d.Type())
+}
+
+func TestIBMDriver_Cleanup(t *testing.T) {
+	d := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeIBM,
+			Config: map[string]string{},
+		},
+	}
+	require.NoError(t, d.Cleanup(context.TODO()))
+}
+
+func TestIBMDriver_Revoke_NoOp(t *testing.T) {
+	d := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeIBM,
+			Config: map[string]string{},
+		},
+	}
+	require.NoError(t, d.Revoke(context.TODO(), "some-lease-id"))
+}
+
+func TestIBMDriver_SupportsRotation(t *testing.T) {
+	t.Run("true when iamID is set", func(t *testing.T) {
+		d := &IBMDriver{iamID: "iam-1234"}
+		assert.True(t, d.SupportsRotation())
+	})
+
+	t.Run("false when iamID is empty", func(t *testing.T) {
+		d := &IBMDriver{}
+		assert.False(t, d.SupportsRotation())
+	})
+}
+
+func TestIBMDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
+	d := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeIBM,
+			Config: map[string]string{},
+		},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-spec",
+		Config: map[string]string{
+			"mint_method": "invalid_method",
+		},
+	}
+
+	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported mint_method")
+}
+
+// ============================================================================
+// Mock Server Tests
+// ============================================================================
+
+// newIBMMockServer creates a test server that mocks IBM Cloud IAM endpoints
+func newIBMMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	// IAM token endpoint
+	mux.HandleFunc("/identity/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+
+		grantType := r.FormValue("grant_type")
+		apiKey := r.FormValue("apikey")
+
+		if grantType != "urn:ibm:params:oauth:grant-type:apikey" {
+			http.Error(w, "invalid grant_type", http.StatusBadRequest)
+			return
+		}
+
+		if apiKey == "" || apiKey == "invalid-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{
+				"errorCode":    "BXNIM0415E",
+				"errorMessage": "Provided API key could not be found.",
+			})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-iam-token-" + apiKey,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"expiration":   time.Now().Add(1 * time.Hour).Unix(),
+		})
+	})
+
+	// API key details endpoint (POST with API key in body)
+	mux.HandleFunc("/v1/apikeys/details", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed; use POST", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var reqBody map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		if reqBody["apikey"] == "" {
+			http.Error(w, "missing apikey in body", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         "ApiKey-12345",
+			"iam_id":     "iam-ServiceId-abcdef",
+			"account_id": "acc-123456",
+			"name":       "warden-test-key",
+		})
+	})
+
+	// Create API key endpoint
+	mux.HandleFunc("/v1/apikeys", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+
+		// Verify description field is present
+		if _, ok := reqBody["description"]; !ok {
+			http.Error(w, "missing description", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     "ApiKey-new-67890",
+			"apikey": "new-rotated-api-key",
+			"name":   reqBody["name"],
+			"iam_id": reqBody["iam_id"],
+		})
+	})
+
+	// Delete API key endpoint
+	mux.HandleFunc("/v1/apikeys/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func newTestIBMDriver(t *testing.T, serverURL string) *IBMDriver {
+	t.Helper()
+	return &IBMDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeIBM,
+			Config: map[string]string{
+				"api_key":      "test-key",
+				"iam_endpoint": serverURL,
+			},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		iamID:      "iam-ServiceId-abcdef",
+		apiKeyID:   "ApiKey-12345",
+	}
+}
+
+func TestIBMDriver_MintIAMToken(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	spec := &credential.CredSpec{
+		Name: "test-spec",
+		Config: map[string]string{
+			"mint_method": "iam_token",
+		},
+	}
+
+	rawData, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, rawData["api_key"])
+	assert.NotEmpty(t, rawData["access_token"])
+	assert.Equal(t, "Bearer", rawData["token_type"])
+	assert.Equal(t, rawData["api_key"], rawData["access_token"])
+	assert.True(t, ttl > 0)
+	assert.Empty(t, leaseID, "IAM tokens should have no lease ID")
+}
+
+func TestIBMDriver_MintIAMToken_DefaultMintMethod(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	spec := &credential.CredSpec{
+		Name:   "test-spec",
+		Config: map[string]string{}, // no mint_method = defaults to iam_token
+	}
+
+	rawData, _, _, err := d.MintCredential(context.TODO(), spec)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rawData["access_token"])
+}
+
+func TestIBMDriver_MintIAMToken_InvalidKey(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.credSource.Config["api_key"] = "invalid-key"
+	d.tokenCache.Clear()
+
+	spec := &credential.CredSpec{
+		Name: "test-spec",
+		Config: map[string]string{
+			"mint_method": "iam_token",
+		},
+	}
+
+	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IBM IAM token")
+}
+
+func TestIBMDriver_TokenCaching(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/identity/token" {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": fmt.Sprintf("token-call-%d", callCount),
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+				"expiration":   time.Now().Add(1 * time.Hour).Unix(),
+			})
+		}
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.tokenCache.Clear()
+
+	// First call should hit the server
+	token1, _, err := d.getIAMToken(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	// Second call should use cache
+	token2, _, err := d.getIAMToken(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "should not have made another server call")
+	assert.Equal(t, token1, token2)
+}
+
+func TestIBMDriver_DiscoverAPIKeyDetails(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeIBM,
+			Config: map[string]string{
+				"api_key":      "test-key",
+				"iam_endpoint": srv.URL,
+			},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	err := d.discoverAPIKeyDetails(context.TODO())
+	require.NoError(t, err)
+
+	assert.Equal(t, "iam-ServiceId-abcdef", d.iamID)
+	assert.Equal(t, "ApiKey-12345", d.apiKeyID)
+	assert.Equal(t, "acc-123456", d.credSource.Config["account_id"])
+}
+
+func TestIBMDriver_PrepareRotation(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.credSource.Config["account_id"] = "acc-123456"
+
+	newConfig, cleanupConfig, activateAfter, err := d.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+
+	assert.Equal(t, "new-rotated-api-key", newConfig["api_key"])
+	assert.Equal(t, "ApiKey-12345", cleanupConfig["api_key_id"])
+	assert.Equal(t, DefaultIBMActivationDelay, activateAfter)
+}
+
+func TestIBMDriver_PrepareRotation_NoIAMID(t *testing.T) {
+	d := &IBMDriver{iamID: ""}
+	_, _, _, err := d.PrepareRotation(context.TODO())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IAM identity not discovered")
+}
+
+func TestIBMDriver_CleanupRotation(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	err := d.CleanupRotation(context.TODO(), map[string]string{
+		"api_key_id": "ApiKey-old-12345",
+	})
+	require.NoError(t, err)
+}
+
+func TestIBMDriver_CleanupRotation_EmptyID(t *testing.T) {
+	d := &IBMDriver{}
+	err := d.CleanupRotation(context.TODO(), map[string]string{})
+	require.NoError(t, err, "empty api_key_id should be a no-op")
+}
+
+func TestIBMDriverFactory_Create(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+
+	f := &IBMDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"api_key":      "test-key",
+		"iam_endpoint": srv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	ibmDriver, ok := driver.(*IBMDriver)
+	require.True(t, ok)
+	assert.Equal(t, "iam-ServiceId-abcdef", ibmDriver.iamID)
+	assert.Equal(t, "ApiKey-12345", ibmDriver.apiKeyID)
+}
+
+func TestIBMDriverFactory_Create_InvalidKey(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+
+	f := &IBMDriverFactory{}
+	_, err := f.Create(map[string]string{
+		"api_key":      "invalid-key",
+		"iam_endpoint": srv.URL,
+	}, log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IBM Cloud authentication failed")
+}
+
+// ============================================================================
+// SpecVerifier Tests
+// ============================================================================
+
+func TestIBMDriver_VerifySpec(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	t.Run("valid spec", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"mint_method": "iam_token",
+			},
+		}
+		err := d.VerifySpec(context.TODO(), spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("default mint method", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name:   "test-spec",
+			Config: map[string]string{},
+		}
+		err := d.VerifySpec(context.TODO(), spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid api key fails verification", func(t *testing.T) {
+		d2 := newTestIBMDriver(t, srv.URL)
+		d2.credSource.Config["api_key"] = "invalid-key"
+		d2.tokenCache.Clear()
+
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"mint_method": "iam_token",
+			},
+		}
+		err := d2.VerifySpec(context.TODO(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec verification failed")
+	})
+}
+
+// ============================================================================
+// Compile-time Interface Assertions
+// ============================================================================
+
+func TestIBMDriver_ImplementsSpecVerifier(t *testing.T) {
+	var _ credential.SpecVerifier = (*IBMDriver)(nil)
+}

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -56,8 +56,8 @@ func (t *OAuthBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
 
 		// Vault source - OAuth2 plugin fields
 		credential.StringField("mint_method").
-			OneOf("oauth2").
-			Describe("Mint method (required for vault source)").
+			OneOf("oauth2", "iam_token").
+			Describe("Mint method (required for vault/ibm source)").
 			Example("oauth2"),
 
 		credential.StringField("oauth2_mount").
@@ -73,10 +73,10 @@ func (t *OAuthBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
 // ValidateConfig validates the Config for an OAuth bearer token credential spec.
 func (t *OAuthBearerTokenCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	switch sourceType {
-	case credential.SourceTypeOAuth2, credential.SourceTypeVault:
+	case credential.SourceTypeOAuth2, credential.SourceTypeVault, credential.SourceTypeIBM:
 		// Supported
 	default:
-		return fmt.Errorf("oauth_bearer_token credentials require an oauth2 or vault source, got: %s", sourceType)
+		return fmt.Errorf("oauth_bearer_token credentials require an oauth2, vault, or ibm source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -84,8 +84,9 @@ func (t *OAuthBearerTokenCredType) ValidateConfig(config map[string]string, sour
 		return err
 	}
 
-	// Vault source requires oauth2 mint_method with mount and credential_name
-	if sourceType == credential.SourceTypeVault {
+	// Source-specific validation
+	switch sourceType {
+	case credential.SourceTypeVault:
 		if config["mint_method"] != "oauth2" {
 			return fmt.Errorf("'mint_method' must be 'oauth2' for vault source, got: %s", config["mint_method"])
 		}
@@ -94,6 +95,11 @@ func (t *OAuthBearerTokenCredType) ValidateConfig(config map[string]string, sour
 		}
 		if config["credential_name"] == "" {
 			return fmt.Errorf("'credential_name' is required when mint_method is oauth2")
+		}
+	case credential.SourceTypeIBM:
+		// IBM source uses iam_token mint method (default); no additional spec config needed
+		if mm := config["mint_method"]; mm != "" && mm != "iam_token" {
+			return fmt.Errorf("'mint_method' must be 'iam_token' for ibm source, got: %s", mm)
 		}
 	}
 

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -46,21 +46,21 @@ func TestOAuthBearerTokenCredType_ValidateConfig(t *testing.T) {
 			config:     map[string]string{},
 			sourceType: credential.SourceTypeLocal,
 			wantErr:    true,
-			errMsg:     "require an oauth2 or vault source",
+			errMsg:     "require an oauth2, vault, or ibm source",
 		},
 		{
 			name:       "unsupported source type - aws",
 			config:     map[string]string{},
 			sourceType: credential.SourceTypeAWS,
 			wantErr:    true,
-			errMsg:     "require an oauth2 or vault source",
+			errMsg:     "require an oauth2, vault, or ibm source",
 		},
 		{
 			name:       "unsupported source type - static apikey",
 			config:     map[string]string{},
 			sourceType: credential.SourceTypeAPIKey,
 			wantErr:    true,
-			errMsg:     "require an oauth2 or vault source",
+			errMsg:     "require an oauth2, vault, or ibm source",
 		},
 	}
 


### PR DESCRIPTION
… rotation

Add a standalone IBM Cloud driver that exchanges long-lived API keys for short-lived IAM bearer tokens, enabling IBM Cloud provider support without requiring a Vault deployment.

- New `ibm` source type with `iam_token` mint method
- IAM token caching with 30s refresh buffer via TokenCache
- API key rotation (prepare/commit/cleanup) with 2-min activation delay
- SpecVerifier for early validation at spec creation time
- Thread-safe via authMu protecting rotation state
- HTTPS-only IAM endpoint validation
- CommitRotation rollback on failure