### PR TITLE
feat(config): add --config-dir flag and env-var interpolation

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -87,6 +87,7 @@ const (
 
 var (
 	configPath string
+	configDir  string
 
 	flagDev          bool
 	flagDevRootToken string
@@ -103,10 +104,19 @@ var (
 		Long: `
 Usage: warden server [options]
 
-  This command starts a Warden server that responds to API requests. By default,
-  Start a server with a configuration file:
+  This command starts a Warden server that responds to API requests.
+
+  Start a server with a single configuration file:
 
       $ warden server --config=/etc/warden/config.hcl
+
+  Or merge multiple HCL files from a directory (lexical order, later files
+  override earlier ones — useful for splitting a ConfigMap and a Secret in
+  Kubernetes):
+
+      $ warden server --config-dir=/etc/warden/conf.d
+
+  Config files may reference environment variables via {{ env "VAR_NAME" }}.
 
   For a full list of examples, please see the documentation.
   `,
@@ -186,6 +196,7 @@ Usage: warden server [options]
 
 func init() {
 	ServerCmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to configuration file (e.g., path/to/warden.hcl)")
+	ServerCmd.Flags().StringVar(&configDir, "config-dir", "", "Path to a directory of .hcl configuration files, merged in lexical order")
 	ServerCmd.Flags().BoolVar(&flagDev, "dev", false, "Enable dev mode: inmem storage, auto-init, auto-unseal")
 	ServerCmd.Flags().StringVar(&flagDevRootToken, "dev-root-token", "", "Custom root token for dev mode (any string)")
 	ServerCmd.Flags().BoolVar(&flagDevTLS, "dev-tls", false, "Enable TLS for dev mode listener (auto-generates self-signed cert)")
@@ -202,6 +213,12 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	if flagDev && configPath != "" {
 		return fmt.Errorf("--config cannot be used with --dev (dev mode always uses inmem storage)")
+	}
+	if flagDev && configDir != "" {
+		return fmt.Errorf("--config-dir cannot be used with --dev (dev mode always uses inmem storage)")
+	}
+	if configPath != "" && configDir != "" {
+		return fmt.Errorf("--config and --config-dir are mutually exclusive")
 	}
 
 	// Infer --dev-tls from explicit cert file flags
@@ -227,14 +244,18 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--dev-tls-require-client-cert requires --dev-tls-ca-cert-file")
 	}
 
-	// Load configuration: dev mode builds defaults, otherwise requires config file
+	// Load configuration: dev mode builds defaults, otherwise requires config file or dir
 	var conf *config.Config
-	if flagDev {
+	switch {
+	case flagDev:
 		conf = config.DevConfig()
-	} else {
-		if configPath == "" {
-			return fmt.Errorf("config file path is required. Use -c or --config flag")
+	case configDir != "":
+		var err error
+		conf, err = config.LoadConfigDir(configDir)
+		if err != nil {
+			return fmt.Errorf("failed to load config dir: %w", err)
 		}
+	case configPath != "":
 		if _, err := os.Stat(configPath); os.IsNotExist(err) {
 			return fmt.Errorf("config file not found: %s", configPath)
 		}
@@ -243,6 +264,8 @@ func run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
+	default:
+		return fmt.Errorf("a config file path or config dir is required. Use -c/--config or --config-dir")
 	}
 
 	// Configure TLS for dev mode

--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,14 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -422,37 +427,134 @@ type ListenerBlock struct {
 	TrustedProxies       []string `hcl:"trusted_proxies,optional"`         // CIDR ranges for LB cert forwarding
 }
 
+// LoadConfig reads a single HCL config file and returns a validated *Config.
+// File contents are pre-processed through a Go-template pass with an `env`
+// function (see InterpolateEnv) so configs may reference environment
+// variables via {{ env "VAR_NAME" }} placeholders.
 func LoadConfig(configFile string) (*Config, error) {
-	var config Config
-
-	// Load HCL using HashiCorp's hclsimple (easiest method)
-	err := hclsimple.DecodeFile(configFile, nil, &config)
+	cfg, err := loadConfigFile(configFile)
 	if err != nil {
 		return nil, err
 	}
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
 
+// LoadConfigDir reads every *.hcl file at the top level of dir in lexical
+// order (no recursion into subdirectories), merges them (later files
+// override earlier ones, slice/pointer blocks are replaced wholesale),
+// and returns a validated *Config. This lets operators split config
+// across multiple sources — e.g. a Kubernetes ConfigMap with non-secret
+// blocks plus a Secret containing the storage credentials and seal
+// block — without losing single-file simplicity.
+func LoadConfigDir(dir string) (*Config, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("config dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("config dir %q is not a directory", dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read config dir %q: %w", dir, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".hcl") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("config dir %q contains no .hcl files", dir)
+	}
+	sort.Strings(files)
+
+	merged := &Config{}
+	for _, f := range files {
+		cfg, err := loadConfigFile(f)
+		if err != nil {
+			return nil, err
+		}
+		mergeConfig(merged, cfg)
+	}
+	if err := validateConfig(merged); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// loadConfigFile reads a single HCL file, runs the env-var template pass,
+// and decodes into a *Config without running validation.
+func loadConfigFile(configFile string) (*Config, error) {
+	src, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", configFile, err)
+	}
+	rendered, err := InterpolateEnv(src)
+	if err != nil {
+		return nil, fmt.Errorf("interpolate env vars in %q: %w", configFile, err)
+	}
+	var cfg Config
+	if err := hclsimple.Decode(configFile, rendered, nil, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// InterpolateEnv runs the given config bytes through a Go-template pass
+// exposing a single `env` function that returns os.Getenv. The template
+// syntax ({{ env "VAR" }}) is used in preference to ${VAR} so it does not
+// collide with HCL's native ${...} interpolation. Missing env vars expand
+// to the empty string, matching shell semantics.
+func InterpolateEnv(src []byte) ([]byte, error) {
+	tmpl, err := template.New("warden-config").
+		Funcs(template.FuncMap{"env": os.Getenv}).
+		Parse(string(src))
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, nil); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// validateConfig checks the cross-field invariants on a Config. Split out
+// of LoadConfig so LoadConfigDir can validate the merged result once,
+// rather than validating each partial file independently.
+func validateConfig(config *Config) error {
 	// Validate rotation period bounds if set
 	var minDur, maxDur time.Duration
+	var err error
 	if config.MinCredSourceRotationPeriod != "" {
 		minDur, err = time.ParseDuration(config.MinCredSourceRotationPeriod)
 		if err != nil {
-			return nil, fmt.Errorf("invalid min_cred_source_rotation_period %q: %w", config.MinCredSourceRotationPeriod, err)
+			return fmt.Errorf("invalid min_cred_source_rotation_period %q: %w", config.MinCredSourceRotationPeriod, err)
 		}
 		if minDur <= 0 {
-			return nil, fmt.Errorf("min_cred_source_rotation_period must be positive, got %s", minDur)
+			return fmt.Errorf("min_cred_source_rotation_period must be positive, got %s", minDur)
 		}
 	}
 	if config.MaxCredSourceRotationPeriod != "" {
 		maxDur, err = time.ParseDuration(config.MaxCredSourceRotationPeriod)
 		if err != nil {
-			return nil, fmt.Errorf("invalid max_cred_source_rotation_period %q: %w", config.MaxCredSourceRotationPeriod, err)
+			return fmt.Errorf("invalid max_cred_source_rotation_period %q: %w", config.MaxCredSourceRotationPeriod, err)
 		}
 		if maxDur <= 0 {
-			return nil, fmt.Errorf("max_cred_source_rotation_period must be positive, got %s", maxDur)
+			return fmt.Errorf("max_cred_source_rotation_period must be positive, got %s", maxDur)
 		}
 	}
 	if minDur > 0 && maxDur > 0 && minDur > maxDur {
-		return nil, fmt.Errorf("min_cred_source_rotation_period (%s) must be <= max_cred_source_rotation_period (%s)", minDur, maxDur)
+		return fmt.Errorf("min_cred_source_rotation_period (%s) must be <= max_cred_source_rotation_period (%s)", minDur, maxDur)
 	}
 
 	// Validate spec rotation period bounds if set
@@ -460,23 +562,23 @@ func LoadConfig(configFile string) (*Config, error) {
 	if config.MinCredSpecRotationPeriod != "" {
 		minSpecDur, err = time.ParseDuration(config.MinCredSpecRotationPeriod)
 		if err != nil {
-			return nil, fmt.Errorf("invalid min_cred_spec_rotation_period %q: %w", config.MinCredSpecRotationPeriod, err)
+			return fmt.Errorf("invalid min_cred_spec_rotation_period %q: %w", config.MinCredSpecRotationPeriod, err)
 		}
 		if minSpecDur <= 0 {
-			return nil, fmt.Errorf("min_cred_spec_rotation_period must be positive, got %s", minSpecDur)
+			return fmt.Errorf("min_cred_spec_rotation_period must be positive, got %s", minSpecDur)
 		}
 	}
 	if config.MaxCredSpecRotationPeriod != "" {
 		maxSpecDur, err = time.ParseDuration(config.MaxCredSpecRotationPeriod)
 		if err != nil {
-			return nil, fmt.Errorf("invalid max_cred_spec_rotation_period %q: %w", config.MaxCredSpecRotationPeriod, err)
+			return fmt.Errorf("invalid max_cred_spec_rotation_period %q: %w", config.MaxCredSpecRotationPeriod, err)
 		}
 		if maxSpecDur <= 0 {
-			return nil, fmt.Errorf("max_cred_spec_rotation_period must be positive, got %s", maxSpecDur)
+			return fmt.Errorf("max_cred_spec_rotation_period must be positive, got %s", maxSpecDur)
 		}
 	}
 	if minSpecDur > 0 && maxSpecDur > 0 && minSpecDur > maxSpecDur {
-		return nil, fmt.Errorf("min_cred_spec_rotation_period (%s) must be <= max_cred_spec_rotation_period (%s)", minSpecDur, maxSpecDur)
+		return fmt.Errorf("min_cred_spec_rotation_period (%s) must be <= max_cred_spec_rotation_period (%s)", minSpecDur, maxSpecDur)
 	}
 
 	// Validate ip_binding_policy if set
@@ -485,14 +587,14 @@ func LoadConfig(configFile string) (*Config, error) {
 		case "disabled", "optional", "required":
 			// valid
 		default:
-			return nil, fmt.Errorf("invalid ip_binding_policy %q: must be one of: disabled, optional, required", config.IPBindingPolicy)
+			return fmt.Errorf("invalid ip_binding_policy %q: must be one of: disabled, optional, required", config.IPBindingPolicy)
 		}
 	}
 
 	// Validate listener TLS config
 	for i, ln := range config.Listeners {
 		if ln.TLSEnabled && (ln.TLSCertFile == "" || ln.TLSKeyFile == "") {
-			return nil, fmt.Errorf("listener[%d]: tls_enabled requires both tls_cert_file and tls_key_file", i)
+			return fmt.Errorf("listener[%d]: tls_enabled requires both tls_cert_file and tls_key_file", i)
 		}
 	}
 
@@ -517,10 +619,10 @@ func LoadConfig(configFile string) (*Config, error) {
 		}
 		d, err := time.ParseDuration(f.value)
 		if err != nil {
-			return nil, fmt.Errorf("invalid %s %q: %w", f.name, f.value, err)
+			return fmt.Errorf("invalid %s %q: %w", f.name, f.value, err)
 		}
 		if d < 0 {
-			return nil, fmt.Errorf("%s must not be negative, got %s", f.name, d)
+			return fmt.Errorf("%s must not be negative, got %s", f.name, d)
 		}
 	}
 
@@ -528,17 +630,17 @@ func LoadConfig(configFile string) (*Config, error) {
 	if config.ClusterAddr != "" {
 		u, err := url.Parse(config.ClusterAddr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid cluster_addr %q: %w", config.ClusterAddr, err)
+			return fmt.Errorf("invalid cluster_addr %q: %w", config.ClusterAddr, err)
 		}
 		if !strings.EqualFold(u.Scheme, "https") {
-			return nil, fmt.Errorf("cluster_addr must use https:// scheme, got %q", config.ClusterAddr)
+			return fmt.Errorf("cluster_addr must use https:// scheme, got %q", config.ClusterAddr)
 		}
 		if u.Host == "" {
-			return nil, fmt.Errorf("cluster_addr must include a host, got %q", config.ClusterAddr)
+			return fmt.Errorf("cluster_addr must include a host, got %q", config.ClusterAddr)
 		}
 	}
 
-	return &config, nil
+	return nil
 }
 
 // DevConfig returns a default configuration suitable for dev mode.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,235 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return p
+}
+
+func TestInterpolateEnv(t *testing.T) {
+	t.Setenv("WARDEN_TEST_HOST", "warden-0.warden-headless.warden.svc")
+	t.Setenv("WARDEN_TEST_EMPTY", "")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple substitution",
+			in:   `api_addr = "https://{{ env "WARDEN_TEST_HOST" }}:8400"`,
+			want: `api_addr = "https://warden-0.warden-headless.warden.svc:8400"`,
+		},
+		{
+			name: "missing var expands to empty",
+			in:   `x = "{{ env "WARDEN_TEST_NOT_SET" }}"`,
+			want: `x = ""`,
+		},
+		{
+			name: "empty var expands to empty",
+			in:   `x = "{{ env "WARDEN_TEST_EMPTY" }}"`,
+			want: `x = ""`,
+		},
+		{
+			name: "HCL-native ${...} is left untouched",
+			in:   `path = "${some_hcl_ref}"`,
+			want: `path = "${some_hcl_ref}"`,
+		},
+		{
+			name: "no interpolation needed",
+			in:   `log_level = "trace"`,
+			want: `log_level = "trace"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := InterpolateEnv([]byte(tt.in))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestLoadConfig_EnvInterpolation(t *testing.T) {
+	t.Setenv("WARDEN_TEST_API_ADDR", "https://node1.warden.svc:8400")
+	t.Setenv("WARDEN_TEST_CLUSTER_ADDR", "https://node1.warden.svc:8401")
+
+	dir := t.TempDir()
+	hcl := `
+api_addr     = "{{ env "WARDEN_TEST_API_ADDR" }}"
+cluster_addr = "{{ env "WARDEN_TEST_CLUSTER_ADDR" }}"
+
+storage "postgres" {
+  connection_url = "postgres://x:y@host:5432/db"
+}
+
+listener "tcp" {
+  address = ":8400"
+}
+`
+	p := writeFile(t, dir, "warden.hcl", hcl)
+
+	cfg, err := LoadConfig(p)
+	require.NoError(t, err)
+	assert.Equal(t, "https://node1.warden.svc:8400", cfg.APIAddr)
+	assert.Equal(t, "https://node1.warden.svc:8401", cfg.ClusterAddr)
+}
+
+func TestLoadConfigDir_LexicalMergeOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	// Base file: full HCL with placeholder values that the overlay will replace.
+	writeFile(t, dir, "00-base.hcl", `
+log_level    = "info"
+log_format   = "json"
+api_addr     = "https://placeholder:8400"
+cluster_addr = "https://placeholder:8401"
+
+storage "postgres" {
+  connection_url = "postgres://placeholder/db"
+}
+
+listener "tcp" {
+  address = ":8400"
+}
+`)
+
+	// Overlay file: only overrides log_level, api_addr, and the storage block
+	// (mirrors the ConfigMap+Secret split where the Secret owns the storage block).
+	writeFile(t, dir, "10-overlay.hcl", `
+log_level = "debug"
+api_addr  = "https://final:8400"
+
+storage "postgres" {
+  connection_url = "postgres://real-user:real-password@db:5432/warden"
+}
+`)
+
+	cfg, err := LoadConfigDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfg.LogLevel, "overlay should override log_level")
+	assert.Equal(t, "json", cfg.LogFormat, "log_format should be preserved from base")
+	assert.Equal(t, "https://final:8400", cfg.APIAddr, "overlay should override api_addr")
+	assert.Equal(t, "https://placeholder:8401", cfg.ClusterAddr, "cluster_addr should be preserved from base")
+	require.NotNil(t, cfg.Storage)
+	assert.Equal(t, "postgres://real-user:real-password@db:5432/warden", cfg.Storage.ConnectionUrl, "overlay should replace storage block")
+	require.Len(t, cfg.Listeners, 1)
+	assert.Equal(t, ":8400", cfg.Listeners[0].Address, "listener should be preserved from base")
+}
+
+func TestLoadConfigDir_EnvInterpolation(t *testing.T) {
+	t.Setenv("WARDEN_TEST_DB_URL", "postgres://prod-user:prod-pw@db:5432/warden")
+	t.Setenv("WARDEN_TEST_API_HOST", "node1.warden.svc")
+
+	dir := t.TempDir()
+	writeFile(t, dir, "00-base.hcl", `
+api_addr = "https://{{ env "WARDEN_TEST_API_HOST" }}:8400"
+
+listener "tcp" {
+  address = ":8400"
+}
+`)
+	writeFile(t, dir, "10-secrets.hcl", `
+storage "postgres" {
+  connection_url = "{{ env "WARDEN_TEST_DB_URL" }}"
+}
+`)
+
+	cfg, err := LoadConfigDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "https://node1.warden.svc:8400", cfg.APIAddr)
+	require.NotNil(t, cfg.Storage)
+	assert.Equal(t, "postgres://prod-user:prod-pw@db:5432/warden", cfg.Storage.ConnectionUrl)
+}
+
+func TestLoadConfigDir_IgnoresNonHCLFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "00-base.hcl", `
+log_level = "info"
+
+storage "postgres" {
+  connection_url = "postgres://x/db"
+}
+
+listener "tcp" {
+  address = ":8400"
+}
+`)
+	writeFile(t, dir, "README.md", "not a config file")
+	writeFile(t, dir, "warden.hcl.bak", "log_level = \"this should be ignored\"")
+
+	cfg, err := LoadConfigDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "info", cfg.LogLevel)
+}
+
+func TestLoadConfigDir_EmptyDirIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadConfigDir(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .hcl files")
+}
+
+func TestLoadConfigDir_MissingDirIsAnError(t *testing.T) {
+	_, err := LoadConfigDir(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+}
+
+func TestLoadConfigDir_PropagatesParseErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "broken.hcl", `this is not valid hcl {{{`)
+	_, err := LoadConfigDir(dir)
+	require.Error(t, err)
+}
+
+func TestLoadConfigDir_ValidatesMergedResult(t *testing.T) {
+	dir := t.TempDir()
+	// Base has an invalid ip_binding_policy that the overlay corrects.
+	// Validation must run on the merged result, not per file, otherwise
+	// the base would be rejected even though the final config is fine.
+	writeFile(t, dir, "00-base.hcl", `
+ip_binding_policy = "bogus"
+
+storage "postgres" {
+  connection_url = "postgres://x/db"
+}
+
+listener "tcp" {
+  address = ":8400"
+}
+`)
+	writeFile(t, dir, "10-overlay.hcl", `
+ip_binding_policy = "optional"
+`)
+	cfg, err := LoadConfigDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "optional", cfg.IPBindingPolicy)
+}
+
+func TestLoadConfigDir_RejectsInvalidMergedResult(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "00-base.hcl", `
+ip_binding_policy = "bogus"
+
+storage "postgres" {
+  connection_url = "postgres://x/db"
+}
+
+listener "tcp" {
+  address = ":8400"
+}
+`)
+	_, err := LoadConfigDir(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ip_binding_policy")
+}

--- a/config/helpers.go
+++ b/config/helpers.go
@@ -3,3 +3,93 @@ package config
 func (c *Config) GetStorage() *StorageBlock {
 	return c.Storage
 }
+
+// mergeConfig copies non-zero fields from src into dst, so a sequence of
+// loaded configs collapses to a single merged *Config with "later wins"
+// semantics. Slice and pointer block fields (Listeners, Storage, Seals)
+// are replaced wholesale when src defines them — there is no per-field
+// merge inside a block, which matches how operators typically split
+// secret vs non-secret HCL (one file owns each block entirely).
+func mergeConfig(dst, src *Config) {
+	if src.LogLevel != "" {
+		dst.LogLevel = src.LogLevel
+	}
+	if src.LogFormat != "" {
+		dst.LogFormat = src.LogFormat
+	}
+	if src.LogFile != "" {
+		dst.LogFile = src.LogFile
+	}
+	if src.LogRotationPeriod != 0 {
+		dst.LogRotationPeriod = src.LogRotationPeriod
+	}
+	if src.LogRotateMegabytes != 0 {
+		dst.LogRotateMegabytes = src.LogRotateMegabytes
+	}
+	if src.LogRotateMaxFiles != 0 {
+		dst.LogRotateMaxFiles = src.LogRotateMaxFiles
+	}
+	if len(src.Listeners) > 0 {
+		dst.Listeners = src.Listeners
+	}
+	if src.Storage != nil {
+		dst.Storage = src.Storage
+	}
+	if len(src.Seals) > 0 {
+		dst.Seals = src.Seals
+	}
+	if src.APIAddr != "" {
+		dst.APIAddr = src.APIAddr
+	}
+	if src.ClusterAddr != "" {
+		dst.ClusterAddr = src.ClusterAddr
+	}
+	if src.DisableClustering {
+		dst.DisableClustering = true
+	}
+	if src.DisableStandbyReads {
+		dst.DisableStandbyReads = true
+	}
+	if src.MinCredSourceRotationPeriod != "" {
+		dst.MinCredSourceRotationPeriod = src.MinCredSourceRotationPeriod
+	}
+	if src.MaxCredSourceRotationPeriod != "" {
+		dst.MaxCredSourceRotationPeriod = src.MaxCredSourceRotationPeriod
+	}
+	if src.MinCredSpecRotationPeriod != "" {
+		dst.MinCredSpecRotationPeriod = src.MinCredSpecRotationPeriod
+	}
+	if src.MaxCredSpecRotationPeriod != "" {
+		dst.MaxCredSpecRotationPeriod = src.MaxCredSpecRotationPeriod
+	}
+	if src.IPBindingPolicy != "" {
+		dst.IPBindingPolicy = src.IPBindingPolicy
+	}
+	if src.GoroutineShutdownTimeout != "" {
+		dst.GoroutineShutdownTimeout = src.GoroutineShutdownTimeout
+	}
+	if src.LockAcquisitionTimeout != "" {
+		dst.LockAcquisitionTimeout = src.LockAcquisitionTimeout
+	}
+	if src.LeaderCleanupInterval != "" {
+		dst.LeaderCleanupInterval = src.LeaderCleanupInterval
+	}
+	if src.StepDownStateLockTimeout != "" {
+		dst.StepDownStateLockTimeout = src.StepDownStateLockTimeout
+	}
+	if src.LeaderLookupTimeout != "" {
+		dst.LeaderLookupTimeout = src.LeaderLookupTimeout
+	}
+	if src.ClockSkewGrace != "" {
+		dst.ClockSkewGrace = src.ClockSkewGrace
+	}
+	if src.ClusterListenerReadTimeout != "" {
+		dst.ClusterListenerReadTimeout = src.ClusterListenerReadTimeout
+	}
+	if src.ClusterListenerWriteTimeout != "" {
+		dst.ClusterListenerWriteTimeout = src.ClusterListenerWriteTimeout
+	}
+	if src.ForwardingTimeout != "" {
+		dst.ForwardingTimeout = src.ForwardingTimeout
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,0 +1,480 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalConfigHCL is a valid HCL config used as the base for tests that
+// then write one additional offending field. Lets each test focus on the
+// invariant being checked instead of restating boilerplate.
+const minimalConfigHCL = `
+storage "postgres" {
+  connection_url = "postgres://u:p@db:5432/warden"
+}
+
+listener "tcp" {
+  address = ":8400"
+}
+`
+
+func loadFromHCL(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "warden.hcl")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return LoadConfig(p)
+}
+
+// TestLoadConfig_BaselineParses establishes that minimalConfigHCL on its
+// own loads cleanly; otherwise every other validation test would be
+// suspect.
+func TestLoadConfig_BaselineParses(t *testing.T) {
+	cfg, err := loadFromHCL(t, minimalConfigHCL)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Storage)
+	require.Len(t, cfg.Listeners, 1)
+}
+
+func TestLoadConfig_IPBindingPolicy(t *testing.T) {
+	tests := []struct {
+		policy  string
+		wantErr bool
+	}{
+		{"", false},          // unset is fine; downstream picks default
+		{"disabled", false},
+		{"optional", false},
+		{"required", false},
+		{"bogus", true},
+		{"OPTIONAL", true}, // case-sensitive
+	}
+	for _, tt := range tests {
+		t.Run(tt.policy, func(t *testing.T) {
+			body := minimalConfigHCL
+			if tt.policy != "" {
+				body += "\nip_binding_policy = \"" + tt.policy + "\"\n"
+			}
+			_, err := loadFromHCL(t, body)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "ip_binding_policy")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_RotationPeriodBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		minStr  string
+		maxStr  string
+		wantErr string // empty → no error expected
+	}{
+		{"both unset", "", "", ""},
+		{"min only valid", "5m", "", ""},
+		{"max only valid", "", "10m", ""},
+		{"valid range", "5m", "1h", ""},
+		{"min equals max", "10m", "10m", ""},
+		{"min greater than max", "1h", "5m", "must be <="},
+		{"unparseable min", "not-a-duration", "", "invalid min_cred_source_rotation_period"},
+		{"unparseable max", "", "still-not-a-duration", "invalid max_cred_source_rotation_period"},
+		{"negative min", "-5m", "", "must be positive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := minimalConfigHCL
+			if tt.minStr != "" {
+				body += "\nmin_cred_source_rotation_period = \"" + tt.minStr + "\"\n"
+			}
+			if tt.maxStr != "" {
+				body += "\nmax_cred_source_rotation_period = \"" + tt.maxStr + "\"\n"
+			}
+			_, err := loadFromHCL(t, body)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_SpecRotationPeriodBounds(t *testing.T) {
+	// Same shape as source bounds — keep one focused case to confirm the
+	// spec variant is wired up too.
+	body := minimalConfigHCL + `
+min_cred_spec_rotation_period = "1h"
+max_cred_spec_rotation_period = "5m"
+`
+	_, err := loadFromHCL(t, body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "min_cred_spec_rotation_period")
+	assert.Contains(t, err.Error(), "must be <=")
+}
+
+func TestLoadConfig_ListenerTLSRequiresCertAndKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		extra   string
+		wantErr bool
+	}{
+		{
+			name: "tls disabled, no cert/key — ok",
+			extra: `
+listener "tcp" {
+  address = ":8410"
+  tls_enabled = false
+}
+`,
+			wantErr: false,
+		},
+		{
+			name: "tls enabled with both cert and key — ok",
+			extra: `
+listener "tcp" {
+  address     = ":8420"
+  tls_enabled = true
+  tls_cert_file = "/c.pem"
+  tls_key_file  = "/k.pem"
+}
+`,
+			wantErr: false,
+		},
+		{
+			name: "tls enabled, missing cert — error",
+			extra: `
+listener "tcp" {
+  address     = ":8430"
+  tls_enabled = true
+  tls_key_file = "/k.pem"
+}
+`,
+			wantErr: true,
+		},
+		{
+			name: "tls enabled, missing key — error",
+			extra: `
+listener "tcp" {
+  address     = ":8440"
+  tls_enabled = true
+  tls_cert_file = "/c.pem"
+}
+`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadFromHCL(t, minimalConfigHCL+tt.extra)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "tls_enabled")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_ClusterAddrValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr string
+	}{
+		{"unset", "", ""},
+		{"valid https", "https://node1.warden.svc:8401", ""},
+		{"http scheme rejected", "http://node1.warden.svc:8401", "https://"},
+		{"no scheme rejected", "node1.warden.svc:8401", "https://"},
+		{"no host rejected", "https://", "must include a host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := minimalConfigHCL
+			if tt.addr != "" {
+				body += "\ncluster_addr = \"" + tt.addr + "\"\n"
+			}
+			_, err := loadFromHCL(t, body)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_ClusterDurationFields(t *testing.T) {
+	tests := []struct {
+		field   string
+		value   string
+		wantErr bool
+	}{
+		{"goroutine_shutdown_timeout", "30s", false},
+		{"goroutine_shutdown_timeout", "1h", false},
+		{"goroutine_shutdown_timeout", "0", false}, // zero is allowed (means "use default" semantically)
+		{"goroutine_shutdown_timeout", "not-a-duration", true},
+		{"goroutine_shutdown_timeout", "-30s", true},
+		{"lock_acquisition_timeout", "5m", false},
+		{"leader_lookup_timeout", "10s", false},
+		{"forwarding_timeout", "1m", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field+"="+tt.value, func(t *testing.T) {
+			body := minimalConfigHCL + "\n" + tt.field + " = \"" + tt.value + "\"\n"
+			_, err := loadFromHCL(t, body)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.field)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDevConfig_Defaults(t *testing.T) {
+	cfg := DevConfig()
+	assert.Equal(t, "trace", cfg.LogLevel)
+	require.NotNil(t, cfg.Storage)
+	assert.Equal(t, "inmem", cfg.Storage.Type)
+	require.Len(t, cfg.Listeners, 1)
+	assert.Equal(t, "tcp", cfg.Listeners[0].Type)
+	assert.Equal(t, "127.0.0.1:8400", cfg.Listeners[0].Address)
+	assert.False(t, cfg.Listeners[0].TLSEnabled)
+	assert.Equal(t, "disabled", cfg.IPBindingPolicy)
+}
+
+func TestGetListenerByType(t *testing.T) {
+	cfg := &Config{
+		Listeners: []ListenerBlock{
+			{Type: "tcp", Address: ":8400"},
+			{Type: "unix", Address: "/var/run/warden.sock"},
+		},
+	}
+	tcp, err := cfg.GetTCPListener()
+	require.NoError(t, err)
+	assert.Equal(t, ":8400", tcp.Address)
+
+	unix, err := cfg.GetUnixListener()
+	require.NoError(t, err)
+	assert.Equal(t, "/var/run/warden.sock", unix.Address)
+
+	_, err = cfg.GetListenerByType("missing")
+	require.Error(t, err)
+}
+
+func TestStorageBlock_Config(t *testing.T) {
+	t.Run("postgres with all fields", func(t *testing.T) {
+		s := &StorageBlock{
+			Type:               "postgres",
+			ConnectionUrl:      "postgres://u:p@db:5432/warden",
+			Table:              "kv_store",
+			MaxIdleConnections: 5,
+			MaxParallel:        "128",
+			HAEnabled:          "true",
+			HATable:            "ha_locks",
+			SkipCreateTable:    "false",
+			MaxConnectRetries:  "10",
+		}
+		got := s.Config()
+		assert.Equal(t, "postgres", got["type"])
+		assert.Equal(t, "postgres://u:p@db:5432/warden", got["connection_url"])
+		assert.Equal(t, "kv_store", got["table"])
+		assert.Equal(t, "5", got["max_idle_connections"])
+		assert.Equal(t, "128", got["max_parallel"])
+		assert.Equal(t, "true", got["ha_enabled"])
+		assert.Equal(t, "ha_locks", got["ha_table"])
+		assert.Equal(t, "false", got["skip_create_table"])
+		assert.Equal(t, "10", got["max_connect_retries"])
+	})
+
+	t.Run("inmem with no extra fields", func(t *testing.T) {
+		s := &StorageBlock{Type: "inmem"}
+		got := s.Config()
+		assert.Equal(t, "inmem", got["type"])
+		_, hasURL := got["connection_url"]
+		assert.False(t, hasURL, "empty fields should not appear in the map")
+		_, hasTable := got["table"]
+		assert.False(t, hasTable)
+	})
+
+	t.Run("file backend uses path", func(t *testing.T) {
+		s := &StorageBlock{Type: "file", Path: "/var/lib/warden/data"}
+		got := s.Config()
+		assert.Equal(t, "file", got["type"])
+		assert.Equal(t, "/var/lib/warden/data", got["path"])
+	})
+
+	t.Run("zero MaxIdleConnections omitted", func(t *testing.T) {
+		s := &StorageBlock{Type: "postgres", ConnectionUrl: "postgres://x"}
+		got := s.Config()
+		_, has := got["max_idle_connections"]
+		assert.False(t, has, "zero int should be omitted, not serialized as \"0\"")
+	})
+}
+
+func TestKMS_Config(t *testing.T) {
+	t.Run("static seal", func(t *testing.T) {
+		k := &KMS{
+			Type:         "static",
+			CurrentKeyID: "2026-05-15",
+			CurrentKey:   "file:///seal/key",
+		}
+		got := k.Config()
+		assert.Equal(t, "static", got["type"])
+		assert.Equal(t, "2026-05-15", got["current_key_id"])
+		assert.Equal(t, "file:///seal/key", got["current_key"])
+	})
+
+	t.Run("transit seal", func(t *testing.T) {
+		k := &KMS{
+			Type:      "transit",
+			Address:   "https://vault.example.com:8200",
+			Token:     "s.abc123",
+			KeyName:   "warden-unseal",
+			MountPath: "transit/",
+			Namespace: "ops",
+		}
+		got := k.Config()
+		assert.Equal(t, "transit", got["type"])
+		assert.Equal(t, "https://vault.example.com:8200", got["address"])
+		assert.Equal(t, "s.abc123", got["token"])
+		assert.Equal(t, "warden-unseal", got["key_name"])
+		assert.Equal(t, "transit/", got["mount_path"])
+		assert.Equal(t, "ops", got["namespace"])
+	})
+
+	t.Run("aws kms seal", func(t *testing.T) {
+		k := &KMS{
+			Type:      "awskms",
+			AwsRegion: "us-east-1",
+			AccessKey: "AKIA...",
+			SecretKey: "secret",
+			KmsKeyID:  "arn:aws:kms:us-east-1:111:key/abc",
+		}
+		got := k.Config()
+		assert.Equal(t, "awskms", got["type"])
+		assert.Equal(t, "us-east-1", got["aws_region"])
+		assert.Equal(t, "AKIA...", got["access_key"])
+		assert.Equal(t, "arn:aws:kms:us-east-1:111:key/abc", got["kms_key_id"])
+	})
+
+	t.Run("purpose list expanded", func(t *testing.T) {
+		k := &KMS{Type: "static", Purpose: []string{"keyring", "recovery"}}
+		got := k.Config()
+		assert.Equal(t, "keyring", got["purpose_0"])
+		assert.Equal(t, "recovery", got["purpose_1"])
+	})
+
+	t.Run("empty optional fields omitted", func(t *testing.T) {
+		k := &KMS{Type: "static"}
+		got := k.Config()
+		assert.Equal(t, "static", got["type"])
+		_, has := got["current_key_id"]
+		assert.False(t, has)
+		_, has = got["address"]
+		assert.False(t, has)
+	})
+}
+
+func TestKMS_IsDisabled(t *testing.T) {
+	// Pins the current — counterintuitive — semantics of KMS.IsDisabled():
+	// returns true iff Disabled is non-empty AND not literally "true". This
+	// matches the underlying Vault/OpenBao convention where the Disabled
+	// field carries a seal-type-name sentinel during seal migration, and an
+	// empty value or the literal string "true" both mean "not migrating".
+	tests := []struct {
+		disabled string
+		want     bool
+	}{
+		{"", false},
+		{"true", false},
+		{"false", true},
+		{"yes", true},
+		{"awskms", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.disabled, func(t *testing.T) {
+			k := &KMS{Disabled: tt.disabled}
+			assert.Equal(t, tt.want, k.IsDisabled())
+		})
+	}
+}
+
+func TestMergeConfig(t *testing.T) {
+	t.Run("scalar fields take overlay non-zero values", func(t *testing.T) {
+		base := &Config{LogLevel: "info", APIAddr: "https://base:8400"}
+		overlay := &Config{LogLevel: "debug"}
+		mergeConfig(base, overlay)
+		assert.Equal(t, "debug", base.LogLevel, "overlay overrides")
+		assert.Equal(t, "https://base:8400", base.APIAddr, "unset overlay field leaves base intact")
+	})
+
+	t.Run("storage pointer replaces wholesale", func(t *testing.T) {
+		base := &Config{Storage: &StorageBlock{Type: "postgres", ConnectionUrl: "postgres://base"}}
+		overlay := &Config{Storage: &StorageBlock{Type: "postgres", ConnectionUrl: "postgres://overlay"}}
+		mergeConfig(base, overlay)
+		require.NotNil(t, base.Storage)
+		assert.Equal(t, "postgres://overlay", base.Storage.ConnectionUrl)
+	})
+
+	t.Run("nil storage in overlay preserves base", func(t *testing.T) {
+		base := &Config{Storage: &StorageBlock{Type: "postgres", ConnectionUrl: "postgres://base"}}
+		overlay := &Config{}
+		mergeConfig(base, overlay)
+		require.NotNil(t, base.Storage)
+		assert.Equal(t, "postgres://base", base.Storage.ConnectionUrl)
+	})
+
+	t.Run("listeners slice replaces wholesale", func(t *testing.T) {
+		base := &Config{Listeners: []ListenerBlock{{Type: "tcp", Address: ":8400"}}}
+		overlay := &Config{Listeners: []ListenerBlock{{Type: "tcp", Address: ":9999"}, {Type: "unix", Address: "/sock"}}}
+		mergeConfig(base, overlay)
+		require.Len(t, base.Listeners, 2)
+		assert.Equal(t, ":9999", base.Listeners[0].Address)
+	})
+
+	t.Run("empty listeners in overlay preserves base", func(t *testing.T) {
+		base := &Config{Listeners: []ListenerBlock{{Type: "tcp", Address: ":8400"}}}
+		overlay := &Config{}
+		mergeConfig(base, overlay)
+		require.Len(t, base.Listeners, 1)
+		assert.Equal(t, ":8400", base.Listeners[0].Address)
+	})
+
+	t.Run("seals slice replaces wholesale", func(t *testing.T) {
+		base := &Config{Seals: []KMS{{Type: "static"}}}
+		overlay := &Config{Seals: []KMS{{Type: "transit"}, {Type: "static"}}}
+		mergeConfig(base, overlay)
+		require.Len(t, base.Seals, 2)
+		assert.Equal(t, "transit", base.Seals[0].Type)
+	})
+
+	t.Run("bool fields can be set true but not turned off", func(t *testing.T) {
+		base := &Config{DisableClustering: true}
+		overlay := &Config{DisableClustering: false}
+		mergeConfig(base, overlay)
+		assert.True(t, base.DisableClustering, "overlay false does not turn off — documented limitation")
+
+		base2 := &Config{}
+		overlay2 := &Config{DisableClustering: true}
+		mergeConfig(base2, overlay2)
+		assert.True(t, base2.DisableClustering)
+	})
+
+	t.Run("int fields take overlay non-zero", func(t *testing.T) {
+		base := &Config{LogRotateMegabytes: 100}
+		overlay := &Config{LogRotateMegabytes: 500}
+		mergeConfig(base, overlay)
+		assert.Equal(t, 500, base.LogRotateMegabytes)
+	})
+}

--- a/deploy/config/warden.hcl
+++ b/deploy/config/warden.hcl
@@ -1,6 +1,15 @@
 log_format  = "standard"
 log_level   = "trace"
 
+# Config values may reference environment variables using Go template syntax,
+# e.g. {{ env "POD_NAME" }}. Missing variables expand to the empty string.
+# This is useful in Kubernetes where each pod advertises a unique address:
+#
+#   api_addr     = "https://{{ env "POD_NAME" }}.warden-headless.{{ env "POD_NAMESPACE" }}.svc.cluster.local:8400"
+#   cluster_addr = "https://{{ env "POD_NAME" }}.warden-headless.{{ env "POD_NAMESPACE" }}.svc.cluster.local:8401"
+#
+# HCL's own ${...} interpolation syntax is left untouched.
+
 # api_addr is the address advertised to clients for API requests.
 # Required when ha_enabled = "true".
 # api_addr = "https://warden.example.com:8400"


### PR DESCRIPTION
Adds two pieces of plumbing needed for Kubernetes-native config splitting, plus broad unit-test coverage for the existing validation rules (config package had no tests before this commit).

  - LoadConfigDir merges all .hcl files in a directory in lexical order, enabling a ConfigMap + Secret split where each owns a subset of blocks. Validation runs once on the merged result so an overlay can correct invalid values in the base file.

  - HCL files are pre-processed through a Go-template pass exposing an `env` function: {{ env "VAR" }}. Missing vars expand to the empty string. HCL's native ${...} interpolation is left untouched.

  - The server command grows a --config-dir flag, mutually exclusive with --config and --dev. Existing single --config behavior is unchanged.

  - Adds unit tests for LoadConfig validation (rotation-period bounds, ip_binding_policy, listener TLS, cluster_addr URL, cluster duration fields), DevConfig defaults, GetListenerByType, StorageBlock.Config map serialization, KMS.Config + IsDisabled semantics, and direct mergeConfig behavior including the bool-one-way and pointer-replace edges. Coverage: 0% -> 75.3%.