### PR TITLE
refactor: extract dbaccess framework for database access providers

### DIFF
--- a/provider/dbaccess/provider.go
+++ b/provider/dbaccess/provider.go
@@ -1,0 +1,257 @@
+// Package dbaccess provides a declarative framework for database "access"
+// backends — providers that vend short-lived database connection strings via
+// a grants/access path pattern. Concrete providers (rds, redshift, …) declare
+// a ProviderSpec and call NewFactory; all CRUD plumbing, storage, transparent
+// auth, and access-endpoint wiring is handled by the framework.
+//
+// This mirrors the shape of provider/httpproxy for streaming providers.
+package dbaccess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// Grant is a provider-defined map of grant fields. The framework adds
+// credential_spec and description automatically; provider-specific fields
+// come from ProviderSpec.GrantFields.
+type Grant map[string]string
+
+// FormatAccessFunc builds the access response from the minted credential, the
+// resolved grant, and the requesting principal. Returned map is delivered to
+// the caller as the response body.
+type FormatAccessFunc func(cred *credential.Credential, grant Grant, principal string) map[string]interface{}
+
+// ProviderSpec fully declares a database access provider.
+type ProviderSpec struct {
+	// Name is the provider identifier (e.g. "rds", "redshift").
+	Name string
+
+	// HelpText is the backend help description.
+	HelpText string
+
+	// GrantFields are provider-specific grant fields. credential_spec and
+	// description are added automatically by the framework — do not include
+	// them here.
+	GrantFields map[string]*framework.FieldSchema
+
+	// FormatAccess builds the response body for /access/{name}. Required.
+	FormatAccess FormatAccessFunc
+}
+
+// NewFactory returns a logical.Factory wired up from spec.
+func NewFactory(spec *ProviderSpec) logical.Factory {
+	return func(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+		if spec.Name == "" {
+			return nil, fmt.Errorf("dbaccess: ProviderSpec.Name is required")
+		}
+		if spec.FormatAccess == nil {
+			return nil, fmt.Errorf("dbaccess: ProviderSpec.FormatAccess is required")
+		}
+
+		b := &dbBackend{spec: spec}
+		b.AccessBackend = &framework.AccessBackend{
+			Backend: &framework.Backend{
+				BackendType:  spec.Name,
+				BackendClass: logical.ClassProvider,
+				Help:         spec.HelpText,
+			},
+			Logger: conf.Logger.WithSubsystem(spec.Name),
+		}
+		b.Backend.Paths = b.paths()
+		if err := b.AccessBackend.Setup(ctx, conf); err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+}
+
+// dbBackend is the shared backend type used by all dbaccess providers.
+type dbBackend struct {
+	*framework.AccessBackend
+	spec *ProviderSpec
+}
+
+func (b *dbBackend) paths() []*framework.Path {
+	return []*framework.Path{
+		b.PathAccessConfig(),
+		b.pathGrants(),
+		b.pathAccess(),
+	}
+}
+
+// --- Grants CRUD ---
+
+func (b *dbBackend) pathGrants() *framework.Path {
+	fields := map[string]*framework.FieldSchema{
+		"name": {
+			Type:        framework.TypeString,
+			Description: "Grant name",
+		},
+		"credential_spec": {
+			Type:        framework.TypeString,
+			Description: "Credential spec name to mint for this grant",
+		},
+		"description": {
+			Type:        framework.TypeString,
+			Description: "Human-readable description of this grant",
+		},
+	}
+	for name, schema := range b.spec.GrantFields {
+		// Provider-specified fields override the framework defaults if names
+		// collide. Collisions on "name" / "credential_spec" / "description"
+		// are programmer error and we silently let the provider win — the
+		// framework still requires credential_spec at write time.
+		fields[name] = schema
+	}
+
+	return &framework.Path{
+		Pattern: "grants/(?P<name>[^/]+)",
+		Fields:  fields,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleGrantRead,
+				Summary:  "Read a grant",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleGrantWrite,
+				Summary:  "Create or update a grant",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.handleGrantDelete,
+				Summary:  "Delete a grant",
+			},
+		},
+		HelpSynopsis:    "Manage " + b.spec.Name + " access grants",
+		HelpDescription: "Grants map a name to a credential spec and database configuration.",
+	}
+}
+
+func (b *dbBackend) handleGrantRead(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	grant, err := b.getGrant(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if grant == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", name)), nil
+	}
+
+	data := make(map[string]any, len(grant))
+	for k, v := range grant {
+		data[k] = v
+	}
+	return &logical.Response{StatusCode: 200, Data: data}, nil
+}
+
+func (b *dbBackend) handleGrantWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	credSpec, _ := d.Get("credential_spec").(string)
+	if credSpec == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("credential_spec is required")), nil
+	}
+
+	grant := Grant{
+		"credential_spec": credSpec,
+	}
+	if desc, ok := d.Get("description").(string); ok && desc != "" {
+		grant["description"] = desc
+	}
+	for fieldName := range b.spec.GrantFields {
+		if v, ok := d.Get(fieldName).(string); ok && v != "" {
+			grant[fieldName] = v
+		}
+	}
+
+	if err := b.putGrant(ctx, name, grant); err != nil {
+		return nil, err
+	}
+	return &logical.Response{StatusCode: 204}, nil
+}
+
+func (b *dbBackend) handleGrantDelete(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if err := b.StorageView.Delete(ctx, "grants/"+name); err != nil {
+		return nil, err
+	}
+	return &logical.Response{StatusCode: 204}, nil
+}
+
+func (b *dbBackend) getGrant(ctx context.Context, name string) (Grant, error) {
+	entry, err := b.StorageView.Get(ctx, "grants/"+name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var grant Grant
+	if err := json.Unmarshal(entry.Value, &grant); err != nil {
+		return nil, fmt.Errorf("failed to decode grant %q: %w", name, err)
+	}
+	return grant, nil
+}
+
+func (b *dbBackend) putGrant(ctx context.Context, name string, grant Grant) error {
+	entry, err := sdklogical.StorageEntryJSON("grants/"+name, grant)
+	if err != nil {
+		return err
+	}
+	return b.StorageView.Put(ctx, entry)
+}
+
+// --- Access endpoint ---
+
+func (b *dbBackend) pathAccess() *framework.Path {
+	return &framework.Path{
+		Pattern: "access/(?P<name>[^/]+)",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Grant name",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleGetAccess,
+				Summary:  "Get a database connection string for the given grant",
+			},
+		},
+		HelpSynopsis:    "Get database access",
+		HelpDescription: "Returns a ready-to-use connection string with IAM authentication.",
+	}
+}
+
+func (b *dbBackend) handleGetAccess(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	grantName := d.Get("name").(string)
+	grant, err := b.getGrant(ctx, grantName)
+	if err != nil {
+		return nil, err
+	}
+	if grant == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", grantName)), nil
+	}
+
+	principal := ""
+	if te := req.TokenEntry(); te != nil {
+		principal = te.PrincipalID
+	}
+
+	credSpec := grant["credential_spec"]
+	format := b.spec.FormatAccess
+	return &logical.Response{
+		AccessData: &logical.AccessData{
+			CredentialSpec: credSpec,
+			ResponseBuilder: func(cred *credential.Credential) map[string]interface{} {
+				return format(cred, grant, principal)
+			},
+		},
+	}, nil
+}

--- a/provider/dbaccess/provider_test.go
+++ b/provider/dbaccess/provider_test.go
@@ -1,0 +1,412 @@
+package dbaccess
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+type inmemStorage struct {
+	mu   sync.RWMutex
+	data map[string]*sdklogical.StorageEntry
+}
+
+func newInmemStorage() *inmemStorage {
+	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
+}
+
+func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			keys = append(keys, k[len(prefix):])
+		}
+	}
+	return keys, nil
+}
+
+func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key], nil
+}
+
+func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[entry.Key] = entry
+	return nil
+}
+
+func (s *inmemStorage) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *inmemStorage) ListPage(_ context.Context, prefix string, _ string, _ int) ([]string, error) {
+	return s.List(context.Background(), prefix)
+}
+
+func testLogger() *logger.GatedLogger {
+	config := &logger.Config{Level: logger.TraceLevel, Format: logger.DefaultFormat}
+	gateConfig := logger.GatedWriterConfig{InitialState: logger.GateOpen}
+	gl, _ := logger.NewGatedLogger(config, gateConfig)
+	return gl
+}
+
+// testSpec is a sample provider spec used to exercise the framework's shared
+// behavior. It declares one provider-specific grant field (`db_name`) and a
+// trivial formatter that echoes its inputs into a deterministic string.
+var testSpec = &ProviderSpec{
+	Name:     "testprov",
+	HelpText: "test provider for dbaccess framework",
+	GrantFields: map[string]*framework.FieldSchema{
+		"db_name": {
+			Type:        framework.TypeString,
+			Description: "Database name",
+		},
+	},
+	FormatAccess: func(cred *credential.Credential, grant Grant, principal string) map[string]interface{} {
+		return map[string]interface{}{
+			"connection_string": fmt.Sprintf("%s/%s/%s/%s", grant["db_name"], cred.Data["db_user"], cred.Data["auth_token"], principal),
+			"lease_duration":    int(cred.LeaseTTL.Seconds()),
+		}
+	},
+}
+
+func setupBackend(t *testing.T) *dbBackend {
+	t.Helper()
+	storage := newInmemStorage()
+	ctx := context.Background()
+	conf := &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      testLogger(),
+	}
+	b, err := NewFactory(testSpec)(ctx, conf)
+	require.NoError(t, err)
+	return b.(*dbBackend)
+}
+
+func makeFieldData(path *framework.Path, raw map[string]interface{}) *framework.FieldData {
+	return &framework.FieldData{
+		Raw:    raw,
+		Schema: path.Fields,
+	}
+}
+
+// --- Factory tests ---
+
+func TestFactory(t *testing.T) {
+	b := setupBackend(t)
+	assert.Equal(t, "testprov", b.Type())
+	assert.Equal(t, logical.ClassProvider, b.Class())
+}
+
+func TestFactory_RequiresName(t *testing.T) {
+	bad := &ProviderSpec{
+		FormatAccess: testSpec.FormatAccess,
+	}
+	_, err := NewFactory(bad)(context.Background(), &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Name")
+}
+
+func TestFactory_RequiresFormatAccess(t *testing.T) {
+	bad := &ProviderSpec{
+		Name: "bad",
+	}
+	_, err := NewFactory(bad)(context.Background(), &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FormatAccess")
+}
+
+// --- Config tests ---
+
+func TestConfigCRUD(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+
+	t.Run("default config", func(t *testing.T) {
+		cfg := b.GetAccessConfig()
+		assert.Equal(t, "", cfg.AutoAuthPath)
+	})
+
+	t.Run("set and get config", func(t *testing.T) {
+		err := b.SetAccessConfig(ctx, &framework.AccessConfig{AutoAuthPath: "auth/jwt/"})
+		require.NoError(t, err)
+
+		cfg := b.GetAccessConfig()
+		assert.Equal(t, "auth/jwt/", cfg.AutoAuthPath)
+	})
+
+	t.Run("config persists via HandleRequest", func(t *testing.T) {
+		resp, err := b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "config",
+			Data:      map[string]any{"auto_auth_path": "auth/cert/"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 204, resp.StatusCode)
+
+		resp, err = b.HandleRequest(ctx, &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "config",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "auth/cert/", resp.Data["auto_auth_path"])
+	})
+}
+
+// --- TransparentModeProvider tests ---
+
+func TestTransparentModeProvider(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		assert.False(t, b.IsTransparentMode())
+		assert.Equal(t, "", b.GetAutoAuthPath())
+	})
+
+	t.Run("enabled after config with auto_auth_path", func(t *testing.T) {
+		err := b.SetAccessConfig(ctx, &framework.AccessConfig{AutoAuthPath: "auth/jwt/"})
+		require.NoError(t, err)
+
+		assert.True(t, b.IsTransparentMode())
+		assert.Equal(t, "auth/jwt/", b.GetAutoAuthPath())
+	})
+
+	t.Run("extracts role from query parameter", func(t *testing.T) {
+		req := &logical.Request{Data: map[string]any{"role": "data-team"}}
+		assert.Equal(t, "data-team", b.GetAuthRole("access/readonly", req))
+	})
+
+	t.Run("returns empty when no role in request", func(t *testing.T) {
+		req := &logical.Request{Data: map[string]any{}}
+		assert.Equal(t, "", b.GetAuthRole("access/readonly", req))
+	})
+
+	t.Run("IsUnauthenticatedPath always false", func(t *testing.T) {
+		assert.False(t, b.IsUnauthenticatedPath("access/readonly"))
+		assert.False(t, b.IsUnauthenticatedPath("config"))
+	})
+}
+
+func TestIsTransparentPath(t *testing.T) {
+	b := setupBackend(t)
+
+	assert.True(t, b.IsTransparentPath("access/readonly"))
+	assert.True(t, b.IsTransparentPath("access/anything"))
+	assert.False(t, b.IsTransparentPath("grants/readonly"))
+	assert.False(t, b.IsTransparentPath("config"))
+	assert.False(t, b.IsTransparentPath(""))
+}
+
+// --- Grant CRUD tests ---
+
+func TestGrantCRUD(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+	req := &logical.Request{}
+	grantsPath := b.pathGrants()
+
+	t.Run("read nonexistent grant returns error", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{"name": "nonexistent"})
+		resp, err := b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("write grant", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{
+			"name":            "readonly",
+			"credential_spec": "the-spec",
+			"db_name":         "myapp",
+			"description":     "Read-only access",
+		})
+		resp, err := b.handleGrantWrite(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, 204, resp.StatusCode)
+	})
+
+	t.Run("read grant", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, "the-spec", resp.Data["credential_spec"])
+		assert.Equal(t, "myapp", resp.Data["db_name"])
+		assert.Equal(t, "Read-only access", resp.Data["description"])
+	})
+
+	t.Run("write grant without credential_spec fails", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{
+			"name":    "bad-grant",
+			"db_name": "myapp",
+		})
+		resp, err := b.handleGrantWrite(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("update grant overwrites fields", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{
+			"name":            "rw",
+			"credential_spec": "v1",
+			"db_name":         "db1",
+		})
+		_, err := b.handleGrantWrite(ctx, req, d)
+		require.NoError(t, err)
+
+		d = makeFieldData(grantsPath, map[string]interface{}{
+			"name":            "rw",
+			"credential_spec": "v2",
+			"db_name":         "db2",
+		})
+		_, err = b.handleGrantWrite(ctx, req, d)
+		require.NoError(t, err)
+
+		d = makeFieldData(grantsPath, map[string]interface{}{"name": "rw"})
+		resp, err := b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, "v2", resp.Data["credential_spec"])
+		assert.Equal(t, "db2", resp.Data["db_name"])
+	})
+
+	t.Run("delete grant", func(t *testing.T) {
+		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGrantDelete(ctx, req, d)
+		require.NoError(t, err)
+		assert.Equal(t, 204, resp.StatusCode)
+
+		resp, err = b.handleGrantRead(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("legacy JSON shape decodes as Grant map", func(t *testing.T) {
+		// Storage compatibility: an entry written by the pre-refactor code
+		// (typed struct serialized as JSON with the same field names) must
+		// still decode through the framework's getGrant.
+		legacyJSON := []byte(`{"credential_spec":"legacy-spec","db_name":"legacy-db","description":"old"}`)
+		require.NoError(t, b.StorageView.Put(ctx, &sdklogical.StorageEntry{
+			Key:   "grants/legacy",
+			Value: legacyJSON,
+		}))
+
+		grant, err := b.getGrant(ctx, "legacy")
+		require.NoError(t, err)
+		require.NotNil(t, grant)
+		assert.Equal(t, "legacy-spec", grant["credential_spec"])
+		assert.Equal(t, "legacy-db", grant["db_name"])
+		assert.Equal(t, "old", grant["description"])
+	})
+}
+
+// --- Access endpoint tests ---
+
+func TestHandleGetAccess(t *testing.T) {
+	b := setupBackend(t)
+	ctx := context.Background()
+	grantsPath := b.pathGrants()
+	accessPath := b.pathAccess()
+
+	d := makeFieldData(grantsPath, map[string]interface{}{
+		"name":            "readonly",
+		"credential_spec": "my-spec",
+		"db_name":         "analytics",
+	})
+	_, err := b.handleGrantWrite(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+
+	t.Run("nonexistent grant returns error", func(t *testing.T) {
+		req := &logical.Request{}
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "nonexistent"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		assert.True(t, resp.IsError())
+	})
+
+	t.Run("AccessData carries grant's credential_spec", func(t *testing.T) {
+		req := &logical.Request{}
+		req.SetTokenEntry(&logical.TokenEntry{PrincipalID: "workload-a"})
+
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+		assert.Equal(t, "my-spec", resp.AccessData.CredentialSpec)
+	})
+
+	t.Run("ResponseBuilder calls FormatAccess with grant + cred + principal", func(t *testing.T) {
+		req := &logical.Request{}
+		req.SetTokenEntry(&logical.TokenEntry{PrincipalID: "workload-a"})
+
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+
+		cred := &credential.Credential{
+			LeaseTTL: 15 * time.Minute,
+			Data: map[string]string{
+				"auth_token": "tok",
+				"db_user":    "u",
+			},
+		}
+		out := resp.AccessData.ResponseBuilder(cred)
+		// testSpec.FormatAccess builds: db_name/user/token/principal
+		assert.Equal(t, "analytics/u/tok/workload-a", out["connection_string"])
+		assert.Equal(t, 900, out["lease_duration"])
+	})
+
+	t.Run("no token entry yields empty principal", func(t *testing.T) {
+		req := &logical.Request{}
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+
+		cred := &credential.Credential{
+			LeaseTTL: 15 * time.Minute,
+			Data:     map[string]string{"auth_token": "t", "db_user": "u"},
+		}
+		out := resp.AccessData.ResponseBuilder(cred)
+		assert.Equal(t, "analytics/u/t/", out["connection_string"])
+	})
+
+	t.Run("?role= is independent of grant selection", func(t *testing.T) {
+		// Documented contract: role overrides the auth role; the grant is
+		// always picked from the path.
+		req := &logical.Request{Data: map[string]any{"role": "data-team"}}
+
+		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
+		resp, err := b.handleGetAccess(ctx, req, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.AccessData)
+		assert.Equal(t, "my-spec", resp.AccessData.CredentialSpec)
+
+		assert.Equal(t, "data-team", b.GetAuthRole("access/readonly", req))
+	})
+}

--- a/provider/rds/provider.go
+++ b/provider/rds/provider.go
@@ -1,244 +1,84 @@
+// Package rds is an access backend that vends ready-to-use database
+// connection strings backed by RDS / Aurora IAM authentication tokens
+// (PostgreSQL and MySQL).
 package rds
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 
-	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/framework"
-	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/dbaccess"
 )
 
-// rdsBackend is an access backend that vends database connection strings
-// using RDS IAM authentication tokens.
-type rdsBackend struct {
-	*framework.AccessBackend
-}
-
-// rdsGrant maps a grant name to a credential spec and database configuration.
-type rdsGrant struct {
-	CredentialSpec string `json:"credential_spec"`
-	DBName         string `json:"db_name"`
-	DBEngine       string `json:"db_engine"`
-	Description    string `json:"description,omitempty"`
+// Spec declares the RDS access backend.
+var Spec = &dbaccess.ProviderSpec{
+	Name: "rds",
+	GrantFields: map[string]*framework.FieldSchema{
+		"db_name": {
+			Type:        framework.TypeString,
+			Description: "Database name to include in the connection string",
+		},
+		"db_engine": {
+			Type:        framework.TypeString,
+			Description: "Database engine (postgres, mysql). Overrides the spec value if set.",
+		},
+	},
+	FormatAccess: formatAccess,
+	HelpText:     rdsBackendHelp,
 }
 
 // Factory creates a new RDS access backend.
-func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-	b := &rdsBackend{}
-	b.AccessBackend = &framework.AccessBackend{
-		Backend: &framework.Backend{
-			BackendType:  "rds",
-			BackendClass: logical.ClassProvider,
-		},
-		Logger: conf.Logger.WithSubsystem("rds"),
-	}
-	b.Backend.Paths = b.paths()
-	if err := b.AccessBackend.Setup(ctx, conf); err != nil {
-		return nil, err
-	}
-	return b, nil
-}
+var Factory = dbaccess.NewFactory(Spec)
 
-func (b *rdsBackend) paths() []*framework.Path {
-	return []*framework.Path{
-		b.PathAccessConfig(),
-		b.pathGrants(),
-		b.pathAccess(),
-	}
-}
-
-// --- Grants CRUD ---
-
-func (b *rdsBackend) pathGrants() *framework.Path {
-	return &framework.Path{
-		Pattern: "grants/(?P<name>[^/]+)",
-		Fields: map[string]*framework.FieldSchema{
-			"name": {
-				Type:        framework.TypeString,
-				Description: "Grant name",
-			},
-			"credential_spec": {
-				Type:        framework.TypeString,
-				Description: "Credential spec name to mint for this grant",
-			},
-			"db_name": {
-				Type:        framework.TypeString,
-				Description: "Database name to include in the connection string",
-			},
-			"db_engine": {
-				Type:        framework.TypeString,
-				Description: "Database engine (postgres, mysql). Overrides the spec value if set.",
-			},
-			"description": {
-				Type:        framework.TypeString,
-				Description: "Human-readable description of this grant",
-			},
-		},
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.handleGrantRead,
-				Summary:  "Read a grant",
-			},
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.handleGrantWrite,
-				Summary:  "Create or update a grant",
-			},
-			logical.DeleteOperation: &framework.PathOperation{
-				Callback: b.handleGrantDelete,
-				Summary:  "Delete a grant",
-			},
-		},
-		HelpSynopsis:    "Manage RDS access grants",
-		HelpDescription: "Grants map a name to a credential spec and database configuration.",
-	}
-}
-
-func (b *rdsBackend) handleGrantRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	grant, err := b.getGrant(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-	if grant == nil {
-		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", name)), nil
-	}
-	return &logical.Response{
-		StatusCode: 200,
-		Data: map[string]any{
-			"credential_spec": grant.CredentialSpec,
-			"db_name":         grant.DBName,
-			"db_engine":       grant.DBEngine,
-			"description":     grant.Description,
-		},
-	}, nil
-}
-
-func (b *rdsBackend) handleGrantWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-
-	credSpec, _ := d.Get("credential_spec").(string)
-	if credSpec == "" {
-		return logical.ErrorResponse(logical.ErrBadRequest("credential_spec is required")), nil
-	}
-
-	grant := &rdsGrant{
-		CredentialSpec: credSpec,
-		DBName:         d.Get("db_name").(string),
-		DBEngine:       d.Get("db_engine").(string),
-		Description:    d.Get("description").(string),
-	}
-
-	if err := b.putGrant(ctx, name, grant); err != nil {
-		return nil, err
-	}
-
-	return &logical.Response{StatusCode: 204}, nil
-}
-
-func (b *rdsBackend) handleGrantDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	if err := b.StorageView.Delete(ctx, "grants/"+name); err != nil {
-		return nil, err
-	}
-	return &logical.Response{StatusCode: 204}, nil
-}
-
-func (b *rdsBackend) getGrant(ctx context.Context, name string) (*rdsGrant, error) {
-	entry, err := b.StorageView.Get(ctx, "grants/"+name)
-	if err != nil {
-		return nil, err
-	}
-	if entry == nil {
-		return nil, nil
-	}
-	var grant rdsGrant
-	if err := json.Unmarshal(entry.Value, &grant); err != nil {
-		return nil, fmt.Errorf("failed to decode grant %q: %w", name, err)
-	}
-	return &grant, nil
-}
-
-func (b *rdsBackend) putGrant(ctx context.Context, name string, grant *rdsGrant) error {
-	entry, err := sdklogical.StorageEntryJSON("grants/"+name, grant)
-	if err != nil {
-		return err
-	}
-	return b.StorageView.Put(ctx, entry)
-}
-
-// --- Access endpoint ---
-
-func (b *rdsBackend) pathAccess() *framework.Path {
-	return &framework.Path{
-		Pattern: "access/(?P<name>[^/]+)",
-		Fields: map[string]*framework.FieldSchema{
-			"name": {
-				Type:        framework.TypeString,
-				Description: "Grant name",
-			},
-		},
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.handleGetAccess,
-				Summary:  "Get a database connection string for the given grant",
-			},
-		},
-		HelpSynopsis:    "Get database access",
-		HelpDescription: "Returns a ready-to-use connection string with IAM authentication.",
-	}
-}
-
-func (b *rdsBackend) handleGetAccess(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	grantName := d.Get("name").(string)
-	grant, err := b.getGrant(ctx, grantName)
-	if err != nil {
-		return nil, err
-	}
-	if grant == nil {
-		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", grantName)), nil
-	}
-
-	principal := ""
-	if te := req.TokenEntry(); te != nil {
-		principal = te.PrincipalID
-	}
-
-	return &logical.Response{
-		AccessData: &logical.AccessData{
-			CredentialSpec: grant.CredentialSpec,
-			ResponseBuilder: func(cred *credential.Credential) map[string]interface{} {
-				return map[string]interface{}{
-					"connection_string": formatConnectionString(cred, grant, principal),
-					"lease_duration":    int(cred.LeaseTTL.Seconds()),
-				}
-			},
-		},
-	}, nil
-}
-
-// formatConnectionString builds a ready-to-use DSN from the minted credential,
-// grant config, and the requesting principal (for attribution).
-func formatConnectionString(cred *credential.Credential, grant *rdsGrant, principal string) string {
+// formatAccess builds an engine-specific DSN. The grant's db_engine takes
+// precedence so an operator can pin a grant to a specific engine even when
+// the credential spec is more permissive; falls back to the engine carried
+// on the minted credential.
+func formatAccess(cred *credential.Credential, grant dbaccess.Grant, principal string) map[string]interface{} {
 	host := cred.Data["db_host"]
 	port := cred.Data["db_port"]
 	user := cred.Data["db_user"]
 	token := cred.Data["auth_token"]
-	dbName := grant.DBName
-	engine := grant.DBEngine
+	dbName := grant["db_name"]
+
+	engine := grant["db_engine"]
 	if engine == "" {
 		engine = cred.Data["db_engine"]
 	}
 
+	var connStr string
 	switch engine {
 	case "mysql":
-		return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?tls=true&connectionAttributes=program_name:%s",
+		connStr = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?tls=true&connectionAttributes=program_name:%s",
 			user, url.QueryEscape(token), host, port, dbName, principal)
 	default: // postgres
-		return fmt.Sprintf("host=%s port=%s dbname=%s user=%s password=%s sslmode=require application_name=%s",
+		connStr = fmt.Sprintf("host=%s port=%s dbname=%s user=%s password=%s sslmode=require application_name=%s",
 			host, port, dbName, user, token, principal)
 	}
+
+	return map[string]interface{}{
+		"connection_string": connStr,
+		"lease_duration":    int(cred.LeaseTTL.Seconds()),
+	}
 }
+
+const rdsBackendHelp = `
+The RDS provider vends short-lived database connection strings backed by IAM
+authentication. Workloads call /rds/access/<grant-name> to receive a ready-to-
+use DSN; Warden does not proxy database traffic.
+
+Supports PostgreSQL and MySQL on Amazon RDS and Aurora via the
+rds_iam_token credential mint method.
+
+Configuration:
+- auto_auth_path: Auth mount path for implicit authentication (e.g. 'auth/jwt/')
+
+Grants (path: rds/grants/<name>):
+- credential_spec: Credential spec name to mint for this grant (required)
+- db_name:         Database name to include in the connection string
+- db_engine:       Database engine (postgres, mysql). Overrides the credential
+                   spec's engine when set.
+- description:     Human-readable description
+`

--- a/provider/rds/provider_test.go
+++ b/provider/rds/provider_test.go
@@ -1,356 +1,21 @@
 package rds
 
 import (
-	"context"
-	"sync"
 	"testing"
-	"time"
 
-	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/credential"
-	"github.com/stephnangue/warden/framework"
-	"github.com/stephnangue/warden/logger"
-	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/dbaccess"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// --- test helpers ---
+// Standard backend behavior (Factory wiring, config CRUD, grant CRUD,
+// transparent mode, access-endpoint plumbing, role query parameter) is
+// covered by provider/dbaccess/provider_test.go against the shared
+// framework. These tests cover only the RDS-specific formatter, including
+// engine-specific DSN shapes and MySQL token escaping.
 
-type inmemStorage struct {
-	mu   sync.RWMutex
-	data map[string]*sdklogical.StorageEntry
-}
-
-func newInmemStorage() *inmemStorage {
-	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
-}
-
-func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	var keys []string
-	for k := range s.data {
-		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
-			keys = append(keys, k[len(prefix):])
-		}
-	}
-	return keys, nil
-}
-
-func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.data[key], nil
-}
-
-func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.data[entry.Key] = entry
-	return nil
-}
-
-func (s *inmemStorage) Delete(_ context.Context, key string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.data, key)
-	return nil
-}
-
-func (s *inmemStorage) ListPage(_ context.Context, prefix string, _ string, _ int) ([]string, error) {
-	return s.List(context.Background(), prefix)
-}
-
-func testLogger() *logger.GatedLogger {
-	config := &logger.Config{Level: logger.TraceLevel, Format: logger.DefaultFormat}
-	gateConfig := logger.GatedWriterConfig{InitialState: logger.GateOpen}
-	gl, _ := logger.NewGatedLogger(config, gateConfig)
-	return gl
-}
-
-func setupBackend(t *testing.T) *rdsBackend {
-	t.Helper()
-	storage := newInmemStorage()
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		StorageView: storage,
-		Logger:      testLogger(),
-	}
-	b, err := Factory(ctx, conf)
-	require.NoError(t, err)
-	return b.(*rdsBackend)
-}
-
-func makeFieldData(path *framework.Path, raw map[string]interface{}) *framework.FieldData {
-	return &framework.FieldData{
-		Raw:    raw,
-		Schema: path.Fields,
-	}
-}
-
-// --- Factory tests ---
-
-func TestFactory(t *testing.T) {
-	b := setupBackend(t)
-	assert.Equal(t, "rds", b.Type())
-	assert.Equal(t, logical.ClassProvider, b.Class())
-}
-
-// --- Config tests ---
-
-func TestConfigCRUD(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-
-	t.Run("default config", func(t *testing.T) {
-		cfg := b.GetAccessConfig()
-		assert.Equal(t, "", cfg.AutoAuthPath)
-	})
-
-	t.Run("set and get config", func(t *testing.T) {
-		err := b.SetAccessConfig(ctx, &framework.AccessConfig{
-			AutoAuthPath: "auth/jwt/",
-		})
-		require.NoError(t, err)
-
-		cfg := b.GetAccessConfig()
-		assert.Equal(t, "auth/jwt/", cfg.AutoAuthPath)
-	})
-
-	t.Run("config persists via HandleRequest", func(t *testing.T) {
-		// Write config via HandleRequest
-		resp, err := b.HandleRequest(ctx, &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      "config",
-			Data: map[string]any{
-				"auto_auth_path": "auth/cert/",
-			},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, 204, resp.StatusCode)
-
-		// Read config via HandleRequest
-		resp, err = b.HandleRequest(ctx, &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      "config",
-		})
-		require.NoError(t, err)
-		assert.Equal(t, "auth/cert/", resp.Data["auto_auth_path"])
-	})
-}
-
-// --- TransparentModeProvider tests ---
-
-func TestTransparentModeProvider(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-
-	t.Run("disabled by default", func(t *testing.T) {
-		assert.False(t, b.IsTransparentMode())
-		assert.Equal(t, "", b.GetAutoAuthPath())
-		assert.Equal(t, "", b.GetAuthRole("access/readonly", nil))
-	})
-
-	t.Run("enabled after config with auto_auth_path", func(t *testing.T) {
-		err := b.SetAccessConfig(ctx, &framework.AccessConfig{
-			AutoAuthPath: "auth/jwt/",
-		})
-		require.NoError(t, err)
-
-		assert.True(t, b.IsTransparentMode())
-		assert.Equal(t, "auth/jwt/", b.GetAutoAuthPath())
-		assert.Equal(t, "", b.GetAuthRole("access/readonly", nil))
-	})
-
-	t.Run("extracts role from query parameter", func(t *testing.T) {
-		req := &logical.Request{
-			Data: map[string]any{"role": "data-team"},
-		}
-		assert.Equal(t, "data-team", b.GetAuthRole("access/readonly", req))
-	})
-
-	t.Run("returns empty when no role in request", func(t *testing.T) {
-		req := &logical.Request{
-			Data: map[string]any{},
-		}
-		assert.Equal(t, "", b.GetAuthRole("access/readonly", req))
-	})
-
-	t.Run("IsUnauthenticatedPath always false", func(t *testing.T) {
-		assert.False(t, b.IsUnauthenticatedPath("access/readonly"))
-		assert.False(t, b.IsUnauthenticatedPath("config"))
-	})
-}
-
-func TestIsTransparentPath(t *testing.T) {
-	b := setupBackend(t)
-
-	assert.True(t, b.IsTransparentPath("access/readonly"))
-	assert.True(t, b.IsTransparentPath("access/readwrite"))
-	assert.False(t, b.IsTransparentPath("grants/readonly"))
-	assert.False(t, b.IsTransparentPath("config"))
-	assert.False(t, b.IsTransparentPath(""))
-}
-
-// --- Grant CRUD tests ---
-
-func TestGrantCRUD(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-	req := &logical.Request{}
-	grantsPath := b.pathGrants()
-
-	t.Run("read nonexistent grant returns error", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{"name": "nonexistent"})
-		resp, err := b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("write grant", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{
-			"name":            "readonly",
-			"credential_spec": "rds-readonly",
-			"db_name":         "myapp",
-			"db_engine":       "postgres",
-			"description":     "Read-only access",
-		})
-		resp, err := b.handleGrantWrite(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, 204, resp.StatusCode)
-	})
-
-	t.Run("read grant", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, "rds-readonly", resp.Data["credential_spec"])
-		assert.Equal(t, "myapp", resp.Data["db_name"])
-		assert.Equal(t, "postgres", resp.Data["db_engine"])
-		assert.Equal(t, "Read-only access", resp.Data["description"])
-	})
-
-	t.Run("write grant without credential_spec fails", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{
-			"name":    "bad-grant",
-			"db_name": "myapp",
-		})
-		resp, err := b.handleGrantWrite(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("delete grant", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGrantDelete(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, 204, resp.StatusCode)
-
-		resp, err = b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-}
-
-// --- Access endpoint tests ---
-
-func TestHandleGetAccess(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-	grantsPath := b.pathGrants()
-	accessPath := b.pathAccess()
-
-	// Create a grant first
-	d := makeFieldData(grantsPath, map[string]interface{}{
-		"name":            "readonly",
-		"credential_spec": "rds-readonly",
-		"db_name":         "myapp",
-		"db_engine":       "postgres",
-	})
-	_, err := b.handleGrantWrite(ctx, &logical.Request{}, d)
-	require.NoError(t, err)
-
-	t.Run("nonexistent grant returns error", func(t *testing.T) {
-		req := &logical.Request{}
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "nonexistent"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("returns AccessData with correct spec", func(t *testing.T) {
-		req := &logical.Request{}
-		te := &logical.TokenEntry{PrincipalID: "workload-a"}
-		req.SetTokenEntry(te)
-
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-		assert.Equal(t, "rds-readonly", resp.AccessData.CredentialSpec)
-	})
-
-	t.Run("ResponseBuilder produces correct connection string", func(t *testing.T) {
-		req := &logical.Request{}
-		te := &logical.TokenEntry{PrincipalID: "workload-a"}
-		req.SetTokenEntry(te)
-
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-
-		cred := &credential.Credential{
-			LeaseTTL: 15 * time.Minute,
-			Data: map[string]string{
-				"auth_token": "iam-token-xyz",
-				"db_host":    "mydb.rds.amazonaws.com",
-				"db_port":    "5432",
-				"db_user":    "app_readonly",
-				"db_engine":  "postgres",
-			},
-		}
-
-		result := resp.AccessData.ResponseBuilder(cred)
-		connStr := result["connection_string"].(string)
-		assert.Contains(t, connStr, "host=mydb.rds.amazonaws.com")
-		assert.Contains(t, connStr, "port=5432")
-		assert.Contains(t, connStr, "dbname=myapp")
-		assert.Contains(t, connStr, "user=app_readonly")
-		assert.Contains(t, connStr, "password=iam-token-xyz")
-		assert.Contains(t, connStr, "sslmode=require")
-		assert.Contains(t, connStr, "application_name=workload-a")
-		assert.Equal(t, 900, result["lease_duration"])
-	})
-
-	t.Run("no token entry still works with empty principal", func(t *testing.T) {
-		req := &logical.Request{}
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-
-		cred := &credential.Credential{
-			LeaseTTL: 15 * time.Minute,
-			Data: map[string]string{
-				"auth_token": "token",
-				"db_host":    "h",
-				"db_port":    "5432",
-				"db_user":    "u",
-				"db_engine":  "postgres",
-			},
-		}
-		result := resp.AccessData.ResponseBuilder(cred)
-		connStr := result["connection_string"].(string)
-		assert.Contains(t, connStr, "application_name=")
-	})
-}
-
-// --- formatConnectionString tests ---
-
-func TestFormatConnectionString(t *testing.T) {
-	cred := &credential.Credential{
+func baseCred() *credential.Credential {
+	return &credential.Credential{
 		Data: map[string]string{
 			"auth_token": "my-token",
 			"db_host":    "mydb.rds.amazonaws.com",
@@ -359,45 +24,57 @@ func TestFormatConnectionString(t *testing.T) {
 			"db_engine":  "postgres",
 		},
 	}
+}
 
-	t.Run("postgres", func(t *testing.T) {
-		grant := &rdsGrant{DBName: "myapp", DBEngine: "postgres"}
-		result := formatConnectionString(cred, grant, "workload-a")
-		assert.Equal(t,
-			"host=mydb.rds.amazonaws.com port=5432 dbname=myapp user=app_user password=my-token sslmode=require application_name=workload-a",
-			result,
-		)
-	})
+func TestFormatAccess_Postgres(t *testing.T) {
+	grant := dbaccess.Grant{"db_name": "myapp", "db_engine": "postgres"}
+	out := formatAccess(baseCred(), grant, "workload-a")
+	assert.Equal(t,
+		"host=mydb.rds.amazonaws.com port=5432 dbname=myapp user=app_user password=my-token sslmode=require application_name=workload-a",
+		out["connection_string"],
+	)
+}
 
-	t.Run("mysql", func(t *testing.T) {
-		grant := &rdsGrant{DBName: "myapp", DBEngine: "mysql"}
-		result := formatConnectionString(cred, grant, "workload-b")
-		assert.Equal(t,
-			"app_user:my-token@tcp(mydb.rds.amazonaws.com:5432)/myapp?tls=true&connectionAttributes=program_name:workload-b",
-			result,
-		)
-	})
+func TestFormatAccess_MySQL(t *testing.T) {
+	grant := dbaccess.Grant{"db_name": "myapp", "db_engine": "mysql"}
+	out := formatAccess(baseCred(), grant, "workload-b")
+	assert.Equal(t,
+		"app_user:my-token@tcp(mydb.rds.amazonaws.com:5432)/myapp?tls=true&connectionAttributes=program_name:workload-b",
+		out["connection_string"],
+	)
+}
 
-	t.Run("engine fallback from credential", func(t *testing.T) {
-		grant := &rdsGrant{DBName: "myapp", DBEngine: ""}
-		result := formatConnectionString(cred, grant, "workload-d")
-		assert.Contains(t, result, "host=")
-		assert.Contains(t, result, "sslmode=require")
-	})
+func TestFormatAccess_EngineFallbackFromCredential(t *testing.T) {
+	// When the grant doesn't specify db_engine, the formatter falls back to
+	// the engine carried on the minted credential.
+	grant := dbaccess.Grant{"db_name": "myapp"}
+	out := formatAccess(baseCred(), grant, "workload-d")
+	connStr := out["connection_string"].(string)
+	assert.Contains(t, connStr, "host=")
+	assert.Contains(t, connStr, "sslmode=require")
+}
 
-	t.Run("token with special characters is escaped in mysql", func(t *testing.T) {
-		specialCred := &credential.Credential{
-			Data: map[string]string{
-				"auth_token": "token/with+special=chars&more",
-				"db_host":    "h",
-				"db_port":    "3306",
-				"db_user":    "u",
-				"db_engine":  "mysql",
-			},
-		}
-		grant := &rdsGrant{DBName: "db", DBEngine: "mysql"}
-		result := formatConnectionString(specialCred, grant, "w")
-		assert.NotContains(t, result, "token/with+special")
-		assert.Contains(t, result, "token%2Fwith%2Bspecial%3Dchars%26more")
-	})
+func TestFormatAccess_MySQLTokenEscaped(t *testing.T) {
+	cred := &credential.Credential{
+		Data: map[string]string{
+			"auth_token": "token/with+special=chars&more",
+			"db_host":    "h",
+			"db_port":    "3306",
+			"db_user":    "u",
+			"db_engine":  "mysql",
+		},
+	}
+	grant := dbaccess.Grant{"db_name": "db", "db_engine": "mysql"}
+	out := formatAccess(cred, grant, "w")
+	connStr := out["connection_string"].(string)
+	assert.NotContains(t, connStr, "token/with+special")
+	assert.Contains(t, connStr, "token%2Fwith%2Bspecial%3Dchars%26more")
+}
+
+func TestFormatAccess_LeaseDuration(t *testing.T) {
+	cred := baseCred()
+	cred.LeaseTTL = 0
+	grant := dbaccess.Grant{"db_name": "myapp", "db_engine": "postgres"}
+	out := formatAccess(cred, grant, "w")
+	assert.Equal(t, 0, out["lease_duration"])
 }

--- a/provider/redshift/provider.go
+++ b/provider/redshift/provider.go
@@ -1,231 +1,65 @@
+// Package redshift is an access backend that vends ready-to-use postgres
+// connection strings backed by Amazon Redshift IAM authentication tokens
+// (provisioned clusters via redshift:GetClusterCredentialsWithIAM, serverless
+// workgroups via redshift-serverless:GetCredentials).
 package redshift
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 
-	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/framework"
-	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/dbaccess"
 )
 
-// redshiftBackend is an access backend that vends database connection strings
-// using Amazon Redshift IAM authentication tokens.
-type redshiftBackend struct {
-	*framework.AccessBackend
-}
-
-// redshiftGrant maps a grant name to a credential spec and database configuration.
-type redshiftGrant struct {
-	CredentialSpec string `json:"credential_spec"`
-	DBName         string `json:"db_name"`
-	Description    string `json:"description,omitempty"`
+// Spec declares the Redshift access backend.
+var Spec = &dbaccess.ProviderSpec{
+	Name: "redshift",
+	GrantFields: map[string]*framework.FieldSchema{
+		"db_name": {
+			Type:        framework.TypeString,
+			Description: "Database name to include in the connection string",
+		},
+	},
+	FormatAccess: formatAccess,
+	HelpText:     redshiftBackendHelp,
 }
 
 // Factory creates a new Redshift access backend.
-func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-	b := &redshiftBackend{}
-	b.AccessBackend = &framework.AccessBackend{
-		Backend: &framework.Backend{
-			BackendType:  "redshift",
-			BackendClass: logical.ClassProvider,
-		},
-		Logger: conf.Logger.WithSubsystem("redshift"),
-	}
-	b.Backend.Paths = b.paths()
-	if err := b.AccessBackend.Setup(ctx, conf); err != nil {
-		return nil, err
-	}
-	return b, nil
-}
+var Factory = dbaccess.NewFactory(Spec)
 
-func (b *redshiftBackend) paths() []*framework.Path {
-	return []*framework.Path{
-		b.PathAccessConfig(),
-		b.pathGrants(),
-		b.pathAccess(),
+// formatAccess builds a libpq-style DSN. Redshift speaks the PostgreSQL wire
+// protocol, so any postgres driver can use the result. The password from
+// GetClusterCredentialsWithIAM / GetCredentials is wrapped in single quotes —
+// libpq treats quoted values as opaque, sidestepping any special characters.
+func formatAccess(cred *credential.Credential, grant dbaccess.Grant, principal string) map[string]interface{} {
+	return map[string]interface{}{
+		"connection_string": fmt.Sprintf(
+			"host=%s port=%s dbname=%s user=%s password='%s' sslmode=require application_name=%s",
+			cred.Data["db_host"],
+			cred.Data["db_port"],
+			grant["db_name"],
+			cred.Data["db_user"],
+			cred.Data["auth_token"],
+			principal,
+		),
+		"lease_duration": int(cred.LeaseTTL.Seconds()),
 	}
 }
 
-// --- Grants CRUD ---
+const redshiftBackendHelp = `
+The Redshift provider vends short-lived postgres connection strings backed by
+IAM authentication. Workloads call /redshift/access/<grant-name> to receive a
+ready-to-use libpq DSN; Warden does not proxy database traffic.
 
-func (b *redshiftBackend) pathGrants() *framework.Path {
-	return &framework.Path{
-		Pattern: "grants/(?P<name>[^/]+)",
-		Fields: map[string]*framework.FieldSchema{
-			"name": {
-				Type:        framework.TypeString,
-				Description: "Grant name",
-			},
-			"credential_spec": {
-				Type:        framework.TypeString,
-				Description: "Credential spec name to mint for this grant",
-			},
-			"db_name": {
-				Type:        framework.TypeString,
-				Description: "Database name to include in the connection string",
-			},
-			"description": {
-				Type:        framework.TypeString,
-				Description: "Human-readable description of this grant",
-			},
-		},
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.handleGrantRead,
-				Summary:  "Read a grant",
-			},
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.handleGrantWrite,
-				Summary:  "Create or update a grant",
-			},
-			logical.DeleteOperation: &framework.PathOperation{
-				Callback: b.handleGrantDelete,
-				Summary:  "Delete a grant",
-			},
-		},
-		HelpSynopsis:    "Manage Redshift access grants",
-		HelpDescription: "Grants map a name to a credential spec and database configuration.",
-	}
-}
+Supports both deployment models — provisioned clusters and serverless
+workgroups — via the same redshift_iam_token credential mint method.
 
-func (b *redshiftBackend) handleGrantRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	grant, err := b.getGrant(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-	if grant == nil {
-		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", name)), nil
-	}
-	return &logical.Response{
-		StatusCode: 200,
-		Data: map[string]any{
-			"credential_spec": grant.CredentialSpec,
-			"db_name":         grant.DBName,
-			"description":     grant.Description,
-		},
-	}, nil
-}
+Configuration:
+- auto_auth_path: Auth mount path for implicit authentication (e.g. 'auth/jwt/')
 
-func (b *redshiftBackend) handleGrantWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-
-	credSpec, _ := d.Get("credential_spec").(string)
-	if credSpec == "" {
-		return logical.ErrorResponse(logical.ErrBadRequest("credential_spec is required")), nil
-	}
-
-	grant := &redshiftGrant{
-		CredentialSpec: credSpec,
-		DBName:         d.Get("db_name").(string),
-		Description:    d.Get("description").(string),
-	}
-
-	if err := b.putGrant(ctx, name, grant); err != nil {
-		return nil, err
-	}
-
-	return &logical.Response{StatusCode: 204}, nil
-}
-
-func (b *redshiftBackend) handleGrantDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	if err := b.StorageView.Delete(ctx, "grants/"+name); err != nil {
-		return nil, err
-	}
-	return &logical.Response{StatusCode: 204}, nil
-}
-
-func (b *redshiftBackend) getGrant(ctx context.Context, name string) (*redshiftGrant, error) {
-	entry, err := b.StorageView.Get(ctx, "grants/"+name)
-	if err != nil {
-		return nil, err
-	}
-	if entry == nil {
-		return nil, nil
-	}
-	var grant redshiftGrant
-	if err := json.Unmarshal(entry.Value, &grant); err != nil {
-		return nil, fmt.Errorf("failed to decode grant %q: %w", name, err)
-	}
-	return &grant, nil
-}
-
-func (b *redshiftBackend) putGrant(ctx context.Context, name string, grant *redshiftGrant) error {
-	entry, err := sdklogical.StorageEntryJSON("grants/"+name, grant)
-	if err != nil {
-		return err
-	}
-	return b.StorageView.Put(ctx, entry)
-}
-
-// --- Access endpoint ---
-
-func (b *redshiftBackend) pathAccess() *framework.Path {
-	return &framework.Path{
-		Pattern: "access/(?P<name>[^/]+)",
-		Fields: map[string]*framework.FieldSchema{
-			"name": {
-				Type:        framework.TypeString,
-				Description: "Grant name",
-			},
-		},
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.handleGetAccess,
-				Summary:  "Get a database connection string for the given grant",
-			},
-		},
-		HelpSynopsis:    "Get database access",
-		HelpDescription: "Returns a ready-to-use Redshift connection string with IAM authentication.",
-	}
-}
-
-func (b *redshiftBackend) handleGetAccess(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	grantName := d.Get("name").(string)
-	grant, err := b.getGrant(ctx, grantName)
-	if err != nil {
-		return nil, err
-	}
-	if grant == nil {
-		return logical.ErrorResponse(logical.ErrNotFoundf("grant %q not found", grantName)), nil
-	}
-
-	principal := ""
-	if te := req.TokenEntry(); te != nil {
-		principal = te.PrincipalID
-	}
-
-	return &logical.Response{
-		AccessData: &logical.AccessData{
-			CredentialSpec: grant.CredentialSpec,
-			ResponseBuilder: func(cred *credential.Credential) map[string]interface{} {
-				return map[string]interface{}{
-					"connection_string": formatConnectionString(cred, grant, principal),
-					"lease_duration":    int(cred.LeaseTTL.Seconds()),
-				}
-			},
-		},
-	}, nil
-}
-
-// formatConnectionString builds a libpq-style DSN. Redshift speaks the
-// PostgreSQL wire protocol, so any postgres driver can use this string.
-// The password from GetClusterCredentialsWithIAM / GetCredentials is wrapped
-// in single quotes — libpq treats quoted values as opaque, sidestepping any
-// special characters.
-func formatConnectionString(cred *credential.Credential, grant *redshiftGrant, principal string) string {
-	host := cred.Data["db_host"]
-	port := cred.Data["db_port"]
-	user := cred.Data["db_user"]
-	password := cred.Data["auth_token"]
-	dbName := grant.DBName
-
-	return fmt.Sprintf(
-		"host=%s port=%s dbname=%s user=%s password='%s' sslmode=require application_name=%s",
-		host, port, dbName, user, password, principal,
-	)
-}
+Grants (path: redshift/grants/<name>):
+- credential_spec: Credential spec name to mint for this grant (required)
+- db_name:         Database name to include in the connection string
+- description:     Human-readable description
+`

--- a/provider/redshift/provider_test.go
+++ b/provider/redshift/provider_test.go
@@ -1,453 +1,72 @@
 package redshift
 
 import (
-	"context"
-	"sync"
 	"testing"
-	"time"
 
-	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/credential"
-	"github.com/stephnangue/warden/framework"
-	"github.com/stephnangue/warden/logger"
-	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/dbaccess"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// --- test helpers ---
+// Standard backend behavior (Factory wiring, config CRUD, grant CRUD,
+// transparent mode, access-endpoint plumbing, role query parameter) is
+// covered by provider/dbaccess/provider_test.go against the shared
+// framework. These tests cover only the Redshift-specific formatter.
 
-type inmemStorage struct {
-	mu   sync.RWMutex
-	data map[string]*sdklogical.StorageEntry
-}
-
-func newInmemStorage() *inmemStorage {
-	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
-}
-
-func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	var keys []string
-	for k := range s.data {
-		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
-			keys = append(keys, k[len(prefix):])
-		}
+func TestFormatAccess_ProvisionedCluster(t *testing.T) {
+	cred := &credential.Credential{
+		Data: map[string]string{
+			"auth_token": "secret-token",
+			"db_host":    "my-cluster.abc123.us-east-1.redshift.amazonaws.com",
+			"db_port":    "5439",
+			"db_user":    "IAMR:warden-role",
+		},
 	}
-	return keys, nil
+	grant := dbaccess.Grant{"db_name": "analytics"}
+
+	out := formatAccess(cred, grant, "workload-a")
+	assert.Equal(t,
+		"host=my-cluster.abc123.us-east-1.redshift.amazonaws.com port=5439 dbname=analytics user=IAMR:warden-role password='secret-token' sslmode=require application_name=workload-a",
+		out["connection_string"],
+	)
 }
 
-func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.data[key], nil
-}
-
-func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.data[entry.Key] = entry
-	return nil
-}
-
-func (s *inmemStorage) Delete(_ context.Context, key string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.data, key)
-	return nil
-}
-
-func (s *inmemStorage) ListPage(_ context.Context, prefix string, _ string, _ int) ([]string, error) {
-	return s.List(context.Background(), prefix)
-}
-
-func testLogger() *logger.GatedLogger {
-	config := &logger.Config{Level: logger.TraceLevel, Format: logger.DefaultFormat}
-	gateConfig := logger.GatedWriterConfig{InitialState: logger.GateOpen}
-	gl, _ := logger.NewGatedLogger(config, gateConfig)
-	return gl
-}
-
-func setupBackend(t *testing.T) *redshiftBackend {
-	t.Helper()
-	storage := newInmemStorage()
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		StorageView: storage,
-		Logger:      testLogger(),
+func TestFormatAccess_PasswordSingleQuoted(t *testing.T) {
+	// Single-quoted password sidesteps special characters that would
+	// otherwise need escaping in libpq DSN format.
+	cred := &credential.Credential{
+		Data: map[string]string{
+			"auth_token": "abc/def+ghi=jkl",
+			"db_host":    "h",
+			"db_port":    "5439",
+			"db_user":    "u",
+		},
 	}
-	b, err := Factory(ctx, conf)
-	require.NoError(t, err)
-	return b.(*redshiftBackend)
+	grant := dbaccess.Grant{"db_name": "db"}
+
+	out := formatAccess(cred, grant, "w")
+	assert.Contains(t, out["connection_string"].(string), "password='abc/def+ghi=jkl'")
 }
 
-func makeFieldData(path *framework.Path, raw map[string]interface{}) *framework.FieldData {
-	return &framework.FieldData{
-		Raw:    raw,
-		Schema: path.Fields,
+func TestFormatAccess_EmptyPrincipal(t *testing.T) {
+	cred := &credential.Credential{
+		Data: map[string]string{
+			"auth_token": "t",
+			"db_host":    "h",
+			"db_port":    "5439",
+			"db_user":    "u",
+		},
 	}
+	grant := dbaccess.Grant{"db_name": "db"}
+
+	out := formatAccess(cred, grant, "")
+	assert.Contains(t, out["connection_string"].(string), "application_name=")
 }
 
-// --- Factory tests ---
-
-func TestFactory(t *testing.T) {
-	b := setupBackend(t)
-	assert.Equal(t, "redshift", b.Type())
-	assert.Equal(t, logical.ClassProvider, b.Class())
-}
-
-// --- Config tests ---
-
-func TestConfigCRUD(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-
-	t.Run("default config", func(t *testing.T) {
-		cfg := b.GetAccessConfig()
-		assert.Equal(t, "", cfg.AutoAuthPath)
-	})
-
-	t.Run("set and get config", func(t *testing.T) {
-		err := b.SetAccessConfig(ctx, &framework.AccessConfig{
-			AutoAuthPath: "auth/jwt/",
-		})
-		require.NoError(t, err)
-
-		cfg := b.GetAccessConfig()
-		assert.Equal(t, "auth/jwt/", cfg.AutoAuthPath)
-	})
-
-	t.Run("config persists via HandleRequest", func(t *testing.T) {
-		resp, err := b.HandleRequest(ctx, &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      "config",
-			Data: map[string]any{
-				"auto_auth_path": "auth/cert/",
-			},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, 204, resp.StatusCode)
-
-		resp, err = b.HandleRequest(ctx, &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      "config",
-		})
-		require.NoError(t, err)
-		assert.Equal(t, "auth/cert/", resp.Data["auto_auth_path"])
-	})
-}
-
-// --- TransparentModeProvider tests ---
-
-func TestTransparentModeProvider(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-
-	t.Run("disabled by default", func(t *testing.T) {
-		assert.False(t, b.IsTransparentMode())
-		assert.Equal(t, "", b.GetAutoAuthPath())
-	})
-
-	t.Run("enabled after config with auto_auth_path", func(t *testing.T) {
-		err := b.SetAccessConfig(ctx, &framework.AccessConfig{
-			AutoAuthPath: "auth/jwt/",
-		})
-		require.NoError(t, err)
-
-		assert.True(t, b.IsTransparentMode())
-		assert.Equal(t, "auth/jwt/", b.GetAutoAuthPath())
-	})
-
-	t.Run("extracts role from query parameter", func(t *testing.T) {
-		req := &logical.Request{
-			Data: map[string]any{"role": "data-team"},
-		}
-		assert.Equal(t, "data-team", b.GetAuthRole("access/readonly", req))
-	})
-
-	t.Run("returns empty when no role in request", func(t *testing.T) {
-		req := &logical.Request{Data: map[string]any{}}
-		assert.Equal(t, "", b.GetAuthRole("access/readonly", req))
-	})
-
-	t.Run("IsUnauthenticatedPath always false", func(t *testing.T) {
-		assert.False(t, b.IsUnauthenticatedPath("access/readonly"))
-		assert.False(t, b.IsUnauthenticatedPath("config"))
-	})
-}
-
-func TestIsTransparentPath(t *testing.T) {
-	b := setupBackend(t)
-
-	assert.True(t, b.IsTransparentPath("access/readonly"))
-	assert.True(t, b.IsTransparentPath("access/serverless"))
-	assert.False(t, b.IsTransparentPath("grants/readonly"))
-	assert.False(t, b.IsTransparentPath("config"))
-	assert.False(t, b.IsTransparentPath(""))
-}
-
-// --- Grant CRUD tests ---
-
-func TestGrantCRUD(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-	req := &logical.Request{}
-	grantsPath := b.pathGrants()
-
-	t.Run("read nonexistent grant returns error", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{"name": "nonexistent"})
-		resp, err := b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("write grant", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{
-			"name":            "readonly",
-			"credential_spec": "redshift-readonly",
-			"db_name":         "analytics",
-			"description":     "Read-only access to analytics db",
-		})
-		resp, err := b.handleGrantWrite(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, 204, resp.StatusCode)
-	})
-
-	t.Run("read grant", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, "redshift-readonly", resp.Data["credential_spec"])
-		assert.Equal(t, "analytics", resp.Data["db_name"])
-		assert.Equal(t, "Read-only access to analytics db", resp.Data["description"])
-	})
-
-	t.Run("write grant without credential_spec fails", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{
-			"name":    "bad-grant",
-			"db_name": "analytics",
-		})
-		resp, err := b.handleGrantWrite(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("delete grant", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGrantDelete(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, 204, resp.StatusCode)
-
-		resp, err = b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("update existing grant overwrites fields", func(t *testing.T) {
-		d := makeFieldData(grantsPath, map[string]interface{}{
-			"name":            "rw",
-			"credential_spec": "spec-v1",
-			"db_name":         "db1",
-		})
-		_, err := b.handleGrantWrite(ctx, req, d)
-		require.NoError(t, err)
-
-		d = makeFieldData(grantsPath, map[string]interface{}{
-			"name":            "rw",
-			"credential_spec": "spec-v2",
-			"db_name":         "db2",
-		})
-		_, err = b.handleGrantWrite(ctx, req, d)
-		require.NoError(t, err)
-
-		d = makeFieldData(grantsPath, map[string]interface{}{"name": "rw"})
-		resp, err := b.handleGrantRead(ctx, req, d)
-		require.NoError(t, err)
-		assert.Equal(t, "spec-v2", resp.Data["credential_spec"])
-		assert.Equal(t, "db2", resp.Data["db_name"])
-	})
-}
-
-// --- Access endpoint tests ---
-
-func TestHandleGetAccess(t *testing.T) {
-	b := setupBackend(t)
-	ctx := context.Background()
-	grantsPath := b.pathGrants()
-	accessPath := b.pathAccess()
-
-	d := makeFieldData(grantsPath, map[string]interface{}{
-		"name":            "readonly",
-		"credential_spec": "redshift-readonly",
-		"db_name":         "analytics",
-	})
-	_, err := b.handleGrantWrite(ctx, &logical.Request{}, d)
-	require.NoError(t, err)
-
-	t.Run("nonexistent grant returns error", func(t *testing.T) {
-		req := &logical.Request{}
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "nonexistent"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		assert.True(t, resp.IsError())
-	})
-
-	t.Run("returns AccessData with correct spec", func(t *testing.T) {
-		req := &logical.Request{}
-		te := &logical.TokenEntry{PrincipalID: "workload-a"}
-		req.SetTokenEntry(te)
-
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-		assert.Equal(t, "redshift-readonly", resp.AccessData.CredentialSpec)
-	})
-
-	t.Run("ResponseBuilder produces correct connection string", func(t *testing.T) {
-		req := &logical.Request{}
-		te := &logical.TokenEntry{PrincipalID: "workload-a"}
-		req.SetTokenEntry(te)
-
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-
-		cred := &credential.Credential{
-			LeaseTTL: 15 * time.Minute,
-			Data: map[string]string{
-				"auth_token": "redshift-temp-password",
-				"db_host":    "my-cluster.abc123.us-east-1.redshift.amazonaws.com",
-				"db_port":    "5439",
-				"db_user":    "IAMR:warden-redshift-connect",
-				"deployment": "provisioned",
-			},
-		}
-
-		result := resp.AccessData.ResponseBuilder(cred)
-		connStr := result["connection_string"].(string)
-		assert.Contains(t, connStr, "host=my-cluster.abc123.us-east-1.redshift.amazonaws.com")
-		assert.Contains(t, connStr, "port=5439")
-		assert.Contains(t, connStr, "dbname=analytics")
-		assert.Contains(t, connStr, "user=IAMR:warden-redshift-connect")
-		assert.Contains(t, connStr, "password='redshift-temp-password'")
-		assert.Contains(t, connStr, "sslmode=require")
-		assert.Contains(t, connStr, "application_name=workload-a")
-		assert.Equal(t, 900, result["lease_duration"])
-	})
-
-	t.Run("no token entry still works with empty principal", func(t *testing.T) {
-		req := &logical.Request{}
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-
-		cred := &credential.Credential{
-			LeaseTTL: 15 * time.Minute,
-			Data: map[string]string{
-				"auth_token": "tok",
-				"db_host":    "h",
-				"db_port":    "5439",
-				"db_user":    "u",
-			},
-		}
-		result := resp.AccessData.ResponseBuilder(cred)
-		connStr := result["connection_string"].(string)
-		assert.Contains(t, connStr, "application_name=")
-	})
-
-	t.Run("lease_duration reflects credential LeaseTTL", func(t *testing.T) {
-		req := &logical.Request{}
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-
-		cred := &credential.Credential{
-			LeaseTTL: 60 * time.Minute,
-			Data: map[string]string{
-				"auth_token": "t",
-				"db_host":    "h",
-				"db_port":    "5439",
-				"db_user":    "u",
-			},
-		}
-		result := resp.AccessData.ResponseBuilder(cred)
-		assert.Equal(t, 3600, result["lease_duration"])
-	})
-
-	t.Run("role query parameter is independent of grant selection", func(t *testing.T) {
-		// Documented behavior: ?role= overrides the auth role used by the
-		// transparent-mode provider, but the grant is always picked from
-		// the path. So passing role=data-team to access/readonly must still
-		// resolve the readonly grant.
-		req := &logical.Request{Data: map[string]any{"role": "data-team"}}
-		d := makeFieldData(accessPath, map[string]interface{}{"name": "readonly"})
-
-		resp, err := b.handleGetAccess(ctx, req, d)
-		require.NoError(t, err)
-		require.NotNil(t, resp.AccessData)
-		assert.Equal(t, "redshift-readonly", resp.AccessData.CredentialSpec)
-
-		assert.Equal(t, "data-team", b.GetAuthRole("access/readonly", req))
-	})
-}
-
-// --- formatConnectionString tests ---
-
-func TestFormatConnectionString(t *testing.T) {
-	t.Run("provisioned cluster", func(t *testing.T) {
-		cred := &credential.Credential{
-			Data: map[string]string{
-				"auth_token": "secret-token",
-				"db_host":    "my-cluster.abc123.us-east-1.redshift.amazonaws.com",
-				"db_port":    "5439",
-				"db_user":    "IAMR:warden-role",
-			},
-		}
-		grant := &redshiftGrant{DBName: "analytics"}
-		result := formatConnectionString(cred, grant, "workload-a")
-		assert.Equal(t,
-			"host=my-cluster.abc123.us-east-1.redshift.amazonaws.com port=5439 dbname=analytics user=IAMR:warden-role password='secret-token' sslmode=require application_name=workload-a",
-			result,
-		)
-	})
-
-	t.Run("password is single-quoted to handle special characters", func(t *testing.T) {
-		cred := &credential.Credential{
-			Data: map[string]string{
-				"auth_token": "abc/def+ghi=jkl",
-				"db_host":    "h",
-				"db_port":    "5439",
-				"db_user":    "u",
-			},
-		}
-		grant := &redshiftGrant{DBName: "db"}
-		result := formatConnectionString(cred, grant, "w")
-		assert.Contains(t, result, "password='abc/def+ghi=jkl'")
-	})
-
-	t.Run("empty principal still produces application_name field", func(t *testing.T) {
-		cred := &credential.Credential{
-			Data: map[string]string{
-				"auth_token": "t",
-				"db_host":    "h",
-				"db_port":    "5439",
-				"db_user":    "u",
-			},
-		}
-		grant := &redshiftGrant{DBName: "db"}
-		result := formatConnectionString(cred, grant, "")
-		assert.Contains(t, result, "application_name=")
-	})
-
-	t.Run("missing fields produce empty values, not panics", func(t *testing.T) {
-		cred := &credential.Credential{Data: map[string]string{}}
-		grant := &redshiftGrant{DBName: ""}
-		assert.NotPanics(t, func() {
-			_ = formatConnectionString(cred, grant, "")
-		})
+func TestFormatAccess_MissingFieldsDoNotPanic(t *testing.T) {
+	cred := &credential.Credential{Data: map[string]string{}}
+	grant := dbaccess.Grant{}
+	assert.NotPanics(t, func() {
+		_ = formatAccess(cred, grant, "")
 	})
 }


### PR DESCRIPTION
The rds and redshift providers were 80%+ duplicated by construction: both were built from the same template with only the backend name, grant fields, and connection-string formatter actually varying between them. The duplication was about to compound — Cloud SQL, Azure SQL, and Snowflake providers are all on the roadmap and would each repeat the same ~200 lines of grant CRUD plumbing.

Lift the shared parts into a new provider/dbaccess package that follows the existing provider/httpproxy pattern: a declarative ProviderSpec struct + a NewFactory(spec) function, with provider-specific behavior expressed via a FormatAccess callback. The framework owns paths, storage, grant CRUD handlers, AccessData/ResponseBuilder wiring, and credential_spec validation. Providers shrink to a Spec declaration and a formatter function (rds: 244 -> 84 lines; redshift: 231 -> 65 lines).

Grants are now stored as map[string]string rather than typed structs. All current grant fields on both providers were already strings, so this is a clean shape and avoids a generics requirement. The on-disk JSON schema is unchanged, so pre-refactor grants round-trip through the new code; a regression test in dbaccess locks this in.

Standard backend behavior (config CRUD, transparent mode, grant CRUD, access endpoint plumbing, role query parameter) moves into provider/dbaccess/provider_test.go where it tests the framework once. Each provider's test file is now a pure unit test of its formatter.

Net change: +210 lines added across the four provider files, -1240 removed; +669 in the new dbaccess package; net repo reduction ~360 lines, with savings compounding for each future db access provider.

Verified: full go test ./... passes; storage compatibility test in dbaccess decodes a literal pre-refactor JSON grant.