### PR TITLE
chore: prepare v0.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Warden are documented in this file.
 
 ## [Unreleased]
 
+## [v0.13.2] — 2026-05-21
+
+### New Features
+
+- **Three new agent-facing provider skills wired into the registry.** Slack — URL pattern, bearer auth, POST-only convention, the `ok`-field error handling that Slack uses instead of HTTP status codes, body-parsing policies, static-token rotation (#215). Ansible Tower — registered behind a tightened slug-validation rule that now accepts underscores so `ansible_tower` validates (#219). Atlassian — one provider type covering Jira Cloud, Confluence Cloud v2, and Bitbucket Cloud, with the agent told to disambiguate via the operator-set mount description and the gotchas each product reliably trips on (Jira v3 ADF descriptions, Confluence v2 numeric `spaceId`, the `GET /search` → `POST /search/jql` deprecation, per-product pagination shapes) (#220). All three follow the existing seed-on-first-mount pattern.
+
+- **Opt-in cert-manager integration for the Helm chart's TLS listener.** Setting `tls.certManager.enabled=true` renders a `cert-manager.io/v1` `Certificate` that produces the Secret the StatefulSet already mounts. Defaults are production-leaning: ECDSA P-256 with `rotationPolicy: Always`, 90-day duration / 15-day `renewBefore`, dnsNames auto-derived from the API and headless Service names, and `usages: [server auth]` (plus client auth when `tls.requireClientCert=true`). The Issuer/ClusterIssuer must already exist — the chart deliberately does not render one. Existing `tls.existingSecret` installs are unaffected; preflight validation rejects setting both `tls.existingSecret` and `tls.certManager.enabled` at once, and rejects `certManager` enabled with an empty `issuerRef.name`. Chart version `0.1.1` → `0.2.0`. (#214)
+
+### Bug Fixes
+
+- **CLI sends JWTs only via `Authorization: Bearer`, never as `X-Warden-Token`.** When `WARDEN_TOKEN` held a JWT, the CLI was setting both headers. The server's transparent-auth gate only fires when `X-Warden-Token` is empty, so implicit JWT auth was being skipped for every `sys/*` call: the JWT was treated as a Warden session token, failed the token-store lookup, and left `sys/*` requests without an identity. Affected `warden role list`, `warden provider list`, and `warden skill read <name>` — i.e. every agent discovery call. Gateway URLs (`<mount>/role/<role>/gateway/...`) went through the streaming branch and were unaffected. The fix detects the `eyJ` JWT prefix, sets `Authorization`, and calls `client.ClearToken()` so `X-Warden-Token` is never sent. (#216)
+
+- **CI now runs the full check suite on release-tag pushes.** On a tag push, the tag sits on the same commit as `main`, so `dorny/paths-filter` computed `main...refs/tags/vX.Y.Z` as zero changed files and every filter returned false. `unit`, `helm-lint`, and `e2e` were then skipped via their `needs.changes.outputs.* == 'true'` gates — on the one ref where the full suite matters most. The `changes` job now force-emits `code=true` and `helm=true` for any ref under `refs/tags/*` before the filter runs. Non-tag pushes and pull requests keep the existing path-based gating intact. (#210)
+
+### Documentation
+
+- **Vault-policy-hygiene tutorial rewritten around the discover-and-connect model.** The mechanics are unchanged — a Goose agent audits OpenBao ACL policies, runs inference against an Anthropic-compatible LLM, and publishes the report to a Slack channel canvas, all under one Forgejo OIDC JWT — but the recipe now contains no URLs, role names, or channel IDs. The workflow exports three env vars (`WARDEN_ADDR`, `WARDEN_NAMESPACE`, `WARDEN_TOKEN`) plus an `ANTHROPIC_HOST`; the agent then asks Warden which roles its JWT can assume, which upstreams are mounted, picks the right combination for each step by reading operator-set descriptions, and fetches each upstream's skill for the exact call shape. (#218)
+
+- **Skill catalog refinements driven by the tutorial rewrite.** `discovery.md` documents the `mount_url` no-re-prefix contract (with the failing-URL example agents tend to construct, `/v1/<ns>/<ns>/<mount>/...`) and adds an "If a call fails" recovery section with one-line summaries per error code, short-circuiting the runaway-retry loop. The Vault skill teaches "use whichever of `vault` or `bao` is on PATH" with a probe snippet, since some environments install one and some the other (both honour `VAULT_*` env vars). The Slack skill ships a full worked example for publishing a channel canvas. (#217)
+
+- **Kubernetes deployment guide gains a Cleanup section.** Three concrete teardown flows: `helm uninstall` and what it does and does not delete (the chart owns its rendered objects; the namespace, operator-managed Secrets, and PostgreSQL are deliberately outside that scope so a reinstall picks the cluster back up without re-running `sys/init`); dev cleanup for the kind quickstart; production cleanup as a per-resource decision table calling out the data-loss risk of deleting the Transit unseal key or seal token without rekeying first. Also documents `helm rollback` as the way to undo a chart upgrade without touching state. (#211)
+
+### Dependencies
+
+- `azure/setup-helm` 4 → 5 in CI workflows. (#212)
+- `github.com/aws/aws-sdk-go-v2/service/redshift` 1.62.7 → 1.62.8. (#213)
+
 ## [v0.13.1] — 2026-05-18
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,26 +1,38 @@
-## Warden v0.13.1
+## Warden v0.13.2
 
 **Warden is the secure gateway connecting AI agents to the enterprise systems they need to do real work.** Agents discover what they're allowed to access, Warden brokers every connection, and operators get one control plane for identity, policy, and audit — across every cloud, code-host, observability stack, database, and SaaS the agent reaches. No upstream credentials ever reach the agent: Warden authenticates the caller (JWT or TLS certificate), evaluates fine-grained policy at request time, and injects short-lived credentials before forwarding — or vends scoped grants like database auth tokens directly.
 
-A patch release focused on the Kubernetes path. The 0.13.0 Helm chart shipped with three template defects that surfaced the first time anyone tried to install it on a clean cluster — none of them caught by `helm lint` or `helm template`, all of them only visible once a pod actually tried to run. v0.13.1 fixes the chart and ships it as `0.1.1`.
+v0.13.2 broadens the agent-facing skill catalog (Slack, Ansible Tower, and Atlassian), streamlines the Kubernetes TLS path with opt-in cert-manager support, and fixes a CLI auth-header bug that was silently breaking every `sys/*` discovery call when `WARDEN_TOKEN` held a JWT. The vault-policy-hygiene tutorial is fully rewritten around the discover-and-connect model — the recipe now contains no URLs, role names, or channel IDs.
 
-### Bug Fixes — Helm chart
+### New Features
 
-- **Default image tag now resolves to a published image.** The release workflow strips the leading `v` from `appVersion` while `.goreleaser.yaml` publishes Docker tags as `v{{ .Version }}`. The chart's default tag derivation therefore resolved to `ghcr.io/stephnangue/warden:0.13.0` — `ImagePullBackOff`. The default is now `v` + `.Chart.AppVersion`, aligning with the existing tag convention without churning any historical tags.
+- **Three new agent-facing provider skills.** Slack (URL pattern, bearer auth, POST-only convention, `ok`-field error handling, body-parsing policies, static-token rotation), Ansible Tower (with the slug validator loosened to accept the underscore in `ansible_tower`), and Atlassian — one provider type covering Jira Cloud, Confluence Cloud v2, and Bitbucket Cloud. The agent disambiguates between the three Atlassian products by reading the operator-set mount description, and the skill flags the gotchas each product reliably trips on (Jira v3 ADF, Confluence v2 numeric `spaceId`, the `GET /search` → `POST /search/jql` deprecation, per-product pagination shapes). All three follow the existing seed-on-first-mount registry pattern.
 
-- **HCL env-interpolation no longer crashes on boot.** `api_addr` and `cluster_addr` were rendered through Helm's `| quote`, which backslash-escaped the inner double quotes of `{{ env "POD_NAME" }}` and produced HCL the warden binary's env-interpolation pass rejected (`unexpected "\" in operand`). The strings are now hand-quoted, matching the pattern already used for `WARDEN_POSTGRES_URL`.
+- **Opt-in cert-manager integration for the Helm chart's TLS listener.** Set `tls.certManager.enabled=true` and the chart renders a `cert-manager.io/v1` `Certificate` resource that produces the Secret the StatefulSet already mounts — no more `openssl` plus `kubectl create secret` ceremony in dev, and a clear production path that rotates automatically. Defaults are production-leaning: ECDSA P-256 with `rotationPolicy: Always`, 90-day duration / 15-day `renewBefore`, dnsNames auto-derived from the API and headless Service names, `usages: [server auth]` (plus client auth when `tls.requireClientCert=true`). The Issuer/ClusterIssuer must already exist; the chart deliberately does not render one, since Issuer choice is environment policy. Existing `tls.existingSecret` installs are unaffected. Chart version `0.1.1` → `0.2.0`.
 
-- **First-time init can create the default audit device under `readOnlyRootFilesystem: true`.** Warden's core registers a default file audit device at the relative path `warden-audit.log`, which resolved against the container's `/app` working directory — read-only when the chart's restricted security context is in effect, so init failed with `failed to create default audit backend: failed to open file: open warden-audit.log: read-only file system`. The container now runs from `/tmp` (writable emptyDir) with an explicit `command: [/app/warden]` so the relative-path entrypoint still finds the binary. Audit logs in `/tmp` are ephemeral by design; operators who need durable auditing should mount a PVC and create an explicit audit device after init.
+### Bug Fixes
+
+- **CLI sends JWTs only via `Authorization: Bearer`, never as `X-Warden-Token`.** When `WARDEN_TOKEN` held a JWT, the CLI was setting both headers. The server's transparent-auth gate only fires when `X-Warden-Token` is empty, so implicit JWT auth was being skipped for every `sys/*` call: the JWT was treated as a Warden session token, failed the token-store lookup, and `sys/*` requests landed without an identity and were denied at the policy layer. Affected `warden role list`, `warden provider list`, and `warden skill read <name>` — every agent discovery call. Gateway URLs (`<mount>/role/<role>/gateway/...`) go through the streaming branch and were never affected.
+
+- **CI runs the full check suite on release-tag pushes.** On a tag push the tag sits on the same commit as `main`, so `dorny/paths-filter` was computing `main...refs/tags/vX.Y.Z` as zero changed files and every filter returned false — `unit`, `helm-lint`, and `e2e` were all skipped on the one ref where the full suite matters most. The `changes` job now force-emits `code=true` and `helm=true` for any ref under `refs/tags/*` before the filter runs; PR and main-branch path-filter gating is unchanged.
+
+### Documentation
+
+- **Vault-policy-hygiene tutorial rewritten around discover-and-connect.** The flagship demonstration of the model. The mechanics are unchanged — a Goose agent audits OpenBao ACL policies, runs inference against an Anthropic-compatible LLM, and publishes the report to a Slack channel canvas, all under one Forgejo OIDC JWT — but the recipe now contains no URLs, role names, or channel IDs. The workflow exports three env vars (`WARDEN_ADDR`, `WARDEN_NAMESPACE`, `WARDEN_TOKEN`) plus an `ANTHROPIC_HOST` for Goose's own LLM SDK; the agent then asks Warden which roles its JWT can assume, which upstreams are mounted, picks the right combination for each step by reading operator-set descriptions, and fetches each upstream's skill for the exact call shape.
+
+- **Skill catalog refinements driven by the tutorial rewrite.** `discovery.md` documents the `mount_url` no-re-prefix contract (with the failing-URL example agents tend to construct) and adds an "If a call fails" recovery section with one-line summaries per error code, short-circuiting the runaway-retry loop. The Vault skill teaches "use whichever of `vault` or `bao` is on PATH" with a probe snippet, since some environments install one and some the other. The Slack skill ships a full worked example for publishing a channel canvas.
+
+- **Kubernetes deployment guide gains a Cleanup section.** `helm uninstall` and what it does and does not delete (the chart owns its rendered objects; the namespace, operator-managed Secrets, and PostgreSQL are deliberately outside that scope so a reinstall picks the cluster back up without re-running `sys/init`); dev cleanup for the kind quickstart; production cleanup as a per-resource decision table that calls out the data-loss risk of deleting the Transit unseal key or seal token without rekeying first. Also documents `helm rollback` as the way to undo a chart upgrade without touching state.
 
 ### Upgrading
 
 ```bash
 helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.1 \
+  --version 0.2.0 \
   -n warden --reuse-values
 ```
 
-The chart's value surface is unchanged from 0.1.0; existing values files apply as-is.
+The chart's value surface is additive — a new optional `tls.certManager` subtree, defaulting to `enabled: false`. Existing values files apply as-is; no migration step.
 
 ### Providers
 
@@ -108,7 +120,7 @@ To stop and clean up: `docker compose -f docker-compose.quickstart.yml down -v`
 
 ```bash
 helm install warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.1 \
+  --version 0.2.0 \
   -n warden --create-namespace \
   --set tls.existingSecret=warden-tls \
   --set storage.existingSecret=warden-db \
@@ -117,7 +129,7 @@ helm install warden oci://ghcr.io/stephnangue/charts/warden \
   --set seal.transit.existingSecret=warden-seal-token
 ```
 
-See [docs/deployment/kubernetes.md](https://github.com/stephnangue/warden/blob/main/docs/deployment/kubernetes.md) for the full guide, including the dev quickstart on kind, PostgreSQL recipes, and the first-time initialization runbook.
+See [docs/deployment/kubernetes.md](https://github.com/stephnangue/warden/blob/main/docs/deployment/kubernetes.md) for the full guide, including the dev quickstart on kind, PostgreSQL recipes, the new cert-manager TLS path, the first-time initialization runbook, and the cleanup procedures.
 
 See the [README](https://github.com/stephnangue/warden#readme) for full documentation and provider guides.
 

--- a/deploy/helm/warden/Chart.yaml
+++ b/deploy/helm/warden/Chart.yaml
@@ -3,7 +3,7 @@ name: warden
 description: Identity-aware egress proxy for AI agents — Helm chart for Kubernetes deployments.
 type: application
 version: 0.2.0
-appVersion: "0.13.1"
+appVersion: "0.13.2"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/stephnangue/warden
 sources:

--- a/docs/tutorials/vault-policy-hygiene/.forgejo/workflows/hygiene.yaml
+++ b/docs/tutorials/vault-policy-hygiene/.forgejo/workflows/hygiene.yaml
@@ -51,7 +51,7 @@ jobs:
           # Warden CLI — the agent uses this for the discovery loop
           # (warden role list / provider list / skill read).
           curl --retry 3 --retry-delay 5 -fsSL \
-            "https://github.com/stephnangue/warden/releases/download/v0.13.1/warden_0.13.1_linux_${ARCH}.tar.gz" \
+            "https://github.com/stephnangue/warden/releases/download/v0.13.2/warden_0.13.2_linux_${ARCH}.tar.gz" \
             | tar xz -C /usr/local/bin warden
 
       - name: Mint Warden JWT from Forgejo OIDC

--- a/docs/tutorials/vault-policy-hygiene/README.md
+++ b/docs/tutorials/vault-policy-hygiene/README.md
@@ -24,7 +24,7 @@ This is the first in a series. A planned follow-up covers an audit-log-driven
 plumbing (and the same `tutorial/` namespace) built here.
 
 Versions pinned in this tutorial: OpenBao **2.5.3**, Forgejo **15.x**,
-Forgejo Runner **12.8.0**, Goose **1.32.0**, Warden **0.13.1**. Forgejo
+Forgejo Runner **12.8.0**, Goose **1.32.0**, Warden **0.13.2**. Forgejo
 15+ and Runner 12.5+ are required for the per-job OIDC token feature
 this tutorial relies on. The JWKS path discovery in section 3 will
 handle Forgejo version drift within the 15.x line automatically.


### PR DESCRIPTION
## Summary

Rolls up the eleven PRs merged since v0.13.1 and prepares the repo for the `v0.13.2` tag.

- **New features**: Slack (#215), Ansible Tower (#219), and Atlassian (#220) agent-facing skills; opt-in cert-manager integration for the Helm TLS listener (#214).
- **Bug fixes**: CLI sends JWT only via `Authorization: Bearer`, restoring implicit `sys/*` auth (#216); CI runs the full check suite on release-tag pushes (#210).
- **Docs**: vault-policy-hygiene tutorial rewritten around discover-and-connect (#218); skill catalog refinements — `mount_url` contract, `vault`/`bao` CLI choice, Slack canvas example (#217); Kubernetes deployment guide gains a Cleanup section (#211).
- **Deps**: `azure/setup-helm` 4 → 5 (#212); `aws-sdk-go-v2/service/redshift` 1.62.7 → 1.62.8 (#213).

Bumps `appVersion` 0.13.1 → 0.13.2. Chart `version:` stays at 0.2.0 (already bumped in #214 for cert-manager, unpublished). Tutorial pin in `docs/tutorials/vault-policy-hygiene/` also moves 0.13.1 → 0.13.2 — tag should be pushed promptly after merge so the workflow download URL resolves.

## Test plan

- [x] `helm lint deploy/helm/warden` — passes clean
- [x] `helm template warden deploy/helm/warden -f deploy/helm/warden/values-dev.yaml --set tls.existingSecret=warden-tls --set storage.existingSecret=warden-db --set seal.static.existingSecret=warden-seal` renders `ghcr.io/stephnangue/warden:v0.13.2` and `app.kubernetes.io/version: "0.13.2"`
- [x] No stale `0.13.1` references remain in tracked files outside CHANGELOG.md / RELEASE_NOTES.md
- [x] `git diff --stat` shows exactly five files changed
- [ ] CI passes (release-tag-checks fix from #210 takes effect on the next tag, not on this PR)
- [ ] After merge: `git tag v0.13.2 && git push origin v0.13.2` triggers the release workflow, which packages the chart with `--app-version 0.13.2` from the tag and pushes the `0.2.0` OCI artifact (refuses if already published — won't be)
- [ ] Smoke-test the released chart: `helm install warden-smoke oci://ghcr.io/stephnangue/charts/warden --version 0.2.0 --dry-run --debug` shows `image: ghcr.io/stephnangue/warden:v0.13.2`
