### PR TITLE
feat(config): switch listener to tls_disable, warn-and-ignore unknown…

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -265,7 +265,7 @@ func run(cmd *cobra.Command, args []string) error {
 		conf = config.DevConfig()
 	case configDir != "":
 		var err error
-		conf, err = config.LoadConfigDir(configDir)
+		conf, err = config.LoadConfigDirWithLogger(configDir, config.StderrWarner{})
 		if err != nil {
 			return fmt.Errorf("failed to load config dir: %w", err)
 		}
@@ -274,7 +274,7 @@ func run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("config file not found: %s", configPath)
 		}
 		var err error
-		conf, err = config.LoadConfig(configPath)
+		conf, err = config.LoadConfigWithLogger(configPath, config.StderrWarner{})
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
@@ -299,7 +299,7 @@ func run(cmd *cobra.Command, args []string) error {
 				}
 			}()
 		}
-		conf.Listeners[0].TLSEnabled = true
+		conf.Listeners[0].TLSDisable = false
 		conf.Listeners[0].TLSCertFile = certFile
 		conf.Listeners[0].TLSKeyFile = keyFile
 		if flagDevTLSCACertFile != "" {
@@ -653,7 +653,7 @@ func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, 
 				TLSCertFile:          lnConfig.TLSCertFile,
 				TLSKeyFile:           lnConfig.TLSKeyFile,
 				TLSClientCAFile:      lnConfig.TLSClientCAFile,
-				TLSEnabled:           lnConfig.TLSEnabled,
+				TLSDisable:           lnConfig.TLSDisable,
 				TLSRequireClientCert: lnConfig.TLSRequireClientCert,
 				TrustedProxies:       lnConfig.TrustedProxies,
 			}, httpHandler)

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	"github.com/hashicorp/hcl/v2/hclsimple"
 )
 
 // Config is the configuration for warden server.
@@ -438,7 +436,7 @@ type ListenerBlock struct {
 	TLSCertFile          string   `hcl:"tls_cert_file,optional"`
 	TLSKeyFile           string   `hcl:"tls_key_file,optional"`
 	TLSClientCAFile      string   `hcl:"tls_client_ca_file,optional"`
-	TLSEnabled           bool     `hcl:"tls_enabled,optional"`
+	TLSDisable           bool     `hcl:"tls_disable,optional"`             // default false => TLS on; requires tls_cert_file + tls_key_file
 	TLSRequireClientCert *bool    `hcl:"tls_require_client_cert,optional"` // nil = default (true when tls_client_ca_file set)
 	TrustedProxies       []string `hcl:"trusted_proxies,optional"`         // CIDR ranges for LB cert forwarding
 }
@@ -446,9 +444,17 @@ type ListenerBlock struct {
 // LoadConfig reads a single HCL config file and returns a validated *Config.
 // File contents are pre-processed through a Go-template pass with an `env`
 // function (see InterpolateEnv) so configs may reference environment
-// variables via {{ env "VAR_NAME" }} placeholders.
+// variables via {{ env "VAR_NAME" }} placeholders. Unknown HCL attributes
+// and blocks are silently dropped; use LoadConfigWithLogger to surface
+// them as warnings.
 func LoadConfig(configFile string) (*Config, error) {
-	cfg, err := loadConfigFile(configFile)
+	return LoadConfigWithLogger(configFile, nil)
+}
+
+// LoadConfigWithLogger is LoadConfig with a logger for warnings about
+// unknown HCL attributes and blocks. nil disables warnings.
+func LoadConfigWithLogger(configFile string, warner Warner) (*Config, error) {
+	cfg, err := loadConfigFile(configFile, warner)
 	if err != nil {
 		return nil, err
 	}
@@ -464,8 +470,16 @@ func LoadConfig(configFile string) (*Config, error) {
 // and returns a validated *Config. This lets operators split config
 // across multiple sources — e.g. a Kubernetes ConfigMap with non-secret
 // blocks plus a Secret containing the storage credentials and seal
-// block — without losing single-file simplicity.
+// block — without losing single-file simplicity. Unknown HCL attributes
+// and blocks are silently dropped; use LoadConfigDirWithLogger to surface
+// them as warnings.
 func LoadConfigDir(dir string) (*Config, error) {
+	return LoadConfigDirWithLogger(dir, nil)
+}
+
+// LoadConfigDirWithLogger is LoadConfigDir with a logger for warnings
+// about unknown HCL attributes and blocks. nil disables warnings.
+func LoadConfigDirWithLogger(dir string, warner Warner) (*Config, error) {
 	info, err := os.Stat(dir)
 	if err != nil {
 		return nil, fmt.Errorf("config dir %q: %w", dir, err)
@@ -495,7 +509,7 @@ func LoadConfigDir(dir string) (*Config, error) {
 
 	merged := &Config{}
 	for _, f := range files {
-		cfg, err := loadConfigFile(f)
+		cfg, err := loadConfigFile(f, warner)
 		if err != nil {
 			return nil, err
 		}
@@ -508,8 +522,10 @@ func LoadConfigDir(dir string) (*Config, error) {
 }
 
 // loadConfigFile reads a single HCL file, runs the env-var template pass,
-// and decodes into a *Config without running validation.
-func loadConfigFile(configFile string) (*Config, error) {
+// and decodes into a *Config without running validation. Unknown HCL
+// attributes and blocks are dropped; if warner is non-nil it receives one
+// Warn() call per removal with source position.
+func loadConfigFile(configFile string, warner Warner) (*Config, error) {
 	src, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("read config %q: %w", configFile, err)
@@ -518,11 +534,7 @@ func loadConfigFile(configFile string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("interpolate env vars in %q: %w", configFile, err)
 	}
-	var cfg Config
-	if err := hclsimple.Decode(configFile, rendered, nil, &cfg); err != nil {
-		return nil, err
-	}
-	return &cfg, nil
+	return decodeConfig(configFile, rendered, warner)
 }
 
 // InterpolateEnv runs the given config bytes through a Go-template pass
@@ -607,10 +619,10 @@ func validateConfig(config *Config) error {
 		}
 	}
 
-	// Validate listener TLS config
+	// Validate listener TLS config. TLS is on by default; opt out with tls_disable.
 	for i, ln := range config.Listeners {
-		if ln.TLSEnabled && (ln.TLSCertFile == "" || ln.TLSKeyFile == "") {
-			return fmt.Errorf("listener[%d]: tls_enabled requires both tls_cert_file and tls_key_file", i)
+		if !ln.TLSDisable && (ln.TLSCertFile == "" || ln.TLSKeyFile == "") {
+			return fmt.Errorf("listener[%d]: TLS is on by default; set tls_disable = true or provide both tls_cert_file and tls_key_file", i)
 		}
 	}
 
@@ -679,7 +691,8 @@ func validateConfig(config *Config) error {
 }
 
 // DevConfig returns a default configuration suitable for dev mode.
-// It uses in-memory storage and a TCP listener on 127.0.0.1:8400.
+// It uses in-memory storage and a TCP listener on 127.0.0.1:8400 with
+// TLS disabled so the loopback API is reachable without certificates.
 func DevConfig() *Config {
 	return &Config{
 		LogLevel: "trace",
@@ -688,8 +701,9 @@ func DevConfig() *Config {
 		},
 		Listeners: []ListenerBlock{
 			{
-				Type:    "tcp",
-				Address: "127.0.0.1:8400",
+				Type:       "tcp",
+				Address:    "127.0.0.1:8400",
+				TLSDisable: true,
 			},
 		},
 		IPBindingPolicy: "disabled",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,8 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `
 	p := writeFile(t, dir, "warden.hcl", hcl)
@@ -100,7 +102,8 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `)
 
@@ -136,7 +139,8 @@ func TestLoadConfigDir_EnvInterpolation(t *testing.T) {
 api_addr = "https://{{ env "WARDEN_TEST_API_HOST" }}:8400"
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `)
 	writeFile(t, dir, "10-secrets.hcl", `
@@ -162,7 +166,8 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `)
 	writeFile(t, dir, "README.md", "not a config file")
@@ -205,7 +210,8 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `)
 	writeFile(t, dir, "10-overlay.hcl", `
@@ -226,7 +232,8 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `)
 	_, err := LoadConfigDir(dir)
@@ -248,7 +255,8 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 
 audit "file" "default" {
@@ -285,7 +293,10 @@ func TestValidateConfig_AuditBlock(t *testing.T) {
 	base := `
 ip_binding_policy = "optional"
 storage "postgres" { connection_url = "postgres://x/db" }
-listener "tcp" { address = ":8400" }
+listener "tcp" {
+  address     = ":8400"
+  tls_disable = true
+}
 `
 
 	t.Run("duplicate type+path rejected", func(t *testing.T) {
@@ -316,7 +327,10 @@ func TestMergeConfig_Audits(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "00-base.hcl", `
 storage "postgres" { connection_url = "postgres://x/db" }
-listener "tcp" { address = ":8400" }
+listener "tcp" {
+  address     = ":8400"
+  tls_disable = true
+}
 
 audit "file" "from-base" { options = { file_path = "/base" } }
 `)
@@ -336,4 +350,68 @@ audit "file" "from-override" { options = { file_path = "/override" } }
 func TestDevConfig_HasNoAudit(t *testing.T) {
 	cfg := DevConfig()
 	assert.Empty(t, cfg.Audits)
+}
+
+// collectingWarner captures warnings for assertion. Implements Warner.
+type collectingWarner struct{ msgs []string }
+
+func (c *collectingWarner) Warn(msg string) { c.msgs = append(c.msgs, msg) }
+
+// TestLoadConfig_IgnoresUnknownStanzas verifies that warden parses a
+// foreign-style HCL config — unknown top-level attributes and blocks
+// (e.g. `ui`, `cluster_name`, `service_registration`), and unknown attrs
+// inside a known block — without erroring. Each removal is reported
+// through the Warner so operators can diagnose stale or typo'd keys.
+func TestLoadConfig_IgnoresUnknownStanzas(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "warden.hcl", `
+ui            = true
+cluster_name  = "some-cluster"
+log_level     = "info"
+
+storage "postgres" {
+  connection_url = "postgres://u:p@db:5432/warden"
+  unknown_attr   = "ignored"
+}
+
+listener "tcp" {
+  address          = ":8400"
+  tls_disable      = true
+  tls_min_version  = "tls13"
+}
+
+seal "static" {
+  current_key_id  = "k1"
+  current_key     = "file:///k"
+  bogus_seal_attr = "x"
+}
+
+service_registration "consul" {
+  address = "127.0.0.1:8500"
+}
+`)
+	w := &collectingWarner{}
+	cfg, err := LoadConfigWithLogger(p, w)
+	require.NoError(t, err)
+	assert.Equal(t, "info", cfg.LogLevel)
+	require.NotNil(t, cfg.Storage)
+	assert.Equal(t, "postgres://u:p@db:5432/warden", cfg.Storage.ConnectionUrl)
+	require.Len(t, cfg.Listeners, 1)
+	assert.True(t, cfg.Listeners[0].TLSDisable)
+
+	require.Len(t, cfg.Seals, 1)
+	assert.Equal(t, "static", cfg.Seals[0].Type)
+	assert.Equal(t, "k1", cfg.Seals[0].CurrentKeyID)
+
+	joined := strings.Join(w.msgs, "\n")
+	for _, want := range []string{
+		`unknown attribute "ui"`,
+		`unknown attribute "cluster_name"`,
+		`unknown attribute "unknown_attr"`,
+		`unknown attribute "tls_min_version"`,
+		`unknown attribute "bogus_seal_attr"`,
+		`unknown block "service_registration"`,
+	} {
+		assert.Contains(t, joined, want, "expected warning for %s", want)
+	}
 }

--- a/config/decode.go
+++ b/config/decode.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// Warner is the minimal sink used to surface parser warnings for
+// unknown HCL attributes and blocks. Single-string signature keeps
+// adapters trivial. cmd/server passes StderrWarner so warnings appear
+// immediately at startup — buffering until the warden GatedLogger is
+// built would lose them if config load fails for any other reason.
+type Warner interface {
+	Warn(msg string)
+}
+
+type nopWarner struct{}
+
+func (nopWarner) Warn(string) {}
+
+// StderrWarner writes warnings directly to os.Stderr with a stable
+// prefix. Suitable for the early config-load path where the warden
+// logger has not been constructed yet.
+type StderrWarner struct{}
+
+func (StderrWarner) Warn(msg string) {
+	fmt.Fprintln(os.Stderr, "[WARN] config: "+msg)
+}
+
+// decodeConfig parses HCL bytes into a *Config, warning-and-ignoring any
+// attribute or block not declared on Config or its known nested block
+// types (listener, storage, seal, audit). Foreign-style top-level keys
+// (`ui`, `cluster_name`, `default_lease_ttl`, etc.) and unknown attrs
+// inside known blocks are dropped with a warning rather than failing the
+// parse.
+func decodeConfig(filename string, src []byte, warner Warner) (*Config, error) {
+	if warner == nil {
+		warner = nopWarner{}
+	}
+
+	file, diags := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, fmt.Errorf("internal: unexpected HCL body type %T", file.Body)
+	}
+
+	pruneBody(body, warner)
+
+	var cfg Config
+	if diags := gohcl.DecodeBody(body, nil, &cfg); diags.HasErrors() {
+		return nil, diags
+	}
+	return &cfg, nil
+}
+
+// pruneBody walks body against the schemas derived from the Config struct
+// hierarchy, deleting any attribute or block that gohcl would otherwise
+// reject as unsupported. Each removal emits a Warn() call carrying the
+// source range so operators can spot stale or typo'd keys.
+func pruneBody(body *hclsyntax.Body, warner Warner) {
+	pruneAgainst(body, configSchema, warner)
+	for _, blk := range body.Blocks {
+		inner, ok := nestedSchemas[blk.Type]
+		if !ok {
+			continue
+		}
+		pruneAgainst(blk.Body, inner, warner)
+	}
+}
+
+func pruneAgainst(body *hclsyntax.Body, schema *hcl.BodySchema, warner Warner) {
+	knownAttrs := make(map[string]struct{}, len(schema.Attributes))
+	for _, a := range schema.Attributes {
+		knownAttrs[a.Name] = struct{}{}
+	}
+	knownBlocks := make(map[string]struct{}, len(schema.Blocks))
+	for _, b := range schema.Blocks {
+		knownBlocks[b.Type] = struct{}{}
+	}
+
+	for name, attr := range body.Attributes {
+		if _, ok := knownAttrs[name]; ok {
+			continue
+		}
+		warner.Warn(fmt.Sprintf("ignoring unknown attribute %q at %s", name, attr.SrcRange))
+		delete(body.Attributes, name)
+	}
+
+	kept := body.Blocks[:0]
+	for _, blk := range body.Blocks {
+		if _, ok := knownBlocks[blk.Type]; ok {
+			kept = append(kept, blk)
+			continue
+		}
+		warner.Warn(fmt.Sprintf("ignoring unknown block %q at %s", blk.Type, blk.DefRange()))
+	}
+	body.Blocks = kept
+}
+
+var (
+	configSchema   *hcl.BodySchema
+	nestedSchemas  map[string]*hcl.BodySchema
+)
+
+func init() {
+	configSchema, _ = gohcl.ImpliedBodySchema(Config{})
+	listenerSchema, _ := gohcl.ImpliedBodySchema(ListenerBlock{})
+	storageSchema, _ := gohcl.ImpliedBodySchema(StorageBlock{})
+	sealSchema, _ := gohcl.ImpliedBodySchema(KMS{})
+	auditSchema, _ := gohcl.ImpliedBodySchema(AuditBlock{})
+	nestedSchemas = map[string]*hcl.BodySchema{
+		"listener": listenerSchema,
+		"storage":  storageSchema,
+		"seal":     sealSchema,
+		"audit":    auditSchema,
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -11,14 +11,16 @@ import (
 
 // minimalConfigHCL is a valid HCL config used as the base for tests that
 // then write one additional offending field. Lets each test focus on the
-// invariant being checked instead of restating boilerplate.
+// invariant being checked instead of restating boilerplate. The listener
+// sets tls_disable = true so a cert/key is not required.
 const minimalConfigHCL = `
 storage "postgres" {
   connection_url = "postgres://u:p@db:5432/warden"
 }
 
 listener "tcp" {
-  address = ":8400"
+  address     = ":8400"
+  tls_disable = true
 }
 `
 
@@ -45,7 +47,7 @@ func TestLoadConfig_IPBindingPolicy(t *testing.T) {
 		policy  string
 		wantErr bool
 	}{
-		{"", false},          // unset is fine; downstream picks default
+		{"", false}, // unset is fine; downstream picks default
 		{"disabled", false},
 		{"optional", false},
 		{"required", false},
@@ -129,18 +131,17 @@ func TestLoadConfig_ListenerTLSRequiresCertAndKey(t *testing.T) {
 			name: "tls disabled, no cert/key — ok",
 			extra: `
 listener "tcp" {
-  address = ":8410"
-  tls_enabled = false
+  address     = ":8410"
+  tls_disable = true
 }
 `,
 			wantErr: false,
 		},
 		{
-			name: "tls enabled with both cert and key — ok",
+			name: "tls on (default) with both cert and key — ok",
 			extra: `
 listener "tcp" {
-  address     = ":8420"
-  tls_enabled = true
+  address       = ":8420"
   tls_cert_file = "/c.pem"
   tls_key_file  = "/k.pem"
 }
@@ -148,22 +149,29 @@ listener "tcp" {
 			wantErr: false,
 		},
 		{
-			name: "tls enabled, missing cert — error",
+			name: "tls on (default), no cert/key — error",
 			extra: `
 listener "tcp" {
-  address     = ":8430"
-  tls_enabled = true
+  address = ":8425"
+}
+`,
+			wantErr: true,
+		},
+		{
+			name: "tls on, missing cert — error",
+			extra: `
+listener "tcp" {
+  address      = ":8430"
   tls_key_file = "/k.pem"
 }
 `,
 			wantErr: true,
 		},
 		{
-			name: "tls enabled, missing key — error",
+			name: "tls on, missing key — error",
 			extra: `
 listener "tcp" {
-  address     = ":8440"
-  tls_enabled = true
+  address       = ":8440"
   tls_cert_file = "/c.pem"
 }
 `,
@@ -175,7 +183,7 @@ listener "tcp" {
 			_, err := loadFromHCL(t, minimalConfigHCL+tt.extra)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "tls_enabled")
+				assert.Contains(t, err.Error(), "tls_disable")
 			} else {
 				require.NoError(t, err)
 			}
@@ -249,7 +257,7 @@ func TestDevConfig_Defaults(t *testing.T) {
 	require.Len(t, cfg.Listeners, 1)
 	assert.Equal(t, "tcp", cfg.Listeners[0].Type)
 	assert.Equal(t, "127.0.0.1:8400", cfg.Listeners[0].Address)
-	assert.False(t, cfg.Listeners[0].TLSEnabled)
+	assert.True(t, cfg.Listeners[0].TLSDisable)
 	assert.Equal(t, "disabled", cfg.IPBindingPolicy)
 }
 

--- a/deploy/config/warden.hcl
+++ b/deploy/config/warden.hcl
@@ -30,7 +30,6 @@ listener "tcp" {
     tls_key_file       = "/certs/warden-key.pem"
     tls_client_ca_file = "/certs/ca.pem"
     tls_require_client_cert = false
-    tls_enabled        = true
 }
 
 # Audit devices are declared with the two-label syntax:

--- a/deploy/config/warden.local.hcl
+++ b/deploy/config/warden.local.hcl
@@ -25,12 +25,11 @@ listener "tcp" {
     tls_key_file            = "./certs/warden/warden-key.pem"
     tls_client_ca_file      = "./certs/warden/ca.pem"
     tls_require_client_cert = false
-    tls_enabled             = true
 }
 
 listener "tcp" {
-    address                 = "127.0.0.1:8500"
-    tls_enabled             = false
+    address     = "127.0.0.1:8500"
+    tls_disable = true
 }
 
 # Audit "TYPE" "NAME" — registered at startup, before the listener accepts

--- a/deploy/helm/warden/templates/configmap-config.yaml
+++ b/deploy/helm/warden/templates/configmap-config.yaml
@@ -28,7 +28,6 @@ data:
 
     listener "tcp" {
       address                 = "0.0.0.0:8400"
-      tls_enabled             = true
       tls_cert_file           = "/certs/{{ .Values.tls.certKey }}"
       tls_key_file            = "/certs/{{ .Values.tls.keyKey }}"
       tls_client_ca_file      = "/certs/{{ .Values.tls.caKey }}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,10 +33,14 @@ storage "postgres" {
 
 listener "tcp" {
   address     = "0.0.0.0:8400"
-  tls_enabled = false
+  tls_disable = true
 }
 ```
 
 ## Configuration
 
 Warden uses HCL configuration files. See `deploy/config/warden.local.hcl` for a full example covering storage backend, listener, providers, and auth methods.
+
+The listener stanza follows the `tls_disable` convention: TLS is on by default and the listener requires both `tls_cert_file` and `tls_key_file`. Set `tls_disable = true` to run plain HTTP (intended for loopback dev work).
+
+Unknown top-level attributes and blocks — and unknown attributes inside known blocks — are dropped at parse time with a startup warning on stderr rather than rejected. This lets operators drop in a foreign-style config (`ui = true`, `cluster_name = "..."`, `service_registration "consul" { ... }`, and similar) without manual cleanup; the warning surfaces typos so they do not pass silently.

--- a/e2e/configs/node1.hcl
+++ b/e2e/configs/node1.hcl
@@ -23,7 +23,6 @@ storage "postgres" {
 
 listener "tcp" {
     address                 = "0.0.0.0:8500"
-    tls_enabled             = true
     tls_cert_file           = "../.certs/server.crt"
     tls_key_file            = "../.certs/server.key"
     tls_client_ca_file      = "../.certs/client-ca.crt"

--- a/e2e/configs/node2.hcl
+++ b/e2e/configs/node2.hcl
@@ -23,7 +23,6 @@ storage "postgres" {
 
 listener "tcp" {
     address                 = "0.0.0.0:8510"
-    tls_enabled             = true
     tls_cert_file           = "../.certs/server.crt"
     tls_key_file            = "../.certs/server.key"
     tls_client_ca_file      = "../.certs/client-ca.crt"

--- a/e2e/configs/node3.hcl
+++ b/e2e/configs/node3.hcl
@@ -23,7 +23,6 @@ storage "postgres" {
 
 listener "tcp" {
     address                 = "0.0.0.0:8520"
-    tls_enabled             = true
     tls_cert_file           = "../.certs/server.crt"
     tls_key_file            = "../.certs/server.key"
     tls_client_ca_file      = "../.certs/client-ca.crt"

--- a/listener/api/listener.go
+++ b/listener/api/listener.go
@@ -18,7 +18,7 @@ import (
 type ApiListener struct {
 	logger      *logger.GatedLogger
 	server      *http.Server
-	tlsEnabled  bool
+	tlsDisable  bool
 	tlsCertFile string
 	tlsKeyFile  string
 	stopped     atomic.Bool
@@ -30,7 +30,7 @@ type ApiListenerConfig struct {
 	TLSCertFile          string
 	TLSKeyFile           string
 	TLSClientCAFile      string
-	TLSEnabled           bool
+	TLSDisable           bool     // default false => TLS on; requires TLSCertFile + TLSKeyFile
 	TLSRequireClientCert *bool    // nil = default (true when TLSClientCAFile set)
 	TrustedProxies       []string // CIDR ranges for LB cert forwarding
 }
@@ -55,9 +55,9 @@ func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListen
 		WriteTimeout: 10 * time.Second,
 	}
 
-	if cfg.TLSEnabled {
+	if !cfg.TLSDisable {
 		if cfg.TLSCertFile == "" || cfg.TLSKeyFile == "" {
-			return nil, fmt.Errorf("tls_enabled requires both tls_cert_file and tls_key_file")
+			return nil, fmt.Errorf("TLS is on by default; set tls_disable = true or provide both tls_cert_file and tls_key_file")
 		}
 
 		tlsCfg := &tls.Config{
@@ -88,7 +88,7 @@ func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListen
 	return &ApiListener{
 		logger:      cfg.Logger,
 		server:      server,
-		tlsEnabled:  cfg.TLSEnabled,
+		tlsDisable:  cfg.TLSDisable,
 		tlsCertFile: cfg.TLSCertFile,
 		tlsKeyFile:  cfg.TLSKeyFile,
 	}, nil
@@ -109,12 +109,12 @@ func (l *ApiListener) Start(ctx context.Context) error {
 	errChan := make(chan error, 1)
 	go func() {
 		var err error
-		if l.tlsEnabled {
-			l.logger.Info("starting HTTPS server", logger.String("address", l.server.Addr))
-			err = l.server.ListenAndServeTLS(l.tlsCertFile, l.tlsKeyFile)
-		} else {
+		if l.tlsDisable {
 			l.logger.Info("starting HTTP server", logger.String("address", l.server.Addr))
 			err = l.server.ListenAndServe()
+		} else {
+			l.logger.Info("starting HTTPS server", logger.String("address", l.server.Addr))
+			err = l.server.ListenAndServeTLS(l.tlsCertFile, l.tlsKeyFile)
 		}
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- err

--- a/listener/api/listener_test.go
+++ b/listener/api/listener_test.go
@@ -32,15 +32,16 @@ func TestNewApiListener_PlainHTTP(t *testing.T) {
 	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
 
 	ln, err := NewApiListener(ApiListenerConfig{
-		Logger:  log,
-		Address: "127.0.0.1:0",
+		Logger:     log,
+		Address:    "127.0.0.1:0",
+		TLSDisable: true,
 	}, http.DefaultServeMux)
 
 	require.NoError(t, err)
 	require.NotNil(t, ln)
 	assert.Equal(t, "127.0.0.1:0", ln.Addr())
 	assert.Equal(t, "api", ln.Type())
-	assert.False(t, ln.tlsEnabled)
+	assert.True(t, ln.tlsDisable)
 }
 
 func TestNewApiListener_TLSEnabled(t *testing.T) {
@@ -50,14 +51,13 @@ func TestNewApiListener_TLSEnabled(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:      log,
 		Address:     "127.0.0.1:0",
-		TLSEnabled:  true,
 		TLSCertFile: certFile,
 		TLSKeyFile:  keyFile,
 	}, http.DefaultServeMux)
 
 	require.NoError(t, err)
 	require.NotNil(t, ln)
-	assert.True(t, ln.tlsEnabled)
+	assert.False(t, ln.tlsDisable)
 	assert.NotNil(t, ln.server.TLSConfig)
 	assert.Equal(t, uint16(tls.VersionTLS12), ln.server.TLSConfig.MinVersion)
 }
@@ -68,7 +68,6 @@ func TestNewApiListener_TLSEnabled_MissingCertFile(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:     log,
 		Address:    "127.0.0.1:0",
-		TLSEnabled: true,
 		TLSKeyFile: "/some/key.pem",
 	}, http.DefaultServeMux)
 
@@ -83,7 +82,6 @@ func TestNewApiListener_TLSEnabled_MissingKeyFile(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:      log,
 		Address:     "127.0.0.1:0",
-		TLSEnabled:  true,
 		TLSCertFile: "/some/cert.pem",
 	}, http.DefaultServeMux)
 
@@ -99,7 +97,6 @@ func TestNewApiListener_TLSWithClientCA(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:          log,
 		Address:         "127.0.0.1:0",
-		TLSEnabled:      true,
 		TLSCertFile:     certFile,
 		TLSKeyFile:      keyFile,
 		TLSClientCAFile: caFile,
@@ -122,7 +119,6 @@ func TestNewApiListener_TLSWithInvalidClientCA(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:          log,
 		Address:         "127.0.0.1:0",
-		TLSEnabled:      true,
 		TLSCertFile:     certFile,
 		TLSKeyFile:      keyFile,
 		TLSClientCAFile: badCA,
@@ -140,7 +136,6 @@ func TestNewApiListener_TLSWithMissingClientCAFile(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:          log,
 		Address:         "127.0.0.1:0",
-		TLSEnabled:      true,
 		TLSCertFile:     certFile,
 		TLSKeyFile:      keyFile,
 		TLSClientCAFile: "/nonexistent/ca.pem",
@@ -170,7 +165,6 @@ func TestApiListener_HTTPS_AcceptsConnection(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:      log,
 		Address:     addr,
-		TLSEnabled:  true,
 		TLSCertFile: certFile,
 		TLSKeyFile:  keyFile,
 	}, handler)
@@ -220,7 +214,6 @@ func TestApiListener_HTTPS_RejectsPlainHTTP(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:      log,
 		Address:     addr,
-		TLSEnabled:  true,
 		TLSCertFile: certFile,
 		TLSKeyFile:  keyFile,
 	}, handler)
@@ -260,7 +253,6 @@ func TestApiListener_mTLS_AcceptsValidClientCert(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:          log,
 		Address:         addr,
-		TLSEnabled:      true,
 		TLSCertFile:     certFile,
 		TLSKeyFile:      keyFile,
 		TLSClientCAFile: caFile,
@@ -314,7 +306,6 @@ func TestApiListener_mTLS_RejectsNoClientCert(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:          log,
 		Address:         addr,
-		TLSEnabled:      true,
 		TLSCertFile:     certFile,
 		TLSKeyFile:      keyFile,
 		TLSClientCAFile: caFile,
@@ -359,7 +350,6 @@ func TestApiListener_StopIdempotent(t *testing.T) {
 	ln, err := NewApiListener(ApiListenerConfig{
 		Logger:      log,
 		Address:     addr,
-		TLSEnabled:  true,
 		TLSCertFile: certFile,
 		TLSKeyFile:  keyFile,
 	}, http.DefaultServeMux)
@@ -391,8 +381,9 @@ func TestApiListener_PlainHTTP_Serves(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 	ln, err := NewApiListener(ApiListenerConfig{
-		Logger:  log,
-		Address: addr,
+		Logger:     log,
+		Address:    addr,
+		TLSDisable: true,
 	}, handler)
 	require.NoError(t, err)
 


### PR DESCRIPTION
… HCL

The listener stanza now follows the tls_disable convention: TLS is on by default and the listener requires both tls_cert_file and tls_key_file. Set tls_disable = true to run plain HTTP.

Unknown top-level HCL attributes and blocks — and unknown attributes inside known blocks — are dropped at parse time with a startup warning on stderr instead of failing the parse. Operators can drop in a foreign config (ui = true, cluster_name = "...", service_registration { ... }, etc.) without manual cleanup; warnings still surface typos.

Implementation: a new config/decode.go replaces hclsimple.Decode with hclsyntax.ParseConfig followed by an in-place body prune against gohcl-implied schemas for Config + listener/storage/seal/audit. Schemas are derived once at init.

Migrates every in-tree HCL (deploy/config, e2e/configs, helm configmap template) plus the architecture doc.

Verified via go test ./... and a full make test-e2e run (14/14 e2e packages green, including the full-cluster-restart and ha-chaos suites that exercise listener startup against the migrated configs).