### PR TITLE
feat: seed provider skills into the registry on first mount

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -157,6 +157,21 @@ Usage: warden server [options]
 		"sentry":        sentry.Factory,
 	}
 
+	// providerSkills maps provider type → agent-facing skill markdown,
+	// shipped alongside each provider's Go code under provider/<type>/skill.md.
+	// Only provider packages that ship a skill.md appear here; on first mount
+	// of one of these types, the markdown is seeded into the global skill
+	// registry. Operator edits to a seeded skill are preserved on subsequent
+	// mounts (SkillStore.SeedProviderSkill is a no-op when the name exists).
+	providerSkills = map[string]string{
+		"aws":      aws.Skill(),
+		"github":   github.Skill(),
+		"openai":   openai.Skill(),
+		"rds":      rds.Skill(),
+		"scaleway": scaleway.Skill(),
+		"vault":    vault.Skill(),
+	}
+
 	authMethods = map[string]wardenlogical.Factory{
 		"jwt":  jwt.Factory,
 		"cert": cert.Factory,
@@ -762,6 +777,7 @@ func createCoreConfig(logger *log.GatedLogger, conf *config.Config, backend phy.
 		UnwrapSeal:         unwrapSeal,
 		AuditDevices:       auditDevices,
 		Providers:          providers,
+		ProviderSkills:     providerSkills,
 		AuthMethods:        authMethods,
 		Logger:             logger,
 		SecureRandomReader: secureRandomReader,

--- a/core/core.go
+++ b/core/core.go
@@ -232,6 +232,11 @@ type Core struct {
 
 	providers map[string]logical.Factory
 
+	// providerSkills maps provider type → agent-facing markdown.
+	// Populated from CoreConfig.ProviderSkills; consumed by the mount
+	// handler to seed the skill registry on first mount of each type.
+	providerSkills map[string]string
+
 	auditManager audit.AuditManager
 
 	audit *MountTable
@@ -334,6 +339,14 @@ type CoreConfig struct {
 	AuthMethods map[string]logical.Factory
 
 	Providers map[string]logical.Factory
+
+	// ProviderSkills maps provider type → agent-facing skill markdown.
+	// Entries are populated by the server wiring (cmd/server) for every
+	// provider package that ships a skill.md. On first mount of each
+	// type, the markdown is parsed and seeded into the SkillStore via
+	// SeedProviderSkill. Types absent from this map simply don't appear
+	// in the agent skill catalog until an operator creates one manually.
+	ProviderSkills map[string]string
 
 	// TokenStore has been moved to core package and is created internally
 	// Deprecated: Remove this field, TokenStore is now created in NewCore
@@ -598,6 +611,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 	// Provider backends
 	c.configureProvider(conf.Providers)
+	c.configureProviderSkills(conf.ProviderSkills)
 
 	// Auth backends
 	c.configureAuthMethods(conf.AuthMethods)
@@ -621,6 +635,12 @@ func (c *Core) configureProvider(backends map[string]logical.Factory) {
 	providers := make(map[string]logical.Factory, len(backends))
 	maps.Copy(providers, backends)
 	c.providers = providers
+}
+
+func (c *Core) configureProviderSkills(skills map[string]string) {
+	out := make(map[string]string, len(skills))
+	maps.Copy(out, skills)
+	c.providerSkills = out
 }
 
 func (c *Core) configureAuthMethods(backends map[string]logical.Factory) {

--- a/core/skill_seed.go
+++ b/core/skill_seed.go
@@ -26,13 +26,56 @@ const (
 	seededMarkerKey = "_meta/seeded"
 )
 
+// SeedProviderSkill installs a provider-type skill into the registry,
+// idempotently. Called by the provider-mount handler with the markdown
+// shipped alongside the provider's Go code.
+//
+// providerType is the mount type the caller is registering (e.g., "aws").
+// The frontmatter's `name` field MUST equal providerType — this guards
+// against wiring errors where a provider's skill markdown gets mapped to
+// the wrong type in CoreConfig.ProviderSkills.
+//
+// Behavior:
+//   - If the skill name already exists (operator edit OR previous mount
+//     of the same type), this is a no-op. The operator's edits are
+//     preserved.
+//   - If the name is absent (never seeded, or operator deleted), the
+//     markdown is parsed and persisted with Origin="seed".
+//   - A bad markdown payload OR name/type mismatch returns an error so
+//     the caller can log; the mount itself must not fail because of a
+//     skill error.
+//
+// Unlike SeedFoundation, this method does not use a marker — each
+// provider type carries its own existence check via the registry.
+func (s *SkillStore) SeedProviderSkill(ctx context.Context, providerType, markdown string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return ErrSkillStoreClosed
+	}
+	if s.storage == nil {
+		return errors.New("skill store storage not initialized")
+	}
+
+	skill, err := parseSkillMarkdown([]byte(markdown))
+	if err != nil {
+		return fmt.Errorf("parse provider skill: %w", err)
+	}
+	if skill.Name != providerType {
+		return fmt.Errorf("provider skill name %q does not match provider type %q (likely a wiring error in CoreConfig.ProviderSkills)", skill.Name, providerType)
+	}
+	return s.seedOne(ctx, skill)
+}
+
 // SeedFoundation writes the embedded foundation skills (discovery,
 // warden-shared, troubleshooting) into the registry on first call.
 // Subsequent calls are no-ops thanks to the seeded marker. Operator
 // deletions of seeded skills are not reverted.
 //
 // Provider-type skills follow a different lifecycle (seeded at provider
-// mount time) and are intentionally not handled here.
+// mount time, see SeedProviderSkill) and are intentionally not handled
+// here.
 func (s *SkillStore) SeedFoundation(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/core/skill_seed_test.go
+++ b/core/skill_seed_test.go
@@ -328,6 +328,170 @@ func TestSkillStore_SeedFoundation_ClosedStoreReturnsError(t *testing.T) {
 	}
 }
 
+// providerSkillMD is the canonical fixture for SeedProviderSkill tests.
+const providerSkillMD = `---
+name: testprov
+description: "fixture skill for tests"
+category: provider-guide
+provider: testprov
+---
+
+# Testprov
+
+body content
+`
+
+func TestSkillStore_SeedProviderSkill_WritesSkillOnFirstCall(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("SeedProviderSkill: %v", err)
+	}
+
+	got, err := store.Get(ctx, "testprov")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Origin != SkillOriginSeed {
+		t.Errorf("Origin = %q, want seed", got.Origin)
+	}
+	if got.Category != SkillCategoryProviderGuide {
+		t.Errorf("Category = %q, want provider-guide", got.Category)
+	}
+	if got.Provider != "testprov" {
+		t.Errorf("Provider = %q, want testprov", got.Provider)
+	}
+	if !strings.Contains(got.Body, "body content") {
+		t.Errorf("Body missing fixture text: %q", got.Body)
+	}
+}
+
+func TestSkillStore_SeedProviderSkill_IdempotentOnReMount(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("first SeedProviderSkill: %v", err)
+	}
+	first, err := store.Get(ctx, "testprov")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("second SeedProviderSkill: %v", err)
+	}
+	second, err := store.Get(ctx, "testprov")
+	if err != nil {
+		t.Fatalf("Get (second): %v", err)
+	}
+	if first.Version != second.Version {
+		t.Errorf("Version changed across re-seed: %d -> %d", first.Version, second.Version)
+	}
+	if !first.UpdatedAt.Equal(second.UpdatedAt) {
+		t.Errorf("UpdatedAt changed across re-seed: %v -> %v", first.UpdatedAt, second.UpdatedAt)
+	}
+}
+
+func TestSkillStore_SeedProviderSkill_PreservesOperatorEdits(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("SeedProviderSkill: %v", err)
+	}
+	if _, err := store.Update(ctx, "testprov", &Skill{Description: "operator override"}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Re-mount of same provider type must not clobber the operator's edit.
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("second SeedProviderSkill: %v", err)
+	}
+	got, err := store.Get(ctx, "testprov")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Description != "operator override" {
+		t.Errorf("Description = %q, operator edit lost", got.Description)
+	}
+}
+
+func TestSkillStore_SeedProviderSkill_ReSeedsAfterDeletion(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("first SeedProviderSkill: %v", err)
+	}
+	if err := store.Delete(ctx, "testprov"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Deletion + new mount of same provider type re-seeds the skill.
+	// (Unlike foundation skills, provider seeding has no sticky marker.)
+	if err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD); err != nil {
+		t.Fatalf("second SeedProviderSkill: %v", err)
+	}
+	got, err := store.Get(ctx, "testprov")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "testprov" {
+		t.Errorf("Name = %q, want testprov", got.Name)
+	}
+}
+
+func TestSkillStore_SeedProviderSkill_RejectsInvalidMarkdown(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	cases := []struct {
+		name     string
+		provType string
+		md       string
+	}{
+		{"missing opening delimiter", "foo", "name: foo\ndescription: bar\ncategory: shared\n"},
+		{"missing closing delimiter", "foo", "---\nname: foo\ndescription: bar\ncategory: shared\n"},
+		{"missing body", "ok", "---\nname: ok\ndescription: bar\ncategory: shared\n---\n"},
+		{"provider-guide without provider", "gw", "---\nname: gw\ndescription: bar\ncategory: provider-guide\n---\n\nbody\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := store.SeedProviderSkill(ctx, tc.provType, tc.md)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestSkillStore_SeedProviderSkill_RejectsNameMismatch verifies the new
+// providerType-vs-skill.Name guard catches wire-up errors where the
+// markdown's declared name does not match the registered provider type.
+func TestSkillStore_SeedProviderSkill_RejectsNameMismatch(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+
+	// providerSkillMD declares `name: testprov` — pass a different type.
+	err := store.SeedProviderSkill(ctx, "wronglabel", providerSkillMD)
+	if err == nil {
+		t.Fatalf("expected name-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not match provider type") {
+		t.Errorf("error %q does not mention mismatch", err.Error())
+	}
+	// And no skill should have been persisted.
+	if _, err := store.Get(ctx, "testprov"); !errors.Is(err, ErrSkillNotFound) {
+		t.Errorf("Get after rejected seed: got %v, want ErrSkillNotFound", err)
+	}
+}
+
+func TestSkillStore_SeedProviderSkill_ClosedStoreReturnsError(t *testing.T) {
+	store, ctx := setupTestSkillStore(t)
+	_ = store.Close()
+
+	err := store.SeedProviderSkill(ctx, "testprov", providerSkillMD)
+	if !errors.Is(err, ErrSkillStoreClosed) {
+		t.Errorf("err = %v, want ErrSkillStoreClosed", err)
+	}
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/core/sys_providers.go
+++ b/core/sys_providers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
 
@@ -94,11 +95,37 @@ func (b *SystemBackend) handleProviderCreate(ctx context.Context, req *logical.R
 		return logical.ErrorResponse(err), nil
 	}
 
+	// Seed the agent-facing skill for this provider type, if one ships
+	// with the package. First mount of a given type registers the skill;
+	// later mounts of the same type are no-ops. Operator edits to a
+	// previously seeded skill are preserved. Skill failures never block
+	// the mount — the cluster is functional without the catalog entry.
+	b.maybeSeedProviderSkill(ctx, providerType)
+
 	return b.respondCreated(map[string]any{
 		"accessor": entry.Accessor,
 		"path":     entry.Path,
 		"message":  fmt.Sprintf("Successfully mounted %s provider at %s", providerType, path),
 	}), nil
+}
+
+// maybeSeedProviderSkill seeds the agent skill for providerType when both
+// the wired-up markdown and the SkillStore are available. Errors are
+// logged but do not propagate — see handleProviderCreate.
+func (b *SystemBackend) maybeSeedProviderSkill(ctx context.Context, providerType string) {
+	if b.core.skillStore == nil {
+		return
+	}
+	md, ok := b.core.providerSkills[providerType]
+	if !ok || md == "" {
+		return
+	}
+	if err := b.core.skillStore.SeedProviderSkill(ctx, providerType, md); err != nil {
+		b.logger.Warn("failed to seed provider skill",
+			logger.String("type", providerType),
+			logger.Err(err),
+		)
+	}
 }
 
 // handleProviderRead handles GET /sys/providers/{path}

--- a/core/sys_skills_test.go
+++ b/core/sys_skills_test.go
@@ -336,6 +336,38 @@ func TestSystemBackend_HandleSkillRead_AllowsAnyNamespace(t *testing.T) {
 	assert.Equal(t, "publicly-visible", resp.Data["name"])
 }
 
+func TestSystemBackend_MaybeSeedProviderSkill_SeedsWhenRegistered(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	core.providerSkills = map[string]string{"testprov": providerSkillMD}
+
+	backend.maybeSeedProviderSkill(ctx, "testprov")
+
+	got, err := core.skillStore.Get(ctx, "testprov")
+	require.NoError(t, err)
+	assert.Equal(t, SkillOriginSeed, got.Origin)
+	assert.Equal(t, "testprov", got.Provider)
+}
+
+func TestSystemBackend_MaybeSeedProviderSkill_NoOpWhenUnregistered(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	// providerSkills has no "unmapped" entry.
+
+	backend.maybeSeedProviderSkill(ctx, "unmapped")
+
+	_, err := core.skillStore.Get(ctx, "unmapped")
+	assert.ErrorIs(t, err, ErrSkillNotFound)
+}
+
+func TestSystemBackend_MaybeSeedProviderSkill_NoOpWhenStoreNil(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	core.skillStore = nil
+	core.providerSkills = map[string]string{"testprov": providerSkillMD}
+
+	// Must not panic, must not error out — the cluster runs fine without
+	// the skill catalog.
+	backend.maybeSeedProviderSkill(ctx, "testprov")
+}
+
 func TestSystemBackend_HandleSkillList_AllowsAnyNamespace(t *testing.T) {
 	backend, ctx, _ := setupTestSystemBackend(t)
 	crudSchema, listSchema := skillPathSchemas(backend)

--- a/e2e/skill/skill_test.go
+++ b/e2e/skill/skill_test.go
@@ -60,6 +60,38 @@ func TestSkill_FoundationSkillsArePresent(t *testing.T) {
 	}
 }
 
+// TestSkill_ProviderSkillSeededOnMount verifies that mounting a provider
+// type seeds the type's skill into the global catalog. The e2e setup
+// mounts a vault provider as part of step 9, so by the time tests run,
+// the "vault" skill must already be present.
+func TestSkill_ProviderSkillSeededOnMount(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	names := skillNames(listSkills(t, port))
+
+	if !names["vault"] {
+		t.Fatalf("provider skill \"vault\" missing — seed-on-mount did not fire (got %v)", names)
+	}
+
+	// Confirm the record has the right provenance.
+	status, body := h.APIRequest(t, "GET", "sys/skills/vault", port, "")
+	if status != 200 {
+		t.Fatalf("read vault skill: status %d, body %s", status, string(body))
+	}
+	var rd readResp
+	if err := json.Unmarshal(body, &rd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rd.Data["origin"] != "seed" {
+		t.Errorf("vault origin = %v, want \"seed\"", rd.Data["origin"])
+	}
+	if rd.Data["provider"] != "vault" {
+		t.Errorf("vault provider field = %v, want \"vault\"", rd.Data["provider"])
+	}
+	if rd.Data["category"] != "provider-guide" {
+		t.Errorf("vault category = %v, want \"provider-guide\"", rd.Data["category"])
+	}
+}
+
 // TestSkill_ReadFoundationSkillReturnsBody verifies that a known foundation
 // skill comes back with its full markdown body via the read endpoint.
 func TestSkill_ReadFoundationSkillReturnsBody(t *testing.T) {

--- a/provider/aws/skill.go
+++ b/provider/aws/skill.go
@@ -1,0 +1,14 @@
+package aws
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the AWS provider.
+// The content is seeded into the global skill registry the first time
+// an AWS provider is mounted in the cluster; subsequent mounts are
+// no-ops and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/aws/skill.md
+++ b/provider/aws/skill.md
@@ -2,6 +2,7 @@
 name: aws
 description: "Call AWS services (S3, EC2, Lambda, DynamoDB, STS, …) through Warden's SigV4 gateway."
 category: provider-guide
+provider: aws
 upstream: AWS
 ---
 

--- a/provider/github/skill.go
+++ b/provider/github/skill.go
@@ -1,0 +1,14 @@
+package github
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the GitHub provider.
+// The content is seeded into the global skill registry the first time a
+// GitHub provider is mounted in the cluster; subsequent mounts are no-ops
+// and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/github/skill.md
+++ b/provider/github/skill.md
@@ -2,6 +2,7 @@
 name: github
 description: "Call the GitHub REST API through Warden — read repos, manage issues, push releases — without holding a GitHub PAT."
 category: provider-guide
+provider: github
 upstream: GitHub REST API (api.github.com or GHE)
 ---
 

--- a/provider/openai/skill.go
+++ b/provider/openai/skill.go
@@ -1,0 +1,14 @@
+package openai
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the OpenAI provider.
+// The content is seeded into the global skill registry the first time an
+// OpenAI provider is mounted in the cluster; subsequent mounts are no-ops
+// and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/openai/skill.md
+++ b/provider/openai/skill.md
@@ -2,6 +2,7 @@
 name: openai
 description: "Call the OpenAI API through Warden — chat, embeddings, moderation — without holding an OpenAI API key."
 category: provider-guide
+provider: openai
 upstream: OpenAI REST API (api.openai.com)
 ---
 

--- a/provider/rds/skill.go
+++ b/provider/rds/skill.go
@@ -1,0 +1,14 @@
+package rds
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the RDS provider.
+// The content is seeded into the global skill registry the first time an
+// RDS provider is mounted in the cluster; subsequent mounts are no-ops
+// and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/rds/skill.md
+++ b/provider/rds/skill.md
@@ -2,6 +2,7 @@
 name: rds
 description: "Get a short-lived database connection string for AWS RDS through Warden — agent connects to the DB directly with a 15-min IAM auth token."
 category: provider-guide
+provider: rds
 upstream: AWS RDS (PostgreSQL, MySQL)
 ---
 

--- a/provider/scaleway/skill.go
+++ b/provider/scaleway/skill.go
@@ -1,0 +1,14 @@
+package scaleway
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the Scaleway provider.
+// The content is seeded into the global skill registry the first time a
+// Scaleway provider is mounted in the cluster; subsequent mounts are
+// no-ops and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/scaleway/skill.md
+++ b/provider/scaleway/skill.md
@@ -2,6 +2,7 @@
 name: scaleway
 description: "Call the Scaleway REST API and Scaleway Object Storage (S3-compatible) through Warden — one provider, two patterns auto-detected."
 category: provider-guide
+provider: scaleway
 upstream: Scaleway REST API + Object Storage
 ---
 

--- a/provider/vault/skill.go
+++ b/provider/vault/skill.go
@@ -1,0 +1,14 @@
+package vault
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the Vault provider.
+// The content is seeded into the global skill registry the first time a
+// Vault provider is mounted in the cluster; subsequent mounts are no-ops
+// and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/vault/skill.md
+++ b/provider/vault/skill.md
@@ -2,6 +2,7 @@
 name: vault
 description: "Call HashiCorp Vault / OpenBao through Warden — read secrets, sign, encrypt, manage PKI — without ever holding a Vault token."
 category: provider-guide
+provider: vault
 upstream: HashiCorp Vault / OpenBao
 ---
 


### PR DESCRIPTION
Provider skills now live alongside the provider Go code at provider/<type>/skill.md (moved from skills/providers/<type>/SKILL.md). Each provider package exposes the markdown via Skill() and that content is piped through CoreConfig.ProviderSkills into Core.providerSkills.

The mount handler in sys_providers.go calls SkillStore.SeedProviderSkill after a successful provider mount. First mount of a given type registers the skill; subsequent mounts are no-ops, and operator edits to a previously seeded skill are preserved across re-mounts. Operators who delete a seeded skill see it re-seeded on the next mount of that type (there is no sticky marker like for foundation skills, by design).

SeedProviderSkill takes the registered providerType and rejects markdown whose frontmatter `name` does not match — guards against wire-up errors where aws.Skill() ends up in providerSkills["azure"] etc. The mismatch surfaces as a Warn at mount time instead of silently miscataloging.

Seed failures never block the mount; the cluster is functional without the catalog entry. The skills/ folder is now fully removed -- the registry is the source of truth.

Tests:
- 7 new unit tests for SeedProviderSkill (happy path, idempotency, preserves edits, re-seeds after delete, invalid markdown, name-vs-type mismatch, closed-store error).
- 3 new handler tests for maybeSeedProviderSkill (seeds when registered, no-op when unregistered, no-op when store nil).
- 1 new e2e test confirming the vault provider mounted by the e2e setup script shows up in the global catalog with the right origin / provider / category.