### PR TITLE
feat: add Grafana provider with httpproxy gateway and source driver

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stephnangue/warden/provider/dynatrace"
 	"github.com/stephnangue/warden/provider/elastic"
 	"github.com/stephnangue/warden/provider/gcp"
+	"github.com/stephnangue/warden/provider/grafana"
 	"github.com/stephnangue/warden/provider/github"
 	"github.com/stephnangue/warden/provider/gitlab"
 	"github.com/stephnangue/warden/provider/kubernetes"
@@ -126,6 +127,7 @@ Usage: warden server [options]
 		"elastic":       elastic.Factory,
 		"kubernetes":    kubernetes.Factory,
 		"gcp":           gcp.Factory,
+		"grafana":       grafana.Factory,
 		"github":        github.Factory,
 		"gitlab":        gitlab.Factory,
 		"mistral":       mistral.Factory,

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -40,6 +40,7 @@ const (
 	SourceTypeScaleway   = "scaleway"
 	SourceTypeOVH        = "ovh"
 	SourceTypeCloudflare = "cloudflare"
+	SourceTypeGrafana    = "grafana"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -74,5 +74,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register Grafana driver factory
+	if err := registry.RegisterFactory(&GrafanaDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -1,0 +1,326 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// grafanaMaxResponseBodySize limits response body reads to prevent OOM
+const grafanaMaxResponseBodySize = 1 << 20 // 1MB
+
+// grafanaMaxRetryAttempts for retryable API operations
+const grafanaMaxRetryAttempts = 3
+
+// grafanaDefaultTokenExpiry is the default TTL for minted service account tokens
+const grafanaDefaultTokenExpiry = 1 * time.Hour
+
+// grafanaDefaultNamePrefix is the default prefix for minted service accounts
+const grafanaDefaultNamePrefix = "warden-"
+
+// grafanaDefaultRole is the default role for minted service accounts
+const grafanaDefaultRole = "Viewer"
+
+// Compile-time interface assertions
+var _ credential.SourceDriver = (*GrafanaDriver)(nil)
+var _ credential.SpecVerifier = (*GrafanaDriver)(nil)
+
+// GrafanaDriver mints credentials from the Grafana HTTP API.
+//
+// The source config holds connection info (grafana_url) and an admin service
+// account token with permissions to create/delete service accounts. Per-spec
+// config controls the role, TTL, and naming of minted service accounts.
+//
+// MintCredential creates a temporary service account and generates a token
+// with a bounded TTL. Revoke deletes the service account (and all its tokens).
+type GrafanaDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// GrafanaDriverFactory creates GrafanaDriver instances
+type GrafanaDriverFactory struct{}
+
+// Type returns the driver type
+func (f *GrafanaDriverFactory) Type() string {
+	return credential.SourceTypeGrafana
+}
+
+// ValidateConfig validates Grafana source configuration using declarative schema.
+func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("grafana_url").
+			Required().
+			Custom(func(v string) error {
+				return validateGrafanaURL(v, credential.GetBool(config, "tls_skip_verify", false))
+			}).
+			Describe("Grafana API base URL").
+			Example("https://mystack.grafana.net"),
+
+		credential.StringField("admin_token").
+			Required().
+			Describe("Admin service account token with ServiceAccount admin permissions"),
+
+		credential.StringField("ca_data").
+			Custom(ValidateCAData).
+			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs"),
+
+		credential.BoolField("tls_skip_verify").
+			Describe("Skip TLS certificate verification (development only)"),
+	)
+}
+
+// SensitiveConfigFields returns source config keys that should be masked.
+func (f *GrafanaDriverFactory) SensitiveConfigFields() []string {
+	return []string{"admin_token", "ca_data"}
+}
+
+// InferCredentialType always returns api_key for Grafana sources.
+func (f *GrafanaDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeAPIKey, nil
+}
+
+// Create instantiates a new GrafanaDriver.
+func (f *GrafanaDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGrafana,
+			Config: config,
+		},
+		logger: log.WithSubsystem(credential.SourceTypeGrafana),
+	}
+
+	httpClient, err := BuildHTTPClient(config, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+	}
+	driver.httpClient = httpClient
+
+	return driver, nil
+}
+
+// getGrafanaURL returns the Grafana API base URL from source config
+func (d *GrafanaDriver) getGrafanaURL() string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, "grafana_url", ""), "/")
+}
+
+// getAdminToken returns the admin service account token from source config
+func (d *GrafanaDriver) getAdminToken() string {
+	return credential.GetString(d.credSource.Config, "admin_token", "")
+}
+
+// MintCredential creates a temporary Grafana service account and token.
+//
+// Flow:
+//  1. POST /api/serviceaccounts — create a service account with the specified role
+//  2. POST /api/serviceaccounts/{id}/tokens — create a token with secondsToLive
+//  3. Return {"api_key": "<token>"} with TTL matching token expiry
+//
+// The leaseID is the service account ID, used for cleanup on Revoke.
+func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	role := credential.GetString(spec.Config, "role", grafanaDefaultRole)
+	namePrefix := credential.GetString(spec.Config, "name_prefix", grafanaDefaultNamePrefix)
+	tokenExpiry := credential.GetDuration(spec.Config, "token_expiry", grafanaDefaultTokenExpiry)
+	orgID := credential.GetString(spec.Config, "org_id", "")
+
+	// Validate role
+	switch role {
+	case "Viewer", "Editor", "Admin":
+	default:
+		return nil, 0, "", fmt.Errorf("invalid role '%s': must be Viewer, Editor, or Admin", role)
+	}
+
+	// Step 1: Create a service account
+	saName := fmt.Sprintf("%s%s-%d", namePrefix, spec.Name, time.Now().UnixMilli())
+	saBody, err := json.Marshal(map[string]interface{}{
+		"name":       saName,
+		"role":       role,
+		"isDisabled": false,
+	})
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to marshal service account request: %w", err)
+	}
+
+	saResp, _, err := d.doGrafanaRequest(ctx, http.MethodPost, "/api/serviceaccounts", saBody, orgID)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to create service account: %w", err)
+	}
+
+	var saResult struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(saResp, &saResult); err != nil {
+		return nil, 0, "", fmt.Errorf("failed to parse service account response: %w", err)
+	}
+	if saResult.ID == 0 {
+		return nil, 0, "", fmt.Errorf("Grafana API returned service account with ID 0")
+	}
+
+	// Step 2: Create a token for the service account
+	secondsToLive := int64(tokenExpiry.Seconds())
+	tokenBody, err := json.Marshal(map[string]interface{}{
+		"name":          "warden-token",
+		"secondsToLive": secondsToLive,
+	})
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to marshal token request: %w", err)
+	}
+
+	tokenPath := fmt.Sprintf("/api/serviceaccounts/%d/tokens", saResult.ID)
+	tokenResp, _, err := d.doGrafanaRequest(ctx, http.MethodPost, tokenPath, tokenBody, orgID)
+	if err != nil {
+		// Best-effort cleanup: delete the service account we just created
+		d.deleteServiceAccount(ctx, saResult.ID, orgID)
+		return nil, 0, "", fmt.Errorf("failed to create service account token: %w", err)
+	}
+
+	var tokenResult struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(tokenResp, &tokenResult); err != nil {
+		d.deleteServiceAccount(ctx, saResult.ID, orgID)
+		return nil, 0, "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+	if tokenResult.Key == "" {
+		d.deleteServiceAccount(ctx, saResult.ID, orgID)
+		return nil, 0, "", fmt.Errorf("Grafana API returned empty token key")
+	}
+
+	// Return credential as api_key for BearerAPIKeyExtractor compatibility
+	rawData := map[string]interface{}{
+		"api_key": tokenResult.Key,
+	}
+
+	// leaseID is the service account ID for cleanup
+	leaseID := fmt.Sprintf("%d", saResult.ID)
+
+	if d.logger != nil {
+		d.logger.Debug("minted Grafana service account token",
+			logger.String("spec", spec.Name),
+			logger.String("service_account", saName),
+			logger.String("role", role),
+			logger.String("ttl", tokenExpiry.String()),
+		)
+	}
+
+	return rawData, tokenExpiry, leaseID, nil
+}
+
+// Revoke deletes the service account (and all its tokens) identified by leaseID.
+func (d *GrafanaDriver) Revoke(ctx context.Context, leaseID string) error {
+	if leaseID == "" {
+		return nil
+	}
+
+	// leaseID is the service account ID
+	path := fmt.Sprintf("/api/serviceaccounts/%s", leaseID)
+	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, ""); err != nil {
+		return fmt.Errorf("failed to delete service account %s: %w", leaseID, err)
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("revoked Grafana service account",
+			logger.String("service_account_id", leaseID),
+		)
+	}
+
+	return nil
+}
+
+// Type returns the driver type
+func (d *GrafanaDriver) Type() string {
+	return credential.SourceTypeGrafana
+}
+
+// Cleanup releases resources
+func (d *GrafanaDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates spec credentials by making a lightweight API call.
+// Creates a test service account, verifies the minted token works, then cleans up.
+func (d *GrafanaDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	// Verify the admin token works by listing service accounts
+	if _, _, err := d.doGrafanaRequest(ctx, http.MethodGet, "/api/serviceaccounts/search?perpage=1", nil, ""); err != nil {
+		return fmt.Errorf("admin token verification failed (GET /api/serviceaccounts/search): %w", err)
+	}
+	return nil
+}
+
+// --- HTTP helpers ---
+
+// doGrafanaRequest executes an authenticated HTTP request to the Grafana API.
+func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path string, body []byte, orgID string) ([]byte, int, error) {
+	apiURL := d.getGrafanaURL() + path
+
+	headers := map[string]string{
+		"Accept":        "application/json",
+		"Authorization": "Bearer " + d.getAdminToken(),
+	}
+	if body != nil {
+		headers["Content-Type"] = "application/json"
+	}
+	if orgID != "" {
+		headers["X-Grafana-Org-Id"] = orgID
+	}
+
+	retryConfig := HTTPRetryConfig{
+		MaxAttempts:       grafanaMaxRetryAttempts,
+		MaxBodySize:       grafanaMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+
+	httpReq := HTTPRequest{
+		Method:  method,
+		URL:     apiURL,
+		Body:    body,
+		Headers: headers,
+	}
+
+	respBody, status, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	if err != nil && d.logger != nil {
+		d.logger.Warn("Grafana API request failed",
+			logger.String("method", method),
+			logger.String("path", path),
+			logger.String("error", err.Error()),
+		)
+	}
+	return respBody, status, err
+}
+
+// deleteServiceAccount is a best-effort cleanup helper.
+func (d *GrafanaDriver) deleteServiceAccount(ctx context.Context, id int64, orgID string) {
+	path := fmt.Sprintf("/api/serviceaccounts/%d", id)
+	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, orgID); err != nil && d.logger != nil {
+		d.logger.Warn("failed to cleanup service account",
+			logger.String("id", fmt.Sprintf("%d", id)),
+			logger.String("error", err.Error()),
+		)
+	}
+}
+
+// validateGrafanaURL validates that the grafana_url is a well-formed HTTPS URL.
+func validateGrafanaURL(rawURL string, tlsSkipVerify bool) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid grafana_url: %w", err)
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && tlsSkipVerify) {
+		return fmt.Errorf("grafana_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("grafana_url must include a host")
+	}
+	return nil
+}

--- a/credential/drivers/grafana_driver_test.go
+++ b/credential/drivers/grafana_driver_test.go
@@ -1,0 +1,637 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrafanaDriverFactory_Type(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+	assert.Equal(t, credential.SourceTypeGrafana, factory.Type())
+}
+
+func TestGrafanaDriverFactory_SensitiveConfigFields(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+	fields := factory.SensitiveConfigFields()
+	assert.Contains(t, fields, "admin_token")
+	assert.Contains(t, fields, "ca_data")
+}
+
+func TestGrafanaDriverFactory_InferCredentialType(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+	credType, err := factory.InferCredentialType(nil)
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeAPIKey, credType)
+}
+
+func TestGrafanaDriverFactory_ValidateConfig(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config",
+			config: map[string]string{
+				"grafana_url": "https://mystack.grafana.net",
+				"admin_token": "glsa_test_token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing grafana_url",
+			config: map[string]string{
+				"admin_token": "glsa_test_token",
+			},
+			wantErr: true,
+			errMsg:  "grafana_url",
+		},
+		{
+			name: "missing admin_token",
+			config: map[string]string{
+				"grafana_url": "https://mystack.grafana.net",
+			},
+			wantErr: true,
+			errMsg:  "admin_token",
+		},
+		{
+			name: "invalid grafana_url scheme",
+			config: map[string]string{
+				"grafana_url": "http://mystack.grafana.net",
+				"admin_token": "glsa_test_token",
+			},
+			wantErr: true,
+			errMsg:  "must use https://",
+		},
+		{
+			name: "http allowed with tls_skip_verify",
+			config: map[string]string{
+				"grafana_url":     "http://grafana.local",
+				"admin_token":     "glsa_test_token",
+				"tls_skip_verify": "true",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGrafanaDriverFactory_Create(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	driver, err := factory.Create(map[string]string{
+		"grafana_url": "https://mystack.grafana.net",
+		"admin_token": "glsa_test_token",
+	}, log)
+	require.NoError(t, err)
+	assert.NotNil(t, driver)
+	assert.Equal(t, credential.SourceTypeGrafana, driver.Type())
+}
+
+func TestGrafanaDriver_Type(t *testing.T) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGrafana,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, credential.SourceTypeGrafana, driver.Type())
+}
+
+func TestGrafanaDriver_Cleanup(t *testing.T) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGrafana,
+			Config: map[string]string{},
+		},
+		httpClient: &http.Client{},
+	}
+	err := driver.Cleanup(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestGrafanaDriver_NotRotatable(t *testing.T) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGrafana,
+			Config: map[string]string{},
+		},
+	}
+	var sd credential.SourceDriver = driver
+	_, ok := sd.(credential.Rotatable)
+	assert.False(t, ok, "GrafanaDriver should not implement credential.Rotatable")
+}
+
+func TestGrafanaDriver_GetGrafanaURL(t *testing.T) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Config: map[string]string{"grafana_url": "https://mystack.grafana.net/"},
+		},
+	}
+	assert.Equal(t, "https://mystack.grafana.net", driver.getGrafanaURL())
+}
+
+func TestGrafanaDriver_MintCredential(t *testing.T) {
+	var saCreateCalled, tokenCreateCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
+			saCreateCalled.Add(1)
+
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "Viewer", body["role"])
+			assert.Equal(t, false, body["isDisabled"])
+			name, _ := body["name"].(string)
+			assert.True(t, strings.HasPrefix(name, "warden-"), "SA name should start with warden-")
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": 42,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/42/tokens":
+			tokenCreateCalled.Add(1)
+
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "warden-token", body["name"])
+			secondsToLive, _ := body["secondsToLive"].(float64)
+			assert.Equal(t, float64(3600), secondsToLive)
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"key": "glsa_minted_token_123",
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin_token",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test-viewer",
+		Type:   credential.TypeAPIKey,
+		Config: map[string]string{},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "glsa_minted_token_123", rawData["api_key"])
+	assert.Equal(t, grafanaDefaultTokenExpiry, ttl)
+	assert.Equal(t, "42", leaseID)
+	assert.Equal(t, int32(1), saCreateCalled.Load())
+	assert.Equal(t, int32(1), tokenCreateCalled.Load())
+}
+
+func TestGrafanaDriver_MintCredential_CustomConfig(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "Admin", body["role"])
+			name, _ := body["name"].(string)
+			assert.True(t, strings.HasPrefix(name, "myprefix-"), "SA name should start with custom prefix")
+
+			// Verify org_id header
+			assert.Equal(t, "99", r.Header.Get("X-Grafana-Org-Id"))
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 100})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/100/tokens":
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			secondsToLive, _ := body["secondsToLive"].(float64)
+			assert.Equal(t, float64(1800), secondsToLive) // 30m
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"key": "glsa_custom"})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-admin",
+		Type: credential.TypeAPIKey,
+		Config: map[string]string{
+			"role":         "Admin",
+			"token_expiry": "30m",
+			"name_prefix":  "myprefix-",
+			"org_id":       "99",
+		},
+	}
+
+	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "glsa_custom", rawData["api_key"])
+	assert.Equal(t, "100", leaseID)
+}
+
+func TestGrafanaDriver_MintCredential_InvalidRole(t *testing.T) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": "https://grafana.test",
+				"admin_token": "test",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-bad-role",
+		Type: credential.TypeAPIKey,
+		Config: map[string]string{
+			"role": "SuperAdmin",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role")
+}
+
+func TestGrafanaDriver_MintCredential_SACreateFails(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"Insufficient permissions"}`))
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_bad_token",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test-fail",
+		Type:   credential.TypeAPIKey,
+		Config: map[string]string{},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create service account")
+}
+
+func TestGrafanaDriver_MintCredential_TokenCreateFails_CleansUpSA(t *testing.T) {
+	var deleteCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 77})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/77/tokens":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"message":"Internal error"}`))
+
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/serviceaccounts/77":
+			deleteCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test-cleanup",
+		Type:   credential.TypeAPIKey,
+		Config: map[string]string{},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create service account token")
+	assert.Equal(t, int32(1), deleteCalled.Load(), "should cleanup service account on token create failure")
+}
+
+func TestGrafanaDriver_MintCredential_EmptyTokenKey(t *testing.T) {
+	var deleteCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 88})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/88/tokens":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"key": ""})
+
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/serviceaccounts/88":
+			deleteCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test-empty-key",
+		Type:   credential.TypeAPIKey,
+		Config: map[string]string{},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty token key")
+	assert.Equal(t, int32(1), deleteCalled.Load(), "should cleanup on empty token key")
+}
+
+func TestGrafanaDriver_Revoke(t *testing.T) {
+	var deleteCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/api/serviceaccounts/42" {
+			deleteCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.Revoke(context.Background(), "42")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), deleteCalled.Load())
+}
+
+func TestGrafanaDriver_Revoke_EmptyLeaseID(t *testing.T) {
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGrafana,
+			Config: map[string]string{},
+		},
+	}
+	err := driver.Revoke(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestGrafanaDriver_Revoke_APIError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Service account not found"}`))
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.Revoke(context.Background(), "999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete service account")
+}
+
+func TestGrafanaDriver_VerifySpec(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/serviceaccounts/search", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("perpage"))
+		assert.Equal(t, "Bearer glsa_admin", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"totalCount":      1,
+			"serviceAccounts": []interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{},
+	})
+	require.NoError(t, err)
+}
+
+func TestGrafanaDriver_VerifySpec_Unauthorized(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_bad_token",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "admin token verification failed")
+}
+
+func TestValidateGrafanaURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{"https://mystack.grafana.net", false, ""},
+		{"https://grafana.example.com", false, ""},
+		{"https://logs-prod-us-central1.grafana.net", false, ""},
+		{"http://grafana.local", true, "must use https://"},
+		{"ftp://grafana.local", true, "must use https://"},
+		{"https://", true, "must include a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateGrafanaURL(tt.url, false)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateGrafanaURL_TLSSkipVerify(t *testing.T) {
+	require.NoError(t, validateGrafanaURL("http://grafana.local", true))
+	require.NoError(t, validateGrafanaURL("https://grafana.local", true))
+	require.Error(t, validateGrafanaURL("ftp://grafana.local", true))
+}
+
+func TestGrafanaDriver_MintCredential_SAZeroID(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 0})
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_admin",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test-zero-id",
+		Type:   credential.TypeAPIKey,
+		Config: map[string]string{},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ID 0")
+}
+
+func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer glsa_my_admin_token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"totalCount":0,"serviceAccounts":[]}`)
+	}))
+	defer server.Close()
+
+	driver := &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGrafana,
+			Config: map[string]string{
+				"grafana_url": server.URL,
+				"admin_token": "glsa_my_admin_token",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	_, _, err := driver.doGrafanaRequest(context.Background(), http.MethodGet, "/api/serviceaccounts/search", nil, "")
+	require.NoError(t, err)
+}

--- a/provider/grafana/README.md
+++ b/provider/grafana/README.md
@@ -1,0 +1,519 @@
+# Grafana Provider
+
+The Grafana provider enables proxied access to the entire Grafana ecosystem through Warden: the dashboard/admin HTTP API, Loki (logs), Mimir (metrics), Tempo (traces), and Pyroscope (profiling). It forwards requests with automatic credential injection and policy evaluation.
+
+A single provider type supports all Grafana services. Mount multiple instances with different `grafana_url` values and use the optional `tenant_id` config to inject the `X-Scope-OrgID` header required by Loki, Mimir, Tempo, and Pyroscope.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [Multi-Service Setup](#multi-service-setup)
+- [TLS Certificate Authentication](#tls-certificate-authentication)
+- [Configuration Reference](#configuration-reference)
+- [Token Management](#token-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- A **Grafana service account token** (from Grafana > Administration > Service Accounts) or a **Grafana Cloud access policy token** (from Grafana Cloud > Access Policies)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Add the binary to your PATH:**
+> ```bash
+> export PATH="$PWD:$PATH"
+> ```
+>
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev --dev-root-token=root
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export PATH="$PWD:$PATH"
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="root"
+> ```
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/grafana-user \
+    token_policies="grafana-access" \
+    user_claim=sub \
+    cred_spec_name=grafana-ops
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the Grafana provider at a path of your choice:
+
+```bash
+warden provider enable --type=grafana
+```
+
+To mount at a custom path (useful for multi-service setups):
+
+```bash
+warden provider enable --type=grafana grafana-loki
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider with `auto_auth_path`. This allows clients to authenticate with their JWT directly — no explicit Warden login required:
+
+```bash
+warden write grafana/config <<EOF
+{
+  "grafana_url": "https://mystack.grafana.net/api",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read grafana/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+### Option A: Static Service Account Token
+
+Create a service account in Grafana:
+1. Go to **Administration > Users and Access > Service Accounts**
+2. Click **Add service account**
+3. Assign a role (Viewer, Editor, or Admin) and create a token
+4. Copy the generated token (it is only displayed once)
+
+```bash
+warden cred source create grafana-src \
+  --type=apikey \
+  --rotation-period=0 \
+  --config=api_url=https://mystack.grafana.net/api \
+  --config=verify_endpoint=/org \
+  --config=display_name=Grafana
+```
+
+Create a credential spec that references the credential source:
+
+```bash
+warden cred spec create grafana-ops \
+  --source grafana-src \
+  --config api_key=glsa_your-service-account-token
+```
+
+### Option B: Dynamic Tokens via Grafana Source Driver
+
+The Grafana source driver uses an admin service account token to programmatically create short-lived service accounts and tokens via the Grafana HTTP API.
+
+```bash
+# Create a Grafana credential source with admin token
+warden cred source create grafana-dynamic-src \
+  --type=grafana \
+  --config=grafana_url=https://mystack.grafana.net \
+  --config=admin_token=glsa_your-admin-token
+```
+
+Create a credential spec for dynamic token minting:
+
+```bash
+warden cred spec create grafana-ops \
+  --source grafana-dynamic-src \
+  --config role=Viewer \
+  --config token_expiry=1h \
+  --config name_prefix=warden-
+```
+
+### Option C: Vault/OpenBao as Credential Source
+
+Store the Grafana token in Vault/OpenBao KV v2 and have Warden fetch it at runtime:
+
+```bash
+warden cred source create grafana-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+```
+
+Create a credential spec using the `static_apikey` mint method:
+
+```bash
+warden cred spec create grafana-ops \
+  --source grafana-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=grafana/ops
+```
+
+## Step 4: Create a Policy
+
+Create a policy that grants access to the Grafana provider gateway:
+
+```bash
+warden policy write grafana-access - <<EOF
+path "grafana/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For multi-service setups, include all mount paths:
+
+```bash
+warden policy write grafana-access - <<EOF
+path "grafana/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+
+path "grafana-loki/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+
+path "grafana-mimir/role/+/gateway*" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+## Step 5: Get a JWT and Make Requests
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+The URL pattern is: `/v1/grafana/role/{role}/gateway/{api-path}`
+
+```bash
+export GRAFANA_ENDPOINT="${WARDEN_ADDR}/v1/grafana/role/grafana-user/gateway"
+```
+
+### Get Organization Info
+
+```bash
+curl -s "${GRAFANA_ENDPOINT}/org" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Dashboards
+
+```bash
+curl -s "${GRAFANA_ENDPOINT}/search?type=dash-db" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### Get a Dashboard by UID
+
+```bash
+curl -s "${GRAFANA_ENDPOINT}/dashboards/uid/{uid}" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Data Sources
+
+```bash
+curl -s "${GRAFANA_ENDPOINT}/datasources" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### Search Service Accounts
+
+```bash
+curl -s "${GRAFANA_ENDPOINT}/serviceaccounts/search" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### List Alerts
+
+```bash
+curl -s "${GRAFANA_ENDPOINT}/alertmanager/grafana/api/v2/alerts" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+## Multi-Service Setup
+
+Mount multiple instances of the Grafana provider for different ecosystem services. All share the same credential (a Grafana Cloud access policy token with the appropriate scopes).
+
+### Loki (Logs)
+
+```bash
+warden provider enable --type=grafana grafana-loki
+
+warden write grafana-loki/config <<EOF
+{
+  "grafana_url": "https://logs-prod-us-central1.grafana.net",
+  "tenant_id": "12345",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+```
+
+```bash
+export LOKI_ENDPOINT="${WARDEN_ADDR}/v1/grafana-loki/role/grafana-user/gateway"
+
+# Query logs
+curl -s "${LOKI_ENDPOINT}/loki/api/v1/query?query={job=\"myapp\"}" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+
+# Query log range
+curl -s "${LOKI_ENDPOINT}/loki/api/v1/query_range?query={job=\"myapp\"}&start=1609459200&end=1609545600" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+
+# List labels
+curl -s "${LOKI_ENDPOINT}/loki/api/v1/labels" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+### Mimir (Metrics)
+
+```bash
+warden provider enable --type=grafana grafana-mimir
+
+warden write grafana-mimir/config <<EOF
+{
+  "grafana_url": "https://prometheus-prod-us-central1.grafana.net",
+  "tenant_id": "12345",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+```
+
+```bash
+export MIMIR_ENDPOINT="${WARDEN_ADDR}/v1/grafana-mimir/role/grafana-user/gateway"
+
+# Instant query
+curl -s "${MIMIR_ENDPOINT}/prometheus/api/v1/query?query=up" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+
+# Range query
+curl -s "${MIMIR_ENDPOINT}/prometheus/api/v1/query_range?query=up&start=1609459200&end=1609545600&step=60" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+### Tempo (Traces)
+
+```bash
+warden provider enable --type=grafana grafana-tempo
+
+warden write grafana-tempo/config <<EOF
+{
+  "grafana_url": "https://tempo-us-central1.grafana.net",
+  "tenant_id": "12345",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+```
+
+```bash
+export TEMPO_ENDPOINT="${WARDEN_ADDR}/v1/grafana-tempo/role/grafana-user/gateway"
+
+# Search traces
+curl -s "${TEMPO_ENDPOINT}/api/search?q={resource.service.name=\"myapp\"}" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+## TLS Certificate Authentication
+
+Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable --type=cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=grafana-user
+```
+
+### Create a Cert Role
+
+```bash
+warden write auth/cert/role/grafana-user \
+    allowed_common_names="agent-*" \
+    token_policies="grafana-access" \
+    cred_spec_name=grafana-ops
+```
+
+### Configure Provider for Cert Auth
+
+```bash
+warden write grafana/config <<EOF
+{
+  "grafana_url": "https://mystack.grafana.net/api",
+  "auto_auth_path": "auth/cert/",
+  "timeout": "30s"
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -s "https://warden.internal/v1/grafana/role/grafana-user/gateway/org" \
+    -H "Content-Type: application/json"
+```
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `grafana_url` | string | `https://grafana.com/api` | Grafana API base URL (must be HTTPS) |
+| `tenant_id` | string | — | Tenant/org ID injected as `X-Scope-OrgID` header (required for Loki, Mimir, Tempo, Pyroscope) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `30s` | Request timeout |
+| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Credential Source Config (Grafana Driver)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `grafana_url` | string | Yes | Grafana API base URL (e.g., `https://mystack.grafana.net`) |
+| `admin_token` | string | Yes | Admin service account token with ServiceAccount admin permissions |
+| `tls_skip_verify` | bool | No | Skip TLS certificate verification (development only) |
+| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
+
+### Credential Spec Config (Grafana Driver)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `role` | string | No | Service account role: `Viewer`, `Editor`, or `Admin` (default: `Viewer`) |
+| `token_expiry` | duration | No | Token expiration duration (default: `1h`) |
+| `name_prefix` | string | No | Service account name prefix (default: `warden-`) |
+| `org_id` | string | No | Organization ID for multi-org setups |
+
+### Credential Source Config (Static API Token)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_url` | string | No | API base URL for token verification |
+| `verify_endpoint` | string | No | Verification path (e.g., `/org`) |
+| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
+
+### Credential Spec Config (Static API Token)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | Grafana service account token or Cloud access policy token (sensitive — masked in output) |
+
+## Token Management
+
+### Static Service Account Token
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Token is stored on the credential spec (not the source) |
+| **Validation** | Token is verified at spec creation via `GET /org` on the Grafana API |
+| **Rotation** | Manual — regenerate in Grafana and update the spec |
+| **Lifetime** | Configurable — service account tokens can be set to expire or never expire |
+
+### Dynamic Tokens (Grafana Source Driver)
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Admin token on the source; minted tokens are ephemeral |
+| **Minting** | Creates a temporary service account + token via the Grafana HTTP API |
+| **TTL** | Configurable via `token_expiry` (default: 1h) |
+| **Cleanup** | Service account is deleted on revoke, which revokes all its tokens |
+
+**To rotate a static token:**
+
+1. Generate a new token in Grafana (Administration > Service Accounts > your service account > Add token)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update grafana-ops \
+     --config api_key=glsa_your-new-token
+   ```
+3. Delete the old token in Grafana
+
+### Grafana Cloud Access Policy Tokens
+
+For Grafana Cloud, access policy tokens can authenticate to multiple services (Grafana, Loki, Mimir, Tempo, Pyroscope) with a single token. Configure the token's scopes to control access:
+
+- `metrics:read`, `metrics:write` — Mimir/Prometheus
+- `logs:read`, `logs:write` — Loki
+- `traces:read`, `traces:write` — Tempo
+- `profiles:read`, `profiles:write` — Pyroscope
+- `alerts:read`, `alerts:write` — Alertmanager
+
+Create the token at **Grafana Cloud > Security > Access Policies** and use it as a static `api_key` credential spec shared across all Grafana provider mounts.

--- a/provider/grafana/provider.go
+++ b/provider/grafana/provider.go
@@ -1,0 +1,129 @@
+package grafana
+
+import (
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/provider/httpproxy"
+)
+
+// DefaultGrafanaURL is the default Grafana Cloud API base URL.
+// For self-hosted instances, configure grafana_url to point to your instance
+// (e.g., https://grafana.example.com/api).
+// For Grafana Cloud telemetry services, use the service-specific URL:
+//   - Loki:      https://logs-prod-<region>.grafana.net
+//   - Mimir:     https://prometheus-prod-<region>.grafana.net
+//   - Tempo:     https://tempo-<region>.grafana.net
+//   - Pyroscope: (found in your Grafana Cloud stack details)
+const DefaultGrafanaURL = "https://grafana.com/api"
+
+// DefaultGrafanaTimeout is the default request timeout for Grafana API calls
+const DefaultGrafanaTimeout = 30 * time.Second
+
+// Spec defines the Grafana provider configuration for the httpproxy framework.
+//
+// A single provider type supports all Grafana ecosystem services (dashboard API,
+// Loki, Mimir, Tempo, Pyroscope) by mounting multiple instances with different
+// grafana_url values. The optional tenant_id config injects the X-Scope-OrgID
+// header required by Loki, Mimir, Tempo, and Pyroscope.
+var Spec = &httpproxy.ProviderSpec{
+	Name:               "grafana",
+	DefaultURL:         DefaultGrafanaURL,
+	URLConfigKey:       "grafana_url",
+	DefaultTimeout:     DefaultGrafanaTimeout,
+	ParseStreamBody:    true,
+	UserAgent:          "warden-grafana-proxy",
+	HelpText:           grafanaBackendHelp,
+	ExtractCredentials: httpproxy.BearerAPIKeyExtractor,
+
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"tenant_id": {
+			Type:        framework.TypeString,
+			Description: "Tenant/org ID injected as X-Scope-OrgID header (required for Loki, Mimir, Tempo, Pyroscope)",
+		},
+	},
+	DynamicHeaders: func(state map[string]any) map[string]string {
+		tenantID, _ := state["tenant_id"].(string)
+		if tenantID == "" {
+			return nil
+		}
+		return map[string]string{"X-Scope-OrgID": tenantID}
+	},
+	OnConfigRead: func(state map[string]any) map[string]any {
+		tenantID, _ := state["tenant_id"].(string)
+		return map[string]any{"tenant_id": tenantID}
+	},
+	OnConfigWrite: func(d *framework.FieldData, state map[string]any) (map[string]any, error) {
+		if val, ok := d.GetOk("tenant_id"); ok {
+			state["tenant_id"] = val.(string)
+		}
+		return state, nil
+	},
+	OnInitialize: func(config map[string]any, state map[string]any) map[string]any {
+		if tid, ok := config["tenant_id"].(string); ok && tid != "" {
+			state["tenant_id"] = tid
+		}
+		return state
+	},
+}
+
+// Factory creates a new Grafana provider backend.
+var Factory = httpproxy.NewFactory(Spec)
+
+const grafanaBackendHelp = `
+The Grafana provider enables proxying requests to Grafana REST APIs with
+automatic credential management and token injection.
+
+Warden performs implicit authentication on every request and obtains a
+Grafana service account token (or Cloud access policy token) from the
+credential manager, injecting it into the proxied request's Authorization
+header.
+
+This single provider type supports the entire Grafana ecosystem by mounting
+multiple instances with different grafana_url values:
+
+  Dashboard API:  grafana_url=https://<stack>.grafana.net/api
+  Loki (logs):    grafana_url=https://logs-prod-<region>.grafana.net
+  Mimir (metrics): grafana_url=https://prometheus-prod-<region>.grafana.net
+  Tempo (traces): grafana_url=https://tempo-<region>.grafana.net
+
+For Loki, Mimir, Tempo, and Pyroscope, set tenant_id in the config to
+inject the X-Scope-OrgID header automatically.
+
+The gateway path format is:
+  /grafana/gateway/{api-path}
+
+The role can be provided via the X-Warden-Role header, or embedded in
+the URL path:
+  /grafana/role/{role}/gateway/{api-path}
+
+Example API paths (dashboard API):
+  /grafana/gateway/org
+  /grafana/gateway/dashboards/uid/{uid}
+  /grafana/gateway/datasources
+  /grafana/gateway/serviceaccounts/search
+  /grafana/gateway/alertmanager/grafana/api/v2/alerts
+
+Example API paths (Loki):
+  /grafana-loki/gateway/loki/api/v1/query
+  /grafana-loki/gateway/loki/api/v1/query_range
+  /grafana-loki/gateway/loki/api/v1/labels
+  /grafana-loki/gateway/loki/api/v1/push
+
+Example API paths (Mimir):
+  /grafana-mimir/gateway/api/v1/push
+  /grafana-mimir/gateway/prometheus/api/v1/query
+  /grafana-mimir/gateway/prometheus/api/v1/query_range
+
+Credential source types:
+- apikey: Static service account token or Cloud access policy token
+- grafana: Dynamic service account tokens minted via the Grafana HTTP API
+
+Configuration:
+- grafana_url: Grafana API base URL (default: https://grafana.com/api)
+- tenant_id: Tenant ID for X-Scope-OrgID header (required for Loki/Mimir/Tempo/Pyroscope)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 30s)
+- auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`


### PR DESCRIPTION
Single provider type supports the entire Grafana ecosystem (dashboard API, Loki, Mimir, Tempo, Pyroscope) via multi-mount with different grafana_url values. Optional tenant_id config injects X-Scope-OrgID header for telemetry services.

Includes a Grafana source driver that mints short-lived service account tokens via the Grafana HTTP API (POST /api/serviceaccounts + tokens), with automatic cleanup on revoke.