### PR TITLE
feat(helm): opt-in cert-manager integration for the TLS listener

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,20 @@ jobs:
             --set seal.static.keyId=dev \
             | kubeconform -strict -summary -verbose
 
+      - name: kubeconform (cert-manager values)
+        run: |
+          helm template warden deploy/helm/warden \
+            --namespace warden \
+            --set tls.certManager.enabled=true \
+            --set tls.certManager.issuerRef.name=warden-ca \
+            --set storage.existingSecret=warden-db \
+            --set seal.transit.address=https://vault.example.com:8200 \
+            --set seal.transit.keyName=warden-unseal \
+            --set seal.transit.existingSecret=warden-seal \
+            | kubeconform -strict -summary -verbose \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
   e2e:
     runs-on: ubuntu-latest
     needs: [unit, changes]

--- a/deploy/helm/warden/Chart.yaml
+++ b/deploy/helm/warden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: warden
 description: Identity-aware egress proxy for AI agents — Helm chart for Kubernetes deployments.
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "0.13.1"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/stephnangue/warden

--- a/deploy/helm/warden/templates/_helpers.tpl
+++ b/deploy/helm/warden/templates/_helpers.tpl
@@ -83,8 +83,18 @@ helm install / helm template fail with an actionable message instead of
 producing manifests that crash-loop at pod startup.
 */}}
 {{- define "warden.preflight" -}}
+{{- $cmEnabled := .Values.tls.certManager.enabled -}}
+{{- if and $cmEnabled .Values.tls.existingSecret -}}
+{{- fail "tls.existingSecret and tls.certManager.enabled are mutually exclusive — pick one" -}}
+{{- end -}}
+{{- if $cmEnabled -}}
+{{- if not .Values.tls.certManager.issuerRef.name -}}
+{{- fail "tls.certManager.issuerRef.name is required when tls.certManager.enabled=true" -}}
+{{- end -}}
+{{- else -}}
 {{- if not .Values.tls.existingSecret -}}
-{{- fail "tls.existingSecret is required: create a kubernetes.io/tls Secret and pass --set tls.existingSecret=<name>" -}}
+{{- fail "tls.existingSecret is required (or set tls.certManager.enabled=true): create a kubernetes.io/tls Secret and pass --set tls.existingSecret=<name>" -}}
+{{- end -}}
 {{- end -}}
 {{- if not (or .Values.storage.existingSecret .Values.storage.connectionUrl) -}}
 {{- fail "Either storage.existingSecret or storage.connectionUrl must be set so the postgres connection URL can be sourced" -}}
@@ -115,6 +125,22 @@ warden boot through the env-interpolation pass added in PR 1, so
 two outer {{`...`}} keep the inner braces literal in the rendered
 ConfigMap.
 */}}
+{{/*
+warden.tlsSecretName resolves the Secret the StatefulSet mounts at
+/certs. Priority:
+  1. tls.certManager.enabled with tls.certManager.secretName set
+  2. tls.certManager.enabled (derives "{fullname}-tls")
+  3. tls.existingSecret (legacy path)
+Preflight enforces that exactly one branch is reachable.
+*/}}
+{{- define "warden.tlsSecretName" -}}
+{{- if .Values.tls.certManager.enabled -}}
+{{- default (printf "%s-tls" (include "warden.fullname" .)) .Values.tls.certManager.secretName -}}
+{{- else -}}
+{{- .Values.tls.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "warden.apiAddrTemplate" -}}
 https://{{`{{ env "POD_NAME" }}`}}.{{ include "warden.headlessName" . }}.{{ .Release.Namespace }}.svc.cluster.local:8400
 {{- end -}}

--- a/deploy/helm/warden/templates/certificate.yaml
+++ b/deploy/helm/warden/templates/certificate.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.tls.certManager.enabled -}}
+{{- $fullname := include "warden.fullname" . -}}
+{{- $headless := include "warden.headlessName" . -}}
+{{- $ns := .Release.Namespace -}}
+{{- $secretName := include "warden.tlsSecretName" . -}}
+{{- $usages := list "server auth" -}}
+{{- if .Values.tls.requireClientCert -}}
+{{- $usages = append $usages "client auth" -}}
+{{- end -}}
+{{- $defaultDns := list
+      $fullname
+      (printf "%s.%s.svc" $fullname $ns)
+      (printf "%s.%s.svc.cluster.local" $fullname $ns)
+      (printf "*.%s.%s.svc.cluster.local" $headless $ns) -}}
+{{- $dnsNames := default $defaultDns .Values.tls.certManager.dnsNames -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "warden.labels" . | nindent 4 }}
+    {{- with .Values.tls.certManager.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.tls.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ $secretName }}
+  secretTemplate:
+    labels:
+      {{- include "warden.labels" . | nindent 6 }}
+  duration: {{ .Values.tls.certManager.duration }}
+  renewBefore: {{ .Values.tls.certManager.renewBefore }}
+  privateKey:
+    algorithm: {{ .Values.tls.certManager.privateKey.algorithm }}
+    size: {{ .Values.tls.certManager.privateKey.size }}
+    rotationPolicy: {{ .Values.tls.certManager.privateKey.rotationPolicy }}
+  usages:
+    {{- range $usages }}
+    - {{ . }}
+    {{- end }}
+  dnsNames:
+    {{- range $dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  issuerRef:
+    name: {{ required "tls.certManager.issuerRef.name is required when tls.certManager.enabled=true" .Values.tls.certManager.issuerRef.name }}
+    kind: {{ .Values.tls.certManager.issuerRef.kind }}
+    group: {{ .Values.tls.certManager.issuerRef.group }}
+{{- end -}}

--- a/deploy/helm/warden/templates/statefulset.yaml
+++ b/deploy/helm/warden/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
             name: {{ include "warden.fullname" . }}-config
         - name: certs
           secret:
-            secretName: {{ .Values.tls.existingSecret }}
+            secretName: {{ include "warden.tlsSecretName" . }}
         - name: tmp
           emptyDir: {}
         {{- if eq .Values.seal.type "static" }}

--- a/deploy/helm/warden/values.yaml
+++ b/deploy/helm/warden/values.yaml
@@ -65,10 +65,10 @@ podDisruptionBudget:
   # maxUnavailable: 1 (default; tolerates one pod down at a time)
   maxUnavailable: 1
 
-# TLS for the API listener. Warden requires TLS, so an existingSecret
-# must be provided. Create a Kubernetes Secret of type kubernetes.io/tls
-# (with optional ca.crt for client-cert validation) and reference its
-# name here.
+# TLS for the API listener. Warden requires TLS. Either supply a
+# pre-existing Secret via tls.existingSecret, or set tls.certManager.
+# enabled=true to have cert-manager issue and rotate the Secret for
+# you. Exactly one path must be active.
 tls:
   existingSecret: ""
   # Field names within the Secret. Defaults match a kubernetes.io/tls
@@ -78,6 +78,32 @@ tls:
   caKey: ca.crt
   # Require client certificates signed by caKey. Off by default.
   requireClientCert: false
+  # Opt-in: have cert-manager issue and rotate the chart's TLS Secret
+  # instead of supplying tls.existingSecret. Mutually exclusive with
+  # tls.existingSecret; enabling both fails preflight.
+  certManager:
+    enabled: false
+    # Name of the kubernetes.io/tls Secret cert-manager will write.
+    # Defaults to "{fullname}-tls".
+    secretName: ""
+    # Required when enabled=true. The Issuer/ClusterIssuer must exist
+    # in the cluster; the chart does NOT create it.
+    issuerRef:
+      name: ""
+      kind: Issuer          # or ClusterIssuer
+      group: cert-manager.io
+    # SANs on the cert. Empty => chart derives the four service DNS
+    # names (fullname, fullname.ns.svc, .svc.cluster.local, and the
+    # headless wildcard). Override to add external hostnames.
+    dnsNames: []
+    duration: 2160h          # 90d
+    renewBefore: 360h        # 15d
+    privateKey:
+      algorithm: ECDSA       # ECDSA | RSA
+      size: 256              # 256/384 for ECDSA, 2048/3072/4096 for RSA
+      rotationPolicy: Always
+    labels: {}
+    annotations: {}
 
 # Storage backend (PostgreSQL is the only supported backend for HA).
 # Provide either storage.existingSecret (recommended) or a literal

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -15,6 +15,7 @@ seal key for quick local testing on kind or minikube.
 - [Dev quickstart on kind](#dev-quickstart-on-kind)
 - [Production install](#production-install)
 - [PostgreSQL options](#postgresql-options)
+- [Streamlined TLS with cert-manager](#streamlined-tls-with-cert-manager)
 - [First-time initialization](#first-time-initialization)
 - [Upgrades](#upgrades)
 - [Operations](#operations)
@@ -50,13 +51,18 @@ On leader failure, a standby acquires the lock within ~10s. See the
   `publishNotReadyAddresses` on headless Services.
 - **PostgreSQL** — bring your own. The chart never bundles a database.
   See [PostgreSQL options](#postgresql-options) for examples.
-- **TLS certificate** — Warden requires TLS on the API listener. Provide
-  a Kubernetes Secret of type `kubernetes.io/tls`, with optional `ca.crt`
-  for client-cert validation.
+- **TLS certificate** — Warden requires TLS on the API listener. Either
+  provide a Kubernetes Secret of type `kubernetes.io/tls` (with optional
+  `ca.crt` for client-cert validation) or set `tls.certManager.enabled=true`
+  to have cert-manager issue and rotate it. See
+  [Streamlined TLS with cert-manager](#streamlined-tls-with-cert-manager).
 - **Seal infrastructure** — for production, a Vault server with a Transit
   key configured for auto-unseal. For dev, a single shared static seal
   key carried in a Secret.
 - **`helm` 3.16+** and **`kubectl`** locally.
+- **cert-manager (optional)** — required only when `tls.certManager.enabled=true`.
+  Any v1.x install works; the chart references whatever `Issuer` or
+  `ClusterIssuer` you point it at.
 
 ---
 
@@ -383,6 +389,107 @@ string. Set `storage.existingSecret=warden-db-app` and
 Create a Secret out-of-band with the full connection URL and reference it
 via `--set storage.existingSecret=<name>`. Use `sslmode=require` (or
 stricter) on production databases.
+
+---
+
+## Streamlined TLS with cert-manager
+
+If [cert-manager](https://cert-manager.io) is installed in the cluster,
+setting `tls.certManager.enabled=true` replaces the
+"openssl + `kubectl create secret`" dance with a single chart-rendered
+`Certificate` resource. cert-manager issues the cert against an `Issuer`
+or `ClusterIssuer` you already trust, writes the `kubernetes.io/tls`
+Secret the StatefulSet mounts, and renews automatically before expiry.
+
+`tls.existingSecret` and `tls.certManager.enabled` are mutually
+exclusive — preflight rejects both.
+
+### Defaults you get out of the box
+
+| Field | Default |
+|---|---|
+| `secretName` | `{fullname}-tls` (override with `tls.certManager.secretName`) |
+| `dnsNames` | `{fullname}`, `{fullname}.{ns}.svc`, `{fullname}.{ns}.svc.cluster.local`, `*.{fullname}-headless.{ns}.svc.cluster.local` |
+| `duration` / `renewBefore` | `2160h` (90d) / `360h` (15d) |
+| `privateKey` | ECDSA P-256, `rotationPolicy: Always` |
+| `usages` | `[server auth]`, plus `client auth` when `tls.requireClientCert=true` |
+
+Required input: `tls.certManager.issuerRef.name`. The chart does **not**
+create the Issuer — that is environment policy and typically lives in a
+different namespace.
+
+### Production: Vault PKI or internal CA
+
+```bash
+helm install warden oci://ghcr.io/stephnangue/charts/warden \
+  --version 0.2.0 \
+  -n warden --create-namespace \
+  --set tls.certManager.enabled=true \
+  --set tls.certManager.issuerRef.name=warden-pki \
+  --set tls.certManager.issuerRef.kind=ClusterIssuer \
+  --set storage.existingSecret=warden-db \
+  --set seal.transit.address=https://vault.internal:8200 \
+  --set seal.transit.keyName=warden-unseal \
+  --set seal.transit.existingSecret=warden-seal-token
+```
+
+### Dev: self-signed `ClusterIssuer` on kind
+
+The dev quickstart [Step 3 (TLS Secret)](#3-create-the-tls-secret) can be
+replaced with cert-manager. Install cert-manager once per cluster, apply a
+self-signed `ClusterIssuer`, and let the chart handle the rest:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml
+kubectl -n cert-manager wait --for=condition=Available deployment --all --timeout=2m
+
+kubectl apply -f - <<'EOF'
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata: { name: selfsigned }
+spec: { selfSigned: {} }
+EOF
+```
+
+Then in [Step 5 (Install the chart)](#5-install-the-chart), drop the
+`tls.existingSecret` flag and pass the cert-manager flags instead:
+
+```bash
+helm install warden ./deploy/helm/warden \
+  -n warden \
+  --set replicaCount=1 \
+  --set seal.type=static \
+  --set podDisruptionBudget.enabled=false \
+  --set tls.certManager.enabled=true \
+  --set tls.certManager.issuerRef.kind=ClusterIssuer \
+  --set tls.certManager.issuerRef.name=selfsigned \
+  --set storage.connectionUrl='postgres://warden:warden@warden-postgres:5432/warden?sslmode=disable' \
+  --set seal.static.existingSecret=warden-seal \
+  --set seal.static.keyId=dev-$(date +%Y%m%d)
+```
+
+### Rotation
+
+cert-manager rotates the Secret in place before the cert expires. Warden
+does **not** hot-reload TLS, so the new cert is not picked up until the
+pod restarts. Trigger a rolling restart manually after each renewal:
+
+```bash
+kubectl rollout restart statefulset/warden -n warden
+```
+
+A future Warden release may add `SIGHUP`/fsnotify-based reload; until
+then this step is unavoidable.
+
+### Pod-startup race
+
+When `tls.certManager.enabled=true`, the Certificate and StatefulSet are
+created together. cert-manager typically writes the Secret within a few
+seconds for in-cluster issuers (self-signed, CA, Vault PKI), low minutes
+for ACME-HTTP01. The chart's startup probe gives 150s
+(`failureThreshold: 30 × periodSeconds: 5`) before declaring the pod
+failed, which absorbs the race for every issuer type we've tested. If
+your issuer needs longer, bump `probes.startup.failureThreshold`.
 
 ---
 


### PR DESCRIPTION
Today the chart requires the operator to pre-create a kubernetes.io/tls Secret and reference it via tls.existingSecret. The dev quickstart in docs/deployment/kubernetes.md walks through six lines of openssl plus kubectl create secret; production deployments need separate tooling to mint and rotate the cert. cert-manager is the standard idiom for this.

Setting tls.certManager.enabled=true makes the chart render a cert-manager.io/v1 Certificate resource that produces the Secret the StatefulSet already mounts. The Issuer/ClusterIssuer must already exist -- the chart deliberately does not render one, since Issuer choice is environment policy and typically lives in a separate namespace. Defaults: ECDSA P-256 key with rotationPolicy=Always, 90d duration / 15d renewBefore, dnsNames derived from the API and headless Service names, and usages=[server auth] plus client auth when tls.requireClientCert=true.

Wiring:

- New tls.certManager value block in values.yaml. enabled defaults to false so existing installs are unaffected.
- New warden.tlsSecretName helper resolves the Secret name across three branches: certManager + explicit secretName, certManager default {fullname}-tls, and the legacy existingSecret path.
- StatefulSet volume secretName routes through the helper.
- warden.preflight grows two new rejections: tls.existingSecret and tls.certManager.enabled set together (conflict), and certManager enabled with empty issuerRef.name.
- New templates/certificate.yaml gated entirely on tls.certManager.enabled.
- Chart bumped 0.1.1 to 0.2.0. No breaking change; the version bump reflects a new optional value subtree.

CI gets a third helm-template + kubeconform step covering the cert-manager values. It uses -schema-location against the datreeio CRDs catalog rather than -ignore-missing-schemas so the Certificate schema is actually validated (catches typos in dnsNames, wrong usages, etc.). The legacy two steps are unchanged.

Docs: new "Streamlined TLS with cert-manager" section in docs/deployment/kubernetes.md covering production (Vault PKI or ClusterIssuer) and dev (self-signed ClusterIssuer on kind), the rotation requirement (kubectl rollout restart, since Warden does not hot-reload TLS), and the startup-probe budget that absorbs the pod-startup race with cert-manager Secret writes. Prerequisites and TOC updated.

Verified end-to-end with helm template:

- existingSecret path still renders, no Certificate
- certManager path renders Certificate, secretName=warden-tls, 4 default dnsNames, usages=[server auth]
- both set: preflight fails (mutually exclusive)
- certManager + no issuerRef: preflight fails (required)
- neither set: preflight fails (is required, or set certManager)
- tls.certManager.secretName override propagates to Certificate and StatefulSet volume
- tls.requireClientCert=true appends client auth to usages