### PR TITLE
feat: add /v1/sys/introspect/roles aggregator across auth mounts

### DIFF
--- a/core/sys_backend.go
+++ b/core/sys_backend.go
@@ -56,6 +56,9 @@ func (b *SystemBackend) paths() []*framework.Path {
 	// Auth paths
 	paths = append(paths, b.pathAuth()...)
 
+	// Introspection aggregator — fans out to per-backend introspect/roles
+	paths = append(paths, b.pathIntrospectRoles()...)
+
 	// Namespace paths
 	paths = append(paths, b.pathNamespaces()...)
 

--- a/core/sys_introspect.go
+++ b/core/sys_introspect.go
@@ -1,0 +1,217 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/listener"
+	lgr "github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// aggregateIntrospectConcurrency caps per-request goroutines so a namespace
+// with many auth mounts cannot spawn unbounded work on a single call.
+const aggregateIntrospectConcurrency = 10
+
+// pathIntrospectRoles exposes GET /v1/sys/introspect/roles.
+// The endpoint detects the caller's credential type (JWT or cert), finds
+// every auth mount of that type in the caller's namespace, fans out an
+// `introspect/roles` call to each, and aggregates the union.
+//
+// Autonomous agents present their identity vehicle with each request and
+// must specify a role so Warden's transparent auth can resolve a cred
+// spec. Introspection lets an agent discover which roles it may specify
+// without having to distribute role names out-of-band.
+func (b *SystemBackend) pathIntrospectRoles() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "introspect/roles",
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleIntrospectRoles,
+					Summary:  "Discover roles the presented credential can assume",
+				},
+			},
+			HelpSynopsis:    "Discover roles assumable by the presented credential",
+			HelpDescription: "Fans out to every auth mount of the detected credential type (JWT or cert) in the current namespace and returns the union of roles each mount reports as assumable.",
+		},
+	}
+}
+
+// aggregatedRole is the per-role payload returned by the system introspection
+// endpoint. auth_path is added by the aggregator (not supplied by backends).
+type aggregatedRole struct {
+	AuthPath    string `json:"auth_path"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+func (b *SystemBackend) handleIntrospectRoles(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	credType := detectIntrospectCredType(req)
+	if credType == "" {
+		return &logical.Response{
+			StatusCode: http.StatusUnauthorized,
+			Err:        fmt.Errorf("introspection requires a JWT bearer token or TLS client certificate"),
+		}, nil
+	}
+
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	// Snapshot matching mount entries under the lock, then release before
+	// dispatching so that concurrent mount writes are not blocked on our
+	// in-process fan-out.
+	b.core.mountsLock.RLock()
+	matching := make([]*MountEntry, 0)
+	for _, entry := range b.core.mounts.Entries {
+		if entry.Class != mountClassAuth || entry.NamespaceID != ns.ID || entry.Type != credType {
+			continue
+		}
+		matching = append(matching, entry)
+	}
+	b.core.mountsLock.RUnlock()
+
+	if len(matching) == 0 {
+		return b.respondSuccess(map[string]any{
+			"roles":    []aggregatedRole{},
+			"warnings": []string{},
+		}), nil
+	}
+
+	// Fan out. Per-mount failures go into warnings[]; they never fail the
+	// whole call. A mount that doesn't implement introspect/roles is
+	// silently skipped (no warning) so we can roll out per-backend support
+	// incrementally.
+	type mountResult struct {
+		entry *MountEntry
+		roles []aggregatedRole
+		err   error
+	}
+	results := make([]mountResult, len(matching))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(aggregateIntrospectConcurrency)
+	for i, entry := range matching {
+		i, entry := i, entry
+		g.Go(func() error {
+			roles, err := b.introspectMount(gctx, req, entry)
+			results[i] = mountResult{entry: entry, roles: roles, err: err}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	aggregated := make([]aggregatedRole, 0)
+	warnings := make([]string, 0)
+	for _, r := range results {
+		if r.err != nil {
+			b.logger.Warn("introspect: mount failed",
+				lgr.String("mount", r.entry.Path),
+				lgr.Err(r.err))
+			warnings = append(warnings, fmt.Sprintf("mount %q: %v", r.entry.Path, r.err))
+			continue
+		}
+		aggregated = append(aggregated, r.roles...)
+	}
+	sort.SliceStable(aggregated, func(i, j int) bool {
+		if aggregated[i].AuthPath != aggregated[j].AuthPath {
+			return aggregated[i].AuthPath < aggregated[j].AuthPath
+		}
+		return aggregated[i].Name < aggregated[j].Name
+	})
+
+	return b.respondSuccess(map[string]any{
+		"roles":    aggregated,
+		"warnings": warnings,
+	}), nil
+}
+
+// introspectMount dispatches an in-process read to a single auth mount's
+// introspect/roles path and normalizes the response into aggregatedRole.
+// Mounts whose backend does not implement introspection (older auth
+// methods, or future ones added before they expose the path) return
+// ErrUnsupportedPath and are silently skipped.
+func (b *SystemBackend) introspectMount(ctx context.Context, parent *logical.Request, entry *MountEntry) ([]aggregatedRole, error) {
+	// Auth mounts are registered in the router under authRoutePrefix +
+	// entry.Path (see mountInternalLocked). Build the child request with
+	// the full router-visible path.
+	childReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      authRoutePrefix + entry.Path + "introspect/roles",
+		// Pass through HTTPRequest so the backend can read Authorization
+		// header / forwarded client cert via the usual helpers.
+		HTTPRequest: parent.HTTPRequest,
+		ClientIP:    parent.ClientIP,
+	}
+
+	resp, err := b.core.router.Route(ctx, childReq)
+	if err != nil {
+		if errors.Is(err, sdklogical.ErrUnsupportedPath) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if resp == nil || resp.Data == nil {
+		return nil, nil
+	}
+	raw, ok := resp.Data["roles"]
+	if !ok {
+		return nil, nil
+	}
+
+	// Normalize via JSON round-trip: each backend returns a slice of its
+	// own package-local struct type (json tagged name/description). The
+	// aggregator cannot reference those types without creating a
+	// coupling, so we serialize and re-parse into an explicit shape. We
+	// unmarshal into an anonymous struct with only the fields we need so
+	// that a backend populating extra fields (now or in the future)
+	// cannot clobber aggregator-owned fields like auth_path.
+	bytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal roles: %w", err)
+	}
+	var parsed []struct {
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshal roles: %w", err)
+	}
+	out := make([]aggregatedRole, len(parsed))
+	for i, p := range parsed {
+		out[i] = aggregatedRole{
+			AuthPath:    entry.Path,
+			Name:        p.Name,
+			Description: p.Description,
+		}
+	}
+	return out, nil
+}
+
+// detectIntrospectCredType mirrors the credential-type detection in
+// performImplicitAuth: client cert takes precedence, then JWT via
+// Authorization: Bearer. Returns "" if neither is present.
+func detectIntrospectCredType(req *logical.Request) string {
+	if req.HTTPRequest == nil {
+		return ""
+	}
+	if cert := listener.ForwardedClientCert(req.HTTPRequest.Context()); cert != nil {
+		return "cert"
+	}
+	if auth := req.HTTPRequest.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return "jwt"
+	}
+	return ""
+}

--- a/core/sys_introspect_test.go
+++ b/core/sys_introspect_test.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/listener"
+	"github.com/stephnangue/warden/logical"
+)
+
+// introspectMock is a per-test controller for the mock auth backend. Each
+// test instantiates its own controller and registers its factory, so
+// tests do not share mutable state and can run in parallel if desired.
+// Map keys are the router-visible mount paths (e.g. "auth/jwt-a/") that
+// appear on logical.Request.MountPoint inside HandleRequest.
+type introspectMock struct {
+	rolesByMount       map[string][]map[string]any
+	errsByMount        map[string]error
+	delayByMount       map[string]time.Duration
+	unsupportedByMount map[string]bool
+}
+
+func newIntrospectMock() *introspectMock {
+	return &introspectMock{
+		rolesByMount:       map[string][]map[string]any{},
+		errsByMount:        map[string]error{},
+		delayByMount:       map[string]time.Duration{},
+		unsupportedByMount: map[string]bool{},
+	}
+}
+
+func (m *introspectMock) factory() logical.Factory {
+	return func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+		return &introspectMockBackend{ctrl: m}, nil
+	}
+}
+
+type introspectMockBackend struct {
+	ctrl *introspectMock
+}
+
+func (b *introspectMockBackend) HandleRequest(ctx context.Context, req *logical.Request) (*logical.Response, error) {
+	if req.Path != "introspect/roles" {
+		return nil, nil
+	}
+	if d := b.ctrl.delayByMount[req.MountPoint]; d > 0 {
+		time.Sleep(d)
+	}
+	if b.ctrl.unsupportedByMount[req.MountPoint] {
+		return nil, sdklogical.ErrUnsupportedPath
+	}
+	if err := b.ctrl.errsByMount[req.MountPoint]; err != nil {
+		return nil, err
+	}
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"roles": b.ctrl.rolesByMount[req.MountPoint],
+		},
+	}, nil
+}
+
+func (b *introspectMockBackend) Cleanup(ctx context.Context)                               {}
+func (b *introspectMockBackend) Setup(ctx context.Context, c *logical.BackendConfig) error { return nil }
+func (b *introspectMockBackend) Initialize(ctx context.Context) error                      { return nil }
+func (b *introspectMockBackend) Config() map[string]any                                    { return nil }
+func (b *introspectMockBackend) Type() string                                              { return "jwt" }
+func (b *introspectMockBackend) Class() logical.BackendClass                               { return logical.ClassAuth }
+func (b *introspectMockBackend) HandleExistenceCheck(ctx context.Context, req *logical.Request) (bool, bool, error) {
+	return false, false, nil
+}
+func (b *introspectMockBackend) SpecialPaths() *logical.Paths        { return nil }
+func (b *introspectMockBackend) ExtractToken(r *http.Request) string { return "" }
+
+// jwtRequest builds a system-backend request with an Authorization: Bearer
+// header, which the aggregator interprets as credType = "jwt".
+func jwtRequest(t *testing.T) *logical.Request {
+	t.Helper()
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/introspect/roles", nil)
+	httpReq.Header.Set("Authorization", "Bearer eyJ.any.token")
+	return &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "introspect/roles",
+		HTTPRequest: httpReq,
+	}
+}
+
+// certRequest builds a system-backend request carrying a forwarded
+// client certificate in the HTTP request context, which the aggregator
+// interprets as credType = "cert".
+func certRequest(t *testing.T) *logical.Request {
+	t.Helper()
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+	}
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/introspect/roles", nil)
+	ctx := listener.WithForwardedClientCert(httpReq.Context(), cert)
+	httpReq = httpReq.WithContext(ctx)
+	return &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "introspect/roles",
+		HTTPRequest: httpReq,
+	}
+}
+
+func TestDetectIntrospectCredType(t *testing.T) {
+	t.Run("no HTTP request returns empty", func(t *testing.T) {
+		assert.Equal(t, "", detectIntrospectCredType(&logical.Request{}))
+	})
+	t.Run("Authorization: Bearer returns jwt", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
+		httpReq.Header.Set("Authorization", "Bearer eyJ.abc.def")
+		assert.Equal(t, "jwt", detectIntrospectCredType(&logical.Request{HTTPRequest: httpReq}))
+	})
+	t.Run("no Bearer prefix returns empty", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
+		httpReq.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+		assert.Equal(t, "", detectIntrospectCredType(&logical.Request{HTTPRequest: httpReq}))
+	})
+	t.Run("forwarded client cert returns cert (takes precedence over JWT)", func(t *testing.T) {
+		cert := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "c"}}
+		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
+		httpReq.Header.Set("Authorization", "Bearer eyJ.abc.def")
+		ctx := listener.WithForwardedClientCert(httpReq.Context(), cert)
+		httpReq = httpReq.WithContext(ctx)
+		assert.Equal(t, "cert", detectIntrospectCredType(&logical.Request{HTTPRequest: httpReq}))
+	})
+}
+
+func TestSystemBackend_Introspect_Unauthenticated(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	resp, err := backend.handleIntrospectRoles(ctx, &logical.Request{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.NotNil(t, resp.Err)
+}
+
+func TestSystemBackend_Introspect_NoMatchingMounts(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	// No auth mounts exist — aggregator should return an empty list, not error.
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	roles := resp.Data["roles"].([]aggregatedRole)
+	assert.Empty(t, roles)
+	warnings := resp.Data["warnings"].([]string)
+	assert.Empty(t, warnings)
+}
+
+func TestSystemBackend_Introspect_JWTFanOut(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	core.authMethods["jwt"] = ctrl.factory()
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "jwt-a/"}))
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "jwt-b/"}))
+
+	ctrl.rolesByMount["auth/jwt-a/"] = []map[string]any{
+		{"name": "reader", "description": "read prod"},
+		{"name": "admin"},
+	}
+	ctrl.rolesByMount["auth/jwt-b/"] = []map[string]any{
+		{"name": "writer", "description": "write staging"},
+	}
+
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	roles := resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, 3)
+	// Sorted by auth_path, then name.
+	assert.Equal(t, "jwt-a/", roles[0].AuthPath)
+	assert.Equal(t, "admin", roles[0].Name)
+	assert.Equal(t, "jwt-a/", roles[1].AuthPath)
+	assert.Equal(t, "reader", roles[1].Name)
+	assert.Equal(t, "read prod", roles[1].Description)
+	assert.Equal(t, "jwt-b/", roles[2].AuthPath)
+	assert.Equal(t, "writer", roles[2].Name)
+
+	warnings := resp.Data["warnings"].([]string)
+	assert.Empty(t, warnings)
+}
+
+func TestSystemBackend_Introspect_FilterByCredType(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	// Register the same factory under both "jwt" and "cert" so we can
+	// verify the aggregator only targets the matching credential type.
+	core.authMethods["jwt"] = ctrl.factory()
+	core.authMethods["cert"] = ctrl.factory()
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "jwt-mount/"}))
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "cert", Path: "cert-mount/"}))
+
+	ctrl.rolesByMount["auth/jwt-mount/"] = []map[string]any{{"name": "jwt-role"}}
+	ctrl.rolesByMount["auth/cert-mount/"] = []map[string]any{{"name": "cert-role"}}
+
+	// JWT request should only hit the JWT mount.
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "jwt-role", roles[0].Name)
+	assert.Equal(t, "jwt-mount/", roles[0].AuthPath)
+
+	// Cert request should only hit the cert mount.
+	resp, err = backend.handleIntrospectRoles(ctx, certRequest(t), nil)
+	require.NoError(t, err)
+	roles = resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "cert-role", roles[0].Name)
+	assert.Equal(t, "cert-mount/", roles[0].AuthPath)
+}
+
+func TestSystemBackend_Introspect_MountError_AppearsInWarnings(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	core.authMethods["jwt"] = ctrl.factory()
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "good/"}))
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "bad/"}))
+
+	ctrl.rolesByMount["auth/good/"] = []map[string]any{{"name": "ok-role"}}
+	ctrl.errsByMount["auth/bad/"] = fmt.Errorf("storage unavailable")
+
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	require.NoError(t, err)
+
+	// The working mount's roles still come through.
+	roles := resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "ok-role", roles[0].Name)
+	assert.Equal(t, "good/", roles[0].AuthPath)
+
+	// The broken mount appears in warnings.
+	warnings := resp.Data["warnings"].([]string)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "bad/")
+	assert.Contains(t, warnings[0], "storage unavailable")
+}
+
+// A backend that returns ErrUnsupportedPath for introspect/roles simulates
+// an older auth method that hasn't been upgraded to expose introspection.
+// These mounts must be silently skipped (no warning, no failure) so that
+// adding introspection support can roll out incrementally across backends.
+func TestSystemBackend_Introspect_SkipsMountsWithoutIntrospect(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	core.authMethods["jwt"] = ctrl.factory()
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "modern/"}))
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "legacy/"}))
+
+	ctrl.rolesByMount["auth/modern/"] = []map[string]any{{"name": "newrole"}}
+	ctrl.unsupportedByMount["auth/legacy/"] = true
+
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	require.NoError(t, err)
+
+	roles := resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "newrole", roles[0].Name)
+	assert.Equal(t, "modern/", roles[0].AuthPath)
+
+	// The legacy mount was silently skipped — no warning.
+	warnings := resp.Data["warnings"].([]string)
+	assert.Empty(t, warnings, "mounts returning ErrUnsupportedPath should be silent, not warn")
+}
+
+// Namespace scoping: an agent calling from namespace B must not see roles
+// from mounts in namespace A. We mount in the root namespace (used by
+// setupTestSystemBackend), then call the handler with a context carrying
+// a different namespace — the filter excludes all mounts.
+func TestSystemBackend_Introspect_NamespaceScoping(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	core.authMethods["jwt"] = ctrl.factory()
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "root-mount/"}))
+	ctrl.rolesByMount["auth/root-mount/"] = []map[string]any{{"name": "root-role"}}
+
+	// Sanity: from the root namespace, the role is visible.
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, 1)
+
+	// Now call from a different, synthetic namespace — the aggregator
+	// must return empty because the mount's NamespaceID does not match.
+	otherNS := &namespace.Namespace{ID: "nsOther", Path: "nsOther/"}
+	otherCtx := namespace.ContextWithNamespace(context.Background(), otherNS)
+	resp, err = backend.handleIntrospectRoles(otherCtx, jwtRequest(t), nil)
+	require.NoError(t, err)
+	roles = resp.Data["roles"].([]aggregatedRole)
+	assert.Empty(t, roles, "roles from another namespace must not leak")
+}
+
+// Fan-out must run mount calls in parallel, not serially. With 5 mounts
+// each sleeping 80ms, serial execution would take ≥400ms; parallel
+// execution should finish close to the single-mount latency.
+func TestSystemBackend_Introspect_FanOutRunsInParallel(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	core.authMethods["jwt"] = ctrl.factory()
+
+	const nMounts = 5
+	const perMountDelay = 80 * time.Millisecond
+	for i := 0; i < nMounts; i++ {
+		path := fmt.Sprintf("p%d/", i)
+		require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: path}))
+		ctrl.delayByMount["auth/"+path] = perMountDelay
+		ctrl.rolesByMount["auth/"+path] = []map[string]any{{"name": fmt.Sprintf("r%d", i)}}
+	}
+
+	start := time.Now()
+	resp, err := backend.handleIntrospectRoles(ctx, jwtRequest(t), nil)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+
+	roles := resp.Data["roles"].([]aggregatedRole)
+	require.Len(t, roles, nMounts)
+
+	// Allow generous headroom for scheduler noise and test machine load
+	// (slow CI). The guard is against regressing to sequential execution,
+	// not a strict p99 budget — sequential would be ≥400ms.
+	const maxAllowed = 250 * time.Millisecond
+	assert.Less(t, elapsed, maxAllowed,
+		"fan-out should run in parallel (%d mounts × %v); got %v", nMounts, perMountDelay, elapsed)
+}


### PR DESCRIPTION
Adds a system-backend endpoint that an autonomous agent can call with only its identity vehicle (JWT bearer or TLS client certificate) to discover which roles it may specify on subsequent transparent-auth requests. This removes the need to distribute role names to agents out-of-band, which does not scale for agents that interact with many external systems.

Behavior:
- Detects the caller's credential type (cert takes precedence over JWT) using the same signals performImplicitAuth uses. Returns 401 if neither is present.
- Under mountsLock, collects auth mounts in the caller's namespace whose Type matches the detected credential type. Releases the lock before dispatch.
- Fans out to each matching mount's auth/{mount}/introspect/roles path via in-process router.Route calls, capped at 10 concurrent goroutines so a namespace with many mounts cannot spawn unbounded work per request.
- Per-mount failures populate warnings[]; they never fail the whole call. Mounts that return ErrUnsupportedPath are silently skipped so introspection support can roll out incrementally across backends.
- Response is sorted by (auth_path, name) for stable output.
- Each per-mount response is JSON-normalized into an explicit {Name, Description} shape so a backend's extra fields cannot clobber aggregator-owned fields like auth_path.

Tests: 12 cases cover credential detection, unauthenticated response, empty-mount case, multi-mount fan-out with sort order, cred-type filtering, per-mount error warnings, silent skip of ErrUnsupportedPath mounts, namespace-scoping (roles from other namespaces do not leak), and a parallelism sanity check (5 mounts x 80ms delay completes in well under serial time).

The mock auth backend used by tests is controller-scoped per test (no package-level mutable state), so tests are self-contained.