### PR TITLE
feat: add description field to JWT and cert roles

### DIFF
--- a/auth/method/cert/path_role.go
+++ b/auth/method/cert/path_role.go
@@ -25,6 +25,10 @@ func (b *certAuthBackend) pathRole() *framework.Path {
 				Description: "Name of the role",
 				Required:    true,
 			},
+			"description": {
+				Type:        framework.TypeString,
+				Description: "Human-readable description of the role's purpose, surfaced via introspection so agents can select an appropriate role",
+			},
 			"allowed_common_names": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "Glob patterns for allowed certificate common names",
@@ -161,6 +165,7 @@ func (b *certAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reque
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
 			"name":                         role.Name,
+			"description":                  role.Description,
 			"allowed_common_names":         role.AllowedCommonNames,
 			"allowed_dns_sans":             role.AllowedDNSSANs,
 			"allowed_email_sans":           role.AllowedEmailSANs,
@@ -190,6 +195,9 @@ func (b *certAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Req
 		role = b.buildRoleFromFieldData(name, d)
 	} else {
 		// Update existing role — only update fields that are provided
+		if v, ok := d.GetOk("description"); ok {
+			role.Description = v.(string)
+		}
 		if v, ok := d.GetOk("allowed_common_names"); ok {
 			role.AllowedCommonNames = v.([]string)
 		}
@@ -352,6 +360,9 @@ func (b *certAuthBackend) buildRoleFromFieldData(name string, d *framework.Field
 		Name: name,
 	}
 
+	if v, ok := d.GetOk("description"); ok {
+		role.Description = v.(string)
+	}
 	if v, ok := d.GetOk("allowed_common_names"); ok {
 		role.AllowedCommonNames = v.([]string)
 	}

--- a/auth/method/cert/path_role_test.go
+++ b/auth/method/cert/path_role_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -429,6 +430,59 @@ func TestHandleRoleUpdate_AllFieldsOnExistingRole(t *testing.T) {
 	assert.Equal(t, []string{"NewOrg"}, updated.AllowedOrganizations)
 	assert.Equal(t, "dns_san", updated.PrincipalClaim)
 	assert.Equal(t, "new-spec", updated.CredSpecName)
+}
+
+func TestPathRole_DescriptionRoundTrip(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	b.config = &CertAuthConfig{PrincipalClaim: "cn"}
+
+	createFD := roleFieldData(map[string]any{
+		"name":        "desc-role",
+		"description": "read-only prod KV secrets",
+	})
+	createFD.Schema["description"] = &framework.FieldSchema{Type: framework.TypeString}
+
+	resp, err := b.handleRoleCreate(ctx, &logical.Request{}, createFD)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	readFD := &framework.FieldData{
+		Raw:    map[string]any{"name": "desc-role"},
+		Schema: map[string]*framework.FieldSchema{"name": {Type: framework.TypeString}},
+	}
+	resp, err = b.handleRoleRead(ctx, &logical.Request{}, readFD)
+	require.NoError(t, err)
+	assert.Equal(t, "read-only prod KV secrets", resp.Data["description"])
+
+	updateFD := roleFieldData(map[string]any{
+		"name":        "desc-role",
+		"description": "updated text",
+	})
+	updateFD.Schema["description"] = &framework.FieldSchema{Type: framework.TypeString}
+	_, err = b.handleRoleUpdate(ctx, &logical.Request{}, updateFD)
+	require.NoError(t, err)
+
+	role, err := b.getRole(ctx, "desc-role")
+	require.NoError(t, err)
+	assert.Equal(t, "updated text", role.Description)
+}
+
+func TestCertRole_PreUpgradeDecodesWithEmptyDescription(t *testing.T) {
+	// A role persisted before the description field existed has no
+	// `description` key in its JSON. Ensure it decodes cleanly.
+	b, ctx := createTestBackend(t)
+
+	raw := []byte(`{"name":"legacy","allowed_common_names":["test-*"],"token_policies":["p"],"token_ttl":"1h0m0s"}`)
+	require.NoError(t, b.storageView.Put(ctx, &sdklogical.StorageEntry{
+		Key:   rolePrefix + "legacy",
+		Value: raw,
+	}))
+
+	role, err := b.getRole(ctx, "legacy")
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	assert.Equal(t, "", role.Description)
+	assert.Equal(t, []string{"test-*"}, role.AllowedCommonNames)
 }
 
 // =============================================================================

--- a/auth/method/cert/role.go
+++ b/auth/method/cert/role.go
@@ -6,6 +6,7 @@ import "time"
 // Used for both runtime and storage (TokenTTL stored as string for JSON readability).
 type CertRole struct {
 	Name                       string   `json:"name"`
+	Description                string   `json:"description,omitempty"`
 	AllowedCommonNames         []string `json:"allowed_common_names,omitempty"`
 	AllowedDNSSANs             []string `json:"allowed_dns_sans,omitempty"`
 	AllowedEmailSANs           []string `json:"allowed_email_sans,omitempty"`

--- a/auth/method/jwt/path_role.go
+++ b/auth/method/jwt/path_role.go
@@ -24,6 +24,10 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 				Description: "Name of the role",
 				Required:    true,
 			},
+			"description": {
+				Type:        framework.TypeString,
+				Description: "Human-readable description of the role's purpose, surfaced via introspection so agents can select an appropriate role",
+			},
 			"bound_audiences": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "List of audiences that are valid for this role",
@@ -164,6 +168,7 @@ func (b *jwtAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reques
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
 			"name":                role.Name,
+			"description":         role.Description,
 			"bound_audiences":     role.BoundAudiences,
 			"bound_subject":       role.BoundSubject,
 			"bound_claims":        role.BoundClaims,
@@ -194,6 +199,9 @@ func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Requ
 		role = b.buildRoleFromFieldData(name, d)
 	} else {
 		// Update existing role — only update fields that are provided
+		if v, ok := d.GetOk("description"); ok {
+			role.Description = v.(string)
+		}
 		if v, ok := d.GetOk("bound_audiences"); ok {
 			role.BoundAudiences = v.([]string)
 		}
@@ -339,6 +347,9 @@ func (b *jwtAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldD
 		Name: name,
 	}
 
+	if v, ok := d.GetOk("description"); ok {
+		role.Description = v.(string)
+	}
 	if v, ok := d.GetOk("bound_audiences"); ok {
 		role.BoundAudiences = v.([]string)
 	}

--- a/auth/method/jwt/path_role_test.go
+++ b/auth/method/jwt/path_role_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -666,6 +667,66 @@ func TestBuildRoleFromFieldData_AllFields(t *testing.T) {
 	assert.Equal(t, "groups", role.GroupsClaim)
 	assert.Equal(t, "grp-", role.GroupPolicyPrefix)
 	assert.Equal(t, "30m", role.MaxAge)
+}
+
+func TestPathRole_DescriptionRoundTrip(t *testing.T) {
+	b, ctx := createTestBackendWithStorage(t)
+
+	schema := map[string]*framework.FieldSchema{
+		"name":        {Type: framework.TypeString},
+		"description": {Type: framework.TypeString},
+	}
+
+	createFD := &framework.FieldData{
+		Raw: map[string]any{
+			"name":        "desc-role",
+			"description": "read-only prod KV secrets",
+		},
+		Schema: schema,
+	}
+	resp, err := b.handleRoleCreate(ctx, &logical.Request{}, createFD)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	readFD := &framework.FieldData{
+		Raw:    map[string]any{"name": "desc-role"},
+		Schema: map[string]*framework.FieldSchema{"name": {Type: framework.TypeString}},
+	}
+	resp, err = b.handleRoleRead(ctx, &logical.Request{}, readFD)
+	require.NoError(t, err)
+	assert.Equal(t, "read-only prod KV secrets", resp.Data["description"])
+
+	updateFD := &framework.FieldData{
+		Raw: map[string]any{
+			"name":        "desc-role",
+			"description": "updated text",
+		},
+		Schema: schema,
+	}
+	_, err = b.handleRoleUpdate(ctx, &logical.Request{}, updateFD)
+	require.NoError(t, err)
+
+	role, err := b.getRole(ctx, "desc-role")
+	require.NoError(t, err)
+	assert.Equal(t, "updated text", role.Description)
+}
+
+func TestJWTRole_PreUpgradeDecodesWithEmptyDescription(t *testing.T) {
+	// A role persisted before the description field existed has no
+	// `description` key in its JSON. Ensure it decodes cleanly.
+	b, ctx := createTestBackendWithStorage(t)
+
+	raw := []byte(`{"name":"legacy","bound_audiences":["aud1"],"token_policies":["p"],"token_ttl":"1h0m0s","user_claim":"sub"}`)
+	require.NoError(t, b.storageView.Put(ctx, &sdklogical.StorageEntry{
+		Key:   rolePrefix + "legacy",
+		Value: raw,
+	}))
+
+	role, err := b.getRole(ctx, "legacy")
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	assert.Equal(t, "", role.Description)
+	assert.Equal(t, []string{"aud1"}, role.BoundAudiences)
 }
 
 // =============================================================================

--- a/auth/method/jwt/role.go
+++ b/auth/method/jwt/role.go
@@ -8,6 +8,7 @@ import (
 // Used for both runtime and storage (TokenTTL stored as string for JSON readability).
 type JWTRole struct {
 	Name              string         `json:"name"`
+	Description       string         `json:"description,omitempty"`
 	BoundAudiences    []string       `json:"bound_audiences,omitempty"`
 	BoundSubject      string         `json:"bound_subject,omitempty"`
 	BoundClaims       map[string]any `json:"bound_claims,omitempty"`


### PR DESCRIPTION
Adds a free-text `description` field to JWTRole and CertRole, surfaced through the role CRUD paths. Enables operators to annotate roles with human-readable purpose (e.g. "read-only prod KV secrets"), which will be consumed by the upcoming agent role-introspection endpoint so autonomous agents can select a suitable role per external system.

Backwards compatible: roles persisted before this change decode with an empty description (verified by PreUpgradeDecodesWithEmptyDescription tests).