### PR TITLE
fix: add TTL to dynamic S3 credentials tied to OAuth2 token lifetime

### DIFF
--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -320,8 +320,10 @@ func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, u
 }
 
 // mintDynamicS3 creates S3 credentials via the OVH cloud API.
+// The TTL is derived from the OAuth2 token used for API auth — S3 keys are
+// revoked and re-created when the credential lease expires (~1h).
 func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
-	token, _, err := d.fetchOAuth2Token(ctx)
+	token, tokenTTL, err := d.fetchOAuth2Token(ctx)
 	if err != nil {
 		return nil, 0, "", fmt.Errorf("failed to get OAuth2 token for S3 credential creation: %w", err)
 	}
@@ -339,6 +341,7 @@ func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec
 	d.logger.Info("created dynamic OVH S3 credentials",
 		logger.String("access_key", truncateID(s3.accessKey, 8)),
 		logger.String("spec", spec.Name),
+		logger.String("ttl", tokenTTL.String()),
 	)
 
 	rawData := map[string]interface{}{
@@ -346,7 +349,7 @@ func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec
 		"secret_key": s3.secretKey,
 	}
 
-	return rawData, 0, s3.leaseID, nil // Static S3 keys — no TTL, but revocable via leaseID
+	return rawData, tokenTTL, s3.leaseID, nil
 }
 
 // mintOAuth2TokenAndS3 mints both a bearer token and S3 credentials.

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -286,7 +286,7 @@ func TestOVHDriver_MintDynamicS3(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "s3-access-key-123", rawData["access_key"])
 	assert.Equal(t, "s3-secret-key-456", rawData["secret_key"])
-	assert.Equal(t, time.Duration(0), ttl) // S3 keys are static
+	assert.Equal(t, 3599*time.Second, ttl) // TTL from OAuth2 token
 	assert.Equal(t, "proj-123/user-456/s3-access-key-123", leaseID)
 }
 

--- a/provider/ovh/README.md
+++ b/provider/ovh/README.md
@@ -152,7 +152,7 @@ warden cred spec create ovh-api \
   --config mint_method=oauth2_token
 ```
 
-**S3-only mode** (dynamic S3 credentials, revocable):
+**S3-only mode** (dynamic S3 credentials, ~1h TTL, revoked and re-created on expiry):
 
 ```bash
 warden cred spec create ovh-s3 \
@@ -519,7 +519,7 @@ aws s3 ls s3://my-bucket/ \
 |--------|---------|
 | **Storage** | OAuth2 `client_id` + `client_secret` stored on the credential source (long-lived) |
 | **API tokens** | Auto-minted via `client_credentials` grant, ~1h TTL, refreshed automatically |
-| **S3 credentials** | Created on demand via OVH API, revoked when credential lease expires |
+| **S3 credentials** | Created on demand via OVH API, ~1h TTL (tied to OAuth2 token lifetime), revoked and re-created on expiry |
 | **Rotation** | Rotate the OAuth2 service account secret in OVHcloud IAM, then update the source |
 
 **To rotate the OAuth2 service account:**

--- a/provider/ovh/provider.go
+++ b/provider/ovh/provider.go
@@ -76,7 +76,7 @@ Credential source: ovh (OAuth2 service account)
 
   Mint methods:
   - oauth2_token: Mints API bearer tokens only
-  - dynamic_s3: Creates S3 access_key + secret_key (revocable)
+  - dynamic_s3: Creates S3 access_key + secret_key (~1h TTL, revocable)
   - oauth2_token_and_s3: Both API token + S3 credentials
 
   Source config: client_id, client_secret, ovh_endpoint (ovh-eu/ovh-ca/ovh-us),


### PR DESCRIPTION
OVH S3 keys don't expire natively, but without a TTL they lived forever. Use the OAuth2 token's expires_in (~1h) as the credential TTL so Warden revokes and re-creates S3 keys on the same cadence as token refresh, limiting exposure window.