### PR TITLE
docs: align skill name field with folder name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ ones:
 
 ```yaml
 ---
-name: provider-<name>
+name: <name>
 description: "<one line: what does this provider expose>"
 category: provider-guide
 upstream: "<service name>"

--- a/skills/providers/openai/SKILL.md
+++ b/skills/providers/openai/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: provider-openai
+name: openai
 description: "Call the OpenAI API through Warden — chat, embeddings, moderation — without holding an OpenAI API key."
 category: provider-guide
 upstream: OpenAI REST API (api.openai.com)


### PR DESCRIPTION
The skill loader expects name: to match the containing folder. Five provider skills already followed this; openai used provider-openai and the AGENTS.md template prescribed the wrong shape. Drop the prefix so name == folder for every provider skill.