### PR TITLE
feat: warden skill CLI, foundation rename, deadlock fix, agent-flow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,20 +8,30 @@ for the *consumer* side.
 
 ## Where to start
 
-1. **`skills/warden-shared/SKILL.md`** — global flags, env vars, exit
-   codes, output framework. Read this first.
-2. **`skills/discovery/SKILL.md`** — how to introspect which roles you
-   can assume and which providers are available, then match the task at
-   hand to a provider + role.
-3. **`skills/providers/<name>/SKILL.md`** — once you know which provider
-   you want, this tells you how to point your CLI/SDK at it.
-4. **`skills/troubleshooting/SKILL.md`** — when something fails:
+Skills are served by the cluster at `/v1/sys/skills`, not from this
+filesystem. Read them in order via the CLI:
+
+1. **`warden skill read foundation --raw`** — global flags, env vars,
+   exit codes, output framework. Read this first.
+2. **`warden skill read discovery --raw`** — how to introspect which
+   roles you can assume and which providers are available, then match
+   the task at hand to a provider + role.
+3. **`warden skill read <provider-type> --raw`** — once you know which
+   provider type you want (`aws`, `vault`, `openai`, …), this tells you
+   how to point your CLI/SDK at it.
+4. **`warden skill read troubleshooting --raw`** — when something fails:
    classified errors, what to retry, what means "ask the operator".
+
+To browse what's in the catalog:
+
+```bash
+warden skill list -F name,description
+```
 
 ## The agent loop
 
 ```
-[ authenticate + set namespace ]
+[ authenticate + set namespace ]      ← runtime sets env vars
        │
        ▼
 [ warden role list ]                  ← what identities can I assume?
@@ -33,42 +43,48 @@ for the *consumer* side.
 [ match task → pick provider+role ]   ← read descriptions; choose the fit
        │
        ▼
-[ read skills/providers/<type>/SKILL.md ]
-       │                              ← the per-provider recipe
+[ warden skill read <type> --raw ]    ← the per-provider recipe
+       │
        ▼
 [ call CLI or SDK with chosen role ]
 ```
 
-Each step is a one-liner; `skills/discovery/` walks through the
-variants.
+The `discovery` skill walks through each step in full.
 
 ## Provider skills available today
 
-| Provider | Skill | Pattern |
+Skills for the six providers below are seeded into the registry the
+first time the corresponding provider type is mounted in the cluster:
+
+| Provider | Skill name | Pattern |
 |---|---|---|
-| AWS | `skills/providers/aws/SKILL.md` | SigV4 gateway |
-| Vault / OpenBao | `skills/providers/vault/SKILL.md` | HTTP gateway |
-| GitHub | `skills/providers/github/SKILL.md` | HTTP gateway |
-| OpenAI | `skills/providers/openai/SKILL.md` | HTTP gateway |
-| Scaleway | `skills/providers/scaleway/SKILL.md` | Dual REST + S3 |
-| RDS | `skills/providers/rds/SKILL.md` | DB credential mint |
+| AWS | `aws` | SigV4 gateway |
+| Vault / OpenBao | `vault` | HTTP gateway |
+| GitHub | `github` | HTTP gateway |
+| OpenAI | `openai` | HTTP gateway |
+| Scaleway | `scaleway` | Dual REST + S3 |
+| RDS | `rds` | DB credential mint |
 
 Other providers (`azure`, `gcp`, `cloudflare`, `datadog`, `sentry`,
 `grafana`, `kubernetes`, `slack`, `tfe`, …) follow the same patterns
-but don't yet have dedicated skills. Until they do, the closest
-existing skill plus the provider's `README.md` is your best reference.
+but don't yet ship skills. Until they do, the closest existing skill
+plus the provider's `README.md` is your best reference.
 
 ## Adding a skill for a new provider
 
 When a new provider lands under `provider/<name>/`, ship a matching
-`skills/providers/<name>/SKILL.md` with the same shape as the existing
-ones:
+`provider/<name>/skill.md` with the same shape as the existing ones,
+and add `<name>.Skill()` to the `providerSkills` map in
+`cmd/server/server.go`. The skill is seeded into the registry on the
+first mount of that provider type.
 
 ```yaml
 ---
 name: <name>
 description: "<one line: what does this provider expose>"
 category: provider-guide
+provider: <name>
+requires: [foundation, discovery]
 upstream: "<service name>"
 ---
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ Warden closes the gap by sitting in the path: the agent identifies itself, Warde
                                     • Audit ✓
 ```
 
-**Discover.** The agent presents its identity — a JWT or TLS client certificate — and asks Warden which roles it is permitted to assume. Warden answers with the set of roles open to that exact identity, each with a human-readable description. The agent learns what it can do without anyone shipping a config file or distributing role names out of band.
+**Discover.** The agent presents its identity — a JWT or TLS client certificate — and runs three introspection calls against Warden:
+
+1. `warden role list` — which roles is this identity permitted to assume in this namespace?
+2. `warden provider list` — which upstream systems are mounted here?
+3. `warden skill read <type>` — for the chosen system, fetch the agent-facing recipe (env vars, endpoint URL, role-selection idiom).
+
+Each response is human-readable JSON or markdown. The agent matches the task to a role and provider by reading operator-set descriptions — no config files, no role names distributed out of band, no SDK to rebuild when a new provider is mounted.
 
 **Connect.** The agent picks a role and points at Warden as if it were the upstream. Warden authenticates the identity, applies the role's policy at request time, and attaches the upstream credential before forwarding — or vends a scoped grant directly, such as a database auth token or a pre-signed URL. The credential belongs to Warden, never to the agent — and is ephemeral wherever the upstream supports it.
 
@@ -69,25 +75,26 @@ Warden closes the gap by sitting in the path: the agent identifies itself, Warde
 What an enterprise gets from putting Warden in the path:
 
 - **Discovery** — identity-scoped introspection. Agents learn which systems and roles are open to them; nothing has to be pre-loaded into the agent's environment.
+- **Self-describing capabilities** — every provider type ships a runtime recipe (an agent skill) that the cluster serves alongside the gateway. The catalog reflects what's currently mounted; adding a provider makes it instantly discoverable, removing one makes it instantly gone. No agent rebuild, no SDK update.
 - **Fine-grained access policy** — per-action capabilities and parameter filters, evaluated at request time against caller IP, time of day, and day of week.
-- **Identity-bound access** — JWT (including SPIFFE JWT-SVID) or TLS client certificate (including SPIFFE X.509-SVID); every grant scoped to the actual caller, not a pooled credential.
+- **Identity-bound access** — JWT (including SPIFFE JWT-SVID) or TLS client certificate (including SPIFFE X.509-SVID); the same identity reaches every upstream the policy permits — no per-system credential sprawl, no API keys handed to agents, nothing to rotate per integration.
 - **Audit** — every request tied to the original identity, the role used, and the upstream called.
-- **Credentials never leave Warden** — a prompt-injected agent has nothing to leak; there is no credential in its environment to exfiltrate.
+- **Compromise-resilient** — a prompt-injected, jailbroken, or otherwise compromised agent has nothing upstream to exfiltrate. The blast radius is bounded by Warden's policy at request time, not by what happens to be in the agent's memory or chat history.
 
 ## Supported systems
 
 33 systems across LLMs, cloud, code-hosting, observability, ITSM, Kubernetes, secrets, and databases. Follow any link below to configure your first endpoint, or see [docs/providers.md](docs/providers.md) for the full list.
 
-| Category | Providers | Warden does | Status |
-|---|---|---|---|
-| LLM APIs | [Anthropic](provider/anthropic/README.md), [OpenAI](provider/openai/README.md), [Mistral](provider/mistral/README.md), [Cohere](provider/cohere/README.md) | Injects API key | ✅ |
-| Cloud infrastructure | [AWS](provider/aws/README.md), [Azure](provider/azure/README.md), [GCP](provider/gcp/README.md), [Alicloud](provider/alicloud/README.md), [IBM Cloud](provider/ibmcloud/README.md), [OVH](provider/ovh/README.md), [Scaleway](provider/scaleway/README.md), [Cloudflare](provider/cloudflare/README.md) | Temporary credentials / Bearer tokens | ✅ |
-| Code hosting & CI/CD | [GitHub](provider/github/README.md), [GitLab](provider/gitlab/README.md), [Atlassian](provider/atlassian/README.md), [Ansible Tower](provider/ansible_tower/README.md), [Terraform Enterprise](provider/tfe/README.md) | Injects App token, PAT, or Bearer token | ✅ |
-| Observability | [Datadog](provider/datadog/README.md), [Dynatrace](provider/dynatrace/README.md), [Elastic](provider/elastic/README.md), [Grafana](provider/grafana/README.md), [Honeycomb](provider/honeycomb/README.md), [New Relic](provider/newrelic/README.md), [Prometheus](provider/prometheus/README.md), [Sentry](provider/sentry/README.md), [Splunk](provider/splunk/README.md) | Injects API key / proxies metrics | ✅ |
-| Incident & ITSM | [PagerDuty](provider/pagerduty/README.md), [ServiceNow](provider/servicenow/README.md), [Slack](provider/slack/README.md) | Injects Bearer token | ✅ |
-| Kubernetes | [Kubernetes](provider/kubernetes/README.md) | Injects service account token | ✅ |
-| Secrets backend | [HashiCorp Vault / OpenBao](provider/vault/README.md) | Mints short-lived tokens | ✅ |
-| Databases | [AWS RDS / Aurora](provider/rds/README.md), [AWS Redshift](provider/redshift/README.md) | Issues IAM database auth token | ✅ |
+| Category | Providers | Warden does |
+|---|---|---|
+| LLM APIs | [Anthropic](provider/anthropic/README.md), [OpenAI](provider/openai/README.md), [Mistral](provider/mistral/README.md), [Cohere](provider/cohere/README.md) | Injects API key |
+| Cloud infrastructure | [AWS](provider/aws/README.md), [Azure](provider/azure/README.md), [GCP](provider/gcp/README.md), [Alicloud](provider/alicloud/README.md), [IBM Cloud](provider/ibmcloud/README.md), [OVH](provider/ovh/README.md), [Scaleway](provider/scaleway/README.md), [Cloudflare](provider/cloudflare/README.md) | Temporary credentials / Bearer tokens |
+| Code hosting & CI/CD | [GitHub](provider/github/README.md), [GitLab](provider/gitlab/README.md), [Atlassian](provider/atlassian/README.md), [Ansible Tower](provider/ansible_tower/README.md), [Terraform Enterprise](provider/tfe/README.md) | Injects App token, PAT, or Bearer token |
+| Observability | [Datadog](provider/datadog/README.md), [Dynatrace](provider/dynatrace/README.md), [Elastic](provider/elastic/README.md), [Grafana](provider/grafana/README.md), [Honeycomb](provider/honeycomb/README.md), [New Relic](provider/newrelic/README.md), [Prometheus](provider/prometheus/README.md), [Sentry](provider/sentry/README.md), [Splunk](provider/splunk/README.md) | Injects API key / proxies metrics |
+| Incident & ITSM | [PagerDuty](provider/pagerduty/README.md), [ServiceNow](provider/servicenow/README.md), [Slack](provider/slack/README.md) | Injects Bearer token |
+| Kubernetes | [Kubernetes](provider/kubernetes/README.md) | Injects service account token |
+| Secrets backend | [HashiCorp Vault / OpenBao](provider/vault/README.md) | Mints short-lived tokens |
+| Databases | [AWS RDS / Aurora](provider/rds/README.md), [AWS Redshift](provider/redshift/README.md) | Issues IAM database auth token |
 
 ## Use cases
 
@@ -126,6 +133,8 @@ A walk-through of the discover-then-connect model end to end:
 - The agent holds zero credentials.
 
 See [docs/tutorials/vault-policy-hygiene/README.md](docs/tutorials/vault-policy-hygiene/README.md) for the full walk-through.
+
+For the system-side reference describing how an agent uses Warden end-to-end — the runtime contract, the five-step discovery loop, error handling, caching strategy — see [docs/agent-flow.md](docs/agent-flow.md).
 
 ## Architecture
 

--- a/cmd/skills/create.go
+++ b/cmd/skills/create.go
@@ -1,0 +1,195 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	createName        string
+	createDescription string
+	createCategory    string
+	createRequires    []string
+	createUpstream    string
+	createProvider    string
+	createBodyFile    string
+	createJSON        string
+
+	CreateCmd = &cobra.Command{
+		Use:           "create [NAME]",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Create a new skill in the global registry (root namespace only)",
+		Long: `
+Usage: warden skill create [NAME] [options]
+
+  Create a new skill. Mutations to /v1/sys/skills require a root
+  namespace token; running this from a sub-namespace surfaces the
+  server's 403 with a clear message.
+
+  Two input modes (mutually exclusive):
+
+    Typed flags (human-friendly):
+
+      $ warden skill create --name=my-runbook --category=custom \
+          --description="ops on-call" --body-file=./runbook.md
+
+    Full JSON payload (agent-friendly):
+
+      $ warden skill create my-runbook --json @skill.json
+      $ cat skill.json | warden skill create my-runbook --json -
+
+  --json is mutually exclusive with --name / --description / --category
+  / --requires / --upstream / --provider / --body-file. The skill name
+  is taken from the positional argument when given, otherwise from
+  --name or the payload's "name" field.
+
+  Required fields (typed or via payload): name, description, category,
+  body. provider-guide skills also require a "provider" field.
+`,
+		RunE: runCreate,
+	}
+)
+
+func init() {
+	CreateCmd.Flags().StringVar(&createName, "name", "",
+		"Skill name (unique slug, [a-z0-9-]{2,64}); required unless --json supplies one")
+	CreateCmd.Flags().StringVar(&createDescription, "description", "",
+		"Human-readable one-line summary; required unless --json")
+	CreateCmd.Flags().StringVar(&createCategory, "category", "",
+		"agent-flow | shared | provider-guide | troubleshooting | custom")
+	CreateCmd.Flags().StringSliceVar(&createRequires, "requires", nil,
+		"Names of other skills this one depends on (repeat or comma-separated)")
+	CreateCmd.Flags().StringVar(&createUpstream, "upstream", "",
+		"Reference to an upstream system, when applicable")
+	CreateCmd.Flags().StringVar(&createProvider, "provider", "",
+		"Provider type this skill describes (required when category=provider-guide)")
+	CreateCmd.Flags().StringVar(&createBodyFile, "body-file", "",
+		"Path to the markdown body file")
+	CreateCmd.Flags().StringVarP(&createJSON, "json", "j", "",
+		"Full JSON payload — '<json>', '@file.json', or '-' for stdin")
+}
+
+func runCreate(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	jsonPayload, err := helpers.ResolveJSONInput(createJSON)
+	if err != nil {
+		return err
+	}
+
+	if jsonPayload != nil {
+		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
+			"--name":        createName != "",
+			"--description": createDescription != "",
+			"--category":    createCategory != "",
+			"--requires":    len(createRequires) > 0,
+			"--upstream":    createUpstream != "",
+			"--provider":    createProvider != "",
+			"--body-file":   createBodyFile != "",
+		}); err != nil {
+			return err
+		}
+		name := skillNameFromArgOrPayload(args, jsonPayload)
+		if name == "" {
+			return fmt.Errorf("--json without a positional NAME and without a 'name' field in the payload: cannot determine skill name: %w", helpers.ErrUsage)
+		}
+		if helpers.ResolveDryRun() {
+			return helpers.DryRun(c, "POST", "sys/skills/{name}", jsonPayload)
+		}
+		resource, err := c.Operator().Post("sys/skills/"+name, jsonPayload)
+		if err != nil {
+			return fmt.Errorf("error creating skill: %w", err)
+		}
+		out := map[string]any{}
+		var resData map[string]any
+		if resource != nil {
+			resData = resource.Data
+		}
+		helpers.MergeServerResponseInto(out, resData, map[string]any{
+			"name":    name,
+			"created": true,
+		})
+		return helpers.RenderMap(out, func() {
+			fmt.Printf("Success! Created skill: %s\n", name)
+		})
+	}
+
+	// Typed mode.
+	name := createName
+	if len(args) > 0 {
+		name = args[0]
+	}
+	if name == "" {
+		return fmt.Errorf("either a positional NAME, --name, or --json is required: %w", helpers.ErrUsage)
+	}
+	if createDescription == "" {
+		return fmt.Errorf("--description is required (or use --json): %w", helpers.ErrUsage)
+	}
+	if createCategory == "" {
+		return fmt.Errorf("--category is required (or use --json): %w", helpers.ErrUsage)
+	}
+	if createBodyFile == "" {
+		return fmt.Errorf("--body-file is required (or use --json): %w", helpers.ErrUsage)
+	}
+	bodyBytes, err := os.ReadFile(createBodyFile)
+	if err != nil {
+		return fmt.Errorf("--body-file %s: %w", createBodyFile, err)
+	}
+
+	payload := map[string]any{
+		"name":        name,
+		"description": createDescription,
+		"category":    createCategory,
+		"body":        string(bodyBytes),
+	}
+	if len(createRequires) > 0 {
+		payload["requires"] = createRequires
+	}
+	if createUpstream != "" {
+		payload["upstream"] = createUpstream
+	}
+	if createProvider != "" {
+		payload["provider"] = createProvider
+	}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "POST", "sys/skills/{name}", payload)
+	}
+
+	resource, err := c.Operator().Post("sys/skills/"+name, payload)
+	if err != nil {
+		return fmt.Errorf("error creating skill: %w", err)
+	}
+	out := map[string]any{}
+	var resData map[string]any
+	if resource != nil {
+		resData = resource.Data
+	}
+	helpers.MergeServerResponseInto(out, resData, map[string]any{
+		"name":    name,
+		"created": true,
+	})
+	return helpers.RenderMap(out, func() {
+		fmt.Printf("Success! Created skill: %s\n", name)
+	})
+}
+
+// skillNameFromArgOrPayload mirrors helpers.MountPathFromArgOrPayload but
+// reads the payload's "name" field instead of "type", and does not
+// suffix with a trailing slash (skills are name-keyed, not path-keyed).
+func skillNameFromArgOrPayload(args []string, payload map[string]any) string {
+	if len(args) > 0 && args[0] != "" {
+		return args[0]
+	}
+	if n, ok := payload["name"].(string); ok {
+		return n
+	}
+	return ""
+}

--- a/cmd/skills/delete.go
+++ b/cmd/skills/delete.go
@@ -1,0 +1,95 @@
+package skills
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	deleteForce bool
+
+	DeleteCmd = &cobra.Command{
+		Use:           "delete NAME",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Delete a skill from the global registry (root namespace only)",
+		Long: `
+Usage: warden skill delete NAME [options]
+
+  Delete a skill. Foundation skills (discovery, foundation,
+  troubleshooting) and seeded provider skills can be deleted — once
+  removed, they stay removed across restarts (the seed marker is
+  sticky). Run 'warden skill list' first if you're not sure of the
+  exact name.
+
+  Mutations require a root namespace token; sub-namespace tokens get 403.
+
+  On a TTY without --force the command prompts for confirmation. In
+  scripts or pipes (stdin not a TTY), confirmation is skipped because
+  there is no one to answer the prompt — use --force in scripts to
+  make the intent explicit.
+
+  Examples:
+
+    Interactive delete:
+
+      $ warden skill delete my-runbook
+
+    Scripted delete:
+
+      $ warden skill delete my-runbook --force
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: runDelete,
+	}
+)
+
+func init() {
+	DeleteCmd.Flags().BoolVar(&deleteForce, "force", false,
+		"Skip the interactive confirmation prompt")
+}
+
+func runDelete(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+
+	if !deleteForce && isatty.IsTerminal(os.Stdin.Fd()) {
+		fmt.Fprintf(os.Stderr, "Delete skill %q? This cannot be undone. (y/N) ", name)
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		if !confirmed(line) {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+	}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "DELETE", "sys/skills/{name}", nil)
+	}
+
+	if _, err := c.Operator().Delete("sys/skills/" + name); err != nil {
+		return fmt.Errorf("error deleting skill %q: %w", name, err)
+	}
+
+	return helpers.RenderMap(map[string]any{
+		"name":    name,
+		"deleted": true,
+	}, func() {
+		fmt.Printf("Success! Deleted skill: %s\n", name)
+	})
+}
+
+func confirmed(line string) bool {
+	s := strings.ToLower(strings.TrimSpace(line))
+	return s == "y" || s == "yes"
+}

--- a/cmd/skills/list.go
+++ b/cmd/skills/list.go
@@ -1,0 +1,133 @@
+package skills
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	listCategoryFilter string
+	listOriginFilter   string
+	listProviderFilter string
+
+	ListCmd = &cobra.Command{
+		Use:           "list",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "List every skill in the global registry",
+		Long: `
+Usage: warden skill list [options]
+
+  Returns the agent skill catalog. The list endpoint returns short-form
+  records (no markdown body) to keep the response cheap; agents that need
+  full content fetch each name via 'warden skill read NAME'.
+
+  Output honors the global --output flag:
+    table    one row per skill (default for TTY)
+    json     [{"name", "description", "category", "origin", ...}, ...]
+    ndjson   one skill per line, agent-friendly for piping into jq
+    text     key=value lines per record
+
+  Composes with --fields, e.g. --fields name,category to project per record.
+
+  Examples:
+
+    All skills:
+
+      $ warden skill list
+
+    Only provider-guide skills, JSON for agents:
+
+      $ warden skill list --category=provider-guide -o json
+
+    Only operator-created skills:
+
+      $ warden skill list --origin=user
+`,
+		Args: cobra.NoArgs,
+		RunE: runList,
+	}
+)
+
+func init() {
+	ListCmd.Flags().StringVar(&listCategoryFilter, "category", "",
+		"Filter by category (agent-flow, shared, provider-guide, troubleshooting, custom)")
+	ListCmd.Flags().StringVar(&listOriginFilter, "origin", "",
+		"Filter by origin (seed for binary-shipped, user for operator-created)")
+	ListCmd.Flags().StringVar(&listProviderFilter, "provider", "",
+		"Filter by provider type (only applies to provider-guide category)")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	resource, err := c.Operator().ReadWithData("sys/skills", map[string][]string{
+		"warden-list": {"true"},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list skills: %w", err)
+	}
+
+	var raw []any
+	if resource != nil && resource.Data != nil {
+		raw, _ = resource.Data["skills"].([]any)
+	}
+
+	items := make([]map[string]any, 0, len(raw))
+	for _, r := range raw {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if listCategoryFilter != "" {
+			if cat, _ := rm["category"].(string); cat != listCategoryFilter {
+				continue
+			}
+		}
+		if listOriginFilter != "" {
+			if origin, _ := rm["origin"].(string); origin != listOriginFilter {
+				continue
+			}
+		}
+		if listProviderFilter != "" {
+			if prov, _ := rm["provider"].(string); prov != listProviderFilter {
+				continue
+			}
+		}
+		items = append(items, rm)
+	}
+
+	// Stable, alphabetical order for deterministic agent output.
+	sort.Slice(items, func(i, j int) bool {
+		ni, _ := items[i]["name"].(string)
+		nj, _ := items[j]["name"].(string)
+		return ni < nj
+	})
+
+	return helpers.RenderList(items, func() {
+		printSkillsTable(items)
+	})
+}
+
+func printSkillsTable(items []map[string]any) {
+	if len(items) == 0 {
+		fmt.Println("No skills match the filters.")
+		return
+	}
+	rows := make([][]any, len(items))
+	for i, it := range items {
+		rows[i] = []any{
+			fmt.Sprintf("%v", it["name"]),
+			fmt.Sprintf("%v", it["category"]),
+			fmt.Sprintf("%v", it["origin"]),
+			fmt.Sprintf("%v", it["description"]),
+		}
+	}
+	helpers.PrintTable([]string{"Name", "Category", "Origin", "Description"}, rows)
+}

--- a/cmd/skills/read.go
+++ b/cmd/skills/read.go
@@ -1,0 +1,101 @@
+package skills
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	readRaw bool
+
+	ReadCmd = &cobra.Command{
+		Use:           "read NAME",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Read one skill's full record",
+		Long: `
+Usage: warden skill read NAME [options]
+
+  Read a single skill by name. The response includes the full markdown
+  body so agents can act on the recipe directly. Use --raw to emit
+  just the markdown (no JSON wrapper) — convenient for piping into a
+  pager or rendering with another tool.
+
+  Output honors the global --output flag (table, json, ndjson, text).
+  --raw overrides --output and always emits plain markdown to stdout.
+
+  Examples:
+
+    Read the discovery skill as JSON for an agent:
+
+      $ warden skill read discovery -o json
+
+    Get the raw markdown to pipe into a renderer:
+
+      $ warden skill read aws --raw | glow -
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: runRead,
+	}
+)
+
+func init() {
+	ReadCmd.Flags().BoolVar(&readRaw, "raw", false,
+		"Emit only the markdown body, bypassing --output and the JSON envelope")
+}
+
+func runRead(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	resource, err := c.Operator().Read("sys/skills/" + name)
+	if err != nil {
+		return fmt.Errorf("failed to read skill %q: %w", name, err)
+	}
+	if resource == nil || resource.Data == nil {
+		return fmt.Errorf("skill %q not found", name)
+	}
+
+	if readRaw {
+		body, _ := resource.Data["body"].(string)
+		fmt.Print(body)
+		return nil
+	}
+
+	return helpers.RenderMap(resource.Data, func() {
+		printSkillRecordTable(resource.Data)
+	})
+}
+
+func printSkillRecordTable(data map[string]any) {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		if k == "body" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	rows := make([][]any, 0, len(keys)+1)
+	for _, k := range keys {
+		rows = append(rows, []any{k, fmt.Sprintf("%v", data[k])})
+	}
+	helpers.PrintTable([]string{"Key", "Value"}, rows)
+
+	// Body goes below the metadata table — it's typically several lines
+	// of markdown and would wreck a key/value table layout.
+	if body, _ := data["body"].(string); body != "" {
+		fmt.Println()
+		fmt.Println("--- body ---")
+		fmt.Print(body)
+		if body[len(body)-1] != '\n' {
+			fmt.Println()
+		}
+	}
+}

--- a/cmd/skills/skills.go
+++ b/cmd/skills/skills.go
@@ -1,0 +1,43 @@
+// Package skills groups the CLI subcommands for the global agent skill
+// registry exposed at /v1/sys/skills. Reads are open to any namespace
+// token; mutations are root-only — invoking create/update/delete from a
+// sub-namespace surfaces the server's 403.
+package skills
+
+import "github.com/spf13/cobra"
+
+var SkillsCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage agent skills served from the global skill registry.",
+	Long: `
+Usage: warden skill <subcommand> [options]
+
+  Browse and manage the global agent skill registry. Skills are the
+  agent-facing recipes that describe how to use Warden's capabilities
+  (the foundation flow plus one record per provider type). Reads are
+  open to any namespace; writes are restricted to the root namespace.
+
+  List every skill in the catalog:
+
+      $ warden skill list
+
+  Read one skill's full markdown body:
+
+      $ warden skill read aws --raw
+
+  Create a custom skill (root namespace only):
+
+      $ warden skill create --name=my-runbook --category=custom \
+          --description="ops on-call" --body-file=./runbook.md
+
+  Please see the individual subcommand help for detailed usage information.
+`,
+}
+
+func init() {
+	SkillsCmd.AddCommand(ListCmd)
+	SkillsCmd.AddCommand(ReadCmd)
+	SkillsCmd.AddCommand(CreateCmd)
+	SkillsCmd.AddCommand(UpdateCmd)
+	SkillsCmd.AddCommand(DeleteCmd)
+}

--- a/cmd/skills/update.go
+++ b/cmd/skills/update.go
@@ -1,0 +1,152 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	updateDescription string
+	updateCategory    string
+	updateRequires    []string
+	updateUpstream    string
+	updateProvider    string
+	updateBodyFile    string
+	updateJSON        string
+
+	UpdateCmd = &cobra.Command{
+		Use:           "update NAME",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Update an existing skill (root namespace only)",
+		Long: `
+Usage: warden skill update NAME [options]
+
+  Update an existing skill. Update is field-by-field merge: only the
+  fields you pass overwrite the stored record. CreatedAt, Origin, Name,
+  and Version are managed by the server and cannot be patched.
+
+  Mutations require a root namespace token; sub-namespace tokens get 403.
+
+  Two input modes (mutually exclusive):
+
+    Typed flags (human-friendly):
+
+      $ warden skill update aws --description="our local override"
+
+    Full JSON payload (agent-friendly):
+
+      $ warden skill update aws --json @patch.json
+      $ cat patch.json | warden skill update aws --json -
+
+  --json is mutually exclusive with the typed --description / --category
+  / --requires / --upstream / --provider / --body-file flags.
+
+  To update the body, point --body-file at a markdown file on disk;
+  the file's content is sent as the new body verbatim.
+
+  Empty values are treated as "don't change" — to clear an optional
+  field (e.g. requires, upstream) use --json with the explicit empty
+  value, e.g. --json '{"requires":[]}'.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: runUpdate,
+	}
+)
+
+func init() {
+	UpdateCmd.Flags().StringVar(&updateDescription, "description", "",
+		"Replace the description")
+	UpdateCmd.Flags().StringVar(&updateCategory, "category", "",
+		"Replace the category (agent-flow|shared|provider-guide|troubleshooting|custom)")
+	UpdateCmd.Flags().StringSliceVar(&updateRequires, "requires", nil,
+		"Replace the requires list (repeat or comma-separated)")
+	UpdateCmd.Flags().StringVar(&updateUpstream, "upstream", "",
+		"Replace the upstream reference")
+	UpdateCmd.Flags().StringVar(&updateProvider, "provider", "",
+		"Replace the provider type (relevant for provider-guide category)")
+	UpdateCmd.Flags().StringVar(&updateBodyFile, "body-file", "",
+		"Replace the body with the contents of a markdown file")
+	UpdateCmd.Flags().StringVarP(&updateJSON, "json", "j", "",
+		"Full JSON payload — '<json>', '@file.json', or '-' for stdin")
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+	name := args[0]
+
+	jsonPayload, err := helpers.ResolveJSONInput(updateJSON)
+	if err != nil {
+		return err
+	}
+
+	var payload map[string]any
+	if jsonPayload != nil {
+		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
+			"--description": updateDescription != "",
+			"--category":    updateCategory != "",
+			"--requires":    len(updateRequires) > 0,
+			"--upstream":    updateUpstream != "",
+			"--provider":    updateProvider != "",
+			"--body-file":   updateBodyFile != "",
+		}); err != nil {
+			return err
+		}
+		payload = jsonPayload
+	} else {
+		// Typed mode — build a patch out of whichever flags were set.
+		payload = map[string]any{}
+		if updateDescription != "" {
+			payload["description"] = updateDescription
+		}
+		if updateCategory != "" {
+			payload["category"] = updateCategory
+		}
+		if len(updateRequires) > 0 {
+			payload["requires"] = updateRequires
+		}
+		if updateUpstream != "" {
+			payload["upstream"] = updateUpstream
+		}
+		if updateProvider != "" {
+			payload["provider"] = updateProvider
+		}
+		if updateBodyFile != "" {
+			bodyBytes, err := os.ReadFile(updateBodyFile)
+			if err != nil {
+				return fmt.Errorf("--body-file %s: %w", updateBodyFile, err)
+			}
+			payload["body"] = string(bodyBytes)
+		}
+		if len(payload) == 0 {
+			return fmt.Errorf("no fields to update: pass at least one flag or use --json: %w", helpers.ErrUsage)
+		}
+	}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "PUT", "sys/skills/{name}", payload)
+	}
+
+	resource, err := c.Operator().Write("sys/skills/"+name, payload)
+	if err != nil {
+		return fmt.Errorf("error updating skill: %w", err)
+	}
+	out := map[string]any{}
+	var resData map[string]any
+	if resource != nil {
+		resData = resource.Data
+	}
+	helpers.MergeServerResponseInto(out, resData, map[string]any{
+		"name":    name,
+		"updated": true,
+	})
+	return helpers.RenderMap(out, func() {
+		fmt.Printf("Success! Updated skill: %s\n", name)
+	})
+}

--- a/cmd/warden.go
+++ b/cmd/warden.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stephnangue/warden/cmd/roles"
 	"github.com/stephnangue/warden/cmd/schema"
 	"github.com/stephnangue/warden/cmd/server"
+	"github.com/stephnangue/warden/cmd/skills"
 )
 
 var (
@@ -74,6 +75,7 @@ func init() {
 	wardenCmd.AddCommand(cred.CredCmd)
 	wardenCmd.AddCommand(schema.SchemaCmd)
 	wardenCmd.AddCommand(roles.RolesCmd)
+	wardenCmd.AddCommand(skills.SkillsCmd)
 	wardenCmd.AddCommand(basic.WriteCmd)
 	wardenCmd.AddCommand(basic.ReadCmd)
 	wardenCmd.AddCommand(basic.ListCmd)

--- a/core/mount.go
+++ b/core/mount.go
@@ -1183,19 +1183,39 @@ func (c *Core) persistMounts(ctx context.Context, barrier sdklogical.Storage, ta
 			}
 
 			if mount != "" && !found {
-				// Delete this component if it exists. This signifies that
-				// we're removing this mount. We don't know which namespace
-				// this entry could belong to, so remove it from all.
-				allNamespaces, err := c.ListNamespaces(ctx)
-				if err != nil {
-					return -1, fmt.Errorf("failed to list namespaces: %w", err)
-				}
-
-				for nsIndex, ns := range allNamespaces {
+				// We're removing a single mount. The caller's ctx is scoped
+				// to the namespace the mount lived in (see callers in
+				// mount() and removeMountEntry()), so target that namespace
+				// directly instead of listing all namespaces.
+				//
+				// This avoids a latent AB-BA deadlock: persistMounts is
+				// always invoked with c.mountsLock held, and ListNamespaces
+				// acquires the NamespaceStore lock. Concurrent CreateNamespace
+				// takes the opposite order (NamespaceStore lock then
+				// mountsLock during pushToMounts), so any overlap can deadlock.
+				// Rapid namespace create/delete cycles (e.g. the skill e2e
+				// suite) hit this in practice.
+				//
+				// If ctx happens to have no namespace (unusual for this
+				// path), fall back to the original "delete from all"
+				// behavior so legacy data still gets cleaned up.
+				if ns, nsErr := namespace.FromContext(ctx); nsErr == nil {
 					view := NamespaceView(barrier, ns)
-					path := path.Join(prefix, mount)
-					if err := view.Delete(ctx, path); err != nil {
-						return -1, fmt.Errorf("requested removal of a mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
+					p := path.Join(prefix, mount)
+					if err := view.Delete(ctx, p); err != nil {
+						return -1, fmt.Errorf("requested removal of a mount from namespace %v but failed: %w", ns.ID, err)
+					}
+				} else {
+					allNamespaces, err := c.ListNamespaces(ctx)
+					if err != nil {
+						return -1, fmt.Errorf("failed to list namespaces: %w", err)
+					}
+					for nsIndex, ns := range allNamespaces {
+						view := NamespaceView(barrier, ns)
+						p := path.Join(prefix, mount)
+						if err := view.Delete(ctx, p); err != nil {
+							return -1, fmt.Errorf("requested removal of a mount from namespace %v (%v) but failed: %w", ns.ID, nsIndex, err)
+						}
 					}
 				}
 			}

--- a/core/seed/skills/discovery.md
+++ b/core/seed/skills/discovery.md
@@ -2,13 +2,13 @@
 name: discovery
 description: "The agent loop: authenticate, introspect roles, list providers, match the task, pick a role, learn how to call the chosen provider."
 category: agent-flow
-requires: [warden-shared]
+requires: [foundation]
 ---
 
 # Discovering what you can do
 
 Before sending any request to an upstream service, an agent on Warden
-runs four steps. Each one returns structured JSON; chain them
+runs five steps. Each one returns structured JSON; chain them
 deterministically.
 
 ## Step 1 — confirm the session
@@ -19,7 +19,7 @@ them; just confirm they're set:
 
 | Env var | Purpose |
 |---|---|
-| `WARDEN_TOKEN` | JWT bearer — sent automatically as both `X-Warden-Token` and `Authorization: Bearer <jwt>` |
+| `WARDEN_TOKEN` | JWT bearer — the CLI auto-detects the JWT prefix and sends `Authorization: Bearer <jwt>` |
 | `WARDEN_CLIENT_CERT` / `WARDEN_CLIENT_KEY` | (alternative to JWT) PEM paths for mTLS |
 | `WARDEN_ADDR` | the Warden server URL |
 | `WARDEN_NAMESPACE` | the namespace to scope every call to |
@@ -34,7 +34,7 @@ If you need a per-call override (unusual for agents), pass
 ## Step 2 — discover assumable roles
 
 ```bash
-warden role list -o json
+warden role list -o json -F name,description
 ```
 
 Returns one record per role your identity can assume in the current
@@ -42,9 +42,9 @@ namespace:
 
 ```json
 [
-  {"name": "data-reader",      "description": "Read-only access to data warehouses",     "auth_path": "jwt/"},
-  {"name": "deploy-bot",       "description": "Deploy via TFE; full access to staging", "auth_path": "jwt/"},
-  {"name": "vault-secrets-ro", "description": "Read app-config secrets from Vault",      "auth_path": "jwt/"}
+  {"name": "data-reader",      "description": "Read-only access to data warehouses"},
+  {"name": "deploy-bot",       "description": "Deploy via TFE; full access to staging"},
+  {"name": "vault-secrets-ro", "description": "Read app-config secrets from Vault"}
 ]
 ```
 
@@ -55,17 +55,17 @@ match to your task.
 ## Step 3 — list providers in this namespace
 
 ```bash
-warden provider list -o json
+warden provider list -o json -F path,type,description
 ```
 
 Returns one record per mounted provider:
 
 ```json
 [
-  {"path": "aws/",    "type": "aws",    "accessor": "...", "description": "Production AWS account 1234"},
-  {"path": "openai/", "type": "openai", "accessor": "...", "description": "OpenAI API for embeddings + chat"},
-  {"path": "rds-pg/", "type": "rds",    "accessor": "...", "description": "RDS PostgreSQL — analytics"},
-  {"path": "vault/",  "type": "vault",  "accessor": "...", "description": "Internal Vault — secrets/, pki/"}
+  {"path": "aws/",    "type": "aws",    "description": "Production AWS account 1234"},
+  {"path": "openai/", "type": "openai", "description": "OpenAI API for embeddings + chat"},
+  {"path": "rds-pg/", "type": "rds",    "description": "RDS PostgreSQL — analytics"},
+  {"path": "vault/",  "type": "vault",  "description": "Internal Vault — secrets/, pki/"}
 ]
 ```
 
@@ -92,8 +92,16 @@ staging). When unsure:
 
 ## Step 5 — call the provider
 
-Read `skills/providers/<type>/SKILL.md` for the chosen provider —
-that's the self-contained recipe: endpoint URL, env vars / auth
-headers, role-selection mechanic, copy-paste examples. Follow it.
+```bash
+warden skill read <type> --raw
+```
 
+Returns the provider's self-contained recipe in markdown: endpoint URL,
+env vars / auth headers, role-selection mechanic, copy-paste examples.
+Follow it.
+
+Provider skills are seeded into the registry the first time a provider
+of that type is mounted; if `warden skill read aws` returns 404, the
+operator hasn't enabled an AWS provider in this cluster — surface to
+the user instead of fabricating an endpoint.
 

--- a/core/seed/skills/foundation.md
+++ b/core/seed/skills/foundation.md
@@ -1,5 +1,5 @@
 ---
-name: warden-shared
+name: foundation
 description: "Foundation: auth env vars, global CLI flags, output framework, exit codes, and the introspection commands every agent uses."
 category: shared
 ---
@@ -56,6 +56,11 @@ Live, server-rendered. Prefer these over any cached knowledge.
 | `warden role list -o json` | `[{name, description, auth_path}]` for every role your identity can assume in the current namespace |
 | `warden provider list -o json` | `[{path, type, accessor, description}]` — one record per provider in the namespace |
 | `warden provider read <mount>` | the same record for one mount, plus `config` (sensitive fields masked) |
+| `warden skill list -o json` | `[{name, description, category, origin, ...}]` — the agent skill catalog (foundation flow plus one record per provider type) |
+| `warden skill read <name> --raw` | the full markdown body for one skill — use this for the provider recipe in step 5 of the discovery flow |
+
+Skills have a `version` field bumped on every update; agents that cache
+skill content can re-fetch only when the version changes.
 
 ## Exit codes and error envelopes
 

--- a/core/seed/skills/troubleshooting.md
+++ b/core/seed/skills/troubleshooting.md
@@ -2,13 +2,13 @@
 name: troubleshooting
 description: "Common agent failures: classified errors, what to retry, what means 'ask the operator'."
 category: shared
-requires: [warden-shared]
+requires: [foundation]
 ---
 
 # Troubleshooting
 
 Every Warden CLI call exits with one of nine codes (see
-`warden-shared`). Branch on `code` from the JSON envelope; don't grep
+`foundation`). Branch on `code` from the JSON envelope; don't grep
 the human message.
 
 ## `auth_required` (exit 4)

--- a/core/skill_seed.go
+++ b/core/skill_seed.go
@@ -69,7 +69,7 @@ func (s *SkillStore) SeedProviderSkill(ctx context.Context, providerType, markdo
 }
 
 // SeedFoundation writes the embedded foundation skills (discovery,
-// warden-shared, troubleshooting) into the registry on first call.
+// foundation, troubleshooting) into the registry on first call.
 // Subsequent calls are no-ops thanks to the seeded marker. Operator
 // deletions of seeded skills are not reverted.
 //
@@ -178,7 +178,7 @@ func loadEmbeddedFoundationSkills() ([]*Skill, error) {
 //	name: discovery
 //	description: "..."
 //	category: agent-flow
-//	requires: [warden-shared]
+//	requires: [foundation]
 //	upstream: github.com/foo
 //	---
 //	<body>

--- a/core/skill_seed_test.go
+++ b/core/skill_seed_test.go
@@ -39,7 +39,7 @@ func TestParseSkillMarkdown_WithList(t *testing.T) {
 name: foo
 description: "bar"
 category: custom
-requires: [warden-shared, troubleshooting]
+requires: [foundation, troubleshooting]
 upstream: example.com
 ---
 body
@@ -51,7 +51,7 @@ body
 	if len(skill.Requires) != 2 {
 		t.Fatalf("Requires len = %d, want 2", len(skill.Requires))
 	}
-	if skill.Requires[0] != "warden-shared" || skill.Requires[1] != "troubleshooting" {
+	if skill.Requires[0] != "foundation" || skill.Requires[1] != "troubleshooting" {
 		t.Errorf("Requires = %v", skill.Requires)
 	}
 	if skill.Upstream != "example.com" {
@@ -194,7 +194,7 @@ func TestLoadEmbeddedFoundationSkills_ParsesAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	// Expected foundation set: discovery, warden-shared, troubleshooting.
+	// Expected foundation set: discovery, foundation, troubleshooting.
 	names := make([]string, 0, len(skills))
 	for _, s := range skills {
 		names = append(names, s.Name)
@@ -203,7 +203,7 @@ func TestLoadEmbeddedFoundationSkills_ParsesAll(t *testing.T) {
 		}
 	}
 	sort.Strings(names)
-	want := []string{"discovery", "troubleshooting", "warden-shared"}
+	want := []string{"discovery", "foundation", "troubleshooting"}
 	if !equalStringSlices(names, want) {
 		t.Errorf("foundation skill names = %v, want %v", names, want)
 	}
@@ -230,7 +230,7 @@ func TestSkillStore_SeedFoundation_WritesAllSkills(t *testing.T) {
 			t.Errorf("Body of %q is empty", s.Name)
 		}
 	}
-	for _, want := range []string{"discovery", "warden-shared", "troubleshooting"} {
+	for _, want := range []string{"discovery", "foundation", "troubleshooting"} {
 		if origin, ok := got[want]; !ok {
 			t.Errorf("missing seeded skill %q", want)
 		} else if origin != SkillOriginSeed {

--- a/docs/agent-flow.md
+++ b/docs/agent-flow.md
@@ -1,0 +1,324 @@
+# Agent end-to-end flow
+
+How an AI agent goes from "I have a task" to "I successfully called an
+upstream service through Warden" — every step, every command, every
+response shape, and where each piece of knowledge comes from.
+
+This document is for two audiences:
+
+- **Operators** who deployed Warden and connected it to an identity
+  issuer (OIDC provider, mTLS CA, …) for agent workloads, and want to
+  trace what an agent does end-to-end — from the JWT its runtime
+  obtained from that issuer, through the discovery loop, to the
+  upstream call.
+- **Agent / runtime developers** wiring Warden into Claude Code, Goose,
+  or a homegrown harness.
+
+The agent's own copy of this flow lives in the binary as three seeded
+skills (`discovery`, `foundation`, `troubleshooting`) served at
+`/v1/sys/skills`. This doc is the system-side view of the same contract.
+
+## 1. The runtime contract
+
+The agent does **not** authenticate against an identity provider, fetch
+tokens, or hard-code endpoints. The runtime that spawns the agent
+populates four environment variables before the agent process starts:
+
+| Env var | Purpose | Set by |
+|---|---|---|
+| `WARDEN_TOKEN` | A JWT bearer token. | Runtime (e.g. CI's per-job OIDC token, an OAuth client_credentials JWT minted at agent spawn). |
+| `WARDEN_ADDR` | Warden server URL. | Runtime (one Warden cluster per environment). |
+| `WARDEN_NAMESPACE` | Namespace to scope every call to. | Runtime (per-tenant or per-team). |
+| `WARDEN_CLIENT_CERT` / `WARDEN_CLIENT_KEY` | (Alternative to `WARDEN_TOKEN`) PEM paths for mTLS. | Runtime (only when the deployment uses cert-based identity). |
+
+That's the whole onboarding ceremony. The agent inherits credentials
+from the environment and never sees an upstream API key.
+
+## 2. The bootstrap prompt
+
+The runtime injects **one sentence** into the agent's system prompt:
+
+> *"To learn how to operate on Warden, run `warden skill read discovery --raw`. Use `warden skill list -F name,description` to browse the catalog of available skills."*
+
+Everything else — the discovery loop, the env-var conventions, the
+provider recipes — the agent learns by reading skills at runtime. No
+hard-coded knowledge, no pre-loaded context, no SDK to keep in sync
+with the server.
+
+This is the **chicken-and-egg shortcut**: a one-liner that points at
+`discovery`, which then expands into the full flow. The discovery skill
+is seeded into every Warden cluster at first unseal, so it's always
+available — there is no "is the skill there?" check the agent has to do
+itself.
+
+## 3. The five-step discovery loop
+
+The `discovery` skill (served from `/v1/sys/skills/discovery`)
+codifies the loop the agent runs **before every request to an upstream
+service**. Every step returns structured JSON; the agent chains them
+deterministically.
+
+### Step 1 — Confirm the session
+
+The agent reads the four env vars and aborts (with a clear message to
+the user) if `WARDEN_NAMESPACE` is missing. Calling the root namespace
+with no scoping is almost always an operator-setup bug — better to
+surface than silently call the wrong scope.
+
+### Step 2 — Discover assumable roles
+
+```bash
+warden role list -o json -F name,description
+```
+
+Hits `GET /v1/sys/introspect/roles`. The endpoint introspects the
+caller's identity vehicle (JWT or client cert) and returns the roles
+that identity can assume in the current namespace. The wire payload
+also carries an `auth_path` (which auth mount granted the role —
+operator-facing metadata for debugging); the `-F name,description`
+projection drops it because the agent decides by description alone.
+
+```json
+[
+  {"name": "data-reader",      "description": "Read-only access to data warehouses"},
+  {"name": "deploy-bot",       "description": "Deploy via TFE; full access to staging"},
+  {"name": "vault-secrets-ro", "description": "Read app-config secrets from Vault"}
+]
+```
+
+Each `description` is **operator-set free text**. It's how operators
+communicate intent to agents at runtime. The agent reads descriptions
+and matches them to the task — it does not memorize role names.
+
+### Step 3 — List providers in this namespace
+
+```bash
+warden provider list -o json -F path,type,description
+```
+
+Hits `GET /v1/sys/providers?warden-list=true`. The wire payload also
+carries an `accessor` per mount (a server-internal opaque ID); the
+`-F path,type,description` projection drops it because the agent never
+uses it. `path` becomes the gateway URL component, `type` is the lookup
+key for the matching provider skill, `description` is what the agent
+matches the task against.
+
+```json
+[
+  {"path": "aws/",    "type": "aws",    "description": "Production AWS account 1234"},
+  {"path": "openai/", "type": "openai", "description": "OpenAI API for embeddings + chat"},
+  {"path": "rds-pg/", "type": "rds",    "description": "RDS PostgreSQL — analytics"},
+  {"path": "vault/",  "type": "vault",  "description": "Internal Vault — secrets/, pki/"}
+]
+```
+
+If the list is empty or returns `forbidden`, that's an operator-setup
+problem — the agent surfaces it, doesn't paper over with a hard-coded
+URL.
+
+### Step 4 — Match task → provider, pick a role
+
+Read role and provider descriptions side-by-side. Most fits are obvious:
+
+> *"Read S3 bucket analytics-events"* →
+> provider `aws/` (description: AWS) +
+> role `data-reader` (description: read-only data warehouses).
+
+When ambiguous (multi-tenant, regional, prod-vs-staging):
+- Prefer the **most-scoped** option (a role described as "read-only X"
+  over "admin").
+- If two providers look equivalent, surface to the user rather than
+  guess.
+
+### Step 5 — Read the provider skill, call the provider
+
+```bash
+warden skill read <type> --raw
+```
+
+Hits `GET /v1/sys/skills/<type>`. Returns the agent-facing recipe in
+markdown — endpoint URL, required env vars, role-selection mechanic,
+copy-paste examples.
+
+If `warden skill read aws` returns 404, the cluster does not have an AWS
+provider configured (provider skills are seeded into the registry the
+first time a provider of that type is mounted). The agent surfaces the
+gap, doesn't fabricate a SigV4 endpoint.
+
+## 4. Worked example — read an S3 bucket through AWS
+
+The runtime spawns the agent with:
+
+```
+WARDEN_TOKEN=eyJhbGc…   # OIDC JWT from CI
+WARDEN_ADDR=https://warden.example.com
+WARDEN_NAMESPACE=team-data
+```
+
+User asks: *"Show me the keys in the staging-events S3 bucket."*
+
+**Agent's actions:**
+
+1. **Session check** — env vars present. ✓
+2. **`warden role list -o json -F name,description`** — finds `data-reader` ("Read-only access to data warehouses").
+3. **`warden provider list -o json -F path,type,description`** — finds `aws/` ("Production AWS account 1234") plus an unrelated `openai/`.
+4. **Match** — `data-reader` + `aws/` fit the task. No ambiguity.
+5. **`warden skill read aws --raw`** — gets the recipe:
+
+   ```bash
+   export AWS_ACCESS_KEY_ID="<role-name>"
+   export AWS_SECRET_ACCESS_KEY="$WARDEN_TOKEN"
+   export AWS_SESSION_TOKEN="$WARDEN_TOKEN"
+   export AWS_ENDPOINT_URL="$WARDEN_ADDR/v1/<mount>/gateway"
+   ```
+
+6. **Substitute and run:**
+
+   ```bash
+   export AWS_ACCESS_KEY_ID=data-reader
+   export AWS_SECRET_ACCESS_KEY=$WARDEN_TOKEN
+   export AWS_SESSION_TOKEN=$WARDEN_TOKEN
+   export AWS_ENDPOINT_URL=https://warden.example.com/v1/aws/gateway
+   aws s3 ls s3://staging-events
+   ```
+
+The SDK signs the request with SigV4 as usual. Warden's AWS provider
+verifies the signature, reads the role name out of the
+`AWS_ACCESS_KEY_ID` slot, looks up the credential spec bound to that
+role, mints fresh AWS credentials, re-signs the request, and proxies to
+`s3.amazonaws.com`. The response streams back through Warden to the
+agent. The real AWS credentials never leave Warden's process; the SDK
+never sees them.
+
+## 5. What changes per provider type
+
+Step 1–4 of the discovery loop are universal. Step 5's recipe varies
+by provider type. The skill registry surfaces the exact recipe for
+each type:
+
+| Provider type | Recipe shape |
+|---|---|
+| `aws`, `scaleway` | SDK env vars (`AWS_ACCESS_KEY_ID` carries the role name, JWT in the secret/session slot, endpoint pointed at the gateway). |
+| `openai`, `anthropic`, `github`, etc. | API key replaced with the JWT; base URL pointed at `…/<mount>/gateway`. |
+| `vault` | API call to `…/<mount>/gateway/v1/<vault-path>` with `X-Vault-Token: $WARDEN_TOKEN`. |
+| `rds` | One-shot API call to mint a short-lived JDBC/PSQL connection string with an embedded IAM auth token; the agent then connects directly to the DB (no proxy in the data path). |
+
+The skill body for each type explains the exact substitution, the quirks
+(e.g. AWS wildcard DNS for S3 virtual-hosted buckets, JWT-expiry
+manifesting as SigV4 `SignatureDoesNotMatch`), and any service-specific
+caveats.
+
+## 6. Error handling
+
+The `troubleshooting` skill (`/v1/sys/skills/troubleshooting`) maps
+every CLI exit code to a category, a likely cause, and a retry policy:
+
+| Exit | Code | When the agent should… |
+|---|---|---|
+| 4 | `auth_required` | Refresh the JWT (typical TTL is 5–60 min) and retry. |
+| 5 | `forbidden` | Re-run `warden role list` and pick a different role; if no role fits, surface to the user — don't escalate. |
+| 6 | `not_found` | Re-run `warden provider list` / `warden role list`; the operator may have changed the namespace's mounts. |
+| 3 | `invalid_input` | Read the error envelope's `message` (validators emit one line per problem with "did you mean" hints) and fix the payload. |
+| 7 | `network` | Backoff + retry. For SigV4 providers, also check wildcard DNS. |
+| 8 | `server` | Read the upstream error verbatim — Warden surfaces it. Bounded retry on transient upstream errors. |
+| 9 | `conflict` | Resource exists. Read it and update, or pick a different name. Don't retry blindly. |
+
+The structured `code` field is the contract — agents branch on it, never
+on the human-readable message.
+
+## 7. Caching strategy
+
+Skills change rarely; agents can cache them. Every skill record carries
+a `version` integer bumped on every update. A long-running agent can:
+
+1. Cache `discovery`, `foundation`, `troubleshooting`, and the
+   provider skills it has read.
+2. On subsequent reads, fetch the LIST endpoint (one cheap call,
+   no bodies) and compare each cached skill's `version` with the
+   server's. Re-fetch only the records whose version changed.
+
+Roles and providers are also stable-ish — re-discover every N minutes
+or on a `not_found` / `forbidden` error, whichever comes first.
+
+## 8. The big picture
+
+### Setup — one-time, by the operator
+
+```
+┌─────────────────────────┐                ┌─────────────────────────┐
+│ Identity issuer         │ ◄─── trust ──► │ Warden cluster          │
+│ (OIDC, mTLS CA, SPIRE…) │                │  • providers mounted    │
+└─────────────────────────┘                │  • roles + policy       │
+                                           │  • skill catalog seeded │
+                                           └─────────────────────────┘
+```
+
+The operator configures the trust relationship between the issuer and
+Warden (JWKS endpoint or CA bundle), then mounts providers, defines
+roles, and writes policies. After this, the operator is not in the
+per-call loop.
+
+### Per-call — every time an agent makes an upstream call
+
+```
+        ┌──────────────────────┐
+        │ Identity issuer      │
+        └─────────┬────────────┘
+                  │ ① mint JWT (per job, per spawn, …)
+                  ▼
+        ┌──────────────────────┐
+        │ Runtime              │   sets WARDEN_TOKEN, WARDEN_ADDR,
+        │ (CI, harness, …)     │        WARDEN_NAMESPACE; injects
+        └─────────┬────────────┘        the bootstrap system prompt
+                  │ ② spawn
+                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ Agent                                                               │
+│                                                                     │
+│  ③ Discovery loop — each step is a GET, response is structured JSON │
+│       foundation, discovery, role list, provider list, match,       │
+│       provider skill         (all under /v1/sys/...)                │
+│                                                                     │
+│  ④ Upstream call    POST /v1/<mount>/gateway/...                    │
+│                     Authorization: Bearer $WARDEN_TOKEN             │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ Warden                                                              │
+│   ⑤ auth      validate the JWT against the issuer's JWKS / CA       │
+│   ⑥ policy    resolve role; check namespace + policy permit the call│
+│   ⑦ credmint  mint a short-lived real upstream credential           │
+│   ⑧ proxy     re-sign / inject the credential; forward to upstream  │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │ ⑨ call with real upstream creds
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ Upstream (AWS, OpenAI, Vault, RDS, GitHub, …)                       │
+│   sees: a normal call from Warden with valid real credentials       │
+│   does NOT see: the agent's JWT, the agent's namespace, role name   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Responses flow back along the same path. Warden does not cache real
+upstream credentials in storage — they're minted per call (or
+short-lived, per the credential spec's TTL) and held only in memory
+for the duration of the proxied request.
+
+## 9. What the agent never does
+
+- **Authenticate to an identity provider.** The runtime hands it a JWT.
+- **Hold long-lived upstream credentials.** Warden mints them per call.
+- **Memorize role names, provider paths, or endpoint URLs.** Every fact
+  comes from a live introspection call or a skill record.
+- **Decide on its own that "the system is broken."** A 4xx/5xx with a
+  structured `code` field maps deterministically to an action (retry,
+  pick another role, surface to the user). Ambiguous failures get
+  surfaced, not papered over.
+
+## 10. Where to go next
+
+- The seeded skills themselves — `warden skill list`, `warden skill read <name> --raw` — are the authoritative agent-facing source. This doc is the system view of the same contract.
+- For a worked tutorial that wires Goose into Warden against three upstreams in parallel, see [tutorials/vault-policy-hygiene/](tutorials/vault-policy-hygiene/).
+- For the proxy/gateway internals (how Warden re-signs SigV4, validates JWTs against the OIDC issuer, etc.), see [architecture.md](architecture.md).
+- For the per-provider catalog (what each type supports and how it's configured), see [providers.md](providers.md).

--- a/e2e/skill/cli_test.go
+++ b/e2e/skill/cli_test.go
@@ -1,0 +1,341 @@
+//go:build e2e
+
+package skill
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// wardenCLI is a small wrapper that auto-supplies WARDEN_TOKEN so each
+// test reads like a single CLI invocation.
+func wardenCLI(t *testing.T, port int, args ...string) (string, error) {
+	t.Helper()
+	return h.WardenCLIWithPort(t, port, map[string]string{
+		"WARDEN_TOKEN": h.RootToken(t),
+	}, args...)
+}
+
+func TestCLI_SkillList_TableAndJSON(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Table output should mention at least one foundation skill.
+	tableOut, err := wardenCLI(t, port, "skill", "list", "-o", "table")
+	if err != nil {
+		t.Fatalf("skill list -o table failed: %v\noutput: %s", err, tableOut)
+	}
+	if !strings.Contains(tableOut, "discovery") {
+		t.Errorf("expected 'discovery' in table output, got:\n%s", tableOut)
+	}
+
+	// JSON output must parse and include the same skill.
+	jsonOut, err := wardenCLI(t, port, "skill", "list", "-o", "json")
+	if err != nil {
+		t.Fatalf("skill list -o json failed: %v\noutput: %s", err, jsonOut)
+	}
+	var items []map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonOut), &items); err != nil {
+		t.Fatalf("unmarshal JSON: %v\noutput: %s", err, jsonOut)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected at least one skill in JSON output")
+	}
+	found := false
+	for _, item := range items {
+		if item["name"] == "discovery" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("'discovery' missing from JSON list output")
+	}
+}
+
+func TestCLI_SkillRead_RawAndStructured(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	// Structured JSON read must include the markdown body inline.
+	jsonOut, err := wardenCLI(t, port, "skill", "read", "discovery", "-o", "json")
+	if err != nil {
+		t.Fatalf("skill read discovery -o json failed: %v\noutput: %s", err, jsonOut)
+	}
+	var rec map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonOut), &rec); err != nil {
+		t.Fatalf("unmarshal JSON: %v\noutput: %s", err, jsonOut)
+	}
+	body, _ := rec["body"].(string)
+	if !strings.Contains(body, "Discovering what you can do") {
+		t.Errorf("JSON body missing expected heading; got %q", body)
+	}
+
+	// --raw must emit just the markdown.
+	rawOut, err := wardenCLI(t, port, "skill", "read", "discovery", "--raw")
+	if err != nil {
+		t.Fatalf("skill read discovery --raw failed: %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(rawOut), "# Discovering what you can do") {
+		// Limit the snippet so a huge body doesn't dominate the failure log.
+		snippet := rawOut
+		if len(snippet) > 100 {
+			snippet = snippet[:100]
+		}
+		t.Errorf("--raw output should start with the discovery heading; got first 100 chars: %q", snippet)
+	}
+	// --raw must NOT contain any JSON envelope markers.
+	if strings.Contains(rawOut, `"data":`) || strings.HasPrefix(strings.TrimSpace(rawOut), "{") {
+		t.Errorf("--raw output should not include JSON envelope; got:\n%s", rawOut)
+	}
+}
+
+func TestCLI_SkillCreate_TypedFlags(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-cli-runbook"
+
+	// Cleanup any leftover state.
+	wardenCLI(t, port, "skill", "delete", name, "--force")
+	t.Cleanup(func() {
+		wardenCLI(t, port, "skill", "delete", name, "--force")
+	})
+
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte("# runbook\nstep 1\n"), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	out, err := wardenCLI(t, port, "skill", "create",
+		"--name="+name,
+		"--description=cli-created",
+		"--category=custom",
+		"--body-file="+bodyFile,
+		"-o", "json",
+	)
+	if err != nil {
+		t.Fatalf("skill create failed: %v\noutput: %s", err, out)
+	}
+	var rec map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &rec); err != nil {
+		t.Fatalf("unmarshal create output: %v\noutput: %s", err, out)
+	}
+	if rec["created"] != true || rec["name"] != name {
+		t.Errorf("create response missing markers: %v", rec)
+	}
+
+	// Verify via read.
+	readOut, err := wardenCLI(t, port, "skill", "read", name, "-o", "json")
+	if err != nil {
+		t.Fatalf("read after create failed: %v\noutput: %s", err, readOut)
+	}
+	var read map[string]interface{}
+	if err := json.Unmarshal([]byte(readOut), &read); err != nil {
+		t.Fatalf("unmarshal read: %v", err)
+	}
+	if read["description"] != "cli-created" {
+		t.Errorf("description = %v, want cli-created", read["description"])
+	}
+	if read["origin"] != "user" {
+		t.Errorf("origin = %v, want user", read["origin"])
+	}
+}
+
+func TestCLI_SkillCreate_JSONFile(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-cli-json"
+
+	wardenCLI(t, port, "skill", "delete", name, "--force")
+	t.Cleanup(func() {
+		wardenCLI(t, port, "skill", "delete", name, "--force")
+	})
+
+	payload := map[string]interface{}{
+		"name":        name,
+		"description": "json-created",
+		"category":    "custom",
+		"body":        "# json body\n",
+	}
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	tmp := filepath.Join(t.TempDir(), "skill.json")
+	if err := os.WriteFile(tmp, bytes, 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	out, err := wardenCLI(t, port, "skill", "create", name, "--json", "@"+tmp, "-o", "json")
+	if err != nil {
+		t.Fatalf("skill create --json failed: %v\noutput: %s", err, out)
+	}
+	var rec map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rec["name"] != name {
+		t.Errorf("name = %v, want %s", rec["name"], name)
+	}
+}
+
+func TestCLI_SkillCreate_JSONFlagsExclusivity(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	out, err := wardenCLI(t, port, "skill", "create", "x",
+		"--name=x", "--json", `{"name":"x"}`,
+	)
+	if err == nil {
+		t.Fatalf("expected error for --name + --json, got success.\noutput: %s", out)
+	}
+	if !strings.Contains(out, "--json cannot be combined with") {
+		t.Errorf("output does not mention the exclusivity error; got:\n%s", out)
+	}
+}
+
+func TestCLI_SkillUpdate_MergeSemantics(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-cli-merge"
+
+	wardenCLI(t, port, "skill", "delete", name, "--force")
+	t.Cleanup(func() {
+		wardenCLI(t, port, "skill", "delete", name, "--force")
+	})
+
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte("# original\n"), 0o600); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	if out, err := wardenCLI(t, port, "skill", "create",
+		"--name="+name,
+		"--description=before",
+		"--category=custom",
+		"--body-file="+bodyFile,
+	); err != nil {
+		t.Fatalf("create: %v\noutput: %s", err, out)
+	}
+
+	// Patch only description — body must survive.
+	if out, err := wardenCLI(t, port, "skill", "update", name,
+		"--description=after",
+		"-o", "json",
+	); err != nil {
+		t.Fatalf("update: %v\noutput: %s", err, out)
+	}
+
+	readOut, err := wardenCLI(t, port, "skill", "read", name, "-o", "json")
+	if err != nil {
+		t.Fatalf("read: %v\noutput: %s", err, readOut)
+	}
+	var rec map[string]interface{}
+	if err := json.Unmarshal([]byte(readOut), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rec["description"] != "after" {
+		t.Errorf("description = %v, want 'after'", rec["description"])
+	}
+	if body, _ := rec["body"].(string); !strings.Contains(body, "# original") {
+		t.Errorf("body lost across update; got %q", body)
+	}
+	if v, _ := rec["version"].(float64); v != 2 {
+		t.Errorf("version = %v, want 2", rec["version"])
+	}
+}
+
+func TestCLI_SkillList_FiltersAreClientSide(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	cases := []struct {
+		name     string
+		args     []string
+		// allowed values for the field — every returned record must match one.
+		matchKey string
+		want     []string
+	}{
+		{
+			name:     "by category",
+			args:     []string{"--category=agent-flow"},
+			matchKey: "category",
+			want:     []string{"agent-flow"},
+		},
+		{
+			name:     "by origin",
+			args:     []string{"--origin=seed"},
+			matchKey: "origin",
+			want:     []string{"seed"},
+		},
+		{
+			name:     "by provider",
+			args:     []string{"--provider=vault"},
+			matchKey: "provider",
+			want:     []string{"vault"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"skill", "list"}, tc.args...)
+			args = append(args, "-o", "json")
+
+			out, err := wardenCLI(t, port, args...)
+			if err != nil {
+				t.Fatalf("skill list %v failed: %v\noutput: %s", tc.args, err, out)
+			}
+			var items []map[string]interface{}
+			if err := json.Unmarshal([]byte(out), &items); err != nil {
+				t.Fatalf("unmarshal: %v\noutput: %s", err, out)
+			}
+			// Foundation + provider seeds mean every test case should match
+			// at least one record. A 0-length response means the filter is
+			// either broken or the cluster missed a seed.
+			if len(items) == 0 {
+				t.Fatalf("expected at least one record matching filter %v", tc.args)
+			}
+			for _, item := range items {
+				got, _ := item[tc.matchKey].(string)
+				matched := false
+				for _, w := range tc.want {
+					if got == w {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					t.Errorf("record %v has %s=%q, want one of %v",
+						item["name"], tc.matchKey, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCLI_SkillDelete_Force(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-cli-delete"
+
+	wardenCLI(t, port, "skill", "delete", name, "--force")
+	t.Cleanup(func() {
+		wardenCLI(t, port, "skill", "delete", name, "--force")
+	})
+
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte("# x\n"), 0o600); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	if out, err := wardenCLI(t, port, "skill", "create",
+		"--name="+name, "--description=x", "--category=custom",
+		"--body-file="+bodyFile,
+	); err != nil {
+		t.Fatalf("create: %v\noutput: %s", err, out)
+	}
+
+	if out, err := wardenCLI(t, port, "skill", "delete", name, "--force"); err != nil {
+		t.Fatalf("delete --force: %v\noutput: %s", err, out)
+	}
+
+	// Read after delete must report an error.
+	if _, err := wardenCLI(t, port, "skill", "read", name); err == nil {
+		t.Error("expected read-after-delete to error, got success")
+	}
+}
+

--- a/e2e/skill/skill_test.go
+++ b/e2e/skill/skill_test.go
@@ -46,14 +46,14 @@ func skillNames(skills []map[string]interface{}) map[string]bool {
 	return names
 }
 
-// TestSkill_FoundationSkillsArePresent verifies the discovery, warden-shared,
+// TestSkill_FoundationSkillsArePresent verifies the discovery, foundation,
 // and troubleshooting skills are seeded at first unseal and visible via the
 // list endpoint.
 func TestSkill_FoundationSkillsArePresent(t *testing.T) {
 	port := h.GetLeaderPort(t)
 	names := skillNames(listSkills(t, port))
 
-	for _, want := range []string{"discovery", "warden-shared", "troubleshooting"} {
+	for _, want := range []string{"discovery", "foundation", "troubleshooting"} {
 		if !names[want] {
 			t.Errorf("foundation skill %q missing from /v1/sys/skills (got %v)", want, names)
 		}
@@ -300,7 +300,7 @@ func TestSkill_GlobalReadFromSubNamespace(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	names := skillNames(lr.Data.Skills)
-	for _, want := range []string{"discovery", "warden-shared", "troubleshooting"} {
+	for _, want := range []string{"discovery", "foundation", "troubleshooting"} {
 		if !names[want] {
 			t.Errorf("foundation skill %q missing from sub-namespace list", want)
 		}

--- a/provider/aws/skill.md
+++ b/provider/aws/skill.md
@@ -3,6 +3,7 @@ name: aws
 description: "Call AWS services (S3, EC2, Lambda, DynamoDB, STS, …) through Warden's SigV4 gateway."
 category: provider-guide
 provider: aws
+requires: [foundation, discovery]
 upstream: AWS
 ---
 
@@ -24,7 +25,7 @@ AWS service. **No SDK code changes** — only env vars.
   this task.
 
 The JWT (`$JWT`) is provided to the agent's environment by its
-runtime — see `warden-shared`. Just use it:
+runtime — see `foundation`. Just use it:
 
 ```bash
 export AWS_ACCESS_KEY_ID="<role-name>"          # role from `warden role list`

--- a/provider/github/skill.md
+++ b/provider/github/skill.md
@@ -3,6 +3,7 @@ name: github
 description: "Call the GitHub REST API through Warden — read repos, manage issues, push releases — without holding a GitHub PAT."
 category: provider-guide
 provider: github
+requires: [foundation, discovery]
 upstream: GitHub REST API (api.github.com or GHE)
 ---
 

--- a/provider/openai/skill.md
+++ b/provider/openai/skill.md
@@ -3,6 +3,7 @@ name: openai
 description: "Call the OpenAI API through Warden — chat, embeddings, moderation — without holding an OpenAI API key."
 category: provider-guide
 provider: openai
+requires: [foundation, discovery]
 upstream: OpenAI REST API (api.openai.com)
 ---
 

--- a/provider/rds/skill.md
+++ b/provider/rds/skill.md
@@ -3,6 +3,7 @@ name: rds
 description: "Get a short-lived database connection string for AWS RDS through Warden — agent connects to the DB directly with a 15-min IAM auth token."
 category: provider-guide
 provider: rds
+requires: [foundation, discovery]
 upstream: AWS RDS (PostgreSQL, MySQL)
 ---
 

--- a/provider/scaleway/skill.md
+++ b/provider/scaleway/skill.md
@@ -3,6 +3,7 @@ name: scaleway
 description: "Call the Scaleway REST API and Scaleway Object Storage (S3-compatible) through Warden — one provider, two patterns auto-detected."
 category: provider-guide
 provider: scaleway
+requires: [foundation, discovery]
 upstream: Scaleway REST API + Object Storage
 ---
 

--- a/provider/vault/skill.md
+++ b/provider/vault/skill.md
@@ -3,6 +3,7 @@ name: vault
 description: "Call HashiCorp Vault / OpenBao through Warden — read secrets, sign, encrypt, manage PKI — without ever holding a Vault token."
 category: provider-guide
 provider: vault
+requires: [foundation, discovery]
 upstream: HashiCorp Vault / OpenBao
 ---
 


### PR DESCRIPTION
CLI surface
  Adds `warden skill {list,read,create,update,delete}` so operators can
  browse and manage the global skill registry without crafting raw HTTP
  calls. Follows the existing typed-flags-OR-`--json` exclusivity pattern
  from `warden provider enable`; `delete` prompts on a TTY unless --force;
  `read --raw` emits just the markdown body for piping into a renderer.

Foundation rename
  `warden-shared` → `foundation`. The original name was both vague ("shared
  with what?") and collided with the `shared` category enum. `foundation`
  describes the skill's role and matches how we've been talking about it
  internally. No migration is shipped: clusters that already booted with
  the old name keep `warden-shared` in their catalog as orphan content
  until manually deleted. New deployments get the new name cleanly.

Namespace-deletion deadlock fix
  The skill e2e suite churns sub-namespaces rapidly and exposed an AB-BA
  deadlock: `CreateNamespace` takes `NamespaceStore.lock` → `mountsLock`
  (via pushToMounts), while `clearNamespaceResources` took `mountsLock` →
  `NamespaceStore.lock` (via persistMounts → ListNamespaces). When the
  two paths overlapped the cluster wedged.

  persistMounts no longer calls ListNamespaces to iterate every namespace
  when removing a single mount. The caller's ctx already carries the
  mount's namespace; use that directly. Falls back to ListNamespaces when
  ctx has no namespace (unusual, but kept for safety). Three consecutive
  runs of the full skill e2e suite now stay green.

Foundation skill content
  - discovery.md: bumped "four steps" → "five", aligned the JWT header description with foundation.md, replaced the stale `skills/providers/<type>/SKILL.md` reference with `warden skill read <type> --raw`, projected the role-list and provider-list examples to just the fields agents actually use.
  - foundation.md (renamed from warden-shared.md): added `warden skill list` and `warden skill read` to the introspection table.

Provider skills
  - All six (aws, github, openai, rds, scaleway, vault) gained `requires: [foundation, discovery]` in frontmatter.

docs/agent-flow.md
  New reference doc explaining the system-side view of how an agent uses
  Warden end-to-end. Covers the runtime contract, the five-step discovery
  loop, per-provider recipe shape, error handling, caching strategy, and
  the trust model (setup vs per-call). Complements the in-binary skills.

README updates
  Tightened the "Discover then connect" section to mention the three
  introspection calls (roles, providers, skills) rather than just roles.
  Added a "Self-describing capabilities" bullet to the control plane list.
  Sharpened the security bullet to lead with the AI-specific threat
  (prompt injection / jailbreak) rather than restating no-credentials-in-env.
  Reframed identity-bound access around one-identity-for-all-upstreams
  (no per-system credential sprawl) instead of pooled-vs-scoped framing.
  Removed the all-✅ Status column from the providers table.
  Added a link to docs/agent-flow.md as the system-side reference.

Tests
  7 new CLI e2e tests in e2e/skill/cli_test.go covering list (table+json,
  client-side filters), read (raw and structured), create (typed flags
  and --json), update merge semantics, --json flag exclusivity, and
  force-delete. Updated unit and e2e tests for the foundation rename.

Verification
  - Full skill e2e suite (23 tests) passes 3 consecutive runs against the live 3-node HA cluster; the namespace-deletion deadlock no longer reproduces, cluster stays healthy.
  - `go test ./core/...` passes under -race.
  - Whole-tree build clean.