### PR TITLE
docs: expand MCP client framing, extract architecture and providers t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@
 
 AI agents need to call cloud APIs, read files, query databases, and interact with third-party services. Today, that means embedding API keys, cloud credentials, or database passwords into the agent's environment — where a single prompt injection can exfiltrate them.
 
-Warden sits at the egress point. Your agent authenticates with its identity. Warden enforces your access policy, injects ephemeral credentials, and forwards the request. The agent never sees a secret.
+The same credential-exposure problem hits **MCP servers** — each one wraps an external API and holds its credential in process env, one per tool, never rotating.
+
+Warden sits at the egress point. Your agent or MCP server authenticates with its identity. Warden enforces your access policy, injects ephemeral credentials, and forwards the request. The caller never sees a secret.
 
 ```
 ┌──────────────┐                    ┌──────────────┐                     ┌──────────────┐
 │              │      Identity      │              │    Scoped Access    │ AWS, Azure   │
 │   AI Agent   │───────────────────▶│    Warden    │───────────────────▶ │ GitHub, GCP  │
-│              │   no credentials   │              │  real credentials   │ Anthropic    │
+│  MCP Server  │   no credentials   │              │  real credentials   │ Anthropic    │
 │              │                    │              │                     │ OpenAI, S3   │
 │              │                    │              │                     │ RDS, ...     │
 └──────────────┘                    └──────────────┘                     └──────────────┘
@@ -57,31 +59,16 @@ AI agents are the most credential-exposed workloads in your stack:
 - **Prompt injection exfiltration** — an agent with API keys in its environment is one adversarial prompt away from leaking them
 - **Over-scoped access** — agents get broad cloud credentials with no per-request policy on what they can actually call
 - **No audit trail** — when an agent calls an API, there is no record tying that specific request to that specific agent identity
-- **Hardcoded secrets** — agent frameworks require API keys in environment variables or config files, creating static secrets that never rotate
-- **Multi-provider sprawl** — an agent calling Anthropic, AWS, and GitHub needs three separate API keys in a single `.env`
+- **Hardcoded secrets** — agent frameworks and MCP servers require API keys in environment variables or config files. Every MCP server wraps one external API and holds one credential baked into its process env. Static secrets, one per tool, never rotating
+- **Multi-provider sprawl** — an agent calling Anthropic, AWS, and GitHub needs three separate API keys in a single `.env`. An agent with a dozen MCP servers has this at N× — every credential for every tool, scattered across process envs
 
 The common thread: **the credential exists in the agent's environment — with more scope than needed, for longer than necessary, and no policy governing its use.**
 
 Warden eliminates the credential from the agent entirely. Your agent authenticates with its identity. Warden handles every credential.
 
-## Quickstart
-
-Follow a provider guide to configure your first endpoint:
-
-- [Anthropic](provider/anthropic/README.md)
-- [OpenAI](provider/openai/README.md)
-- [Mistral](provider/mistral/README.md)
-- [AWS](provider/aws/README.md)
-- [GCP](provider/gcp/README.md)
-- [Azure](provider/azure/README.md)
-- [GitHub](provider/github/README.md)
-- [GitLab](provider/gitlab/README.md)
-- [Vault / OpenBao](provider/vault/README.md)
-- [AWS RDS / Aurora](provider/rds/README.md)
-
 ## What Warden covers
  
-| Your agent needs | Warden handles |
+| Your client needs | Warden handles |
 |---|---|
 | Call LLM APIs (Anthropic, OpenAI, Mistral...) | Request forwarding, with injected API keys |
 | Call cloud APIs (AWS, GCP, Azure, GitHub, GitLab...) | Request forwarding, with injected ephemeral credentials |
@@ -90,28 +77,20 @@ Follow a provider guide to configure your first endpoint:
 
 One binary. One policy model. One audit log. Across every API your agent touches.
 
-## Supported Providers
+## Providers
 
-| Provider | Warden does | Status |
-|---|---|---|
-| AWS | Injects credentials | ✅ |
-| GCP | Injects credentials | ✅ |
-| Azure | Injects credentials | ✅ |
-| GitHub | Injects credentials | ✅ |
-| GitLab | Injects credentials | ✅ |
-| Anthropic | Injects credentials | ✅ |
-| Mistral | Injects credentials | ✅ |
-| OpenAI | Injects credentials | ✅ |
-| HashiCorp Vault / OpenBao | Injects credentials | ✅ |
-| AWS RDS / Aurora | Issues database auth token | 🔜 |
-| AWS Redshift | Issues database auth token | 🔜 |
-| GCP Cloud SQL | Issues database auth token | 🔜 |
-| Azure SQL | Issues database auth token | 🔜 |
-| Snowflake | Issues database auth token | 🔜 |
-| AWS S3 | Issues pre-signed URL | 🔜 |
-| GCP Cloud Storage | Issues pre-signed URL | 🔜 |
-| Azure Blob Storage | Issues pre-signed URL | 🔜 |
- 
+Warden supports 31 providers across LLMs, cloud, observability, secrets, and more. Follow a provider link below to configure your first endpoint, or see [docs/providers.md](docs/providers.md) for the full list.
+
+| Provider | Category | Warden does | Status |
+|---|---|---|---|
+| [Anthropic](provider/anthropic/README.md), [OpenAI](provider/openai/README.md), [Mistral](provider/mistral/README.md), [Cohere](provider/cohere/README.md) | LLM APIs | Injects API key | ✅ |
+| [AWS](provider/aws/README.md), [Azure](provider/azure/README.md), [GCP](provider/gcp/README.md) | Cloud infrastructure | Temporary credentials | ✅ |
+| [GitHub](provider/github/README.md), [GitLab](provider/gitlab/README.md) | Code hosting & CI/CD | Injects App token or PAT | ✅ |
+| [Datadog](provider/datadog/README.md), [Grafana](provider/grafana/README.md), [Prometheus](provider/prometheus/README.md) | Observability | Injects API key / proxies metrics | ✅ |
+| [HashiCorp Vault / OpenBao](provider/vault/README.md) | Secrets backend | Mints short-lived tokens | ✅ |
+| [Kubernetes](provider/kubernetes/README.md) | Infrastructure automation | Injects service account token | ✅ |
+| [AWS RDS / Aurora](provider/rds/README.md) | Database | Issues IAM auth token | 🔜 |
+
 
 ## Use Cases
 
@@ -123,7 +102,7 @@ One binary. One policy model. One audit log. Across every API your agent touches
 
 **Multi-model orchestration** — an agent calling Anthropic for reasoning, OpenAI for embeddings, and Mistral for classification has three API keys today. With Warden, it has zero — one identity, one policy layer, one audit log across all providers.
 
-**Tool-use agents** — agents with MCP tools that call arbitrary cloud APIs get per-tool, per-request policy enforcement. The agent can only reach the APIs your policy allows, regardless of what a prompt tells it to do.
+**MCP servers** — an MCP server that wraps the GitHub API or the AWS SDK holds a credential per tool. Point it at Warden instead: the MCP server authenticates with its identity, Warden injects the credential per request, and a prompt injection in the agent above cannot exfiltrate anything — there is nothing in the MCP process to exfiltrate.
 
 **Autonomous workflows** — long-running agents that operate over hours or days get time-scoped access. Warden issues ephemeral credentials per request — no long-lived tokens that accumulate risk over the lifetime of the workflow.
 
@@ -136,57 +115,18 @@ Warden supports multiple methods for verifying caller identity.
 
 | Method | Identity Source | Best For |
 |--------|----------------|----------|
-| **JWT** | Signed JWT token or SPIFFE JWT-SVID | AI agents, agentic frameworks, any workload with an OIDC/JWT issuer or SPIFFE runtime |
+| **JWT** | Signed JWT token or SPIFFE JWT-SVID | AI agents, MCP servers, agentic frameworks, any workload with an OIDC/JWT issuer or SPIFFE runtime |
 | **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Agents in service mesh environments, Kubernetes pods, VMs with machine certificates |
 
 SPIFFE is supported in both methods — JWT-SVIDs via JWT auth and X.509-SVIDs via certificate auth. Both methods produce the same internal session. Once authenticated, the caller interacts with Warden identically regardless of how they proved their identity.
 
-## How agents interact with Warden
+## How clients interact with Warden
 
-Your agent points at Warden's endpoint instead of the provider's and includes its identity token (JWT) in the request — or connects via mTLS. Warden authenticates the agent, checks the access policy, injects ephemeral credentials, and forwards the request to the provider. For databases and storage, Warden returns an access grant (auth token, pre-signed URL) directly. No Warden-specific SDK, no login step — just swap the base URL.
+Your agent or MCP server points at Warden's endpoint instead of the provider's and includes its identity token (JWT) in the request — or connects via mTLS. Warden authenticates the caller, checks the access policy, injects ephemeral credentials, and forwards the request to the provider. For databases and storage, Warden returns an access grant (auth token, pre-signed URL) directly. No Warden-specific SDK, no login step — just swap the base URL.
 
 ## Architecture
 
-Warden is a Go service that sits between workloads and providers. Providers are registered as either streaming backends (which proxy traffic to upstream services) or access backends (which vend credentials directly without proxying). Each backend has its own credential source driver, authentication flow, and policy rules.
-
-**Key design decisions:**
-- **Seal/unseal model** — Like Vault, Warden protects secrets at rest using envelope encryption. Supports dev mode (in-memory) and production mode with multiple seal types (Shamir, Transit, AWS KMS, GCP KMS, Azure Key Vault, OCI KMS, PKCS11, KMIP) and PostgreSQL storage.
-- **Active/standby HA** — See [High Availability](#high-availability) below.
-- **Access grants over proxying for databases** — For providers like RDS where Warden doesn't need to sit in the data path, access backends return ready-to-use connection strings with short-lived tokens. This avoids the latency and complexity of proxying database traffic while preserving identity-based access control and audit attribution.
-- **Namespace isolation** — Every credential source, policy, and mount point is scoped to a namespace with hard boundaries. Policies cannot leak across namespaces.
-
-### High Availability
-
-Warden supports active/standby HA. Multiple nodes share the same storage backend and use PostgreSQL advisory locks for leader election. One node becomes the active leader; the rest are hot standbys that automatically promote on leader failure.
-
-**How it works:**
-
-- **Standby forwarding** — Standby nodes forward all write and read requests to the active leader via mTLS reverse proxy. Clients can send requests to any node; the response is the same regardless of which node receives it.
-- **Automatic failover** — If the leader fails, a standby acquires the lock and promotes itself. Standby nodes detect the leader change and redirect their forwarding proxy to the new leader.
-- **Sealed node protection** — Sealed nodes are prevented from acquiring the leadership lock, ensuring only fully operational nodes can become leader.
-
-**Configuration** — each node needs `api_addr` (its own API address, used by the leader to advertise itself), `cluster_addr` (its mTLS cluster address for inter-node communication), and a shared storage backend with `ha_enabled`:
-
-```hcl
-api_addr     = "http://10.0.1.1:8400"
-cluster_addr = "https://10.0.1.1:8401"
-
-storage "postgres" {
-  connection_url = "postgres://warden:password@db:5432/warden?sslmode=require"
-  table          = "warden_store"
-  ha_table       = "warden_ha_locks"
-  ha_enabled     = "true"
-}
-
-listener "tcp" {
-  address     = "0.0.0.0:8400"
-  tls_enabled = false
-}
-```
-
-### Configuration
-
-Warden uses HCL configuration files. See `deploy/config/warden.local.hcl` for a full example covering storage backend, listener, providers, and auth methods.
+See [docs/architecture.md](docs/architecture.md) for Warden's design decisions, high availability model, and deployment configuration.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,42 @@
+# Architecture
+
+Warden is a Go service that sits between workloads and providers. Providers are registered as either streaming backends (which proxy traffic to upstream services) or access backends (which vend credentials directly without proxying). Each backend has its own credential source driver, authentication flow, and policy rules.
+
+**Key design decisions:**
+- **Seal/unseal model** — Like Vault, Warden protects secrets at rest using envelope encryption. Supports dev mode (in-memory) and production mode with multiple seal types (Shamir, Transit, AWS KMS, GCP KMS, Azure Key Vault, OCI KMS, PKCS11, KMIP) and PostgreSQL storage.
+- **Active/standby HA** — See [High Availability](#high-availability) below.
+- **Access grants over proxying for databases** — For providers like RDS where Warden doesn't need to sit in the data path, access backends return ready-to-use connection strings with short-lived tokens. This avoids the latency and complexity of proxying database traffic while preserving identity-based access control and audit attribution.
+- **Namespace isolation** — Every credential source, policy, and mount point is scoped to a namespace with hard boundaries. Policies cannot leak across namespaces.
+
+## High Availability
+
+Warden supports active/standby HA. Multiple nodes share the same storage backend and use PostgreSQL advisory locks for leader election. One node becomes the active leader; the rest are hot standbys that automatically promote on leader failure.
+
+**How it works:**
+
+- **Standby forwarding** — Standby nodes forward all write and read requests to the active leader via mTLS reverse proxy. Clients can send requests to any node; the response is the same regardless of which node receives it.
+- **Automatic failover** — If the leader fails, a standby acquires the lock and promotes itself. Standby nodes detect the leader change and redirect their forwarding proxy to the new leader.
+- **Sealed node protection** — Sealed nodes are prevented from acquiring the leadership lock, ensuring only fully operational nodes can become leader.
+
+**Configuration** — each node needs `api_addr` (its own API address, used by the leader to advertise itself), `cluster_addr` (its mTLS cluster address for inter-node communication), and a shared storage backend with `ha_enabled`:
+
+```hcl
+api_addr     = "http://10.0.1.1:8400"
+cluster_addr = "https://10.0.1.1:8401"
+
+storage "postgres" {
+  connection_url = "postgres://warden:password@db:5432/warden?sslmode=require"
+  table          = "warden_store"
+  ha_table       = "warden_ha_locks"
+  ha_enabled     = "true"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8400"
+  tls_enabled = false
+}
+```
+
+## Configuration
+
+Warden uses HCL configuration files. See `deploy/config/warden.local.hcl` for a full example covering storage backend, listener, providers, and auth methods.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,92 @@
+# Providers
+
+Warden supports 31 providers across LLMs, cloud, observability, code hosting, secrets, and more. Follow the link for each provider to configure your endpoint.
+
+Status: ✅ available, 🔜 on the roadmap.
+
+## LLM APIs
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [Anthropic](../provider/anthropic/README.md) | Injects `x-api-key` | ✅ |
+| [OpenAI](../provider/openai/README.md) | Injects `Authorization: Bearer` API key | ✅ |
+| [Mistral](../provider/mistral/README.md) | Injects `Authorization: Bearer` API key | ✅ |
+| [Cohere](../provider/cohere/README.md) | Injects `Authorization: Bearer` API token | ✅ |
+
+## Cloud infrastructure
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [AWS](../provider/aws/README.md) | Re-signs requests with temporary STS credentials | ✅ |
+| [Azure](../provider/azure/README.md) | Issues Microsoft Entra ID Bearer tokens | ✅ |
+| [GCP](../provider/gcp/README.md) | Issues temporary access tokens | ✅ |
+| [IBM Cloud](../provider/ibmcloud/README.md) | Issues IAM Bearer tokens | ✅ |
+| [OVH](../provider/ovh/README.md) | Injects Bearer token | ✅ |
+| [Scaleway](../provider/scaleway/README.md) | Injects Bearer token | ✅ |
+| [Cloudflare](../provider/cloudflare/README.md) | Injects Bearer token (API and Logpush) | ✅ |
+
+## Code hosting & CI/CD
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [GitHub](../provider/github/README.md) | Injects GitHub App installation token or PAT | ✅ |
+| [GitLab](../provider/gitlab/README.md) | Injects access token | ✅ |
+| [Atlassian](../provider/atlassian/README.md) | Injects token (Jira, Bitbucket) | ✅ |
+| [Ansible Tower](../provider/ansible_tower/README.md) | Injects Bearer token | ✅ |
+| [Terraform Enterprise](../provider/tfe/README.md) | Injects Bearer token | ✅ |
+
+## Observability
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [Datadog](../provider/datadog/README.md) | Injects `DD-API-KEY` and `DD-APPLICATION-KEY` | ✅ |
+| [Dynatrace](../provider/dynatrace/README.md) | Injects credentials | ✅ |
+| [Elastic](../provider/elastic/README.md) | Injects basic auth or token (Elasticsearch, Kibana) | ✅ |
+| [Grafana](../provider/grafana/README.md) | Injects Bearer token (Grafana, Loki, Mimir, Tempo, Pyroscope) | ✅ |
+| [Honeycomb](../provider/honeycomb/README.md) | Injects Bearer token | ✅ |
+| [New Relic](../provider/newrelic/README.md) | Injects `Api-Key` header | ✅ |
+| [Prometheus](../provider/prometheus/README.md) | Proxies API | ✅ |
+| [Sentry](../provider/sentry/README.md) | Injects Bearer token | ✅ |
+| [Splunk](../provider/splunk/README.md) | Injects Bearer token | ✅ |
+
+## Incident & ITSM
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [PagerDuty](../provider/pagerduty/README.md) | Injects Bearer token | ✅ |
+| [ServiceNow](../provider/servicenow/README.md) | Injects Bearer token | ✅ |
+| [Slack](../provider/slack/README.md) | Injects Bearer token | ✅ |
+
+## Infrastructure automation
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [Kubernetes](../provider/kubernetes/README.md) | Injects service account token | ✅ |
+
+## Secrets
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [HashiCorp Vault / OpenBao](../provider/vault/README.md) | Mints short-lived Vault tokens | ✅ |
+
+## Databases
+
+| Provider | Warden does | Status |
+|---|---|---|
+| [AWS RDS / Aurora](../provider/rds/README.md) | Issues IAM database auth token | 🔜 |
+| AWS Redshift | Issues IAM database auth token | 🔜 |
+| GCP Cloud SQL | Issues IAM database auth token | 🔜 |
+| Azure SQL | Issues Entra database auth token | 🔜 |
+| Snowflake | Issues database auth token | 🔜 |
+
+## Object storage
+
+| Provider | Warden does | Status |
+|---|---|---|
+| AWS S3 | Issues pre-signed URL | 🔜 |
+| GCP Cloud Storage | Issues pre-signed URL | 🔜 |
+| Azure Blob Storage | Issues pre-signed URL | 🔜 |
+
+## Internal backends
+
+`httpproxy`, `sigv4`, and `dualgateway` live in the `provider/` directory but are not standalone providers — they are shared frameworks used to build the providers above (generic HTTP proxy scaffolding, AWS SigV4 signing, and the dual-mode gateway backend for providers supporting both role-embedded and header-based authentication). Contributors building a new provider typically start from these.


### PR DESCRIPTION
…o docs/

Broaden the README's client framing beyond AI-agents-only to also name MCP servers and MCP gateways — the workloads that actually hold external API credentials in today's MCP ecosystem. Updates the problem paragraph, ASCII diagram, problem bullets, auth methods table, client-interaction section, and use cases.

Move the dense Architecture / HA / Configuration block to docs/architecture.md and leave a one-line pointer behind. Keeps the top of the README focused on the AI/MCP audience while preserving operator/contributor reference material.

Replace the 17-row Supported Providers table with a curated 7-row flagship overview plus a comprehensive docs/providers.md covering all 31 user-facing providers grouped by category. Internal plumbing backends (httpproxy, sigv4, dualgateway) are documented separately so they do not pollute the user-facing list.