### PR TITLE
feat: SkillStore data layer for global skill registry

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -198,6 +198,10 @@ type Core struct {
 	// credConfigStore manages credential specs and sources with namespace isolation
 	credConfigStore *CredentialConfigStore
 
+	// skillStore manages the global agent-skill registry (one set, shared
+	// across namespaces; root-only mutations are enforced at the HTTP layer).
+	skillStore *SkillStore
+
 	// policy store is used to manage named CBP policies
 	policyStore *PolicyStore
 
@@ -572,6 +576,9 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, fmt.Errorf("failed to create credential config store: %w", err)
 	}
 	c.credConfigStore = credConfigStore
+
+	// Create SkillStore (storage view is wired up at unseal time).
+	c.skillStore = NewSkillStore(c)
 
 	// Initialize global credential type and driver registries
 	c.credentialTypeRegistry = credential.NewTypeRegistry()
@@ -1289,6 +1296,11 @@ func (c *Core) preSeal() error {
 		c.logger.Warn("error tearing down credential config store", logger.Err(err))
 	}
 
+	// Unload skill store caches (records remain in storage for next unseal).
+	if err := c.teardownSkillStore(); err != nil {
+		c.logger.Warn("error tearing down skill store", logger.Err(err))
+	}
+
 	// Stop all credential managers
 	if err := c.teardownCredentialManager(); err != nil {
 		c.logger.Warn("error tearing down credential managers", logger.Err(err))
@@ -1347,6 +1359,9 @@ func (readonlyUnsealStrategy) unsealShared(ctx context.Context, log *logger.Gate
 		return err
 	}
 	if err := c.setupCredentialManager(ctx); err != nil {
+		return err
+	}
+	if err := c.setupSkillStore(ctx); err != nil {
 		return err
 	}
 

--- a/core/skill_store.go
+++ b/core/skill_store.go
@@ -1,0 +1,353 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+const (
+	skillStorePath = "core/skills/"
+)
+
+var (
+	ErrSkillStoreClosed   = errors.New("skill store is closed")
+	ErrSkillNotFound      = errors.New("skill not found")
+	ErrSkillAlreadyExists = errors.New("skill already exists")
+)
+
+// SkillStore manages the global set of agent skill records.
+//
+// Skills are not per-namespace: every namespace's agents read the same
+// catalog. Mutations are gated at the HTTP layer (PathsSpecial.Root); this
+// store does not enforce authorization itself.
+//
+// Storage layout (under barrier view at "core/skills/"):
+//
+//	{skill-name}        -> JSON-encoded storedSkill
+//	_meta/seeded        -> sentinel byte set after the one-time seed runs
+//
+// Skills are read-light and written rarely; no in-memory cache is
+// maintained. Skill bodies are bounded (see maxSkillBodyBytes) so a
+// straight List-then-Get is acceptable.
+type SkillStore struct {
+	core    *Core
+	logger  *logger.GatedLogger
+	storage sdklogical.Storage
+
+	mu     sync.RWMutex
+	closed bool
+}
+
+// storedSkill is the on-disk format. The Version field exists so future
+// schema changes can be detected and migrated lazily on read.
+type storedSkill struct {
+	Version int    `json:"version"`
+	Skill   *Skill `json:"skill"`
+}
+
+// NewSkillStore constructs the store. Storage is wired up later by
+// LoadFromStorage so the store can be allocated before the barrier is ready.
+func NewSkillStore(c *Core) *SkillStore {
+	return &SkillStore{
+		core:   c,
+		logger: c.logger.WithSystem("skill.store"),
+	}
+}
+
+// LoadFromStorage initializes the barrier-backed storage view. Called once
+// the barrier is unsealed.
+func (s *SkillStore) LoadFromStorage(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		s.storage = NewBarrierView(s.core.barrier, skillStorePath)
+	}
+	s.logger.Debug("skill store initialized")
+	return nil
+}
+
+// UnloadFromCache is the seal-time inverse of LoadFromStorage. There is no
+// in-memory cache today, so this is a no-op — the BarrierView is left in
+// place exactly as CredentialConfigStore.UnloadFromCache leaves its
+// storage view. The hook exists so a future cache (e.g. parsed seed
+// markdown) has a clear teardown point.
+func (s *SkillStore) UnloadFromCache() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.logger.Debug("skill store cache unloaded (no-op)")
+}
+
+// Close shuts the store down. Idempotent.
+func (s *SkillStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+// Create persists a new skill. Returns ErrSkillAlreadyExists if a skill
+// with the same name already exists.
+//
+// Mutates the input: CreatedAt, UpdatedAt, Version, and (if empty) Origin
+// are written back onto skill so callers can read them post-create. This
+// matches CredentialConfigStore.CreateSpec behaviour.
+func (s *SkillStore) Create(ctx context.Context, skill *Skill) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		return errors.New("skill store storage not initialized")
+	}
+
+	if err := validateSkill(skill); err != nil {
+		return err
+	}
+
+	if skill.Origin == "" {
+		skill.Origin = SkillOriginUser
+	}
+	if skill.Origin != SkillOriginSeed && skill.Origin != SkillOriginUser {
+		return logical.ErrBadRequestf("invalid origin %q", skill.Origin)
+	}
+
+	existing, err := s.load(ctx, skill.Name)
+	if err != nil && !errors.Is(err, ErrSkillNotFound) {
+		return err
+	}
+	if existing != nil {
+		return ErrSkillAlreadyExists
+	}
+
+	now := time.Now()
+	skill.CreatedAt = now
+	skill.UpdatedAt = now
+	skill.Version = 1
+
+	if err := s.persist(ctx, skill); err != nil {
+		return err
+	}
+
+	s.logger.Info("created skill",
+		logger.String("name", skill.Name),
+		logger.String("category", skill.Category),
+		logger.String("origin", skill.Origin),
+	)
+	return nil
+}
+
+// Get reads a single skill by name.
+func (s *SkillStore) Get(ctx context.Context, name string) (*Skill, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		return nil, errors.New("skill store storage not initialized")
+	}
+
+	return s.load(ctx, name)
+}
+
+// Update merges patch fields into the existing skill. Non-zero patch
+// fields overwrite. CreatedAt, Origin, and Name are preserved from the
+// existing record; Version is bumped.
+func (s *SkillStore) Update(ctx context.Context, name string, patch *Skill) (*Skill, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		return nil, errors.New("skill store storage not initialized")
+	}
+
+	existing, err := s.load(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := *existing
+	if patch != nil {
+		if patch.Description != "" {
+			merged.Description = patch.Description
+		}
+		if patch.Category != "" {
+			merged.Category = patch.Category
+		}
+		if patch.Requires != nil {
+			merged.Requires = patch.Requires
+		}
+		if patch.Upstream != "" {
+			merged.Upstream = patch.Upstream
+		}
+		if patch.Body != "" {
+			merged.Body = patch.Body
+		}
+		if patch.Provider != "" {
+			merged.Provider = patch.Provider
+		}
+	}
+
+	if err := validateSkill(&merged); err != nil {
+		return nil, err
+	}
+
+	merged.UpdatedAt = time.Now()
+	merged.Version = existing.Version + 1
+	merged.CreatedAt = existing.CreatedAt
+	merged.Origin = existing.Origin
+	merged.Name = existing.Name
+
+	if err := s.persist(ctx, &merged); err != nil {
+		return nil, err
+	}
+
+	s.logger.Debug("updated skill",
+		logger.String("name", name),
+		logger.Int("version", merged.Version),
+	)
+	return &merged, nil
+}
+
+// Delete removes a skill by name. Returns ErrSkillNotFound if absent.
+func (s *SkillStore) Delete(ctx context.Context, name string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		return errors.New("skill store storage not initialized")
+	}
+
+	if _, err := s.load(ctx, name); err != nil {
+		return err
+	}
+
+	if err := s.storage.Delete(ctx, name); err != nil {
+		return fmt.Errorf("failed to delete skill: %w", err)
+	}
+
+	s.logger.Info("deleted skill", logger.String("name", name))
+	return nil
+}
+
+// List returns every skill record. Records are returned with full bodies;
+// HTTP handlers strip Body for list responses. The internal _meta/ prefix
+// is filtered out.
+func (s *SkillStore) List(ctx context.Context) ([]*Skill, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		return nil, errors.New("skill store storage not initialized")
+	}
+
+	keys, err := s.storage.List(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list skills: %w", err)
+	}
+
+	skills := make([]*Skill, 0, len(keys))
+	for _, key := range keys {
+		// Skip internal metadata entries (e.g. _meta/seeded).
+		if len(key) > 0 && key[0] == '_' {
+			continue
+		}
+		skill, err := s.load(ctx, key)
+		if err != nil {
+			s.logger.Warn("failed to load skill during list",
+				logger.String("name", key),
+				logger.Err(err),
+			)
+			continue
+		}
+		skills = append(skills, skill)
+	}
+	return skills, nil
+}
+
+// load reads one skill record from storage. Returns ErrSkillNotFound if the
+// key is absent. Caller must hold the read lock.
+func (s *SkillStore) load(ctx context.Context, name string) (*Skill, error) {
+	entry, err := s.storage.Get(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read skill: %w", err)
+	}
+	if entry == nil {
+		return nil, ErrSkillNotFound
+	}
+
+	var stored storedSkill
+	if err := json.Unmarshal(entry.Value, &stored); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal skill %q: %w", name, err)
+	}
+	if stored.Skill == nil {
+		return nil, fmt.Errorf("skill %q decoded to nil", name)
+	}
+	return stored.Skill, nil
+}
+
+// setupSkillStore is called during unseal to wire the SkillStore's
+// storage view to the unsealed barrier. PR 1 only loads; the seed step
+// lands in PR 2.
+func (c *Core) setupSkillStore(ctx context.Context) error {
+	if c.skillStore == nil {
+		return fmt.Errorf("skill store not initialized")
+	}
+	return c.skillStore.LoadFromStorage(ctx)
+}
+
+// teardownSkillStore is the seal-time inverse of setupSkillStore.
+func (c *Core) teardownSkillStore() error {
+	if c.skillStore != nil {
+		c.skillStore.UnloadFromCache()
+	}
+	return nil
+}
+
+// persist writes one skill record to storage. Caller must hold the read
+// lock and have validated the skill.
+func (s *SkillStore) persist(ctx context.Context, skill *Skill) error {
+	stored := &storedSkill{
+		Version: 1,
+		Skill:   skill,
+	}
+	data, err := json.Marshal(stored)
+	if err != nil {
+		return fmt.Errorf("failed to marshal skill: %w", err)
+	}
+	entry := &sdklogical.StorageEntry{
+		Key:   skill.Name,
+		Value: data,
+	}
+	if err := s.storage.Put(ctx, entry); err != nil {
+		return fmt.Errorf("failed to write skill: %w", err)
+	}
+	return nil
+}

--- a/core/skill_store_test.go
+++ b/core/skill_store_test.go
@@ -1,0 +1,326 @@
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/openbao/openbao/sdk/v2/physical/inmem"
+	"github.com/stephnangue/warden/logger"
+)
+
+// setupTestSkillStore creates a SkillStore backed by an unsealed in-memory
+// barrier — enough to exercise CRUD without spinning up a full Core.
+func setupTestSkillStore(t *testing.T) (*SkillStore, context.Context) {
+	t.Helper()
+
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	physical, _ := inmem.NewInmem(nil, nil)
+	barrier, err := NewAESGCMBarrier(physical)
+	if err != nil {
+		t.Fatalf("create barrier: %v", err)
+	}
+	testKey, _ := barrier.GenerateKey(rand.Reader)
+	if err := barrier.Initialize(context.Background(), testKey, nil, rand.Reader); err != nil {
+		t.Fatalf("initialize barrier: %v", err)
+	}
+	if err := barrier.Unseal(context.Background(), testKey); err != nil {
+		t.Fatalf("unseal barrier: %v", err)
+	}
+
+	core := &Core{
+		barrier: barrier,
+		logger:  log,
+	}
+	store := NewSkillStore(core)
+	store.storage = NewBarrierView(barrier, skillStorePath)
+
+	return store, context.Background()
+}
+
+// validSkill returns a fresh, schema-valid Skill suitable for CRUD tests.
+func validSkill(name string) *Skill {
+	return &Skill{
+		Name:        name,
+		Description: "test skill",
+		Category:    SkillCategoryCustom,
+		Body:        "# body\n",
+	}
+}
+
+func TestSkillStore_CreateAndGet(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	skill := validSkill("runbook-1")
+	if err := store.Create(ctx, skill); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := store.Get(ctx, "runbook-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "runbook-1" {
+		t.Errorf("Name = %q, want runbook-1", got.Name)
+	}
+	if got.Origin != SkillOriginUser {
+		t.Errorf("Origin = %q, want %q (default for empty)", got.Origin, SkillOriginUser)
+	}
+	if got.Version != 1 {
+		t.Errorf("Version = %d, want 1", got.Version)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Errorf("timestamps not set: created=%v updated=%v", got.CreatedAt, got.UpdatedAt)
+	}
+}
+
+func TestSkillStore_CreateDuplicateRejected(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.Create(ctx, validSkill("dup")); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	err := store.Create(ctx, validSkill("dup"))
+	if !errors.Is(err, ErrSkillAlreadyExists) {
+		t.Fatalf("expected ErrSkillAlreadyExists, got %v", err)
+	}
+}
+
+func TestSkillStore_GetMissingReturnsNotFound(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	_, err := store.Get(ctx, "missing")
+	if !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected ErrSkillNotFound, got %v", err)
+	}
+}
+
+func TestSkillStore_UpdateMergesAndBumpsVersion(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	original := validSkill("evolves")
+	original.Description = "first"
+	original.Body = "# v1\n"
+	if err := store.Create(ctx, original); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	patch := &Skill{Description: "second"}
+	updated, err := store.Update(ctx, "evolves", patch)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Description != "second" {
+		t.Errorf("Description = %q, want second", updated.Description)
+	}
+	if updated.Body != "# v1\n" {
+		t.Errorf("Body should be preserved, got %q", updated.Body)
+	}
+	if updated.Version != 2 {
+		t.Errorf("Version = %d, want 2", updated.Version)
+	}
+	if !updated.CreatedAt.Equal(original.CreatedAt) {
+		t.Errorf("CreatedAt drift: original=%v updated=%v", original.CreatedAt, updated.CreatedAt)
+	}
+}
+
+func TestSkillStore_UpdatePreservesOrigin(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	seed := validSkill("seedling")
+	seed.Origin = SkillOriginSeed
+	if err := store.Create(ctx, seed); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Operator tries to flip Origin to user — must be ignored.
+	patch := &Skill{Origin: SkillOriginUser, Description: "patched"}
+	updated, err := store.Update(ctx, "seedling", patch)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Origin != SkillOriginSeed {
+		t.Errorf("Origin = %q, want %q (must be preserved)", updated.Origin, SkillOriginSeed)
+	}
+}
+
+func TestSkillStore_UpdateMissingReturnsNotFound(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	_, err := store.Update(ctx, "ghost", &Skill{Description: "x"})
+	if !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected ErrSkillNotFound, got %v", err)
+	}
+}
+
+func TestSkillStore_Delete(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.Create(ctx, validSkill("trash")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Delete(ctx, "trash"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_, err := store.Get(ctx, "trash")
+	if !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected ErrSkillNotFound after delete, got %v", err)
+	}
+}
+
+func TestSkillStore_DeleteMissingReturnsNotFound(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	err := store.Delete(ctx, "ghost")
+	if !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected ErrSkillNotFound, got %v", err)
+	}
+}
+
+func TestSkillStore_List(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	for _, name := range []string{"alpha", "bravo", "charlie"} {
+		if err := store.Create(ctx, validSkill(name)); err != nil {
+			t.Fatalf("Create %q: %v", name, err)
+		}
+	}
+
+	skills, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(skills) != 3 {
+		t.Fatalf("len = %d, want 3", len(skills))
+	}
+	seen := map[string]bool{}
+	for _, s := range skills {
+		seen[s.Name] = true
+	}
+	for _, want := range []string{"alpha", "bravo", "charlie"} {
+		if !seen[want] {
+			t.Errorf("missing %q in list", want)
+		}
+	}
+}
+
+func TestSkillStore_ListFiltersInternalMetaKeys(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.Create(ctx, validSkill("real")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Simulate a future _meta/seeded marker; List must skip it.
+	if err := store.storage.Put(ctx, &sdklogical.StorageEntry{
+		Key:   "_meta/seeded",
+		Value: []byte("1"),
+	}); err != nil {
+		t.Fatalf("put marker: %v", err)
+	}
+
+	skills, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("len = %d, want 1 (real only)", len(skills))
+	}
+	if skills[0].Name != "real" {
+		t.Errorf("name = %q, want real", skills[0].Name)
+	}
+}
+
+func TestValidateSkill_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(s *Skill)
+		wantSub string
+	}{
+		{"empty name", func(s *Skill) { s.Name = "" }, "invalid skill name"},
+		{"bad name uppercase", func(s *Skill) { s.Name = "BadName" }, "invalid skill name"},
+		{"bad name leading hyphen", func(s *Skill) { s.Name = "-bad" }, "invalid skill name"},
+		{"empty description", func(s *Skill) { s.Description = "" }, "description"},
+		{"unknown category", func(s *Skill) { s.Category = "weird" }, "invalid skill category"},
+		{"empty body", func(s *Skill) { s.Body = "" }, "body"},
+		{"oversize body", func(s *Skill) { s.Body = strings.Repeat("x", maxSkillBodyBytes+1) }, "body exceeds"},
+		{"too many requires", func(s *Skill) {
+			s.Requires = make([]string, maxSkillRequiresLen+1)
+			for i := range s.Requires {
+				s.Requires[i] = "ok"
+			}
+		}, "requires exceeds"},
+		{"bad require entry", func(s *Skill) { s.Requires = []string{"BAD"} }, "invalid requires entry"},
+		{"provider-guide missing provider", func(s *Skill) {
+			s.Category = SkillCategoryProviderGuide
+			s.Provider = ""
+		}, "provider field is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := validSkill("ok")
+			tc.mutate(s)
+			err := validateSkill(s)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestValidateSkill_Accepts(t *testing.T) {
+	good := validSkill("good")
+	if err := validateSkill(good); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+
+	providerGuide := validSkill("aws")
+	providerGuide.Category = SkillCategoryProviderGuide
+	providerGuide.Provider = "aws"
+	if err := validateSkill(providerGuide); err != nil {
+		t.Errorf("provider-guide with provider should pass: %v", err)
+	}
+}
+
+func TestSkillStore_CreateRejectsInvalid(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	bad := validSkill("ok")
+	bad.Body = ""
+	err := store.Create(ctx, bad)
+	if err == nil {
+		t.Fatalf("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "body") {
+		t.Errorf("error should mention body, got %q", err.Error())
+	}
+}
+
+func TestSkillStore_ClosedStoreReturnsError(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := store.Create(ctx, validSkill("late")); !errors.Is(err, ErrSkillStoreClosed) {
+		t.Errorf("Create after close: got %v, want ErrSkillStoreClosed", err)
+	}
+	if _, err := store.Get(ctx, "x"); !errors.Is(err, ErrSkillStoreClosed) {
+		t.Errorf("Get after close: got %v, want ErrSkillStoreClosed", err)
+	}
+	if _, err := store.List(ctx); !errors.Is(err, ErrSkillStoreClosed) {
+		t.Errorf("List after close: got %v, want ErrSkillStoreClosed", err)
+	}
+	if err := store.Delete(ctx, "x"); !errors.Is(err, ErrSkillStoreClosed) {
+		t.Errorf("Delete after close: got %v, want ErrSkillStoreClosed", err)
+	}
+	if _, err := store.Update(ctx, "x", &Skill{}); !errors.Is(err, ErrSkillStoreClosed) {
+		t.Errorf("Update after close: got %v, want ErrSkillStoreClosed", err)
+	}
+}

--- a/core/skill_types.go
+++ b/core/skill_types.go
@@ -1,0 +1,127 @@
+package core
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// Skill is an agent-facing capability description stored globally.
+// Skills are markdown documents with structured metadata that agents read
+// at discovery time. There is one global set, seeded at first system unseal
+// and freely mutable by root admins thereafter; sub-namespace agents have
+// read-only access.
+type Skill struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Category    string    `json:"category"`
+	Requires    []string  `json:"requires,omitempty"`
+	Upstream    string    `json:"upstream,omitempty"`
+	Body        string    `json:"body"`
+	Origin      string    `json:"origin"`
+	Provider    string    `json:"provider,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Version     int       `json:"version"`
+}
+
+// Skill category enum.
+const (
+	SkillCategoryAgentFlow       = "agent-flow"
+	SkillCategoryShared          = "shared"
+	SkillCategoryProviderGuide   = "provider-guide"
+	SkillCategoryTroubleshooting = "troubleshooting"
+	SkillCategoryCustom          = "custom"
+)
+
+// Skill origin enum. Origin is informational and does not gate mutation.
+const (
+	SkillOriginSeed = "seed"
+	SkillOriginUser = "user"
+)
+
+// Skill validation limits. Name length is enforced by skillNameRegex
+// directly (2-64 characters); the regex below is the authoritative bound.
+const (
+	maxSkillBodyBytes   = 256 * 1024
+	maxSkillRequiresLen = 32
+	maxSkillUpstreamLen = 256
+	maxSkillProviderLen = 64
+	maxSkillDescription = 1024
+)
+
+var skillNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,63}$`)
+
+var skillCategories = map[string]struct{}{
+	SkillCategoryAgentFlow:       {},
+	SkillCategoryShared:          {},
+	SkillCategoryProviderGuide:   {},
+	SkillCategoryTroubleshooting: {},
+	SkillCategoryCustom:          {},
+}
+
+// validateSkill enforces the skill schema. Returns logical.ErrBadRequest
+// (400) on any failure so handlers can pass it straight through.
+//
+// Caller responsibilities:
+//   - timestamps and Version are set by the store, not validated here.
+//   - Origin defaults to "user" at the store level if empty.
+//   - Provider-existence (does this driver factory exist?) is checked by the
+//     caller against the live driver registry — this validator only enforces
+//     shape, not cross-package referential integrity.
+func validateSkill(s *Skill) error {
+	if s == nil {
+		return logical.ErrBadRequest("skill cannot be nil")
+	}
+
+	if !skillNameRegex.MatchString(s.Name) {
+		return logical.ErrBadRequestf(
+			"invalid skill name %q: must match %s",
+			s.Name, skillNameRegex.String())
+	}
+
+	if s.Description == "" {
+		return logical.ErrBadRequest("skill description cannot be empty")
+	}
+	if len(s.Description) > maxSkillDescription {
+		return logical.ErrBadRequestf("skill description exceeds %d bytes", maxSkillDescription)
+	}
+
+	if _, ok := skillCategories[s.Category]; !ok {
+		return logical.ErrBadRequestf(
+			"invalid skill category %q: must be one of agent-flow, shared, provider-guide, troubleshooting, custom",
+			s.Category)
+	}
+
+	if s.Body == "" {
+		return logical.ErrBadRequest("skill body cannot be empty")
+	}
+	if len(s.Body) > maxSkillBodyBytes {
+		return logical.ErrBadRequestf("skill body exceeds %d bytes", maxSkillBodyBytes)
+	}
+
+	if len(s.Requires) > maxSkillRequiresLen {
+		return logical.ErrBadRequestf("skill requires exceeds %d entries", maxSkillRequiresLen)
+	}
+	for _, req := range s.Requires {
+		if !skillNameRegex.MatchString(req) {
+			return logical.ErrBadRequestf("invalid requires entry %q: must match %s", req, skillNameRegex.String())
+		}
+	}
+
+	if len(s.Upstream) > maxSkillUpstreamLen {
+		return logical.ErrBadRequestf("skill upstream exceeds %d bytes", maxSkillUpstreamLen)
+	}
+
+	if s.Category == SkillCategoryProviderGuide {
+		if s.Provider == "" {
+			return logical.ErrBadRequest("provider field is required for provider-guide category")
+		}
+	}
+	if len(s.Provider) > maxSkillProviderLen {
+		return logical.ErrBadRequestf("skill provider exceeds %d bytes", maxSkillProviderLen)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Lays the groundwork for /v1/sys/skills (PR 3) and the warden skill CLI (PR 4). Adds the Skill struct + validators, a global per-process SkillStore over a barrier view at core/skills/, and wires unseal/seal hooks. No HTTP, no CLI, and no seed yet -- those land in subsequent PRs.

Skills are global (one set shared across namespaces) rather than per-namespace because they describe the capabilities of the binary (provider types, agent flow), not tenant data. Mutations will be gated to the root namespace at the HTTP layer in PR 3.