### PR TITLE
feat: server-side OpenAPI 3.0 schema endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Warden are documented in this file.
 
 ### New Features
 
+- **Server-side OpenAPI 3.0 schema endpoint** at `GET /v1/sys/schema` and the Vault-compatible alias `GET /v1/sys/internal/specs/openapi`. Returns a namespace-scoped OpenAPI document covering the system backend (`sys/*`) plus every framework-based mount reachable in the caller's namespace, so a tenant cannot enumerate another tenant's backends. Pass `?path=<path>` to project to a single operation. Implementation ports OpenBao's SDK OpenAPI generator into warden's framework fork (adapted to warden's local `logical.BackendClass`/`Operation`/`Response` types) and restores OAS-doc bundling in `handleRootHelp` so per-mount `?warden-help=1` returns the document directly. New `framework.DocumentPathsWithMountPrefix` prepends the mount prefix to path keys when assembling a server-wide doc, and a new `Router.WalkFrameworkBackends(ctx, fn)` walks the namespace's mounts.
 - **Input hardening at the CLI boundary.** Three validators in `cmd/helpers/path.go` reject malformed inputs before any HTTP call, with errors classified as exit code `3` (`invalid_input`):
   - `ValidatePath` — every path/name positional arg across all read/list/write/delete and typed mutating commands. Rejects traversal (`..`), absolute paths, control bytes, `?`/`#`, and `%` percent-encoding.
   - `ValidateHeaderValue` — `--namespace` and `--role`. Rejects CR/LF (header injection) and control bytes.

--- a/core/router.go
+++ b/core/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/armon/go-radix"
 	"github.com/openbao/openbao/sdk/v2/helper/salt"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -857,6 +858,46 @@ func pathsToRadix(paths []string) *radix.Tree {
 	}
 
 	return tree
+}
+
+// WalkFrameworkBackends invokes fn for every framework-based mount in the
+// caller's namespace (derived from ctx), passing the namespace-relative mount
+// prefix and the *framework.Backend. Backends that don't implement
+// framework.Backend (audit devices, custom implementations) are skipped.
+// Stop walking by returning false.
+//
+// Used by the sys/schema handler to assemble a namespace-scoped OpenAPI doc:
+// a tenant in namespace `team-a/` only sees their own mounts, not other
+// tenants'.
+//
+// The callback runs while the router's read lock is held. Callers must keep
+// the callback fast and non-blocking (no I/O, no router mutations, no
+// acquiring this lock again) or risk stalling all routing on this server.
+func (r *Router) WalkFrameworkBackends(ctx context.Context, fn func(prefix string, b *framework.Backend) bool) error {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	r.root.WalkPrefix(ns.Path, func(fullPrefix string, value any) bool {
+		re, ok := value.(*routeEntry)
+		if !ok || re == nil {
+			return false
+		}
+		fb, ok := re.backend.(*framework.Backend)
+		if !ok {
+			return false
+		}
+		// Strip the namespace path so callers see the mount prefix relative
+		// to the namespace, matching how the API addresses the mount.
+		relPrefix := strings.TrimPrefix(fullPrefix, ns.Path)
+		// Walk callback returns true to STOP; our fn returns true to CONTINUE.
+		return !fn(relPrefix, fb)
+	})
+	return nil
 }
 
 func wildcardError(path, msg string) error {

--- a/core/router_test.go
+++ b/core/router_test.go
@@ -5,12 +5,188 @@ import (
 	"testing"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newFrameworkTestBackend constructs a minimal framework.Backend that satisfies
+// logical.Backend, suitable for mounting in router tests.
+func newFrameworkTestBackend(t *testing.T, name string) *framework.Backend {
+	t.Helper()
+	b := &framework.Backend{
+		Help:         "test backend " + name,
+		BackendType:  name,
+		BackendClass: logical.ClassProvider,
+		Paths: []*framework.Path{
+			{
+				Pattern: "config",
+				Operations: map[logical.Operation]framework.OperationHandler{
+					logical.ReadOperation: &framework.PathOperation{
+						Callback: func(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+							return &logical.Response{}, nil
+						},
+					},
+				},
+			},
+		},
+	}
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	require.NoError(t, b.Setup(context.Background(), &logical.BackendConfig{Logger: log, Config: map[string]any{}}))
+	return b
+}
+
+// TestRouter_WalkFrameworkBackends_FindsMounts asserts the walker yields each
+// framework-based mount in the caller's namespace exactly once and exposes
+// the namespace-relative prefix.
+func TestRouter_WalkFrameworkBackends_FindsMounts(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	router := NewRouter(log)
+
+	awsBackend := newFrameworkTestBackend(t, "aws")
+	azureBackend := newFrameworkTestBackend(t, "azure")
+
+	for _, m := range []struct {
+		prefix  string
+		uuid    string
+		backend logical.Backend
+	}{
+		{"aws/", "aws-uuid", awsBackend},
+		{"azure/", "azure-uuid", azureBackend},
+	} {
+		entry := &MountEntry{
+			Path: m.prefix, Type: "mock", Class: mountClassProvider,
+			UUID: m.uuid, Accessor: "mock_" + m.uuid,
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		}
+		view := &mockBarrierView{prefix: "provider/" + m.uuid + "/"}
+		require.NoError(t, router.Mount(m.prefix, m.backend, entry, view))
+	}
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	seen := map[string]string{}
+	err := router.WalkFrameworkBackends(ctx, func(prefix string, b *framework.Backend) bool {
+		seen[prefix] = b.BackendType
+		return true
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "aws", seen["aws/"], "aws mount should be visible at relative prefix \"aws/\"")
+	assert.Equal(t, "azure", seen["azure/"], "azure mount should be visible at relative prefix \"azure/\"")
+	assert.Len(t, seen, 2, "walker yielded duplicates or missed a mount: %v", seen)
+}
+
+// TestRouter_WalkFrameworkBackends_SkipsNonFramework asserts that mounts
+// implementing logical.Backend but not *framework.Backend are silently
+// skipped (audit devices, custom implementations).
+func TestRouter_WalkFrameworkBackends_SkipsNonFramework(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	router := NewRouter(log)
+
+	mock := newMockProvider()
+	entry := &MountEntry{
+		Path: "mock/", Type: "mock", Class: mountClassProvider,
+		UUID: "mock-uuid", Accessor: "mock_acc",
+		NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+	}
+	view := &mockBarrierView{prefix: "provider/mock-uuid/"}
+	require.NoError(t, router.Mount("mock/", mock, entry, view))
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	count := 0
+	err := router.WalkFrameworkBackends(ctx, func(prefix string, b *framework.Backend) bool {
+		count++
+		return true
+	})
+	require.NoError(t, err)
+	assert.Zero(t, count, "non-framework backend should be skipped")
+}
+
+// TestRouter_WalkFrameworkBackends_StopEarly verifies the walker honors a
+// false return as a stop signal (so callers can short-circuit on first match).
+func TestRouter_WalkFrameworkBackends_StopEarly(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	router := NewRouter(log)
+
+	for _, name := range []string{"aws", "azure", "gcp"} {
+		entry := &MountEntry{
+			Path: name + "/", Type: "mock", Class: mountClassProvider,
+			UUID: name + "-uuid", Accessor: "mock_" + name,
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		}
+		view := &mockBarrierView{prefix: "provider/" + name + "-uuid/"}
+		require.NoError(t, router.Mount(name+"/", newFrameworkTestBackend(t, name), entry, view))
+	}
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	count := 0
+	err := router.WalkFrameworkBackends(ctx, func(prefix string, b *framework.Backend) bool {
+		count++
+		return false // stop after the first
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "walker should stop after callback returns false")
+}
+
+// TestRouter_WalkFrameworkBackends_NamespaceIsolation is the security-critical
+// test: a tenant in namespace A must NOT see backends mounted in namespace B
+// when they walk. Without this guarantee, the sys/schema endpoint would leak
+// every tenant's mount tree to every other tenant.
+func TestRouter_WalkFrameworkBackends_NamespaceIsolation(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	router := NewRouter(log)
+
+	teamA := &namespace.Namespace{ID: "ns-team-a", UUID: "uuid-a", Path: "team-a/"}
+	teamB := &namespace.Namespace{ID: "ns-team-b", UUID: "uuid-b", Path: "team-b/"}
+
+	mount := func(t *testing.T, mp string, ns *namespace.Namespace, name string) {
+		t.Helper()
+		entry := &MountEntry{
+			Path: mp, Type: "mock", Class: mountClassProvider,
+			UUID: ns.ID + "-" + name + "-uuid", Accessor: "mock_" + ns.ID + "_" + name,
+			NamespaceID: ns.ID, namespace: ns,
+		}
+		view := &mockBarrierView{prefix: "provider/" + entry.UUID + "/"}
+		require.NoError(t, router.Mount(mp, newFrameworkTestBackend(t, name), entry, view))
+	}
+
+	mount(t, "aws/", teamA, "aws-a")
+	mount(t, "azure/", teamA, "azure-a")
+	mount(t, "aws/", teamB, "aws-b")
+
+	collect := func(ns *namespace.Namespace) map[string]string {
+		ctx := namespace.ContextWithNamespace(context.Background(), ns)
+		seen := map[string]string{}
+		err := router.WalkFrameworkBackends(ctx, func(prefix string, b *framework.Backend) bool {
+			seen[prefix] = b.BackendType
+			return true
+		})
+		require.NoError(t, err)
+		return seen
+	}
+
+	a := collect(teamA)
+	assert.Equal(t, map[string]string{"aws/": "aws-a", "azure/": "azure-a"}, a, "team-a should see only its own mounts")
+
+	b := collect(teamB)
+	assert.Equal(t, map[string]string{"aws/": "aws-b"}, b, "team-b should see only its own mount, not team-a's")
+}
+
+// TestRouter_WalkFrameworkBackends_RequiresNamespaceContext asserts the
+// walker errors when the caller forgot to set a namespace on the context.
+// Without this guard, a buggy caller could leak cross-tenant data.
+func TestRouter_WalkFrameworkBackends_RequiresNamespaceContext(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	router := NewRouter(log)
+
+	err := router.WalkFrameworkBackends(context.Background(), func(_ string, _ *framework.Backend) bool {
+		t.Fatal("callback should not run when context lacks a namespace")
+		return false
+	})
+	require.Error(t, err)
+}
 
 // TestNewRouter tests creating a new router
 func TestNewRouter(t *testing.T) {

--- a/core/sys_backend.go
+++ b/core/sys_backend.go
@@ -72,6 +72,9 @@ func (b *SystemBackend) paths() []*framework.Path {
 	paths = append(paths, b.pathAudit()...)
 	paths = append(paths, b.pathAuditHash()...)
 
+	// OpenAPI / schema endpoint (agent-facing introspection)
+	paths = append(paths, b.pathOpenAPI()...)
+
 	return paths
 }
 

--- a/core/sys_openapi.go
+++ b/core/sys_openapi.go
@@ -1,0 +1,121 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathOpenAPI registers the OpenAPI document endpoints. The Vault-compatible
+// alias `internal/specs/openapi` is included so existing Vault/OpenBao tooling
+// (codegen, SDK generators) keeps working unchanged. `schema` is the
+// agent-friendly alias documented in the warden CLI.
+//
+// Both endpoints are namespace-scoped: the response only includes mounts
+// reachable in the caller's namespace (X-Warden-Namespace), so a tenant
+// cannot enumerate another tenant's backends through the schema surface.
+func (b *SystemBackend) pathOpenAPI() []*framework.Path {
+	pathField := map[string]*framework.FieldSchema{
+		"path": {
+			Type:        framework.TypeString,
+			Description: "Optional. Restrict the response to a single OpenAPI path (e.g. \"aws/config\").",
+			Query:       true,
+		},
+	}
+
+	return []*framework.Path{
+		{
+			Pattern: "internal/specs/openapi",
+			Fields:  pathField,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleOpenAPI,
+				},
+			},
+			HelpSynopsis:    "Generate the OpenAPI document for the running server (caller's namespace only).",
+			HelpDescription: "Returns an OpenAPI 3.0 document describing every backend mounted in the caller's namespace, plus the system backend. Pass `?path=PATH` to project to a single operation.",
+		},
+		{
+			Pattern: "schema",
+			Fields:  pathField,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleOpenAPI,
+				},
+			},
+			HelpSynopsis:    "Agent-friendly alias for internal/specs/openapi.",
+			HelpDescription: "Same content as `sys/internal/specs/openapi` — exposed as `sys/schema` for ergonomics.",
+		},
+	}
+}
+
+// handleOpenAPI assembles a namespace-scoped OpenAPI document. It documents:
+//  1. The system backend itself (which hosts this handler and is not in the
+//     mount table; without this, sys/* paths would be missing entirely).
+//  2. Every framework-based mount reachable in the caller's namespace.
+//
+// If the caller passes ?path=<path>, the response is projected to just that
+// operation — the agent-friendly path for `warden schema PATH`.
+func (b *SystemBackend) handleOpenAPI(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Info.Version is left empty: warden has no clean dependency from core
+	// onto cmd (where the build version is set), and agents that need version
+	// comparison should look at the server build SHA via /sys/health instead.
+	doc := framework.NewOASDocument("")
+
+	// 1. Document the system backend itself. It hosts this handler and is
+	//    NOT in the router's mount table, so the walker below would miss it.
+	if err := framework.DocumentPathsWithMountPrefix(b.Backend, "sys/", doc); err != nil {
+		b.logger.Warn("openapi: failed to document system backend", logger.Err(err))
+	}
+
+	// 2. Walk every framework-based mount in the caller's namespace.
+	if err := b.core.router.WalkFrameworkBackends(ctx, func(prefix string, backend *framework.Backend) bool {
+		if err := framework.DocumentPathsWithMountPrefix(backend, prefix, doc); err != nil {
+			b.logger.Warn("openapi: failed to document mount", logger.String("mount", prefix), logger.Err(err))
+		}
+		return true
+	}); err != nil {
+		return nil, err
+	}
+
+	// 3. Optional projection to a single path.
+	if pathFilter, _ := d.Get("path").(string); pathFilter != "" {
+		projected := projectOASToPath(doc, pathFilter)
+		if projected == nil {
+			return logical.ErrorResponse(fmt.Errorf("path %q not found in schema", pathFilter)), nil
+		}
+		doc = projected
+	}
+
+	return b.respondSuccess(map[string]any{"openapi": doc}), nil
+}
+
+// projectOASToPath returns a new OASDocument containing only the operation
+// matching `path`. Several common spellings are tried (with/without leading or
+// trailing slash) so callers don't have to reason about path normalization.
+// Returns nil if no spelling matches.
+func projectOASToPath(doc *framework.OASDocument, path string) *framework.OASDocument {
+	if doc == nil {
+		return nil
+	}
+	candidates := []string{
+		path,
+		"/" + strings.TrimPrefix(path, "/"),
+		strings.TrimSuffix(path, "/"),
+		"/" + strings.TrimPrefix(strings.TrimSuffix(path, "/"), "/"),
+	}
+	for _, c := range candidates {
+		if item, ok := doc.Paths[c]; ok {
+			out := framework.NewOASDocument(doc.Info.Version)
+			out.Info = doc.Info
+			out.Paths[c] = item
+			return out
+		}
+	}
+	return nil
+}
+

--- a/core/sys_openapi_test.go
+++ b/core/sys_openapi_test.go
@@ -1,0 +1,127 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+)
+
+// TestOpenAPI_Endpoint_RegisteredPaths confirms the system backend exposes
+// both the canonical Vault-compatible path and the agent-friendly alias.
+func TestOpenAPI_Endpoint_RegisteredPaths(t *testing.T) {
+	backend, _, _ := setupTestSystemBackend(t)
+
+	paths := backend.pathOpenAPI()
+	require.Len(t, paths, 2, "expected canonical + alias paths")
+
+	patterns := map[string]bool{}
+	for _, p := range paths {
+		patterns[p.Pattern] = true
+	}
+	require.True(t, patterns["internal/specs/openapi"], "missing canonical path")
+	require.True(t, patterns["schema"], "missing agent-friendly alias")
+}
+
+// TestOpenAPI_Endpoint_ReturnsDocument confirms the handler returns a non-empty
+// OpenAPI document and includes the system backend's own sys/* paths (which
+// would be missing if the explicit document-system-backend step were omitted).
+func TestOpenAPI_Endpoint_ReturnsDocument(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	schema := backend.pathOpenAPI()[0].Fields
+	fieldData := createFieldData(schema, map[string]any{})
+	req := createTestRequest("read", "internal/specs/openapi", nil)
+
+	resp, err := backend.handleOpenAPI(ctx, req, fieldData)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError(), "unexpected error response: %v", resp.Data)
+
+	doc, ok := resp.Data["openapi"].(*framework.OASDocument)
+	require.True(t, ok, "expected *OASDocument under .openapi, got %T", resp.Data["openapi"])
+	require.NotEmpty(t, doc.Paths, "OpenAPI doc has no paths — system backend was likely not documented")
+
+	hasSys := false
+	for p := range doc.Paths {
+		if strings.HasPrefix(p, "/sys/") || strings.HasPrefix(p, "sys/") {
+			hasSys = true
+			break
+		}
+	}
+	require.True(t, hasSys, "expected sys/* paths in OpenAPI doc; system backend not documented? paths: %v", pathKeys(doc))
+}
+
+// TestOpenAPI_Endpoint_PathProjection confirms that ?path=PATH narrows the
+// document to a single operation when the path exists.
+func TestOpenAPI_Endpoint_PathProjection(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema := backend.pathOpenAPI()[0].Fields
+
+	// First fetch the full doc, pick any path the test core has, then query
+	// it back via projection. This makes the test resilient to the exact set
+	// of paths the system backend exposes.
+	full, err := backend.handleOpenAPI(ctx, createTestRequest("read", "internal/specs/openapi", nil), createFieldData(schema, map[string]any{}))
+	require.NoError(t, err)
+	doc := full.Data["openapi"].(*framework.OASDocument)
+
+	var anyPath string
+	for p := range doc.Paths {
+		anyPath = p
+		break
+	}
+	require.NotEmpty(t, anyPath, "test core has no documented paths")
+
+	fieldData := createFieldData(schema, map[string]any{"path": strings.TrimPrefix(anyPath, "/")})
+	resp, err := backend.handleOpenAPI(ctx, createTestRequest("read", "internal/specs/openapi", nil), fieldData)
+	require.NoError(t, err)
+	require.False(t, resp.IsError(), "projection returned error for known path %q: %v", anyPath, resp.Data)
+
+	projected := resp.Data["openapi"].(*framework.OASDocument)
+	require.Len(t, projected.Paths, 1, "projection should return exactly one path; got %v", pathKeys(projected))
+}
+
+// TestOpenAPI_Endpoint_PathProjection_Unknown confirms that ?path=PATH with a
+// non-existent path returns a structured error (not a 200 with empty paths,
+// which would silently mislead agents).
+func TestOpenAPI_Endpoint_PathProjection_Unknown(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema := backend.pathOpenAPI()[0].Fields
+
+	fieldData := createFieldData(schema, map[string]any{"path": "definitely/not/a/real/path"})
+	resp, err := backend.handleOpenAPI(ctx, createTestRequest("read", "internal/specs/openapi", nil), fieldData)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.IsError(), "expected error response for unknown projection path")
+}
+
+// TestOpenAPI_AliasAndCanonicalAreEquivalent verifies that the agent-friendly
+// alias `sys/schema` produces the same content as the canonical path.
+func TestOpenAPI_AliasAndCanonicalAreEquivalent(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schemaCanonical := backend.pathOpenAPI()[0].Fields
+	schemaAlias := backend.pathOpenAPI()[1].Fields
+
+	canonical, err := backend.handleOpenAPI(ctx, createTestRequest("read", "internal/specs/openapi", nil), createFieldData(schemaCanonical, map[string]any{}))
+	require.NoError(t, err)
+	alias, err := backend.handleOpenAPI(ctx, createTestRequest("read", "schema", nil), createFieldData(schemaAlias, map[string]any{}))
+	require.NoError(t, err)
+
+	cBytes, err := json.Marshal(canonical.Data["openapi"])
+	require.NoError(t, err)
+	aBytes, err := json.Marshal(alias.Data["openapi"])
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(cBytes), string(aBytes), "canonical and alias must return identical content")
+}
+
+func pathKeys(doc *framework.OASDocument) []string {
+	keys := make([]string, 0, len(doc.Paths))
+	for k := range doc.Paths {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/framework/backend.go
+++ b/framework/backend.go
@@ -368,10 +368,23 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 		return nil, err
 	}
 
+	data := map[string]interface{}{
+		"help": help,
+	}
+
+	// Bundle the OpenAPI document for this backend so an agent can fetch the
+	// schema with `?warden-help=1`. Generation failure is logged but does not
+	// fail the request — the partial doc plus the human help text is still
+	// useful on its own. handleRootHelp only runs after Setup, so b.logger is
+	// always initialized here.
+	doc := NewOASDocument("")
+	if err := DocumentPaths(b, "", doc); err != nil {
+		b.logger.Warn("error generating OpenAPI document for help response", logger.Err(err))
+	}
+	data["openapi"] = doc
+
 	return &logical.Response{
-		Data: map[string]interface{}{
-			"help": help,
-		},
+		Data: data,
 	}, nil
 }
 

--- a/framework/openapi.go
+++ b/framework/openapi.go
@@ -1,0 +1,1176 @@
+package framework
+
+// Ported from github.com/openbao/openbao/sdk/v2/framework/openapi.go and
+// adapted for warden's local types (logical.BackendClass, logical.Operation,
+// logical.Response without Secret/WrapInfo, logical.Paths with only Root +
+// Unauthenticated).
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"regexp/syntax"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/stephnangue/warden/logical"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// OpenAPI specification (OAS): https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
+const OASVersion = "3.0.2"
+
+// NewOASDocument returns an empty OpenAPI document.
+func NewOASDocument(version string) *OASDocument {
+	return &OASDocument{
+		Version: OASVersion,
+		Info: OASInfo{
+			Title:       "Warden API",
+			Description: "HTTP API for the Warden identity-aware access fabric. All API routes are prefixed with `/v1/`.",
+			Version:     version,
+			License: OASLicense{
+				Name: "Mozilla Public License 2.0",
+				URL:  "https://www.mozilla.org/en-US/MPL/2.0",
+			},
+		},
+		Paths: make(map[string]*OASPathItem),
+		Components: OASComponents{
+			Schemas: make(map[string]*OASSchema),
+		},
+	}
+}
+
+// NewOASDocumentFromMap builds an OASDocument from an existing map version of
+// a document. After a JSON round-trip the document is a map[string]interface{}
+// and needs special handling beyond the default mapstructure decoding.
+func NewOASDocumentFromMap(input map[string]interface{}) (*OASDocument, error) {
+	// The Responses map uses integer keys (the response code), but once translated into JSON
+	// these become strings. mapstructure will not coerce these back to integers
+	// without a custom decode hook.
+	decodeHook := func(src reflect.Type, tgt reflect.Type, inputRaw interface{}) (interface{}, error) {
+		// Only alter data if:
+		//  1. going from string to int
+		//  2. string represent an int in status code range (100-599)
+		if src.Kind() == reflect.String && tgt.Kind() == reflect.Int {
+			if input, ok := inputRaw.(string); ok {
+				if intval, err := strconv.Atoi(input); err == nil {
+					if intval >= 100 && intval < 600 {
+						return intval, nil
+					}
+				}
+			}
+		}
+		return inputRaw, nil
+	}
+
+	doc := new(OASDocument)
+
+	config := &mapstructure.DecoderConfig{
+		DecodeHook: decodeHook,
+		Result:     doc,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+type OASDocument struct {
+	Version    string                  `json:"openapi" mapstructure:"openapi"`
+	Info       OASInfo                 `json:"info"`
+	Paths      map[string]*OASPathItem `json:"paths"`
+	Components OASComponents           `json:"components"`
+}
+
+type OASComponents struct {
+	Schemas map[string]*OASSchema `json:"schemas"`
+}
+
+type OASInfo struct {
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Version     string     `json:"version"`
+	License     OASLicense `json:"license"`
+}
+
+type OASLicense struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type OASPathItem struct {
+	Description       string             `json:"description,omitempty"`
+	Parameters        []OASParameter     `json:"parameters,omitempty"`
+	Sudo              bool               `json:"x-vault-sudo,omitempty" mapstructure:"x-vault-sudo"`
+	Unauthenticated   bool               `json:"x-vault-unauthenticated,omitempty" mapstructure:"x-vault-unauthenticated"`
+	CreateSupported   bool               `json:"x-vault-createSupported,omitempty" mapstructure:"x-vault-createSupported"`
+	DisplayNavigation bool               `json:"x-vault-displayNavigation,omitempty" mapstructure:"x-vault-displayNavigation"`
+	DisplayAttrs      *DisplayAttributes `json:"x-vault-displayAttrs,omitempty" mapstructure:"x-vault-displayAttrs"`
+
+	Get    *OASOperation `json:"get,omitempty"`
+	Post   *OASOperation `json:"post,omitempty"`
+	Delete *OASOperation `json:"delete,omitempty"`
+}
+
+// NewOASOperation creates an empty OpenAPI Operations object.
+func NewOASOperation() *OASOperation {
+	return &OASOperation{
+		Responses: make(map[int]*OASResponse),
+	}
+}
+
+type OASOperation struct {
+	Summary     string               `json:"summary,omitempty"`
+	Description string               `json:"description,omitempty"`
+	OperationID string               `json:"operationId,omitempty"`
+	Tags        []string             `json:"tags,omitempty"`
+	Parameters  []OASParameter       `json:"parameters,omitempty"`
+	RequestBody *OASRequestBody      `json:"requestBody,omitempty"`
+	Responses   map[int]*OASResponse `json:"responses"`
+	Deprecated  bool                 `json:"deprecated,omitempty"`
+}
+
+type OASParameter struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description,omitempty"`
+	In          string     `json:"in"`
+	Schema      *OASSchema `json:"schema,omitempty"`
+	Required    bool       `json:"required,omitempty"`
+	Deprecated  bool       `json:"deprecated,omitempty"`
+}
+
+type OASRequestBody struct {
+	Description string     `json:"description,omitempty"`
+	Required    bool       `json:"required,omitempty"`
+	Content     OASContent `json:"content,omitempty"`
+}
+
+type OASContent map[string]*OASMediaTypeObject
+
+type OASMediaTypeObject struct {
+	Schema *OASSchema `json:"schema,omitempty"`
+}
+
+type OASSchema struct {
+	Ref         string                `json:"$ref,omitempty"`
+	Type        string                `json:"type,omitempty"`
+	Description string                `json:"description,omitempty"`
+	Properties  map[string]*OASSchema `json:"properties,omitempty"`
+
+	// Required is a list of keys in Properties that are required to be present. This is a different
+	// approach than OASParameter (unfortunately), but is how JSONSchema handles 'required'.
+	Required []string `json:"required,omitempty"`
+
+	Items        *OASSchema    `json:"items,omitempty"`
+	Format       string        `json:"format,omitempty"`
+	Pattern      string        `json:"pattern,omitempty"`
+	Enum         []interface{} `json:"enum,omitempty"`
+	Default      interface{}   `json:"default,omitempty"`
+	Example      interface{}   `json:"example,omitempty"`
+	Deprecated   bool          `json:"deprecated,omitempty"`
+	DisplayValue interface{}   `json:"x-vault-displayValue,omitempty" mapstructure:"x-vault-displayValue,omitempty"`
+	DisplaySensitive bool               `json:"x-vault-displaySensitive,omitempty" mapstructure:"x-vault-displaySensitive,omitempty"`
+	DisplayGroup     string             `json:"x-vault-displayGroup,omitempty" mapstructure:"x-vault-displayGroup,omitempty"`
+	DisplayAttrs     *DisplayAttributes `json:"x-vault-displayAttrs,omitempty" mapstructure:"x-vault-displayAttrs,omitempty"`
+}
+
+type OASResponse struct {
+	Description string     `json:"description"`
+	Content     OASContent `json:"content,omitempty"`
+}
+
+var OASStdRespOK = &OASResponse{
+	Description: "OK",
+}
+
+var OASStdRespNoContent = &OASResponse{
+	Description: "empty body",
+}
+
+// Regex for handling fields in paths, and string cleanup.
+// Predefined here to avoid substantial recompilation.
+
+var (
+	nonWordRe    = regexp.MustCompile(`[^\w]+`)  // Match a sequence of non-word characters
+	pathFieldsRe = regexp.MustCompile(`{(\w+)}`) // Capture OpenAPI-style named parameters, e.g. "lookup/{urltoken}",
+	wsRe         = regexp.MustCompile(`\s+`)     // Match whitespace, to be compressed during cleaning
+)
+
+// DocumentPathsWithMountPrefix is the warden-facing entry point for assembling
+// a server-wide OAS doc. It documents `backend` into `doc`, prepending
+// `mountPrefix` to every path key so multiple mounts don't collide. The
+// upstream `requestResponsePrefix` argument controls operation-ID and
+// component-schema naming and is set to a slug derived from the mount.
+//
+// `mountPrefix` must be non-empty; passing "" returns an error rather than
+// silently producing malformed `//<path>` keys that would conflict across
+// mounts.
+//
+// Use DocumentPaths (no prefix) when you want a single backend's spec
+// without mount-relative path prefixing, e.g. for the per-backend
+// `?warden-help=1` response.
+func DocumentPathsWithMountPrefix(backend *Backend, mountPrefix string, doc *OASDocument) error {
+	mp := strings.Trim(mountPrefix, "/")
+	if mp == "" {
+		return errors.New("DocumentPathsWithMountPrefix: mountPrefix must be non-empty")
+	}
+
+	tmp := NewOASDocument(doc.Info.Version)
+	requestResponsePrefix := strings.ReplaceAll(mp, "/", "-")
+	if err := DocumentPaths(backend, requestResponsePrefix, tmp); err != nil {
+		return err
+	}
+	for path, item := range tmp.Paths {
+		// `path` looks like "/config" or "/role/{name}"; produce
+		// "/aws/config", "/aws/role/{name}".
+		full := "/" + mp + "/" + strings.TrimPrefix(path, "/")
+		doc.Paths[full] = item
+	}
+	for name, schema := range tmp.Components.Schemas {
+		if doc.Components.Schemas == nil {
+			doc.Components.Schemas = map[string]*OASSchema{}
+		}
+		doc.Components.Schemas[name] = schema
+	}
+	return nil
+}
+
+// DocumentPaths parses all paths in a framework.Backend into OpenAPI paths.
+// Path keys in the result are relative to the backend (not mount-prefixed).
+// For a server-wide assembly, prefer DocumentPathsWithMountPrefix.
+func DocumentPaths(backend *Backend, requestResponsePrefix string, doc *OASDocument) error {
+	for _, p := range backend.Paths {
+		if err := documentPath(p, backend.SpecialPaths(), requestResponsePrefix, backend.BackendClass, doc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// documentPath parses a framework.Path into one or more OpenAPI paths.
+func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix string, backendClass logical.BackendClass, doc *OASDocument) error {
+	var sudoPaths []string
+	var unauthPaths []string
+
+	if specialPaths != nil {
+		sudoPaths = specialPaths.Root
+		unauthPaths = specialPaths.Unauthenticated
+	}
+
+	// Convert optional parameters into distinct patterns to be processed independently.
+	forceUnpublished := false
+	paths, err := expandPattern(p.Pattern)
+	if err != nil {
+		if errors.Is(err, errUnsupportableRegexpOperationForOpenAPI) {
+			// Pattern cannot be transformed into sensible OpenAPI paths. In this case, we override the later
+			// processing to use the regexp, as is, as the path, and behave as if Unpublished was set on every
+			// operation (meaning the operations will not be represented in the OpenAPI document).
+			//
+			// This allows a human reading the OpenAPI document to notice that, yes, a path handler does exist,
+			// even though it was not able to contribute actual OpenAPI operations.
+			forceUnpublished = true
+			paths = []string{p.Pattern}
+		} else {
+			return err
+		}
+	}
+
+	for pathIndex, path := range paths {
+		// Construct a top level PathItem which will be populated as the path is processed.
+		pi := OASPathItem{
+			Description: cleanString(p.HelpSynopsis),
+		}
+
+		pi.Sudo = specialPathMatch(path, sudoPaths)
+		pi.Unauthenticated = specialPathMatch(path, unauthPaths)
+		pi.DisplayAttrs = withoutOperationHints(p.DisplayAttrs)
+
+		// If the newer style Operations map isn't defined, create one from the legacy fields.
+		operations := p.Operations
+		if operations == nil {
+			operations = make(map[logical.Operation]OperationHandler)
+
+			for opType, cb := range p.Callbacks {
+				operations[opType] = &PathOperation{
+					Callback: cb,
+					Summary:  p.HelpSynopsis,
+				}
+			}
+		}
+
+		// Process path and header parameters, which are common to all operations.
+		// Body fields will be added to individual operations.
+		pathFields, bodyFields := splitFields(p.Fields, path)
+
+		for name, field := range pathFields {
+			location := "path"
+			required := true
+
+			if field == nil {
+				continue
+			}
+
+			if field.Query {
+				location = "query"
+				required = false
+			}
+
+			t := convertType(field.Type)
+			p := OASParameter{
+				Name:        name,
+				Description: cleanString(field.Description),
+				In:          location,
+				Schema: &OASSchema{
+					Type:         t.baseType,
+					Pattern:      t.pattern,
+					Enum:         field.AllowedValues,
+					Default:      field.Default,
+					DisplayAttrs: withoutOperationHints(field.DisplayAttrs),
+				},
+				Required:   required,
+				Deprecated: field.Deprecated,
+			}
+			pi.Parameters = append(pi.Parameters, p)
+		}
+
+		// Sort parameters for a stable output
+		sort.Slice(pi.Parameters, func(i, j int) bool {
+			return strings.ToLower(pi.Parameters[i].Name) < strings.ToLower(pi.Parameters[j].Name)
+		})
+
+		// Process each supported operation by building up an Operation object
+		// with descriptions, properties and examples from the framework.Path data.
+		for opType, opHandler := range operations {
+			props := opHandler.Properties()
+			if props.Unpublished || forceUnpublished {
+				continue
+			}
+
+			if opType == logical.CreateOperation {
+				pi.CreateSupported = true
+
+				// If both Create and Update are defined, only process Update.
+				if operations[logical.UpdateOperation] != nil {
+					continue
+				}
+			}
+
+			// If both List and Read are defined, only process Read.
+			if opType == logical.ListOperation && operations[logical.ReadOperation] != nil {
+				continue
+			}
+
+			op := NewOASOperation()
+
+			operationID := constructOperationID(
+				path,
+				pathIndex,
+				p.DisplayAttrs,
+				opType,
+				props.DisplayAttrs,
+				requestResponsePrefix,
+			)
+
+			op.Summary = props.Summary
+			op.Description = props.Description
+			op.Deprecated = props.Deprecated
+			op.OperationID = operationID
+
+			// Add any fields not present in the path as body parameters for POST.
+			if opType == logical.CreateOperation || opType == logical.UpdateOperation {
+				s := &OASSchema{
+					Type:       "object",
+					Properties: make(map[string]*OASSchema),
+					Required:   make([]string, 0),
+				}
+
+				for name, field := range bodyFields {
+					openapiField := convertType(field.Type)
+					if field.Required {
+						s.Required = append(s.Required, name)
+					}
+
+					p := OASSchema{
+						Type:         openapiField.baseType,
+						Description:  cleanString(field.Description),
+						Format:       openapiField.format,
+						Pattern:      openapiField.pattern,
+						Enum:         field.AllowedValues,
+						Default:      field.Default,
+						Deprecated:   field.Deprecated,
+						DisplayAttrs: withoutOperationHints(field.DisplayAttrs),
+					}
+					if openapiField.baseType == "array" {
+						p.Items = &OASSchema{
+							Type: openapiField.items,
+						}
+					}
+					s.Properties[name] = &p
+				}
+
+				// Make the ordering deterministic, so that the generated OpenAPI spec document, observed over several
+				// versions, doesn't contain spurious non-semantic changes.
+				sort.Strings(s.Required)
+
+				// If examples were given, use the first one as the sample
+				// of this schema.
+				if len(props.Examples) > 0 {
+					s.Example = props.Examples[0].Data
+				}
+
+				// Set the final request body. Only JSON request data is supported.
+				if len(s.Properties) > 0 || s.Example != nil {
+					requestName := hyphenatedToTitleCase(operationID) + "Request"
+					doc.Components.Schemas[requestName] = s
+					op.RequestBody = &OASRequestBody{
+						Required: true,
+						Content: OASContent{
+							"application/json": &OASMediaTypeObject{
+								Schema: &OASSchema{Ref: fmt.Sprintf("#/components/schemas/%s", requestName)},
+							},
+						},
+					}
+				}
+			}
+
+			// LIST is represented as GET with a `list` query parameter.
+			if opType == logical.ListOperation {
+				// Only accepts List (due to the above skipping of ListOperations that also have ReadOperations)
+				op.Parameters = append(op.Parameters, OASParameter{
+					Name:        "list",
+					Description: "Must be set to `true`",
+					Required:    true,
+					In:          "query",
+					Schema:      &OASSchema{Type: "string", Enum: []interface{}{"true"}},
+				})
+			} else if opType == logical.ScanOperation {
+				// Only accepts List (due to the above skipping of ListOperations that also have ReadOperations)
+				op.Parameters = append(op.Parameters, OASParameter{
+					Name:        "scan",
+					Description: "Must be set to `true`",
+					Required:    true,
+					In:          "query",
+					Schema:      &OASSchema{Type: "string", Enum: []interface{}{"true"}},
+				})
+			} else if opType == logical.ReadOperation && operations[logical.ListOperation] != nil {
+				// Accepts both Read and List
+				op.Parameters = append(op.Parameters, OASParameter{
+					Name:        "list",
+					Description: "Return a list if `true`",
+					In:          "query",
+					Schema:      &OASSchema{Type: "string"},
+				})
+			} else if opType == logical.ReadOperation && operations[logical.ScanOperation] != nil {
+				// Accepts both Read and List
+				op.Parameters = append(op.Parameters, OASParameter{
+					Name:        "scan",
+					Description: "Return a recursive list if `true`",
+					In:          "query",
+					Schema:      &OASSchema{Type: "string"},
+				})
+			}
+
+			// Add tags based on backend class.
+			var tags []string
+			switch backendClass {
+			case logical.ClassProvider:
+				tags = []string{"providers"}
+			case logical.ClassAuth:
+				tags = []string{"auth"}
+			case logical.ClassSystem:
+				tags = []string{"system"}
+			}
+
+			op.Tags = append(op.Tags, tags...)
+
+			// Set default responses.
+			if len(props.Responses) == 0 {
+				if opType == logical.DeleteOperation {
+					op.Responses[204] = OASStdRespNoContent
+				} else {
+					op.Responses[200] = OASStdRespOK
+				}
+			}
+
+			// Add any defined response details.
+			for code, responses := range props.Responses {
+				var description string
+				content := make(OASContent)
+
+				for i, resp := range responses {
+					if i == 0 {
+						description = resp.Description
+					}
+					if resp.Example != nil {
+						mediaType := resp.MediaType
+						if mediaType == "" {
+							mediaType = "application/json"
+						}
+
+						// create a version of the response that will not emit null items
+						cr := cleanResponse(resp.Example)
+
+						// Only one example per media type is allowed, so first one wins
+						if _, ok := content[mediaType]; !ok {
+							content[mediaType] = &OASMediaTypeObject{
+								Schema: &OASSchema{
+									Example: cr,
+								},
+							}
+						}
+					}
+
+					responseSchema := &OASSchema{
+						Type:       "object",
+						Properties: make(map[string]*OASSchema),
+					}
+
+					for name, field := range resp.Fields {
+						openapiField := convertType(field.Type)
+						p := OASSchema{
+							Type:         openapiField.baseType,
+							Description:  cleanString(field.Description),
+							Format:       openapiField.format,
+							Pattern:      openapiField.pattern,
+							Enum:         field.AllowedValues,
+							Default:      field.Default,
+							Deprecated:   field.Deprecated,
+							DisplayAttrs: withoutOperationHints(field.DisplayAttrs),
+						}
+						if openapiField.baseType == "array" {
+							p.Items = &OASSchema{
+								Type: openapiField.items,
+							}
+						}
+						responseSchema.Properties[name] = &p
+					}
+
+					if len(resp.Fields) != 0 {
+						// Use custom schema name if provided, otherwise generate from operationID
+						responseName := resp.SchemaName
+						if responseName == "" {
+							responseName = hyphenatedToTitleCase(operationID) + "Response"
+						}
+
+						// Only add to schemas if not already present (allows schema reuse)
+						if _, exists := doc.Components.Schemas[responseName]; !exists {
+							doc.Components.Schemas[responseName] = responseSchema
+						}
+
+						content = OASContent{
+							"application/json": &OASMediaTypeObject{
+								Schema: &OASSchema{Ref: fmt.Sprintf("#/components/schemas/%s", responseName)},
+							},
+						}
+					}
+				}
+
+				op.Responses[code] = &OASResponse{
+					Description: description,
+					Content:     content,
+				}
+			}
+
+			switch opType {
+			case logical.CreateOperation, logical.UpdateOperation:
+				pi.Post = op
+			case logical.ReadOperation, logical.ListOperation:
+				pi.Get = op
+			case logical.DeleteOperation:
+				pi.Delete = op
+			}
+		}
+
+		doc.Paths["/"+path] = &pi
+	}
+
+	return nil
+}
+
+// specialPathMatch checks whether the given path matches one of the special
+// paths, taking into account * and + wildcards (e.g. foo/+/bar/*)
+func specialPathMatch(path string, specialPaths []string) bool {
+	// pathMatchesByParts determines if the path matches the special path's
+	// pattern, accounting for the '+' and '*' wildcards
+	pathMatchesByParts := func(pathParts []string, specialPathParts []string) bool {
+		if len(pathParts) < len(specialPathParts) {
+			return false
+		}
+		for i := 0; i < len(specialPathParts); i++ {
+			var (
+				part    = pathParts[i]
+				pattern = specialPathParts[i]
+			)
+			if pattern == "+" {
+				continue
+			}
+			if pattern == "*" {
+				return true
+			}
+			if strings.HasSuffix(pattern, "*") && strings.HasPrefix(part, pattern[0:len(pattern)-1]) {
+				return true
+			}
+			if pattern != part {
+				return false
+			}
+		}
+		return len(pathParts) == len(specialPathParts)
+	}
+
+	pathParts := strings.Split(path, "/")
+
+	for _, sp := range specialPaths {
+		// exact match
+		if sp == path {
+			return true
+		}
+
+		// match *
+		if strings.HasSuffix(sp, "*") && strings.HasPrefix(path, sp[0:len(sp)-1]) {
+			return true
+		}
+
+		// match +
+		if strings.Contains(sp, "+") && pathMatchesByParts(pathParts, strings.Split(sp, "/")) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// constructOperationID joins the given inputs into a hyphen-separated
+// lower-case operation id, which is also used as a prefix for request and
+// response names.
+//
+// The OperationPrefix / -Verb / -Suffix found in display attributes will be
+// used, if provided. Otherwise, the function falls back to using the path and
+// the operation.
+//
+// Examples of generated operation identifiers:
+//   - kvv2-write
+//   - kvv2-read
+//   - google-cloud-login
+//   - google-cloud-write-role
+func constructOperationID(
+	path string,
+	pathIndex int,
+	pathAttributes *DisplayAttributes,
+	operation logical.Operation,
+	operationAttributes *DisplayAttributes,
+	defaultPrefix string,
+) string {
+	var (
+		prefix string
+		verb   string
+		suffix string
+	)
+
+	if operationAttributes != nil {
+		prefix = operationAttributes.OperationPrefix
+		verb = operationAttributes.OperationVerb
+		suffix = operationAttributes.OperationSuffix
+	}
+
+	if pathAttributes != nil {
+		if prefix == "" {
+			prefix = pathAttributes.OperationPrefix
+		}
+		if verb == "" {
+			verb = pathAttributes.OperationVerb
+		}
+		if suffix == "" {
+			suffix = pathAttributes.OperationSuffix
+		}
+	}
+
+	// A single suffix string can contain multiple pipe-delimited strings. To
+	// determine the actual suffix, we attempt to match it by the index of the
+	// paths returned from `expandPattern(...)`. For example:
+	//
+	//  pki/
+	//  	Pattern: "keys/generate/(internal|exported|kms)",
+	//      DisplayAttrs: {
+	//          ...
+	//          OperationSuffix: "internal-key|exported-key|kms-key",
+	//      },
+	//
+	//  will expand into three paths and corresponding suffixes:
+	//
+	//      path 0: "keys/generate/internal"  suffix: internal-key
+	//      path 1: "keys/generate/exported"  suffix: exported-key
+	//      path 2: "keys/generate/kms"       suffix: kms-key
+	//
+	pathIndexOutOfRange := false
+
+	if suffixes := strings.Split(suffix, "|"); len(suffixes) > 1 || pathIndex > 0 {
+		// if the index is out of bounds, fall back to the old logic
+		if pathIndex >= len(suffixes) {
+			suffix = ""
+			pathIndexOutOfRange = true
+		} else {
+			suffix = suffixes[pathIndex]
+		}
+	}
+
+	// a helper that hyphenates & lower-cases the slice except the empty elements
+	toLowerHyphenate := func(parts []string) string {
+		filtered := make([]string, 0, len(parts))
+		for _, e := range parts {
+			if e != "" {
+				filtered = append(filtered, e)
+			}
+		}
+		return strings.ToLower(strings.Join(filtered, "-"))
+	}
+
+	// fall back to using the path + operation to construct the operation id
+	var (
+		needPrefix = prefix == "" && verb == ""
+		needVerb   = verb == ""
+		needSuffix = suffix == "" && (verb == "" || pathIndexOutOfRange)
+	)
+
+	if needPrefix {
+		prefix = defaultPrefix
+	}
+
+	if needVerb {
+		if operation == logical.UpdateOperation {
+			verb = "write"
+		} else {
+			verb = string(operation)
+		}
+	}
+
+	if needSuffix {
+		suffix = toLowerHyphenate(nonWordRe.Split(path, -1))
+	}
+
+	return toLowerHyphenate([]string{prefix, verb, suffix})
+}
+
+// expandPattern expands a regex pattern by generating permutations of any optional parameters
+// and changing named parameters into their {openapi} equivalents.
+func expandPattern(pattern string) ([]string, error) {
+	// Happily, the Go regexp library exposes its underlying "parse to AST" functionality, so we can rely on that to do
+	// the hard work of interpreting the regexp syntax.
+	rx, err := syntax.Parse(pattern, syntax.Perl)
+	if err != nil {
+		// This should be impossible to reach, since regexps have previously been compiled with MustCompile in
+		// Backend.init.
+		panic(err)
+	}
+
+	paths, err := collectPathsFromRegexpAST(rx)
+	if err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+type pathCollector struct {
+	strings.Builder
+	conditionalSlashAppendedAtLength int
+}
+
+// collectPathsFromRegexpAST performs a depth-first recursive walk through a regexp AST, collecting an OpenAPI-style
+// path as it goes.
+//
+// Each time it encounters alternation (a|b) or an optional part (a?), it forks its processing to produce additional
+// results, to account for each possibility. A pattern with many such regex features can therefore produce many
+// distinct OpenAPI endpoints — for example a pattern like
+//
+//	"issuer/" + framework.GenericNameRegex("ref") + "/crl(/pem|/der|/delta(/pem|/der)?)?"
+//
+// expands to six separate paths.
+//
+// Each named capture group - i.e. (?P<name>something here) - is replaced with an OpenAPI parameter - i.e. {name} - and
+// the subtree of regexp AST inside the parameter is completely skipped.
+func collectPathsFromRegexpAST(rx *syntax.Regexp) ([]string, error) {
+	pathCollectors, err := collectPathsFromRegexpASTInternal(rx, []*pathCollector{{}})
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(pathCollectors))
+	for _, collector := range pathCollectors {
+		if collector.conditionalSlashAppendedAtLength != collector.Len() {
+			paths = append(paths, collector.String())
+		}
+	}
+	return paths, nil
+}
+
+var errUnsupportableRegexpOperationForOpenAPI = errors.New("path regexp uses an operation that cannot be translated to an OpenAPI pattern")
+
+func collectPathsFromRegexpASTInternal(rx *syntax.Regexp, appendingTo []*pathCollector) ([]*pathCollector, error) {
+	var err error
+
+	// Depending on the type of this regexp AST node (its Op, i.e. operation), figure out whether it contributes any
+	// characters to the URL path, and whether we need to recurse through child AST nodes.
+	//
+	// Each element of the appendingTo slice tracks a separate path, defined by the alternatives chosen when traversing
+	// the | and ? conditional regexp features, and new elements are added as each of these features are traversed.
+	//
+	// To share this slice across multiple recursive calls of this function, it is passed down as a parameter to each
+	// recursive call, potentially modified throughout this switch block, and passed back up as a return value at the
+	// end of this function - the parent call uses the return value to update its own local variable.
+	switch rx.Op {
+
+	// These AST operations are leaf nodes (no children), that match zero characters, so require no processing at all
+	case syntax.OpEmptyMatch: // e.g. (?:)
+	case syntax.OpBeginLine: // i.e. ^ when (?m)
+	case syntax.OpEndLine: // i.e. $ when (?m)
+	case syntax.OpBeginText: // i.e. \A, or ^ when (?-m)
+	case syntax.OpEndText: // i.e. \z, or $ when (?-m)
+	case syntax.OpWordBoundary: // i.e. \b
+	case syntax.OpNoWordBoundary: // i.e. \B
+
+	// OpConcat simply represents multiple parts of the pattern appearing one after the other, so just recurse through
+	// those pieces.
+	case syntax.OpConcat:
+		for _, child := range rx.Sub {
+			appendingTo, err = collectPathsFromRegexpASTInternal(child, appendingTo)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+	// OpLiteral is a literal string in the pattern - append it to the paths we are building.
+	case syntax.OpLiteral:
+		for _, collector := range appendingTo {
+			collector.WriteString(string(rx.Rune))
+		}
+
+	// OpAlternate, i.e. a|b, means we clone all of the pathCollector instances we are currently accumulating paths
+	// into, and independently recurse through each alternate option.
+	case syntax.OpAlternate: // i.e |
+		var totalAppendingTo []*pathCollector
+		lastIndex := len(rx.Sub) - 1
+		for index, child := range rx.Sub {
+			var childAppendingTo []*pathCollector
+			if index == lastIndex {
+				// Optimization: last time through this loop, we can simply re-use the existing set of pathCollector
+				// instances, as we no longer need to preserve them unmodified to make further copies of.
+				childAppendingTo = appendingTo
+			} else {
+				for _, collector := range appendingTo {
+					newCollector := new(pathCollector)
+					newCollector.WriteString(collector.String())
+					newCollector.conditionalSlashAppendedAtLength = collector.conditionalSlashAppendedAtLength
+					childAppendingTo = append(childAppendingTo, newCollector)
+				}
+			}
+			childAppendingTo, err = collectPathsFromRegexpASTInternal(child, childAppendingTo)
+			if err != nil {
+				return nil, err
+			}
+			totalAppendingTo = append(totalAppendingTo, childAppendingTo...)
+		}
+		appendingTo = totalAppendingTo
+
+	// OpQuest, i.e. a?, is much like an alternation between exactly two options, one of which is the empty string.
+	case syntax.OpQuest:
+		child := rx.Sub[0]
+		var childAppendingTo []*pathCollector
+		for _, collector := range appendingTo {
+			newCollector := new(pathCollector)
+			newCollector.WriteString(collector.String())
+			newCollector.conditionalSlashAppendedAtLength = collector.conditionalSlashAppendedAtLength
+			childAppendingTo = append(childAppendingTo, newCollector)
+		}
+		childAppendingTo, err = collectPathsFromRegexpASTInternal(child, childAppendingTo)
+		if err != nil {
+			return nil, err
+		}
+		appendingTo = append(appendingTo, childAppendingTo...)
+
+		// Many path patterns end with `/?` to accept paths that end with or without a slash. Our current
+		// convention for generating the OpenAPI is to strip away these slashes. To do that, this very special case
+		// detects when we just appended a single conditional slash, and records the length of the path at this point,
+		// so we can later discard this path variant, if nothing else is appended to it later.
+		if child.Op == syntax.OpLiteral && string(child.Rune) == "/" {
+			for _, collector := range childAppendingTo {
+				collector.conditionalSlashAppendedAtLength = collector.Len()
+			}
+		}
+
+	// OpCapture, i.e. ( ) or (?P<name> ), a capturing group
+	case syntax.OpCapture:
+		if rx.Name == "" {
+			// An unnamed capturing group is not actually used for capturing.
+			// Treat it exactly the same as OpConcat.
+			for _, child := range rx.Sub {
+				appendingTo, err = collectPathsFromRegexpASTInternal(child, appendingTo)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			// A named capturing group is replaced with the OpenAPI parameter syntax, and the regexp inside the group
+			// is NOT added to the OpenAPI path.
+			for _, builder := range appendingTo {
+				builder.WriteRune('{')
+				builder.WriteString(rx.Name)
+				builder.WriteRune('}')
+			}
+		}
+
+	// Any other kind of operation is a problem, and will trigger an error, resulting in the pattern being left out of
+	// the OpenAPI entirely - that's better than generating a path which is incorrect.
+	//
+	// The Op types we expect to hit the default condition are:
+	//
+	//     OpCharClass    - i.e. [something]
+	//     OpAnyCharNotNL - i.e. .
+	//     OpAnyChar      - i.e. (?s:.)
+	//     OpStar         - i.e. *
+	//     OpPlus         - i.e. +
+	//     OpRepeat       - i.e. {N}, {N,M}, etc.
+	//
+	// In any of these conditions, there is no sensible translation of the path to OpenAPI syntax. (Note, this only
+	// applies to these appearing outside of a named capture group, otherwise they are handled in the previous case.)
+	//
+	// Such patterns are typically catch-alls used for custom error handling and are normally marked Unpublished,
+	// so they are withheld from the OpenAPI doc anyway.
+	//
+	// For completeness, one other Op type exists, OpNoMatch, which is never generated by syntax.Parse - only by
+	// subsequent Simplify in preparation to Compile, which is not used here.
+	default:
+		return nil, errUnsupportableRegexpOperationForOpenAPI
+	}
+
+	return appendingTo, nil
+}
+
+// schemaType is a subset of the JSON Schema elements used as a target
+// for conversions from the framework's standard FieldTypes.
+type schemaType struct {
+	baseType string
+	items    string
+	format   string
+	pattern  string
+}
+
+// convertType translates a FieldType into an OpenAPI type.
+// In the case of arrays, a subtype is returned as well.
+func convertType(t FieldType) schemaType {
+	ret := schemaType{}
+
+	switch t {
+	case TypeString, TypeHeader:
+		ret.baseType = "string"
+	case TypeNameString:
+		ret.baseType = "string"
+		ret.pattern = `\w([\w-.]*\w)?`
+	case TypeLowerCaseString:
+		ret.baseType = "string"
+		ret.format = "lowercase"
+	case TypeInt:
+		ret.baseType = "integer"
+	case TypeInt64:
+		ret.baseType = "integer"
+		ret.format = "int64"
+	case TypeDurationSecond, TypeSignedDurationSecond:
+		ret.baseType = "integer"
+		ret.format = "seconds"
+	case TypeBool:
+		ret.baseType = "boolean"
+	case TypeMap:
+		ret.baseType = "object"
+		ret.format = "map"
+	case TypeKVPairs:
+		ret.baseType = "object"
+		ret.format = "kvpairs"
+	case TypeSlice:
+		ret.baseType = "array"
+		ret.items = "object"
+	case TypeStringSlice, TypeCommaStringSlice:
+		ret.baseType = "array"
+		ret.items = "string"
+	case TypeCommaIntSlice:
+		ret.baseType = "array"
+		ret.items = "integer"
+	case TypeTime:
+		ret.baseType = "string"
+		ret.format = "date-time"
+	case TypeFloat:
+		ret.baseType = "number"
+		ret.format = "float"
+	default:
+		log.L().Warn("error parsing field type", "type", t)
+		ret.format = "unknown"
+	}
+
+	return ret
+}
+
+// cleanString prepares s for inclusion in the output
+func cleanString(s string) string {
+	// clean leading/trailing whitespace, and replace whitespace runs into a single space
+	s = strings.TrimSpace(s)
+	s = wsRe.ReplaceAllString(s, " ")
+	return s
+}
+
+// splitFields partitions fields into path and body groups
+// The input pattern is expected to have been run through expandPattern,
+// with paths parameters denotes in {braces}.
+func splitFields(allFields map[string]*FieldSchema, pattern string) (pathFields, bodyFields map[string]*FieldSchema) {
+	pathFields = make(map[string]*FieldSchema)
+	bodyFields = make(map[string]*FieldSchema)
+
+	for _, match := range pathFieldsRe.FindAllStringSubmatch(pattern, -1) {
+		name := match[1]
+		pathFields[name] = allFields[name]
+	}
+
+	for name, field := range allFields {
+		if _, ok := pathFields[name]; !ok {
+			if field.Query {
+				pathFields[name] = field
+			} else {
+				bodyFields[name] = field
+			}
+		}
+	}
+
+	return pathFields, bodyFields
+}
+
+// withoutOperationHints returns a copy of the given DisplayAttributes without
+// OperationPrefix / OperationVerb / OperationSuffix since we don't need these
+// fields in the final output.
+func withoutOperationHints(in *DisplayAttributes) *DisplayAttributes {
+	if in == nil {
+		return nil
+	}
+
+	copy := *in
+
+	copy.OperationPrefix = ""
+	copy.OperationVerb = ""
+	copy.OperationSuffix = ""
+
+	// return nil if all fields are empty to avoid empty JSON objects
+	if copy == (DisplayAttributes{}) {
+		return nil
+	}
+
+	return &copy
+}
+
+func hyphenatedToTitleCase(in string) string {
+	var b strings.Builder
+
+	title := cases.Title(language.English, cases.NoLower)
+
+	for _, word := range strings.Split(in, "-") {
+		b.WriteString(title.String(word))
+	}
+
+	return b.String()
+}
+
+// cleanedResponse mirrors warden's logical.Response with nulls omitted from
+// JSON encoding. Warden's Response has no Secret, Redirect, or WrapInfo
+// fields (those upstream concepts don't apply here), so they're not included.
+type cleanedResponse struct {
+	Auth     *logical.Auth          `json:"auth,omitempty"`
+	Data     map[string]interface{} `json:"data,omitempty"`
+	Warnings []string               `json:"warnings,omitempty"`
+	Headers  map[string][]string    `json:"headers,omitempty"`
+}
+
+func cleanResponse(resp *logical.Response) *cleanedResponse {
+	return &cleanedResponse{
+		Auth:     resp.Auth,
+		Data:     resp.Data,
+		Warnings: resp.Warnings,
+		Headers:  resp.Headers,
+	}
+}
+
+// CreateOperationIDs generates unique operationIds for all paths/methods.
+// The transform will convert path/method into camelcase. e.g.:
+//
+// /sys/tools/random/{urlbytes} -> postSysToolsRandomUrlbytes
+//
+// In the unlikely case of a duplicate ids, a numeric suffix is added:
+//
+//	postSysToolsRandomUrlbytes_2
+//
+// An optional user-provided suffix ("context") may also be appended.
+//
+// Deprecated: operationID's are now populated using `constructOperationID`.
+// This function is here for backwards compatibility with older OpenAPI consumers.
+func (d *OASDocument) CreateOperationIDs(context string) {
+	opIDCount := make(map[string]int)
+	var paths []string
+
+	// traverse paths in a stable order to ensure stable output
+	for path := range d.Paths {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	titleCaser := cases.Title(language.English, cases.NoLower)
+
+	for _, path := range paths {
+		pi := d.Paths[path]
+		for _, method := range []string{"get", "post", "delete"} {
+			var oasOperation *OASOperation
+			switch method {
+			case "get":
+				oasOperation = pi.Get
+			case "post":
+				oasOperation = pi.Post
+			case "delete":
+				oasOperation = pi.Delete
+			}
+
+			if oasOperation == nil {
+				continue
+			}
+
+			if oasOperation.OperationID != "" {
+				continue
+			}
+
+			// Discard "_mount_path" from any {thing_mount_path} parameters
+			path = strings.Replace(path, "_mount_path", "", 1)
+
+			// Space-split on non-words, title case everything, recombine
+			opID := nonWordRe.ReplaceAllString(strings.ToLower(path), " ")
+			opID = titleCaser.String(opID)
+			opID = method + strings.ReplaceAll(opID, " ", "")
+
+			// deduplicate operationIds. This is a safeguard, since generated IDs should
+			// already be unique given our current path naming conventions.
+			opIDCount[opID]++
+			if opIDCount[opID] > 1 {
+				opID = fmt.Sprintf("%s_%d", opID, opIDCount[opID])
+			}
+
+			if context != "" {
+				opID += "_" + context
+			}
+
+			oasOperation.OperationID = opID
+		}
+	}
+}

--- a/framework/openapi_test.go
+++ b/framework/openapi_test.go
@@ -1,0 +1,386 @@
+// Ported from github.com/openbao/openbao/sdk/v2/framework/openapi_test.go.
+// Tests that depended on upstream-only types (logical.Secret, wrapping types,
+// logical.Paths fields warden doesn't have) and on golden-file fixtures are
+// omitted; warden covers equivalent behavior with endpoint-level tests against
+// the running server.
+
+package framework
+
+import (
+	"reflect"
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+func TestOpenAPI_Regex(t *testing.T) {
+	t.Run("Path fields", func(t *testing.T) {
+		input := `/foo/bar/{inner}/baz/{outer}`
+
+		matches := pathFieldsRe.FindAllStringSubmatch(input, -1)
+
+		exp1 := "inner"
+		exp2 := "outer"
+		if matches[0][1] != exp1 || matches[1][1] != exp2 {
+			t.Fatalf("Capture error. Expected %s and %s, got %v", exp1, exp2, matches)
+		}
+
+		input = `/foo/bar/inner/baz/outer`
+		matches = pathFieldsRe.FindAllStringSubmatch(input, -1)
+
+		if matches != nil {
+			t.Fatalf("Expected nil match (%s), got %+v", input, matches)
+		}
+	})
+	t.Run("Filtering", func(t *testing.T) {
+		tests := []struct {
+			input  string
+			regex  *regexp.Regexp
+			output string
+		}{
+			{
+				input:  `abcde`,
+				regex:  wsRe,
+				output: "abcde",
+			},
+			{
+				input:  `  a         b    cd   e   `,
+				regex:  wsRe,
+				output: "abcde",
+			},
+		}
+
+		for _, test := range tests {
+			result := test.regex.ReplaceAllString(test.input, "")
+			if result != test.output {
+				t.Fatalf("Clean Regex error (%s). Expected %s, got %s", test.input, test.output, result)
+			}
+		}
+	})
+}
+
+func TestOpenAPI_ExpandPattern(t *testing.T) {
+	tests := []struct {
+		inPattern   string
+		outPathlets []string
+	}{
+		// A simple string without regexp metacharacters passes through as is
+		{"rotate/root/backup", []string{"rotate/root/backup"}},
+		// A trailing regexp anchor metacharacter is removed
+		{"rotate/root/backup$", []string{"rotate/root/backup"}},
+		// As is a leading one
+		{"^rotate/root/backup", []string{"rotate/root/backup"}},
+		// Named capture groups become OpenAPI parameters
+		{"auth/(?P<path>.+?)/tune$", []string{"auth/{path}/tune"}},
+		{"auth/(?P<path>.+?)/tune/(?P<more>.*?)$", []string{"auth/{path}/tune/{more}"}},
+		// Even if the capture group contains very complex regexp structure inside it
+		{"something/(?P<something>(a|b(c|d))|e+|f{1,3}[ghi-k]?.*)", []string{"something/{something}"}},
+		// A question-mark results in a result without and with the optional path part
+		{"tools/hash(/(?P<urlalgorithm>.+))?", []string{
+			"tools/hash",
+			"tools/hash/{urlalgorithm}",
+		}},
+		// Multiple question-marks evaluate each possible combination
+		{"(leases/)?renew(/(?P<url_lease_id>.+))?", []string{
+			"leases/renew",
+			"leases/renew/{url_lease_id}",
+			"renew",
+			"renew/{url_lease_id}",
+		}},
+		// GenericNameRegex is one particular way of writing a named capture group, so behaves the same
+		{`config/ui/headers/` + GenericNameRegex("header"), []string{"config/ui/headers/{header}"}},
+		// The question-mark behaviour is still works when the question-mark is directly applied to a named capture group
+		{`leases/lookup/(?P<prefix>.+?)?`, []string{
+			"leases/lookup/",
+			"leases/lookup/{prefix}",
+		}},
+		// Optional trailing slashes at the end of the path get stripped - even if appearing deep inside an alternation
+		{`(raw/?$|raw/(?P<path>.+))`, []string{
+			"raw",
+			"raw/{path}",
+		}},
+		// OptionalParamRegex is also another way of writing a named capture group, that is optional
+		{"lookup" + OptionalParamRegex("urltoken"), []string{
+			"lookup",
+			"lookup/{urltoken}",
+		}},
+		// Optional trailing slashes at the end of the path get stripped in simpler cases too
+		{"roles/?$", []string{
+			"roles",
+		}},
+		{"roles/?", []string{
+			"roles",
+		}},
+		// Non-optional trailing slashes remain... although don't do this, it breaks HelpOperation.
+		{"accessors/$", []string{
+			"accessors/",
+		}},
+		// GenericNameRegex and OptionalParamRegex still work when concatenated
+		{"verify/" + GenericNameRegex("name") + OptionalParamRegex("urlalgorithm"), []string{
+			"verify/{name}",
+			"verify/{name}/{urlalgorithm}",
+		}},
+		// Named capture groups that specify enum-like parameters work as expected
+		{"^plugins/catalog/(?P<type>auth|database|secret)/(?P<name>.+)$", []string{
+			"plugins/catalog/{type}/{name}",
+		}},
+		{"^plugins/catalog/(?P<type>auth|database|secret)/?$", []string{
+			"plugins/catalog/{type}",
+		}},
+		// Alternations between various literal path segments work
+		{"(pathOne|pathTwo)/", []string{"pathOne/", "pathTwo/"}},
+		{"(pathOne|pathTwo)/" + GenericNameRegex("name"), []string{"pathOne/{name}", "pathTwo/{name}"}},
+		{
+			"(pathOne|path-2|Path_3)/" + GenericNameRegex("name"),
+			[]string{"Path_3/{name}", "path-2/{name}", "pathOne/{name}"},
+		},
+		// They still work when combined with GenericNameWithAtRegex
+		{"(creds|sts)/" + GenericNameWithAtRegex("name"), []string{
+			"creds/{name}",
+			"sts/{name}",
+		}},
+		// And when they're somewhere other than the start of the pattern
+		{"keys/generate/(internal|exported|kms)", []string{
+			"keys/generate/exported",
+			"keys/generate/internal",
+			"keys/generate/kms",
+		}},
+		// Singular and plural list-operation patterns expand to two paths
+		{"rolesets?/?", []string{"roleset", "rolesets"}},
+		// Complex nested alternation and question-marks are correctly interpreted
+		{"crl(/pem|/delta(/pem)?)?", []string{"crl", "crl/delta", "crl/delta/pem", "crl/pem"}},
+	}
+
+	for i, test := range tests {
+		out, err := expandPattern(test.inPattern)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(out)
+		if !reflect.DeepEqual(out, test.outPathlets) {
+			t.Fatalf("Test %d: Expected %v got %v", i, test.outPathlets, out)
+		}
+	}
+}
+
+func TestOpenAPI_ExpandPattern_ReturnsError(t *testing.T) {
+	tests := []struct {
+		inPattern string
+		outError  error
+	}{
+		// None of these regexp constructs are allowed outside of named capture groups.
+		{"[a-z]", errUnsupportableRegexpOperationForOpenAPI},
+		{".", errUnsupportableRegexpOperationForOpenAPI},
+		{"a+", errUnsupportableRegexpOperationForOpenAPI},
+		{"a*", errUnsupportableRegexpOperationForOpenAPI},
+		// Combinations of the above are also rejected.
+		{".*", errUnsupportableRegexpOperationForOpenAPI},
+	}
+
+	for i, test := range tests {
+		_, err := expandPattern(test.inPattern)
+		if err != test.outError {
+			t.Fatalf("Test %d: Expected %q got %q", i, test.outError, err)
+		}
+	}
+}
+
+func TestOpenAPI_SplitFields(t *testing.T) {
+	fields := map[string]*FieldSchema{
+		"a": {Description: "path"},
+		"b": {Description: "body"},
+		"c": {Description: "body"},
+		"d": {Description: "body"},
+		"e": {Description: "path"},
+	}
+
+	pathFields, bodyFields := splitFields(fields, "some/{a}/path/{e}")
+
+	lp := len(pathFields)
+	lb := len(bodyFields)
+	l := len(fields)
+	if lp+lb != l {
+		t.Fatalf("split length error: %d + %d != %d", lp, lb, l)
+	}
+
+	for name, field := range pathFields {
+		if field.Description != "path" {
+			t.Fatalf("expected field %s to be in 'path', found in %s", name, field.Description)
+		}
+	}
+	for name, field := range bodyFields {
+		if field.Description != "body" {
+			t.Fatalf("expected field %s to be in 'body', found in %s", name, field.Description)
+		}
+	}
+}
+
+func TestOpenAPI_hyphenatedToTitleCase(t *testing.T) {
+	tests := map[string]struct {
+		in       string
+		expected string
+	}{
+		"simple": {
+			in:       "test",
+			expected: "Test",
+		},
+		"two-words": {
+			in:       "two-words",
+			expected: "TwoWords",
+		},
+		"three-words": {
+			in:       "one-two-three",
+			expected: "OneTwoThree",
+		},
+		"not-hyphenated": {
+			in:       "something_like_this",
+			expected: "Something_like_this",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actual := hyphenatedToTitleCase(test.in)
+			if actual != test.expected {
+				t.Fatalf("expected: %s; got: %s", test.expected, actual)
+			}
+		})
+	}
+}
+
+// TestDocumentPathsWithMountPrefix_PrependsMount confirms that the mount
+// prefix is prepended to every path key in the resulting OAS doc, so multiple
+// mounts with overlapping Pattern values produce distinct keys.
+func TestDocumentPathsWithMountPrefix_PrependsMount(t *testing.T) {
+	b := &Backend{
+		BackendType:  "aws",
+		BackendClass: logical.ClassProvider,
+		Paths: []*Path{
+			{
+				Pattern: "config",
+				Operations: map[logical.Operation]OperationHandler{
+					logical.ReadOperation: &PathOperation{},
+				},
+				HelpSynopsis: "AWS config",
+			},
+			{
+				Pattern: "role/" + GenericNameRegex("name"),
+				Operations: map[logical.Operation]OperationHandler{
+					logical.ReadOperation:   &PathOperation{},
+					logical.UpdateOperation: &PathOperation{},
+				},
+				HelpSynopsis: "AWS role",
+			},
+		},
+	}
+
+	doc := NewOASDocument("test")
+	if err := DocumentPathsWithMountPrefix(b, "aws/", doc); err != nil {
+		t.Fatalf("DocumentPathsWithMountPrefix: %v", err)
+	}
+
+	want := []string{"/aws/config", "/aws/role/{name}"}
+	got := pathKeysAny(doc)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %v; want %v", got, want)
+	}
+}
+
+// TestDocumentPathsWithMountPrefix_DoesNotCollideAcrossMounts confirms that
+// two backends with the same internal Pattern produce distinct keys after
+// prefixing — the whole reason this wrapper exists.
+func TestDocumentPathsWithMountPrefix_DoesNotCollideAcrossMounts(t *testing.T) {
+	mk := func(name string) *Backend {
+		return &Backend{
+			BackendType:  name,
+			BackendClass: logical.ClassProvider,
+			Paths: []*Path{{
+				Pattern: "config",
+				Operations: map[logical.Operation]OperationHandler{
+					logical.ReadOperation: &PathOperation{},
+				},
+				HelpSynopsis: name + " config",
+			}},
+		}
+	}
+
+	doc := NewOASDocument("test")
+	if err := DocumentPathsWithMountPrefix(mk("aws"), "aws/", doc); err != nil {
+		t.Fatalf("aws: %v", err)
+	}
+	if err := DocumentPathsWithMountPrefix(mk("azure"), "azure/", doc); err != nil {
+		t.Fatalf("azure: %v", err)
+	}
+
+	if _, ok := doc.Paths["/aws/config"]; !ok {
+		t.Errorf("missing /aws/config; have: %v", pathKeysAny(doc))
+	}
+	if _, ok := doc.Paths["/azure/config"]; !ok {
+		t.Errorf("missing /azure/config; have: %v", pathKeysAny(doc))
+	}
+	if len(doc.Paths) != 2 {
+		t.Errorf("paths = %d; want 2 — collision between mounts: %v", len(doc.Paths), pathKeysAny(doc))
+	}
+}
+
+// TestDocumentPathsWithMountPrefix_NormalizesSlashes ensures both "x/" and "x"
+// produce the same key form (no double slashes, no missing slash).
+func TestDocumentPathsWithMountPrefix_NormalizesSlashes(t *testing.T) {
+	b := &Backend{
+		BackendType:  "x",
+		BackendClass: logical.ClassProvider,
+		Paths: []*Path{{
+			Pattern: "config",
+			Operations: map[logical.Operation]OperationHandler{
+				logical.ReadOperation: &PathOperation{},
+			},
+			HelpSynopsis: "x",
+		}},
+	}
+
+	for _, prefix := range []string{"x/", "x"} {
+		doc := NewOASDocument("test")
+		if err := DocumentPathsWithMountPrefix(b, prefix, doc); err != nil {
+			t.Fatalf("prefix %q: %v", prefix, err)
+		}
+		if _, ok := doc.Paths["/x/config"]; !ok {
+			t.Errorf("prefix %q produced unexpected paths: %v", prefix, pathKeysAny(doc))
+		}
+	}
+}
+
+// TestDocumentPathsWithMountPrefix_RejectsEmptyPrefix guards against silent
+// malformed keys. Passing an empty mount prefix would produce paths like
+// "//config" that conflict across mounts.
+func TestDocumentPathsWithMountPrefix_RejectsEmptyPrefix(t *testing.T) {
+	b := &Backend{
+		BackendType:  "x",
+		BackendClass: logical.ClassProvider,
+		Paths: []*Path{{
+			Pattern: "config",
+			Operations: map[logical.Operation]OperationHandler{
+				logical.ReadOperation: &PathOperation{},
+			},
+			HelpSynopsis: "x",
+		}},
+	}
+
+	for _, prefix := range []string{"", "/", "//"} {
+		doc := NewOASDocument("test")
+		if err := DocumentPathsWithMountPrefix(b, prefix, doc); err == nil {
+			t.Errorf("prefix %q: expected error, got nil; doc paths: %v", prefix, pathKeysAny(doc))
+		}
+	}
+}
+
+func pathKeysAny(doc *OASDocument) []string {
+	ks := make([]string, 0, len(doc.Paths))
+	for k := range doc.Paths {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
 	github.com/cenkalti/backoff/v5 v5.0.3
+	github.com/go-test/deep v1.1.1
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-uuid v1.0.3


### PR DESCRIPTION
Expose every framework-based mount's OpenAPI document at GET /v1/sys/schema (and the Vault-compatible alias GET /v1/sys/internal/specs/openapi). The endpoint is namespace-scoped: a tenant cannot enumerate other tenants' backends through the schema surface.

Implementation has three parts:

1. Port OpenBao's SDK OpenAPI generator into warden/framework/openapi.go, adapted to warden's local types:
   - logical.BackendType → logical.BackendClass (Provider/Auth/System)
   - logical.Operation, Response from warden's local logical (no Secret, no WrapInfo, no Redirect — none of those concepts apply here)
   - logical.Paths with only Root + Unauthenticated (warden has no LocalStorage, SealWrapStorage, etc.)
   - documentPaths exported as DocumentPaths
   - Stale upstream references cleaned (OpenBao API title, KVv2/PKI examples, plugin transport comments)

2. New framework.DocumentPathsWithMountPrefix that wraps DocumentPaths and prepends a mount prefix to every path key, so a server-wide doc with multiple mounts can't collide on overlapping internal Patterns. Rejects empty mount prefixes explicitly so callers can't silently produce malformed `//config` keys.

3. Restore OAS-doc bundling in framework/backend.go:handleRootHelp, so per-mount `?warden-help=1` returns the document directly. Generation failure is logged and a partial doc is returned — the human help text is unaffected.

4. New core/sys_openapi.go registers the /sys/schema and /sys/internal/specs/openapi paths and the handleOpenAPI handler. The handler: a. Documents the system backend itself (which hosts this handler and is NOT in the router's mount table — without this step, sys/* paths would be missing entirely). b. Walks every framework-based mount in the caller's namespace via Router.WalkFrameworkBackends. c. Optionally projects to a single path via ?path=<path>. Multiple slash variants are tried so callers don't have to normalize.

5. New Router.WalkFrameworkBackends(ctx, fn) walks every framework-based mount in the namespace derived from ctx, yielding the namespace-relative prefix and *framework.Backend. Errors when the context lacks a namespace, so a buggy caller can't accidentally walk global state. The lock contract (callback runs under RLock) is documented.

Tests:
- framework/openapi_test.go — ported pure-logic tests (regex, expand pattern, expand-error, split fields, hyphenated-to-title-case) plus 4 new tests for DocumentPathsWithMountPrefix (prepends mount, no collision across mounts, normalizes leading/trailing slashes, rejects empty prefix).
- core/router_test.go — 5 new tests for WalkFrameworkBackends (finds mounts, skips non-framework, stops early on false return, namespace isolation, requires namespace context).
- core/sys_openapi_test.go — 5 endpoint integration tests via the test-system-backend helper (registered paths, returns document with sys/* paths, path projection, projection unknown returns error, alias matches canonical).

Smoke test against `warden server --dev` confirms 18 paths documented with correct /sys/* prefixing, title "Warden API", correct tags (system/secrets/auth from BackendClass), and that
`?path=/sys/auth` projection returns a single operation slice.

Foundation PR for making warden agent-native (PR 4 of 9; companion CLI piece is PR 5 — `warden schema` command).