### PR TITLE
feat(cli): accept Vault-style single-dash long flags

### DIFF
--- a/cmd/helpers/flagnorm.go
+++ b/cmd/helpers/flagnorm.go
@@ -1,0 +1,87 @@
+package helpers
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// NormalizeSingleDashFlags rewrites Vault-style single-dash long flags
+// (e.g. -format=json) to Cobra-style double-dash long flags
+// (--format=json) so operators migrating from Vault don't trip on the
+// muscle-memory difference. pflag is POSIX-strict and treats `-format`
+// as `-f` taking value `ormat=json` — see cobra#2192 (closed wontfix).
+//
+// Short flags, the `--` terminator, and tokens whose name doesn't match
+// a registered long flag pass through unchanged so pflag's existing
+// error paths still run on genuine typos.
+func NormalizeSingleDashFlags(root *cobra.Command, args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+	// Don't touch cobra's shell-completion subcommands — they have their
+	// own internal arg format (e.g. partial flag fragments mid-typing)
+	// that we must not rewrite.
+	if args[0] == "__complete" || args[0] == "__completeNoDesc" {
+		return args
+	}
+
+	longFlags := collectLongFlagNames(root)
+
+	out := make([]string, 0, len(args))
+	afterTerminator := false
+	for _, arg := range args {
+		if afterTerminator {
+			out = append(out, arg)
+			continue
+		}
+		if arg == "--" {
+			afterTerminator = true
+			out = append(out, arg)
+			continue
+		}
+		if len(arg) < 2 || arg[0] != '-' || arg == "-" || strings.HasPrefix(arg, "--") {
+			out = append(out, arg)
+			continue
+		}
+
+		rest := arg[1:]
+		name, _, _ := strings.Cut(rest, "=")
+		if longFlags[name] {
+			out = append(out, "--"+rest)
+		} else {
+			out = append(out, arg)
+		}
+	}
+	return out
+}
+
+func collectLongFlagNames(cmd *cobra.Command) map[string]bool {
+	// Cobra auto-adds --help and --version per command lazily during
+	// Execute(); they aren't always in the flagsets at preprocessing
+	// time, so seed them explicitly.
+	//
+	// NOTE: if any subtree ever calls Flags().SetNormalizeFunc, the
+	// canonical name pflag returns from VisitAll may differ from the
+	// literal token the user typed (e.g. dry_run → dry-run). The lookup
+	// below would miss the user's form. The codebase doesn't use
+	// SetNormalizeFunc today; if that changes, apply the same
+	// normalizer to `name` before the map lookup in
+	// NormalizeSingleDashFlags.
+	names := map[string]bool{"help": true, "version": true}
+	visit := func(f *pflag.Flag) { names[f.Name] = true }
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		// Cobra merges PersistentFlags into c.Flags() lazily at parse
+		// time, so we must visit both sets explicitly to catch
+		// persistents declared at this command.
+		c.PersistentFlags().VisitAll(visit)
+		c.Flags().VisitAll(visit)
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(cmd)
+	return names
+}

--- a/cmd/helpers/flagnorm_test.go
+++ b/cmd/helpers/flagnorm_test.go
@@ -1,0 +1,172 @@
+package helpers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestTree() *cobra.Command {
+	root := &cobra.Command{Use: "warden"}
+	var ns, output string
+	var dryRun bool
+	root.PersistentFlags().StringVarP(&ns, "namespace", "n", "", "")
+	root.PersistentFlags().StringVarP(&output, "output", "o", "", "")
+	root.PersistentFlags().BoolVarP(&dryRun, "dry-run", "D", false, "")
+
+	auth := &cobra.Command{Use: "auth"}
+	enable := &cobra.Command{Use: "enable"}
+	var typeFlag, pathFlag string
+	enable.Flags().StringVar(&typeFlag, "type", "", "")
+	enable.Flags().StringVar(&pathFlag, "path", "", "")
+	auth.AddCommand(enable)
+	root.AddCommand(auth)
+
+	operator := &cobra.Command{Use: "operator"}
+	initCmd := &cobra.Command{Use: "init"}
+	var format string
+	initCmd.Flags().StringVar(&format, "format", "", "")
+	operator.AddCommand(initCmd)
+	root.AddCommand(operator)
+
+	return root
+}
+
+func TestNormalizeSingleDashFlags(t *testing.T) {
+	root := newTestTree()
+
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "double-dash long flag unchanged",
+			in:   []string{"operator", "init", "--format=json"},
+			want: []string{"operator", "init", "--format=json"},
+		},
+		{
+			name: "single-dash long flag with equals rewritten",
+			in:   []string{"operator", "init", "-format=json"},
+			want: []string{"operator", "init", "--format=json"},
+		},
+		{
+			name: "single-dash long flag space-separated rewritten",
+			in:   []string{"-namespace", "ns1", "auth", "enable"},
+			want: []string{"--namespace", "ns1", "auth", "enable"},
+		},
+		{
+			name: "short flag preserved",
+			in:   []string{"-n", "ns1", "auth", "enable"},
+			want: []string{"-n", "ns1", "auth", "enable"},
+		},
+		{
+			name: "bundled shorthand unknown long flag preserved",
+			in:   []string{"-no", "ns1"},
+			want: []string{"-no", "ns1"},
+		},
+		{
+			name: "subcommand-only long flag rewritten",
+			in:   []string{"auth", "enable", "-type=jwt", "jwt-X"},
+			want: []string{"auth", "enable", "--type=jwt", "jwt-X"},
+		},
+		{
+			name: "double-dash terminator stops rewriting",
+			in:   []string{"auth", "enable", "--", "-format=json"},
+			want: []string{"auth", "enable", "--", "-format=json"},
+		},
+		{
+			name: "single dash alone preserved",
+			in:   []string{"-"},
+			want: []string{"-"},
+		},
+		{
+			name: "single-dash unknown long flag preserved",
+			in:   []string{"-totallyunknown"},
+			want: []string{"-totallyunknown"},
+		},
+		{
+			name: "single-dash bool long flag rewritten",
+			in:   []string{"-dry-run", "auth", "list"},
+			want: []string{"--dry-run", "auth", "list"},
+		},
+		{
+			name: "short flag bundled with equals value preserved",
+			in:   []string{"-n=ns1"},
+			want: []string{"-n=ns1"},
+		},
+		{
+			name: "multiple flags interspersed",
+			in:   []string{"-namespace", "ns1", "auth", "enable", "-type=jwt", "-path=jwt-X"},
+			want: []string{"--namespace", "ns1", "auth", "enable", "--type=jwt", "--path=jwt-X"},
+		},
+		{
+			// Cobra adds --help lazily per command; we seed "help" in
+			// the map explicitly so single-dash usage always works.
+			name: "single-dash help rewritten",
+			in:   []string{"-help"},
+			want: []string{"--help"},
+		},
+		{
+			name: "single-dash version rewritten",
+			in:   []string{"-version"},
+			want: []string{"--version"},
+		},
+		{
+			// Cobra shell-completion subcommands have their own arg
+			// format (partial fragments mid-typing); we must not
+			// rewrite them.
+			name: "__complete short-circuited",
+			in:   []string{"__complete", "auth", "-form"},
+			want: []string{"__complete", "auth", "-form"},
+		},
+		{
+			name: "__completeNoDesc short-circuited",
+			in:   []string{"__completeNoDesc", "auth", "-form"},
+			want: []string{"__completeNoDesc", "auth", "-form"},
+		},
+		{
+			// Negative numeric value following a short flag: -5 isn't
+			// a registered long flag name, so passes through.
+			name: "negative numeric value passes through",
+			in:   []string{"-n", "-5"},
+			want: []string{"-n", "-5"},
+		},
+		{
+			// Known limitation: we don't track "previous flag expects
+			// a value", so a value that itself names a long flag is
+			// rewritten. pflag then errors loudly (flag needs value,
+			// can't consume another flag), so it's not silent
+			// corruption. Vault users with dash-prefixed values should
+			// use the -key=value form or the -- terminator.
+			name: "value-that-names-a-flag is rewritten (known limitation)",
+			in:   []string{"-output", "-format=json"},
+			want: []string{"--output", "--format=json"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeSingleDashFlags(root, tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("NormalizeSingleDashFlags(%v) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSingleDashFlags_DoesNotMutateInput(t *testing.T) {
+	root := newTestTree()
+	in := []string{"-namespace", "ns1", "auth", "enable"}
+	original := append([]string{}, in...)
+	_ = NormalizeSingleDashFlags(root, in)
+	if !reflect.DeepEqual(in, original) {
+		t.Errorf("input slice was mutated: got %v, want %v", in, original)
+	}
+}

--- a/cmd/warden.go
+++ b/cmd/warden.go
@@ -65,7 +65,7 @@ func init() {
 	wardenCmd.PersistentFlags().StringVarP(&flagRole, "role", "r", "", "Warden role to use for the command (can also use WARDEN_ROLE env var)")
 	wardenCmd.PersistentFlags().StringVarP(helpers.OutputFlagPtr(), "output", "o", "", "Output format: table, json, ndjson, text. Defaults to table on a TTY, json otherwise. Honors WARDEN_OUTPUT.")
 	wardenCmd.PersistentFlags().StringVarP(helpers.FieldsFlagPtr(), "fields", "F", "", "Comma-separated dot-paths to project from structured output (e.g. name,metadata.created_at,tokens.*.id). Honors WARDEN_FIELDS.")
-	wardenCmd.PersistentFlags().BoolVarP(helpers.DryRunFlagPtr(), "dry-run", "D", false, "Send X-Warden-Dry-Run on every request so the server validates without mutating. Honors WARDEN_DRY_RUN. Server enforcement is not yet shipped — see CHANGELOG.")
+	wardenCmd.PersistentFlags().BoolVarP(helpers.DryRunFlagPtr(), "dry-run", "D", false, "Validate the payload locally against the server's schema and exit without sending the request. Catches hallucinated parameters before they hit the wire. Honors WARDEN_DRY_RUN.")
 
 	wardenCmd.AddCommand(server.ServerCmd)
 	wardenCmd.AddCommand(status.StatusCmd)

--- a/cmd/warden.go
+++ b/cmd/warden.go
@@ -54,6 +54,7 @@ safe operations, and complete visibility.`,
 )
 
 func Execute() {
+	wardenCmd.SetArgs(helpers.NormalizeSingleDashFlags(wardenCmd, os.Args[1:]))
 	if err := wardenCmd.Execute(); err != nil {
 		os.Exit(int(helpers.RenderError(err)))
 	}


### PR DESCRIPTION
## Summary

- **`feat(cli)`: accept Vault-style single-dash long flags** — preprocesses `os.Args` so `-format=json` is rewritten to `--format=json` before pflag parses it. Cobra/pflag is POSIX-strict (`-format` parses as `-f` taking value `ormat=json`); upstream declined to add native support (cobra#2192). The preprocessor walks the command tree, collects registered long-flag names, and only rewrites tokens that match. Short flags, `--` terminator, shell-completion subcommands, and unknown tokens pass through untouched. `help` and `version` are seeded explicitly since cobra adds them lazily per command.
- **`docs(cli)`: correct `--dry-run` help text** — the previous description referenced a non-existent `X-Warden-Dry-Run` header and an unshipped server enforcement path. Dry-run is client-side schema validation per `cmd/helpers/dry_run.go` and `CHANGELOG.md`. Replaced with text that matches the shipped behavior.

## Test plan

- [x] `go test ./cmd/helpers/...` — 19 new cases in `flagnorm_test.go` + non-mutation test, all pass
- [x] `go build ./...` clean
- [x] `go vet ./cmd/...` clean
- [x] Manual smoke — `warden -format=json operator init`, `warden auth enable -type=jwt`, `warden -dry-run --help`, `warden -help` all behave identically to their double-dash form
- [x] Regression — `warden -n NS auth list` (short flag preserved), `warden -unknownflag` (pflag error path unchanged), `warden auth list -- -format=json` (terminator respected)
- [ ] CI green