### PR TITLE
feat: add per-backend role introspection for JWT and cert

### DIFF
--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -54,6 +54,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"login",
+				"introspect/roles",
 			},
 		},
 		Paths: []*framework.Path{
@@ -61,6 +62,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathConfig(),
 			b.pathRole(),
 			b.pathRoleList(),
+			b.pathIntrospect(),
 		},
 	}
 

--- a/auth/method/cert/path_introspect.go
+++ b/auth/method/cert/path_introspect.go
@@ -1,0 +1,113 @@
+package cert
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+
+	"github.com/stephnangue/warden/framework"
+	lgr "github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathIntrospect returns the introspection path definition.
+// Agents call GET auth/{mount}/introspect/roles with only their client
+// certificate and receive back the roles they could assume.
+func (b *certAuthBackend) pathIntrospect() *framework.Path {
+	return &framework.Path{
+		Pattern: "introspect/roles",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleIntrospectRoles,
+				Summary:  "List roles this certificate is allowed to assume",
+			},
+		},
+		HelpSynopsis:    "Discover roles assumable by the presented certificate",
+		HelpDescription: "Returns the roles within this mount whose constraints are satisfied by the client certificate presented via mTLS or a trusted forwarding header.",
+	}
+}
+
+// introspectedRole is the per-role payload returned by introspection.
+type introspectedRole struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// handleIntrospectRoles returns the subset of this mount's roles that the
+// presented certificate could successfully assume. Intentionally lenient:
+// if no certificate is presented, returns an empty list — the system-backend
+// aggregator (Part 3) fans out across multiple mounts and must tolerate
+// non-matching mounts without error.
+func (b *certAuthBackend) handleIntrospectRoles(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	b.configMu.RLock()
+	defer b.configMu.RUnlock()
+
+	cert := extractClientCert(req)
+	if cert == nil {
+		return introspectEmpty(), nil
+	}
+
+	roleNames, err := b.listRoles(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	matches := make([]introspectedRole, 0, len(roleNames))
+	for _, name := range roleNames {
+		role, err := b.getRole(ctx, name)
+		if err != nil {
+			b.logger.Warn("introspect: failed to load role", lgr.String("role", name), lgr.Err(err))
+			continue
+		}
+		if role == nil {
+			continue
+		}
+
+		if err := verifyCertForRole(cert, role, b); err != nil {
+			continue
+		}
+		if err := validateCertConstraints(cert, role); err != nil {
+			continue
+		}
+		matches = append(matches, introspectedRole{
+			Name:        role.Name,
+			Description: role.Description,
+		})
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"roles": matches,
+		},
+	}, nil
+}
+
+func introspectEmpty() *logical.Response {
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"roles": []introspectedRole{},
+		},
+	}
+}
+
+// verifyCertForRole performs the chain-of-trust check that login does
+// before calling validateCertConstraints — the certificate must verify
+// against the role's effective CA pool. Revocation checks are skipped
+// here; introspection is advisory, and the full revocation check runs
+// at login time.
+func verifyCertForRole(cert *x509.Certificate, role *CertRole, b *certAuthBackend) error {
+	caPool, err := b.getCAPool(role)
+	if err != nil {
+		return err
+	}
+	if caPool == nil {
+		return errCertAuthFailed
+	}
+	_, err = cert.Verify(x509.VerifyOptions{
+		Roots:     caPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	return err
+}

--- a/auth/method/cert/path_introspect_test.go
+++ b/auth/method/cert/path_introspect_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package cert
+
+import (
+	"crypto/x509"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+func TestPathIntrospect_Structure(t *testing.T) {
+	b, _ := createTestBackend(t)
+	p := b.pathIntrospect()
+
+	assert.Equal(t, "introspect/roles", p.Pattern)
+	_, hasRead := p.Operations[logical.ReadOperation]
+	assert.True(t, hasRead)
+}
+
+func TestHandleIntrospect_NoCert(t *testing.T) {
+	// No client cert in the request context.
+	b, ctx := createTestBackend(t)
+	b.config = &CertAuthConfig{PrincipalClaim: "cn"}
+
+	resp, err := b.handleIntrospectRoles(ctx, &logical.Request{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}
+
+func TestHandleIntrospect_FiltersByCertConstraints(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent-prod", func(tmpl *x509.Certificate) {
+		tmpl.DNSNames = []string{"agent-prod.example.com"}
+	})
+
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{
+		"trusted_ca_pem":  caPEM,
+		"principal_claim": "cn",
+	}))
+
+	// matches
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:               "prod-reader",
+		Description:        "read-only prod",
+		AllowedCommonNames: []string{"agent-prod"},
+		TokenTTL:           "1h",
+	}))
+	// does not match — CN constraint is different
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:               "staging-reader",
+		Description:        "read-only staging",
+		AllowedCommonNames: []string{"agent-staging"},
+		TokenTTL:           "1h",
+	}))
+
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, cert)}
+	resp, err := b.handleIntrospectRoles(ctx, req, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	roles := resp.Data["roles"].([]introspectedRole)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "prod-reader", roles[0].Name)
+	assert.Equal(t, "read-only prod", roles[0].Description)
+}
+
+func TestHandleIntrospect_RejectsCertFromUnknownCA(t *testing.T) {
+	// Cert signed by CA A; backend trusts CA B.
+	caA, caAKey, _ := testCA(t)
+	_, _, caBPEM := testCA(t)
+
+	cert := testClientCert(t, caA, caAKey, "agent-prod")
+
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{
+		"trusted_ca_pem":  caBPEM, // different CA
+		"principal_claim": "cn",
+	}))
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:               "role1",
+		AllowedCommonNames: []string{"agent-*"},
+		TokenTTL:           "1h",
+	}))
+
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, cert)}
+	resp, err := b.handleIntrospectRoles(ctx, req, nil)
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles, "cert signed by untrusted CA should match no roles")
+}
+
+func TestHandleIntrospect_EmptyWhenNoRoles(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	cert := testClientCert(t, caCert, caKey, "agent")
+
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{
+		"trusted_ca_pem":  caPEM,
+		"principal_claim": "cn",
+	}))
+
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, cert)}
+	resp, err := b.handleIntrospectRoles(ctx, req, nil)
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}

--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -75,6 +75,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"login",
+				"introspect/roles",
 			},
 		},
 		Paths: []*framework.Path{
@@ -82,6 +83,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathConfig(),
 			b.pathRole(),
 			b.pathRoleList(),
+			b.pathIntrospect(),
 		},
 	}
 

--- a/auth/method/jwt/path_introspect.go
+++ b/auth/method/jwt/path_introspect.go
@@ -1,0 +1,164 @@
+package jwt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/cap/jwt"
+	"github.com/stephnangue/warden/auth/helper"
+	"github.com/stephnangue/warden/framework"
+	lgr "github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathIntrospect returns the introspection path definition.
+// Agents call GET auth/{mount}/introspect/roles with only their JWT and
+// receive back the roles they could assume, so they can select a role
+// per external system without knowing role names up front.
+func (b *jwtAuthBackend) pathIntrospect() *framework.Path {
+	return &framework.Path{
+		Pattern: "introspect/roles",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleIntrospectRoles,
+				Summary:  "List roles this JWT is allowed to assume",
+			},
+		},
+		HelpSynopsis:    "Discover roles assumable by the presented JWT",
+		HelpDescription: "Returns the roles within this mount whose constraints are satisfied by the JWT in the Authorization header.",
+	}
+}
+
+// introspectedRole is the per-role payload returned by introspection.
+type introspectedRole struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// handleIntrospectRoles returns the subset of this mount's roles that the
+// presented JWT could successfully assume. The response is intentionally
+// lenient: if the JWT is missing or does not apply to this mount at all,
+// return an empty list rather than an error — the system-backend aggregator
+// (Part 3) fans out across multiple mounts and must tolerate non-matches.
+func (b *jwtAuthBackend) handleIntrospectRoles(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	b.configMu.RLock()
+	config := b.config
+	b.configMu.RUnlock()
+
+	if config == nil || config.validator == nil {
+		return introspectEmpty(), nil
+	}
+
+	jwtToken := extractJWTFromRequest(req)
+	if jwtToken == "" {
+		return introspectEmpty(), nil
+	}
+
+	roleNames, err := b.listRoles(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	matches := make([]introspectedRole, 0, len(roleNames))
+	for _, name := range roleNames {
+		role, err := b.getRole(ctx, name)
+		if err != nil {
+			b.logger.Warn("introspect: failed to load role", lgr.String("role", name), lgr.Err(err))
+			continue
+		}
+		if role == nil {
+			continue
+		}
+
+		claims, err := validateJWTForRole(ctx, config, role, jwtToken)
+		if err != nil {
+			// JWT fails this role's signature/issuer/subject/audience checks.
+			continue
+		}
+		if err := matchRole(claims, config.BoundClaims, role); err != nil {
+			continue
+		}
+		matches = append(matches, introspectedRole{
+			Name:        role.Name,
+			Description: role.Description,
+		})
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"roles": matches,
+		},
+	}, nil
+}
+
+func introspectEmpty() *logical.Response {
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"roles": []introspectedRole{},
+		},
+	}
+}
+
+// extractJWTFromRequest pulls a JWT off an introspect request. Two paths:
+//  1. Direct HTTP call — Authorization: Bearer <jwt>.
+//  2. In-process call from the system-backend aggregator (Part 3) — the
+//     aggregator places the raw JWT in req.ClientToken before dispatching.
+func extractJWTFromRequest(req *logical.Request) string {
+	if req.HTTPRequest != nil {
+		if auth := req.HTTPRequest.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+			return strings.TrimPrefix(auth, "Bearer ")
+		}
+	}
+	return req.ClientToken
+}
+
+// validateJWTForRole runs the mount's validator with role-specific
+// constraints (issuer, subject, audiences) — same construction as login.
+// Returns claims on success.
+func validateJWTForRole(ctx context.Context, config *JWTAuthConfig, role *JWTRole, jwtToken string) (map[string]any, error) {
+	expected := jwt.Expected{
+		SigningAlgorithms: []jwt.Alg{jwt.RS256, jwt.RS384, jwt.RS512, jwt.ES256, jwt.ES384, jwt.ES512},
+	}
+	if config.BoundIssuer != "" {
+		expected.Issuer = config.BoundIssuer
+	}
+	if role.BoundSubject != "" {
+		expected.Subject = role.BoundSubject
+	} else if config.BoundSubject != "" {
+		expected.Subject = config.BoundSubject
+	}
+	if len(role.BoundAudiences) > 0 {
+		expected.Audiences = role.BoundAudiences
+	} else if len(config.BoundAudiences) > 0 {
+		expected.Audiences = config.BoundAudiences
+	}
+	return config.validator.Validate(ctx, jwtToken, expected)
+}
+
+// matchRole runs the post-Validate claim checks from the login flow:
+// config-level bound claims, role-level bound claims, and bound URI
+// patterns. Kept as a shared helper so login and introspection cannot
+// drift on which checks are enforced.
+func matchRole(claims map[string]any, configBoundClaims map[string]any, role *JWTRole) error {
+	if err := validateBoundClaims(claims, configBoundClaims); err != nil {
+		return err
+	}
+	if err := validateBoundClaims(claims, role.BoundClaims); err != nil {
+		return err
+	}
+	if len(role.BoundURIPatterns) > 0 {
+		uriClaim := role.URIClaim
+		if uriClaim == "" {
+			uriClaim = "sub"
+		}
+		claimValue := extractClaim(claims, uriClaim)
+		if claimValue == "" || !helper.MatchAny(claimValue, role.BoundURIPatterns) {
+			return fmt.Errorf("URI pattern mismatch")
+		}
+	}
+	return nil
+}

--- a/auth/method/jwt/path_introspect_test.go
+++ b/auth/method/jwt/path_introspect_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package jwt
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+func TestPathIntrospect_Structure(t *testing.T) {
+	b, _ := createTestBackendWithStorage(t)
+	p := b.pathIntrospect()
+
+	assert.Equal(t, "introspect/roles", p.Pattern)
+	_, hasRead := p.Operations[logical.ReadOperation]
+	assert.True(t, hasRead)
+}
+
+func TestHandleIntrospect_NoConfig(t *testing.T) {
+	b, ctx := createTestBackendWithStorage(t)
+	b.config = nil
+
+	resp, err := b.handleIntrospectRoles(ctx, &logical.Request{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}
+
+func TestHandleIntrospect_NoValidator(t *testing.T) {
+	b, ctx := createTestBackendWithStorage(t)
+	b.config = &JWTAuthConfig{}
+
+	resp, err := b.handleIntrospectRoles(ctx, &logical.Request{}, nil)
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}
+
+func TestExtractJWTFromRequest(t *testing.T) {
+	t.Run("from Authorization header", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodGet, "/foo", nil)
+		httpReq.Header.Set("Authorization", "Bearer eyJ.payload.sig")
+		got := extractJWTFromRequest(&logical.Request{HTTPRequest: httpReq})
+		assert.Equal(t, "eyJ.payload.sig", got)
+	})
+
+	t.Run("no Bearer prefix → empty", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodGet, "/foo", nil)
+		httpReq.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+		got := extractJWTFromRequest(&logical.Request{HTTPRequest: httpReq})
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("falls back to ClientToken when no HTTP request", func(t *testing.T) {
+		got := extractJWTFromRequest(&logical.Request{ClientToken: "eyJ.from.aggregator"})
+		assert.Equal(t, "eyJ.from.aggregator", got)
+	})
+
+	t.Run("empty when neither present", func(t *testing.T) {
+		got := extractJWTFromRequest(&logical.Request{})
+		assert.Equal(t, "", got)
+	})
+}
+
+func TestMatchRole_EmptyConstraintsMatchAnyClaims(t *testing.T) {
+	claims := map[string]any{"sub": "alice", "email": "alice@example.com"}
+	role := &JWTRole{Name: "any"}
+
+	assert.NoError(t, matchRole(claims, nil, role))
+}
+
+func TestMatchRole_ConfigBoundClaimMismatch(t *testing.T) {
+	claims := map[string]any{"sub": "alice", "dept": "eng"}
+	configBound := map[string]any{"dept": "sales"}
+
+	err := matchRole(claims, configBound, &JWTRole{Name: "r"})
+	assert.Error(t, err)
+}
+
+func TestMatchRole_RoleBoundClaimMismatch(t *testing.T) {
+	claims := map[string]any{"sub": "alice", "dept": "eng"}
+	role := &JWTRole{Name: "r", BoundClaims: map[string]any{"dept": "sales"}}
+
+	err := matchRole(claims, nil, role)
+	assert.Error(t, err)
+}
+
+func TestMatchRole_RoleBoundClaimMatches(t *testing.T) {
+	claims := map[string]any{"sub": "alice", "dept": "eng"}
+	role := &JWTRole{Name: "r", BoundClaims: map[string]any{"dept": "eng"}}
+
+	assert.NoError(t, matchRole(claims, nil, role))
+}
+
+func TestMatchRole_URIPatternMismatch(t *testing.T) {
+	claims := map[string]any{"sub": "spiffe://other/ns/foo"}
+	role := &JWTRole{
+		Name:             "r",
+		BoundURIPatterns: []string{"spiffe://trusted/ns/*"},
+	}
+
+	err := matchRole(claims, nil, role)
+	assert.Error(t, err)
+}
+
+func TestMatchRole_URIPatternMatches(t *testing.T) {
+	claims := map[string]any{"sub": "spiffe://trusted/ns/foo"}
+	role := &JWTRole{
+		Name:             "r",
+		BoundURIPatterns: []string{"spiffe://trusted/ns/*"},
+	}
+
+	assert.NoError(t, matchRole(claims, nil, role))
+}
+
+func TestMatchRole_URIPatternUsesConfiguredClaim(t *testing.T) {
+	claims := map[string]any{"sub": "alice", "spiffe_id": "spiffe://trusted/ns/foo"}
+	role := &JWTRole{
+		Name:             "r",
+		URIClaim:         "spiffe_id",
+		BoundURIPatterns: []string{"spiffe://trusted/ns/*"},
+	}
+
+	assert.NoError(t, matchRole(claims, nil, role))
+}
+

--- a/auth/method/jwt/path_login.go
+++ b/auth/method/jwt/path_login.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/cap/jwt"
-	"github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/framework"
 	lgr "github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -122,38 +121,14 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 		}, nil
 	}
 
-	// Validate bound claims from config
-	if err := validateBoundClaims(claims, config.BoundClaims); err != nil {
-		b.logger.Warn("login failed: config bound claims check", lgr.Err(err), lgr.String("role", roleName))
+	// Post-Validate claim checks (config + role bound claims, bound URIs).
+	// Shared with introspection via matchRole so the two paths cannot drift.
+	if err := matchRole(claims, config.BoundClaims, role); err != nil {
+		b.logger.Warn("login failed: bound claims check", lgr.Err(err), lgr.String("role", roleName))
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
 			Err:        errAuthFailed,
 		}, nil
-	}
-
-	// Validate bound claims from role
-	if err := validateBoundClaims(claims, role.BoundClaims); err != nil {
-		b.logger.Warn("login failed: role bound claims check", lgr.Err(err), lgr.String("role", roleName))
-		return &logical.Response{
-			StatusCode: http.StatusUnauthorized,
-			Err:        errAuthFailed,
-		}, nil
-	}
-
-	// Validate bound URI patterns against the configured claim
-	if len(role.BoundURIPatterns) > 0 {
-		uriClaim := role.URIClaim
-		if uriClaim == "" {
-			uriClaim = "sub"
-		}
-		claimValue := extractClaim(claims, uriClaim)
-		if claimValue == "" || !helper.MatchAny(claimValue, role.BoundURIPatterns) {
-			b.logger.Warn("login failed: URI pattern mismatch", lgr.String("claim", uriClaim), lgr.String("role", roleName))
-			return &logical.Response{
-				StatusCode: http.StatusUnauthorized,
-				Err:        errAuthFailed,
-			}, nil
-		}
 	}
 
 	// Extract principal identity - use role's user_claim or fallback to config


### PR DESCRIPTION
Adds GET auth/{mount}/introspect/roles to both the JWT and certificate auth backends. An agent presents only its identity vehicle (JWT via Authorization: Bearer, or a client certificate via mTLS) and receives back the roles within that mount whose constraints the credential actually satisfies.

This removes the chicken-and-egg problem where autonomous agents had to know role names out-of-band before they could login. An agent that interacts with multiple external systems needs a role per system (a role binds to a cred spec), so the set of usable roles is large and hand-distributing the names does not scale.

Implementation:
- Each backend owns its own introspect path. The system-backend aggregator (Part 3) will fan out to all matching mounts in a namespace.
- JWT: iterates all roles, runs per-role Validate plus a new shared matchRole helper. Login is refactored to call the same matchRole so the two paths cannot drift on which claims are enforced.
- Cert: iterates all roles, runs chain verification against the role's effective CA pool and reuses validateCertConstraints from login.
- Response: {"roles": [{"name", "description"}]} - deliberately minimal.
- Unauthenticated (like login) - credentials are presented on the call itself, not via a Warden token.
- Responses are lenient (empty list rather than error) when the credential does not apply, so the aggregator can tolerate non-matching mounts without failing the whole call.