### PR TITLE
feat: HTTP API at /v1/sys/skills with root-only write gating

### DIFF
--- a/core/sys_backend.go
+++ b/core/sys_backend.go
@@ -66,6 +66,9 @@ func (b *SystemBackend) paths() []*framework.Path {
 	// Credential paths
 	paths = append(paths, b.pathCredentials()...)
 
+	// Skill registry paths
+	paths = append(paths, b.pathSkills()...)
+
 	// Policy paths
 	paths = append(paths, b.pathPolicies()...)
 

--- a/core/sys_skills.go
+++ b/core/sys_skills.go
@@ -1,0 +1,269 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathSkills returns the paths for skill registry operations.
+//
+// Skills are a single global set shared across all namespaces. Reads are
+// open to any authenticated caller in any namespace; mutations
+// (create/update/delete) are restricted to the root namespace, enforced
+// inside the handlers (see requireRootNamespace).
+func (b *SystemBackend) pathSkills() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "skills/" + framework.GenericNameRegex("name"),
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Description: "The skill name (unique slug)",
+					Required:    true,
+				},
+				"description": {
+					Type:        framework.TypeString,
+					Description: "Human-friendly one-line summary",
+				},
+				"category": {
+					Type:        framework.TypeString,
+					Description: "Skill category: agent-flow, shared, provider-guide, troubleshooting, custom",
+				},
+				"requires": {
+					Type:        framework.TypeStringSlice,
+					Description: "Names of other skills this one depends on",
+				},
+				"upstream": {
+					Type:        framework.TypeString,
+					Description: "Reference to an upstream system, when applicable",
+				},
+				"provider": {
+					Type:        framework.TypeString,
+					Description: "Provider type this skill describes (required for provider-guide category)",
+				},
+				"body": {
+					Type:        framework.TypeString,
+					Description: "Markdown body — the agent-facing recipe",
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.handleSkillCreate,
+					Summary:  "Create a new skill (root namespace only)",
+				},
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleSkillRead,
+					Summary:  "Read a skill record",
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.handleSkillUpdate,
+					Summary:  "Update an existing skill (root namespace only)",
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.handleSkillDelete,
+					Summary:  "Delete a skill (root namespace only)",
+				},
+			},
+			HelpSynopsis:    "Manage agent skills",
+			HelpDescription: "Create, read, update, and delete entries in the global agent skill registry. Reads are open to any namespace; writes are restricted to the root namespace.",
+		},
+		{
+			Pattern: "skills/?$",
+			Fields:  map[string]*framework.FieldSchema{},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.handleSkillList,
+					Summary:  "List all skills",
+				},
+			},
+			HelpSynopsis:    "List agent skills",
+			HelpDescription: "List every skill in the global agent skill registry.",
+		},
+	}
+}
+
+// requireRootNamespace returns nil if the request is scoped to the root
+// namespace, otherwise a 403 CodedError. Used to gate the write
+// operations on /v1/sys/skills/*.
+func requireRootNamespace(ctx context.Context) error {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return logical.ErrForbidden("namespace required")
+	}
+	if ns.ID != namespace.RootNamespaceID {
+		return logical.ErrForbidden("skill mutations are restricted to the root namespace")
+	}
+	return nil
+}
+
+// skillToMap converts a Skill record into the JSON-serializable map used
+// in API responses. When omitBody is true, the body is excluded — used
+// by LIST responses to keep payloads small.
+func skillToMap(s *Skill, omitBody bool) map[string]any {
+	out := map[string]any{
+		"name":        s.Name,
+		"description": s.Description,
+		"category":    s.Category,
+		"origin":      s.Origin,
+		"version":     s.Version,
+		"created_at":  s.CreatedAt,
+		"updated_at":  s.UpdatedAt,
+	}
+	if len(s.Requires) > 0 {
+		out["requires"] = s.Requires
+	}
+	if s.Upstream != "" {
+		out["upstream"] = s.Upstream
+	}
+	if s.Provider != "" {
+		out["provider"] = s.Provider
+	}
+	if !omitBody {
+		out["body"] = s.Body
+	}
+	return out
+}
+
+// skillFromFields builds a Skill record from incoming request fields.
+// Used by CREATE; UPDATE re-uses the same shape via merge semantics.
+func skillFromFields(d *framework.FieldData) *Skill {
+	skill := &Skill{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Category:    d.Get("category").(string),
+		Upstream:    d.Get("upstream").(string),
+		Provider:    d.Get("provider").(string),
+		Body:        d.Get("body").(string),
+	}
+	if req, ok := d.GetOk("requires"); ok {
+		skill.Requires = req.([]string)
+	}
+	return skill
+}
+
+// handleSkillCreate handles POST /sys/skills/{name}.
+func (b *SystemBackend) handleSkillCreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := requireRootNamespace(ctx); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+	if b.core.skillStore == nil {
+		return logical.ErrorResponse(logical.ErrInternal("skill store not initialized")), nil
+	}
+
+	skill := skillFromFields(d)
+
+	if err := b.core.skillStore.Create(ctx, skill); err != nil {
+		if errors.Is(err, ErrSkillAlreadyExists) {
+			return logical.ErrorResponse(logical.ErrConflictf("skill %q already exists", skill.Name)), nil
+		}
+		return logical.ErrorResponse(err), nil
+	}
+
+	b.logger.Info("created skill",
+		logger.String("name", skill.Name),
+		logger.String("category", skill.Category),
+	)
+	return b.respondCreated(skillToMap(skill, false)), nil
+}
+
+// handleSkillRead handles GET /sys/skills/{name}.
+func (b *SystemBackend) handleSkillRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if b.core.skillStore == nil {
+		return logical.ErrorResponse(logical.ErrInternal("skill store not initialized")), nil
+	}
+	name := d.Get("name").(string)
+
+	skill, err := b.core.skillStore.Get(ctx, name)
+	if err != nil {
+		if errors.Is(err, ErrSkillNotFound) {
+			return logical.ErrorResponse(logical.ErrNotFoundf("skill %q not found", name)), nil
+		}
+		return logical.ErrorResponse(err), nil
+	}
+
+	return b.respondSuccess(skillToMap(skill, false)), nil
+}
+
+// handleSkillUpdate handles PUT /sys/skills/{name}. Empty fields in the
+// payload are treated as "don't change"; non-empty values overwrite.
+// CreatedAt, Origin, Name, and Version are managed by the store.
+func (b *SystemBackend) handleSkillUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := requireRootNamespace(ctx); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+	if b.core.skillStore == nil {
+		return logical.ErrorResponse(logical.ErrInternal("skill store not initialized")), nil
+	}
+
+	name := d.Get("name").(string)
+	patch := skillFromFields(d)
+	patch.Name = "" // never patch the primary key
+
+	updated, err := b.core.skillStore.Update(ctx, name, patch)
+	if err != nil {
+		if errors.Is(err, ErrSkillNotFound) {
+			return logical.ErrorResponse(logical.ErrNotFoundf("skill %q not found", name)), nil
+		}
+		return logical.ErrorResponse(err), nil
+	}
+
+	b.logger.Info("updated skill",
+		logger.String("name", updated.Name),
+		logger.Int("version", updated.Version),
+	)
+	return b.respondSuccess(skillToMap(updated, false)), nil
+}
+
+// handleSkillDelete handles DELETE /sys/skills/{name}.
+func (b *SystemBackend) handleSkillDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := requireRootNamespace(ctx); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+	if b.core.skillStore == nil {
+		return logical.ErrorResponse(logical.ErrInternal("skill store not initialized")), nil
+	}
+
+	name := d.Get("name").(string)
+
+	if err := b.core.skillStore.Delete(ctx, name); err != nil {
+		if errors.Is(err, ErrSkillNotFound) {
+			return logical.ErrorResponse(logical.ErrNotFoundf("skill %q not found", name)), nil
+		}
+		return logical.ErrorResponse(err), nil
+	}
+
+	b.logger.Info("deleted skill", logger.String("name", name))
+	return b.respondSuccess(map[string]any{
+		"message": fmt.Sprintf("Successfully deleted skill %s", name),
+	}), nil
+}
+
+// handleSkillList handles GET /sys/skills.
+//
+// Returns short-form records (body omitted) to keep payloads small.
+// Agents that need full content fetch each name individually via READ.
+func (b *SystemBackend) handleSkillList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if b.core.skillStore == nil {
+		return logical.ErrorResponse(logical.ErrInternal("skill store not initialized")), nil
+	}
+
+	skills, err := b.core.skillStore.List(ctx)
+	if err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+
+	items := make([]map[string]any, 0, len(skills))
+	for _, s := range skills {
+		items = append(items, skillToMap(s, true))
+	}
+
+	return b.respondSuccess(map[string]any{
+		"skills": items,
+	}), nil
+}

--- a/core/sys_skills_test.go
+++ b/core/sys_skills_test.go
@@ -1,0 +1,354 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validSkillFields returns a complete, schema-valid field map for creating
+// a skill. Tests mutate the returned map to exercise edge cases.
+func validSkillFields(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        name,
+		"description": "a test skill",
+		"category":    SkillCategoryCustom,
+		"body":        "# heading\nbody text\n",
+	}
+}
+
+// skillPathSchemas returns the field schemas for the CRUD and LIST paths,
+// in that order.
+func skillPathSchemas(b *SystemBackend) (crud, list map[string]*framework.FieldSchema) {
+	paths := b.pathSkills()
+	return paths[0].Fields, paths[1].Fields
+}
+
+func TestSystemBackend_PathSkills_Shape(t *testing.T) {
+	backend, _, _ := setupTestSystemBackend(t)
+
+	paths := backend.pathSkills()
+	require.Len(t, paths, 2)
+	assert.Equal(t, "skills/"+framework.GenericNameRegex("name"), paths[0].Pattern)
+	assert.Equal(t, "skills/?$", paths[1].Pattern)
+
+	// CRUD path must expose all four operations.
+	for _, op := range []logical.Operation{
+		logical.CreateOperation,
+		logical.ReadOperation,
+		logical.UpdateOperation,
+		logical.DeleteOperation,
+	} {
+		_, ok := paths[0].Operations[op]
+		assert.True(t, ok, "operation %s missing from CRUD path", op)
+	}
+
+	// LIST path exposes only the list operation.
+	_, ok := paths[1].Operations[logical.ListOperation]
+	assert.True(t, ok)
+}
+
+func TestSystemBackend_HandleSkillCreate_Success(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := validSkillFields("runbook-1")
+	req := createTestRequest(logical.CreateOperation, "skills/runbook-1", raw)
+	fd := createFieldData(schema, raw)
+
+	resp, err := backend.handleSkillCreate(ctx, req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "runbook-1", resp.Data["name"])
+	assert.Equal(t, SkillOriginUser, resp.Data["origin"])
+	// LIST short-form is the only place body is omitted; CREATE returns it.
+	assert.Equal(t, "# heading\nbody text\n", resp.Data["body"])
+}
+
+func TestSystemBackend_HandleSkillCreate_Duplicate(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := validSkillFields("dup")
+	req := createTestRequest(logical.CreateOperation, "skills/dup", raw)
+	fd := createFieldData(schema, raw)
+
+	_, err := backend.handleSkillCreate(ctx, req, fd)
+	require.NoError(t, err)
+
+	resp, err := backend.handleSkillCreate(ctx, req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillCreate_ValidationRejected(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+
+	cases := []struct {
+		name   string
+		mutate func(m map[string]interface{})
+	}{
+		{"bad name", func(m map[string]interface{}) { m["name"] = "Bad_Name" }},
+		{"bad category", func(m map[string]interface{}) { m["category"] = "weird" }},
+		{"empty body", func(m map[string]interface{}) { m["body"] = "" }},
+		{"provider-guide without provider", func(m map[string]interface{}) {
+			m["category"] = SkillCategoryProviderGuide
+			delete(m, "provider")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := validSkillFields("ok-name")
+			tc.mutate(raw)
+			req := createTestRequest(logical.CreateOperation, "skills/x", raw)
+			fd := createFieldData(schema, raw)
+
+			resp, err := backend.handleSkillCreate(ctx, req, fd)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "case %q", tc.name)
+		})
+	}
+}
+
+func TestSystemBackend_HandleSkillRead_Success(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := validSkillFields("readable")
+	req := createTestRequest(logical.CreateOperation, "skills/readable", raw)
+	fd := createFieldData(schema, raw)
+	_, err := backend.handleSkillCreate(ctx, req, fd)
+	require.NoError(t, err)
+
+	readReq := createTestRequest(logical.ReadOperation, "skills/readable", raw)
+	resp, err := backend.handleSkillRead(ctx, readReq, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "readable", resp.Data["name"])
+	assert.Equal(t, "# heading\nbody text\n", resp.Data["body"])
+}
+
+func TestSystemBackend_HandleSkillRead_NotFound(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := map[string]interface{}{"name": "ghost"}
+	req := createTestRequest(logical.ReadOperation, "skills/ghost", raw)
+	fd := createFieldData(schema, raw)
+
+	resp, err := backend.handleSkillRead(ctx, req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillUpdate_MergesAndBumpsVersion(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+
+	createRaw := validSkillFields("evolves")
+	createReq := createTestRequest(logical.CreateOperation, "skills/evolves", createRaw)
+	createFD := createFieldData(schema, createRaw)
+	_, err := backend.handleSkillCreate(ctx, createReq, createFD)
+	require.NoError(t, err)
+
+	updateRaw := map[string]interface{}{
+		"name":        "evolves",
+		"description": "patched description",
+	}
+	updateReq := createTestRequest(logical.UpdateOperation, "skills/evolves", updateRaw)
+	updateFD := createFieldData(schema, updateRaw)
+
+	resp, err := backend.handleSkillUpdate(ctx, updateReq, updateFD)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "patched description", resp.Data["description"])
+	// Body unchanged because patch did not include it.
+	assert.Equal(t, "# heading\nbody text\n", resp.Data["body"])
+	assert.Equal(t, 2, resp.Data["version"])
+}
+
+func TestSystemBackend_HandleSkillUpdate_NotFound(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := map[string]interface{}{
+		"name":        "ghost",
+		"description": "x",
+	}
+	req := createTestRequest(logical.UpdateOperation, "skills/ghost", raw)
+	fd := createFieldData(schema, raw)
+
+	resp, err := backend.handleSkillUpdate(ctx, req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillDelete_Success(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+
+	createRaw := validSkillFields("trash")
+	createReq := createTestRequest(logical.CreateOperation, "skills/trash", createRaw)
+	createFD := createFieldData(schema, createRaw)
+	_, err := backend.handleSkillCreate(ctx, createReq, createFD)
+	require.NoError(t, err)
+
+	deleteReq := createTestRequest(logical.DeleteOperation, "skills/trash", createRaw)
+	resp, err := backend.handleSkillDelete(ctx, deleteReq, createFD)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Confirm gone.
+	readResp, _ := backend.handleSkillRead(ctx, deleteReq, createFD)
+	assert.Equal(t, http.StatusNotFound, readResp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillDelete_NotFound(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := map[string]interface{}{"name": "ghost"}
+	req := createTestRequest(logical.DeleteOperation, "skills/ghost", raw)
+	fd := createFieldData(schema, raw)
+
+	resp, err := backend.handleSkillDelete(ctx, req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillList_OmitsBody(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	crudSchema, listSchema := skillPathSchemas(backend)
+
+	for _, name := range []string{"alpha", "bravo"} {
+		raw := validSkillFields(name)
+		req := createTestRequest(logical.CreateOperation, "skills/"+name, raw)
+		fd := createFieldData(crudSchema, raw)
+		_, err := backend.handleSkillCreate(ctx, req, fd)
+		require.NoError(t, err)
+	}
+
+	listReq := createTestRequest(logical.ListOperation, "skills/", nil)
+	resp, err := backend.handleSkillList(ctx, listReq, createFieldData(listSchema, nil))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	items, ok := resp.Data["skills"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, items, 2)
+	for _, item := range items {
+		_, hasBody := item["body"]
+		assert.False(t, hasBody, "LIST response must omit body for skill %v", item["name"])
+		assert.NotEmpty(t, item["name"])
+		assert.NotEmpty(t, item["description"])
+	}
+}
+
+// nonRootContext returns a context bound to a non-root namespace.
+func nonRootContext(t *testing.T) context.Context {
+	t.Helper()
+	ns := &namespace.Namespace{
+		ID:   "child-namespace-id",
+		Path: "child/",
+		UUID: "child-uuid",
+	}
+	return namespace.ContextWithNamespace(context.Background(), ns)
+}
+
+func TestSystemBackend_HandleSkillCreate_RejectsNonRootNamespace(t *testing.T) {
+	backend, _, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+	raw := validSkillFields("nope")
+	req := createTestRequest(logical.CreateOperation, "skills/nope", raw)
+	fd := createFieldData(schema, raw)
+
+	resp, err := backend.handleSkillCreate(nonRootContext(t), req, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillUpdate_RejectsNonRootNamespace(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+
+	createRaw := validSkillFields("existing")
+	createReq := createTestRequest(logical.CreateOperation, "skills/existing", createRaw)
+	createFD := createFieldData(schema, createRaw)
+	_, err := backend.handleSkillCreate(ctx, createReq, createFD)
+	require.NoError(t, err)
+
+	updateRaw := map[string]interface{}{"name": "existing", "description": "child override"}
+	updateReq := createTestRequest(logical.UpdateOperation, "skills/existing", updateRaw)
+	updateFD := createFieldData(schema, updateRaw)
+
+	resp, err := backend.handleSkillUpdate(nonRootContext(t), updateReq, updateFD)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillDelete_RejectsNonRootNamespace(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+
+	createRaw := validSkillFields("guarded")
+	createReq := createTestRequest(logical.CreateOperation, "skills/guarded", createRaw)
+	createFD := createFieldData(schema, createRaw)
+	_, err := backend.handleSkillCreate(ctx, createReq, createFD)
+	require.NoError(t, err)
+
+	deleteReq := createTestRequest(logical.DeleteOperation, "skills/guarded", createRaw)
+	resp, err := backend.handleSkillDelete(nonRootContext(t), deleteReq, createFD)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleSkillRead_AllowsAnyNamespace(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema, _ := skillPathSchemas(backend)
+
+	createRaw := validSkillFields("publicly-visible")
+	createReq := createTestRequest(logical.CreateOperation, "skills/publicly-visible", createRaw)
+	createFD := createFieldData(schema, createRaw)
+	_, err := backend.handleSkillCreate(ctx, createReq, createFD)
+	require.NoError(t, err)
+
+	// Reading from a non-root namespace must succeed — skills are global,
+	// read-open by design.
+	readReq := createTestRequest(logical.ReadOperation, "skills/publicly-visible", createRaw)
+	resp, err := backend.handleSkillRead(nonRootContext(t), readReq, createFD)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "publicly-visible", resp.Data["name"])
+}
+
+func TestSystemBackend_HandleSkillList_AllowsAnyNamespace(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	crudSchema, listSchema := skillPathSchemas(backend)
+
+	createRaw := validSkillFields("listed")
+	createReq := createTestRequest(logical.CreateOperation, "skills/listed", createRaw)
+	createFD := createFieldData(crudSchema, createRaw)
+	_, err := backend.handleSkillCreate(ctx, createReq, createFD)
+	require.NoError(t, err)
+
+	listReq := createTestRequest(logical.ListOperation, "skills/", nil)
+	resp, err := backend.handleSkillList(nonRootContext(t), listReq, createFieldData(listSchema, nil))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -570,6 +570,10 @@ func createTestCore(t *testing.T) *Core {
 	// Initialize credential manager (required for source/spec operations)
 	_ = core.setupCredentialManager(ctx)
 
+	// Initialize skill store
+	core.skillStore = NewSkillStore(core)
+	core.skillStore.storage = NewBarrierView(barrier, skillStorePath)
+
 	// Initialize policy store
 	core.policyStore, _ = NewPolicyStore(ctx, core, log)
 

--- a/e2e/skill/skill_test.go
+++ b/e2e/skill/skill_test.go
@@ -1,0 +1,328 @@
+//go:build e2e
+
+// Package skill holds end-to-end tests for the /v1/sys/skills API.
+package skill
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// listResp matches the shape returned by GET /v1/sys/skills.
+type listResp struct {
+	Data struct {
+		Skills []map[string]interface{} `json:"skills"`
+	} `json:"data"`
+}
+
+// readResp matches the shape returned by GET /v1/sys/skills/<name>.
+type readResp struct {
+	Data map[string]interface{} `json:"data"`
+}
+
+func listSkills(t *testing.T, port int) []map[string]interface{} {
+	t.Helper()
+	status, body := h.APIRequest(t, "GET", "sys/skills?warden-list=true", port, "")
+	if status != 200 {
+		t.Fatalf("list skills: status %d, body %s", status, string(body))
+	}
+	var out listResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("unmarshal list: %v\nbody: %s", err, string(body))
+	}
+	return out.Data.Skills
+}
+
+func skillNames(skills []map[string]interface{}) map[string]bool {
+	names := make(map[string]bool, len(skills))
+	for _, s := range skills {
+		if n, ok := s["name"].(string); ok {
+			names[n] = true
+		}
+	}
+	return names
+}
+
+// TestSkill_FoundationSkillsArePresent verifies the discovery, warden-shared,
+// and troubleshooting skills are seeded at first unseal and visible via the
+// list endpoint.
+func TestSkill_FoundationSkillsArePresent(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	names := skillNames(listSkills(t, port))
+
+	for _, want := range []string{"discovery", "warden-shared", "troubleshooting"} {
+		if !names[want] {
+			t.Errorf("foundation skill %q missing from /v1/sys/skills (got %v)", want, names)
+		}
+	}
+}
+
+// TestSkill_ReadFoundationSkillReturnsBody verifies that a known foundation
+// skill comes back with its full markdown body via the read endpoint.
+func TestSkill_ReadFoundationSkillReturnsBody(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	status, body := h.APIRequest(t, "GET", "sys/skills/discovery", port, "")
+	if status != 200 {
+		t.Fatalf("read discovery: status %d, body %s", status, string(body))
+	}
+	var out readResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, string(body))
+	}
+	bodyStr, _ := out.Data["body"].(string)
+	if !strings.Contains(bodyStr, "Discovering what you can do") {
+		t.Errorf("discovery body does not contain expected heading; got %q", bodyStr)
+	}
+	if out.Data["origin"] != "seed" {
+		t.Errorf("origin = %v, want \"seed\"", out.Data["origin"])
+	}
+}
+
+// TestSkill_ListOmitsBody verifies that the list endpoint returns short-form
+// records (no body) so the catalog stays cheap to scan.
+func TestSkill_ListOmitsBody(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	skills := listSkills(t, port)
+	if len(skills) == 0 {
+		t.Fatal("expected at least one skill in the catalog")
+	}
+	for _, s := range skills {
+		if _, hasBody := s["body"]; hasBody {
+			t.Errorf("list response for %v includes body field (should be omitted)", s["name"])
+		}
+	}
+}
+
+// TestSkillCRUD_RoundTrip exercises create/read/update/delete for an
+// operator-owned skill.
+func TestSkillCRUD_RoundTrip(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-runbook"
+
+	// Belt-and-braces cleanup in case a previous run left the skill behind.
+	h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+	})
+
+	createPayload := mustJSON(t, map[string]interface{}{
+		"name":        name,
+		"description": "operator-owned runbook",
+		"category":    "custom",
+		"body":        "# runbook\nstep 1\n",
+	})
+	status, body := h.APIRequest(t, "POST", "sys/skills/"+name, port, createPayload)
+	if status != 201 {
+		t.Fatalf("create: expected 201, got %d, body %s", status, string(body))
+	}
+
+	status, body = h.APIRequest(t, "GET", "sys/skills/"+name, port, "")
+	if status != 200 {
+		t.Fatalf("read: expected 200, got %d, body %s", status, string(body))
+	}
+	var rd readResp
+	if err := json.Unmarshal(body, &rd); err != nil {
+		t.Fatalf("unmarshal read: %v", err)
+	}
+	if rd.Data["description"] != "operator-owned runbook" {
+		t.Errorf("description = %v", rd.Data["description"])
+	}
+	if rd.Data["origin"] != "user" {
+		t.Errorf("origin = %v, want \"user\"", rd.Data["origin"])
+	}
+
+	updatePayload := mustJSON(t, map[string]interface{}{
+		"description": "patched",
+	})
+	status, body = h.APIRequest(t, "PUT", "sys/skills/"+name, port, updatePayload)
+	if status != 200 {
+		t.Fatalf("update: expected 200, got %d, body %s", status, string(body))
+	}
+	if err := json.Unmarshal(body, &rd); err != nil {
+		t.Fatalf("unmarshal update: %v", err)
+	}
+	if rd.Data["description"] != "patched" {
+		t.Errorf("after update, description = %v", rd.Data["description"])
+	}
+	if v, _ := rd.Data["version"].(float64); v != 2 {
+		t.Errorf("version = %v, want 2", rd.Data["version"])
+	}
+
+	status, _ = h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+	if status != 200 {
+		t.Fatalf("delete: expected 200, got %d", status)
+	}
+
+	status, _ = h.APIRequest(t, "GET", "sys/skills/"+name, port, "")
+	if status != 404 {
+		t.Errorf("read after delete: expected 404, got %d", status)
+	}
+}
+
+// TestSkillCreate_DuplicateConflicts verifies a second create with the
+// same name returns 409.
+func TestSkillCreate_DuplicateConflicts(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-dup"
+
+	h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+	})
+
+	payload := mustJSON(t, map[string]interface{}{
+		"name":        name,
+		"description": "first",
+		"category":    "custom",
+		"body":        "# x\n",
+	})
+	status, _ := h.APIRequest(t, "POST", "sys/skills/"+name, port, payload)
+	if status != 201 {
+		t.Fatalf("first create: expected 201, got %d", status)
+	}
+
+	status, _ = h.APIRequest(t, "POST", "sys/skills/"+name, port, payload)
+	if status != 409 {
+		t.Errorf("duplicate create: expected 409, got %d", status)
+	}
+}
+
+// TestSkillCreate_ValidationRejects verifies that invalid payloads produce 400.
+func TestSkillCreate_ValidationRejects(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	cases := []struct {
+		name    string
+		path    string
+		payload map[string]interface{}
+	}{
+		{
+			name: "bad category",
+			path: "e2e-bad-category",
+			payload: map[string]interface{}{
+				"description": "x",
+				"category":    "not-a-real-category",
+				"body":        "# x\n",
+			},
+		},
+		{
+			name: "empty body",
+			path: "e2e-empty-body",
+			payload: map[string]interface{}{
+				"description": "x",
+				"category":    "custom",
+				"body":        "",
+			},
+		},
+		{
+			name: "provider-guide without provider",
+			path: "e2e-needs-provider",
+			payload: map[string]interface{}{
+				"description": "x",
+				"category":    "provider-guide",
+				"body":        "# x\n",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h.APIRequest(t, "DELETE", "sys/skills/"+tc.path, port, "")
+			t.Cleanup(func() {
+				h.APIRequest(t, "DELETE", "sys/skills/"+tc.path, port, "")
+			})
+			tc.payload["name"] = tc.path
+			body := mustJSON(t, tc.payload)
+			status, _ := h.APIRequest(t, "POST", "sys/skills/"+tc.path, port, body)
+			if status != 400 {
+				t.Errorf("expected 400, got %d", status)
+			}
+		})
+	}
+}
+
+// TestSkill_GlobalReadFromSubNamespace verifies the read+list endpoints
+// return the same global catalog regardless of namespace scope.
+func TestSkill_GlobalReadFromSubNamespace(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const ns = "e2e-skill-read"
+
+	h.APIRequest(t, "DELETE", "sys/namespaces/"+ns, port, "")
+	createStatus, _ := h.APIRequest(t, "POST", "sys/namespaces/"+ns, port, "")
+	if createStatus != 201 && createStatus != 200 {
+		t.Fatalf("create namespace: expected 201/200, got %d", createStatus)
+	}
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/namespaces/"+ns, port, "")
+	})
+
+	// LIST under the sub-namespace token must succeed and include foundation skills.
+	status, body := h.NSAPIRequest(t, "GET", "sys/skills?warden-list=true", ns, port, "")
+	if status != 200 {
+		t.Fatalf("list under sub-namespace: expected 200, got %d, body %s", status, string(body))
+	}
+	var lr listResp
+	if err := json.Unmarshal(body, &lr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	names := skillNames(lr.Data.Skills)
+	for _, want := range []string{"discovery", "warden-shared", "troubleshooting"} {
+		if !names[want] {
+			t.Errorf("foundation skill %q missing from sub-namespace list", want)
+		}
+	}
+
+	// READ under the sub-namespace token must succeed.
+	status, _ = h.NSAPIRequest(t, "GET", "sys/skills/discovery", ns, port, "")
+	if status != 200 {
+		t.Errorf("read discovery from sub-namespace: expected 200, got %d", status)
+	}
+}
+
+// TestSkill_WriteFromSubNamespaceRejected verifies that mutations from a
+// non-root namespace are rejected with 403.
+func TestSkill_WriteFromSubNamespaceRejected(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const ns = "e2e-skill-write-denied"
+	const name = "e2e-should-not-create"
+
+	h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+	h.APIRequest(t, "DELETE", "sys/namespaces/"+ns, port, "")
+	createStatus, _ := h.APIRequest(t, "POST", "sys/namespaces/"+ns, port, "")
+	if createStatus != 201 && createStatus != 200 {
+		t.Fatalf("create namespace: expected 201/200, got %d", createStatus)
+	}
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/skills/"+name, port, "")
+		h.APIRequest(t, "DELETE", "sys/namespaces/"+ns, port, "")
+	})
+
+	payload := mustJSON(t, map[string]interface{}{
+		"name":        name,
+		"description": "should not land",
+		"category":    "custom",
+		"body":        "# x\n",
+	})
+	status, body := h.NSAPIRequest(t, "POST", "sys/skills/"+name, ns, port, payload)
+	if status != 403 {
+		t.Errorf("create from sub-namespace: expected 403, got %d, body %s", status, string(body))
+	}
+
+	// The global catalog must NOT contain the rejected name.
+	for _, s := range listSkills(t, port) {
+		if s["name"] == name {
+			t.Errorf("rejected skill %q appeared in catalog: %v", name, s)
+		}
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Exposes the skill registry over HTTP. Reads (GET, LIST) are open to any authenticated namespace token -- agents in sub-namespaces can browse and fetch the catalog they need. Mutations (CREATE, UPDATE, DELETE) are restricted to the root namespace and return 403 from elsewhere.

PathsSpecial.Root is operation-agnostic in this codebase, so the namespace check lives in the handlers (requireRootNamespace) rather than at the framework level -- a path-level Root would also block reads.

The LIST response omits the markdown body to keep payloads small; agents that need full content fetch each name via the per-record READ.

Tests:
- 18 unit handler tests: path shape, CRUD success, conflict/notfound, validation rejection, body-omitted-on-list, root-only writes, open reads from sub-namespaces.
- 8 e2e tests against the 3-node HA cluster: foundation skills present after seed, list-omits-body, CRUD round-trip, duplicate conflict, validation rejection, cross-namespace read, write from sub-namespace rejected with catalog unchanged.

createTestCore wires up a SkillStore so existing handler-test fixtures pick it up without per-test boilerplate.