### PR TITLE
feat: add Cloudflare provider dual-mode gateway with R2 S3 support

### DIFF
--- a/credential/credential.go
+++ b/credential/credential.go
@@ -20,6 +20,7 @@ const (
 	TypeKubernetesToken   = "kubernetes_token"
 	TypeScalewayKeys     = "scaleway_keys"
 	TypeOVHKeys          = "ovh_keys"
+	TypeCloudflareKeys   = "cloudflare_keys"
 )
 
 // Source type constants
@@ -37,6 +38,7 @@ const (
 	SourceTypeElastic    = "elastic"
 	SourceTypeKubernetes = "kubernetes"
 	SourceTypeScaleway   = "scaleway"
+	SourceTypeCloudflare = "cloudflare"
 )
 
 // Category constants for credential categorization

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -64,5 +64,10 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
+	// Register Cloudflare keys type
+	if err := registry.Register(&CloudflareKeysCredType{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/types/cloudflare_keys.go
+++ b/credential/types/cloudflare_keys.go
@@ -1,0 +1,202 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+)
+
+// CloudflareKeysCredType handles Cloudflare cloud credentials.
+// A single credential holds an API token for the REST API and
+// S3-compatible access_key_id + secret_access_key for R2 Object Storage (SigV4).
+type CloudflareKeysCredType struct{}
+
+// Metadata returns the type's metadata
+func (t *CloudflareKeysCredType) Metadata() credential.TypeMetadata {
+	return credential.TypeMetadata{
+		Name:        credential.TypeCloudflareKeys,
+		Category:    credential.CategoryCloudIAM,
+		Description: "Cloudflare keys (api_token for REST API, access_key_id + secret_access_key for R2 Object Storage)",
+		DefaultTTL:  0,
+	}
+}
+
+// ConfigSchema returns the declarative schema for Cloudflare key credential config
+func (t *CloudflareKeysCredType) ConfigSchema() []*credential.FieldValidator {
+	return []*credential.FieldValidator{
+		credential.StringField("access_key_id").
+			Describe("Cloudflare R2 access key ID").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("secret_access_key").
+			Describe("Cloudflare R2 secret access key").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("api_token").
+			Describe("Cloudflare API bearer token for REST API").
+			Example("v1.0-xxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("mint_method").
+			OneOf("static_keys", "static_cloudflare").
+			Describe("Mint method for credential minting").
+			Example("static_keys"),
+
+		// Vault source fields
+		credential.StringField("kv2_mount").
+			Describe("Vault KV2 mount path (required for static_cloudflare)").
+			Example("secret"),
+
+		credential.StringField("secret_path").
+			Describe("Path to secret in KV2 (required for static_cloudflare)").
+			Example("cloudflare/prod/keys"),
+	}
+}
+
+// ValidateConfig validates the Config for a Cloudflare credential spec
+func (t *CloudflareKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	switch sourceType {
+	case credential.SourceTypeLocal, credential.SourceTypeVault:
+		// Supported
+	default:
+		return fmt.Errorf("cloudflare_keys credentials require a local or vault source, got: %s", sourceType)
+	}
+
+	schema := t.ConfigSchema()
+	if err := credential.ValidateSchema(config, schema...); err != nil {
+		return err
+	}
+
+	switch sourceType {
+	case credential.SourceTypeVault:
+		if config["mint_method"] != "static_cloudflare" {
+			return fmt.Errorf("'mint_method' must be 'static_cloudflare' for vault source, got: %s", config["mint_method"])
+		}
+		if config["kv2_mount"] == "" {
+			return fmt.Errorf("'kv2_mount' is required when mint_method is static_cloudflare")
+		}
+		if config["secret_path"] == "" {
+			return fmt.Errorf("'secret_path' is required when mint_method is static_cloudflare")
+		}
+	default:
+		hasAPI := config["api_token"] != ""
+		hasR2 := config["access_key_id"] != "" || config["secret_access_key"] != ""
+		if !hasAPI && !hasR2 {
+			return fmt.Errorf("at least one of 'api_token' (for API) or 'access_key_id'+'secret_access_key' (for R2) is required")
+		}
+		// If R2 fields are partially set, both must be present
+		if config["access_key_id"] != "" && config["secret_access_key"] == "" {
+			return fmt.Errorf("'secret_access_key' is required when 'access_key_id' is set")
+		}
+		if config["secret_access_key"] != "" && config["access_key_id"] == "" {
+			return fmt.Errorf("'access_key_id' is required when 'secret_access_key' is set")
+		}
+	}
+
+	return nil
+}
+
+// Parse converts raw credential data from source into structured Credential.
+// At least one mode must be present: api_token (API) or access_key_id+secret_access_key (R2).
+func (t *CloudflareKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+	accessKeyID, _ := rawData["access_key_id"].(string)
+	secretAccessKey, _ := rawData["secret_access_key"].(string)
+	apiToken, _ := rawData["api_token"].(string)
+
+	// Partial R2 credentials are invalid — check this first
+	if (accessKeyID != "" && secretAccessKey == "") || (accessKeyID == "" && secretAccessKey != "") {
+		return nil, fmt.Errorf("%w: both access_key_id and secret_access_key are required for R2", credential.ErrInvalidCredential)
+	}
+
+	hasAPI := apiToken != ""
+	hasR2 := accessKeyID != "" && secretAccessKey != ""
+
+	if !hasAPI && !hasR2 {
+		return nil, fmt.Errorf("%w: at least one of api_token or access_key_id+secret_access_key is required", credential.ErrInvalidCredential)
+	}
+
+	data := make(map[string]string)
+	if apiToken != "" {
+		data["api_token"] = apiToken
+	}
+	if accessKeyID != "" {
+		data["access_key_id"] = accessKeyID
+	}
+	if secretAccessKey != "" {
+		data["secret_access_key"] = secretAccessKey
+	}
+
+	return &credential.Credential{
+		Type:      credential.TypeCloudflareKeys,
+		Category:  credential.CategoryCloudIAM,
+		LeaseTTL:  leaseTTL,
+		LeaseID:   leaseID,
+		IssuedAt:  time.Now(),
+		Revocable: leaseTTL > 0,
+		Data:      data,
+	}, nil
+}
+
+// Validate checks if credential data is well-formed.
+// At least one mode must be present: api_token (API) or access_key_id+secret_access_key (R2).
+func (t *CloudflareKeysCredType) Validate(cred *credential.Credential) error {
+	if cred.Type != credential.TypeCloudflareKeys {
+		return fmt.Errorf("%w: expected type %s, got %s", credential.ErrInvalidCredential, credential.TypeCloudflareKeys, cred.Type)
+	}
+
+	// Partial R2 credentials are invalid — check this first
+	if (cred.Data["access_key_id"] != "" && cred.Data["secret_access_key"] == "") ||
+		(cred.Data["access_key_id"] == "" && cred.Data["secret_access_key"] != "") {
+		return fmt.Errorf("%w: both access_key_id and secret_access_key are required for R2", credential.ErrInvalidCredential)
+	}
+
+	hasAPI := cred.Data["api_token"] != ""
+	hasR2 := cred.Data["access_key_id"] != "" && cred.Data["secret_access_key"] != ""
+
+	if !hasAPI && !hasR2 {
+		return fmt.Errorf("%w: at least one of api_token or access_key_id+secret_access_key is required", credential.ErrInvalidCredential)
+	}
+
+	return nil
+}
+
+// Revoke releases the credential (best-effort).
+// Revocation is delegated to the SourceDriver when a LeaseID is present.
+func (t *CloudflareKeysCredType) Revoke(ctx context.Context, cred *credential.Credential, driver credential.SourceDriver) error {
+	if cred.LeaseID == "" {
+		return nil
+	}
+	if err := driver.Revoke(ctx, cred.LeaseID); err != nil {
+		return fmt.Errorf("%w: %v", credential.ErrRevocationFailed, err)
+	}
+	return nil
+}
+
+// RequiresSpecRotation returns false — Cloudflare keys don't embed rotatable credentials in spec config
+func (t *CloudflareKeysCredType) RequiresSpecRotation() bool {
+	return false
+}
+
+// SensitiveConfigFields returns spec config keys that should be masked in output
+func (t *CloudflareKeysCredType) SensitiveConfigFields() []string {
+	return []string{"secret_access_key", "api_token"}
+}
+
+// FieldSchemas returns metadata about the credential's data fields
+func (t *CloudflareKeysCredType) FieldSchemas() map[string]*credential.CredentialFieldSchema {
+	return map[string]*credential.CredentialFieldSchema{
+		"access_key_id": {
+			Description: "Cloudflare R2 access key ID",
+			Sensitive:   false,
+		},
+		"secret_access_key": {
+			Description: "Cloudflare R2 secret access key",
+			Sensitive:   true,
+		},
+		"api_token": {
+			Description: "Cloudflare API bearer token",
+			Sensitive:   true,
+		},
+	}
+}

--- a/credential/types/cloudflare_keys_test.go
+++ b/credential/types/cloudflare_keys_test.go
@@ -1,0 +1,404 @@
+package types
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudflareKeysCredType_Metadata(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	m := ct.Metadata()
+
+	assert.Equal(t, credential.TypeCloudflareKeys, m.Name)
+	assert.Equal(t, credential.CategoryCloudIAM, m.Category)
+	assert.Contains(t, m.Description, "Cloudflare")
+	assert.Equal(t, time.Duration(0), m.DefaultTTL)
+}
+
+func TestCloudflareKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid full config",
+			config: map[string]string{
+				"access_key_id":     "test-access-key-id",
+				"secret_access_key": "test-secret-access-key",
+				"api_token":         "test-api-token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid API-only config",
+			config: map[string]string{
+				"api_token": "test-api-token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid R2-only config",
+			config: map[string]string{
+				"access_key_id":     "test-access-key-id",
+				"secret_access_key": "test-secret-access-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "partial R2 - missing secret_access_key",
+			config: map[string]string{
+				"access_key_id": "test-access-key-id",
+			},
+			wantErr: true,
+			errMsg:  "secret_access_key",
+		},
+		{
+			name: "partial R2 - missing access_key_id",
+			config: map[string]string{
+				"secret_access_key": "test-secret-access-key",
+			},
+			wantErr: true,
+			errMsg:  "access_key_id",
+		},
+		{
+			name:    "empty config",
+			config:  map[string]string{},
+			wantErr: true,
+			errMsg:  "at least one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeLocal)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCloudflareKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid vault config",
+			config: map[string]string{
+				"mint_method": "static_cloudflare",
+				"kv2_mount":   "secret",
+				"secret_path": "cloudflare/prod/keys",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing mint_method",
+			config: map[string]string{
+				"kv2_mount":   "secret",
+				"secret_path": "cloudflare/prod/keys",
+			},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			name: "wrong mint_method",
+			config: map[string]string{
+				"mint_method": "static_keys",
+				"kv2_mount":   "secret",
+				"secret_path": "cloudflare/prod/keys",
+			},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			name: "missing kv2_mount",
+			config: map[string]string{
+				"mint_method": "static_cloudflare",
+				"secret_path": "cloudflare/prod/keys",
+			},
+			wantErr: true,
+			errMsg:  "kv2_mount",
+		},
+		{
+			name: "missing secret_path",
+			config: map[string]string{
+				"mint_method": "static_cloudflare",
+				"kv2_mount":   "secret",
+			},
+			wantErr: true,
+			errMsg:  "secret_path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCloudflareKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	err := ct.ValidateConfig(map[string]string{
+		"access_key_id":     "test-access-key-id",
+		"secret_access_key": "test-secret-access-key",
+		"api_token":         "test-api-token",
+	}, credential.SourceTypeAWS)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local or vault")
+}
+
+func TestCloudflareKeysCredType_Parse(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	tests := []struct {
+		name     string
+		rawData  map[string]interface{}
+		leaseTTL time.Duration
+		leaseID  string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name: "valid full credentials",
+			rawData: map[string]interface{}{
+				"access_key_id":     "test-access-key-id",
+				"secret_access_key": "test-secret-access-key",
+				"api_token":         "test-api-token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid API-only credentials",
+			rawData: map[string]interface{}{
+				"api_token": "test-api-token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid R2-only credentials",
+			rawData: map[string]interface{}{
+				"access_key_id":     "test-access-key-id",
+				"secret_access_key": "test-secret-access-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with lease",
+			rawData: map[string]interface{}{
+				"access_key_id":     "test-access-key-id",
+				"secret_access_key": "test-secret-access-key",
+				"api_token":         "test-api-token",
+			},
+			leaseTTL: 1 * time.Hour,
+			leaseID:  "lease-123",
+			wantErr:  false,
+		},
+		{
+			name: "partial R2 - missing secret_access_key",
+			rawData: map[string]interface{}{
+				"access_key_id": "test-access-key-id",
+			},
+			wantErr: true,
+			errMsg:  "both access_key_id and secret_access_key",
+		},
+		{
+			name: "partial R2 - missing access_key_id",
+			rawData: map[string]interface{}{
+				"secret_access_key": "test-secret-access-key",
+			},
+			wantErr: true,
+			errMsg:  "both access_key_id and secret_access_key",
+		},
+		{
+			name:    "empty raw data",
+			rawData: map[string]interface{}{},
+			wantErr: true,
+			errMsg:  "at least one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, credential.TypeCloudflareKeys, cred.Type)
+				assert.Equal(t, credential.CategoryCloudIAM, cred.Category)
+				assert.Equal(t, tt.leaseTTL, cred.LeaseTTL)
+				assert.Equal(t, tt.leaseID, cred.LeaseID)
+				if tt.leaseTTL > 0 {
+					assert.True(t, cred.Revocable)
+				} else {
+					assert.False(t, cred.Revocable)
+				}
+				// Only check fields that were provided
+				if v, ok := tt.rawData["api_token"]; ok {
+					assert.Equal(t, v, cred.Data["api_token"])
+				}
+				if v, ok := tt.rawData["access_key_id"]; ok {
+					assert.Equal(t, v, cred.Data["access_key_id"])
+				}
+				if v, ok := tt.rawData["secret_access_key"]; ok {
+					assert.Equal(t, v, cred.Data["secret_access_key"])
+				}
+			}
+		})
+	}
+}
+
+func TestCloudflareKeysCredType_Validate(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	tests := []struct {
+		name    string
+		cred    *credential.Credential
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid full credential",
+			cred: &credential.Credential{
+				Type: credential.TypeCloudflareKeys,
+				Data: map[string]string{
+					"access_key_id":     "test-access-key-id",
+					"secret_access_key": "test-secret-access-key",
+					"api_token":         "test-api-token",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid API-only credential",
+			cred: &credential.Credential{
+				Type: credential.TypeCloudflareKeys,
+				Data: map[string]string{
+					"api_token": "test-api-token",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid R2-only credential",
+			cred: &credential.Credential{
+				Type: credential.TypeCloudflareKeys,
+				Data: map[string]string{
+					"access_key_id":     "test-access-key-id",
+					"secret_access_key": "test-secret-access-key",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong type",
+			cred: &credential.Credential{
+				Type: credential.TypeAPIKey,
+				Data: map[string]string{
+					"api_token": "test-api-token",
+				},
+			},
+			wantErr: true,
+			errMsg:  "expected type",
+		},
+		{
+			name: "partial R2 - missing secret_access_key",
+			cred: &credential.Credential{
+				Type: credential.TypeCloudflareKeys,
+				Data: map[string]string{
+					"access_key_id": "test-access-key-id",
+				},
+			},
+			wantErr: true,
+			errMsg:  "both access_key_id and secret_access_key",
+		},
+		{
+			name: "partial R2 - missing access_key_id",
+			cred: &credential.Credential{
+				Type: credential.TypeCloudflareKeys,
+				Data: map[string]string{
+					"secret_access_key": "test-secret-access-key",
+				},
+			},
+			wantErr: true,
+			errMsg:  "both access_key_id and secret_access_key",
+		},
+		{
+			name: "empty data",
+			cred: &credential.Credential{
+				Type: credential.TypeCloudflareKeys,
+				Data: map[string]string{},
+			},
+			wantErr: true,
+			errMsg:  "at least one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.Validate(tt.cred)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCloudflareKeysCredType_Revoke(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+
+	t.Run("no lease - noop", func(t *testing.T) {
+		cred := &credential.Credential{
+			Type:    credential.TypeCloudflareKeys,
+			LeaseID: "",
+		}
+		err := ct.Revoke(context.Background(), cred, nil)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCloudflareKeysCredType_RequiresSpecRotation(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	assert.False(t, ct.RequiresSpecRotation())
+}
+
+func TestCloudflareKeysCredType_SensitiveConfigFields(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	fields := ct.SensitiveConfigFields()
+	assert.Contains(t, fields, "secret_access_key")
+	assert.Contains(t, fields, "api_token")
+}
+
+func TestCloudflareKeysCredType_FieldSchemas(t *testing.T) {
+	ct := &CloudflareKeysCredType{}
+	schemas := ct.FieldSchemas()
+
+	require.Contains(t, schemas, "access_key_id")
+	assert.False(t, schemas["access_key_id"].Sensitive)
+
+	require.Contains(t, schemas, "secret_access_key")
+	assert.True(t, schemas["secret_access_key"].Sensitive)
+
+	require.Contains(t, schemas, "api_token")
+	assert.True(t, schemas["api_token"].Sensitive)
+}

--- a/provider/cloudflare/README.md
+++ b/provider/cloudflare/README.md
@@ -1,6 +1,9 @@
 # Cloudflare Provider
 
-The Cloudflare provider enables proxied access to the Cloudflare API v4 through Warden. It forwards requests to Cloudflare endpoints (zones, DNS records, Workers, accounts, etc.) with automatic credential injection and policy evaluation. Cloudflare API tokens are the supported credential mode (`apikey` source type), as Cloudflare does not natively support OAuth2 client credentials for API access.
+The Cloudflare provider enables proxied access to Cloudflare APIs through Warden. It supports two authentication modes, auto-detected per request:
+
+- **Standard API** — Injects `Authorization: Bearer` header with the API token. Covers zones, DNS records, Workers, accounts, firewall rules, and all other Cloudflare products.
+- **R2 Object Storage** — Verifies the client's SigV4 signature, re-signs with real Cloudflare R2 credentials, and forwards to `<account_id>.r2.cloudflarestorage.com`. Compatible with any S3 client (AWS CLI, boto3, s3cmd, MinIO).
 
 ## Table of Contents
 
@@ -10,6 +13,7 @@ The Cloudflare provider enables proxied access to the Cloudflare API v4 through 
 - [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
 - [Step 4: Create a Policy](#step-4-create-a-policy)
 - [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [R2 Object Storage](#r2-object-storage)
 - [TLS Certificate Authentication](#tls-certificate-authentication)
 - [Configuration Reference](#configuration-reference)
 - [Token Management](#token-management)
@@ -17,7 +21,9 @@ The Cloudflare provider enables proxied access to the Cloudflare API v4 through 
 ## Prerequisites
 
 - Docker and Docker Compose installed and running
-- A **Cloudflare API Token** (from Cloudflare Dashboard > My Profile > API Tokens)
+- A **Cloudflare account** with:
+  - An API token (from Cloudflare Dashboard > My Profile > API Tokens) for the REST API
+  - R2 API credentials (access key ID + secret access key) for Object Storage — generate via Cloudflare Dashboard > R2 > Manage R2 API Tokens
 
 > **New to Warden?** Follow these steps to get a local dev environment running:
 >
@@ -100,15 +106,30 @@ Verify the provider is enabled:
 warden provider list
 ```
 
-Configure the provider with `auto_auth_path`. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+Configure the provider with `auto_auth_path` and `account_id`. The `account_id` is required for R2 Object Storage and can be found in the Cloudflare Dashboard URL (`https://dash.cloudflare.com/<account_id>`):
 
 ```bash
 warden write cloudflare/config <<EOF
 {
   "cloudflare_url": "https://api.cloudflare.com/client/v4",
+  "account_id": "your-cloudflare-account-id",
   "auto_auth_path": "auth/jwt/",
   "timeout": "30s",
   "max_body_size": 10485760
+}
+EOF
+```
+
+For EU or FedRAMP jurisdictions, add the `r2_jurisdiction` field:
+
+```bash
+warden write cloudflare/config <<EOF
+{
+  "cloudflare_url": "https://api.cloudflare.com/client/v4",
+  "account_id": "your-cloudflare-account-id",
+  "r2_jurisdiction": "eu",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
 }
 EOF
 ```
@@ -121,39 +142,55 @@ warden read cloudflare/config
 
 ## Step 3: Create a Credential Source and Spec
 
-### Option A: Static API Token
+### Option A: Static Keys
 
-The credential source holds only connection info (`api_url`). The API token is stored on the credential spec below, allowing multiple specs with different tokens to share one source.
+Create a Cloudflare credential source and spec. You can configure both modes or just the one you need:
+
+**Dual-mode (API + R2):**
 
 ```bash
 warden cred source create cloudflare-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.cloudflare.com/client/v4 \
-  --config=verify_endpoint=/user/tokens/verify \
-  --config=display_name=Cloudflare
-```
+  --type=local
 
-Create a credential spec that references the credential source. The spec carries the API token and gets associated with tokens at login time.
-
-```bash
 warden cred spec create cloudflare-ops \
   --source cloudflare-src \
-  --config api_key=your-cloudflare-api-token
+  --type=cloudflare_keys \
+  --config mint_method=static_keys \
+  --config access_key_id=your-r2-access-key-id \
+  --config secret_access_key=your-r2-secret-access-key \
+  --config api_token=your-cloudflare-api-token
 ```
 
-The API token is validated at creation time via a `GET /user/tokens/verify` call to the Cloudflare API (SpecVerifier). If the token is invalid, spec creation will fail.
+**API-only (no R2):**
+
+```bash
+warden cred spec create cloudflare-api-only \
+  --source cloudflare-src \
+  --type=cloudflare_keys \
+  --config mint_method=static_keys \
+  --config api_token=your-cloudflare-api-token
+```
+
+**R2-only (no API):**
+
+```bash
+warden cred spec create cloudflare-r2-only \
+  --source cloudflare-src \
+  --type=cloudflare_keys \
+  --config mint_method=static_keys \
+  --config access_key_id=your-r2-access-key-id \
+  --config secret_access_key=your-r2-secret-access-key
+```
 
 ### Option B: Vault/OpenBao as Credential Source
 
-Instead of storing the API token directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime. This centralizes secret management in Vault.
+Store your Cloudflare credentials in a Vault/OpenBao KV v2 secret engine and have Warden fetch them at runtime.
 
 **Prerequisites:** A Vault/OpenBao instance with:
-- A KV v2 mount containing your Cloudflare API token (e.g., at `secret/cloudflare/ops` with an `api_key` field)
+- A KV v2 mount containing your Cloudflare credentials (e.g., at `secret/cloudflare/prod` with at least `api_token` and/or `access_key_id` + `secret_access_key` fields)
 - An AppRole configured for Warden access
 
 ```bash
-# Create a Vault credential source
 warden cred source create cloudflare-vault-src \
   --type=hvault \
   --config=vault_address=https://vault.example.com \
@@ -163,19 +200,16 @@ warden cred source create cloudflare-vault-src \
   --config=approle_mount=approle \
   --config=role_name=warden-role \
   --rotation-period=24h
-```
 
-Create a credential spec using the `static_apikey` mint method:
-
-```bash
 warden cred spec create cloudflare-ops \
   --source cloudflare-vault-src \
-  --config mint_method=static_apikey \
+  --type=cloudflare_keys \
+  --config mint_method=static_cloudflare \
   --config kv2_mount=secret \
-  --config secret_path=cloudflare/ops
+  --config secret_path=cloudflare/prod
 ```
 
-The KV v2 secret at `secret/cloudflare/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
+The KV v2 secret at `secret/cloudflare/prod` should contain at least `api_token` (for API mode) and/or `access_key_id` + `secret_access_key` (for R2 mode).
 
 Verify:
 
@@ -306,6 +340,60 @@ curl -s "${CF_ENDPOINT}/accounts/${ACCOUNT_ID}" \
   -H "Content-Type: application/json"
 ```
 
+## R2 Object Storage
+
+The Cloudflare provider auto-detects R2 requests by the presence of a SigV4 `Authorization` header. Any S3-compatible client works — AWS CLI, boto3, s3cmd, MinIO Client.
+
+### R2 Transparent Auth with JWT
+
+Configure your S3 client to point at Warden's gateway endpoint. Use your JWT as both the access key and secret key:
+
+```bash
+aws configure set aws_access_key_id "${JWT_TOKEN}"
+aws configure set aws_secret_access_key "${JWT_TOKEN}"
+aws configure set region auto
+```
+
+### R2 Transparent Auth with Certificates
+
+For certificate-based authentication, use the role name as both the access key and secret key:
+
+```bash
+aws configure set aws_access_key_id "cloudflare-user"
+aws configure set aws_secret_access_key "cloudflare-user"
+aws configure set region auto
+```
+
+### R2 Operations
+
+```bash
+# List buckets
+aws s3 ls \
+  --endpoint-url "${WARDEN_ADDR}/v1/cloudflare/role/cloudflare-user/gateway"
+
+# List objects in a bucket
+aws s3 ls s3://my-bucket/ \
+  --endpoint-url "${WARDEN_ADDR}/v1/cloudflare/role/cloudflare-user/gateway"
+
+# Upload a file
+aws s3 cp myfile.txt s3://my-bucket/myfile.txt \
+  --endpoint-url "${WARDEN_ADDR}/v1/cloudflare/role/cloudflare-user/gateway"
+
+# Download a file
+aws s3 cp s3://my-bucket/myfile.txt ./downloaded.txt \
+  --endpoint-url "${WARDEN_ADDR}/v1/cloudflare/role/cloudflare-user/gateway"
+```
+
+### R2 Jurisdictions
+
+| Jurisdiction | R2 Endpoint | Config |
+|-------------|-------------|--------|
+| Default | `<account_id>.r2.cloudflarestorage.com` | `r2_jurisdiction` omitted or empty |
+| EU | `<account_id>.eu.r2.cloudflarestorage.com` | `r2_jurisdiction=eu` |
+| FedRAMP | `<account_id>.fedramp.r2.cloudflarestorage.com` | `r2_jurisdiction=fedramp` |
+
+R2 always uses `auto` as the region for SigV4 signing. The `account_id` is configured in the provider config (Step 2).
+
 ## Cleanup
 
 To stop Warden and the identity provider:
@@ -364,6 +452,7 @@ Update the provider config to use cert auth:
 warden write cloudflare/config <<EOF
 {
   "cloudflare_url": "https://api.cloudflare.com/client/v4",
+  "account_id": "your-cloudflare-account-id",
   "auto_auth_path": "auth/cert/",
   "timeout": "30s",
   "max_body_size": 10485760
@@ -373,11 +462,20 @@ EOF
 
 ### Make Requests with Certificates
 
+Standard API:
+
 ```bash
 curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/cloudflare/role/cloudflare-user/gateway/zones" \
     -H "Content-Type: application/json"
+```
+
+R2 Object Storage:
+
+```bash
+aws s3 ls s3://my-bucket/ \
+  --endpoint-url "https://warden.internal/v1/cloudflare/role/cloudflare-user/gateway"
 ```
 
 ## Configuration Reference
@@ -386,25 +484,32 @@ curl --cert client.pem --key client-key.pem \
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `cloudflare_url` | string | `https://api.cloudflare.com/client/v4` | Cloudflare API base URL (must be HTTPS) |
+| `cloudflare_url` | string | `https://api.cloudflare.com/client/v4` | Cloudflare API base URL |
+| `account_id` | string | — | Cloudflare account ID (required for R2 Object Storage) |
+| `r2_jurisdiction` | string | — | R2 jurisdiction: empty (default), `eu`, or `fedramp` |
 | `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
 | `timeout` | duration | `30s` | Request timeout |
 | `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
 | `default_role` | string | — | Fallback role when not specified in URL |
 
-### Credential Source Config (Static API Token)
+### Credential Spec Config (static_keys)
+
+At least one mode must be configured: `api_token` for the REST API, or `access_key_id` + `secret_access_key` for R2. Both can be set for dual-mode access.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.cloudflare.com/client/v4`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/user/tokens/verify`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
+| `mint_method` | string | Yes | Must be `static_keys` |
+| `access_key_id` | string | R2 mode | Cloudflare R2 access key ID (required with `secret_access_key`) |
+| `secret_access_key` | string | R2 mode | Cloudflare R2 secret access key (sensitive — required with `access_key_id`) |
+| `api_token` | string | API mode | API bearer token for the REST API (sensitive) |
 
-### Credential Spec Config (Static API Token)
+### Credential Spec Config (Vault — static_cloudflare)
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `api_key` | string | Yes | Cloudflare API token (sensitive — masked in output) |
+| `mint_method` | string | Yes | Must be `static_cloudflare` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ### Credential Source Config (Vault/OpenBao)
 
@@ -418,32 +523,34 @@ curl --cert client.pem --key client-key.pem \
 | `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
 | `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
 
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
 ## Token Management
 
-### Static API Token
+### Static Keys
 
 | Aspect | Details |
 |--------|---------|
-| **Storage** | API token is stored on the credential spec (not the source) |
-| **Validation** | Token is verified at spec creation via `GET /user/tokens/verify` |
-| **Rotation** | Manual — regenerate in Cloudflare and update the spec |
-| **Lifetime** | Configurable expiration in Cloudflare Dashboard; Warden does not auto-rotate |
+| **Storage** | Credentials (api_token and/or access_key_id + secret_access_key) are stored on the credential spec |
+| **Rotation** | Manual — regenerate in Cloudflare Dashboard and update the spec |
+| **Lifetime** | Static — no expiration or auto-refresh |
 
-**To rotate a static API token:**
+**To rotate static credentials:**
 
-1. Create a new API token in Cloudflare (My Profile > API Tokens > Create Token)
-2. Update the credential spec:
+1. Generate new credentials in Cloudflare Dashboard (R2 > Manage R2 API Tokens for R2 keys, My Profile > API Tokens for API tokens)
+2. Update the credential spec with the fields you use:
    ```bash
+   # Dual-mode
    warden cred spec update cloudflare-ops \
-     --config api_key=your-new-api-token
-   ```
-3. Delete the old token in Cloudflare Dashboard
+     --config access_key_id=new-access-key-id \
+     --config secret_access_key=new-secret-access-key \
+     --config api_token=new-api-token
 
+   # API-only
+   warden cred spec update cloudflare-api-only \
+     --config api_token=new-api-token
+
+   # R2-only
+   warden cred spec update cloudflare-r2-only \
+     --config access_key_id=new-access-key-id \
+     --config secret_access_key=new-secret-access-key
+   ```
+3. Revoke the old credentials in the Cloudflare Dashboard

--- a/provider/cloudflare/e2e_test/README.md
+++ b/provider/cloudflare/e2e_test/README.md
@@ -1,0 +1,214 @@
+# Cloudflare Provider E2E Tests
+
+End-to-end Terraform tests for the Warden Cloudflare gateway. These tests validate that Warden correctly proxies requests to Cloudflare APIs with automatic credential injection (Bearer token for REST API, SigV4 re-signing for R2 Object Storage).
+
+## Cost
+
+All tests use **free or near-free** resources only:
+- Cloudflare REST API read operations (zones, accounts, user, DNS records) — **free**
+- R2 Object Storage buckets with tiny objects — **free** (first 10 GB stored free, destroyed on cleanup)
+- Direct HTTP data sources — **free** (read-only API calls)
+- **No** Workers, Pages, load balancers, or paid add-ons
+
+## Test Suite
+
+| File | Tests | Provider | What's Tested | Cost |
+|------|-------|----------|---------------|------|
+| `test-01-api.tf` | 1-6 | http | Zones, token verify, user, accounts, query params, DNS records | Free |
+| `test-02-r2-object-storage.tf` | 7-11 | aws (S3) | Buckets, objects (JSON + text), CORS, lifecycle | ~Free |
+| `test-03-edge-cases.tf` | 12-18 | http + aws (S3) | Auth failures, 404s, query encoding, R2 edge cases | ~Free |
+
+### Provider Strategy
+
+- **`http`** — for REST API operations (Bearer token injection). Cloudflare's Terraform provider does not support custom endpoints, so we use raw HTTP data sources. Warden intercepts the `Authorization: Bearer` header, authenticates the JWT, and replaces it with the real Cloudflare API token.
+- **`hashicorp/aws`** — for R2 Object Storage operations (SigV4 path). The AWS provider performs real SigV4 signing using the JWT as both `access_key` and `secret_key`. Warden detects the `AWS4-HMAC-SHA256` header, verifies the signature, re-signs with real Cloudflare R2 credentials, and forwards to `<account_id>.r2.cloudflarestorage.com`.
+
+## Prerequisites
+
+1. **Warden server running** with the Cloudflare provider mounted
+2. **Cloudflare account** with:
+   - An API token with Zone Read permissions (from My Profile > API Tokens)
+   - R2 API credentials (access key ID + secret access key) from R2 > Manage R2 API Tokens
+3. **Cloudflare credentials** stored as `cloudflare_keys` credential type in Warden
+4. **JWT auth configured** with a role bound to the Cloudflare credential spec
+5. **Terraform >= 1.10** installed
+
+### Cloudflare API Token Permissions
+
+The API token (`api_token`) needs the following permissions for the test suite:
+
+| Permission | Level | Used By | Purpose |
+|------------|-------|---------|---------|
+| Zone Read | All zones | Tests 1, 5, 6, 14 | List zones, DNS records |
+| User Details Read | User | Tests 2, 3 | Token verify, user details |
+| Account Read | All accounts | Test 4 | List accounts |
+| API Tokens Read | User | Test 16 | List tokens |
+
+The R2 credentials (`access_key_id` + `secret_access_key`) must have **Object Read & Write** permission for tests 7-11, 17-18.
+
+All REST API permissions are **read-only**. No write operations are performed on the Cloudflare REST API — only R2 (S3) tests create/destroy resources.
+
+### Cloudflare Credential Setup
+
+The Cloudflare provider uses `cloudflare_keys` credentials. You can configure all three fields for dual-mode, or just the fields for the mode you need:
+
+| Field | Purpose | How to Obtain |
+|-------|---------|---------------|
+| `api_token` | Bearer token for REST API | Cloudflare Dashboard > My Profile > API Tokens > Create Token |
+| `access_key_id` | R2 access key for Object Storage | Cloudflare Dashboard > R2 > Manage R2 API Tokens |
+| `secret_access_key` | R2 secret key for Object Storage | Generated alongside access_key_id |
+
+## Setup
+
+### 1. Start the identity provider (Hydra)
+
+From the repo root:
+
+```bash
+docker compose -f deploy/docker-compose.quickstart.yml up -d
+```
+
+### 2. Start Warden (dev mode)
+
+```bash
+warden server --dev --dev-root-token=root
+```
+
+### 3. Configure Warden
+
+```bash
+export WARDEN_ADDR="http://127.0.0.1:8400"
+export WARDEN_TOKEN="root"
+
+# Enable JWT auth
+warden auth enable --type=jwt
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create role
+warden write auth/jwt/role/cloudflare-user \
+    token_policies="cloudflare-access" \
+    user_claim=sub \
+    cred_spec_name=cloudflare-ops
+
+# Enable Cloudflare provider
+warden provider enable --type=cloudflare
+
+# Configure provider (account_id required for R2)
+warden write cloudflare/config <<EOF
+{
+  "cloudflare_url": "https://api.cloudflare.com/client/v4",
+  "account_id": "<your-cloudflare-account-id>",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+
+# Create credential source
+warden cred source create cloudflare-src \
+  --type=local
+
+# Create credential spec with Cloudflare keys (dual-mode)
+warden cred spec create cloudflare-ops \
+  --source cloudflare-src \
+  --type=cloudflare_keys \
+  --config mint_method=static_keys \
+  --config access_key_id=<your-r2-access-key-id> \
+  --config secret_access_key=<your-r2-secret-access-key> \
+  --config api_token=<your-cloudflare-api-token>
+
+# Create policy
+warden policy write cloudflare-access - <<EOF
+path "cloudflare/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+### 4. Get a JWT token
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+### 5. Run tests
+
+```bash
+cd provider/cloudflare/e2e_test
+
+export TF_VAR_access_token="${JWT_TOKEN}"
+
+terraform init
+terraform apply -auto-approve
+```
+
+### 6. Cleanup
+
+```bash
+# Destroy R2 resources
+terraform destroy -auto-approve
+
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop Hydra
+docker compose -f deploy/docker-compose.quickstart.yml down -v
+```
+
+## What's Verified
+
+### Standard API (Bearer token injection) — via http
+- Tests 1, 5: Zone listing (basic and with query parameters)
+- Test 2: API token verification
+- Test 3: User details
+- Test 4: Account listing
+- Test 6: DNS records for a zone (nested path)
+- Test 16: User tokens (deep API path)
+
+### R2 Object Storage (SigV4 re-signing) — via hashicorp/aws
+- Test 7: Bucket creation (CreateBucket via SigV4)
+- Tests 8-9: Object upload (PutObject with SigV4 signing, JSON + text)
+- Test 10: Bucket with CORS configuration
+- Test 11: Bucket with lifecycle rules
+- Test 17: Bucket with dots and hyphens in name
+- Test 18: Object with deep nested key path
+
+The AWS provider performs real SigV4 signing with region `auto`. Warden auto-detects this via the `Authorization: AWS4-HMAC-SHA256` header, verifies the client signature, re-signs with real Cloudflare R2 credentials, and forwards to `<account_id>.r2.cloudflarestorage.com`.
+
+### Edge Cases
+- Test 12: Unauthenticated request (expect 401/403)
+- Test 13: Invalid JWT token (expect 401/403)
+- Test 14: Non-existent resource (expect 404/403 forwarded)
+- Test 15: Query parameters with pagination and ordering
+
+## R2 Jurisdictions
+
+R2 supports jurisdiction-restricted buckets. To test a specific jurisdiction, update the provider config:
+
+```bash
+warden write cloudflare/config <<EOF
+{
+  "cloudflare_url": "https://api.cloudflare.com/client/v4",
+  "account_id": "<your-cloudflare-account-id>",
+  "r2_jurisdiction": "eu",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+```
+
+| Jurisdiction | R2 Endpoint |
+|-------------|-------------|
+| Default | `<account_id>.r2.cloudflarestorage.com` |
+| EU | `<account_id>.eu.r2.cloudflarestorage.com` |
+| FedRAMP | `<account_id>.fedramp.r2.cloudflarestorage.com` |
+
+## Customization
+
+Override defaults via variables:
+
+```bash
+# Use a different Warden endpoint
+export TF_VAR_warden_address="http://localhost:8400/v1/cloudflare/role/my-role/gateway"
+```

--- a/provider/cloudflare/e2e_test/main.tf
+++ b/provider/cloudflare/e2e_test/main.tf
@@ -1,0 +1,123 @@
+# main.tf - Cloudflare Provider Test Suite for Warden Cloudflare Gateway
+# Tests Cloudflare API and R2 Object Storage operations through Warden's gateway
+#
+# Uses two provider types:
+# - http: read-only API calls and edge case tests (Bearer token injection)
+# - aws (S3 only): R2 Object Storage operations via SigV4 signing
+#
+# Cloudflare does not have a native Terraform provider that supports custom
+# endpoints, so we use the http data source for REST API tests and the AWS
+# provider for R2 (S3-compatible) operations.
+#
+# Prerequisites:
+#   1. Hydra running (deploy/docker-compose.quickstart.yml)
+#   2. Warden server running with Cloudflare provider mounted
+#   3. Cloudflare credential source and spec configured (cloudflare_keys type)
+#   4. JWT auth configured with a role bound to the credential spec
+#
+# Usage:
+#   export TF_VAR_access_token="<your-jwt-token>"
+#   terraform init && terraform apply
+
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}
+
+################################################################################
+# Variables
+################################################################################
+
+variable "warden_address" {
+  type        = string
+  description = "Warden Cloudflare gateway endpoint URL"
+  default     = "http://localhost:8400/v1/cloudflare/role/cloudflare-user/gateway"
+}
+
+variable "access_token" {
+  type        = string
+  description = "JWT token for Warden authentication (transparent mode)"
+  sensitive   = true
+}
+
+################################################################################
+# Providers
+################################################################################
+
+# AWS provider for R2 Object Storage operations (SigV4 signing)
+# Pointed at Warden's gateway — Warden detects the SigV4 Authorization header,
+# verifies the client signature, re-signs with real Cloudflare R2 credentials,
+# and forwards to <account_id>.r2.cloudflarestorage.com.
+# The JWT is used as both access_key and secret_key (Warden transparent auth).
+# R2 always uses region "auto" for SigV4 signing.
+provider "aws" {
+  region     = "auto"
+  access_key = var.access_token
+  secret_key = var.access_token
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+
+  endpoints {
+    s3 = var.warden_address
+  }
+
+  s3_use_path_style = true
+}
+
+################################################################################
+# Random suffix for unique naming
+################################################################################
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+################################################################################
+# Locals
+################################################################################
+
+locals {
+  name_prefix = "warden-cf-test-${random_id.suffix.hex}"
+
+  # Common headers for http data source requests
+  common_headers = {
+    Accept        = "application/json"
+    Authorization = "Bearer ${var.access_token}"
+  }
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "name_prefix" {
+  value       = local.name_prefix
+  description = "Name prefix used for all test resources"
+}
+
+output "test_timestamp" {
+  value       = timestamp()
+  description = "Timestamp when tests were run"
+}
+
+output "warden_gateway_url" {
+  value       = var.warden_address
+  description = "Warden Cloudflare gateway URL used for testing"
+}

--- a/provider/cloudflare/e2e_test/test-01-api.tf
+++ b/provider/cloudflare/e2e_test/test-01-api.tf
@@ -1,0 +1,116 @@
+# test-01-api.tf
+# Tests 1-6: Cloudflare REST API operations via http data source (zero cost)
+# Validates: Bearer token injection, GET proxying, various Cloudflare API endpoints
+
+################################################################################
+# Test 1: List zones
+# Verifies the gateway injects the Bearer token and proxies GET /zones
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_01_zones" {
+  url             = "${var.warden_address}/zones"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 2: Verify API token
+# Verifies GET /user/tokens/verify through the gateway
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_02_verify_token" {
+  url             = "${var.warden_address}/user/tokens/verify"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 3: Get user details
+# Verifies GET /user through the gateway
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_03_user" {
+  url             = "${var.warden_address}/user"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 4: List accounts
+# Verifies GET /accounts through the gateway
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_04_accounts" {
+  url             = "${var.warden_address}/accounts"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 5: List zones with query parameters
+# Verifies query string passthrough (per_page, status filter)
+# Cost: FREE (read-only)
+################################################################################
+data "http" "test_05_zones_filtered" {
+  url             = "${var.warden_address}/zones?per_page=5&status=active"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 6: List zone DNS records (requires at least one zone)
+# Verifies nested resource path /zones/{zone_id}/dns_records
+# Cost: FREE (read-only)
+# Note: Uses the first zone from test 1; skips if no zones exist
+################################################################################
+data "http" "test_06_dns_records" {
+  count = try(length(jsondecode(data.http.test_01_zones.response_body).result), 0) > 0 ? 1 : 0
+
+  url             = "${var.warden_address}/zones/${jsondecode(data.http.test_01_zones.response_body).result[0].id}/dns_records"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_01_zones" {
+  value = {
+    status_code = data.http.test_01_zones.status_code
+    zone_count  = try(length(jsondecode(data.http.test_01_zones.response_body).result), 0)
+  }
+  description = "Test 1: List zones"
+}
+
+output "test_02_verify_token" {
+  value = {
+    status_code = data.http.test_02_verify_token.status_code
+    success     = try(jsondecode(data.http.test_02_verify_token.response_body).success, false)
+  }
+  description = "Test 2: Verify API token"
+}
+
+output "test_03_user" {
+  value = {
+    status_code = data.http.test_03_user.status_code
+    success     = try(jsondecode(data.http.test_03_user.response_body).success, false)
+  }
+  description = "Test 3: Get user details"
+}
+
+output "test_04_accounts" {
+  value = {
+    status_code   = data.http.test_04_accounts.status_code
+    account_count = try(length(jsondecode(data.http.test_04_accounts.response_body).result), 0)
+  }
+  description = "Test 4: List accounts"
+}
+
+output "test_05_zones_filtered" {
+  value = {
+    status_code = data.http.test_05_zones_filtered.status_code
+  }
+  description = "Test 5: List zones with query params"
+}
+
+output "test_06_dns_records" {
+  value = {
+    status_code = try(data.http.test_06_dns_records[0].status_code, "skipped")
+  }
+  description = "Test 6: Zone DNS records (skipped if no zones)"
+}

--- a/provider/cloudflare/e2e_test/test-02-r2-object-storage.tf
+++ b/provider/cloudflare/e2e_test/test-02-r2-object-storage.tf
@@ -1,0 +1,136 @@
+# test-02-r2-object-storage.tf
+# Tests 7-11: R2 Object Storage via AWS provider (SigV4 signing)
+# Validates: SigV4 auto-detection, signature verification, re-signing,
+#            bucket CRUD, object upload
+# Cost: ~FREE (charges only for stored data, destroyed on cleanup)
+#
+# The AWS provider performs real SigV4 signing using the JWT as both
+# access_key and secret_key. Warden detects the AWS4-HMAC-SHA256
+# Authorization header, verifies the client signature, re-signs with
+# real Cloudflare R2 credentials, and forwards to
+# <account_id>.r2.cloudflarestorage.com.
+#
+# R2 limitations vs full S3:
+# - No versioning support
+# - No object tagging
+# - Region is always "auto"
+
+################################################################################
+# Test 7: Create a basic R2 bucket
+# Verifies SigV4 signature detection and re-signing for bucket creation
+################################################################################
+resource "aws_s3_bucket" "test_07" {
+  bucket        = "${local.name_prefix}-basic"
+  force_destroy = true
+}
+
+################################################################################
+# Test 8: Upload a JSON object
+# Verifies PUT object with custom content type through SigV4 re-signing
+################################################################################
+resource "aws_s3_object" "test_08" {
+  bucket       = aws_s3_bucket.test_07.id
+  key          = "test/data.json"
+  content      = jsonencode({ message = "hello from warden", provider = "cloudflare", version = 1 })
+  content_type = "application/json"
+}
+
+################################################################################
+# Test 9: Upload a text object
+# Verifies PUT object with SigV4 re-signing
+################################################################################
+resource "aws_s3_object" "test_09" {
+  bucket  = aws_s3_bucket.test_07.id
+  key     = "test/hello.txt"
+  content = "Hello from Warden Cloudflare R2 e2e test"
+}
+
+################################################################################
+# Test 10: Create a bucket with CORS configuration
+# Verifies S3 CORS rules through the R2 gateway
+################################################################################
+resource "aws_s3_bucket" "test_10" {
+  bucket        = "${local.name_prefix}-cors"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_cors_configuration" "test_10" {
+  bucket = aws_s3_bucket.test_10.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT"]
+    allowed_origins = ["https://example.com"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}
+
+################################################################################
+# Test 11: Create a bucket with lifecycle rules
+# Verifies lifecycle configuration through the R2 gateway
+################################################################################
+resource "aws_s3_bucket" "test_11" {
+  bucket        = "${local.name_prefix}-lifecycle"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test_11" {
+  bucket = aws_s3_bucket.test_11.id
+
+  rule {
+    id     = "expire-old-objects"
+    status = "Enabled"
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_07_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_07.id
+    bucket = aws_s3_bucket.test_07.bucket
+    arn    = aws_s3_bucket.test_07.arn
+  }
+  description = "Test 7: Basic R2 bucket"
+}
+
+output "test_08_json_object" {
+  value = {
+    bucket = aws_s3_object.test_08.bucket
+    key    = aws_s3_object.test_08.key
+    etag   = aws_s3_object.test_08.etag
+  }
+  description = "Test 8: JSON object"
+}
+
+output "test_09_text_object" {
+  value = {
+    bucket = aws_s3_object.test_09.bucket
+    key    = aws_s3_object.test_09.key
+    etag   = aws_s3_object.test_09.etag
+  }
+  description = "Test 9: Text object"
+}
+
+output "test_10_cors_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_10.id
+    bucket = aws_s3_bucket.test_10.bucket
+  }
+  description = "Test 10: CORS bucket"
+}
+
+output "test_11_lifecycle_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_11.id
+    bucket = aws_s3_bucket.test_11.bucket
+  }
+  description = "Test 11: Lifecycle bucket"
+}

--- a/provider/cloudflare/e2e_test/test-03-edge-cases.tf
+++ b/provider/cloudflare/e2e_test/test-03-edge-cases.tf
@@ -1,0 +1,146 @@
+# test-03-edge-cases.tf
+# Tests 12-18: Edge cases and error handling through Warden gateway
+# Validates: auth failures, 404s, special characters, R2 edge cases
+# Cost: ~FREE
+
+################################################################################
+# Test 12: Request without authentication (should fail)
+# Verifies Warden rejects unauthenticated requests to the gateway
+################################################################################
+data "http" "test_12_no_auth" {
+  url = "${var.warden_address}/zones"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 401 || self.status_code == 403
+      error_message = "Expected 401/403 for unauthenticated request, got ${self.status_code}"
+    }
+  }
+}
+
+################################################################################
+# Test 13: Request with invalid token (should fail)
+# Verifies Warden rejects requests with invalid JWT tokens
+################################################################################
+data "http" "test_13_invalid_token" {
+  url = "${var.warden_address}/zones"
+
+  request_headers = {
+    Accept        = "application/json"
+    Authorization = "Bearer invalid-token-value-not-a-jwt"
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 401 || self.status_code == 403
+      error_message = "Expected 401/403 for invalid token, got ${self.status_code}"
+    }
+  }
+}
+
+################################################################################
+# Test 14: Non-existent zone (should return 404 from Cloudflare)
+# Verifies the gateway forwards Cloudflare's error for missing resources
+################################################################################
+data "http" "test_14_not_found" {
+  url             = "${var.warden_address}/zones/00000000000000000000000000000000"
+  request_headers = local.common_headers
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 404 || self.status_code == 403
+      error_message = "Expected 404/403 for non-existent zone, got ${self.status_code}"
+    }
+  }
+}
+
+################################################################################
+# Test 15: Query parameters with encoding
+# Verifies the gateway preserves query strings
+################################################################################
+data "http" "test_15_query_params" {
+  url             = "${var.warden_address}/zones?per_page=1&page=1&order=name&direction=asc"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 16: Deep nested API path
+# Verifies the gateway handles long URL paths correctly
+################################################################################
+data "http" "test_16_deep_path" {
+  url             = "${var.warden_address}/user/tokens"
+  request_headers = local.common_headers
+}
+
+################################################################################
+# Test 17: R2 bucket with special characters in name
+# Verifies SigV4 handles bucket names with dots and hyphens
+################################################################################
+resource "aws_s3_bucket" "test_17" {
+  bucket        = "${local.name_prefix}-edge.case-bucket"
+  force_destroy = true
+}
+
+################################################################################
+# Test 18: R2 object with deep key path
+# Verifies SigV4 re-signing handles complex object keys
+################################################################################
+resource "aws_s3_object" "test_18" {
+  bucket  = aws_s3_bucket.test_17.id
+  key     = "deep/nested/path/with-special_chars/file.json"
+  content = jsonencode({ test = true, number = 18 })
+}
+
+################################################################################
+# Outputs
+################################################################################
+
+output "test_12_no_auth" {
+  value       = data.http.test_12_no_auth.status_code
+  description = "Test 12: Unauthenticated request (expected 401/403)"
+}
+
+output "test_13_invalid_token" {
+  value       = data.http.test_13_invalid_token.status_code
+  description = "Test 13: Invalid token (expected 401/403)"
+}
+
+output "test_14_not_found" {
+  value       = data.http.test_14_not_found.status_code
+  description = "Test 14: Non-existent zone (expected 404/403)"
+}
+
+output "test_15_query_params" {
+  value = {
+    status_code = data.http.test_15_query_params.status_code
+  }
+  description = "Test 15: Query params with encoding"
+}
+
+output "test_16_deep_path" {
+  value = {
+    status_code = data.http.test_16_deep_path.status_code
+  }
+  description = "Test 16: Deep nested API path"
+}
+
+output "test_17_edge_bucket" {
+  value = {
+    id     = aws_s3_bucket.test_17.id
+    bucket = aws_s3_bucket.test_17.bucket
+  }
+  description = "Test 17: R2 bucket with dots and hyphens in name"
+}
+
+output "test_18_edge_object" {
+  value = {
+    bucket = aws_s3_object.test_18.bucket
+    key    = aws_s3_object.test_18.key
+    etag   = aws_s3_object.test_18.etag
+  }
+  description = "Test 18: R2 object with deep key path"
+}

--- a/provider/cloudflare/provider.go
+++ b/provider/cloudflare/provider.go
@@ -1,9 +1,14 @@
 package cloudflare
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/stephnangue/warden/provider/httpproxy"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/dualgateway"
 )
 
 // DefaultCloudflareURL is the default Cloudflare API base URL
@@ -12,48 +17,116 @@ const DefaultCloudflareURL = "https://api.cloudflare.com/client/v4"
 // DefaultCloudflareTimeout is the default request timeout for Cloudflare API calls
 const DefaultCloudflareTimeout = 30 * time.Second
 
-// Spec defines the Cloudflare provider configuration for the httpproxy framework.
-var Spec = &httpproxy.ProviderSpec{
-	Name:               "cloudflare",
-	DefaultURL:         DefaultCloudflareURL,
-	URLConfigKey:       "cloudflare_url",
-	DefaultTimeout:     DefaultCloudflareTimeout,
-	ParseStreamBody:    true,
-	UserAgent:          "warden-cloudflare-proxy",
-	HelpText:           cloudflareBackendHelp,
-	ExtractCredentials: httpproxy.BearerAPIKeyExtractor,
+// Spec defines the Cloudflare dual-mode gateway provider.
+var Spec = &dualgateway.ProviderSpec{
+	Name:           "cloudflare",
+	HelpText:       cloudflareBackendHelp,
+	CredentialType: credential.TypeCloudflareKeys,
+
+	DefaultURL:     DefaultCloudflareURL,
+	URLConfigKey:   "cloudflare_url",
+	DefaultTimeout: DefaultCloudflareTimeout,
+	UserAgent:      "warden-cloudflare-proxy",
+
+	APIAuth: dualgateway.APIAuthStrategy{
+		HeaderName:         "Authorization",
+		HeaderValueFormat:  "Bearer %s",
+		CredentialField:    "api_token",
+		StripAuthorization: true,
+	},
+
+	ExtraConfigKeys: []string{"account_id", "r2_jurisdiction"},
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"account_id": {
+			Type:        framework.TypeString,
+			Description: "Cloudflare account ID (required for R2 S3 Object Storage)",
+		},
+		"r2_jurisdiction": {
+			Type:        framework.TypeString,
+			Description: "R2 jurisdiction: empty (default), 'eu', or 'fedramp'",
+		},
+	},
+	OnConfigParsed: func(config map[string]any) map[string]any {
+		return map[string]any{
+			"account_id":      framework.GetConfigString(config, "account_id", ""),
+			"r2_jurisdiction": framework.GetConfigString(config, "r2_jurisdiction", ""),
+		}
+	},
+	S3Endpoint: func(state map[string]any, region string) string {
+		accountID, _ := state["account_id"].(string)
+		jurisdiction, _ := state["r2_jurisdiction"].(string)
+		if jurisdiction != "" {
+			return fmt.Sprintf("%s.%s.r2.cloudflarestorage.com", accountID, jurisdiction)
+		}
+		return fmt.Sprintf("%s.r2.cloudflarestorage.com", accountID)
+	},
+
+	// Override: R2 uses access_key_id/secret_access_key (not access_key/secret_key)
+	ExtractS3Credentials: func(req *logical.Request) (awssdk.Credentials, error) {
+		if req.Credential == nil {
+			return awssdk.Credentials{}, fmt.Errorf("no credential available")
+		}
+		if req.Credential.Type != credential.TypeCloudflareKeys {
+			return awssdk.Credentials{}, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+		}
+		ak := req.Credential.Data["access_key_id"]
+		sk := req.Credential.Data["secret_access_key"]
+		if ak == "" || sk == "" {
+			return awssdk.Credentials{}, fmt.Errorf("credential missing access_key_id or secret_access_key")
+		}
+		return awssdk.Credentials{AccessKeyID: ak, SecretAccessKey: sk}, nil
+	},
 }
 
 // Factory creates a new Cloudflare provider backend.
-var Factory = httpproxy.NewFactory(Spec)
+var Factory = dualgateway.NewFactory(Spec)
 
 const cloudflareBackendHelp = `
-The Cloudflare provider enables proxying requests to the Cloudflare API v4
-with automatic credential management and token injection.
+The Cloudflare provider enables proxying requests to Cloudflare APIs with
+automatic credential management and dual authentication mode support.
 
-Warden performs implicit authentication on every request and obtains a
-Cloudflare API token from the credential manager, injecting it into the
-proxied request's Authorization header. This allows Warden to broker
-Cloudflare access without exposing tokens to clients.
+The provider auto-detects the request type based on the Authorization header:
+- Standard API requests: injects Authorization: Bearer header with the API
+  token and forwards to the configured cloudflare_url (default: https://api.cloudflare.com/client/v4)
+- R2 Object Storage requests (AWS SigV4): verifies the incoming signature, re-signs
+  with real Cloudflare R2 credentials, and forwards to <account_id>.r2.cloudflarestorage.com
 
 The gateway path format is:
   /cloudflare/gateway/{api-path}
-
-Examples:
-  /cloudflare/gateway/zones
-  /cloudflare/gateway/zones/{zone_id}/dns_records
-  /cloudflare/gateway/user/tokens/verify
-  /cloudflare/gateway/accounts/{account_id}/workers/scripts
 
 The role can be provided via the X-Warden-Role header, or embedded in
 the URL path:
   /cloudflare/role/{role}/gateway/{api-path}
 
-The supported credential source type is:
-- apikey: Static API token (stored in spec config as api_key)
+Standard API examples:
+  /cloudflare/role/{role}/gateway/zones
+  /cloudflare/role/{role}/gateway/zones/{zone_id}/dns_records
+  /cloudflare/role/{role}/gateway/user/tokens/verify
+  /cloudflare/role/{role}/gateway/accounts/{account_id}/workers/scripts
+
+R2 Object Storage:
+  Clients sign requests with SigV4 using their Warden JWT (as both
+  aws_access_key_id and aws_secret_access_key) or role name (cert auth).
+  Warden verifies the signature, re-signs with real Cloudflare R2 keys, and
+  forwards to the R2 endpoint.
+
+  R2 region is always "auto" for SigV4 signing.
+
+  R2 jurisdictions: default (empty), eu, fedramp
+
+Credential type: cloudflare_keys (at least one mode required)
+  - api_token: API bearer token for the REST API (API mode)
+  - access_key_id: R2 access key ID for Object Storage (R2 mode)
+  - secret_access_key: R2 secret access key for Object Storage (R2 mode)
+
+Two credential source types are supported:
+- local (static_keys): Static credentials stored on the spec
+- hvault (static_cloudflare): Keys fetched from a Vault/OpenBao KV v2 secret
 
 Configuration:
 - cloudflare_url: Cloudflare API base URL (default: https://api.cloudflare.com/client/v4)
+- account_id: Cloudflare account ID (required for R2 S3 Object Storage)
+- r2_jurisdiction: R2 jurisdiction - empty (default), 'eu', or 'fedramp'
 - max_body_size: Maximum request body size (default: 10MB, max: 100MB)
 - timeout: Request timeout duration (default: 30s)
 - auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')


### PR DESCRIPTION
Rewrite Cloudflare provider from httpproxy (Bearer-only) to dualgateway framework, adding auto-detected R2 Object Storage support via SigV4 verify/re-sign alongside the existing REST API Bearer token injection.

- Add cloudflare_keys credential type with flexible mode support: API-only (api_token), R2-only (access_key_id + secret_access_key), or dual-mode (all three fields)
- Use dualgateway extensibility hooks (ExtraConfigKeys, OnConfigParsed, S3Endpoint with state) for account_id-based R2 endpoint construction
- Support R2 jurisdictions: default, eu, fedramp
- Add comprehensive e2e Terraform test suite (18 tests) covering REST API proxying, R2 bucket/object operations, and edge cases