### PR TITLE
feat(cli): honour `-o json` on `operator init`

### DIFF
--- a/cmd/helpers/client.go
+++ b/cmd/helpers/client.go
@@ -11,6 +11,10 @@ var (
 	c *api.Client
 )
 
+// SetTestClient installs an api.Client that Client() returns instead of
+// constructing one from the environment. Pass nil to clear. Intended for tests.
+func SetTestClient(client *api.Client) { c = client }
+
 // Construct the HTTP API client
 func Client() (*api.Client, error) {
 	// Read the test client if present

--- a/cmd/operator/init.go
+++ b/cmd/operator/init.go
@@ -51,6 +51,9 @@ Usage:
   # Initialize with PGP-encrypted root token
   $ warden operator init --root-token-pgp-key="keybase:admin"
 
+  # Emit machine-readable JSON for IaC scripts
+  $ warden operator init -o json
+
 IMPORTANT: The unseal keys and root token are displayed only once. Store them securely.
 You will need the threshold number of unseal keys to unseal Warden after restart.
 `,
@@ -99,54 +102,69 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("initialization failed: %w", err)
 	}
 
-	// Display initialization results
-	fmt.Println()
-	fmt.Println("=========================================")
-	fmt.Println("   WARDEN INITIALIZATION COMPLETE")
-	fmt.Println("=========================================")
-	fmt.Println()
-
-	// Display unseal keys
-	if len(initResp.Keys) > 0 {
-		fmt.Println("Unseal Keys:")
-		for i, key := range initResp.Keys {
-			fmt.Printf("Unseal Key %d: %s\n", i+1, key)
+	// Coerce nil slices to empty slices so JSON serializes them as `[]` rather
+	// than `null` — consumers can rely on a stable schema regardless of Shamir
+	// vs auto-unseal mode.
+	emptyIfNil := func(s []string) []string {
+		if s == nil {
+			return []string{}
 		}
+		return s
+	}
+	data := map[string]any{
+		"unseal_keys":          emptyIfNil(initResp.Keys),
+		"unseal_keys_base64":   emptyIfNil(initResp.KeysBase64),
+		"recovery_keys":        emptyIfNil(initResp.RecoveryKeys),
+		"recovery_keys_base64": emptyIfNil(initResp.RecoveryKeysBase64),
+		"root_token":           initResp.RootToken,
+	}
+
+	tableFn := func() {
+		fmt.Println()
+		fmt.Println("=========================================")
+		fmt.Println("   WARDEN INITIALIZATION COMPLETE")
+		fmt.Println("=========================================")
+		fmt.Println()
+
+		if len(initResp.Keys) > 0 {
+			fmt.Println("Unseal Keys:")
+			for i, key := range initResp.Keys {
+				fmt.Printf("Unseal Key %d: %s\n", i+1, key)
+			}
+			fmt.Println()
+		}
+
+		if len(initResp.RecoveryKeys) > 0 {
+			fmt.Println("Recovery Keys:")
+			for i, key := range initResp.RecoveryKeys {
+				fmt.Printf("Recovery Key %d: %s\n", i+1, key)
+			}
+			fmt.Println()
+		}
+
+		fmt.Println("Root Token:")
+		fmt.Println(initResp.RootToken)
+		fmt.Println()
+
+		fmt.Println("IMPORTANT: These keys will not be shown again!")
+		fmt.Println("Store them securely. You will need:")
+		if len(initResp.Keys) > 0 {
+			fmt.Printf("  - %d of %d unseal keys to unseal Warden\n", secretThreshold, secretShares)
+		}
+		fmt.Println("  - The root token for system administration")
+		fmt.Println()
+
+		fmt.Println("The root token can be used to:")
+		fmt.Println("  - Mount/unmount auth methods")
+		fmt.Println("  - Mount/unmount providers")
+		fmt.Println("  - Perform system administration")
+		fmt.Println()
+
+		fmt.Println("Export root token to environment:")
+		fmt.Printf("  export WARDEN_TOKEN=%s\n", initResp.RootToken)
+		fmt.Println("=========================================")
 		fmt.Println()
 	}
 
-	// Display recovery keys (if auto-unseal)
-	if len(initResp.RecoveryKeys) > 0 {
-		fmt.Println("Recovery Keys:")
-		for i, key := range initResp.RecoveryKeys {
-			fmt.Printf("Recovery Key %d: %s\n", i+1, key)
-		}
-		fmt.Println()
-	}
-
-	// Display root token
-	fmt.Println("Root Token:")
-	fmt.Println(initResp.RootToken)
-	fmt.Println()
-
-	fmt.Println("IMPORTANT: These keys will not be shown again!")
-	fmt.Println("Store them securely. You will need:")
-	if len(initResp.Keys) > 0 {
-		fmt.Printf("  - %d of %d unseal keys to unseal Warden\n", secretThreshold, secretShares)
-	}
-	fmt.Println("  - The root token for system administration")
-	fmt.Println()
-
-	fmt.Println("The root token can be used to:")
-	fmt.Println("  - Mount/unmount auth methods")
-	fmt.Println("  - Mount/unmount providers")
-	fmt.Println("  - Perform system administration")
-	fmt.Println()
-
-	fmt.Println("Export root token to environment:")
-	fmt.Printf("  export WARDEN_TOKEN=%s\n", initResp.RootToken)
-	fmt.Println("=========================================")
-	fmt.Println()
-
-	return nil
+	return helpers.RenderMap(data, tableFn)
 }

--- a/cmd/operator/init_test.go
+++ b/cmd/operator/init_test.go
@@ -1,0 +1,152 @@
+package operator
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/api"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+// setupInitTest spins up an httptest server that returns the given /v1/sys/init
+// response body, installs a real api.Client pointed at it via the helpers test
+// hook, captures stdout/stderr, and resets every piece of package-level state
+// in cleanup so tests stay independent.
+func setupInitTest(t *testing.T, respBody string) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(respBody))
+	}))
+
+	cfg := api.DefaultConfig()
+	cfg.Address = server.URL
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+	helpers.SetTestClient(client)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	helpers.SetOutputWriter(stdout)
+	helpers.SetErrorWriter(stderr)
+
+	origShares, origThreshold := secretShares, secretThreshold
+	secretShares, secretThreshold = 5, 3
+
+	t.Cleanup(func() {
+		server.Close()
+		helpers.SetTestClient(nil)
+		helpers.SetOutputFormat("")
+		helpers.SetFields("")
+		helpers.ResetWriters()
+		secretShares, secretThreshold = origShares, origThreshold
+	})
+
+	return stdout, stderr
+}
+
+func TestInit_JSONOutput(t *testing.T) {
+	body := `{"data":{"root_token":"hvs.root123","keys":["k1","k2","k3"],"keys_base64":["a2V5MQ==","a2V5Mg==","a2V5Mw=="]}}`
+	stdout, stderr := setupInitTest(t, body)
+	helpers.SetOutputFormat("json")
+
+	if err := run(nil, nil); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	if stderr.Len() != 0 {
+		t.Errorf("expected empty stderr in JSON mode; got %q", stderr.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, stdout.String())
+	}
+
+	for _, k := range []string{"unseal_keys", "unseal_keys_base64", "recovery_keys", "recovery_keys_base64", "root_token"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("JSON output missing field %q", k)
+		}
+	}
+
+	if got["root_token"] != "hvs.root123" {
+		t.Errorf("root_token = %v; want hvs.root123", got["root_token"])
+	}
+
+	unseal, ok := got["unseal_keys"].([]any)
+	if !ok || len(unseal) != 3 {
+		t.Errorf("unseal_keys = %v; want 3-element slice", got["unseal_keys"])
+	}
+
+	// Stable schema: recovery_keys must be [] (not null) even when the server
+	// omits the field — Shamir-mode bootstraps have no recovery keys.
+	recovery, ok := got["recovery_keys"].([]any)
+	if !ok {
+		t.Errorf("recovery_keys = %v (%T); want empty []any", got["recovery_keys"], got["recovery_keys"])
+	} else if len(recovery) != 0 {
+		t.Errorf("recovery_keys = %v; want empty slice", recovery)
+	}
+
+	if strings.Contains(stdout.String(), "WARDEN INITIALIZATION COMPLETE") {
+		t.Errorf("JSON output contains banner text; got %q", stdout.String())
+	}
+}
+
+// Table-mode banner output is intentionally not asserted here: the existing
+// helpers.PrintTable pipeline writes directly to os.Stdout rather than through
+// helpers.SetOutputWriter, so the captured buffer never sees it. The banner
+// text is unchanged verbatim from pre-change behavior — see the diff on
+// cmd/operator/init.go — and the JSON tests below cover the new code path.
+
+func TestInit_AutoUnsealJSON(t *testing.T) {
+	body := `{"data":{"root_token":"hvs.x","recovery_keys":["r1","r2"],"recovery_keys_base64":["cjE=","cjI="]}}`
+	stdout, _ := setupInitTest(t, body)
+	helpers.SetOutputFormat("json")
+
+	if err := run(nil, nil); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	unseal, _ := got["unseal_keys"].([]any)
+	if len(unseal) != 0 {
+		t.Errorf("auto-unseal: unseal_keys = %v; want empty", unseal)
+	}
+	recovery, ok := got["recovery_keys"].([]any)
+	if !ok || len(recovery) != 2 {
+		t.Errorf("auto-unseal: recovery_keys = %v; want 2-element slice", got["recovery_keys"])
+	}
+}
+
+func TestInit_FieldsProjection(t *testing.T) {
+	body := `{"data":{"root_token":"hvs.proj","keys":["k1"],"keys_base64":["b1"]}}`
+	stdout, _ := setupInitTest(t, body)
+	helpers.SetOutputFormat("json")
+	helpers.SetFields("root_token")
+
+	if err := run(nil, nil); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("--fields root_token: got %d keys; want 1\n%v", len(got), got)
+	}
+	if got["root_token"] != "hvs.proj" {
+		t.Errorf("root_token = %v; want hvs.proj", got["root_token"])
+	}
+}

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -193,7 +193,7 @@ echo "  Node reachable (health: $HEALTH_CODE)"
 
 if [ "$HEALTH_CODE" = "501" ]; then
   echo "  Cluster not initialized. Running operator init..."
-  INIT_OUTPUT=$("$BIN_DIR/warden" operator init --secret-shares=1 --secret-threshold=1 2>&1)
+  INIT_OUTPUT=$("$BIN_DIR/warden" operator init -o table --secret-shares=1 --secret-threshold=1 2>&1)
   echo "$INIT_OUTPUT"
 
   # Extract root token from init output


### PR DESCRIPTION
## Summary

- `warden operator init` now routes through `helpers.RenderMap`, emitting structured JSON when `-o json` (or `WARDEN_OUTPUT=json`, or a non-TTY stdout) is set. Banner output is preserved verbatim in table mode.
- JSON shape: `{unseal_keys, unseal_keys_base64, recovery_keys, recovery_keys_base64, root_token}` — empty slices serialize as `[]` (not `null`) so IaC consumers get a stable schema across Shamir and auto-unseal modes.
- Adds `helpers.SetTestClient` to unlock command-level tests (the existing `// Read the test client if present` comment in `client.go` already anticipated it), plus three new tests covering JSON shape, the auto-unseal path, and `--fields` projection.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/operator/... ./cmd/helpers/...`
- [x] `go test ./cmd/operator/... ./cmd/helpers/...` — 3 new tests pass
- [ ] Manual: spin up an uninitialised dev server and run `warden operator init -o json | jq .root_token` — expect a token string
- [ ] Manual: confirm TTY default (no `-o` flag) still prints the banner unchanged
- [ ] Manual: pipe to file with no `-o` (`warden operator init > out.json`) — expect autodetect JSON