### PR TITLE
feat: add Scaleway provider with dual-mode gateway, SigV4 shared pack…

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/stephnangue/warden/provider/ovh"
 	"github.com/stephnangue/warden/provider/pagerduty"
 	"github.com/stephnangue/warden/provider/rds"
+	"github.com/stephnangue/warden/provider/scaleway"
 	"github.com/stephnangue/warden/provider/servicenow"
 	"github.com/stephnangue/warden/provider/slack"
 	"github.com/stephnangue/warden/provider/splunk"
@@ -137,6 +138,7 @@ Usage: warden server [options]
 		"tfe":           tfe.Factory,
 		"vault":         vault.Factory,
 		"rds":           rds.Factory,
+		"scaleway":      scaleway.Factory,
 	}
 
 	authMethods = map[string]wardenlogical.Factory{

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -18,6 +18,7 @@ const (
 	TypeDBAuthToken       = "db_auth_token"
 	TypeOAuthBearerToken  = "oauth_bearer_token"
 	TypeKubernetesToken   = "kubernetes_token"
+	TypeScalewayKeys     = "scaleway_keys"
 )
 
 // Source type constants
@@ -34,6 +35,7 @@ const (
 	SourceTypeIBM        = "ibm"
 	SourceTypeElastic    = "elastic"
 	SourceTypeKubernetes = "kubernetes"
+	SourceTypeScaleway   = "scaleway"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -64,5 +64,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register Scaleway driver factory
+	if err := registry.RegisterFactory(&ScalewayDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/scaleway_driver.go
+++ b/credential/drivers/scaleway_driver.go
@@ -1,0 +1,597 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+const scalewayMaxResponseBodySize = 1 << 20 // 1MB
+const scalewayMaxRetryAttempts = 3
+
+// DefaultScalewayIAMPath is the default IAM API path prefix.
+// Currently v1alpha1 — update this when Scaleway promotes the API to stable.
+const DefaultScalewayIAMPath = "/iam/v1alpha1"
+
+// DefaultScalewayActivationDelay is the default delay before activating rotated
+// management keys. While Scaleway IAM is likely immediately consistent, a short
+// delay guards against any internal propagation across regions.
+const DefaultScalewayActivationDelay = 30 * time.Second
+
+// Compile-time interface assertions
+var _ credential.SourceDriver = (*ScalewayDriver)(nil)
+var _ credential.SpecVerifier = (*ScalewayDriver)(nil)
+var _ credential.Rotatable = (*ScalewayDriver)(nil)
+
+// ScalewayDriver mints credentials from Scaleway IAM.
+//
+// Two mint methods are supported (configured per-spec via mint_method):
+//   - static_keys: Reads access_key + secret_key from spec config (no TTL, no lease)
+//   - dynamic_keys: Creates a fresh API key via POST /iam/v1alpha1/api-keys
+//     with an optional expires_at. The key is revoked on lease expiry via DELETE.
+//
+// The source config holds connection info and a management secret key with
+// IAM permissions to create/delete API keys.
+type ScalewayDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+
+	// configMu protects credSource.Config during rotation. MintCredential reads
+	// management_secret_key while CommitRotation writes it.
+	configMu sync.RWMutex
+}
+
+// ScalewayDriverFactory creates ScalewayDriver instances.
+type ScalewayDriverFactory struct{}
+
+// Type returns the driver type identifier.
+func (f *ScalewayDriverFactory) Type() string {
+	return credential.SourceTypeScaleway
+}
+
+// ValidateConfig validates Scaleway source configuration.
+func (f *ScalewayDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("scaleway_url").
+			Custom(func(v string) error {
+				if v == "" {
+					return nil // uses default
+				}
+				return validateScalewayURL(v, credential.GetBool(config, "tls_skip_verify", false))
+			}).
+			Describe("Scaleway API URL (default: https://api.scaleway.com)").
+			Example("https://api.scaleway.com"),
+
+		credential.StringField("management_access_key").
+			Custom(func(v string) error {
+				if v != "" && !strings.HasPrefix(v, "SCW") {
+					return fmt.Errorf("management_access_key must start with SCW, got: %s (did you swap access_key and secret_key?)", v)
+				}
+				return nil
+			}).
+			Describe("Access key for management API key (starts with SCW)").
+			Example("SCWXXXXXXXXXXXXXXXXX"),
+
+		credential.StringField("management_secret_key").
+			Custom(func(v string) error {
+				if v != "" && strings.HasPrefix(v, "SCW") {
+					return fmt.Errorf("management_secret_key starts with SCW — this looks like an access key (did you swap access_key and secret_key?)")
+				}
+				return nil
+			}).
+			Describe("Secret key with IAM permissions to create/delete API keys (UUID format)").
+			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+
+		credential.StringField("iam_api_path").
+			Describe("IAM API path prefix (default: /iam/v1alpha1). Update when Scaleway promotes the API to stable.").
+			Example("/iam/v1alpha1"),
+
+		credential.StringField("ca_data").
+			Custom(ValidateCAData).
+			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs").
+			Example("LS0tLS1CRUdJTi..."),
+
+		credential.BoolField("tls_skip_verify").
+			Describe("Skip TLS certificate verification (development only)").
+			Example("false"),
+	)
+}
+
+// SensitiveConfigFields returns source config keys that should be masked.
+func (f *ScalewayDriverFactory) SensitiveConfigFields() []string {
+	return []string{"management_secret_key", "ca_data"}
+}
+
+// InferCredentialType always returns scaleway_keys for Scaleway sources.
+func (f *ScalewayDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeScalewayKeys, nil
+}
+
+// Create instantiates a new ScalewayDriver.
+func (f *ScalewayDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &ScalewayDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeScaleway,
+			Config: config,
+		},
+		logger: log.WithSubsystem(credential.SourceTypeScaleway),
+	}
+
+	httpClient, err := BuildHTTPClient(config, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+	}
+	driver.httpClient = httpClient
+
+	return driver, nil
+}
+
+// Type returns the driver type.
+func (d *ScalewayDriver) Type() string {
+	return credential.SourceTypeScaleway
+}
+
+// getScalewayURL returns the Scaleway API base URL from source config.
+// Thread-safe: scaleway_url is never modified by rotation.
+func (d *ScalewayDriver) getScalewayURL() string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, "scaleway_url", "https://api.scaleway.com"), "/")
+}
+
+// getManagementSecretKeyLocked returns the management secret key from source config.
+// Caller must hold configMu (read or write).
+func (d *ScalewayDriver) getManagementSecretKeyLocked() string {
+	return credential.GetString(d.credSource.Config, "management_secret_key", "")
+}
+
+// getIAMAPIPath returns the IAM API path prefix from source config.
+// Defaults to DefaultScalewayIAMPath (/iam/v1alpha1).
+func (d *ScalewayDriver) getIAMAPIPath() string {
+	return credential.GetString(d.credSource.Config, "iam_api_path", DefaultScalewayIAMPath)
+}
+
+// iamURL builds a full IAM API URL for the given subpath (e.g., "/api-keys").
+func (d *ScalewayDriver) iamURL(subpath string) string {
+	return d.getScalewayURL() + d.getIAMAPIPath() + subpath
+}
+
+// MintCredential returns Scaleway credentials for the given spec.
+func (d *ScalewayDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "static_keys")
+	switch mintMethod {
+	case "static_keys":
+		return d.mintStaticCredential(spec)
+	case "dynamic_keys":
+		return d.mintDynamicCredential(ctx, spec)
+	default:
+		return nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected static_keys or dynamic_keys)", mintMethod)
+	}
+}
+
+// mintStaticCredential reads access_key and secret_key from spec config.
+func (d *ScalewayDriver) mintStaticCredential(spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	accessKey := credential.GetString(spec.Config, "access_key", "")
+	if accessKey == "" {
+		return nil, 0, "", fmt.Errorf("no access_key configured in spec")
+	}
+	secretKey := credential.GetString(spec.Config, "secret_key", "")
+	if secretKey == "" {
+		return nil, 0, "", fmt.Errorf("no secret_key configured in spec")
+	}
+
+	rawData := map[string]interface{}{
+		"access_key": accessKey,
+		"secret_key": secretKey,
+	}
+
+	return rawData, 0, "", nil // Static — no TTL, no lease
+}
+
+// mintDynamicCredential creates a new API key via the Scaleway IAM API.
+func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	d.configMu.RLock()
+	managementKey := d.getManagementSecretKeyLocked()
+	d.configMu.RUnlock()
+	if managementKey == "" {
+		return nil, 0, "", fmt.Errorf("management_secret_key is required on source for dynamic_keys mint method")
+	}
+
+	applicationID := credential.GetString(spec.Config, "application_id", "")
+	if applicationID == "" {
+		return nil, 0, "", fmt.Errorf("application_id is required for dynamic_keys mint method")
+	}
+
+	ttl := credential.GetDuration(spec.Config, "ttl", 1*time.Hour)
+	description := credential.GetString(spec.Config, "description", fmt.Sprintf("warden-%s", spec.Name))
+	defaultProjectID := credential.GetString(spec.Config, "default_project_id", "")
+
+	// Build request body
+	reqBody := map[string]interface{}{
+		"application_id": applicationID,
+		"description":    description,
+		"expires_at":     time.Now().Add(ttl).UTC().Format(time.RFC3339),
+	}
+	if defaultProjectID != "" {
+		reqBody["default_project_id"] = defaultProjectID
+	}
+
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	apiURL := d.iamURL("/api-keys")
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       scalewayMaxRetryAttempts,
+		MaxBodySize:       scalewayMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodPost,
+		URL:    apiURL,
+		Body:   bodyJSON,
+		Headers: map[string]string{
+			"X-Auth-Token": managementKey,
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to create Scaleway API key: %w", err)
+	}
+
+	// Parse response
+	var resp struct {
+		AccessKey        string `json:"access_key"`
+		SecretKey        string `json:"secret_key"`
+		ApplicationID    string `json:"application_id"`
+		DefaultProjectID string `json:"default_project_id"`
+		Description      string `json:"description"`
+		ExpiresAt        string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, 0, "", fmt.Errorf("failed to parse Scaleway API response: %w", err)
+	}
+
+	if resp.AccessKey == "" || resp.SecretKey == "" {
+		return nil, 0, "", fmt.Errorf("Scaleway API returned empty access_key or secret_key")
+	}
+
+	d.logger.Info("created dynamic Scaleway API key",
+		logger.String("access_key", resp.AccessKey),
+		logger.String("application_id", resp.ApplicationID),
+		logger.String("spec", spec.Name),
+		logger.String("expires_at", resp.ExpiresAt),
+	)
+
+	rawData := map[string]interface{}{
+		"access_key": resp.AccessKey,
+		"secret_key": resp.SecretKey,
+	}
+
+	// LeaseID is the access_key — used by Revoke to delete the key
+	return rawData, ttl, resp.AccessKey, nil
+}
+
+// Revoke deletes a dynamically created API key via DELETE /iam/v1alpha1/api-keys/{access_key}.
+func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
+	if leaseID == "" {
+		if d.logger != nil {
+			d.logger.Debug("static Scaleway API keys have no lease, skipping revocation")
+		}
+		return nil
+	}
+
+	d.configMu.RLock()
+	managementKey := d.getManagementSecretKeyLocked()
+	d.configMu.RUnlock()
+	if managementKey == "" {
+		return fmt.Errorf("management_secret_key is required to revoke Scaleway API keys")
+	}
+
+	apiURL := d.iamURL("/api-keys/" + leaseID)
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       scalewayMaxRetryAttempts,
+		MaxBodySize:       scalewayMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodDelete,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"X-Auth-Token": managementKey,
+			"Accept":       "application/json",
+		},
+		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
+	}
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("failed to revoke Scaleway API key %s: %w", leaseID, err)
+	}
+
+	d.logger.Info("revoked dynamic Scaleway API key",
+		logger.String("access_key", leaseID),
+	)
+
+	return nil
+}
+
+// Cleanup releases resources.
+func (d *ScalewayDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// --- Rotatable interface (management key rotation) ---
+
+// SupportsRotation returns true if the driver has a management key that can be rotated.
+// Rotation requires both management_secret_key and management_access_key.
+func (d *ScalewayDriver) SupportsRotation() bool {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.getManagementSecretKeyLocked() != "" &&
+		credential.GetString(d.credSource.Config, "management_access_key", "") != ""
+}
+
+// PrepareRotation creates a new management API key via the IAM API using the current key.
+// Both old and new keys remain valid during the overlap period.
+func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	d.configMu.RLock()
+	managementKey := d.getManagementSecretKeyLocked()
+	managementAccessKey := credential.GetString(d.credSource.Config, "management_access_key", "")
+	configSnapshot := make(map[string]string, len(d.credSource.Config))
+	for k, v := range d.credSource.Config {
+		configSnapshot[k] = v
+	}
+	d.configMu.RUnlock()
+
+	if managementKey == "" {
+		return nil, nil, 0, fmt.Errorf("management_secret_key is required for rotation")
+	}
+	if managementAccessKey == "" {
+		return nil, nil, 0, fmt.Errorf("management_access_key is required for rotation")
+	}
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       scalewayMaxRetryAttempts,
+		MaxBodySize:       scalewayMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	// Look up the current key to find its bearer (application_id or user_id)
+	getURL := d.iamURL("/api-keys/" + managementAccessKey)
+	getReq := HTTPRequest{
+		Method:  http.MethodGet,
+		URL:     getURL,
+		Headers: map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, getReq, retryConfig)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to look up current management key: %w", err)
+	}
+
+	var keyInfo struct {
+		ApplicationID string `json:"application_id"`
+		UserID        string `json:"user_id"`
+	}
+	if err := json.Unmarshal(respBody, &keyInfo); err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to parse key info: %w", err)
+	}
+
+	// Create a new management key for the same bearer
+	createBody := map[string]interface{}{
+		"description": "warden-management-key-rotated",
+	}
+	if keyInfo.ApplicationID != "" {
+		createBody["application_id"] = keyInfo.ApplicationID
+	} else if keyInfo.UserID != "" {
+		createBody["user_id"] = keyInfo.UserID
+	} else {
+		return nil, nil, 0, fmt.Errorf("current management key has no application_id or user_id")
+	}
+
+	bodyJSON, err := json.Marshal(createBody)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to marshal create request: %w", err)
+	}
+
+	createURL := d.iamURL("/api-keys")
+	createReq := HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     createURL,
+		Body:    bodyJSON,
+		Headers: map[string]string{"X-Auth-Token": managementKey, "Content-Type": "application/json", "Accept": "application/json"},
+	}
+
+	respBody, _, err = ExecuteWithRetry(ctx, d.httpClient, createReq, retryConfig)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to create new management key: %w", err)
+	}
+
+	var newKey struct {
+		AccessKey string `json:"access_key"`
+		SecretKey string `json:"secret_key"`
+	}
+	if err := json.Unmarshal(respBody, &newKey); err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to parse new key response: %w", err)
+	}
+
+	if newKey.AccessKey == "" || newKey.SecretKey == "" {
+		return nil, nil, 0, fmt.Errorf("Scaleway API returned empty access_key or secret_key for new management key")
+	}
+
+	// Build new config with rotated management credentials
+	newConfig := configSnapshot
+	newConfig["management_secret_key"] = newKey.SecretKey
+	newConfig["management_access_key"] = newKey.AccessKey
+
+	// Build cleanup config to delete the old key
+	cleanupConfig := map[string]string{
+		"access_key": managementAccessKey,
+	}
+
+	d.logger.Info("prepared new management key for rotation",
+		logger.String("new_access_key", newKey.AccessKey),
+	)
+
+	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultScalewayActivationDelay)
+	return newConfig, cleanupConfig, activateAfter, nil
+}
+
+// CommitRotation activates the new management key in driver state.
+func (d *ScalewayDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
+	d.configMu.Lock()
+	defer d.configMu.Unlock()
+
+	d.credSource.Config = newConfig
+
+	d.logger.Info("committed rotated management key",
+		logger.String("new_access_key", credential.GetString(newConfig, "management_access_key", "")),
+	)
+
+	return nil
+}
+
+// CleanupRotation deletes the old management key via the IAM API.
+func (d *ScalewayDriver) CleanupRotation(ctx context.Context, cleanupConfig map[string]string) error {
+	oldAccessKey := cleanupConfig["access_key"]
+	if oldAccessKey == "" {
+		return nil
+	}
+
+	d.configMu.RLock()
+	managementKey := d.getManagementSecretKeyLocked()
+	d.configMu.RUnlock()
+
+	if managementKey == "" {
+		return fmt.Errorf("management_secret_key is required to clean up old key")
+	}
+
+	deleteURL := d.iamURL("/api-keys/" + oldAccessKey)
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       scalewayMaxRetryAttempts,
+		MaxBodySize:       scalewayMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	deleteReq := HTTPRequest{
+		Method:     http.MethodDelete,
+		URL:        deleteURL,
+		Headers:    map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
+		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
+	}
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, deleteReq, retryConfig)
+	if err != nil {
+		d.logger.Warn("failed to delete old management key during cleanup",
+			logger.Err(err),
+			logger.String("access_key", oldAccessKey),
+		)
+		return fmt.Errorf("failed to delete old management key: %w", err)
+	}
+
+	d.logger.Info("deleted old management key",
+		logger.String("access_key", oldAccessKey),
+	)
+
+	return nil
+}
+
+// VerifySpec validates that the spec's credentials are functional.
+func (d *ScalewayDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "static_keys")
+
+	switch mintMethod {
+	case "static_keys":
+		return d.verifyStaticKeys(ctx, spec)
+	case "dynamic_keys":
+		return d.verifyDynamicConfig(spec)
+	default:
+		return fmt.Errorf("unsupported mint_method: %s", mintMethod)
+	}
+}
+
+// verifyStaticKeys verifies that the static access_key exists via the IAM API.
+func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.CredSpec) error {
+	secretKey := credential.GetString(spec.Config, "secret_key", "")
+	if secretKey == "" {
+		return fmt.Errorf("no secret_key configured in spec")
+	}
+
+	accessKey := credential.GetString(spec.Config, "access_key", "")
+	if accessKey == "" {
+		return fmt.Errorf("no access_key configured in spec")
+	}
+
+	// Verify the key works by calling a lightweight IAM endpoint
+	apiURL := d.iamURL("/api-keys/" + accessKey)
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       scalewayMaxRetryAttempts,
+		MaxBodySize:       scalewayMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodGet,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"X-Auth-Token": secretKey,
+			"Accept":       "application/json",
+		},
+	}
+
+	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("Scaleway API key verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// verifyDynamicConfig validates that the dynamic_keys config has the required fields.
+func (d *ScalewayDriver) verifyDynamicConfig(spec *credential.CredSpec) error {
+	d.configMu.RLock()
+	hasKey := d.getManagementSecretKeyLocked() != ""
+	d.configMu.RUnlock()
+	if !hasKey {
+		return fmt.Errorf("management_secret_key is required on source for dynamic_keys mint method")
+	}
+	if credential.GetString(spec.Config, "application_id", "") == "" {
+		return fmt.Errorf("application_id is required for dynamic_keys mint method")
+	}
+	return nil
+}
+
+// validateScalewayURL validates that the URL is well-formed HTTPS.
+func validateScalewayURL(rawURL string, tlsSkipVerify bool) error {
+	if rawURL == "" {
+		return nil
+	}
+	return validateAPIKeyURL(rawURL, tlsSkipVerify)
+}

--- a/credential/drivers/scaleway_driver.go
+++ b/credential/drivers/scaleway_driver.go
@@ -271,8 +271,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 	}
 
 	d.logger.Info("created dynamic Scaleway API key",
-		logger.String("access_key", resp.AccessKey),
-		logger.String("application_id", resp.ApplicationID),
+		logger.String("access_key", truncateID(resp.AccessKey, 8)),
 		logger.String("spec", spec.Name),
 		logger.String("expires_at", resp.ExpiresAt),
 	)
@@ -328,7 +327,7 @@ func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
 	}
 
 	d.logger.Info("revoked dynamic Scaleway API key",
-		logger.String("access_key", leaseID),
+		logger.String("access_key", truncateID(leaseID, 8)),
 	)
 
 	return nil
@@ -452,7 +451,7 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 	}
 
 	d.logger.Info("prepared new management key for rotation",
-		logger.String("new_access_key", newKey.AccessKey),
+		logger.String("new_access_key", truncateID(newKey.AccessKey, 8)),
 	)
 
 	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultScalewayActivationDelay)
@@ -467,7 +466,7 @@ func (d *ScalewayDriver) CommitRotation(ctx context.Context, newConfig map[strin
 	d.credSource.Config = newConfig
 
 	d.logger.Info("committed rotated management key",
-		logger.String("new_access_key", credential.GetString(newConfig, "management_access_key", "")),
+		logger.String("new_access_key", truncateID(credential.GetString(newConfig, "management_access_key", ""), 8)),
 	)
 
 	return nil
@@ -508,13 +507,13 @@ func (d *ScalewayDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	if err != nil {
 		d.logger.Warn("failed to delete old management key during cleanup",
 			logger.Err(err),
-			logger.String("access_key", oldAccessKey),
+			logger.String("access_key", truncateID(oldAccessKey, 8)),
 		)
 		return fmt.Errorf("failed to delete old management key: %w", err)
 	}
 
 	d.logger.Info("deleted old management key",
-		logger.String("access_key", oldAccessKey),
+		logger.String("access_key", truncateID(oldAccessKey, 8)),
 	)
 
 	return nil

--- a/credential/drivers/scaleway_driver_test.go
+++ b/credential/drivers/scaleway_driver_test.go
@@ -1,0 +1,698 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createScalewayTestLogger() *logger.GatedLogger {
+	config := &logger.Config{
+		Level:   logger.TraceLevel,
+		Format:  logger.DefaultFormat,
+		Outputs: []io.Writer{io.Discard},
+	}
+	gl, _ := logger.NewGatedLogger(config, logger.GatedWriterConfig{
+		Underlying:   io.Discard,
+		InitialState: logger.GateOpen,
+	})
+	return gl
+}
+
+// --- Factory tests ---
+
+func TestScalewayDriverFactory_Type(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	assert.Equal(t, credential.SourceTypeScaleway, f.Type())
+}
+
+func TestScalewayDriverFactory_InferCredentialType(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	ct, err := f.InferCredentialType(map[string]string{})
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeScalewayKeys, ct)
+}
+
+func TestScalewayDriverFactory_ValidateConfig(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+
+	t.Run("empty config is valid", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid config with all fields", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"scaleway_url":          "https://api.scaleway.com",
+			"management_secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"scaleway_url": "http://api.scaleway.com",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "https")
+	})
+}
+
+func TestScalewayDriverFactory_SensitiveConfigFields(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	fields := f.SensitiveConfigFields()
+	assert.Contains(t, fields, "management_secret_key")
+	assert.Contains(t, fields, "ca_data")
+}
+
+func TestScalewayDriverFactory_Create(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          "https://api.scaleway.com",
+		"management_secret_key": "test-key",
+	}, log)
+	require.NoError(t, err)
+	require.NotNil(t, driver)
+	assert.Equal(t, credential.SourceTypeScaleway, driver.Type())
+}
+
+// --- Static credential tests ---
+
+func TestScalewayDriver_MintStaticCredential(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{}, log)
+	require.NoError(t, err)
+
+	t.Run("valid static keys", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"mint_method": "static_keys",
+				"access_key":  "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key":  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+		}
+
+		rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+		require.NoError(t, err)
+		assert.Equal(t, "SCWXXXXXXXXXXXXXXXXX", rawData["access_key"])
+		assert.Equal(t, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", rawData["secret_key"])
+		assert.Equal(t, time.Duration(0), ttl)
+		assert.Empty(t, leaseID)
+	})
+
+	t.Run("default mint_method is static_keys", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+		}
+
+		rawData, _, _, err := driver.MintCredential(context.Background(), spec)
+		require.NoError(t, err)
+		assert.Equal(t, "SCWXXXXXXXXXXXXXXXXX", rawData["access_key"])
+	})
+
+	t.Run("missing access_key", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"mint_method": "static_keys",
+				"secret_key":  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+		}
+
+		_, _, _, err := driver.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key")
+	})
+
+	t.Run("missing secret_key", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"mint_method": "static_keys",
+				"access_key":  "SCWXXXXXXXXXXXXXXXXX",
+			},
+		}
+
+		_, _, _, err := driver.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret_key")
+	})
+
+	t.Run("unsupported mint_method", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "test-spec",
+			Config: map[string]string{
+				"mint_method": "unknown",
+			},
+		}
+
+		_, _, _, err := driver.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported mint_method")
+	})
+}
+
+// --- Dynamic credential tests ---
+
+func TestScalewayDriver_MintDynamicCredential(t *testing.T) {
+	// Mock Scaleway IAM API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		assert.Equal(t, "mgmt-secret-key", r.Header.Get("X-Auth-Token"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/iam/v1alpha1/api-keys":
+			// Parse request body
+			var reqBody map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&reqBody)
+
+			assert.Equal(t, "app-123", reqBody["application_id"])
+			assert.NotEmpty(t, reqBody["expires_at"])
+			assert.NotEmpty(t, reqBody["description"])
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_key":     "SCWNEWKEYXXXXXXXXXX",
+				"secret_key":     "new-uuid-secret-key",
+				"application_id": "app-123",
+				"description":    reqBody["description"],
+				"expires_at":     reqBody["expires_at"],
+			})
+
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"tls_skip_verify":       "true",
+	}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{
+		Name: "dynamic-spec",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+			"ttl":            "2h",
+			"description":    "test-key",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "SCWNEWKEYXXXXXXXXXX", rawData["access_key"])
+	assert.Equal(t, "new-uuid-secret-key", rawData["secret_key"])
+	assert.Equal(t, 2*time.Hour, ttl)
+	assert.Equal(t, "SCWNEWKEYXXXXXXXXXX", leaseID) // leaseID = access_key
+}
+
+func TestScalewayDriver_MintDynamicCredential_MissingManagementKey(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{
+		Name: "dynamic-spec",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+		},
+	}
+
+	_, _, _, err = driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "management_secret_key")
+}
+
+func TestScalewayDriver_MintDynamicCredential_MissingApplicationID(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"management_secret_key": "mgmt-key",
+	}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{
+		Name: "dynamic-spec",
+		Config: map[string]string{
+			"mint_method": "dynamic_keys",
+		},
+	}
+
+	_, _, _, err = driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "application_id")
+}
+
+// --- Revoke tests ---
+
+func TestScalewayDriver_Revoke(t *testing.T) {
+	var deletedKey string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			assert.Equal(t, "mgmt-secret-key", r.Header.Get("X-Auth-Token"))
+			deletedKey = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"tls_skip_verify":       "true",
+	}, log)
+	require.NoError(t, err)
+
+	err = driver.Revoke(context.Background(), "SCWNEWKEYXXXXXXXXXX")
+	require.NoError(t, err)
+	assert.Equal(t, "/iam/v1alpha1/api-keys/SCWNEWKEYXXXXXXXXXX", deletedKey)
+}
+
+func TestScalewayDriver_Revoke_EmptyLeaseID(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{}, log)
+	require.NoError(t, err)
+
+	// Empty leaseID should be a no-op
+	err = driver.Revoke(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestScalewayDriver_Revoke_MissingManagementKey(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{}, log)
+	require.NoError(t, err)
+
+	err = driver.Revoke(context.Background(), "SCWKEY123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "management_secret_key")
+}
+
+// --- VerifySpec tests ---
+
+func TestScalewayDriver_VerifySpec_StaticKeys(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX" {
+			assert.Equal(t, "test-secret", r.Header.Get("X-Auth-Token"))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_key":"SCWXXXXXXXXXXXXXXXXX"}`))
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":    server.URL,
+		"tls_skip_verify": "true",
+	}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{
+		Name: "test-spec",
+		Config: map[string]string{
+			"mint_method": "static_keys",
+			"access_key":  "SCWXXXXXXXXXXXXXXXXX",
+			"secret_key":  "test-secret",
+		},
+	}
+
+	scwDriver := driver.(*ScalewayDriver)
+	err = scwDriver.VerifySpec(context.Background(), spec)
+	assert.NoError(t, err)
+}
+
+func TestScalewayDriver_VerifySpec_DynamicKeys(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"management_secret_key": "mgmt-key",
+	}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{
+		Name: "dynamic-spec",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+		},
+	}
+
+	scwDriver := driver.(*ScalewayDriver)
+	err = scwDriver.VerifySpec(context.Background(), spec)
+	assert.NoError(t, err)
+}
+
+func TestScalewayDriver_VerifySpec_DynamicKeys_MissingFields(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{}, log)
+	require.NoError(t, err)
+
+	t.Run("missing management_secret_key", func(t *testing.T) {
+		spec := &credential.CredSpec{
+			Name: "dynamic-spec",
+			Config: map[string]string{
+				"mint_method":    "dynamic_keys",
+				"application_id": "app-123",
+			},
+		}
+		scwDriver := driver.(*ScalewayDriver)
+		err := scwDriver.VerifySpec(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "management_secret_key")
+	})
+
+	t.Run("missing application_id", func(t *testing.T) {
+		f2 := &ScalewayDriverFactory{}
+		driver2, _ := f2.Create(map[string]string{
+			"management_secret_key": "mgmt-key",
+		}, log)
+		spec := &credential.CredSpec{
+			Name: "dynamic-spec",
+			Config: map[string]string{
+				"mint_method": "dynamic_keys",
+			},
+		}
+		scwDriver := driver2.(*ScalewayDriver)
+		err := scwDriver.VerifySpec(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "application_id")
+	})
+}
+
+// --- Cleanup test ---
+
+func TestScalewayDriver_Cleanup(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{}, log)
+	require.NoError(t, err)
+
+	// Should not panic
+	err = driver.(*ScalewayDriver).Cleanup(context.Background())
+	assert.NoError(t, err)
+}
+
+// --- Rotation tests ---
+
+func TestScalewayDriver_SupportsRotation(t *testing.T) {
+	t.Run("supports when both keys present", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{
+				"management_secret_key": "secret",
+				"management_access_key": "SCWMGMTKEY",
+			}},
+		}
+		assert.True(t, d.SupportsRotation())
+	})
+
+	t.Run("does not support without access key", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{
+				"management_secret_key": "secret",
+			}},
+		}
+		assert.False(t, d.SupportsRotation())
+	})
+
+	t.Run("does not support without secret key", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{
+				"management_access_key": "SCWMGMTKEY",
+			}},
+		}
+		assert.False(t, d.SupportsRotation())
+	})
+
+	t.Run("does not support with empty config", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{}},
+		}
+		assert.False(t, d.SupportsRotation())
+	})
+}
+
+func TestScalewayDriver_PrepareRotation(t *testing.T) {
+	// Mock Scaleway IAM API for rotation
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "old-mgmt-secret", r.Header.Get("X-Auth-Token"))
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/iam/v1alpha1/api-keys/SCWOLDMGMTKEY":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_key":     "SCWOLDMGMTKEY",
+				"application_id": "app-mgmt-123",
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/iam/v1alpha1/api-keys":
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "app-mgmt-123", body["application_id"])
+			assert.Equal(t, "warden-management-key-rotated", body["description"])
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_key": "SCWNEWMGMTKEY",
+				"secret_key": "new-mgmt-secret",
+			})
+
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "old-mgmt-secret",
+		"management_access_key": "SCWOLDMGMTKEY",
+		"tls_skip_verify":       "true",
+	}, log)
+	require.NoError(t, err)
+
+	scwDriver := driver.(*ScalewayDriver)
+	newConfig, cleanupConfig, activateAfter, err := scwDriver.PrepareRotation(context.Background())
+	require.NoError(t, err)
+
+	// Verify new config
+	assert.Equal(t, "new-mgmt-secret", newConfig["management_secret_key"])
+	assert.Equal(t, "SCWNEWMGMTKEY", newConfig["management_access_key"])
+	// Original config fields should be preserved
+	assert.Equal(t, server.URL, newConfig["scaleway_url"])
+	assert.Equal(t, "true", newConfig["tls_skip_verify"])
+
+	// Verify cleanup config
+	assert.Equal(t, "SCWOLDMGMTKEY", cleanupConfig["access_key"])
+
+	// Verify activation delay
+	assert.Equal(t, DefaultScalewayActivationDelay, activateAfter)
+}
+
+func TestScalewayDriver_PrepareRotation_MissingFields(t *testing.T) {
+	log := createScalewayTestLogger()
+
+	t.Run("missing management_secret_key", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{
+				"management_access_key": "SCWKEY",
+			}},
+			logger: log,
+		}
+		_, _, _, err := d.PrepareRotation(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "management_secret_key")
+	})
+
+	t.Run("missing management_access_key", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{
+				"management_secret_key": "secret",
+			}},
+			logger: log,
+		}
+		_, _, _, err := d.PrepareRotation(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "management_access_key")
+	})
+}
+
+func TestScalewayDriver_CommitRotation(t *testing.T) {
+	log := createScalewayTestLogger()
+
+	d := &ScalewayDriver{
+		credSource: &credential.CredSource{Config: map[string]string{
+			"management_secret_key": "old-secret",
+			"management_access_key": "SCWOLDKEY",
+			"scaleway_url":          "https://api.scaleway.com",
+		}},
+		logger: log,
+	}
+
+	newConfig := map[string]string{
+		"management_secret_key": "new-secret",
+		"management_access_key": "SCWNEWKEY",
+		"scaleway_url":          "https://api.scaleway.com",
+	}
+
+	err := d.CommitRotation(context.Background(), newConfig)
+	require.NoError(t, err)
+
+	// Config should be updated
+	d.configMu.RLock()
+	assert.Equal(t, "new-secret", d.getManagementSecretKeyLocked())
+	assert.Equal(t, "SCWNEWKEY", credential.GetString(d.credSource.Config, "management_access_key", ""))
+	d.configMu.RUnlock()
+}
+
+func TestScalewayDriver_CleanupRotation(t *testing.T) {
+	var deletedPath string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			assert.Equal(t, "new-mgmt-secret", r.Header.Get("X-Auth-Token"))
+			deletedPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "new-mgmt-secret",
+		"management_access_key": "SCWNEWMGMTKEY",
+		"tls_skip_verify":       "true",
+	}, log)
+	require.NoError(t, err)
+
+	scwDriver := driver.(*ScalewayDriver)
+	err = scwDriver.CleanupRotation(context.Background(), map[string]string{
+		"access_key": "SCWOLDMGMTKEY",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/iam/v1alpha1/api-keys/SCWOLDMGMTKEY", deletedPath)
+}
+
+func TestScalewayDriver_CleanupRotation_EmptyAccessKey(t *testing.T) {
+	log := createScalewayTestLogger()
+
+	d := &ScalewayDriver{
+		credSource: &credential.CredSource{Config: map[string]string{}},
+		logger:     log,
+	}
+
+	err := d.CleanupRotation(context.Background(), map[string]string{})
+	assert.NoError(t, err)
+}
+
+func TestScalewayDriver_PrepareRotation_CustomActivationDelay(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_key":     "SCWKEY",
+				"application_id": "app-123",
+			})
+		case r.Method == http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_key": "SCWNEWKEY",
+				"secret_key": "new-secret",
+			})
+		}
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	log := createScalewayTestLogger()
+
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "secret",
+		"management_access_key": "SCWKEY",
+		"activation_delay":      "2m",
+		"tls_skip_verify":       "true",
+	}, log)
+	require.NoError(t, err)
+
+	scwDriver := driver.(*ScalewayDriver)
+	_, _, activateAfter, err := scwDriver.PrepareRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Minute, activateAfter)
+}
+
+// --- URL helper tests ---
+
+func TestScalewayDriver_GetScalewayURL(t *testing.T) {
+	t.Run("default URL", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{}},
+		}
+		assert.Equal(t, "https://api.scaleway.com", d.getScalewayURL())
+	})
+
+	t.Run("custom URL", func(t *testing.T) {
+		d := &ScalewayDriver{
+			credSource: &credential.CredSource{Config: map[string]string{
+				"scaleway_url": "https://api.fr-par.scaleway.com/",
+			}},
+		}
+		assert.Equal(t, "https://api.fr-par.scaleway.com", d.getScalewayURL())
+	})
+}

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -54,5 +54,10 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
+	// Register Scaleway keys type
+	if err := registry.Register(&ScalewayKeysCredType{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -1,0 +1,209 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+)
+
+// ScalewayKeysCredType handles Scaleway API key credentials.
+// A single key pair serves both the standard API (secret_key as X-Auth-Token)
+// and S3 Object Storage (access_key + secret_key for SigV4 signing).
+type ScalewayKeysCredType struct{}
+
+// Metadata returns the type's metadata
+func (t *ScalewayKeysCredType) Metadata() credential.TypeMetadata {
+	return credential.TypeMetadata{
+		Name:        credential.TypeScalewayKeys,
+		Category:    credential.CategoryCloudIAM,
+		Description: "Scaleway API keys (access key + secret key for API and S3 Object Storage)",
+		DefaultTTL:  0, // Static keys have no default TTL
+	}
+}
+
+// ConfigSchema returns the declarative schema for Scaleway key credential config
+func (t *ScalewayKeysCredType) ConfigSchema() []*credential.FieldValidator {
+	return []*credential.FieldValidator{
+		credential.StringField("access_key").
+			Describe("Scaleway access key (starts with SCW)").
+			Example("SCWXXXXXXXXXXXXXXXXX"),
+
+		credential.StringField("secret_key").
+			Describe("Scaleway secret key (UUID format)").
+			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+
+		credential.StringField("mint_method").
+			OneOf("static_scaleway", "static_keys", "dynamic_keys").
+			Describe("Mint method for credential minting").
+			Example("static_keys"),
+
+		// Vault source fields
+		credential.StringField("kv2_mount").
+			Describe("Vault KV2 mount path (required for static_scaleway)").
+			Example("secret"),
+
+		credential.StringField("secret_path").
+			Describe("Path to secret in KV2 (required for static_scaleway)").
+			Example("scaleway/prod/keys"),
+
+		// Scaleway dynamic_keys fields
+		credential.StringField("application_id").
+			Describe("IAM application ID to create keys for (required for dynamic_keys)").
+			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+
+		credential.StringField("default_project_id").
+			Describe("Default project ID for Object Storage (optional)").
+			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+
+		credential.StringField("description").
+			Describe("Description for dynamically created keys (max 200 chars)").
+			Example("warden-managed-key"),
+
+		credential.DurationField("ttl").
+			Describe("TTL for dynamically created keys (default: 1h)").
+			Example("1h"),
+	}
+}
+
+// ValidateConfig validates the Config for a Scaleway credential spec
+func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	switch sourceType {
+	case credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeScaleway:
+		// Supported
+	default:
+		return fmt.Errorf("scaleway_keys credentials require a local, vault, or scaleway source, got: %s", sourceType)
+	}
+
+	schema := t.ConfigSchema()
+	if err := credential.ValidateSchema(config, schema...); err != nil {
+		return err
+	}
+
+	switch sourceType {
+	case credential.SourceTypeVault:
+		if config["mint_method"] != "static_scaleway" {
+			return fmt.Errorf("'mint_method' must be 'static_scaleway' for vault source, got: %s", config["mint_method"])
+		}
+		if config["kv2_mount"] == "" {
+			return fmt.Errorf("'kv2_mount' is required when mint_method is static_scaleway")
+		}
+		if config["secret_path"] == "" {
+			return fmt.Errorf("'secret_path' is required when mint_method is static_scaleway")
+		}
+	case credential.SourceTypeScaleway:
+		mintMethod := config["mint_method"]
+		switch mintMethod {
+		case "static_keys":
+			if config["access_key"] == "" {
+				return fmt.Errorf("'access_key' is required for static_keys")
+			}
+			if config["secret_key"] == "" {
+				return fmt.Errorf("'secret_key' is required for static_keys")
+			}
+		case "dynamic_keys":
+			if config["application_id"] == "" {
+				return fmt.Errorf("'application_id' is required for dynamic_keys")
+			}
+		default:
+			return fmt.Errorf("'mint_method' must be 'static_keys' or 'dynamic_keys' for scaleway source, got: %s", mintMethod)
+		}
+	default:
+		if config["access_key"] == "" {
+			return fmt.Errorf("'access_key' is required")
+		}
+		if config["secret_key"] == "" {
+			return fmt.Errorf("'secret_key' is required")
+		}
+	}
+
+	return nil
+}
+
+// Parse converts raw credential data from source into structured Credential
+func (t *ScalewayKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+	accessKey, ok := rawData["access_key"].(string)
+	if !ok || accessKey == "" {
+		return nil, fmt.Errorf("%w: missing or invalid access_key", credential.ErrInvalidCredential)
+	}
+
+	secretKey, ok := rawData["secret_key"].(string)
+	if !ok || secretKey == "" {
+		return nil, fmt.Errorf("%w: missing or invalid secret_key", credential.ErrInvalidCredential)
+	}
+
+	return &credential.Credential{
+		Type:      credential.TypeScalewayKeys,
+		Category:  credential.CategoryCloudIAM,
+		LeaseTTL:  leaseTTL,
+		LeaseID:   leaseID,
+		IssuedAt:  time.Now(),
+		Revocable: leaseTTL > 0,
+		Data: map[string]string{
+			"access_key": accessKey,
+			"secret_key": secretKey,
+		},
+	}, nil
+}
+
+// Validate checks if credential data is well-formed
+func (t *ScalewayKeysCredType) Validate(cred *credential.Credential) error {
+	if cred.Type != credential.TypeScalewayKeys {
+		return fmt.Errorf("%w: expected type %s, got %s", credential.ErrInvalidCredential, credential.TypeScalewayKeys, cred.Type)
+	}
+
+	accessKey, ok := cred.Data["access_key"]
+	if !ok || accessKey == "" {
+		return fmt.Errorf("%w: missing access_key", credential.ErrInvalidCredential)
+	}
+
+	if !strings.HasPrefix(accessKey, "SCW") {
+		return fmt.Errorf("%w: invalid access_key format (must start with SCW)", credential.ErrInvalidCredential)
+	}
+
+	secretKey, ok := cred.Data["secret_key"]
+	if !ok || secretKey == "" {
+		return fmt.Errorf("%w: missing secret_key", credential.ErrInvalidCredential)
+	}
+
+	return nil
+}
+
+// Revoke releases the credential (best-effort).
+// Scaleway API keys can be deleted via DELETE /iam/v1alpha1/api-keys/{access_key}.
+// Revocation is delegated to the SourceDriver when a LeaseID is present.
+func (t *ScalewayKeysCredType) Revoke(ctx context.Context, cred *credential.Credential, driver credential.SourceDriver) error {
+	if cred.LeaseID == "" {
+		return nil // Static credentials without a lease cannot be revoked
+	}
+	if err := driver.Revoke(ctx, cred.LeaseID); err != nil {
+		return fmt.Errorf("%w: %v", credential.ErrRevocationFailed, err)
+	}
+	return nil
+}
+
+// RequiresSpecRotation returns false — Scaleway keys don't embed rotatable credentials in spec config
+func (t *ScalewayKeysCredType) RequiresSpecRotation() bool {
+	return false
+}
+
+// SensitiveConfigFields returns spec config keys that should be masked in output
+func (t *ScalewayKeysCredType) SensitiveConfigFields() []string {
+	return []string{"secret_key"}
+}
+
+// FieldSchemas returns metadata about the credential's data fields
+func (t *ScalewayKeysCredType) FieldSchemas() map[string]*credential.CredentialFieldSchema {
+	return map[string]*credential.CredentialFieldSchema{
+		"access_key": {
+			Description: "Scaleway access key",
+			Sensitive:   false,
+		},
+		"secret_key": {
+			Description: "Scaleway secret key",
+			Sensitive:   true,
+		},
+	}
+}

--- a/credential/types/scaleway_keys_test.go
+++ b/credential/types/scaleway_keys_test.go
@@ -1,0 +1,421 @@
+package types
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScalewayKeysCredType_Metadata(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	m := ct.Metadata()
+
+	assert.Equal(t, credential.TypeScalewayKeys, m.Name)
+	assert.Equal(t, credential.CategoryCloudIAM, m.Category)
+	assert.Contains(t, m.Description, "Scaleway")
+	assert.Equal(t, time.Duration(0), m.DefaultTTL)
+}
+
+func TestScalewayKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid local config",
+			config: map[string]string{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing access_key",
+			config: map[string]string{
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: true,
+			errMsg:  "access_key",
+		},
+		{
+			name: "missing secret_key",
+			config: map[string]string{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+			},
+			wantErr: true,
+			errMsg:  "secret_key",
+		},
+		{
+			name:    "empty config",
+			config:  map[string]string{},
+			wantErr: true,
+			errMsg:  "access_key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeLocal)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScalewayKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid vault config",
+			config: map[string]string{
+				"mint_method": "static_scaleway",
+				"kv2_mount":   "secret",
+				"secret_path": "scaleway/prod/keys",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing mint_method",
+			config: map[string]string{
+				"kv2_mount":   "secret",
+				"secret_path": "scaleway/prod/keys",
+			},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			name: "wrong mint_method",
+			config: map[string]string{
+				"mint_method": "dynamic_aws",
+				"kv2_mount":   "secret",
+				"secret_path": "scaleway/prod/keys",
+			},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			name: "missing kv2_mount",
+			config: map[string]string{
+				"mint_method": "static_scaleway",
+				"secret_path": "scaleway/prod/keys",
+			},
+			wantErr: true,
+			errMsg:  "kv2_mount",
+		},
+		{
+			name: "missing secret_path",
+			config: map[string]string{
+				"mint_method": "static_scaleway",
+				"kv2_mount":   "secret",
+			},
+			wantErr: true,
+			errMsg:  "secret_path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScalewayKeysCredType_ValidateConfig_ScalewaySource(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid static_keys",
+			config: map[string]string{
+				"mint_method": "static_keys",
+				"access_key":  "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key":  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid dynamic_keys",
+			config: map[string]string{
+				"mint_method":    "dynamic_keys",
+				"application_id": "app-123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "dynamic_keys missing application_id",
+			config: map[string]string{
+				"mint_method": "dynamic_keys",
+			},
+			wantErr: true,
+			errMsg:  "application_id",
+		},
+		{
+			name: "missing mint_method",
+			config: map[string]string{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+			},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			name: "invalid mint_method",
+			config: map[string]string{
+				"mint_method": "unknown",
+			},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeScaleway)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScalewayKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	err := ct.ValidateConfig(map[string]string{
+		"access_key": "SCWXXXXXXXXXXXXXXXXX",
+		"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+	}, credential.SourceTypeAWS)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local, vault, or scaleway")
+}
+
+func TestScalewayKeysCredType_Parse(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	tests := []struct {
+		name     string
+		rawData  map[string]interface{}
+		leaseTTL time.Duration
+		leaseID  string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "valid credentials",
+			rawData: map[string]interface{}{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with lease",
+			rawData: map[string]interface{}{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			leaseTTL: 1 * time.Hour,
+			leaseID:  "lease-123",
+			wantErr:  false,
+		},
+		{
+			name: "missing access_key",
+			rawData: map[string]interface{}{
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: true,
+			errMsg:  "access_key",
+		},
+		{
+			name: "missing secret_key",
+			rawData: map[string]interface{}{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+			},
+			wantErr: true,
+			errMsg:  "secret_key",
+		},
+		{
+			name: "empty access_key",
+			rawData: map[string]interface{}{
+				"access_key": "",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: true,
+			errMsg:  "access_key",
+		},
+		{
+			name:    "empty raw data",
+			rawData: map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "access_key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, credential.TypeScalewayKeys, cred.Type)
+				assert.Equal(t, credential.CategoryCloudIAM, cred.Category)
+				assert.Equal(t, tt.rawData["access_key"], cred.Data["access_key"])
+				assert.Equal(t, tt.rawData["secret_key"], cred.Data["secret_key"])
+				assert.Equal(t, tt.leaseTTL, cred.LeaseTTL)
+				assert.Equal(t, tt.leaseID, cred.LeaseID)
+				if tt.leaseTTL > 0 {
+					assert.True(t, cred.Revocable)
+				} else {
+					assert.False(t, cred.Revocable)
+				}
+			}
+		})
+	}
+}
+
+func TestScalewayKeysCredType_Validate(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	tests := []struct {
+		name    string
+		cred    *credential.Credential
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid credential",
+			cred: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"access_key": "SCWXXXXXXXXXXXXXXXXX",
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong type",
+			cred: &credential.Credential{
+				Type: credential.TypeAPIKey,
+				Data: map[string]string{
+					"access_key": "SCWXXXXXXXXXXXXXXXXX",
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected type",
+		},
+		{
+			name: "missing access_key",
+			cred: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+			wantErr: true,
+			errMsg:  "missing access_key",
+		},
+		{
+			name: "invalid access_key prefix",
+			cred: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"access_key": "AKIAIOSFODNN7EXAMPLE",
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+			wantErr: true,
+			errMsg:  "must start with SCW",
+		},
+		{
+			name: "missing secret_key",
+			cred: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				},
+			},
+			wantErr: true,
+			errMsg:  "missing secret_key",
+		},
+		{
+			name: "empty data",
+			cred: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{},
+			},
+			wantErr: true,
+			errMsg:  "missing access_key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.Validate(tt.cred)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScalewayKeysCredType_Revoke(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+
+	t.Run("no lease - noop", func(t *testing.T) {
+		cred := &credential.Credential{
+			Type:    credential.TypeScalewayKeys,
+			LeaseID: "",
+		}
+		err := ct.Revoke(context.Background(), cred, nil)
+		assert.NoError(t, err)
+	})
+}
+
+func TestScalewayKeysCredType_RequiresSpecRotation(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	assert.False(t, ct.RequiresSpecRotation())
+}
+
+func TestScalewayKeysCredType_SensitiveConfigFields(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	fields := ct.SensitiveConfigFields()
+	assert.Contains(t, fields, "secret_key")
+}
+
+func TestScalewayKeysCredType_FieldSchemas(t *testing.T) {
+	ct := &ScalewayKeysCredType{}
+	schemas := ct.FieldSchemas()
+
+	require.Contains(t, schemas, "access_key")
+	assert.False(t, schemas["access_key"].Sensitive)
+
+	require.Contains(t, schemas, "secret_key")
+	assert.True(t, schemas["secret_key"].Sensitive)
+}

--- a/framework/config.go
+++ b/framework/config.go
@@ -1,0 +1,260 @@
+package framework
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// MaxBodySizeLimit is the maximum allowed value for max_body_size (100MB).
+	MaxBodySizeLimit = 104857600
+)
+
+// ParseMaxBodySize extracts max_body_size from config.
+// Handles int, int64, float64, json.Number, and string.
+// Returns DefaultMaxBodySize if missing or invalid.
+func ParseMaxBodySize(conf map[string]any) int64 {
+	maxSize, ok := conf["max_body_size"]
+	if !ok {
+		return DefaultMaxBodySize
+	}
+	switch v := maxSize.(type) {
+	case int:
+		if v > 0 {
+			return int64(v)
+		}
+	case int64:
+		if v > 0 {
+			return v
+		}
+	case float64:
+		if v > 0 {
+			return int64(v)
+		}
+	case json.Number:
+		if parsed, err := v.Int64(); err == nil && parsed > 0 {
+			return parsed
+		}
+	case string:
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return DefaultMaxBodySize
+}
+
+// ParseTimeout extracts timeout from config.
+// Handles string (duration format) and int/float64 (seconds).
+// Returns defaultTimeout if missing or invalid.
+func ParseTimeout(conf map[string]any, defaultTimeout time.Duration) time.Duration {
+	timeout, ok := conf["timeout"]
+	if !ok {
+		return defaultTimeout
+	}
+	switch v := timeout.(type) {
+	case string:
+		if parsed, err := time.ParseDuration(v); err == nil && parsed > 0 {
+			return parsed
+		}
+	case int:
+		if v > 0 {
+			return time.Duration(v) * time.Second
+		}
+	case float64:
+		if v > 0 {
+			return time.Duration(v) * time.Second
+		}
+	}
+	return defaultTimeout
+}
+
+// ParseTLSConfig extracts tls_skip_verify and ca_data from config.
+func ParseTLSConfig(conf map[string]any) (tlsSkipVerify bool, caData string) {
+	if v, ok := conf["tls_skip_verify"]; ok {
+		switch b := v.(type) {
+		case bool:
+			tlsSkipVerify = b
+		case string:
+			tlsSkipVerify = b == "true" || b == "1"
+		}
+	}
+	if v, ok := conf["ca_data"].(string); ok {
+		caData = v
+	}
+	return
+}
+
+// GetConfigString extracts a string value from config with a default.
+func GetConfigString(conf map[string]any, key, defaultValue string) string {
+	if v, ok := conf[key].(string); ok && v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+// ValidateAllowedKeys checks that all keys in conf are in the allowed set.
+func ValidateAllowedKeys(conf map[string]any, allowed ...string) error {
+	allowedSet := make(map[string]bool, len(allowed))
+	for _, k := range allowed {
+		allowedSet[k] = true
+	}
+	for key := range conf {
+		if !allowedSet[key] {
+			sort.Strings(allowed)
+			return fmt.Errorf("unknown configuration key: %s (allowed: %s)", key, strings.Join(allowed, ", "))
+		}
+	}
+	return nil
+}
+
+// ValidateMaxBodySize validates that max_body_size is a valid integer within bounds.
+func ValidateMaxBodySize(conf map[string]any) error {
+	maxSize, ok := conf["max_body_size"]
+	if !ok {
+		return nil
+	}
+	var size int64
+	switch v := maxSize.(type) {
+	case int:
+		size = int64(v)
+	case int64:
+		size = v
+	case float64:
+		size = int64(v)
+	case json.Number:
+		parsed, err := v.Int64()
+		if err != nil {
+			return fmt.Errorf("max_body_size must be an integer: %w", err)
+		}
+		size = parsed
+	case string:
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("max_body_size must be an integer: %w", err)
+		}
+		size = parsed
+	default:
+		return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
+	}
+	if size <= 0 {
+		return fmt.Errorf("max_body_size must be greater than 0")
+	}
+	if size > MaxBodySizeLimit {
+		return fmt.Errorf("max_body_size must not exceed %d bytes (100MB)", MaxBodySizeLimit)
+	}
+	return nil
+}
+
+// ValidateTimeout validates that timeout is a valid duration string or integer.
+func ValidateTimeout(conf map[string]any) error {
+	timeout, ok := conf["timeout"]
+	if !ok {
+		return nil
+	}
+	switch v := timeout.(type) {
+	case string:
+		if _, err := time.ParseDuration(v); err != nil {
+			return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
+		}
+	case int:
+		if v < 0 {
+			return fmt.Errorf("timeout must be greater than 0 seconds")
+		}
+	case float64:
+		if v < 0 {
+			return fmt.Errorf("timeout must be greater than 0 seconds")
+		}
+	default:
+		return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
+	}
+	return nil
+}
+
+// ValidateTLSConfig validates tls_skip_verify and ca_data fields.
+func ValidateTLSConfig(conf map[string]any) error {
+	if v, ok := conf["tls_skip_verify"]; ok {
+		switch v := v.(type) {
+		case bool:
+			// valid
+		case string:
+			if v != "true" && v != "false" && v != "1" && v != "0" {
+				return fmt.Errorf("tls_skip_verify must be a boolean, got string: %s", v)
+			}
+		default:
+			return fmt.Errorf("tls_skip_verify must be a boolean, got %T", v)
+		}
+	}
+	if v, ok := conf["ca_data"]; ok {
+		caStr, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("ca_data must be a string")
+		}
+		if caStr != "" {
+			pemBytes, err := base64.StdEncoding.DecodeString(caStr)
+			if err != nil {
+				return fmt.Errorf("ca_data is not valid base64: %w", err)
+			}
+			block, _ := pem.Decode(pemBytes)
+			if block == nil {
+				return fmt.Errorf("ca_data contains no valid PEM data")
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateURL validates that a URL is well-formed with an https:// scheme.
+// When tlsSkipVerify is true, http:// is also accepted for dev/test environments.
+// urlKey is used in error messages (e.g., "scaleway_url", "openai_url").
+func ValidateURL(addr string, urlKey string, tlsSkipVerify bool) error {
+	if addr == "" {
+		return nil
+	}
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %w", urlKey, err)
+	}
+	if parsed.Scheme != "https" {
+		if parsed.Scheme == "http" && tlsSkipVerify {
+			// Allow HTTP when TLS verification is disabled (dev/test)
+		} else {
+			return fmt.Errorf("%s must use https:// scheme, got: %s", urlKey, parsed.Scheme)
+		}
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("%s must include a host", urlKey)
+	}
+	return nil
+}
+
+// ValidateStringField validates that a config field, if present, is a string.
+func ValidateStringField(conf map[string]any, key string) error {
+	if v, ok := conf[key]; ok {
+		if _, ok := v.(string); !ok {
+			return fmt.Errorf("%s must be a string", key)
+		}
+	}
+	return nil
+}
+
+// ValidateCommonConfig validates the fields common to all providers:
+// max_body_size, timeout, auto_auth_path, and default_role.
+func ValidateCommonConfig(conf map[string]any) error {
+	if err := ValidateMaxBodySize(conf); err != nil {
+		return err
+	}
+	if err := ValidateTimeout(conf); err != nil {
+		return err
+	}
+	if err := ValidateStringField(conf, "auto_auth_path"); err != nil {
+		return err
+	}
+	return ValidateStringField(conf, "default_role")
+}

--- a/framework/config_test.go
+++ b/framework/config_test.go
@@ -1,0 +1,340 @@
+package framework
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ParseMaxBodySize ---
+
+func TestParseMaxBodySize(t *testing.T) {
+	tests := []struct {
+		name     string
+		conf     map[string]any
+		expected int64
+	}{
+		{"missing key", map[string]any{}, DefaultMaxBodySize},
+		{"int", map[string]any{"max_body_size": 5242880}, int64(5242880)},
+		{"int64", map[string]any{"max_body_size": int64(5242880)}, int64(5242880)},
+		{"float64", map[string]any{"max_body_size": float64(5242880)}, int64(5242880)},
+		{"json.Number", map[string]any{"max_body_size": json.Number("5242880")}, int64(5242880)},
+		{"string", map[string]any{"max_body_size": "5242880"}, int64(5242880)},
+		{"zero returns default", map[string]any{"max_body_size": 0}, DefaultMaxBodySize},
+		{"negative returns default", map[string]any{"max_body_size": -1}, DefaultMaxBodySize},
+		{"invalid string returns default", map[string]any{"max_body_size": "abc"}, DefaultMaxBodySize},
+		{"invalid json.Number returns default", map[string]any{"max_body_size": json.Number("abc")}, DefaultMaxBodySize},
+		{"bool returns default", map[string]any{"max_body_size": true}, DefaultMaxBodySize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ParseMaxBodySize(tt.conf))
+		})
+	}
+}
+
+// --- ParseTimeout ---
+
+func TestParseTimeout(t *testing.T) {
+	defaultTimeout := 30 * time.Second
+
+	tests := []struct {
+		name     string
+		conf     map[string]any
+		expected time.Duration
+	}{
+		{"missing key", map[string]any{}, defaultTimeout},
+		{"string duration", map[string]any{"timeout": "60s"}, 60 * time.Second},
+		{"string minutes", map[string]any{"timeout": "5m"}, 5 * time.Minute},
+		{"int seconds", map[string]any{"timeout": 45}, 45 * time.Second},
+		{"float64 seconds", map[string]any{"timeout": float64(90)}, 90 * time.Second},
+		{"zero string returns default", map[string]any{"timeout": "0s"}, defaultTimeout},
+		{"zero int returns default", map[string]any{"timeout": 0}, defaultTimeout},
+		{"negative returns default", map[string]any{"timeout": -1}, defaultTimeout},
+		{"invalid string returns default", map[string]any{"timeout": "invalid"}, defaultTimeout},
+		{"bool returns default", map[string]any{"timeout": true}, defaultTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ParseTimeout(tt.conf, defaultTimeout))
+		})
+	}
+}
+
+// --- ParseTLSConfig ---
+
+func TestParseTLSConfig(t *testing.T) {
+	t.Run("missing both", func(t *testing.T) {
+		skip, ca := ParseTLSConfig(map[string]any{})
+		assert.False(t, skip)
+		assert.Empty(t, ca)
+	})
+
+	t.Run("tls_skip_verify bool true", func(t *testing.T) {
+		skip, _ := ParseTLSConfig(map[string]any{"tls_skip_verify": true})
+		assert.True(t, skip)
+	})
+
+	t.Run("tls_skip_verify bool false", func(t *testing.T) {
+		skip, _ := ParseTLSConfig(map[string]any{"tls_skip_verify": false})
+		assert.False(t, skip)
+	})
+
+	t.Run("tls_skip_verify string true", func(t *testing.T) {
+		skip, _ := ParseTLSConfig(map[string]any{"tls_skip_verify": "true"})
+		assert.True(t, skip)
+	})
+
+	t.Run("tls_skip_verify string 1", func(t *testing.T) {
+		skip, _ := ParseTLSConfig(map[string]any{"tls_skip_verify": "1"})
+		assert.True(t, skip)
+	})
+
+	t.Run("tls_skip_verify string false", func(t *testing.T) {
+		skip, _ := ParseTLSConfig(map[string]any{"tls_skip_verify": "false"})
+		assert.False(t, skip)
+	})
+
+	t.Run("tls_skip_verify unsupported type ignored", func(t *testing.T) {
+		skip, _ := ParseTLSConfig(map[string]any{"tls_skip_verify": 42})
+		assert.False(t, skip)
+	})
+
+	t.Run("ca_data present", func(t *testing.T) {
+		_, ca := ParseTLSConfig(map[string]any{"ca_data": "LS0tLS1CRUdJTi..."})
+		assert.Equal(t, "LS0tLS1CRUdJTi...", ca)
+	})
+
+	t.Run("ca_data non-string ignored", func(t *testing.T) {
+		_, ca := ParseTLSConfig(map[string]any{"ca_data": 123})
+		assert.Empty(t, ca)
+	})
+}
+
+// --- GetConfigString ---
+
+func TestGetConfigString(t *testing.T) {
+	tests := []struct {
+		name         string
+		conf         map[string]any
+		key          string
+		defaultValue string
+		expected     string
+	}{
+		{"present", map[string]any{"url": "https://example.com"}, "url", "default", "https://example.com"},
+		{"missing", map[string]any{}, "url", "default", "default"},
+		{"empty string returns default", map[string]any{"url": ""}, "url", "default", "default"},
+		{"non-string returns default", map[string]any{"url": 123}, "url", "default", "default"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetConfigString(tt.conf, tt.key, tt.defaultValue))
+		})
+	}
+}
+
+// --- ValidateAllowedKeys ---
+
+func TestValidateAllowedKeys(t *testing.T) {
+	t.Run("all keys allowed", func(t *testing.T) {
+		err := ValidateAllowedKeys(map[string]any{"a": 1, "b": 2}, "a", "b", "c")
+		assert.NoError(t, err)
+	})
+
+	t.Run("unknown key", func(t *testing.T) {
+		err := ValidateAllowedKeys(map[string]any{"a": 1, "unknown": 2}, "a", "b")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown")
+		assert.Contains(t, err.Error(), "allowed:")
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		err := ValidateAllowedKeys(map[string]any{}, "a", "b")
+		assert.NoError(t, err)
+	})
+
+	t.Run("no allowed keys rejects any key", func(t *testing.T) {
+		err := ValidateAllowedKeys(map[string]any{"a": 1})
+		require.Error(t, err)
+	})
+}
+
+// --- ValidateMaxBodySize ---
+
+func TestValidateMaxBodySize(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    map[string]any
+		wantErr bool
+		errMsg  string
+	}{
+		{"missing is valid", map[string]any{}, false, ""},
+		{"valid int", map[string]any{"max_body_size": 1024}, false, ""},
+		{"valid int64", map[string]any{"max_body_size": int64(1024)}, false, ""},
+		{"valid float64", map[string]any{"max_body_size": float64(1024)}, false, ""},
+		{"valid json.Number", map[string]any{"max_body_size": json.Number("1024")}, false, ""},
+		{"valid string", map[string]any{"max_body_size": "1024"}, false, ""},
+		{"zero", map[string]any{"max_body_size": 0}, true, "greater than 0"},
+		{"negative", map[string]any{"max_body_size": -1}, true, "greater than 0"},
+		{"exceeds 100MB", map[string]any{"max_body_size": 200000000}, true, "must not exceed"},
+		{"exactly 100MB", map[string]any{"max_body_size": MaxBodySizeLimit}, false, ""},
+		{"invalid string", map[string]any{"max_body_size": "abc"}, true, "must be an integer"},
+		{"invalid json.Number", map[string]any{"max_body_size": json.Number("abc")}, true, "must be an integer"},
+		{"bool type", map[string]any{"max_body_size": true}, true, "must be an integer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMaxBodySize(tt.conf)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- ValidateTimeout ---
+
+func TestValidateTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    map[string]any
+		wantErr bool
+		errMsg  string
+	}{
+		{"missing is valid", map[string]any{}, false, ""},
+		{"valid string", map[string]any{"timeout": "30s"}, false, ""},
+		{"valid minutes", map[string]any{"timeout": "5m"}, false, ""},
+		{"valid int", map[string]any{"timeout": 30}, false, ""},
+		{"valid float64", map[string]any{"timeout": float64(30)}, false, ""},
+		{"zero string is valid", map[string]any{"timeout": "0s"}, false, ""},
+		{"zero int is valid", map[string]any{"timeout": 0}, false, ""},
+		{"negative int", map[string]any{"timeout": -1}, true, "greater than 0"},
+		{"negative float", map[string]any{"timeout": float64(-1)}, true, "greater than 0"},
+		{"invalid string", map[string]any{"timeout": "invalid"}, true, "invalid timeout format"},
+		{"bool type", map[string]any{"timeout": true}, true, "must be a duration string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTimeout(tt.conf)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- ValidateTLSConfig ---
+
+func TestValidateTLSConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    map[string]any
+		wantErr bool
+		errMsg  string
+	}{
+		{"missing is valid", map[string]any{}, false, ""},
+		{"tls_skip_verify bool", map[string]any{"tls_skip_verify": true}, false, ""},
+		{"tls_skip_verify string true", map[string]any{"tls_skip_verify": "true"}, false, ""},
+		{"tls_skip_verify string false", map[string]any{"tls_skip_verify": "false"}, false, ""},
+		{"tls_skip_verify string 1", map[string]any{"tls_skip_verify": "1"}, false, ""},
+		{"tls_skip_verify string 0", map[string]any{"tls_skip_verify": "0"}, false, ""},
+		{"tls_skip_verify invalid string", map[string]any{"tls_skip_verify": "yes"}, true, "must be a boolean"},
+		{"tls_skip_verify int", map[string]any{"tls_skip_verify": 1}, true, "must be a boolean"},
+		{"ca_data empty string", map[string]any{"ca_data": ""}, false, ""},
+		{"ca_data invalid base64", map[string]any{"ca_data": "not-base64!"}, true, "not valid base64"},
+		{"ca_data non-string", map[string]any{"ca_data": 123}, true, "ca_data must be a string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTLSConfig(tt.conf)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- ValidateStringField ---
+
+func TestValidateStringField(t *testing.T) {
+	t.Run("missing is valid", func(t *testing.T) {
+		err := ValidateStringField(map[string]any{}, "key")
+		assert.NoError(t, err)
+	})
+
+	t.Run("string is valid", func(t *testing.T) {
+		err := ValidateStringField(map[string]any{"key": "value"}, "key")
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty string is valid", func(t *testing.T) {
+		err := ValidateStringField(map[string]any{"key": ""}, "key")
+		assert.NoError(t, err)
+	})
+
+	t.Run("int is invalid", func(t *testing.T) {
+		err := ValidateStringField(map[string]any{"key": 123}, "key")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key must be a string")
+	})
+
+	t.Run("bool is invalid", func(t *testing.T) {
+		err := ValidateStringField(map[string]any{"key": true}, "key")
+		require.Error(t, err)
+	})
+}
+
+// --- ValidateCommonConfig ---
+
+func TestValidateCommonConfig(t *testing.T) {
+	t.Run("empty config", func(t *testing.T) {
+		err := ValidateCommonConfig(map[string]any{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("all valid fields", func(t *testing.T) {
+		err := ValidateCommonConfig(map[string]any{
+			"max_body_size":  1024,
+			"timeout":        "30s",
+			"auto_auth_path": "auth/jwt/",
+			"default_role":   "reader",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid max_body_size propagates", func(t *testing.T) {
+		err := ValidateCommonConfig(map[string]any{"max_body_size": true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "max_body_size")
+	})
+
+	t.Run("invalid timeout propagates", func(t *testing.T) {
+		err := ValidateCommonConfig(map[string]any{"timeout": "invalid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("non-string auto_auth_path", func(t *testing.T) {
+		err := ValidateCommonConfig(map[string]any{"auto_auth_path": 123})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auto_auth_path must be a string")
+	})
+
+	t.Run("non-string default_role", func(t *testing.T) {
+		err := ValidateCommonConfig(map[string]any{"default_role": true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "default_role must be a string")
+	})
+}

--- a/provider/ansible_tower/provider.go
+++ b/provider/ansible_tower/provider.go
@@ -25,11 +25,7 @@ var Spec = &httpproxy.ProviderSpec{
 		if !ok || addr == "" {
 			return fmt.Errorf("ansible_tower_url is required")
 		}
-		skipVerify := false
-		if v, ok := conf["tls_skip_verify"].(bool); ok {
-			skipVerify = v
-		}
-		return httpproxy.ValidateURL(addr, "ansible_tower_url", skipVerify)
+		return nil
 	},
 }
 

--- a/provider/aws/config.go
+++ b/provider/aws/config.go
@@ -1,8 +1,7 @@
 package aws
 
 import (
-	"encoding/json"
-	"strconv"
+	"fmt"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -20,7 +19,10 @@ type ProviderConfig struct {
 func parseConfig(conf map[string]any) ProviderConfig {
 	config := ProviderConfig{
 		ProxyDomains: []string{"localhost"},
+		MaxBodySize:  framework.ParseMaxBodySize(conf),
+		Timeout:      framework.ParseTimeout(conf, framework.DefaultTimeout),
 	}
+
 	// Parse proxy_domains
 	if domains, ok := conf["proxy_domains"].([]string); ok {
 		config.ProxyDomains = domains
@@ -33,53 +35,37 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		}
 	}
 
-	// Parse max_body_size
-	maxBodySize := framework.DefaultMaxBodySize
-	if maxSize, ok := conf["max_body_size"].(int64); ok && maxSize > 0 {
-		maxBodySize = maxSize
-	} else if maxSize, ok := conf["max_body_size"].(int); ok && maxSize > 0 {
-		maxBodySize = int64(maxSize)
-	} else if maxSize, ok := conf["max_body_size"].(float64); ok && maxSize > 0 {
-		maxBodySize = int64(maxSize)
-	} else if maxSize, ok := conf["max_body_size"].(json.Number); ok {
-		// Handle json.Number type (from JSON decoder with UseNumber)
-		if parsed, err := maxSize.Int64(); err == nil && parsed > 0 {
-			maxBodySize = parsed
-		}
-	} else if maxSize, ok := conf["max_body_size"].(string); ok {
-		// Handle string conversion (e.g., from JSON number stored as string)
-		if parsed, err := strconv.ParseInt(maxSize, 10, 64); err == nil && parsed > 0 {
-			maxBodySize = parsed
-		}
-	}
-	config.MaxBodySize = maxBodySize
-
-	// Parse timeout
-	timeOut := framework.DefaultTimeout
-	if timeout, ok := conf["timeout"].(int); ok {
-		timeOut = time.Duration(timeout) * time.Second
-	} else if timeout, ok := conf["timeout"].(string); ok {
-		if d, err := time.ParseDuration(timeout); err == nil {
-			timeOut = d
-		}
-	}
-	if timeOut == 0 {
-		timeOut = framework.DefaultTimeout
-	}
-	config.Timeout = timeOut
-
-	// Parse TLS settings
-	if v, ok := conf["tls_skip_verify"]; ok {
-		switch b := v.(type) {
-		case bool:
-			config.TLSSkipVerify = b
-		case string:
-			config.TLSSkipVerify = b == "true" || b == "1"
-		}
-	}
-	if v, ok := conf["ca_data"].(string); ok {
-		config.CAData = v
-	}
+	config.TLSSkipVerify, config.CAData = framework.ParseTLSConfig(conf)
 
 	return config
+}
+
+// ValidateConfig validates AWS provider-specific configuration
+func ValidateConfig(config map[string]any) error {
+	if err := framework.ValidateAllowedKeys(config,
+		"proxy_domains", "max_body_size", "timeout", "tls_skip_verify", "ca_data",
+		"auto_auth_path", "default_role"); err != nil {
+		return err
+	}
+
+	// Validate proxy_domains
+	if domains, ok := config["proxy_domains"]; ok {
+		switch v := domains.(type) {
+		case []any:
+			for i, d := range v {
+				if _, ok := d.(string); !ok {
+					return fmt.Errorf("proxy_domains[%d] must be a string", i)
+				}
+			}
+		case []string:
+		default:
+			return fmt.Errorf("proxy_domains must be an array of strings")
+		}
+	}
+
+	if err := framework.ValidateCommonConfig(config); err != nil {
+		return err
+	}
+
+	return framework.ValidateTLSConfig(config)
 }

--- a/provider/aws/path_config_test.go
+++ b/provider/aws/path_config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sigv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -434,7 +435,7 @@ func TestExtractAccessKeyID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, extractAccessKeyID(tt.header))
+			assert.Equal(t, tt.expected, sigv4.ExtractAccessKeyID(tt.header))
 		})
 	}
 }
@@ -463,20 +464,20 @@ func TestRemoveAWSChunkedEncoding(t *testing.T) {
 	t.Run("only aws-chunked", func(t *testing.T) {
 		r, _ := http.NewRequest("PUT", "/", nil)
 		r.Header.Set("Content-Encoding", "aws-chunked")
-		removeAWSChunkedEncoding(r)
+		sigv4.RemoveAWSChunkedEncoding(r)
 		assert.Empty(t, r.Header.Get("Content-Encoding"))
 	})
 
 	t.Run("aws-chunked with gzip", func(t *testing.T) {
 		r, _ := http.NewRequest("PUT", "/", nil)
 		r.Header.Set("Content-Encoding", "gzip, aws-chunked")
-		removeAWSChunkedEncoding(r)
+		sigv4.RemoveAWSChunkedEncoding(r)
 		assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
 	})
 
 	t.Run("no content-encoding", func(t *testing.T) {
 		r, _ := http.NewRequest("PUT", "/", nil)
-		removeAWSChunkedEncoding(r)
+		sigv4.RemoveAWSChunkedEncoding(r)
 		assert.Empty(t, r.Header.Get("Content-Encoding"))
 	})
 }
@@ -503,28 +504,28 @@ func TestPaths(t *testing.T) {
 
 func TestDecodeAWSChunkedBody_MultipleChunks(t *testing.T) {
 	body := []byte("5;chunk-signature=aaa\r\nhello\r\n6;chunk-signature=bbb\r\n world\r\n0;chunk-signature=ccc\r\n\r\n")
-	decoded, err := decodeAWSChunkedBody(body)
+	decoded, err := sigv4.DecodeAWSChunkedBody(body)
 	require.NoError(t, err)
 	assert.Equal(t, "hello world", string(decoded))
 }
 
 func TestDecodeAWSChunkedBody_InvalidHexSize(t *testing.T) {
 	body := []byte("ZZ;chunk-signature=aaa\r\ndata\r\n")
-	_, err := decodeAWSChunkedBody(body)
+	_, err := sigv4.DecodeAWSChunkedBody(body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid chunk size")
 }
 
 func TestDecodeAWSChunkedBody_Empty(t *testing.T) {
 	body := []byte("0;chunk-signature=aaa\r\n\r\n")
-	decoded, err := decodeAWSChunkedBody(body)
+	decoded, err := sigv4.DecodeAWSChunkedBody(body)
 	require.NoError(t, err)
 	assert.Empty(t, decoded)
 }
 
 func TestDecodeAWSChunkedBody_TruncatedData(t *testing.T) {
 	body := []byte("a;chunk-signature=aaa\r\nshort\r\n")
-	_, err := decodeAWSChunkedBody(body)
+	_, err := sigv4.DecodeAWSChunkedBody(body)
 	assert.Error(t, err)
 }
 
@@ -554,13 +555,13 @@ func jsonNumber(s string) json.Number {
 
 func TestIsAWSChunked(t *testing.T) {
 	r, _ := http.NewRequest("PUT", "/", nil)
-	assert.False(t, isAWSChunked(r))
+	assert.False(t, sigv4.IsAWSChunked(r))
 
 	r.Header.Set("Content-Encoding", "aws-chunked")
-	assert.True(t, isAWSChunked(r))
+	assert.True(t, sigv4.IsAWSChunked(r))
 
 	r.Header.Set("Content-Encoding", "gzip, aws-chunked")
-	assert.True(t, isAWSChunked(r))
+	assert.True(t, sigv4.IsAWSChunked(r))
 }
 
 // --- Factory tests ---
@@ -715,7 +716,7 @@ func TestProcessRequest_ValidSignature_NoCredential(t *testing.T) {
 	// (access_key_id = secret_access_key = role name)
 	httpReq := httptest.NewRequest(http.MethodGet, "http://s3.us-east-1.amazonaws.com/gateway/my-bucket/key", nil)
 	httpReq.Host = "s3.us-east-1.amazonaws.com"
-	httpReq.Header.Set("X-Amz-Content-Sha256", computePayloadHash([]byte{}))
+	httpReq.Header.Set("X-Amz-Content-Sha256", sigv4.ComputePayloadHash([]byte{}))
 
 	signingTime := time.Now().UTC()
 	creds := aws.Credentials{
@@ -723,7 +724,7 @@ func TestProcessRequest_ValidSignature_NoCredential(t *testing.T) {
 		SecretAccessKey: "my-role",
 	}
 	signer := v4.NewSigner()
-	_ = signer.SignHTTP(context.Background(), creds, httpReq, computePayloadHash([]byte{}), "s3", "us-east-1", signingTime)
+	_ = signer.SignHTTP(context.Background(), creds, httpReq, sigv4.ComputePayloadHash([]byte{}), "s3", "us-east-1", signingTime)
 
 	rr := httptest.NewRecorder()
 	req := &logical.Request{
@@ -765,7 +766,7 @@ func TestProcessRequest_ValidSignature_WithCredential(t *testing.T) {
 
 	httpReq := httptest.NewRequest(http.MethodGet, "http://s3.us-east-1.amazonaws.com/gateway/my-bucket/key", nil)
 	httpReq.Host = "s3.us-east-1.amazonaws.com"
-	httpReq.Header.Set("X-Amz-Content-Sha256", computePayloadHash([]byte{}))
+	httpReq.Header.Set("X-Amz-Content-Sha256", sigv4.ComputePayloadHash([]byte{}))
 
 	signingTime := time.Now().UTC()
 	creds := aws.Credentials{
@@ -773,7 +774,7 @@ func TestProcessRequest_ValidSignature_WithCredential(t *testing.T) {
 		SecretAccessKey: "my-role",
 	}
 	signer := v4.NewSigner()
-	_ = signer.SignHTTP(context.Background(), creds, httpReq, computePayloadHash([]byte{}), "s3", "us-east-1", signingTime)
+	_ = signer.SignHTTP(context.Background(), creds, httpReq, sigv4.ComputePayloadHash([]byte{}), "s3", "us-east-1", signingTime)
 
 	rr := httptest.NewRecorder()
 	req := &logical.Request{
@@ -819,7 +820,7 @@ func TestForwardDirect(t *testing.T) {
 	r.RequestURI = ""
 	rr := httptest.NewRecorder()
 
-	b.forwardDirect(rr, r, []byte{})
+	sigv4.ForwardDirect(b.Logger, rr, r, []byte{}, b.Proxy.Transport)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "test", rr.Header().Get("X-Custom"))

--- a/provider/aws/path_gateway.go
+++ b/provider/aws/path_gateway.go
@@ -1,42 +1,19 @@
 package aws
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/aws/processor"
-)
-
-var (
-	authRegex          = regexp.MustCompile(`AWS4-HMAC-SHA256 Credential=([^/]+)/([^/]+)/([^/]+)/([^/]+)/aws4_request`)
-	signRegex          = regexp.MustCompile(`Signature=([a-f0-9]+)`)
-	signedHeadersRegex = regexp.MustCompile(`SignedHeaders=([^,]+)`)
-)
-
-type contextKey string
-
-const (
-	ClientTokenKey contextKey = "clientToken"
-	AWSCredsKey    contextKey = "awsCreds"
-	TokenKey       contextKey = "token"
-	RoleNameKey    contextKey = "roleName"
-	PrincipalIDKey contextKey = "principalID"
-	TargetURLKey   contextKey = "targetURL"
-	ServiceKey     contextKey = "service"
-	RegionKey      contextKey = "region"
+	"github.com/stephnangue/warden/provider/sigv4"
 )
 
 func (b *awsBackend) handleGateway(ctx context.Context, req *logical.Request) {
@@ -71,14 +48,18 @@ func (b *awsBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	// Forward directly via transport, bypassing httputil.ReverseProxy which
 	// modifies headers (hop-by-hop cleanup, header reordering) and breaks
 	// AWS signatures.
-	b.forwardDirect(req.ResponseWriter, r, body)
+	transport := b.Proxy.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	sigv4.ForwardDirect(b.Logger, req.ResponseWriter, r, body, transport)
 }
 
 // processRequest handles all request processing before forwarding.
 // Returns the prepared request and body bytes to forward.
 func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (*http.Request, []byte, error) {
 	// Step 1: Read and buffer request body
-	bodyBytes, err := b.readRequestBody(req.HTTPRequest)
+	bodyBytes, err := sigv4.ReadRequestBody(req.HTTPRequest, b.MaxBodySize)
 	if err != nil {
 		http.Error(req.ResponseWriter, "Failed to read request body", http.StatusBadRequest)
 		return nil, nil, err
@@ -88,7 +69,7 @@ func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (
 	}
 
 	// Step 2: Extract service, region, and credentials from Authorization header
-	service, region, _, err := extractFromAuthHeader(req.HTTPRequest.Header.Get("Authorization"))
+	service, region, _, err := sigv4.ExtractFromAuthHeader(req.HTTPRequest.Header.Get("Authorization"))
 	if err != nil {
 		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
 		return nil, nil, err
@@ -97,20 +78,20 @@ func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (
 	// Step 3: Reconstruct the credentials the client used for signing.
 	// The core already performed JWT/cert auth via performImplicitAuth.
 	// We verify the SigV4 signature for request integrity protection.
-	accessKeyID := extractAccessKeyID(req.HTTPRequest.Header.Get("Authorization"))
+	accessKeyID := sigv4.ExtractAccessKeyID(req.HTTPRequest.Header.Get("Authorization"))
 	securityToken := req.HTTPRequest.Header.Get("X-Amz-Security-Token")
 
-	var verifyCreds aws.Credentials
+	var verifyCreds awssdk.Credentials
 	if strings.HasPrefix(securityToken, "eyJ") {
 		// JWT transparent: client used JWT as secret_access_key and session_token
-		verifyCreds = aws.Credentials{
+		verifyCreds = awssdk.Credentials{
 			AccessKeyID:     accessKeyID,
 			SecretAccessKey: securityToken,
 			SessionToken:    securityToken,
 		}
 	} else {
 		// Cert transparent: client used role name as both access_key_id and secret_access_key
-		verifyCreds = aws.Credentials{
+		verifyCreds = awssdk.Credentials{
 			AccessKeyID:     accessKeyID,
 			SecretAccessKey: accessKeyID,
 		}
@@ -246,72 +227,17 @@ func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (
 	return req.HTTPRequest, bodyBytes, nil
 }
 
-// forwardDirect sends the signed request directly using the proxy's transport,
-// bypassing httputil.ReverseProxy which modifies headers and breaks AWS signatures.
-func (b *awsBackend) forwardDirect(w http.ResponseWriter, r *http.Request, body []byte) {
-	// Build a fresh request to avoid any state from the original
-	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), bytes.NewReader(body))
-	if err != nil {
-		b.Logger.Error("failed to create direct request", logger.Err(err))
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-	outReq.Header = r.Header.Clone()
-	outReq.Host = r.Host
-	outReq.ContentLength = int64(len(body))
-
-	// Use the proxy's transport (shares TLS config, connection pooling)
-	transport := b.Proxy.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-
-	resp, err := transport.RoundTrip(outReq)
-	if err != nil {
-		b.Logger.Error("direct forward failed", logger.Err(err))
-		http.Error(w, "Bad Gateway", http.StatusBadGateway)
-		return
-	}
-	defer resp.Body.Close()
-
-	// Copy response headers
-	for k, vv := range resp.Header {
-		for _, v := range vv {
-			w.Header().Add(k, v)
-		}
-	}
-	w.WriteHeader(resp.StatusCode)
-
-	// For streaming responses (SSE, chunked), flush after each write so
-	// the client sees data incrementally instead of waiting for the buffer.
-	if flusher, ok := w.(http.Flusher); ok {
-		buf := make([]byte, 32*1024)
-		for {
-			n, readErr := resp.Body.Read(buf)
-			if n > 0 {
-				w.Write(buf[:n])
-				flusher.Flush()
-			}
-			if readErr != nil {
-				break
-			}
-		}
-	} else {
-		io.Copy(w, resp.Body)
-	}
-}
-
-func (b *awsBackend) getCredentials(req *logical.Request) (aws.Credentials, error) {
+func (b *awsBackend) getCredentials(req *logical.Request) (awssdk.Credentials, error) {
 	switch req.Credential.Type {
 	case credential.TypeAWSAccessKeys:
 		if req.Credential.LeaseTTL == 0 {
-			return aws.Credentials{
+			return awssdk.Credentials{
 				AccessKeyID:     req.Credential.Data["access_key_id"],
 				SecretAccessKey: req.Credential.Data["secret_access_key"],
 				Source:          req.Credential.Data["cred_source"],
 			}, nil
 		} else {
-			return aws.Credentials{
+			return awssdk.Credentials{
 				AccessKeyID:     req.Credential.Data["access_key_id"],
 				SecretAccessKey: req.Credential.Data["secret_access_key"],
 				Source:          req.Credential.Data["cred_source"],
@@ -321,71 +247,6 @@ func (b *awsBackend) getCredentials(req *logical.Request) (aws.Credentials, erro
 			}, nil
 		}
 	default:
-		return aws.Credentials{}, fmt.Errorf("unsupported aws credential type : %s", req.Credential.Type)
-	}
-}
-
-// extractFromAuthHeader parses service, region, and access key from Authorization header
-func extractFromAuthHeader(authHeader string) (service, region, accessKeyID string, err error) {
-	if authHeader == "" {
-		return "", "", "", fmt.Errorf("empty authorization header")
-	}
-
-	matches := authRegex.FindStringSubmatch(authHeader)
-	if len(matches) != 5 {
-		return "", "", "", fmt.Errorf("invalid authorization header format")
-	}
-
-	accessKeyID = matches[1]
-	region = matches[3]
-	service = matches[4]
-
-	return service, region, accessKeyID, nil
-}
-
-// computePayloadHash computes SHA256 hash of the payload
-func computePayloadHash(body []byte) string {
-	h := sha256.New()
-	h.Write(body)
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-// parseAWSDate parses AWS date format (YYYYMMDDTHHMMSSZ)
-func parseAWSDate(dateStr string) (time.Time, error) {
-	return time.Parse("20060102T150405Z", dateStr)
-}
-
-func (b *awsBackend) readRequestBody(r *http.Request) ([]byte, error) {
-	if r.Body == nil {
-		return nil, nil
-	}
-
-	// Limit body size if configured
-	reader := io.Reader(r.Body)
-	if b.MaxBodySize > 0 {
-		reader = io.LimitReader(r.Body, b.MaxBodySize)
-	}
-
-	bodyBytes, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-	r.Body.Close()
-
-	// Check if we hit the size limit
-	if b.MaxBodySize > 0 && int64(len(bodyBytes)) >= b.MaxBodySize {
-		return nil, fmt.Errorf("request body exceeds maximum size of %d bytes", b.MaxBodySize)
-	}
-
-	return bodyBytes, nil
-}
-
-func (b *awsBackend) restoreRequestBody(r *http.Request, bodyBytes []byte) {
-	if len(bodyBytes) > 0 {
-		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		r.ContentLength = int64(len(bodyBytes))
-	} else {
-		r.Body = nil
-		r.ContentLength = 0
+		return awssdk.Credentials{}, fmt.Errorf("unsupported aws credential type : %s", req.Credential.Type)
 	}
 }

--- a/provider/aws/path_gateway_test.go
+++ b/provider/aws/path_gateway_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/provider/sigv4"
 )
 
 // createTestLogger creates a logger for testing that discards output
@@ -83,7 +84,7 @@ func TestExtractFromAuthHeader(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			service, region, accessKey, err := extractFromAuthHeader(tt.authHeader)
+			service, region, accessKey, err := sigv4.ExtractFromAuthHeader(tt.authHeader)
 
 			if tt.expectError {
 				if err == nil {
@@ -138,9 +139,9 @@ func TestComputePayloadHash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := computePayloadHash(tt.body)
+			got := sigv4.ComputePayloadHash(tt.body)
 			if got != tt.expected {
-				t.Errorf("computePayloadHash() = %s, want %s", got, tt.expected)
+				t.Errorf("sigv4.ComputePayloadHash() = %s, want %s", got, tt.expected)
 			}
 		})
 	}
@@ -190,7 +191,7 @@ func TestParseAWSDate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseAWSDate(tt.dateStr)
+			got, err := sigv4.ParseAWSDate(tt.dateStr)
 
 			if tt.expectError {
 				if err == nil {
@@ -203,7 +204,7 @@ func TestParseAWSDate(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			if !got.Equal(tt.expected) {
-				t.Errorf("parseAWSDate() = %v, want %v", got, tt.expected)
+				t.Errorf("sigv4.ParseAWSDate() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
@@ -255,15 +256,9 @@ func TestAwsBackend_ReadRequestBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &awsBackend{
-				StreamingBackend: &framework.StreamingBackend{
-					MaxBodySize: tt.maxBodySize,
-				},
-			}
-
 			req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(tt.body))
 
-			got, err := b.readRequestBody(req)
+			got, err := sigv4.ReadRequestBody(req, tt.maxBodySize)
 
 			if tt.expectError {
 				if err == nil {
@@ -283,16 +278,10 @@ func TestAwsBackend_ReadRequestBody(t *testing.T) {
 }
 
 func TestAwsBackend_ReadRequestBody_NilBody(t *testing.T) {
-	b := &awsBackend{
-		StreamingBackend: &framework.StreamingBackend{
-			MaxBodySize: 1024,
-		},
-	}
-
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Body = nil
 
-	got, err := b.readRequestBody(req)
+	got, err := sigv4.ReadRequestBody(req, 1024)
 
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -323,10 +312,9 @@ func TestAwsBackend_RestoreRequestBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &awsBackend{}
 			req := httptest.NewRequest(http.MethodPost, "/test", nil)
 
-			b.restoreRequestBody(req, tt.bodyBytes)
+			sigv4.RestoreRequestBody(req, tt.bodyBytes)
 
 			if len(tt.bodyBytes) > 0 {
 				// Body should be restored
@@ -527,7 +515,7 @@ func BenchmarkExtractFromAuthHeader(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		extractFromAuthHeader(authHeader)
+		sigv4.ExtractFromAuthHeader(authHeader)
 	}
 }
 
@@ -536,7 +524,7 @@ func BenchmarkComputePayloadHash(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		computePayloadHash(body)
+		sigv4.ComputePayloadHash(body)
 	}
 }
 
@@ -545,7 +533,7 @@ func BenchmarkParseAWSDate(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		parseAWSDate(dateStr)
+		sigv4.ParseAWSDate(dateStr)
 	}
 }
 

--- a/provider/aws/provider.go
+++ b/provider/aws/provider.go
@@ -2,12 +2,8 @@ package aws
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +12,7 @@ import (
 	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/aws/processor"
 	"github.com/stephnangue/warden/provider/aws/processor/s3"
+	"github.com/stephnangue/warden/provider/sigv4"
 )
 
 // HostRewrite contains information about a rewritten virtual-hosted URL
@@ -50,29 +47,7 @@ func extractToken(r *http.Request) string {
 	if !strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256") {
 		return ""
 	}
-	return extractAccessKeyID(authHeader)
-}
-
-// extractAccessKeyID extracts the Access Key ID from an AWS SigV4 Authorization header.
-// Format: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20231215/us-east-1/s3/aws4_request
-func extractAccessKeyID(authHeader string) string {
-	const prefix = "Credential="
-	idx := strings.Index(authHeader, prefix)
-	if idx == -1 {
-		return ""
-	}
-
-	start := idx + len(prefix)
-	if start >= len(authHeader) {
-		return ""
-	}
-
-	end := strings.IndexByte(authHeader[start:], '/')
-	if end == -1 {
-		return ""
-	}
-
-	return authHeader[start : start+end]
+	return sigv4.ExtractAccessKeyID(authHeader)
 }
 
 // Compile-time interface assertion
@@ -82,7 +57,7 @@ var _ logical.TransparentAuthRoleExtractor = (*awsBackend)(nil)
 // Returns (role, true) when access_key_id is present (used as the role name).
 // Returns ("", false) when no Authorization header is present.
 func (b *awsBackend) GetAuthRoleFromRequest(r *http.Request) (string, bool) {
-	accessKeyID := extractAccessKeyID(r.Header.Get("Authorization"))
+	accessKeyID := sigv4.ExtractAccessKeyID(r.Header.Get("Authorization"))
 	if accessKeyID == "" {
 		return "", false
 	}
@@ -255,128 +230,6 @@ func (b *awsBackend) initializeProcessors() {
 	b.processorRegistry.Register(s3.NewS3ControlProcessor(b.proxyDomains, b.Logger))
 	b.processorRegistry.Register(s3.NewS3Processor(b.proxyDomains, b.Logger))
 	b.processorRegistry.Register(processor.NewGenericAWSProcessor(b.proxyDomains, b.Logger))
-}
-
-// ValidateConfig validates AWS provider-specific configuration
-func ValidateConfig(config map[string]any) error {
-	allowedKeys := map[string]bool{
-		"proxy_domains":   true,
-		"max_body_size":   true,
-		"timeout":         true,
-		"tls_skip_verify": true,
-		"ca_data":         true,
-		"auto_auth_path":  true,
-		"default_role":    true,
-	}
-
-	// Check for unknown keys
-	for key := range config {
-		if !allowedKeys[key] {
-			return fmt.Errorf("unknown configuration key: %s (allowed: proxy_domains, max_body_size, timeout, tls_skip_verify, ca_data, auto_auth_path, default_role)", key)
-		}
-	}
-
-	// Validate proxy_domains
-	if domains, ok := config["proxy_domains"]; ok {
-		switch v := domains.(type) {
-		case []any:
-			for i, d := range v {
-				if _, ok := d.(string); !ok {
-					return fmt.Errorf("proxy_domains[%d] must be a string", i)
-				}
-			}
-		case []string:
-		default:
-			return fmt.Errorf("proxy_domains must be an array of strings")
-		}
-	}
-
-	// Validate max_body_size
-	if maxSize, ok := config["max_body_size"]; ok {
-		var size int64
-		switch v := maxSize.(type) {
-		case int:
-			size = int64(v)
-		case int64:
-			size = v
-		case float64:
-			size = int64(v)
-		case json.Number:
-			parsed, err := v.Int64()
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
-			}
-			size = parsed
-		case string:
-			parsed, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
-			}
-			size = parsed
-		default:
-			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
-		}
-		if size < 0 {
-			return fmt.Errorf("max_body_size must be greater than 0")
-		}
-		if size > 104857600 { // 100MB
-			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
-		}
-	}
-
-	// Validate timeout
-	if timeout, ok := config["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if _, err := time.ParseDuration(v); err != nil {
-				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
-			}
-		case int:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		case float64:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		default:
-			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
-		}
-	}
-
-	// Validate tls_skip_verify
-	if v, ok := config["tls_skip_verify"]; ok {
-		switch v := v.(type) {
-		case bool:
-			// valid
-		case string:
-			if v != "true" && v != "false" && v != "1" && v != "0" {
-				return fmt.Errorf("tls_skip_verify must be a boolean, got string: %s", v)
-			}
-		default:
-			return fmt.Errorf("tls_skip_verify must be a boolean, got %T", v)
-		}
-	}
-
-	// Validate ca_data
-	if v, ok := config["ca_data"]; ok {
-		caStr, ok := v.(string)
-		if !ok {
-			return fmt.Errorf("ca_data must be a string")
-		}
-		if caStr != "" {
-			pemBytes, err := base64.StdEncoding.DecodeString(caStr)
-			if err != nil {
-				return fmt.Errorf("ca_data is not valid base64: %w", err)
-			}
-			block, _ := pem.Decode(pemBytes)
-			if block == nil {
-				return fmt.Errorf("ca_data contains no valid PEM data")
-			}
-		}
-	}
-
-	return nil
 }
 
 // SensitiveConfigFields returns the list of config fields that should be masked in output

--- a/provider/aws/signature.go
+++ b/provider/aws/signature.go
@@ -1,19 +1,12 @@
 package aws
 
 import (
-	"bytes"
 	"context"
-	"crypto/subtle"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
-	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/go-chi/chi/middleware"
-	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/provider/sigv4"
 )
 
 // normalizeRequest prepares a request for re-signing by decoding aws-chunked
@@ -21,87 +14,7 @@ import (
 // headers that would break the AWS signature. Returns the (possibly decoded)
 // body bytes to forward.
 func (b *awsBackend) normalizeRequest(r *http.Request, bodyBytes []byte) []byte {
-	// Decode aws-chunked body: the chunk signatures were computed with the
-	// client's credentials, which AWS will reject. Decode to plain body and
-	// remove streaming-related headers.
-	if isAWSChunked(r) {
-		decoded, err := decodeAWSChunkedBody(bodyBytes)
-		if err != nil {
-			b.Logger.Warn("failed to decode aws-chunked body, using original",
-				logger.Err(err),
-				logger.String("request_id", middleware.GetReqID(r.Context())),
-			)
-		} else {
-			bodyBytes = decoded
-		}
-
-		removeAWSChunkedEncoding(r)
-		r.Header.Del("X-Amz-Decoded-Content-Length")
-		r.Header.Del("X-Amz-Content-Sha256")
-		r.Header.Del("Accept-Encoding")
-		r.Header.Del("Content-Length")
-		r.Header.Del("Expect")
-	}
-
-	// Strip trailing-checksum headers when X-Amz-Trailer is present.
-	// The SDK sends X-Amz-Trailer to indicate a checksum will follow the body
-	// as a trailing chunk. Since we decode aws-chunked, the trailing checksum
-	// is lost. Strip the promise headers so AWS doesn't expect a checksum that
-	// won't arrive. When X-Amz-Trailer is absent, checksum headers are regular
-	// (inline) values that some S3 operations require (e.g., PutObjectLockConfiguration).
-	if r.Header.Get("X-Amz-Trailer") != "" {
-		r.Header.Del("X-Amz-Trailer")
-		r.Header.Del("X-Amz-Sdk-Checksum-Algorithm")
-		r.Header.Del("X-Amz-Checksum-Algorithm")
-		for key := range r.Header {
-			if strings.HasPrefix(strings.ToLower(key), "x-amz-checksum-") {
-				r.Header.Del(key)
-			}
-		}
-	}
-
-	// Remove hop-by-hop headers (RFC 2616 Section 13.5.1)
-	removedHeaders := []string{}
-	for _, h := range []string{
-		"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
-		"Te", "Trailer", "Trailers", "Transfer-Encoding", "Upgrade",
-	} {
-		if r.Header.Get(h) != "" {
-			removedHeaders = append(removedHeaders, h)
-			r.Header.Del(h)
-		}
-	}
-
-	// Remove proxy-specific headers
-	for _, h := range []string{
-		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
-		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",
-	} {
-		if r.Header.Get(h) != "" {
-			removedHeaders = append(removedHeaders, h)
-			r.Header.Del(h)
-		}
-	}
-
-	// Remove headers listed in Connection header
-	if connectionHeaders := r.Header.Get("Connection"); connectionHeaders != "" {
-		for _, connHeader := range strings.Split(connectionHeaders, ",") {
-			trimmed := strings.TrimSpace(connHeader)
-			if trimmed != "" {
-				removedHeaders = append(removedHeaders, trimmed)
-				r.Header.Del(trimmed)
-			}
-		}
-	}
-
-	if len(removedHeaders) > 0 {
-		b.Logger.Trace("headers removed during normalization",
-			logger.Any("removed_headers", removedHeaders),
-			logger.String("request_id", middleware.GetReqID(r.Context())),
-		)
-	}
-
-	return bodyBytes
+	return sigv4.NormalizeRequest(b.Logger, r, bodyBytes)
 }
 
 // resignRequest re-signs the request with valid AWS credentials.
@@ -109,117 +22,11 @@ func (b *awsBackend) normalizeRequest(r *http.Request, bodyBytes []byte) []byte 
 func (b *awsBackend) resignRequest(
 	ctx context.Context,
 	r *http.Request,
-	creds aws.Credentials,
+	creds awssdk.Credentials,
 	service, region string,
 	bodyBytes []byte,
 ) error {
-	// Compute payload hash and set the header. S3 requires
-	// X-Amz-Content-Sha256 explicitly; the v4 signer uses the payloadHash
-	// for signature computation but does not set the header.
-	payloadHash := computePayloadHash(bodyBytes)
-	r.Header.Set("X-Amz-Content-Sha256", payloadHash)
-
-	// Get signing time from original request or use current time
-	signingTime := time.Now()
-	if amzDate := r.Header.Get("X-Amz-Date"); amzDate != "" {
-		if t, err := parseAWSDate(amzDate); err == nil {
-			signingTime = t
-		}
-	}
-
-	// Remove old authorization header
-	r.Header.Del("Authorization")
-
-	// Restore body for signing
-	b.restoreRequestBody(r, bodyBytes)
-
-	// Sign the request with the appropriate signer
-	signer := b.getSigner(service)
-	if err := signer.SignHTTP(ctx, creds, r, payloadHash, service, region, signingTime); err != nil {
-		return fmt.Errorf("failed to sign request: %w", err)
-	}
-
-	return nil
-}
-
-// isAWSChunked returns true if the request uses aws-chunked content encoding.
-func isAWSChunked(r *http.Request) bool {
-	return strings.Contains(r.Header.Get("Content-Encoding"), "aws-chunked")
-}
-
-// decodeAWSChunkedBody decodes an aws-chunked encoded body into plain bytes.
-// AWS chunked format: <hex-size>;chunk-signature=<sig>\r\n<data>\r\n...0;chunk-signature=<sig>\r\n[trailer]\r\n
-func decodeAWSChunkedBody(data []byte) ([]byte, error) {
-	var decoded bytes.Buffer
-	buf := bytes.NewBuffer(data)
-
-	for {
-		// Read the chunk header line: "<hex-size>;chunk-signature=<sig>\r\n"
-		line, err := buf.ReadString('\n')
-		if err != nil {
-			if err == io.EOF && line == "" {
-				break
-			}
-			if err == io.EOF {
-				// Partial line at end — may be trailing data, stop
-				break
-			}
-			return nil, fmt.Errorf("error reading chunk header: %w", err)
-		}
-
-		line = strings.TrimRight(line, "\r\n")
-
-		// Extract hex size (everything before the first ';')
-		sizeStr := line
-		if idx := strings.IndexByte(line, ';'); idx >= 0 {
-			sizeStr = line[:idx]
-		}
-
-		var chunkSize int64
-		if _, err := fmt.Sscanf(sizeStr, "%x", &chunkSize); err != nil {
-			return nil, fmt.Errorf("invalid chunk size %q: %w", sizeStr, err)
-		}
-
-		if chunkSize == 0 {
-			// Terminal chunk — skip any trailing headers
-			break
-		}
-
-		// Read chunkSize bytes of data
-		chunk := make([]byte, chunkSize)
-		if _, err := io.ReadFull(buf, chunk); err != nil {
-			return nil, fmt.Errorf("error reading chunk data: %w", err)
-		}
-		decoded.Write(chunk)
-
-		// Consume trailing \r\n after chunk data
-		if _, err := buf.ReadString('\n'); err != nil && err != io.EOF {
-			return nil, fmt.Errorf("error reading chunk trailer: %w", err)
-		}
-	}
-
-	return decoded.Bytes(), nil
-}
-
-// removeAWSChunkedEncoding removes "aws-chunked" from the Content-Encoding header
-// while preserving any other encodings (e.g., "gzip").
-func removeAWSChunkedEncoding(r *http.Request) {
-	ce := r.Header.Get("Content-Encoding")
-	if ce == "" {
-		return
-	}
-	var remaining []string
-	for _, part := range strings.Split(ce, ",") {
-		trimmed := strings.TrimSpace(part)
-		if !strings.EqualFold(trimmed, "aws-chunked") {
-			remaining = append(remaining, trimmed)
-		}
-	}
-	if len(remaining) == 0 {
-		r.Header.Del("Content-Encoding")
-	} else {
-		r.Header.Set("Content-Encoding", strings.Join(remaining, ", "))
-	}
+	return sigv4.ResignRequest(ctx, b.getSigner(service), r, creds, service, region, bodyBytes)
 }
 
 // getSigner returns the appropriate signer for the service.
@@ -235,153 +42,18 @@ func (b *awsBackend) getSigner(service string) *v4.Signer {
 func (b *awsBackend) verifyIncomingSignature(
 	r *http.Request,
 	bodyBytes []byte,
-	creds aws.Credentials,
+	creds awssdk.Credentials,
 	service, region string,
 ) (bool, error) {
-	// Extract the provided signature from Authorization header
-	authHeader := r.Header.Get("Authorization")
-	signMatches := signRegex.FindStringSubmatch(authHeader)
-	if len(signMatches) != 2 {
-		return false, fmt.Errorf("signature not found in authorization header")
-	}
-	providedSignature := signMatches[1]
+	return sigv4.VerifyIncomingSignature(b.Logger, b.getSignerOpts(service), r, bodyBytes, creds, service, region)
+}
 
-	// Extract the signed headers list from the Authorization header
-	signedHeadersMatches := signedHeadersRegex.FindStringSubmatch(authHeader)
-	if len(signedHeadersMatches) != 2 {
-		return false, fmt.Errorf("signed headers not found in authorization header")
-	}
-	signedHeadersList := strings.Split(signedHeadersMatches[1], ";")
-
-	// Get the signing time from headers
-	amzDate := r.Header.Get("X-Amz-Date")
-	if amzDate == "" {
-		amzDate = r.Header.Get("Date")
-	}
-	if amzDate == "" {
-		return false, fmt.Errorf("no date header found")
-	}
-
-	signingTime, err := parseAWSDate(amzDate)
-	if err != nil {
-		return false, fmt.Errorf("invalid date format: %w", err)
-	}
-
-	// Check if signature is not too old (prevent replay attacks)
-	if time.Since(signingTime) > 15*time.Minute {
-		return false, fmt.Errorf("signature expired: signed at %s", signingTime.Format(time.RFC3339))
-	}
-
-	// Clone the request for verification
-	testReq := r.Clone(r.Context())
-
-	b.Logger.Trace("Signature Verification Debug",
-		logger.String("method", testReq.Method),
-		logger.String("url", testReq.URL.String()),
-		logger.String("host", testReq.Host),
-		logger.String("path", testReq.URL.Path),
-		logger.String("rawPath", testReq.URL.RawPath),
-		logger.String("escapedPath", testReq.URL.EscapedPath()),
-		logger.String("rawQuery", testReq.URL.RawQuery),
-		logger.String("signingTime", signingTime.Format(time.RFC3339)),
-		logger.String("service", service),
-		logger.String("region", region),
-		logger.Any("signedHeaders", signedHeadersList),
-		logger.String("request_id", middleware.GetReqID(r.Context())),
-	)
-
-	// Build a new header map containing only the headers the client signed.
-	// This ensures the signer produces the same canonical request.
-	newHeaders := make(http.Header)
-	contentLengthSigned := false
-	for _, signedHeader := range signedHeadersList {
-		signedHeaderLower := strings.ToLower(strings.TrimSpace(signedHeader))
-
-		if signedHeaderLower == "authorization" {
-			continue
-		}
-		if signedHeaderLower == "content-length" {
-			contentLengthSigned = true
-		}
-		if signedHeaderLower == "host" {
-			testReq.Host = r.Host
-			testReq.URL.Host = r.Host
-			continue
-		}
-
-		// Find this header in the original request (case-insensitive)
-		for originalHeaderKey, originalHeaderValues := range r.Header {
-			if strings.ToLower(originalHeaderKey) == signedHeaderLower {
-				canonicalKey := http.CanonicalHeaderKey(signedHeader)
-				newHeaders[canonicalKey] = originalHeaderValues
-				break
-			}
-		}
-
-		if newHeaders.Get(http.CanonicalHeaderKey(signedHeader)) == "" && signedHeaderLower != "host" {
-			b.Logger.Warn("signed header not found in request",
-				logger.String("header", signedHeader),
-				logger.String("request_id", middleware.GetReqID(r.Context())),
-			)
+// getSignerOpts returns the signer options for the given service.
+func (b *awsBackend) getSignerOpts(service string) []func(*v4.SignerOptions) {
+	if service == "s3" || service == "s3-control" {
+		return []func(*v4.SignerOptions){
+			func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true },
 		}
 	}
-	testReq.Header = newHeaders
-
-	// Restore body in the cloned request
-	if len(bodyBytes) > 0 {
-		testReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-	}
-
-	// Only set ContentLength if the client signed it. The AWS SDK v4 signer
-	// automatically includes content-length in canonical headers when
-	// ContentLength > 0, causing a mismatch if the client didn't sign it.
-	if contentLengthSigned {
-		testReq.ContentLength = int64(len(bodyBytes))
-	} else {
-		testReq.ContentLength = -1
-	}
-
-	// Determine payload hash for signature verification. For streaming uploads
-	// (aws-chunked), the client uses "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
-	// instead of the actual body SHA256. Use the value from the header.
-	payloadHash := r.Header.Get("X-Amz-Content-Sha256")
-	if payloadHash == "" {
-		payloadHash = computePayloadHash(bodyBytes)
-	}
-
-	// Sign the test request with the retrieved credentials
-	signer := b.getSigner(service)
-	err = signer.SignHTTP(r.Context(), creds, testReq, payloadHash, service, region, signingTime)
-	if err != nil {
-		return false, fmt.Errorf("failed to sign request for signature verification: %w", err)
-	}
-
-	// Extract the calculated signature
-	calculatedAuth := testReq.Header.Get("Authorization")
-	calculatedMatches := signRegex.FindStringSubmatch(calculatedAuth)
-	if len(calculatedMatches) != 2 {
-		return false, fmt.Errorf("failed to extract calculated signature")
-	}
-	calculatedSignature := calculatedMatches[1]
-
-	// Compare signatures using constant-time comparison to prevent timing attacks
-	match := subtle.ConstantTimeCompare([]byte(providedSignature), []byte(calculatedSignature)) == 1
-
-	b.Logger.Trace("Signature comparison",
-		logger.String("provided", providedSignature),
-		logger.String("calculated", calculatedSignature),
-		logger.String("originalAuth", authHeader),
-		logger.String("calculatedAuth", calculatedAuth),
-		logger.String("request_id", middleware.GetReqID(r.Context())),
-	)
-
-	if !match {
-		b.Logger.Warn("signature mismatch",
-			logger.String("provided", providedSignature),
-			logger.String("calculated", calculatedSignature),
-			logger.String("request_id", middleware.GetReqID(r.Context())),
-		)
-	}
-
-	return match, nil
+	return nil
 }

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -1,8 +1,6 @@
 package azure
 
 import (
-	"encoding/json"
-	"strconv"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -20,77 +18,13 @@ type ProviderConfig struct {
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
 func parseConfig(conf map[string]any) ProviderConfig {
-	config := ProviderConfig{
-		MaxBodySize: framework.DefaultMaxBodySize,
-		Timeout:     framework.DefaultTimeout,
+	tlsSkipVerify, caData := framework.ParseTLSConfig(conf)
+	return ProviderConfig{
+		MaxBodySize:     framework.ParseMaxBodySize(conf),
+		Timeout:         framework.ParseTimeout(conf, framework.DefaultTimeout),
+		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
+		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
+		TLSSkipVerify:   tlsSkipVerify,
+		CAData:          caData,
 	}
-
-	// Parse max_body_size - handle various JSON number types
-	if maxSize, ok := conf["max_body_size"]; ok {
-		switch v := maxSize.(type) {
-		case int:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case int64:
-			if v > 0 {
-				config.MaxBodySize = v
-			}
-		case float64:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case json.Number:
-			if parsed, err := v.Int64(); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		case string:
-			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		}
-	}
-
-	// Parse timeout - handle duration string or number
-	if timeout, ok := conf["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if parsed, err := time.ParseDuration(v); err == nil {
-				config.Timeout = parsed
-			}
-		case int:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		case float64:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		}
-	}
-
-	// Parse auto_auth_path
-	if aap, ok := conf["auto_auth_path"].(string); ok {
-		config.AutoAuthPath = aap
-	}
-
-	// Parse default_role
-	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultAuthRole = dr
-	}
-
-	// Parse TLS settings
-	if v, ok := conf["tls_skip_verify"]; ok {
-		switch b := v.(type) {
-		case bool:
-			config.TLSSkipVerify = b
-		case string:
-			config.TLSSkipVerify = b == "true" || b == "1"
-		}
-	}
-	if v, ok := conf["ca_data"].(string); ok {
-		config.CAData = v
-	}
-
-	return config
 }

--- a/provider/azure/provider.go
+++ b/provider/azure/provider.go
@@ -2,12 +2,8 @@ package azure
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -236,122 +232,15 @@ func (b *azureBackend) handleTransparentGatewayStreaming(ctx context.Context, re
 
 // ValidateConfig validates Azure provider-specific configuration
 func ValidateConfig(config map[string]any) error {
-	allowedKeys := map[string]bool{
-		"max_body_size":   true,
-		"timeout":         true,
-		"tls_skip_verify": true,
-		"ca_data":         true,
-		"auto_auth_path":  true,
-		"default_role":    true,
+	if err := framework.ValidateAllowedKeys(config,
+		"max_body_size", "timeout", "tls_skip_verify", "ca_data",
+		"auto_auth_path", "default_role"); err != nil {
+		return err
 	}
-
-	// Check for unknown keys
-	for key := range config {
-		if !allowedKeys[key] {
-			return fmt.Errorf("unknown configuration key: %s (allowed: max_body_size, timeout, tls_skip_verify, ca_data, auto_auth_path, default_role)", key)
-		}
+	if err := framework.ValidateCommonConfig(config); err != nil {
+		return err
 	}
-
-	// Validate max_body_size
-	if maxSize, ok := config["max_body_size"]; ok {
-		var size int64
-		switch v := maxSize.(type) {
-		case int:
-			size = int64(v)
-		case int64:
-			size = v
-		case float64:
-			size = int64(v)
-		case json.Number:
-			parsed, err := v.Int64()
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
-			}
-			size = parsed
-		case string:
-			parsed, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
-			}
-			size = parsed
-		default:
-			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
-		}
-		if size < 0 {
-			return fmt.Errorf("max_body_size must be greater than 0")
-		}
-		if size > 104857600 { // 100MB
-			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
-		}
-	}
-
-	// Validate timeout
-	if timeout, ok := config["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if _, err := time.ParseDuration(v); err != nil {
-				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
-			}
-		case int:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		case float64:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		default:
-			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
-		}
-	}
-
-	// Validate auto_auth_path
-	if aap, ok := config["auto_auth_path"]; ok {
-		if _, ok := aap.(string); !ok {
-			return fmt.Errorf("auto_auth_path must be a string")
-		}
-	}
-
-	// Validate default_role
-	if dr, ok := config["default_role"]; ok {
-		if _, ok := dr.(string); !ok {
-			return fmt.Errorf("default_role must be a string")
-		}
-	}
-
-	// Validate tls_skip_verify
-	if v, ok := config["tls_skip_verify"]; ok {
-		switch v := v.(type) {
-		case bool:
-			// valid
-		case string:
-			if v != "true" && v != "false" && v != "1" && v != "0" {
-				return fmt.Errorf("tls_skip_verify must be a boolean, got string: %s", v)
-			}
-		default:
-			return fmt.Errorf("tls_skip_verify must be a boolean, got %T", v)
-		}
-	}
-
-	// Validate ca_data
-	if v, ok := config["ca_data"]; ok {
-		caStr, ok := v.(string)
-		if !ok {
-			return fmt.Errorf("ca_data must be a string")
-		}
-		if caStr != "" {
-			pemBytes, err := base64.StdEncoding.DecodeString(caStr)
-			if err != nil {
-				return fmt.Errorf("ca_data is not valid base64: %w", err)
-			}
-			block, _ := pem.Decode(pemBytes)
-			if block == nil {
-				return fmt.Errorf("ca_data contains no valid PEM data")
-			}
-		}
-	}
-
-	return nil
+	return framework.ValidateTLSConfig(config)
 }
 
 // SensitiveConfigFields returns the list of config fields that should be masked in output

--- a/provider/dynatrace/provider.go
+++ b/provider/dynatrace/provider.go
@@ -44,13 +44,20 @@ func dynatraceCredentialExtractor(req *logical.Request) (map[string]string, erro
 // Spec defines the Dynatrace provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
 	Name:               "dynatrace",
-	DefaultURL:         "https://{environment-id}.live.dynatrace.com",
+	DefaultURL:         "", // Instance-specific, must be configured
 	URLConfigKey:       "dynatrace_url",
 	DefaultTimeout:     DefaultDynatraceTimeout,
 	ParseStreamBody:    true,
 	UserAgent:          "warden-dynatrace-proxy",
 	HelpText:           dynatraceBackendHelp,
 	ExtractCredentials: dynatraceCredentialExtractor,
+	ValidateExtraConfig: func(conf map[string]any) error {
+		addr, ok := conf["dynatrace_url"].(string)
+		if !ok || addr == "" {
+			return fmt.Errorf("dynatrace_url is required")
+		}
+		return nil
+	},
 }
 
 // Factory creates a new Dynatrace provider backend.

--- a/provider/elastic/provider.go
+++ b/provider/elastic/provider.go
@@ -3,7 +3,6 @@ package elastic
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
@@ -53,25 +52,6 @@ func extractToken(r *http.Request) string {
 	return ""
 }
 
-// validateElasticURL validates that the elastic_url is a well-formed HTTPS URL.
-// When tlsSkipVerify is true, http:// is also accepted for dev/test environments.
-func validateElasticURL(addr string, tlsSkipVerify bool) error {
-	if addr == "" {
-		return fmt.Errorf("elastic_url is required")
-	}
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid elastic_url: %w", err)
-	}
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && tlsSkipVerify) {
-		return fmt.Errorf("elastic_url must use https:// scheme, got: %s", parsed.Scheme)
-	}
-	if parsed.Host == "" {
-		return fmt.Errorf("elastic_url must include a host")
-	}
-	return nil
-}
-
 // Spec defines the Elastic provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
 	Name:               "elastic",
@@ -88,11 +68,7 @@ var Spec = &httpproxy.ProviderSpec{
 		if !ok || addr == "" {
 			return fmt.Errorf("elastic_url is required")
 		}
-		skipVerify := false
-		if v, ok := conf["tls_skip_verify"].(bool); ok {
-			skipVerify = v
-		}
-		return validateElasticURL(addr, skipVerify)
+		return nil
 	},
 }
 

--- a/provider/gcp/config.go
+++ b/provider/gcp/config.go
@@ -1,8 +1,6 @@
 package gcp
 
 import (
-	"encoding/json"
-	"strconv"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -20,77 +18,13 @@ type ProviderConfig struct {
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
 func parseConfig(conf map[string]any) ProviderConfig {
-	config := ProviderConfig{
-		MaxBodySize: framework.DefaultMaxBodySize,
-		Timeout:     framework.DefaultTimeout,
+	tlsSkipVerify, caData := framework.ParseTLSConfig(conf)
+	return ProviderConfig{
+		MaxBodySize:     framework.ParseMaxBodySize(conf),
+		Timeout:         framework.ParseTimeout(conf, framework.DefaultTimeout),
+		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
+		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
+		TLSSkipVerify:   tlsSkipVerify,
+		CAData:          caData,
 	}
-
-	// Parse max_body_size - handle various JSON number types
-	if maxSize, ok := conf["max_body_size"]; ok {
-		switch v := maxSize.(type) {
-		case int:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case int64:
-			if v > 0 {
-				config.MaxBodySize = v
-			}
-		case float64:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case json.Number:
-			if parsed, err := v.Int64(); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		case string:
-			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		}
-	}
-
-	// Parse timeout - handle duration string or number
-	if timeout, ok := conf["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if parsed, err := time.ParseDuration(v); err == nil {
-				config.Timeout = parsed
-			}
-		case int:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		case float64:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		}
-	}
-
-	// Parse auto_auth_path
-	if aap, ok := conf["auto_auth_path"].(string); ok {
-		config.AutoAuthPath = aap
-	}
-
-	// Parse default_role
-	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultAuthRole = dr
-	}
-
-	// Parse TLS settings
-	if v, ok := conf["tls_skip_verify"]; ok {
-		switch b := v.(type) {
-		case bool:
-			config.TLSSkipVerify = b
-		case string:
-			config.TLSSkipVerify = b == "true" || b == "1"
-		}
-	}
-	if v, ok := conf["ca_data"].(string); ok {
-		config.CAData = v
-	}
-
-	return config
 }

--- a/provider/gcp/provider.go
+++ b/provider/gcp/provider.go
@@ -2,12 +2,8 @@ package gcp
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -234,122 +230,15 @@ func (b *gcpBackend) handleTransparentGatewayStreaming(ctx context.Context, req 
 
 // ValidateConfig validates GCP provider-specific configuration
 func ValidateConfig(config map[string]any) error {
-	allowedKeys := map[string]bool{
-		"max_body_size":   true,
-		"timeout":         true,
-		"tls_skip_verify": true,
-		"ca_data":         true,
-		"auto_auth_path":  true,
-		"default_role":    true,
+	if err := framework.ValidateAllowedKeys(config,
+		"max_body_size", "timeout", "tls_skip_verify", "ca_data",
+		"auto_auth_path", "default_role"); err != nil {
+		return err
 	}
-
-	// Check for unknown keys
-	for key := range config {
-		if !allowedKeys[key] {
-			return fmt.Errorf("unknown configuration key: %s (allowed: max_body_size, timeout, tls_skip_verify, ca_data, auto_auth_path, default_role)", key)
-		}
+	if err := framework.ValidateCommonConfig(config); err != nil {
+		return err
 	}
-
-	// Validate max_body_size
-	if maxSize, ok := config["max_body_size"]; ok {
-		var size int64
-		switch v := maxSize.(type) {
-		case int:
-			size = int64(v)
-		case int64:
-			size = v
-		case float64:
-			size = int64(v)
-		case json.Number:
-			parsed, err := v.Int64()
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
-			}
-			size = parsed
-		case string:
-			parsed, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
-			}
-			size = parsed
-		default:
-			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
-		}
-		if size < 0 {
-			return fmt.Errorf("max_body_size must be greater than 0")
-		}
-		if size > 104857600 { // 100MB
-			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
-		}
-	}
-
-	// Validate timeout
-	if timeout, ok := config["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if _, err := time.ParseDuration(v); err != nil {
-				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
-			}
-		case int:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		case float64:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		default:
-			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
-		}
-	}
-
-	// Validate auto_auth_path
-	if aap, ok := config["auto_auth_path"]; ok {
-		if _, ok := aap.(string); !ok {
-			return fmt.Errorf("auto_auth_path must be a string")
-		}
-	}
-
-	// Validate default_role
-	if dr, ok := config["default_role"]; ok {
-		if _, ok := dr.(string); !ok {
-			return fmt.Errorf("default_role must be a string")
-		}
-	}
-
-	// Validate tls_skip_verify
-	if v, ok := config["tls_skip_verify"]; ok {
-		switch v := v.(type) {
-		case bool:
-			// valid
-		case string:
-			if v != "true" && v != "false" && v != "1" && v != "0" {
-				return fmt.Errorf("tls_skip_verify must be a boolean, got string: %s", v)
-			}
-		default:
-			return fmt.Errorf("tls_skip_verify must be a boolean, got %T", v)
-		}
-	}
-
-	// Validate ca_data
-	if v, ok := config["ca_data"]; ok {
-		caStr, ok := v.(string)
-		if !ok {
-			return fmt.Errorf("ca_data must be a string")
-		}
-		if caStr != "" {
-			pemBytes, err := base64.StdEncoding.DecodeString(caStr)
-			if err != nil {
-				return fmt.Errorf("ca_data is not valid base64: %w", err)
-			}
-			block, _ := pem.Decode(pemBytes)
-			if block == nil {
-				return fmt.Errorf("ca_data contains no valid PEM data")
-			}
-		}
-	}
-
-	return nil
+	return framework.ValidateTLSConfig(config)
 }
 
 // SensitiveConfigFields returns the list of config fields that should be masked in output

--- a/provider/gitlab/provider.go
+++ b/provider/gitlab/provider.go
@@ -3,7 +3,6 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/stephnangue/warden/credential"
@@ -26,25 +25,6 @@ func extractToken(r *http.Request) string {
 	return ""
 }
 
-// validateGitLabAddress validates that the gitlab_address is a well-formed URL.
-// Unlike other providers, GitLab allows HTTP for development instances.
-func validateGitLabAddress(addr string) error {
-	if addr == "" {
-		return fmt.Errorf("gitlab_address is required")
-	}
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid gitlab_address: %w", err)
-	}
-	if parsed.Scheme != "https" && parsed.Scheme != "http" {
-		return fmt.Errorf("gitlab_address must use http:// or https:// scheme, got: %s", parsed.Scheme)
-	}
-	if parsed.Host == "" {
-		return fmt.Errorf("gitlab_address must include a host")
-	}
-	return nil
-}
-
 // Spec defines the GitLab provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
 	Name:                 "gitlab",
@@ -62,7 +42,7 @@ var Spec = &httpproxy.ProviderSpec{
 		if !ok || addr == "" {
 			return fmt.Errorf("gitlab_address is required")
 		}
-		return validateGitLabAddress(addr)
+		return nil
 	},
 }
 

--- a/provider/httpproxy/config.go
+++ b/provider/httpproxy/config.go
@@ -1,12 +1,6 @@
 package httpproxy
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
-	"fmt"
-	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -26,231 +20,32 @@ type BaseConfig struct {
 // ParseConfig parses standard configuration fields from a mount config map.
 // urlKey is the provider-specific config key for the URL (e.g., "openai_url").
 func ParseConfig(conf map[string]any, urlKey string, defaultURL string, defaultTimeout time.Duration) BaseConfig {
-	config := BaseConfig{
-		ProviderURL: defaultURL,
-		MaxBodySize: framework.DefaultMaxBodySize,
-		Timeout:     defaultTimeout,
+	tlsSkipVerify, caData := framework.ParseTLSConfig(conf)
+	return BaseConfig{
+		ProviderURL:     framework.GetConfigString(conf, urlKey, defaultURL),
+		MaxBodySize:     framework.ParseMaxBodySize(conf),
+		Timeout:         framework.ParseTimeout(conf, defaultTimeout),
+		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
+		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
+		TLSSkipVerify:   tlsSkipVerify,
+		CAData:          caData,
 	}
-
-	if addr, ok := conf[urlKey].(string); ok && addr != "" {
-		config.ProviderURL = addr
-	}
-
-	// Parse max_body_size — handle various JSON number types
-	if maxSize, ok := conf["max_body_size"]; ok {
-		switch v := maxSize.(type) {
-		case int:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case int64:
-			if v > 0 {
-				config.MaxBodySize = v
-			}
-		case float64:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case json.Number:
-			if parsed, err := v.Int64(); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		case string:
-			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		}
-	}
-
-	// Parse timeout — handle duration string or number
-	if timeout, ok := conf["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if parsed, err := time.ParseDuration(v); err == nil {
-				config.Timeout = parsed
-			}
-		case int:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		case float64:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		}
-	}
-
-	// Parse auth settings
-	if aap, ok := conf["auto_auth_path"].(string); ok {
-		config.AutoAuthPath = aap
-	}
-	if dr, ok := conf["default_role"].(string); ok {
-		config.DefaultAuthRole = dr
-	}
-
-	// Parse TLS settings
-	if v, ok := conf["tls_skip_verify"]; ok {
-		switch b := v.(type) {
-		case bool:
-			config.TLSSkipVerify = b
-		case string:
-			config.TLSSkipVerify = b == "true" || b == "1"
-		}
-	}
-	if v, ok := conf["ca_data"].(string); ok {
-		config.CAData = v
-	}
-
-	return config
 }
 
 // ValidateConfig validates the standard configuration fields.
 // urlKey is the provider-specific config key for the URL (e.g., "openai_url").
 func ValidateConfig(conf map[string]any, urlKey string) error {
-	// Parse tls_skip_verify before URL validation so HTTP can be conditionally allowed
-	skipVerify := false
-	if v, ok := conf["tls_skip_verify"]; ok {
-		switch b := v.(type) {
-		case bool:
-			skipVerify = b
-		case string:
-			skipVerify = b == "true" || b == "1"
-		}
-	}
+	skipVerify, _ := framework.ParseTLSConfig(conf)
 
-	// Validate URL if provided
 	if addr, ok := conf[urlKey].(string); ok && addr != "" {
-		if err := ValidateURL(addr, urlKey, skipVerify); err != nil {
+		if err := framework.ValidateURL(addr, urlKey, skipVerify); err != nil {
 			return err
 		}
 	}
 
-	// Validate max_body_size if provided
-	if maxSize, ok := conf["max_body_size"]; ok {
-		var size int64
-		switch v := maxSize.(type) {
-		case int:
-			size = int64(v)
-		case int64:
-			size = v
-		case float64:
-			size = int64(v)
-		case json.Number:
-			parsed, err := v.Int64()
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got json.Number that can't be parsed: %w", err)
-			}
-			size = parsed
-		case string:
-			parsed, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("max_body_size must be an integer, got string that can't be parsed: %w", err)
-			}
-			size = parsed
-		default:
-			return fmt.Errorf("max_body_size must be an integer, got %T", maxSize)
-		}
-		if size <= 0 {
-			return fmt.Errorf("max_body_size must be greater than 0")
-		}
-		if size > 104857600 { // 100MB
-			return fmt.Errorf("max_body_size must not exceed 104857600 bytes (100MB)")
-		}
+	if err := framework.ValidateCommonConfig(conf); err != nil {
+		return err
 	}
 
-	// Validate timeout if provided
-	if timeout, ok := conf["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if _, err := time.ParseDuration(v); err != nil {
-				return fmt.Errorf("invalid timeout format: %w (expected format: '30s', '5m', '1h')", err)
-			}
-		case int:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		case float64:
-			if v < 0 {
-				return fmt.Errorf("timeout must be greater than 0 seconds")
-			}
-		default:
-			return fmt.Errorf("timeout must be a duration string (e.g., '30s') or integer (seconds)")
-		}
-	}
-
-	// Validate auto_auth_path
-	if aap, ok := conf["auto_auth_path"]; ok {
-		if _, ok := aap.(string); !ok {
-			return fmt.Errorf("auto_auth_path must be a string")
-		}
-	}
-
-	// Validate default_role
-	if dr, ok := conf["default_role"]; ok {
-		if _, ok := dr.(string); !ok {
-			return fmt.Errorf("default_role must be a string")
-		}
-	}
-
-	// Validate tls_skip_verify
-	if v, ok := conf["tls_skip_verify"]; ok {
-		switch v := v.(type) {
-		case bool:
-			// valid
-		case string:
-			s := v
-			if s != "true" && s != "false" && s != "1" && s != "0" {
-				return fmt.Errorf("tls_skip_verify must be a boolean, got string: %s", s)
-			}
-		default:
-			return fmt.Errorf("tls_skip_verify must be a boolean, got %T", v)
-		}
-	}
-
-	// Validate ca_data
-	if v, ok := conf["ca_data"]; ok {
-		caStr, ok := v.(string)
-		if !ok {
-			return fmt.Errorf("ca_data must be a string")
-		}
-		if caStr != "" {
-			pemBytes, err := base64.StdEncoding.DecodeString(caStr)
-			if err != nil {
-				return fmt.Errorf("ca_data is not valid base64: %w", err)
-			}
-			block, _ := pem.Decode(pemBytes)
-			if block == nil {
-				return fmt.Errorf("ca_data contains no valid PEM data")
-			}
-		}
-	}
-
-	return nil
-}
-
-// ValidateURL validates that a URL is well-formed with an https:// scheme.
-// When tlsSkipVerify is true, http:// is also accepted for dev/test environments.
-func ValidateURL(addr string, urlKey string, tlsSkipVerify bool) error {
-	if addr == "" {
-		return nil
-	}
-
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid %s: %w", urlKey, err)
-	}
-
-	if parsed.Scheme != "https" {
-		if parsed.Scheme == "http" && tlsSkipVerify {
-			// Allow HTTP when TLS verification is disabled (dev/test)
-		} else {
-			return fmt.Errorf("%s must use https:// scheme, got: %s", urlKey, parsed.Scheme)
-		}
-	}
-
-	if parsed.Host == "" {
-		return fmt.Errorf("%s must include a host", urlKey)
-	}
-
-	return nil
+	return framework.ValidateTLSConfig(conf)
 }

--- a/provider/httpproxy/httpproxy_test.go
+++ b/provider/httpproxy/httpproxy_test.go
@@ -286,7 +286,7 @@ func TestValidateURL(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateURL(tc.addr, "api_url", tc.tlsSkipVerify)
+			err := framework.ValidateURL(tc.addr, "api_url", tc.tlsSkipVerify)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/provider/httpproxy/path_config.go
+++ b/provider/httpproxy/path_config.go
@@ -117,7 +117,7 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		addr := val.(string)
 		if addr != "" {
 			addr = strings.TrimRight(addr, "/")
-			if err := ValidateURL(addr, b.spec.URLConfigKey, skipVerify); err != nil {
+			if err := framework.ValidateURL(addr, b.spec.URLConfigKey, skipVerify); err != nil {
 				return &logical.Response{
 					StatusCode: http.StatusBadRequest,
 					Err:        logical.ErrBadRequest(err.Error()),

--- a/provider/kubernetes/provider.go
+++ b/provider/kubernetes/provider.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
@@ -26,25 +25,6 @@ func extractToken(r *http.Request) string {
 	return ""
 }
 
-// validateKubernetesURL validates that the kubernetes_url is a well-formed HTTPS URL.
-// When tlsSkipVerify is true, http:// is also accepted for dev/test environments.
-func validateKubernetesURL(addr string, tlsSkipVerify bool) error {
-	if addr == "" {
-		return fmt.Errorf("kubernetes_url is required")
-	}
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid kubernetes_url: %w", err)
-	}
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && tlsSkipVerify) {
-		return fmt.Errorf("kubernetes_url must use https:// scheme, got: %s", parsed.Scheme)
-	}
-	if parsed.Host == "" {
-		return fmt.Errorf("kubernetes_url must include a host")
-	}
-	return nil
-}
-
 // Spec defines the Kubernetes provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
 	Name:            "kubernetes",
@@ -63,11 +43,7 @@ var Spec = &httpproxy.ProviderSpec{
 		if !ok || addr == "" {
 			return fmt.Errorf("kubernetes_url is required")
 		}
-		skipVerify := false
-		if v, ok := conf["tls_skip_verify"].(bool); ok {
-			skipVerify = v
-		}
-		return validateKubernetesURL(addr, skipVerify)
+		return nil
 	},
 }
 

--- a/provider/scaleway/README.md
+++ b/provider/scaleway/README.md
@@ -1,0 +1,608 @@
+# Scaleway Provider
+
+The Scaleway provider enables proxied access to Scaleway APIs through Warden. It supports two authentication modes, auto-detected per request:
+
+- **Standard API** — Injects `X-Auth-Token` header with the Scaleway secret key. Covers Instances, Kubernetes, Databases, IAM, Load Balancers, Registries, and all other Scaleway products.
+- **S3 Object Storage** — Verifies the client's SigV4 signature, re-signs with real Scaleway credentials, and forwards to `s3.{region}.scw.cloud`. Compatible with any S3 client (AWS CLI, boto3, s3cmd, MinIO).
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [S3 Object Storage](#s3-object-storage)
+- [TLS Certificate Authentication](#tls-certificate-authentication)
+- [Configuration Reference](#configuration-reference)
+- [Token Management](#token-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- A **Scaleway account** with an API key (access key + secret key) — generate one at [Scaleway Console > IAM > API Keys](https://console.scaleway.com/iam/api-keys)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Add the binary to your PATH:**
+> ```bash
+> export PATH="$PWD:$PATH"
+> ```
+>
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev --dev-root-token=root
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export PATH="$PWD:$PATH"
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="root"
+> ```
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/scaleway-user \
+    token_policies="scaleway-access" \
+    user_claim=sub \
+    cred_spec_name=scaleway-ops
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the Scaleway provider at a path of your choice:
+
+```bash
+warden provider enable --type=scaleway
+```
+
+To mount at a custom path:
+
+```bash
+warden provider enable --type=scaleway scaleway-prod
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider with `auto_auth_path`. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write scaleway/config <<EOF
+{
+  "scaleway_url": "https://api.scaleway.com",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read scaleway/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+### Option A: Static API Keys
+
+Create a Scaleway credential source and spec with your API key pair. The spec is validated at creation time by calling `GET /iam/v1alpha1/api-keys/{access_key}` to verify the key exists.
+
+```bash
+warden cred source create scaleway-src \
+  --type=scaleway \
+  --config=scaleway_url=https://api.scaleway.com
+
+warden cred spec create scaleway-ops \
+  --source scaleway-src \
+  --config mint_method=static_keys \
+  --config access_key=SCWXXXXXXXXXXXXXXXXX \
+  --config secret_key=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+### Option B: Dynamic API Keys (Recommended)
+
+Have Warden create short-lived API keys on demand via the Scaleway IAM API. Keys are automatically revoked when they expire. No long-lived secrets are stored in credential specs.
+
+> **Note:** The Scaleway IAM API is currently `v1alpha1`. While it has been stable in practice (used by the CLI, Terraform, and all SDKs), Scaleway may introduce breaking changes without a deprecation period. If the API version changes, update the `iam_api_path` config on the credential source (e.g., `--config=iam_api_path=/iam/v2`). No code changes required.
+
+**Prerequisites:**
+- A **management API key** with IAM permissions to create and delete API keys
+- A **Scaleway IAM application** that the dynamic keys will be attached to
+
+```bash
+warden cred source create scaleway-dynamic-src \
+  --type=scaleway \
+  --rotation-period=24h \
+  --config=scaleway_url=https://api.scaleway.com \
+  --config=management_secret_key=your-management-secret-key \
+  --config=management_access_key=SCWXXXXXXXXXXXXXXXXX
+
+warden cred spec create scaleway-ops \
+  --source scaleway-dynamic-src \
+  --config mint_method=dynamic_keys \
+  --config application_id=your-iam-application-id \
+  --config default_project_id=your-project-id \
+  --config ttl=1h \
+  --config description=warden-managed
+```
+
+Each credential request creates a fresh API key via `POST /iam/v1alpha1/api-keys` with the configured TTL. When the lease expires, Warden revokes the key via `DELETE /iam/v1alpha1/api-keys/{access_key}`.
+
+### Option C: Vault/OpenBao as Credential Source
+
+Store your Scaleway keys in a Vault/OpenBao KV v2 secret engine and have Warden fetch them at runtime.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your Scaleway keys (e.g., at `secret/scaleway/prod` with `access_key` and `secret_key` fields)
+- An AppRole configured for Warden access
+
+```bash
+warden cred source create scaleway-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+
+warden cred spec create scaleway-ops \
+  --source scaleway-vault-src \
+  --type=scaleway_keys \
+  --config mint_method=static_scaleway \
+  --config kv2_mount=secret \
+  --config secret_path=scaleway/prod
+```
+
+The KV v2 secret at `secret/scaleway/prod` should contain `access_key` and `secret_key` fields.
+
+Verify:
+
+```bash
+warden cred spec read scaleway-ops
+```
+
+## Step 4: Create a Policy
+
+Create a policy that grants access to the Scaleway provider gateway:
+
+```bash
+warden policy write scaleway-access - <<EOF
+path "scaleway/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For fine-grained access control, restrict which Scaleway APIs and regions a role can use:
+
+```bash
+warden policy write scaleway-readonly - <<EOF
+# Allow read-only access to instances in fr-par
+path "scaleway/role/+/gateway/instance/v1/zones/fr-par-*" {
+  capabilities = ["read"]
+}
+
+# Allow read-only access to Kubernetes clusters
+path "scaleway/role/+/gateway/k8s/v1/regions/*" {
+  capabilities = ["read"]
+}
+
+# Allow read-only access to IAM
+path "scaleway/role/+/gateway/iam/*" {
+  capabilities = ["read"]
+}
+
+# Allow read-only access to databases
+path "scaleway/role/+/gateway/rdb/v1/regions/*" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+Verify:
+
+```bash
+warden policy read scaleway-access
+```
+
+## Step 5: Get a JWT and Make Requests
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+Requests use role-based paths. Warden performs implicit JWT authentication and injects the Scaleway credentials automatically.
+
+The URL pattern is: `/v1/scaleway/role/{role}/gateway/{api-path}`
+
+Export SCW_ENDPOINT as environment variable:
+```bash
+export SCW_ENDPOINT="${WARDEN_ADDR}/v1/scaleway/role/scaleway-user/gateway"
+```
+
+### List Instances
+
+```bash
+curl -s "${SCW_ENDPOINT}/instance/v1/zones/fr-par-1/servers" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Kubernetes Clusters
+
+```bash
+curl -s "${SCW_ENDPOINT}/k8s/v1/regions/fr-par/clusters" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Database Instances
+
+```bash
+curl -s "${SCW_ENDPOINT}/rdb/v1/regions/fr-par/instances" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List API Keys (IAM)
+
+```bash
+curl -s "${SCW_ENDPOINT}/iam/v1alpha1/api-keys" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Load Balancers
+
+```bash
+curl -s "${SCW_ENDPOINT}/lb/v1/zones/fr-par-1/lbs" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### Create an Instance
+
+```bash
+curl -s -X POST "${SCW_ENDPOINT}/instance/v1/zones/fr-par-1/servers" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-instance",
+    "commercial_type": "DEV1-S",
+    "image": "ubuntu_jammy",
+    "project": "your-project-id"
+  }'
+```
+
+### Delete an Instance
+
+```bash
+curl -s -X DELETE "${SCW_ENDPOINT}/instance/v1/zones/fr-par-1/servers/{server-id}" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+## S3 Object Storage
+
+The Scaleway provider auto-detects S3 requests by the presence of a SigV4 `Authorization` header. Any S3-compatible client works — AWS CLI, boto3, s3cmd, MinIO Client.
+
+### S3 Transparent Auth with JWT
+
+Configure your S3 client to point at Warden's gateway endpoint. Use your JWT as both the access key and secret key:
+
+```bash
+aws configure set aws_access_key_id "${JWT_TOKEN}"
+aws configure set aws_secret_access_key "${JWT_TOKEN}"
+aws configure set region fr-par
+```
+
+### S3 Transparent Auth with Certificates
+
+For certificate-based authentication, use the role name as both the access key and secret key:
+
+```bash
+aws configure set aws_access_key_id "scaleway-user"
+aws configure set aws_secret_access_key "scaleway-user"
+aws configure set region fr-par
+```
+
+### S3 Operations
+
+```bash
+# List buckets
+aws s3 ls \
+  --endpoint-url "${WARDEN_ADDR}/v1/scaleway/role/scaleway-user/gateway"
+
+# List objects in a bucket
+aws s3 ls s3://my-bucket/ \
+  --endpoint-url "${WARDEN_ADDR}/v1/scaleway/role/scaleway-user/gateway"
+
+# Upload a file
+aws s3 cp myfile.txt s3://my-bucket/myfile.txt \
+  --endpoint-url "${WARDEN_ADDR}/v1/scaleway/role/scaleway-user/gateway"
+
+# Download a file
+aws s3 cp s3://my-bucket/myfile.txt ./downloaded.txt \
+  --endpoint-url "${WARDEN_ADDR}/v1/scaleway/role/scaleway-user/gateway"
+```
+
+### Supported S3 Regions
+
+| Region | Location | S3 Endpoint |
+|--------|----------|-------------|
+| `fr-par` | Paris, France | `s3.fr-par.scw.cloud` |
+| `nl-ams` | Amsterdam, Netherlands | `s3.nl-ams.scw.cloud` |
+| `pl-waw` | Warsaw, Poland | `s3.pl-waw.scw.cloud` |
+| `it-mil` | Milan, Italy | `s3.it-mil.scw.cloud` |
+
+The region is extracted from the SigV4 Authorization header and used to route to the correct Scaleway S3 endpoint.
+
+## Terraform Provider Limitation
+
+The native [Scaleway Terraform provider](https://registry.terraform.io/providers/scaleway/scaleway/latest) (`scaleway/scaleway`) validates that `secret_key` is a UUID, which is incompatible with Warden's JWT-based transparent authentication. It cannot be used to manage Scaleway resources through the Warden gateway.
+
+**Workarounds for Terraform users:**
+
+- **Standard API** — Use the [`Mastercard/restapi`](https://registry.terraform.io/providers/Mastercard/restapi) provider with the JWT in the `Authorization: Bearer` header. This covers all Scaleway API operations (instances, IAM, databases, etc.).
+- **S3 Object Storage** — Use the [`hashicorp/aws`](https://registry.terraform.io/providers/hashicorp/aws) provider with `skip_region_validation = true` and the S3 endpoint set to the Warden gateway URL. The AWS provider performs real SigV4 signing, which Warden detects and re-signs with real Scaleway credentials.
+
+See [`e2e_test/`](e2e_test/) for a working example of this approach.
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
+
+## TLS Certificate Authentication
+
+Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable --type=cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=scaleway-user
+```
+
+### Create a Cert Role
+
+Create a role that binds allowed certificate identities to a credential spec and policy:
+
+```bash
+warden write auth/cert/role/scaleway-user \
+    allowed_common_names="agent-*" \
+    token_policies="scaleway-access" \
+    cred_spec_name=scaleway-ops
+```
+
+The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+
+### Configure Provider for Cert Auth
+
+Update the provider config to use cert auth:
+
+```bash
+warden write scaleway/config <<EOF
+{
+  "scaleway_url": "https://api.scaleway.com",
+  "auto_auth_path": "auth/cert/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+Standard API:
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -s "https://warden.internal/v1/scaleway/role/scaleway-user/gateway/instance/v1/zones/fr-par-1/servers" \
+    -H "Content-Type: application/json"
+```
+
+S3 Object Storage:
+
+```bash
+aws s3 ls s3://my-bucket/ \
+  --endpoint-url "https://warden.internal/v1/scaleway/role/scaleway-user/gateway"
+```
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `scaleway_url` | string | `https://api.scaleway.com` | Scaleway API base URL |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `30s` | Request timeout |
+| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Credential Source Config (Scaleway)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scaleway_url` | string | No | Scaleway API URL (default: `https://api.scaleway.com`) |
+| `management_secret_key` | string | Yes* | Secret key with IAM permissions to create/delete API keys (*required for `dynamic_keys` and rotation) |
+| `management_access_key` | string | Yes* | Access key matching the management secret key (*required for rotation) |
+| `activation_delay` | duration | No | Delay before activating rotated management key (default: `30s`) |
+| `iam_api_path` | string | No | IAM API path prefix (default: `/iam/v1alpha1`). Update when Scaleway promotes the API to stable. |
+| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom CAs |
+| `tls_skip_verify` | bool | No | Skip TLS verification (development only) |
+
+### Credential Spec Config (static_keys)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_keys` |
+| `access_key` | string | Yes | Scaleway access key (starts with `SCW`) |
+| `secret_key` | string | Yes | Scaleway secret key (UUID format, sensitive — masked in output) |
+
+### Credential Spec Config (dynamic_keys)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `dynamic_keys` |
+| `application_id` | string | Yes | IAM application ID to attach keys to |
+| `default_project_id` | string | No | Default project for Object Storage |
+| `ttl` | duration | No | Key lifetime (default: `1h`) |
+| `description` | string | No | Description for created keys (max 200 chars, default: `warden-{spec-name}`) |
+
+### Credential Spec Config (Vault — static_scaleway)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_scaleway` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
+
+### Credential Source Config (Vault/OpenBao)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
+| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
+| `auth_method` | string | No | Authentication method (`approle`) |
+| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
+| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
+| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
+| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
+
+## Token Management
+
+### Static API Keys
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Access key and secret key are stored on the credential spec |
+| **Rotation** | Manual — regenerate in Scaleway Console and update the spec |
+| **Lifetime** | Static — no expiration or auto-refresh |
+| **Revocation** | Scaleway API keys can be deleted via `DELETE /iam/v1alpha1/api-keys/{access_key}` |
+
+**To rotate static API keys:**
+
+1. Generate a new API key in [Scaleway Console > IAM > API Keys](https://console.scaleway.com/iam/api-keys)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update scaleway-ops \
+     --config access_key=SCWNEWKEYXXXXXXXXXX \
+     --config secret_key=new-uuid-secret-key
+   ```
+3. Delete the old API key in Scaleway Console
+
+### Dynamic API Keys
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Management key on the source; no long-lived keys on specs |
+| **Minting** | Fresh API key created via `POST /iam/v1alpha1/api-keys` on each credential request |
+| **Lifetime** | Configurable via `ttl` (default: 1h); Scaleway enforces `expires_at` on the key |
+| **Revocation** | Automatic — Warden calls `DELETE /iam/v1alpha1/api-keys/{access_key}` on lease expiry |
+| **Rotation** | Not needed — keys are ephemeral |
+
+**Automatic management key rotation:**
+
+When both `management_secret_key` and `management_access_key` are configured on the source, Warden can automatically rotate the management key itself. Set a `rotation-period` on the source to enable it:
+
+```bash
+warden cred source create scaleway-dynamic-src \
+  --type=scaleway \
+  --rotation-period=24h \
+  --config=scaleway_url=https://api.scaleway.com \
+  --config=management_secret_key=your-management-secret-key \
+  --config=management_access_key=SCWXXXXXXXXXXXXXXXXX
+```
+
+The rotation flow:
+1. Warden creates a new management key via `POST /iam/v1alpha1/api-keys` for the same IAM application or user
+2. Waits `activation_delay` (default: 30s) for propagation
+3. Activates the new key in the driver
+4. Deletes the old key via `DELETE /iam/v1alpha1/api-keys/{old_access_key}`
+
+Both old and new keys remain valid during the overlap period, ensuring zero downtime.
+
+**Manual management key rotation:**
+
+If automatic rotation is not configured, rotate manually:
+
+1. Generate a new management API key in [Scaleway Console > IAM > API Keys](https://console.scaleway.com/iam/api-keys)
+2. Update the credential source:
+   ```bash
+   warden cred source update scaleway-dynamic-src \
+     --config=management_secret_key=new-management-secret-key \
+     --config=management_access_key=SCWNEWKEYXXXXXXXXXX
+   ```
+3. Delete the old management API key in Scaleway Console

--- a/provider/scaleway/config.go
+++ b/provider/scaleway/config.go
@@ -1,0 +1,54 @@
+package scaleway
+
+import (
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+)
+
+// DefaultScalewayURL is the default Scaleway API base URL (global endpoint)
+const DefaultScalewayURL = "https://api.scaleway.com"
+
+// DefaultScalewayTimeout is the default request timeout for Scaleway API calls
+const DefaultScalewayTimeout = 30 * time.Second
+
+// ProviderConfig holds parsed configuration
+type ProviderConfig struct {
+	ScalewayURL   string
+	MaxBodySize   int64
+	Timeout       time.Duration
+	TLSSkipVerify bool
+	CAData        string
+}
+
+func parseConfig(conf map[string]any) ProviderConfig {
+	tlsSkipVerify, caData := framework.ParseTLSConfig(conf)
+	return ProviderConfig{
+		ScalewayURL:   framework.GetConfigString(conf, "scaleway_url", DefaultScalewayURL),
+		MaxBodySize:   framework.ParseMaxBodySize(conf),
+		Timeout:       framework.ParseTimeout(conf, DefaultScalewayTimeout),
+		TLSSkipVerify: tlsSkipVerify,
+		CAData:        caData,
+	}
+}
+
+// ValidateConfig validates Scaleway provider-specific configuration
+func ValidateConfig(config map[string]any) error {
+	if err := framework.ValidateAllowedKeys(config,
+		"scaleway_url", "max_body_size", "timeout", "auto_auth_path", "default_role",
+		"tls_skip_verify", "ca_data"); err != nil {
+		return err
+	}
+
+	skipVerify, _ := framework.ParseTLSConfig(config)
+	if addr, ok := config["scaleway_url"].(string); ok && addr != "" {
+		if err := framework.ValidateURL(addr, "scaleway_url", skipVerify); err != nil {
+			return err
+		}
+	}
+
+	if err := framework.ValidateCommonConfig(config); err != nil {
+		return err
+	}
+	return framework.ValidateTLSConfig(config)
+}

--- a/provider/scaleway/e2e_test/README.md
+++ b/provider/scaleway/e2e_test/README.md
@@ -1,0 +1,202 @@
+# Scaleway Provider E2E Tests
+
+End-to-end Terraform tests for the Warden Scaleway gateway. These tests validate that Warden correctly proxies requests to Scaleway APIs with automatic credential injection (X-Auth-Token for standard API, SigV4 re-signing for S3 Object Storage).
+
+## Cost
+
+All tests use **free or near-free** resources only:
+- Security groups, IAM applications, IAM policies, IAM API keys — **free**
+- Object Storage buckets with tiny objects — **free** (billed per GB stored, destroyed on cleanup)
+- Direct HTTP data sources — **free** (read-only API calls)
+- **No** compute instances, databases, load balancers, or reserved IPs
+
+## Test Suite
+
+| File | Tests | Provider | What's Tested | Cost |
+|------|-------|----------|---------------|------|
+| `test-01-instances.tf` | 1-3 | restapi + http | Security group CRUD, image listing | Free |
+| `test-02-object-storage.tf` | 4-8 | aws (S3) | Buckets, versioning, lifecycle, objects, CORS | ~Free |
+| `test-03-iam.tf` | 9-13 | restapi + http | IAM application, policy, API key CRUD | Free |
+| `test-04-direct-api.tf` | 14-17 | http | Direct HTTP calls to various Scaleway APIs | Free |
+| `test-05-edge-cases.tf` | 18-25 | http + aws (S3) | Auth failures, 404s, special chars, S3 edge cases | ~Free |
+
+### Provider Strategy
+
+The native Scaleway Terraform provider validates that `secret_key` is a UUID, which conflicts with JWT-based transparent auth. Instead, this test suite uses:
+
+- **`restapi` + `http`** — for standard Scaleway API operations (X-Auth-Token path). The JWT is passed via `Authorization: Bearer` header.
+- **`hashicorp/aws`** — for S3 Object Storage operations (SigV4 path). The AWS provider performs real SigV4 signing using the JWT as both `access_key` and `secret_key`. Warden detects the `AWS4-HMAC-SHA256` header, verifies the signature, re-signs with real Scaleway credentials, and forwards to `s3.{region}.scw.cloud`.
+
+## Prerequisites
+
+1. **Warden server running** with the Scaleway provider mounted
+2. **Scaleway account** with two IAM applications configured (see below)
+3. **JWT auth configured** with a role bound to a Scaleway credential spec
+4. **Terraform >= 1.10** installed
+
+### Scaleway IAM Setup
+
+Create two IAM applications in [Scaleway Console > IAM > Applications](https://console.scaleway.com/iam/applications):
+
+**Application 1: `warden-management`** — manages API key lifecycle
+
+Create a policy with:
+
+| Scope | Permission Set |
+|-------|---------------|
+| Organization | `IAMManager` |
+
+Create an API key for this application. The `access_key` and `secret_key` go into the credential source config (`management_access_key` and `management_secret_key`).
+
+**Application 2: `warden-workload`** — grants access to Scaleway resources
+
+Dynamic API keys are minted for this application by the credential spec. Create a policy with:
+
+| Scope | Permission Set | Used By |
+|-------|---------------|---------|
+| Project | `InstancesFullAccess` | Tests 1-3, 14, 18-21 |
+| Project | `ObjectStorageFullAccess` | Tests 4-8, 24-25 |
+| Project | `KubernetesReadOnly` | Test 22 |
+| Project | `ContainerRegistryReadOnly` | Test 17 |
+| Project | `DomainsDNSReadOnly` | Test 23 |
+| Organization | `IAMManager` | Tests 9-12 |
+| Organization | `ProjectReadOnly` | Test 16 |
+
+Note the application ID of `warden-workload` — it goes into the credential spec config as `application_id`.
+
+## Setup
+
+### 1. Start the identity provider (Hydra)
+
+From the repo root:
+
+```bash
+docker compose -f deploy/docker-compose.quickstart.yml up -d
+```
+
+### 2. Start Warden (dev mode)
+
+```bash
+warden server --dev --dev-root-token=root
+```
+
+### 3. Configure Warden
+
+```bash
+export WARDEN_ADDR="http://127.0.0.1:8400"
+export WARDEN_TOKEN="root"
+
+# Enable JWT auth
+warden auth enable --type=jwt
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create role
+warden write auth/jwt/role/scaleway-user \
+    token_policies="scaleway-access" \
+    user_claim=sub \
+    cred_spec_name=scaleway-ops
+
+# Enable Scaleway provider
+warden provider enable --type=scaleway
+
+# Configure provider
+warden write scaleway/config <<EOF
+{
+  "scaleway_url": "https://api.scaleway.com",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+
+# Create credential source with management app keys (Application 1)
+warden cred source create scaleway-src \
+  --type=scaleway \
+  --rotation-period=24h \
+  --config=management_secret_key=<warden-management-secret-key> \
+  --config=management_access_key=<warden-management-access-key>
+
+# Create credential spec pointing to workload app (Application 2)
+warden cred spec create scaleway-ops \
+  --source scaleway-src \
+  --config mint_method=dynamic_keys \
+  --config application_id=<warden-workload-application-id> \
+  --config default_project_id=<your-project-id> \
+  --config ttl=1h
+
+# Create policy
+warden policy write scaleway-access - <<EOF
+path "scaleway/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+### 4. Get a JWT token
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+### 5. Run tests
+
+```bash
+cd provider/scaleway/e2e_test
+
+export TF_VAR_access_token="${JWT_TOKEN}"
+export TF_VAR_scaleway_project_id="your-project-id"
+
+terraform init
+terraform apply -auto-approve
+```
+
+### 6. Cleanup
+
+```bash
+# Destroy Scaleway resources
+terraform destroy -auto-approve
+
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop Hydra
+docker compose -f deploy/docker-compose.quickstart.yml down -v
+```
+
+## What's Verified
+
+### Standard API (X-Auth-Token injection) — via restapi + http
+- Tests 1-3: Instance operations (image listing, security group CRUD)
+- Tests 9-13: IAM operations (application, policy, API key CRUD)
+- Tests 14-17: Direct HTTP calls to Instance, IAM, Account, and Registry APIs
+
+### S3 Object Storage (SigV4 re-signing) — via hashicorp/aws
+- Tests 4-6: Bucket operations (create, versioning, lifecycle)
+- Test 7: Object upload (PUT with SigV4 signing)
+- Test 8: Bucket with CORS configuration
+- Test 24: Bucket with dots and hyphens in name
+- Test 25: Object with deep nested key path
+
+The AWS provider performs real SigV4 signing. Warden auto-detects this via the `Authorization: AWS4-HMAC-SHA256` header, verifies the client signature, re-signs with real Scaleway credentials, and forwards to `s3.{region}.scw.cloud`.
+
+### Edge Cases
+- Test 18: Unauthenticated request (expect 401/403)
+- Test 19: Invalid JWT token (expect 401/403)
+- Test 20: Non-existent resource (expect 404 forwarded)
+- Test 21: Query parameters with URL-encoded characters
+- Test 22: Deep nested API path (K8s clusters)
+- Test 23: Different API product (DNS zones)
+
+## Customization
+
+Override defaults via variables:
+
+```bash
+# Use a different Warden endpoint
+export TF_VAR_warden_address="http://localhost:8400/v1/scaleway/role/my-role/gateway"
+
+# Use a different region/zone
+export TF_VAR_scaleway_region="nl-ams"
+export TF_VAR_scaleway_zone="nl-ams-1"
+```

--- a/provider/scaleway/e2e_test/main.tf
+++ b/provider/scaleway/e2e_test/main.tf
@@ -1,0 +1,173 @@
+# main.tf - Scaleway Provider Test Suite for Warden Scaleway Gateway
+# Tests Scaleway API operations through Warden's Scaleway proxy/gateway
+#
+# Uses three provider types:
+# - restapi: CRUD operations on Scaleway standard API (X-Auth-Token injection)
+# - http: read-only API calls and edge case tests
+# - aws (S3 only): Object Storage operations via SigV4 signing
+#
+# The native Scaleway Terraform provider cannot be used because it validates
+# that secret_key is a UUID, which conflicts with JWT-based transparent auth.
+# The AWS provider is used for S3 because it performs SigV4 signing which is
+# how Warden detects and proxies Object Storage requests.
+#
+# Prerequisites:
+#   1. Hydra running (deploy/docker-compose.quickstart.yml)
+#   2. Warden server running with Scaleway provider mounted
+#   3. Scaleway credential source and spec configured
+#   4. JWT auth configured with a role bound to the credential spec
+#
+# Usage:
+#   export TF_VAR_access_token="<your-jwt-token>"
+#   export TF_VAR_scaleway_project_id="<your-project-id>"
+#   terraform init && terraform apply
+
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    restapi = {
+      source  = "Mastercard/restapi"
+      version = ">= 1.20"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
+  }
+}
+
+################################################################################
+# Variables
+################################################################################
+
+variable "warden_address" {
+  type        = string
+  description = "Warden Scaleway gateway endpoint URL"
+  default     = "http://localhost:8400/v1/scaleway/role/scaleway-user/gateway"
+}
+
+variable "access_token" {
+  type        = string
+  description = "JWT token for Warden authentication (transparent mode)"
+  sensitive   = true
+}
+
+variable "scaleway_project_id" {
+  type        = string
+  description = "Scaleway project ID for resource creation"
+}
+
+variable "scaleway_region" {
+  type        = string
+  description = "Scaleway region for resources"
+  default     = "fr-par"
+}
+
+variable "scaleway_zone" {
+  type        = string
+  description = "Scaleway zone for zonal resources"
+  default     = "fr-par-1"
+}
+
+variable "scaleway_organization_id" {
+  type        = string
+  description = "Scaleway organization ID (required for IAM operations)"
+}
+
+################################################################################
+# Providers
+################################################################################
+
+# Scaleway standard API via Warden gateway (for CRUD operations)
+# Warden authenticates via the Authorization: Bearer header, then injects
+# the real X-Auth-Token for the upstream Scaleway API.
+provider "restapi" {
+  uri                  = var.warden_address
+  write_returns_object = true
+  create_method        = "POST"
+  update_method        = "PATCH"
+  destroy_method       = "DELETE"
+  id_attribute         = "id"
+
+  headers = {
+    Content-Type  = "application/json"
+    Accept        = "application/json"
+    Authorization = "Bearer ${var.access_token}"
+  }
+}
+
+# AWS provider for S3 Object Storage operations (SigV4 signing)
+# Pointed at Warden's gateway — Warden detects the SigV4 Authorization header,
+# verifies the client signature, re-signs with real Scaleway credentials, and
+# forwards to s3.{region}.scw.cloud.
+# The JWT is used as both access_key and secret_key (Warden transparent auth).
+provider "aws" {
+  region     = var.scaleway_region
+  access_key = var.access_token
+  secret_key = var.access_token
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+
+  endpoints {
+    s3 = var.warden_address
+  }
+
+  s3_use_path_style = true
+}
+
+################################################################################
+# Random suffix for unique naming
+################################################################################
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+################################################################################
+# Locals
+################################################################################
+
+locals {
+  name_prefix = "warden-scw-test-${random_id.suffix.hex}"
+
+  # Common headers for http data source requests
+  common_headers = {
+    Accept        = "application/json"
+    Authorization = "Bearer ${var.access_token}"
+  }
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "name_prefix" {
+  value       = local.name_prefix
+  description = "Name prefix used for all test resources"
+}
+
+output "test_timestamp" {
+  value       = timestamp()
+  description = "Timestamp when tests were run"
+}
+
+output "warden_gateway_url" {
+  value       = var.warden_address
+  description = "Warden Scaleway gateway URL used for testing"
+}

--- a/provider/scaleway/e2e_test/test-01-instances.tf
+++ b/provider/scaleway/e2e_test/test-01-instances.tf
@@ -1,0 +1,74 @@
+# test-01-instances.tf
+# Tests 1-3: Scaleway Instance operations via restapi/http (zero cost)
+# Validates: X-Auth-Token injection, GET proxying, security group CRUD
+
+################################################################################
+# Test 1: List available instance images
+# Verifies the gateway injects X-Auth-Token and proxies GET requests
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_01_images" {
+  url             = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/images?per_page=1&arch=x86_64"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 2: Create a security group
+# Verifies POST/DELETE operations through the gateway
+# Cost: FREE (security groups are not billed)
+################################################################################
+resource "restapi_object" "test_02_security_group" {
+  path         = "/instance/v1/zones/${var.scaleway_zone}/security_groups"
+  read_path    = "/instance/v1/zones/${var.scaleway_zone}/security_groups/{id}"
+  destroy_path = "/instance/v1/zones/${var.scaleway_zone}/security_groups/{id}"
+
+  data = jsonencode({
+    name                    = "${local.name_prefix}-sg"
+    description             = "Warden Scaleway e2e test security group"
+    project                 = var.scaleway_project_id
+    inbound_default_policy  = "drop"
+    outbound_default_policy = "accept"
+    stateful                = true
+  })
+
+  id_attribute = "security_group/id"
+}
+
+################################################################################
+# Test 3: Read back the security group
+# Verifies GET with resource ID lookup
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_03_sg_read" {
+  url             = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/security_groups/${restapi_object.test_02_security_group.id}"
+  request_headers = local.common_headers
+
+  depends_on = [restapi_object.test_02_security_group]
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_01_images" {
+  value = {
+    status_code = data.http.test_01_images.status_code
+    has_images  = try(length(jsondecode(data.http.test_01_images.response_body).images) > 0, false)
+  }
+  description = "Test 1: Instance images list"
+}
+
+output "test_02_security_group" {
+  value = {
+    id = restapi_object.test_02_security_group.id
+  }
+  description = "Test 2: Security group created"
+}
+
+output "test_03_sg_read" {
+  value = {
+    status_code = data.http.test_03_sg_read.status_code
+    name        = try(jsondecode(data.http.test_03_sg_read.response_body).security_group.name, "")
+  }
+  description = "Test 3: Security group read-back"
+}

--- a/provider/scaleway/e2e_test/test-02-object-storage.tf
+++ b/provider/scaleway/e2e_test/test-02-object-storage.tf
@@ -1,0 +1,148 @@
+# test-02-object-storage.tf
+# Tests 4-8: Scaleway Object Storage via AWS provider (SigV4 signing)
+# Validates: SigV4 auto-detection, signature verification, re-signing,
+#            bucket CRUD, object upload
+# Cost: ~FREE (charges only for stored data, destroyed on cleanup)
+#
+# The AWS provider performs real SigV4 signing using the JWT as both
+# access_key and secret_key. Warden detects the AWS4-HMAC-SHA256
+# Authorization header, verifies the client signature, re-signs with
+# real Scaleway credentials, and forwards to s3.{region}.scw.cloud.
+
+################################################################################
+# Test 4: Create a basic S3 bucket
+# Verifies SigV4 signature detection and re-signing for bucket creation
+################################################################################
+resource "aws_s3_bucket" "test_04" {
+  bucket        = "${local.name_prefix}-basic"
+  force_destroy = true
+
+  tags = {
+    Name       = "Warden S3 basic test"
+    TestNumber = "04"
+  }
+}
+
+################################################################################
+# Test 5: Create a bucket with versioning
+# Verifies complex S3 configuration through the gateway
+################################################################################
+resource "aws_s3_bucket" "test_05" {
+  bucket        = "${local.name_prefix}-versioned"
+  force_destroy = true
+
+  tags = {
+    Name       = "Warden S3 versioned test"
+    TestNumber = "05"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test_05" {
+  bucket = aws_s3_bucket.test_05.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+################################################################################
+# Test 6: Upload a second object with different content type
+# Verifies PUT object with custom headers through SigV4 re-signing
+################################################################################
+resource "aws_s3_object" "test_06" {
+  bucket       = aws_s3_bucket.test_04.id
+  key          = "test/data.json"
+  content      = jsonencode({ message = "hello", version = 1 })
+  content_type = "application/json"
+
+  tags = {
+    TestNumber = "06"
+  }
+}
+
+################################################################################
+# Test 7: Upload a small object
+# Verifies PUT object with SigV4 re-signing
+################################################################################
+resource "aws_s3_object" "test_07" {
+  bucket  = aws_s3_bucket.test_04.id
+  key     = "test/hello.txt"
+  content = "Hello from Warden Scaleway e2e test"
+
+  tags = {
+    TestNumber = "07"
+  }
+}
+
+################################################################################
+# Test 8: Create a bucket with CORS configuration
+# Verifies complex S3 CORS rules through the gateway
+################################################################################
+resource "aws_s3_bucket" "test_08" {
+  bucket        = "${local.name_prefix}-cors"
+  force_destroy = true
+
+  tags = {
+    Name       = "Warden S3 CORS test"
+    TestNumber = "08"
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "test_08" {
+  bucket = aws_s3_bucket.test_08.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["https://example.com"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_04_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_04.id
+    bucket = aws_s3_bucket.test_04.bucket
+    arn    = aws_s3_bucket.test_04.arn
+  }
+  description = "Test 4: Basic bucket"
+}
+
+output "test_05_versioned_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_05.id
+    bucket = aws_s3_bucket.test_05.bucket
+  }
+  description = "Test 5: Versioned bucket"
+}
+
+output "test_06_json_object" {
+  value = {
+    bucket = aws_s3_object.test_06.bucket
+    key    = aws_s3_object.test_06.key
+    etag   = aws_s3_object.test_06.etag
+  }
+  description = "Test 6: JSON object"
+}
+
+output "test_07_object" {
+  value = {
+    bucket = aws_s3_object.test_07.bucket
+    key    = aws_s3_object.test_07.key
+    etag   = aws_s3_object.test_07.etag
+  }
+  description = "Test 7: Uploaded object"
+}
+
+output "test_08_cors_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_08.id
+    bucket = aws_s3_bucket.test_08.bucket
+  }
+  description = "Test 8: CORS bucket"
+}

--- a/provider/scaleway/e2e_test/test-03-iam.tf
+++ b/provider/scaleway/e2e_test/test-03-iam.tf
@@ -1,0 +1,142 @@
+# test-03-iam.tf
+# Tests 9-13: Scaleway IAM operations via restapi/http (zero cost)
+# Validates: IAM application, policy, API key CRUD through the gateway
+
+locals {
+  api_key_expires_at = timeadd(timestamp(), "1h")
+}
+
+################################################################################
+# Test 9: Create an IAM application
+# Verifies IAM API access through the gateway
+# Cost: FREE
+################################################################################
+resource "restapi_object" "test_09_application" {
+  path         = "/iam/v1alpha1/applications"
+  read_path    = "/iam/v1alpha1/applications/{id}"
+  destroy_path = "/iam/v1alpha1/applications/{id}"
+
+  data = jsonencode({
+    name            = "${local.name_prefix}-app"
+    description     = "Warden Scaleway e2e test application"
+    organization_id = var.scaleway_organization_id
+  })
+}
+
+################################################################################
+# Test 10: Create an IAM policy for the application
+# Verifies policy creation with nested rules
+# Cost: FREE
+################################################################################
+resource "restapi_object" "test_10_policy" {
+  path         = "/iam/v1alpha1/policies"
+  read_path    = "/iam/v1alpha1/policies/{id}"
+  destroy_path = "/iam/v1alpha1/policies/{id}"
+
+  data = jsonencode({
+    name            = "${local.name_prefix}-policy"
+    description     = "Warden e2e test policy - read-only Object Storage"
+    organization_id = var.scaleway_organization_id
+    application_id  = restapi_object.test_09_application.id
+    rules = [
+      {
+        project_ids          = [var.scaleway_project_id]
+        permission_set_names = ["ObjectStorageReadOnly"]
+      }
+    ]
+  })
+
+  depends_on = [restapi_object.test_09_application]
+}
+
+################################################################################
+# Test 11: Create an API key for the application
+# Verifies POST /iam/v1alpha1/api-keys (same endpoint used by the driver)
+# Cost: FREE
+################################################################################
+resource "restapi_object" "test_11_api_key" {
+  path         = "/iam/v1alpha1/api-keys"
+  read_path    = "/iam/v1alpha1/api-keys/{id}"
+  destroy_path = "/iam/v1alpha1/api-keys/{id}"
+
+  data = jsonencode({
+    application_id     = restapi_object.test_09_application.id
+    description        = "Warden e2e test key"
+    default_project_id = var.scaleway_project_id
+    expires_at         = local.api_key_expires_at
+  })
+
+  id_attribute = "access_key"
+
+  depends_on = [restapi_object.test_09_application]
+}
+
+################################################################################
+# Test 12: Read back the API key
+# Verifies GET /iam/v1alpha1/api-keys/{access_key}
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_12_api_key_read" {
+  url             = "${var.warden_address}/iam/v1alpha1/api-keys/${restapi_object.test_11_api_key.id}"
+  request_headers = local.common_headers
+
+  depends_on = [restapi_object.test_11_api_key]
+}
+
+################################################################################
+# Test 13: Create a second application
+# Verifies multiple IAM resources can coexist
+# Cost: FREE
+################################################################################
+resource "restapi_object" "test_13_application_2" {
+  path         = "/iam/v1alpha1/applications"
+  read_path    = "/iam/v1alpha1/applications/{id}"
+  destroy_path = "/iam/v1alpha1/applications/{id}"
+
+  data = jsonencode({
+    name            = "${local.name_prefix}-app-2"
+    description     = "Warden Scaleway e2e second test application"
+    organization_id = var.scaleway_organization_id
+  })
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_09_application" {
+  value = {
+    id = restapi_object.test_09_application.id
+  }
+  description = "Test 9: IAM application"
+}
+
+output "test_10_policy" {
+  value = {
+    id = restapi_object.test_10_policy.id
+  }
+  description = "Test 10: IAM policy"
+}
+
+output "test_11_api_key" {
+  value = {
+    access_key = restapi_object.test_11_api_key.id
+  }
+  description = "Test 11: IAM API key"
+  sensitive   = true
+}
+
+output "test_12_api_key_read" {
+  value = {
+    status_code    = data.http.test_12_api_key_read.status_code
+    application_id = try(jsondecode(data.http.test_12_api_key_read.response_body).application_id, "")
+  }
+  description = "Test 12: IAM API key read-back"
+}
+
+output "test_13_application_2" {
+  value = {
+    id = restapi_object.test_13_application_2.id
+  }
+  description = "Test 13: Second IAM application"
+}

--- a/provider/scaleway/e2e_test/test-04-direct-api.tf
+++ b/provider/scaleway/e2e_test/test-04-direct-api.tf
@@ -1,0 +1,71 @@
+# test-04-direct-api.tf
+# Tests 14-17: Direct HTTP API calls through the Warden gateway (zero cost)
+# Validates: raw HTTP proxying, query parameters, various API products
+
+################################################################################
+# Test 14: List instances via direct API call
+# Verifies raw GET proxying with X-Auth-Token injection
+################################################################################
+data "http" "test_14_instances" {
+  url             = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/servers?per_page=1"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 15: List IAM API keys via direct API call
+# Verifies IAM API proxying (v1alpha1 path)
+################################################################################
+data "http" "test_15_iam" {
+  url             = "${var.warden_address}/iam/v1alpha1/api-keys?page_size=1"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 16: List projects via Account API
+# Verifies a different API product through the same gateway
+################################################################################
+data "http" "test_16_account" {
+  url             = "${var.warden_address}/account/v3/projects?page_size=1"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 17: List container registry namespaces
+# Verifies yet another API product
+################################################################################
+data "http" "test_17_registry" {
+  url             = "${var.warden_address}/registry/v1/regions/${var.scaleway_region}/namespaces?page_size=1"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_14_instances" {
+  value = {
+    status_code = data.http.test_14_instances.status_code
+  }
+  description = "Test 14: Direct Instance API call"
+}
+
+output "test_15_iam" {
+  value = {
+    status_code = data.http.test_15_iam.status_code
+  }
+  description = "Test 15: Direct IAM API call"
+}
+
+output "test_16_account" {
+  value = {
+    status_code = data.http.test_16_account.status_code
+  }
+  description = "Test 16: Direct Account API call"
+}
+
+output "test_17_registry" {
+  value = {
+    status_code = data.http.test_17_registry.status_code
+  }
+  description = "Test 17: Direct Registry API call"
+}

--- a/provider/scaleway/e2e_test/test-05-edge-cases.tf
+++ b/provider/scaleway/e2e_test/test-05-edge-cases.tf
@@ -1,0 +1,167 @@
+# test-05-edge-cases.tf
+# Tests 18-25: Edge cases and error handling through Warden gateway
+# Validates: auth failures, 404s, special characters, S3 edge cases
+# Cost: ~FREE
+
+################################################################################
+# Test 18: Request without authentication (should fail)
+# Verifies Warden rejects unauthenticated requests to the gateway
+################################################################################
+data "http" "test_18_no_auth" {
+  url = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/servers"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 401 || self.status_code == 403
+      error_message = "Expected 401/403 for unauthenticated request, got ${self.status_code}"
+    }
+  }
+}
+
+################################################################################
+# Test 19: Request with invalid token (should fail)
+# Verifies Warden rejects requests with invalid JWT tokens
+################################################################################
+data "http" "test_19_invalid_token" {
+  url = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/servers"
+
+  request_headers = {
+    Accept        = "application/json"
+    Authorization = "Bearer invalid-token-value-not-a-jwt"
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 401 || self.status_code == 403
+      error_message = "Expected 401/403 for invalid token, got ${self.status_code}"
+    }
+  }
+}
+
+################################################################################
+# Test 20: Non-existent resource (should return 404)
+# Verifies the gateway forwards Scaleway's 404 for missing resources
+################################################################################
+data "http" "test_20_not_found" {
+  url             = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/servers/00000000-0000-0000-0000-000000000000"
+  request_headers = local.common_headers
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 404
+      error_message = "Expected 404 for non-existent server, got ${self.status_code}"
+    }
+  }
+}
+
+################################################################################
+# Test 21: Query parameters with special characters
+# Verifies the gateway preserves query strings with encoding
+################################################################################
+data "http" "test_21_query_params" {
+  url             = "${var.warden_address}/instance/v1/zones/${var.scaleway_zone}/servers?per_page=1&page=1&name=nonexistent%20server"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 22: Deep nested API path (Kubernetes)
+# Verifies the gateway handles long URL paths correctly
+################################################################################
+data "http" "test_22_deep_path" {
+  url             = "${var.warden_address}/k8s/v1/regions/${var.scaleway_region}/clusters?page_size=1"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 23: Different API product — DNS
+# Verifies the gateway works across different Scaleway API products
+################################################################################
+data "http" "test_23_dns" {
+  url             = "${var.warden_address}/domain/v2beta1/dns-zones?page_size=1"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 24: S3 bucket with special characters in name
+# Verifies SigV4 handles bucket names with dots and hyphens
+################################################################################
+resource "aws_s3_bucket" "test_24" {
+  bucket        = "${local.name_prefix}-edge.case-bucket"
+  force_destroy = true
+
+  tags = {
+    Name       = "Warden S3 edge case"
+    TestNumber = "24"
+  }
+}
+
+################################################################################
+# Test 25: S3 object with deep key path
+# Verifies SigV4 re-signing handles complex object keys
+################################################################################
+resource "aws_s3_object" "test_25" {
+  bucket  = aws_s3_bucket.test_24.id
+  key     = "deep/nested/path/file.json"
+  content = jsonencode({ test = true, number = 25 })
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_18_no_auth" {
+  value       = data.http.test_18_no_auth.status_code
+  description = "Test 18: Unauthenticated request (expected 401/403)"
+}
+
+output "test_19_invalid_token" {
+  value       = data.http.test_19_invalid_token.status_code
+  description = "Test 19: Invalid token (expected 401/403)"
+}
+
+output "test_20_not_found" {
+  value       = data.http.test_20_not_found.status_code
+  description = "Test 20: Non-existent resource (expected 404)"
+}
+
+output "test_21_query_params" {
+  value = {
+    status_code = data.http.test_21_query_params.status_code
+  }
+  description = "Test 21: Query params with encoding"
+}
+
+output "test_22_deep_path" {
+  value = {
+    status_code = data.http.test_22_deep_path.status_code
+  }
+  description = "Test 22: Deep nested API path (K8s)"
+}
+
+output "test_23_dns" {
+  value = {
+    status_code = data.http.test_23_dns.status_code
+  }
+  description = "Test 23: DNS API product"
+}
+
+output "test_24_edge_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_24.id
+    bucket = aws_s3_bucket.test_24.bucket
+  }
+  description = "Test 24: Bucket with dots and hyphens in name"
+}
+
+output "test_25_edge_object" {
+  value = {
+    bucket = aws_s3_object.test_25.bucket
+    key    = aws_s3_object.test_25.key
+    etag   = aws_s3_object.test_25.etag
+  }
+  description = "Test 25: Object with deep key path"
+}

--- a/provider/scaleway/path_config.go
+++ b/provider/scaleway/path_config.go
@@ -1,0 +1,148 @@
+package scaleway
+
+import (
+	"context"
+	"net/http"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathConfig returns the config path definition for the Scaleway provider
+func (b *scalewayBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"scaleway_url": {
+				Type:        framework.TypeString,
+				Description: "Scaleway API base URL (default: https://api.scaleway.com)",
+				Default:     DefaultScalewayURL,
+			},
+			"max_body_size": {
+				Type:        framework.TypeInt,
+				Description: "Maximum request body size in bytes (default: 10MB, max: 100MB)",
+				Default:     framework.DefaultMaxBodySize,
+			},
+			"timeout": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Request timeout duration (e.g., '30s', '5m')",
+				Default:     "30s",
+			},
+			"auto_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Path to auth mount for implicit authentication (e.g., 'auth/jwt/', 'auth/cert/')",
+			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default auth role when not specified in the request",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read Scaleway provider configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure Scaleway provider settings",
+			},
+		},
+		HelpSynopsis:    "Configure Scaleway provider",
+		HelpDescription: "This endpoint configures the Scaleway provider settings including API URL, body size limits, and timeouts.",
+	}
+}
+
+// handleConfigRead handles reading the Scaleway provider configuration
+func (b *scalewayBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"scaleway_url":   b.scalewayURL,
+			"max_body_size":  b.MaxBodySize,
+			"timeout":        b.Timeout.String(),
+			"auto_auth_path": tc.AutoAuthPath,
+			"default_role":   tc.DefaultAuthRole,
+		},
+	}, nil
+}
+
+// handleConfigWrite handles writing the Scaleway provider configuration
+func (b *scalewayBackend) handleConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	conf := make(map[string]any)
+
+	if val, ok := d.GetOk("scaleway_url"); ok {
+		conf["scaleway_url"] = val
+	}
+	if val, ok := d.GetOk("max_body_size"); ok {
+		conf["max_body_size"] = val
+	}
+	if val, ok := d.GetOk("timeout"); ok {
+		conf["timeout"] = val
+	}
+
+	if err := ValidateConfig(conf); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        err,
+		}, nil
+	}
+
+	parsedConfig := parseConfig(conf)
+	b.scalewayURL = parsedConfig.ScalewayURL
+	b.MaxBodySize = parsedConfig.MaxBodySize
+	b.Timeout = parsedConfig.Timeout
+
+	// Transparent mode settings
+	tc := &framework.TransparentConfig{
+		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
+		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+	}
+	if val, ok := d.GetOk("auto_auth_path"); ok {
+		tc.AutoAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("default_role"); ok {
+		tc.DefaultAuthRole = val.(string)
+	}
+
+	if tc.AutoAuthPath == "" {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+		}, nil
+	}
+
+	b.StreamingBackend.SetTransparentConfig(tc)
+
+	// Persist config to storage
+	if b.StorageView != nil {
+		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+			"scaleway_url":   b.scalewayURL,
+			"max_body_size":  b.MaxBodySize,
+			"timeout":        b.Timeout.String(),
+			"auto_auth_path": tc.AutoAuthPath,
+			"default_role":   tc.DefaultAuthRole,
+		})
+		if err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+		if err := b.StorageView.Put(ctx, entry); err != nil {
+			return &logical.Response{
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"message": "configuration updated",
+		},
+	}, nil
+}

--- a/provider/scaleway/path_gateway.go
+++ b/provider/scaleway/path_gateway.go
@@ -1,0 +1,278 @@
+package scaleway
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sigv4"
+)
+
+// extractAPIPath strips the Warden gateway prefix from the request URL path,
+// returning only the upstream API path (e.g., "/instance/v1/zones/fr-par-1/servers").
+func extractAPIPath(fullPath string) string {
+	idx := strings.Index(fullPath, "/gateway")
+	if idx == -1 {
+		return fullPath
+	}
+	apiPath := fullPath[idx+len("/gateway"):]
+	if apiPath == "" {
+		return "/"
+	}
+	return apiPath
+}
+
+// handleGateway auto-detects the request type and delegates accordingly.
+func (b *scalewayBackend) handleGateway(ctx context.Context, req *logical.Request) {
+	if b.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		defer cancel()
+		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
+	}
+
+	if sigv4.IsSigV4Request(req.HTTPRequest) {
+		b.handleS3Request(ctx, req)
+	} else {
+		b.handleAPIRequest(ctx, req)
+	}
+}
+
+// handleAPIRequest proxies standard Scaleway API requests with X-Auth-Token injection.
+func (b *scalewayBackend) handleAPIRequest(ctx context.Context, req *logical.Request) {
+	bodyBytes, err := sigv4.ReadRequestBody(req.HTTPRequest, b.MaxBodySize)
+	if err != nil {
+		http.Error(req.ResponseWriter, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+
+	secretKey, err := b.getSecretKey(req)
+	if err != nil {
+		b.Logger.Warn("Failed to extract Scaleway credentials", logger.Err(err))
+		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Build target URL — strip the Warden gateway prefix
+	apiPath := extractAPIPath(req.HTTPRequest.URL.Path)
+	targetURL := strings.TrimRight(b.scalewayURL, "/") + apiPath
+
+	outReq, err := http.NewRequestWithContext(ctx, req.HTTPRequest.Method, targetURL, nil)
+	if err != nil {
+		b.Logger.Error("failed to create outgoing request", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers, strip Warden/proxy headers
+	for k, vv := range req.HTTPRequest.Header {
+		for _, v := range vv {
+			outReq.Header.Add(k, v)
+		}
+	}
+	for _, h := range []string{
+		"X-Warden-Token", "X-Warden-Role",
+		"Connection", "Keep-Alive", "Transfer-Encoding", "Upgrade",
+		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
+		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",
+		"Proxy-Authenticate", "Proxy-Authorization",
+	} {
+		outReq.Header.Del(h)
+	}
+
+	// Inject Scaleway auth
+	outReq.Header.Set("X-Auth-Token", secretKey)
+	outReq.Header.Set("User-Agent", "warden-scaleway-proxy")
+
+	// Set body
+	if len(bodyBytes) > 0 {
+		outReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		outReq.ContentLength = int64(len(bodyBytes))
+	}
+
+	// Copy query string
+	outReq.URL.RawQuery = req.HTTPRequest.URL.RawQuery
+
+	// Forward
+	transport := b.Proxy.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	resp, err := transport.RoundTrip(outReq)
+	if err != nil {
+		b.Logger.Error("API forward failed", logger.Err(err))
+		http.Error(req.ResponseWriter, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			req.ResponseWriter.Header().Add(k, v)
+		}
+	}
+	req.ResponseWriter.WriteHeader(resp.StatusCode)
+
+	if flusher, ok := req.ResponseWriter.(http.Flusher); ok {
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				req.ResponseWriter.Write(buf[:n])
+				flusher.Flush()
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	} else {
+		io.Copy(req.ResponseWriter, resp.Body)
+	}
+}
+
+// handleS3Request proxies S3-compatible requests with SigV4 verification and re-signing.
+func (b *scalewayBackend) handleS3Request(ctx context.Context, req *logical.Request) {
+	// Set URL scheme and host
+	if req.HTTPRequest.URL.Scheme == "" {
+		if req.HTTPRequest.TLS != nil {
+			req.HTTPRequest.URL.Scheme = "https"
+		} else {
+			req.HTTPRequest.URL.Scheme = "http"
+		}
+	}
+	if req.HTTPRequest.URL.Host == "" {
+		req.HTTPRequest.URL.Host = req.HTTPRequest.Host
+	}
+
+	// Step 1: Read and buffer request body
+	bodyBytes, err := sigv4.ReadRequestBody(req.HTTPRequest, b.MaxBodySize)
+	if err != nil {
+		http.Error(req.ResponseWriter, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+	if bodyBytes == nil {
+		bodyBytes = []byte{}
+	}
+
+	// Step 2: Extract service, region, and access key from Authorization header
+	service, region, _, err := sigv4.ExtractFromAuthHeader(req.HTTPRequest.Header.Get("Authorization"))
+	if err != nil {
+		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Step 3: Reconstruct client credentials for signature verification
+	accessKeyID := sigv4.ExtractAccessKeyID(req.HTTPRequest.Header.Get("Authorization"))
+	verifyCreds := awssdk.Credentials{
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: accessKeyID, // JWT or cert: client uses same value for both
+	}
+
+	// Step 4: Verify incoming signature
+	s3SignerOpts := []func(*v4.SignerOptions){
+		func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true },
+	}
+	valid, err := sigv4.VerifyIncomingSignature(b.Logger, s3SignerOpts, req.HTTPRequest, bodyBytes, verifyCreds, service, region)
+	if err != nil {
+		b.Logger.Warn("Signature verification failed", logger.Err(err))
+		http.Error(req.ResponseWriter, "Signature verification failed", http.StatusForbidden)
+		return
+	}
+	if !valid {
+		b.Logger.Warn("Signature does not match")
+		http.Error(req.ResponseWriter, "Signature does not match", http.StatusForbidden)
+		return
+	}
+
+	// Step 5: Get real Scaleway credentials
+	scaleCreds, err := b.getS3Credentials(req)
+	if err != nil {
+		b.Logger.Warn("Failed to extract Scaleway S3 credentials", logger.Err(err))
+		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Step 6: Build target URL for Scaleway S3
+	// Strip the Warden gateway prefix and set the S3 endpoint
+	apiPath := extractAPIPath(req.HTTPRequest.URL.Path)
+	targetHost := fmt.Sprintf("s3.%s.scw.cloud", region)
+	req.HTTPRequest.URL.Scheme = "https"
+	req.HTTPRequest.URL.Host = targetHost
+	req.HTTPRequest.URL.Path = apiPath
+	req.HTTPRequest.URL.RawPath = ""
+	req.HTTPRequest.Host = targetHost
+	req.HTTPRequest.RequestURI = ""
+
+	b.Logger.Trace("S3 request details",
+		logger.String("method", req.HTTPRequest.Method),
+		logger.String("targetHost", targetHost),
+		logger.String("path", req.HTTPRequest.URL.Path),
+		logger.String("service", service),
+		logger.String("region", region),
+		logger.String("request_id", req.RequestID),
+	)
+
+	// Step 7: Normalize request
+	bodyBytes = sigv4.NormalizeRequest(b.Logger, req.HTTPRequest, bodyBytes)
+
+	// Step 8: Re-sign with real Scaleway credentials
+	if err := sigv4.ResignRequest(ctx, b.s3Signer, req.HTTPRequest, scaleCreds, "s3", region, bodyBytes); err != nil {
+		b.Logger.Error("Failed to re-sign request", logger.Err(err))
+		http.Error(req.ResponseWriter, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Step 9: Forward directly
+	transport := b.Proxy.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	sigv4.ForwardDirect(b.Logger, req.ResponseWriter, req.HTTPRequest, bodyBytes, transport)
+}
+
+// getSecretKey extracts the Scaleway secret key from the credential.
+func (b *scalewayBackend) getSecretKey(req *logical.Request) (string, error) {
+	if req.Credential == nil {
+		return "", fmt.Errorf("no credential available")
+	}
+	switch req.Credential.Type {
+	case credential.TypeScalewayKeys:
+		secretKey := req.Credential.Data["secret_key"]
+		if secretKey == "" {
+			return "", fmt.Errorf("credential missing secret_key")
+		}
+		return secretKey, nil
+	default:
+		return "", fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+	}
+}
+
+// getS3Credentials extracts Scaleway access_key and secret_key for SigV4 signing.
+func (b *scalewayBackend) getS3Credentials(req *logical.Request) (awssdk.Credentials, error) {
+	if req.Credential == nil {
+		return awssdk.Credentials{}, fmt.Errorf("no credential available")
+	}
+	switch req.Credential.Type {
+	case credential.TypeScalewayKeys:
+		accessKey := req.Credential.Data["access_key"]
+		secretKey := req.Credential.Data["secret_key"]
+		if accessKey == "" || secretKey == "" {
+			return awssdk.Credentials{}, fmt.Errorf("credential missing access_key or secret_key")
+		}
+		return awssdk.Credentials{
+			AccessKeyID:     accessKey,
+			SecretAccessKey: secretKey,
+		}, nil
+	default:
+		return awssdk.Credentials{}, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+	}
+}

--- a/provider/scaleway/provider.go
+++ b/provider/scaleway/provider.go
@@ -1,0 +1,258 @@
+package scaleway
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sigv4"
+)
+
+// scalewayBackend is the backend for Scaleway provider operations
+type scalewayBackend struct {
+	*framework.StreamingBackend
+	s3Signer    *v4.Signer // SigV4 signer with DisableURIPathEscaping for S3
+	scalewayURL string     // Scaleway API base URL (default: https://api.scaleway.com)
+}
+
+// extractToken extracts the client token from the request.
+// Handles three modes:
+//   - Standard: X-Warden-Token or Authorization: Bearer
+//   - S3 JWT transparent: JWT (eyJ prefix) in SigV4 Credential access_key_id
+//   - S3 Cert transparent: role name from SigV4 Credential access_key_id
+func extractToken(r *http.Request) string {
+	// Standard Warden token
+	if token := r.Header.Get("X-Warden-Token"); token != "" {
+		return token
+	}
+
+	// Bearer token
+	authHeader := r.Header.Get("Authorization")
+	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
+		return authHeader[7:]
+	}
+
+	// S3 transparent: extract access_key_id from SigV4 header
+	if sigv4.IsSigV4Request(r) {
+		accessKeyID := sigv4.ExtractAccessKeyID(authHeader)
+		if accessKeyID != "" {
+			return accessKeyID
+		}
+	}
+
+	return ""
+}
+
+// Compile-time interface assertion
+var _ logical.TransparentAuthRoleExtractor = (*scalewayBackend)(nil)
+
+// GetAuthRoleFromRequest extracts the auth role from the SigV4 Authorization header.
+// For S3 requests, the access_key_id is used as the role name (cert transparent auth).
+// For JWT transparent auth, the JWT is the access_key_id and role comes from the path or X-Warden-Role.
+func (b *scalewayBackend) GetAuthRoleFromRequest(r *http.Request) (string, bool) {
+	if !sigv4.IsSigV4Request(r) {
+		return "", false
+	}
+	accessKeyID := sigv4.ExtractAccessKeyID(r.Header.Get("Authorization"))
+	if accessKeyID == "" {
+		return "", false
+	}
+	// JWT tokens start with "eyJ" — they carry auth identity, not the role name
+	if strings.HasPrefix(accessKeyID, "eyJ") {
+		return "", false
+	}
+	return accessKeyID, true
+}
+
+// Factory creates a new Scaleway provider backend
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &scalewayBackend{
+		s3Signer: v4.NewSigner(func(o *v4.SignerOptions) {
+			o.DisableURIPathEscaping = true
+		}),
+		scalewayURL: DefaultScalewayURL,
+	}
+
+	b.StreamingBackend = &framework.StreamingBackend{
+		StreamingPaths: []*framework.StreamingPath{
+			{
+				Pattern:         "gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Scaleway Gateway proxy",
+				HelpDescription: "Proxies requests to Scaleway APIs with auto-detection of standard API vs S3",
+			},
+			{
+				Pattern:         "gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Scaleway Gateway proxy",
+				HelpDescription: "Proxies requests to Scaleway APIs with auto-detection of standard API vs S3",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Scaleway Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to Scaleway APIs with role embedded in URL path",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "Scaleway Transparent Gateway proxy",
+				HelpDescription: "Proxies requests to Scaleway APIs with role embedded in URL path",
+			},
+		},
+		TransparentConfig: &framework.TransparentConfig{
+			AutoAuthPath:    "",
+			DefaultAuthRole: "",
+		},
+		Backend: &framework.Backend{
+			Help:           scalewayBackendHelp,
+			BackendType:    "scaleway",
+			BackendClass:   logical.ClassProvider,
+			TokenExtractor: extractToken,
+			Paths:          b.paths(),
+		},
+	}
+
+	b.Logger = conf.Logger.WithSubsystem("scaleway")
+	b.StorageView = conf.StorageView
+
+	initTransport()
+	b.StreamingBackend.InitProxy(sharedTransport)
+
+	if conf.RegisterShutdownHook != nil {
+		conf.RegisterShutdownHook("scaleway-transport", ShutdownHTTPTransport)
+	}
+
+	if err := b.StreamingBackend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	if len(conf.Config) > 0 {
+		if err := ValidateConfig(conf.Config); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+		parsedConfig := parseConfig(conf.Config)
+		b.scalewayURL = parsedConfig.ScalewayURL
+		b.MaxBodySize = parsedConfig.MaxBodySize
+		b.Timeout = parsedConfig.Timeout
+	}
+
+	if b.MaxBodySize <= 0 {
+		b.MaxBodySize = framework.DefaultMaxBodySize
+	}
+	if b.Timeout <= 0 {
+		b.Timeout = DefaultScalewayTimeout
+	}
+
+	return b, nil
+}
+
+// Initialize loads persisted config from storage
+func (b *scalewayBackend) Initialize(ctx context.Context) error {
+	if b.StorageView == nil {
+		return nil
+	}
+
+	entry, err := b.StorageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry != nil {
+		var config struct {
+			ScalewayURL     string `json:"scaleway_url"`
+			MaxBodySize     int64  `json:"max_body_size"`
+			Timeout         string `json:"timeout"`
+			AutoAuthPath    string `json:"auto_auth_path"`
+			DefaultAuthRole string `json:"default_role"`
+		}
+		if err := entry.DecodeJSON(&config); err != nil {
+			return fmt.Errorf("failed to decode config: %w", err)
+		}
+		if config.ScalewayURL != "" {
+			b.scalewayURL = config.ScalewayURL
+		}
+		b.MaxBodySize = config.MaxBodySize
+		if config.Timeout != "" {
+			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
+				b.Timeout = timeout
+			}
+		}
+
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			AutoAuthPath:    config.AutoAuthPath,
+			DefaultAuthRole: config.DefaultAuthRole,
+		})
+	}
+	return nil
+}
+
+// paths returns the configuration paths for the Scaleway provider
+func (b *scalewayBackend) paths() []*framework.Path {
+	return []*framework.Path{
+		b.pathConfig(),
+	}
+}
+
+// handleGatewayStreaming wraps handleGateway for the streaming path handler
+func (b *scalewayBackend) handleGatewayStreaming(ctx context.Context, req *logical.Request, fd *framework.FieldData) error {
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// SensitiveConfigFields returns the list of config fields that should be masked in output
+func (b *scalewayBackend) SensitiveConfigFields() []string {
+	return []string{}
+}
+
+const scalewayBackendHelp = `
+The Scaleway provider enables proxying requests to Scaleway APIs with automatic
+credential management and dual authentication mode support.
+
+The provider auto-detects the request type based on the Authorization header:
+- Standard API requests: injects X-Auth-Token header with the Scaleway secret key
+  and forwards to the configured scaleway_url (default: https://api.scaleway.com)
+- S3 Object Storage requests (AWS SigV4): verifies the incoming signature, re-signs
+  with real Scaleway credentials, and forwards to s3.{region}.scw.cloud
+
+The gateway path format is:
+  /scaleway/gateway/{api-path}
+
+The role can be provided via the X-Warden-Role header, or embedded in
+the URL path:
+  /scaleway/role/{role}/gateway/{api-path}
+
+Standard API examples:
+  /scaleway/role/{role}/gateway/instance/v1/zones/fr-par-1/servers
+  /scaleway/role/{role}/gateway/k8s/v1/regions/fr-par/clusters
+  /scaleway/role/{role}/gateway/rdb/v1/regions/fr-par/instances
+  /scaleway/role/{role}/gateway/iam/v1alpha1/api-keys
+  /scaleway/role/{role}/gateway/lb/v1/zones/fr-par-1/lbs
+  /scaleway/role/{role}/gateway/registry/v1/regions/fr-par/namespaces
+
+S3 Object Storage:
+  Clients sign requests with SigV4 using their Warden JWT (as both
+  aws_access_key_id and aws_secret_access_key) or role name (cert auth).
+  Warden verifies the signature, re-signs with real Scaleway keys, and
+  forwards to the regional S3 endpoint.
+
+  Supported S3 regions: fr-par, nl-ams, pl-waw, it-mil
+
+Three credential source types are supported:
+- scaleway (static_keys): Static API keys stored on the spec
+- scaleway (dynamic_keys): Ephemeral API keys minted via the IAM API
+  (POST /iam/v1alpha1/api-keys) with automatic revocation on lease expiry.
+  The management key supports automatic rotation.
+- hvault (static_scaleway): Keys fetched from a Vault/OpenBao KV v2 secret
+
+Configuration:
+- scaleway_url: Scaleway API base URL (default: https://api.scaleway.com)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 30s)
+- auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`

--- a/provider/scaleway/provider_test.go
+++ b/provider/scaleway/provider_test.go
@@ -1,0 +1,563 @@
+package scaleway
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sigv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+type inmemStorage struct {
+	mu   sync.RWMutex
+	data map[string]*sdklogical.StorageEntry
+}
+
+func newInmemStorage() *inmemStorage {
+	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
+}
+
+func (s *inmemStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func (s *inmemStorage) ListPage(ctx context.Context, prefix string, after string, limit int) ([]string, error) {
+	return s.List(ctx, prefix)
+}
+
+func (s *inmemStorage) Get(ctx context.Context, key string) (*sdklogical.StorageEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key], nil
+}
+
+func (s *inmemStorage) Put(ctx context.Context, entry *sdklogical.StorageEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[entry.Key] = entry
+	return nil
+}
+
+func (s *inmemStorage) Delete(ctx context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func createTestLogger() *logger.GatedLogger {
+	config := &logger.Config{
+		Level:   logger.TraceLevel,
+		Format:  logger.DefaultFormat,
+		Outputs: []io.Writer{io.Discard},
+	}
+	gl, _ := logger.NewGatedLogger(config, logger.GatedWriterConfig{
+		Underlying:   io.Discard,
+		InitialState: logger.GateOpen,
+	})
+	return gl
+}
+
+func makeFieldData(path *framework.Path, raw map[string]interface{}) *framework.FieldData {
+	return &framework.FieldData{
+		Raw:    raw,
+		Schema: path.Fields,
+	}
+}
+
+// --- Factory tests ---
+
+func TestFactory(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	sb := b.(*scalewayBackend)
+	assert.Equal(t, DefaultScalewayURL, sb.scalewayURL)
+	assert.Equal(t, framework.DefaultMaxBodySize, sb.MaxBodySize)
+	assert.Equal(t, DefaultScalewayTimeout, sb.Timeout)
+	assert.NotNil(t, sb.s3Signer)
+}
+
+func TestFactory_WithConfig(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+		Config: map[string]any{
+			"scaleway_url":  "https://api.fr-par.scaleway.com",
+			"max_body_size": int64(5242880),
+			"timeout":       "60s",
+		},
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+
+	sb := b.(*scalewayBackend)
+	assert.Equal(t, "https://api.fr-par.scaleway.com", sb.scalewayURL)
+	assert.Equal(t, int64(5242880), sb.MaxBodySize)
+}
+
+func TestFactory_InvalidConfig(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+		Config: map[string]any{
+			"unknown_key": "value",
+		},
+	}
+
+	_, err := Factory(ctx, conf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown configuration key")
+}
+
+// --- Config path tests ---
+
+func TestPathConfig_ReadDefaults(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+
+	sb := b.(*scalewayBackend)
+	path := sb.pathConfig()
+
+	resp, err := sb.handleConfigRead(ctx, &logical.Request{}, makeFieldData(path, nil))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, DefaultScalewayURL, resp.Data["scaleway_url"])
+}
+
+func TestPathConfig_Write(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+
+	sb := b.(*scalewayBackend)
+	path := sb.pathConfig()
+
+	raw := map[string]interface{}{
+		"scaleway_url":   "https://api.nl-ams.scaleway.com",
+		"timeout":        30,
+		"auto_auth_path": "auth/jwt/",
+		"default_role":   "reader",
+	}
+
+	resp, err := sb.handleConfigWrite(ctx, &logical.Request{}, makeFieldData(path, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, "https://api.nl-ams.scaleway.com", sb.scalewayURL)
+}
+
+func TestPathConfig_Write_MissingAutoAuthPath(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+
+	sb := b.(*scalewayBackend)
+	path := sb.pathConfig()
+
+	raw := map[string]interface{}{
+		"scaleway_url": "https://api.scaleway.com",
+	}
+
+	resp, err := sb.handleConfigWrite(ctx, &logical.Request{}, makeFieldData(path, raw))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// --- Token extraction tests ---
+
+func TestExtractToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected string
+	}{
+		{
+			name:     "X-Warden-Token",
+			headers:  map[string]string{"X-Warden-Token": "my-token"},
+			expected: "my-token",
+		},
+		{
+			name:     "Bearer token",
+			headers:  map[string]string{"Authorization": "Bearer my-jwt"},
+			expected: "my-jwt",
+		},
+		{
+			name:     "SigV4 with JWT access key",
+			headers:  map[string]string{"Authorization": "AWS4-HMAC-SHA256 Credential=eyJhbGciOiJSUzI1NiJ9/20260410/fr-par/s3/aws4_request, SignedHeaders=host, Signature=abc123"},
+			expected: "eyJhbGciOiJSUzI1NiJ9",
+		},
+		{
+			name:     "SigV4 with role name access key",
+			headers:  map[string]string{"Authorization": "AWS4-HMAC-SHA256 Credential=my-role/20260410/fr-par/s3/aws4_request, SignedHeaders=host, Signature=abc123"},
+			expected: "my-role",
+		},
+		{
+			name:     "no auth headers",
+			headers:  map[string]string{},
+			expected: "",
+		},
+		{
+			name:     "X-Warden-Token takes precedence",
+			headers:  map[string]string{"X-Warden-Token": "warden-token", "Authorization": "Bearer other"},
+			expected: "warden-token",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			for k, v := range tt.headers {
+				r.Header.Set(k, v)
+			}
+			assert.Equal(t, tt.expected, extractToken(r))
+		})
+	}
+}
+
+// --- TransparentAuthRoleExtractor tests ---
+
+func TestGetAuthRoleFromRequest(t *testing.T) {
+	b := &scalewayBackend{}
+
+	tests := []struct {
+		name       string
+		authHeader string
+		wantRole   string
+		wantOK     bool
+	}{
+		{
+			name:       "cert transparent - role name as access_key_id",
+			authHeader: "AWS4-HMAC-SHA256 Credential=scaleway-admin/20260410/fr-par/s3/aws4_request, SignedHeaders=host, Signature=abc",
+			wantRole:   "scaleway-admin",
+			wantOK:     true,
+		},
+		{
+			name:       "JWT transparent - JWT as access_key_id - no role",
+			authHeader: "AWS4-HMAC-SHA256 Credential=eyJhbGciOiJSUzI1NiJ9/20260410/fr-par/s3/aws4_request, SignedHeaders=host, Signature=abc",
+			wantRole:   "",
+			wantOK:     false,
+		},
+		{
+			name:       "non-SigV4 request",
+			authHeader: "Bearer some-token",
+			wantRole:   "",
+			wantOK:     false,
+		},
+		{
+			name:       "empty authorization header",
+			authHeader: "",
+			wantRole:   "",
+			wantOK:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			if tt.authHeader != "" {
+				r.Header.Set("Authorization", tt.authHeader)
+			}
+			role, ok := b.GetAuthRoleFromRequest(r)
+			assert.Equal(t, tt.wantRole, role)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+// --- IsSigV4Request detection tests ---
+
+func TestIsSigV4RequestDetection(t *testing.T) {
+	t.Run("SigV4 request", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/", nil)
+		r.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260410/fr-par/s3/aws4_request")
+		assert.True(t, sigv4.IsSigV4Request(r))
+	})
+
+	t.Run("Bearer request", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/", nil)
+		r.Header.Set("Authorization", "Bearer some-token")
+		assert.False(t, sigv4.IsSigV4Request(r))
+	})
+
+	t.Run("no auth header", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/", nil)
+		assert.False(t, sigv4.IsSigV4Request(r))
+	})
+}
+
+// --- Credential extraction tests ---
+
+func TestGetSecretKey(t *testing.T) {
+	b := &scalewayBackend{}
+
+	t.Run("valid scaleway_keys credential", func(t *testing.T) {
+		req := &logical.Request{
+			Credential: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"access_key": "SCWXXXXXXXXXXXXXXXXX",
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+		}
+		key, err := b.getSecretKey(req)
+		require.NoError(t, err)
+		assert.Equal(t, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", key)
+	})
+
+	t.Run("missing secret_key field", func(t *testing.T) {
+		req := &logical.Request{
+			Credential: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				},
+			},
+		}
+		_, err := b.getSecretKey(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret_key")
+	})
+
+	t.Run("nil credential", func(t *testing.T) {
+		req := &logical.Request{}
+		_, err := b.getSecretKey(req)
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported credential type", func(t *testing.T) {
+		req := &logical.Request{
+			Credential: &credential.Credential{
+				Type: credential.TypeAPIKey,
+				Data: map[string]string{"api_key": "test"},
+			},
+		}
+		_, err := b.getSecretKey(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported")
+	})
+}
+
+func TestGetS3Credentials(t *testing.T) {
+	b := &scalewayBackend{}
+
+	t.Run("valid credentials", func(t *testing.T) {
+		req := &logical.Request{
+			Credential: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"access_key": "SCWXXXXXXXXXXXXXXXXX",
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+		}
+		creds, err := b.getS3Credentials(req)
+		require.NoError(t, err)
+		assert.Equal(t, "SCWXXXXXXXXXXXXXXXXX", creds.AccessKeyID)
+		assert.Equal(t, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", creds.SecretAccessKey)
+	})
+
+	t.Run("missing access_key", func(t *testing.T) {
+		req := &logical.Request{
+			Credential: &credential.Credential{
+				Type: credential.TypeScalewayKeys,
+				Data: map[string]string{
+					"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				},
+			},
+		}
+		_, err := b.getS3Credentials(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key or secret_key")
+	})
+
+	t.Run("nil credential", func(t *testing.T) {
+		req := &logical.Request{}
+		_, err := b.getS3Credentials(req)
+		require.Error(t, err)
+	})
+}
+
+// --- API gateway tests ---
+
+func TestHandleAPIRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "warden-scaleway-proxy", r.Header.Get("User-Agent"))
+		assert.NotEmpty(t, r.Header.Get("X-Auth-Token"))
+		assert.Empty(t, r.Header.Get("X-Warden-Token"))
+		assert.Equal(t, "/instance/v1/zones/fr-par-1/servers", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"servers":[]}`))
+	}))
+	defer upstream.Close()
+
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+	sb := b.(*scalewayBackend)
+	sb.scalewayURL = upstream.URL // set after factory to bypass HTTPS validation
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("GET", "/instance/v1/zones/fr-par-1/servers", nil)
+	httpReq.Header.Set("X-Warden-Token", "should-be-stripped")
+
+	req := &logical.Request{
+		HTTPRequest:    httpReq,
+		ResponseWriter: rec,
+		Credential: &credential.Credential{
+			Type: credential.TypeScalewayKeys,
+			Data: map[string]string{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "test-secret-key",
+			},
+		},
+	}
+
+	sb.handleAPIRequest(ctx, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "servers")
+}
+
+// --- Config validation tests ---
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]any
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid config",
+			config:  map[string]any{"scaleway_url": "https://api.scaleway.com", "timeout": "30s"},
+			wantErr: false,
+		},
+		{
+			name:    "unknown key",
+			config:  map[string]any{"unknown": "value"},
+			wantErr: true,
+			errMsg:  "unknown configuration key",
+		},
+		{
+			name:    "max_body_size too large",
+			config:  map[string]any{"max_body_size": int64(200000000)},
+			wantErr: true,
+			errMsg:  "must not exceed",
+		},
+		{
+			name:    "invalid timeout format",
+			config:  map[string]any{"timeout": "invalid"},
+			wantErr: true,
+			errMsg:  "invalid timeout format",
+		},
+		{
+			name:    "empty config",
+			config:  map[string]any{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- SensitiveConfigFields test ---
+
+func TestSensitiveConfigFields(t *testing.T) {
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	}
+
+	b, err := Factory(ctx, conf)
+	require.NoError(t, err)
+
+	sb := b.(*scalewayBackend)
+	assert.Empty(t, sb.SensitiveConfigFields())
+}
+
+// --- Paths test ---
+
+func TestPaths(t *testing.T) {
+	b := &scalewayBackend{}
+	paths := b.paths()
+	require.Len(t, paths, 1)
+	assert.Equal(t, "config", paths[0].Pattern)
+}
+
+// --- Transport tests ---
+
+func TestShutdownHTTPTransport(t *testing.T) {
+	// Should not panic
+	ShutdownHTTPTransport()
+}

--- a/provider/scaleway/transport.go
+++ b/provider/scaleway/transport.go
@@ -1,0 +1,61 @@
+package scaleway
+
+import (
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+var (
+	sharedTransport *http.Transport
+	transportOnce   sync.Once
+)
+
+func initTransport() {
+	transportOnce.Do(func() {
+		sharedTransport = newTransport()
+	})
+}
+
+// newTransport creates an HTTP transport optimized for Scaleway workloads
+func newTransport() *http.Transport {
+	transport := &http.Transport{
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 100,
+		MaxConnsPerHost:     0,
+		IdleConnTimeout:     90 * time.Second,
+
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ClientSessionCache: tls.NewLRUClientSessionCache(100),
+		},
+
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 20 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+
+	if err := http2.ConfigureTransport(transport); err != nil {
+		log.Printf("Failed to configure HTTP/2: %v", err)
+	}
+
+	return transport
+}
+
+// ShutdownHTTPTransport should be called during application shutdown
+func ShutdownHTTPTransport() {
+	if sharedTransport != nil {
+		sharedTransport.CloseIdleConnections()
+	}
+}

--- a/provider/servicenow/provider.go
+++ b/provider/servicenow/provider.go
@@ -2,7 +2,6 @@ package servicenow
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/stephnangue/warden/provider/httpproxy"
@@ -11,25 +10,6 @@ import (
 // DefaultServiceNowTimeout is the default request timeout for ServiceNow API calls.
 // ServiceNow APIs can be slow for large table queries, so a 60s default is used.
 const DefaultServiceNowTimeout = 60 * time.Second
-
-// validateServiceNowURL validates that the servicenow_url is a well-formed HTTPS URL.
-// When tlsSkipVerify is true, http:// is also accepted for dev/test environments.
-func validateServiceNowURL(addr string, tlsSkipVerify bool) error {
-	if addr == "" {
-		return fmt.Errorf("servicenow_url is required")
-	}
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid servicenow_url: %w", err)
-	}
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && tlsSkipVerify) {
-		return fmt.Errorf("servicenow_url must use https:// scheme, got: %s", parsed.Scheme)
-	}
-	if parsed.Host == "" {
-		return fmt.Errorf("servicenow_url must include a host")
-	}
-	return nil
-}
 
 // Spec defines the ServiceNow provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
@@ -46,11 +26,7 @@ var Spec = &httpproxy.ProviderSpec{
 		if !ok || addr == "" {
 			return fmt.Errorf("servicenow_url is required")
 		}
-		skipVerify := false
-		if v, ok := conf["tls_skip_verify"].(bool); ok {
-			skipVerify = v
-		}
-		return validateServiceNowURL(addr, skipVerify)
+		return nil
 	},
 }
 

--- a/provider/sigv4/sigv4.go
+++ b/provider/sigv4/sigv4.go
@@ -1,0 +1,494 @@
+// Package sigv4 provides reusable AWS Signature Version 4 utilities for
+// providers that proxy S3-compatible storage APIs (AWS, Scaleway, Cloudflare R2, OVH).
+package sigv4
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/go-chi/chi/middleware"
+	"github.com/stephnangue/warden/logger"
+)
+
+
+var (
+	// AuthRegex parses the SigV4 Authorization header into access_key_id, date, region, service.
+	AuthRegex = regexp.MustCompile(`AWS4-HMAC-SHA256 Credential=([^/]+)/([^/]+)/([^/]+)/([^/]+)/aws4_request`)
+
+	// SignRegex extracts the hex signature value.
+	SignRegex = regexp.MustCompile(`Signature=([a-f0-9]+)`)
+
+	// SignedHeadersRegex extracts the semicolon-delimited signed headers list.
+	SignedHeadersRegex = regexp.MustCompile(`SignedHeaders=([^,]+)`)
+)
+
+// IsSigV4Request returns true if the request carries an AWS SigV4 Authorization header.
+func IsSigV4Request(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256")
+}
+
+// ExtractFromAuthHeader parses service, region, and access key from a SigV4 Authorization header.
+func ExtractFromAuthHeader(authHeader string) (service, region, accessKeyID string, err error) {
+	if authHeader == "" {
+		return "", "", "", fmt.Errorf("empty authorization header")
+	}
+	matches := AuthRegex.FindStringSubmatch(authHeader)
+	if len(matches) != 5 {
+		return "", "", "", fmt.Errorf("invalid authorization header format")
+	}
+	return matches[4], matches[3], matches[1], nil
+}
+
+// ExtractAccessKeyID extracts the Access Key ID from a SigV4 Authorization header.
+func ExtractAccessKeyID(authHeader string) string {
+	const prefix = "Credential="
+	idx := strings.Index(authHeader, prefix)
+	if idx == -1 {
+		return ""
+	}
+	start := idx + len(prefix)
+	if start >= len(authHeader) {
+		return ""
+	}
+	end := strings.IndexByte(authHeader[start:], '/')
+	if end == -1 {
+		return ""
+	}
+	return authHeader[start : start+end]
+}
+
+// ComputePayloadHash computes the SHA256 hash of the payload.
+func ComputePayloadHash(body []byte) string {
+	h := sha256.New()
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ParseAWSDate parses the AWS date format (YYYYMMDDTHHMMSSZ).
+func ParseAWSDate(dateStr string) (time.Time, error) {
+	return time.Parse("20060102T150405Z", dateStr)
+}
+
+// ReadRequestBody reads and buffers the request body, enforcing maxSize.
+func ReadRequestBody(r *http.Request, maxSize int64) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	reader := io.Reader(r.Body)
+	if maxSize > 0 {
+		reader = io.LimitReader(r.Body, maxSize)
+	}
+	bodyBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	r.Body.Close()
+	if maxSize > 0 && int64(len(bodyBytes)) >= maxSize {
+		return nil, fmt.Errorf("request body exceeds maximum size of %d bytes", maxSize)
+	}
+	return bodyBytes, nil
+}
+
+// RestoreRequestBody sets the request body back to the given bytes.
+func RestoreRequestBody(r *http.Request, bodyBytes []byte) {
+	if len(bodyBytes) > 0 {
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		r.ContentLength = int64(len(bodyBytes))
+	} else {
+		r.Body = nil
+		r.ContentLength = 0
+	}
+}
+
+// NormalizeRequest prepares a request for re-signing by decoding aws-chunked
+// bodies, stripping trailer-related headers, and removing hop-by-hop/proxy
+// headers that would break the signature. Returns the (possibly decoded) body bytes.
+func NormalizeRequest(log *logger.GatedLogger, r *http.Request, bodyBytes []byte) []byte {
+	// Decode aws-chunked body
+	if IsAWSChunked(r) {
+		decoded, err := DecodeAWSChunkedBody(bodyBytes)
+		if err != nil {
+			log.Warn("failed to decode aws-chunked body, using original",
+				logger.Err(err),
+				logger.String("request_id", middleware.GetReqID(r.Context())),
+			)
+		} else {
+			bodyBytes = decoded
+		}
+		RemoveAWSChunkedEncoding(r)
+		r.Header.Del("X-Amz-Decoded-Content-Length")
+		r.Header.Del("X-Amz-Content-Sha256")
+		r.Header.Del("Accept-Encoding")
+		r.Header.Del("Content-Length")
+		r.Header.Del("Expect")
+	}
+
+	// Strip trailing-checksum headers when X-Amz-Trailer is present.
+	if r.Header.Get("X-Amz-Trailer") != "" {
+		r.Header.Del("X-Amz-Trailer")
+		r.Header.Del("X-Amz-Sdk-Checksum-Algorithm")
+		r.Header.Del("X-Amz-Checksum-Algorithm")
+		for key := range r.Header {
+			if strings.HasPrefix(strings.ToLower(key), "x-amz-checksum-") {
+				r.Header.Del(key)
+			}
+		}
+	}
+
+	// Remove hop-by-hop headers (RFC 2616 Section 13.5.1)
+	removedHeaders := []string{}
+	for _, h := range []string{
+		"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
+		"Te", "Trailer", "Trailers", "Transfer-Encoding", "Upgrade",
+	} {
+		if r.Header.Get(h) != "" {
+			removedHeaders = append(removedHeaders, h)
+			r.Header.Del(h)
+		}
+	}
+
+	// Remove proxy-specific headers
+	for _, h := range []string{
+		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
+		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",
+	} {
+		if r.Header.Get(h) != "" {
+			removedHeaders = append(removedHeaders, h)
+			r.Header.Del(h)
+		}
+	}
+
+	// Remove headers listed in Connection header
+	if connectionHeaders := r.Header.Get("Connection"); connectionHeaders != "" {
+		for _, connHeader := range strings.Split(connectionHeaders, ",") {
+			trimmed := strings.TrimSpace(connHeader)
+			if trimmed != "" {
+				removedHeaders = append(removedHeaders, trimmed)
+				r.Header.Del(trimmed)
+			}
+		}
+	}
+
+	if len(removedHeaders) > 0 {
+		log.Trace("headers removed during normalization",
+			logger.Any("removed_headers", removedHeaders),
+			logger.String("request_id", middleware.GetReqID(r.Context())),
+		)
+	}
+
+	return bodyBytes
+}
+
+// ResignRequest re-signs the request with the given credentials.
+// The request must already be normalized via NormalizeRequest.
+func ResignRequest(
+	ctx context.Context,
+	signer *v4.Signer,
+	r *http.Request,
+	creds aws.Credentials,
+	service, region string,
+	bodyBytes []byte,
+) error {
+	payloadHash := ComputePayloadHash(bodyBytes)
+	r.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	signingTime := time.Now()
+	if amzDate := r.Header.Get("X-Amz-Date"); amzDate != "" {
+		if t, err := ParseAWSDate(amzDate); err == nil {
+			signingTime = t
+		}
+	}
+
+	r.Header.Del("Authorization")
+	RestoreRequestBody(r, bodyBytes)
+
+	if err := signer.SignHTTP(ctx, creds, r, payloadHash, service, region, signingTime); err != nil {
+		return fmt.Errorf("failed to sign request: %w", err)
+	}
+	return nil
+}
+
+// VerifyIncomingSignature verifies the AWS Signature V4 of the incoming request.
+// It accepts signer options rather than a signer instance because the v4.Signer
+// caches derived signing keys — reusing a signer across different credentials
+// produces incorrect results. A fresh signer is created per verification call.
+func VerifyIncomingSignature(
+	log *logger.GatedLogger,
+	signerOpts []func(*v4.SignerOptions),
+	r *http.Request,
+	bodyBytes []byte,
+	creds aws.Credentials,
+	service, region string,
+) (bool, error) {
+	// Extract the provided signature
+	authHeader := r.Header.Get("Authorization")
+	signMatches := SignRegex.FindStringSubmatch(authHeader)
+	if len(signMatches) != 2 {
+		return false, fmt.Errorf("signature not found in authorization header")
+	}
+	providedSignature := signMatches[1]
+
+	// Extract the signed headers list
+	signedHeadersMatches := SignedHeadersRegex.FindStringSubmatch(authHeader)
+	if len(signedHeadersMatches) != 2 {
+		return false, fmt.Errorf("signed headers not found in authorization header")
+	}
+	signedHeadersList := strings.Split(signedHeadersMatches[1], ";")
+
+	// Get the signing time
+	amzDate := r.Header.Get("X-Amz-Date")
+	if amzDate == "" {
+		amzDate = r.Header.Get("Date")
+	}
+	if amzDate == "" {
+		return false, fmt.Errorf("no date header found")
+	}
+	signingTime, err := ParseAWSDate(amzDate)
+	if err != nil {
+		return false, fmt.Errorf("invalid date format: %w", err)
+	}
+
+	// Replay protection
+	if time.Since(signingTime) > 15*time.Minute {
+		return false, fmt.Errorf("signature expired: signed at %s", signingTime.Format(time.RFC3339))
+	}
+
+	// Clone the request for verification
+	testReq := r.Clone(r.Context())
+
+	log.Trace("Signature Verification Debug",
+		logger.String("method", testReq.Method),
+		logger.String("url", testReq.URL.String()),
+		logger.String("host", testReq.Host),
+		logger.String("path", testReq.URL.Path),
+		logger.String("rawPath", testReq.URL.RawPath),
+		logger.String("escapedPath", testReq.URL.EscapedPath()),
+		logger.String("rawQuery", testReq.URL.RawQuery),
+		logger.String("signingTime", signingTime.Format(time.RFC3339)),
+		logger.String("service", service),
+		logger.String("region", region),
+		logger.Any("signedHeaders", signedHeadersList),
+		logger.String("request_id", middleware.GetReqID(r.Context())),
+	)
+
+	// Build a new header map containing only the headers the client signed.
+	newHeaders := make(http.Header)
+	contentLengthSigned := false
+	for _, signedHeader := range signedHeadersList {
+		signedHeaderLower := strings.ToLower(strings.TrimSpace(signedHeader))
+
+		if signedHeaderLower == "authorization" {
+			continue
+		}
+		if signedHeaderLower == "content-length" {
+			contentLengthSigned = true
+		}
+		if signedHeaderLower == "host" {
+			testReq.Host = r.Host
+			testReq.URL.Host = r.Host
+			continue
+		}
+
+		for originalHeaderKey, originalHeaderValues := range r.Header {
+			if strings.ToLower(originalHeaderKey) == signedHeaderLower {
+				canonicalKey := http.CanonicalHeaderKey(signedHeader)
+				newHeaders[canonicalKey] = originalHeaderValues
+				break
+			}
+		}
+
+		if newHeaders.Get(signedHeader) == "" && signedHeaderLower != "host" {
+			log.Warn("signed header not found in request",
+				logger.String("header", signedHeader),
+				logger.String("request_id", middleware.GetReqID(r.Context())),
+			)
+		}
+	}
+	testReq.Header = newHeaders
+
+	// Restore body in the cloned request
+	if len(bodyBytes) > 0 {
+		testReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	if contentLengthSigned {
+		testReq.ContentLength = int64(len(bodyBytes))
+	} else {
+		testReq.ContentLength = -1
+	}
+
+	// Determine payload hash for signature verification
+	payloadHash := r.Header.Get("X-Amz-Content-Sha256")
+	if payloadHash == "" {
+		payloadHash = ComputePayloadHash(bodyBytes)
+	}
+
+	// Create a fresh signer to avoid key caching from prior calls with
+	// different credentials. v4.NewSigner is cheap (struct allocation only).
+	verifySigner := v4.NewSigner(signerOpts...)
+	err = verifySigner.SignHTTP(r.Context(), creds, testReq, payloadHash, service, region, signingTime)
+	if err != nil {
+		return false, fmt.Errorf("failed to sign request for signature verification: %w", err)
+	}
+
+	// Extract calculated signature
+	calculatedAuth := testReq.Header.Get("Authorization")
+	calculatedMatches := SignRegex.FindStringSubmatch(calculatedAuth)
+	if len(calculatedMatches) != 2 {
+		return false, fmt.Errorf("failed to extract calculated signature")
+	}
+	calculatedSignature := calculatedMatches[1]
+
+	// Constant-time comparison
+	match := subtle.ConstantTimeCompare([]byte(providedSignature), []byte(calculatedSignature)) == 1
+
+	log.Trace("Signature comparison",
+		logger.String("provided", providedSignature),
+		logger.String("calculated", calculatedSignature),
+		logger.String("originalAuth", authHeader),
+		logger.String("calculatedAuth", calculatedAuth),
+		logger.String("request_id", middleware.GetReqID(r.Context())),
+	)
+
+	if !match {
+		log.Warn("signature mismatch",
+			logger.String("provided", providedSignature),
+			logger.String("calculated", calculatedSignature),
+			logger.String("request_id", middleware.GetReqID(r.Context())),
+		)
+	}
+
+	return match, nil
+}
+
+// IsAWSChunked returns true if the request uses aws-chunked content encoding.
+func IsAWSChunked(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Content-Encoding"), "aws-chunked")
+}
+
+// DecodeAWSChunkedBody decodes an aws-chunked encoded body into plain bytes.
+func DecodeAWSChunkedBody(data []byte) ([]byte, error) {
+	var decoded bytes.Buffer
+	buf := bytes.NewBuffer(data)
+
+	for {
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			if err == io.EOF && line == "" {
+				break
+			}
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("error reading chunk header: %w", err)
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+
+		sizeStr := line
+		if idx := strings.IndexByte(line, ';'); idx >= 0 {
+			sizeStr = line[:idx]
+		}
+
+		var chunkSize int64
+		if _, err := fmt.Sscanf(sizeStr, "%x", &chunkSize); err != nil {
+			return nil, fmt.Errorf("invalid chunk size %q: %w", sizeStr, err)
+		}
+
+		if chunkSize == 0 {
+			break
+		}
+
+		chunk := make([]byte, chunkSize)
+		if _, err := io.ReadFull(buf, chunk); err != nil {
+			return nil, fmt.Errorf("error reading chunk data: %w", err)
+		}
+		decoded.Write(chunk)
+
+		if _, err := buf.ReadString('\n'); err != nil && err != io.EOF {
+			return nil, fmt.Errorf("error reading chunk trailer: %w", err)
+		}
+	}
+
+	return decoded.Bytes(), nil
+}
+
+// RemoveAWSChunkedEncoding removes "aws-chunked" from the Content-Encoding header.
+func RemoveAWSChunkedEncoding(r *http.Request) {
+	ce := r.Header.Get("Content-Encoding")
+	if ce == "" {
+		return
+	}
+	var remaining []string
+	for _, part := range strings.Split(ce, ",") {
+		trimmed := strings.TrimSpace(part)
+		if !strings.EqualFold(trimmed, "aws-chunked") {
+			remaining = append(remaining, trimmed)
+		}
+	}
+	if len(remaining) == 0 {
+		r.Header.Del("Content-Encoding")
+	} else {
+		r.Header.Set("Content-Encoding", strings.Join(remaining, ", "))
+	}
+}
+
+// ForwardDirect sends a signed request directly using the given transport,
+// bypassing httputil.ReverseProxy which modifies headers and breaks SigV4 signatures.
+func ForwardDirect(log *logger.GatedLogger, w http.ResponseWriter, r *http.Request, body []byte, transport http.RoundTripper) {
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), bytes.NewReader(body))
+	if err != nil {
+		log.Error("failed to create direct request", logger.Err(err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	outReq.Header = r.Header.Clone()
+	outReq.Host = r.Host
+	outReq.ContentLength = int64(len(body))
+
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	resp, err := transport.RoundTrip(outReq)
+	if err != nil {
+		log.Error("direct forward failed", logger.Err(err))
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, vv := range resp.Header {
+		for _, val := range vv {
+			w.Header().Add(k, val)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if flusher, ok := w.(http.Flusher); ok {
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				w.Write(buf[:n])
+				flusher.Flush()
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	} else {
+		io.Copy(w, resp.Body)
+	}
+}

--- a/provider/sigv4/sigv4.go
+++ b/provider/sigv4/sigv4.go
@@ -21,6 +21,11 @@ import (
 	"github.com/stephnangue/warden/logger"
 )
 
+// maxChunkSize caps individual chunk allocation when decoding aws-chunked bodies
+// to prevent denial-of-service via a malicious chunk header. AWS SDKs use chunks
+// up to ~1MB; 10MB per chunk is generous.
+const maxChunkSize = 10 << 20 // 10MB
+
 
 var (
 	// AuthRegex parses the SigV4 Authorization header into access_key_id, date, region, service.
@@ -408,6 +413,10 @@ func DecodeAWSChunkedBody(data []byte) ([]byte, error) {
 
 		if chunkSize == 0 {
 			break
+		}
+
+		if chunkSize < 0 || chunkSize > maxChunkSize {
+			return nil, fmt.Errorf("chunk size %d exceeds maximum allowed (%d bytes)", chunkSize, maxChunkSize)
 		}
 
 		chunk := make([]byte, chunkSize)

--- a/provider/sigv4/sigv4_test.go
+++ b/provider/sigv4/sigv4_test.go
@@ -1,0 +1,490 @@
+package sigv4
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestLogger() *logger.GatedLogger {
+	config := &logger.Config{
+		Level:   logger.TraceLevel,
+		Format:  logger.DefaultFormat,
+		Outputs: []io.Writer{io.Discard},
+	}
+	gl, _ := logger.NewGatedLogger(config, logger.GatedWriterConfig{
+		Underlying:   io.Discard,
+		InitialState: logger.GateOpen,
+	})
+	return gl
+}
+
+// --- IsSigV4Request ---
+
+func TestIsSigV4Request(t *testing.T) {
+	tests := []struct {
+		name     string
+		authHdr  string
+		expected bool
+	}{
+		{"valid SigV4", "AWS4-HMAC-SHA256 Credential=AKIA.../s3/aws4_request", true},
+		{"bearer token", "Bearer some-token", false},
+		{"empty header", "", false},
+		{"partial match", "AWS4-HMAC", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			if tt.authHdr != "" {
+				r.Header.Set("Authorization", tt.authHdr)
+			}
+			assert.Equal(t, tt.expected, IsSigV4Request(r))
+		})
+	}
+}
+
+// --- ExtractFromAuthHeader ---
+
+func TestExtractFromAuthHeader(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		wantSvc   string
+		wantReg   string
+		wantAKID  string
+		wantErr   bool
+	}{
+		{
+			name:     "valid header",
+			header:   "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20231215/us-east-1/s3/aws4_request",
+			wantSvc:  "s3",
+			wantReg:  "us-east-1",
+			wantAKID: "AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:     "scaleway region",
+			header:   "AWS4-HMAC-SHA256 Credential=SCWXXXXXXXXXXXXXXXXX/20260410/fr-par/s3/aws4_request",
+			wantSvc:  "s3",
+			wantReg:  "fr-par",
+			wantAKID: "SCWXXXXXXXXXXXXXXXXX",
+		},
+		{
+			name:     "JWT as access key",
+			header:   "AWS4-HMAC-SHA256 Credential=eyJhbGciOiJSUzI1NiJ9/20260410/nl-ams/s3/aws4_request",
+			wantSvc:  "s3",
+			wantReg:  "nl-ams",
+			wantAKID: "eyJhbGciOiJSUzI1NiJ9",
+		},
+		{
+			name:    "empty header",
+			header:  "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			header:  "Bearer some-token",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, reg, akid, err := ExtractFromAuthHeader(tt.header)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantSvc, svc)
+				assert.Equal(t, tt.wantReg, reg)
+				assert.Equal(t, tt.wantAKID, akid)
+			}
+		})
+	}
+}
+
+// --- ExtractAccessKeyID ---
+
+func TestExtractAccessKeyID(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected string
+	}{
+		{
+			name:     "standard AWS key",
+			header:   "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20231215/us-east-1/s3/aws4_request",
+			expected: "AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:     "scaleway key",
+			header:   "AWS4-HMAC-SHA256 Credential=SCWXXXXXXXXXXXXXXXXX/20260410/fr-par/s3/aws4_request",
+			expected: "SCWXXXXXXXXXXXXXXXXX",
+		},
+		{
+			name:     "JWT key",
+			header:   "AWS4-HMAC-SHA256 Credential=eyJhbGciOiJSUzI1NiJ9/20260410/fr-par/s3/aws4_request",
+			expected: "eyJhbGciOiJSUzI1NiJ9",
+		},
+		{
+			name:     "no credential",
+			header:   "AWS4-HMAC-SHA256 SignedHeaders=host",
+			expected: "",
+		},
+		{
+			name:     "credential no slash",
+			header:   "Credential=AKIATEST",
+			expected: "",
+		},
+		{
+			name:     "empty",
+			header:   "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ExtractAccessKeyID(tt.header))
+		})
+	}
+}
+
+// --- ComputePayloadHash ---
+
+func TestComputePayloadHash(t *testing.T) {
+	t.Run("empty body", func(t *testing.T) {
+		hash := ComputePayloadHash([]byte{})
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash)
+	})
+
+	t.Run("non-empty body", func(t *testing.T) {
+		hash := ComputePayloadHash([]byte("hello"))
+		assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", hash)
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		h1 := ComputePayloadHash([]byte("test"))
+		h2 := ComputePayloadHash([]byte("test"))
+		assert.Equal(t, h1, h2)
+	})
+}
+
+// --- ParseAWSDate ---
+
+func TestParseAWSDate(t *testing.T) {
+	t.Run("valid date", func(t *testing.T) {
+		ts, err := ParseAWSDate("20260410T120000Z")
+		require.NoError(t, err)
+		assert.Equal(t, 2026, ts.Year())
+		assert.Equal(t, time.Month(4), ts.Month())
+		assert.Equal(t, 10, ts.Day())
+		assert.Equal(t, 12, ts.Hour())
+	})
+
+	t.Run("invalid date", func(t *testing.T) {
+		_, err := ParseAWSDate("not-a-date")
+		require.Error(t, err)
+	})
+}
+
+// --- ReadRequestBody ---
+
+func TestReadRequestBody(t *testing.T) {
+	t.Run("normal body", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", bytes.NewBufferString("hello world"))
+		body, err := ReadRequestBody(r, 1024)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(body))
+	})
+
+	t.Run("nil body", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Body = nil
+		body, err := ReadRequestBody(r, 1024)
+		require.NoError(t, err)
+		assert.Nil(t, body)
+	})
+
+	t.Run("exceeds max size", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", bytes.NewBufferString("hello world"))
+		_, err := ReadRequestBody(r, 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum size")
+	})
+
+	t.Run("zero max size - no limit", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", bytes.NewBufferString("hello world"))
+		body, err := ReadRequestBody(r, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(body))
+	})
+}
+
+// --- RestoreRequestBody ---
+
+func TestRestoreRequestBody(t *testing.T) {
+	t.Run("non-empty body", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", nil)
+		RestoreRequestBody(r, []byte("restored"))
+		got, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "restored", string(got))
+		assert.Equal(t, int64(8), r.ContentLength)
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", nil)
+		RestoreRequestBody(r, []byte{})
+		assert.Nil(t, r.Body)
+		assert.Equal(t, int64(0), r.ContentLength)
+	})
+}
+
+// --- IsAWSChunked ---
+
+func TestIsAWSChunked(t *testing.T) {
+	t.Run("aws-chunked", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		r.Header.Set("Content-Encoding", "aws-chunked")
+		assert.True(t, IsAWSChunked(r))
+	})
+
+	t.Run("gzip and aws-chunked", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		r.Header.Set("Content-Encoding", "gzip, aws-chunked")
+		assert.True(t, IsAWSChunked(r))
+	})
+
+	t.Run("no content-encoding", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		assert.False(t, IsAWSChunked(r))
+	})
+
+	t.Run("gzip only", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		r.Header.Set("Content-Encoding", "gzip")
+		assert.False(t, IsAWSChunked(r))
+	})
+}
+
+// --- DecodeAWSChunkedBody ---
+
+func TestDecodeAWSChunkedBody(t *testing.T) {
+	t.Run("single chunk", func(t *testing.T) {
+		body := []byte("5;chunk-signature=aaa\r\nhello\r\n0;chunk-signature=bbb\r\n\r\n")
+		decoded, err := DecodeAWSChunkedBody(body)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(decoded))
+	})
+
+	t.Run("multiple chunks", func(t *testing.T) {
+		body := []byte("5;chunk-signature=aaa\r\nhello\r\n6;chunk-signature=bbb\r\n world\r\n0;chunk-signature=ccc\r\n\r\n")
+		decoded, err := DecodeAWSChunkedBody(body)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(decoded))
+	})
+
+	t.Run("empty body - zero chunk", func(t *testing.T) {
+		body := []byte("0;chunk-signature=aaa\r\n\r\n")
+		decoded, err := DecodeAWSChunkedBody(body)
+		require.NoError(t, err)
+		assert.Empty(t, decoded)
+	})
+
+	t.Run("invalid hex size", func(t *testing.T) {
+		body := []byte("ZZ;chunk-signature=aaa\r\ndata\r\n")
+		_, err := DecodeAWSChunkedBody(body)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid chunk size")
+	})
+
+	t.Run("truncated data", func(t *testing.T) {
+		body := []byte("a;chunk-signature=aaa\r\nshort\r\n")
+		_, err := DecodeAWSChunkedBody(body)
+		require.Error(t, err)
+	})
+}
+
+// --- RemoveAWSChunkedEncoding ---
+
+func TestRemoveAWSChunkedEncoding(t *testing.T) {
+	t.Run("only aws-chunked", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		r.Header.Set("Content-Encoding", "aws-chunked")
+		RemoveAWSChunkedEncoding(r)
+		assert.Empty(t, r.Header.Get("Content-Encoding"))
+	})
+
+	t.Run("aws-chunked with gzip", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		r.Header.Set("Content-Encoding", "gzip, aws-chunked")
+		RemoveAWSChunkedEncoding(r)
+		assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+	})
+
+	t.Run("no content-encoding", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		RemoveAWSChunkedEncoding(r)
+		assert.Empty(t, r.Header.Get("Content-Encoding"))
+	})
+}
+
+// --- NormalizeRequest ---
+
+func TestNormalizeRequest(t *testing.T) {
+	log := createTestLogger()
+
+	t.Run("strips hop-by-hop headers", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/", nil)
+		r.Header.Set("Connection", "keep-alive")
+		r.Header.Set("Keep-Alive", "timeout=5")
+		r.Header.Set("Transfer-Encoding", "chunked")
+		r.Header.Set("X-Custom", "preserved")
+
+		NormalizeRequest(log, r, []byte{})
+
+		assert.Empty(t, r.Header.Get("Connection"))
+		assert.Empty(t, r.Header.Get("Keep-Alive"))
+		assert.Empty(t, r.Header.Get("Transfer-Encoding"))
+		assert.Equal(t, "preserved", r.Header.Get("X-Custom"))
+	})
+
+	t.Run("strips proxy headers", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "/", nil)
+		r.Header.Set("X-Forwarded-For", "1.2.3.4")
+		r.Header.Set("X-Real-Ip", "1.2.3.4")
+		r.Header.Set("Forwarded", "for=1.2.3.4")
+
+		NormalizeRequest(log, r, []byte{})
+
+		assert.Empty(t, r.Header.Get("X-Forwarded-For"))
+		assert.Empty(t, r.Header.Get("X-Real-Ip"))
+		assert.Empty(t, r.Header.Get("Forwarded"))
+	})
+
+	t.Run("strips trailer headers when X-Amz-Trailer present", func(t *testing.T) {
+		r, _ := http.NewRequest("PUT", "/", nil)
+		r.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32")
+		r.Header.Set("X-Amz-Sdk-Checksum-Algorithm", "CRC32")
+		r.Header.Set("X-Amz-Checksum-Crc32", "abc123")
+
+		NormalizeRequest(log, r, []byte{})
+
+		assert.Empty(t, r.Header.Get("X-Amz-Trailer"))
+		assert.Empty(t, r.Header.Get("X-Amz-Sdk-Checksum-Algorithm"))
+		assert.Empty(t, r.Header.Get("X-Amz-Checksum-Crc32"))
+	})
+}
+
+// --- ResignRequest + VerifyIncomingSignature round-trip ---
+
+func TestResignAndVerify(t *testing.T) {
+	log := createTestLogger()
+	s3Opts := []func(*v4.SignerOptions){
+		func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true },
+	}
+	signer := v4.NewSigner(s3Opts...)
+
+	creds := aws.Credentials{
+		AccessKeyID:     "SCWXXXXXXXXXXXXXXXXX",
+		SecretAccessKey: "test-secret-key-uuid",
+	}
+
+	body := []byte(`{"key":"value"}`)
+
+	r, _ := http.NewRequest("PUT", "https://s3.fr-par.scw.cloud/my-bucket/test.txt", bytes.NewReader(body))
+	r.Header.Set("Host", "s3.fr-par.scw.cloud")
+
+	err := ResignRequest(context.Background(), signer, r, creds, "s3", "fr-par", body)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, r.Header.Get("Authorization"))
+	assert.Contains(t, r.Header.Get("Authorization"), "AWS4-HMAC-SHA256")
+	assert.NotEmpty(t, r.Header.Get("X-Amz-Content-Sha256"))
+	assert.NotEmpty(t, r.Header.Get("X-Amz-Date"))
+
+	valid, err := VerifyIncomingSignature(log, s3Opts, r, body, creds, "s3", "fr-par")
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestVerifyIncomingSignature_Mismatch(t *testing.T) {
+	log := createTestLogger()
+	s3Opts := []func(*v4.SignerOptions){
+		func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true },
+	}
+	signer := v4.NewSigner(s3Opts...)
+
+	signingCreds := aws.Credentials{
+		AccessKeyID:     "SCWXXXXXXXXXXXXXXXXX",
+		SecretAccessKey: "correct-secret-key-value",
+	}
+
+	body := []byte("test body")
+
+	r, _ := http.NewRequest("PUT", "https://s3.fr-par.scw.cloud/bucket/key", bytes.NewReader(body))
+	r.Header.Set("Host", "s3.fr-par.scw.cloud")
+
+	err := ResignRequest(context.Background(), signer, r, signingCreds, "s3", "fr-par", body)
+	require.NoError(t, err)
+
+	// Verify with correct credentials should succeed
+	valid, err := VerifyIncomingSignature(log, s3Opts, r, body, signingCreds, "s3", "fr-par")
+	require.NoError(t, err)
+	require.True(t, valid, "correct creds must verify")
+
+	// Verify with wrong credentials should fail
+	wrongCreds := aws.Credentials{
+		AccessKeyID:     "SCWXXXXXXXXXXXXXXXXX",
+		SecretAccessKey: "wrong-secret-key-value",
+	}
+	valid, err = VerifyIncomingSignature(log, s3Opts, r, body, wrongCreds, "s3", "fr-par")
+	require.NoError(t, err)
+	assert.False(t, valid, "wrong secret should produce signature mismatch")
+}
+
+// --- ForwardDirect ---
+
+func TestForwardDirect(t *testing.T) {
+	log := createTestLogger()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "custom-value", r.Header.Get("X-Custom"))
+		w.Header().Set("X-Response", "ok")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("response body"))
+	}))
+	defer upstream.Close()
+
+	r, _ := http.NewRequest("GET", upstream.URL+"/test", nil)
+	r.Header.Set("X-Custom", "custom-value")
+	r.RequestURI = ""
+
+	rec := httptest.NewRecorder()
+	ForwardDirect(log, rec, r, []byte{}, upstream.Client().Transport)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Header().Get("X-Response"))
+	assert.Contains(t, rec.Body.String(), "response body")
+}
+
+func TestForwardDirect_UpstreamError(t *testing.T) {
+	log := createTestLogger()
+
+	// Use a URL that won't connect
+	r, _ := http.NewRequest("GET", "http://127.0.0.1:1/unreachable", nil)
+	r.RequestURI = ""
+
+	rec := httptest.NewRecorder()
+	ForwardDirect(log, rec, r, []byte{}, http.DefaultTransport)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}

--- a/provider/splunk/provider.go
+++ b/provider/splunk/provider.go
@@ -3,7 +3,6 @@ package splunk
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/stephnangue/warden/provider/httpproxy"
@@ -30,25 +29,6 @@ func extractToken(r *http.Request) string {
 	return ""
 }
 
-// validateSplunkURL validates that the splunk_url is a well-formed HTTPS URL.
-// When tlsSkipVerify is true, http:// is also accepted for dev/test environments.
-func validateSplunkURL(addr string, tlsSkipVerify bool) error {
-	if addr == "" {
-		return fmt.Errorf("splunk_url is required")
-	}
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid splunk_url: %w", err)
-	}
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && tlsSkipVerify) {
-		return fmt.Errorf("splunk_url must use https:// scheme, got: %s", parsed.Scheme)
-	}
-	if parsed.Host == "" {
-		return fmt.Errorf("splunk_url must include a host")
-	}
-	return nil
-}
-
 // Spec defines the Splunk provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
 	Name:               "splunk",
@@ -65,11 +45,7 @@ var Spec = &httpproxy.ProviderSpec{
 		if !ok || addr == "" {
 			return fmt.Errorf("splunk_url is required")
 		}
-		skipVerify := false
-		if v, ok := conf["tls_skip_verify"].(bool); ok {
-			skipVerify = v
-		}
-		return validateSplunkURL(addr, skipVerify)
+		return nil
 	},
 }
 

--- a/provider/vault/config.go
+++ b/provider/vault/config.go
@@ -1,10 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -21,95 +18,21 @@ type ProviderConfig struct {
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
 func parseConfig(conf map[string]any) ProviderConfig {
-	config := ProviderConfig{
-		MaxBodySize: framework.DefaultMaxBodySize,
-		Timeout:     framework.DefaultTimeout,
+	tlsSkipVerify, caData := framework.ParseTLSConfig(conf)
+	return ProviderConfig{
+		VaultAddress:  framework.GetConfigString(conf, "vault_address", ""),
+		MaxBodySize:   framework.ParseMaxBodySize(conf),
+		Timeout:       framework.ParseTimeout(conf, framework.DefaultTimeout),
+		TLSSkipVerify: tlsSkipVerify,
+		CAData:        caData,
 	}
-
-	if addr, ok := conf["vault_address"].(string); ok {
-		config.VaultAddress = addr
-	}
-
-	// Parse max_body_size - handle various JSON number types
-	if maxSize, ok := conf["max_body_size"]; ok {
-		switch v := maxSize.(type) {
-		case int:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case int64:
-			if v > 0 {
-				config.MaxBodySize = v
-			}
-		case float64:
-			if v > 0 {
-				config.MaxBodySize = int64(v)
-			}
-		case json.Number:
-			if parsed, err := v.Int64(); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		case string:
-			if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
-				config.MaxBodySize = parsed
-			}
-		}
-	}
-
-	// Parse timeout - handle duration string or number
-	if timeout, ok := conf["timeout"]; ok {
-		switch v := timeout.(type) {
-		case string:
-			if parsed, err := time.ParseDuration(v); err == nil {
-				config.Timeout = parsed
-			}
-		case int:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		case float64:
-			if v > 0 {
-				config.Timeout = time.Duration(v) * time.Second
-			}
-		}
-	}
-
-	// Parse tls_skip_verify
-	if tlsSkip, ok := conf["tls_skip_verify"]; ok {
-		switch v := tlsSkip.(type) {
-		case bool:
-			config.TLSSkipVerify = v
-		case string:
-			config.TLSSkipVerify = v == "true"
-		}
-	}
-
-	// Parse ca_data
-	if v, ok := conf["ca_data"].(string); ok {
-		config.CAData = v
-	}
-
-	return config
 }
 
-// validateVaultAddress validates that the vault_address is a well-formed URL
+// validateVaultAddress validates that the vault_address is a well-formed URL.
+// Vault accepts both http:// and https:// (http is common in dev mode).
 func validateVaultAddress(addr string) error {
 	if addr == "" {
 		return fmt.Errorf("vault_address is required")
 	}
-
-	parsed, err := url.Parse(addr)
-	if err != nil {
-		return fmt.Errorf("invalid vault_address: %w", err)
-	}
-
-	if parsed.Scheme != "https" && parsed.Scheme != "http" {
-		return fmt.Errorf("vault_address must use http:// or https:// scheme, got: %s", parsed.Scheme)
-	}
-
-	if parsed.Host == "" {
-		return fmt.Errorf("vault_address must include a host")
-	}
-
-	return nil
+	return framework.ValidateURL(addr, "vault_address", true) // true: allow http
 }


### PR DESCRIPTION
…age, and config deduplication

Add Scaleway provider supporting auto-detection of standard API (X-Auth-Token injection) and S3 Object Storage (SigV4 signature verification and re-signing).

Key changes:
- provider/sigv4: Extract shared SigV4 utilities from AWS provider (NormalizeRequest, ResignRequest, VerifyIncomingSignature, ForwardDirect) for reuse by Scaleway, and future Cloudflare R2 / OVH providers. Fix v4.Signer key caching bug by accepting signerOpts instead of a signer instance for verification.
- provider/scaleway: Custom streaming backend with gateway auto-detection, transparent auth (JWT in SigV4 access_key_id), role-based paths, config persistence, and S3 regional endpoint routing (fr-par, nl-ams, pl-waw, it-mil).
- credential/types/scaleway_keys: Credential type with access_key (SCW prefix) and secret_key (UUID) serving both API and S3 authentication modes.
- credential/drivers/scaleway_driver: Source driver with static_keys and dynamic_keys mint methods (POST /iam/v1alpha1/api-keys), automatic revocation (DELETE), management key rotation with configurable activation delay, and access_key/secret_key swap detection.
- framework/config: Extract shared config parsing and validation utilities (ParseMaxBodySize, ParseTimeout, ParseTLSConfig, ValidateURL, ValidateCommonConfig, ValidateTLSConfig) used by all non-httpproxy providers, eliminating ~1400 lines of duplicated code across AWS, Azure, GCP, Vault, httpproxy, and Scaleway.
- provider/dynatrace: Fix invalid default URL placeholder.
- e2e_test: Terraform tests using restapi+http (standard API) and hashicorp/aws (S3 SigV4) with 25 test cases covering CRUD, edge cases, and auth failures.