### PR TITLE
feat(cli): accept --path flag on path-taking commands

### DIFF
--- a/cmd/audit/disable.go
+++ b/cmd/audit/disable.go
@@ -8,16 +8,18 @@ import (
 )
 
 var (
+	disablePath string
+
 	DisableCmd = &cobra.Command{
-		Use:           "disable PATH",
+		Use:           "disable [PATH]",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "This command disables an audit device.",
 		Long: `
-Usage: warden audit disable PATH
+Usage: warden audit disable [PATH]
 
-  Disables an audit device at the given PATH. The argument corresponds to
-  the enabled PATH of the audit device.
+  Disables an audit device at the given PATH. The PATH may be supplied
+  either positionally or via --path (pick one — combining both is rejected).
 
   WARNING: Warden operates in fail-closed mode. You cannot disable the last
   remaining audit device. Attempting to do so will result in an error.
@@ -29,20 +31,28 @@ Usage: warden audit disable PATH
   Disable the audit device enabled at file/:
 
       $ warden audit disable file/
+      $ warden audit disable --path=file/
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: runDisable,
 	}
 )
 
+func init() {
+	DisableCmd.Flags().StringVar(&disablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
+}
+
 func runDisable(cmd *cobra.Command, args []string) error {
-	c, err := helpers.Client()
+	path, err := helpers.RequirePath(args, disablePath)
 	if err != nil {
 		return err
 	}
-
-	path := args[0]
 	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
 		return err
 	}
 

--- a/cmd/audit/enable.go
+++ b/cmd/audit/enable.go
@@ -14,6 +14,7 @@ var (
 	enableDescription string
 	enableFilePath    string
 	enableFormat      string
+	enablePath        string
 	enableJSON        string
 
 	EnableCmd = &cobra.Command{
@@ -25,14 +26,16 @@ var (
 Usage: warden audit enable [options] [PATH]
 
   Enable an audit device. By default the mount path matches the TYPE, but a
-  custom path can be supplied as a positional argument. Each device gets a
-  unique HMAC salt for log hashing — generated on enable, lost on disable.
-  Two input modes:
+  custom path can be supplied either positionally or via --path. Each device
+  gets a unique HMAC salt for log hashing — generated on enable, lost on
+  disable. Note: --path is the device's mount path, while --file-path is the
+  audit log file location — they are distinct. Two input modes:
 
     Typed flags (human-friendly):
 
       $ warden audit enable --type=file --file-path=/var/log/warden-audit.log
       $ warden audit enable --type=file --file-path=/var/log/audit.log prod-audit
+      $ warden audit enable --type=file --file-path=/var/log/audit.log --path=prod-audit
 
     Full JSON payload (agent-friendly):
 
@@ -40,9 +43,10 @@ Usage: warden audit enable [options] [PATH]
       $ cat audit-file.json | warden audit enable file --json -
 
   --json is mutually exclusive with --type / --description / --file-path /
-  --format. The mount path is the positional argument when given, otherwise
-  derived from the payload's "type" field. Combine with --dry-run to validate
-  the payload locally without enabling the device.
+  --format. The mount path may be provided positionally or via --path (pick
+  one — combining both is rejected). When neither is set, the path is
+  derived from --type or from the JSON payload's "type" field. Combine with
+  --dry-run to validate the payload locally without enabling the device.
 
   For a full list of audit device types and examples, please see the documentation.
 `,
@@ -55,10 +59,16 @@ func init() {
 	EnableCmd.Flags().StringVar(&enableDescription, "description", "", "Human-friendly description of the audit device")
 	EnableCmd.Flags().StringVar(&enableFilePath, "file-path", "", "Path to the audit log file (required for file type)")
 	EnableCmd.Flags().StringVar(&enableFormat, "format", "json", "Log format (currently only 'json' is supported)")
+	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
 	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with the typed flags)")
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
+	explicitPath, err := helpers.ResolvePath(args, enablePath)
+	if err != nil {
+		return err
+	}
+
 	c, err := helpers.Client()
 	if err != nil {
 		return err
@@ -78,9 +88,9 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		}); err != nil {
 			return err
 		}
-		path := helpers.MountPathFromArgOrPayload(args, jsonPayload)
+		path := helpers.MountPathFromArgOrPayload(explicitPath, jsonPayload)
 		if path == "" {
-			return fmt.Errorf("--json without a positional PATH and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
+			return fmt.Errorf("--json without a PATH (positional or --path) and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
 		}
 		if err := helpers.ValidatePath(path); err != nil {
 			return err
@@ -106,15 +116,12 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Determine path from positional argument or use type as default
 	var path string
-	if len(args) > 0 {
-		path = args[0]
+	if explicitPath != "" {
+		path = explicitPath
 	} else {
 		path = enableType + "/"
 	}
-
-	// Ensure path ends with /
 	if !strings.HasSuffix(path, "/") {
 		path = path + "/"
 	}

--- a/cmd/audit/read.go
+++ b/cmd/audit/read.go
@@ -8,32 +8,46 @@ import (
 	"github.com/stephnangue/warden/cmd/helpers"
 )
 
-var ReadCmd = &cobra.Command{
-	Use:           "read PATH",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "Show information on an audit device",
-	Long: `
-Usage: warden audit read PATH
+var (
+	readPath string
 
-  Show information on an audit device enabled on the provided PATH.
+	ReadCmd = &cobra.Command{
+		Use:           "read [PATH]",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Show information on an audit device",
+		Long: `
+Usage: warden audit read [PATH]
+
+  Show information on an audit device enabled on the provided PATH. The
+  PATH may be supplied either positionally or via --path (pick one —
+  combining both is rejected).
 
   Read the audit device enabled at file/:
 
       $ warden audit read file/
+      $ warden audit read --path=file/
 `,
-	Args: cobra.ExactArgs(1),
-	RunE: runRead,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runRead,
+	}
+)
+
+func init() {
+	ReadCmd.Flags().StringVar(&readPath, "path", "", "Mount path (alternative to the positional PATH argument)")
 }
 
 func runRead(cmd *cobra.Command, args []string) error {
-	c, err := helpers.Client()
+	path, err := helpers.RequirePath(args, readPath)
 	if err != nil {
 		return err
 	}
-
-	path := args[0]
 	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
 		return err
 	}
 

--- a/cmd/auth/disable.go
+++ b/cmd/auth/disable.go
@@ -8,35 +8,44 @@ import (
 )
 
 var (
+	disablePath string
+
 	DisableCmd = &cobra.Command{
-		Use:           "disable PATH",
+		Use:           "disable [PATH]",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "This command disables an auth method.",
 		Long: `
-Usage: warden auth disable PATH
+Usage: warden auth disable [PATH]
 
-  Disables an auth method at the given PATH. The argument corresponds to
-  the enabled PATH of the auth method.
+  Disables an auth method at the given PATH. The PATH may be supplied
+  either positionally or via --path (pick one — combining both is rejected).
 
   Disable the auth method enabled at jwt/:
 
       $ warden auth disable jwt/
+      $ warden auth disable --path=jwt/
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: runDisable,
 	}
 )
 
+func init() {
+	DisableCmd.Flags().StringVar(&disablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
+}
+
 func runDisable(cmd *cobra.Command, args []string) error {
-	// Create the client
-	c, err := helpers.Client()
+	path, err := helpers.RequirePath(args, disablePath)
 	if err != nil {
 		return err
 	}
-
-	path := args[0]
 	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
 		return err
 	}
 

--- a/cmd/auth/enable.go
+++ b/cmd/auth/enable.go
@@ -12,6 +12,7 @@ import (
 var (
 	enableType        string
 	enableDescription string
+	enablePath        string
 	enableJSON        string
 
 	EnableCmd = &cobra.Command{
@@ -23,12 +24,14 @@ var (
 Usage: warden auth enable [options] [PATH]
 
   Enable an auth method. By default the mount path matches the TYPE, but a
-  custom path can be supplied as a positional argument. Two input modes:
+  custom path can be supplied either positionally or via --path. Two input
+  modes:
 
     Typed flags (human-friendly):
 
       $ warden auth enable --type=jwt
       $ warden auth enable --type=oidc oidc-prod
+      $ warden auth enable --type=oidc --path=oidc-prod
       $ warden auth enable --type=jwt --description="Hydra OIDC"
 
     Full JSON payload (agent-friendly):
@@ -38,9 +41,10 @@ Usage: warden auth enable [options] [PATH]
       $ cat auth-jwt.json | warden auth enable jwt --json -
 
   --json is mutually exclusive with --type / --description. The mount path
-  is the positional argument when given, otherwise it is derived from the
-  payload's "type" field (e.g. type "jwt" → mount "jwt/"). Combine with
-  --dry-run to validate the payload locally without enabling the mount.
+  may be provided positionally or via --path (pick one — combining both is
+  rejected). When neither is set, the path is derived from --type or from
+  the JSON payload's "type" field (e.g. type "jwt" → mount "jwt/"). Combine
+  with --dry-run to validate the payload locally without enabling the mount.
 
   For a full list of auth methods and examples, please see the documentation.
 `,
@@ -51,10 +55,16 @@ Usage: warden auth enable [options] [PATH]
 func init() {
 	EnableCmd.Flags().StringVar(&enableType, "type", "", "Type of the auth method (e.g., jwt, oidc, ldap) (required unless --json)")
 	EnableCmd.Flags().StringVar(&enableDescription, "description", "", "Human-friendly description of the auth method")
+	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
 	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --type/--description)")
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
+	explicitPath, err := helpers.ResolvePath(args, enablePath)
+	if err != nil {
+		return err
+	}
+
 	c, err := helpers.Client()
 	if err != nil {
 		return err
@@ -72,11 +82,11 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		}); err != nil {
 			return err
 		}
-		// --json mode still needs a path — derive from the positional arg
-		// or from the payload's "type" field.
-		path := helpers.MountPathFromArgOrPayload(args, jsonPayload)
+		// --json mode still needs a path — use the explicit path (positional
+		// or --path) or derive it from the payload's "type" field.
+		path := helpers.MountPathFromArgOrPayload(explicitPath, jsonPayload)
 		if path == "" {
-			return fmt.Errorf("--json without a positional PATH and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
+			return fmt.Errorf("--json without a PATH (positional or --path) and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
 		}
 		if err := helpers.ValidatePath(path); err != nil {
 			return err
@@ -106,15 +116,12 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--type is required (or use --json): %w", helpers.ErrUsage)
 	}
 
-	// Determine path from positional argument or use type as default
 	var path string
-	if len(args) > 0 {
-		path = args[0]
+	if explicitPath != "" {
+		path = explicitPath
 	} else {
 		path = enableType + "/"
 	}
-
-	// Ensure path ends with /
 	if !strings.HasSuffix(path, "/") {
 		path = path + "/"
 	}

--- a/cmd/auth/read.go
+++ b/cmd/auth/read.go
@@ -8,32 +8,46 @@ import (
 	"github.com/stephnangue/warden/cmd/helpers"
 )
 
-var ReadCmd = &cobra.Command{
-	Use:           "read PATH",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "Show information on an auth method",
-	Long: `
-Usage: warden auth read PATH
+var (
+	readPath string
 
-  Show information on an auth method enabled on the provided PATH.
+	ReadCmd = &cobra.Command{
+		Use:           "read [PATH]",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Show information on an auth method",
+		Long: `
+Usage: warden auth read [PATH]
+
+  Show information on an auth method enabled on the provided PATH. The
+  PATH may be supplied either positionally or via --path (pick one —
+  combining both is rejected).
 
   Read the auth method enabled at jwt/:
 
       $ warden auth read jwt/
+      $ warden auth read --path=jwt/
 `,
-	Args: cobra.ExactArgs(1),
-	RunE: runRead,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runRead,
+	}
+)
+
+func init() {
+	ReadCmd.Flags().StringVar(&readPath, "path", "", "Mount path (alternative to the positional PATH argument)")
 }
 
 func runRead(cmd *cobra.Command, args []string) error {
-	c, err := helpers.Client()
+	path, err := helpers.RequirePath(args, readPath)
 	if err != nil {
 		return err
 	}
-
-	path := args[0]
 	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
 		return err
 	}
 

--- a/cmd/basic/delete.go
+++ b/cmd/basic/delete.go
@@ -17,11 +17,13 @@ var (
 		SilenceErrors: true,
 		Short:         "Delete data at a path",
 		Long: `
-Usage: warden delete PATH [flags]
+Usage: warden delete [PATH] [flags]
 
-  Delete data at the given path. The path should be in the format
-  "provider_mount/resource" or "auth/auth_mount/resource" or "sys/path/to/resource"
-  and will be converted to the appropriate API path.
+  Delete data at the given path. The PATH may be supplied either
+  positionally or via --path (pick one — combining both is rejected).
+  The path should be in the format "provider_mount/resource" or
+  "auth/auth_mount/resource" or "sys/path/to/resource" and will be
+  converted to the appropriate API path.
 
   By default, this command will ask for confirmation before deleting.
   Use the -f/--force flag to skip the confirmation prompt.
@@ -31,6 +33,7 @@ Usage: warden delete PATH [flags]
     Delete a JWT auth role (with confirmation):
 
       $ warden delete auth/jwt/role/developer
+      $ warden delete --path=auth/jwt/role/developer
 
     Delete a provider (skip confirmation):
 
@@ -40,19 +43,24 @@ Usage: warden delete PATH [flags]
 
       $ warden delete sys/namespaces/test
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: runDelete,
 	}
 
 	deleteForce bool
+	deletePath  string
 )
 
 func init() {
 	DeleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation prompt")
+	DeleteCmd.Flags().StringVar(&deletePath, "path", "", "API path (alternative to the positional PATH argument)")
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
-	path := args[0]
+	path, err := helpers.RequirePath(args, deletePath)
+	if err != nil {
+		return err
+	}
 	if err := helpers.ValidatePath(path); err != nil {
 		return err
 	}

--- a/cmd/basic/list.go
+++ b/cmd/basic/list.go
@@ -8,23 +8,29 @@ import (
 	"github.com/stephnangue/warden/cmd/helpers"
 )
 
-var ListCmd = &cobra.Command{
-	Use:           "list",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "List data from a path",
-	Long: `
-Usage: warden list PATH
+var (
+	listPath string
 
-  List data from the given path. The path should be in the format
-  "provider_mount/resource" or "auth/auth_mount/resource" or "sys/path/to/resource"
-  and will be converted to the appropriate API path.
+	ListCmd = &cobra.Command{
+		Use:           "list",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "List data from a path",
+		Long: `
+Usage: warden list [PATH]
+
+  List data from the given path. The PATH may be supplied either
+  positionally or via --path (pick one — combining both is rejected).
+  The path should be in the format "provider_mount/resource" or
+  "auth/auth_mount/resource" or "sys/path/to/resource" and will be
+  converted to the appropriate API path.
 
   Examples:
 
     List JWT auth roles:
 
       $ warden list auth/jwt/role
+      $ warden list --path=auth/jwt/role
 
     List providers:
 
@@ -34,12 +40,20 @@ Usage: warden list PATH
 
       $ warden list sys/namespaces
 `,
-	Args: cobra.ExactArgs(1),
-	RunE: runList,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runList,
+	}
+)
+
+func init() {
+	ListCmd.Flags().StringVar(&listPath, "path", "", "API path (alternative to the positional PATH argument)")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	path := args[0]
+	path, err := helpers.RequirePath(args, listPath)
+	if err != nil {
+		return err
+	}
 	if err := helpers.ValidatePath(path); err != nil {
 		return err
 	}

--- a/cmd/basic/read.go
+++ b/cmd/basic/read.go
@@ -8,23 +8,29 @@ import (
 	"github.com/stephnangue/warden/cmd/helpers"
 )
 
-var ReadCmd = &cobra.Command{
-	Use:           "read",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "Read data from a path",
-	Long: `
-Usage: warden read PATH
+var (
+	readPath string
 
-  Read data from the given path. The path should be in the format
-  "provider_mount/resource" or "auth/auth_mount/resource" or "sys/path/to/resource"
-  and will be converted to the appropriate API path.
+	ReadCmd = &cobra.Command{
+		Use:           "read",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Read data from a path",
+		Long: `
+Usage: warden read [PATH]
+
+  Read data from the given path. The PATH may be supplied either
+  positionally or via --path (pick one — combining both is rejected).
+  The path should be in the format "provider_mount/resource" or
+  "auth/auth_mount/resource" or "sys/path/to/resource" and will be
+  converted to the appropriate API path.
 
   Examples:
 
     Read AWS provider configuration:
 
       $ warden read aws/config
+      $ warden read --path=aws/config
 
     Read JWT auth configuration:
 
@@ -38,12 +44,20 @@ Usage: warden read PATH
 
       $ warden read aws/config --fields proxy_domains,timeout
 `,
-	Args: cobra.ExactArgs(1),
-	RunE: runRead,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runRead,
+	}
+)
+
+func init() {
+	ReadCmd.Flags().StringVar(&readPath, "path", "", "API path (alternative to the positional PATH argument)")
 }
 
 func runRead(cmd *cobra.Command, args []string) error {
-	path := args[0]
+	path, err := helpers.RequirePath(args, readPath)
+	if err != nil {
+		return err
+	}
 	if err := helpers.ValidatePath(path); err != nil {
 		return err
 	}

--- a/cmd/basic/write.go
+++ b/cmd/basic/write.go
@@ -13,18 +13,23 @@ import (
 )
 
 var (
+	writePath string
+
 	WriteCmd = &cobra.Command{
 		Use:           "write",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "Write data to a path",
 		Long: `
-Usage: warden write PATH [DATA]
+Usage: warden write [PATH] [DATA]
 
-  Write data to the given path. The data can be provided as JSON via stdin,
-  as JSON arguments, or as key=value pairs. The path should be in the format
-  "provider_mount/resource" or "auth/auth_mount/resource" or "sys/path/to/resource"
-  and will be converted to the appropriate API path.
+  Write data to the given path. The PATH may be supplied either positionally
+  or via --path (pick one — combining both is rejected). When --path is used,
+  all remaining positional arguments are treated as DATA. The data can be
+  provided as JSON via stdin, as JSON arguments, or as key=value pairs. The
+  path should be in the format "provider_mount/resource" or
+  "auth/auth_mount/resource" or "sys/path/to/resource" and will be converted
+  to the appropriate API path.
 
   Write configuration using JSON via stdin:
 
@@ -39,18 +44,35 @@ Usage: warden write PATH [DATA]
   Write configuration using key=value format:
 
       $ warden write aws/config token_ttl=1h proxy_domains='["localhost","warden"]'
+      $ warden write --path=aws/config token_ttl=1h
 
   Use @file to read a value from a file (useful for PEM certificates, large payloads, etc.):
 
       $ warden write auth/cert/config trusted_ca_pem=@/path/to/ca.pem default_role=my-role
 `,
-		Args: cobra.MinimumNArgs(1),
 		RunE: runWrite,
 	}
 )
 
+func init() {
+	WriteCmd.Flags().StringVar(&writePath, "path", "", "API path (alternative to the positional PATH argument)")
+}
+
 func runWrite(cmd *cobra.Command, args []string) error {
-	path := args[0]
+	// --path frees args[0] for DATA; without --path, args[0] is the PATH.
+	var path string
+	var dataArgs []string
+	if writePath != "" {
+		path = writePath
+		dataArgs = args
+	} else {
+		p, err := helpers.RequirePath(args, "")
+		if err != nil {
+			return err
+		}
+		path = p
+		dataArgs = args[1:]
+	}
 	if err := helpers.ValidatePath(path); err != nil {
 		return err
 	}
@@ -78,14 +100,14 @@ func runWrite(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to parse JSON: %w", err)
 			}
 		}
-	} else if len(args) > 1 {
+	} else if len(dataArgs) > 0 {
 		// Try to parse remaining args as key=value pairs or JSON
 		data = make(map[string]interface{})
 
 		// Check if first arg looks like key=value format
-		if strings.Contains(args[1], "=") {
+		if strings.Contains(dataArgs[0], "=") {
 			// Parse as key=value pairs with type inference
-			for _, arg := range args[1:] {
+			for _, arg := range dataArgs {
 				parts := strings.SplitN(arg, "=", 2)
 				if len(parts) != 2 {
 					return fmt.Errorf("invalid key=value format %q: %w", arg, helpers.ErrInvalidInput)
@@ -108,7 +130,7 @@ func runWrite(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			// Try to parse as JSON
-			jsonStr := strings.Join(args[1:], " ")
+			jsonStr := strings.Join(dataArgs, " ")
 			if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
 				return fmt.Errorf("failed to parse JSON from arguments: %w", err)
 			}

--- a/cmd/helpers/input.go
+++ b/cmd/helpers/input.go
@@ -92,10 +92,44 @@ func RejectFlagsWithJSON(jsonProvided bool, flags map[string]bool) error {
 		strings.Join(conflicting, ", "), ErrUsage)
 }
 
+// ResolvePath returns the explicit path from either the positional
+// argument or the --path flag, with a usage error when both are
+// supplied. Returns "" when neither is set — callers may then fall
+// back to deriving the path (e.g. from --type or from a JSON payload's
+// "type" field), or treat empty as a usage error.
+func ResolvePath(args []string, pathFlag string) (string, error) {
+	if len(args) > 0 && pathFlag != "" {
+		return "", fmt.Errorf(
+			"cannot specify both --path=%q and positional PATH %q: %w",
+			pathFlag, args[0], ErrUsage)
+	}
+	if len(args) > 0 {
+		return args[0], nil
+	}
+	return pathFlag, nil
+}
+
+// RequirePath is ResolvePath plus a usage error when neither source
+// supplied a value. Use this in commands where PATH is mandatory
+// (disable, read, etc.). Commands that fall back to deriving the path
+// from --type or a JSON payload should call ResolvePath directly and
+// handle the empty case themselves.
+func RequirePath(args []string, pathFlag string) (string, error) {
+	path, err := ResolvePath(args, pathFlag)
+	if err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "", fmt.Errorf("PATH is required (provide positionally or via --path): %w", ErrUsage)
+	}
+	return path, nil
+}
+
 // MountPathFromArgOrPayload resolves the mount path for `enable` commands
-// that accept either an explicit positional path OR a `--json` payload
-// containing a "type" field. The positional argument wins when present;
-// otherwise we derive the path from the payload's "type" (e.g. "jwt" → "jwt/").
+// that accept either an explicit path (already resolved from positional
+// or --path via ResolvePath) OR a `--json` payload containing a "type"
+// field. The explicit path wins when present; otherwise we derive the
+// path from the payload's "type" (e.g. "jwt" → "jwt/").
 //
 // Returns "" when neither source supplies a value — callers should error
 // out with a clear "cannot determine mount path" message rather than
@@ -103,12 +137,12 @@ func RejectFlagsWithJSON(jsonProvided bool, flags map[string]bool) error {
 // surface a misleading "absolute path" error.
 //
 // A non-empty result always has a trailing slash.
-func MountPathFromArgOrPayload(args []string, payload map[string]any) string {
-	var path string
-	if len(args) > 0 {
-		path = args[0]
-	} else if t, ok := payload["type"].(string); ok && t != "" {
-		path = t + "/"
+func MountPathFromArgOrPayload(explicitPath string, payload map[string]any) string {
+	path := explicitPath
+	if path == "" {
+		if t, ok := payload["type"].(string); ok && t != "" {
+			path = t + "/"
+		}
 	}
 	if path == "" {
 		return ""

--- a/cmd/helpers/input_test.go
+++ b/cmd/helpers/input_test.go
@@ -210,45 +210,149 @@ func TestRejectFlagsWithJSON_DeterministicOrder(t *testing.T) {
 
 func TestMountPathFromArgOrPayload(t *testing.T) {
 	cases := []struct {
-		name    string
-		args    []string
-		payload map[string]any
-		want    string
+		name         string
+		explicitPath string
+		payload      map[string]any
+		want         string
 	}{
 		{
-			name: "positional arg wins",
-			args: []string{"custom-mount"},
-			payload: map[string]any{"type": "jwt"},
-			want: "custom-mount/",
+			name:         "explicit path wins",
+			explicitPath: "custom-mount",
+			payload:      map[string]any{"type": "jwt"},
+			want:         "custom-mount/",
 		},
 		{
-			name: "no arg, derive from payload type",
-			args: nil,
-			payload: map[string]any{"type": "jwt"},
-			want: "jwt/",
+			name:         "no explicit path, derive from payload type",
+			explicitPath: "",
+			payload:      map[string]any{"type": "jwt"},
+			want:         "jwt/",
 		},
 		{
-			name: "no arg, no type → empty",
-			args: nil,
-			payload: map[string]any{},
-			want: "",
+			name:         "no explicit path, no type → empty",
+			explicitPath: "",
+			payload:      map[string]any{},
+			want:         "",
 		},
 		{
-			name: "no arg, nil payload → empty",
-			args: nil,
-			payload: nil,
-			want: "",
+			name:         "no explicit path, nil payload → empty",
+			explicitPath: "",
+			payload:      nil,
+			want:         "",
 		},
 		{
-			name: "trailing slash preserved",
-			args: []string{"already-slashed/"},
-			payload: nil,
-			want: "already-slashed/",
+			name:         "trailing slash preserved",
+			explicitPath: "already-slashed/",
+			payload:      nil,
+			want:         "already-slashed/",
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MountPathFromArgOrPayload(tt.args, tt.payload); got != tt.want {
+			if got := MountPathFromArgOrPayload(tt.explicitPath, tt.payload); got != tt.want {
+				t.Errorf("got %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequirePath(t *testing.T) {
+	t.Run("positional only", func(t *testing.T) {
+		got, err := RequirePath([]string{"jwt/"}, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "jwt/" {
+			t.Errorf("got %q; want %q", got, "jwt/")
+		}
+	})
+	t.Run("flag only", func(t *testing.T) {
+		got, err := RequirePath(nil, "jwt/")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "jwt/" {
+			t.Errorf("got %q; want %q", got, "jwt/")
+		}
+	})
+	t.Run("both → conflict error", func(t *testing.T) {
+		_, err := RequirePath([]string{"a"}, "b")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !errors.Is(err, ErrUsage) {
+			t.Errorf("expected ErrUsage; got %v", err)
+		}
+	})
+	t.Run("neither → required error", func(t *testing.T) {
+		_, err := RequirePath(nil, "")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !errors.Is(err, ErrUsage) {
+			t.Errorf("expected ErrUsage; got %v", err)
+		}
+		if !strings.Contains(err.Error(), "PATH is required") {
+			t.Errorf("expected 'PATH is required' in error; got %q", err.Error())
+		}
+	})
+}
+
+func TestResolvePath(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		pathFlag  string
+		want      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "positional only",
+			args: []string{"jwt-X"},
+			want: "jwt-X",
+		},
+		{
+			name:     "flag only",
+			pathFlag: "jwt-X",
+			want:     "jwt-X",
+		},
+		{
+			name:      "both set → error",
+			args:      []string{"pos"},
+			pathFlag:  "flag",
+			wantErr:   true,
+			errSubstr: "cannot specify both",
+		},
+		{
+			name: "neither → empty, no error",
+			want: "",
+		},
+		{
+			name:     "empty positional slice, flag set",
+			args:     []string{},
+			pathFlag: "jwt-X",
+			want:     "jwt-X",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolvePath(tt.args, tt.pathFlag)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error; got nil")
+				}
+				if !errors.Is(err, ErrUsage) {
+					t.Errorf("expected ErrUsage; got %v", err)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error to contain %q; got %q", tt.errSubstr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
 				t.Errorf("got %q; want %q", got, tt.want)
 			}
 		})

--- a/cmd/providers/disable.go
+++ b/cmd/providers/disable.go
@@ -8,35 +8,44 @@ import (
 )
 
 var (
+	disablePath string
+
 	DisableCmd = &cobra.Command{
-		Use:           "disable PATH",
+		Use:           "disable [PATH]",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "This command disable a provider.",
 		Long: `
-Usage: warden provider disable PATH
+Usage: warden provider disable [PATH]
 
-  Disables a provider at the given PATH. The argument corresponds to
-  the enabled PATH of the provider.
+  Disables a provider at the given PATH. The PATH may be supplied either
+  positionally or via --path (pick one — combining both is rejected).
 
   Disable the provider enabled at aws/:
 
       $ warden provider disable aws/
+      $ warden provider disable --path=aws/
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: runDisable,
 	}
 )
 
+func init() {
+	DisableCmd.Flags().StringVar(&disablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
+}
+
 func runDisable(cmd *cobra.Command, args []string) error {
-	// Create the client
-	c, err := helpers.Client()
+	path, err := helpers.RequirePath(args, disablePath)
 	if err != nil {
 		return err
 	}
-
-	path := args[0]
 	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
 		return err
 	}
 

--- a/cmd/providers/enable.go
+++ b/cmd/providers/enable.go
@@ -12,6 +12,7 @@ import (
 var (
 	enableType        string
 	enableDescription string
+	enablePath        string
 	enableJSON        string
 
 	EnableCmd = &cobra.Command{
@@ -23,12 +24,14 @@ var (
 Usage: warden provider enable [options] [PATH]
 
   Enable a provider. By default the mount path matches the TYPE, but a
-  custom path can be supplied as a positional argument. Two input modes:
+  custom path can be supplied either positionally or via --path. Two input
+  modes:
 
     Typed flags (human-friendly):
 
       $ warden provider enable --type=aws
       $ warden provider enable --type=azure azure-prod
+      $ warden provider enable --type=azure --path=azure-prod
       $ warden provider enable --type=aws --description="Production AWS"
 
     Full JSON payload (agent-friendly):
@@ -37,9 +40,10 @@ Usage: warden provider enable [options] [PATH]
       $ cat provider-aws.json | warden provider enable aws --json -
 
   --json is mutually exclusive with --type / --description. The mount path
-  is the positional argument when given, otherwise derived from the
-  payload's "type" field. Combine with --dry-run to validate the payload
-  locally without enabling the provider.
+  may be provided positionally or via --path (pick one — combining both is
+  rejected). When neither is set, the path is derived from --type or from
+  the JSON payload's "type" field. Combine with --dry-run to validate the
+  payload locally without enabling the provider.
 
   For a full list of providers and examples, please see the documentation.
 `,
@@ -50,10 +54,16 @@ Usage: warden provider enable [options] [PATH]
 func init() {
 	EnableCmd.Flags().StringVar(&enableType, "type", "", "Type of the provider (e.g., aws, azure, gcp) (required unless --json)")
 	EnableCmd.Flags().StringVar(&enableDescription, "description", "", "Human-friendly description of the provider")
+	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
 	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --type/--description)")
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
+	explicitPath, err := helpers.ResolvePath(args, enablePath)
+	if err != nil {
+		return err
+	}
+
 	c, err := helpers.Client()
 	if err != nil {
 		return err
@@ -71,9 +81,9 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		}); err != nil {
 			return err
 		}
-		path := helpers.MountPathFromArgOrPayload(args, jsonPayload)
+		path := helpers.MountPathFromArgOrPayload(explicitPath, jsonPayload)
 		if path == "" {
-			return fmt.Errorf("--json without a positional PATH and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
+			return fmt.Errorf("--json without a PATH (positional or --path) and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
 		}
 		if err := helpers.ValidatePath(path); err != nil {
 			return err
@@ -103,15 +113,12 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--type is required (or use --json): %w", helpers.ErrUsage)
 	}
 
-	// Determine path from positional argument or use type as default
 	var path string
-	if len(args) > 0 {
-		path = args[0]
+	if explicitPath != "" {
+		path = explicitPath
 	} else {
 		path = enableType + "/"
 	}
-
-	// Ensure path ends with /
 	if !strings.HasSuffix(path, "/") {
 		path = path + "/"
 	}

--- a/cmd/providers/read.go
+++ b/cmd/providers/read.go
@@ -8,32 +8,46 @@ import (
 	"github.com/stephnangue/warden/cmd/helpers"
 )
 
-var ReadCmd = &cobra.Command{
-	Use:           "read PATH",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "Show information on a provider",
-	Long: `
-Usage: warden provider read PATH
+var (
+	readPath string
 
-  Show information on a provider enabled on the provided PATH.
+	ReadCmd = &cobra.Command{
+		Use:           "read [PATH]",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Show information on a provider",
+		Long: `
+Usage: warden provider read [PATH]
+
+  Show information on a provider enabled on the provided PATH. The PATH
+  may be supplied either positionally or via --path (pick one — combining
+  both is rejected).
 
   Read the provider enabled at aws/:
 
       $ warden provider read aws/
+      $ warden provider read --path=aws/
 `,
-	Args: cobra.ExactArgs(1),
-	RunE: runRead,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runRead,
+	}
+)
+
+func init() {
+	ReadCmd.Flags().StringVar(&readPath, "path", "", "Mount path (alternative to the positional PATH argument)")
 }
 
 func runRead(cmd *cobra.Command, args []string) error {
-	c, err := helpers.Client()
+	path, err := helpers.RequirePath(args, readPath)
 	if err != nil {
 		return err
 	}
-
-	path := args[0]
 	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
 		return err
 	}
 

--- a/docs/tutorials/vault-policy-hygiene/README.md
+++ b/docs/tutorials/vault-policy-hygiene/README.md
@@ -498,8 +498,12 @@ cred spec mints OpenBao tokens via the `policy-reader` token role;
 ```bash
 warden provider enable --type=vault \
     --description="Internal OpenBao cluster — ACL policies, mounts, identity (read-mostly)" \
-    vault
+    --path=vault
 ```
+
+The mount path can be supplied either positionally or via `--path` —
+both forms work and Vault-style single-dash long flags (`-path=vault`)
+are accepted too.
 
 ```bash
 warden write auth/jwt/role/policy-scanner \

--- a/e2e/auth/json_payload_test.go
+++ b/e2e/auth/json_payload_test.go
@@ -50,6 +50,58 @@ func TestJSON_AuthEnableWithJSON(t *testing.T) {
 	}
 }
 
+// TestJSON_AuthEnableWithPathFlag verifies that -path works as an
+// alternative to the positional PATH argument. Uses Vault-style single-dash
+// long flags so this test also exercises the flag-normalization layer
+// against the newly-added -path flag.
+func TestJSON_AuthEnableWithPathFlag(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	const path = "e2e-pathflag-auth"
+	h.APIRequest(t, "DELETE", "sys/auth/"+path, port, "")
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/auth/"+path, port, "")
+	})
+
+	out, err := h.WardenCLIWithPort(t, port, map[string]string{
+		"WARDEN_TOKEN": h.RootToken(t),
+	}, "auth", "enable",
+		"-type", "jwt",
+		"-path", path,
+		"-o", "json")
+	if err != nil {
+		t.Fatalf("auth enable -path failed: %v\nOutput:\n%s", err, out)
+	}
+
+	var resp map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &resp); jsonErr != nil {
+		t.Fatalf("output not JSON: %v\n%s", jsonErr, out)
+	}
+	if resp["enabled"] != true {
+		t.Errorf("expected enabled=true marker; got %v", resp)
+	}
+	if resp["path"] != path+"/" {
+		t.Errorf("expected path %q in response; got %v", path+"/", resp["path"])
+	}
+}
+
+// TestJSON_AuthEnableRejectsPathAndPositionalConflict pins the conflict
+// rule: supplying both -path and a positional PATH must fail with a
+// usage error (not silently prefer one).
+func TestJSON_AuthEnableRejectsPathAndPositionalConflict(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	out, err := h.WardenCLIWithPort(t, port, map[string]string{
+		"WARDEN_TOKEN": h.RootToken(t),
+	}, "auth", "enable", "positional-path",
+		"-type", "jwt",
+		"-path", "flag-path",
+		"-o", "json")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for -path + positional PATH; got success.\nOutput:\n%s", out)
+	}
+}
+
 // TestJSON_AuthEnableDerivesPathFromPayloadType verifies the no-positional-arg
 // path-resolution: when the agent omits the positional PATH, the mount
 // path is derived from payload["type"] (e.g. "jwt" → "jwt/").

--- a/e2e/provider/json_payload_test.go
+++ b/e2e/provider/json_payload_test.go
@@ -52,3 +52,47 @@ func TestJSON_ProviderEnableRejectsTypedFlagConflict(t *testing.T) {
 		t.Fatalf("expected non-zero exit for conflicting flags; got success.\nOutput:\n%s", out)
 	}
 }
+
+// TestJSON_ProviderEnableWithPathFlagDryRun verifies that -path works on
+// provider enable. Uses Vault-style single-dash long flags so this test
+// also exercises the flag-normalization layer against the newly-added
+// -path flag.
+func TestJSON_ProviderEnableWithPathFlagDryRun(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	out, err := h.WardenCLIWithPort(t, port, map[string]string{
+		"WARDEN_TOKEN": h.RootToken(t),
+	}, "provider", "enable",
+		"-type", "vault",
+		"-path", "e2e-pathflag-provider",
+		"-dry-run",
+		"-o", "json")
+	if err != nil {
+		t.Fatalf("provider enable -path -dry-run failed: %v\nOutput:\n%s", err, out)
+	}
+
+	var resp map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &resp); jsonErr != nil {
+		t.Fatalf("output not JSON: %v\n%s", jsonErr, out)
+	}
+	if resp["dry_run"] != true || resp["validated"] != true {
+		t.Errorf("expected dry_run=true and validated=true; got %v", resp)
+	}
+}
+
+// TestJSON_ProviderEnableRejectsPathAndPositionalConflict pins the conflict
+// rule: supplying both -path and a positional PATH must fail with a usage
+// error.
+func TestJSON_ProviderEnableRejectsPathAndPositionalConflict(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	out, err := h.WardenCLIWithPort(t, port, map[string]string{
+		"WARDEN_TOKEN": h.RootToken(t),
+	}, "provider", "enable", "positional-path",
+		"-type", "vault",
+		"-path", "flag-path",
+		"-o", "json")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for -path + positional PATH; got success.\nOutput:\n%s", out)
+	}
+}


### PR DESCRIPTION
Operators reasonably try `warden auth enable --type=jwt --path=jwt-X` because --path looks like a natural flag, but it failed with "unknown flag." The PATH was only accepted positionally.

Add --path to every CLI command that takes a path positionally:
- mount-path commands: {auth, provider, audit} × {enable, disable, read}
- API-path commands: warden {read, list, delete, write}

Either form works; supplying both at once is rejected with a clear usage error. The positional form remains the primary spelling — --path is the discoverable, Vault-equivalent alternative. Single-dash long flags (-path=X) work automatically via the existing flag normalizer.

Two new helpers in cmd/helpers/input.go (renamed from json_input.go):
- ResolvePath(args, pathFlag): positional vs flag, with conflict error
- RequirePath: ResolvePath + empty-result usage error

Usage errors now fail before client construction in every affected command (previously a few hit Client() first, since cobra.ExactArgs(1) caught the empty-args case before runX).