### PR TITLE
feat(auth/jwt)!: drop redundant mode field, infer from key source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Warden are documented in this file.
 
 ### Breaking Changes
 
+- **JWT auth: `mode` field removed from `auth/{mount}/config` schema.** `mode=jwt|oidc` was redundant with the three mutually-exclusive key-source fields (`oidc_discovery_url`, `jwks_url`, `jwt_validation_pubkeys`) — the backend can derive everything it needs from which one is set. The schema field is gone; exactly one of those three key sources must now be provided, and the write returns `exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys must be set (got N)` otherwise. Existing scripts passing `mode=jwt` / `mode=oidc` will emit a framework warning ("unknown field 'mode'") but continue to succeed — the framework treats unknown fields as non-fatal. The `mode` key is also no longer returned by `warden read auth/{mount}/config`. Drop the `mode=...` argument from any wrapping scripts. (this PR)
+
 - **`X-Warden-Role` header now overrides any role embedded in the URL.** Previously a role in `role/<role>/gateway/...` URL took priority over the header; now the header wins unconditionally in both header-routing mode and path-routing mode. The change aligns `X-Warden-Role` precedence with the brand-new `X-Warden-Provider` so the two headers obey one rule: header beats URL, URL beats default. `req.Path` and `HTTPRequest.URL.Path` are rewritten so the streaming backend's role parser sees the same role the auth resolver chooses. The skills shipped in-tree, the Helm chart, and the CLI never produce the URL-role + header-role combination, so the affected surface is likely zero — but any caller that today relied on URL-role winning over a stray `X-Warden-Role` header must drop the header or align it with the URL. (this PR)
 
 

--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -19,10 +19,10 @@ import (
 	"github.com/stephnangue/warden/logical"
 )
 
-// JWTAuthConfig represents JWT/OIDC authentication configuration
+// JWTAuthConfig represents JWT authentication configuration. Exactly one
+// of OIDCDiscoveryURL, JWKSURL, or JWTValidationPubKeys must be set; the
+// chosen field determines how token signatures are verified.
 type JWTAuthConfig struct {
-	Mode string `json:"mode"` // "jwt" or "oidc" (required)
-
 	// OIDC Discovery
 	OIDCDiscoveryURL string `json:"oidc_discovery_url,omitempty"`
 	OIDCDiscoveryCA  string `json:"oidc_discovery_ca_pem,omitempty"`
@@ -120,21 +120,28 @@ func (b *jwtAuthBackend) setupJWTConfig(ctx context.Context, conf map[string]any
 		config.UserClaim = "sub"
 	}
 
-	// Validate mode is specified
-	if config.Mode == "" {
-		return fmt.Errorf("mode is required: must be 'jwt' or 'oidc'")
+	// Exactly one of the three key sources must be set; the chosen field
+	// determines how token signatures are verified.
+	hasOIDC := config.OIDCDiscoveryURL != ""
+	hasJWKS := config.JWKSURL != ""
+	hasPubKeys := len(config.JWTValidationPubKeys) > 0
+
+	sourcesSet := 0
+	if hasOIDC {
+		sourcesSet++
+	}
+	if hasJWKS {
+		sourcesSet++
+	}
+	if hasPubKeys {
+		sourcesSet++
+	}
+	if sourcesSet != 1 {
+		return fmt.Errorf("exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys must be set (got %d)", sourcesSet)
 	}
 
-	// Initialize KeySet based on Mode
-	switch config.Mode {
-	case "oidc":
-		if config.OIDCDiscoveryURL == "" {
-			return fmt.Errorf("oidc_discovery_url is required for OIDC mode")
-		}
-		if config.JWKSURL != "" {
-			return fmt.Errorf("jwks_url cannot be used with OIDC mode; use oidc_discovery_url instead")
-		}
-		// Verify OIDC discovery URL is reachable before persisting config
+	switch {
+	case hasOIDC:
 		if err := verifyOIDCDiscoveryURLReachable(ctx, config.OIDCDiscoveryURL, config.OIDCDiscoveryCA); err != nil {
 			return fmt.Errorf("oidc_discovery_url is not reachable: %v", err)
 		}
@@ -142,42 +149,27 @@ func (b *jwtAuthBackend) setupJWTConfig(ctx context.Context, conf map[string]any
 		if err != nil {
 			return fmt.Errorf("failed to create OIDC discovery keyset: %v", err)
 		}
-
-	case "jwt":
-		if config.OIDCDiscoveryURL != "" {
-			return fmt.Errorf("oidc_discovery_url cannot be used with JWT mode; use jwks_url or jwt_validation_pubkeys instead")
+	case hasJWKS:
+		if err := verifyJWKSURLReachable(ctx, config.JWKSURL, config.JWKSCA); err != nil {
+			return fmt.Errorf("jwks_url is not reachable: %v", err)
 		}
-		if config.JWKSURL != "" && len(config.JWTValidationPubKeys) > 0 {
-			return fmt.Errorf("jwks_url and jwt_validation_pubkeys are mutually exclusive")
+		keySet, err = jwt.NewJSONWebKeySet(ctx, config.JWKSURL, config.JWKSCA)
+		if err != nil {
+			return fmt.Errorf("failed to create JWKS keyset: %v", err)
 		}
-		switch {
-		case config.JWKSURL != "":
-			if err := verifyJWKSURLReachable(ctx, config.JWKSURL, config.JWKSCA); err != nil {
-				return fmt.Errorf("jwks_url is not reachable: %v", err)
-			}
-			keySet, err = jwt.NewJSONWebKeySet(ctx, config.JWKSURL, config.JWKSCA)
+	case hasPubKeys:
+		pubKeys := make([]crypto.PublicKey, 0, len(config.JWTValidationPubKeys))
+		for i, pemStr := range config.JWTValidationPubKeys {
+			pubKey, err := jwt.ParsePublicKeyPEM([]byte(pemStr))
 			if err != nil {
-				return fmt.Errorf("failed to create JWKS keyset: %v", err)
+				return fmt.Errorf("jwt_validation_pubkeys[%d]: failed to parse PEM: %v", i, err)
 			}
-		case len(config.JWTValidationPubKeys) > 0:
-			pubKeys := make([]crypto.PublicKey, 0, len(config.JWTValidationPubKeys))
-			for i, pemStr := range config.JWTValidationPubKeys {
-				pubKey, err := jwt.ParsePublicKeyPEM([]byte(pemStr))
-				if err != nil {
-					return fmt.Errorf("jwt_validation_pubkeys[%d]: failed to parse PEM: %v", i, err)
-				}
-				pubKeys = append(pubKeys, pubKey)
-			}
-			keySet, err = jwt.NewStaticKeySet(pubKeys)
-			if err != nil {
-				return fmt.Errorf("failed to create static keyset: %v", err)
-			}
-		default:
-			return fmt.Errorf("one of jwks_url or jwt_validation_pubkeys is required for JWT mode")
+			pubKeys = append(pubKeys, pubKey)
 		}
-
-	default:
-		return fmt.Errorf("invalid mode: must be 'jwt' or 'oidc'")
+		keySet, err = jwt.NewStaticKeySet(pubKeys)
+		if err != nil {
+			return fmt.Errorf("failed to create static keyset: %v", err)
+		}
 	}
 
 	config.keySet = keySet

--- a/auth/method/jwt/backend_test.go
+++ b/auth/method/jwt/backend_test.go
@@ -129,26 +129,22 @@ func TestFactory_SpecialPaths(t *testing.T) {
 
 func TestJWTAuthConfig_Defaults(t *testing.T) {
 	config := &JWTAuthConfig{}
-	assert.Empty(t, config.Mode)
 	assert.Empty(t, config.JWKSURL)
 	assert.Empty(t, config.OIDCDiscoveryURL)
+	assert.Empty(t, config.JWTValidationPubKeys)
 }
 
-func TestJWTAuthConfig_ModeJWT(t *testing.T) {
+func TestJWTAuthConfig_JWKSURL(t *testing.T) {
 	config := &JWTAuthConfig{
-		Mode:    "jwt",
 		JWKSURL: "https://example.com/.well-known/jwks.json",
 	}
-	assert.Equal(t, "jwt", config.Mode)
 	assert.Equal(t, "https://example.com/.well-known/jwks.json", config.JWKSURL)
 }
 
-func TestJWTAuthConfig_ModeOIDC(t *testing.T) {
+func TestJWTAuthConfig_OIDCDiscoveryURL(t *testing.T) {
 	config := &JWTAuthConfig{
-		Mode:             "oidc",
 		OIDCDiscoveryURL: "https://issuer.example.com/.well-known/openid-configuration",
 	}
-	assert.Equal(t, "oidc", config.Mode)
 	assert.Equal(t, "https://issuer.example.com/.well-known/openid-configuration", config.OIDCDiscoveryURL)
 }
 
@@ -185,7 +181,7 @@ func TestJWTAuthConfig_ClaimMappings(t *testing.T) {
 // setupJWTConfig Tests
 // =============================================================================
 
-func TestSetupJWTConfig_InvalidMode(t *testing.T) {
+func TestSetupJWTConfig_NoKeySource(t *testing.T) {
 	ctx := context.Background()
 	conf := &logical.BackendConfig{
 		Logger: testLogger(),
@@ -195,14 +191,12 @@ func TestSetupJWTConfig_InvalidMode(t *testing.T) {
 	require.NoError(t, err)
 
 	b := backend.(*jwtAuthBackend)
-	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode": "invalid",
-	})
+	err = b.setupJWTConfig(ctx, map[string]any{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid mode")
+	assert.Contains(t, err.Error(), "exactly one of")
 }
 
-func TestSetupJWTConfig_OIDCMissingDiscoveryURL(t *testing.T) {
+func TestSetupJWTConfig_MultipleKeySources(t *testing.T) {
 	ctx := context.Background()
 	conf := &logical.BackendConfig{
 		Logger: testLogger(),
@@ -213,82 +207,11 @@ func TestSetupJWTConfig_OIDCMissingDiscoveryURL(t *testing.T) {
 
 	b := backend.(*jwtAuthBackend)
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode": "oidc",
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "oidc_discovery_url is required")
-}
-
-func TestSetupJWTConfig_JWTMissingKeySource(t *testing.T) {
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		Logger: testLogger(),
-	}
-
-	backend, err := Factory(ctx, conf)
-	require.NoError(t, err)
-
-	b := backend.(*jwtAuthBackend)
-	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode": "jwt",
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "one of jwks_url or jwt_validation_pubkeys is required")
-}
-
-func TestSetupJWTConfig_MissingMode(t *testing.T) {
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		Logger: testLogger(),
-	}
-
-	backend, err := Factory(ctx, conf)
-	require.NoError(t, err)
-
-	b := backend.(*jwtAuthBackend)
-	err = b.setupJWTConfig(ctx, map[string]any{
-		"jwks_url": "https://example.com/.well-known/jwks.json",
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "mode is required")
-}
-
-func TestSetupJWTConfig_JWTModeWithOIDCDiscoveryURL(t *testing.T) {
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		Logger: testLogger(),
-	}
-
-	backend, err := Factory(ctx, conf)
-	require.NoError(t, err)
-
-	b := backend.(*jwtAuthBackend)
-	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":               "jwt",
 		"jwks_url":           "https://example.com/.well-known/jwks.json",
 		"oidc_discovery_url": "https://issuer.example.com/.well-known/openid-configuration",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "oidc_discovery_url cannot be used with JWT mode")
-}
-
-func TestSetupJWTConfig_OIDCModeWithJWKSURL(t *testing.T) {
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		Logger: testLogger(),
-	}
-
-	backend, err := Factory(ctx, conf)
-	require.NoError(t, err)
-
-	b := backend.(*jwtAuthBackend)
-	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":               "oidc",
-		"oidc_discovery_url": "https://issuer.example.com/.well-known/openid-configuration",
-		"jwks_url":           "https://example.com/.well-known/jwks.json",
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "jwks_url cannot be used with OIDC mode")
+	assert.Contains(t, err.Error(), "exactly one of")
 }
 
 func TestSetupJWTConfig_StaticPubKeys_ValidRSA(t *testing.T) {
@@ -301,7 +224,6 @@ func TestSetupJWTConfig_StaticPubKeys_ValidRSA(t *testing.T) {
 	_, pemStr := genTestPubKeyPEM(t, "RSA")
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{pemStr},
 	})
 	require.NoError(t, err)
@@ -321,7 +243,6 @@ func TestSetupJWTConfig_StaticPubKeys_ValidECDSA(t *testing.T) {
 	_, pemStr := genTestPubKeyPEM(t, "ECDSA")
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{pemStr},
 	})
 	require.NoError(t, err)
@@ -340,7 +261,6 @@ func TestSetupJWTConfig_StaticPubKeys_MultipleKeys(t *testing.T) {
 	_, pem2 := genTestPubKeyPEM(t, "ECDSA")
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{pem1, pem2},
 	})
 	require.NoError(t, err)
@@ -356,7 +276,6 @@ func TestSetupJWTConfig_StaticPubKeys_InvalidPEM(t *testing.T) {
 	b := backend.(*jwtAuthBackend)
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{"not a pem"},
 	})
 	require.Error(t, err)
@@ -364,7 +283,7 @@ func TestSetupJWTConfig_StaticPubKeys_InvalidPEM(t *testing.T) {
 	assert.Contains(t, err.Error(), "jwt_validation_pubkeys[0]")
 }
 
-func TestSetupJWTConfig_StaticPubKeys_MutuallyExclusiveWithJWKS(t *testing.T) {
+func TestSetupJWTConfig_MultipleKeySources_JWKSAndPubKeys(t *testing.T) {
 	ctx := context.Background()
 	conf := &logical.BackendConfig{Logger: testLogger()}
 	backend, err := Factory(ctx, conf)
@@ -374,12 +293,11 @@ func TestSetupJWTConfig_StaticPubKeys_MutuallyExclusiveWithJWKS(t *testing.T) {
 	_, pemStr := genTestPubKeyPEM(t, "RSA")
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwks_url":               "https://example.com/.well-known/jwks.json",
 		"jwt_validation_pubkeys": []string{pemStr},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "mutually exclusive")
+	assert.Contains(t, err.Error(), "exactly one of")
 }
 
 func TestSetupJWTConfig_StaticPubKeys_StorageRoundTrip(t *testing.T) {
@@ -387,7 +305,6 @@ func TestSetupJWTConfig_StaticPubKeys_StorageRoundTrip(t *testing.T) {
 
 	_, pemStr := genTestPubKeyPEM(t, "RSA")
 	cfg := map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{pemStr},
 	}
 
@@ -421,7 +338,6 @@ func TestSetupJWTConfig_JWKSURLNotReachable(t *testing.T) {
 
 	b := backend.(*jwtAuthBackend)
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":     "jwt",
 		"jwks_url": "http://localhost:99999/.well-known/jwks.json",
 	})
 	require.Error(t, err)
@@ -439,7 +355,6 @@ func TestSetupJWTConfig_OIDCDiscoveryURLNotReachable(t *testing.T) {
 
 	b := backend.(*jwtAuthBackend)
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":               "oidc",
 		"oidc_discovery_url": "http://localhost:99999/.well-known/openid-configuration",
 	})
 	require.Error(t, err)
@@ -556,7 +471,6 @@ func TestInitialize_WithPersistedConfig(t *testing.T) {
 
 	// Store a config that will fail (no reachable JWKS) - to verify Initialize tries
 	configMap := map[string]any{
-		"mode":     "jwt",
 		"jwks_url": "http://localhost:1/.well-known/jwks.json",
 	}
 	entry, err := sdklogical.StorageEntryJSON("config", configMap)
@@ -620,7 +534,6 @@ func TestStaticPubKeys_SignAndVerify(t *testing.T) {
 	b := backend.(*jwtAuthBackend)
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{pemStr},
 	})
 	require.NoError(t, err)
@@ -669,7 +582,6 @@ func TestStaticPubKeys_SignAndVerify_TamperedPayload(t *testing.T) {
 	b := backend.(*jwtAuthBackend)
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{pemStr},
 	})
 	require.NoError(t, err)
@@ -706,7 +618,6 @@ func TestStaticPubKeys_SignAndVerify_WrongKey(t *testing.T) {
 	b := backend.(*jwtAuthBackend)
 
 	err = b.setupJWTConfig(ctx, map[string]any{
-		"mode":                   "jwt",
 		"jwt_validation_pubkeys": []string{otherPEM},
 	})
 	require.NoError(t, err)

--- a/auth/method/jwt/parser_test.go
+++ b/auth/method/jwt/parser_test.go
@@ -15,35 +15,30 @@ import (
 // mapToJWTAuthConfig Tests
 // =============================================================================
 
-func TestMapToJWTAuthConfig_BasicJWTMode(t *testing.T) {
+func TestMapToJWTAuthConfig_BasicJWKS(t *testing.T) {
 	data := map[string]any{
-		"mode":     "jwt",
 		"jwks_url": "https://example.com/.well-known/jwks.json",
 	}
 
 	config, err := mapToJWTAuthConfig(data)
 	require.NoError(t, err)
 
-	assert.Equal(t, "jwt", config.Mode)
 	assert.Equal(t, "https://example.com/.well-known/jwks.json", config.JWKSURL)
 }
 
-func TestMapToJWTAuthConfig_BasicOIDCMode(t *testing.T) {
+func TestMapToJWTAuthConfig_BasicOIDC(t *testing.T) {
 	data := map[string]any{
-		"mode":               "oidc",
 		"oidc_discovery_url": "https://issuer.example.com/.well-known/openid-configuration",
 	}
 
 	config, err := mapToJWTAuthConfig(data)
 	require.NoError(t, err)
 
-	assert.Equal(t, "oidc", config.Mode)
 	assert.Equal(t, "https://issuer.example.com/.well-known/openid-configuration", config.OIDCDiscoveryURL)
 }
 
 func TestMapToJWTAuthConfig_DefaultValues(t *testing.T) {
 	data := map[string]any{
-		"mode":     "jwt",
 		"jwks_url": "https://example.com/.well-known/jwks.json",
 	}
 
@@ -57,7 +52,6 @@ func TestMapToJWTAuthConfig_DefaultValues(t *testing.T) {
 
 func TestMapToJWTAuthConfig_CustomTokenTTL(t *testing.T) {
 	data := map[string]any{
-		"mode":      "jwt",
 		"jwks_url":  "https://example.com/.well-known/jwks.json",
 		"token_ttl": "2h",
 	}
@@ -70,7 +64,6 @@ func TestMapToJWTAuthConfig_CustomTokenTTL(t *testing.T) {
 
 func TestMapToJWTAuthConfig_CustomUserClaim(t *testing.T) {
 	data := map[string]any{
-		"mode":       "jwt",
 		"jwks_url":   "https://example.com/.well-known/jwks.json",
 		"user_claim": "email",
 	}
@@ -83,7 +76,6 @@ func TestMapToJWTAuthConfig_CustomUserClaim(t *testing.T) {
 
 func TestMapToJWTAuthConfig_BoundIssuer(t *testing.T) {
 	data := map[string]any{
-		"mode":         "jwt",
 		"jwks_url":     "https://example.com/.well-known/jwks.json",
 		"bound_issuer": "https://issuer.example.com",
 	}
@@ -96,7 +88,6 @@ func TestMapToJWTAuthConfig_BoundIssuer(t *testing.T) {
 
 func TestMapToJWTAuthConfig_BoundAudiences(t *testing.T) {
 	data := map[string]any{
-		"mode":            "jwt",
 		"jwks_url":        "https://example.com/.well-known/jwks.json",
 		"bound_audiences": []string{"aud1", "aud2", "aud3"},
 	}
@@ -109,7 +100,6 @@ func TestMapToJWTAuthConfig_BoundAudiences(t *testing.T) {
 
 func TestMapToJWTAuthConfig_BoundSubject(t *testing.T) {
 	data := map[string]any{
-		"mode":          "jwt",
 		"jwks_url":      "https://example.com/.well-known/jwks.json",
 		"bound_subject": "expected-subject",
 	}
@@ -122,7 +112,6 @@ func TestMapToJWTAuthConfig_BoundSubject(t *testing.T) {
 
 func TestMapToJWTAuthConfig_BoundClaims(t *testing.T) {
 	data := map[string]any{
-		"mode":     "jwt",
 		"jwks_url": "https://example.com/.well-known/jwks.json",
 		"bound_claims": map[string]any{
 			"tenant": "acme",
@@ -140,7 +129,6 @@ func TestMapToJWTAuthConfig_BoundClaims(t *testing.T) {
 
 func TestMapToJWTAuthConfig_ClaimMappings(t *testing.T) {
 	data := map[string]any{
-		"mode":     "jwt",
 		"jwks_url": "https://example.com/.well-known/jwks.json",
 		"claim_mappings": map[string]string{
 			"preferred_username": "username",
@@ -158,7 +146,6 @@ func TestMapToJWTAuthConfig_ClaimMappings(t *testing.T) {
 
 func TestMapToJWTAuthConfig_GroupsClaim(t *testing.T) {
 	data := map[string]any{
-		"mode":         "jwt",
 		"jwks_url":     "https://example.com/.well-known/jwks.json",
 		"groups_claim": "roles",
 	}
@@ -171,7 +158,6 @@ func TestMapToJWTAuthConfig_GroupsClaim(t *testing.T) {
 
 func TestMapToJWTAuthConfig_WithCACerts(t *testing.T) {
 	data := map[string]any{
-		"mode":                  "oidc",
 		"oidc_discovery_url":    "https://issuer.example.com/.well-known/openid-configuration",
 		"oidc_discovery_ca_pem": "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
 	}
@@ -184,7 +170,6 @@ func TestMapToJWTAuthConfig_WithCACerts(t *testing.T) {
 
 func TestMapToJWTAuthConfig_JWKSWithCA(t *testing.T) {
 	data := map[string]any{
-		"mode":        "jwt",
 		"jwks_url":    "https://example.com/.well-known/jwks.json",
 		"jwks_ca_pem": "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
 	}
@@ -208,7 +193,6 @@ func TestMapToJWTAuthConfig_EmptyMap(t *testing.T) {
 
 func TestMapToJWTAuthConfig_AllFields(t *testing.T) {
 	data := map[string]any{
-		"mode":            "jwt",
 		"jwks_url":        "https://example.com/.well-known/jwks.json",
 		"jwks_ca_pem":     "cert-content",
 		"bound_issuer":    "https://issuer.example.com",
@@ -224,7 +208,6 @@ func TestMapToJWTAuthConfig_AllFields(t *testing.T) {
 	config, err := mapToJWTAuthConfig(data)
 	require.NoError(t, err)
 
-	assert.Equal(t, "jwt", config.Mode)
 	assert.Equal(t, "https://example.com/.well-known/jwks.json", config.JWKSURL)
 	assert.Equal(t, "cert-content", config.JWKSCA)
 	assert.Equal(t, "https://issuer.example.com", config.BoundIssuer)
@@ -257,7 +240,6 @@ func TestMapToJWTAuthConfig_DurationParsing(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			data := map[string]any{
-				"mode":      "jwt",
 				"jwks_url":  "https://example.com/.well-known/jwks.json",
 				"token_ttl": tc.tokenTTL,
 			}
@@ -272,7 +254,6 @@ func TestMapToJWTAuthConfig_DurationParsing(t *testing.T) {
 func TestMapToJWTAuthConfig_DurationAsNumber(t *testing.T) {
 	// Duration passed as number (nanoseconds in Go)
 	data := map[string]any{
-		"mode":      "jwt",
 		"jwks_url":  "https://example.com/.well-known/jwks.json",
 		"token_ttl": time.Hour, // duration directly
 	}
@@ -289,27 +270,9 @@ func TestMapToJWTAuthConfig_DurationAsNumber(t *testing.T) {
 func TestMapToJWTAuthConfig_InvalidJSON(t *testing.T) {
 	// Create an unmarshallable value
 	data := map[string]any{
-		"mode":     "jwt",
 		"jwks_url": func() {}, // Functions can't be marshaled to JSON
 	}
 
 	_, err := mapToJWTAuthConfig(data)
 	assert.Error(t, err)
-}
-
-// =============================================================================
-// Mode Inference Tests
-// =============================================================================
-
-func TestMapToJWTAuthConfig_ModeRequired(t *testing.T) {
-	// Mode is no longer inferred - it must be explicitly specified
-	// The validation happens in setupJWTConfig, not mapToJWTAuthConfig
-	data := map[string]any{
-		"mode":     "jwt",
-		"jwks_url": "https://example.com/jwks",
-	}
-
-	config, err := mapToJWTAuthConfig(data)
-	require.NoError(t, err)
-	assert.Equal(t, "jwt", config.Mode)
 }

--- a/auth/method/jwt/path_config.go
+++ b/auth/method/jwt/path_config.go
@@ -15,14 +15,9 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 	return &framework.Path{
 		Pattern: "config",
 		Fields: map[string]*framework.FieldSchema{
-			"mode": {
-				Type:        framework.TypeString,
-				Description: "Authentication mode: 'jwt' or 'oidc' (required)",
-				Required:    true,
-			},
 			"oidc_discovery_url": {
 				Type:        framework.TypeString,
-				Description: "OIDC Discovery URL (required for OIDC mode, mutually exclusive with jwks_url)",
+				Description: "OIDC Discovery URL. Set exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys.",
 			},
 			"oidc_discovery_ca_pem": {
 				Type:        framework.TypeString,
@@ -30,7 +25,7 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 			},
 			"jwks_url": {
 				Type:        framework.TypeString,
-				Description: "JWKS URL (required for JWT mode, mutually exclusive with oidc_discovery_url)",
+				Description: "JWKS URL. Set exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys.",
 			},
 			"jwks_ca_pem": {
 				Type:        framework.TypeString,
@@ -58,7 +53,7 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 			},
 			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: "List of PEM-encoded public keys for JWT validation (alternative to jwks_url)",
+				Description: "PEM-encoded RSA or ECDSA public keys for static JWT validation. Set exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys.",
 			},
 			"user_claim": {
 				Type:        framework.TypeString,
@@ -94,11 +89,11 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 			},
 		},
 		HelpSynopsis: "Configure JWT authentication",
-		HelpDescription: `This endpoint configures the JWT/OIDC authentication method.
+		HelpDescription: `This endpoint configures the JWT authentication method.
 
-Set 'mode' to 'jwt' with a 'jwks_url' or 'jwt_validation_pubkeys' for static
-key validation, or to 'oidc' with an 'oidc_discovery_url' for auto-discovered
-key rotation.
+Set exactly one of 'oidc_discovery_url' (OIDC discovery), 'jwks_url' (JWKS
+endpoint), or 'jwt_validation_pubkeys' (static PEM-encoded RSA/ECDSA keys)
+to configure how token signatures are verified.
 
 Use 'bound_issuer', 'bound_audiences', 'bound_subject', and 'bound_claims'
 to constrain which tokens are accepted. Use 'claim_mappings' to copy JWT
@@ -121,7 +116,6 @@ func (b *jwtAuthBackend) handleConfigRead(ctx context.Context, req *logical.Requ
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
-			"mode":                   b.config.Mode,
 			"oidc_discovery_url":     b.config.OIDCDiscoveryURL,
 			"oidc_discovery_ca_pem":  b.config.OIDCDiscoveryCA,
 			"jwks_url":               b.config.JWKSURL,
@@ -149,7 +143,6 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 	// Copy existing config if present (under lock to avoid data race)
 	b.configMu.RLock()
 	if b.config != nil {
-		conf["mode"] = b.config.Mode
 		conf["oidc_discovery_url"] = b.config.OIDCDiscoveryURL
 		conf["oidc_discovery_ca_pem"] = b.config.OIDCDiscoveryCA
 		conf["jwks_url"] = b.config.JWKSURL
@@ -189,7 +182,6 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 	if b.storageView != nil {
 		b.configMu.RLock()
 		normalized := map[string]any{
-			"mode":                   b.config.Mode,
 			"oidc_discovery_url":     b.config.OIDCDiscoveryURL,
 			"oidc_discovery_ca_pem":  b.config.OIDCDiscoveryCA,
 			"jwks_url":               b.config.JWKSURL,
@@ -235,20 +227,24 @@ const jwtAuthHelp = `
 The JWT auth method authenticates users by validating JSON Web Tokens
 signed by a trusted identity provider.
 
-Two modes are supported:
+Three key sources are supported; exactly one must be configured per mount:
 
-  jwt   - Validates tokens using a JWKS endpoint or static public keys.
-          Suitable for service-to-service auth and CI/CD pipelines.
-
-  oidc  - Validates tokens using OIDC Discovery (/.well-known/openid-configuration).
-          Suitable for SSO with providers like Okta, Auth0, or Azure AD.
+  oidc_discovery_url     - OIDC Discovery (/.well-known/openid-configuration).
+                           Suitable for SSO with providers like Okta, Auth0,
+                           or Azure AD.
+  jwks_url               - JWKS endpoint. Suitable for service-to-service
+                           auth and CI/CD pipelines with a reachable JWKS
+                           server.
+  jwt_validation_pubkeys - Static PEM-encoded RSA or ECDSA public keys.
+                           Suitable for air-gapped clusters and fixed-issuer
+                           workloads where no JWKS endpoint is reachable.
 
 Tokens are validated against configurable bound claims (issuer, audience,
 subject, custom claims). The user_claim field (default: sub) determines the
 authenticated principal identity.
 
 Configuration:
-  POST /auth/{mount}/config   - Configure mode, key source, and claim bindings
+  POST /auth/{mount}/config   - Configure key source and claim bindings
   GET  /auth/{mount}/config   - Read current configuration
   POST /auth/{mount}/role/:name - Create roles with per-role claim constraints
 `

--- a/auth/method/jwt/path_config_test.go
+++ b/auth/method/jwt/path_config_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
-	"net/http/httptest"
 )
 
 // testLoggerConfig creates a logger for tests that discards output
@@ -207,7 +207,6 @@ func TestHandleConfigRead_WithConfig(t *testing.T) {
 
 	b := backend.(*jwtAuthBackend)
 	b.config = &JWTAuthConfig{
-		Mode:           "jwt",
 		JWKSURL:        "https://example.com/.well-known/jwks.json",
 		BoundIssuer:    "https://issuer.example.com",
 		BoundAudiences: []string{"aud1", "aud2"},
@@ -228,7 +227,6 @@ func TestHandleConfigRead_WithConfig(t *testing.T) {
 	require.NotNil(t, resp)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "jwt", resp.Data["mode"])
 	assert.Equal(t, "https://example.com/.well-known/jwks.json", resp.Data["jwks_url"])
 	assert.Equal(t, "https://issuer.example.com", resp.Data["bound_issuer"])
 	assert.Equal(t, []string{"aud1", "aud2"}, resp.Data["bound_audiences"])
@@ -238,7 +236,7 @@ func TestHandleConfigRead_WithConfig(t *testing.T) {
 	assert.Equal(t, "2h0m0s", resp.Data["token_ttl"])
 }
 
-func TestHandleConfigRead_OIDCMode(t *testing.T) {
+func TestHandleConfigRead_OIDC(t *testing.T) {
 	ctx := context.Background()
 	conf := &logical.BackendConfig{
 		Logger: testLoggerConfig(),
@@ -249,7 +247,6 @@ func TestHandleConfigRead_OIDCMode(t *testing.T) {
 
 	b := backend.(*jwtAuthBackend)
 	b.config = &JWTAuthConfig{
-		Mode:             "oidc",
 		OIDCDiscoveryURL: "https://issuer.example.com/.well-known/openid-configuration",
 		UserClaim:        "sub",
 		GroupsClaim:      "groups",
@@ -267,7 +264,6 @@ func TestHandleConfigRead_OIDCMode(t *testing.T) {
 	require.NotNil(t, resp)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "oidc", resp.Data["mode"])
 	assert.Equal(t, "https://issuer.example.com/.well-known/openid-configuration", resp.Data["oidc_discovery_url"])
 }
 
@@ -275,7 +271,7 @@ func TestHandleConfigRead_OIDCMode(t *testing.T) {
 // handleConfigWrite Tests
 // =============================================================================
 
-func TestHandleConfigWrite_MissingRequiredFields(t *testing.T) {
+func TestHandleConfigWrite_NoKeySource(t *testing.T) {
 	ctx := context.Background()
 	conf := &logical.BackendConfig{
 		Logger: testLoggerConfig(),
@@ -289,64 +285,6 @@ func TestHandleConfigWrite_MissingRequiredFields(t *testing.T) {
 	req := &logical.Request{}
 	d := &framework.FieldData{
 		Raw: map[string]any{
-			"mode": "jwt",
-			// Missing jwks_url
-		},
-		Schema: b.pathConfig().Fields,
-	}
-
-	resp, err := b.handleConfigWrite(ctx, req, d)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-
-	// Should fail because jwks_url is required for JWT mode
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.NotNil(t, resp.Err)
-}
-
-func TestHandleConfigWrite_InvalidMode(t *testing.T) {
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		Logger: testLoggerConfig(),
-	}
-
-	backend, err := Factory(ctx, conf)
-	require.NoError(t, err)
-
-	b := backend.(*jwtAuthBackend)
-
-	req := &logical.Request{}
-	d := &framework.FieldData{
-		Raw: map[string]any{
-			"mode": "invalid",
-		},
-		Schema: b.pathConfig().Fields,
-	}
-
-	resp, err := b.handleConfigWrite(ctx, req, d)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.NotNil(t, resp.Err)
-	assert.Contains(t, resp.Err.Error(), "invalid mode")
-}
-
-func TestHandleConfigWrite_NoModeNoDiscoveryNoJWKS(t *testing.T) {
-	ctx := context.Background()
-	conf := &logical.BackendConfig{
-		Logger: testLoggerConfig(),
-	}
-
-	backend, err := Factory(ctx, conf)
-	require.NoError(t, err)
-
-	b := backend.(*jwtAuthBackend)
-
-	req := &logical.Request{}
-	d := &framework.FieldData{
-		Raw: map[string]any{
-			// Mode is required but not provided
 			"user_claim": "email",
 		},
 		Schema: b.pathConfig().Fields,
@@ -356,10 +294,9 @@ func TestHandleConfigWrite_NoModeNoDiscoveryNoJWKS(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	// Should fail because mode is required
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.NotNil(t, resp.Err)
-	assert.Contains(t, resp.Err.Error(), "mode is required")
+	assert.Contains(t, resp.Err.Error(), "exactly one of")
 }
 
 // =============================================================================
@@ -415,7 +352,6 @@ func TestHandleConfigWrite_PersistsToStorage(t *testing.T) {
 
 	d := &framework.FieldData{
 		Raw: map[string]any{
-			"mode":     "jwt",
 			"jwks_url": srv.URL,
 		},
 		Schema: b.pathConfig().Fields,
@@ -447,7 +383,6 @@ func TestHandleConfigWrite_MergesExisting(t *testing.T) {
 	// First write
 	d := &framework.FieldData{
 		Raw: map[string]any{
-			"mode":     "jwt",
 			"jwks_url": srv.URL,
 		},
 		Schema: b.pathConfig().Fields,
@@ -476,7 +411,6 @@ func TestHandleConfigWrite_MergesExisting(t *testing.T) {
 func TestHandleConfigRead_WithDefaultRole(t *testing.T) {
 	b, _ := createTestBackendWithStorage(t)
 	b.config = &JWTAuthConfig{
-		Mode:        "jwt",
 		JWKSURL:     "https://example.com/jwks",
 		DefaultRole: "auto-role",
 		UserClaim:   "sub",

--- a/docs/tutorials/aws-access-hygiene/warden-init.sh
+++ b/docs/tutorials/aws-access-hygiene/warden-init.sh
@@ -103,7 +103,6 @@ export WARDEN_NAMESPACE=tutorial-aws
 # 5b. JWT auth pointed at Forgejo's Actions OIDC.
 $WARDEN auth enable --type=jwt 2>/dev/null || true
 $WARDEN write auth/jwt/config \
-    mode=jwt \
     jwks_url=http://forgejo.local:3000/api/actions/.well-known/keys \
     bound_issuer=http://forgejo.local:3000/api/actions \
     default_audience=http://warden.local \

--- a/docs/tutorials/vault-policy-hygiene/warden-init.sh
+++ b/docs/tutorials/vault-policy-hygiene/warden-init.sh
@@ -103,7 +103,6 @@ export WARDEN_NAMESPACE=tutorial
 # for the agent to run the discovery loop.
 $WARDEN auth enable --type=jwt 2>/dev/null || true
 $WARDEN write auth/jwt/config \
-    mode=jwt \
     jwks_url=http://forgejo.local:3000/api/actions/.well-known/keys \
     bound_issuer=http://forgejo.local:3000/api/actions \
     default_audience=http://warden.local \

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -449,7 +449,7 @@ func SetupNSVaultEnv(t *testing.T, port int) {
 	// JWT auth method
 	NSAPIRequest(t, "POST", "sys/auth/jwt", ns, port, `{"type":"jwt"}`)
 	NSAPIRequest(t, "PUT", "auth/jwt/config", ns, port,
-		`{"mode":"oidc","oidc_discovery_url":"http://localhost:4444","bound_issuer":"http://localhost:4444"}`)
+		`{"oidc_discovery_url":"http://localhost:4444","bound_issuer":"http://localhost:4444"}`)
 
 	// JWT role
 	NSAPIRequest(t, "POST", "auth/jwt/role/e2e-reader", ns, port,

--- a/provider/alicloud/README.md
+++ b/provider/alicloud/README.md
@@ -41,7 +41,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/alicloud-user \

--- a/provider/ansible_tower/README.md
+++ b/provider/ansible_tower/README.md
@@ -72,7 +72,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/ansible-tower-user \

--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/anthropic-user \

--- a/provider/atlassian/README.md
+++ b/provider/atlassian/README.md
@@ -73,7 +73,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/atlassian-user \

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -158,7 +158,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role
 warden write auth/jwt/role/aws-user \

--- a/provider/aws/e2e_test/README.md
+++ b/provider/aws/e2e_test/README.md
@@ -83,7 +83,7 @@ EOF
 
 # Enable JWT authentication
 ./warden -n PROD/SEC auth enable --type=jwt --description="jwt test auth method"
-./warden -n PROD/SEC write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+./warden -n PROD/SEC write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create JWT roles
 ./warden -n PROD/SEC write auth/jwt/role/aws-streamer \

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -119,7 +119,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/azure-user \

--- a/provider/cloudflare/README.md
+++ b/provider/cloudflare/README.md
@@ -77,7 +77,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/cloudflare-user \

--- a/provider/cloudflare/e2e_test/README.md
+++ b/provider/cloudflare/e2e_test/README.md
@@ -82,7 +82,7 @@ export WARDEN_TOKEN="root"
 
 # Enable JWT auth
 warden auth enable --type=jwt
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create role
 warden write auth/jwt/role/cloudflare-user \

--- a/provider/cohere/README.md
+++ b/provider/cohere/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/cohere-user \

--- a/provider/datadog/README.md
+++ b/provider/datadog/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/datadog-user \

--- a/provider/dynatrace/README.md
+++ b/provider/dynatrace/README.md
@@ -73,7 +73,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/dynatrace-user \

--- a/provider/elastic/README.md
+++ b/provider/elastic/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/elastic-user \

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -84,7 +84,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/gcp-user \

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -73,7 +73,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/github-user \

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -75,7 +75,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/gitlab-user \

--- a/provider/grafana/README.md
+++ b/provider/grafana/README.md
@@ -74,7 +74,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/grafana-user \

--- a/provider/honeycomb/README.md
+++ b/provider/honeycomb/README.md
@@ -73,7 +73,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/honeycomb-user \

--- a/provider/ibmcloud/README.md
+++ b/provider/ibmcloud/README.md
@@ -102,7 +102,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/ibmcloud-user \

--- a/provider/kubernetes/README.md
+++ b/provider/kubernetes/README.md
@@ -46,7 +46,6 @@ warden auth enable --type=jwt --path=auth/jwt/
 
 # Configure JWT auth with your OIDC provider
 warden write auth/jwt/config \
-  mode=jwt \
   jwks_url="http://localhost:4444/.well-known/jwks.json" \
   default_role="k8s-user"
 

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/mistral-user \

--- a/provider/newrelic/README.md
+++ b/provider/newrelic/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/newrelic-user \

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/openai-user \

--- a/provider/ovh/README.md
+++ b/provider/ovh/README.md
@@ -77,7 +77,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/ovh-user \

--- a/provider/ovh/e2e_test/README.md
+++ b/provider/ovh/e2e_test/README.md
@@ -165,7 +165,7 @@ export WARDEN_TOKEN="root"
 
 # Enable JWT auth
 warden auth enable --type=jwt
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create role
 warden write auth/jwt/role/ovh-user \

--- a/provider/pagerduty/README.md
+++ b/provider/pagerduty/README.md
@@ -72,7 +72,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/pagerduty-user \

--- a/provider/prometheus/README.md
+++ b/provider/prometheus/README.md
@@ -73,7 +73,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/prometheus-user \

--- a/provider/rds/README.md
+++ b/provider/rds/README.md
@@ -155,7 +155,6 @@ Set up JWT auth for workload authentication. The auth role does **not** need a `
 warden auth enable --type=jwt
 
 warden write auth/jwt/config \
-    mode=jwt \
     jwks_url=http://localhost:4444/.well-known/jwks.json \
     default_role=db-user
 
@@ -172,7 +171,6 @@ Setting `default_role=db-user` means workloads don't need to pass `?role=` — t
 >
 > ```bash
 > warden write auth/jwt/config \
->     mode=jwt \
 >     jwks_url=http://localhost:4444/.well-known/jwks.json \
 >     default_role=db-user \
 >     groups_claim=groups \

--- a/provider/redshift/README.md
+++ b/provider/redshift/README.md
@@ -158,7 +158,6 @@ Set up JWT auth for workload authentication. The auth role does **not** need a `
 warden auth enable --type=jwt
 
 warden write auth/jwt/config \
-    mode=jwt \
     jwks_url=http://localhost:4444/.well-known/jwks.json \
     default_role=db-user
 

--- a/provider/scaleway/README.md
+++ b/provider/scaleway/README.md
@@ -75,7 +75,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/scaleway-user \

--- a/provider/scaleway/e2e_test/README.md
+++ b/provider/scaleway/e2e_test/README.md
@@ -88,7 +88,7 @@ export WARDEN_TOKEN="root"
 
 # Enable JWT auth
 warden auth enable --type=jwt
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create role
 warden write auth/jwt/role/scaleway-user \

--- a/provider/sentry/README.md
+++ b/provider/sentry/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/sentry-user \

--- a/provider/servicenow/README.md
+++ b/provider/servicenow/README.md
@@ -73,7 +73,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/servicenow-user \

--- a/provider/slack/README.md
+++ b/provider/slack/README.md
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/slack-user \

--- a/provider/splunk/README.md
+++ b/provider/splunk/README.md
@@ -72,7 +72,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/splunk-user \

--- a/provider/tfe/README.md
+++ b/provider/tfe/README.md
@@ -72,7 +72,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 warden auth enable --type=jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/tfe-user \

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -551,7 +551,7 @@ Steps 1, 3-5 (provider setup) are identical. Replace Steps 2 and 6 with the foll
 warden auth enable --type=jwt
 
 # Configure JWT with the identity provider's JWKS endpoint
-warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
 warden write auth/jwt/role/vault-user \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -143,10 +143,10 @@ EOF
 # test auth methods managment
 
 ./warden auth enable --type=jwt --description="jwt test auth method"
-./warden write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+./warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 ./warden read auth/jwt/config
 ./warden auth enable --type=jwt test-jwt --description="test auth method"
-./warden write auth/test-jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+./warden write auth/test-jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 ./warden read auth/test-jwt/config
 ./warden auth disable test-jwt
 
@@ -238,7 +238,7 @@ EOF
   --max-ttl 8h
 
 ./warden -n PROD/SEC auth enable --type=jwt --description="jwt test auth method"
-./warden -n PROD/SEC write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+./warden -n PROD/SEC write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 ./warden -n PROD/SEC write auth/jwt/role/aws-streamer \
     token_type=aws_access_keys \
@@ -384,7 +384,7 @@ path "+/role/+/gateway*" {
 EOF
 
 ./warden -n PROD/DEV auth enable --type=jwt --description="jwt test auth method"
-./warden -n PROD/DEV write auth/jwt/config mode=jwt jwks_url=http://localhost:4444/.well-known/jwks.json
+./warden -n PROD/DEV write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 ./warden -n PROD/DEV cred spec create provisionner \
   --type vault_token \


### PR DESCRIPTION
## Summary

- Removes `mode=jwt|oidc` from `auth/{mount}/config` and the `JWTAuthConfig.Mode` struct field. The three key-source fields (`oidc_discovery_url`, `jwks_url`, `jwt_validation_pubkeys`) are already mutually exclusive and unambiguously imply how the keyset is built — `mode` was forcing extra ceremony on every config call without adding information.
- Replaces the two-switch dispatch in `setupJWTConfig` with a single `sourcesSet != 1` guard followed by a flat builder switch. Zero or multi-key configs now fail with one message: `exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys must be set (got N)`.
- Updates 35 provider READMEs, 2 tutorial shell scripts, `scripts/test.sh`, and `e2e/helpers/helpers.go` so docs and helpers match the new shape. Existing scripts passing `mode=jwt` continue to succeed (framework treats unknown fields as a non-fatal warning); old stored configs reload cleanly via Go's default JSON ignore-unknown-fields behavior.

## Test plan

- [x] `go test ./auth/method/jwt/... -count=1 -race` — all pass
- [x] `go build ./...` — clean
- [x] `go build -tags e2e ./...` — clean
- [x] `make test-e2e` — all 14 E2E packages pass (audit, auth, cluster, concurrency, credential, forwarding, ha, loadbalancer, mtls, namespace, provider, rotation, seal, skill). `e2e/auth` and `e2e/ha` exercise the `SetupNSVaultEnv` helper that this PR modified.
- [x] Repo-wide `grep` for `mode=jwt|mode=oidc|"mode":"jwt"|"mode":"oidc"` returns zero hits outside CHANGELOG.
