### PR TITLE
docs(tutorial): aws-access-hygiene — AWS prereqs and Warden wiring

### DIFF
--- a/docs/tutorials/aws-access-hygiene/README.md
+++ b/docs/tutorials/aws-access-hygiene/README.md
@@ -1,6 +1,6 @@
 # AWS Access Hygiene Audit with Goose, the AWS CLI, and Warden
 
-> **Status:** scaffolding only. This PR ships the Forgejo + runner stack and the directory layout. AWS provider wiring, the Goose recipe, the CI workflow, and the conceptual narrative arrive in follow-up PRs.
+> **Status:** operator setup is complete (Forgejo + runner stack and the AWS / Warden / Slack wiring); the Goose recipe, the CI workflow, the conceptual narrative, and the audit-log walkthrough arrive in follow-up PRs.
 
 This tutorial stands up an AI agent that audits a sandbox AWS account's IAM
 through **four read-only lenses** — inventory, recent usage, external
@@ -66,23 +66,38 @@ the workflow, inspect Security Hub and Slack. Production is a URL swap.
 
 ## 2. Prerequisites
 
-PR 1 only stands up the Forgejo + runner stack. The full tutorial adds
-prerequisites for AWS and Slack in follow-up PRs; this section will be
-expanded then.
-
 - Docker + Docker Compose, ~1 GB RAM free (Forgejo ~250 MB, runner ~80 MB).
+  Warden runs on the host.
 - `git` client.
-- `curl` and `jq` for the OIDC discovery step in §3 step 5.
+- `curl` and `jq` (the latter is also used by `aws-init.sh` to build
+  IAM trust policies).
+- A Go toolchain for `go install` of Warden, or a prebuilt `warden`
+  binary on PATH.
+- An AWS sandbox account and the **AWS CLI v2** authenticated as a
+  principal that can create IAM users, IAM roles, and access keys. The
+  audit also calls Security Hub, so **Security Hub must be enabled in
+  the chosen region** (default `us-east-1`). The credentials you use to
+  run `aws-init.sh` are only used to bootstrap the broker; they never
+  enter Warden or the agent's environment.
+- (Optional, for Slack delivery) A Slack workspace, a [bot user OAuth token](https://api.slack.com/authentication/token-types#bot)
+  (`xoxb-...`) with the `canvases:write`, `channels:read`, and
+  `chat:write` scopes, and a channel ID the bot is a member of. The
+  token goes into Warden, never into a CI variable. The channel ID and
+  name are passed to `warden-init.sh` and embedded into the
+  `hygiene-poster` role description — the agent reads them from there,
+  not from any env var. Skip this to fall back to Security Hub-only
+  delivery.
 
-A Go toolchain (for `go install` of Warden) and an AWS sandbox account
-are required for the follow-up PRs but not for this scaffold.
+The `aws`, `goose`, and `warden` CLIs are installed inside the Actions
+job's container in PR 3; you do not run them on the host beyond the
+operator setup steps below.
 
 ## 3. Bring up the stack with Docker Compose
 
-The three files we'll use (`docker-compose.yml`, `forgejo-init.sh`,
-and — in a follow-up PR — `aws-init.sh` / `warden-init.sh`) are
-alongside this README. Either `cd` into this folder to run them in
-place, or copy them to a fresh working directory.
+The files we'll use (`docker-compose.yml`, `forgejo-init.sh`,
+`aws-init.sh`, `warden-init.sh`) are alongside this README. Either `cd`
+into this folder to run them in place, or copy them to a fresh working
+directory.
 
 `docker-compose.yml` runs Forgejo, the Forgejo runner, and a one-shot
 init service that bootstraps the `siteowner` admin user:
@@ -203,10 +218,249 @@ Then:
    `http://forgejo.local:3000/api/actions/.well-known/keys`. Use whatever
    the discovery endpoint returns — do not hardcode.
 
+## 4. Start Warden in dev mode
+
+In a new shell:
+
+```bash
+warden server --dev --dev-root-token=dev-warden-root
+```
+
+Dev mode persists everything to an ephemeral in-memory store and writes
+an audit log to `warden-audit.log` in the current directory — convenient
+for the demo and disposable. For the admin shell that runs the wiring
+script in §5, export:
+
+```bash
+export WARDEN_ADDR=http://127.0.0.1:8400
+export WARDEN_TOKEN=dev-warden-root
+```
+
+The agent will use a different token (the Forgejo Actions OIDC JWT)
+when it runs in §9; these admin variables are only for `warden-init.sh`.
+
+## 5. Wire Warden: namespace, JWT auth, AWS + Slack providers, roles, policies
+
+The wiring runs in two scripts, both alongside this README:
+
+- `aws-init.sh` — provisions the **AWS-side primitives** Warden's
+  AssumeRole specs depend on: one broker IAM user and five
+  narrowly-scoped IAM roles in your sandbox account. Outputs broker
+  access keys and role ARNs to `aws-out/creds.env`.
+- `warden-init.sh` — wires **Warden**: namespace, JWT auth, AWS
+  provider, one credential source (the broker keys), five AssumeRole
+  credential specs (one per active Warden role), the five active
+  Warden roles, three decoy roles, the Slack provider (optional), and
+  all access policies. Reads `aws-out/creds.env` for ARNs and keys.
+
+The decoupling is deliberate. Warden never holds the AWS-side
+permission policies; those live entirely at AWS on the assumed IAM
+roles. Warden holds only the broker user's static keys and the
+configuration that says "for role X, assume IAM role Y." Per-lens
+least-privilege is therefore enforced **at AWS** via the AssumeRole
+chain — Warden's contribution is per-call audit attribution and the
+credential-routing chain itself.
+
+### 5a. Provision the AWS-side prereqs
+
+Make `aws-init.sh` executable and run it against your sandbox account:
+
+```bash
+chmod +x aws-init.sh
+./aws-init.sh                                  # uses caller's account, us-east-1
+./aws-init.sh --account-id=123456789012 \
+              --region=eu-west-1               # or specify explicitly
+```
+
+What the script does, idempotently:
+
+1. Creates a broker IAM user `warden-aws-tutorial-broker` with **no**
+   operational permissions. Its only attached policy allows
+   `sts:AssumeRole` on exactly the five role ARNs the script also
+   creates — no wildcards, no other actions.
+2. Creates five IAM roles, each with:
+   - A trust policy admitting only the broker IAM user as a principal:
+     ```json
+     {
+       "Version": "2012-10-17",
+       "Statement": [{
+         "Effect": "Allow",
+         "Principal": { "AWS": "arn:aws:iam::<account>:user/warden-aws-tutorial-broker" },
+         "Action": "sts:AssumeRole"
+       }]
+     }
+     ```
+   - A narrow inline permissions policy matching its purpose. Example
+     for `tutorial-iam-reader-role`:
+     ```json
+     {
+       "Version": "2012-10-17",
+       "Statement": [{
+         "Effect": "Allow",
+         "Action": ["iam:Get*", "iam:List*"],
+         "Resource": "*"
+       }]
+     }
+     ```
+   The other four roles get equivalently narrow policies for
+   `cloudtrail:LookupEvents` + `cloudtrail:Describe*`,
+   `access-analyzer:Get*` + `access-analyzer:List*`,
+   `iam:SimulatePrincipalPolicy`, and
+   `securityhub:BatchImportFindings` only.
+3. Mints a broker access key pair and writes everything to
+   `aws-out/creds.env` for `warden-init.sh` to source.
+
+If the broker user already exists but `aws-out/creds.env` is missing
+(AWS won't let you re-read a secret access key after creation),
+re-run with `--rotate-key` to drop the orphan key and mint a fresh
+one.
+
+### 5b. Run the Warden wiring
+
+With Warden running (§4) and `aws-out/creds.env` populated:
+
+```bash
+chmod +x warden-init.sh
+./warden-init.sh                                                      # AWS only
+./warden-init.sh --slack-token=xoxb-... \
+                 --slack-channel-id=C0XXXXXXX \
+                 --slack-channel-name='#access-audits'                # + Slack
+```
+
+What it provisions, in order:
+
+1. **Namespace** `tutorial-aws/` with `custom_metadata.auto_auth_path=auth/jwt/`
+   — so the agent's bare-JWT discovery calls to `/v1/sys/*` get
+   implicit authentication.
+2. **JWT auth** pointed at Forgejo's Actions OIDC (the JWKS URL
+   discovered in §3 step 5), with `default_role=discovery-baseline`
+   as the fallback when the URL carries no role segment.
+3. **discovery-baseline role + policy** — read-only access on the four
+   `sys/*` paths the agent's discovery loop hits, scoped to the
+   tutorial repo by `bound_claims`.
+4. **AWS provider** enabled at `aws/`, configured with the
+   *mandatory* `auto_auth_path=auth/jwt/`:
+   ```bash
+   warden write aws/config auto_auth_path=auth/jwt/
+   ```
+   `proxy_domains` is left unset. Unlike Vault's provider where it
+   gates request forwarding, the AWS provider's `proxy_domains` is
+   consulted only by the S3 processors for virtual-hosted bucket URL
+   rewriting — and this tutorial uses no S3 calls.
+5. **One AWS credential source** `demo-aws-source` (type `aws`,
+   `mint_method` implicit) backed by the broker's access keys plus the
+   chosen region. Stored once in Warden; never enters the agent's
+   environment.
+6. **Five AWS credential specs**, each of type `aws_access_keys`
+   (inferred), with `mint_method=sts_assume_role` and a distinct
+   target IAM role ARN. At runtime, when the agent calls Warden under
+   `iam-reader`, Warden uses the broker keys to `sts:AssumeRole` on
+   `tutorial-iam-reader-role`, gets 1-hour temporary credentials,
+   resigns the request, and forwards. Each call therefore lands at
+   AWS as a *narrow, temporary, lens-specific* identity:
+   ```bash
+   warden cred spec create iam-reader-spec --source demo-aws-source \
+       --config mint_method=sts_assume_role \
+       --config role_arn="$WARDEN_AWS_ROLE_IAM_READER_ARN" \
+       --config session_name=warden-iam-reader \
+       --config ttl=1h
+   # ...repeated for cloudtrail-reader-spec, access-analyzer-reader-spec,
+   # policy-simulator-spec, securityhub-writer-spec.
+   ```
+7. **Five active AWS Warden roles**, each bound to one spec. Role
+   descriptions are dense and operator-set — the agent reads them
+   verbatim from `warden role list` and matches each one to a lens by
+   what data it can access, what region's resources it covers (for
+   regional services), and what it is *not* for. The call-shape
+   contract (env vars, URL pattern) is *not* in the role description
+   — it lives in the AWS provider's skill (`warden skill read aws`):
+   - **`iam-reader`** — read-only IAM inventory (global service)
+   - **`cloudtrail-reader`** — CloudTrail `LookupEvents` in the
+     chosen region
+   - **`access-analyzer-reader`** — Access Analyzer
+     `ListAnalyzers`/`ListFindings` in the chosen region
+   - **`policy-simulator-runner`** — IAM `SimulatePrincipalPolicy`
+     (global service, dry-run effective access)
+   - **`securityhub-writer`** — `securityhub:BatchImportFindings`
+     in the chosen region; ingest only
+8. **Three AWS decoy roles** — `iam-admin`, `securityhub-admin`,
+   `account-root-bridge`. Same JWT identity as the active roles,
+   descriptions that explicitly warn they are destructive or
+   break-glass, and **no `cred_spec_name`**. Invoking one fails at
+   credential minting before any AWS call leaves Warden. Decoys exist
+   for the agent to read and *reject* by description — they prove that
+   the picker is description-driven, not provider-typed.
+9. **One AWS access policy** `aws-gateway-access`, attached to all
+   five active AWS roles. It is uniform across roles because Warden's
+   AWS gateway cannot distinguish SigV4 service or action at the
+   policy layer (the AWS provider does not set `ParseStreamBody`).
+   The capability list mirrors what the AWS API actually uses — `read`
+   for GETs, `create` for POSTs, `list` for paginated `?list=true`
+   GETs:
+   ```hcl
+   path "aws/gateway"   { capabilities = ["read", "create", "list"] }
+   path "aws/gateway/*" { capabilities = ["read", "create", "list"] }
+   ```
+   Per-lens least-privilege is enforced *at AWS*, not by this policy.
+10. **Slack provider** (only when `--slack-token` is given) plus its
+    source, spec, the active `hygiene-poster` role (channel embedded
+    in the description), and a `slack-hygiene-poster` policy granting
+    `create` on the Slack Web API methods the agent will call. A
+    `alert-poster` decoy role is added without a spec.
+
+### 5c. Sanity-check the wiring
+
+In the admin shell, read the Warden config back:
+
+```bash
+export WARDEN_NAMESPACE=tutorial-aws
+warden role list -F name,description
+warden provider list -F type,description,mount_url
+warden policy read aws-gateway-access
+warden cred source read demo-aws-source
+warden cred spec read iam-reader-spec
+```
+
+You should see ten roles (`discovery-baseline` + 5 active AWS + 3 decoy
+AWS + `hygiene-poster` if Slack is on + `alert-poster` decoy if Slack
+is on), two provider mounts (`aws` and `slack` if enabled), and the
+two-line gateway policy above. Decoy roles show empty `cred_spec_name`
+fields — that is intentional; they fail at credential minting if the
+agent picks them.
+
+AWS-side trust smoke test — confirm the broker user can actually
+assume each of the five IAM roles before any agent runs. This uses
+the broker keys directly, bypassing Warden, to isolate the
+IAM-trust-policy half of the chain:
+
+```bash
+. aws-out/creds.env
+
+for arn in "$WARDEN_AWS_ROLE_IAM_READER_ARN" \
+           "$WARDEN_AWS_ROLE_CLOUDTRAIL_READER_ARN" \
+           "$WARDEN_AWS_ROLE_ACCESS_ANALYZER_ARN" \
+           "$WARDEN_AWS_ROLE_POLICY_SIMULATOR_ARN" \
+           "$WARDEN_AWS_ROLE_SECURITYHUB_WRITER_ARN"; do
+  AWS_ACCESS_KEY_ID="$WARDEN_AWS_BROKER_ACCESS_KEY_ID" \
+  AWS_SECRET_ACCESS_KEY="$WARDEN_AWS_BROKER_SECRET_ACCESS_KEY" \
+  aws sts assume-role \
+    --role-arn "$arn" \
+    --role-session-name "smoke-$(basename "$arn")" \
+    --query 'AssumedRoleUser.Arn' --output text
+done
+```
+
+Each line should print an `arn:aws:sts::<account>:assumed-role/...`
+identity matching the corresponding role. If a role's trust policy or
+the broker's `sts:AssumeRole` policy is wrong, the call fails — fix
+`aws-init.sh` or re-run with `--rotate-key`.
+
+The end-to-end Warden → AWS test (which requires a Forgejo-signed JWT)
+runs as part of PR 3's first agent invocation.
+
 ---
 
-> The remaining sections — Warden dev-mode startup (§4), namespace and
-> provider wiring (§5), the within-provider role-switching narrative (§6),
-> Goose's discovery loop (§7), the recipe (§8), the Forgejo Actions
-> workflow (§9), the audit-log walkthrough (§10), and production / cleanup
-> / next steps (§11–13) — arrive in follow-up PRs.
+> The remaining sections — the within-provider role-switching narrative
+> (§6), Goose's discovery loop (§7), the recipe (§8), the Forgejo Actions
+> workflow (§9), the audit-log walkthrough (§10), and production /
+> cleanup / next steps (§11–13) — arrive in follow-up PRs.

--- a/docs/tutorials/aws-access-hygiene/aws-init.sh
+++ b/docs/tutorials/aws-access-hygiene/aws-init.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Idempotent AWS-side bootstrap for the aws-access-hygiene tutorial.
+#
+# Provisions, in the reader's sandbox AWS account:
+#   1. One broker IAM user (default: warden-aws-tutorial-broker) whose
+#      only permission is sts:AssumeRole on the five role ARNs below.
+#      Its long-lived access keys are what Warden holds. The keys cannot
+#      be used to do anything operational on their own.
+#   2. Five IAM roles, each with a trust policy admitting only the broker
+#      user as a principal and a narrow inline permissions policy
+#      matching its purpose:
+#        tutorial-iam-reader-role          → iam:Get*, iam:List*
+#        tutorial-cloudtrail-reader-role   → cloudtrail:LookupEvents,
+#                                            cloudtrail:Describe*
+#        tutorial-access-analyzer-role     → access-analyzer:Get*,
+#                                            access-analyzer:List*
+#        tutorial-policy-simulator-role    → iam:SimulatePrincipalPolicy
+#        tutorial-securityhub-writer-role  → securityhub:BatchImportFindings
+#   3. Writes the broker access keys and the five role ARNs to
+#      aws-out/creds.env, which warden-init.sh sources.
+#
+# Idempotent: re-running with the same name prefix is safe. Existing
+# users/roles/policies are left alone; missing pieces are created. The
+# broker access key is rotated only when --rotate-key is passed
+# (otherwise existing keys are preserved).
+#
+# Requires:
+#   - aws CLI v2, logged in as a principal that can create IAM users/roles
+#     and access keys in the chosen sandbox account.
+#   - jq (used for trust-policy JSON construction).
+#
+# Usage:
+#   ./aws-init.sh
+#   ./aws-init.sh --account-id=123456789012 --name-prefix=tutorial
+#   ./aws-init.sh --rotate-key      # forces a new access key
+set -euo pipefail
+
+ACCOUNT_ID=""
+NAME_PREFIX="tutorial"
+BROKER_NAME="warden-aws-tutorial-broker"
+REGION="us-east-1"
+ROTATE_KEY="false"
+
+for arg in "$@"; do
+  case $arg in
+    --account-id=*)   ACCOUNT_ID="${arg#--account-id=}" ;;
+    --name-prefix=*)  NAME_PREFIX="${arg#--name-prefix=}" ;;
+    --broker-name=*)  BROKER_NAME="${arg#--broker-name=}" ;;
+    --region=*)       REGION="${arg#--region=}" ;;
+    --rotate-key)     ROTATE_KEY="true" ;;
+    *) echo "unknown arg: $arg" >&2; exit 1 ;;
+  esac
+done
+
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI not found" >&2; exit 1; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq not found" >&2; exit 1; }
+
+if [ -z "$ACCOUNT_ID" ]; then
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+fi
+
+BROKER_ARN="arn:aws:iam::${ACCOUNT_ID}:user/${BROKER_NAME}"
+ROLE_IAM_READER="${NAME_PREFIX}-iam-reader-role"
+ROLE_CLOUDTRAIL_READER="${NAME_PREFIX}-cloudtrail-reader-role"
+ROLE_ACCESS_ANALYZER="${NAME_PREFIX}-access-analyzer-role"
+ROLE_POLICY_SIMULATOR="${NAME_PREFIX}-policy-simulator-role"
+ROLE_SECURITYHUB_WRITER="${NAME_PREFIX}-securityhub-writer-role"
+
+ROLE_NAMES=(
+  "$ROLE_IAM_READER"
+  "$ROLE_CLOUDTRAIL_READER"
+  "$ROLE_ACCESS_ANALYZER"
+  "$ROLE_POLICY_SIMULATOR"
+  "$ROLE_SECURITYHUB_WRITER"
+)
+
+# 1. Broker IAM user.
+if aws iam get-user --user-name "$BROKER_NAME" >/dev/null 2>&1; then
+  echo "aws-init: broker user '$BROKER_NAME' already exists"
+else
+  aws iam create-user --user-name "$BROKER_NAME" >/dev/null
+  echo "aws-init: created broker user '$BROKER_NAME'"
+fi
+
+# 2. Five IAM roles, each trusting only the broker user.
+#
+# Why a fresh trust policy per role rather than a shared assume-role
+# principal: each role's trust statement names the broker by ARN, so if
+# the broker is ever recreated under a different account or path,
+# updating the trust policies is the single point of change.
+TRUST_POLICY=$(jq -n --arg arn "$BROKER_ARN" '{
+  Version: "2012-10-17",
+  Statement: [{
+    Effect: "Allow",
+    Principal: { AWS: $arn },
+    Action: "sts:AssumeRole"
+  }]
+}')
+
+create_or_update_role () {
+  local role_name="$1"
+  if aws iam get-role --role-name "$role_name" >/dev/null 2>&1; then
+    aws iam update-assume-role-policy \
+      --role-name "$role_name" \
+      --policy-document "$TRUST_POLICY" >/dev/null
+    echo "aws-init: refreshed trust policy on role '$role_name'"
+  else
+    aws iam create-role \
+      --role-name "$role_name" \
+      --assume-role-policy-document "$TRUST_POLICY" \
+      --description "Warden tutorial — narrowly-scoped role assumed via the broker user" \
+      >/dev/null
+    echo "aws-init: created role '$role_name'"
+  fi
+}
+
+# Inline permission policies — each one names exactly the AWS actions
+# that role's lens needs and nothing else. These are the AWS-layer
+# enforcement of the read/write split: SecurityHub:BatchImportFindings is
+# reachable only from the writer role; everything else is read-only.
+PERMS_IAM_READER='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iam:Get*", "iam:List*"],
+    "Resource": "*"
+  }]
+}'
+
+PERMS_CLOUDTRAIL_READER='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["cloudtrail:LookupEvents", "cloudtrail:Describe*", "cloudtrail:Get*"],
+    "Resource": "*"
+  }]
+}'
+
+PERMS_ACCESS_ANALYZER='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["access-analyzer:Get*", "access-analyzer:List*"],
+    "Resource": "*"
+  }]
+}'
+
+PERMS_POLICY_SIMULATOR='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iam:SimulatePrincipalPolicy"],
+    "Resource": "*"
+  }]
+}'
+
+PERMS_SECURITYHUB_WRITER='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["securityhub:BatchImportFindings"],
+    "Resource": "*"
+  }]
+}'
+
+attach_inline_policy () {
+  local role_name="$1"
+  local policy_name="$2"
+  local policy_doc="$3"
+  aws iam put-role-policy \
+    --role-name "$role_name" \
+    --policy-name "$policy_name" \
+    --policy-document "$policy_doc" >/dev/null
+  echo "aws-init: attached inline policy '$policy_name' to role '$role_name'"
+}
+
+for role in "${ROLE_NAMES[@]}"; do
+  create_or_update_role "$role"
+done
+
+attach_inline_policy "$ROLE_IAM_READER"          "iam-read-only"           "$PERMS_IAM_READER"
+attach_inline_policy "$ROLE_CLOUDTRAIL_READER"   "cloudtrail-read-only"    "$PERMS_CLOUDTRAIL_READER"
+attach_inline_policy "$ROLE_ACCESS_ANALYZER"     "access-analyzer-read"    "$PERMS_ACCESS_ANALYZER"
+attach_inline_policy "$ROLE_POLICY_SIMULATOR"    "policy-simulator-read"   "$PERMS_POLICY_SIMULATOR"
+attach_inline_policy "$ROLE_SECURITYHUB_WRITER"  "securityhub-batch-write" "$PERMS_SECURITYHUB_WRITER"
+
+# 3. Broker user policy — sts:AssumeRole on exactly those five role ARNs.
+#
+# No wildcards, no other actions. The broker cannot escalate.
+BROKER_POLICY=$(jq -n \
+  --arg r1 "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_IAM_READER}" \
+  --arg r2 "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_CLOUDTRAIL_READER}" \
+  --arg r3 "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_ACCESS_ANALYZER}" \
+  --arg r4 "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_POLICY_SIMULATOR}" \
+  --arg r5 "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_SECURITYHUB_WRITER}" \
+  '{
+    Version: "2012-10-17",
+    Statement: [{
+      Effect: "Allow",
+      Action: "sts:AssumeRole",
+      Resource: [$r1, $r2, $r3, $r4, $r5]
+    }]
+  }')
+
+aws iam put-user-policy \
+  --user-name "$BROKER_NAME" \
+  --policy-name "assume-tutorial-roles" \
+  --policy-document "$BROKER_POLICY" >/dev/null
+echo "aws-init: attached AssumeRole policy to broker user"
+
+# 4. Broker access key.
+#
+# IAM users can hold at most two active access keys. If --rotate-key was
+# given we delete the existing key(s) before creating a new one.
+# Otherwise: if exactly one key already exists we keep it (and emit
+# creds.env with a placeholder note), and if zero exist we create one.
+ACCESS_KEY_FILE="aws-out/access-key.json"
+mkdir -p aws-out
+
+current_key_count=$(aws iam list-access-keys --user-name "$BROKER_NAME" \
+  --query 'length(AccessKeyMetadata)' --output text)
+
+if [ "$ROTATE_KEY" = "true" ] && [ "$current_key_count" -gt 0 ]; then
+  for k in $(aws iam list-access-keys --user-name "$BROKER_NAME" \
+        --query 'AccessKeyMetadata[].AccessKeyId' --output text); do
+    aws iam delete-access-key --user-name "$BROKER_NAME" --access-key-id "$k" >/dev/null
+    echo "aws-init: rotated out access key '$k'"
+  done
+  current_key_count=0
+fi
+
+if [ "$current_key_count" -eq 0 ]; then
+  aws iam create-access-key --user-name "$BROKER_NAME" > "$ACCESS_KEY_FILE"
+  ACCESS_KEY_ID=$(jq -r '.AccessKey.AccessKeyId'     "$ACCESS_KEY_FILE")
+  SECRET_ACCESS_KEY=$(jq -r '.AccessKey.SecretAccessKey' "$ACCESS_KEY_FILE")
+  echo "aws-init: created new access key (saved to $ACCESS_KEY_FILE)"
+elif [ -f "$ACCESS_KEY_FILE" ]; then
+  ACCESS_KEY_ID=$(jq -r '.AccessKey.AccessKeyId'     "$ACCESS_KEY_FILE")
+  SECRET_ACCESS_KEY=$(jq -r '.AccessKey.SecretAccessKey' "$ACCESS_KEY_FILE")
+  echo "aws-init: reusing access key from $ACCESS_KEY_FILE"
+else
+  cat >&2 <<MSG
+aws-init: broker user has an existing access key but $ACCESS_KEY_FILE
+is missing. AWS does not let you re-read a secret access key after
+creation. Re-run with --rotate-key to drop the orphan key and mint a
+fresh one, or restore $ACCESS_KEY_FILE from a backup if you have one.
+MSG
+  exit 1
+fi
+
+# 5. Emit creds.env for warden-init.sh.
+cat > aws-out/creds.env <<EOF
+# Generated by aws-init.sh — sourced by warden-init.sh.
+# Treat as a secret: it contains the broker IAM user's static credentials.
+WARDEN_AWS_ACCOUNT_ID=${ACCOUNT_ID}
+WARDEN_AWS_REGION=${REGION}
+WARDEN_AWS_BROKER_NAME=${BROKER_NAME}
+WARDEN_AWS_BROKER_ACCESS_KEY_ID=${ACCESS_KEY_ID}
+WARDEN_AWS_BROKER_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}
+
+WARDEN_AWS_ROLE_IAM_READER_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_IAM_READER}
+WARDEN_AWS_ROLE_CLOUDTRAIL_READER_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_CLOUDTRAIL_READER}
+WARDEN_AWS_ROLE_ACCESS_ANALYZER_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_ACCESS_ANALYZER}
+WARDEN_AWS_ROLE_POLICY_SIMULATOR_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_POLICY_SIMULATOR}
+WARDEN_AWS_ROLE_SECURITYHUB_WRITER_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_SECURITYHUB_WRITER}
+EOF
+
+chmod 600 aws-out/creds.env
+echo "aws-init: wrote aws-out/creds.env"
+echo "aws-init: done. Run warden-init.sh next."

--- a/docs/tutorials/aws-access-hygiene/warden-init.sh
+++ b/docs/tutorials/aws-access-hygiene/warden-init.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Idempotent Warden bootstrap for the aws-access-hygiene tutorial.
+#
+# What this provisions, all under the `tutorial-aws/` namespace:
+#   1. Namespace `tutorial-aws/` with custom_metadata.auto_auth_path=jwt/
+#      so bare-JWT calls to /v1/sys/* (introspect, provider list,
+#      skill read) get implicit authentication.
+#   2. JWT auth method pointed at Forgejo's Actions OIDC, with
+#      default_role=discovery-baseline as the fallback for /v1/sys/*.
+#   3. discovery-baseline role + policy — read-only on the four sys/*
+#      paths the agent's discovery loop needs.
+#   4. AWS provider + 1 source (the broker IAM user's keys produced by
+#      aws-init.sh) + 5 sts_assume_role credential specs (one per active
+#      Warden role, each targeting a distinct narrowly-scoped IAM role).
+#      The 3 AWS decoy roles deliberately have no credential spec, so
+#      invoking one fails at credential minting.
+#   5. Slack provider (optional, --slack-token=...) + 1 source + 1 spec
+#      for the canvas-posting role; 1 decoy without a spec.
+#   6. Per-role access policies. The AWS policy is uniform across all
+#      five active AWS roles: read/create/list on path "aws/gateway" and
+#      "aws/gateway/*" — Warden's AWS gateway cannot inspect SigV4
+#      service/action at the policy layer, so per-lens least-privilege is
+#      enforced AWS-side via the AssumeRole + IAM-role-policy chain.
+#
+# Requires:
+#   - WARDEN_ADDR + WARDEN_TOKEN exported (admin shell from section 4).
+#   - aws-out/creds.env populated by aws-init.sh.
+#
+# Usage:
+#   ./warden-init.sh
+#   ./warden-init.sh --slack-token=xoxb-... \
+#                    --slack-channel-id=C0XXXXXXX \
+#                    --slack-channel-name='#access-audits' \
+#                    --repo=siteowner/aws-access-hygiene
+#
+# --slack-token is optional; without it the Slack provider/role/spec
+# are skipped (the agent will fail the canvas post but Goose's audit
+# still produces Security Hub findings).
+set -euo pipefail
+
+SLACK_TOKEN="${SLACK_TOKEN:-}"
+SLACK_CHANNEL_ID="${SLACK_CHANNEL_ID:-}"
+SLACK_CHANNEL_NAME="${SLACK_CHANNEL_NAME:-}"
+REPO="siteowner/aws-access-hygiene"
+
+for arg in "$@"; do
+  case $arg in
+    --slack-token=*)         SLACK_TOKEN="${arg#--slack-token=}" ;;
+    --slack-channel-id=*)    SLACK_CHANNEL_ID="${arg#--slack-channel-id=}" ;;
+    --slack-channel-name=*)  SLACK_CHANNEL_NAME="${arg#--slack-channel-name=}" ;;
+    --repo=*)                REPO="${arg#--repo=}" ;;
+    *) echo "unknown arg: $arg" >&2; exit 1 ;;
+  esac
+done
+
+if [ -n "$SLACK_TOKEN" ] && { [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$SLACK_CHANNEL_NAME" ]; }; then
+  echo "ERROR: --slack-token requires --slack-channel-id=C... and --slack-channel-name=#..." >&2
+  exit 1
+fi
+
+if [ ! -f aws-out/creds.env ]; then
+  echo "ERROR: aws-out/creds.env missing — run ./aws-init.sh first" >&2
+  exit 1
+fi
+. ./aws-out/creds.env
+
+WARDEN="${WARDEN:-warden}"
+command -v "$WARDEN" >/dev/null 2>&1 || { [ -x ./warden ] && WARDEN=./warden; } \
+  || { echo "ERROR: warden binary not found. Set WARDEN=/path/to/warden" >&2; exit 1; }
+
+BOUND_CLAIMS_FULL=$(printf '{"repository":"%s","ref":"refs/heads/main","ref_type":"branch"}' "$REPO")
+BOUND_CLAIMS_REPO=$(printf '{"repository":"%s"}' "$REPO")
+
+# 5a. Create the tutorial-aws namespace.
+#
+# The discovery loop hits /v1/sys/* as a bare JWT (no Warden session,
+# no role segment in the URL). auto_auth_path tells Warden which auth
+# mount to resolve those calls against.
+$WARDEN namespace create tutorial-aws --metadata=auto_auth_path=auth/jwt/ 2>/dev/null || true
+export WARDEN_NAMESPACE=tutorial-aws
+
+# 5b. JWT auth pointed at Forgejo's Actions OIDC.
+$WARDEN auth enable --type=jwt 2>/dev/null || true
+$WARDEN write auth/jwt/config \
+    mode=jwt \
+    jwks_url=http://forgejo.local:3000/api/actions/.well-known/keys \
+    bound_issuer=http://forgejo.local:3000/api/actions \
+    default_audience=http://warden.local \
+    default_role=discovery-baseline
+
+# 5c. discovery-baseline role + policy.
+$WARDEN write auth/jwt/role/discovery-baseline \
+    description="Baseline namespace identity for any authenticated agent. Grants read on sys/introspect/roles, sys/providers, and sys/skills/*. No upstream credentials are minted by this role." \
+    bound_audiences=http://warden.local \
+    bound_claims="$BOUND_CLAIMS_REPO" \
+    user_claim=sub
+
+cat > /tmp/aws-tut-discovery-baseline.hcl <<'EOF'
+# `warden provider list` and `warden skill list` send GET ?warden-list=true,
+# which Warden classifies as LIST (not READ). The discovery loop needs
+# both: `list` for the listings, `read` for per-record reads.
+path "sys/introspect/roles" { capabilities = ["read"] }
+path "sys/providers"        { capabilities = ["read", "list"] }
+path "sys/providers/*"      { capabilities = ["read"] }
+path "sys/skills"           { capabilities = ["read", "list"] }
+path "sys/skills/*"         { capabilities = ["read"] }
+EOF
+$WARDEN policy write discovery-baseline /tmp/aws-tut-discovery-baseline.hcl
+
+$WARDEN write auth/jwt/role/discovery-baseline \
+    token_policies=discovery-baseline
+
+# 5d. AWS provider, one source, five AssumeRole specs.
+#
+# auto_auth_path is REQUIRED on the AWS provider's config — unlike the
+# vault provider where it's optional metadata. proxy_domains is not set
+# here: it is only consulted by the S3 processors for virtual-hosted
+# bucket URL rewriting, and this tutorial uses no S3 calls.
+$WARDEN provider enable --type=aws \
+    --description="AWS sandbox account proxied via the warden-aws-tutorial-broker IAM user — five lenses for IAM/CloudTrail/AccessAnalyzer/PolicySimulator/SecurityHub" \
+    aws 2>/dev/null || true
+$WARDEN write aws/config \
+    auto_auth_path=auth/jwt/
+
+# Order matters: drop specs before source (specs reference source).
+for spec in iam-reader-spec cloudtrail-reader-spec access-analyzer-reader-spec policy-simulator-spec securityhub-writer-spec; do
+  $WARDEN cred spec delete -f "$spec" 2>/dev/null || true
+done
+$WARDEN cred source delete -f demo-aws-source 2>/dev/null || true
+
+$WARDEN cred source create demo-aws-source --type=aws \
+    --rotation-period=0 \
+    --config=access_key_id="$WARDEN_AWS_BROKER_ACCESS_KEY_ID" \
+    --config=secret_access_key="$WARDEN_AWS_BROKER_SECRET_ACCESS_KEY" \
+    --config=region="$WARDEN_AWS_REGION"
+
+# Five specs, one per active Warden role. The source is shared; the
+# differentiator is the target IAM role ARN each spec assumes.
+$WARDEN cred spec create iam-reader-spec --source demo-aws-source \
+    --config mint_method=sts_assume_role \
+    --config role_arn="$WARDEN_AWS_ROLE_IAM_READER_ARN" \
+    --config session_name=warden-iam-reader \
+    --config ttl=1h
+
+$WARDEN cred spec create cloudtrail-reader-spec --source demo-aws-source \
+    --config mint_method=sts_assume_role \
+    --config role_arn="$WARDEN_AWS_ROLE_CLOUDTRAIL_READER_ARN" \
+    --config session_name=warden-cloudtrail-reader \
+    --config ttl=1h
+
+$WARDEN cred spec create access-analyzer-reader-spec --source demo-aws-source \
+    --config mint_method=sts_assume_role \
+    --config role_arn="$WARDEN_AWS_ROLE_ACCESS_ANALYZER_ARN" \
+    --config session_name=warden-access-analyzer \
+    --config ttl=1h
+
+$WARDEN cred spec create policy-simulator-spec --source demo-aws-source \
+    --config mint_method=sts_assume_role \
+    --config role_arn="$WARDEN_AWS_ROLE_POLICY_SIMULATOR_ARN" \
+    --config session_name=warden-policy-simulator \
+    --config ttl=1h
+
+$WARDEN cred spec create securityhub-writer-spec --source demo-aws-source \
+    --config mint_method=sts_assume_role \
+    --config role_arn="$WARDEN_AWS_ROLE_SECURITYHUB_WRITER_ARN" \
+    --config session_name=warden-securityhub-writer \
+    --config ttl=1h
+
+# Five active Warden roles — each pointing at one spec. Descriptions
+# carry what the agent needs to pick the right role per lens: what data
+# it can access, what region's resources it covers, and what it is NOT
+# for. The call-shape contract (env vars, URL pattern) lives in the AWS
+# provider skill (warden skill read aws), not here.
+$WARDEN write auth/jwt/role/iam-reader \
+    description="Read-only IAM inventory: list roles, users, groups; read attached/inline policy documents, trust policies, and last-accessed data. IAM is a global service — applies account-wide. Not for STS AssumeRole into other accounts, not for IAM writes, not for CloudTrail or Access Analyzer." \
+    bound_claims="$BOUND_CLAIMS_FULL" \
+    cred_spec_name=iam-reader-spec \
+    token_policies=aws-gateway-access
+
+$WARDEN write auth/jwt/role/cloudtrail-reader \
+    description="Read CloudTrail management-event history via LookupEvents in region ${WARDEN_AWS_REGION}. Not for trail configuration, not for data events, not for IAM data or Access Analyzer. Use when correlating IAM principals with actual API usage windows." \
+    bound_claims="$BOUND_CLAIMS_FULL" \
+    cred_spec_name=cloudtrail-reader-spec \
+    token_policies=aws-gateway-access
+
+$WARDEN write auth/jwt/role/access-analyzer-reader \
+    description="Read IAM Access Analyzer external-trust findings (ListAnalyzers, ListFindings) in region ${WARDEN_AWS_REGION}. Not for archiving or resolving findings, not for analyzer configuration. Use when surfacing trust policies that allow external accounts or anonymous principals." \
+    bound_claims="$BOUND_CLAIMS_FULL" \
+    cred_spec_name=access-analyzer-reader-spec \
+    token_policies=aws-gateway-access
+
+$WARDEN write auth/jwt/role/policy-simulator-runner \
+    description="Run IAM policy simulator (SimulatePrincipalPolicy) — read-only dry-run of effective access. IAM simulator is a global service — applies account-wide. Not for IAM data inventory or for live calls; use only to verify what a principal could do, not what it has done." \
+    bound_claims="$BOUND_CLAIMS_FULL" \
+    cred_spec_name=policy-simulator-spec \
+    token_policies=aws-gateway-access
+
+$WARDEN write auth/jwt/role/securityhub-writer \
+    description="Write structured findings into AWS Security Hub via BatchImportFindings in region ${WARDEN_AWS_REGION}. Cannot read findings, cannot disable controls, cannot delete; ingest only. Use only after audit analysis is complete and findings are formatted to ASFF. Not for read-side audit work." \
+    bound_claims="$BOUND_CLAIMS_FULL" \
+    cred_spec_name=securityhub-writer-spec \
+    token_policies=aws-gateway-access
+
+# Three AWS decoy roles — same JWT identity, descriptions that warn off,
+# and NO cred_spec_name so invocation fails at credential minting before
+# any AWS call leaves Warden. They exist for the agent to read and
+# reject by description: proof that the picker is description-driven,
+# not provider-typed.
+$WARDEN write auth/jwt/role/iam-admin \
+    description="Administer IAM: create/delete principals, attach/detach policies, rotate access keys. Destructive scope; do not pick for any audit, simulator, or finding-publication task." \
+    bound_claims="$BOUND_CLAIMS_REPO" \
+    token_policies=discovery-baseline \
+    user_claim=sub
+
+$WARDEN write auth/jwt/role/securityhub-admin \
+    description="Administer Security Hub: enable/disable controls, manage insights, delete findings, configure subscriptions. Destructive; do not pick for finding-import-only tasks." \
+    bound_claims="$BOUND_CLAIMS_REPO" \
+    token_policies=discovery-baseline \
+    user_claim=sub
+
+$WARDEN write auth/jwt/role/account-root-bridge \
+    description="Bridge to root-account-level operations via STS AssumeRole into the management account. Break-glass only; do not pick for routine audits or read-only inventory." \
+    bound_claims="$BOUND_CLAIMS_REPO" \
+    token_policies=discovery-baseline \
+    user_claim=sub
+
+# Access policy for the AWS gateway. One policy, attached to all five
+# active AWS roles. It is identical across roles because Warden's AWS
+# gateway cannot distinguish service/action at the policy layer (no
+# ParseStreamBody on the aws provider). Per-lens least-privilege lives
+# at the AssumeRole + IAM-role-policy layer, set up by aws-init.sh.
+cat > /tmp/aws-tut-aws-gateway-access.hcl <<'EOF'
+# AWS uses both GET (read) and POST (create) extensively, and warden
+# classifies paginated GET ?list=true as LIST. Grant all three on the
+# gateway path; service/action scoping is AWS-side via the assumed role.
+path "aws/gateway"   { capabilities = ["read", "create", "list"] }
+path "aws/gateway/*" { capabilities = ["read", "create", "list"] }
+EOF
+$WARDEN policy write aws-gateway-access /tmp/aws-tut-aws-gateway-access.hcl
+
+# 5e. Slack provider (optional).
+if [ -n "$SLACK_TOKEN" ]; then
+  $WARDEN provider enable --type=slack \
+      --description="Slack workspace for access-audit canvas reports — channel embedded in the hygiene-poster role description" \
+      slack 2>/dev/null || true
+  $WARDEN write slack/config slack_url=https://slack.com/api auto_auth_path=auth/jwt/
+
+  $WARDEN cred spec delete -f hygiene-poster-spec 2>/dev/null || true
+  $WARDEN cred source delete -f demo-slack-source 2>/dev/null || true
+  $WARDEN cred source create demo-slack-source --type=apikey \
+      --rotation-period=0 \
+      --config=api_url=https://slack.com/api \
+      --config=verify_endpoint=/auth.test \
+      --config=verify_method=POST
+  $WARDEN cred spec create hygiene-poster-spec --source demo-slack-source \
+      --config api_key="$SLACK_TOKEN"
+
+  $WARDEN write auth/jwt/role/hygiene-poster \
+      description="Post hygiene canvases to ${SLACK_CHANNEL_NAME} (${SLACK_CHANNEL_ID}) via the Slack provider at /v1/tutorial-aws/slack/. Canvas create/update + one-line notify. Not for alerts or incident dispatch." \
+      bound_claims="$BOUND_CLAIMS_FULL" \
+      cred_spec_name=hygiene-poster-spec \
+      token_policies=slack-hygiene-poster
+
+  cat > /tmp/aws-tut-slack-hygiene-poster.hcl <<'EOF'
+# Slack Web API is all POST, so every method maps to the create capability.
+path "slack/role/hygiene-poster/gateway/conversations.info"            { capabilities = ["create"] }
+path "slack/role/hygiene-poster/gateway/conversations.canvases.create" { capabilities = ["create"] }
+path "slack/role/hygiene-poster/gateway/canvases.create"               { capabilities = ["create"] }
+path "slack/role/hygiene-poster/gateway/canvases.edit"                 { capabilities = ["create"] }
+path "slack/role/hygiene-poster/gateway/canvases.delete"               { capabilities = ["create"] }
+path "slack/role/hygiene-poster/gateway/chat.postMessage"              { capabilities = ["create"] }
+path "slack/role/hygiene-poster/gateway/auth.test"                     { capabilities = ["create"] }
+EOF
+  $WARDEN policy write slack-hygiene-poster /tmp/aws-tut-slack-hygiene-poster.hcl
+
+  $WARDEN write auth/jwt/role/alert-poster \
+      description="Dispatch short alert pings to #ops-alerts via the Slack provider. One-line text messages only; not for canvases or hygiene reports." \
+      bound_claims="$BOUND_CLAIMS_REPO" \
+      token_policies=discovery-baseline \
+      user_claim=sub
+
+  echo "warden-init: section 5 complete (namespace=tutorial-aws, Slack delivery enabled)"
+else
+  echo "warden-init: section 5 complete (namespace=tutorial-aws, Slack delivery skipped — no --slack-token given)"
+fi


### PR DESCRIPTION
Second of four PRs delivering the tutorial. Adds the operator-side provisioning that makes per-call AWS role switching enforceable both at Warden and at AWS:

aws-init.sh — idempotent AWS-side bootstrap. Provisions one broker IAM user with sts:AssumeRole-only on five specific role ARNs, plus the five IAM roles each with a trust policy admitting only the broker and a narrow inline permissions policy (iam:Get*/List*, cloudtrail LookupEvents, access-analyzer Get*/List*, iam:SimulatePrincipalPolicy, securityhub:BatchImportFindings). Emits broker keys and role ARNs to aws-out/creds.env for warden-init.sh to source.

warden-init.sh — idempotent Warden-side bootstrap. Namespace, JWT auth pointed at Forgejo Actions OIDC, discovery-baseline role+policy, AWS provider with auto_auth_path (no proxy_domains — only S3 needs it), one source from the broker keys, five sts_assume_role specs (1h TTL each), five active AWS Warden roles, three decoy roles with no specs (invocation fails at credential minting), a uniform aws-gateway-access policy granting read/create/list on aws/gateway, and an optional Slack provider with hygiene-poster role + alert-poster decoy.

Per-lens least-privilege is enforced at AWS via the AssumeRole chain, not at Warden's policy layer — the AWS provider has no ParseStreamBody so Warden cannot constrain service/action.

README adds full §2 prereqs (AWS sandbox + Security Hub + AWS CLI v2), new §4 (start Warden in dev mode), and new §5 with subsections for each setup step including the trust-policy JSON template, role descriptions, the cred-source/spec layout, and an AWS-side trust smoke test using the broker keys directly (the end-to-end test needs a Forgejo JWT and lives in PR 3).