### PR TITLE
fix(cli): send JWT only via Authorization: Bearer, not X-Warden-Token

### DIFF
--- a/cmd/helpers/client.go
+++ b/cmd/helpers/client.go
@@ -35,16 +35,19 @@ func Client() (*api.Client, error) {
 		client.SetMaxRetries(0)
 	}
 
-	// If WARDEN_TOKEN is a JWT, also send it as `Authorization: Bearer` so
-	// identity-introspection endpoints (sys/introspect/roles, the AWS
-	// gateway, etc.) can read the JWT directly. The "eyJ" prefix is the
-	// base64 of `{"`, the start of every JWT header — the same heuristic
-	// used server-side by provider/aws to detect JWT-shaped tokens.
-	// X-Warden-Token is still set; this is additive.
+	// If WARDEN_TOKEN is a JWT, send it as `Authorization: Bearer` and
+	// strip X-Warden-Token. The server's transparent-auth gate fires only
+	// when X-Warden-Token is empty (a JWT is not a Warden session token
+	// and would fail token-store lookup); routing the credential through
+	// the Authorization header lets implicit auth resolve it against the
+	// namespace's auto_auth_path. The "eyJ" prefix is the base64 of `{"`,
+	// the start of every JWT header — the same heuristic used server-side
+	// by provider/aws to detect JWT-shaped tokens.
 	if token := client.Token(); strings.HasPrefix(token, "eyJ") {
 		h := client.Headers()
 		h.Set("Authorization", "Bearer "+token)
 		client.SetHeaders(h)
+		client.ClearToken()
 	}
 
 	c = client


### PR DESCRIPTION
## Summary

- CLI was sending JWT tokens as **both** `X-Warden-Token: <jwt>` and `Authorization: Bearer <jwt>`. The server's transparent-auth gate (`core/request_handler.go:607`) only fires when `X-Warden-Token` is empty, so implicit JWT auth was being skipped for every CLI request.
- The JWT was then treated as a Warden session token, failed the token-store lookup, and left `sys/*` calls without an identity — denied at the policy layer with `permission denied`.
- Fix: when `WARDEN_TOKEN` has the JWT `eyJ` prefix, set `Authorization: Bearer <jwt>` and call `client.ClearToken()` so `X-Warden-Token` is never sent. The implicit-auth path then resolves the JWT via the namespace's `auto_auth_path` metadata and the auth method's `default_role` — which is the documented behaviour.

## Why it matters

This unblocks every CLI-driven agent flow that uses a JWT:
- `warden role list` — discovery of assumable roles
- `warden provider list` — discovery of mounted providers
- `warden skill read <name>` — fetching agent-facing recipes

Without the fix, the server documentation in `core/seed/skills/foundation.md` ("the CLI auto-detects the JWT prefix and sends `Authorization: Bearer <jwt>`...") describes a flow that doesn't actually work end-to-end.

## What's not affected

Gateway URLs (`<mount>/role/<role>/gateway/...`) go through the streaming branch (`request_handler.go:681`) which extracts the role from the URL and doesn't gate on the `X-Warden-Token` header. Provider gateway calls were never broken.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/helpers/... ./core/...` — all pass
- [ ] Manual: `warden role list` against a namespace with `auto_auth_path=auth/jwt/` and `default_role=<some-role>` returns the role list rather than `permission denied`
- [ ] Manual: a JWT with no matching `bound_claims` still gets `forbidden` (gate isn't accidentally bypassing identity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
