### PR TITLE
fix: encode orgID in Grafana leaseID to prevent service account leak

### DIFF
--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -199,8 +199,14 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		"api_key": tokenResult.Key,
 	}
 
-	// leaseID is the service account ID for cleanup
-	leaseID := fmt.Sprintf("%d", saResult.ID)
+	// leaseID encodes orgID and service account ID for cleanup.
+	// Format: "<orgID>:<saID>" when orgID is set, "<saID>" otherwise.
+	var leaseID string
+	if orgID != "" {
+		leaseID = fmt.Sprintf("%s:%d", orgID, saResult.ID)
+	} else {
+		leaseID = fmt.Sprintf("%d", saResult.ID)
+	}
 
 	if d.logger != nil {
 		d.logger.Debug("minted Grafana service account token",
@@ -220,9 +226,9 @@ func (d *GrafanaDriver) Revoke(ctx context.Context, leaseID string) error {
 		return nil
 	}
 
-	// leaseID is the service account ID
-	path := fmt.Sprintf("/api/serviceaccounts/%s", leaseID)
-	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, ""); err != nil {
+	saID, orgID := parseGrafanaLeaseID(leaseID)
+	path := fmt.Sprintf("/api/serviceaccounts/%s", saID)
+	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, orgID); err != nil {
 		return fmt.Errorf("failed to delete service account %s: %w", leaseID, err)
 	}
 
@@ -297,6 +303,15 @@ func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path strin
 		)
 	}
 	return respBody, status, err
+}
+
+// parseGrafanaLeaseID splits a leaseID into (saID, orgID).
+// Format: "<orgID>:<saID>" or "<saID>" (legacy / default org).
+func parseGrafanaLeaseID(leaseID string) (saID, orgID string) {
+	if i := strings.LastIndex(leaseID, ":"); i >= 0 {
+		return leaseID[i+1:], leaseID[:i]
+	}
+	return leaseID, ""
 }
 
 // deleteServiceAccount is a best-effort cleanup helper.

--- a/credential/drivers/grafana_driver_test.go
+++ b/credential/drivers/grafana_driver_test.go
@@ -278,7 +278,7 @@ func TestGrafanaDriver_MintCredential_CustomConfig(t *testing.T) {
 	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "glsa_custom", rawData["api_key"])
-	assert.Equal(t, "100", leaseID)
+	assert.Equal(t, "99:100", leaseID)
 }
 
 func TestGrafanaDriver_MintCredential_InvalidRole(t *testing.T) {
@@ -634,4 +634,21 @@ func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
 
 	_, _, err := driver.doGrafanaRequest(context.Background(), http.MethodGet, "/api/serviceaccounts/search", nil, "")
 	require.NoError(t, err)
+}
+
+func TestParseGrafanaLeaseID(t *testing.T) {
+	tests := []struct {
+		leaseID       string
+		wantSAID      string
+		wantOrgID     string
+	}{
+		{"1337", "1337", ""},
+		{"42:1337", "1337", "42"},
+		{"org:with:colon:99", "99", "org:with:colon"},
+	}
+	for _, tc := range tests {
+		saID, orgID := parseGrafanaLeaseID(tc.leaseID)
+		assert.Equal(t, tc.wantSAID, saID, "leaseID=%q saID", tc.leaseID)
+		assert.Equal(t, tc.wantOrgID, orgID, "leaseID=%q orgID", tc.leaseID)
+	}
 }


### PR DESCRIPTION
In multi-org Grafana setups, Revoke was calling DELETE /api/serviceaccounts/{id} without the X-Grafana-Org-Id header, causing 404s and permanent service account leaks. The leaseID now encodes orgID as "<orgID>:<saID>" when an org is configured.