### PR TITLE
feat(cli): add `warden status` with cluster-aware /v1/sys/health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Warden are documented in this file.
 
 ### New Features
 
+- **`warden status` subcommand.** New top-level CLI command that reports server health (initialized, sealed, standby, HA cluster role, leader address, active-since timestamp, server version) by wrapping `GET /v1/sys/health`. Honours the existing `--output table|json|ndjson|text` and `--fields` flags. Exit code is `0` on a healthy unsealed node (active or standby), `7` on a transport error, and `10` when the server reports sealed or uninitialized — scriptable so `if warden status; then ...` works in operator playbooks. The matching `(*api.Sys).Health` / `HealthWithContext` methods are added for SDK callers; the client allow-list now treats `429/501/503` from `/v1/sys/health` as decodable operational states instead of HTTP errors. (this PR)
+
+- **`/v1/sys/health` now returns cluster-aware fields.** The response body grows additively to include `ha_enabled`, `is_leader`, `leader_address`, `active_time` (RFC3339, only set on the active leader), and `version` (server build, surfaced through a new `HandlerProperties.Version` plumbed from `cmd.SetVersion`). Operators no longer need three round-trips (`/sys/health`, `/sys/leader`, `/sys/seal-status`) to assemble a status view. Leader lookup is gated on `!sealed && ha_enabled`, so a sealed HA node no longer logs an error on every k8s probe. (this PR)
+
+### Breaking Changes
+
+- **`/v1/sys/health` and `/v1/sys/leader`: `is_self` is renamed to `is_leader`.** The Vault legacy name was confusing in isolation ("self relative to what?") and the new name is symmetric across both endpoints. Any external script that grepped for `"is_self":` against these endpoints needs to be updated. (this PR)
+
+- **`/v1/sys/health`: `server_time_utc` (int64 Unix seconds) is replaced with `server_time` (RFC3339 string).** The new format is human-readable and sortable as text. The old integer field is gone, not aliased. (this PR)
+
 - **Audit devices declared in the HCL server config.** New `audit "TYPE" "PATH" { description = "..." options = { ... } }` block, parsed alongside `listener`, `storage`, and `seal`. Devices declared this way are registered during unseal *before the API listener accepts traffic* — a misconfigured sink (unwritable path, missing parent directory, permission denied) is a hard startup error, not a half-initialized cluster. Declarative (HCL) and imperative (API-enabled) devices coexist at different paths; an HCL block colliding with an API-enabled path refuses to start, and declarative devices cannot be modified or deleted via `sys/audit/{path}` (operators edit HCL and restart instead). The reconciler on every unseal handles add / refresh-options / drop-from-config transitions, preserving each entry's accessor and HMAC salt across restarts so audit-log HMACs stay stable. `GET /v1/sys/audit` and `GET /v1/sys/audit/{path}` responses now expose a `declarative` boolean so operators can tell the two origins apart. The auto-create-default-on-first-unseal logic is **removed** — the Helm chart ships a working `audit "file"` block by default, dev mode (`warden server -dev`) intentionally ships no audit, and bare-binary operators add a one-line block to their HCL (or accept zero-audit + bootstrap via API). (this PR)
 
 ### Bug Fixes

--- a/api/client.go
+++ b/api/client.go
@@ -1195,6 +1195,15 @@ func (c *Client) withConfiguredTimeout(ctx context.Context) (context.Context, co
 // It is the same as retryablehttp.DefaultRetryPolicy except that it also retries
 // 412 requests, and explicitly does NOT retry 4xx client errors (except 429)
 func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// /v1/sys/health surfaces 429/501/503 as deterministic operational states
+	// (standby / uninitialized / sealed). Retrying just delays the answer.
+	if resp != nil && resp.Request != nil && resp.Request.URL.Path == "/v1/sys/health" {
+		switch resp.StatusCode {
+		case 429, 501, 503:
+			return false, nil
+		}
+	}
+
 	// Don't retry on client errors (4xx) except for specific cases
 	if resp != nil {
 		// Never retry validation errors and other client errors

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -762,6 +762,42 @@ func TestDefaultRetryPolicy(t *testing.T) {
 			t.Error("expected retry to be false for 404 status")
 		}
 	})
+
+	// 429/501/503 on /v1/sys/health are deterministic operational states
+	// (standby / uninitialized / sealed). Retrying just delays the answer.
+	t.Run("does not retry health operational states", func(t *testing.T) {
+		for _, code := range []int{429, 501, 503} {
+			req, _ := http.NewRequest(http.MethodGet, "http://example.com/v1/sys/health", nil)
+			resp := &http.Response{
+				StatusCode: code,
+				Request:    req,
+			}
+			retry, err := DefaultRetryPolicy(ctx, resp, nil)
+			if err != nil {
+				t.Fatalf("unexpected error for code %d: %v", code, err)
+			}
+			if retry {
+				t.Errorf("expected retry=false for /v1/sys/health %d, got true", code)
+			}
+		}
+	})
+
+	// The health no-retry exemption MUST be path-scoped: 503 on a different
+	// URL still follows the default-policy (retry 5xx).
+	t.Run("503 on non-health path still retries", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com/v1/sys/seal-status", nil)
+		resp := &http.Response{
+			StatusCode: 503,
+			Request:    req,
+		}
+		retry, err := DefaultRetryPolicy(ctx, resp, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !retry {
+			t.Error("expected retry=true for 503 on /v1/sys/seal-status, got false")
+		}
+	})
 }
 
 func TestClient_RawRequestWithContext(t *testing.T) {

--- a/api/response.go
+++ b/api/response.go
@@ -26,9 +26,13 @@ func (r *Response) DecodeJSON(out interface{}) error {
 // this will fully consume the response body, but will not close it. The
 // body must still be closed manually.
 func (r *Response) Error() error {
-	// 200 to 399 are okay status codes. 429 is the code for health status of
-	// standby nodes, otherwise, 429 is treated as quota limit reached.
-	if (r.StatusCode >= 200 && r.StatusCode < 400) || (r.StatusCode == 429 && r.Request.URL.Path == "/v1/sys/health") {
+	// 200 to 399 are okay status codes. 429/501/503 are legitimate operational
+	// states for /v1/sys/health (standby / uninitialized / sealed) and carry
+	// a JSON body the caller wants to decode — treat them as non-errors so the
+	// Health() method can return a populated *HealthResponse.
+	if (r.StatusCode >= 200 && r.StatusCode < 400) ||
+		(r.Request.URL.Path == "/v1/sys/health" &&
+			(r.StatusCode == 429 || r.StatusCode == 501 || r.StatusCode == 503)) {
 		return nil
 	}
 

--- a/api/response_test.go
+++ b/api/response_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -170,5 +171,64 @@ func TestResponse_Error_HealthStandby429(t *testing.T) {
 	}
 	if err := resp.Error(); err != nil {
 		t.Errorf("expected no error for 429 on health endpoint, got %v", err)
+	}
+}
+
+// /v1/sys/health is special-cased: 429/501/503 are legitimate operational
+// states (standby / uninitialized / sealed) and carry a JSON body the caller
+// wants to decode. Treat them as non-errors so Health() can return a populated
+// *HealthResponse.
+func TestResponse_Error_HealthAllowedStatusCodes(t *testing.T) {
+	for _, code := range []int{429, 501, 503} {
+		t.Run(fmt.Sprintf("code_%d", code), func(t *testing.T) {
+			url, _ := http.NewRequest("GET", "http://example.com/v1/sys/health", nil)
+			resp := &Response{
+				Response: &http.Response{
+					StatusCode: code,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    url,
+				},
+			}
+			if err := resp.Error(); err != nil {
+				t.Errorf("expected no error for %d on /v1/sys/health, got %v", code, err)
+			}
+		})
+	}
+}
+
+// The /v1/sys/health allow-list MUST be path-scoped. 429/501/503 on any other
+// URL is a real error (rate limit, not-implemented, service unavailable) and
+// must still surface as *ResponseError.
+func TestResponse_Error_NonHealthPathStillErrors(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		code int
+	}{
+		{"/v1/sys/seal-status", 429},
+		{"/v1/sys/init", 503},
+		{"/v1/providers/aws/config", 501},
+		{"/v1/sys/healthz", 429}, // close-but-not-the-same path: must NOT match
+	} {
+		t.Run(fmt.Sprintf("%s_%d", tc.path, tc.code), func(t *testing.T) {
+			url, _ := http.NewRequest("GET", "http://example.com"+tc.path, nil)
+			resp := &Response{
+				Response: &http.Response{
+					StatusCode: tc.code,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":["nope"]}`)),
+					Request:    url,
+				},
+			}
+			err := resp.Error()
+			if err == nil {
+				t.Fatalf("expected error for %d on %s, got nil", tc.code, tc.path)
+			}
+			respErr, ok := err.(*ResponseError)
+			if !ok {
+				t.Fatalf("expected *ResponseError, got %T", err)
+			}
+			if respErr.StatusCode != tc.code {
+				t.Errorf("StatusCode = %d; want %d", respErr.StatusCode, tc.code)
+			}
+		})
 	}
 }

--- a/api/sys.go
+++ b/api/sys.go
@@ -164,6 +164,49 @@ func (c *Sys) InitWithRequestAndContext(ctx context.Context, initReq *InitReques
 	return initResp, nil
 }
 
+// HealthResponse mirrors the server's /v1/sys/health JSON shape. StatusCode is
+// lifted from the HTTP response and is not part of the wire body — callers
+// can use it to distinguish active (200) / standby (429) / sealed (503) /
+// uninitialized (501) without re-deriving from Sealed/Initialized flags.
+type HealthResponse struct {
+	Initialized   bool   `json:"initialized"`
+	Sealed        bool   `json:"sealed"`
+	Standby       bool   `json:"standby"`
+	HAEnabled     bool   `json:"ha_enabled"`
+	IsLeader      bool   `json:"is_leader"`
+	LeaderAddress string `json:"leader_address,omitempty"`
+	ActiveTime    string `json:"active_time,omitempty"`
+	Version       string `json:"version,omitempty"`
+	ServerTime    string `json:"server_time"`
+	StatusCode    int    `json:"-"`
+}
+
+// Health queries /v1/sys/health.
+func (c *Sys) Health() (*HealthResponse, error) {
+	return c.HealthWithContext(context.Background())
+}
+
+// HealthWithContext queries /v1/sys/health with a caller-supplied context.
+// 429/501/503 are not errors here — they are decoded into the response just
+// like 200, so callers can render sealed/standby/uninitialized states uniformly.
+func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
+	ctx, cancel := c.c.withConfiguredTimeout(ctx)
+	defer cancel()
+
+	r := c.c.NewRequest(http.MethodGet, "/v1/sys/health")
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	out := &HealthResponse{StatusCode: resp.StatusCode}
+	if err := resp.DecodeJSON(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // RevokeRootToken revokes the current root token.
 func (c *Sys) RevokeRootToken() error {
 	return c.RevokeRootTokenWithContext(context.Background())

--- a/api/sys_test.go
+++ b/api/sys_test.go
@@ -67,6 +67,130 @@ func TestSys_InitWithRequest(t *testing.T) {
 	}
 }
 
+func TestSys_Health_Active(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/sys/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"initialized":true,"sealed":false,"standby":false,"ha_enabled":true,"is_leader":true,"leader_address":"https://leader:8200","active_time":"2026-05-22T18:03:11Z","version":"0.4.2","server_time":"2026-05-23T14:34:22Z"}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.Address = server.URL
+	client, _ := NewClient(config)
+
+	resp, err := client.Sys().Health()
+	if err != nil {
+		t.Fatalf("Health failed: %v", err)
+	}
+	if !resp.Initialized || resp.Sealed || resp.Standby {
+		t.Errorf("expected active node, got initialized=%v sealed=%v standby=%v", resp.Initialized, resp.Sealed, resp.Standby)
+	}
+	if !resp.HAEnabled || !resp.IsLeader {
+		t.Errorf("expected HA leader, got ha_enabled=%v is_leader=%v", resp.HAEnabled, resp.IsLeader)
+	}
+	if resp.LeaderAddress != "https://leader:8200" {
+		t.Errorf("leader_address = %q", resp.LeaderAddress)
+	}
+	if resp.Version != "0.4.2" {
+		t.Errorf("version = %q", resp.Version)
+	}
+	if resp.ServerTime != "2026-05-23T14:34:22Z" {
+		t.Errorf("server_time = %q", resp.ServerTime)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d; want 200", resp.StatusCode)
+	}
+}
+
+func TestSys_Health_StandbyReturns429(t *testing.T) {
+	// Standby case: ha_enabled=true, is_leader=false. Critical that
+	// is_leader is emitted as a literal `false` and not silently dropped.
+	// Otherwise the consumer can't distinguish "HA on, this is a standby"
+	// from "HA off entirely".
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"initialized":true,"sealed":false,"standby":true,"ha_enabled":true,"is_leader":false,"leader_address":"https://leader:8200","server_time":"2026-05-23T14:34:22Z"}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.Address = server.URL
+	client, _ := NewClient(config)
+
+	resp, err := client.Sys().Health()
+	if err != nil {
+		t.Fatalf("Health on standby (429) should not error, got %v", err)
+	}
+	if !resp.Standby || resp.IsLeader {
+		t.Errorf("expected standby node, got standby=%v is_leader=%v", resp.Standby, resp.IsLeader)
+	}
+	if !resp.HAEnabled {
+		t.Errorf("standby case must surface ha_enabled=true; got false")
+	}
+	if resp.LeaderAddress != "https://leader:8200" {
+		t.Errorf("leader_address = %q; want https://leader:8200", resp.LeaderAddress)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d; want 429", resp.StatusCode)
+	}
+}
+
+func TestSys_Health_SealedReturns503(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"initialized":true,"sealed":true,"standby":false,"ha_enabled":true,"server_time":"2026-05-23T14:34:22Z"}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.Address = server.URL
+	client, _ := NewClient(config)
+
+	resp, err := client.Sys().Health()
+	if err != nil {
+		t.Fatalf("Health on sealed (503) should not error, got %v", err)
+	}
+	if !resp.Sealed {
+		t.Errorf("expected sealed=true")
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("StatusCode = %d; want 503", resp.StatusCode)
+	}
+}
+
+func TestSys_Health_UninitializedReturns501(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		w.Write([]byte(`{"initialized":false,"sealed":true,"standby":false,"ha_enabled":false,"server_time":"2026-05-23T14:34:22Z"}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.Address = server.URL
+	client, _ := NewClient(config)
+
+	resp, err := client.Sys().Health()
+	if err != nil {
+		t.Fatalf("Health on uninitialized (501) should not error, got %v", err)
+	}
+	if resp.Initialized {
+		t.Errorf("expected initialized=false")
+	}
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Errorf("StatusCode = %d; want 501", resp.StatusCode)
+	}
+}
+
 func TestSys_RevokeRootToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/cmd/helpers/errors.go
+++ b/cmd/helpers/errors.go
@@ -24,6 +24,7 @@ const (
 	ExitNetwork      ExitCode = 7
 	ExitServer       ExitCode = 8
 	ExitConflict     ExitCode = 9
+	ExitSealed       ExitCode = 10
 )
 
 // ErrorCode is the stable string identifier surfaced in JSON envelopes.
@@ -40,6 +41,7 @@ const (
 	CodeNetwork      ErrorCode = "network"
 	CodeServer       ErrorCode = "server"
 	CodeConflict     ErrorCode = "conflict"
+	CodeSealed       ErrorCode = "sealed"
 )
 
 // Sentinel errors. Wrap with fmt.Errorf("context: %w", helpers.ErrXxx) so the
@@ -53,6 +55,7 @@ var (
 	ErrNetwork      = errors.New("network error")
 	ErrServer       = errors.New("server error")
 	ErrConflict     = errors.New("conflict")
+	ErrSealed       = errors.New("warden is sealed or uninitialized")
 )
 
 // WardenError is the JSON envelope emitted on stderr when --output is json or
@@ -110,6 +113,8 @@ func classify(err error) (ErrorCode, ExitCode) {
 		return CodeServer, ExitServer
 	case errors.Is(err, ErrConflict):
 		return CodeConflict, ExitConflict
+	case errors.Is(err, ErrSealed):
+		return CodeSealed, ExitSealed
 	}
 
 	// 3. Network/transport errors (DNS, connection refused, timeout, TLS).
@@ -224,6 +229,8 @@ func DefaultHint(code ErrorCode) string {
 		return "The warden server returned an internal error; check server logs"
 	case CodeConflict:
 		return "The resource already exists or has been modified concurrently"
+	case CodeSealed:
+		return "Unseal warden with `warden operator unseal` (or initialize it with `warden operator init`)"
 	case CodeUsage:
 		return "Run with --help for usage"
 	default:

--- a/cmd/helpers/errors_test.go
+++ b/cmd/helpers/errors_test.go
@@ -66,6 +66,7 @@ func TestClassify_Sentinels(t *testing.T) {
 		{"network", ErrNetwork, CodeNetwork, ExitNetwork},
 		{"server", ErrServer, CodeServer, ExitServer},
 		{"conflict", ErrConflict, CodeConflict, ExitConflict},
+		{"sealed", ErrSealed, CodeSealed, ExitSealed},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -214,7 +215,7 @@ func TestHumanMessage_PrefersAPIErrorList(t *testing.T) {
 
 func TestDefaultHint_PerCategory(t *testing.T) {
 	// At minimum, the categories with non-empty defaults should produce text.
-	for _, code := range []ErrorCode{CodeAuth, CodeForbidden, CodeNetwork, CodeServer, CodeConflict, CodeUsage} {
+	for _, code := range []ErrorCode{CodeAuth, CodeForbidden, CodeNetwork, CodeServer, CodeConflict, CodeSealed, CodeUsage} {
 		if DefaultHint(code) == "" {
 			t.Errorf("DefaultHint(%q) returned empty; want non-empty hint", code)
 		}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -85,6 +85,17 @@ const (
 	listenerTypeUnix = "unix"
 )
 
+// buildVersion is the binary version surfaced in /v1/sys/health. Set by
+// cmd/warden.SetVersion before the server starts so the value flows into
+// http.HandlerProperties below.
+var buildVersion string
+
+// SetBuildVersion records the binary version for inclusion in the health
+// response. Called from cmd.SetVersion.
+func SetBuildVersion(v string) {
+	buildVersion = v
+}
+
 var (
 	configPath string
 	configDir  string
@@ -420,6 +431,7 @@ func run(cmd *cobra.Command, args []string) error {
 	httpHandler := wardenhttp.Handler(&wardenhttp.HandlerProperties{
 		Core:                 newCore,
 		Logger:               logger,
+		Version:              buildVersion,
 		ClusterTLSConfigFunc: newCore.ClusterTLSConfig,
 		ForwardingTimeout:    newCore.ClusterConfig().ForwardingTimeout,
 	})

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -1,0 +1,76 @@
+package status
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var StatusCmd = &cobra.Command{
+	Use:           "status",
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Short:         "Show Warden server status",
+	Long: `
+Usage: warden status
+
+  Prints initialization, seal, and HA/cluster state. Thin wrapper over
+  /v1/sys/health.
+
+  Exit codes (rough parity with vault status, mapped onto warden's scheme):
+    0    initialized and unsealed (active or standby)
+    7    transport / connection error
+    10   sealed or uninitialized
+
+Examples:
+
+  $ warden status
+  $ warden status -o json
+  $ warden status -o json --fields sealed,is_leader,leader_address
+`,
+	RunE: runStatus,
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	h, err := c.Sys().HealthWithContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	data := map[string]any{
+		"initialized": h.Initialized,
+		"sealed":      h.Sealed,
+		"standby":     h.Standby,
+		"ha_enabled":  h.HAEnabled,
+		"is_leader":   h.IsLeader,
+		"server_time": h.ServerTime,
+	}
+	// leader_address and active_time are only meaningful when HA is on.
+	// version is omitted from the table when the server didn't report one
+	// (older server, or stripped binary).
+	if h.HAEnabled {
+		if h.LeaderAddress != "" {
+			data["leader_address"] = h.LeaderAddress
+		}
+		if h.ActiveTime != "" {
+			data["active_time"] = h.ActiveTime
+		}
+	}
+	if h.Version != "" {
+		data["version"] = h.Version
+	}
+
+	if err := helpers.RenderMap(data, nil); err != nil {
+		return err
+	}
+
+	if h.Sealed || !h.Initialized {
+		return helpers.ErrSealed
+	}
+	return nil
+}

--- a/cmd/warden.go
+++ b/cmd/warden.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stephnangue/warden/cmd/schema"
 	"github.com/stephnangue/warden/cmd/server"
 	"github.com/stephnangue/warden/cmd/skills"
+	"github.com/stephnangue/warden/cmd/status"
 )
 
 var (
@@ -66,6 +67,7 @@ func init() {
 	wardenCmd.PersistentFlags().BoolVarP(helpers.DryRunFlagPtr(), "dry-run", "D", false, "Send X-Warden-Dry-Run on every request so the server validates without mutating. Honors WARDEN_DRY_RUN. Server enforcement is not yet shipped — see CHANGELOG.")
 
 	wardenCmd.AddCommand(server.ServerCmd)
+	wardenCmd.AddCommand(status.StatusCmd)
 	wardenCmd.AddCommand(operator.OperatorCmd)
 	wardenCmd.AddCommand(providers.ProvidersCmd)
 	wardenCmd.AddCommand(auth.AuthCmd)
@@ -83,10 +85,22 @@ func init() {
 	wardenCmd.AddCommand(basic.PathHelpCmd)
 }
 
+// serverVersion holds the binary's build version once SetVersion has been
+// called. It's read by cmd/server when constructing the HTTP handler so the
+// /v1/sys/health response can surface it.
+var serverVersion string
+
 // SetVersion sets the version string on the root command.
 // Called from main with the value injected via ldflags.
 func SetVersion(v string) {
 	wardenCmd.Version = v
+	serverVersion = v
+	server.SetBuildVersion(v)
+}
+
+// Version returns the build version previously set via SetVersion.
+func Version() string {
+	return serverVersion
 }
 
 // Namespace returns the currently configured namespace from the flag

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -553,10 +553,10 @@ kubectl -n warden get pods
 kubectl -n warden get endpoints warden
 # Should list all pod IPs.
 
-# Verify exactly one pod reports is_self=true:
+# Verify exactly one pod reports is_leader=true:
 for i in 0 1 2; do
   kubectl -n warden exec warden-$i -- \
-    curl -sk https://localhost:8400/v1/sys/leader | grep -o '"is_self":[a-z]*'
+    curl -sk https://localhost:8400/v1/sys/leader | grep -o '"is_leader":[a-z]*'
 done
 ```
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -84,7 +84,7 @@ You can also use raw `curl` commands for more control.
 | Method | Path | Response Codes |
 |--------|------|----------------|
 | GET | `/v1/sys/health` | 200=active, 429=standby, 503=sealed, 501=uninitialized |
-| GET | `/v1/sys/leader` | `{ha_enabled, is_self, leader_address, active_time}` |
+| GET | `/v1/sys/leader` | `{ha_enabled, is_leader, leader_address, active_time}` |
 | PUT | `/v1/sys/step-down` | Forces leadership step-down |
 | GET | `/v1/sys/seal-status` | Seal status |
 
@@ -211,7 +211,7 @@ Also report INFO-level findings for successful resilience observations worth not
 
 ### Category 7: Split-Brain Detection
 - After every failover, check ALL nodes' `/v1/sys/leader` response
-- Verify NEVER more than 1 node reports `is_self=true`
+- Verify NEVER more than 1 node reports `is_leader=true`
 - Check during rapid step-down cycles
 
 ### Category 8: CRUD During HA Events
@@ -244,7 +244,7 @@ Also report INFO-level findings for successful resilience observations worth not
 **HIGH severity** (report immediately):
 - Process crash or panic (check logs for `panic:`, `runtime error:`)
 - Data loss (resource existed but disappeared after failover)
-- Split-brain (two nodes both report `is_self=true`)
+- Split-brain (two nodes both report `is_leader=true`)
 - Request hangs indefinitely (>60s with no response)
 - Authentication bypass (request without token succeeds on protected endpoint)
 - Vault token leaked in error response or logs (check for `hvs.` tokens)

--- a/e2e/cluster/cluster_test.go
+++ b/e2e/cluster/cluster_test.go
@@ -10,14 +10,14 @@ import (
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
 
-// TestSplitBrainCheck verifies exactly 1 node reports is_self=true (T08).
+// TestSplitBrainCheck verifies exactly 1 node reports is_leader=true (T08).
 func TestSplitBrainCheck(t *testing.T) {
 	leader := h.GetLeaderPort(t)
 	h.StepDown(t, leader)
 	time.Sleep(5 * time.Second)
 	h.WaitForCluster(t, 15, 2*time.Second)
 
-	selfCount := 0
+	leaderCount := 0
 	for _, port := range h.NodePorts {
 		status, body := h.TryRequest("GET",
 			fmt.Sprintf("%s/v1/sys/leader", h.NodeURL(port)), nil, "")
@@ -25,12 +25,12 @@ func TestSplitBrainCheck(t *testing.T) {
 			continue
 		}
 		data := h.ParseJSON(t, body)
-		if isSelf, ok := data["is_self"].(bool); ok && isSelf {
-			selfCount++
+		if isLeader, ok := data["is_leader"].(bool); ok && isLeader {
+			leaderCount++
 		}
 	}
 
-	if selfCount != 1 {
-		t.Fatalf("expected exactly 1 node with is_self=true, got %d", selfCount)
+	if leaderCount != 1 {
+		t.Fatalf("expected exactly 1 node with is_leader=true, got %d", leaderCount)
 	}
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -31,6 +31,10 @@ type HandlerProperties struct {
 	Core   *core.Core
 	Logger *logger.GatedLogger
 
+	// Version is the server build version surfaced in /v1/sys/health.
+	// Empty means the version field is omitted from the response.
+	Version string
+
 	// ClusterTLSConfigFunc returns the current cluster mTLS config for
 	// forwarding requests from standby to active. When nil, forwarding
 	// uses plain HTTP (backward compatible).
@@ -59,7 +63,7 @@ func Handler(props *HandlerProperties) http.Handler {
 
 	// HA endpoints — must work on standby and sealed nodes.
 	// Register before the /v1/sys/ catch-all.
-	mux.Handle("/v1/sys/health", handleSysHealth(core, log))
+	mux.Handle("/v1/sys/health", handleSysHealth(core, log, props.Version))
 	mux.Handle("/v1/sys/ready", handleSysReady(core, log))
 	mux.Handle("/v1/sys/leader", handleSysLeader(core, log))
 	mux.Handle("/v1/sys/step-down", handleSysStepDown(core, log))

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -11,11 +12,21 @@ import (
 )
 
 // HealthResponse represents the response from the health endpoint.
+//
+// Fields beyond {initialized, sealed, standby, server_time} are populated
+// when the corresponding feature is available: ha_enabled/is_leader/
+// leader_address/active_time come from the HA backend, version from the
+// build-time version passed in via HandlerProperties.
 type HealthResponse struct {
-	Initialized   bool  `json:"initialized"`
-	Sealed        bool  `json:"sealed"`
-	Standby       bool  `json:"standby"`
-	ServerTimeUTC int64 `json:"server_time_utc"`
+	Initialized   bool   `json:"initialized"`
+	Sealed        bool   `json:"sealed"`
+	Standby       bool   `json:"standby"`
+	HAEnabled     bool   `json:"ha_enabled"`
+	IsLeader      bool   `json:"is_leader"`
+	LeaderAddress string `json:"leader_address,omitempty"`
+	ActiveTime    string `json:"active_time,omitempty"`
+	Version       string `json:"version,omitempty"`
+	ServerTime    string `json:"server_time"`
 }
 
 // handleSysHealth returns an HTTP handler for the /v1/sys/health endpoint.
@@ -24,7 +35,7 @@ type HealthResponse struct {
 //   - 429: standby node (unsealed but not active)
 //   - 501: not initialized
 //   - 503: sealed
-func handleSysHealth(c *core.Core, log *logger.GatedLogger) http.Handler {
+func handleSysHealth(c *core.Core, log *logger.GatedLogger, version string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -58,10 +69,28 @@ func handleSysHealth(c *core.Core, log *logger.GatedLogger) http.Handler {
 		}
 
 		resp := &HealthResponse{
-			Initialized:   initialized,
-			Sealed:        sealed,
-			Standby:       standby,
-			ServerTimeUTC: time.Now().UTC().Unix(),
+			Initialized: initialized,
+			Sealed:      sealed,
+			Standby:     standby,
+			HAEnabled:   c.HAEnabled(),
+			Version:     version,
+			ServerTime:  time.Now().UTC().Format(time.RFC3339),
+		}
+
+		// Leader lookup is only meaningful when HA is configured AND the node
+		// is unsealed. A sealed node's c.Leader() returns consts.ErrSealed,
+		// which we don't want to log on every k8s probe.
+		if resp.HAEnabled && !sealed {
+			isLeader, leaderAddr, _, err := c.Leader()
+			if err != nil && !errors.Is(err, core.ErrHANotEnabled) {
+				log.Warn("failed to read HA leader state for /sys/health", logger.Err(err))
+			} else if err == nil {
+				resp.IsLeader = isLeader
+				resp.LeaderAddress = leaderAddr
+				if isLeader {
+					resp.ActiveTime = c.ActiveTime().Format(time.RFC3339)
+				}
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -172,7 +172,12 @@ func TestHealthResponse_JSON(t *testing.T) {
 		Initialized:   true,
 		Sealed:        false,
 		Standby:       false,
-		ServerTimeUTC: 1234567890,
+		HAEnabled:     true,
+		IsLeader:      true,
+		LeaderAddress: "https://leader:8200",
+		ActiveTime:    "2026-05-22T18:03:11Z",
+		Version:       "0.4.2",
+		ServerTime:    "2026-05-23T14:34:22Z",
 	}
 
 	data, err := json.Marshal(resp)
@@ -185,13 +190,40 @@ func TestHealthResponse_JSON(t *testing.T) {
 	assert.Equal(t, resp.Initialized, decoded.Initialized)
 	assert.Equal(t, resp.Sealed, decoded.Sealed)
 	assert.Equal(t, resp.Standby, decoded.Standby)
-	assert.Equal(t, resp.ServerTimeUTC, decoded.ServerTimeUTC)
+	assert.Equal(t, resp.HAEnabled, decoded.HAEnabled)
+	assert.Equal(t, resp.IsLeader, decoded.IsLeader)
+	assert.Equal(t, resp.LeaderAddress, decoded.LeaderAddress)
+	assert.Equal(t, resp.ActiveTime, decoded.ActiveTime)
+	assert.Equal(t, resp.Version, decoded.Version)
+	assert.Equal(t, resp.ServerTime, decoded.ServerTime)
+}
+
+func TestHealthResponse_OmitsEmptyHAFields(t *testing.T) {
+	resp := &HealthResponse{
+		Initialized: true,
+		Sealed:      false,
+		Standby:     false,
+		HAEnabled:   false,
+		ServerTime:  "2026-05-23T14:34:22Z",
+	}
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	s := string(data)
+	// is_leader is NOT omitempty: a standby legitimately reports
+	// `"is_leader": false`, and dropping false would collapse "standby with
+	// HA on" and "no HA at all" into the same JSON shape. Always emit.
+	assert.Contains(t, s, `"is_leader":false`)
+	assert.NotContains(t, s, "leader_address")
+	assert.NotContains(t, s, "active_time")
+	assert.NotContains(t, s, "version")
+	assert.Contains(t, s, `"ha_enabled":false`)
+	assert.Contains(t, s, `"server_time":"2026-05-23T14:34:22Z"`)
 }
 
 func TestLeaderResponse_JSON(t *testing.T) {
 	resp := LeaderResponse{
 		HAEnabled:     true,
-		IsSelf:        true,
+		IsLeader:      true,
 		LeaderAddress: "https://leader:8200",
 		ActiveTime:    "2026-01-01T00:00:00Z",
 	}
@@ -207,7 +239,7 @@ func TestLeaderResponse_JSON(t *testing.T) {
 func TestLeaderResponse_OmitsEmptyActiveTime(t *testing.T) {
 	resp := LeaderResponse{
 		HAEnabled:     true,
-		IsSelf:        false,
+		IsLeader:      false,
 		LeaderAddress: "https://leader:8200",
 	}
 
@@ -273,7 +305,7 @@ func createTestCoreForHTTP(t *testing.T) (*core.Core, *logger.GatedLogger) {
 
 func TestHandleSysHealth_SealedNode(t *testing.T) {
 	c, log := createTestCoreForHTTP(t)
-	handler := handleSysHealth(c, log)
+	handler := handleSysHealth(c, log, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/sys/health", nil)
 	w := httptest.NewRecorder()
@@ -291,7 +323,7 @@ func TestHandleSysHealth_SealedNode(t *testing.T) {
 
 func TestHandleSysHealth_MethodNotAllowed(t *testing.T) {
 	c, log := createTestCoreForHTTP(t)
-	handler := handleSysHealth(c, log)
+	handler := handleSysHealth(c, log, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/sys/health", nil)
 	w := httptest.NewRecorder()
@@ -302,7 +334,7 @@ func TestHandleSysHealth_MethodNotAllowed(t *testing.T) {
 
 func TestHandleSysHealth_HEAD(t *testing.T) {
 	c, log := createTestCoreForHTTP(t)
-	handler := handleSysHealth(c, log)
+	handler := handleSysHealth(c, log, "")
 
 	req := httptest.NewRequest(http.MethodHead, "/v1/sys/health", nil)
 	w := httptest.NewRecorder()
@@ -315,7 +347,7 @@ func TestHandleSysHealth_HEAD(t *testing.T) {
 
 func TestHandleSysHealth_WithOverrides(t *testing.T) {
 	c, log := createTestCoreForHTTP(t)
-	handler := handleSysHealth(c, log)
+	handler := handleSysHealth(c, log, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/sys/health?uninitcode=200", nil)
 	w := httptest.NewRecorder()
@@ -474,7 +506,7 @@ func TestHandleSysHealth_InitializedButSealed(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Now test health - should return 503 (sealed)
-	healthHandler := handleSysHealth(c, log)
+	healthHandler := handleSysHealth(c, log, "")
 	req2 := httptest.NewRequest(http.MethodGet, "/v1/sys/health", nil)
 	w2 := httptest.NewRecorder()
 	healthHandler.ServeHTTP(w2, req2)
@@ -543,7 +575,7 @@ func TestHandleSysLeader_AfterInit(t *testing.T) {
 
 func TestHandleSysHealth_SealedCode(t *testing.T) {
 	c, log := createTestCoreForHTTP(t)
-	handler := handleSysHealth(c, log)
+	handler := handleSysHealth(c, log, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/sys/health?sealedcode=200", nil)
 	w := httptest.NewRecorder()

--- a/http/sys_leader.go
+++ b/http/sys_leader.go
@@ -12,7 +12,7 @@ import (
 // LeaderResponse represents the response from the leader endpoint.
 type LeaderResponse struct {
 	HAEnabled     bool   `json:"ha_enabled"`
-	IsSelf        bool   `json:"is_self"`
+	IsLeader      bool   `json:"is_leader"`
 	LeaderAddress string `json:"leader_address"`
 	ActiveTime    string `json:"active_time,omitempty"`
 }
@@ -37,7 +37,7 @@ func handleSysLeader(c *core.Core, log *logger.GatedLogger) http.Handler {
 
 		resp := &LeaderResponse{
 			HAEnabled:     true,
-			IsSelf:        isLeader,
+			IsLeader:      isLeader,
 			LeaderAddress: leaderAddr,
 		}
 


### PR DESCRIPTION
## Summary

- **New `warden status` subcommand.** Thin wrapper over `/v1/sys/health` honouring the existing `--output table|json|ndjson|text` and `--fields` flags. Exit codes: `0` unsealed (active or standby), `7` transport error, `10` sealed or uninitialized — scriptable so `if warden status; then ...` works in operator playbooks.
- **`/v1/sys/health` extended with cluster context.** Response now includes `ha_enabled`, `is_leader`, `leader_address`, `active_time`, and `version` (plumbed from `cmd.SetVersion` via a new `HandlerProperties.Version` field). Operators no longer need three round-trips (`/sys/health` + `/sys/leader` + `/sys/seal-status`) to assemble a status view. Leader lookup is gated on `!sealed && ha_enabled` so a sealed HA node no longer logs an error on every k8s probe.
- **SDK addition.** `(*api.Sys).Health` and `HealthWithContext` methods. The response allow-list and `DefaultRetryPolicy` treat `429/501/503` on `/v1/sys/health` as decodable operational states — path-scoped, so the same codes on any other URL continue to error / retry as before.

## Breaking changes (CHANGELOG)

- `is_self` → `is_leader` on both `/v1/sys/health` and `/v1/sys/leader` (was Vault legacy; symmetric across endpoints now).
- `server_time_utc` (int64 Unix seconds) → `server_time` (RFC3339 string) on `/v1/sys/health`.

Helm chart probes are status-code-only consumers of `/v1/sys/health`, so no chart changes were needed.

## Test plan

- [x] `go test ./...` — clean across 43 packages
- [x] `make test-e2e` — passes; 207 tests across 14 packages on a real 3-node HA cluster
  - Includes `e2e/cluster/TestSplitBrainCheck`, which now reads `is_leader` against the renamed wire field
  - `e2e/ha` (167s of HA scenarios) and `e2e/loadbalancer` exercise the new fields end-to-end
- [x] Live smoke against `warden server --dev`: table, json, ndjson, text formats, `--fields` projection
- [x] Exit-code paths verified: `0` on active, `7` on network error, `10` on sealed/uninit, `2` on `warden status garbage` (cobra usage)
- [x] New unit coverage: response allow-list (positive + negative cases including the look-alike `/v1/sys/healthz` path), retry-policy branch, and the new `ErrSealed` sentinel through `helpers.classify`

## Follow-ups (intentionally out of scope)

- No unit test exercising the HA-on-leader branch of `handleSysHealth` (no fake HA backend in the test harness). The e2e suite covers this in a real cluster.
- `/v1/sys/leader` still 500s on sealed nodes — pre-existing behaviour on a different endpoint.
- `cluster_id` / `cluster_name` / `performance_standby` / replication fields — warden core doesn't track these yet.
