### PR TITLE
feat: add OVH source driver with OAuth2 credential minting

### DIFF
--- a/credential/credential.go
+++ b/credential/credential.go
@@ -38,6 +38,7 @@ const (
 	SourceTypeElastic    = "elastic"
 	SourceTypeKubernetes = "kubernetes"
 	SourceTypeScaleway   = "scaleway"
+	SourceTypeOVH        = "ovh"
 	SourceTypeCloudflare = "cloudflare"
 )
 

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -69,5 +69,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register OVH driver factory
+	if err := registry.RegisterFactory(&OVHDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -1,0 +1,456 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+const ovhMaxResponseBodySize = 1 << 20 // 1MB
+const ovhMaxRetryAttempts = 3
+
+// ovhEndpoint holds the resolved API and OAuth2 token URLs for a region.
+type ovhEndpoint struct {
+	apiURL   string
+	tokenURL string
+}
+
+// ovhEndpoints maps endpoint names to their API and token URLs.
+var ovhEndpoints = map[string]ovhEndpoint{
+	"ovh-eu": {apiURL: "https://eu.api.ovh.com/1.0", tokenURL: "https://www.ovh.com/auth/oauth2/token"},
+	"ovh-ca": {apiURL: "https://ca.api.ovh.com/1.0", tokenURL: "https://ca.ovh.com/auth/oauth2/token"},
+	"ovh-us": {apiURL: "https://api.us.ovhcloud.com/1.0", tokenURL: "https://us.ovhcloud.com/auth/oauth2/token"},
+}
+
+// Compile-time interface assertions
+var _ credential.SourceDriver = (*OVHDriver)(nil)
+var _ credential.SpecVerifier = (*OVHDriver)(nil)
+
+// OVHDriver mints credentials from OVHcloud APIs.
+//
+// Two mint methods are supported (configured per-spec via mint_method):
+//   - oauth2_token: Mints a bearer token via OAuth2 client_credentials grant (~1h TTL)
+//   - dynamic_s3: Creates S3 credentials via the OVH cloud API (static, revocable)
+//   - oauth2_token_and_s3: Mints both a bearer token and S3 credentials
+//
+// The source config holds an OAuth2 service account (client_id + client_secret)
+// and optionally default project_id + user_id for S3 credential management.
+type OVHDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+	apiURL     string // resolved API base URL
+	tokenURL   string // resolved OAuth2 token URL
+
+	// configMu protects credSource.Config reads during potential future rotation.
+	configMu sync.RWMutex
+}
+
+// OVHDriverFactory creates OVHDriver instances.
+type OVHDriverFactory struct{}
+
+// Type returns the driver type identifier.
+func (f *OVHDriverFactory) Type() string {
+	return credential.SourceTypeOVH
+}
+
+// ValidateConfig validates OVH source configuration.
+func (f *OVHDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("client_id").
+			Required().
+			Describe("OAuth2 service account client ID").
+			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+
+		credential.StringField("client_secret").
+			Required().
+			Describe("OAuth2 service account client secret").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("ovh_endpoint").
+			OneOf("ovh-eu", "ovh-ca", "ovh-us").
+			Describe("OVH regional endpoint (default: ovh-eu)").
+			Example("ovh-eu"),
+
+		credential.StringField("project_id").
+			Describe("Default Public Cloud project ID for S3 credential management").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		credential.StringField("user_id").
+			Describe("Default Public Cloud user ID for S3 credential management").
+			Example("12345"),
+
+		credential.StringField("ca_data").
+			Custom(ValidateCAData).
+			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs").
+			Example("LS0tLS1CRUdJTi..."),
+
+		credential.BoolField("tls_skip_verify").
+			Describe("Skip TLS certificate verification (development only)").
+			Example("false"),
+	)
+}
+
+// SensitiveConfigFields returns source config keys that should be masked.
+func (f *OVHDriverFactory) SensitiveConfigFields() []string {
+	return []string{"client_secret", "ca_data"}
+}
+
+// InferCredentialType always returns ovh_keys for OVH sources.
+func (f *OVHDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeOVHKeys, nil
+}
+
+// Create instantiates a new OVHDriver.
+func (f *OVHDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	endpointName := credential.GetString(config, "ovh_endpoint", "ovh-eu")
+	ep, ok := ovhEndpoints[endpointName]
+	if !ok {
+		return nil, fmt.Errorf("unknown ovh_endpoint: %s (expected ovh-eu, ovh-ca, or ovh-us)", endpointName)
+	}
+
+	httpClient, err := BuildHTTPClient(config, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+	}
+
+	driver := &OVHDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOVH,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(credential.SourceTypeOVH),
+		httpClient: httpClient,
+		apiURL:     ep.apiURL,
+		tokenURL:   ep.tokenURL,
+	}
+
+	return driver, nil
+}
+
+// Type returns the driver type.
+func (d *OVHDriver) Type() string {
+	return credential.SourceTypeOVH
+}
+
+// MintCredential returns OVH credentials for the given spec.
+func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	switch mintMethod {
+	case "oauth2_token":
+		return d.mintOAuth2Token(ctx)
+	case "dynamic_s3":
+		return d.mintDynamicS3(ctx, spec)
+	case "oauth2_token_and_s3":
+		return d.mintOAuth2TokenAndS3(ctx, spec)
+	default:
+		return nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected oauth2_token, dynamic_s3, or oauth2_token_and_s3)", mintMethod)
+	}
+}
+
+// getClientCredentials reads client_id and client_secret from source config under RLock.
+func (d *OVHDriver) getClientCredentials() (clientID, clientSecret string) {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	clientID = credential.GetString(d.credSource.Config, "client_id", "")
+	clientSecret = credential.GetString(d.credSource.Config, "client_secret", "")
+	return
+}
+
+// resolveProjectAndUser resolves project_id and user_id from spec config, falling back to source config.
+func (d *OVHDriver) resolveProjectAndUser(spec *credential.CredSpec) (projectID, userID string, err error) {
+	projectID = credential.GetString(spec.Config, "project_id", "")
+	if projectID == "" {
+		d.configMu.RLock()
+		projectID = credential.GetString(d.credSource.Config, "project_id", "")
+		d.configMu.RUnlock()
+	}
+	if projectID == "" {
+		return "", "", fmt.Errorf("project_id is required for S3 credential management (set on source or spec)")
+	}
+
+	userID = credential.GetString(spec.Config, "user_id", "")
+	if userID == "" {
+		d.configMu.RLock()
+		userID = credential.GetString(d.credSource.Config, "user_id", "")
+		d.configMu.RUnlock()
+	}
+	if userID == "" {
+		return "", "", fmt.Errorf("user_id is required for S3 credential management (set on source or spec)")
+	}
+
+	return projectID, userID, nil
+}
+
+// fetchOAuth2Token performs the OAuth2 client_credentials exchange and returns the access token and TTL.
+func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, ttl time.Duration, err error) {
+	clientID, clientSecret := d.getClientCredentials()
+	if clientID == "" || clientSecret == "" {
+		return "", 0, fmt.Errorf("client_id and client_secret are required on source config")
+	}
+
+	formData := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       ovhMaxRetryAttempts,
+		MaxBodySize:       ovhMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodPost,
+		URL:    d.tokenURL,
+		Body:   []byte(formData.Encode()),
+		Headers: map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept":       "application/json",
+		},
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return "", 0, fmt.Errorf("OAuth2 token request failed: %w", err)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", 0, fmt.Errorf("failed to parse OAuth2 token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", 0, fmt.Errorf("OVH OAuth2 response returned empty access_token")
+	}
+
+	tokenTTL := time.Duration(tokenResp.ExpiresIn) * time.Second
+	if tokenTTL <= 0 {
+		tokenTTL = 1 * time.Hour // fallback if expires_in is missing
+	}
+
+	return tokenResp.AccessToken, tokenTTL, nil
+}
+
+// mintOAuth2Token mints a bearer token via the OAuth2 client_credentials grant.
+func (d *OVHDriver) mintOAuth2Token(ctx context.Context) (map[string]interface{}, time.Duration, string, error) {
+	token, ttl, err := d.fetchOAuth2Token(ctx)
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	d.logger.Info("minted OVH OAuth2 bearer token",
+		logger.String("ttl", ttl.String()),
+	)
+
+	rawData := map[string]interface{}{
+		"api_token": token,
+	}
+
+	return rawData, ttl, "", nil // No leaseID — token expires naturally
+}
+
+// s3CredentialResult holds the result of an S3 credential creation call.
+type s3CredentialResult struct {
+	accessKey string
+	secretKey string
+	leaseID   string // projectId/userId/accessKeyId — used for revocation
+}
+
+// createS3Credentials creates S3 credentials via the OVH cloud API.
+// The token must be a valid OAuth2 bearer token for API auth.
+func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, userID string) (*s3CredentialResult, error) {
+	apiURL := fmt.Sprintf("%s/cloud/project/%s/user/%s/s3Credentials", d.apiURL, projectID, userID)
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       ovhMaxRetryAttempts,
+		MaxBodySize:       ovhMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodPost,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + token,
+			"Content-Type":  "application/json",
+			"Accept":        "application/json",
+		},
+	}
+
+	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OVH S3 credentials: %w", err)
+	}
+
+	var s3Resp struct {
+		Access string `json:"access"`
+		Secret string `json:"secret"`
+	}
+	if err := json.Unmarshal(respBody, &s3Resp); err != nil {
+		return nil, fmt.Errorf("failed to parse S3 credentials response: %w", err)
+	}
+
+	if s3Resp.Access == "" || s3Resp.Secret == "" {
+		return nil, fmt.Errorf("OVH API returned empty S3 access or secret key")
+	}
+
+	return &s3CredentialResult{
+		accessKey: s3Resp.Access,
+		secretKey: s3Resp.Secret,
+		leaseID:   fmt.Sprintf("%s/%s/%s", projectID, userID, s3Resp.Access),
+	}, nil
+}
+
+// mintDynamicS3 creates S3 credentials via the OVH cloud API.
+func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	token, _, err := d.fetchOAuth2Token(ctx)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to get OAuth2 token for S3 credential creation: %w", err)
+	}
+
+	projectID, userID, err := d.resolveProjectAndUser(spec)
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	s3, err := d.createS3Credentials(ctx, token, projectID, userID)
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	d.logger.Info("created dynamic OVH S3 credentials",
+		logger.String("access_key", truncateID(s3.accessKey, 8)),
+		logger.String("spec", spec.Name),
+	)
+
+	rawData := map[string]interface{}{
+		"access_key": s3.accessKey,
+		"secret_key": s3.secretKey,
+	}
+
+	return rawData, 0, s3.leaseID, nil // Static S3 keys — no TTL, but revocable via leaseID
+}
+
+// mintOAuth2TokenAndS3 mints both a bearer token and S3 credentials.
+func (d *OVHDriver) mintOAuth2TokenAndS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	token, tokenTTL, err := d.fetchOAuth2Token(ctx)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to mint OAuth2 token for dual-mode credential: %w", err)
+	}
+
+	projectID, userID, err := d.resolveProjectAndUser(spec)
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	s3, err := d.createS3Credentials(ctx, token, projectID, userID)
+	if err != nil {
+		return nil, 0, "", err
+	}
+
+	d.logger.Info("minted OVH dual-mode credentials (OAuth2 token + S3)",
+		logger.String("access_key", truncateID(s3.accessKey, 8)),
+		logger.String("token_ttl", tokenTTL.String()),
+		logger.String("spec", spec.Name),
+	)
+
+	rawData := map[string]interface{}{
+		"api_token":  token,
+		"access_key": s3.accessKey,
+		"secret_key": s3.secretKey,
+	}
+
+	// TTL = token TTL (shorter-lived governs refresh; S3 keys are revoked on refresh)
+	return rawData, tokenTTL, s3.leaseID, nil
+}
+
+// Revoke deletes dynamically created S3 credentials.
+// The leaseID format is: projectId/userId/accessKeyId
+func (d *OVHDriver) Revoke(ctx context.Context, leaseID string) error {
+	if leaseID == "" {
+		return nil
+	}
+
+	parts := strings.SplitN(leaseID, "/", 3)
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid OVH lease ID format: %s (expected projectId/userId/accessKeyId)", leaseID)
+	}
+	projectID, userID, accessKeyID := parts[0], parts[1], parts[2]
+
+	// Mint a fresh token for API auth
+	token, _, err := d.fetchOAuth2Token(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get OAuth2 token for S3 credential revocation: %w", err)
+	}
+
+	apiURL := fmt.Sprintf("%s/cloud/project/%s/user/%s/s3Credentials/%s", d.apiURL, projectID, userID, accessKeyID)
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       ovhMaxRetryAttempts,
+		MaxBodySize:       ovhMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method: http.MethodDelete,
+		URL:    apiURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + token,
+			"Accept":        "application/json",
+		},
+		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
+	}
+
+	_, _, err = ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil {
+		return fmt.Errorf("failed to revoke OVH S3 credentials %s: %w", accessKeyID, err)
+	}
+
+	d.logger.Info("revoked OVH S3 credentials",
+		logger.String("access_key", truncateID(accessKeyID, 8)),
+	)
+
+	return nil
+}
+
+// Cleanup releases resources.
+func (d *OVHDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates that the spec config is valid for the chosen mint method.
+func (d *OVHDriver) VerifySpec(_ context.Context, spec *credential.CredSpec) error {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+
+	switch mintMethod {
+	case "oauth2_token":
+		// No extra config needed — uses source's client_id/secret
+		return nil
+	case "dynamic_s3", "oauth2_token_and_s3":
+		_, _, err := d.resolveProjectAndUser(spec)
+		return err
+	default:
+		return fmt.Errorf("unsupported mint_method: %s (expected oauth2_token, dynamic_s3, or oauth2_token_and_s3)", mintMethod)
+	}
+}

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -1,0 +1,749 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createOVHTestLogger() *logger.GatedLogger {
+	config := &logger.Config{
+		Level:   logger.TraceLevel,
+		Format:  logger.DefaultFormat,
+		Outputs: []io.Writer{io.Discard},
+	}
+	gl, _ := logger.NewGatedLogger(config, logger.GatedWriterConfig{
+		Underlying:   io.Discard,
+		InitialState: logger.GateOpen,
+	})
+	return gl
+}
+
+// createOVHTestDriver creates an OVHDriver pointing at a test server.
+// The driver's apiURL and tokenURL are overridden to point at the test server.
+func createOVHTestDriver(t *testing.T, serverURL string, extraConfig map[string]string) *OVHDriver {
+	t.Helper()
+
+	config := map[string]string{
+		"client_id":       "test-client-id",
+		"client_secret":   "test-client-secret",
+		"ovh_endpoint":    "ovh-eu",
+		"tls_skip_verify": "true",
+	}
+	for k, v := range extraConfig {
+		config[k] = v
+	}
+
+	log := createOVHTestLogger()
+
+	httpClient, err := BuildHTTPClient(config, 30*time.Second)
+	require.NoError(t, err)
+
+	driver := &OVHDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeOVH,
+			Config: config,
+		},
+		logger:     log.WithSubsystem(credential.SourceTypeOVH),
+		httpClient: httpClient,
+		apiURL:     serverURL,
+		tokenURL:   serverURL + "/auth/oauth2/token",
+	}
+
+	return driver
+}
+
+// --- Factory tests ---
+
+func TestOVHDriverFactory_Type(t *testing.T) {
+	f := &OVHDriverFactory{}
+	assert.Equal(t, credential.SourceTypeOVH, f.Type())
+}
+
+func TestOVHDriverFactory_InferCredentialType(t *testing.T) {
+	f := &OVHDriverFactory{}
+	ct, err := f.InferCredentialType(map[string]string{})
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeOVHKeys, ct)
+}
+
+func TestOVHDriverFactory_ValidateConfig(t *testing.T) {
+	f := &OVHDriverFactory{}
+
+	t.Run("valid config", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+			"ovh_endpoint":  "ovh-eu",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid config with S3 fields", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+			"project_id":    "proj-123",
+			"user_id":       "user-456",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing client_id", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"client_secret": "test-secret",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client_id")
+	})
+
+	t.Run("missing client_secret", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"client_id": "test-id",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client_secret")
+	})
+
+	t.Run("invalid endpoint", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+			"ovh_endpoint":  "ovh-invalid",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ovh_endpoint")
+	})
+}
+
+func TestOVHDriverFactory_SensitiveConfigFields(t *testing.T) {
+	f := &OVHDriverFactory{}
+	fields := f.SensitiveConfigFields()
+	assert.Contains(t, fields, "client_secret")
+	assert.Contains(t, fields, "ca_data")
+}
+
+func TestOVHDriverFactory_Create(t *testing.T) {
+	f := &OVHDriverFactory{}
+	log := createOVHTestLogger()
+
+	t.Run("valid creation", func(t *testing.T) {
+		driver, err := f.Create(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+		}, log)
+		require.NoError(t, err)
+		require.NotNil(t, driver)
+		assert.Equal(t, credential.SourceTypeOVH, driver.Type())
+	})
+
+	t.Run("defaults to ovh-eu", func(t *testing.T) {
+		driver, err := f.Create(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+		}, log)
+		require.NoError(t, err)
+		ovhDriver := driver.(*OVHDriver)
+		assert.Equal(t, "https://eu.api.ovh.com/1.0", ovhDriver.apiURL)
+		assert.Equal(t, "https://www.ovh.com/auth/oauth2/token", ovhDriver.tokenURL)
+	})
+
+	t.Run("ovh-us endpoint", func(t *testing.T) {
+		driver, err := f.Create(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+			"ovh_endpoint":  "ovh-us",
+		}, log)
+		require.NoError(t, err)
+		ovhDriver := driver.(*OVHDriver)
+		assert.Equal(t, "https://api.us.ovhcloud.com/1.0", ovhDriver.apiURL)
+		assert.Equal(t, "https://us.ovhcloud.com/auth/oauth2/token", ovhDriver.tokenURL)
+	})
+
+	t.Run("unknown endpoint", func(t *testing.T) {
+		_, err := f.Create(map[string]string{
+			"client_id":     "test-id",
+			"client_secret": "test-secret",
+			"ovh_endpoint":  "ovh-invalid",
+		}, log)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown ovh_endpoint")
+	})
+}
+
+// --- OAuth2 token mint tests ---
+
+func TestOVHDriver_MintOAuth2Token(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token" {
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+			r.ParseForm()
+			assert.Equal(t, "client_credentials", r.PostForm.Get("grant_type"))
+			assert.Equal(t, "test-client-id", r.PostForm.Get("client_id"))
+			assert.Equal(t, "test-client-secret", r.PostForm.Get("client_secret"))
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "eyJhbGciOiJSUzI1NiIs.test-token",
+				"token_type":   "Bearer",
+				"expires_in":   3599,
+			})
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+
+	spec := &credential.CredSpec{
+		Name: "api-spec",
+		Config: map[string]string{
+			"mint_method": "oauth2_token",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJhbGciOiJSUzI1NiIs.test-token", rawData["api_token"])
+	assert.Equal(t, 3599*time.Second, ttl)
+	assert.Empty(t, leaseID) // OAuth2 tokens expire naturally
+}
+
+func TestOVHDriver_MintOAuth2Token_EmptyResponse(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "",
+			"token_type":   "Bearer",
+			"expires_in":   3599,
+		})
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+
+	spec := &credential.CredSpec{
+		Name:   "api-spec",
+		Config: map[string]string{"mint_method": "oauth2_token"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty access_token")
+}
+
+// --- Dynamic S3 credential tests ---
+
+func TestOVHDriver_MintDynamicS3(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "temp-token",
+				"token_type":   "Bearer",
+				"expires_in":   3599,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/proj-123/user/user-456/s3Credentials":
+			assert.Equal(t, "Bearer temp-token", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access": "s3-access-key-123",
+				"secret": "s3-secret-key-456",
+			})
+
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "user-456",
+	})
+
+	spec := &credential.CredSpec{
+		Name: "s3-spec",
+		Config: map[string]string{
+			"mint_method": "dynamic_s3",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "s3-access-key-123", rawData["access_key"])
+	assert.Equal(t, "s3-secret-key-456", rawData["secret_key"])
+	assert.Equal(t, time.Duration(0), ttl) // S3 keys are static
+	assert.Equal(t, "proj-123/user-456/s3-access-key-123", leaseID)
+}
+
+func TestOVHDriver_MintDynamicS3_SpecOverridesSource(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "temp-token",
+				"token_type":   "Bearer",
+				"expires_in":   3599,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/spec-proj/user/spec-user/s3Credentials":
+			// Spec-level project_id and user_id should be used
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access": "s3-key",
+				"secret": "s3-secret",
+			})
+
+		default:
+			http.Error(w, "unexpected: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "source-proj",
+		"user_id":    "source-user",
+	})
+
+	spec := &credential.CredSpec{
+		Name: "s3-spec",
+		Config: map[string]string{
+			"mint_method": "dynamic_s3",
+			"project_id":  "spec-proj",
+			"user_id":     "spec-user",
+		},
+	}
+
+	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "s3-key", rawData["access_key"])
+	assert.Equal(t, "spec-proj/spec-user/s3-key", leaseID)
+}
+
+func TestOVHDriver_MintDynamicS3_MissingProjectID(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "temp-token",
+			"expires_in":   3599,
+		})
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil) // No project_id on source
+
+	spec := &credential.CredSpec{
+		Name: "s3-spec",
+		Config: map[string]string{
+			"mint_method": "dynamic_s3",
+			// No project_id on spec either
+			"user_id": "user-123",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project_id")
+}
+
+func TestOVHDriver_MintDynamicS3_MissingUserID(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "temp-token",
+			"expires_in":   3599,
+		})
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+	})
+
+	spec := &credential.CredSpec{
+		Name: "s3-spec",
+		Config: map[string]string{
+			"mint_method": "dynamic_s3",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user_id")
+}
+
+// --- Dual mode (oauth2_token_and_s3) tests ---
+
+func TestOVHDriver_MintOAuth2TokenAndS3(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "dual-token",
+				"token_type":   "Bearer",
+				"expires_in":   3599,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/proj-123/user/user-456/s3Credentials":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access": "dual-s3-key",
+				"secret": "dual-s3-secret",
+			})
+
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "user-456",
+	})
+
+	spec := &credential.CredSpec{
+		Name: "dual-spec",
+		Config: map[string]string{
+			"mint_method": "oauth2_token_and_s3",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "dual-token", rawData["api_token"])
+	assert.Equal(t, "dual-s3-key", rawData["access_key"])
+	assert.Equal(t, "dual-s3-secret", rawData["secret_key"])
+	assert.Equal(t, 3599*time.Second, ttl) // Token TTL governs refresh
+	assert.Equal(t, "proj-123/user-456/dual-s3-key", leaseID)
+}
+
+// --- Unsupported mint method ---
+
+func TestOVHDriver_MintCredential_UnsupportedMethod(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+
+	spec := &credential.CredSpec{
+		Name: "bad-spec",
+		Config: map[string]string{
+			"mint_method": "unknown",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported mint_method")
+}
+
+// --- Revoke tests ---
+
+func TestOVHDriver_Revoke(t *testing.T) {
+	var deletedPath string
+	tokenCalled := false
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
+			tokenCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "revoke-token",
+				"expires_in":   3599,
+			})
+
+		case r.Method == http.MethodDelete:
+			assert.Equal(t, "Bearer revoke-token", r.Header.Get("Authorization"))
+			deletedPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+
+	err := driver.Revoke(context.Background(), "proj-123/user-456/s3-key-789")
+	require.NoError(t, err)
+	assert.True(t, tokenCalled)
+	assert.Equal(t, "/cloud/project/proj-123/user/user-456/s3Credentials/s3-key-789", deletedPath)
+}
+
+func TestOVHDriver_Revoke_EmptyLeaseID(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+	err := driver.Revoke(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestOVHDriver_Revoke_InvalidLeaseID(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+	err := driver.Revoke(context.Background(), "invalid-format")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid OVH lease ID format")
+}
+
+// --- VerifySpec tests ---
+
+func TestOVHDriver_VerifySpec(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "user-456",
+	})
+
+	t.Run("oauth2_token - no extra config needed", func(t *testing.T) {
+		err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+			Name:   "api-spec",
+			Config: map[string]string{"mint_method": "oauth2_token"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("dynamic_s3 - source has project_id and user_id", func(t *testing.T) {
+		err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+			Name:   "s3-spec",
+			Config: map[string]string{"mint_method": "dynamic_s3"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("dynamic_s3 - missing project_id", func(t *testing.T) {
+		driverNoProject := createOVHTestDriver(t, "https://unused", nil)
+		err := driverNoProject.VerifySpec(context.Background(), &credential.CredSpec{
+			Name:   "s3-spec",
+			Config: map[string]string{"mint_method": "dynamic_s3"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project_id")
+	})
+
+	t.Run("unsupported mint_method", func(t *testing.T) {
+		err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+			Name:   "bad-spec",
+			Config: map[string]string{"mint_method": "unknown"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported mint_method")
+	})
+}
+
+// --- Error handling tests ---
+
+func TestOVHDriver_MintOAuth2Token_ServerError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid_client","error_description":"unknown client"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+	spec := &credential.CredSpec{
+		Name:   "api-spec",
+		Config: map[string]string{"mint_method": "oauth2_token"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OAuth2 token request failed")
+}
+
+func TestOVHDriver_MintOAuth2Token_MalformedJSON(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":`)) // truncated JSON
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+	spec := &credential.CredSpec{
+		Name:   "api-spec",
+		Config: map[string]string{"mint_method": "oauth2_token"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse OAuth2 token response")
+}
+
+func TestOVHDriver_MintOAuth2Token_MissingExpiresIn(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "valid-token",
+			"token_type":   "Bearer",
+			// no expires_in — should fall back to 1h
+		})
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+	spec := &credential.CredSpec{
+		Name:   "api-spec",
+		Config: map[string]string{"mint_method": "oauth2_token"},
+	}
+
+	rawData, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "valid-token", rawData["api_token"])
+	assert.Equal(t, 1*time.Hour, ttl) // fallback TTL
+}
+
+func TestOVHDriver_MintDynamicS3_EmptySecret(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "temp-token",
+				"expires_in":   3599,
+			})
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access": "s3-key",
+				"secret": "", // empty secret
+			})
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "user-456",
+	})
+
+	spec := &credential.CredSpec{
+		Name:   "s3-spec",
+		Config: map[string]string{"mint_method": "dynamic_s3"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty S3 access or secret key")
+}
+
+func TestOVHDriver_MintDynamicS3_APIError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "temp-token",
+				"expires_in":   3599,
+			})
+		default:
+			http.Error(w, `{"message":"User not found"}`, http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "bad-user",
+	})
+
+	spec := &credential.CredSpec{
+		Name:   "s3-spec",
+		Config: map[string]string{"mint_method": "dynamic_s3"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create OVH S3 credentials")
+}
+
+func TestOVHDriver_MintOAuth2TokenAndS3_CallCount(t *testing.T) {
+	var tokenCalls, s3Calls int
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
+			tokenCalls++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "counted-token",
+				"expires_in":   3599,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/proj-123/user/user-456/s3Credentials":
+			s3Calls++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access": "counted-key",
+				"secret": "counted-secret",
+			})
+
+		default:
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "user-456",
+	})
+
+	spec := &credential.CredSpec{
+		Name:   "dual-spec",
+		Config: map[string]string{"mint_method": "oauth2_token_and_s3"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, 1, tokenCalls, "should make exactly 1 token call")
+	assert.Equal(t, 1, s3Calls, "should make exactly 1 S3 credential call")
+}
+
+func TestOVHDriver_MintOAuth2TokenAndS3_S3APIError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "good-token",
+				"expires_in":   3599,
+			})
+		default:
+			http.Error(w, `{"message":"Forbidden"}`, http.StatusForbidden)
+		}
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, map[string]string{
+		"project_id": "proj-123",
+		"user_id":    "user-456",
+	})
+
+	spec := &credential.CredSpec{
+		Name:   "dual-spec",
+		Config: map[string]string{"mint_method": "oauth2_token_and_s3"},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create OVH S3 credentials")
+}
+
+// --- Cleanup test ---
+
+func TestOVHDriver_Cleanup(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+	err := driver.Cleanup(context.Background())
+	assert.NoError(t, err)
+}

--- a/credential/types/ovh_keys.go
+++ b/credential/types/ovh_keys.go
@@ -26,41 +26,26 @@ func (t *OVHKeysCredType) Metadata() credential.TypeMetadata {
 // ConfigSchema returns the declarative schema for OVH key credential config
 func (t *OVHKeysCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
-		credential.StringField("access_key").
-			Describe("OVH S3 access key").
-			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
-
-		credential.StringField("secret_key").
-			Describe("OVH S3 secret key").
-			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
-
-		credential.StringField("api_token").
-			Describe("OVH API bearer token for REST API").
-			Example("eyJhbGciOiJSUzI1NiIs..."),
-
 		credential.StringField("mint_method").
-			OneOf("static_keys", "static_ovh").
+			OneOf("oauth2_token", "dynamic_s3", "oauth2_token_and_s3").
 			Describe("Mint method for credential minting").
-			Example("static_keys"),
+			Example("oauth2_token"),
 
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_ovh)").
-			Example("secret"),
+		// Per-spec overrides for S3 user targeting
+		credential.StringField("project_id").
+			Describe("Public Cloud project ID (overrides source default, required for dynamic_s3/oauth2_token_and_s3)").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_ovh)").
-			Example("ovh/prod/keys"),
+		credential.StringField("user_id").
+			Describe("Public Cloud user ID (overrides source default, required for dynamic_s3/oauth2_token_and_s3)").
+			Example("12345"),
 	}
 }
 
 // ValidateConfig validates the Config for an OVH credential spec
 func (t *OVHKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	switch sourceType {
-	case credential.SourceTypeLocal, credential.SourceTypeVault:
-		// Supported
-	default:
-		return fmt.Errorf("ovh_keys credentials require a local or vault source, got: %s", sourceType)
+	if sourceType != credential.SourceTypeOVH {
+		return fmt.Errorf("ovh_keys credentials require an ovh source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -68,27 +53,12 @@ func (t *OVHKeysCredType) ValidateConfig(config map[string]string, sourceType st
 		return err
 	}
 
-	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_ovh" {
-			return fmt.Errorf("'mint_method' must be 'static_ovh' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_ovh")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_ovh")
-		}
+	mintMethod := config["mint_method"]
+	switch mintMethod {
+	case "oauth2_token", "dynamic_s3", "oauth2_token_and_s3":
+		// Valid — driver handles the rest
 	default:
-		if config["access_key"] == "" {
-			return fmt.Errorf("'access_key' is required")
-		}
-		if config["secret_key"] == "" {
-			return fmt.Errorf("'secret_key' is required")
-		}
-		if config["api_token"] == "" {
-			return fmt.Errorf("'api_token' is required")
-		}
+		return fmt.Errorf("'mint_method' must be 'oauth2_token', 'dynamic_s3', or 'oauth2_token_and_s3', got: %s", mintMethod)
 	}
 
 	return nil
@@ -96,19 +66,33 @@ func (t *OVHKeysCredType) ValidateConfig(config map[string]string, sourceType st
 
 // Parse converts raw credential data from source into structured Credential
 func (t *OVHKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
-	accessKey, ok := rawData["access_key"].(string)
-	if !ok || accessKey == "" {
-		return nil, fmt.Errorf("%w: missing or invalid access_key", credential.ErrInvalidCredential)
+	accessKey, _ := rawData["access_key"].(string)
+	secretKey, _ := rawData["secret_key"].(string)
+	apiToken, _ := rawData["api_token"].(string)
+
+	// S3 mode fields must come as a pair
+	if (accessKey != "") != (secretKey != "") {
+		if accessKey == "" {
+			return nil, fmt.Errorf("%w: access_key is required when secret_key is provided", credential.ErrInvalidCredential)
+		}
+		return nil, fmt.Errorf("%w: secret_key is required when access_key is provided", credential.ErrInvalidCredential)
 	}
 
-	secretKey, ok := rawData["secret_key"].(string)
-	if !ok || secretKey == "" {
-		return nil, fmt.Errorf("%w: missing or invalid secret_key", credential.ErrInvalidCredential)
+	hasS3 := accessKey != "" && secretKey != ""
+	hasAPI := apiToken != ""
+
+	// At least one complete mode required
+	if !hasS3 && !hasAPI {
+		return nil, fmt.Errorf("%w: at least one mode is required: api_token for API mode, or access_key + secret_key for S3 mode", credential.ErrInvalidCredential)
 	}
 
-	apiToken, ok := rawData["api_token"].(string)
-	if !ok || apiToken == "" {
-		return nil, fmt.Errorf("%w: missing or invalid api_token", credential.ErrInvalidCredential)
+	data := make(map[string]string)
+	if hasS3 {
+		data["access_key"] = accessKey
+		data["secret_key"] = secretKey
+	}
+	if hasAPI {
+		data["api_token"] = apiToken
 	}
 
 	return &credential.Credential{
@@ -118,11 +102,7 @@ func (t *OVHKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Du
 		LeaseID:   leaseID,
 		IssuedAt:  time.Now(),
 		Revocable: leaseTTL > 0,
-		Data: map[string]string{
-			"access_key": accessKey,
-			"secret_key": secretKey,
-			"api_token":  apiToken,
-		},
+		Data:      data,
 	}, nil
 }
 
@@ -132,14 +112,22 @@ func (t *OVHKeysCredType) Validate(cred *credential.Credential) error {
 		return fmt.Errorf("%w: expected type %s, got %s", credential.ErrInvalidCredential, credential.TypeOVHKeys, cred.Type)
 	}
 
-	if cred.Data["access_key"] == "" {
-		return fmt.Errorf("%w: missing access_key", credential.ErrInvalidCredential)
+	hasAccessKey := cred.Data["access_key"] != ""
+	hasSecretKey := cred.Data["secret_key"] != ""
+	hasAPIToken := cred.Data["api_token"] != ""
+
+	// S3 mode fields must come as a pair
+	if hasAccessKey != hasSecretKey {
+		if !hasAccessKey {
+			return fmt.Errorf("%w: missing access_key (required when secret_key is present)", credential.ErrInvalidCredential)
+		}
+		return fmt.Errorf("%w: missing secret_key (required when access_key is present)", credential.ErrInvalidCredential)
 	}
-	if cred.Data["secret_key"] == "" {
-		return fmt.Errorf("%w: missing secret_key", credential.ErrInvalidCredential)
-	}
-	if cred.Data["api_token"] == "" {
-		return fmt.Errorf("%w: missing api_token", credential.ErrInvalidCredential)
+
+	hasS3 := hasAccessKey && hasSecretKey
+
+	if !hasS3 && !hasAPIToken {
+		return fmt.Errorf("%w: at least one mode is required: api_token or access_key + secret_key", credential.ErrInvalidCredential)
 	}
 
 	return nil
@@ -164,22 +152,22 @@ func (t *OVHKeysCredType) RequiresSpecRotation() bool {
 
 // SensitiveConfigFields returns spec config keys that should be masked in output
 func (t *OVHKeysCredType) SensitiveConfigFields() []string {
-	return []string{"secret_key", "api_token"}
+	return nil
 }
 
 // FieldSchemas returns metadata about the credential's data fields
 func (t *OVHKeysCredType) FieldSchemas() map[string]*credential.CredentialFieldSchema {
 	return map[string]*credential.CredentialFieldSchema{
 		"access_key": {
-			Description: "OVH S3 access key",
+			Description: "OVH S3 access key (required for S3 mode, optional if only using API mode)",
 			Sensitive:   false,
 		},
 		"secret_key": {
-			Description: "OVH S3 secret key",
+			Description: "OVH S3 secret key (required for S3 mode, optional if only using API mode)",
 			Sensitive:   true,
 		},
 		"api_token": {
-			Description: "OVH API bearer token",
+			Description: "OVH API bearer token (required for API mode, optional if only using S3 mode)",
 			Sensitive:   true,
 		},
 	}

--- a/credential/types/ovh_keys_test.go
+++ b/credential/types/ovh_keys_test.go
@@ -20,7 +20,7 @@ func TestOVHKeysCredType_Metadata(t *testing.T) {
 	assert.Equal(t, time.Duration(0), m.DefaultTTL)
 }
 
-func TestOVHKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
+func TestOVHKeysCredType_ValidateConfig_OVHSource(t *testing.T) {
 	ct := &OVHKeysCredType{}
 	tests := []struct {
 		name    string
@@ -29,119 +29,41 @@ func TestOVHKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid local config",
-			config: map[string]string{
-				"access_key": "test-access-key",
-				"secret_key": "test-secret-key",
-				"api_token":  "test-api-token",
-			},
+			name:    "valid: oauth2_token",
+			config:  map[string]string{"mint_method": "oauth2_token"},
 			wantErr: false,
 		},
 		{
-			name: "missing access_key",
-			config: map[string]string{
-				"secret_key": "test-secret-key",
-				"api_token":  "test-api-token",
-			},
-			wantErr: true,
-			errMsg:  "access_key",
+			name:    "valid: dynamic_s3",
+			config:  map[string]string{"mint_method": "dynamic_s3"},
+			wantErr: false,
 		},
 		{
-			name: "missing secret_key",
-			config: map[string]string{
-				"access_key": "test-access-key",
-				"api_token":  "test-api-token",
-			},
-			wantErr: true,
-			errMsg:  "secret_key",
+			name:    "valid: oauth2_token_and_s3",
+			config:  map[string]string{"mint_method": "oauth2_token_and_s3"},
+			wantErr: false,
 		},
 		{
-			name: "missing api_token",
-			config: map[string]string{
-				"access_key": "test-access-key",
-				"secret_key": "test-secret-key",
-			},
-			wantErr: true,
-			errMsg:  "api_token",
+			name:    "valid: dynamic_s3 with project_id and user_id overrides",
+			config:  map[string]string{"mint_method": "dynamic_s3", "project_id": "proj-123", "user_id": "user-456"},
+			wantErr: false,
 		},
 		{
-			name:    "empty config",
+			name:    "invalid: missing mint_method",
 			config:  map[string]string{},
 			wantErr: true,
-			errMsg:  "access_key",
+			errMsg:  "mint_method",
+		},
+		{
+			name:    "invalid: wrong mint_method",
+			config:  map[string]string{"mint_method": "static_keys"},
+			wantErr: true,
+			errMsg:  "mint_method",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ct.ValidateConfig(tt.config, credential.SourceTypeLocal)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestOVHKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
-	ct := &OVHKeysCredType{}
-	tests := []struct {
-		name    string
-		config  map[string]string
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name: "valid vault config",
-			config: map[string]string{
-				"mint_method": "static_ovh",
-				"kv2_mount":   "secret",
-				"secret_path": "ovh/prod/keys",
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing mint_method",
-			config: map[string]string{
-				"kv2_mount":   "secret",
-				"secret_path": "ovh/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "wrong mint_method",
-			config: map[string]string{
-				"mint_method": "static_keys",
-				"kv2_mount":   "secret",
-				"secret_path": "ovh/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "missing kv2_mount",
-			config: map[string]string{
-				"mint_method": "static_ovh",
-				"secret_path": "ovh/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "kv2_mount",
-		},
-		{
-			name: "missing secret_path",
-			config: map[string]string{
-				"mint_method": "static_ovh",
-				"kv2_mount":   "secret",
-			},
-			wantErr: true,
-			errMsg:  "secret_path",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeOVH)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)
@@ -154,102 +76,90 @@ func TestOVHKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
 
 func TestOVHKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
 	ct := &OVHKeysCredType{}
-	err := ct.ValidateConfig(map[string]string{
-		"access_key": "test-access-key",
-		"secret_key": "test-secret-key",
-		"api_token":  "test-api-token",
-	}, credential.SourceTypeAWS)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "local or vault")
+
+	for _, sourceType := range []string{credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeAWS} {
+		t.Run(sourceType, func(t *testing.T) {
+			err := ct.ValidateConfig(map[string]string{"mint_method": "oauth2_token"}, sourceType)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ovh source")
+		})
+	}
 }
 
 func TestOVHKeysCredType_Parse(t *testing.T) {
 	ct := &OVHKeysCredType{}
-	tests := []struct {
-		name     string
-		rawData  map[string]interface{}
-		leaseTTL time.Duration
-		leaseID  string
-		wantErr  bool
-		errMsg   string
-	}{
-		{
-			name: "valid credentials",
-			rawData: map[string]interface{}{
-				"access_key": "test-access-key",
-				"secret_key": "test-secret-key",
-				"api_token":  "test-api-token",
-			},
-			wantErr: false,
-		},
-		{
-			name: "with lease",
-			rawData: map[string]interface{}{
-				"access_key": "test-access-key",
-				"secret_key": "test-secret-key",
-				"api_token":  "test-api-token",
-			},
-			leaseTTL: 1 * time.Hour,
-			leaseID:  "lease-123",
-			wantErr:  false,
-		},
-		{
-			name: "missing access_key",
-			rawData: map[string]interface{}{
-				"secret_key": "test-secret-key",
-				"api_token":  "test-api-token",
-			},
-			wantErr: true,
-			errMsg:  "access_key",
-		},
-		{
-			name: "missing secret_key",
-			rawData: map[string]interface{}{
-				"access_key": "test-access-key",
-				"api_token":  "test-api-token",
-			},
-			wantErr: true,
-			errMsg:  "secret_key",
-		},
-		{
-			name: "missing api_token",
-			rawData: map[string]interface{}{
-				"access_key": "test-access-key",
-				"secret_key": "test-secret-key",
-			},
-			wantErr: true,
-			errMsg:  "api_token",
-		},
-		{
-			name:    "empty raw data",
-			rawData: map[string]interface{}{},
-			wantErr: true,
-			errMsg:  "access_key",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, credential.TypeOVHKeys, cred.Type)
-				assert.Equal(t, credential.CategoryCloudIAM, cred.Category)
-				assert.Equal(t, tt.rawData["access_key"], cred.Data["access_key"])
-				assert.Equal(t, tt.rawData["secret_key"], cred.Data["secret_key"])
-				assert.Equal(t, tt.rawData["api_token"], cred.Data["api_token"])
-				assert.Equal(t, tt.leaseTTL, cred.LeaseTTL)
-				assert.Equal(t, tt.leaseID, cred.LeaseID)
-				if tt.leaseTTL > 0 {
-					assert.True(t, cred.Revocable)
-				} else {
-					assert.False(t, cred.Revocable)
-				}
-			}
-		})
-	}
+
+	t.Run("valid: all three (dual mode)", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key": "test-access-key",
+			"secret_key": "test-secret-key",
+			"api_token":  "test-api-token",
+		}, 0, "")
+		require.NoError(t, err)
+		assert.Equal(t, credential.TypeOVHKeys, cred.Type)
+		assert.Equal(t, "test-access-key", cred.Data["access_key"])
+		assert.Equal(t, "test-secret-key", cred.Data["secret_key"])
+		assert.Equal(t, "test-api-token", cred.Data["api_token"])
+		assert.Len(t, cred.Data, 3)
+	})
+
+	t.Run("valid: api_token only (API mode)", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"api_token": "test-api-token",
+		}, 0, "")
+		require.NoError(t, err)
+		assert.Equal(t, "test-api-token", cred.Data["api_token"])
+		assert.Len(t, cred.Data, 1)
+		_, hasAccessKey := cred.Data["access_key"]
+		assert.False(t, hasAccessKey)
+	})
+
+	t.Run("valid: S3 only", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key": "test-access-key",
+			"secret_key": "test-secret-key",
+		}, 0, "")
+		require.NoError(t, err)
+		assert.Equal(t, "test-access-key", cred.Data["access_key"])
+		assert.Equal(t, "test-secret-key", cred.Data["secret_key"])
+		assert.Len(t, cred.Data, 2)
+		_, hasAPIToken := cred.Data["api_token"]
+		assert.False(t, hasAPIToken)
+	})
+
+	t.Run("valid: with lease", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key": "test-access-key",
+			"secret_key": "test-secret-key",
+			"api_token":  "test-api-token",
+		}, 1*time.Hour, "lease-123")
+		require.NoError(t, err)
+		assert.Equal(t, 1*time.Hour, cred.LeaseTTL)
+		assert.Equal(t, "lease-123", cred.LeaseID)
+		assert.True(t, cred.Revocable)
+	})
+
+	t.Run("invalid: access_key without secret_key", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{
+			"access_key": "test-access-key",
+		}, 0, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret_key")
+	})
+
+	t.Run("invalid: secret_key without access_key", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{
+			"secret_key": "test-secret-key",
+		}, 0, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key")
+	})
+
+	t.Run("invalid: empty raw data", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{}, 0, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one mode")
+	})
 }
 
 func TestOVHKeysCredType_Validate(t *testing.T) {
@@ -261,13 +171,34 @@ func TestOVHKeysCredType_Validate(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid credential",
+			name: "valid: all three (dual mode)",
 			cred: &credential.Credential{
 				Type: credential.TypeOVHKeys,
 				Data: map[string]string{
 					"access_key": "test-access-key",
 					"secret_key": "test-secret-key",
 					"api_token":  "test-api-token",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: api_token only",
+			cred: &credential.Credential{
+				Type: credential.TypeOVHKeys,
+				Data: map[string]string{
+					"api_token": "test-api-token",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: S3 only",
+			cred: &credential.Credential{
+				Type: credential.TypeOVHKeys,
+				Data: map[string]string{
+					"access_key": "test-access-key",
+					"secret_key": "test-secret-key",
 				},
 			},
 			wantErr: false,
@@ -286,49 +217,35 @@ func TestOVHKeysCredType_Validate(t *testing.T) {
 			errMsg:  "expected type",
 		},
 		{
-			name: "missing access_key",
-			cred: &credential.Credential{
-				Type: credential.TypeOVHKeys,
-				Data: map[string]string{
-					"secret_key": "test-secret-key",
-					"api_token":  "test-api-token",
-				},
-			},
-			wantErr: true,
-			errMsg:  "missing access_key",
-		},
-		{
-			name: "missing secret_key",
+			name: "invalid: access_key without secret_key",
 			cred: &credential.Credential{
 				Type: credential.TypeOVHKeys,
 				Data: map[string]string{
 					"access_key": "test-access-key",
-					"api_token":  "test-api-token",
 				},
 			},
 			wantErr: true,
-			errMsg:  "missing secret_key",
+			errMsg:  "secret_key",
 		},
 		{
-			name: "missing api_token",
+			name: "invalid: secret_key without access_key",
 			cred: &credential.Credential{
 				Type: credential.TypeOVHKeys,
 				Data: map[string]string{
-					"access_key": "test-access-key",
 					"secret_key": "test-secret-key",
 				},
 			},
 			wantErr: true,
-			errMsg:  "missing api_token",
+			errMsg:  "access_key",
 		},
 		{
-			name: "empty data",
+			name: "invalid: empty data",
 			cred: &credential.Credential{
 				Type: credential.TypeOVHKeys,
 				Data: map[string]string{},
 			},
 			wantErr: true,
-			errMsg:  "missing access_key",
+			errMsg:  "at least one mode",
 		},
 	}
 	for _, tt := range tests {
@@ -364,9 +281,7 @@ func TestOVHKeysCredType_RequiresSpecRotation(t *testing.T) {
 
 func TestOVHKeysCredType_SensitiveConfigFields(t *testing.T) {
 	ct := &OVHKeysCredType{}
-	fields := ct.SensitiveConfigFields()
-	assert.Contains(t, fields, "secret_key")
-	assert.Contains(t, fields, "api_token")
+	assert.Nil(t, ct.SensitiveConfigFields())
 }
 
 func TestOVHKeysCredType_FieldSchemas(t *testing.T) {

--- a/provider/ovh/README.md
+++ b/provider/ovh/README.md
@@ -22,9 +22,8 @@ The OVH provider enables proxied access to OVHcloud APIs through Warden. It supp
 ## Prerequisites
 
 - Docker and Docker Compose installed and running
-- An **OVHcloud account** with:
-  - An API token (from [OVHcloud IAM](https://www.ovh.com/auth/)) for the REST API
-  - S3 credentials (access key + secret key) for Object Storage — generate via `openstack ec2 credentials create` or the OVHcloud Control Panel
+- An **OVHcloud account** with an OAuth2 service account (`client_id` + `client_secret`) — create one via [OVHcloud IAM](https://www.ovh.com/auth/) with `flow: "CLIENT_CREDENTIALS"`
+- For S3 Object Storage: a Public Cloud project ID and user ID
 
 > **New to Warden?** Follow these steps to get a local dev environment running:
 >
@@ -128,56 +127,73 @@ warden read ovh/config
 
 ## Step 3: Create a Credential Source and Spec
 
-### Option A: Static Keys
+Create an OVH credential source using an OAuth2 service account. Warden automatically mints bearer tokens (~1h TTL, auto-refreshed) and/or creates S3 credentials on demand.
 
-Create an OVH credential source and spec with your API token and S3 keys:
+**Prerequisites:** An OVH OAuth2 service account — create one via `POST /me/api/oauth2/client` with `flow: "CLIENT_CREDENTIALS"`. See the [e2e test README](e2e_test/README.md#creating-an-oauth2-api-token) for step-by-step instructions.
 
 ```bash
 warden cred source create ovh-src \
-  --type=local
-
-warden cred spec create ovh-ops \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=static_keys \
-  --config access_key=your-s3-access-key \
-  --config secret_key=your-s3-secret-key \
-  --config api_token=your-oauth2-bearer-token
+  --type=ovh \
+  --config client_id=your-client-id \
+  --config client_secret=your-client-secret \
+  --config ovh_endpoint=ovh-eu \
+  --config project_id=your-cloud-project-id \
+  --config user_id=your-cloud-user-id
 ```
 
-### Option B: Vault/OpenBao as Credential Source
+The `project_id` and `user_id` are only needed for S3 credential management (`dynamic_s3` and `oauth2_token_and_s3` mint methods). They can be omitted if you only need API tokens, or overridden per-spec for multi-tenant S3 access.
 
-Store your OVH credentials in a Vault/OpenBao KV v2 secret engine and have Warden fetch them at runtime.
-
-**Prerequisites:** A Vault/OpenBao instance with:
-- A KV v2 mount containing your OVH credentials (e.g., at `secret/ovh/prod` with `access_key`, `secret_key`, and `api_token` fields)
-- An AppRole configured for Warden access
+**API-only mode** (auto-refreshed OAuth2 bearer tokens):
 
 ```bash
-warden cred source create ovh-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
-
-warden cred spec create ovh-ops \
-  --source ovh-vault-src \
+warden cred spec create ovh-api \
+  --source ovh-src \
   --type=ovh_keys \
-  --config mint_method=static_ovh \
-  --config kv2_mount=secret \
-  --config secret_path=ovh/prod
+  --config mint_method=oauth2_token
 ```
 
-The KV v2 secret at `secret/ovh/prod` should contain `access_key`, `secret_key`, and `api_token` fields.
+**S3-only mode** (dynamic S3 credentials, revocable):
+
+```bash
+warden cred spec create ovh-s3 \
+  --source ovh-src \
+  --type=ovh_keys \
+  --config mint_method=dynamic_s3
+```
+
+**Dual mode** (OAuth2 token + S3 credentials):
+
+```bash
+warden cred spec create ovh-dual \
+  --source ovh-src \
+  --type=ovh_keys \
+  --config mint_method=oauth2_token_and_s3
+```
+
+**Multi-tenant S3 access** — override `project_id` and `user_id` per-spec to target different S3 users:
+
+```bash
+# Read-only S3 user
+warden cred spec create ovh-s3-reader \
+  --source ovh-src \
+  --type=ovh_keys \
+  --config mint_method=dynamic_s3 \
+  --config project_id=my-project \
+  --config user_id=reader-user-id
+
+# Read-write S3 user
+warden cred spec create ovh-s3-writer \
+  --source ovh-src \
+  --type=ovh_keys \
+  --config mint_method=dynamic_s3 \
+  --config project_id=my-project \
+  --config user_id=writer-user-id
+```
 
 Verify:
 
 ```bash
-warden cred spec read ovh-ops
+warden cred spec read ovh-api
 ```
 
 ## Step 4: Create a Policy
@@ -465,53 +481,54 @@ aws s3 ls s3://my-bucket/ \
 | `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
 | `default_role` | string | — | Fallback role when not specified in URL |
 
-### Credential Spec Config (static_keys)
+### Credential Source Config (OVH OAuth2)
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_keys` |
-| `access_key` | string | Yes | OVH S3 access key |
-| `secret_key` | string | Yes | OVH S3 secret key (sensitive — masked in output) |
-| `api_token` | string | Yes | API bearer token for the REST API (sensitive — masked in output) |
+| `client_id` | string | Yes | OAuth2 service account client ID |
+| `client_secret` | string | Yes | OAuth2 service account client secret (sensitive) |
+| `ovh_endpoint` | string | No | Regional endpoint: `ovh-eu` (default), `ovh-ca`, or `ovh-us` |
+| `project_id` | string | For S3 | Default Public Cloud project ID (can be overridden per-spec) |
+| `user_id` | string | For S3 | Default Public Cloud user ID (can be overridden per-spec) |
 
-### Credential Spec Config (Vault — static_ovh)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_ovh` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Source Config (Vault/OpenBao)
+### Credential Spec Config (OVH source — oauth2_token)
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
+| `mint_method` | string | Yes | Must be `oauth2_token` |
+
+### Credential Spec Config (OVH source — dynamic_s3)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `dynamic_s3` |
+| `project_id` | string | No | Override source default project ID |
+| `user_id` | string | No | Override source default user ID |
+
+### Credential Spec Config (OVH source — oauth2_token_and_s3)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `oauth2_token_and_s3` |
+| `project_id` | string | No | Override source default project ID |
+| `user_id` | string | No | Override source default user ID |
 
 ## Token Management
 
-### Static Keys
-
 | Aspect | Details |
 |--------|---------|
-| **Storage** | Access key, secret key, and API token are stored on the credential spec |
-| **Rotation** | Manual — regenerate in OVHcloud Control Panel and update the spec |
-| **Lifetime** | Static — no expiration or auto-refresh |
+| **Storage** | OAuth2 `client_id` + `client_secret` stored on the credential source (long-lived) |
+| **API tokens** | Auto-minted via `client_credentials` grant, ~1h TTL, refreshed automatically |
+| **S3 credentials** | Created on demand via OVH API, revoked when credential lease expires |
+| **Rotation** | Rotate the OAuth2 service account secret in OVHcloud IAM, then update the source |
 
-**To rotate static credentials:**
+**To rotate the OAuth2 service account:**
 
-1. Generate new S3 credentials via `openstack ec2 credentials create` and/or a new API token in OVHcloud IAM
-2. Update the credential spec:
+1. Create a new service account or regenerate the secret in OVHcloud IAM
+2. Update the credential source:
    ```bash
-   warden cred spec update ovh-ops \
-     --config access_key=new-access-key \
-     --config secret_key=new-secret-key \
-     --config api_token=new-api-token
+   warden cred source update ovh-src \
+     --config client_id=new-client-id \
+     --config client_secret=new-client-secret
    ```
-3. Revoke the old credentials in the OVHcloud Control Panel
+3. Revoke the old service account in OVHcloud IAM

--- a/provider/ovh/e2e_test/README.md
+++ b/provider/ovh/e2e_test/README.md
@@ -29,13 +29,13 @@ All tests use **free or near-free** resources only:
 
 1. **Warden server running** with the OVH provider mounted
 2. **OVHcloud account** with a Public Cloud project
-3. **OVH credentials** — API token + S3 access key/secret key (stored as `ovh_keys` credential type)
+3. **OVH OAuth2 service account** (`client_id` + `client_secret`) — see [Creating an OAuth2 API Token](#creating-an-oauth2-api-token) below
 4. **JWT auth configured** with a role bound to an OVH credential spec
 5. **Terraform >= 1.10** installed
 
 ### OVH API Permissions
 
-The API token (`api_token`) must have the following OVHcloud API permissions (`{serviceName}` is your Public Cloud project ID, i.e. the `ovh_service_name` variable):
+The OAuth2 service account must have the following OVHcloud API permissions (`{serviceName}` is your Public Cloud project ID, i.e. the `ovh_service_name` variable):
 
 | API Route | Method | Used By | Purpose |
 |-----------|--------|---------|---------|
@@ -60,13 +60,14 @@ All permissions are **read-only**. No write operations are performed on the OVH 
 
 ### OVH Credential Setup
 
-The OVH provider uses `ovh_keys` credentials with three fields:
+The OVH provider uses an OVH source (`--type=ovh`) with an OAuth2 service account to automatically mint bearer tokens and S3 credentials.
 
 | Field | Purpose | How to Obtain |
 |-------|---------|---------------|
-| `api_token` | Bearer token for REST API | See [Creating an OAuth2 token](#creating-an-oauth2-api-token) below |
-| `access_key` | S3 access key for Object Storage | See [Creating S3 credentials](#creating-s3-credentials) below |
-| `secret_key` | S3 secret key for Object Storage | Generated alongside access_key |
+| `client_id` | OAuth2 service account ID | See [Creating an OAuth2 API Token](#creating-an-oauth2-api-token) below (steps 1-2) |
+| `client_secret` | OAuth2 service account secret | Generated alongside client_id (step 2) |
+| `project_id` | Public Cloud project ID (for S3) | OVHcloud Control Panel > Public Cloud |
+| `user_id` | Public Cloud user ID (for S3) | OVHcloud Control Panel > Public Cloud > Users & Roles |
 
 #### Creating an OAuth2 API Token
 
@@ -113,6 +114,8 @@ The token is valid for **1 hour**. For regional endpoints, use the matching toke
 - EU: `https://www.ovh.com/auth/oauth2/token`
 - CA: `https://ca.ovh.com/auth/oauth2/token`
 - US: `https://us.ovhcloud.com/auth/oauth2/token`
+
+> **Note:** Warden handles token minting automatically using the `client_id` and `client_secret` from steps 2-3. Step 4 is only needed if you want to test the OVH API directly outside of Warden.
 
 #### Creating S3 Credentials
 
@@ -181,20 +184,28 @@ warden write ovh/config <<EOF
   "timeout": "30s"
 }
 EOF
+```
 
-# Create credential source
+```bash
+# Create OVH credential source with OAuth2 service account
 warden cred source create ovh-src \
-  --type=local
+  --type=ovh \
+  --config client_id=<your-client-id> \
+  --config client_secret=<your-client-secret> \
+  --config ovh_endpoint=ovh-eu \
+  --config project_id=<your-cloud-project-id> \
+  --config user_id=<your-cloud-user-id>
 
-# Create credential spec with OVH keys
+# Create credential spec — dual mode (auto-minted API token + dynamic S3 keys)
 warden cred spec create ovh-ops \
   --source ovh-src \
   --type=ovh_keys \
-  --config mint_method=static_keys \
-  --config access_key=<your-s3-access-key> \
-  --config secret_key=<your-s3-secret-key> \
-  --config api_token=<your-api-bearer-token>
+  --config mint_method=oauth2_token_and_s3
+```
 
+Other mint methods: `oauth2_token` (API only), `dynamic_s3` (S3 only).
+
+```bash
 # Create policy
 warden policy write ovh-access - <<EOF
 path "ovh/role/+/gateway*" {

--- a/provider/ovh/provider.go
+++ b/provider/ovh/provider.go
@@ -70,9 +70,17 @@ Credential type: ovh_keys
   - access_key: S3 access key for Object Storage
   - secret_key: S3 secret key for Object Storage
 
-Two credential source types are supported:
-- local (static_keys): Static credentials stored on the spec
-- hvault (static_ovh): Keys fetched from a Vault/OpenBao KV v2 secret
+Credential source: ovh (OAuth2 service account)
+  Warden automatically mints bearer tokens via client_credentials grant
+  (~1h TTL, auto-refreshed) and creates S3 credentials on demand.
+
+  Mint methods:
+  - oauth2_token: Mints API bearer tokens only
+  - dynamic_s3: Creates S3 access_key + secret_key (revocable)
+  - oauth2_token_and_s3: Both API token + S3 credentials
+
+  Source config: client_id, client_secret, ovh_endpoint (ovh-eu/ovh-ca/ovh-us),
+  project_id, user_id (for S3). project_id and user_id can be overridden per-spec.
 
 Regional API endpoints and their matching OAuth2 token URLs:
 - EU:  ovh_url=https://eu.api.ovh.com/1.0   token_url=https://www.ovh.com/auth/oauth2/token


### PR DESCRIPTION
Replace static local/vault credential sources with a dedicated OVH source driver that automatically mints credentials via the OVHcloud OAuth2 API.

The driver supports three mint methods:
- oauth2_token: mints bearer tokens via client_credentials (~1h TTL)
- dynamic_s3: creates S3 credentials via cloud API (revocable)
- oauth2_token_and_s3: both combined, TTL governed by token expiry

Each mode is optional on the credential data side - the gateway returns 401 if a request targets a mode whose credentials were not minted.

Source config holds client_id + client_secret (long-lived OAuth2 service account). project_id and user_id for S3 can be set on the source or overridden per-spec for multi-tenant access.