### PR TITLE
feat: return mount_url from sys/providers and README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ Warden also secures non-agent workloads — CI/CD pipelines, microservices, deve
 
 Warden supports multiple methods for verifying caller identity.
 
-| Method | Identity Source | Best For |
-|--------|----------------|----------|
-| **JWT** | Signed JWT token or SPIFFE JWT-SVID | AI agents, MCP servers, agentic frameworks, any workload with an OIDC/JWT issuer or SPIFFE runtime |
-| **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Agents in service mesh environments, Kubernetes pods, VMs with machine certificates |
+| Method | Identity Source | How the agent presents the credential to its SDK |
+|--------|----------------|----|
+| **JWT** | Signed JWT token or SPIFFE JWT-SVID | The **same JWT** goes in whichever credential slot the upstream SDK natively expects (`AWS_SECRET_ACCESS_KEY`, `OPENAI_API_KEY`, `X-Vault-Token`, `Authorization: Bearer`, …). Warden detects it, validates the identity, and swaps in the real upstream credential. Existing SDK code keeps working — only the base URL changes. |
+| **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Identity is proven at the TLS handshake (or forwarded by a TLS-terminating proxy via `X-SSL-Client-Cert`). The SDK's credential slot is filled with any placeholder value — Warden ignores it once cert auth has proven the identity. Role selection follows the same per-provider conventions as JWT mode. |
 
-SPIFFE is supported in both methods — JWT-SVIDs via JWT auth and X.509-SVIDs via certificate auth. Both methods produce the same internal session. Once authenticated, the caller interacts with Warden identically regardless of how they proved their identity.
+This is the design property that makes Warden a *drop-in* layer rather than a rewrite tax: a pre-existing boto3, openai-python, Vault CLI, or curl-against-GitHub script becomes Warden-mediated by setting the base URL to Warden and putting the JWT where the secret used to go. It also separates Warden from MCP (which adds a protocol the agent host must speak) and from dedicated auth proxies (which typically require client libraries).
 
 ## Tutorial: one identity, three systems, zero credentials
 

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -192,4 +192,9 @@ type MountOutput struct {
 	Description string         `json:"description"`
 	Accessor    string         `json:"accessor"`
 	Config      map[string]any `json:"config" mapstructure:"config"`
+	// MountURL is the relative URL path that resolves to this mount.
+	// Agents append it to $WARDEN_ADDR plus the per-provider suffix
+	// (e.g. "gateway", "role/<role>/gateway", "access/<grant>") to reach
+	// the upstream. Has the namespace and mount path already baked in.
+	MountURL string `json:"mount_url" mapstructure:"mount_url"`
 }

--- a/cmd/providers/list.go
+++ b/cmd/providers/list.go
@@ -58,6 +58,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			"type":        mount.Type,
 			"accessor":    mount.Accessor,
 			"description": mount.Description,
+			"mount_url":   mount.MountURL,
 		})
 	}
 

--- a/cmd/providers/read.go
+++ b/cmd/providers/read.go
@@ -47,6 +47,7 @@ func runRead(cmd *cobra.Command, args []string) error {
 		"type":        mountInfo.Type,
 		"accessor":    mountInfo.Accessor,
 		"description": mountInfo.Description,
+		"mount_url":   mountInfo.MountURL,
 	}
 	if len(mountInfo.Config) > 0 {
 		cfg := make(map[string]any, len(mountInfo.Config))

--- a/core/seed/skills/discovery.md
+++ b/core/seed/skills/discovery.md
@@ -55,19 +55,24 @@ match to your task.
 ## Step 3 — list providers in this namespace
 
 ```bash
-warden provider list -o json -F path,type,description
+warden provider list -o json -F type,description,mount_url
 ```
 
 Returns one record per mounted provider:
 
 ```json
 [
-  {"path": "aws/",    "type": "aws",    "description": "Production AWS account 1234"},
-  {"path": "openai/", "type": "openai", "description": "OpenAI API for embeddings + chat"},
-  {"path": "rds-pg/", "type": "rds",    "description": "RDS PostgreSQL — analytics"},
-  {"path": "vault/",  "type": "vault",  "description": "Internal Vault — secrets/, pki/"}
+  {"type": "aws",    "description": "Production AWS account 1234",     "mount_url": "/v1/team-data/aws/"},
+  {"type": "openai", "description": "OpenAI API for embeddings + chat", "mount_url": "/v1/team-data/openai/"},
+  {"type": "rds",    "description": "RDS PostgreSQL — analytics",      "mount_url": "/v1/team-data/rds-pg/"},
+  {"type": "vault",  "description": "Internal Vault — secrets/, pki/", "mount_url": "/v1/team-data/vault/"}
 ]
 ```
+
+`mount_url` is the relative URL path with the namespace and mount path
+already baked in — append `$WARDEN_ADDR` plus the per-provider suffix
+(e.g. `gateway`, `role/<role>/gateway`, `access/<grant>`) from the
+provider's skill to build the full upstream URL.
 
 Listing providers requires capabilities granted by your role's
 policy — by convention this is included in the namespace's default

--- a/core/sys_providers.go
+++ b/core/sys_providers.go
@@ -128,6 +128,27 @@ func (b *SystemBackend) maybeSeedProviderSkill(ctx context.Context, providerType
 	}
 }
 
+// mountURL builds the agent-facing relative URL path for a mount. The
+// return value is what an agent appends to $WARDEN_ADDR to reach the
+// mount's root; the agent then appends the per-provider suffix
+// (e.g. "gateway", "role/<role>/gateway", "access/<grant>") taken from
+// the matching skill.
+//
+// Examples:
+//
+//	root namespace, mount "aws/"        → "/v1/aws/"
+//	namespace "team-data/", mount "aws/" → "/v1/team-data/aws/"
+//
+// The format mirrors how the request router resolves mounts internally
+// (ns.Path + mount + req.Path in core/router.go), so the value is
+// guaranteed to match the route an agent's HTTP call would hit.
+func mountURL(ns *namespace.Namespace, mountPath string) string {
+	if ns == nil {
+		return "/v1/" + mountPath
+	}
+	return "/v1/" + ns.Path + mountPath
+}
+
 // handleProviderRead handles GET /sys/providers/{path}
 func (b *SystemBackend) handleProviderRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	path := d.Get("path").(string)
@@ -163,6 +184,7 @@ func (b *SystemBackend) handleProviderRead(ctx context.Context, req *logical.Req
 		"description": entry.Description,
 		"accessor":    entry.Accessor,
 		"config":      maskedConfig,
+		"mount_url":   mountURL(entry.Namespace(), entry.Path),
 	}), nil
 }
 
@@ -212,6 +234,7 @@ func (b *SystemBackend) handleProviderList(ctx context.Context, req *logical.Req
 			"description": entry.Description,
 			"accessor":    entry.Accessor,
 			"config":      maskedConfig,
+			"mount_url":   mountURL(ns, entry.Path),
 		}
 	}
 

--- a/core/sys_providers_test.go
+++ b/core/sys_providers_test.go
@@ -5,10 +5,51 @@ import (
 	"testing"
 
 	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMountURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		ns        *namespace.Namespace
+		mountPath string
+		want      string
+	}{
+		{
+			name:      "root namespace",
+			ns:        namespace.RootNamespace,
+			mountPath: "aws/",
+			want:      "/v1/aws/",
+		},
+		{
+			name:      "sub-namespace",
+			ns:        &namespace.Namespace{Path: "team-data/"},
+			mountPath: "aws/",
+			want:      "/v1/team-data/aws/",
+		},
+		{
+			name:      "nested namespace",
+			ns:        &namespace.Namespace{Path: "team-data/sub-team/"},
+			mountPath: "vault/",
+			want:      "/v1/team-data/sub-team/vault/",
+		},
+		{
+			name:      "nil namespace falls back to no prefix",
+			ns:        nil,
+			mountPath: "aws/",
+			want:      "/v1/aws/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mountURL(tc.ns, tc.mountPath)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
 
 func TestSystemBackend_PathProviders(t *testing.T) {
 	backend, _, _ := setupTestSystemBackend(t)
@@ -100,6 +141,9 @@ func TestSystemBackend_HandleProviderRead(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "mock", resp.Data["type"])
 	assert.Equal(t, "test-provider/", resp.Data["path"])
+	// The agent-facing URL must come back with the namespace baked in so
+	// agents don't have to do string surgery on $WARDEN_NAMESPACE + path.
+	assert.Equal(t, "/v1/test-provider/", resp.Data["mount_url"])
 }
 
 func TestSystemBackend_HandleProviderRead_NotFound(t *testing.T) {
@@ -186,4 +230,13 @@ func TestSystemBackend_HandleProviderList(t *testing.T) {
 	mounts, ok := resp.Data["mounts"].(map[string]any)
 	require.True(t, ok)
 	assert.Len(t, mounts, 2)
+
+	// Every entry must carry a mount_url that agents can prepend
+	// $WARDEN_ADDR to without further string manipulation.
+	for path, entry := range mounts {
+		em, ok := entry.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "/v1/"+path, em["mount_url"],
+			"mount_url for %q should be /v1/%s", path, path)
+	}
 }

--- a/docs/agent-flow.md
+++ b/docs/agent-flow.md
@@ -93,22 +93,29 @@ and matches them to the task — it does not memorize role names.
 ### Step 3 — List providers in this namespace
 
 ```bash
-warden provider list -o json -F path,type,description
+warden provider list -o json -F type,description,mount_url
 ```
 
 Hits `GET /v1/sys/providers?warden-list=true`. The wire payload also
-carries an `accessor` per mount (a server-internal opaque ID); the
-`-F path,type,description` projection drops it because the agent never
-uses it. `path` becomes the gateway URL component, `type` is the lookup
-key for the matching provider skill, `description` is what the agent
-matches the task against.
+carries `path` (the bare mount slug like `aws/`) and `accessor` (a
+server-internal opaque ID); the projection drops both because the
+agent has everything it needs in `mount_url`. Three fields the agent
+keeps:
+
+- `type` — the lookup key for the matching provider skill.
+- `description` — what the agent matches the task against.
+- `mount_url` — the relative URL path with namespace + mount baked in.
+  The agent appends `$WARDEN_ADDR` plus the per-provider suffix (e.g.
+  `gateway`, `role/<role>/gateway`, `access/<grant>`) from the
+  provider's skill to construct the upstream URL. No string surgery
+  on `$WARDEN_NAMESPACE`.
 
 ```json
 [
-  {"path": "aws/",    "type": "aws",    "description": "Production AWS account 1234"},
-  {"path": "openai/", "type": "openai", "description": "OpenAI API for embeddings + chat"},
-  {"path": "rds-pg/", "type": "rds",    "description": "RDS PostgreSQL — analytics"},
-  {"path": "vault/",  "type": "vault",  "description": "Internal Vault — secrets/, pki/"}
+  {"type": "aws",    "description": "Production AWS account 1234",     "mount_url": "/v1/team-data/aws/"},
+  {"type": "openai", "description": "OpenAI API for embeddings + chat", "mount_url": "/v1/team-data/openai/"},
+  {"type": "rds",    "description": "RDS PostgreSQL — analytics",      "mount_url": "/v1/team-data/rds-pg/"},
+  {"type": "vault",  "description": "Internal Vault — secrets/, pki/", "mount_url": "/v1/team-data/vault/"}
 ]
 ```
 
@@ -161,7 +168,7 @@ User asks: *"Show me the keys in the staging-events S3 bucket."*
 
 1. **Session check** — env vars present. ✓
 2. **`warden role list -o json -F name,description`** — finds `data-reader` ("Read-only access to data warehouses").
-3. **`warden provider list -o json -F path,type,description`** — finds `aws/` ("Production AWS account 1234") plus an unrelated `openai/`.
+3. **`warden provider list -o json -F type,description,mount_url`** — finds an `aws` provider ("Production AWS account 1234", `mount_url=/v1/team-data/aws/`) plus an unrelated `openai`.
 4. **Match** — `data-reader` + `aws/` fit the task. No ambiguity.
 5. **`warden skill read aws --raw`** — gets the recipe:
 
@@ -169,16 +176,16 @@ User asks: *"Show me the keys in the staging-events S3 bucket."*
    export AWS_ACCESS_KEY_ID="<role-name>"
    export AWS_SECRET_ACCESS_KEY="$WARDEN_TOKEN"
    export AWS_SESSION_TOKEN="$WARDEN_TOKEN"
-   export AWS_ENDPOINT_URL="$WARDEN_ADDR/v1/<mount>/gateway"
+   export AWS_ENDPOINT_URL="$WARDEN_ADDR<mount-url>gateway"
    ```
 
-6. **Substitute and run:**
+6. **Substitute and run** (using `mount_url=/v1/team-data/aws/` from step 3):
 
    ```bash
    export AWS_ACCESS_KEY_ID=data-reader
    export AWS_SECRET_ACCESS_KEY=$WARDEN_TOKEN
    export AWS_SESSION_TOKEN=$WARDEN_TOKEN
-   export AWS_ENDPOINT_URL=https://warden.example.com/v1/aws/gateway
+   export AWS_ENDPOINT_URL=https://warden.example.com/v1/team-data/aws/gateway
    aws s3 ls s3://staging-events
    ```
 
@@ -196,12 +203,12 @@ Step 1–4 of the discovery loop are universal. Step 5's recipe varies
 by provider type. The skill registry surfaces the exact recipe for
 each type:
 
-| Provider type | Recipe shape |
-|---|---|
-| `aws`, `scaleway` | SDK env vars (`AWS_ACCESS_KEY_ID` carries the role name, JWT in the secret/session slot, endpoint pointed at the gateway). |
-| `openai`, `anthropic`, `github`, etc. | API key replaced with the JWT; base URL pointed at `…/<mount>/gateway`. |
-| `vault` | API call to `…/<mount>/gateway/v1/<vault-path>` with `X-Vault-Token: $WARDEN_TOKEN`. |
-| `rds` | One-shot API call to mint a short-lived JDBC/PSQL connection string with an embedded IAM auth token; the agent then connects directly to the DB (no proxy in the data path). |
+| Provider type | Recipe shape | How role is passed |
+|---|---|---|
+| `aws`, `scaleway` | SDK env vars (`AWS_ACCESS_KEY_ID` carries the role name, JWT in the secret/session slot, endpoint pointed at the gateway). | Role embedded in `AWS_ACCESS_KEY_ID` (extracted by Warden from the SigV4 header). |
+| `openai`, `anthropic`, `github`, etc. | API key replaced with the JWT; base URL pointed at `<mount_url>role/<role>/gateway`. | URL path segment: `…/role/<role>/gateway/…`. |
+| `vault` | API call to `<mount_url>role/<role>/gateway/v1/<vault-path>` with `X-Vault-Token: $WARDEN_TOKEN`. | URL path segment, same as the other HTTP gateways. |
+| `rds` | One-shot API call to mint a short-lived JDBC/PSQL connection string with an embedded IAM auth token; the agent then connects directly to the DB (no proxy in the data path). | Query parameter: `…/access/<grant>?role=<role>` (access backends, not gateways, so role lives in the query string). |
 
 The skill body for each type explains the exact substitution, the quirks
 (e.g. AWS wildcard DNS for S3 virtual-hosted buckets, JWT-expiry

--- a/e2e/provider/mount_url_test.go
+++ b/e2e/provider/mount_url_test.go
@@ -1,0 +1,133 @@
+//go:build e2e
+
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// TestProviderList_IncludesMountURL verifies the LIST endpoint returns
+// a `mount_url` per entry with the namespace + mount path baked in.
+// Agents use this to build upstream URLs without doing string surgery
+// on $WARDEN_NAMESPACE.
+func TestProviderList_IncludesMountURL(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	status, body := h.APIRequest(t, "GET", "sys/providers?warden-list=true", port, "")
+	if status != 200 {
+		t.Fatalf("list providers: status %d, body %s", status, string(body))
+	}
+
+	var resp struct {
+		Data struct {
+			Mounts map[string]map[string]interface{} `json:"mounts"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, string(body))
+	}
+	if len(resp.Data.Mounts) == 0 {
+		t.Fatal("expected at least one provider in the list")
+	}
+
+	// The e2e setup mounts `vault` in the root namespace. Confirm its
+	// mount_url is the canonical /v1/<path>.
+	vaultEntry, ok := resp.Data.Mounts["vault/"]
+	if !ok {
+		t.Fatalf("vault/ not in mounts: %v", resp.Data.Mounts)
+	}
+	got, _ := vaultEntry["mount_url"].(string)
+	if got != "/v1/vault/" {
+		t.Errorf("vault mount_url = %q, want /v1/vault/", got)
+	}
+
+	// Every entry must carry mount_url, and it must start with /v1/
+	// (the api root) and contain the mount key.
+	for path, entry := range resp.Data.Mounts {
+		mu, _ := entry["mount_url"].(string)
+		if mu == "" {
+			t.Errorf("%q: mount_url missing", path)
+			continue
+		}
+		if !strings.HasPrefix(mu, "/v1/") {
+			t.Errorf("%q: mount_url=%q does not start with /v1/", path, mu)
+		}
+		if !strings.HasSuffix(mu, "/"+path) {
+			t.Errorf("%q: mount_url=%q does not end with mount path", path, mu)
+		}
+	}
+}
+
+// TestProviderRead_IncludesMountURL verifies the READ endpoint returns
+// mount_url symmetrically with LIST.
+func TestProviderRead_IncludesMountURL(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	status, body := h.APIRequest(t, "GET", "sys/providers/vault", port, "")
+	if status != 200 {
+		t.Fatalf("read vault provider: status %d, body %s", status, string(body))
+	}
+
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, string(body))
+	}
+	got, _ := resp.Data["mount_url"].(string)
+	if got != "/v1/vault/" {
+		t.Errorf("mount_url = %q, want /v1/vault/", got)
+	}
+}
+
+// TestProviderList_MountURLIncludesNamespace verifies the URL is
+// namespace-aware: mounting a provider inside a sub-namespace must
+// produce a mount_url that includes that namespace's path.
+func TestProviderList_MountURLIncludesNamespace(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const ns = "e2e-mount-url-ns"
+	const mountName = "vault-in-ns"
+
+	// Pre-clean (cleanup is also wired below in case the test mid-fails).
+	h.APIRequest(t, "DELETE", "sys/namespaces/"+ns, port, "")
+
+	createNS, _ := h.APIRequest(t, "POST", "sys/namespaces/"+ns, port, "")
+	if createNS != 201 && createNS != 200 {
+		t.Fatalf("create namespace: expected 201/200, got %d", createNS)
+	}
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/namespaces/"+ns, port, "")
+	})
+
+	createProv, _ := h.NSAPIRequest(t, "POST", "sys/providers/"+mountName, ns, port, `{"type":"vault"}`)
+	if createProv != 200 && createProv != 201 {
+		t.Fatalf("mount in sub-namespace: expected 200/201, got %d", createProv)
+	}
+
+	status, body := h.NSAPIRequest(t, "GET", "sys/providers?warden-list=true", ns, port, "")
+	if status != 200 {
+		t.Fatalf("list under sub-namespace: status %d, body %s", status, string(body))
+	}
+
+	var resp struct {
+		Data struct {
+			Mounts map[string]map[string]interface{} `json:"mounts"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	entry, ok := resp.Data.Mounts[mountName+"/"]
+	if !ok {
+		t.Fatalf("%s/ not found in sub-namespace list: %v", mountName, resp.Data.Mounts)
+	}
+	got, _ := entry["mount_url"].(string)
+	want := "/v1/" + ns + "/" + mountName + "/"
+	if got != want {
+		t.Errorf("mount_url = %q, want %q", got, want)
+	}
+}

--- a/provider/aws/skill.md
+++ b/provider/aws/skill.md
@@ -18,20 +18,21 @@ AWS service. **No SDK code changes** — only env vars.
 
 ## Configure the CLI/SDK
 
-`<mount>` and `<role-name>` below come from the discovery flow:
-- `<mount>` is the chosen provider's path from `warden provider list`
-  (e.g. `aws/`, `aws-prod/` — whichever your task matches).
+`<mount-url>` and `<role-name>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/aws/`, `/v1/team-data/aws-prod/`).
+  Warden has already baked the namespace + mount path in — just append
+  the per-provider suffix (`gateway` for AWS).
 - `<role-name>` is the role you picked from `warden role list` to perform
   this task.
 
-The JWT (`$JWT`) is provided to the agent's environment by its
-runtime — see `foundation`. Just use it:
+The JWT comes in via `$WARDEN_TOKEN` — see `foundation`. Just use it:
 
 ```bash
 export AWS_ACCESS_KEY_ID="<role-name>"          # role from `warden role list`
-export AWS_SECRET_ACCESS_KEY="$JWT"
-export AWS_SESSION_TOKEN="$JWT"                 # Warden detects "eyJ" prefix
-export AWS_ENDPOINT_URL="$WARDEN_ADDR/v1/<mount>/gateway"
+export AWS_SECRET_ACCESS_KEY="$WARDEN_TOKEN"
+export AWS_SESSION_TOKEN="$WARDEN_TOKEN"        # Warden detects "eyJ" prefix
+export AWS_ENDPOINT_URL="$WARDEN_ADDR<mount-url>gateway"
 ```
 
 The role-selection idiom is non-obvious: **`AWS_ACCESS_KEY_ID` carries

--- a/provider/github/skill.md
+++ b/provider/github/skill.md
@@ -19,47 +19,48 @@ The agent **never holds a PAT**.
 
 ## Configure the CLI/SDK
 
-`<mount>` and `<role>` below come from the discovery flow:
-- `<mount>` is the chosen provider's path from `warden provider list`
-  (e.g. `github/`, `github-enterprise/`).
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/github/`, `/v1/team-data/github-enterprise/`).
+  Warden has already baked the namespace + mount path in.
 - `<role>` is the role you picked from `warden role list` to perform this
   task — it goes in the URL path.
 
 ```bash
-URL pattern : $WARDEN_ADDR/v1/<mount>/role/<role>/gateway/<github-api-path>
-Auth header : Authorization: Bearer <JWT>
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<github-api-path>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
 ```
 
 For `curl` or any HTTP client: rewrite the GitHub host to
-`<warden>/v1/<mount>/role/<role>/gateway` and add the bearer JWT.
+`$WARDEN_ADDR<mount-url>role/<role>/gateway` and add the bearer token.
 
 ## Examples
 
-(All examples assume mount `github/` and role `repo-reader`;
+(All examples assume `mount_url = /v1/github/` and role `repo-reader`;
 substitute yours.)
 
 List your authenticated user's repos:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/github/role/repo-reader/gateway/user/repos
 ```
 
 Read a specific repo's issues:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/github/role/repo-reader/gateway/repos/myorg/myrepo/issues
 ```
 
 Open an issue (operator must grant a write-capable role):
 ```bash
-curl -X POST -H "Authorization: Bearer $JWT" \
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
   -H "Accept: application/vnd.github+json" \
   -d '{"title":"Bug","body":"..."}' \
   $WARDEN_ADDR/v1/github/role/issue-writer/gateway/repos/myorg/myrepo/issues
 ```
 
 For the Octokit JS / PyGithub clients: configure the `baseUrl` /
-`base_url` to `$WARDEN_ADDR/v1/<mount>/role/<role>/gateway`
+`base_url` to `$WARDEN_ADDR<mount-url>role/<role>/gateway`
 and supply your JWT as the auth token.
 
 ## Quirks

--- a/provider/openai/skill.md
+++ b/provider/openai/skill.md
@@ -19,15 +19,17 @@ and forwards. The agent **never holds an API key**.
 
 ## Configure the CLI/SDK
 
-`<mount>` and `<role>` below come from the discovery flow:
-- `<mount>` is the chosen provider's path from `warden provider list`
-  (e.g. `openai/`, `openai-prod/`).
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/openai/`, `/v1/team-data/openai-prod/`).
+  Warden has already baked the namespace + mount path in — append
+  `role/<role>/gateway/<openai-api-path>` for transparent mode.
 - `<role>` is the role you picked from `warden role list` to perform this
   task — it goes in the URL path.
 
 ```bash
-URL pattern : $WARDEN_ADDR/v1/<mount>/role/<role>/gateway/<openai-api-path>
-Auth header : Authorization: Bearer <JWT>
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<openai-api-path>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
 ```
 
 The same shape as upstream OpenAI requests, just with the host swapped
@@ -38,8 +40,8 @@ out and a JWT instead of an API key.
 ```python
 from openai import OpenAI
 client = OpenAI(
-    base_url="$WARDEN_ADDR/v1/<mount>/role/llm-app/gateway",
-    api_key=JWT,                           # JWT, not an OpenAI key
+    base_url=f"{WARDEN_ADDR}{MOUNT_URL}role/llm-app/gateway",
+    api_key=WARDEN_TOKEN,                  # JWT, not an OpenAI key
 )
 ```
 
@@ -48,18 +50,18 @@ client = OpenAI(
 ```js
 import OpenAI from "openai";
 const client = new OpenAI({
-  baseURL: "$WARDEN_ADDR/v1/<mount>/role/llm-app/gateway",
-  apiKey: process.env.JWT,
+  baseURL: `${process.env.WARDEN_ADDR}${MOUNT_URL}role/llm-app/gateway`,
+  apiKey: process.env.WARDEN_TOKEN,
 });
 ```
 
 ## Examples
 
-(All examples assume mount `openai/`; substitute yours.)
+(All examples assume `mount_url = /v1/openai/`; substitute yours.)
 
 Chat completion via `curl`:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}]}' \
   $WARDEN_ADDR/v1/openai/role/llm-app/gateway/chat/completions
@@ -67,7 +69,7 @@ curl -H "Authorization: Bearer $JWT" \
 
 Embeddings:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"model":"text-embedding-3-small","input":"some text"}' \
   $WARDEN_ADDR/v1/openai/role/embeddings/gateway/embeddings
@@ -75,7 +77,7 @@ curl -H "Authorization: Bearer $JWT" \
 
 List models:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/openai/role/llm-app/gateway/models
 ```
 

--- a/provider/rds/skill.md
+++ b/provider/rds/skill.md
@@ -26,30 +26,34 @@ The Warden call returns a *connection string* you feed to your
 PostgreSQL or MySQL client unchanged. There's no SDK setup; this is
 a single HTTP call followed by a regular DB connection.
 
-`<mount>` and `<grant-name>` below come from the discovery flow plus
-one extra step:
-- `<mount>` is the chosen provider's path from `warden provider list`
-  (e.g. `rds/`, `rds-prod/`, `pg-warehouse/`).
+`<mount-url>`, `<grant-name>`, and `<role>` below come from the discovery
+flow plus one extra step:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/rds/`, `/v1/team-data/rds-prod/`).
+  Warden has already baked the namespace + mount path in.
 - `<grant-name>` is a pre-configured grant (operator decides which
   RDS instance + DB user + capabilities each grant exposes). List them
-  with `warden list <mount>/access` and pick by description.
-
-The role from `warden role list` is implicit here — RDS is transparent-only,
-so the JWT itself selects the role; there's no per-call role flag.
+  with `warden list <mount-url>access` and pick by description.
+- `<role>` is the role you picked from `warden role list`. Access
+  backends take the role as a **query parameter** on the access URL
+  (gateway providers take it as a path segment — different shape).
 
 ```bash
-URL pattern : $WARDEN_ADDR/v1/<mount>/access/<grant-name>
-Auth header : Authorization: Bearer <JWT>
+URL pattern : $WARDEN_ADDR<mount-url>access/<grant-name>?role=<role>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
 ```
+
+If the operator has set a `default_role` on the auth method, omitting
+`?role=` falls back to that default.
 
 ## Examples
 
-(All examples assume mount `rds-prod/`; substitute yours.)
+(All examples assume `mount_url = /v1/rds-prod/`; substitute yours.)
 
 ```bash
-# Mint a connection string
-RESP=$(curl -sH "Authorization: Bearer $JWT" \
-  $WARDEN_ADDR/v1/rds-prod/access/analytics-reader)
+# Mint a connection string (role passed as query param)
+RESP=$(curl -sH "Authorization: Bearer $WARDEN_TOKEN" \
+  "$WARDEN_ADDR/v1/rds-prod/access/analytics-reader?role=analytics-ro")
 
 # {"connection_string":"host=db.example.com port=5432 dbname=analytics user=ro_user password=eyJ...IAM-TOKEN... sslmode=require","lease_duration":900}
 
@@ -98,6 +102,10 @@ to get a fresh token-bearing connection string.
 - **`rds_iam_token` is the underlying mint method.** RDS instances
   must have IAM database authentication enabled and the DB user
   pre-created with `rds_iam` group membership.
+- **Role selection** is via `?role=<name>` query parameter on the
+  access URL — distinct from gateway providers, which take the role as
+  a path segment (`/role/<name>/gateway/...`). Falls back to the auth
+  method's `default_role` when omitted.
 - **Connection failures are not Warden's responsibility.** A
   successful mint followed by a connection error means the DB
   endpoint, security group, or DB user is misconfigured — diagnose

--- a/provider/scaleway/skill.md
+++ b/provider/scaleway/skill.md
@@ -24,10 +24,11 @@ cares about *one* of the two modes per task.
 
 ## Configure the CLI/SDK
 
-`<mount>`, `<role>`, and (for S3 mode) `<role-name>` below come from
+`<mount-url>`, `<role>`, and (for S3 mode) `<role-name>` below come from
 the discovery flow:
-- `<mount>` is the chosen provider's path from `warden provider list`
-  (e.g. `scaleway/`, `scaleway-prod/`).
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/scaleway/`, `/v1/team-data/scaleway-prod/`).
+  Warden has already baked the namespace + mount path in.
 - `<role>` / `<role-name>` is the role you picked from `warden role list`
   for this task — REST mode puts it in the URL path; S3 mode puts the
   same value in `AWS_ACCESS_KEY_ID`.
@@ -35,8 +36,8 @@ the discovery flow:
 ### REST API (HTTP, Bearer-style)
 
 ```bash
-URL pattern : $WARDEN_ADDR/v1/<mount>/role/<role>/gateway/<scaleway-api-path>
-Auth header : Authorization: Bearer <JWT>
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<scaleway-api-path>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
 ```
 
 The official Scaleway CLI (`scw`) authenticates via `X-Auth-Token`
@@ -49,7 +50,7 @@ header.
 
 `curl`:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/scaleway/role/cloud-reader/gateway/instance/v1/zones/fr-par-1/servers
 ```
 
@@ -59,7 +60,7 @@ import os, requests
 base = f"{os.environ['WARDEN_ADDR']}/v1/scaleway/role/cloud-reader/gateway"
 r = requests.get(
     f"{base}/instance/v1/zones/fr-par-1/servers",
-    headers={"Authorization": f"Bearer {os.environ['JWT']}"},
+    headers={"Authorization": f"Bearer {os.environ['WARDEN_TOKEN']}"},
 )
 r.raise_for_status()
 servers = r.json()["servers"]
@@ -72,9 +73,9 @@ provider but pointing at this mount:
 
 ```bash
 export AWS_ACCESS_KEY_ID="<role-name>"
-export AWS_SECRET_ACCESS_KEY="$JWT"
-export AWS_SESSION_TOKEN="$JWT"
-export AWS_ENDPOINT_URL="$WARDEN_ADDR/v1/<mount>/role/<role>/gateway"
+export AWS_SECRET_ACCESS_KEY="$WARDEN_TOKEN"
+export AWS_SESSION_TOKEN="$WARDEN_TOKEN"
+export AWS_ENDPOINT_URL="$WARDEN_ADDR<mount-url>role/<role>/gateway"
 ```
 
 Then any AWS S3-compatible CLI/SDK works:
@@ -89,17 +90,17 @@ keys.
 
 ## Examples
 
-(All examples assume mount `scaleway/`; substitute yours.)
+(All examples assume `mount_url = /v1/scaleway/`; substitute yours.)
 
 Read your IAM users (REST):
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/scaleway/role/iam-reader/gateway/iam/v1alpha1/users
 ```
 
 List instances in a zone (REST):
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/scaleway/role/compute/gateway/instance/v1/zones/fr-par-1/servers
 ```
 

--- a/provider/vault/skill.md
+++ b/provider/vault/skill.md
@@ -19,17 +19,18 @@ The agent **never holds a Vault token**.
 
 ## Configure the CLI/SDK
 
-`<mount>` and `<role>` below come from the discovery flow:
-- `<mount>` is the chosen provider's path from `warden provider list`
-  (e.g. `vault/`, `secrets-prod/`).
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/vault/`, `/v1/team-data/secrets-prod/`).
+  Warden has already baked the namespace + mount path in.
 - `<role>` is the role you picked from `warden role list` to perform this
   task — it goes in the URL path.
 
 Auth is your JWT:
 
 ```bash
-URL pattern : $WARDEN_ADDR/v1/<mount>/role/<role>/gateway/<vault-api-path>
-Auth header : Authorization: Bearer <JWT>     # OR X-Vault-Token: <JWT>
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<vault-api-path>
+Auth header : Authorization: Bearer $WARDEN_TOKEN  # OR X-Vault-Token: $WARDEN_TOKEN
 ```
 
 ### Vault CLI
@@ -39,8 +40,8 @@ Warden gateway and use the JWT as the Vault token. Warden detects
 the JWT prefix in `X-Vault-Token` and treats it as identity.
 
 ```bash
-export VAULT_ADDR="$WARDEN_ADDR/v1/<mount>/role/<role>/gateway"
-export VAULT_TOKEN="$JWT"
+export VAULT_ADDR="$WARDEN_ADDR<mount-url>role/<role>/gateway"
+export VAULT_TOKEN="$WARDEN_TOKEN"
 
 vault kv get secret/myapp/config
 vault kv put secret/myapp/config foo=bar
@@ -53,19 +54,19 @@ The agent never holds a real Vault token; the JWT is the identity.
 ### Vault SDK
 
 For the official Go / Python / Node Vault SDKs, the same shape: set
-the client's `Address` to `$WARDEN_ADDR/v1/<mount>/role/<role>/gateway`
+the client's `Address` to `$WARDEN_ADDR<mount-url>role/<role>/gateway`
 and its `Token` to the JWT.
 
 ### Raw HTTP (curl)
 
 ```bash
-curl -H "Authorization: Bearer $JWT" \
-  $WARDEN_ADDR/v1/<mount>/role/<role>/gateway/v1/secret/data/myapp/config
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  "$WARDEN_ADDR<mount-url>role/<role>/gateway/v1/secret/data/myapp/config"
 ```
 
 ## Examples
 
-(All examples assume mount `vault/` and role `secrets-reader`;
+(All examples assume `mount_url = /v1/vault/` and role `secrets-reader`;
 substitute yours. `VAULT_ADDR` and `VAULT_TOKEN` are exported as
 shown above.)
 
@@ -93,7 +94,7 @@ vault write pki/sign/server-tpl csr=@./req.csr
 
 Same operations via raw HTTP for scripting:
 ```bash
-curl -H "Authorization: Bearer $JWT" \
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/vault/role/secrets-reader/gateway/v1/secret/data/app/db
 ```
 


### PR DESCRIPTION
Provider list/read now carry a `mount_url` field with the namespace and mount path already baked in (e.g. `/v1/team-data/aws/`). Agents append `$WARDEN_ADDR` plus the per-provider suffix from the skill (`gateway`, `role/<role>/gateway`, `access/<grant>`) to construct upstream URLs -- no string surgery on `$WARDEN_NAMESPACE`, no guesswork about whether mount paths carry trailing slashes.

The shape varies per provider class. Captured the variation in the agent-flow doc:
- SigV4 gateways (AWS, Scaleway-S3): append `gateway`; role lives in `AWS_ACCESS_KEY_ID`.
- HTTP gateways (OpenAI, Vault, GitHub, etc.): append `role/<role>/gateway/<api-path>`.
- Access backends (RDS): append `access/<grant>?role=<role>` -- role is a query parameter, not a path segment (corrected the RDS skill which had previously said role was implicit).

Server side:
- `core/sys_providers.go`: new `mountURL` helper; LIST and READ responses include `mount_url`.
- `api/sys_mounts.go`: `MountOutput.MountURL` field with mapstructure tag.
- `cmd/providers/list.go` / `read.go`: surface the field in JSON output.

Tests:
- 4 unit tests for `mountURL` (root namespace, sub-namespace, nested, nil-fallback) plus assertions in existing list/read handler tests.
- 3 e2e tests verifying the field is present and namespace-aware, including a fresh sub-namespace mount.

Provider skills (6): rewrote URL templates to use `<mount-url>` substituted from the new field. Discovery and agent-flow docs updated to advertise the projection `-F type,description,mount_url` (drops `path`, now redundant given `mount_url`).

README polish (incremental, separate motivation):
- "One JWT, every SDK slot" framing replaces the bland "Best For" column on the auth-method table. JWT row shows the slots the same token fills; cert row says the SDK slot takes any placeholder once TLS proves identity. New paragraph below the table calls out the drop-in property and contrasts with MCP / dedicated auth proxies.