### PR TITLE
ci(helm): add helm-smoke job — kind + helm install + audit assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,35 @@ jobs:
                 -schema-location default \
                 -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 
+  helm-smoke:
+    name: helm-smoke
+    needs: [changes]
+    # Run on chart OR code changes — chart shape can break from either side.
+    # See deploy/helm/warden/ci/smoke.sh for the orchestration this wraps.
+    if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.2
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: warden-smoke
+          wait: 60s
+
+      - name: Run helm smoke test
+        run: bash deploy/helm/warden/ci/smoke.sh warden warden warden-smoke
+
   e2e:
     runs-on: ubuntu-latest
     needs: [unit, changes]

--- a/deploy/Dockerfile.smoke
+++ b/deploy/Dockerfile.smoke
@@ -1,0 +1,30 @@
+# Self-contained multi-stage build for the CI helm-smoke job.
+# Designed for `docker buildx build` on the GitHub ubuntu-latest
+# runner (16 GB RAM, buildx preinstalled). Local devs with smaller
+# Docker Desktop memory caps may OOM on the AWS SDK compile — see
+# ci/smoke.sh for the alternative host-build pattern.
+#
+# Base / WORKDIR / ENTRYPOINT match Dockerfile.goreleaser so the
+# chart exercises the same surface as the production image.
+FROM golang:1.26-bookworm AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -o /out/warden .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+WORKDIR /app
+
+COPY --from=build /out/warden ./warden
+
+EXPOSE 8400
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["./warden", "server"]
+CMD ["--config", "/config/warden.hcl"]

--- a/deploy/helm/warden/ci/postgres.yaml
+++ b/deploy/helm/warden/ci/postgres.yaml
@@ -1,0 +1,77 @@
+# Ephemeral PostgreSQL for the helm-smoke CI job. Uses emptyDir
+# storage on purpose — every smoke run gets a fresh DB. Not for
+# production use; the chart's values.yaml deliberately positions
+# postgres as a BYO dependency.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: warden-postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: warden-smoke
+type: Opaque
+stringData:
+  POSTGRES_USER: warden
+  POSTGRES_PASSWORD: smoke-password
+  POSTGRES_DB: warden
+  # Connection URL consumed by warden via WARDEN_POSTGRES_URL.
+  connection_url: postgres://warden:smoke-password@warden-postgres:5432/warden?sslmode=disable
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: warden-postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: warden-smoke
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: warden-smoke
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: warden-postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: warden-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/part-of: warden-smoke
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: warden-smoke
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: warden-postgres
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "warden", "-d", "warden"]
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 2
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/deploy/helm/warden/ci/seal-key.sh
+++ b/deploy/helm/warden/ci/seal-key.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Generate a 32-byte AES-256-GCM-96 seal key and kubectl-create the
+# Secret the chart's static-seal path expects (mounted at /seal/key).
+# Mirrors the pattern at e2e/setup.sh:148-152.
+#
+# Usage: bash seal-key.sh <namespace>
+set -euo pipefail
+
+NS="${1:?namespace required}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+openssl rand 32 > "$TMPDIR/seal.key"
+
+kubectl -n "$NS" create secret generic warden-seal \
+  --from-file=current_key="$TMPDIR/seal.key" \
+  --dry-run=client -o yaml | kubectl apply -f -

--- a/deploy/helm/warden/ci/smoke-values.yaml
+++ b/deploy/helm/warden/ci/smoke-values.yaml
@@ -1,0 +1,42 @@
+# Helm value overrides for the helm-smoke CI job.
+# Combined with the secrets created by seal-key.sh and tls-cert.sh
+# alongside the postgres.yaml manifest in this directory, this should
+# bring a single-replica warden up against a real kind cluster.
+# Mirrors values-dev.yaml's shape (single replica, static seal, no
+# topology spread) but pins the image to the locally-built smoke tag.
+
+image:
+  repository: warden
+  tag: smoke
+  pullPolicy: Never        # kind load handles the image; never pull
+
+replicaCount: 1
+
+topologySpreadConstraints: []
+podDisruptionBudget:
+  enabled: false
+
+storage:
+  existingSecret: warden-postgres
+  haEnabled: "true"
+
+tls:
+  existingSecret: warden-tls
+
+seal:
+  type: static
+  static:
+    existingSecret: warden-seal
+    keyId: smoke-1
+    currentKeyKey: current_key
+
+# Smoke test asserts the chart-provisioned audit device is registered
+# with declarative=true and that its file lands at /var/log/warden/.
+# These are all chart defaults; restating here to make the smoke
+# contract explicit (the assertion in smoke.sh requires audit.enabled).
+audit:
+  enabled: true
+  type: file
+  name: default
+  description: chart-provisioned smoke-test audit
+  filePath: /var/log/warden/audit.log

--- a/deploy/helm/warden/ci/smoke.sh
+++ b/deploy/helm/warden/ci/smoke.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Helm chart smoke test. Boots a real warden against a real kind
+# cluster, runs `operator init`, asserts the chart-provisioned audit
+# device registered. Same script the CI helm-smoke job runs.
+#
+# Prerequisites on the host:
+#   - docker (with buildx), kind, kubectl, helm, openssl, curl, jq
+#   - A running kind cluster (this script does NOT create or delete it;
+#     see make targets or CI for cluster lifecycle)
+#
+# Usage (from repo root):
+#   bash deploy/helm/warden/ci/smoke.sh [release-name] [namespace] [kind-cluster]
+#
+# The smoke test uses kubectl port-forward + host curl to talk to the
+# warden HTTPS API. This deliberately avoids the warden CLI inside the
+# distroless container — distroless has no `env` binary so passing
+# WARDEN_ADDR etc. via `kubectl exec` is awkward, and the smoke job's
+# scope is validating the chart + server, not exercising the CLI
+# (which has its own unit + e2e coverage).
+#
+# Image build uses `docker buildx build --load` with the multi-stage
+# Dockerfile.smoke (golang:1.26 -> distroless). Comfortable inside
+# CI's 16 GB ubuntu-latest runners; Docker Desktop with the default
+# 8 GB cap may OOM on the AWS SDK compile — bump to 12 GB+ locally.
+#
+# Defaults: release=warden, namespace=warden, kind-cluster=kind
+set -euo pipefail
+
+RELEASE="${1:-warden}"
+NS="${2:-warden}"
+KIND_CLUSTER="${3:-kind}"
+IMAGE_TAG="warden:smoke"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+CI_DIR="$REPO_ROOT/deploy/helm/warden/ci"
+CHART_DIR="$REPO_ROOT/deploy/helm/warden"
+SMOKE_DOCKERFILE="$REPO_ROOT/deploy/Dockerfile.smoke"
+
+PF_PID=""
+
+cleanup() {
+  if [ -n "$PF_PID" ] && kill -0 "$PF_PID" 2>/dev/null; then
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+log() { printf '\033[1;36m[smoke]\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[1;31m[smoke]\033[0m %s\n' "$*" >&2; dump_state; exit 1; }
+
+dump_state() {
+  echo "---- failure diagnostics ----" >&2
+  kubectl -n "$NS" get all 2>&1 || true
+  echo "---- events ----" >&2
+  kubectl -n "$NS" get events --sort-by=.lastTimestamp 2>&1 || true
+  echo "---- pod describe (warden-0) ----" >&2
+  kubectl -n "$NS" describe pod "${RELEASE}-0" 2>&1 || true
+  echo "---- pod logs (warden-0, tail=200) ----" >&2
+  kubectl -n "$NS" logs "${RELEASE}-0" --tail=200 2>&1 || true
+}
+
+# --- 1. Build the smoke image (multi-stage, via buildx). ----------
+log "building smoke image $IMAGE_TAG (buildx, multi-stage)"
+docker buildx build --load \
+  -f "$SMOKE_DOCKERFILE" \
+  -t "$IMAGE_TAG" \
+  "$REPO_ROOT" >/dev/null
+
+# --- 2. Load it into the kind cluster. -----------------------------
+log "loading $IMAGE_TAG into kind cluster '$KIND_CLUSTER'"
+kind load docker-image "$IMAGE_TAG" --name "$KIND_CLUSTER"
+
+# --- 3. Namespace + secrets. ---------------------------------------
+log "creating namespace $NS"
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+
+log "creating seal-key secret"
+bash "$CI_DIR/seal-key.sh" "$NS"
+
+log "creating TLS secret"
+bash "$CI_DIR/tls-cert.sh" "$NS" "$RELEASE"
+
+# --- 4. Postgres. --------------------------------------------------
+log "applying postgres manifest"
+kubectl apply -n "$NS" -f "$CI_DIR/postgres.yaml"
+log "waiting for postgres to be ready"
+kubectl -n "$NS" wait --for=condition=Available deployment/warden-postgres --timeout=120s
+
+# --- 5. Helm install. ----------------------------------------------
+log "helm install $RELEASE"
+helm upgrade --install "$RELEASE" "$CHART_DIR" \
+  -n "$NS" \
+  -f "$CI_DIR/smoke-values.yaml"
+
+# --- 6. Wait for the warden pod to be Running. ---------------------
+# Readiness probe needs init+unseal so we can't wait for Ready here.
+# PodScheduled + phase=Running is enough to port-forward into.
+log "waiting for ${RELEASE}-0 to be schedulable"
+kubectl -n "$NS" wait --for=condition=PodScheduled "pod/${RELEASE}-0" --timeout=120s
+
+log "waiting for ${RELEASE}-0 container to be Running"
+for i in $(seq 1 60); do
+  phase=$(kubectl -n "$NS" get pod "${RELEASE}-0" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  if [ "$phase" = "Running" ]; then
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    fail "${RELEASE}-0 did not reach Running within 120s (last phase: ${phase:-unknown})"
+  fi
+  sleep 2
+done
+
+# --- 7. Port-forward + wait for the listener to accept. ------------
+log "starting kubectl port-forward 8400 -> ${RELEASE}-0:8400"
+kubectl -n "$NS" port-forward "pod/${RELEASE}-0" 8400:8400 >/tmp/warden-smoke-pf.log 2>&1 &
+PF_PID=$!
+
+# Wait for the port-forward to be ready (sys/health is unauthenticated
+# and returns 501 pre-init, which is enough to confirm the listener is up).
+log "waiting for the listener to accept connections"
+for i in $(seq 1 30); do
+  code=$(curl -sk -o /dev/null -w '%{http_code}' \
+    "https://127.0.0.1:8400/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200" \
+    2>/dev/null || echo "000")
+  if [ "$code" = "200" ]; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    fail "listener did not accept connections within 60s (last code: ${code})"
+  fi
+  sleep 2
+done
+
+# --- 8. Operator init via API. -------------------------------------
+log "running sys/init"
+INIT_RESP=$(curl -sk -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"secret_shares":1,"secret_threshold":1}' \
+  "https://127.0.0.1:8400/v1/sys/init") \
+  || fail "POST /v1/sys/init failed"
+
+ROOT_TOKEN=$(printf '%s' "$INIT_RESP" | jq -r '.root_token // empty')
+[ -n "$ROOT_TOKEN" ] || fail "could not extract root_token from init response: $INIT_RESP"
+
+# --- 9. Wait for cluster to reach active. --------------------------
+# Static seal auto-unseals after init. Poll sys/health until the
+# unauthenticated 200 fires (active leader).
+log "waiting for cluster to reach active"
+for i in $(seq 1 30); do
+  code=$(curl -sk -o /dev/null -w '%{http_code}' \
+    "https://127.0.0.1:8400/v1/sys/health" \
+    2>/dev/null || echo "000")
+  if [ "$code" = "200" ]; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    fail "cluster did not reach active within 60s (last sys/health: ${code})"
+  fi
+  sleep 2
+done
+
+# --- 10. Assertions. -----------------------------------------------
+log "asserting declarative audit device is registered"
+AUDIT_JSON=$(curl -sk -H "X-Warden-Token: $ROOT_TOKEN" \
+  "https://127.0.0.1:8400/v1/sys/audit?warden-list=true") \
+  || fail "GET /v1/sys/audit failed"
+
+# The list endpoint returns a map keyed by audit path; each value has
+# a `declarative` bool added by the audit-hcl PR. Use jq for a real
+# parse rather than a string grep.
+DECLARATIVE_COUNT=$(printf '%s' "$AUDIT_JSON" | jq '[..|.declarative? // empty | select(.==true)] | length')
+[ "${DECLARATIVE_COUNT:-0}" -ge 1 ] \
+  || fail "expected >=1 declarative audit device; got ${DECLARATIVE_COUNT:-0}. Full response: $AUDIT_JSON"
+
+log "smoke test PASSED — $DECLARATIVE_COUNT declarative audit device(s), cluster active"

--- a/deploy/helm/warden/ci/tls-cert.sh
+++ b/deploy/helm/warden/ci/tls-cert.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Generate a self-signed ECDSA TLS cert + matching CA bundle for the
+# warden API listener and kubectl-create the Secret the chart's
+# tls.existingSecret path expects. Mirrors e2e/setup.sh:34-52.
+#
+# SANs cover the in-cluster service DNS names the StatefulSet uses,
+# plus 127.0.0.1 for the `kubectl exec` health-check poll. Self-signed,
+# 1-day duration — only ever used in CI.
+#
+# Usage: bash tls-cert.sh <namespace> <release-name>
+set -euo pipefail
+
+NS="${1:?namespace required}"
+RELEASE="${2:?release name required (e.g. warden)}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+SAN="subjectAltName=DNS:${RELEASE},DNS:${RELEASE}.${NS}.svc,DNS:${RELEASE}.${NS}.svc.cluster.local,DNS:${RELEASE}-headless,DNS:${RELEASE}-headless.${NS}.svc,DNS:${RELEASE}-headless.${NS}.svc.cluster.local,DNS:*.${RELEASE}-headless.${NS}.svc.cluster.local,DNS:localhost,IP:127.0.0.1"
+
+# CA — self-signed, only used to satisfy the chart's tls_client_ca_file
+# mount; mTLS is off in smoke (tls.requireClientCert=false default).
+openssl ecparam -genkey -name prime256v1 -noout -out "$TMPDIR/ca.key" 2>/dev/null
+openssl req -x509 -new -key "$TMPDIR/ca.key" -out "$TMPDIR/ca.crt" \
+  -days 1 -subj "/CN=warden-smoke-ca/O=Warden Smoke" 2>/dev/null
+
+# Server cert signed by the CA.
+openssl ecparam -genkey -name prime256v1 -noout -out "$TMPDIR/tls.key" 2>/dev/null
+openssl req -new -key "$TMPDIR/tls.key" -out "$TMPDIR/tls.csr" \
+  -subj "/CN=${RELEASE}/O=Warden Smoke" 2>/dev/null
+openssl x509 -req -in "$TMPDIR/tls.csr" \
+  -CA "$TMPDIR/ca.crt" -CAkey "$TMPDIR/ca.key" -CAcreateserial \
+  -out "$TMPDIR/tls.crt" -days 1 \
+  -extfile <(printf '%s' "$SAN") 2>/dev/null
+
+kubectl -n "$NS" create secret generic warden-tls \
+  --from-file=tls.crt="$TMPDIR/tls.crt" \
+  --from-file=tls.key="$TMPDIR/tls.key" \
+  --from-file=ca.crt="$TMPDIR/ca.crt" \
+  --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
## Summary

- New `helm-smoke` CI job that boots a real `kind` cluster, installs the chart, runs `warden operator init`, and asserts the chart-provisioned declarative audit device registered.
- Gated on the same path-filter as `helm-lint` (runs on chart **or** code changes).
- ≤15-minute job timeout; expected ~5 min wall-clock per run.

Closes the [`project_chart_smoke_test`](memory/project_chart_smoke_test.md) follow-up. Catches the class of bugs `helm lint` + `kubeconform` can't: broken HCL inside rendered ConfigMaps (PR #208), image-tag mismatches, volume/mount/`readOnlyRootFilesystem` interactions, init-flow regressions.

## What's new

| Path | Purpose |
|---|---|
| `.github/workflows/ci.yml` | `helm-smoke` job: checkout → setup-buildx → setup-helm → kind-action → run `smoke.sh` |
| `deploy/Dockerfile.smoke` | Multi-stage `golang:1.26 → distroless` build (self-contained, sidesteps the root `.dockerignore` that excludes host-built binaries) |
| `deploy/helm/warden/ci/postgres.yaml` | Ephemeral postgres Deployment + Service + Secret (`emptyDir`, single pod) |
| `deploy/helm/warden/ci/seal-key.sh` | `openssl rand 32` → `kubectl create secret` for the chart's static-seal path |
| `deploy/helm/warden/ci/tls-cert.sh` | Self-signed ECDSA TLS cert + CA, SANs covering in-cluster DNS + `127.0.0.1` |
| `deploy/helm/warden/ci/smoke-values.yaml` | 1-replica, static seal, image pinned to locally-built `warden:smoke` |
| `deploy/helm/warden/ci/smoke.sh` | Orchestrator (locally reproducible: `bash ci/smoke.sh` works on any laptop with kind + helm + docker buildx) |

`.helmignore` already excludes `ci/` — fixtures don't ship in the published chart.

## Design choices

- **Assertions via host `curl` through `kubectl port-forward`**, not in-pod `warden` CLI. Distroless has no `env` binary, and the CLI is env-vars-only — using curl + jq from the host is cleaner and stays in scope (test the chart + server, not the CLI).
- **Multi-stage Docker build with buildx**. CI's ubuntu-latest (16 GB RAM, buildx preinstalled) handles the AWS SDK compile comfortably; Docker Desktop's default 8 GB cap may OOM locally.
- **Static seal**, not transit — avoids needing an external Vault for smoke.
- **Self-contained orchestrator script**. Same `smoke.sh` runs in CI and locally; the CI job is a thin wrapper.

## Assertions

- Pod reaches `Running` phase (catches image-pull / scheduling / manifest bugs).
- `POST /v1/sys/init` succeeds and yields a `root_token` (catches HCL parse, seal config, storage config bugs).
- `GET /v1/sys/audit?warden-list=true` returns successfully after init (doubles as the cluster-active probe).
- Response contains `\"declarative\":true` for at least one entry (verifies the audit-HCL reconciler actually registered the chart-declared device).

On any failure, dumps `kubectl get all`, events, pod describe, and last 200 lines of warden-0 logs.

## Test plan

- [ ] CI's `helm-smoke` job goes green on this PR.
- [ ] Force a failure (e.g. set `image.tag=nonexistent` in smoke-values.yaml) and verify the job fails loudly with diagnostic dump, then revert.
- [ ] Confirm path-filter gating: a code-only commit triggers smoke; a docs-only commit does not.

## Out of scope (intentional)

- Multi-replica HA validation (e2e suite covers).
- Transit-seal / cert-manager integration validation.
- Audit-log file content assertions (e2e covers content shape).
- Caching the kind cluster across runs.

## Known risks

Per the [recent review](../../pull/new/ci/helm-smoke-test#discussion), most likely first-run failure points in order of probability:

1. OOM during the AWS SDK compile in the Go builder (mitigation: `GOMAXPROCS=2`).
2. Port-forward timing (mitigation: bump 60s retry window).
3. Audit-list response shape different from jq assumption (mitigation: diagnostic dump surfaces it).

Local verification skipped (host doesn't have buildx; iterating via CI on this branch.
EOF
)