### PR TITLE
feat(deploy): first-party Helm chart, OCI publishing, and K8s deploym…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      helm: ${{ steps.filter.outputs.helm }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -26,6 +27,9 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'e2e/**'
+            helm:
+              - 'deploy/helm/**'
+              - '.github/workflows/ci.yml'
 
   unit:
     needs: [changes]
@@ -52,6 +56,67 @@ jobs:
 
       - name: Build
         run: go build -o warden .
+
+  helm:
+    name: helm-lint
+    needs: [changes]
+    if: needs.changes.outputs.helm == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Install kubeconform
+        run: |
+          curl -L -o kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz
+          tar -xzf kubeconform.tar.gz
+          sudo install -m 0755 kubeconform /usr/local/bin/
+
+      - name: helm lint (production values)
+        run: |
+          helm lint deploy/helm/warden \
+            --set tls.existingSecret=warden-tls \
+            --set storage.existingSecret=warden-db \
+            --set seal.transit.address=https://vault.example.com:8200 \
+            --set seal.transit.keyName=warden-unseal \
+            --set seal.transit.existingSecret=warden-seal
+
+      - name: helm lint (dev values)
+        run: |
+          helm lint deploy/helm/warden \
+            -f deploy/helm/warden/values-dev.yaml \
+            --set tls.existingSecret=warden-tls \
+            --set storage.connectionUrl='postgres://example' \
+            --set seal.static.existingSecret=warden-seal \
+            --set seal.static.keyId=dev
+
+      - name: kubeconform (production values)
+        run: |
+          helm template warden deploy/helm/warden \
+            --namespace warden \
+            --set tls.existingSecret=warden-tls \
+            --set storage.existingSecret=warden-db \
+            --set seal.transit.address=https://vault.example.com:8200 \
+            --set seal.transit.keyName=warden-unseal \
+            --set seal.transit.existingSecret=warden-seal \
+            | kubeconform -strict -summary -verbose
+
+      - name: kubeconform (dev values)
+        run: |
+          helm template warden deploy/helm/warden \
+            --namespace warden \
+            -f deploy/helm/warden/values-dev.yaml \
+            --set tls.existingSecret=warden-tls \
+            --set storage.connectionUrl='postgres://example' \
+            --set seal.static.existingSecret=warden-seal \
+            --set seal.static.keyId=dev \
+            | kubeconform -strict -summary -verbose
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,45 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Package and publish Helm chart to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          CHART_VERSION="$(awk '/^version:/{print $2}' deploy/helm/warden/Chart.yaml)"
+
+          # Refuse to clobber an existing chart artifact at the same
+          # version. The Warden binary version (the git tag) bumps every
+          # release, but the chart version is independent and only moves
+          # when the chart templates or values change. If you hit this
+          # error: bump version: in deploy/helm/warden/Chart.yaml before
+          # re-tagging.
+          if helm pull "oci://ghcr.io/stephnangue/charts/warden" \
+               --version "$CHART_VERSION" --destination /tmp 2>/dev/null; then
+            echo "ERROR: chart version $CHART_VERSION is already published."
+            echo "Bump deploy/helm/warden/Chart.yaml 'version:' before tagging."
+            exit 1
+          fi
+
+          # Pin appVersion to the tag so end users always pull the Docker
+          # image matching the chart they installed, regardless of what
+          # the Chart.yaml committed at tag time happens to say.
+          helm package deploy/helm/warden --app-version "$VERSION"
+          CHART_TGZ="$(ls warden-*.tgz | head -1)"
+          echo "Built $CHART_TGZ"
+
+          # Push the OCI artifact. Helm authenticates against ghcr.io
+          # using the existing docker/login-action session.
+          helm push "$CHART_TGZ" oci://ghcr.io/stephnangue/charts
+
+          # Attach the same tarball to the GitHub Release for users who
+          # cannot use OCI registries (air-gapped clusters, restrictive
+          # network policies, etc.).
+          gh release upload "$GITHUB_REF_NAME" "$CHART_TGZ" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@
 *.dylib
 mysql-proxy
 covenant
-warden
+# Anchored to the repo root so the deploy/helm/warden/ chart directory
+# stays tracked. `warden` (no slash) would otherwise match any path
+# component named "warden" anywhere in the tree.
+/warden
 
 # Test binary
 *.test

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ For the system-side reference describing how an agent uses Warden end-to-end —
 
 See [docs/architecture.md](docs/architecture.md) for Warden's design decisions, high availability model, and deployment configuration.
 
+## Kubernetes
+
+A first-party Helm chart deploys Warden as a 3-replica HA cluster on any Kubernetes 1.27+ cluster — bring your own Postgres, your own TLS certificate, and either a Vault Transit endpoint for auto-unseal or a static seal key for development. The chart ships production-leaning defaults; a quickstart values file shrinks the install to a single replica for kind or minikube.
+
+See [docs/deployment/kubernetes.md](docs/deployment/kubernetes.md) for the full guide.
+
 ## Contributing
 
 We welcome contributions! See the [contributing guide](CONTRIBUTING.md) for setup instructions, build commands, testing conventions, and submission guidelines.

--- a/deploy/helm/warden/.helmignore
+++ b/deploy/helm/warden/.helmignore
@@ -1,0 +1,17 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+ci/

--- a/deploy/helm/warden/Chart.yaml
+++ b/deploy/helm/warden/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: warden
+description: Identity-aware egress proxy for AI agents — Helm chart for Kubernetes deployments.
+type: application
+version: 0.1.0
+appVersion: "0.12.0"
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/stephnangue/warden
+sources:
+  - https://github.com/stephnangue/warden
+keywords:
+  - security
+  - secrets
+  - egress-proxy
+  - identity
+  - ai-agents
+maintainers:
+  - name: stephnangue
+    url: https://github.com/stephnangue

--- a/deploy/helm/warden/templates/NOTES.txt
+++ b/deploy/helm/warden/templates/NOTES.txt
@@ -1,0 +1,32 @@
+Warden {{ .Chart.AppVersion }} has been installed as release "{{ .Release.Name }}".
+
+API service:
+  {{ include "warden.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Headless service (per-pod DNS for inter-node cluster comms and direct
+operator access while pods are NotReady):
+  pod-name.{{ include "warden.headlessName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+NEXT STEP — first-time initialization
+=====================================
+On a fresh install the pods come up uninitialized: readiness fails
+with 501 and they are excluded from the {{ include "warden.fullname" . }}
+Service. Initialize the cluster manually:
+
+  kubectl -n {{ .Release.Namespace }} port-forward pod/{{ include "warden.fullname" . }}-0 8400:8400 &
+
+  curl -k -X POST https://127.0.0.1:8400/v1/sys/init \
+    -H 'Content-Type: application/json' \
+    -d '{"secret_shares": 1, "secret_threshold": 1}'
+
+Store the returned root_token and unseal_keys_b64 securely — you
+cannot recover them later. Once one pod is initialized the rest will
+auto-unseal{{ if eq .Values.seal.type "transit" }} via the Transit
+seal at {{ .Values.seal.transit.address | quote }}{{ else }} using the
+shared static seal key{{ end }} and become Ready within ~30 seconds.
+
+{{- if eq .Values.seal.type "static" }}
+
+WARNING: seal.type=static — this profile is meant for development and
+CI only. Production deployments should use Transit or KMS auto-unseal.
+{{- end }}

--- a/deploy/helm/warden/templates/_helpers.tpl
+++ b/deploy/helm/warden/templates/_helpers.tpl
@@ -1,0 +1,124 @@
+{{/*
+Common chart helpers.
+*/}}
+
+{{- define "warden.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "warden.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "warden.headlessName" -}}
+{{- printf "%s-headless" (include "warden.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "warden.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels — applied to every object the chart renders.
+*/}}
+{{- define "warden.labels" -}}
+helm.sh/chart: {{ include "warden.chart" . }}
+{{ include "warden.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels — stable across upgrades; used by Services and the
+StatefulSet's pod template selector.
+*/}}
+{{- define "warden.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "warden.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "warden.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "warden.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the chart-managed Secret that holds the postgres connection URL
+and the seal token, when literal values were provided in values.yaml.
+Existing user Secrets are referenced by name directly and bypass this.
+*/}}
+{{- define "warden.credentialsSecretName" -}}
+{{- printf "%s-credentials" (include "warden.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+True when the chart needs to create its own credentials Secret because
+the user passed a literal connectionUrl or token rather than an
+existingSecret reference.
+*/}}
+{{- define "warden.needsCredentialsSecret" -}}
+{{- $needPg := and (eq (.Values.storage.existingSecret | default "") "") (ne (.Values.storage.connectionUrl | default "") "") -}}
+{{- $needTransit := and (eq .Values.seal.type "transit") (and (eq (.Values.seal.transit.existingSecret | default "") "") (ne (.Values.seal.transit.token | default "") "")) -}}
+{{- if or $needPg $needTransit -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+warden.preflight enforces fail-fast on values that cannot be deferred
+to runtime — calling this from statefulset.yaml (always rendered) makes
+helm install / helm template fail with an actionable message instead of
+producing manifests that crash-loop at pod startup.
+*/}}
+{{- define "warden.preflight" -}}
+{{- if not .Values.tls.existingSecret -}}
+{{- fail "tls.existingSecret is required: create a kubernetes.io/tls Secret and pass --set tls.existingSecret=<name>" -}}
+{{- end -}}
+{{- if not (or .Values.storage.existingSecret .Values.storage.connectionUrl) -}}
+{{- fail "Either storage.existingSecret or storage.connectionUrl must be set so the postgres connection URL can be sourced" -}}
+{{- end -}}
+{{- if eq .Values.seal.type "transit" -}}
+{{- if not .Values.seal.transit.address -}}
+{{- fail "seal.transit.address is required when seal.type=transit" -}}
+{{- end -}}
+{{- if not .Values.seal.transit.keyName -}}
+{{- fail "seal.transit.keyName is required when seal.type=transit" -}}
+{{- end -}}
+{{- if not (or .Values.seal.transit.existingSecret .Values.seal.transit.token) -}}
+{{- fail "Either seal.transit.existingSecret or seal.transit.token must be set when seal.type=transit" -}}
+{{- end -}}
+{{- else if eq .Values.seal.type "static" -}}
+{{- if not .Values.seal.static.existingSecret -}}
+{{- fail "seal.static.existingSecret is required when seal.type=static — reference a Secret containing the seal key" -}}
+{{- end -}}
+{{- else -}}
+{{- fail (printf "seal.type must be 'transit' or 'static', got %q" .Values.seal.type) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Per-pod api_addr / cluster_addr templates. The HCL is rendered at
+warden boot through the env-interpolation pass added in PR 1, so
+{{ env "POD_NAME" }} resolves to the actual pod name. The chart's
+two outer {{`...`}} keep the inner braces literal in the rendered
+ConfigMap.
+*/}}
+{{- define "warden.apiAddrTemplate" -}}
+https://{{`{{ env "POD_NAME" }}`}}.{{ include "warden.headlessName" . }}.{{ .Release.Namespace }}.svc.cluster.local:8400
+{{- end -}}
+
+{{- define "warden.clusterAddrTemplate" -}}
+https://{{`{{ env "POD_NAME" }}`}}.{{ include "warden.headlessName" . }}.{{ .Release.Namespace }}.svc.cluster.local:8401
+{{- end -}}

--- a/deploy/helm/warden/templates/configmap-config.yaml
+++ b/deploy/helm/warden/templates/configmap-config.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "warden.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+data:
+  # Single base HCL file consumed by `warden server --config-dir /config`.
+  # Sensitive values (postgres connection_url, seal token, static seal key)
+  # are pulled in at boot from env vars via the warden binary's
+  # env-interpolation pass (see config/config.go).
+  00-base.hcl: |
+    log_format = {{ .Values.logFormat | quote }}
+    log_level  = {{ .Values.logLevel | quote }}
+
+    api_addr     = {{ include "warden.apiAddrTemplate" . | quote }}
+    cluster_addr = {{ include "warden.clusterAddrTemplate" . | quote }}
+
+    ip_binding_policy = {{ .Values.ipBindingPolicy | quote }}
+
+    storage "postgres" {
+      connection_url = "{{`{{ env "WARDEN_POSTGRES_URL" }}`}}"
+      table          = {{ .Values.storage.table | quote }}
+      ha_enabled     = {{ .Values.storage.haEnabled | quote }}
+      ha_table       = {{ .Values.storage.haTable | quote }}
+    }
+
+    listener "tcp" {
+      address                 = "0.0.0.0:8400"
+      tls_enabled             = true
+      tls_cert_file           = "/certs/{{ .Values.tls.certKey }}"
+      tls_key_file            = "/certs/{{ .Values.tls.keyKey }}"
+      tls_client_ca_file      = "/certs/{{ .Values.tls.caKey }}"
+      tls_require_client_cert = {{ .Values.tls.requireClientCert }}
+    }
+
+  {{- if eq .Values.seal.type "transit" }}
+  10-seal.hcl: |
+    seal "transit" {
+      address    = {{ .Values.seal.transit.address | quote }}
+      token      = "{{`{{ env "WARDEN_SEAL_TOKEN" }}`}}"
+      key_name   = {{ .Values.seal.transit.keyName | quote }}
+      mount_path = {{ .Values.seal.transit.mountPath | quote }}
+      {{- with .Values.seal.transit.namespace }}
+      namespace  = {{ . | quote }}
+      {{- end }}
+    }
+  {{- else if eq .Values.seal.type "static" }}
+  10-seal.hcl: |
+    seal "static" {
+      {{- with .Values.seal.static.keyId }}
+      current_key_id = {{ . | quote }}
+      {{- end }}
+      # The Secret named in seal.static.existingSecret is projected at
+      # /seal/key by the StatefulSet's seal volume mount.
+      current_key    = "file:///seal/key"
+    }
+  {{- end }}

--- a/deploy/helm/warden/templates/pdb.yaml
+++ b/deploy/helm/warden/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "warden.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "warden.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/warden/templates/secret-credentials.yaml
+++ b/deploy/helm/warden/templates/secret-credentials.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Chart-managed Secret holding any sensitive values that were passed as
+literal strings in values (rather than referenced via existingSecret).
+This exists for the dev/quickstart path; production deployments should
+reference operator-managed Secrets via storage.existingSecret /
+seal.transit.existingSecret / seal.static.existingSecret.
+*/ -}}
+{{- if eq (include "warden.needsCredentialsSecret" .) "true" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "warden.credentialsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if and (eq (.Values.storage.existingSecret | default "") "") .Values.storage.connectionUrl }}
+  {{ .Values.storage.connectionUrlKey }}: {{ .Values.storage.connectionUrl | quote }}
+  {{- end }}
+  {{- if and (eq .Values.seal.type "transit") (eq (.Values.seal.transit.existingSecret | default "") "") .Values.seal.transit.token }}
+  {{ .Values.seal.transit.tokenKey }}: {{ .Values.seal.transit.token | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/warden/templates/service-api.yaml
+++ b/deploy/helm/warden/templates/service-api.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "warden.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: api
+      port: {{ .Values.service.port }}
+      targetPort: api
+      protocol: TCP
+  # Readiness probe gates sealed/uninit pods out of this Service.
+  selector:
+    {{- include "warden.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/warden/templates/service-headless.yaml
+++ b/deploy/helm/warden/templates/service-headless.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "warden.headlessName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+spec:
+  # Headless: each pod gets a DNS A record at
+  #   pod-name.<service>.<namespace>.svc.cluster.local
+  # The HCL `api_addr` and `cluster_addr` resolve against this.
+  clusterIP: None
+  # Expose unready pods on the headless Service so the operator can
+  # reach Warden during the uninitialized window (readiness fails 501
+  # until /v1/sys/init runs) and so standby->active mTLS forwarding
+  # works across pod restarts.
+  publishNotReadyAddresses: true
+  ports:
+    - name: api
+      port: 8400
+      targetPort: api
+      protocol: TCP
+    - name: cluster
+      port: 8401
+      targetPort: cluster
+      protocol: TCP
+  selector:
+    {{- include "warden.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/warden/templates/serviceaccount.yaml
+++ b/deploy/helm/warden/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "warden.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# Warden does not talk to the Kubernetes API, so suppress the default
+# ServiceAccount-token mount entirely.
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/warden/templates/statefulset.yaml
+++ b/deploy/helm/warden/templates/statefulset.yaml
@@ -1,0 +1,173 @@
+{{- include "warden.preflight" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "warden.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "warden.headlessName" . }}
+  replicas: {{ .Values.replicaCount }}
+  # HA leader election uses PostgreSQL advisory locks, not ordered
+  # startup, so pods can come up in parallel.
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "warden.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "warden.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Roll pods when the rendered HCL or chart-managed credentials change.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
+        {{- if eq (include "warden.needsCredentialsSecret" .) "true" }}
+        checksum/credentials: {{ include (print $.Template.BasePath "/secret-credentials.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "warden.serviceAccountName" . }}
+      # Defense-in-depth: also suppress the SA-token mount at the Pod
+      # level. The chart sets the same on the ServiceAccount, but pod-
+      # level settings are what some compliance scanners check.
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range .Values.topologySpreadConstraints }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "warden.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: warden
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - server
+            - --config-dir
+            - /config
+          ports:
+            - name: api
+              containerPort: 8400
+              protocol: TCP
+            - name: cluster
+              containerPort: 8401
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: WARDEN_POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.existingSecret | default (include "warden.credentialsSecretName" .) }}
+                  key: {{ .Values.storage.connectionUrlKey }}
+            {{- if eq .Values.seal.type "transit" }}
+            - name: WARDEN_SEAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.seal.transit.existingSecret | default (include "warden.credentialsSecretName" .) }}
+                  key: {{ .Values.seal.transit.tokenKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200
+              port: api
+              scheme: HTTPS
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /v1/sys/health?standbyok=true
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- if eq .Values.seal.type "static" }}
+            - name: seal
+              mountPath: /seal
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "warden.fullname" . }}-config
+        - name: certs
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
+        - name: tmp
+          emptyDir: {}
+        {{- if eq .Values.seal.type "static" }}
+        - name: seal
+          secret:
+            secretName: {{ .Values.seal.static.existingSecret }}
+            items:
+              - key: {{ .Values.seal.static.currentKeyKey }}
+                path: key
+        {{- end }}

--- a/deploy/helm/warden/templates/tests/test-connection.yaml
+++ b/deploy/helm/warden/templates/tests/test-connection.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "warden.fullname" . }}-test-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.10.1
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          URL="https://{{ include "warden.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"
+          echo "GET $URL"
+          # The sealedcode and uninitcode overrides force a 200 for those
+          # states so that even unhealthy-but-running pods pass the smoke
+          # test — this validates the listener, not cluster initialization.
+          # If the API Service has no endpoints (e.g. all pods are NotReady
+          # because /v1/sys/init has not been run yet), curl will fail to
+          # connect and the test will exit non-zero — see NOTES.txt for
+          # the init runbook.
+          CODE=$(curl -sk -o /tmp/body -w '%{http_code}' "$URL" || echo "connect_failed")
+          echo "HTTP $CODE"
+          cat /tmp/body 2>/dev/null || true
+          echo
+          case "$CODE" in
+            2*) exit 0 ;;
+            *)  exit 1 ;;
+          esac
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532

--- a/deploy/helm/warden/values-dev.yaml
+++ b/deploy/helm/warden/values-dev.yaml
@@ -1,0 +1,48 @@
+# Quickstart overrides for local development on kind / minikube / k3s.
+#
+#   helm install warden ./deploy/helm/warden \
+#     -n warden --create-namespace \
+#     -f ./deploy/helm/warden/values-dev.yaml \
+#     --set tls.existingSecret=warden-tls \
+#     --set storage.connectionUrl='postgres://warden:warden@warden-postgres:5432/warden?sslmode=disable' \
+#     --set seal.static.existingSecret=warden-seal \
+#     --set seal.static.keyId=dev-2026-05-15
+#
+# WARNING: these defaults shrink the cluster to a single replica and
+# switch to a static seal key for unattended unsealing. They are
+# explicitly NOT safe for production — see deploy/helm/warden/values.yaml
+# for the production baseline.
+
+replicaCount: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+logLevel: debug
+logFormat: standard
+
+# Static seal: a single shared key carried in a Secret. Convenient
+# for kind clusters; never use this layout outside of dev or CI.
+seal:
+  type: static
+
+# A single replica's PDB would block voluntary evictions entirely;
+# disable for the dev profile.
+podDisruptionBudget:
+  enabled: false
+
+# Topology spread across zones makes no sense for a 1-pod kind cluster.
+topologySpreadConstraints: []
+
+probes:
+  startup:
+    failureThreshold: 60
+    periodSeconds: 2
+  liveness:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+  readiness:
+    initialDelaySeconds: 2
+    periodSeconds: 5

--- a/deploy/helm/warden/values.yaml
+++ b/deploy/helm/warden/values.yaml
@@ -1,0 +1,156 @@
+# Default values for the Warden Helm chart.
+#
+# These defaults target a production HA deployment. For a one-command
+# local quickstart, install with -f values-dev.yaml from the chart
+# directory.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/stephnangue/warden
+  # tag defaults to .Chart.AppVersion when unset
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Replica count. Warden's HA election runs on PostgreSQL advisory locks;
+# any odd or even number works. Three is a common default.
+replicaCount: 3
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podLabels: {}
+podAnnotations: {}
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+# Pod-level securityContext. The distroless base already runs as
+# nonroot (UID 65532).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+
+podDisruptionBudget:
+  enabled: true
+  # maxUnavailable: 1 (default; tolerates one pod down at a time)
+  maxUnavailable: 1
+
+# TLS for the API listener. Warden requires TLS, so an existingSecret
+# must be provided. Create a Kubernetes Secret of type kubernetes.io/tls
+# (with optional ca.crt for client-cert validation) and reference its
+# name here.
+tls:
+  existingSecret: ""
+  # Field names within the Secret. Defaults match a kubernetes.io/tls
+  # Secret plus the conventional ca.crt for the CA bundle.
+  certKey: tls.crt
+  keyKey: tls.key
+  caKey: ca.crt
+  # Require client certificates signed by caKey. Off by default.
+  requireClientCert: false
+
+# Storage backend (PostgreSQL is the only supported backend for HA).
+# Provide either storage.existingSecret (recommended) or a literal
+# storage.connectionUrl. The chart never bundles PostgreSQL — bring
+# your own (Bitnami postgresql, CloudNativePG, RDS, …).
+storage:
+  table: warden_kv_store
+  haEnabled: "true"
+  haTable: warden_ha_locks
+
+  # Recommended: reference an existing Secret containing the full
+  # postgres:// connection URL.
+  existingSecret: ""
+  connectionUrlKey: connection_url
+
+  # Or pass a literal URL (chart will create a Secret of its own).
+  # Avoid in production — values files are rarely encrypted.
+  connectionUrl: ""
+
+# Seal configuration. Auto-unseal is strongly recommended for
+# production — pods restart frequently in Kubernetes and a static seal
+# requires manual unseal on each restart.
+seal:
+  # type: transit | static
+  type: transit
+
+  transit:
+    address: ""               # e.g. https://vault.example.com:8200
+    keyName: ""               # transit key used for unsealing
+    mountPath: "transit/"
+    namespace: ""
+
+    # Vault token. Reference an existing Secret (recommended) or pass
+    # a literal token (chart creates a Secret).
+    existingSecret: ""
+    tokenKey: token
+    token: ""
+
+  static:
+    # Used only when seal.type=static. Reference a Secret whose
+    # named key contains the raw seal-key bytes. The chart projects
+    # that Secret as a file at /seal/key and points the HCL at it
+    # via current_key = "file:///seal/key".
+    existingSecret: ""
+    keyId: ""
+    currentKeyKey: current_key
+
+# Logging
+logLevel: info
+logFormat: json
+
+# IP-binding policy: disabled | optional | required
+ipBindingPolicy: optional
+
+probes:
+  startup:
+    failureThreshold: 30
+    periodSeconds: 5
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+
+service:
+  type: ClusterIP
+  port: 8400
+  annotations: {}
+
+# Extra environment variables passed to the warden container.
+# Useful for advanced cases where the HCL needs additional
+# {{ env "..." }} placeholders.
+extraEnv: []

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,599 @@
+# Deploying Warden on Kubernetes
+
+This guide walks through installing Warden on a Kubernetes cluster using the
+first-party Helm chart at [`deploy/helm/warden/`](../../deploy/helm/warden/).
+
+The chart deploys a 3-replica HA cluster by default: one active leader and
+two hot standbys, backed by an external PostgreSQL database, with TLS on
+the API listener and auto-unseal via HashiCorp Vault Transit. A dev profile
+(`values-dev.yaml`) shrinks the install to a single replica using a static
+seal key for quick local testing on kind or minikube.
+
+- [Architecture overview](#architecture-overview)
+- [Prerequisites](#prerequisites)
+- [Installing the chart](#installing-the-chart)
+- [Dev quickstart on kind](#dev-quickstart-on-kind)
+- [Production install](#production-install)
+- [PostgreSQL options](#postgresql-options)
+- [First-time initialization](#first-time-initialization)
+- [Upgrades](#upgrades)
+- [Operations](#operations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture overview
+
+The chart renders these objects per release:
+
+| Object | Purpose |
+|---|---|
+| `StatefulSet/<release>` | Warden pods with stable per-pod DNS names. `podManagementPolicy: Parallel` — leader election is lock-based and doesn't require ordered startup. |
+| `Service/<release>` (ClusterIP) | Client-facing API on port 8400. Readiness probe gates sealed/uninit pods out automatically. |
+| `Service/<release>-headless` (clusterIP None, `publishNotReadyAddresses: true`) | Per-pod DNS for inter-node mTLS forwarding on 8401, and for operator access while pods are NotReady. |
+| `ConfigMap/<release>-config` | HCL config files mounted at `/config`. References env vars via `{{ env "VAR" }}`. |
+| `Secret/<release>-credentials` | _Only when literal credentials were passed via values_ — the chart-managed Secret used for the dev quickstart path. |
+| `ServiceAccount/<release>` | `automountServiceAccountToken: false`. Warden does not call the Kubernetes API. |
+| `PodDisruptionBudget/<release>` | `maxUnavailable: 1`. Bounds voluntary disruption during node drains and rolling upgrades. |
+
+Three pods become one active leader (via Postgres advisory locks) and two
+standbys. Standbys forward writes to the leader over mTLS on port 8401.
+On leader failure, a standby acquires the lock within ~10s. See the
+[Architecture doc](../architecture.md) for the high-availability model.
+
+---
+
+## Prerequisites
+
+- **Kubernetes 1.27+** — the chart depends on GA semantics of
+  `publishNotReadyAddresses` on headless Services.
+- **PostgreSQL** — bring your own. The chart never bundles a database.
+  See [PostgreSQL options](#postgresql-options) for examples.
+- **TLS certificate** — Warden requires TLS on the API listener. Provide
+  a Kubernetes Secret of type `kubernetes.io/tls`, with optional `ca.crt`
+  for client-cert validation.
+- **Seal infrastructure** — for production, a Vault server with a Transit
+  key configured for auto-unseal. For dev, a single shared static seal
+  key carried in a Secret.
+- **`helm` 3.16+** and **`kubectl`** locally.
+
+---
+
+## Installing the chart
+
+The chart is published to the GitHub Container Registry on every release
+tag, as an OCI artifact alongside the Warden Docker image. Pick the
+method that matches your environment.
+
+### From the OCI registry (recommended)
+
+Helm 3.8+ pulls OCI charts natively — no `helm repo add` needed:
+
+```bash
+helm install warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.0 \
+  -n warden --create-namespace \
+  -f your-values.yaml
+```
+
+`--version` refers to the *chart* version (currently `0.1.0`), which is
+independent of the Warden binary version. The chart pins the matching
+Warden image automatically via the release pipeline.
+
+To pin to a specific Warden binary version against the same chart:
+
+```bash
+helm install warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.0 \
+  --set image.tag=0.12.0 \
+  -n warden --create-namespace \
+  -f your-values.yaml
+```
+
+### From a release tarball (air-gapped)
+
+For clusters that cannot reach OCI registries — for example, those
+restricted to an internal mirror — every release also attaches the chart
+tarball to the GitHub Release page:
+
+```bash
+curl -L -o warden-chart.tgz \
+  https://github.com/stephnangue/warden/releases/download/v0.12.0/warden-0.1.0.tgz
+
+helm install warden ./warden-chart.tgz \
+  -n warden --create-namespace \
+  -f your-values.yaml
+```
+
+### From the source repo (development)
+
+For chart development or to install an unreleased version:
+
+```bash
+git clone https://github.com/stephnangue/warden
+helm install warden ./warden/deploy/helm/warden \
+  -n warden --create-namespace \
+  -f your-values.yaml
+```
+
+The commands in the rest of this guide use the OCI form. Substitute the
+local-path form (`./deploy/helm/warden`) if you are working from a clone.
+
+---
+
+## Dev quickstart on kind
+
+A complete end-to-end install on a local kind cluster. Total time ~5 min.
+
+### 1. Create a cluster and namespace
+
+```bash
+kind create cluster --name warden
+kubectl create namespace warden
+```
+
+### 2. Deploy PostgreSQL
+
+A bare-minimum single-pod Postgres for dev only:
+
+```bash
+cat <<'EOF' | kubectl apply -n warden -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: warden-postgres-creds
+stringData:
+  POSTGRES_USER: warden
+  POSTGRES_PASSWORD: warden
+  POSTGRES_DB: warden
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: warden-postgres
+spec:
+  serviceName: warden-postgres
+  replicas: 1
+  selector:
+    matchLabels: { app: warden-postgres }
+  template:
+    metadata:
+      labels: { app: warden-postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          envFrom: [{ secretRef: { name: warden-postgres-creds } }]
+          ports: [{ containerPort: 5432 }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: warden-postgres
+spec:
+  selector: { app: warden-postgres }
+  ports: [{ port: 5432 }]
+EOF
+
+kubectl -n warden wait --for=condition=Ready pod/warden-postgres-0 --timeout=2m
+```
+
+### 3. Create the TLS Secret
+
+Generate a self-signed cert for testing:
+
+```bash
+mkdir -p /tmp/warden-tls
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -subj "/CN=warden.warden.svc" \
+  -addext "subjectAltName=DNS:warden,DNS:warden.warden.svc,DNS:warden.warden.svc.cluster.local,DNS:*.warden-headless.warden.svc.cluster.local" \
+  -keyout /tmp/warden-tls/tls.key \
+  -out /tmp/warden-tls/tls.crt
+
+# CA bundle (self-signed cert is its own CA)
+cp /tmp/warden-tls/tls.crt /tmp/warden-tls/ca.crt
+
+kubectl -n warden create secret generic warden-tls \
+  --from-file=/tmp/warden-tls/tls.crt \
+  --from-file=/tmp/warden-tls/tls.key \
+  --from-file=/tmp/warden-tls/ca.crt
+```
+
+### 4. Create the static seal Secret
+
+```bash
+# 32 raw bytes for AES-256-GCM (NOT base64-encoded — Warden reads the
+# file verbatim, mirroring the format used by e2e/setup.sh).
+openssl rand 32 > /tmp/warden-seal.key
+kubectl -n warden create secret generic warden-seal \
+  --from-file=current_key=/tmp/warden-seal.key
+```
+
+### 5. Install the chart
+
+The dev values file lives inside the chart, so for the OCI install path
+download it first with `helm show values`:
+
+```bash
+helm show values oci://ghcr.io/stephnangue/charts/warden --version 0.1.0 \
+  > /tmp/warden-values.yaml
+# Edit /tmp/warden-values.yaml — or skip this step and use --set flags only.
+
+helm install warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.0 \
+  -n warden \
+  --set replicaCount=1 \
+  --set seal.type=static \
+  --set podDisruptionBudget.enabled=false \
+  --set tls.existingSecret=warden-tls \
+  --set storage.connectionUrl='postgres://warden:warden@warden-postgres:5432/warden?sslmode=disable' \
+  --set seal.static.existingSecret=warden-seal \
+  --set seal.static.keyId=dev-$(date +%Y%m%d)
+```
+
+If you have the source repo cloned, the equivalent using the bundled
+`values-dev.yaml` is one flag:
+
+```bash
+helm install warden ./deploy/helm/warden \
+  -n warden \
+  -f ./deploy/helm/warden/values-dev.yaml \
+  --set tls.existingSecret=warden-tls \
+  --set storage.connectionUrl='postgres://warden:warden@warden-postgres:5432/warden?sslmode=disable' \
+  --set seal.static.existingSecret=warden-seal \
+  --set seal.static.keyId=dev-$(date +%Y%m%d)
+```
+
+Pods will start uninitialized — readiness fails with 501 and they are not
+yet in the `warden` Service endpoints. This is expected. See
+[First-time initialization](#first-time-initialization) for the next step.
+
+---
+
+## Production install
+
+### 1. Decide on auto-unseal
+
+Use HashiCorp Vault Transit auto-unseal so pods unseal themselves on every
+restart without operator intervention. Static seals require manual unseal
+on each restart and are not appropriate for production.
+
+Set up a Transit key on your Vault server:
+
+```bash
+vault secrets enable transit
+vault write -f transit/keys/warden-unseal
+
+# Policy that only allows encrypt/decrypt on the unseal key:
+vault policy write warden-unseal - <<'EOF'
+path "transit/encrypt/warden-unseal" { capabilities = ["update"] }
+path "transit/decrypt/warden-unseal" { capabilities = ["update"] }
+EOF
+
+# Long-lived periodic token (auto-renewed by Warden):
+vault token create -policy=warden-unseal -period=720h -orphan \
+  -display-name=warden-unseal -format=json | jq -r .auth.client_token
+# Save the token — you will store it in the warden-seal-token Secret below.
+```
+
+### 2. Provision secrets
+
+Operator-managed Secrets are referenced from values rather than baked into
+the chart-rendered ConfigMap. For each, create a Secret in the warden
+namespace:
+
+```bash
+kubectl -n warden create secret generic warden-db \
+  --from-literal=connection_url='postgres://warden:STRONG_PASSWORD@db.internal:5432/warden?sslmode=require'
+
+kubectl -n warden create secret generic warden-seal-token \
+  --from-literal=token='hvs.SOME_VAULT_TOKEN'
+
+kubectl -n warden create secret tls warden-tls \
+  --cert=./warden-tls.crt --key=./warden-tls.key
+# Append the CA bundle if you need client-cert validation. Note: `base64 -w0`
+# is GNU; on macOS use `base64 -i ./ca.crt` and strip the trailing newline.
+kubectl -n warden patch secret warden-tls --type=merge \
+  -p '{"data":{"ca.crt":"'"$(base64 < ./ca.crt | tr -d '\n')"'"}}'
+```
+
+If you use [External Secrets Operator](https://external-secrets.io) or
+[secrets-store-csi-driver](https://secrets-store-csi-driver.sigs.k8s.io/),
+reference your synced Secret names via `--set` instead.
+
+### 3. Install the chart
+
+```bash
+helm install warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.0 \
+  -n warden --create-namespace \
+  --set tls.existingSecret=warden-tls \
+  --set storage.existingSecret=warden-db \
+  --set seal.transit.address=https://vault.internal:8200 \
+  --set seal.transit.keyName=warden-unseal \
+  --set seal.transit.existingSecret=warden-seal-token \
+  --set replicaCount=3
+```
+
+Pods will start uninitialized — proceed to
+[First-time initialization](#first-time-initialization).
+
+### 4. Notable defaults that you may want to override
+
+- `image.tag` — defaults to the chart's `appVersion`. Override to pin a
+  specific Warden release independently of the chart version.
+- `resources` — 100m CPU / 256Mi memory request, 512Mi memory limit. Bump
+  for high-throughput deployments.
+- `topologySpreadConstraints` — defaults to one entry spreading pods
+  across `topology.kubernetes.io/zone` with `whenUnsatisfiable:
+  ScheduleAnyway`. Tighten to `DoNotSchedule` if your cluster has
+  guaranteed multi-zone capacity.
+- `tls.requireClientCert` — set to `true` for mTLS on the API listener.
+  Clients must present a certificate signed by the CA in `ca.crt`.
+
+---
+
+## PostgreSQL options
+
+The chart never bundles PostgreSQL. Recommended approaches:
+
+### Bitnami postgresql Helm chart
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install warden-db bitnami/postgresql -n warden \
+  --set auth.username=warden \
+  --set auth.database=warden \
+  --set primary.persistence.size=10Gi
+
+# Wait for it, then capture the credentials Helm generated:
+DB_PW=$(kubectl -n warden get secret warden-db-postgresql \
+  -o jsonpath='{.data.password}' | base64 -d)
+
+kubectl -n warden create secret generic warden-db \
+  --from-literal=connection_url="postgres://warden:${DB_PW}@warden-db-postgresql:5432/warden?sslmode=require"
+```
+
+### CloudNativePG
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: warden-db
+  namespace: warden
+spec:
+  instances: 3
+  storage:
+    size: 20Gi
+  bootstrap:
+    initdb:
+      database: warden
+      owner: warden
+```
+
+CloudNativePG creates a Secret called `warden-db-app` containing both
+`username` / `password` and a `uri` field with the full connection
+string. Set `storage.existingSecret=warden-db-app` and
+`storage.connectionUrlKey=uri`.
+
+### Managed Postgres (RDS, Cloud SQL, Aiven, etc.)
+
+Create a Secret out-of-band with the full connection URL and reference it
+via `--set storage.existingSecret=<name>`. Use `sslmode=require` (or
+stricter) on production databases.
+
+---
+
+## First-time initialization
+
+On a fresh install, pods come up uninitialized: the `/v1/sys/health`
+endpoint returns 501, the readiness probe fails, and the `warden` Service
+has no endpoints. This is the intended state — Warden needs an operator
+to run `sys/init` once to generate the root token and unseal keys.
+
+### Why not auto-init?
+
+The chart deliberately does not auto-run `sys/init`. The init response
+contains the root token and unseal keys; auto-storing them in a Kubernetes
+Secret is only safe if etcd is encrypted at rest, and the failure mode of
+"chart-managed root token gets accidentally deleted with the release" is
+catastrophic. Operators run init explicitly and store the response in
+their own secrets-management system.
+
+### Initialize the cluster
+
+The headless Service has `publishNotReadyAddresses: true`, so you can
+reach any pod directly even while readiness is failing:
+
+```bash
+kubectl -n warden port-forward pod/warden-0 8400:8400 &
+PF_PID=$!
+
+# secret_shares=1 / threshold=1 is convenient for dev; production should
+# use Shamir splitting (e.g. 5 shares with a threshold of 3) so no single
+# operator can recover or use the unseal keys alone.
+curl -k -X POST https://127.0.0.1:8400/v1/sys/init \
+  -H 'Content-Type: application/json' \
+  -d '{"secret_shares": 1, "secret_threshold": 1}'
+
+# Output:
+# {
+#   "root_token": "...",
+#   "unseal_keys_b64": ["..."],
+#   "unseal_keys_hex": ["..."]
+# }
+
+kill $PF_PID
+```
+
+Store `root_token` and `unseal_keys_b64` securely — they cannot be
+recovered. With Transit auto-unseal the recovery shares only matter for
+disaster recovery; with Shamir-only (no auto-unseal), you must collect
+`threshold` shares for every restart.
+
+For production deployments using auto-unseal, the remaining pods will
+auto-unseal within ~10 seconds and become Ready. For the static-seal dev
+profile, all pods share the same key so they also auto-unseal.
+
+### Verify the cluster is healthy
+
+```bash
+kubectl -n warden get pods
+# All pods should be Ready.
+
+kubectl -n warden get endpoints warden
+# Should list all pod IPs.
+
+# Verify exactly one pod reports is_self=true:
+for i in 0 1 2; do
+  kubectl -n warden exec warden-$i -- \
+    curl -sk https://localhost:8400/v1/sys/leader | grep -o '"is_self":[a-z]*'
+done
+```
+
+---
+
+## Upgrades
+
+### Chart upgrades
+
+```bash
+helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.1 \
+  -n warden -f your-values.yaml
+```
+
+The StatefulSet has `checksum/config` and (when present) `checksum/credentials`
+pod annotations. Any change that affects the rendered ConfigMap or
+chart-managed credentials Secret triggers a rolling restart bounded by
+the PDB's `maxUnavailable: 1`: one pod at a time, the leader steps down
+when its pod is replaced, and a standby is promoted within ~10s. There
+is no client-visible downtime as long as `replicaCount >= 2`.
+
+### Warden binary upgrades
+
+Bump `image.tag` (or upgrade the chart whose `appVersion` advances):
+
+```bash
+helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.0 \
+  -n warden --reuse-values \
+  --set image.tag=0.13.0
+```
+
+Same rolling-restart mechanics. Check release notes for any
+configuration changes that require an HCL update first.
+
+### Rotating the seal token (Transit auto-unseal)
+
+Generate a new Vault token, update the operator-managed Secret, then roll
+the pods so they pick up the new token:
+
+```bash
+kubectl -n warden patch secret warden-seal-token \
+  -p '{"stringData":{"token":"hvs.NEW_TOKEN"}}'
+
+kubectl -n warden rollout restart statefulset/warden
+```
+
+---
+
+## Operations
+
+### Sealing a single pod
+
+```bash
+kubectl -n warden exec warden-0 -- \
+  curl -sk -X PUT https://localhost:8400/v1/sys/seal \
+  -H "X-Warden-Token: $ROOT_TOKEN"
+```
+
+The pod will fail readiness immediately, be removed from the API Service,
+and (with auto-unseal) re-unseal on its next reconciliation loop. Useful
+for testing failover.
+
+### Forcing a leader step-down
+
+```bash
+LEADER=$(kubectl -n warden get pods -l app.kubernetes.io/name=warden \
+  -o name | head -1 | sed 's|pod/||')
+
+kubectl -n warden exec "$LEADER" -- \
+  curl -sk -X PUT https://localhost:8400/v1/sys/step-down \
+  -H "X-Warden-Token: $ROOT_TOKEN"
+```
+
+A standby is promoted within ~10s.
+
+### Increasing replica count
+
+```bash
+helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.1.0 \
+  -n warden --reuse-values \
+  --set replicaCount=5
+```
+
+New pods join the cluster as standbys after auto-unseal. No data
+migration needed — everything is in Postgres.
+
+---
+
+## Troubleshooting
+
+### Pods stuck in `Running` but never `Ready`
+
+Check the pod logs:
+
+```bash
+kubectl -n warden logs warden-0 --tail=50
+```
+
+Common causes:
+- **Postgres unreachable** — verify the connection URL secret, network
+  policies, and that `warden-postgres` is Ready.
+- **Sealed forever, no auto-unseal** — for Transit, check that
+  `seal.transit.address` is reachable from the pod and the token Secret
+  is correct. For static seal, ensure the `current_key` Secret value is
+  consistent across all pods.
+- **Not initialized** — pods stay NotReady until `/v1/sys/init` runs. See
+  [First-time initialization](#first-time-initialization).
+
+### `helm install` fails immediately with a value error
+
+The chart's preflight validator emits clear messages:
+
+- `tls.existingSecret is required` — create a `kubernetes.io/tls` Secret.
+- `Either storage.existingSecret or storage.connectionUrl must be set` —
+  provide the postgres connection URL.
+- `seal.transit.address is required when seal.type=transit` — Transit
+  auto-unseal needs a Vault endpoint.
+- `seal.type must be 'transit' or 'static'` — typo in `--set seal.type=`.
+
+### TLS verification errors on `/v1/sys/init`
+
+The `curl -k` flag in the init runbook disables certificate verification
+because you typically use a self-signed cert for the API listener (the
+cluster trusts it via the CA bundle). For client-side verification, pass
+`--cacert ca.crt`.
+
+### Standby pods not forwarding writes
+
+The distroless Warden image has no shell or DNS tools, so verify the
+headless Service is resolving from an ephemeral debug pod instead:
+
+```bash
+kubectl -n warden run dns-debug --rm -it --restart=Never \
+  --image=busybox:1.36 -- \
+  nslookup warden-0.warden-headless.warden.svc.cluster.local
+```
+
+If DNS fails, the `publishNotReadyAddresses` and per-pod-hostname behavior
+of StatefulSets may be misconfigured by a cluster-wide DNS policy.
+
+### `helm test` fails with connection_refused
+
+The test pod hits the `warden` API Service. If no pods are Ready (e.g.
+because init has not run yet), the Service has no endpoints and the curl
+fails. Run `helm test` after the init flow completes.


### PR DESCRIPTION
…ent guide

Ships everything needed to install Warden on Kubernetes from a registry, not just from a checked-out source tree.

Helm chart (deploy/helm/warden/):

  - StatefulSet with podManagementPolicy=Parallel and per-pod DNS via a headless Service that resolves `pod-name.<headless>.<ns>.svc...` for the api_addr / cluster_addr advertisements.
  - Two Services: ClusterIP `warden` for clients (readiness gates sealed and uninit pods out automatically), headless `warden-headless` with publishNotReadyAddresses for operator access pre-init and inter-node mTLS forwarding on 8401.
  - HTTPS probes hitting /v1/sys/health with ?standbyok=true plus the sealedcode/uninitcode overrides — relies on the severity-ordered override fix.
  - ConfigMap-rendered HCL with {{ env "VAR" }} placeholders for the postgres URL, transit token, and POD_NAME — resolved at warden boot by the binary's env-interpolation pass. Pod env vars come from downwardAPI and secretKeyRef.
  - Preflight validator in _helpers.tpl fails `helm install` at template time when tls.existingSecret, storage credentials, transit address/ keyName/token, or seal.static.existingSecret are missing — instead of producing manifests that crash-loop at startup.
  - Static seal projects the Secret as a file at /seal/key and points the HCL at it via `current_key = "file:///seal/key"`, matching the raw- bytes format e2e/setup.sh uses (`openssl rand 32`).
  - PDB with maxUnavailable=1, topology spread across zones, dedicated ServiceAccount with automountServiceAccountToken=false on both the SA and the Pod spec.
  - Production-leaning values.yaml plus a values-dev.yaml for kind/ minikube (1 replica, static seal, PDB disabled).
  - `helm test` smoke pod with debuggable output on failure.

CI + publishing:

  - .github/workflows/ci.yml grows a helm-lint job that runs `helm lint`
    + `kubeconform -strict` on both production and dev values, gated by a paths-filter so Go-only changes don't trigger it.
  - .github/workflows/release.yml `helm package`s the chart on every v* tag, pins appVersion to the tag, pushes the OCI artifact to oci://ghcr.io/stephnangue/charts, and attaches the tarball to the GitHub Release for air-gapped users. Refuses to publish if the chart version already exists in the registry (prevents silent clobbering when only the binary version bumped).

.gitignore fix:

  - The unanchored `warden` rule was matching the deploy/helm/warden/ directory in addition to the intended root binary. Anchored to `/warden` so the chart stays tracked.

Docs:

  - docs/deployment/kubernetes.md — full deployment guide covering architecture, prerequisites, OCI install / tarball download / source repo, dev quickstart on kind, production install with Vault Transit auto-unseal, PostgreSQL options (Bitnami, CloudNativePG, managed), first-time /v1/sys/init runbook, upgrades, seal-token rotation, and troubleshooting.
  - README.md — short Kubernetes section linking to the guide. Marketing tone per project convention.