### PR TITLE
feat: add Honeycomb provider with httpproxy gateway and source driver

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/stephnangue/warden/provider/elastic"
 	"github.com/stephnangue/warden/provider/gcp"
 	"github.com/stephnangue/warden/provider/grafana"
+	"github.com/stephnangue/warden/provider/honeycomb"
 	"github.com/stephnangue/warden/provider/github"
 	"github.com/stephnangue/warden/provider/gitlab"
 	"github.com/stephnangue/warden/provider/kubernetes"
@@ -131,6 +132,7 @@ Usage: warden server [options]
 		"kubernetes":    kubernetes.Factory,
 		"gcp":           gcp.Factory,
 		"grafana":       grafana.Factory,
+		"honeycomb":     honeycomb.Factory,
 		"github":        github.Factory,
 		"gitlab":        gitlab.Factory,
 		"mistral":       mistral.Factory,

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -41,6 +41,7 @@ const (
 	SourceTypeOVH        = "ovh"
 	SourceTypeCloudflare = "cloudflare"
 	SourceTypeGrafana    = "grafana"
+	SourceTypeHoneycomb  = "honeycomb"
 )
 
 // Category constants for credential categorization

--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -79,5 +79,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register Honeycomb driver factory
+	if err := registry.RegisterFactory(&HoneycombDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/honeycomb_driver.go
+++ b/credential/drivers/honeycomb_driver.go
@@ -1,0 +1,385 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+)
+
+// honeycombMaxResponseBodySize limits response body reads to prevent OOM
+const honeycombMaxResponseBodySize = 1 << 20 // 1MB
+
+// honeycombMaxRetryAttempts for retryable API operations
+const honeycombMaxRetryAttempts = 3
+
+// honeycombDefaultKeyNamePrefix is the default prefix for minted API keys
+const honeycombDefaultKeyNamePrefix = "warden-"
+
+// honeycombDefaultKeyType is the default type of API key to mint
+const honeycombDefaultKeyType = "ingest"
+
+// honeycombDefaultKeyTTL is the default lease TTL for minted API keys.
+// Honeycomb keys don't expire natively, so this controls the Warden lease duration.
+const honeycombDefaultKeyTTL = 24 * time.Hour
+
+// honeycombContentType is the JSON:API content type required by Honeycomb V2 API
+const honeycombContentType = "application/vnd.api+json"
+
+// Compile-time interface assertions
+var _ credential.SourceDriver = (*HoneycombDriver)(nil)
+var _ credential.SpecVerifier = (*HoneycombDriver)(nil)
+
+// HoneycombDriver mints credentials from the Honeycomb V2 key management API.
+//
+// The source config holds a management key (key_id + key_secret) with permissions
+// to create and delete API keys. Per-spec config controls the environment,
+// key type, naming, and permissions of minted keys.
+//
+// MintCredential creates a new ingest or configuration API key via POST
+// /2/teams/{teamSlug}/api-keys. Revoke deletes the key via DELETE endpoint.
+// Key secrets are only returned at creation time, making Warden's capture
+// critical.
+type HoneycombDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// HoneycombDriverFactory creates HoneycombDriver instances
+type HoneycombDriverFactory struct{}
+
+// Type returns the driver type
+func (f *HoneycombDriverFactory) Type() string {
+	return credential.SourceTypeHoneycomb
+}
+
+// ValidateConfig validates Honeycomb source configuration using declarative schema.
+func (f *HoneycombDriverFactory) ValidateConfig(config map[string]string) error {
+	return credential.ValidateSchema(config,
+		credential.StringField("honeycomb_url").
+			Custom(func(v string) error {
+				return validateHoneycombURL(v, credential.GetBool(config, "tls_skip_verify", false))
+			}).
+			Describe("Honeycomb API base URL (default: https://api.honeycomb.io)").
+			Example("https://api.honeycomb.io"),
+
+		credential.StringField("management_key_id").
+			Required().
+			Describe("Management key ID (hcxmk_ prefix) for API key management"),
+
+		credential.StringField("management_key_secret").
+			Required().
+			Describe("Management key secret paired with the key ID"),
+
+		credential.StringField("team_slug").
+			Required().
+			Describe("Honeycomb team slug used in API paths").
+			Example("my-team"),
+
+		credential.StringField("ca_data").
+			Custom(ValidateCAData).
+			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs"),
+
+		credential.BoolField("tls_skip_verify").
+			Describe("Skip TLS certificate verification (development only)"),
+	)
+}
+
+// SensitiveConfigFields returns source config keys that should be masked.
+func (f *HoneycombDriverFactory) SensitiveConfigFields() []string {
+	return []string{"management_key_id", "management_key_secret", "ca_data"}
+}
+
+// InferCredentialType always returns api_key for Honeycomb sources.
+func (f *HoneycombDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeAPIKey, nil
+}
+
+// Create instantiates a new HoneycombDriver.
+func (f *HoneycombDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeHoneycomb,
+			Config: config,
+		},
+		logger: log.WithSubsystem(credential.SourceTypeHoneycomb),
+	}
+
+	httpClient, err := BuildHTTPClient(config, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+	}
+	driver.httpClient = httpClient
+
+	return driver, nil
+}
+
+// getHoneycombURL returns the Honeycomb API base URL from source config
+func (d *HoneycombDriver) getHoneycombURL() string {
+	raw := credential.GetString(d.credSource.Config, "honeycomb_url", "https://api.honeycomb.io")
+	return strings.TrimRight(raw, "/")
+}
+
+// getManagementKeyID returns the management key ID from source config
+func (d *HoneycombDriver) getManagementKeyID() string {
+	return credential.GetString(d.credSource.Config, "management_key_id", "")
+}
+
+// getManagementKeySecret returns the management key secret from source config
+func (d *HoneycombDriver) getManagementKeySecret() string {
+	return credential.GetString(d.credSource.Config, "management_key_secret", "")
+}
+
+// getTeamSlug returns the team slug from source config
+func (d *HoneycombDriver) getTeamSlug() string {
+	return credential.GetString(d.credSource.Config, "team_slug", "")
+}
+
+// MintCredential creates a new Honeycomb API key via the V2 key management API.
+//
+// Flow:
+//  1. Build JSON:API request body with key type, name, environment, and permissions
+//  2. POST /2/teams/{teamSlug}/api-keys — create the API key
+//  3. Return {"api_key": "<secret>"} with lease TTL from spec config
+//
+// The leaseID is the Honeycomb key ID (e.g., "hcxik_..."), used for revocation.
+// The key secret is only available at creation time.
+func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	keyType := credential.GetString(spec.Config, "key_type", honeycombDefaultKeyType)
+	namePrefix := credential.GetString(spec.Config, "key_name_prefix", honeycombDefaultKeyNamePrefix)
+	environmentID := credential.GetString(spec.Config, "environment_id", "")
+	keyTTL := credential.GetDuration(spec.Config, "key_ttl", honeycombDefaultKeyTTL)
+	permissionsJSON := credential.GetString(spec.Config, "permissions", "")
+
+	// Validate key_type
+	switch keyType {
+	case "ingest", "configuration":
+	default:
+		return nil, 0, "", fmt.Errorf("invalid key_type '%s': must be 'ingest' or 'configuration'", keyType)
+	}
+
+	if environmentID == "" {
+		return nil, 0, "", fmt.Errorf("environment_id is required in spec config")
+	}
+
+	// Build key name
+	keyName := fmt.Sprintf("%s%s-%d", namePrefix, spec.Name, time.Now().UnixMilli())
+
+	// Build JSON:API request body
+	attributes := map[string]interface{}{
+		"key_type": keyType,
+		"name":     keyName,
+	}
+
+	// Parse and add permissions if specified (configuration keys only)
+	if permissionsJSON != "" {
+		if keyType != "configuration" {
+			return nil, 0, "", fmt.Errorf("permissions can only be set for configuration keys, not %s keys", keyType)
+		}
+		var permissions map[string]interface{}
+		if err := json.Unmarshal([]byte(permissionsJSON), &permissions); err != nil {
+			return nil, 0, "", fmt.Errorf("invalid permissions JSON: %w", err)
+		}
+		attributes["permissions"] = permissions
+	}
+
+	reqBody := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type":       "api-keys",
+			"attributes": attributes,
+			"relationships": map[string]interface{}{
+				"environment": map[string]interface{}{
+					"data": map[string]interface{}{
+						"type": "environments",
+						"id":   environmentID,
+					},
+				},
+			},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to marshal API key request: %w", err)
+	}
+
+	// Create the API key
+	teamSlug := d.getTeamSlug()
+	path := fmt.Sprintf("/2/teams/%s/api-keys", url.PathEscape(teamSlug))
+	respBody, _, err := d.doHoneycombRequest(ctx, http.MethodPost, path, bodyBytes)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to create API key: %w", err)
+	}
+
+	// Parse response — JSON:API format
+	var resp struct {
+		Data struct {
+			ID         string `json:"id"`
+			Attributes struct {
+				Secret string `json:"secret"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, 0, "", fmt.Errorf("failed to parse API key response: %w", err)
+	}
+	if resp.Data.ID == "" {
+		return nil, 0, "", fmt.Errorf("Honeycomb API returned key with empty ID")
+	}
+	if resp.Data.Attributes.Secret == "" {
+		return nil, 0, "", fmt.Errorf("Honeycomb API returned key with empty secret")
+	}
+
+	rawData := map[string]interface{}{
+		"api_key":  resp.Data.Attributes.Secret,
+		"key_type": keyType,
+	}
+
+	// leaseID is the Honeycomb key ID for revocation
+	leaseID := resp.Data.ID
+
+	if d.logger != nil {
+		d.logger.Debug("minted Honeycomb API key",
+			logger.String("spec", spec.Name),
+			logger.String("key_name", keyName),
+			logger.String("key_type", keyType),
+			logger.String("key_id", leaseID),
+			logger.String("ttl", keyTTL.String()),
+		)
+	}
+
+	return rawData, keyTTL, leaseID, nil
+}
+
+// Revoke deletes the API key identified by leaseID.
+// Treats 404 as success since the key may have already been deleted.
+func (d *HoneycombDriver) Revoke(ctx context.Context, leaseID string) error {
+	if leaseID == "" {
+		return nil
+	}
+
+	teamSlug := d.getTeamSlug()
+	path := fmt.Sprintf("/2/teams/%s/api-keys/%s", url.PathEscape(teamSlug), url.PathEscape(leaseID))
+
+	// 204 = deleted, 404 = already gone — both are success
+	if _, _, err := d.doHoneycombRequest(ctx, http.MethodDelete, path, nil, 204, 404); err != nil {
+		return fmt.Errorf("failed to delete API key %s: %w", leaseID, err)
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("revoked Honeycomb API key",
+			logger.String("key_id", leaseID),
+		)
+	}
+
+	return nil
+}
+
+// Type returns the driver type
+func (d *HoneycombDriver) Type() string {
+	return credential.SourceTypeHoneycomb
+}
+
+// Cleanup releases resources
+func (d *HoneycombDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// VerifySpec validates spec configuration and credentials.
+// Checks that required spec config fields are present, then lists API keys
+// with a page size of 1 to confirm the management key works and the team slug
+// is valid.
+func (d *HoneycombDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	// Validate required spec config fields early
+	environmentID := credential.GetString(spec.Config, "environment_id", "")
+	if environmentID == "" {
+		return fmt.Errorf("spec config missing required field: environment_id")
+	}
+
+	keyType := credential.GetString(spec.Config, "key_type", honeycombDefaultKeyType)
+	switch keyType {
+	case "ingest", "configuration":
+	default:
+		return fmt.Errorf("invalid key_type '%s': must be 'ingest' or 'configuration'", keyType)
+	}
+
+	// Verify management key and team slug by listing keys
+	teamSlug := d.getTeamSlug()
+	path := fmt.Sprintf("/2/teams/%s/api-keys?page[size]=1&filter[type]=%s",
+		url.PathEscape(teamSlug), url.QueryEscape(keyType))
+
+	if _, _, err := d.doHoneycombRequest(ctx, http.MethodGet, path, nil); err != nil {
+		return fmt.Errorf("management key verification failed (GET /2/teams/%s/api-keys): %w", teamSlug, err)
+	}
+	return nil
+}
+
+// --- HTTP helpers ---
+
+// honeycombRetryConfig is the shared retry configuration for all Honeycomb API calls.
+var honeycombRetryConfig = HTTPRetryConfig{
+	MaxAttempts:       honeycombMaxRetryAttempts,
+	MaxBodySize:       honeycombMaxResponseBodySize,
+	RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+	BaseBackoff:       1 * time.Second,
+	JitterPercent:     20,
+}
+
+// doHoneycombRequest executes an authenticated HTTP request to the Honeycomb V2 API.
+// Optional okStatuses override the default 2xx success check (e.g., pass []int{204, 404}
+// to treat 404 as success during revocation).
+func (d *HoneycombDriver) doHoneycombRequest(ctx context.Context, method, path string, body []byte, okStatuses ...int) ([]byte, int, error) {
+	apiURL := d.getHoneycombURL() + path
+
+	headers := map[string]string{
+		"Accept":        honeycombContentType,
+		"Authorization": "Bearer " + d.getManagementKeyID() + ":" + d.getManagementKeySecret(),
+	}
+	if body != nil {
+		headers["Content-Type"] = honeycombContentType
+	}
+
+	httpReq := HTTPRequest{
+		Method:     method,
+		URL:        apiURL,
+		Body:       body,
+		Headers:    headers,
+		OKStatuses: okStatuses,
+	}
+
+	respBody, status, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, honeycombRetryConfig)
+	if err != nil && d.logger != nil {
+		d.logger.Warn("Honeycomb API request failed",
+			logger.String("method", method),
+			logger.String("path", path),
+			logger.String("error", err.Error()),
+		)
+	}
+	return respBody, status, err
+}
+
+// validateHoneycombURL validates that the honeycomb_url is a well-formed HTTPS URL.
+func validateHoneycombURL(rawURL string, tlsSkipVerify bool) error {
+	if rawURL == "" {
+		return nil // will use default
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid honeycomb_url: %w", err)
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && tlsSkipVerify) {
+		return fmt.Errorf("honeycomb_url must use https:// scheme, got: %s", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("honeycomb_url must include a host")
+	}
+	return nil
+}

--- a/credential/drivers/honeycomb_driver_test.go
+++ b/credential/drivers/honeycomb_driver_test.go
@@ -1,0 +1,899 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHoneycombDriverFactory_Type(t *testing.T) {
+	factory := &HoneycombDriverFactory{}
+	assert.Equal(t, credential.SourceTypeHoneycomb, factory.Type())
+}
+
+func TestHoneycombDriverFactory_SensitiveConfigFields(t *testing.T) {
+	factory := &HoneycombDriverFactory{}
+	fields := factory.SensitiveConfigFields()
+	assert.Contains(t, fields, "management_key_id")
+	assert.Contains(t, fields, "management_key_secret")
+	assert.Contains(t, fields, "ca_data")
+}
+
+func TestHoneycombDriverFactory_InferCredentialType(t *testing.T) {
+	factory := &HoneycombDriverFactory{}
+	credType, err := factory.InferCredentialType(nil)
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeAPIKey, credType)
+}
+
+func TestHoneycombDriverFactory_ValidateConfig(t *testing.T) {
+	factory := &HoneycombDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config",
+			config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc123",
+				"management_key_secret": "secret-value",
+				"team_slug":             "my-team",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config without url (uses default)",
+			config: map[string]string{
+				"management_key_id":     "hcxmk_01abc123",
+				"management_key_secret": "secret-value",
+				"team_slug":             "my-team",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing management_key_id",
+			config: map[string]string{
+				"management_key_secret": "secret-value",
+				"team_slug":             "my-team",
+			},
+			wantErr: true,
+			errMsg:  "management_key_id",
+		},
+		{
+			name: "missing management_key_secret",
+			config: map[string]string{
+				"management_key_id": "hcxmk_01abc123",
+				"team_slug":         "my-team",
+			},
+			wantErr: true,
+			errMsg:  "management_key_secret",
+		},
+		{
+			name: "missing team_slug",
+			config: map[string]string{
+				"management_key_id":     "hcxmk_01abc123",
+				"management_key_secret": "secret-value",
+			},
+			wantErr: true,
+			errMsg:  "team_slug",
+		},
+		{
+			name: "invalid honeycomb_url scheme",
+			config: map[string]string{
+				"honeycomb_url":         "http://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc123",
+				"management_key_secret": "secret-value",
+				"team_slug":             "my-team",
+			},
+			wantErr: true,
+			errMsg:  "must use https://",
+		},
+		{
+			name: "http allowed with tls_skip_verify",
+			config: map[string]string{
+				"honeycomb_url":         "http://honeycomb.local",
+				"management_key_id":     "hcxmk_01abc123",
+				"management_key_secret": "secret-value",
+				"team_slug":             "my-team",
+				"tls_skip_verify":       "true",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHoneycombDriverFactory_Create(t *testing.T) {
+	factory := &HoneycombDriverFactory{}
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	driver, err := factory.Create(map[string]string{
+		"honeycomb_url":         "https://api.honeycomb.io",
+		"management_key_id":     "hcxmk_01abc123",
+		"management_key_secret": "secret-value",
+		"team_slug":             "my-team",
+	}, log)
+	require.NoError(t, err)
+	assert.NotNil(t, driver)
+	assert.Equal(t, credential.SourceTypeHoneycomb, driver.Type())
+}
+
+func TestHoneycombDriver_Type(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeHoneycomb,
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, credential.SourceTypeHoneycomb, driver.Type())
+}
+
+func TestHoneycombDriver_Cleanup(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeHoneycomb,
+			Config: map[string]string{},
+		},
+		httpClient: &http.Client{},
+	}
+	err := driver.Cleanup(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestHoneycombDriver_NotRotatable(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeHoneycomb,
+			Config: map[string]string{},
+		},
+	}
+	var sd credential.SourceDriver = driver
+	_, ok := sd.(credential.Rotatable)
+	assert.False(t, ok, "HoneycombDriver should not implement credential.Rotatable")
+}
+
+func TestHoneycombDriver_GetHoneycombURL(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Config: map[string]string{"honeycomb_url": "https://api.honeycomb.io/"},
+		},
+	}
+	assert.Equal(t, "https://api.honeycomb.io", driver.getHoneycombURL())
+}
+
+func TestHoneycombDriver_GetHoneycombURL_Default(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Config: map[string]string{},
+		},
+	}
+	assert.Equal(t, "https://api.honeycomb.io", driver.getHoneycombURL())
+}
+
+func TestHoneycombDriver_MintCredential(t *testing.T) {
+	var createCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/2/teams/my-team/api-keys" {
+			createCalled.Add(1)
+
+			assert.Equal(t, honeycombContentType, r.Header.Get("Content-Type"))
+			assert.Equal(t, honeycombContentType, r.Header.Get("Accept"))
+			assert.Equal(t, "Bearer hcxmk_01abc:secret123", r.Header.Get("Authorization"))
+
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+
+			data, _ := body["data"].(map[string]interface{})
+			assert.Equal(t, "api-keys", data["type"])
+
+			attrs, _ := data["attributes"].(map[string]interface{})
+			assert.Equal(t, "ingest", attrs["key_type"])
+
+			rels, _ := data["relationships"].(map[string]interface{})
+			env, _ := rels["environment"].(map[string]interface{})
+			envData, _ := env["data"].(map[string]interface{})
+			assert.Equal(t, "env-123", envData["id"])
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":   "hcxik_01xyz",
+					"type": "api-keys",
+					"attributes": map[string]interface{}{
+						"secret": "secret-ingest-key-value",
+						"name":   attrs["name"],
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-ingest",
+		Type: credential.TypeAPIKey,
+		Config: map[string]string{
+			"environment_id": "env-123",
+		},
+	}
+
+	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "secret-ingest-key-value", rawData["api_key"])
+	assert.Equal(t, "ingest", rawData["key_type"])
+	assert.Equal(t, honeycombDefaultKeyTTL, ttl)
+	assert.Equal(t, "hcxik_01xyz", leaseID)
+	assert.Equal(t, int32(1), createCalled.Load())
+}
+
+func TestHoneycombDriver_MintCredential_ConfigurationKey(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/2/teams/my-team/api-keys" {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+
+			data, _ := body["data"].(map[string]interface{})
+			attrs, _ := data["attributes"].(map[string]interface{})
+			assert.Equal(t, "configuration", attrs["key_type"])
+
+			perms, _ := attrs["permissions"].(map[string]interface{})
+			assert.Equal(t, true, perms["run_queries"])
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id": "hcxlk_01xyz",
+					"attributes": map[string]interface{}{
+						"secret": "secret-config-key",
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-config",
+		Type: credential.TypeAPIKey,
+		Config: map[string]string{
+			"environment_id": "env-456",
+			"key_type":       "configuration",
+			"permissions":    `{"run_queries":true}`,
+		},
+	}
+
+	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "secret-config-key", rawData["api_key"])
+	assert.Equal(t, "configuration", rawData["key_type"])
+	assert.Equal(t, "hcxlk_01xyz", leaseID)
+}
+
+func TestHoneycombDriver_MintCredential_CustomConfig(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/2/teams/my-team/api-keys" {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+
+			data, _ := body["data"].(map[string]interface{})
+			attrs, _ := data["attributes"].(map[string]interface{})
+			name, _ := attrs["name"].(string)
+			assert.True(t, len(name) > 0 && name[:7] == "myapp--", "key name should start with custom prefix: got %q", name)
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id": "hcxik_custom",
+					"attributes": map[string]interface{}{
+						"secret": "secret-custom",
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "",
+		Type: credential.TypeAPIKey,
+		Config: map[string]string{
+			"environment_id":  "env-123",
+			"key_type":        "ingest",
+			"key_name_prefix": "myapp-",
+			"key_ttl":         "1h",
+		},
+	}
+
+	rawData, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "secret-custom", rawData["api_key"])
+	assert.Equal(t, "ingest", rawData["key_type"])
+	assert.Equal(t, 1*time.Hour, ttl)
+}
+
+func TestHoneycombDriver_MintCredential_InvalidPermissionsJSON(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-bad-perms",
+		Config: map[string]string{
+			"environment_id": "env-123",
+			"key_type":       "configuration",
+			"permissions":    `{not valid json`,
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid permissions JSON")
+}
+
+func TestHoneycombDriver_MintCredential_EmptyID(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id": "",
+				"attributes": map[string]interface{}{
+					"secret": "some-secret",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-empty-id",
+		Config: map[string]string{
+			"environment_id": "env-123",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty ID")
+}
+
+func TestHoneycombDriver_MintCredential_InvalidKeyType(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-bad-type",
+		Config: map[string]string{
+			"environment_id": "env-123",
+			"key_type":       "management",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key_type")
+}
+
+func TestHoneycombDriver_MintCredential_MissingEnvironmentID(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name:   "test-no-env",
+		Config: map[string]string{},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment_id is required")
+}
+
+func TestHoneycombDriver_MintCredential_PermissionsOnIngestKey(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-perms-ingest",
+		Config: map[string]string{
+			"environment_id": "env-123",
+			"key_type":       "ingest",
+			"permissions":    `{"create_datasets":true}`,
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permissions can only be set for configuration keys")
+}
+
+func TestHoneycombDriver_MintCredential_APIError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"errors":[{"title":"Forbidden"}]}`))
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_bad",
+				"management_key_secret": "bad-secret",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-error",
+		Config: map[string]string{
+			"environment_id": "env-123",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create API key")
+}
+
+func TestHoneycombDriver_MintCredential_EmptySecret(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id": "hcxik_01xyz",
+				"attributes": map[string]interface{}{
+					"secret": "",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-empty-secret",
+		Config: map[string]string{
+			"environment_id": "env-123",
+		},
+	}
+
+	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty secret")
+}
+
+func TestHoneycombDriver_Revoke(t *testing.T) {
+	var deleteCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/2/teams/my-team/api-keys/hcxik_01xyz" {
+			deleteCalled.Add(1)
+			assert.Equal(t, "Bearer hcxmk_01abc:secret123", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.Revoke(context.Background(), "hcxik_01xyz")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), deleteCalled.Load())
+}
+
+func TestHoneycombDriver_Revoke_EmptyLeaseID(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeHoneycomb,
+			Config: map[string]string{},
+		},
+	}
+	err := driver.Revoke(context.Background(), "")
+	assert.NoError(t, err)
+}
+
+func TestHoneycombDriver_Revoke_AlreadyDeleted(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"errors":[{"title":"Not Found"}]}`))
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	// 404 should be treated as success (key already deleted)
+	err := driver.Revoke(context.Background(), "hcxik_gone")
+	require.NoError(t, err)
+}
+
+func TestHoneycombDriver_VerifySpec(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/2/teams/my-team/api-keys", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("page[size]"))
+		assert.Equal(t, "ingest", r.URL.Query().Get("filter[type]"))
+		assert.Equal(t, "Bearer hcxmk_01abc:secret123", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name: "test",
+		Config: map[string]string{
+			"environment_id": "env-123",
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestHoneycombDriver_VerifySpec_MissingEnvironmentID(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment_id")
+}
+
+func TestHoneycombDriver_VerifySpec_InvalidKeyType(t *testing.T) {
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         "https://api.honeycomb.io",
+				"management_key_id":     "hcxmk_01abc",
+				"management_key_secret": "secret123",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: &http.Client{},
+	}
+
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name: "test",
+		Config: map[string]string{
+			"environment_id": "env-123",
+			"key_type":       "management",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key_type")
+}
+
+func TestHoneycombDriver_VerifySpec_Unauthorized(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"errors":[{"title":"Unauthorized"}]}`))
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_bad",
+				"management_key_secret": "bad-secret",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name: "test",
+		Config: map[string]string{
+			"environment_id": "env-123",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "management key verification failed")
+}
+
+func TestValidateHoneycombURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{"https://api.honeycomb.io", false, ""},
+		{"https://api.eu1.honeycomb.io", false, ""},
+		{"", false, ""}, // empty uses default
+		{"http://honeycomb.local", true, "must use https://"},
+		{"ftp://honeycomb.local", true, "must use https://"},
+		{"https://", true, "must include a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateHoneycombURL(tt.url, false)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateHoneycombURL_TLSSkipVerify(t *testing.T) {
+	require.NoError(t, validateHoneycombURL("http://honeycomb.local", true))
+	require.NoError(t, validateHoneycombURL("https://honeycomb.local", true))
+	require.Error(t, validateHoneycombURL("ftp://honeycomb.local", true))
+}
+
+func TestHoneycombDriver_AuthorizationHeader(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer hcxmk_mykey:mysecret", r.Header.Get("Authorization"))
+		assert.Equal(t, honeycombContentType, r.Header.Get("Accept"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_mykey",
+				"management_key_secret": "mysecret",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	_, _, err := driver.doHoneycombRequest(context.Background(), http.MethodGet, "/2/teams/my-team/api-keys", nil)
+	require.NoError(t, err)
+}
+
+func TestHoneycombDriver_ContentTypeOnPost(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, honeycombContentType, r.Header.Get("Content-Type"))
+		assert.Equal(t, honeycombContentType, r.Header.Get("Accept"))
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":         "hcxik_test",
+				"attributes": map[string]interface{}{"secret": "s"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_k",
+				"management_key_secret": "s",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	_, _, err := driver.doHoneycombRequest(context.Background(), http.MethodPost, "/2/teams/my-team/api-keys", []byte(`{}`))
+	require.NoError(t, err)
+}
+
+func TestHoneycombDriver_NoContentTypeOnGet(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Content-Type"), "GET requests should not set Content-Type")
+		assert.Equal(t, honeycombContentType, r.Header.Get("Accept"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	driver := &HoneycombDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeHoneycomb,
+			Config: map[string]string{
+				"honeycomb_url":         server.URL,
+				"management_key_id":     "hcxmk_k",
+				"management_key_secret": "s",
+				"team_slug":             "my-team",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	_, _, err := driver.doHoneycombRequest(context.Background(), http.MethodGet, "/2/teams/my-team/api-keys", nil)
+	require.NoError(t, err)
+}

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # Vault dev server for testing gateway proxy
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.18
     container_name: e2e-vault
     ports:
       - "8200:8200"

--- a/provider/honeycomb/README.md
+++ b/provider/honeycomb/README.md
@@ -1,0 +1,540 @@
+# Honeycomb Provider
+
+The Honeycomb provider enables proxied access to the Honeycomb API through Warden. It forwards requests to Honeycomb endpoints (`/1/events/{dataset}`, `/1/queries/{dataset}`, `/2/teams/{team}/api-keys`, etc.) with automatic credential injection and policy evaluation. Honeycomb uses two authentication modes: the `X-Honeycomb-Team` header for ingest and configuration keys, and `Authorization: Bearer <key_id>:<key_secret>` for management keys. Credentials can be static tokens from an `apikey` source or dynamically minted API keys from the `honeycomb` source driver.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [Cleanup](#cleanup)
+- [TLS Certificate Authentication](#tls-certificate-authentication)
+- [Configuration Reference](#configuration-reference)
+- [Token Management](#token-management)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- A Honeycomb account with a management key (key ID + key secret) for dynamic key minting, **or** a static ingest/configuration key
+- Team slug from your Honeycomb organization (visible in your Honeycomb URL)
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary:**
+> ```bash
+> # macOS (Apple Silicon)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+>
+> # macOS (Intel)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+>
+> # Linux (x86_64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+>
+> # Linux (ARM64)
+> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+> ```
+>
+> **3. Add the binary to your PATH:**
+> ```bash
+> export PATH="$PWD:$PATH"
+> ```
+>
+> **4. Start the Warden server** in dev mode:
+> ```bash
+> warden server --dev --dev-root-token=root
+> ```
+>
+> **5. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export PATH="$PWD:$PATH"
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="root"
+> ```
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable --type=jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/honeycomb-user \
+    token_policies="honeycomb-access" \
+    user_claim=sub \
+    cred_spec_name=honeycomb-ops
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the Honeycomb provider at a path of your choice:
+
+```bash
+warden provider enable --type=honeycomb
+```
+
+To mount at a custom path (e.g., for the EU region):
+
+```bash
+warden provider enable --type=honeycomb honeycomb-eu
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider:
+
+```bash
+warden write honeycomb/config <<EOF
+{
+  "honeycomb_url": "https://api.honeycomb.io",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+For EU region:
+
+```bash
+warden write honeycomb-eu/config <<EOF
+{
+  "honeycomb_url": "https://api.eu1.honeycomb.io",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "30s"
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read honeycomb/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+### Option A: Static API Key
+
+Use this when you already have a Honeycomb ingest or configuration key and want Warden to proxy requests with it.
+
+```bash
+warden cred source create honeycomb-src \
+  --type=apikey \
+  --rotation-period=0 \
+  --config=api_url=https://api.honeycomb.io \
+  --config=display_name=Honeycomb
+```
+
+Create a credential spec with your API key:
+
+```bash
+warden cred spec create honeycomb-ops \
+  --source honeycomb-src \
+  --config api_key=your-honeycomb-api-key
+```
+
+### Option B: Dynamic API Keys (Honeycomb Source Driver)
+
+Use this to have Warden dynamically create and revoke Honeycomb API keys using a management key. This is the recommended approach for production as it provides automatic key rotation and revocation.
+
+**Prerequisites:**
+- A Honeycomb management key (Settings > Team Settings > API Keys > Manage Management Keys)
+- The team slug from your Honeycomb account
+- An environment ID (visible in the URL when you select an environment)
+
+Create a credential source backed by the Honeycomb API:
+
+```bash
+warden cred source create honeycomb-src \
+  --type=honeycomb \
+  --rotation-period=24h \
+  --config=management_key_id=hcxmk_01abc123 \
+  --config=management_key_secret=your-management-key-secret \
+  --config=team_slug=my-team \
+  --config=honeycomb_url=https://api.honeycomb.io
+```
+
+Create a credential spec that mints ingest keys:
+
+```bash
+warden cred spec create honeycomb-ops \
+  --source honeycomb-src \
+  --config environment_id=your-environment-id \
+  --config key_type=ingest \
+  --config key_name_prefix=warden- \
+  --config key_ttl=24h
+```
+
+For configuration keys with specific permissions:
+
+```bash
+warden cred spec create honeycomb-config \
+  --source honeycomb-src \
+  --config environment_id=your-environment-id \
+  --config key_type=configuration \
+  --config key_name_prefix=warden- \
+  --config key_ttl=24h \
+  --config 'permissions={"send_events":true,"create_datasets":true,"run_queries":true}'
+```
+
+### Option C: Vault/OpenBao as Credential Source
+
+Instead of storing the API key directly in Warden, you can store it in a Vault/OpenBao KV v2 secret engine and have Warden fetch it at runtime.
+
+**Prerequisites:** A Vault/OpenBao instance with:
+- A KV v2 mount containing your Honeycomb API key (e.g., at `secret/honeycomb/ops` with an `api_key` field)
+- An AppRole configured for Warden access
+
+```bash
+# Create a Vault credential source
+warden cred source create honeycomb-vault-src \
+  --type=hvault \
+  --config=vault_address=https://vault.example.com \
+  --config=auth_method=approle \
+  --config=role_id=your-role-id \
+  --config=secret_id=your-secret-id \
+  --config=approle_mount=approle \
+  --config=role_name=warden-role \
+  --rotation-period=24h
+```
+
+Create a credential spec using the `static_apikey` mint method:
+
+```bash
+warden cred spec create honeycomb-ops \
+  --source honeycomb-vault-src \
+  --config mint_method=static_apikey \
+  --config kv2_mount=secret \
+  --config secret_path=honeycomb/ops
+```
+
+The KV v2 secret at `secret/honeycomb/ops` must contain an `api_key` field with your Honeycomb ingest or configuration key.
+
+Verify:
+
+```bash
+warden cred spec read honeycomb-ops
+```
+
+## Step 4: Create a Policy
+
+Create a policy that grants access to the Honeycomb provider gateway:
+
+```bash
+warden policy write honeycomb-access - <<EOF
+path "honeycomb/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For read-only access (querying only):
+
+```bash
+warden policy write honeycomb-readonly - <<EOF
+path "honeycomb/role/+/gateway/1/queries*" {
+  capabilities = ["create", "read"]
+}
+
+path "honeycomb/role/+/gateway/1/boards*" {
+  capabilities = ["read"]
+}
+
+path "honeycomb/role/+/gateway/1/slos*" {
+  capabilities = ["read"]
+}
+
+path "honeycomb/role/+/gateway/1/auth" {
+  capabilities = ["read"]
+}
+EOF
+```
+
+Verify:
+
+```bash
+warden policy read honeycomb-access
+```
+
+## Step 5: Get a JWT and Make Requests
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+Requests use role-based paths. Warden performs implicit JWT authentication and injects the Honeycomb credential automatically.
+
+The URL pattern is: `/v1/honeycomb/role/{role}/gateway/{api-path}`
+
+Export the base endpoint:
+
+```bash
+export HC_ENDPOINT="${WARDEN_ADDR}/v1/honeycomb/role/honeycomb-user/gateway"
+```
+
+### Verify Authentication
+
+```bash
+curl -s "${HC_ENDPOINT}/1/auth" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+### Send an Event
+
+```bash
+curl -s -X POST "${HC_ENDPOINT}/1/events/my-dataset" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "hello from warden", "duration_ms": 42}'
+```
+
+### Send a Batch of Events
+
+```bash
+curl -s -X POST "${HC_ENDPOINT}/1/batch/my-dataset" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '[{"data": {"message": "event 1"}}, {"data": {"message": "event 2"}}]'
+```
+
+### Query Data
+
+```bash
+curl -s -X POST "${HC_ENDPOINT}/1/queries/my-dataset" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "calculations": [{"op": "COUNT"}],
+    "time_range": 3600
+  }'
+```
+
+### List Boards
+
+```bash
+curl -s "${HC_ENDPOINT}/1/boards" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+### List SLOs
+
+```bash
+curl -s "${HC_ENDPOINT}/1/slos" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+### List Markers
+
+```bash
+curl -s "${HC_ENDPOINT}/1/markers/my-dataset" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+### List Triggers
+
+```bash
+curl -s "${HC_ENDPOINT}/1/triggers" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
+
+## TLS Certificate Authentication
+
+Steps 1-4 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable --type=cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=honeycomb-user
+```
+
+### Create a Cert Role
+
+```bash
+warden write auth/cert/role/honeycomb-user \
+    allowed_common_names="agent-*" \
+    token_policies="honeycomb-access" \
+    cred_spec_name=honeycomb-ops
+```
+
+The `allowed_common_names` field supports glob patterns. You can also match on `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+
+### Configure Provider for Cert Auth
+
+```bash
+warden write honeycomb/config <<EOF
+{
+  "honeycomb_url": "https://api.honeycomb.io",
+  "auto_auth_path": "auth/cert/",
+  "timeout": "30s",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -s "https://warden.internal/v1/honeycomb/role/honeycomb-user/gateway/1/auth"
+```
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `honeycomb_url` | string | `https://api.honeycomb.io` | Honeycomb API base URL |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `30s` | Request timeout |
+| `auto_auth_path` | string | -- | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | -- | Fallback role when not specified in URL |
+
+### Credential Source Config (Honeycomb Driver)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `management_key_id` | string | Yes | Management key ID (`hcxmk_` prefix) for API key operations |
+| `management_key_secret` | string | Yes | Management key secret paired with the key ID |
+| `team_slug` | string | Yes | Honeycomb team slug used in API paths |
+| `honeycomb_url` | string | No | Honeycomb API base URL (default: `https://api.honeycomb.io`) |
+| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
+| `tls_skip_verify` | bool | No | Skip TLS certificate verification (development only) |
+
+### Credential Spec Config (Honeycomb Driver)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `environment_id` | string | -- | **Required.** Target Honeycomb environment ID |
+| `key_type` | string | `ingest` | Type of key to mint: `ingest` or `configuration` |
+| `key_name_prefix` | string | `warden-` | Prefix for generated key names |
+| `key_ttl` | duration | `24h` | Warden lease TTL for the minted key |
+| `permissions` | string (JSON) | -- | JSON permissions object (configuration keys only) |
+
+### Credential Source Config (Static API Key)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_url` | string | No | Honeycomb API base URL (informational only) |
+| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
+
+### Credential Spec Config (Static API Key)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `api_key` | string | Yes | Honeycomb ingest or configuration key (sensitive -- masked in output) |
+
+### Credential Source Config (Vault/OpenBao)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
+| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
+| `auth_method` | string | No | Authentication method (`approle`) |
+| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
+| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
+| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
+| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
+
+### Credential Spec Config (Vault -- static_apikey)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mint_method` | string | Yes | Must be `static_apikey` |
+| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
+| `secret_path` | string | Yes | Path to the secret within the mount |
+
+## Token Management
+
+### Static API Key
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Key is stored on the credential spec |
+| **Rotation** | Manual -- generate a new key in Honeycomb and update the spec |
+| **Lifetime** | Does not expire unless deleted in Honeycomb |
+
+### Dynamic API Keys (Honeycomb Source Driver)
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | Key secret is captured at creation and managed by Warden |
+| **Rotation** | Automatic -- Warden creates a new key and deletes the old one on the configured rotation period |
+| **Lifetime** | Controlled by `key_ttl` in the spec config; keys are revoked (deleted) when the lease expires |
+| **Revocation** | On lease expiry or manual revocation, Warden calls `DELETE /2/teams/{team}/api-keys/{id}` |
+
+**To rotate static credentials:**
+
+1. Generate a new API key in Honeycomb (Settings > Team Settings > API Keys)
+2. Update the credential spec:
+   ```bash
+   warden cred spec update honeycomb-ops \
+     --config api_key=your-new-api-key
+   ```
+3. Delete the old key in Honeycomb
+
+**To rotate the management key (source driver):**
+
+1. Create a new management key in Honeycomb
+2. Update the credential source:
+   ```bash
+   warden cred source update honeycomb-src \
+     --config management_key_id=new-key-id \
+     --config management_key_secret=new-key-secret
+   ```
+3. Delete the old management key in Honeycomb

--- a/provider/honeycomb/provider.go
+++ b/provider/honeycomb/provider.go
@@ -1,0 +1,127 @@
+package honeycomb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/httpproxy"
+)
+
+// DefaultHoneycombURL is the default Honeycomb API base URL (US region).
+// For EU region, configure honeycomb_url to https://api.eu1.honeycomb.io.
+const DefaultHoneycombURL = "https://api.honeycomb.io"
+
+// DefaultHoneycombTimeout is the default request timeout for Honeycomb API calls.
+const DefaultHoneycombTimeout = 30 * time.Second
+
+// honeycombExtractor injects credentials as the appropriate Honeycomb auth header
+// depending on the credential data fields:
+//
+//   - key_id + key_secret present → Authorization: Bearer <key_id>:<key_secret>
+//     Used for: Management key operations (V2 key management API).
+//
+//   - api_key only → X-Honeycomb-Team: <api_key>
+//     Used for: Ingest and Configuration key operations (V1/V2 data APIs).
+func honeycombExtractor(req *logical.Request) (map[string]string, error) {
+	if req.Credential == nil {
+		return nil, fmt.Errorf("no credential available")
+	}
+	if req.Credential.Type != credential.TypeAPIKey {
+		return nil, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+	}
+
+	// Management key mode: key_id + key_secret
+	if keyID := req.Credential.Data["key_id"]; keyID != "" {
+		keySecret := req.Credential.Data["key_secret"]
+		if keySecret == "" {
+			return nil, fmt.Errorf("management key credential missing key_secret field")
+		}
+		return map[string]string{
+			"Authorization": "Bearer " + keyID + ":" + keySecret,
+		}, nil
+	}
+
+	// Ingest/configuration key mode: api_key → X-Honeycomb-Team header
+	apiKey := req.Credential.Data["api_key"]
+	if apiKey == "" {
+		return nil, fmt.Errorf("credential missing api_key field")
+	}
+	return map[string]string{"X-Honeycomb-Team": apiKey}, nil
+}
+
+// Spec defines the Honeycomb provider configuration for the httpproxy framework.
+//
+// Honeycomb uses X-Honeycomb-Team for ingest/configuration keys and Bearer tokens
+// for management keys. A single provider type supports both US and EU regions by
+// mounting multiple instances with different honeycomb_url values.
+var Spec = &httpproxy.ProviderSpec{
+	Name:               "honeycomb",
+	DefaultURL:         DefaultHoneycombURL,
+	URLConfigKey:       "honeycomb_url",
+	DefaultTimeout:     DefaultHoneycombTimeout,
+	ParseStreamBody:    true,
+	UserAgent:          "warden-honeycomb-proxy",
+	HelpText:           honeycombBackendHelp,
+	ExtractCredentials: honeycombExtractor,
+}
+
+// Factory creates a new Honeycomb provider backend.
+var Factory = httpproxy.NewFactory(Spec)
+
+const honeycombBackendHelp = `
+The Honeycomb provider enables proxying requests to the Honeycomb API with
+automatic credential management and auth header injection.
+
+Warden performs implicit authentication on every request and obtains a
+Honeycomb credential from the credential manager, injecting it into the
+proxied request. Auth mode is detected automatically from the credential data:
+
+  Ingest/Configuration key (default):
+    Injected as X-Honeycomb-Team header.
+    Used for: sending events, querying data, managing datasets, triggers,
+    boards, SLOs, and other environment-scoped operations.
+
+  Management key (key_id + key_secret present):
+    Injected as Authorization: Bearer <key_id>:<key_secret> header.
+    Used for: creating, listing, and deleting API keys via the V2
+    key management API.
+
+This provider supports both Honeycomb regions by mounting multiple
+instances with different honeycomb_url values:
+
+  US region (default): honeycomb_url=https://api.honeycomb.io
+  EU region:           honeycomb_url=https://api.eu1.honeycomb.io
+
+The gateway path format is:
+  /honeycomb/gateway/{api-path}
+
+The role can be provided via the X-Warden-Role header, or embedded in
+the URL path:
+  /honeycomb/role/{role}/gateway/{api-path}
+
+Example API paths:
+  /honeycomb/gateway/1/events/{dataset}
+  /honeycomb/gateway/1/batch/{dataset}
+  /honeycomb/gateway/1/queries/{dataset}
+  /honeycomb/gateway/1/boards
+  /honeycomb/gateway/1/triggers
+  /honeycomb/gateway/1/markers/{dataset}
+  /honeycomb/gateway/1/slos
+  /honeycomb/gateway/1/auth
+
+V2 key management paths (requires management key credentials):
+  /honeycomb/gateway/2/teams/{team}/api-keys
+
+Credential source types:
+- apikey: Static ingest or configuration key
+- honeycomb: Dynamic API keys minted via the Honeycomb V2 key management API
+
+Configuration:
+- honeycomb_url: Honeycomb API base URL (default: https://api.honeycomb.io)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Request timeout duration (default: 30s)
+- auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')
+- default_role: Fallback role when not specified in the URL path
+`

--- a/provider/honeycomb/provider_test.go
+++ b/provider/honeycomb/provider_test.go
@@ -1,0 +1,81 @@
+package honeycomb
+
+import (
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHoneycombExtractor_IngestKey(t *testing.T) {
+	headers, err := honeycombExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"api_key": "hcxik_my_ingest_key",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hcxik_my_ingest_key", headers["X-Honeycomb-Team"])
+	assert.Empty(t, headers["Authorization"])
+}
+
+func TestHoneycombExtractor_ManagementKey(t *testing.T) {
+	headers, err := honeycombExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"key_id":     "hcxmk_01abc123",
+				"key_secret": "mgmt-secret-value",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer hcxmk_01abc123:mgmt-secret-value", headers["Authorization"])
+	assert.Empty(t, headers["X-Honeycomb-Team"])
+}
+
+func TestHoneycombExtractor_ManagementKey_MissingSecret(t *testing.T) {
+	_, err := honeycombExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"key_id": "hcxmk_01abc123",
+			},
+		},
+	})
+	assert.ErrorContains(t, err, "missing key_secret")
+}
+
+func TestHoneycombExtractor_NoCredential(t *testing.T) {
+	_, err := honeycombExtractor(&logical.Request{})
+	assert.ErrorContains(t, err, "no credential available")
+}
+
+func TestHoneycombExtractor_WrongType(t *testing.T) {
+	_, err := honeycombExtractor(&logical.Request{
+		Credential: &credential.Credential{Type: "vault_token"},
+	})
+	assert.ErrorContains(t, err, "unsupported credential type")
+}
+
+func TestHoneycombExtractor_MissingAPIKey(t *testing.T) {
+	_, err := honeycombExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{},
+		},
+	})
+	assert.ErrorContains(t, err, "missing api_key")
+}
+
+func TestSpec(t *testing.T) {
+	assert.Equal(t, "honeycomb", Spec.Name)
+	assert.Equal(t, "https://api.honeycomb.io", Spec.DefaultURL)
+	assert.Equal(t, "honeycomb_url", Spec.URLConfigKey)
+	assert.NotNil(t, Spec.ExtractCredentials)
+	assert.NotNil(t, Factory)
+}


### PR DESCRIPTION
Add a Honeycomb provider that supports both gateway proxying and dynamic API key minting via the Honeycomb V2 key management API.

Gateway (provider/honeycomb): proxies requests to Honeycomb with automatic credential injection. Ingest/configuration keys use X-Honeycomb-Team header, management keys use Authorization: Bearer key_id:key_secret. Supports US and EU regions via honeycomb_url config.

Source driver (credential/drivers/honeycomb_driver.go): mints and revokes Honeycomb API keys using a management key. Creates ingest or configuration keys scoped to a specific environment with configurable permissions. Key secrets are captured at creation time (only available once from the API). Implements SourceDriver and SpecVerifier interfaces.