### PR TITLE
docs(tutorial): aws-access-hygiene — seed targets, Goose recipe, CI w…

### DIFF
--- a/docs/tutorials/aws-access-hygiene/.forgejo/workflows/access-audit.yaml
+++ b/docs/tutorials/aws-access-hygiene/.forgejo/workflows/access-audit.yaml
@@ -1,0 +1,120 @@
+name: access-audit
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+enable-openid-connect: true   # Forgejo's equivalent of GitHub's `permissions: id-token: write`
+
+jobs:
+  audit:
+    runs-on: docker
+    container:
+      image: node:20-bookworm-slim
+    env:
+      # Runtime contract (see docs/agent-flow.md §1):
+      #   WARDEN_ADDR + WARDEN_NAMESPACE + WARDEN_TOKEN bootstrap the agent.
+      #   Everything else (provider URLs, role names, Slack channel, AWS
+      #   account ID) is discovered at runtime via warden role list /
+      #   warden provider list / warden skill read <type>.
+      #
+      # ANTHROPIC_HOST is the one exception: Goose's own Anthropic SDK is
+      # configured by the runtime before the agent process starts, so the
+      # LLM leg is wired through Warden but not via the discovery loop.
+      WARDEN_ADDR:      http://host.docker.internal:8400
+      WARDEN_NAMESPACE: tutorial-aws
+      ANTHROPIC_HOST:   http://host.docker.internal:8400/v1/tutorial-aws/anthropic/role/anthropic-ops/gateway
+    steps:
+      - name: Install git (so actions/checkout uses git clone, not REST)
+        run: apt-get update && apt-get install -y --no-install-recommends git ca-certificates
+
+      - uses: actions/checkout@v4
+
+      - name: Install aws + goose + warden CLIs
+        run: |
+          set -euo pipefail
+          apt-get install -y --no-install-recommends curl jq bash bzip2 unzip libgomp1 libxcb1 libdbus-1-3
+          # AWS CLI uses the kernel arch name (aarch64); Warden release
+          # archives use the GOARCH name (arm64). Map both at once.
+          case "$(uname -m)" in
+            aarch64|arm64) AWS_ARCH=aarch64; WARDEN_ARCH=arm64  ;;
+            x86_64|amd64)  AWS_ARCH=x86_64;  WARDEN_ARCH=x86_64 ;;
+          esac
+          # AWS CLI v2 — needed for AWS_ENDPOINT_URL support and the SigV4
+          # idiom Warden's aws skill describes.
+          curl --retry 3 --retry-delay 5 -fsSL \
+            "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          /tmp/aws/install
+          # Goose pinned at v1.32.0 — see vault-policy-hygiene's notes on
+          # the v2 release-candidate situation; same constraint applies.
+          curl --retry 3 --retry-delay 5 -fsSL \
+            https://github.com/aaif-goose/goose/releases/download/v1.32.0/download_cli.sh \
+            | CONFIGURE=false bash
+          mv /root/.local/bin/goose /usr/local/bin/
+          # Warden CLI — used for the discovery loop.
+          curl --retry 3 --retry-delay 5 -fsSL \
+            "https://github.com/stephnangue/warden/releases/download/v0.13.2/warden_0.13.2_linux_${WARDEN_ARCH}.tar.gz" \
+            | tar xz -C /usr/local/bin warden
+
+      - name: Mint Warden JWT from Forgejo OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          RESPONSE=$(curl -sSL \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=http://warden.local")
+          WARDEN_JWT=$(echo "$RESPONSE" | jq -r .value)
+          if [ -z "$WARDEN_JWT" ] || [ "$WARDEN_JWT" = "null" ]; then
+            echo "Failed to mint JWT. OIDC response was:"
+            echo "$RESPONSE"
+            exit 1
+          fi
+          if [[ "$WARDEN_JWT" != eyJ* ]]; then
+            echo "JWT doesn't look like a JWT (got ${WARDEN_JWT:0:20}...)"
+            exit 1
+          fi
+          # Print claims (public — signed but not encrypted) so bound_claims mismatches are visible
+          PAYLOAD=$(echo "$WARDEN_JWT" | cut -d. -f2)
+          while [ $(( ${#PAYLOAD} % 4 )) -ne 0 ]; do PAYLOAD="${PAYLOAD}="; done
+          echo "JWT claims:"
+          echo "$PAYLOAD" | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
+          echo "::add-mask::$WARDEN_JWT"
+          echo "WARDEN_JWT=$WARDEN_JWT" >> $GITHUB_ENV
+
+      - name: Pre-flight discovery
+        # Confirms the runtime contract works end-to-end before burning
+        # LLM tokens: bare-JWT call to /v1/sys/* gets implicit auth via
+        # the namespace's auto_auth_path metadata + JWT default_role.
+        # If this step fails, the agent's first discovery call would
+        # too — surface it here with a clean error.
+        run: |
+          set -euo pipefail
+          export WARDEN_TOKEN="$WARDEN_JWT"
+          echo "--- roles assumable by this identity ---"
+          warden role list -o json -F name,description | jq .
+          echo "--- providers in the namespace (account-id and region are in descriptions) ---"
+          warden provider list -o json -F type,description,mount_url | jq .
+          echo "--- aws skill (head) ---"
+          warden skill read aws --raw | head -30
+
+      - name: Run Goose access-hygiene audit
+        env:
+          GOOSE_STREAM_TIMEOUT: "300"   # default 30s is too short for the structured output
+        run: |
+          export WARDEN_TOKEN="$WARDEN_JWT"
+          export ANTHROPIC_API_KEY="$WARDEN_JWT"
+          # --max-turns caps runaway loops. The audit has four read
+          # lenses, a synthesis step, a Security Hub publish, and a
+          # Slack canvas publish — plus discovery and skill reads.
+          # 100 leaves headroom; runs against the seed targets usually
+          # complete in ~50–70 turns.
+          goose run --debug --max-turns 100 --recipe access-hygiene.yaml
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: access-hygiene-output
+          path: |
+            findings.json
+            canvas.md

--- a/docs/tutorials/aws-access-hygiene/README.md
+++ b/docs/tutorials/aws-access-hygiene/README.md
@@ -1,6 +1,6 @@
 # AWS Access Hygiene Audit with Goose, the AWS CLI, and Warden
 
-> **Status:** operator setup is complete (Forgejo + runner stack and the AWS / Warden / Slack wiring); the Goose recipe, the CI workflow, the conceptual narrative, and the audit-log walkthrough arrive in follow-up PRs.
+> **Status:** runnable end-to-end (operator setup + the Goose recipe + the Forgejo Actions workflow). The conceptual narrative for §6 and the audit-log walkthrough for §10 arrive in the next PR.
 
 This tutorial stands up an AI agent that audits a sandbox AWS account's IAM
 through **four read-only lenses** — inventory, recent usage, external
@@ -75,10 +75,24 @@ the workflow, inspect Security Hub and Slack. Production is a URL swap.
   binary on PATH.
 - An AWS sandbox account and the **AWS CLI v2** authenticated as a
   principal that can create IAM users, IAM roles, and access keys. The
-  audit also calls Security Hub, so **Security Hub must be enabled in
-  the chosen region** (default `us-east-1`). The credentials you use to
-  run `aws-init.sh` are only used to bootstrap the broker; they never
-  enter Warden or the agent's environment.
+  audit also calls Security Hub and Access Analyzer, so both must be
+  enabled in the chosen region (default `us-east-1`):
+  ```bash
+  aws securityhub enable-security-hub
+  aws accessanalyzer create-analyzer \
+      --analyzer-name tutorial-analyzer --type ACCOUNT
+  ```
+  Access Analyzer findings for the seeded external-trust target may
+  take a few minutes to appear after `seed-aws.sh` runs. The
+  credentials you use here only bootstrap the broker user and the
+  audit targets; they never enter Warden or the agent's environment.
+- An API key for an Anthropic-compatible LLM endpoint, used by Goose
+  itself. The tutorial defaults to DeepSeek's Anthropic-compatible
+  endpoint (`https://api.deepseek.com/anthropic`). To switch to
+  Anthropic-proper, change `anthropic_url` in `warden-init.sh` §5e.
+  **The key goes into Warden's credential store, not into any CI
+  variable.** You paste it once during §5 (`--anthropic-key=...`)
+  and never again.
 - (Optional, for Slack delivery) A Slack workspace, a [bot user OAuth token](https://api.slack.com/authentication/token-types#bot)
   (`xoxb-...`) with the `canvases:write`, `channels:read`, and
   `chat:write` scopes, and a channel ID the bot is a member of. The
@@ -89,15 +103,16 @@ the workflow, inspect Security Hub and Slack. Production is a URL swap.
   delivery.
 
 The `aws`, `goose`, and `warden` CLIs are installed inside the Actions
-job's container in PR 3; you do not run them on the host beyond the
-operator setup steps below.
+job's container; you do not run them on the host beyond the operator
+setup steps below.
 
 ## 3. Bring up the stack with Docker Compose
 
 The files we'll use (`docker-compose.yml`, `forgejo-init.sh`,
-`aws-init.sh`, `warden-init.sh`) are alongside this README. Either `cd`
-into this folder to run them in place, or copy them to a fresh working
-directory.
+`aws-init.sh`, `warden-init.sh`, `seed-aws.sh`, `access-hygiene.yaml`,
+and `.forgejo/workflows/access-audit.yaml`) are alongside this README.
+Either `cd` into this folder to run them in place, or copy them to a
+fresh working directory.
 
 `docker-compose.yml` runs Forgejo, the Forgejo runner, and a one-shot
 init service that bootstraps the `siteowner` admin user:
@@ -321,11 +336,17 @@ With Warden running (§4) and `aws-out/creds.env` populated:
 
 ```bash
 chmod +x warden-init.sh
-./warden-init.sh                                                      # AWS only
-./warden-init.sh --slack-token=xoxb-... \
+./warden-init.sh --anthropic-key=sk-...                               # AWS + Anthropic only
+./warden-init.sh --anthropic-key=sk-... \
+                 --slack-token=xoxb-... \
                  --slack-channel-id=C0XXXXXXX \
                  --slack-channel-name='#access-audits'                # + Slack
 ```
+
+`--anthropic-key` is required — it's the LLM key Goose uses to drive
+the audit, held by Warden and proxied at runtime; it never enters
+the agent's environment. If you use Anthropic directly rather than
+DeepSeek, change `anthropic_url` in `warden-init.sh` §5e.
 
 What it provisions, in order:
 
@@ -402,7 +423,15 @@ What it provisions, in order:
    path "aws/gateway/*" { capabilities = ["read", "create", "list"] }
    ```
    Per-lens least-privilege is enforced *at AWS*, not by this policy.
-10. **Slack provider** (only when `--slack-token` is given) plus its
+10. **Anthropic provider** for Goose's LLM leg — `--type=anthropic`
+    against an Anthropic-compatible endpoint (DeepSeek by default).
+    One source (the key passed via `--anthropic-key`), one spec, and
+    an `anthropic-ops` role marked *Internal — used by Goose runtime,
+    not chosen by agents.* The workflow exports
+    `ANTHROPIC_HOST=$WARDEN_ADDR/v1/tutorial-aws/anthropic/role/anthropic-ops/gateway`
+    before starting Goose so the LLM round-trip flows through Warden
+    too.
+11. **Slack provider** (only when `--slack-token` is given) plus its
     source, spec, the active `hygiene-poster` role (channel embedded
     in the description), and a `slack-hygiene-poster` policy granting
     `create` on the Slack Web API methods the agent will call. A
@@ -456,11 +485,203 @@ the broker's `sts:AssumeRole` policy is wrong, the call fails — fix
 `aws-init.sh` or re-run with `--rotate-key`.
 
 The end-to-end Warden → AWS test (which requires a Forgejo-signed JWT)
-runs as part of PR 3's first agent invocation.
+runs as part of §9's first workflow invocation.
+
+### 5d. Seed AWS audit targets
+
+`seed-aws.sh` provisions five demo IAM roles in the same sandbox
+account that exhibit specific access-hygiene smells the audit will
+flag. These targets are deliberately distinct from the broker user and
+the five AssumeRole-backed roles `aws-init.sh` set up — the targets
+exist purely so the audit has something interesting to find:
+
+| Target role                                 | Smell                                              | Lens that flags it    |
+|---------------------------------------------|----------------------------------------------------|-----------------------|
+| `tutorial-target-clean-role`                | None — narrow read scope. Baseline for contrast.   | (no findings)         |
+| `tutorial-target-wildcard-role`             | Attached `iam:*` on `*`                            | inventory             |
+| `tutorial-target-stale-role`                | `LastUsed` is null (never assumed)                 | recent_usage          |
+| `tutorial-target-external-trust-role`       | Trust policy admits a non-self account             | external_exposure     |
+| `tutorial-target-under-described-role`      | Description says "read-only S3" but policy is `s3:*`| effective_access     |
+
+```bash
+chmod +x seed-aws.sh
+./seed-aws.sh                                              # default external account 999999999999
+./seed-aws.sh --external-account-id=222222222222           # or pick another
+./seed-aws.sh --teardown                                   # remove all five targets
+```
+
+Access Analyzer findings for the external-trust target typically
+appear within a few minutes of seeding; the analyzer was created in
+§2.
+
+## 6. The within-provider dimension: per-call role selection
+
+*(arrives in PR 4 — the conceptual narrative covering role-as-deterministic-intent, hallucination containment, and the read/write split)*
+
+## 7. How Goose discovers Warden
+
+Three workflow env vars bootstrap the agent:
+
+```
+WARDEN_ADDR=http://host.docker.internal:8400
+WARDEN_NAMESPACE=tutorial-aws
+WARDEN_TOKEN=<Forgejo-minted OIDC JWT, per workflow §9>
+```
+
+Everything else — the AWS account ID being audited, the region, the
+Slack channel for canvas delivery, the AssumeRole target each lens
+uses, even the names of the AWS lens roles — comes from Warden at
+runtime via three introspection calls the agent makes against
+`/v1/sys/*`. Those four `sys/*` paths are exactly what the
+`discovery-baseline` policy from §5c grants the agent.
+
+The agent's loop, per `docs/agent-flow.md`:
+
+1. **Read the bootstrap skills.**
+   ```bash
+   warden skill read foundation --raw   # the runtime contract: env vars, exit codes, list/raw flags
+   warden skill read discovery  --raw   # the 5-step loop itself
+   ```
+   These are seeded into every Warden cluster; the agent fetches
+   them on first run.
+
+2. **List the roles the JWT can assume in this namespace.**
+   ```bash
+   warden role list -o json -F name,description
+   ```
+   Returns the ten roles `warden-init.sh` provisioned —
+   `discovery-baseline` + 5 active AWS + 3 decoy AWS +
+   `hygiene-poster` (if Slack on) + `alert-poster` decoy. The agent
+   reads descriptions, not names: each active role's description
+   spells out which lens it serves, what region's data it covers,
+   and what it is *not* for. Decoys' descriptions explicitly warn
+   they are destructive — the agent rejects them.
+
+3. **List the providers mounted in the namespace.**
+   ```bash
+   warden provider list -o json -F type,description,mount_url
+   ```
+   Returns `aws` and (optionally) `slack` mounts. The AWS provider's
+   description embeds the audited **account ID** (set by `warden-init.sh`
+   from `WARDEN_AWS_ACCOUNT_ID`); the Slack role description embeds
+   the channel ID and name. The agent reads both straight from the
+   discovery output — no env var carries either, by design.
+
+4. **Fetch the provider skill for each provider it will use.**
+   ```bash
+   warden skill read aws --raw    # SigV4 env-var contract, gateway URL pattern, quirks
+   warden skill read slack --raw  # Slack Web API call shape
+   ```
+   The aws skill tells the agent that the role name goes in
+   `AWS_ACCESS_KEY_ID`, the JWT goes in `AWS_SECRET_ACCESS_KEY` and
+   `AWS_SESSION_TOKEN`, and the endpoint URL is composed from
+   `WARDEN_ADDR` plus the AWS provider's `mount_url`. The recipe in
+   §8 contains none of this — the agent reads it fresh.
+
+5. **Execute the audit.** Between AWS calls, the agent re-exports
+   `AWS_ACCESS_KEY_ID` with the next lens's role — a sequence
+   visible in §10's audit log walkthrough as distinct
+   `auth.role_name` values under one `auth.token_hmac`.
+
+The workflow runs a **pre-flight discovery** step (§9) that performs
+steps 1–4 outside of Goose, before any LLM tokens are spent. If
+discovery fails — a wrong issuer, a bad `bound_claims`, a missing
+namespace — the workflow surfaces it as a clean error rather than as
+a confused agent.
+
+## 8. The Goose recipe
+
+`access-hygiene.yaml` describes the task in pure semantics — four
+analytical lenses, severity logic, two deliverables — and **does not
+hardcode any Warden role names, provider URLs, or AWS env-var
+contracts**. It bootstraps the agent with one line pointing at the
+`foundation` and `discovery` skills; everything else the agent learns
+at runtime, per §7.
+
+The four lenses (full definitions in the recipe):
+
+| Lens               | What it inspects                                                                   | AWS calls used                                          |
+|--------------------|------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `inventory`        | Permissions held: wildcards, missing MFA conditions                                | `iam:ListRoles`, `GetRole`, `GetPolicyVersion`, etc.    |
+| `recent_usage`     | When the principal last exercised its permissions                                  | `iam:ListRoles` (`RoleLastUsed`), `cloudtrail:LookupEvents` |
+| `external_exposure`| Trust policies admitting external/anonymous principals                             | `access-analyzer:ListAnalyzers`, `ListFindings`         |
+| `effective_access` | What the principal *could* do, accounting for the union of all attached policies   | `iam:SimulatePrincipalPolicy`                            |
+
+Severity is deterministic: 3+ lenses → CRITICAL; 2 lenses → HIGH;
+1 lens → MEDIUM. The simulator flagging a delete-style or
+`AssumeRole` action also forces CRITICAL.
+
+Deliverables, in this order:
+
+(a) Security Hub findings, one per flagged principal, in ASFF format
+   (SchemaVersion `2018-10-08`). The recipe spells out the required
+   ASFF fields and the `ProductArn` shape (the default
+   custom-integration ARN); the agent builds `findings.json`
+   incrementally with `jq '.Findings += [...]'` so the JSON never
+   re-enters its context across turns.
+
+(b) Slack channel canvas summarizing the same findings grouped by
+   severity, posted as one POST to the slack gateway with the body
+   passed via `jq --rawfile`.
+
+The recipe also instructs the agent to skip AWS service-linked
+roles (names starting with `AWSServiceRole`) and to emit empty
+deliverables (`{"Findings": []}` and a canvas saying "No findings")
+even when zero principals are flagged — so absence is observable.
+
+## 9. The Forgejo Actions workflow
+
+`.forgejo/workflows/access-audit.yaml` is what triggers the audit on
+push to `main`. The workflow mirrors `vault-policy-hygiene`'s shape
+(same OIDC JWT mint, same pre-flight discovery, same runner-config
+host-mapping hack so the job container can resolve
+`forgejo.local`) — the differences are which CLIs it installs and
+which env vars it sets.
+
+```yaml
+env:
+  WARDEN_ADDR:      http://host.docker.internal:8400
+  WARDEN_NAMESPACE: tutorial-aws
+  ANTHROPIC_HOST:   http://host.docker.internal:8400/v1/tutorial-aws/anthropic/role/anthropic-ops/gateway
+```
+
+Three env vars are *not* set: `AWS_ENDPOINT_URL`, `AWS_REGION`, and
+anything Slack-related. The agent discovers all of those.
+
+The four job steps:
+
+1. **Install CLIs** — AWS CLI v2 (the bundled binary; the apt
+   package is v1 with weaker `AWS_ENDPOINT_URL` support), Goose
+   v1.32.0 (matching `vault-policy-hygiene`'s pin and its rationale),
+   and Warden v0.13.2.
+
+2. **Mint Warden JWT from Forgejo OIDC.** Curls
+   `$ACTIONS_ID_TOKEN_REQUEST_URL&audience=http://warden.local` with
+   the Forgejo-supplied bearer token, parses the response, prints
+   the JWT claims for visibility, redacts the JWT in subsequent log
+   output, and exports it as `$WARDEN_JWT` for later steps.
+
+3. **Pre-flight discovery.** Runs the discovery loop's first four
+   steps (§7) outside of Goose. If `bound_claims` doesn't match, if
+   the JWT issuer is wrong, or if `auto_auth_path` metadata is
+   missing on the namespace, this step fails — cleanly — before any
+   LLM tokens are spent.
+
+4. **Run Goose.** Exports `WARDEN_TOKEN=$WARDEN_JWT` and
+   `ANTHROPIC_API_KEY=$WARDEN_JWT` (Goose's Anthropic SDK reads it
+   as the bearer for the proxied LLM URL), then invokes
+   `goose run --recipe access-hygiene.yaml --max-turns 100`. The
+   max-turn ceiling caps runaway loops; the seed-target corpus
+   typically completes in ~50–70 turns.
+
+On any exit (success or failure) the workflow uploads
+`findings.json` and `canvas.md` as the `access-hygiene-output`
+artifact — recoverable for inspection even if the Security Hub
+publish or Slack canvas delivery fails on the last step.
 
 ---
 
-> The remaining sections — the within-provider role-switching narrative
-> (§6), Goose's discovery loop (§7), the recipe (§8), the Forgejo Actions
-> workflow (§9), the audit-log walkthrough (§10), and production /
-> cleanup / next steps (§11–13) — arrive in follow-up PRs.
+> The remaining sections — the within-provider role-switching
+> narrative (§6, expanded), the audit-log walkthrough (§10), and
+> production / cleanup / next steps (§11–13) — arrive in the
+> follow-up PR.

--- a/docs/tutorials/aws-access-hygiene/access-hygiene.yaml
+++ b/docs/tutorials/aws-access-hygiene/access-hygiene.yaml
@@ -1,0 +1,162 @@
+version: "1.0.0"
+title: "AWS access hygiene audit"
+description: "Audit IAM principals in the connected AWS account through four read-only lenses (inventory, recent usage, external exposure, effective access). Emits findings to Security Hub and a Slack channel canvas."
+
+instructions: |
+  You operate on Warden. To learn how, run
+
+      warden skill read foundation --raw
+      warden skill read discovery  --raw
+
+  Browse the full catalog with `warden skill list -F name,description`.
+
+  TASK — AWS access hygiene audit
+
+  Audit every IAM principal (role, user, group) in the AWS account
+  you reach via Warden. The audit examines each principal through
+  four lenses; for each principal that any lens flags, emit one
+  finding. Do not invent other lenses.
+
+    1. inventory
+       What permissions does the principal hold across attached and
+       inline policies? Flag wildcard actions (e.g. `iam:*`, `s3:*`),
+       wildcard resources combined with broad actions, and absence of
+       MFA conditions on sensitive (Delete/Detach/Put) operations.
+
+    2. recent_usage
+       When did the principal last exercise its permissions? Flag
+       principals whose `LastUsed` is null OR older than 90 days
+       from now. CloudTrail `LookupEvents` corroborates this.
+
+    3. external_exposure
+       Does the principal's trust policy admit external accounts,
+       anonymous principals, or overly broad service principals?
+       Access Analyzer findings are the authoritative source.
+
+    4. effective_access
+       What can the principal actually do today, accounting for the
+       union of attached and group-inherited policies? Use
+       `SimulatePrincipalPolicy` to dry-run sensitive actions against
+       the principal (delete-style operations on s3 / iam / kms,
+       cross-account `sts:AssumeRole`). Flag where the simulator
+       returns `allowed` for an action that the role's declared
+       description suggests it should not be able to perform.
+
+  Severity is deterministic, not subjective:
+    - critical: flagged by THREE or more lenses, OR flagged by the
+      effective_access lens for any delete-style or AssumeRole action.
+    - high:     flagged by TWO lenses.
+    - medium:   flagged by ONE lens.
+    - ok:       no findings (do not emit a finding for ok principals).
+
+  Skip AWS service-linked roles (names starting with `AWSServiceRole`)
+  and AWS-managed administrative principals — they are not in scope.
+
+  DELIVERABLES — in this order
+
+  (a) Security Hub findings, one per flagged principal, emitted via
+      `securityhub:BatchImportFindings`. Use the ASFF schema
+      (SchemaVersion "2018-10-08"). Required fields the agent must
+      populate: a stable Id per principal, GeneratorId set to
+      "warden-tutorial/access-hygiene", ProductArn set to the audited
+      account's default custom-integration ARN
+      (`arn:aws:securityhub:<region>:<account>:product/<account>/default`),
+      AwsAccountId, Types ["Software and Configuration Checks/AWS
+      Security Best Practices"], CreatedAt and UpdatedAt (ISO-8601),
+      Severity {Label: "CRITICAL"|"HIGH"|"MEDIUM"}, Title (short,
+      principal-specific), Description (which lenses flagged it and
+      the evidence), and a Resources array citing the principal's
+      ARN and region. Build the findings array incrementally in a
+      file; do not compose the full JSON in a single assistant
+      message.
+
+  (b) Slack channel canvas summarizing the same findings grouped by
+      severity, with a one-line count summary at top. A channel
+      carries at most one canvas, so replace any prior one. Pass an
+      explicit `title` (e.g. "AWS access hygiene — $(date -u +%Y-%m-%d)")
+      so the canvas does not inherit the channel name.
+
+  EFFICIENCY
+
+  Pipe verbose JSON through `jq` to extract only the fields you need.
+  Raw list outputs are large and accumulate across LLM turns, eating
+  into the input-token rate limit.
+
+prompt: |
+  Run the audit and publish both deliverables. Build the findings
+  file and the canvas markdown incrementally with shell calls — do
+  NOT compose the full report in a single final assistant message.
+  Your final message should be one short line confirming counts.
+
+  Sequence:
+
+    1. Bootstrap. Read foundation + discovery skills. Then
+       `warden role list` and `warden provider list`. Identify the
+       roles for each of the four read lenses and for the Security
+       Hub write and Slack canvas publish steps by reading their
+       descriptions. Do not assume role names — extract them from
+       discovery output.
+
+    2. Read the `aws` provider skill (`warden skill read aws --raw`)
+       and the slack provider skill if present. Follow the call-shape
+       contracts they define — do not invent endpoints or
+       authentication mechanisms.
+
+    3. Gather ground truth per lens. For each lens, switch to that
+       lens's role and run the appropriate calls. Output to per-lens
+       jq-filtered JSON files; do not let full raw responses re-enter
+       your context.
+
+         inventory:         list roles / attached + inline policies / policy documents
+         recent_usage:      list roles + RoleLastUsed + CloudTrail LookupEvents
+         external_exposure: Access Analyzer ListAnalyzers + ListFindings
+         effective_access:  per principal, SimulatePrincipalPolicy on
+                            the sensitive-action probe set
+
+    4. Synthesize. For each principal, count lens hits, derive
+       severity, and append one ASFF finding object to findings.json
+       using a one-shell-call append so the JSON never re-enters your
+       context. Initialize once with `printf '{"Findings": []}\n' > findings.json`,
+       then for each principal compose the finding JSON in a tmp
+       variable and append:
+
+           jq --argjson new "$FINDING_JSON" '.Findings += [$new]' \
+             findings.json > tmp && mv tmp findings.json
+
+       Drop per-principal evidence from your context once written —
+       the file is the source of truth.
+
+    5. Publish to Security Hub. Switch to the finding-publication
+       role and call `aws securityhub batch-import-findings` with
+       findings.json. That role's IAM scope at AWS permits exactly
+       this one action — accidental reads or other writes will fail.
+
+    6. Build the canvas markdown incrementally:
+         printf '# AWS access hygiene\n\n' > canvas.md
+         For each severity (CRITICAL → HIGH → MEDIUM):
+           printf '## %s\n' "$sev" >> canvas.md
+           Append one bullet per finding citing principal ARN and
+           the lens(es) that flagged it.
+       Then append a Summary section with counts per severity.
+
+    7. Publish the canvas through the slack gateway, piping canvas.md
+       through `jq --rawfile` so the body does not enter your
+       context. Use the channel embedded in the slack role's
+       description.
+
+    8. Final assistant message — one short line, e.g.
+       "Audit complete: 23 principals; 2 critical, 5 high, 4 medium.
+       Security Hub + canvas updated."
+
+  Do NOT skip either publish even when findings are zero. Emit an
+  empty findings.json with `{"Findings": []}` (BatchImportFindings
+  accepts it) and publish a canvas that says "No findings."
+
+extensions:
+  - type: builtin
+    name: developer
+    description: "Shell + file tools so the agent can run CLIs, curl, and jq"
+
+settings:
+  goose_provider: anthropic
+  goose_model: deepseek-chat

--- a/docs/tutorials/aws-access-hygiene/seed-aws.sh
+++ b/docs/tutorials/aws-access-hygiene/seed-aws.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Idempotent AWS-side seed of audit-target IAM roles for the
+# aws-access-hygiene tutorial.
+#
+# These targets are distinct from the broker user and the five
+# AssumeRole-backed roles provisioned by aws-init.sh, which power
+# Warden's specs. The targets exist purely to give the audit something
+# interesting to find.
+#
+# What gets seeded:
+#   1. tutorial-target-clean-role
+#      Clean baseline — narrow scope, no smells. Anchor for contrast.
+#   2. tutorial-target-wildcard-role
+#      Triggers the inventory lens: attached inline policy with
+#      Action "iam:*" + Resource "*".
+#   3. tutorial-target-stale-role
+#      Triggers the usage lens: created here, never invoked elsewhere,
+#      so LastUsed is null. The audit treats "no recorded activity in
+#      the last 90 days" as stale — null/never-used fits.
+#   4. tutorial-target-external-trust-role
+#      Triggers the exposure lens: trust policy admits a non-self
+#      account ID (default: 999999999999). Access Analyzer flags this
+#      as external trust.
+#   5. tutorial-target-under-described-role
+#      Triggers the effective-access lens: description claims "read-only
+#      S3 bucket inventory" but the attached policy grants s3:* on *.
+#      The simulator dry-run surfaces the mismatch.
+#
+# Idempotent — re-runnable; existing targets are left alone. Use
+# --teardown to remove them.
+#
+# Requires:
+#   - aws CLI v2, logged in as a principal that can create IAM roles
+#     and attach inline policies in the chosen sandbox account.
+#   - jq.
+#
+# Usage:
+#   ./seed-aws.sh
+#   ./seed-aws.sh --account-id=123456789012
+#   ./seed-aws.sh --external-account-id=222222222222
+#   ./seed-aws.sh --teardown
+set -euo pipefail
+
+ACCOUNT_ID=""
+EXTERNAL_ACCOUNT_ID="999999999999"
+TEARDOWN="false"
+
+for arg in "$@"; do
+  case $arg in
+    --account-id=*)          ACCOUNT_ID="${arg#--account-id=}" ;;
+    --external-account-id=*) EXTERNAL_ACCOUNT_ID="${arg#--external-account-id=}" ;;
+    --teardown)              TEARDOWN="true" ;;
+    *) echo "unknown arg: $arg" >&2; exit 1 ;;
+  esac
+done
+
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI not found" >&2; exit 1; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq not found" >&2; exit 1; }
+
+if [ -z "$ACCOUNT_ID" ]; then
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+fi
+
+# All five targets get a self-trust policy so they're assumable in
+# principle by anything inside the account — keeps them realistic
+# without trusting anything outside. The external-trust target
+# overrides this with a cross-account trust.
+SELF_TRUST=$(jq -n --arg arn "arn:aws:iam::${ACCOUNT_ID}:root" '{
+  Version: "2012-10-17",
+  Statement: [{
+    Effect: "Allow",
+    Principal: { AWS: $arn },
+    Action: "sts:AssumeRole"
+  }]
+}')
+
+EXTERNAL_TRUST=$(jq -n --arg arn "arn:aws:iam::${EXTERNAL_ACCOUNT_ID}:root" '{
+  Version: "2012-10-17",
+  Statement: [{
+    Effect: "Allow",
+    Principal: { AWS: $arn },
+    Action: "sts:AssumeRole"
+  }]
+}')
+
+# Inline permission policies — each one is shaped to trip exactly the
+# lens the role's name advertises. Names are agent-facing in the
+# audit; descriptions matter too.
+PERMS_NARROW='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:GetObject"],
+    "Resource": "arn:aws:s3:::tutorial-target-clean-bucket/*"
+  }]
+}'
+
+PERMS_WILDCARD='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "iam:*",
+    "Resource": "*"
+  }]
+}'
+
+PERMS_STALE='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["cloudwatch:GetMetricData"],
+    "Resource": "*"
+  }]
+}'
+
+PERMS_UNDER_DESCRIBED='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "s3:*",
+    "Resource": "*"
+  }]
+}'
+
+ROLE_CLEAN="tutorial-target-clean-role"
+ROLE_WILDCARD="tutorial-target-wildcard-role"
+ROLE_STALE="tutorial-target-stale-role"
+ROLE_EXTERNAL_TRUST="tutorial-target-external-trust-role"
+ROLE_UNDER_DESCRIBED="tutorial-target-under-described-role"
+
+ALL_TARGETS=(
+  "$ROLE_CLEAN"
+  "$ROLE_WILDCARD"
+  "$ROLE_STALE"
+  "$ROLE_EXTERNAL_TRUST"
+  "$ROLE_UNDER_DESCRIBED"
+)
+
+teardown_role () {
+  local role_name="$1"
+  if ! aws iam get-role --role-name "$role_name" >/dev/null 2>&1; then
+    echo "seed-aws: target '$role_name' not present"
+    return 0
+  fi
+  for policy in $(aws iam list-role-policies --role-name "$role_name" \
+        --query 'PolicyNames[]' --output text); do
+    aws iam delete-role-policy --role-name "$role_name" --policy-name "$policy" >/dev/null
+  done
+  aws iam delete-role --role-name "$role_name" >/dev/null
+  echo "seed-aws: removed target '$role_name'"
+}
+
+if [ "$TEARDOWN" = "true" ]; then
+  for role in "${ALL_TARGETS[@]}"; do
+    teardown_role "$role"
+  done
+  echo "seed-aws: teardown complete"
+  exit 0
+fi
+
+# Seed (idempotent).
+seed_role () {
+  local role_name="$1"
+  local trust_policy="$2"
+  local description="$3"
+  local inline_policy_name="$4"
+  local inline_policy_doc="$5"
+
+  if aws iam get-role --role-name "$role_name" >/dev/null 2>&1; then
+    aws iam update-assume-role-policy \
+      --role-name "$role_name" \
+      --policy-document "$trust_policy" >/dev/null
+    aws iam update-role \
+      --role-name "$role_name" \
+      --description "$description" >/dev/null
+    echo "seed-aws: refreshed target '$role_name'"
+  else
+    aws iam create-role \
+      --role-name "$role_name" \
+      --assume-role-policy-document "$trust_policy" \
+      --description "$description" \
+      >/dev/null
+    echo "seed-aws: created target '$role_name'"
+  fi
+
+  aws iam put-role-policy \
+    --role-name "$role_name" \
+    --policy-name "$inline_policy_name" \
+    --policy-document "$inline_policy_doc" >/dev/null
+}
+
+# Role descriptions read like ops-written role notes — they do NOT
+# state what the audit should find. The audit must reach its
+# conclusions from underlying data (attached policies, RoleLastUsed,
+# trust policies, simulator output). The one exception is the
+# under-described target, whose description is deliberately narrower
+# than its actual policy — that mismatch is what the effective_access
+# lens is built to catch.
+
+seed_role "$ROLE_CLEAN" "$SELF_TRUST" \
+  "S3 GetObject for the internal ETL job that reads tutorial-target-clean-bucket." \
+  "clean-narrow" "$PERMS_NARROW"
+
+seed_role "$ROLE_WILDCARD" "$SELF_TRUST" \
+  "Legacy platform-team IAM admin role — used during account bootstrap and still attached for break-glass." \
+  "wildcard-iam" "$PERMS_WILDCARD"
+
+seed_role "$ROLE_STALE" "$SELF_TRUST" \
+  "Metrics reader for the deprecated Q2 dashboards prototype." \
+  "stale-metrics-reader" "$PERMS_STALE"
+
+seed_role "$ROLE_EXTERNAL_TRUST" "$EXTERNAL_TRUST" \
+  "Cross-account audit role granting read access from partner-org account ${EXTERNAL_ACCOUNT_ID}." \
+  "external-trust-empty" "$PERMS_NARROW"
+
+seed_role "$ROLE_UNDER_DESCRIBED" "$SELF_TRUST" \
+  "Read-only S3 bucket inventory for the data-discovery team." \
+  "under-described-s3" "$PERMS_UNDER_DESCRIBED"
+
+echo "seed-aws: seeded 5 audit-target roles"
+echo "seed-aws: Access Analyzer findings for '${ROLE_EXTERNAL_TRUST}' may take a few minutes to appear."

--- a/docs/tutorials/aws-access-hygiene/warden-init.sh
+++ b/docs/tutorials/aws-access-hygiene/warden-init.sh
@@ -27,17 +27,23 @@
 #   - aws-out/creds.env populated by aws-init.sh.
 #
 # Usage:
-#   ./warden-init.sh
-#   ./warden-init.sh --slack-token=xoxb-... \
+#   ./warden-init.sh --anthropic-key=sk-...
+#   ./warden-init.sh --anthropic-key=sk-... \
+#                    --slack-token=xoxb-... \
 #                    --slack-channel-id=C0XXXXXXX \
 #                    --slack-channel-name='#access-audits' \
 #                    --repo=siteowner/aws-access-hygiene
+#
+# --anthropic-key is required (the LLM key Warden hands to Goose at
+# runtime; it never enters the agent's environment). It can also be
+# passed via the ANTHROPIC_API_KEY env var.
 #
 # --slack-token is optional; without it the Slack provider/role/spec
 # are skipped (the agent will fail the canvas post but Goose's audit
 # still produces Security Hub findings).
 set -euo pipefail
 
+ANTHROPIC_KEY="${ANTHROPIC_API_KEY:-}"
 SLACK_TOKEN="${SLACK_TOKEN:-}"
 SLACK_CHANNEL_ID="${SLACK_CHANNEL_ID:-}"
 SLACK_CHANNEL_NAME="${SLACK_CHANNEL_NAME:-}"
@@ -45,6 +51,7 @@ REPO="siteowner/aws-access-hygiene"
 
 for arg in "$@"; do
   case $arg in
+    --anthropic-key=*)       ANTHROPIC_KEY="${arg#--anthropic-key=}" ;;
     --slack-token=*)         SLACK_TOKEN="${arg#--slack-token=}" ;;
     --slack-channel-id=*)    SLACK_CHANNEL_ID="${arg#--slack-channel-id=}" ;;
     --slack-channel-name=*)  SLACK_CHANNEL_NAME="${arg#--slack-channel-name=}" ;;
@@ -52,6 +59,12 @@ for arg in "$@"; do
     *) echo "unknown arg: $arg" >&2; exit 1 ;;
   esac
 done
+
+if [ -z "$ANTHROPIC_KEY" ]; then
+  echo "ERROR: pass --anthropic-key=sk-... or set ANTHROPIC_API_KEY" >&2
+  echo "       (this is the LLM key Warden hands to Goose at runtime; never enters the agent env)" >&2
+  exit 1
+fi
 
 if [ -n "$SLACK_TOKEN" ] && { [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$SLACK_CHANNEL_NAME" ]; }; then
   echo "ERROR: --slack-token requires --slack-channel-id=C... and --slack-channel-name=#..." >&2
@@ -117,7 +130,7 @@ $WARDEN write auth/jwt/role/discovery-baseline \
 # here: it is only consulted by the S3 processors for virtual-hosted
 # bucket URL rewriting, and this tutorial uses no S3 calls.
 $WARDEN provider enable --type=aws \
-    --description="AWS sandbox account proxied via the warden-aws-tutorial-broker IAM user — five lenses for IAM/CloudTrail/AccessAnalyzer/PolicySimulator/SecurityHub" \
+    --description="AWS sandbox account ${WARDEN_AWS_ACCOUNT_ID} proxied via the warden-aws-tutorial-broker IAM user — five lenses for IAM/CloudTrail/AccessAnalyzer/PolicySimulator/SecurityHub" \
     aws 2>/dev/null || true
 $WARDEN write aws/config \
     auto_auth_path=auth/jwt/
@@ -238,7 +251,46 @@ path "aws/gateway/*" { capabilities = ["read", "create", "list"] }
 EOF
 $WARDEN policy write aws-gateway-access /tmp/aws-tut-aws-gateway-access.hcl
 
-# 5e. Slack provider (optional).
+# 5e. Anthropic provider — Goose's LLM leg.
+#
+# Goose's Anthropic SDK is configured by the runtime (ANTHROPIC_HOST +
+# ANTHROPIC_API_KEY=<JWT>) before the agent process starts. This is
+# not part of the agent's discovery loop — it's wired in for the
+# Goose runtime itself. The role is marked "Internal" so an agent
+# does not pick it for a task.
+$WARDEN provider enable --type=anthropic \
+    --description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
+    anthropic 2>/dev/null || true
+$WARDEN write anthropic/config \
+    anthropic_url=https://api.deepseek.com/anthropic \
+    auto_auth_path=auth/jwt/ \
+    timeout=120s
+
+$WARDEN cred spec delete -f anthropic-ops 2>/dev/null || true
+$WARDEN cred source delete -f anthropic-src 2>/dev/null || true
+$WARDEN cred source create anthropic-src --type=apikey \
+    --rotation-period=0 \
+    --config=api_url=https://api.deepseek.com \
+    --config=verify_endpoint=/v1/models \
+    --config=auth_header_type=custom_header \
+    --config=auth_header_name=x-api-key \
+    --config=extra_headers=anthropic-version:2023-06-01
+$WARDEN cred spec create anthropic-ops --source anthropic-src \
+    --config api_key="$ANTHROPIC_KEY"
+
+$WARDEN write auth/jwt/role/anthropic-ops \
+    description="LLM inference for the access-hygiene auditor agent. Used internally by Goose — agents do not call this role directly." \
+    bound_claims="$BOUND_CLAIMS_FULL" \
+    cred_spec_name=anthropic-ops \
+    token_policies=anthropic-ops
+
+cat > /tmp/aws-tut-anthropic-ops.hcl <<'EOF'
+path "anthropic/role/anthropic-ops/gateway/v1/messages" { capabilities = ["create"] }
+path "anthropic/role/anthropic-ops/gateway/v1/models"   { capabilities = ["read"] }
+EOF
+$WARDEN policy write anthropic-ops /tmp/aws-tut-anthropic-ops.hcl
+
+# 5f. Slack provider (optional).
 if [ -n "$SLACK_TOKEN" ]; then
   $WARDEN provider enable --type=slack \
       --description="Slack workspace for access-audit canvas reports — channel embedded in the hygiene-poster role description" \


### PR DESCRIPTION
…orkflow

Third of four PRs. Makes the tutorial runnable end-to-end: seeded audit targets, a Goose recipe that decomposes the task into four read-only lenses plus a write step, and a Forgejo Actions workflow that drives the agent under a per-job OIDC JWT.

New files:

- seed-aws.sh — idempotent AWS-side seed of five demo IAM audit targets (clean baseline + one per lens-smell), with --teardown. Role descriptions read like ops-written notes; the audit must reach lens conclusions from policy/usage/trust data, not from description hints. The under-described target keeps a deliberately narrow declared description vs a broad attached policy — what the effective_access lens is built to catch.
- access-hygiene.yaml — Goose recipe in pure task semantics. Defines the four lenses (inventory, recent_usage, external_exposure, effective_access), severity logic (3+ lenses critical, 2 high, 1 medium), and two deliverables (ASFF findings to Security Hub, then a Slack channel canvas). No Warden role names, no provider URLs, no AWS env-var contracts; the agent learns those from foundation
  + discovery + the aws provider skill at runtime.
- .forgejo/workflows/access-audit.yaml — same OIDC-mint + pre-flight pattern as vault-policy-hygiene, swapped to install aws CLI v2, Goose v1.32.0, and warden v0.13.2. ANTHROPIC_HOST points at the tutorial-aws namespace's anthropic gateway; everything else is discovered.

warden-init.sh updates:

- --anthropic-key=sk-... is now required (Goose's LLM leg). Without it the agent can't run.
- AWS provider description embeds the account ID — agents read the audited account from discovery output, not from any env var.
- New §5e Anthropic provider + source + spec + role + policy block (Slack section renumbered to 5f).

README updates:

- §2 prereqs list aws CLI v2 + Security Hub + Access Analyzer enablement commands, the Anthropic key, and Slack details.
- §3 file inventory expanded to include the new files.
- §5b warden-init.sh usage updated to require --anthropic-key; the numbered wiring list now has 11 items (10 = Anthropic).
- §5d walks seed-aws.sh with a target → smell → lens table.
- §6 stub (full content arrives in PR 4).
- §7 walks Goose's discovery loop with concrete commands.
- §8 walks the recipe (lens table, severity, deliverables).
- §9 walks the workflow (env contract, four job steps).

End-to-end verification (push → workflow → Security Hub findings → Slack canvas) requires an AWS sandbox and lives in the README's §9 guidance; local checks (bash -n, yaml load) all pass.