### PR TITLE
feat(audit): extract JWT act claim into Auth.actors (RFC 8693)

### DIFF
--- a/auth/method/jwt/helper.go
+++ b/auth/method/jwt/helper.go
@@ -3,7 +3,14 @@ package jwt
 import (
 	"fmt"
 	"strings"
+
+	"github.com/stephnangue/warden/logical"
 )
+
+// maxActChainDepth bounds the depth of nested "act" claims walked by
+// extractActChain. RFC 8693 §4.1 allows arbitrary nesting; this cap
+// protects against IdP misconfiguration or pathological tokens.
+const maxActChainDepth = 4
 
 // errAuthFailed is a generic error returned for all authentication failures
 // to prevent information leakage about which specific check failed.
@@ -99,6 +106,41 @@ func extractClaim(claims map[string]interface{}, claimName string) string {
 		}
 	}
 	return ""
+}
+
+// extractActChain walks the RFC 8693 §4.1 "act" claim chain into a
+// flat verified actor list. Returns nil when no "act" claim is present.
+// Terminates without erroring on malformed layers (non-object, missing
+// "sub", non-string "sub") and on chains deeper than maxActChainDepth.
+//
+// Example input:
+//
+//	{"act": {"sub": "broker-beta", "act": {"sub": "agents/alpha"}}}
+//
+// Example output:
+//
+//	[{Subject: "broker-beta", Verified: true},
+//	 {Subject: "agents/alpha", Verified: true}]
+func extractActChain(claims map[string]interface{}) []logical.ActorRef {
+	var actors []logical.ActorRef
+	current := claims
+	for depth := 0; depth < maxActChainDepth; depth++ {
+		raw, ok := current["act"]
+		if !ok {
+			break
+		}
+		act, ok := raw.(map[string]interface{})
+		if !ok {
+			break // malformed: act must be a JSON object
+		}
+		sub, ok := act["sub"].(string)
+		if !ok || sub == "" {
+			break // malformed: layer must carry a non-empty string sub
+		}
+		actors = append(actors, logical.ActorRef{Subject: sub, Verified: true})
+		current = act
+	}
+	return actors
 }
 
 // extractGroupsClaim extracts a string slice from a JWT claim.

--- a/auth/method/jwt/helper_test.go
+++ b/auth/method/jwt/helper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stephnangue/warden/auth/helper"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 )
 
 // =============================================================================
@@ -592,5 +593,109 @@ func TestVerifyOIDCDiscoveryURLReachable(t *testing.T) {
 }
 
 // =============================================================================
-// handleConfigWrite with storage persistence
+// extractActChain Tests (RFC 8693 §4.1 "act" claim)
 // =============================================================================
+
+func TestExtractActChain_NoActClaim(t *testing.T) {
+	claims := map[string]interface{}{"sub": "mcp-github"}
+	assert.Nil(t, extractActChain(claims))
+}
+
+func TestExtractActChain_SingleHop(t *testing.T) {
+	claims := map[string]interface{}{
+		"sub": "mcp-github",
+		"act": map[string]interface{}{"sub": "agents/alpha"},
+	}
+	got := extractActChain(claims)
+	require.Len(t, got, 1)
+	assert.Equal(t, "agents/alpha", got[0].Subject)
+	assert.True(t, got[0].Verified)
+}
+
+func TestExtractActChain_NestedChain(t *testing.T) {
+	claims := map[string]interface{}{
+		"sub": "mcp-github",
+		"act": map[string]interface{}{
+			"sub": "broker-beta",
+			"act": map[string]interface{}{
+				"sub": "agents/alpha",
+			},
+		},
+	}
+	got := extractActChain(claims)
+	require.Len(t, got, 2)
+	assert.Equal(t, "broker-beta", got[0].Subject)
+	assert.Equal(t, "agents/alpha", got[1].Subject)
+	for _, a := range got {
+		assert.True(t, a.Verified, "all act-claim actors are verified")
+	}
+}
+
+func TestExtractActChain_NonObjectAct(t *testing.T) {
+	// "act" must be a JSON object; a string here is malformed and ends the walk.
+	claims := map[string]interface{}{
+		"sub": "mcp-github",
+		"act": "agents/alpha",
+	}
+	assert.Empty(t, extractActChain(claims))
+}
+
+func TestExtractActChain_MissingSubInLayer(t *testing.T) {
+	// Inner layer has no sub → walk terminates without recording.
+	claims := map[string]interface{}{
+		"sub": "mcp-github",
+		"act": map[string]interface{}{
+			"act": map[string]interface{}{"sub": "agents/alpha"},
+		},
+	}
+	assert.Empty(t, extractActChain(claims))
+}
+
+func TestExtractActChain_NonStringSub(t *testing.T) {
+	// sub must be a string; a number here is malformed.
+	claims := map[string]interface{}{
+		"sub": "mcp-github",
+		"act": map[string]interface{}{"sub": 42},
+	}
+	assert.Empty(t, extractActChain(claims))
+}
+
+func TestExtractActChain_EmptyStringSub(t *testing.T) {
+	claims := map[string]interface{}{
+		"sub": "mcp-github",
+		"act": map[string]interface{}{"sub": ""},
+	}
+	assert.Empty(t, extractActChain(claims))
+}
+
+func TestExtractActChain_DepthCap(t *testing.T) {
+	// Build a chain deeper than maxActChainDepth (4). The walk should stop
+	// after 4 layers, retaining the layers CLOSEST to the principal (not
+	// the innermost ones) — i.e. the first 4 entries when walking outward.
+	innermost := map[string]interface{}{"sub": "layer-6"}
+	chain := innermost
+	for i := 5; i >= 1; i-- {
+		chain = map[string]interface{}{
+			"sub": strconv.Itoa(i),
+			"act": chain,
+		}
+	}
+	// Re-assign subs as "layer-N" once nesting is built, so we can assert order.
+	walk := chain
+	for i := 1; i <= 5; i++ {
+		walk["sub"] = "layer-" + strconv.Itoa(i)
+		next, ok := walk["act"].(map[string]interface{})
+		if !ok {
+			break
+		}
+		walk = next
+	}
+	claims := map[string]interface{}{"sub": "principal", "act": chain}
+
+	got := extractActChain(claims)
+	require.Len(t, got, maxActChainDepth)
+	assert.Equal(t, "layer-1", got[0].Subject, "outermost act layer must come first")
+	assert.Equal(t, "layer-2", got[1].Subject)
+	assert.Equal(t, "layer-3", got[2].Subject)
+	assert.Equal(t, "layer-4", got[3].Subject)
+}

--- a/auth/method/jwt/path_login.go
+++ b/auth/method/jwt/path_login.go
@@ -249,6 +249,10 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 		}
 	}
 
+	// On-behalf-of chain attested by the IdP via RFC 8693 §4.1 "act"
+	// claim. Recorded with verified=true; flows through to audit.
+	actors := extractActChain(claims)
+
 	// Return auth response using role configuration.
 	// ClientToken carries the raw JWT so that LoginCreateToken can pass it to
 	// JWTRoleTokenType.Generate(), which hashes jwt+role to compute the
@@ -264,6 +268,7 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 			TokenTTL:       effectiveTTL,
 			ClientIP:       req.ClientIP,
 			ClientToken:    jwtToken,
+			Actors:         actors,
 		},
 		Data: map[string]any{
 			"principal_id": principalID,

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -543,6 +543,7 @@ func (c *Core) LoginCreateToken(ctx context.Context, resp *logical.Response) (*l
 		Policies:       auth.Policies,
 		ClientIP:       auth.ClientIP,
 		TokenValue:     auth.ClientToken,
+		Actors:         auth.Actors,
 	}
 
 	tokenValue, err := c.tokenStore.GenerateToken(ctx, auth.TokenType, &authData)

--- a/core/token_store.go
+++ b/core/token_store.go
@@ -386,6 +386,7 @@ func (s *TokenStore) generateWithCollisionDetection(
 			Policies:       authData.Policies,
 			CredentialSpec: authData.CredentialSpec,
 			CreatedByIP:    authData.ClientIP,
+			Actors:         authData.Actors,
 		}
 
 		// Generate accessor (Tier 2)
@@ -976,6 +977,7 @@ func (s *TokenStore) ReplaceRootTokenValue(customToken string) error {
 		CredentialSpec: oldEntry.CredentialSpec,
 		CreatedByIP:    oldEntry.CreatedByIP,
 		Data:           map[string]string{"token": customToken},
+		Actors:         oldEntry.Actors,
 	}
 
 	// Compute new ID from custom token value

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -71,4 +71,9 @@ type AuthData struct {
 	Policies       []string
 	ClientIP       string
 	TokenValue     string // External token value (e.g., JWT for transparent mode)
+
+	// Actors carries the verified on-behalf-of chain extracted at login
+	// (e.g. JWT "act" claim) so it can be persisted onto the issued
+	// TokenEntry for transparent-mode cache reuse.
+	Actors []ActorRef
 }


### PR DESCRIPTION
## Summary

- Adds the verified ingestion path for the on-behalf-of audit propagation feature: when a JWT login carries an `act` claim (RFC 8693 section 4.1), each nested layer becomes an audit actor with `verified: true`.
- New `extractActChain` helper walks the nested chain with a depth cap of 4, silently terminating on malformed layers.
- Verified chain is persisted onto the issued `TokenEntry` so it survives transparent-mode token caching.

> Stacked on #235. Merge that first; this branch is based on it. Once #235 lands, GitHub will rebase this PR onto main.

## Why

The header-path PR addressed the immediate MCP audit-gap with `verified: false` entries. This PR adds the cryptographically-attested counterpart: when an IdP itself encodes delegation via the standard JWT `act` claim, Warden records `verified: true`. Audit readers get a one-flag distinction between unverified (what the principal claimed) and verified (what the IdP attested).

## Implementation notes

- `extractActChain` returns `nil` when no `act` claim is present, so a non-delegating JWT looks identical to today.
- Depth-cap (4) protects against IdP misconfiguration or pathological tokens; chains deeper than 4 are truncated to the outermost 4 layers (closest to the principal). 4 is well above the depth needed for realistic concentrator topologies.
- Malformed layers (non-object `act`, missing `sub`, non-string `sub`, empty `sub`) terminate the walk silently rather than failing the login — these are IdP-side data quality issues, not security failures.
- No regex sanitization on the extracted `sub` values: unlike the header path, JWT content is cryptographically attested by a trusted IdP. JSON encoding handles safe rendering at audit emission.
- Persistence: `TokenEntry` is JSON-marshaled to storage; the new `Actors []ActorRef` field round-trips with Go's default field-name capitalization, matching the surrounding tag-free convention. Forward- and backward-compatible — older binaries skip the unknown field, older entries decode with nil `Actors`.
- `ReplaceRootTokenValue` copies `Actors` for defensive completeness even though root tokens won't realistically carry one.

## Merge logic verified across both PRs

`CheckToken` builds a fresh `auth` from scratch on each request (does not copy `te.Actors`). The PR 1 header block populates `auth.Actors` only when the header is set. `buildAuditAuth` then merges:

- Subsequent request with no header → `te.Actors` (verified chain from login) surfaces in audit.
- Subsequent request with a header → unverified header actor wins per the documented per-request rule.

## Test plan

- [x] `auth/method/jwt/helper_test.go` — 8 cases for `extractActChain`: no-act, single hop, nested chain, non-object act, missing inner sub, non-string sub, empty-string sub, depth cap (with FIFO ordering assertion)
- [x] `go test ./auth/method/jwt/... ./core/... ./logical/...` — all pass
- [x] `go build ./...` — clean
- [ ] E2E Scenario B (verified `act` claim end-to-end, including the "header wins" bonus case) — deferred
- [ ] CI green