### PR TITLE
docs(skills): vault/bao CLI choice, Slack canvas worked example, discovery error recovery

### DIFF
--- a/core/seed/skills/discovery.md
+++ b/core/seed/skills/discovery.md
@@ -74,6 +74,12 @@ already baked in — append `$WARDEN_ADDR` plus the per-provider suffix
 (e.g. `gateway`, `role/<role>/gateway`, `access/<grant>`) from the
 provider's skill to build the full upstream URL.
 
+**Do not re-prefix the namespace.** `mount_url` already starts with
+`/v1/<namespace>/<mount>/`; the full URL is `$WARDEN_ADDR<mount_url>...`.
+Concatenating `$WARDEN_NAMESPACE` separately produces a double-
+namespaced path that doesn't route (e.g.
+`/v1/tutorial/tutorial/vault/...` → `no route found`).
+
 Listing providers requires capabilities granted by your role's
 policy — by convention this is included in the namespace's default
 role. If your `roles` list is empty or the list call returns
@@ -109,4 +115,22 @@ Provider skills are seeded into the registry the first time a provider
 of that type is mounted; if `warden skill read aws` returns 404, the
 operator hasn't enabled an AWS provider in this cluster — surface to
 the user instead of fabricating an endpoint.
+
+## If a call fails
+
+Don't loop blindly. The CLI returns structured error envelopes whose
+`code` field maps deterministically to a recovery action — read the
+`troubleshooting` skill before retrying:
+
+```bash
+warden skill read troubleshooting --raw
+```
+
+In short: `auth_required` → refresh the token; `forbidden` → re-run
+`warden role list` and pick a more-scoped role (usually the *right*
+role for the task you didn't read carefully enough the first time —
+descriptions are operator-set free text, read them); `not_found` →
+re-list providers (the namespace's mounts may have changed);
+`network`/`server` → bounded backoff. Surface the rest to the user
+rather than retrying.
 

--- a/provider/slack/skill.md
+++ b/provider/slack/skill.md
@@ -69,6 +69,63 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
   $WARDEN_ADDR/v1/slack/role/slack-user/gateway/auth.test
 ```
 
+### Publishing a channel canvas
+
+A canvas is the right format for long, formatted text published to a
+channel (a `.md` file upload renders as a download blob with no
+formatting; a canvas renders Markdown natively). A channel can hold
+at most one canvas, so replace any prior one. Four calls in order:
+
+1. **Check for an existing canvas** — `conversations.info` reads
+   `.channel.properties.canvas.file_id`:
+   ```bash
+   EXISTING=$(curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{"channel":"C01ABC123"}' \
+        $WARDEN_ADDR/v1/slack/role/slack-user/gateway/conversations.info \
+     | jq -r '.channel.properties.canvas.file_id // empty')
+   ```
+
+2. **Delete the prior canvas** (if any) — `canvases.delete`:
+   ```bash
+   if [ -n "$EXISTING" ]; then
+     jq -n --arg id "$EXISTING" '{canvas_id:$id}' \
+       | curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+              -H "Content-Type: application/json" --data @- \
+              $WARDEN_ADDR/v1/slack/role/slack-user/gateway/canvases.delete
+   fi
+   ```
+
+3. **Create the new canvas** — `conversations.canvases.create`. Pipe
+   the report body via `jq --rawfile` so the markdown never
+   re-enters the agent's context:
+   ```bash
+   jq -n --arg ch "C01ABC123" \
+         --arg title "Report — $(date -u +%Y-%m-%d)" \
+         --rawfile md report.md \
+         '{channel_id:$ch, title:$title,
+           document_content:{type:"markdown", markdown:$md}}' \
+     | curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+            -H "Content-Type: application/json" --data @- \
+            $WARDEN_ADDR/v1/slack/role/slack-user/gateway/conversations.canvases.create
+   ```
+
+4. **Notify the channel** — `chat.postMessage`. The canvas is pinned
+   in the channel header but a short message draws attention:
+   ```bash
+   jq -n --arg ch "C01ABC123" '{channel:$ch, text:"Report updated."}' \
+     | curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+            -H "Content-Type: application/json" --data @- \
+            $WARDEN_ADDR/v1/slack/role/slack-user/gateway/chat.postMessage
+   ```
+
+The Slack app's bot needs the `canvases:write`, `channels:read`, and
+`chat:write` scopes for this sequence. **Do not invent shortcut method
+names** like `canvas.set` or `canvas.update` — they don't exist on the
+Slack Web API. The four above are the real ones.
+
+### Using SDK clients
+
 For the `@slack/web-api` (Node) or `slack_sdk` (Python) clients:
 point the `slackApiUrl` / `base_url` at
 `$WARDEN_ADDR<mount-url>role/<role>/gateway` and supply your JWT as the

--- a/provider/vault/skill.md
+++ b/provider/vault/skill.md
@@ -33,20 +33,35 @@ URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<vault-api-path>
 Auth header : Authorization: Bearer $WARDEN_TOKEN  # OR X-Vault-Token: $WARDEN_TOKEN
 ```
 
-### Vault CLI
+### Vault / OpenBao CLI
 
 The Vault CLI works against Warden unchanged — point it at the
 Warden gateway and use the JWT as the Vault token. Warden detects
 the JWT prefix in `X-Vault-Token` and treats it as identity.
 
+**Use whichever binary the environment has.** OpenBao ships its CLI
+as `bao` (a fork of `vault`); some environments install one, some
+the other, some both. The two are command-compatible — pick the one
+on `PATH`. Probe order:
+
+```bash
+if command -v vault >/dev/null; then CLI=vault
+elif command -v bao >/dev/null; then CLI=bao
+else echo "neither vault nor bao is installed" >&2; exit 1
+fi
+```
+
+Both honour `VAULT_ADDR` + `VAULT_TOKEN` (yes, `bao` reads
+`VAULT_*` env vars too):
+
 ```bash
 export VAULT_ADDR="$WARDEN_ADDR<mount-url>role/<role>/gateway"
 export VAULT_TOKEN="$WARDEN_TOKEN"
 
-vault kv get secret/myapp/config
-vault kv put secret/myapp/config foo=bar
-vault list secret/myapp/
-vault write pki/sign/server-tpl csr=@./req.csr
+$CLI kv get secret/myapp/config
+$CLI kv put secret/myapp/config foo=bar
+$CLI list secret/myapp/
+$CLI write pki/sign/server-tpl csr=@./req.csr
 ```
 
 The agent never holds a real Vault token; the JWT is the identity.


### PR DESCRIPTION
## Summary

Three independent content updates to the seeded skill catalog, addressing gaps surfaced while building an end-to-end agent tutorial against Warden.

- **`discovery` skill** — documents the `mount_url` contract ("do not re-prefix the namespace") with the exact failing-URL shape that the prior wording let agents construct. Adds an "If a call fails" section cross-linking `troubleshooting` with one-line summaries per error code so agents don't runaway-retry on a single deny.
- **`vault` skill** — CLI section now teaches "use whichever binary is on `PATH` — `vault` or `bao`". OpenBao ships its CLI as `bao` (a fork); some environments install one, some the other, both honour `VAULT_*` env vars.
- **`slack` skill** — adds a full worked example for publishing a channel canvas (`conversations.info` → `canvases.delete` → `conversations.canvases.create` → `chat.postMessage`), with the report body piped via `jq --rawfile` so it never re-enters the agent's context across LLM turns. Explicit warning against inventing shortcut method names — when the worked example is missing, agents tend to fabricate `canvas.set` or `canvas.update`, neither of which exist on the Slack Web API.

## What's not changed

- No code change. Skill bodies are markdown content embedded via `//go:embed` and seeded into the skill registry on first provider mount.
- Existing skills (`foundation`, `troubleshooting`, `aws`, `github`, `openai`, `rds`, `scaleway`) untouched.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./core/...` — passes (skill registry seed/load tests included)
- [ ] Manual on a dev cluster: `warden skill read vault --raw`, `warden skill read slack --raw`, `warden skill read discovery --raw` all return the updated bodies after a fresh `warden server --dev` + provider remount

🤖 Generated with [Claude Code](https://claude.com/claude-code)
