### PR TITLE
docs: revamp README to focus on AI agents as primary audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,67 +29,66 @@
 
 # Warden
 
-**Every team that ships code has credentials it shouldn't have.**
- 
-**Developers with AWS keys on their laptops. Data pipelines with Snowflake passwords in config files. AI agents with ambient cloud access and no policy. CI pipelines with secrets that never rotate.**
- 
-**Warden is the single layer that eliminates all of it.**
- 
+**The open-source egress gateway for AI agents — every API call is authenticated, authorized, and audited. No credentials ever reach the agent.**
+
 ---
 
-Your workload authenticates to Warden with its identity. Warden verifies who is calling, checks the policy, and issues ephemeral request-scoped access — either by forwarding the request with access token injected, returning a database auth token, or returning a pre-signed URL. Your workload has no secrets to leak.
+AI agents need to call cloud APIs, read files, query databases, and interact with third-party services. Today, that means embedding API keys, cloud credentials, or database passwords into the agent's environment — where a single prompt injection can exfiltrate them.
+
+Warden sits at the egress point. Your agent authenticates with its identity. Warden enforces your access policy, injects ephemeral credentials, and forwards the request. The agent never sees a secret.
 
 ```
 ┌──────────────┐                    ┌──────────────┐                     ┌──────────────┐
-│  Developer   │      Identity      │              │    Scoped Access    │ AWS, Azure   │
-│  K8s pod     │───────────────────▶│    Warden    │───────────────────▶ │ GitHub, GCP  │
-│  Pipeline    │   no credentials   │              │  real credentials   │ Anthropic    │
-│  AI agent    │                    │              │                     │ Mistral      │
-│              │                    │              │                     │ RDS, S3...   │
+│              │      Identity      │              │    Scoped Access    │ AWS, Azure   │
+│   AI Agent   │───────────────────▶│    Warden    │───────────────────▶ │ GitHub, GCP  │
+│              │   no credentials   │              │  real credentials   │ Anthropic    │
+│              │                    │              │                     │ OpenAI, S3   │
+│              │                    │              │                     │ RDS, ...     │
 └──────────────┘                    └──────────────┘                     └──────────────┘
-                                    • Auth ✓
+                                    • Identity ✓
                                     • Policy ✓
                                     • Audit ✓
 ```
 
 ## The problem
- 
-Exposed credentials are the root cause of most cloud security incidents:
- 
-- An AI agent with ambient cloud credentials — no policy on what it can call, no audit trail of what it did
-- A `DATABASE_URL` in a `.env` — one accidental commit away from being in your repository forever
-- A developer laptop with a `~/.aws/credentials` — production access on a device that gets lost, stolen, or compromised
-- An AWS key in a Lambda environment variable — visible in plaintext to anyone with console access or a logging misconfiguration
-- A GitHub PAT in a CI environment variable — a bearer token any compromised runner can extract and use from any IP
- 
-The common thread: **the credential exists somewhere it shouldn't, with more scope than needed, for longer than necessary.**
- 
-Warden eliminates the credential from the equation entirely. Your workloads authenticate with their identity. Warden handles the credential.
+
+AI agents are the most credential-exposed workloads in your stack:
+
+- **Prompt injection exfiltration** — an agent with API keys in its environment is one adversarial prompt away from leaking them
+- **Over-scoped access** — agents get broad cloud credentials with no per-request policy on what they can actually call
+- **No audit trail** — when an agent calls an API, there is no record tying that specific request to that specific agent identity
+- **Hardcoded secrets** — agent frameworks require API keys in environment variables or config files, creating static secrets that never rotate
+- **Multi-provider sprawl** — an agent calling Anthropic, AWS, and GitHub needs three separate API keys in a single `.env`
+
+The common thread: **the credential exists in the agent's environment — with more scope than needed, for longer than necessary, and no policy governing its use.**
+
+Warden eliminates the credential from the agent entirely. Your agent authenticates with its identity. Warden handles every credential.
 
 ## Quickstart
 
 Follow a provider guide to configure your first endpoint:
 
+- [Anthropic](provider/anthropic/README.md)
+- [OpenAI](provider/openai/README.md)
+- [Mistral](provider/mistral/README.md)
 - [AWS](provider/aws/README.md)
-- [Azure](provider/azure/README.md)
 - [GCP](provider/gcp/README.md)
+- [Azure](provider/azure/README.md)
 - [GitHub](provider/github/README.md)
 - [GitLab](provider/gitlab/README.md)
 - [Vault / OpenBao](provider/vault/README.md)
-- [Anthropic](provider/anthropic/README.md)
-- [Mistral](provider/mistral/README.md)
-- [OpenAI](provider/openai/README.md)
 - [AWS RDS / Aurora](provider/rds/README.md)
 
 ## What Warden covers
  
-| Your workload needs | Warden handles |
+| Your agent needs | Warden handles |
 |---|---|
+| Call LLM APIs (Anthropic, OpenAI, Mistral...) | Request forwarding, with injected API keys |
 | Call cloud APIs (AWS, GCP, Azure, GitHub, GitLab...) | Request forwarding, with injected ephemeral credentials |
-| Connect to a database (RDS, Cloud SQL, Redshift, Azure SQL, Snowflake...) | Ephemeral database auth tokens — replacing static passwords entirely |
+| Query databases (RDS, Cloud SQL, Redshift, Snowflake...) | Ephemeral database auth tokens — replacing static passwords entirely |
 | Read and write files (S3, GCS, Azure Blob...) | Pre-signed URLs, scoped to exactly one object and operation |
 
-One binary. One policy model. One audit log. Across your entire stack.
+One binary. One policy model. One audit log. Across every API your agent touches.
 
 ## Supported Providers
 
@@ -115,22 +114,20 @@ One binary. One policy model. One audit log. Across your entire stack.
  
 
 ## Use Cases
- 
-**AI agents** — agents authenticate with their identity and can only reach the APIs your policy allows. Every file read, every API call, every database query is logged with the agent's identity. Prompt injection can't exfiltrate credentials that don't exist in the agent's environment.
- 
-**CI/CD pipelines** — pipelines authenticate with their OIDC token (GitHub Actions, GitLab CI, Kubernetes). No credentials stored as CI secrets. Per-job audit trail across every cloud and SaaS API the pipeline touches.
- 
-**Data pipelines** — dbt, Airflow, Spark, and custom ELT jobs touch more external services per run than almost any other workload. With Warden, each pipeline run authenticates with its job identity and gets scoped, ephemeral credentials for every source database, data warehouse, and staging bucket it needs. No shared Snowflake passwords in `profiles.yml`. No Redshift user shared across 30 DAGs. Full per-run audit trail of every query and file operation.
- 
-**Developer machines** — developers authenticate with a mTLS certificate or short-lived JWT. No static keys on disk. Full per-developer audit trail in production-like environments.
- 
-**Microservices** — each service authenticates with its Kubernetes service account JWT or SPIFFE SVID. Gets exactly the credentials it needs. Credential sprawl — one IAM user per service — is eliminated at the architecture level.
- 
-**Database access** — no static password in your `DATABASE_URL`. Your workload asks Warden for a database auth token when it needs one. It expires in 15 minutes. Nothing to leak, nothing to rotate, nothing to store.
- 
-**Storage access** — no AWS credentials in your Lambda to generate pre-signed URLs. Your backend calls Warden with the object path and gets a pre-signed URL valid for 5 minutes, scoped to exactly that object and operation.
- 
-**Multi-provider workloads** — a single service that calls AWS for storage, GCP for ML inference, GitHub for source access, and Anthropic for LLM completions has four separate credential problems today. With Warden, it has one: authenticate once with its identity, and let Warden handle every provider behind a single policy layer and a single audit log.
+
+**SRE agents** — incident response agents that query Prometheus, read logs from Grafana, restart services, and page on-call need broad infrastructure access. Warden scopes each API call to the agent's identity and policy — the agent can query dashboards but can't delete them, can restart a pod but can't modify IAM roles. Full audit trail of every action taken during an incident.
+
+**Agentic coding** — code agents that push to GitHub, deploy to AWS, and read from S3 authenticate once with their identity. Warden enforces which repos they can push to, which buckets they can read, and logs every action.
+
+**RAG pipelines** — retrieval agents that query databases and read from object storage get scoped, ephemeral credentials for each request. No database password in the agent's config. No S3 keys in the environment.
+
+**Multi-model orchestration** — an agent calling Anthropic for reasoning, OpenAI for embeddings, and Mistral for classification has three API keys today. With Warden, it has zero — one identity, one policy layer, one audit log across all providers.
+
+**Tool-use agents** — agents with MCP tools that call arbitrary cloud APIs get per-tool, per-request policy enforcement. The agent can only reach the APIs your policy allows, regardless of what a prompt tells it to do.
+
+**Autonomous workflows** — long-running agents that operate over hours or days get time-scoped access. Warden issues ephemeral credentials per request — no long-lived tokens that accumulate risk over the lifetime of the workflow.
+
+Warden also secures non-agent workloads — CI/CD pipelines, microservices, developer machines — with the same identity-based model.
 
 
 ## Authentication Methods
@@ -139,27 +136,14 @@ Warden supports multiple methods for verifying caller identity.
 
 | Method | Identity Source | Best For |
 |--------|----------------|----------|
-| **JWT** | Signed JWT token or SPIFFE JWT-SVID | CI/CD pipelines, AI agents, any workload with an OIDC/JWT issuer or SPIFFE runtime |
-| **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Developers, Kubernetes pods, service mesh workloads, VMs with machine certificates |
+| **JWT** | Signed JWT token or SPIFFE JWT-SVID | AI agents, agentic frameworks, any workload with an OIDC/JWT issuer or SPIFFE runtime |
+| **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Agents in service mesh environments, Kubernetes pods, VMs with machine certificates |
 
 SPIFFE is supported in both methods — JWT-SVIDs via JWT auth and X.509-SVIDs via certificate auth. Both methods produce the same internal session. Once authenticated, the caller interacts with Warden identically regardless of how they proved their identity.
 
-## How workloads interact with Warden
+## How agents interact with Warden
 
-Your tool points at Warden's endpoint and makes a normal HTTP request with a JWT in the `Authorization` header (for AWS, the JWT is embedded in the SigV4 signing flow), or via mTLS. Warden authenticates, injects credentials, and either forwards the request to the provider or returns an access grant (database auth token, pre-signed URL) directly. No Warden-specific SDK or login step is required.
-
-## Why not just use the cloud provider's native tooling?
- 
-AWS IRSA, GCP Workload Identity, and Azure Managed Identity each let workloads authenticate to their respective cloud without static secrets — but none of them:
-
-- Keep cloud credentials out of the workload entirely — the workload still receives and handles cloud credentials (e.g., an STS token injected into the pod). With Warden, the workload only uses its own identity (JWT or certificate)
-- Work across multiple cloud providers from a single policy layer
-- Cover databases and storage with the same identity and audit model
-- Give you request-level audit tied to the specific workload identity — not just the IAM role shared by many workloads
-- Work for GitHub, GitLab, or any SaaS API
-- Can be deployed on-premises or in air-gapped environments
-
-Warden is the layer that makes workload identity work everywhere, for every credential type, from a single control plane you own.
+Your agent points at Warden's endpoint instead of the provider's and includes its identity token (JWT) in the request — or connects via mTLS. Warden authenticates the agent, checks the access policy, injects ephemeral credentials, and forwards the request to the provider. For databases and storage, Warden returns an access grant (auth token, pre-signed URL) directly. No Warden-specific SDK, no login step — just swap the base URL.
 
 ## Architecture
 


### PR DESCRIPTION
Reframe Warden positioning from a general-purpose credential gateway to an egress gateway for AI agents. Lead with prompt injection risks, agent-specific use cases (SRE agents, agentic coding, RAG, multi-model orchestration, tool-use, autonomous workflows), and agent-first messaging throughout.