### PR TITLE
feat(ansible_tower): add agent-facing skill

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -50,11 +50,11 @@ import (
 	"github.com/stephnangue/warden/provider/dynatrace"
 	"github.com/stephnangue/warden/provider/elastic"
 	"github.com/stephnangue/warden/provider/gcp"
-	"github.com/stephnangue/warden/provider/grafana"
-	"github.com/stephnangue/warden/provider/ibmcloud"
-	"github.com/stephnangue/warden/provider/honeycomb"
 	"github.com/stephnangue/warden/provider/github"
 	"github.com/stephnangue/warden/provider/gitlab"
+	"github.com/stephnangue/warden/provider/grafana"
+	"github.com/stephnangue/warden/provider/honeycomb"
+	"github.com/stephnangue/warden/provider/ibmcloud"
 	"github.com/stephnangue/warden/provider/kubernetes"
 	"github.com/stephnangue/warden/provider/mistral"
 	"github.com/stephnangue/warden/provider/newrelic"
@@ -174,13 +174,14 @@ Usage: warden server [options]
 	// registry. Operator edits to a seeded skill are preserved on subsequent
 	// mounts (SkillStore.SeedProviderSkill is a no-op when the name exists).
 	providerSkills = map[string]string{
-		"aws":      aws.Skill(),
-		"github":   github.Skill(),
-		"openai":   openai.Skill(),
-		"rds":      rds.Skill(),
-		"scaleway": scaleway.Skill(),
-		"slack":    slack.Skill(),
-		"vault":    vault.Skill(),
+		"ansible_tower": ansible_tower.Skill(),
+		"aws":           aws.Skill(),
+		"github":        github.Skill(),
+		"openai":        openai.Skill(),
+		"rds":           rds.Skill(),
+		"scaleway":      scaleway.Skill(),
+		"slack":         slack.Skill(),
+		"vault":         vault.Skill(),
 	}
 
 	authMethods = map[string]wardenlogical.Factory{

--- a/cmd/skills/create.go
+++ b/cmd/skills/create.go
@@ -56,7 +56,7 @@ Usage: warden skill create [NAME] [options]
 
 func init() {
 	CreateCmd.Flags().StringVar(&createName, "name", "",
-		"Skill name (unique slug, [a-z0-9-]{2,64}); required unless --json supplies one")
+		"Skill name (unique slug, [a-z0-9_-]{2,64}); required unless --json supplies one")
 	CreateCmd.Flags().StringVar(&createDescription, "description", "",
 		"Human-readable one-line summary; required unless --json")
 	CreateCmd.Flags().StringVar(&createCategory, "category", "",

--- a/core/skill_types.go
+++ b/core/skill_types.go
@@ -51,7 +51,7 @@ const (
 	maxSkillDescription = 1024
 )
 
-var skillNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,63}$`)
+var skillNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{1,63}$`)
 
 var skillCategories = map[string]struct{}{
 	SkillCategoryAgentFlow:       {},

--- a/provider/ansible_tower/skill.go
+++ b/provider/ansible_tower/skill.go
@@ -1,0 +1,14 @@
+package ansible_tower
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the Ansible Tower provider.
+// The content is seeded into the global skill registry the first time an
+// Ansible Tower provider is mounted in the cluster; subsequent mounts are
+// no-ops and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/ansible_tower/skill.md
+++ b/provider/ansible_tower/skill.md
@@ -1,0 +1,105 @@
+---
+name: ansible_tower
+description: "Call the Ansible Tower / AWX / AAP REST API through Warden — launch job templates, read inventories, check job status — without holding a PAT."
+category: provider-guide
+provider: ansible_tower
+requires: [foundation, discovery]
+upstream: Ansible Tower / AWX / AAP REST API (api/v2)
+---
+
+# Ansible Tower through Warden
+
+## What it does
+
+Warden proxies Ansible Tower REST API requests. The agent calls a
+Warden URL; Warden authenticates the caller (JWT/cert), looks up the
+Ansible Tower Personal Access Token bound to the chosen role, injects
+it as `Authorization: Bearer <pat>`, and forwards to Tower. The agent
+**never holds a PAT**.
+
+## Configure the CLI/SDK
+
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/ansible_tower/`,
+  `/v1/team-ops/tower-prod/`). Warden has already baked the namespace
+  + mount path in.
+- `<role>` is the role you picked from `warden role list` to perform
+  this task — it goes in the URL path.
+
+```bash
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/api/v2/<endpoint>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
+```
+
+Tower's API path (`/api/v2/…`) is part of the upstream URL — Warden
+does not strip or prepend it. Write the upstream path verbatim after
+`/gateway/`.
+
+## Examples
+
+(All examples assume `mount_url = /v1/ansible_tower/` and role
+`ansible-ops`; substitute yours.)
+
+Ping (health check):
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/ping/
+```
+
+Current user (verifies the injected PAT is valid):
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/me/
+```
+
+List job templates:
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/job_templates/
+```
+
+Launch a job template with extra_vars (replace `42` with the template id):
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"extra_vars":{"target_host":"web01","deploy_version":"1.2.3"}}' \
+  $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/job_templates/42/launch/
+```
+
+Check job status (`<id>` comes from the launch response's `job` field):
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/jobs/<id>/
+```
+
+List inventories:
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/inventories/
+```
+
+## Quirks
+
+- **Trailing slashes matter.** Tower's REST API requires a trailing
+  `/` on collection and detail URLs (`…/jobs/`, `…/jobs/17/`). Without
+  it Tower returns a `301` redirect that the gateway does not follow,
+  so the agent sees an empty body or a `301`. Always include the
+  trailing slash.
+- **`/launch/` is POST even with no overrides.** Use `POST` with an
+  empty `{}` body if you have no `extra_vars`. A `GET` on the launch
+  endpoint returns the template's launch metadata, not a job run.
+- **PATs are static.** Tower Personal Access Tokens do not auto-rotate;
+  the operator rotates them out-of-band via the Tower UI/API and
+  updates the credential spec. Your agent does not need to handle
+  token refresh.
+- **AAP platform gateway uses a different path prefix.** Self-hosted
+  Red Hat AAP behind the platform gateway exposes the controller API
+  at `/api/controller/v2/`, not `/api/v2/`. If the operator pointed
+  `ansible_tower_url` at the platform gateway, swap the prefix in
+  your URLs accordingly; AWX and AAP-direct both use `/api/v2/`.
+- **Policies can restrict request body fields.** Warden parses the
+  request body, so an operator's policy may allow only specific
+  `extra_vars` keys, job template IDs, or inventory IDs. If a request
+  is rejected before reaching Tower, the error comes from Warden, not
+  Tower.


### PR DESCRIPTION
Register the Ansible Tower skill in the provider skill registry and allow underscores in skill names so the `ansible_tower` slug validates.