### PR TITLE
feat(audit): propagate X-Warden-On-Behalf-Of into Auth.actors

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -106,6 +106,21 @@ type Auth struct {
 
 	// Creation context
 	CreatedByIP string `json:"created_by_ip,omitempty"`
+
+	// Actor chain — subjects this request was made on behalf of.
+	// Sources: X-Warden-On-Behalf-Of header (verified=false) and
+	// JWT "act" claim per RFC 8693 §4.1 (verified=true).
+	Actors []ActorRef `json:"actors,omitempty"`
+}
+
+// ActorRef identifies a subject in the on-behalf-of chain alongside
+// the authenticated principal. The Verified flag tells audit readers
+// whether the actor was cryptographically attested (true, e.g. JWT
+// "act" claim) or self-reported by the authenticated principal (false,
+// e.g. X-Warden-On-Behalf-Of header).
+type ActorRef struct {
+	Subject  string `json:"subject"`
+	Verified bool   `json:"verified"`
 }
 
 // PolicyResults captures which policies granted access
@@ -276,6 +291,10 @@ func (e *LogEntry) Clone() *LogEntry {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))
 				copy(clone.Auth.PolicyResults.GrantingPolicies, e.Auth.PolicyResults.GrantingPolicies)
 			}
+		}
+		if e.Auth.Actors != nil {
+			clone.Auth.Actors = make([]ActorRef, len(e.Auth.Actors))
+			copy(clone.Auth.Actors, e.Auth.Actors)
 		}
 	}
 

--- a/audit/types_test.go
+++ b/audit/types_test.go
@@ -81,6 +81,10 @@ func TestCloneFull(t *testing.T) {
 			NamespaceID:   "ns1",
 			NamespacePath: "root/",
 			CreatedByIP:   "10.0.0.1",
+			Actors: []ActorRef{
+				{Subject: "agent-alpha@pod-xyz", Verified: false},
+				{Subject: "broker-beta", Verified: true},
+			},
 		},
 	}
 
@@ -120,6 +124,17 @@ func TestCloneFull(t *testing.T) {
 	entry.Response.AuthResult.Policies[0] = "modified"
 	if clone.Response.AuthResult.Policies[0] == "modified" {
 		t.Error("clone auth result policies should be independent")
+	}
+
+	entry.Auth.Actors[0].Subject = "modified"
+	if clone.Auth.Actors[0].Subject == "modified" {
+		t.Error("clone auth actors should be independent")
+	}
+	if len(clone.Auth.Actors) != 2 {
+		t.Errorf("clone auth actors should have 2 entries, got %d", len(clone.Auth.Actors))
+	}
+	if !clone.Auth.Actors[1].Verified || clone.Auth.Actors[1].Subject != "broker-beta" {
+		t.Errorf("clone auth actors[1] mismatch: %+v", clone.Auth.Actors[1])
 	}
 }
 

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -156,7 +156,29 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 		}
 	}
 
+	// Per-request actors (header) win over token-bound actors (jwt act)
+	// so a concentrator reusing one transparent JWT for many agents still
+	// gets correct per-call audit attribution.
+	if auth != nil && len(auth.Actors) > 0 {
+		auditAuth.Actors = toAuditActors(auth.Actors)
+	} else if te != nil && len(te.Actors) > 0 {
+		auditAuth.Actors = toAuditActors(te.Actors)
+	}
+
 	return auditAuth
+}
+
+// toAuditActors translates the on-behalf-of chain from the logical layer
+// into its audit-layer shape.
+func toAuditActors(actors []logical.ActorRef) []audit.ActorRef {
+	if len(actors) == 0 {
+		return nil
+	}
+	out := make([]audit.ActorRef, len(actors))
+	for i, a := range actors {
+		out[i] = audit.ActorRef{Subject: a.Subject, Verified: a.Verified}
+	}
+	return out
 }
 
 // buildAuditAuthResult converts logical.Auth (from login response) to audit.AuthResult

--- a/core/audit_test.go
+++ b/core/audit_test.go
@@ -1078,6 +1078,61 @@ func TestBuildAuditAuth_AuthOverridesTE(t *testing.T) {
 	assert.Equal(t, "new-role", result.RoleName)
 }
 
+func TestBuildAuditAuth_ActorsFromAuth(t *testing.T) {
+	auth := &logical.Auth{
+		PrincipalID: "mcp-github",
+		Actors: []logical.ActorRef{
+			{Subject: "agents/alpha", Verified: false},
+		},
+	}
+	result := buildAuditAuth(auth, nil)
+	require.NotNil(t, result)
+	require.Len(t, result.Actors, 1)
+	assert.Equal(t, "agents/alpha", result.Actors[0].Subject)
+	assert.False(t, result.Actors[0].Verified)
+}
+
+func TestBuildAuditAuth_ActorsFromTokenEntry(t *testing.T) {
+	te := &logical.TokenEntry{
+		PrincipalID: "mcp-github",
+		Actors: []logical.ActorRef{
+			{Subject: "agents/alpha", Verified: true},
+		},
+	}
+	result := buildAuditAuth(nil, te)
+	require.NotNil(t, result)
+	require.Len(t, result.Actors, 1)
+	assert.Equal(t, "agents/alpha", result.Actors[0].Subject)
+	assert.True(t, result.Actors[0].Verified)
+}
+
+func TestBuildAuditAuth_ActorsHeaderWinsOverTokenEntry(t *testing.T) {
+	te := &logical.TokenEntry{
+		PrincipalID: "mcp-github",
+		Actors: []logical.ActorRef{
+			{Subject: "verified-default", Verified: true},
+		},
+	}
+	auth := &logical.Auth{
+		PrincipalID: "mcp-github",
+		Actors: []logical.ActorRef{
+			{Subject: "this-call-actor", Verified: false},
+		},
+	}
+	result := buildAuditAuth(auth, te)
+	require.NotNil(t, result)
+	require.Len(t, result.Actors, 1)
+	assert.Equal(t, "this-call-actor", result.Actors[0].Subject)
+	assert.False(t, result.Actors[0].Verified)
+}
+
+func TestBuildAuditAuth_NoActors(t *testing.T) {
+	te := &logical.TokenEntry{PrincipalID: "mcp-github"}
+	result := buildAuditAuth(nil, te)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Actors)
+}
+
 // =============================================================================
 // buildAuditAuthResult Tests
 // =============================================================================

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -13,7 +13,9 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -751,6 +753,43 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		}
 	}
 
+	// On-behalf-of header (X-Warden-On-Behalf-Of): an authenticated
+	// principal — typically an MCP concentrator — names the upstream
+	// caller it is acting for so per-agent attribution survives the
+	// concentrator hop. Recorded with verified=false; the strip-list
+	// keeps the header from leaking upstream.
+	//
+	// Gated on te != nil so an unauthenticated caller on a stream-
+	// unauthenticated path can't plant an actor into the response
+	// audit entry (which is emitted unconditionally upstream in
+	// handleCancelableRequest).
+	if te != nil && req.HTTPRequest != nil {
+		if obo := strings.TrimSpace(req.HTTPRequest.Header.Get("X-Warden-On-Behalf-Of")); obo != "" {
+			if !validActorSubject(obo) {
+				// Truncate the offending value so the warn log isn't a vehicle
+				// for an attacker-controlled string of arbitrary length. Quote
+				// for safe rendering since the input may contain non-ASCII or
+				// control bytes that would otherwise corrupt the log.
+				logged := obo
+				if len(logged) > 64 {
+					logged = logged[:64] + "..."
+				}
+				c.logger.Warn("dropped X-Warden-On-Behalf-Of: invalid subject",
+					logger.String("actor", strconv.Quote(logged)),
+					logger.String("path", req.Path),
+				)
+			} else {
+				if auth == nil {
+					auth = &logical.Auth{}
+				}
+				auth.Actors = append(auth.Actors, logical.ActorRef{
+					Subject:  obo,
+					Verified: false,
+				})
+			}
+		}
+	}
+
 	// Create an audit trail of the request.
 	// Skip for unauthenticated streaming paths (e.g., public PKI certificates) because:
 	// 1. No authentication context exists - no token, principal, or policies to audit
@@ -1036,6 +1075,18 @@ func extractToken(r *http.Request) string {
 		return authHeader[7:]
 	}
 	return ""
+}
+
+// actorSubjectPattern enforces the wire-format of X-Warden-On-Behalf-Of
+// values: ASCII alphanumerics plus a small punctuation set, 1-256 bytes.
+// Comma is deliberately excluded so the header carries a single actor.
+var actorSubjectPattern = regexp.MustCompile(`^[A-Za-z0-9._:@/+\-]{1,256}$`)
+
+// validActorSubject reports whether s is acceptable as an on-behalf-of
+// actor subject. Rejects empty strings, oversized values, control bytes,
+// and any character outside the allowed set.
+func validActorSubject(s string) bool {
+	return actorSubjectPattern.MatchString(s)
 }
 
 // isTransparentRequest checks if this request needs implicit authentication.

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1653,3 +1653,33 @@ func TestHandleNonLoginRequest_StreamingWithoutBodyParsing(t *testing.T) {
 		assert.Nil(t, req.Data)
 	})
 }
+
+func TestValidActorSubject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty rejected", "", false},
+		{"simple alpha", "agent-alpha", true},
+		{"namespaced path", "agents/alpha", true},
+		{"email-ish", "alpha@pod-xyz", true},
+		{"colon ok", "kind:agent-alpha", true},
+		{"plus ok", "alpha+test", true},
+		{"dot ok", "alpha.bot", true},
+		{"underscore ok", "agent_alpha", true},
+		{"comma rejected (single-actor enforcement)", "alpha,beta", false},
+		{"space rejected", "alpha beta", false},
+		{"CR rejected", "alpha\rinjected", false},
+		{"LF rejected", "alpha\ninjected", false},
+		{"tab rejected", "alpha\tbeta", false},
+		{"unicode rejected", "agent-α", false},
+		{"at-256-bytes accepted", strings.Repeat("a", 256), true},
+		{"over-256-bytes rejected", strings.Repeat("a", 257), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, validActorSubject(tc.input))
+		})
+	}
+}

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -45,6 +45,21 @@ type Auth struct {
 	NamespacePath string // Namespace path
 
 	ClientIP string
+
+	// Actors is the on-behalf-of chain attached by ingestion paths
+	// (X-Warden-On-Behalf-Of header or JWT "act" claim). Flows
+	// through buildAuditAuth into the audit log; not used for policy
+	// decisions.
+	Actors []ActorRef
+}
+
+// ActorRef identifies a subject in the on-behalf-of chain. Verified
+// is true when the actor was cryptographically attested by an IdP
+// (e.g. JWT "act" claim per RFC 8693 §4.1) and false for self-reported
+// subjects from request headers.
+type ActorRef struct {
+	Subject  string
+	Verified bool
 }
 
 // AuthData contains the authentication data used to generate a token.

--- a/logical/token.go
+++ b/logical/token.go
@@ -42,6 +42,12 @@ type TokenEntry struct {
 
 	// Credential spec for this token if any
 	CredentialSpec string
+
+	// Actors persists a verified on-behalf-of chain (JWT "act" claim)
+	// so that it survives transparent-mode token caching. Populated by
+	// the JWT auth method at login time. Header-supplied actors are
+	// per-request and are never written here.
+	Actors []ActorRef
 }
 
 // MarkUsed marks the token as used (for one-time use tokens)

--- a/provider/alicloud/path_gateway.go
+++ b/provider/alicloud/path_gateway.go
@@ -34,6 +34,7 @@ var headersToStrip = []string{
 	// Warden-specific
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop
 	"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
 	"Te", "Trailer", "Trailers", "Transfer-Encoding", "Upgrade",

--- a/provider/azure/path_gateway.go
+++ b/provider/azure/path_gateway.go
@@ -21,6 +21,7 @@ var headersToRemove = []string{
 	"Authorization",
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/gcp/path_gateway.go
+++ b/provider/gcp/path_gateway.go
@@ -21,6 +21,7 @@ var headersToRemove = []string{
 	"Authorization",
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -128,7 +128,7 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 	}
 
 	headersToRemove := []string{
-		"X-Warden-Token", "X-Warden-Role",
+		"X-Warden-Token", "X-Warden-Role", "X-Warden-On-Behalf-Of",
 		"Connection", "Keep-Alive", "Transfer-Encoding", "Upgrade",
 		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
 		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",

--- a/provider/sdk/httpproxy/headers.go
+++ b/provider/sdk/httpproxy/headers.go
@@ -7,6 +7,7 @@ var BaseHeadersToRemove = []string{
 	"Authorization",
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -16,11 +16,12 @@ import (
 // Headers to remove before proxying
 var headersToRemove = []string{
 	// Security headers (will be replaced with real values)
-	"Authorization",   // Remove Warden auth token to prevent leakage
-	"X-Vault-Token",   // Will be replaced with real Vault token
-	"X-Vault-Request", // Internal Vault header
-	"X-Warden-Token",  // Warden-specific auth header
-	"X-Warden-Role",   // Warden role header
+	"Authorization",         // Remove Warden auth token to prevent leakage
+	"X-Vault-Token",         // Will be replaced with real Vault token
+	"X-Vault-Request",       // Internal Vault header
+	"X-Warden-Token",        // Warden-specific auth header
+	"X-Warden-Role",         // Warden role header
+	"X-Warden-On-Behalf-Of", // Warden audit-propagation header — internal-only
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",


### PR DESCRIPTION
## Summary

- Adds `Actors []ActorRef` field on `audit.Auth` so MCP-style concentrators can attach per-agent attribution to audit log entries.
- Wires the unverified (header) ingestion path: `X-Warden-On-Behalf-Of` from an authenticated non-login request is recorded as `actors[i]` with `verified: false`.
- Adds the header to all six provider gateway strip-lists so it never leaks upstream.

## Why

When an MCP concentrator authenticates to Warden with its own JWT and forwards calls on behalf of N upstream agents, the audit log previously lost per-agent attribution and only recorded the concentrator. This addresses item 2.8 from the v0.11 retrospective.

This PR is the load-bearing half of the fix. A follow-up PR adds the verified path via JWT `act` claim (RFC 8693 section 4.1).

## Trust model

The header is unauthenticated and forgeable, but the `verified: false` flag is the trust signal. Audit readers always see both `principal_id` (who actually called) and `actors[]` (who they claimed to be acting for), and can never mistake one for the other. No authorization gate is needed because the header does not escalate privileges, does not change request behavior, and does not reach upstream (strip-list). Mirrors how Vault honors `X-Vault-*` headers when present and `X-Forwarded-For` via trusted-proxy IP rather than per-principal allowlist.

## Implementation notes

- Header read in `handleNonLoginRequest` gated on `te != nil` so an unauthenticated caller on a stream-unauthenticated path cannot plant an actor into the response audit (which is emitted unconditionally upstream).
- `validActorSubject` regex `^[A-Za-z0-9._:@/+\-]{1,256}$` rejects empty, oversized, comma-containing (single-actor enforcement), and control-byte values.
- Warn-log on invalid subjects uses `strconv.Quote` so attacker-controlled non-ASCII or control bytes cannot corrupt the log line.
- `buildAuditAuth` merges actor sources with per-request header winning over token-bound. The token-bound branch is dead code in PR 1 (`te.Actors` is never populated yet); the follow-up PR wires the JWT `act` claim into it.
- All six strip-list sites updated: `httpproxy.BaseHeadersToRemove`, `dualgateway`, `alicloud`, `azure`, `gcp`, `vault`.

## Note on a dangling adjacent feature

While reading the JWT auth code I noticed `JWTAuthConfig.ClaimMappings` is declared and documented (auth/method/jwt/backend.go:39, auth/method/jwt/path_config.go:55-58) but never consumed in `path_login.go`. Out of scope here; flagged for a separate PR so it does not get re-discovered.

## Test plan

- [x] `audit/types_test.go` — `Actors` round-trip + `Clone()` deep-copy
- [x] `core/audit_test.go` — 4 new `buildAuditAuth` cases (auth-only actors, te-only actors, header-wins merge, no-actors baseline)
- [x] `core/request_handler_test.go` — 16-case table-driven `validActorSubject` (charset, length boundaries, CR/LF/tab/unicode rejection, comma single-actor enforcement)
- [x] `go test ./audit/... ./core/... ./logical/... ./provider/...` — all pass
- [x] `go build ./...` — clean
- [x] `grep -RIn '"X-Warden-On-Behalf-Of"' provider/ | grep -v _test.go` returns all six strip-list sites
- [ ] E2E Scenarios A (JWT + header) and C (cert + header) — deferred; the strip-list change is grep-verified and the merge logic is unit-tested
- [ ] CI green