### PR TITLE
fix(http): apply /v1/sys/health overrides in severity order

### DIFF
--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -75,29 +75,43 @@ func handleSysHealth(c *core.Core, log *logger.GatedLogger) http.Handler {
 
 // parseHealthStatusOverrides checks query parameters for status code overrides.
 // This is useful for load balancers that need specific codes for routing.
+//
+// Overrides are applied in severity order: uninitialized > sealed > standby.
+// A more severe condition wins over a less severe override — in particular
+// ?standbyok=true does NOT return 200 for a sealed or uninitialized node,
+// because a sealed node naturally has standby=true (it can never acquire
+// the HA lock), and Kubernetes readiness probes relying on ?standbyok=true
+// would otherwise route traffic to pods that cannot serve.
+//
+// A return of 0 means "no override applies" — the caller should use the
+// base status code computed by the switch in handleSysHealth.
 func parseHealthStatusOverrides(r *http.Request, initialized, sealed, standby bool) int {
 	q := r.URL.Query()
 
-	// ?standbyok makes standby nodes return 200
-	if standby && q.Get("standbyok") == "true" {
-		return http.StatusOK
+	if !initialized {
+		return parseCustomCode(q.Get("uninitcode"))
 	}
-
-	if v := q.Get("standbycode"); v != "" && standby {
-		if code, err := strconv.Atoi(v); err == nil && code >= 100 && code < 600 {
-			return code
+	if sealed {
+		return parseCustomCode(q.Get("sealedcode"))
+	}
+	if standby {
+		if q.Get("standbyok") == "true" {
+			return http.StatusOK
 		}
+		return parseCustomCode(q.Get("standbycode"))
 	}
-	if v := q.Get("sealedcode"); v != "" && sealed {
-		if code, err := strconv.Atoi(v); err == nil && code >= 100 && code < 600 {
-			return code
-		}
-	}
-	if v := q.Get("uninitcode"); v != "" && !initialized {
-		if code, err := strconv.Atoi(v); err == nil && code >= 100 && code < 600 {
-			return code
-		}
-	}
-
 	return 0
+}
+
+// parseCustomCode parses a query-parameter value as an HTTP status code,
+// returning 0 (no override) for empty, unparseable, or out-of-range values.
+func parseCustomCode(v string) int {
+	if v == "" {
+		return 0
+	}
+	code, err := strconv.Atoi(v)
+	if err != nil || code < 100 || code >= 600 {
+		return 0
+	}
+	return code
 }

--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -24,54 +24,137 @@ func TestParseHealthStatusOverrides(t *testing.T) {
 		standby     bool
 		wantCode    int
 	}{
+		// Baseline: an active node with no overrides returns 0 (no override).
 		{
-			name:     "no overrides",
-			query:    "",
-			standby:  true,
-			wantCode: 0,
+			name:        "no overrides on active",
+			query:       "",
+			initialized: true,
+			wantCode:    0,
 		},
 		{
-			name:     "standbyok makes standby return 200",
-			query:    "standbyok=true",
-			standby:  true,
-			wantCode: http.StatusOK,
+			name:        "no overrides on standby",
+			query:       "",
+			initialized: true,
+			standby:     true,
+			wantCode:    0,
+		},
+
+		// standbyok: applies only to running standbys (initialized, unsealed).
+		{
+			name:        "standbyok on standby returns 200",
+			query:       "standbyok=true",
+			initialized: true,
+			standby:     true,
+			wantCode:    http.StatusOK,
 		},
 		{
-			name:     "standbyok ignored when not standby",
-			query:    "standbyok=true",
-			standby:  false,
-			wantCode: 0,
+			name:        "standbyok ignored on active",
+			query:       "standbyok=true",
+			initialized: true,
+			wantCode:    0,
 		},
+
+		// standbycode: applies only to running standbys.
 		{
-			name:     "custom standby code",
-			query:    "standbycode=200",
-			standby:  true,
-			wantCode: 200,
+			name:        "standbycode on standby",
+			query:       "standbycode=200",
+			initialized: true,
+			standby:     true,
+			wantCode:    200,
 		},
+
+		// sealedcode: applies only when sealed AND initialized.
 		{
-			name:        "custom sealed code",
+			name:        "sealedcode on sealed",
 			query:       "sealedcode=200",
 			initialized: true,
 			sealed:      true,
+			standby:     true, // sealed nodes are always standby
 			wantCode:    200,
 		},
+
+		// uninitcode: applies only when not initialized.
 		{
-			name:        "custom uninit code",
-			query:       "uninitcode=200",
+			name:     "uninitcode on uninit",
+			query:    "uninitcode=200",
+			sealed:   true, // uninit nodes are always sealed
+			standby:  true, // and always standby
+			wantCode: 200,
+		},
+
+		// Severity ordering (the bug PR 2 fixes): a more severe condition
+		// must win over a less severe override. Without this ordering, K8s
+		// readiness probes using ?standbyok=true would route traffic to
+		// sealed or uninitialized pods because those pods naturally have
+		// standby=true.
+		{
+			name:        "standbyok does NOT mask sealed",
+			query:       "standbyok=true",
+			initialized: true,
+			sealed:      true,
+			standby:     true,
+			wantCode:    0,
+		},
+		{
+			name:     "standbyok does NOT mask uninit",
+			query:    "standbyok=true",
+			sealed:   true,
+			standby:  true,
+			wantCode: 0,
+		},
+		{
+			name:        "standbycode does NOT mask sealed",
+			query:       "standbycode=200",
+			initialized: true,
+			sealed:      true,
+			standby:     true,
+			wantCode:    0,
+		},
+		{
+			name:     "sealedcode does NOT mask uninit",
+			query:    "sealedcode=200",
+			sealed:   true,
+			standby:  true,
+			wantCode: 0,
+		},
+		{
+			name:        "uninitcode + sealedcode: uninit wins",
+			query:       "uninitcode=200&sealedcode=503",
 			initialized: false,
+			sealed:      true,
+			standby:     true,
 			wantCode:    200,
 		},
 		{
-			name:     "invalid code ignored",
-			query:    "standbycode=abc",
-			standby:  true,
-			wantCode: 0,
+			name:        "sealedcode + standbyok: sealed wins",
+			query:       "sealedcode=503&standbyok=true",
+			initialized: true,
+			sealed:      true,
+			standby:     true,
+			wantCode:    503,
+		},
+
+		// Invalid override values must be ignored (treated as "no override").
+		{
+			name:        "non-numeric code ignored",
+			query:       "standbycode=abc",
+			initialized: true,
+			standby:     true,
+			wantCode:    0,
 		},
 		{
-			name:     "out of range code ignored",
-			query:    "standbycode=999",
-			standby:  true,
-			wantCode: 0,
+			name:        "out of range code ignored",
+			query:       "standbycode=999",
+			initialized: true,
+			standby:     true,
+			wantCode:    0,
+		},
+		{
+			name:        "negative code ignored",
+			query:       "sealedcode=-1",
+			initialized: true,
+			sealed:      true,
+			wantCode:    0,
 		},
 	}
 
@@ -466,11 +549,11 @@ func TestHandleSysHealth_SealedCode(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	// sealedcode applies when sealed; the core is both not-init and sealed,
-	// but not-init check comes first. If sealedcode=200 is set and the node
-	// happens to match the sealed condition too, override may apply.
-	// Just verify the endpoint responds without error.
-	assert.True(t, w.Code >= 200 && w.Code < 600)
+	// The test core is uninitialized AND sealed. Per the documented
+	// severity ordering (uninit > sealed > standby), the uninit state
+	// wins and sealedcode does not apply — so the response is 501, the
+	// base uninit code, not the 200 override.
+	assert.Equal(t, http.StatusNotImplemented, w.Code)
 }
 
 // =============================================================================


### PR DESCRIPTION
The previous parseHealthStatusOverrides early-returned on ?standbyok=true whenever standby was true, even if the node was also sealed or uninitialized. Sealed nodes naturally have standby=true (they cannot acquire the HA lock), so a K8s readiness probe using ?standbyok=true — the typical configuration for a multi-node Warden cluster — would silently mark sealed pods Ready and route traffic to them.

This commit reorders overrides by severity (uninit > sealed > standby), early-returning at each tier. A more severe condition can no longer be masked by a less severe override. The duplicated Atoi/range-check block is extracted as parseCustomCode.

Behavior changes:

  - ?standbyok=true on a sealed or uninitialized pod no longer returns
    200. The probe sees 503 or 501 respectively. Pods correctly drop out of Service endpoints.

  - ?sealedcode applies only when the pod is initialized AND sealed (previously it applied for sealed even if uninit, since uninit fall-through happened later).

  - ?standbycode applies only on a healthy standby (initialized, unsealed, not active).

Tests grow from 8 to 16 sub-cases, with the new ones explicitly covering the precedence pairs. The integration test that previously asserted only "responds without error" is tightened to expect 501 for the uninit-and-sealed test core.