### PR TITLE
feat(routing): add X-Warden-Provider header for mount routing

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -48,6 +48,12 @@ const (
 	// RoleHeaderName is the header name used to specify the role
 	RoleHeaderName = "X-Warden-Role"
 
+	// ProviderHeaderName is the header name used to specify the provider mount.
+	// When set, the server treats the request URL as a literal upstream API path
+	// and synthesises the canonical /<provider>/role/<role>/gateway/<api-path>
+	// shape before mount lookup.
+	ProviderHeaderName = "X-Warden-Provider"
+
 	TLSErrorString = "This error usually means that the server is running with TLS disabled\n" +
 		"but the client is configured to use TLS. Please either enable TLS\n" +
 		"on the server or run the client with -address set to an address\n" +
@@ -1018,6 +1024,60 @@ func (c *Client) WithRole(role string) *Client {
 		c2.ClearRole()
 	} else {
 		c2.SetRole(role)
+	}
+	return &c2
+}
+
+// SetProvider sets the provider mount on the client headers. Subsequent
+// requests will be routed to that mount by the server; the request URL
+// is treated as the literal upstream API path.
+func (c *Client) SetProvider(provider string) {
+	c.modifyLock.Lock()
+	defer c.modifyLock.Unlock()
+	c.setProvider(provider)
+}
+
+// setProvider sets the provider in the client headers. This method requires
+// that the caller hold the client's modifyLock.
+func (c *Client) setProvider(provider string) {
+	if c.headers == nil {
+		c.headers = make(http.Header)
+	}
+
+	c.headers.Set(ProviderHeaderName, provider)
+}
+
+// ClearProvider removes the provider header from the client if it exists.
+func (c *Client) ClearProvider() {
+	c.modifyLock.Lock()
+	defer c.modifyLock.Unlock()
+	if c.headers != nil {
+		c.headers.Del(ProviderHeaderName)
+	}
+}
+
+// Provider returns the provider currently set in this client. It will
+// return an empty string if there is no provider set.
+func (c *Client) Provider() string {
+	c.modifyLock.Lock()
+	defer c.modifyLock.Unlock()
+	if c.headers == nil {
+		return ""
+	}
+	return c.headers.Get(ProviderHeaderName)
+}
+
+// WithProvider makes a shallow copy of Client, modifies it to use
+// the given provider, and returns it. Passing an empty string will
+// temporarily unset the provider.
+func (c *Client) WithProvider(provider string) *Client {
+	c2 := *c
+	c2.modifyLock = sync.RWMutex{}
+	c2.headers = c.Headers()
+	if provider == "" {
+		c2.ClearProvider()
+	} else {
+		c2.SetProvider(provider)
 	}
 	return &c2
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1188,6 +1188,45 @@ func TestClient_WithRole(t *testing.T) {
 	}
 }
 
+func TestClient_ProviderOperations(t *testing.T) {
+	config := DefaultConfig()
+	client, _ := NewClient(config)
+
+	if p := client.Provider(); p != "" {
+		t.Errorf("expected empty provider, got %q", p)
+	}
+
+	client.SetProvider("github")
+	if p := client.Provider(); p != "github" {
+		t.Errorf("expected github, got %q", p)
+	}
+
+	client.ClearProvider()
+	if p := client.Provider(); p != "" {
+		t.Errorf("expected empty after clear, got %q", p)
+	}
+}
+
+func TestClient_WithProvider(t *testing.T) {
+	config := DefaultConfig()
+	client, _ := NewClient(config)
+
+	client.SetProvider("github")
+
+	c2 := client.WithProvider("gitlab")
+	if c2.Provider() != "gitlab" {
+		t.Errorf("expected gitlab, got %q", c2.Provider())
+	}
+	if client.Provider() != "github" {
+		t.Errorf("expected github unchanged, got %q", client.Provider())
+	}
+
+	c3 := client.WithProvider("")
+	if c3.Provider() != "" {
+		t.Errorf("expected empty, got %q", c3.Provider())
+	}
+}
+
 func TestClient_Headers(t *testing.T) {
 	config := DefaultConfig()
 	client, _ := NewClient(config)

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -327,6 +327,28 @@ func (c *Core) HandleRequest(ctx context.Context, req *logical.Request) (*logica
 		}
 	}(activeCtx, ctx)
 
+	// Header-routing mode: when X-Warden-Provider is present, the request URL
+	// is treated as the literal upstream API path and the canonical
+	// <provider>/role/<role>/gateway/<api> shape is synthesized before mount
+	// lookup. The header is never honored against the system backend. The
+	// underlying HTTPRequest.URL.Path is also realigned so providers that
+	// read URL.Path directly see the same shape as a path-routed request.
+	if req.HTTPRequest != nil {
+		if provider := req.HTTPRequest.Header.Get("X-Warden-Provider"); provider != "" {
+			if strings.HasPrefix(req.Path, "sys/") {
+				return logical.ErrorResponse(logical.ErrBadRequest("X-Warden-Provider is not honored on system backend paths")), nil
+			}
+			headerRole := req.HTTPRequest.Header.Get("X-Warden-Role")
+			synthesized, err := synthesizeGatewayPath(provider, headerRole, req.Path)
+			if err != nil {
+				return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+			}
+			req.Path = synthesized
+			req.HTTPRequest.URL.Path = "/v1/" + synthesized
+			req.HTTPRequest.URL.RawPath = ""
+		}
+	}
+
 	// For help operations, mount-root paths (e.g., "azure") may arrive without
 	// a trailing slash because path.Join in the API client strips them.
 	// Use the silent MatchingMount to probe with a trailing slash first,
@@ -349,6 +371,47 @@ func (c *Core) HandleRequest(ctx context.Context, req *logical.Request) (*logica
 	resp, err := c.handleCancelableRequest(ctx, req)
 	req.SetTokenEntry(nil)
 	return resp, err
+}
+
+// synthesizeGatewayPath builds the canonical gateway path from a provider
+// mount value and optional role. The result matches the shape the router
+// and streaming backend expect:
+//
+//	role present: <provider>/role/<role>/gateway/<api>
+//	role empty:   <provider>/gateway/<api>
+//
+// One leading and one trailing slash on the provider value are tolerated
+// and stripped. Empty path segments and bare ".." segments are rejected.
+// Whether the resolved mount exists is the caller's concern (the router's
+// existing 404 path handles that).
+func synthesizeGatewayPath(provider, role, apiPath string) (string, error) {
+	provider = strings.TrimSuffix(provider, "/")
+	provider = strings.TrimPrefix(provider, "/")
+	if provider == "" {
+		return "", fmt.Errorf("X-Warden-Provider value is empty")
+	}
+	for _, seg := range strings.Split(provider, "/") {
+		if seg == "" {
+			return "", fmt.Errorf("X-Warden-Provider value contains an empty path segment")
+		}
+		if seg == ".." {
+			return "", fmt.Errorf("X-Warden-Provider value contains a path-traversal segment")
+		}
+	}
+
+	apiPath = strings.TrimPrefix(apiPath, "/")
+
+	var b strings.Builder
+	b.WriteString(provider)
+	b.WriteString("/")
+	if role != "" {
+		b.WriteString("role/")
+		b.WriteString(role)
+		b.WriteString("/")
+	}
+	b.WriteString("gateway/")
+	b.WriteString(apiPath)
+	return b.String(), nil
 }
 
 func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request) (resp *logical.Response, err error) {

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -170,6 +170,141 @@ func TestHandleRequest_NamespaceHeader(t *testing.T) {
 	_ = err // err may contain permission denied
 }
 
+// TestSynthesizeGatewayPath covers the normalization rules for the
+// X-Warden-Provider header value and the role-empty / role-present
+// branches of the path-synthesis helper.
+func TestSynthesizeGatewayPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		role     string
+		apiPath  string
+		want     string
+		wantErr  bool
+	}{
+		// Successful normalisations.
+		{"single segment", "github", "repo-reader", "repos/org/repo", "github/role/repo-reader/gateway/repos/org/repo", false},
+		{"trailing slash stripped", "github/", "repo-reader", "repos/org/repo", "github/role/repo-reader/gateway/repos/org/repo", false},
+		{"leading slash stripped", "/github", "repo-reader", "repos/org/repo", "github/role/repo-reader/gateway/repos/org/repo", false},
+		{"multi-segment mount", "gitlab/prod", "ci", "api/v4/projects/1", "gitlab/prod/role/ci/gateway/api/v4/projects/1", false},
+		{"multi-segment with trailing slash", "gitlab/prod/", "ci", "api/v4/projects/1", "gitlab/prod/role/ci/gateway/api/v4/projects/1", false},
+		{"role empty", "github", "", "repos/org/repo", "github/gateway/repos/org/repo", false},
+		{"api path with leading slash", "github", "r", "/repos/org/repo", "github/role/r/gateway/repos/org/repo", false},
+		{"double-dot infix is OK", "gitlab/..eu-west", "r", "p", "gitlab/..eu-west/role/r/gateway/p", false},
+
+		// Malformed values that must error.
+		{"empty provider", "", "r", "p", "", true},
+		{"slash only", "/", "r", "p", "", true},
+		{"empty middle segment", "gitlab//prod", "r", "p", "", true},
+		{"bare double-dot", "..", "r", "p", "", true},
+		{"trailing double-dot", "gitlab/..", "r", "p", "", true},
+		{"whitespace only passes synthesis", "   ", "r", "p", "   /role/r/gateway/p", false},
+	}
+	// Whitespace is not stripped or rejected per-segment; the helper trusts
+	// that no real mount has whitespace-only names, so the request lands on
+	// the existing 404 path rather than 400. The case above documents that.
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := synthesizeGatewayPath(tc.provider, tc.role, tc.apiPath)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestHandleRequest_ProviderHeader_SysRejected verifies that a request
+// carrying X-Warden-Provider against a /v1/sys/... URL is rejected with
+// 400, regardless of whether the named mount exists.
+func TestHandleRequest_ProviderHeader_SysRejected(t *testing.T) {
+	core := createTestCore(t)
+
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/mounts", nil)
+	httpReq.Header.Set("X-Warden-Provider", "github")
+
+	req := &logical.Request{
+		Path:        "sys/mounts",
+		Operation:   logical.ReadOperation,
+		HTTPRequest: httpReq,
+	}
+
+	resp, err := core.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHandleRequest_ProviderHeader_SysRejected_WithNamespace confirms the
+// sys-backend exclusion fires after namespace strip, not just when the raw
+// URL begins with /v1/sys/.
+func TestHandleRequest_ProviderHeader_SysRejected_WithNamespace(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	childNs := &namespace.Namespace{Path: "tenant-a/"}
+	require.NoError(t, core.namespaceStore.SetNamespace(ctx, childNs))
+
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/tenant-a/sys/mounts", nil)
+	httpReq.Header.Set("X-Warden-Provider", "github")
+
+	req := &logical.Request{
+		Path:        "tenant-a/sys/mounts",
+		Operation:   logical.ReadOperation,
+		HTTPRequest: httpReq,
+	}
+
+	resp, err := core.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHandleRequest_ProviderHeader_Malformed verifies that a structurally
+// malformed X-Warden-Provider value returns 400 (not 404).
+func TestHandleRequest_ProviderHeader_Malformed(t *testing.T) {
+	core := createTestCore(t)
+
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/repos/org/repo", nil)
+	httpReq.Header.Set("X-Warden-Provider", "gitlab/..")
+
+	req := &logical.Request{
+		Path:        "repos/org/repo",
+		Operation:   logical.ReadOperation,
+		HTTPRequest: httpReq,
+	}
+
+	resp, err := core.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHandleRequest_ProviderHeader_NoSuchMount verifies that a well-formed
+// X-Warden-Provider value naming an unmounted provider returns 404, not 400.
+// This is the error-class split: 400 = malformed header, 404 = unknown mount.
+func TestHandleRequest_ProviderHeader_NoSuchMount(t *testing.T) {
+	core := createTestCore(t)
+
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/repos/org/repo", nil)
+	httpReq.Header.Set("X-Warden-Provider", "doesnotexist")
+
+	req := &logical.Request{
+		Path:        "repos/org/repo",
+		Operation:   logical.ReadOperation,
+		HTTPRequest: httpReq,
+	}
+
+	resp, err := core.HandleRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 // TestParseRequestBody tests the parseRequestBody function
 func TestParseRequestBody(t *testing.T) {
 	core := createTestCore(t)

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -386,6 +386,23 @@ func NSVaultTransparentHeaderRequest(t *testing.T, method, vaultPath, role, name
 	return DoRequest(t, method, u, headers, "")
 }
 
+// NSVaultTransparentProviderRequest makes a namespace-scoped transparent Vault
+// gateway request using X-Warden-Provider for mount routing and X-Warden-Role
+// for the auth role. The URL carries only the literal upstream Vault API path
+// (e.g. v1/secret/data/foo), so the on-the-wire URL ends up /v1/v1/<vault-path>:
+// the outer /v1/ is Warden's prefix, the inner v1/<...> is Vault's API path.
+func NSVaultTransparentProviderRequest(t *testing.T, method, vaultPath, role, namespace string, port int, jwt string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/v1/%s", NodeURL(port), vaultPath)
+	headers := map[string]string{
+		"Authorization":      "Bearer " + jwt,
+		"X-Warden-Namespace": namespace,
+		"X-Warden-Provider":  "vault",
+		"X-Warden-Role":      role,
+	}
+	return DoRequest(t, method, u, headers, "")
+}
+
 // --- Namespace Setup/Teardown ---
 
 const NSVaultNS = "e2e-ci-ns-gw"

--- a/e2e/provider/vault_gateway_test.go
+++ b/e2e/provider/vault_gateway_test.go
@@ -88,3 +88,23 @@ func TestNSVaultTransparentHeaderRole(t *testing.T) {
 	// Teardown
 	h.TeardownNSVaultEnv(t, leader)
 }
+
+// TestNSVaultTransparentProviderHeader verifies that a request carrying
+// X-Warden-Provider (and X-Warden-Role) reaches the same Vault gateway
+// backend as the path-routed equivalent. The URL is the literal upstream
+// API path (v1/secret/data/...); the mount and role come from headers.
+func TestNSVaultTransparentProviderHeader(t *testing.T) {
+	leader := h.GetLeaderPort(t)
+
+	h.SetupNSVaultEnv(t, leader)
+	defer h.TeardownNSVaultEnv(t, leader)
+
+	jwt := h.GetDefaultJWT(t)
+
+	// Header-routing mode: provider in header, role in header, URL is the
+	// literal Vault path. Same upstream call as the path-routed test above.
+	status, _ := h.NSVaultTransparentProviderRequest(t, "GET", "secret/data/e2e/app-config", "e2e-reader", h.NSVaultNS, leader, jwt)
+	if status != 200 {
+		t.Fatalf("provider header: expected 200, got %d", status)
+	}
+}

--- a/provider/alicloud/path_gateway.go
+++ b/provider/alicloud/path_gateway.go
@@ -34,6 +34,7 @@ var headersToStrip = []string{
 	// Warden-specific
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop
 	"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",

--- a/provider/azure/path_gateway.go
+++ b/provider/azure/path_gateway.go
@@ -21,6 +21,7 @@ var headersToRemove = []string{
 	"Authorization",
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop headers
 	"Connection",

--- a/provider/gcp/path_gateway.go
+++ b/provider/gcp/path_gateway.go
@@ -21,6 +21,7 @@ var headersToRemove = []string{
 	"Authorization",
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop headers
 	"Connection",

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -128,7 +128,7 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 	}
 
 	headersToRemove := []string{
-		"X-Warden-Token", "X-Warden-Role", "X-Warden-On-Behalf-Of",
+		"X-Warden-Token", "X-Warden-Role", "X-Warden-Provider", "X-Warden-On-Behalf-Of",
 		"Connection", "Keep-Alive", "Transfer-Encoding", "Upgrade",
 		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
 		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",

--- a/provider/sdk/httpproxy/headers.go
+++ b/provider/sdk/httpproxy/headers.go
@@ -7,6 +7,7 @@ var BaseHeadersToRemove = []string{
 	"Authorization",
 	"X-Warden-Token",
 	"X-Warden-Role",
+	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
 	// Hop-by-hop headers
 	"Connection",

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -21,6 +21,7 @@ var headersToRemove = []string{
 	"X-Vault-Request",       // Internal Vault header
 	"X-Warden-Token",        // Warden-specific auth header
 	"X-Warden-Role",         // Warden role header
+	"X-Warden-Provider",     // Warden provider-mount routing header
 	"X-Warden-On-Behalf-Of", // Warden audit-propagation header — internal-only
 	// Hop-by-hop headers
 	"Connection",


### PR DESCRIPTION
## Summary

- New `X-Warden-Provider` header lets non-agent clients (legacy SDKs with a single-string `base_url`, copy-pasted `curl`, scripted tools) reach a provider without rewriting the URL. Send the request to `/v1/<literal-upstream-api-path>` with `X-Warden-Provider: <mount>` and `X-Warden-Role: <role>`; the server synthesises the canonical `<provider>/role/<role>/gateway/<api>` shape before mount lookup.
- System-backend paths (`/v1/sys/...`) reject the header with 400 — never silently ignored.
- Multi-segment mount paths (`gitlab/prod`) accepted; empty path segments and bare `..` segments rejected as 400; unknown-but-well-formed values fall through to the existing 404.
- Header added to all six provider strip-lists so it never leaks upstream.

## Why

This addresses §2.7 of the v0.11 retrospective: URL-rewriting friction is the biggest remaining non-agent-client adoption hurdle. AI agents already have a clean answer via the Skills system (per-provider `skill.md` templates make path routing trivially correct), but legacy SDKs that accept only a single `base_url` string, copy-pasted `curl` from upstream docs, and scripted tools that cannot read a skill catalog at startup still have to mangle the URL into `/v1/<mount>/role/<role>/gateway/<api>`. Header routing collapses that to "set one hostname, add two headers".

## Implementation notes

- Synthesis runs in `core/request_handler.go` between namespace resolution and mount lookup, so namespaces compose naturally (`X-Warden-Namespace: parent/child` + `X-Warden-Provider: leaf-mount`).
- `req.HTTPRequest.URL.Path` is realigned with the synthesised path (`/v1/` + canonical) and `RawPath` cleared, so the six providers that read `URL.Path` directly (vault, azure, gcp, alicloud, aws, httpproxy) see the same shape as a path-routed request. This step was caught only by the e2e run — unit tests passed because they exercise the synthesis but not the upstream proxy.
- Header-value normalisation deliberately does not re-implement `ValidateMountPath` character allowlist at runtime: by construction every mounted prefix already satisfies it. Structurally-invalid values (empty segment, bare `..`) return 400; unknown-but-well-formed values land on the existing 404 path. Keeps the 400/404 split clean.
- `api.Client` gains `SetProvider` / `Provider` / `ClearProvider` / `WithProvider` mirroring the existing `Role` / `Namespace` shape.

## Scope

- `X-Warden-Role` precedence is unchanged in this PR. Path-routed clients are unaffected.
- A follow-up PR will align `X-Warden-Role` to "header wins" so the two headers obey the same rule (a deliberate, single-version breaking change with a CHANGELOG callout).

## Test plan

- [x] `go test ./core/... ./api/... ./provider/...` — all pass
- [x] `go build ./...` — clean
- [x] Unit: 14-case table-driven `TestSynthesizeGatewayPath` covering trim, multi-segment, empty-segment, bare `..`, leading slash, whitespace fall-through
- [x] Unit: `TestHandleRequest_ProviderHeader_SysRejected` (and the namespace-prefixed variant), `_Malformed`, `_NoSuchMount`
- [x] Unit: `TestClient_ProviderOperations`, `TestClient_WithProvider`
- [x] E2E: `TestNSVaultTransparentProviderHeader` sends `/v1/v1/secret/data/...` with `X-Warden-Provider: vault` + `X-Warden-Role: e2e-reader` and verifies 200 from the same Vault gateway the path-routed test reaches
- [x] `make test-e2e` (full 13-package suite) — green after the `URL.Path` realignment landed
- [x] `grep '"X-Warden-Provider"' provider/ --include='*.go' -r` returns all six strip-list sites
- [ ] CI green
