### PR TITLE
feat(cli)!: drop --type on enable, take TYPE positional; switch docs …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to Warden are documented in this file.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`auth enable`, `provider enable`, `audit enable` take TYPE as a positional, like Vault.** The `-type` flag is gone; pass the type as the trailing argument (`warden auth enable jwt`, `warden provider enable aws`, `warden audit enable file`). The mount path still defaults to TYPE; override it with `-path=<mount>` (Vault's exact form). Migration: `-type=jwt jwt-prod` → `-path=jwt-prod jwt`; `-type=aws` → `aws`. In `-json` mode, if the payload carries a `type` field it must match the TYPE positional or the CLI rejects with a usage error. (this PR)
+
+- **All operator-facing documentation switched to single-dash long flags.** READMEs, the CHANGELOG, tutorial scripts, provider docs, and cobra help text now consistently spell flags as `-config`, `-output`, `-path`, etc. — matching the Vault muscle memory the binary's flag normalizer ([cmd/warden.go](cmd/warden.go)) was built for. Flag *registrations* in code remain `--foo` (cobra/pflag canonical), so `warden --help` still prints `--`. The binary already accepts both forms; this is a docs/UX cleanup, not a behavior change. (this PR)
+
 ### New Features
 
-- **`warden status` subcommand.** New top-level CLI command that reports server health (initialized, sealed, standby, HA cluster role, leader address, active-since timestamp, server version) by wrapping `GET /v1/sys/health`. Honours the existing `--output table|json|ndjson|text` and `--fields` flags. Exit code is `0` on a healthy unsealed node (active or standby), `7` on a transport error, and `10` when the server reports sealed or uninitialized — scriptable so `if warden status; then ...` works in operator playbooks. The matching `(*api.Sys).Health` / `HealthWithContext` methods are added for SDK callers; the client allow-list now treats `429/501/503` from `/v1/sys/health` as decodable operational states instead of HTTP errors. (this PR)
+- **`warden status` subcommand.** New top-level CLI command that reports server health (initialized, sealed, standby, HA cluster role, leader address, active-since timestamp, server version) by wrapping `GET /v1/sys/health`. Honours the existing `-output table|json|ndjson|text` and `-fields` flags. Exit code is `0` on a healthy unsealed node (active or standby), `7` on a transport error, and `10` when the server reports sealed or uninitialized — scriptable so `if warden status; then ...` works in operator playbooks. The matching `(*api.Sys).Health` / `HealthWithContext` methods are added for SDK callers; the client allow-list now treats `429/501/503` from `/v1/sys/health` as decodable operational states instead of HTTP errors. (this PR)
 
 - **`/v1/sys/health` now returns cluster-aware fields.** The response body grows additively to include `ha_enabled`, `is_leader`, `leader_address`, `active_time` (RFC3339, only set on the active leader), and `version` (server build, surfaced through a new `HandlerProperties.Version` plumbed from `cmd.SetVersion`). Operators no longer need three round-trips (`/sys/health`, `/sys/leader`, `/sys/seal-status`) to assemble a status view. Leader lookup is gated on `!sealed && ha_enabled`, so a sealed HA node no longer logs an error on every k8s probe. (this PR)
 
@@ -37,7 +43,7 @@ All notable changes to Warden are documented in this file.
 
 ### Documentation
 
-- **Tutorials updated for the audit-config redesign.** Both [vault-policy-hygiene](docs/tutorials/vault-policy-hygiene/README.md) and [aws-access-hygiene](docs/tutorials/aws-access-hygiene/README.md) used to rely on the auto-default audit device that's gone in this PR. Their `warden-init.sh` wiring scripts now call `warden audit enable --type=file --file-path=./warden-audit.log audit-default` as their first step (idempotent, no-op on re-runs), and the README prose was rewritten to explain the broker fail-open posture instead of "no audit enable command needed." Existing `jq` walkthroughs that tail `warden-audit.log` continue to work unchanged. (this PR)
+- **Tutorials updated for the audit-config redesign.** Both [vault-policy-hygiene](docs/tutorials/vault-policy-hygiene/README.md) and [aws-access-hygiene](docs/tutorials/aws-access-hygiene/README.md) used to rely on the auto-default audit device that's gone in this PR. Their `warden-init.sh` wiring scripts now call `warden audit enable -file-path=./warden-audit.log -path=audit-default file` as their first step (idempotent, no-op on re-runs), and the README prose was rewritten to explain the broker fail-open posture instead of "no audit enable command needed." Existing `jq` walkthroughs that tail `warden-audit.log` continue to work unchanged. (this PR)
 
 - **AWS access hygiene tutorial added.** End-to-end demo of the *within-provider* dimension of discover-and-connect: a Goose agent audits IAM in a sandbox AWS account through four read-only lenses (inventory, recent usage, external exposure, effective access), publishes findings to Security Hub as ASFF, and posts a summary canvas to Slack — switching Warden roles between calls within a single AWS mount, with each role assuming a distinct narrowly-scoped IAM role via STS. Warden holds only the broker IAM user's static keys; the agent declares per-call intent via `AWS_ACCESS_KEY_ID`, and the audit log records each declared intent as `auth.role_name`. A hallucinated cross-role write — e.g. `BatchImportFindings` under the `iam-reader` intent — is denied at AWS by the assumed role's narrow IAM policy, not by Warden's gateway policy, and surfaces as an anomaly signature in the audit log. Tutorial ships as a four-script setup (`aws-init.sh`, `warden-init.sh`, `seed-aws.sh`, plus a Forgejo Actions workflow that runs Goose under a per-job OIDC JWT) with a thirteen-section README covering the operator setup, the discovery loop, the lens-based recipe, and a `jq`-driven audit-log walkthrough including a negative test. (#222, #223, #225, this PR)
 
@@ -88,7 +94,7 @@ All notable changes to Warden are documented in this file.
 
 - **OCI chart publishing on every release tag.** The release workflow now packages the chart, pins its `appVersion` to the git tag, pushes the OCI artifact to `oci://ghcr.io/stephnangue/charts`, and attaches the same tarball to the GitHub Release for air-gapped users. Refuses to publish a chart version that already exists in the registry. End users install with `helm install warden oci://ghcr.io/stephnangue/charts/warden --version 0.1.0` — no `helm repo add`, no source checkout. (#206)
 
-- **`--config-dir` flag on `warden server`.** Merges every `*.hcl` file in a directory in lexical order, with later files overriding earlier ones. Enables a Kubernetes ConfigMap + Secret split where each owns a disjoint subset of HCL blocks without sacrificing single-file simplicity. Mutually exclusive with `--config` and `--dev`. (#204)
+- **`-config-dir` flag on `warden server`.** Merges every `*.hcl` file in a directory in lexical order, with later files overriding earlier ones. Enables a Kubernetes ConfigMap + Secret split where each owns a disjoint subset of HCL blocks without sacrificing single-file simplicity. Mutually exclusive with `-config` and `-dev`. (#204)
 
 - **Environment-variable interpolation in HCL config files.** Config files are pre-processed through a Go-template pass exposing a single `env` function — `{{ env "POD_NAME" }}` resolves at load time from `os.Getenv`. Missing variables expand to the empty string (matches shell semantics). HCL's native `${...}` interpolation syntax is intentionally left untouched. (#204)
 
@@ -118,23 +124,23 @@ All notable changes to Warden are documented in this file.
 
 ### Breaking Changes
 
-- **`--format` / `-f` flag removed.** Replaced by a global persistent `--output` / `-o` flag (`table`, `json`, `ndjson`, `text`). Autodetects `table` on a TTY, `json` when piped or redirected. Honors `WARDEN_OUTPUT`.
+- **`-format` / `-f` flag removed.** Replaced by a global persistent `-output` / `-o` flag (`table`, `json`, `ndjson`, `text`). Autodetects `table` on a TTY, `json` when piped or redirected. Honors `WARDEN_OUTPUT`.
 - **CLI success and empty-list messages are now JSON in non-table modes.** Plain-text strings like `Success! Enabled ...`, `Successfully deleted ...`, and `No providers enabled` become structured envelopes (`{"path": "...", "enabled": true}`, `{"deleted": true}`, `[]`). Scripts that grep the human strings need to update; agents already parse JSON. Pass `-o table` to keep the human form.
-- **Top-level `skills/` directory removed.** Foundation skills moved to embedded seed data; provider skills moved into their owning provider package (`provider/<type>/skill.md`). Agents fetch skills from the runtime registry — `warden skill read <name> --raw` or `GET /v1/sys/skills/<name>` — rather than reading them from a repo checkout. `AGENTS.md` was rewritten to point at the new surface.
+- **Top-level `skills/` directory removed.** Foundation skills moved to embedded seed data; provider skills moved into their owning provider package (`provider/<type>/skill.md`). Agents fetch skills from the runtime registry — `warden skill read <name> -raw` or `GET /v1/sys/skills/<name>` — rather than reading them from a repo checkout. `AGENTS.md` was rewritten to point at the new surface.
 
 ### New Features
 
 - **Skill registry — agent-facing capability catalog served by the cluster.** New `/v1/sys/skills` API and `warden skill {list, read, create, update, delete}` CLI. Foundation skills (`discovery`, `foundation`, `troubleshooting`) seed at first unseal; per-provider skills (`aws`, `vault`, `openai`, `github`, `rds`, `scaleway`) seed the first time a provider of that type is mounted — the catalog reflects what the cluster actually exposes. Reads are open to any namespace token; writes are root-only. Operator edits and deletions are sticky across restarts.
 - **`mount_url` field on `/v1/sys/providers` responses.** Returns the relative URL path with namespace and mount baked in (e.g., `/v1/team-data/aws/`). Agents prepend `$WARDEN_ADDR` plus the per-provider suffix from the skill (`gateway`, `role/<role>/gateway`, `access/<grant>`) — no string surgery on `$WARDEN_NAMESPACE`. Surfaced on `MountOutput.MountURL` and through `warden provider list` / `read`.
-- **`--json` payload on every mutating typed command.** Accepts a JSON literal, `@file.json`, or `-` (stdin) on `cred source create/update`, `cred spec create/update`, `auth enable`, `audit enable`, `namespace create/update`, `provider enable`. Mutually exclusive with the typed flags (combining errors with exit `2`). Composes with `--dry-run`.
-- **Global `--dry-run` / `-D` flag — local schema validation, no server round-trip.** Fetches the operation's schema from `/v1/sys/schema?path=<path>`, validates the payload structurally (required fields, unknown-field detection with "did you mean" hints, type and enum checks), and exits without sending the request. Catches hallucinated parameters before they hit the wire. Honors `WARDEN_DRY_RUN`. Wired into every mutating CLI command.
-- **`warden role list` CLI command.** Agent-facing role introspection over `/v1/sys/introspect/roles`. Lists `{name, description, auth_path}` for every role the caller's identity (JWT or TLS client cert) can assume in the namespace. Composes with `--output` and `--fields`; per-mount failures surface on stderr without changing the exit code.
-- **`warden schema` CLI command.** Agent-facing OpenAPI projection. Three modes: `warden schema PATH` (single path, friendly shape with merged body fields and `sensitive` flags); `warden schema --list` (every path in the namespace, NDJSON-friendly); `warden schema PATH --raw` (raw OpenAPI fragment for codegen tools).
-- **`warden path-help` honors the `--output` framework.** Returns `{"help": "..."}` in `json`/`ndjson`/`text` modes; prose in `table` mode. Missing help exits `6` (`not_found`) instead of silently exiting `0`.
+- **`-json` payload on every mutating typed command.** Accepts a JSON literal, `@file.json`, or `-` (stdin) on `cred source create/update`, `cred spec create/update`, `auth enable`, `audit enable`, `namespace create/update`, `provider enable`. Mutually exclusive with the typed flags (combining errors with exit `2`). Composes with `-dry-run`.
+- **Global `-dry-run` / `-D` flag — local schema validation, no server round-trip.** Fetches the operation's schema from `/v1/sys/schema?path=<path>`, validates the payload structurally (required fields, unknown-field detection with "did you mean" hints, type and enum checks), and exits without sending the request. Catches hallucinated parameters before they hit the wire. Honors `WARDEN_DRY_RUN`. Wired into every mutating CLI command.
+- **`warden role list` CLI command.** Agent-facing role introspection over `/v1/sys/introspect/roles`. Lists `{name, description, auth_path}` for every role the caller's identity (JWT or TLS client cert) can assume in the namespace. Composes with `-output` and `-fields`; per-mount failures surface on stderr without changing the exit code.
+- **`warden schema` CLI command.** Agent-facing OpenAPI projection. Three modes: `warden schema PATH` (single path, friendly shape with merged body fields and `sensitive` flags); `warden schema --list` (every path in the namespace, NDJSON-friendly); `warden schema PATH -raw` (raw OpenAPI fragment for codegen tools).
+- **`warden path-help` honors the `-output` framework.** Returns `{"help": "..."}` in `json`/`ndjson`/`text` modes; prose in `table` mode. Missing help exits `6` (`not_found`) instead of silently exiting `0`.
 - **Server-side OpenAPI 3.0 schema endpoint** at `GET /v1/sys/schema` (and the Vault-compatible alias `GET /v1/sys/internal/specs/openapi`). Returns a namespace-scoped document covering `sys/*` plus every framework-based mount reachable in the caller's namespace. `?path=<path>` projects to a single operation.
-- **Input hardening at the CLI boundary.** Three validators in `cmd/helpers/path.go` reject malformed inputs before any HTTP call, classified as exit `3` (`invalid_input`): `ValidatePath` (path traversal, absolute paths, control bytes, `?`/`#`/`%`); `ValidateHeaderValue` (CR/LF injection in `--namespace` / `--role`); `ValidateIdentifier` (`--type` on cred-source/spec create).
-- **Global `--output` / `-o` flag with TTY autodetect.** Persistent flag for `table`, `json`, `ndjson`, `text`. Defaults to `table` on a terminal, `json` when piped — agents and scripts get machine-readable output without configuration.
-- **Global `--fields` / `-F` flag for context-window discipline.** Comma-separated dot-paths project structured output to only the requested fields (e.g., `--fields name,rules.*.path`; `*` matches every key/element at a level). Honors `WARDEN_FIELDS`. Keeps agent context windows small.
+- **Input hardening at the CLI boundary.** Three validators in `cmd/helpers/path.go` reject malformed inputs before any HTTP call, classified as exit `3` (`invalid_input`): `ValidatePath` (path traversal, absolute paths, control bytes, `?`/`#`/`%`); `ValidateHeaderValue` (CR/LF injection in `-namespace` / `-role`); `ValidateIdentifier` (`-type` on cred-source/spec create).
+- **Global `-output` / `-o` flag with TTY autodetect.** Persistent flag for `table`, `json`, `ndjson`, `text`. Defaults to `table` on a terminal, `json` when piped — agents and scripts get machine-readable output without configuration.
+- **Global `-fields` / `-F` flag for context-window discipline.** Comma-separated dot-paths project structured output to only the requested fields (e.g., `-fields name,rules.*.path`; `*` matches every key/element at a level). Honors `WARDEN_FIELDS`. Keeps agent context windows small.
 - **Structured JSON errors and stable exit codes.** Every CLI failure produces a category-specific exit code and (in JSON/NDJSON modes) a `{"error": {code, message, hint}}` envelope on stderr. Stable codes: `usage` (2), `invalid_input` (3), `auth_required` (4), `forbidden` (5), `not_found` (6), `network` (7), `server` (8), `conflict` (9), `unknown` (1).
 
 ### Bug Fixes
@@ -258,7 +264,7 @@ All notable changes to Warden are documented in this file.
 
 ### Bug Fixes
 
-- **`--type` flag no longer required on `cred spec create`** — The CLI enforced `--type` as required even though the server can infer the credential type from the source driver. The flag is now optional, matching the server-side behavior documented since v0.7.0. (#111)
+- **`-type` flag no longer required on `cred spec create`** — The CLI enforced `-type` as required even though the server can infer the credential type from the source driver. The flag is now optional, matching the server-side behavior documented since v0.7.0. (#111)
 
 ### Documentation
 
@@ -296,7 +302,7 @@ All notable changes to Warden are documented in this file.
 
 ### Breaking Changes
 
-- **`apikey` replaces per-provider source types** — The source types `anthropic`, `openai`, `mistral`, `slack`, and `pagerduty` have been removed. A single `apikey` driver type handles all static API key providers. Existing sources must be recreated with `--type=apikey` and explicit config fields. Source type constants `SourceTypeAnthropic`, `SourceTypeOpenAI`, `SourceTypeMistral`, `SourceTypeSlack`, and `SourceTypePagerDuty` are removed from the Go API.
+- **`apikey` replaces per-provider source types** — The source types `anthropic`, `openai`, `mistral`, `slack`, and `pagerduty` have been removed. A single `apikey` driver type handles all static API key providers. Existing sources must be recreated with `-type=apikey` and explicit config fields. Source type constants `SourceTypeAnthropic`, `SourceTypeOpenAI`, `SourceTypeMistral`, `SourceTypeSlack`, and `SourceTypePagerDuty` are removed from the Go API.
 
 - **`oauth2` replaces `pagerduty_oauth2`** — The `pagerduty_oauth2` source type has been removed. A single `oauth2` driver type handles all OAuth2 client credentials providers. `token_url` is now a required field (no provider-specific defaults). Source type constant `SourceTypePagerDutyOAuth` is removed from the Go API.
 
@@ -328,7 +334,7 @@ All notable changes to Warden are documented in this file.
 
 - **HTTP Proxy Framework** — Extracted a generic `httpproxy` framework from the provider implementations. All streaming providers (Anthropic, GitHub, GitLab, Mistral, OpenAI, PagerDuty, Slack) now share a single `ProviderSpec`-based implementation, reducing per-provider code from ~500 lines to ~30 lines. (#114)
 
-- **Credential Type Inference** — The `--type` flag on `warden cred spec create` is now optional. When omitted, the credential type is inferred from the source driver via `InferCredentialType`. All provider READMEs updated to omit the flag. (#111)
+- **Credential Type Inference** — The `-type` flag on `warden cred spec create` is now optional. When omitted, the credential type is inferred from the source driver via `InferCredentialType`. All provider READMEs updated to omit the flag. (#111)
 
 - **Slack Provider** — New streaming gateway provider for the Slack Web API with body parsing for policy evaluation on request fields (channel, text, user). (#97)
 
@@ -351,7 +357,7 @@ All notable changes to Warden are documented in this file.
 
 ### Documentation
 
-- **Provider READMEs** — Removed `--type` from all `cred spec create` examples (now inferred). Added PagerDuty provider README with full quickstart for both static API token and OAuth2 client credentials modes.
+- **Provider READMEs** — Removed `-type` from all `cred spec create` examples (now inferred). Added PagerDuty provider README with full quickstart for both static API token and OAuth2 client credentials modes.
 
 ## [v0.6.0] — 2026-03-27
 
@@ -369,7 +375,7 @@ All notable changes to Warden are documented in this file.
 
 - **RDS Provider (Access Backend)** — New provider type that vends credentials directly instead of proxying traffic. The RDS provider issues short-lived IAM authentication tokens for PostgreSQL and MySQL on RDS/Aurora. Introduces the access backend framework for credential-vending providers. (#88)
 
-- **TLS in Dev Mode** — New `--dev-tls` and `--dev-tls-san` flags generate a self-signed TLS certificate at startup, enabling HTTPS in development without manual certificate management. (#86)
+- **TLS in Dev Mode** — New `-dev-tls` and `-dev-tls-san` flags generate a self-signed TLS certificate at startup, enabling HTTPS in development without manual certificate management. (#86)
 
 ### Removed
 
@@ -429,9 +435,9 @@ All notable changes to Warden are documented in this file.
 
 - **SPIFFE Support Across Auth Methods** — Both the JWT and cert auth methods now support SPIFFE workload identities. In cert auth, the `spiffe_id` principal claim extracts the SPIFFE URI from X.509 SVIDs, and `allowed_uri_sans` constraints use segment-aware pattern matching (`+` = one segment, `*` = one or more trailing segments, e.g. `spiffe://+/ns/*/sa/*`). In JWT auth, new `bound_uri_patterns` and `uri_claim` role fields validate SPIFFE JWT-SVIDs using the same pattern syntax.
 
-- **Certificate Auth CLI Client** — The `warden login` command now supports certificate-based login via the `cert` method. Flags: `--cert` and `--key` (or env vars `WARDEN_CLIENT_CERT` / `WARDEN_CLIENT_KEY`). Custom mount path via `--mount` / `--path`.
+- **Certificate Auth CLI Client** — The `warden login` command now supports certificate-based login via the `cert` method. Flags: `--cert` and `--key` (or env vars `WARDEN_CLIENT_CERT` / `WARDEN_CLIENT_KEY`). Custom mount path via `--mount` / `-path`.
 
-- **`WARDEN_ROLE` Environment Variable** — The role used by all `warden` CLI commands can now be set via the `WARDEN_ROLE` environment variable (or the global `--role` / `-r` flag). The flag sets the env var internally, so any sub-command automatically picks it up without repeating it per invocation.
+- **`WARDEN_ROLE` Environment Variable** — The role used by all `warden` CLI commands can now be set via the `WARDEN_ROLE` environment variable (or the global `-role` / `-r` flag). The flag sets the env var internally, so any sub-command automatically picks it up without repeating it per invocation.
 
 - **X-Warden-Role Header** — Clients can now specify their auth role via the `X-Warden-Role` HTTP header. Role resolution precedence (highest to lowest): URL-embedded role path → `X-Warden-Role` header → provider `default_role` → auth method `default_role`. The header is stripped before the request is proxied upstream.
 
@@ -528,7 +534,7 @@ All notable changes to Warden are documented in this file.
 
 ### Bug Fix
 
-- **fix: handle custom dev root tokens in LookupToken** — `LookupToken` failed with `"failed to detect token type"` when using `--dev-root-token` with a custom value that lacks a standard prefix. Added the same dev-mode fallback that `ResolveToken` already had. (#33)
+- **fix: handle custom dev root tokens in LookupToken** — `LookupToken` failed with `"failed to detect token type"` when using `-dev-root-token` with a custom value that lacks a standard prefix. Added the same dev-mode fallback that `ResolveToken` already had. (#33)
 
 ## [v0.1.0] — 2025-12-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,30 @@ make brd-fast
 
 ## Code Style Guidelines
 
+### CLI flag style in docs
+
+Document warden CLI flags with a single dash (`-config`, `-type`, `-path`),
+matching the Vault muscle memory the binary's flag normalizer is built for
+(see `NormalizeSingleDashFlags` in [cmd/warden.go](cmd/warden.go)). Flag
+registrations in code stay `--foo` (cobra/pflag canonical), so `warden
+--help` still prints `--`, but operator-facing docs, tutorials, and cobra
+Long/Example help text use `-foo`. The binary accepts both forms.
+
+Never rewrite flags belonging to other tools — `curl --cert`, `aws iam
+--user-name`, `helm install --set`, `kubectl --namespace`, `openssl req
+-subj`, `docker run --name` keep their native style.
+
+For `enable` commands (auth/provider/audit), follow Vault's exact form:
+TYPE is a required positional, and `-path=<mount>` overrides the default
+(which equals TYPE).
+
+```bash
+warden auth     enable jwt                            # mount at auth/jwt/
+warden auth     enable -path=jwt-prod jwt             # mount at auth/jwt-prod/
+warden provider enable -path=aws-staging aws          # mount at aws-staging/
+warden audit    enable -file-path=/var/log/audit.log file
+```
+
 ### Formatting
 
 - Use Go standard formatting: `go fmt ./...`

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -23,7 +23,7 @@ Usage: warden audit <subcommand> [options]
 
   Enable a new audit device:
 
-      $ warden audit enable --type=file --file-path=/var/log/warden-audit.log
+      $ warden audit enable file -file-path=/var/log/warden-audit.log
 
   Read audit device details:
 

--- a/cmd/audit/disable.go
+++ b/cmd/audit/disable.go
@@ -19,7 +19,7 @@ var (
 Usage: warden audit disable [PATH]
 
   Disables an audit device at the given PATH. The PATH may be supplied
-  either positionally or via --path (pick one — combining both is rejected).
+  either positionally or via -path (pick one — combining both is rejected).
 
   WARNING: Warden operates in fail-closed mode. You cannot disable the last
   remaining audit device. Attempting to do so will result in an error.
@@ -31,7 +31,7 @@ Usage: warden audit disable [PATH]
   Disable the audit device enabled at file/:
 
       $ warden audit disable file/
-      $ warden audit disable --path=file/
+      $ warden audit disable -path=file/
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runDisable,

--- a/cmd/audit/enable.go
+++ b/cmd/audit/enable.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-	enableType        string
 	enableDescription string
 	enableFilePath    string
 	enableFormat      string
@@ -18,35 +17,35 @@ var (
 	enableJSON        string
 
 	EnableCmd = &cobra.Command{
-		Use:           "enable [PATH]",
+		Use:           "enable TYPE",
+		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "This command enables an audit device.",
 		Long: `
-Usage: warden audit enable [options] [PATH]
+Usage: warden audit enable [options] TYPE
 
-  Enable an audit device. By default the mount path matches the TYPE, but a
-  custom path can be supplied either positionally or via --path. Each device
-  gets a unique HMAC salt for log hashing — generated on enable, lost on
-  disable. Note: --path is the device's mount path, while --file-path is the
-  audit log file location — they are distinct. Two input modes:
+  Enable an audit device. TYPE is the device type (currently only "file" is
+  supported). By default the mount path matches TYPE; pass -path to mount at
+  a custom location. Each device gets a unique HMAC salt for log hashing —
+  generated on enable, lost on disable. Note: -path is the device's mount
+  path, while -file-path is the audit log file location — they are distinct.
+  Two input modes:
 
     Typed flags (human-friendly):
 
-      $ warden audit enable --type=file --file-path=/var/log/warden-audit.log
-      $ warden audit enable --type=file --file-path=/var/log/audit.log prod-audit
-      $ warden audit enable --type=file --file-path=/var/log/audit.log --path=prod-audit
+      $ warden audit enable -file-path=/var/log/warden-audit.log file
+      $ warden audit enable -path=prod-audit -file-path=/var/log/audit.log file
 
     Full JSON payload (agent-friendly):
 
-      $ warden audit enable file --json @audit-file.json
-      $ cat audit-file.json | warden audit enable file --json -
+      $ warden audit enable file -json @audit-file.json
+      $ cat audit-file.json | warden audit enable file -json -
 
-  --json is mutually exclusive with --type / --description / --file-path /
-  --format. The mount path may be provided positionally or via --path (pick
-  one — combining both is rejected). When neither is set, the path is
-  derived from --type or from the JSON payload's "type" field. Combine with
-  --dry-run to validate the payload locally without enabling the device.
+  -json is mutually exclusive with -description / -file-path / -format. The
+  mount path defaults to TYPE; override it with -path. If the JSON payload
+  includes a "type" field, it must match TYPE. Combine with -dry-run to
+  validate the payload locally without enabling the device.
 
   For a full list of audit device types and examples, please see the documentation.
 `,
@@ -55,19 +54,15 @@ Usage: warden audit enable [options] [PATH]
 )
 
 func init() {
-	EnableCmd.Flags().StringVar(&enableType, "type", "file", "Type of the audit device (currently only 'file' is supported)")
 	EnableCmd.Flags().StringVar(&enableDescription, "description", "", "Human-friendly description of the audit device")
 	EnableCmd.Flags().StringVar(&enableFilePath, "file-path", "", "Path to the audit log file (required for file type)")
 	EnableCmd.Flags().StringVar(&enableFormat, "format", "json", "Log format (currently only 'json' is supported)")
-	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
+	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Custom mount path (default: TYPE)")
 	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with the typed flags)")
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
-	explicitPath, err := helpers.ResolvePath(args, enablePath)
-	if err != nil {
-		return err
-	}
+	enableType := strings.TrimSuffix(args[0], "/")
 
 	c, err := helpers.Client()
 	if err != nil {
@@ -79,21 +74,29 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	path := enablePath
+	if path == "" {
+		path = enableType
+	}
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--type":        cmd.Flags().Changed("type"),
-			"--description": enableDescription != "",
-			"--file-path":   enableFilePath != "",
-			"--format":      cmd.Flags().Changed("format"),
+			"-description": enableDescription != "",
+			"-file-path":   enableFilePath != "",
+			"-format":      cmd.Flags().Changed("format"),
 		}); err != nil {
 			return err
 		}
-		path := helpers.MountPathFromArgOrPayload(explicitPath, jsonPayload)
-		if path == "" {
-			return fmt.Errorf("--json without a PATH (positional or --path) and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
-		}
-		if err := helpers.ValidatePath(path); err != nil {
-			return err
+		if payloadType, ok := jsonPayload["type"].(string); ok && payloadType != "" && payloadType != enableType {
+			return fmt.Errorf(
+				"TYPE positional %q disagrees with -json payload \"type\":%q: %w",
+				enableType, payloadType, helpers.ErrUsage)
 		}
 		if helpers.ResolveDryRun() {
 			return helpers.DryRun(c, "POST", "sys/audit/{path}", jsonPayload)
@@ -116,21 +119,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	var path string
-	if explicitPath != "" {
-		path = explicitPath
-	} else {
-		path = enableType + "/"
-	}
-	if !strings.HasSuffix(path, "/") {
-		path = path + "/"
-	}
-
-	if err := helpers.ValidatePath(path); err != nil {
-		return err
-	}
-
-	// Build config
 	config := make(map[string]any)
 	if enableFilePath != "" {
 		config["file_path"] = enableFilePath
@@ -139,7 +127,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		config["format"] = enableFormat
 	}
 
-	// Build audit input
 	auditInput := &api.AuditInput{
 		Type:        enableType,
 		Description: enableDescription,
@@ -157,7 +144,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return helpers.DryRun(c, "POST", "sys/audit/{path}", payload)
 	}
 
-	// Enable the audit device
 	err = c.Sys().EnableAudit(path, auditInput)
 	if err != nil {
 		return fmt.Errorf("error enabling audit device: %w", err)
@@ -167,4 +153,3 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Success! Enabled %s audit device at: %s\n", enableType, path)
 	})
 }
-

--- a/cmd/audit/read.go
+++ b/cmd/audit/read.go
@@ -20,13 +20,13 @@ var (
 Usage: warden audit read [PATH]
 
   Show information on an audit device enabled on the provided PATH. The
-  PATH may be supplied either positionally or via --path (pick one —
+  PATH may be supplied either positionally or via -path (pick one —
   combining both is rejected).
 
   Read the audit device enabled at file/:
 
       $ warden audit read file/
-      $ warden audit read --path=file/
+      $ warden audit read -path=file/
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runRead,

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -19,7 +19,7 @@ Usage: warden auth <subcommand> [options]
 
   Enable a new auth method:
 
-      $ warden auth enable --type=jwt
+      $ warden auth enable jwt
 
   Please see the individual subcommand help for detailed usage information.
 `,

--- a/cmd/auth/disable.go
+++ b/cmd/auth/disable.go
@@ -19,12 +19,12 @@ var (
 Usage: warden auth disable [PATH]
 
   Disables an auth method at the given PATH. The PATH may be supplied
-  either positionally or via --path (pick one — combining both is rejected).
+  either positionally or via -path (pick one — combining both is rejected).
 
   Disable the auth method enabled at jwt/:
 
       $ warden auth disable jwt/
-      $ warden auth disable --path=jwt/
+      $ warden auth disable -path=jwt/
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runDisable,

--- a/cmd/auth/enable.go
+++ b/cmd/auth/enable.go
@@ -10,41 +10,39 @@ import (
 )
 
 var (
-	enableType        string
 	enableDescription string
 	enablePath        string
 	enableJSON        string
 
 	EnableCmd = &cobra.Command{
-		Use:           "enable [PATH]",
+		Use:           "enable TYPE",
+		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "This command enables an auth method.",
 		Long: `
-Usage: warden auth enable [options] [PATH]
+Usage: warden auth enable [options] TYPE
 
-  Enable an auth method. By default the mount path matches the TYPE, but a
-  custom path can be supplied either positionally or via --path. Two input
-  modes:
+  Enable an auth method. TYPE is the auth method to enable (e.g. jwt, oidc).
+  By default the mount path matches TYPE; pass -path to mount at a custom
+  location. Two input modes:
 
     Typed flags (human-friendly):
 
-      $ warden auth enable --type=jwt
-      $ warden auth enable --type=oidc oidc-prod
-      $ warden auth enable --type=oidc --path=oidc-prod
-      $ warden auth enable --type=jwt --description="Hydra OIDC"
+      $ warden auth enable jwt
+      $ warden auth enable -path=jwt-prod jwt
+      $ warden auth enable -description="Hydra OIDC" jwt
 
     Full JSON payload (agent-friendly):
 
-      $ warden auth enable jwt --json @auth-jwt.json
-      $ warden auth enable jwt --json '{"type":"jwt","description":"..."}'
-      $ cat auth-jwt.json | warden auth enable jwt --json -
+      $ warden auth enable jwt -json @auth-jwt.json
+      $ warden auth enable jwt -json '{"type":"jwt","description":"..."}'
+      $ cat auth-jwt.json | warden auth enable jwt -json -
 
-  --json is mutually exclusive with --type / --description. The mount path
-  may be provided positionally or via --path (pick one — combining both is
-  rejected). When neither is set, the path is derived from --type or from
-  the JSON payload's "type" field (e.g. type "jwt" → mount "jwt/"). Combine
-  with --dry-run to validate the payload locally without enabling the mount.
+  -json is mutually exclusive with -description. The mount path defaults to
+  TYPE; override it with -path. If the JSON payload includes a "type" field,
+  it must match TYPE. Combine with -dry-run to validate the payload locally
+  without enabling the mount.
 
   For a full list of auth methods and examples, please see the documentation.
 `,
@@ -53,17 +51,13 @@ Usage: warden auth enable [options] [PATH]
 )
 
 func init() {
-	EnableCmd.Flags().StringVar(&enableType, "type", "", "Type of the auth method (e.g., jwt, oidc, ldap) (required unless --json)")
 	EnableCmd.Flags().StringVar(&enableDescription, "description", "", "Human-friendly description of the auth method")
-	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
-	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --type/--description)")
+	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Custom mount path (default: TYPE)")
+	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -description)")
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
-	explicitPath, err := helpers.ResolvePath(args, enablePath)
-	if err != nil {
-		return err
-	}
+	enableType := strings.TrimSuffix(args[0], "/")
 
 	c, err := helpers.Client()
 	if err != nil {
@@ -75,21 +69,27 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	path := enablePath
+	if path == "" {
+		path = enableType
+	}
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--type":        enableType != "",
-			"--description": enableDescription != "",
+			"-description": enableDescription != "",
 		}); err != nil {
 			return err
 		}
-		// --json mode still needs a path — use the explicit path (positional
-		// or --path) or derive it from the payload's "type" field.
-		path := helpers.MountPathFromArgOrPayload(explicitPath, jsonPayload)
-		if path == "" {
-			return fmt.Errorf("--json without a PATH (positional or --path) and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
-		}
-		if err := helpers.ValidatePath(path); err != nil {
-			return err
+		if payloadType, ok := jsonPayload["type"].(string); ok && payloadType != "" && payloadType != enableType {
+			return fmt.Errorf(
+				"TYPE positional %q disagrees with -json payload \"type\":%q: %w",
+				enableType, payloadType, helpers.ErrUsage)
 		}
 		if helpers.ResolveDryRun() {
 			return helpers.DryRun(c, "POST", "sys/auth/{path}", jsonPayload)
@@ -112,25 +112,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	if enableType == "" {
-		return fmt.Errorf("--type is required (or use --json): %w", helpers.ErrUsage)
-	}
-
-	var path string
-	if explicitPath != "" {
-		path = explicitPath
-	} else {
-		path = enableType + "/"
-	}
-	if !strings.HasSuffix(path, "/") {
-		path = path + "/"
-	}
-
-	if err := helpers.ValidatePath(path); err != nil {
-		return err
-	}
-
-	// Build auth mount input
 	authInput := &api.AuthMountInput{
 		Type:        enableType,
 		Description: enableDescription,
@@ -144,7 +125,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return helpers.DryRun(c, "POST", "sys/auth/{path}", payload)
 	}
 
-	// Enable the auth method
 	err = c.Sys().EnableAuth(path, authInput)
 	if err != nil {
 		return fmt.Errorf("error enabling auth method: %w", err)
@@ -154,4 +134,3 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Success! Enabled %s auth method at: %s\n", enableType, path)
 	})
 }
-

--- a/cmd/auth/read.go
+++ b/cmd/auth/read.go
@@ -20,13 +20,13 @@ var (
 Usage: warden auth read [PATH]
 
   Show information on an auth method enabled on the provided PATH. The
-  PATH may be supplied either positionally or via --path (pick one —
+  PATH may be supplied either positionally or via -path (pick one —
   combining both is rejected).
 
   Read the auth method enabled at jwt/:
 
       $ warden auth read jwt/
-      $ warden auth read --path=jwt/
+      $ warden auth read -path=jwt/
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runRead,

--- a/cmd/basic/delete.go
+++ b/cmd/basic/delete.go
@@ -20,20 +20,20 @@ var (
 Usage: warden delete [PATH] [flags]
 
   Delete data at the given path. The PATH may be supplied either
-  positionally or via --path (pick one — combining both is rejected).
+  positionally or via -path (pick one — combining both is rejected).
   The path should be in the format "provider_mount/resource" or
   "auth/auth_mount/resource" or "sys/path/to/resource" and will be
   converted to the appropriate API path.
 
   By default, this command will ask for confirmation before deleting.
-  Use the -f/--force flag to skip the confirmation prompt.
+  Use the -f/-force flag to skip the confirmation prompt.
 
   Examples:
 
     Delete a JWT auth role (with confirmation):
 
       $ warden delete auth/jwt/role/developer
-      $ warden delete --path=auth/jwt/role/developer
+      $ warden delete -path=auth/jwt/role/developer
 
     Delete a provider (skip confirmation):
 
@@ -71,7 +71,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// --dry-run: validate the path resolves to a known DELETE-supporting
+	// -dry-run: validate the path resolves to a known DELETE-supporting
 	// schema entry and stop before any prompt or HTTP call. Skipping the
 	// confirmation prompt is intentional — a non-mutating preview shouldn't
 	// require interactive consent.

--- a/cmd/basic/list.go
+++ b/cmd/basic/list.go
@@ -20,7 +20,7 @@ var (
 Usage: warden list [PATH]
 
   List data from the given path. The PATH may be supplied either
-  positionally or via --path (pick one — combining both is rejected).
+  positionally or via -path (pick one — combining both is rejected).
   The path should be in the format "provider_mount/resource" or
   "auth/auth_mount/resource" or "sys/path/to/resource" and will be
   converted to the appropriate API path.
@@ -30,7 +30,7 @@ Usage: warden list [PATH]
     List JWT auth roles:
 
       $ warden list auth/jwt/role
-      $ warden list --path=auth/jwt/role
+      $ warden list -path=auth/jwt/role
 
     List providers:
 
@@ -76,7 +76,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	keys := extractKeys(resource.Data)
 
 	// Table mode keeps the existing "Keys\n  key1\n  key2" layout. Other
-	// formats render via the shared helper, which honors --fields.
+	// formats render via the shared helper, which honors -fields.
 	if helpers.ResolveFormat() == helpers.FormatTable {
 		printKeys(keys)
 		return nil

--- a/cmd/basic/path_help.go
+++ b/cmd/basic/path_help.go
@@ -22,7 +22,7 @@ Usage: warden path-help PATH
   If it points to a specific path (e.g., "aws/config"), returns help for
   that path.
 
-  Output honors the global --output flag: in TTY/table mode the help text
+  Output honors the global -output flag: in TTY/table mode the help text
   is printed verbatim, in JSON/NDJSON/text the response is returned as
   {"help": "..."} so agents can pipe it into jq.
 

--- a/cmd/basic/read.go
+++ b/cmd/basic/read.go
@@ -20,7 +20,7 @@ var (
 Usage: warden read [PATH]
 
   Read data from the given path. The PATH may be supplied either
-  positionally or via --path (pick one — combining both is rejected).
+  positionally or via -path (pick one — combining both is rejected).
   The path should be in the format "provider_mount/resource" or
   "auth/auth_mount/resource" or "sys/path/to/resource" and will be
   converted to the appropriate API path.
@@ -30,7 +30,7 @@ Usage: warden read [PATH]
     Read AWS provider configuration:
 
       $ warden read aws/config
-      $ warden read --path=aws/config
+      $ warden read -path=aws/config
 
     Read JWT auth configuration:
 
@@ -42,7 +42,7 @@ Usage: warden read [PATH]
 
     Project specific fields:
 
-      $ warden read aws/config --fields proxy_domains,timeout
+      $ warden read aws/config -fields proxy_domains,timeout
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runRead,

--- a/cmd/basic/write.go
+++ b/cmd/basic/write.go
@@ -24,7 +24,7 @@ var (
 Usage: warden write [PATH] [DATA]
 
   Write data to the given path. The PATH may be supplied either positionally
-  or via --path (pick one — combining both is rejected). When --path is used,
+  or via -path (pick one — combining both is rejected). When -path is used,
   all remaining positional arguments are treated as DATA. The data can be
   provided as JSON via stdin, as JSON arguments, or as key=value pairs. The
   path should be in the format "provider_mount/resource" or
@@ -44,7 +44,7 @@ Usage: warden write [PATH] [DATA]
   Write configuration using key=value format:
 
       $ warden write aws/config token_ttl=1h proxy_domains='["localhost","warden"]'
-      $ warden write --path=aws/config token_ttl=1h
+      $ warden write -path=aws/config token_ttl=1h
 
   Use @file to read a value from a file (useful for PEM certificates, large payloads, etc.):
 
@@ -59,7 +59,7 @@ func init() {
 }
 
 func runWrite(cmd *cobra.Command, args []string) error {
-	// --path frees args[0] for DATA; without --path, args[0] is the PATH.
+	// -path frees args[0] for DATA; without -path, args[0] is the PATH.
 	var path string
 	var dataArgs []string
 	if writePath != "" {
@@ -137,7 +137,7 @@ func runWrite(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// --dry-run: validate the payload locally against the server's published
+	// -dry-run: validate the payload locally against the server's published
 	// schema and stop here. Nothing leaves the process.
 	if helpers.ResolveDryRun() {
 		return helpers.DryRun(c, "POST", path, data)

--- a/cmd/cred/source/create.go
+++ b/cmd/cred/source/create.go
@@ -26,20 +26,20 @@ Usage: warden cred source create <name> [flags]
     Typed flags (human-friendly):
 
       $ warden cred source create my-aws \
-          --type=aws \
-          --config=access_key_id=... \
-          --config=secret_access_key=... \
-          --config=region=us-east-1 \
-          --rotation-period=24h
+          -type=aws \
+          -config=access_key_id=... \
+          -config=secret_access_key=... \
+          -config=region=us-east-1 \
+          -rotation-period=24h
 
     Full JSON payload (agent-friendly):
 
-      $ warden cred source create my-aws --json @aws-source.json
-      $ warden cred source create my-aws --json '{"type":"aws", ...}'
-      $ cat aws-source.json | warden cred source create my-aws --json -
+      $ warden cred source create my-aws -json @aws-source.json
+      $ warden cred source create my-aws -json '{"type":"aws", ...}'
+      $ cat aws-source.json | warden cred source create my-aws -json -
 
-  --json is mutually exclusive with --type / --config / --rotation-period.
-  Combine with --dry-run to validate the payload locally without creating
+  -json is mutually exclusive with -type / -config / -rotation-period.
+  Combine with -dry-run to validate the payload locally without creating
   the resource.
 `,
 		SilenceUsage:  true,
@@ -50,10 +50,10 @@ Usage: warden cred source create <name> [flags]
 )
 
 func init() {
-	CreateCmd.Flags().StringVar(&createType, "type", "", "Source type (required unless --json)")
+	CreateCmd.Flags().StringVar(&createType, "type", "", "Source type (required unless -json)")
 	CreateCmd.Flags().StringToStringVar(&createConfig, "config", nil, "Source configuration (key=value)")
-	CreateCmd.Flags().StringVar(&createRotationPeriod, "rotation-period", "", "Rotation period for credential source (e.g., 24h, 30m) (required unless --json)")
-	CreateCmd.Flags().StringVarP(&createJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --type/--config/--rotation-period)")
+	CreateCmd.Flags().StringVar(&createRotationPeriod, "rotation-period", "", "Rotation period for credential source (e.g., 24h, 30m) (required unless -json)")
+	CreateCmd.Flags().StringVarP(&createJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -type/-config/-rotation-period)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -74,24 +74,24 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--type":            createType != "",
-			"--config":          len(createConfig) > 0,
-			"--rotation-period": createRotationPeriod != "",
+			"-type":            createType != "",
+			"-config":          len(createConfig) > 0,
+			"-rotation-period": createRotationPeriod != "",
 		}); err != nil {
 			return err
 		}
 		return runCreateWithJSON(c, name, jsonPayload)
 	}
 
-	// Typed-flag path: required-flag validation moves here so --json can
+	// Typed-flag path: required-flag validation moves here so -json can
 	// satisfy them without tripping cobra's MarkFlagRequired.
 	if createType == "" {
-		return fmt.Errorf("--type is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-type is required (or use -json): %w", helpers.ErrUsage)
 	}
 	if createRotationPeriod == "" {
-		return fmt.Errorf("--rotation-period is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-rotation-period is required (or use -json): %w", helpers.ErrUsage)
 	}
-	if err := helpers.ValidateIdentifier("--type", createType); err != nil {
+	if err := helpers.ValidateIdentifier("-type", createType); err != nil {
 		return err
 	}
 

--- a/cmd/cred/source/update.go
+++ b/cmd/cred/source/update.go
@@ -22,14 +22,14 @@ Usage: warden cred source update <name> [flags]
 
     Typed flags (human-friendly):
 
-      $ warden cred source update my-aws --config=region=eu-west-1
+      $ warden cred source update my-aws -config=region=eu-west-1
 
     Full JSON payload (agent-friendly):
 
-      $ warden cred source update my-aws --json @aws-source.json
-      $ cat aws-source.json | warden cred source update my-aws --json -
+      $ warden cred source update my-aws -json @aws-source.json
+      $ cat aws-source.json | warden cred source update my-aws -json -
 
-  --json is mutually exclusive with --config. Combine with --dry-run to
+  -json is mutually exclusive with -config. Combine with -dry-run to
   validate the payload locally without modifying the source.
 `,
 		SilenceUsage:  true,
@@ -41,7 +41,7 @@ Usage: warden cred source update <name> [flags]
 
 func init() {
 	UpdateCmd.Flags().StringToStringVar(&updateConfig, "config", nil, "Source configuration (key=value)")
-	UpdateCmd.Flags().StringVarP(&updateJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --config)")
+	UpdateCmd.Flags().StringVarP(&updateJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -config)")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -62,7 +62,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--config": len(updateConfig) > 0,
+			"-config": len(updateConfig) > 0,
 		}); err != nil {
 			return err
 		}
@@ -88,7 +88,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(updateConfig) == 0 {
-		return fmt.Errorf("--config is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-config is required (or use -json): %w", helpers.ErrUsage)
 	}
 
 	resolvedConfig, err := helpers.ResolveFileRefs(updateConfig)

--- a/cmd/cred/spec/create.go
+++ b/cmd/cred/spec/create.go
@@ -29,18 +29,18 @@ Usage: warden cred spec create <name> [flags]
     Typed flags (human-friendly):
 
       $ warden cred spec create developer \
-          --source=my-aws \
-          --config=mint_method=sts_assume_role \
-          --config=role_arn=arn:aws:iam::1234:role/dev \
-          --min-ttl=1h --max-ttl=24h
+          -source=my-aws \
+          -config=mint_method=sts_assume_role \
+          -config=role_arn=arn:aws:iam::1234:role/dev \
+          -min-ttl=1h -max-ttl=24h
 
     Full JSON payload (agent-friendly):
 
-      $ warden cred spec create developer --json @spec.json
-      $ cat spec.json | warden cred spec create developer --json -
+      $ warden cred spec create developer -json @spec.json
+      $ cat spec.json | warden cred spec create developer -json -
 
-  --json is mutually exclusive with --type / --source / --config /
-  --min-ttl / --max-ttl / --rotation-period. Combine with --dry-run to
+  -json is mutually exclusive with -type / -source / -config /
+  -min-ttl / -max-ttl / -rotation-period. Combine with -dry-run to
   validate the payload locally without creating the spec.
 `,
 		SilenceUsage:  true,
@@ -52,7 +52,7 @@ Usage: warden cred spec create <name> [flags]
 
 func init() {
 	CreateCmd.Flags().StringVar(&createType, "type", "", "Credential type (optional — inferred from source when omitted)")
-	CreateCmd.Flags().StringVar(&createSource, "source", "", "Source name (required unless --json)")
+	CreateCmd.Flags().StringVar(&createSource, "source", "", "Source name (required unless -json)")
 	CreateCmd.Flags().StringToStringVar(&createConfig, "config", nil, "Type-specific configuration (key=value)")
 	CreateCmd.Flags().StringVar(&createMinTTL, "min-ttl", "1h", "Minimum TTL")
 	CreateCmd.Flags().StringVar(&createMaxTTL, "max-ttl", "24h", "Maximum TTL")
@@ -78,12 +78,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--type":            createType != "",
-			"--source":          createSource != "",
-			"--config":          len(createConfig) > 0,
-			"--min-ttl":         cmd.Flags().Changed("min-ttl"),
-			"--max-ttl":         cmd.Flags().Changed("max-ttl"),
-			"--rotation-period": createRotationPeriod != "",
+			"-type":            createType != "",
+			"-source":          createSource != "",
+			"-config":          len(createConfig) > 0,
+			"-min-ttl":         cmd.Flags().Changed("min-ttl"),
+			"-max-ttl":         cmd.Flags().Changed("max-ttl"),
+			"-rotation-period": createRotationPeriod != "",
 		}); err != nil {
 			return err
 		}
@@ -109,10 +109,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if createSource == "" {
-		return fmt.Errorf("--source is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-source is required (or use -json): %w", helpers.ErrUsage)
 	}
 	if createType != "" {
-		if err := helpers.ValidateIdentifier("--type", createType); err != nil {
+		if err := helpers.ValidateIdentifier("-type", createType); err != nil {
 			return err
 		}
 	}

--- a/cmd/cred/spec/update.go
+++ b/cmd/cred/spec/update.go
@@ -26,16 +26,16 @@ Usage: warden cred spec update <name> [flags]
 
     Typed flags (human-friendly):
 
-      $ warden cred spec update developer --max-ttl=4h
-      $ warden cred spec update developer --config=role_arn=arn:...
+      $ warden cred spec update developer -max-ttl=4h
+      $ warden cred spec update developer -config=role_arn=arn:...
 
     Full JSON payload (agent-friendly):
 
-      $ warden cred spec update developer --json @spec.json
-      $ cat spec.json | warden cred spec update developer --json -
+      $ warden cred spec update developer -json @spec.json
+      $ cat spec.json | warden cred spec update developer -json -
 
-  --json is mutually exclusive with --config / --min-ttl / --max-ttl /
-  --rotation-period. Combine with --dry-run to validate the payload locally
+  -json is mutually exclusive with -config / -min-ttl / -max-ttl /
+  -rotation-period. Combine with -dry-run to validate the payload locally
   without modifying the spec.
 `,
 		SilenceUsage:  true,
@@ -71,10 +71,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--config":          len(updateConfig) > 0,
-			"--min-ttl":         updateMinTTL != "",
-			"--max-ttl":         updateMaxTTL != "",
-			"--rotation-period": updateRotationPeriod != "",
+			"-config":          len(updateConfig) > 0,
+			"-min-ttl":         updateMinTTL != "",
+			"-max-ttl":         updateMaxTTL != "",
+			"-rotation-period": updateRotationPeriod != "",
 		}); err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Require at least one update parameter
 	if len(updateConfig) == 0 && updateMinTTL == "" && updateMaxTTL == "" && updateRotationPeriod == "" {
-		return fmt.Errorf("no update parameters provided (use --config, --min-ttl, --max-ttl, --rotation-period, or --json): %w", helpers.ErrInvalidInput)
+		return fmt.Errorf("no update parameters provided (use -config, -min-ttl, -max-ttl, -rotation-period, or -json): %w", helpers.ErrInvalidInput)
 	}
 
 	resolvedConfig, err := helpers.ResolveFileRefs(updateConfig)

--- a/cmd/helpers/config.go
+++ b/cmd/helpers/config.go
@@ -8,7 +8,7 @@ import (
 
 // ResolveFileRefs processes a config map and replaces values prefixed with "@"
 // with the contents of the referenced file. This allows CLI users to pass file
-// contents via --config=key=@/path/to/file (similar to curl's @ syntax).
+// contents via -config=key=@/path/to/file (similar to curl's @ syntax).
 func ResolveFileRefs(config map[string]string) (map[string]string, error) {
 	for key, value := range config {
 		if strings.HasPrefix(value, "@") {

--- a/cmd/helpers/dry_run.go
+++ b/cmd/helpers/dry_run.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// Persistent --dry-run flag value, populated by cmd/warden.go via the pointer
+// Persistent -dry-run flag value, populated by cmd/warden.go via the pointer
 // accessor. Read once per command invocation through ResolveDryRun.
 var dryRunFlag bool
 
@@ -16,7 +16,7 @@ func DryRunFlagPtr() *bool { return &dryRunFlag }
 func SetDryRun(v bool) { dryRunFlag = v }
 
 // ResolveDryRun returns true when the user has requested dry-run mode via
-// the --dry-run flag or the WARDEN_DRY_RUN env var. Any value of
+// the -dry-run flag or the WARDEN_DRY_RUN env var. Any value of
 // WARDEN_DRY_RUN other than "" / "0" / "false" / "no" / "off" (case
 // insensitive) is treated as true.
 //

--- a/cmd/helpers/errors.go
+++ b/cmd/helpers/errors.go
@@ -58,7 +58,7 @@ var (
 	ErrSealed       = errors.New("warden is sealed or uninitialized")
 )
 
-// WardenError is the JSON envelope emitted on stderr when --output is json or
+// WardenError is the JSON envelope emitted on stderr when -output is json or
 // ndjson. Agents key off Code (stable string) for branching; Message is
 // human-readable; Hint is an optional recovery suggestion.
 type WardenError struct {

--- a/cmd/helpers/input.go
+++ b/cmd/helpers/input.go
@@ -11,20 +11,20 @@ import (
 	"strings"
 )
 
-// ResolveJSONInput parses the value of a `--json` flag in three forms:
+// ResolveJSONInput parses the value of a `-json` flag in three forms:
 //
-//	literal :  --json '{"type":"aws","region":"us-east-1"}'
-//	file    :  --json @aws-source.json
-//	stdin   :  --json -                                   (use with `<` or `|`)
+//	literal :  -json '{"type":"aws","region":"us-east-1"}'
+//	file    :  -json @aws-source.json
+//	stdin   :  -json -                                   (use with `<` or `|`)
 //
 // Returns (nil, nil) when v is empty so callers can branch on
-// "no --json was provided" without a separate flag check. Errors are
+// "no -json was provided" without a separate flag check. Errors are
 // wrapped with ErrInvalidInput so the central renderer maps them to
 // exit code 3.
 //
 // JSON null at the root is rejected (treating it as "no payload" would
 // silently fall through to typed-flag mode and confuse the user).
-// `--json -` with stdin attached to a terminal is rejected upfront so
+// `-json -` with stdin attached to a terminal is rejected upfront so
 // the user isn't stuck at a blocking ReadAll waiting for EOF.
 func ResolveJSONInput(v string) (map[string]any, error) {
 	v = strings.TrimSpace(v)
@@ -37,40 +37,40 @@ func ResolveJSONInput(v string) (map[string]any, error) {
 	switch {
 	case v == "-":
 		if stat, statErr := os.Stdin.Stat(); statErr == nil && (stat.Mode()&os.ModeCharDevice) != 0 {
-			return nil, fmt.Errorf("--json -: stdin is a terminal; pipe a payload via `<` or `|`: %w", ErrInvalidInput)
+			return nil, fmt.Errorf("-json -: stdin is a terminal; pipe a payload via `<` or `|`: %w", ErrInvalidInput)
 		}
 		raw, err = io.ReadAll(os.Stdin)
 		if err != nil {
-			return nil, fmt.Errorf("--json -: read stdin: %w", err)
+			return nil, fmt.Errorf("-json -: read stdin: %w", err)
 		}
 	case strings.HasPrefix(v, "@"):
 		path := v[1:]
 		raw, err = os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("--json @%s: %w", path, err)
+			return nil, fmt.Errorf("-json @%s: %w", path, err)
 		}
 	default:
 		raw = []byte(v)
 	}
 
 	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil, fmt.Errorf("--json input is empty: %w", ErrInvalidInput)
+		return nil, fmt.Errorf("-json input is empty: %w", ErrInvalidInput)
 	}
 
 	var data map[string]any
 	if err := json.Unmarshal(raw, &data); err != nil {
-		return nil, fmt.Errorf("--json: invalid JSON (%v): %w", err, ErrInvalidInput)
+		return nil, fmt.Errorf("-json: invalid JSON (%v): %w", err, ErrInvalidInput)
 	}
 	if data == nil {
 		// JSON `null` at the root unmarshals into a nil map, which would
 		// silently fall through to typed-flag mode. Reject explicitly.
-		return nil, fmt.Errorf("--json: payload cannot be null: %w", ErrInvalidInput)
+		return nil, fmt.Errorf("-json: payload cannot be null: %w", ErrInvalidInput)
 	}
 	return data, nil
 }
 
 // RejectFlagsWithJSON returns ErrUsage if any of `flags` (a map of
-// human-readable flag names → "this flag was set") is true AND --json was
+// human-readable flag names → "this flag was set") is true AND -json was
 // also provided. The combination is ambiguous — pick one input mode per
 // command. Flag names in the resulting error are sorted for deterministic
 // output (map iteration order is otherwise non-stable).
@@ -88,19 +88,19 @@ func RejectFlagsWithJSON(jsonProvided bool, flags map[string]bool) error {
 		return nil
 	}
 	sort.Strings(conflicting)
-	return fmt.Errorf("--json cannot be combined with %s: %w",
+	return fmt.Errorf("-json cannot be combined with %s: %w",
 		strings.Join(conflicting, ", "), ErrUsage)
 }
 
 // ResolvePath returns the explicit path from either the positional
-// argument or the --path flag, with a usage error when both are
+// argument or the -path flag, with a usage error when both are
 // supplied. Returns "" when neither is set — callers may then fall
-// back to deriving the path (e.g. from --type or from a JSON payload's
+// back to deriving the path (e.g. from -type or from a JSON payload's
 // "type" field), or treat empty as a usage error.
 func ResolvePath(args []string, pathFlag string) (string, error) {
 	if len(args) > 0 && pathFlag != "" {
 		return "", fmt.Errorf(
-			"cannot specify both --path=%q and positional PATH %q: %w",
+			"cannot specify both -path=%q and positional PATH %q: %w",
 			pathFlag, args[0], ErrUsage)
 	}
 	if len(args) > 0 {
@@ -112,7 +112,7 @@ func ResolvePath(args []string, pathFlag string) (string, error) {
 // RequirePath is ResolvePath plus a usage error when neither source
 // supplied a value. Use this in commands where PATH is mandatory
 // (disable, read, etc.). Commands that fall back to deriving the path
-// from --type or a JSON payload should call ResolvePath directly and
+// from -type or a JSON payload should call ResolvePath directly and
 // handle the empty case themselves.
 func RequirePath(args []string, pathFlag string) (string, error) {
 	path, err := ResolvePath(args, pathFlag)
@@ -120,37 +120,9 @@ func RequirePath(args []string, pathFlag string) (string, error) {
 		return "", err
 	}
 	if path == "" {
-		return "", fmt.Errorf("PATH is required (provide positionally or via --path): %w", ErrUsage)
+		return "", fmt.Errorf("PATH is required (provide positionally or via -path): %w", ErrUsage)
 	}
 	return path, nil
-}
-
-// MountPathFromArgOrPayload resolves the mount path for `enable` commands
-// that accept either an explicit path (already resolved from positional
-// or --path via ResolvePath) OR a `--json` payload containing a "type"
-// field. The explicit path wins when present; otherwise we derive the
-// path from the payload's "type" (e.g. "jwt" → "jwt/").
-//
-// Returns "" when neither source supplies a value — callers should error
-// out with a clear "cannot determine mount path" message rather than
-// pass an empty/degenerate path through to validation, which would
-// surface a misleading "absolute path" error.
-//
-// A non-empty result always has a trailing slash.
-func MountPathFromArgOrPayload(explicitPath string, payload map[string]any) string {
-	path := explicitPath
-	if path == "" {
-		if t, ok := payload["type"].(string); ok && t != "" {
-			path = t + "/"
-		}
-	}
-	if path == "" {
-		return ""
-	}
-	if !strings.HasSuffix(path, "/") {
-		path = path + "/"
-	}
-	return path
 }
 
 // MergeServerResponseInto copies fields from `resource.Data` (if any) into

--- a/cmd/helpers/input_test.go
+++ b/cmd/helpers/input_test.go
@@ -208,53 +208,6 @@ func TestRejectFlagsWithJSON_DeterministicOrder(t *testing.T) {
 	}
 }
 
-func TestMountPathFromArgOrPayload(t *testing.T) {
-	cases := []struct {
-		name         string
-		explicitPath string
-		payload      map[string]any
-		want         string
-	}{
-		{
-			name:         "explicit path wins",
-			explicitPath: "custom-mount",
-			payload:      map[string]any{"type": "jwt"},
-			want:         "custom-mount/",
-		},
-		{
-			name:         "no explicit path, derive from payload type",
-			explicitPath: "",
-			payload:      map[string]any{"type": "jwt"},
-			want:         "jwt/",
-		},
-		{
-			name:         "no explicit path, no type → empty",
-			explicitPath: "",
-			payload:      map[string]any{},
-			want:         "",
-		},
-		{
-			name:         "no explicit path, nil payload → empty",
-			explicitPath: "",
-			payload:      nil,
-			want:         "",
-		},
-		{
-			name:         "trailing slash preserved",
-			explicitPath: "already-slashed/",
-			payload:      nil,
-			want:         "already-slashed/",
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := MountPathFromArgOrPayload(tt.explicitPath, tt.payload); got != tt.want {
-				t.Errorf("got %q; want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestRequirePath(t *testing.T) {
 	t.Run("positional only", func(t *testing.T) {
 		got, err := RequirePath([]string{"jwt/"}, "")

--- a/cmd/helpers/output.go
+++ b/cmd/helpers/output.go
@@ -55,7 +55,7 @@ func ResetWriters() {
 }
 
 // ResolveFormat returns the effective output format. Resolution order:
-// explicit --output flag, then $WARDEN_OUTPUT, then TTY autodetect (table on
+// explicit -output flag, then $WARDEN_OUTPUT, then TTY autodetect (table on
 // terminal, json otherwise).
 func ResolveFormat() Format {
 	if outputFlag != "" {
@@ -70,7 +70,7 @@ func ResolveFormat() Format {
 	return FormatJSON
 }
 
-// ResolveFields returns the parsed list of dot-paths from --fields or
+// ResolveFields returns the parsed list of dot-paths from -fields or
 // $WARDEN_FIELDS. Returns nil when no projection is requested.
 func ResolveFields() []string {
 	raw := fieldsFlag
@@ -105,7 +105,7 @@ func ValidateFormat(f Format) error {
 
 // RenderMap emits a single map at the resolved format. tableFn renders the
 // table form; pass nil to fall back to PrintMapAsTable. Field projection is
-// applied to all non-table formats; in table mode with --fields set, the
+// applied to all non-table formats; in table mode with -fields set, the
 // bespoke tableFn is bypassed in favor of a generic projected key/value table.
 func RenderMap(data map[string]any, tableFn func()) error {
 	format := ResolveFormat()
@@ -117,7 +117,7 @@ func RenderMap(data map[string]any, tableFn func()) error {
 
 	if format == FormatTable {
 		if fields != nil {
-			fmt.Fprintln(errWriter, "warning: --fields with table output uses a generic key/value layout; use -o json for the structured form")
+			fmt.Fprintln(errWriter, "warning: -fields with table output uses a generic key/value layout; use -o json for the structured form")
 			PrintMapAsTable(ProjectMap(data, fields))
 			return nil
 		}
@@ -147,7 +147,7 @@ func RenderMap(data map[string]any, tableFn func()) error {
 // RenderList emits a slice of records at the resolved format. tableFn renders
 // the table form (and is responsible for any "no items" message in table mode
 // when items is empty). Field projection is applied to non-table formats; in
-// table mode with --fields set, the bespoke tableFn is bypassed in favor of a
+// table mode with -fields set, the bespoke tableFn is bypassed in favor of a
 // projected per-column table.
 func RenderList(items []map[string]any, tableFn func()) error {
 	format := ResolveFormat()
@@ -159,7 +159,7 @@ func RenderList(items []map[string]any, tableFn func()) error {
 
 	if format == FormatTable {
 		if fields != nil {
-			fmt.Fprintln(errWriter, "warning: --fields with table output uses a generic projected layout; use -o json for the structured form")
+			fmt.Fprintln(errWriter, "warning: -fields with table output uses a generic projected layout; use -o json for the structured form")
 			renderProjectedListTable(items, fields)
 			return nil
 		}
@@ -204,7 +204,7 @@ func RenderList(items []map[string]any, tableFn func()) error {
 }
 
 // RenderStrings emits a list of plain strings (e.g. policy names, list keys)
-// at the resolved format. tableFn renders the table form. --fields is ignored
+// at the resolved format. tableFn renders the table form. -fields is ignored
 // since strings have no fields to project.
 func RenderStrings(items []string, tableFn func()) error {
 	format := ResolveFormat()
@@ -310,7 +310,7 @@ func needsQuoting(s string) bool {
 }
 
 // renderProjectedListTable prints a table with one column per requested field
-// and one row per record, used when --fields is set in table mode.
+// and one row per record, used when -fields is set in table mode.
 func renderProjectedListTable(items []map[string]any, fields []string) {
 	if len(items) == 0 {
 		fmt.Fprintln(outWriter, "No data to display")

--- a/cmd/helpers/output_test.go
+++ b/cmd/helpers/output_test.go
@@ -289,9 +289,9 @@ func TestRenderMap_FieldsInTableModeBypassesTableFnAndWarns(t *testing.T) {
 		t.Fatalf("RenderMap: %v", err)
 	}
 	if called {
-		t.Error("tableFn should be bypassed when --fields is set in table mode")
+		t.Error("tableFn should be bypassed when -fields is set in table mode")
 	}
-	if !strings.Contains(stderr.String(), "warning: --fields with table output") {
+	if !strings.Contains(stderr.String(), "warning: -fields with table output") {
 		t.Errorf("expected stderr warning, got: %q", stderr.String())
 	}
 }
@@ -311,9 +311,9 @@ func TestRenderList_FieldsInTableModeBypassesTableFnAndWarns(t *testing.T) {
 		t.Fatalf("RenderList: %v", err)
 	}
 	if called {
-		t.Error("tableFn should be bypassed when --fields is set in table mode")
+		t.Error("tableFn should be bypassed when -fields is set in table mode")
 	}
-	if !strings.Contains(stderr.String(), "warning: --fields with table output") {
+	if !strings.Contains(stderr.String(), "warning: -fields with table output") {
 		t.Errorf("expected stderr warning, got: %q", stderr.String())
 	}
 }

--- a/cmd/helpers/path.go
+++ b/cmd/helpers/path.go
@@ -31,7 +31,7 @@ func ValidatePath(p string) error {
 			return fmt.Errorf("path %q contains control character (byte 0x%02x at position %d): %w", p, b, i, ErrInvalidInput)
 		}
 		if b == '?' || b == '#' {
-			return fmt.Errorf("path %q contains URL-reserved character %q (use --output / --fields for query-like behavior): %w", p, b, ErrInvalidInput)
+			return fmt.Errorf("path %q contains URL-reserved character %q (use -output / -fields for query-like behavior): %w", p, b, ErrInvalidInput)
 		}
 	}
 
@@ -45,7 +45,7 @@ func ValidatePath(p string) error {
 }
 
 // ValidateHeaderValue checks that v is safe to send as an HTTP header value
-// (used for `--namespace`/`--role` which become X-Warden-Namespace and
+// (used for `-namespace`/`-role` which become X-Warden-Namespace and
 // X-Warden-Role headers). Rejects CR/LF (header injection), other control
 // characters, and leading/trailing whitespace. Empty is allowed since callers
 // treat it as "absent."
@@ -66,7 +66,7 @@ func ValidateHeaderValue(name, v string) error {
 }
 
 // ValidateIdentifier checks that v is a well-formed single-segment identifier
-// (used for `--type` flag values that go into JSON bodies or URL segments).
+// (used for `-type` flag values that go into JSON bodies or URL segments).
 // Rejects empty, whitespace, slashes (use ValidatePath for multi-segment), and
 // the same control/percent-encoding hazards as ValidatePath.
 func ValidateIdentifier(name, v string) error {

--- a/cmd/namespaces/create.go
+++ b/cmd/namespaces/create.go
@@ -27,14 +27,14 @@ Usage: warden namespace create <path> [options]
 
       $ warden namespace create my-team
       $ warden namespace create org/engineering
-      $ warden namespace create my-team --metadata=environment=prod --metadata=team=platform
+      $ warden namespace create my-team -metadata=environment=prod -metadata=team=platform
 
     Full JSON payload (agent-friendly):
 
-      $ warden namespace create my-team --json @ns.json
-      $ cat ns.json | warden namespace create my-team --json -
+      $ warden namespace create my-team -json @ns.json
+      $ cat ns.json | warden namespace create my-team -json -
 
-  --json is mutually exclusive with --metadata. Combine with --dry-run to
+  -json is mutually exclusive with -metadata. Combine with -dry-run to
   validate the payload locally without creating the namespace.
 
   For more information about namespaces, please see the documentation.
@@ -46,7 +46,7 @@ Usage: warden namespace create <path> [options]
 
 func init() {
 	CreateCmd.Flags().StringToStringVar(&createMetadata, "metadata", nil, "Custom metadata for the namespace (can be specified multiple times)")
-	CreateCmd.Flags().StringVarP(&createJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --metadata)")
+	CreateCmd.Flags().StringVarP(&createJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -metadata)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -67,7 +67,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--metadata": len(createMetadata) > 0,
+			"-metadata": len(createMetadata) > 0,
 		}); err != nil {
 			return err
 		}

--- a/cmd/namespaces/delete.go
+++ b/cmd/namespaces/delete.go
@@ -28,7 +28,7 @@ Usage: warden namespace delete <path> [options]
   WARNING: This is a destructive operation and cannot be undone!
 
   By default, this command will ask for confirmation before deleting.
-  Use the -f/--force flag to skip the confirmation prompt.
+  Use the -f/-force flag to skip the confirmation prompt.
 
   Delete a namespace (with confirmation):
 
@@ -68,7 +68,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return helpers.DryRun(c, "DELETE", "sys/namespaces/{path}", nil)
 	}
 
-	// Confirmation prompt (unless --force is used)
+	// Confirmation prompt (unless -force is used)
 	if !deleteForce {
 		fmt.Printf("WARNING: This will permanently delete the namespace '%s' and all its contents.\n", path)
 		fmt.Print("Are you sure you want to continue? (yes/no): ")

--- a/cmd/namespaces/list.go
+++ b/cmd/namespaces/list.go
@@ -32,7 +32,7 @@ Usage: warden namespace list [options]
 
   List namespaces including the parent:
 
-      $ warden namespace list --include-parent
+      $ warden namespace list -include-parent
 
   Output as JSON:
 

--- a/cmd/namespaces/update.go
+++ b/cmd/namespaces/update.go
@@ -25,15 +25,15 @@ Usage: warden namespace update <path> [options]
 
     Typed flags (human-friendly):
 
-      $ warden namespace update my-team --metadata=environment=staging --metadata=team=devops
-      $ warden namespace update my-team --metadata=""        # clear
+      $ warden namespace update my-team -metadata=environment=staging -metadata=team=devops
+      $ warden namespace update my-team -metadata=""        # clear
 
     Full JSON payload (agent-friendly):
 
-      $ warden namespace update my-team --json @ns.json
-      $ cat ns.json | warden namespace update my-team --json -
+      $ warden namespace update my-team -json @ns.json
+      $ cat ns.json | warden namespace update my-team -json -
 
-  --json is mutually exclusive with --metadata. Combine with --dry-run to
+  -json is mutually exclusive with -metadata. Combine with -dry-run to
   validate the payload locally without modifying the namespace.
 
   For more information about namespaces, please see the documentation.
@@ -45,7 +45,7 @@ Usage: warden namespace update <path> [options]
 
 func init() {
 	UpdateCmd.Flags().StringToStringVar(&updateMetadata, "metadata", nil, "Custom metadata for the namespace (can be specified multiple times)")
-	UpdateCmd.Flags().StringVarP(&updateJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --metadata)")
+	UpdateCmd.Flags().StringVarP(&updateJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -metadata)")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -66,7 +66,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--metadata": cmd.Flags().Changed("metadata"),
+			"-metadata": cmd.Flags().Changed("metadata"),
 		}); err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cmd.Flags().Changed("metadata") {
-		return fmt.Errorf("--metadata is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-metadata is required (or use -json): %w", helpers.ErrUsage)
 	}
 
 	// Build namespace update input

--- a/cmd/operator/init.go
+++ b/cmd/operator/init.go
@@ -43,13 +43,13 @@ Usage:
   $ warden operator init
 
   # Initialize with custom shares and threshold
-  $ warden operator init --secret-shares=7 --secret-threshold=4
+  $ warden operator init -secret-shares=7 -secret-threshold=4
 
   # Initialize with PGP encryption for unseal keys
-  $ warden operator init --pgp-keys="keybase:user1,keybase:user2,keybase:user3,keybase:user4,keybase:user5"
+  $ warden operator init -pgp-keys="keybase:user1,keybase:user2,keybase:user3,keybase:user4,keybase:user5"
 
   # Initialize with PGP-encrypted root token
-  $ warden operator init --root-token-pgp-key="keybase:admin"
+  $ warden operator init -root-token-pgp-key="keybase:admin"
 
   # Emit machine-readable JSON for IaC scripts
   $ warden operator init -o json

--- a/cmd/policies/delete.go
+++ b/cmd/policies/delete.go
@@ -26,7 +26,7 @@ Usage: warden policy delete <name> [flags]
   WARNING: This is a destructive operation and cannot be undone!
 
   By default, this command will ask for confirmation before deleting.
-  Use the -f/--force flag to skip the confirmation prompt.
+  Use the -f/-force flag to skip the confirmation prompt.
 
   Examples:
 
@@ -62,7 +62,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return helpers.DryRun(c, "DELETE", "sys/policies/{name}", nil)
 	}
 
-	// Confirmation prompt (unless --force is used)
+	// Confirmation prompt (unless -force is used)
 	if !deleteForce {
 		fmt.Printf("Are you sure you want to delete policy '%s'? (yes/no): ", name)
 

--- a/cmd/providers/disable.go
+++ b/cmd/providers/disable.go
@@ -19,12 +19,12 @@ var (
 Usage: warden provider disable [PATH]
 
   Disables a provider at the given PATH. The PATH may be supplied either
-  positionally or via --path (pick one — combining both is rejected).
+  positionally or via -path (pick one — combining both is rejected).
 
   Disable the provider enabled at aws/:
 
       $ warden provider disable aws/
-      $ warden provider disable --path=aws/
+      $ warden provider disable -path=aws/
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runDisable,

--- a/cmd/providers/enable.go
+++ b/cmd/providers/enable.go
@@ -10,40 +10,38 @@ import (
 )
 
 var (
-	enableType        string
 	enableDescription string
 	enablePath        string
 	enableJSON        string
 
 	EnableCmd = &cobra.Command{
-		Use:           "enable [PATH]",
+		Use:           "enable TYPE",
+		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Short:         "This command enable a provider.",
+		Short:         "This command enables a provider.",
 		Long: `
-Usage: warden provider enable [options] [PATH]
+Usage: warden provider enable [options] TYPE
 
-  Enable a provider. By default the mount path matches the TYPE, but a
-  custom path can be supplied either positionally or via --path. Two input
-  modes:
+  Enable a provider. TYPE is the provider to enable (e.g. aws, azure, gcp).
+  By default the mount path matches TYPE; pass -path to mount at a custom
+  location. Two input modes:
 
     Typed flags (human-friendly):
 
-      $ warden provider enable --type=aws
-      $ warden provider enable --type=azure azure-prod
-      $ warden provider enable --type=azure --path=azure-prod
-      $ warden provider enable --type=aws --description="Production AWS"
+      $ warden provider enable aws
+      $ warden provider enable -path=azure-prod azure
+      $ warden provider enable -description="Production AWS" aws
 
     Full JSON payload (agent-friendly):
 
-      $ warden provider enable aws --json @provider-aws.json
-      $ cat provider-aws.json | warden provider enable aws --json -
+      $ warden provider enable aws -json @provider-aws.json
+      $ cat provider-aws.json | warden provider enable aws -json -
 
-  --json is mutually exclusive with --type / --description. The mount path
-  may be provided positionally or via --path (pick one — combining both is
-  rejected). When neither is set, the path is derived from --type or from
-  the JSON payload's "type" field. Combine with --dry-run to validate the
-  payload locally without enabling the provider.
+  -json is mutually exclusive with -description. The mount path defaults to
+  TYPE; override it with -path. If the JSON payload includes a "type" field,
+  it must match TYPE. Combine with -dry-run to validate the payload locally
+  without enabling the provider.
 
   For a full list of providers and examples, please see the documentation.
 `,
@@ -52,17 +50,13 @@ Usage: warden provider enable [options] [PATH]
 )
 
 func init() {
-	EnableCmd.Flags().StringVar(&enableType, "type", "", "Type of the provider (e.g., aws, azure, gcp) (required unless --json)")
 	EnableCmd.Flags().StringVar(&enableDescription, "description", "", "Human-friendly description of the provider")
-	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Mount path (alternative to the positional PATH argument)")
-	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with --type/--description)")
+	EnableCmd.Flags().StringVar(&enablePath, "path", "", "Custom mount path (default: TYPE)")
+	EnableCmd.Flags().StringVarP(&enableJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -description)")
 }
 
 func runEnable(cmd *cobra.Command, args []string) error {
-	explicitPath, err := helpers.ResolvePath(args, enablePath)
-	if err != nil {
-		return err
-	}
+	enableType := strings.TrimSuffix(args[0], "/")
 
 	c, err := helpers.Client()
 	if err != nil {
@@ -74,19 +68,27 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	path := enablePath
+	if path == "" {
+		path = enableType
+	}
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--type":        enableType != "",
-			"--description": enableDescription != "",
+			"-description": enableDescription != "",
 		}); err != nil {
 			return err
 		}
-		path := helpers.MountPathFromArgOrPayload(explicitPath, jsonPayload)
-		if path == "" {
-			return fmt.Errorf("--json without a PATH (positional or --path) and without a 'type' field in the payload: cannot determine mount path: %w", helpers.ErrUsage)
-		}
-		if err := helpers.ValidatePath(path); err != nil {
-			return err
+		if payloadType, ok := jsonPayload["type"].(string); ok && payloadType != "" && payloadType != enableType {
+			return fmt.Errorf(
+				"TYPE positional %q disagrees with -json payload \"type\":%q: %w",
+				enableType, payloadType, helpers.ErrUsage)
 		}
 		if helpers.ResolveDryRun() {
 			return helpers.DryRun(c, "POST", "sys/providers/{path}", jsonPayload)
@@ -109,25 +111,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	if enableType == "" {
-		return fmt.Errorf("--type is required (or use --json): %w", helpers.ErrUsage)
-	}
-
-	var path string
-	if explicitPath != "" {
-		path = explicitPath
-	} else {
-		path = enableType + "/"
-	}
-	if !strings.HasSuffix(path, "/") {
-		path = path + "/"
-	}
-
-	if err := helpers.ValidatePath(path); err != nil {
-		return err
-	}
-
-	// Build mount input
 	mountInput := &api.MountInput{
 		Type:        enableType,
 		Description: enableDescription,
@@ -141,7 +124,6 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		return helpers.DryRun(c, "POST", "sys/providers/{path}", payload)
 	}
 
-	// Mount the provider
 	err = c.Sys().Mount(path, mountInput)
 	if err != nil {
 		return fmt.Errorf("error enabling provider: %w", err)
@@ -151,4 +133,3 @@ func runEnable(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Success! Enabled %s provider at: %s\n", enableType, path)
 	})
 }
-

--- a/cmd/providers/providers.go
+++ b/cmd/providers/providers.go
@@ -19,7 +19,7 @@ Usage: warden provider <subcommand> [options]
 
   Enable a new provider:
 
-      $ warden provider enable --type=aws
+      $ warden provider enable aws
 
   Please see the individual subcommand help for detailed usage information.
 `,

--- a/cmd/providers/read.go
+++ b/cmd/providers/read.go
@@ -20,13 +20,13 @@ var (
 Usage: warden provider read [PATH]
 
   Show information on a provider enabled on the provided PATH. The PATH
-  may be supplied either positionally or via --path (pick one — combining
+  may be supplied either positionally or via -path (pick one — combining
   both is rejected).
 
   Read the provider enabled at aws/:
 
       $ warden provider read aws/
-      $ warden provider read --path=aws/
+      $ warden provider read -path=aws/
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runRead,

--- a/cmd/roles/list.go
+++ b/cmd/roles/list.go
@@ -25,13 +25,13 @@ Usage: warden role list
   certificate the request was made with — Warden never needs the role names
   to be distributed out-of-band.
 
-  Output honors the global --output flag:
+  Output honors the global -output flag:
     table    one row per role (default for TTY)
     json     [{"name", "description", "auth_path"}, ...]
     ndjson   one role per line, agent-friendly for piping into jq
     text     key=value lines per role
 
-  Composes with --fields, e.g. --fields name,auth_path to project to just
+  Composes with -fields, e.g. -fields name,auth_path to project to just
   those two fields per record.
 
   Mounts that fail introspection are reported as warnings on stderr; the
@@ -50,7 +50,7 @@ Usage: warden role list
 
     Filter to a specific auth mount:
 
-      $ warden role list --auth-path auth/jwt/
+      $ warden role list -auth-path auth/jwt/
 
     Pipe just the names into jq:
 

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -35,7 +35,7 @@ Usage: warden schema PATH        # describe a single path
   By default, "warden schema PATH" returns a friendly shape:
     { path, methods, description, parameters, response_schema, auth_required }
 
-  Pass --raw to emit the underlying OpenAPI fragment instead. This is
+  Pass -raw to emit the underlying OpenAPI fragment instead. This is
   useful for consumers that already speak OpenAPI (Stainless, openapi-typescript,
   oapi-codegen, etc.).
 
@@ -51,9 +51,9 @@ Usage: warden schema PATH        # describe a single path
 
     Get the raw OpenAPI fragment for tooling consumption:
 
-      $ warden schema sys/auth --raw
+      $ warden schema sys/auth -raw
 
-  The endpoint is namespace-scoped: --namespace (or WARDEN_NAMESPACE)
+  The endpoint is namespace-scoped: -namespace (or WARDEN_NAMESPACE)
   controls which mounts are visible, so a tenant cannot enumerate other
   tenants' backends. Authentication is required (set WARDEN_TOKEN, an mTLS
   client cert, or pass an Authorization: Bearer JWT).
@@ -114,7 +114,7 @@ func runSingle(path string) error {
 			"path":    key,
 			"openapi": item,
 		}, func() {
-			// In table mode --raw still prints valid JSON so the output
+			// In table mode -raw still prints valid JSON so the output
 			// stays useful for tools like Stainless / openapi-typescript
 			// that consume schema fragments via shell pipes.
 			b, err := json.MarshalIndent(map[string]any{key: item}, "", "  ")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -119,13 +119,13 @@ Usage: warden server [options]
 
   Start a server with a single configuration file:
 
-      $ warden server --config=/etc/warden/config.hcl
+      $ warden server -config=/etc/warden/config.hcl
 
   Or merge multiple HCL files from a directory (lexical order, later files
   override earlier ones — useful for splitting a ConfigMap and a Secret in
   Kubernetes):
 
-      $ warden server --config-dir=/etc/warden/conf.d
+      $ warden server -config-dir=/etc/warden/conf.d
 
   Config files may reference environment variables via {{ env "VAR_NAME" }}.
 
@@ -223,39 +223,39 @@ func init() {
 func run(cmd *cobra.Command, args []string) error {
 	// Validate flag combinations
 	if flagDevRootToken != "" && !flagDev {
-		return fmt.Errorf("--dev-root-token can only be used with --dev")
+		return fmt.Errorf("-dev-root-token can only be used with -dev")
 	}
 	if flagDev && configPath != "" {
-		return fmt.Errorf("--config cannot be used with --dev (dev mode always uses inmem storage)")
+		return fmt.Errorf("-config cannot be used with -dev (dev mode always uses inmem storage)")
 	}
 	if flagDev && configDir != "" {
-		return fmt.Errorf("--config-dir cannot be used with --dev (dev mode always uses inmem storage)")
+		return fmt.Errorf("-config-dir cannot be used with -dev (dev mode always uses inmem storage)")
 	}
 	if configPath != "" && configDir != "" {
-		return fmt.Errorf("--config and --config-dir are mutually exclusive")
+		return fmt.Errorf("-config and -config-dir are mutually exclusive")
 	}
 
-	// Infer --dev-tls from explicit cert file flags
+	// Infer -dev-tls from explicit cert file flags
 	if flagDevTLSCertFile != "" || flagDevTLSKeyFile != "" || flagDevTLSCACertFile != "" {
 		flagDevTLS = true
 	}
 
-	// Validate dev-tls flags require --dev
+	// Validate dev-tls flags require -dev
 	if flagDevTLS && !flagDev {
-		return fmt.Errorf("--dev-tls can only be used with --dev")
+		return fmt.Errorf("-dev-tls can only be used with -dev")
 	}
 	if flagDevTLSRequireClientCert && !flagDev {
-		return fmt.Errorf("--dev-tls-require-client-cert can only be used with --dev")
+		return fmt.Errorf("-dev-tls-require-client-cert can only be used with -dev")
 	}
 
 	// Validate cert and key must be provided together
 	if (flagDevTLSCertFile != "") != (flagDevTLSKeyFile != "") {
-		return fmt.Errorf("--dev-tls-cert-file and --dev-tls-key-file must be provided together")
+		return fmt.Errorf("-dev-tls-cert-file and -dev-tls-key-file must be provided together")
 	}
 
 	// Validate require-client-cert needs a CA cert
 	if flagDevTLSRequireClientCert && flagDevTLSCACertFile == "" {
-		return fmt.Errorf("--dev-tls-require-client-cert requires --dev-tls-ca-cert-file")
+		return fmt.Errorf("-dev-tls-require-client-cert requires -dev-tls-ca-cert-file")
 	}
 
 	// Load configuration: dev mode builds defaults, otherwise requires config file or dir
@@ -279,7 +279,7 @@ func run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 	default:
-		return fmt.Errorf("a config file path or config dir is required. Use -c/--config or --config-dir")
+		return fmt.Errorf("a config file path or config dir is required. Use -c/-config or -config-dir")
 	}
 
 	// Configure TLS for dev mode

--- a/cmd/skills/create.go
+++ b/cmd/skills/create.go
@@ -34,18 +34,18 @@ Usage: warden skill create [NAME] [options]
 
     Typed flags (human-friendly):
 
-      $ warden skill create --name=my-runbook --category=custom \
-          --description="ops on-call" --body-file=./runbook.md
+      $ warden skill create -name=my-runbook -category=custom \
+          -description="ops on-call" -body-file=./runbook.md
 
     Full JSON payload (agent-friendly):
 
-      $ warden skill create my-runbook --json @skill.json
-      $ cat skill.json | warden skill create my-runbook --json -
+      $ warden skill create my-runbook -json @skill.json
+      $ cat skill.json | warden skill create my-runbook -json -
 
-  --json is mutually exclusive with --name / --description / --category
-  / --requires / --upstream / --provider / --body-file. The skill name
+  -json is mutually exclusive with -name / -description / -category
+  / -requires / -upstream / -provider / -body-file. The skill name
   is taken from the positional argument when given, otherwise from
-  --name or the payload's "name" field.
+  -name or the payload's "name" field.
 
   Required fields (typed or via payload): name, description, category,
   body. provider-guide skills also require a "provider" field.
@@ -56,9 +56,9 @@ Usage: warden skill create [NAME] [options]
 
 func init() {
 	CreateCmd.Flags().StringVar(&createName, "name", "",
-		"Skill name (unique slug, [a-z0-9_-]{2,64}); required unless --json supplies one")
+		"Skill name (unique slug, [a-z0-9_-]{2,64}); required unless -json supplies one")
 	CreateCmd.Flags().StringVar(&createDescription, "description", "",
-		"Human-readable one-line summary; required unless --json")
+		"Human-readable one-line summary; required unless -json")
 	CreateCmd.Flags().StringVar(&createCategory, "category", "",
 		"agent-flow | shared | provider-guide | troubleshooting | custom")
 	CreateCmd.Flags().StringSliceVar(&createRequires, "requires", nil,
@@ -86,19 +86,19 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--name":        createName != "",
-			"--description": createDescription != "",
-			"--category":    createCategory != "",
-			"--requires":    len(createRequires) > 0,
-			"--upstream":    createUpstream != "",
-			"--provider":    createProvider != "",
-			"--body-file":   createBodyFile != "",
+			"-name":        createName != "",
+			"-description": createDescription != "",
+			"-category":    createCategory != "",
+			"-requires":    len(createRequires) > 0,
+			"-upstream":    createUpstream != "",
+			"-provider":    createProvider != "",
+			"-body-file":   createBodyFile != "",
 		}); err != nil {
 			return err
 		}
 		name := skillNameFromArgOrPayload(args, jsonPayload)
 		if name == "" {
-			return fmt.Errorf("--json without a positional NAME and without a 'name' field in the payload: cannot determine skill name: %w", helpers.ErrUsage)
+			return fmt.Errorf("-json without a positional NAME and without a 'name' field in the payload: cannot determine skill name: %w", helpers.ErrUsage)
 		}
 		if helpers.ResolveDryRun() {
 			return helpers.DryRun(c, "POST", "sys/skills/{name}", jsonPayload)
@@ -127,20 +127,20 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		name = args[0]
 	}
 	if name == "" {
-		return fmt.Errorf("either a positional NAME, --name, or --json is required: %w", helpers.ErrUsage)
+		return fmt.Errorf("either a positional NAME, -name, or -json is required: %w", helpers.ErrUsage)
 	}
 	if createDescription == "" {
-		return fmt.Errorf("--description is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-description is required (or use -json): %w", helpers.ErrUsage)
 	}
 	if createCategory == "" {
-		return fmt.Errorf("--category is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-category is required (or use -json): %w", helpers.ErrUsage)
 	}
 	if createBodyFile == "" {
-		return fmt.Errorf("--body-file is required (or use --json): %w", helpers.ErrUsage)
+		return fmt.Errorf("-body-file is required (or use -json): %w", helpers.ErrUsage)
 	}
 	bodyBytes, err := os.ReadFile(createBodyFile)
 	if err != nil {
-		return fmt.Errorf("--body-file %s: %w", createBodyFile, err)
+		return fmt.Errorf("-body-file %s: %w", createBodyFile, err)
 	}
 
 	payload := map[string]any{
@@ -181,9 +181,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	})
 }
 
-// skillNameFromArgOrPayload mirrors helpers.MountPathFromArgOrPayload but
-// reads the payload's "name" field instead of "type", and does not
-// suffix with a trailing slash (skills are name-keyed, not path-keyed).
+// skillNameFromArgOrPayload returns the positional argument if present, else
+// the payload's "name" field. Skills are name-keyed, not path-keyed, so no
+// trailing slash is appended.
 func skillNameFromArgOrPayload(args []string, payload map[string]any) string {
 	if len(args) > 0 && args[0] != "" {
 		return args[0]

--- a/cmd/skills/delete.go
+++ b/cmd/skills/delete.go
@@ -30,9 +30,9 @@ Usage: warden skill delete NAME [options]
 
   Mutations require a root namespace token; sub-namespace tokens get 403.
 
-  On a TTY without --force the command prompts for confirmation. In
+  On a TTY without -force the command prompts for confirmation. In
   scripts or pipes (stdin not a TTY), confirmation is skipped because
-  there is no one to answer the prompt — use --force in scripts to
+  there is no one to answer the prompt — use -force in scripts to
   make the intent explicit.
 
   Examples:
@@ -43,7 +43,7 @@ Usage: warden skill delete NAME [options]
 
     Scripted delete:
 
-      $ warden skill delete my-runbook --force
+      $ warden skill delete my-runbook -force
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runDelete,

--- a/cmd/skills/list.go
+++ b/cmd/skills/list.go
@@ -25,13 +25,13 @@ Usage: warden skill list [options]
   records (no markdown body) to keep the response cheap; agents that need
   full content fetch each name via 'warden skill read NAME'.
 
-  Output honors the global --output flag:
+  Output honors the global -output flag:
     table    one row per skill (default for TTY)
     json     [{"name", "description", "category", "origin", ...}, ...]
     ndjson   one skill per line, agent-friendly for piping into jq
     text     key=value lines per record
 
-  Composes with --fields, e.g. --fields name,category to project per record.
+  Composes with -fields, e.g. -fields name,category to project per record.
 
   Examples:
 
@@ -41,11 +41,11 @@ Usage: warden skill list [options]
 
     Only provider-guide skills, JSON for agents:
 
-      $ warden skill list --category=provider-guide -o json
+      $ warden skill list -category=provider-guide -o json
 
     Only operator-created skills:
 
-      $ warden skill list --origin=user
+      $ warden skill list -origin=user
 `,
 		Args: cobra.NoArgs,
 		RunE: runList,

--- a/cmd/skills/read.go
+++ b/cmd/skills/read.go
@@ -20,12 +20,12 @@ var (
 Usage: warden skill read NAME [options]
 
   Read a single skill by name. The response includes the full markdown
-  body so agents can act on the recipe directly. Use --raw to emit
+  body so agents can act on the recipe directly. Use -raw to emit
   just the markdown (no JSON wrapper) — convenient for piping into a
   pager or rendering with another tool.
 
-  Output honors the global --output flag (table, json, ndjson, text).
-  --raw overrides --output and always emits plain markdown to stdout.
+  Output honors the global -output flag (table, json, ndjson, text).
+  -raw overrides -output and always emits plain markdown to stdout.
 
   Examples:
 
@@ -35,7 +35,7 @@ Usage: warden skill read NAME [options]
 
     Get the raw markdown to pipe into a renderer:
 
-      $ warden skill read aws --raw | glow -
+      $ warden skill read aws -raw | glow -
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runRead,
@@ -44,7 +44,7 @@ Usage: warden skill read NAME [options]
 
 func init() {
 	ReadCmd.Flags().BoolVar(&readRaw, "raw", false,
-		"Emit only the markdown body, bypassing --output and the JSON envelope")
+		"Emit only the markdown body, bypassing -output and the JSON envelope")
 }
 
 func runRead(cmd *cobra.Command, args []string) error {

--- a/cmd/skills/skills.go
+++ b/cmd/skills/skills.go
@@ -23,12 +23,12 @@ Usage: warden skill <subcommand> [options]
 
   Read one skill's full markdown body:
 
-      $ warden skill read aws --raw
+      $ warden skill read aws -raw
 
   Create a custom skill (root namespace only):
 
-      $ warden skill create --name=my-runbook --category=custom \
-          --description="ops on-call" --body-file=./runbook.md
+      $ warden skill create -name=my-runbook -category=custom \
+          -description="ops on-call" -body-file=./runbook.md
 
   Please see the individual subcommand help for detailed usage information.
 `,

--- a/cmd/skills/update.go
+++ b/cmd/skills/update.go
@@ -35,22 +35,22 @@ Usage: warden skill update NAME [options]
 
     Typed flags (human-friendly):
 
-      $ warden skill update aws --description="our local override"
+      $ warden skill update aws -description="our local override"
 
     Full JSON payload (agent-friendly):
 
-      $ warden skill update aws --json @patch.json
-      $ cat patch.json | warden skill update aws --json -
+      $ warden skill update aws -json @patch.json
+      $ cat patch.json | warden skill update aws -json -
 
-  --json is mutually exclusive with the typed --description / --category
-  / --requires / --upstream / --provider / --body-file flags.
+  -json is mutually exclusive with the typed -description / -category
+  / -requires / -upstream / -provider / -body-file flags.
 
-  To update the body, point --body-file at a markdown file on disk;
+  To update the body, point -body-file at a markdown file on disk;
   the file's content is sent as the new body verbatim.
 
   Empty values are treated as "don't change" — to clear an optional
-  field (e.g. requires, upstream) use --json with the explicit empty
-  value, e.g. --json '{"requires":[]}'.
+  field (e.g. requires, upstream) use -json with the explicit empty
+  value, e.g. -json '{"requires":[]}'.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runUpdate,
@@ -89,12 +89,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	var payload map[string]any
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"--description": updateDescription != "",
-			"--category":    updateCategory != "",
-			"--requires":    len(updateRequires) > 0,
-			"--upstream":    updateUpstream != "",
-			"--provider":    updateProvider != "",
-			"--body-file":   updateBodyFile != "",
+			"-description": updateDescription != "",
+			"-category":    updateCategory != "",
+			"-requires":    len(updateRequires) > 0,
+			"-upstream":    updateUpstream != "",
+			"-provider":    updateProvider != "",
+			"-body-file":   updateBodyFile != "",
 		}); err != nil {
 			return err
 		}
@@ -120,12 +120,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		if updateBodyFile != "" {
 			bodyBytes, err := os.ReadFile(updateBodyFile)
 			if err != nil {
-				return fmt.Errorf("--body-file %s: %w", updateBodyFile, err)
+				return fmt.Errorf("-body-file %s: %w", updateBodyFile, err)
 			}
 			payload["body"] = string(bodyBytes)
 		}
 		if len(payload) == 0 {
-			return fmt.Errorf("no fields to update: pass at least one flag or use --json: %w", helpers.ErrUsage)
+			return fmt.Errorf("no fields to update: pass at least one flag or use -json: %w", helpers.ErrUsage)
 		}
 	}
 

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -26,7 +26,7 @@ Examples:
 
   $ warden status
   $ warden status -o json
-  $ warden status -o json --fields sealed,is_leader,leader_address
+  $ warden status -o json -fields sealed,is_leader,leader_address
 `,
 	RunE: runStatus,
 }

--- a/cmd/warden.go
+++ b/cmd/warden.go
@@ -36,10 +36,10 @@ safe operations, and complete visibility.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := helpers.ValidateHeaderValue("--namespace", flagNamespace); err != nil {
+			if err := helpers.ValidateHeaderValue("-namespace", flagNamespace); err != nil {
 				return err
 			}
-			if err := helpers.ValidateHeaderValue("--role", flagRole); err != nil {
+			if err := helpers.ValidateHeaderValue("-role", flagRole); err != nil {
 				return err
 			}
 			if flagNamespace != "" {

--- a/docs/agent-flow.md
+++ b/docs/agent-flow.md
@@ -38,7 +38,7 @@ from the environment and never sees an upstream API key.
 
 The runtime injects **one sentence** into the agent's system prompt:
 
-> *"To learn how to operate on Warden, run `warden skill read discovery --raw`. Use `warden skill list -F name,description` to browse the catalog of available skills."*
+> *"To learn how to operate on Warden, run `warden skill read discovery -raw`. Use `warden skill list -F name,description` to browse the catalog of available skills."*
 
 Everything else — the discovery loop, the env-var conventions, the
 provider recipes — the agent learns by reading skills at runtime. No
@@ -140,7 +140,7 @@ When ambiguous (multi-tenant, regional, prod-vs-staging):
 ### Step 5 — Read the provider skill, call the provider
 
 ```bash
-warden skill read <type> --raw
+warden skill read <type> -raw
 ```
 
 Hits `GET /v1/sys/skills/<type>`. Returns the agent-facing recipe in
@@ -170,7 +170,7 @@ User asks: *"Show me the keys in the staging-events S3 bucket."*
 2. **`warden role list -o json -F name,description`** — finds `data-reader` ("Read-only access to data warehouses").
 3. **`warden provider list -o json -F type,description,mount_url`** — finds an `aws` provider ("Production AWS account 1234", `mount_url=/v1/team-data/aws/`) plus an unrelated `openai`.
 4. **Match** — `data-reader` + `aws/` fit the task. No ambiguity.
-5. **`warden skill read aws --raw`** — gets the recipe:
+5. **`warden skill read aws -raw`** — gets the recipe:
 
    ```bash
    export AWS_ACCESS_KEY_ID="<role-name>"
@@ -325,7 +325,7 @@ for the duration of the proxied request.
 
 ## 10. Where to go next
 
-- The seeded skills themselves — `warden skill list`, `warden skill read <name> --raw` — are the authoritative agent-facing source. This doc is the system view of the same contract.
+- The seeded skills themselves — `warden skill list`, `warden skill read <name> -raw` — are the authoritative agent-facing source. This doc is the system view of the same contract.
 - For a worked tutorial that wires Goose into Warden against three upstreams in parallel, see [tutorials/vault-policy-hygiene/](tutorials/vault-policy-hygiene/).
 - For the proxy/gateway internals (how Warden re-signs SigV4, validates JWTs against the OIDC issuer, etc.), see [architecture.md](architecture.md).
 - For the per-provider catalog (what each type supports and how it's configured), see [providers.md](providers.md).

--- a/docs/tutorials/aws-access-hygiene/.forgejo/workflows/access-audit.yaml
+++ b/docs/tutorials/aws-access-hygiene/.forgejo/workflows/access-audit.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "--- providers in the namespace (account-id and region are in descriptions) ---"
           warden provider list -o json -F type,description,mount_url | jq .
           echo "--- aws skill (head) ---"
-          warden skill read aws --raw | head -30
+          warden skill read aws -raw | head -30
 
       - name: Run Goose access-hygiene audit
         env:

--- a/docs/tutorials/aws-access-hygiene/README.md
+++ b/docs/tutorials/aws-access-hygiene/README.md
@@ -78,7 +78,7 @@ the workflow, inspect Security Hub and Slack. Production is a URL swap.
   ```bash
   aws securityhub enable-security-hub
   aws accessanalyzer create-analyzer \
-      --analyzer-name tutorial-analyzer --type ACCOUNT
+      --analyzer-name tutorial-analyzer -type ACCOUNT
   ```
   Access Analyzer findings for the seeded external-trust target may
   take a few minutes to appear after `seed-aws.sh` runs. The
@@ -89,7 +89,7 @@ the workflow, inspect Security Hub and Slack. Production is a URL swap.
   endpoint (`https://api.deepseek.com/anthropic`). To switch to
   Anthropic-proper, change `anthropic_url` in `warden-init.sh` §5e.
   **The key goes into Warden's credential store, not into any CI
-  variable.** You paste it once during §5 (`--anthropic-key=...`)
+  variable.** You paste it once during §5 (`-anthropic-key=...`)
   and never again.
 - (Optional, for Slack delivery) A Slack workspace, a [bot user OAuth token](https://api.slack.com/authentication/token-types#bot)
   (`xoxb-...`) with the `canvases:write`, `channels:read`, and
@@ -163,7 +163,7 @@ volumes:
 #!/bin/sh
 set -eu
 
-FORGEJO="forgejo --config /data/gitea/conf/app.ini"
+FORGEJO="forgejo -config /data/gitea/conf/app.ini"
 
 if $FORGEJO admin user list 2>/dev/null | awk '{print $2}' | grep -qx siteowner; then
   exit 0
@@ -205,7 +205,7 @@ Then:
      --no-interactive \
      --instance http://forgejo.local:3000 \
      --token <REGISTRATION_TOKEN> \
-     --name local-runner \
+     -name local-runner \
      --labels "docker:docker://node:20-bookworm-slim"
    ```
    Create a runner config so spawned job containers can resolve
@@ -236,7 +236,7 @@ Then:
 In a new shell:
 
 ```bash
-warden server --dev --dev-root-token=dev-warden-root
+warden server -dev -dev-root-token=dev-warden-root
 ```
 
 Dev mode persists everything to an ephemeral in-memory store. The
@@ -336,14 +336,14 @@ With Warden running (§4) and `aws-out/creds.env` populated:
 
 ```bash
 chmod +x warden-init.sh
-./warden-init.sh --anthropic-key=sk-...                               # AWS + Anthropic only
-./warden-init.sh --anthropic-key=sk-... \
-                 --slack-token=xoxb-... \
-                 --slack-channel-id=C0XXXXXXX \
-                 --slack-channel-name='#access-audits'                # + Slack
+./warden-init.sh -anthropic-key=sk-...                               # AWS + Anthropic only
+./warden-init.sh -anthropic-key=sk-... \
+                 -slack-token=xoxb-... \
+                 -slack-channel-id=C0XXXXXXX \
+                 -slack-channel-name='#access-audits'                # + Slack
 ```
 
-`--anthropic-key` is required — it's the LLM key Goose uses to drive
+`-anthropic-key` is required — it's the LLM key Goose uses to drive
 the audit, held by Warden and proxied at runtime; it never enters
 the agent's environment. If you use Anthropic directly rather than
 DeepSeek, change `anthropic_url` in `warden-init.sh` §5e.
@@ -380,11 +380,11 @@ What it provisions, in order:
    resigns the request, and forwards. Each call therefore lands at
    AWS as a *narrow, temporary, lens-specific* identity:
    ```bash
-   warden cred spec create iam-reader-spec --source demo-aws-source \
-       --config mint_method=sts_assume_role \
-       --config role_arn="$WARDEN_AWS_ROLE_IAM_READER_ARN" \
-       --config session_name=warden-iam-reader \
-       --config ttl=1h
+   warden cred spec create iam-reader-spec -source demo-aws-source \
+       -config mint_method=sts_assume_role \
+       -config role_arn="$WARDEN_AWS_ROLE_IAM_READER_ARN" \
+       -config session_name=warden-iam-reader \
+       -config ttl=1h
    # ...repeated for cloudtrail-reader-spec, access-analyzer-reader-spec,
    # policy-simulator-spec, securityhub-writer-spec.
    ```
@@ -426,15 +426,15 @@ What it provisions, in order:
    path "aws/gateway/*" { capabilities = ["read", "create", "list"] }
    ```
    Per-lens least-privilege is enforced *at AWS*, not by this policy.
-10. **Anthropic provider** for Goose's LLM leg — `--type=anthropic`
+10. **Anthropic provider** for Goose's LLM leg — `-type=anthropic`
     against an Anthropic-compatible endpoint (DeepSeek by default).
-    One source (the key passed via `--anthropic-key`), one spec, and
+    One source (the key passed via `-anthropic-key`), one spec, and
     an `anthropic-ops` role marked *Internal — used by Goose runtime,
     not chosen by agents.* The workflow exports
     `ANTHROPIC_HOST=$WARDEN_ADDR/v1/tutorial-aws/anthropic/role/anthropic-ops/gateway`
     before starting Goose so the LLM round-trip flows through Warden
     too.
-11. **Slack provider** (only when `--slack-token` is given) plus its
+11. **Slack provider** (only when `-slack-token` is given) plus its
     source, spec, the active `hygiene-poster` role (channel embedded
     in the description), and a `slack-hygiene-poster` policy granting
     `create` on the Slack Web API methods the agent will call. A
@@ -476,9 +476,9 @@ for arn in "$WARDEN_AWS_ROLE_IAM_READER_ARN" \
   AWS_ACCESS_KEY_ID="$WARDEN_AWS_BROKER_ACCESS_KEY_ID" \
   AWS_SECRET_ACCESS_KEY="$WARDEN_AWS_BROKER_SECRET_ACCESS_KEY" \
   aws sts assume-role \
-    --role-arn "$arn" \
-    --role-session-name "smoke-$(basename "$arn")" \
-    --query 'AssumedRoleUser.Arn' --output text
+    -role-arn "$arn" \
+    -role-session-name "smoke-$(basename "$arn")" \
+    --query 'AssumedRoleUser.Arn' -output text
 done
 ```
 
@@ -649,8 +649,8 @@ The agent's loop, per `docs/agent-flow.md`:
 
 1. **Read the bootstrap skills.**
    ```bash
-   warden skill read foundation --raw   # the runtime contract: env vars, exit codes, list/raw flags
-   warden skill read discovery  --raw   # the 5-step loop itself
+   warden skill read foundation -raw   # the runtime contract: env vars, exit codes, list/raw flags
+   warden skill read discovery  -raw   # the 5-step loop itself
    ```
    These are seeded into every Warden cluster; the agent fetches
    them on first run.
@@ -684,8 +684,8 @@ The agent's loop, per `docs/agent-flow.md`:
 
 4. **Fetch the provider skill for each provider it will use.**
    ```bash
-   warden skill read aws --raw    # SigV4 env-var contract, gateway URL pattern, quirks
-   warden skill read slack --raw  # Slack Web API call shape
+   warden skill read aws -raw    # SigV4 env-var contract, gateway URL pattern, quirks
+   warden skill read slack -raw  # Slack Web API call shape
    ```
    The aws skill tells the agent that the role name goes in
    `AWS_ACCESS_KEY_ID`, the JWT goes in `AWS_SECRET_ACCESS_KEY` and
@@ -1015,7 +1015,7 @@ docker compose down -v          # stop containers + drop named volumes (forgejo-
 rm -rf aws-out runner-config    # local artefacts: broker keys + runner registration
 ```
 
-Stop Warden (`Ctrl-C` in its shell — `--dev` mode is in-memory, so
+Stop Warden (`Ctrl-C` in its shell — `-dev` mode is in-memory, so
 nothing to clean up on disk besides the audit log), and optionally
 remove the host mapping:
 
@@ -1040,7 +1040,7 @@ aws accessanalyzer delete-analyzer --analyzer-name tutorial-analyzer
 ```
 
 To rerun from a clean slate, just `docker compose up -d forgejo &&
-docker compose up forgejo-init && ./aws-init.sh && warden-init.sh --anthropic-key=...`
+docker compose up forgejo-init && ./aws-init.sh && warden-init.sh -anthropic-key=...`
 again — every script in the tutorial is idempotent.
 
 ## 13. What's next

--- a/docs/tutorials/aws-access-hygiene/access-hygiene.yaml
+++ b/docs/tutorials/aws-access-hygiene/access-hygiene.yaml
@@ -5,8 +5,8 @@ description: "Audit IAM principals in the connected AWS account through four rea
 instructions: |
   You operate on Warden. To learn how, run
 
-      warden skill read foundation --raw
-      warden skill read discovery  --raw
+      warden skill read foundation -raw
+      warden skill read discovery  -raw
 
   Browse the full catalog with `warden skill list -F name,description`.
 
@@ -101,7 +101,7 @@ prompt: |
        descriptions. Do not assume role names — extract them from
        discovery output.
 
-    2. Read the `aws` provider skill (`warden skill read aws --raw`)
+    2. Read the `aws` provider skill (`warden skill read aws -raw`)
        and the slack provider skill if present. Follow the call-shape
        contracts they define — do not invent endpoints or
        authentication mechanisms.

--- a/docs/tutorials/aws-access-hygiene/forgejo-init.sh
+++ b/docs/tutorials/aws-access-hygiene/forgejo-init.sh
@@ -3,7 +3,7 @@
 # Creates the 'siteowner' admin if it doesn't already exist.
 set -eu
 
-FORGEJO="forgejo --config /data/gitea/conf/app.ini"
+FORGEJO="forgejo -config /data/gitea/conf/app.ini"
 
 if $FORGEJO admin user list 2>/dev/null | awk '{print $2}' | grep -qx siteowner; then
   echo "forgejo-init: 'siteowner' already exists"

--- a/docs/tutorials/aws-access-hygiene/warden-init.sh
+++ b/docs/tutorials/aws-access-hygiene/warden-init.sh
@@ -14,7 +14,7 @@
 #      Warden role, each targeting a distinct narrowly-scoped IAM role).
 #      The 3 AWS decoy roles deliberately have no credential spec, so
 #      invoking one fails at credential minting.
-#   5. Slack provider (optional, --slack-token=...) + 1 source + 1 spec
+#   5. Slack provider (optional, -slack-token=...) + 1 source + 1 spec
 #      for the canvas-posting role; 1 decoy without a spec.
 #   6. Per-role access policies. The AWS policy is uniform across all
 #      five active AWS roles: read/create/list on path "aws/gateway" and
@@ -27,18 +27,18 @@
 #   - aws-out/creds.env populated by aws-init.sh.
 #
 # Usage:
-#   ./warden-init.sh --anthropic-key=sk-...
-#   ./warden-init.sh --anthropic-key=sk-... \
-#                    --slack-token=xoxb-... \
-#                    --slack-channel-id=C0XXXXXXX \
-#                    --slack-channel-name='#access-audits' \
-#                    --repo=siteowner/aws-access-hygiene
+#   ./warden-init.sh -anthropic-key=sk-...
+#   ./warden-init.sh -anthropic-key=sk-... \
+#                    -slack-token=xoxb-... \
+#                    -slack-channel-id=C0XXXXXXX \
+#                    -slack-channel-name='#access-audits' \
+#                    -repo=siteowner/aws-access-hygiene
 #
-# --anthropic-key is required (the LLM key Warden hands to Goose at
+# -anthropic-key is required (the LLM key Warden hands to Goose at
 # runtime; it never enters the agent's environment). It can also be
 # passed via the ANTHROPIC_API_KEY env var.
 #
-# --slack-token is optional; without it the Slack provider/role/spec
+# -slack-token is optional; without it the Slack provider/role/spec
 # are skipped (the agent will fail the canvas post but Goose's audit
 # still produces Security Hub findings).
 set -euo pipefail
@@ -51,23 +51,23 @@ REPO="siteowner/aws-access-hygiene"
 
 for arg in "$@"; do
   case $arg in
-    --anthropic-key=*)       ANTHROPIC_KEY="${arg#--anthropic-key=}" ;;
-    --slack-token=*)         SLACK_TOKEN="${arg#--slack-token=}" ;;
-    --slack-channel-id=*)    SLACK_CHANNEL_ID="${arg#--slack-channel-id=}" ;;
-    --slack-channel-name=*)  SLACK_CHANNEL_NAME="${arg#--slack-channel-name=}" ;;
-    --repo=*)                REPO="${arg#--repo=}" ;;
+    --anthropic-key=*|-anthropic-key=*)           ANTHROPIC_KEY="${arg#*=}" ;;
+    --slack-token=*|-slack-token=*)               SLACK_TOKEN="${arg#*=}" ;;
+    --slack-channel-id=*|-slack-channel-id=*)     SLACK_CHANNEL_ID="${arg#*=}" ;;
+    --slack-channel-name=*|-slack-channel-name=*) SLACK_CHANNEL_NAME="${arg#*=}" ;;
+    --repo=*|-repo=*)                             REPO="${arg#*=}" ;;
     *) echo "unknown arg: $arg" >&2; exit 1 ;;
   esac
 done
 
 if [ -z "$ANTHROPIC_KEY" ]; then
-  echo "ERROR: pass --anthropic-key=sk-... or set ANTHROPIC_API_KEY" >&2
+  echo "ERROR: pass -anthropic-key=sk-... or set ANTHROPIC_API_KEY" >&2
   echo "       (this is the LLM key Warden hands to Goose at runtime; never enters the agent env)" >&2
   exit 1
 fi
 
 if [ -n "$SLACK_TOKEN" ] && { [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$SLACK_CHANNEL_NAME" ]; }; then
-  echo "ERROR: --slack-token requires --slack-channel-id=C... and --slack-channel-name=#..." >&2
+  echo "ERROR: -slack-token requires -slack-channel-id=C... and -slack-channel-name=#..." >&2
   exit 1
 fi
 
@@ -86,7 +86,7 @@ command -v "$WARDEN" >/dev/null 2>&1 || { [ -x ./warden ] && WARDEN=./warden; } 
 # until we enable one. §10 of the README tails this file to verify
 # per-call role attribution; without this step the file never exists.
 if ! "$WARDEN" audit list 2>/dev/null | grep -q "^audit-default/"; then
-  "$WARDEN" audit enable --type=file --file-path=./warden-audit.log audit-default
+  "$WARDEN" audit enable -file-path=./warden-audit.log -path=audit-default file
 fi
 
 BOUND_CLAIMS_FULL=$(printf '{"repository":"%s","ref":"refs/heads/main","ref_type":"branch"}' "$REPO")
@@ -97,11 +97,11 @@ BOUND_CLAIMS_REPO=$(printf '{"repository":"%s"}' "$REPO")
 # The discovery loop hits /v1/sys/* as a bare JWT (no Warden session,
 # no role segment in the URL). auto_auth_path tells Warden which auth
 # mount to resolve those calls against.
-$WARDEN namespace create tutorial-aws --metadata=auto_auth_path=auth/jwt/ 2>/dev/null || true
+$WARDEN namespace create tutorial-aws -metadata=auto_auth_path=auth/jwt/ 2>/dev/null || true
 export WARDEN_NAMESPACE=tutorial-aws
 
 # 5b. JWT auth pointed at Forgejo's Actions OIDC.
-$WARDEN auth enable --type=jwt 2>/dev/null || true
+$WARDEN auth enable jwt 2>/dev/null || true
 $WARDEN write auth/jwt/config \
     jwks_url=http://forgejo.local:3000/api/actions/.well-known/keys \
     bound_issuer=http://forgejo.local:3000/api/actions \
@@ -136,9 +136,9 @@ $WARDEN write auth/jwt/role/discovery-baseline \
 # vault provider where it's optional metadata. proxy_domains is not set
 # here: it is only consulted by the S3 processors for virtual-hosted
 # bucket URL rewriting, and this tutorial uses no S3 calls.
-$WARDEN provider enable --type=aws \
-    --description="AWS gateway proxied via the warden-aws-tutorial-broker IAM user — five lenses across IAM, CloudTrail, Access Analyzer, IAM Policy Simulator, and Security Hub. Each role's description names the AWS account its assumed IAM role lives in." \
-    aws 2>/dev/null || true
+$WARDEN provider enable \
+    -description="AWS gateway proxied via the warden-aws-tutorial-broker IAM user — five lenses across IAM, CloudTrail, Access Analyzer, IAM Policy Simulator, and Security Hub. Each role's description names the AWS account its assumed IAM role lives in." \
+    -path=aws aws 2>/dev/null || true
 $WARDEN write aws/config \
     auto_auth_path=auth/jwt/
 
@@ -148,43 +148,43 @@ for spec in iam-reader-spec cloudtrail-reader-spec access-analyzer-reader-spec p
 done
 $WARDEN cred source delete -f demo-aws-source 2>/dev/null || true
 
-$WARDEN cred source create demo-aws-source --type=aws \
-    --rotation-period=0 \
-    --config=access_key_id="$WARDEN_AWS_BROKER_ACCESS_KEY_ID" \
-    --config=secret_access_key="$WARDEN_AWS_BROKER_SECRET_ACCESS_KEY" \
-    --config=region="$WARDEN_AWS_REGION"
+$WARDEN cred source create demo-aws-source -type=aws \
+    -rotation-period=0 \
+    -config=access_key_id="$WARDEN_AWS_BROKER_ACCESS_KEY_ID" \
+    -config=secret_access_key="$WARDEN_AWS_BROKER_SECRET_ACCESS_KEY" \
+    -config=region="$WARDEN_AWS_REGION"
 
 # Five specs, one per active Warden role. The source is shared; the
 # differentiator is the target IAM role ARN each spec assumes.
-$WARDEN cred spec create iam-reader-spec --source demo-aws-source \
-    --config mint_method=sts_assume_role \
-    --config role_arn="$WARDEN_AWS_ROLE_IAM_READER_ARN" \
-    --config session_name=warden-iam-reader \
-    --config ttl=1h
+$WARDEN cred spec create iam-reader-spec -source demo-aws-source \
+    -config mint_method=sts_assume_role \
+    -config role_arn="$WARDEN_AWS_ROLE_IAM_READER_ARN" \
+    -config session_name=warden-iam-reader \
+    -config ttl=1h
 
-$WARDEN cred spec create cloudtrail-reader-spec --source demo-aws-source \
-    --config mint_method=sts_assume_role \
-    --config role_arn="$WARDEN_AWS_ROLE_CLOUDTRAIL_READER_ARN" \
-    --config session_name=warden-cloudtrail-reader \
-    --config ttl=1h
+$WARDEN cred spec create cloudtrail-reader-spec -source demo-aws-source \
+    -config mint_method=sts_assume_role \
+    -config role_arn="$WARDEN_AWS_ROLE_CLOUDTRAIL_READER_ARN" \
+    -config session_name=warden-cloudtrail-reader \
+    -config ttl=1h
 
-$WARDEN cred spec create access-analyzer-reader-spec --source demo-aws-source \
-    --config mint_method=sts_assume_role \
-    --config role_arn="$WARDEN_AWS_ROLE_ACCESS_ANALYZER_ARN" \
-    --config session_name=warden-access-analyzer \
-    --config ttl=1h
+$WARDEN cred spec create access-analyzer-reader-spec -source demo-aws-source \
+    -config mint_method=sts_assume_role \
+    -config role_arn="$WARDEN_AWS_ROLE_ACCESS_ANALYZER_ARN" \
+    -config session_name=warden-access-analyzer \
+    -config ttl=1h
 
-$WARDEN cred spec create policy-simulator-spec --source demo-aws-source \
-    --config mint_method=sts_assume_role \
-    --config role_arn="$WARDEN_AWS_ROLE_POLICY_SIMULATOR_ARN" \
-    --config session_name=warden-policy-simulator \
-    --config ttl=1h
+$WARDEN cred spec create policy-simulator-spec -source demo-aws-source \
+    -config mint_method=sts_assume_role \
+    -config role_arn="$WARDEN_AWS_ROLE_POLICY_SIMULATOR_ARN" \
+    -config session_name=warden-policy-simulator \
+    -config ttl=1h
 
-$WARDEN cred spec create securityhub-writer-spec --source demo-aws-source \
-    --config mint_method=sts_assume_role \
-    --config role_arn="$WARDEN_AWS_ROLE_SECURITYHUB_WRITER_ARN" \
-    --config session_name=warden-securityhub-writer \
-    --config ttl=1h
+$WARDEN cred spec create securityhub-writer-spec -source demo-aws-source \
+    -config mint_method=sts_assume_role \
+    -config role_arn="$WARDEN_AWS_ROLE_SECURITYHUB_WRITER_ARN" \
+    -config session_name=warden-securityhub-writer \
+    -config ttl=1h
 
 # Five active Warden roles — each pointing at one spec. Descriptions
 # carry what the agent needs to pick the right role per lens: what data
@@ -265,9 +265,9 @@ $WARDEN policy write aws-gateway-access /tmp/aws-tut-aws-gateway-access.hcl
 # not part of the agent's discovery loop — it's wired in for the
 # Goose runtime itself. The role is marked "Internal" so an agent
 # does not pick it for a task.
-$WARDEN provider enable --type=anthropic \
-    --description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
-    anthropic 2>/dev/null || true
+$WARDEN provider enable \
+    -description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
+    -path=anthropic anthropic 2>/dev/null || true
 $WARDEN write anthropic/config \
     anthropic_url=https://api.deepseek.com/anthropic \
     auto_auth_path=auth/jwt/ \
@@ -275,15 +275,15 @@ $WARDEN write anthropic/config \
 
 $WARDEN cred spec delete -f anthropic-ops 2>/dev/null || true
 $WARDEN cred source delete -f anthropic-src 2>/dev/null || true
-$WARDEN cred source create anthropic-src --type=apikey \
-    --rotation-period=0 \
-    --config=api_url=https://api.deepseek.com \
-    --config=verify_endpoint=/v1/models \
-    --config=auth_header_type=custom_header \
-    --config=auth_header_name=x-api-key \
-    --config=extra_headers=anthropic-version:2023-06-01
-$WARDEN cred spec create anthropic-ops --source anthropic-src \
-    --config api_key="$ANTHROPIC_KEY"
+$WARDEN cred source create anthropic-src -type=apikey \
+    -rotation-period=0 \
+    -config=api_url=https://api.deepseek.com \
+    -config=verify_endpoint=/v1/models \
+    -config=auth_header_type=custom_header \
+    -config=auth_header_name=x-api-key \
+    -config=extra_headers=anthropic-version:2023-06-01
+$WARDEN cred spec create anthropic-ops -source anthropic-src \
+    -config api_key="$ANTHROPIC_KEY"
 
 $WARDEN write auth/jwt/role/anthropic-ops \
     description="LLM inference for the access-hygiene auditor agent. Used internally by Goose — agents do not call this role directly." \
@@ -299,20 +299,20 @@ $WARDEN policy write anthropic-ops /tmp/aws-tut-anthropic-ops.hcl
 
 # 5f. Slack provider (optional).
 if [ -n "$SLACK_TOKEN" ]; then
-  $WARDEN provider enable --type=slack \
-      --description="Slack workspace for access-audit canvas reports — channel embedded in the hygiene-poster role description" \
-      slack 2>/dev/null || true
+  $WARDEN provider enable \
+      -description="Slack workspace for access-audit canvas reports — channel embedded in the hygiene-poster role description" \
+      -path=slack slack 2>/dev/null || true
   $WARDEN write slack/config slack_url=https://slack.com/api auto_auth_path=auth/jwt/
 
   $WARDEN cred spec delete -f hygiene-poster-spec 2>/dev/null || true
   $WARDEN cred source delete -f demo-slack-source 2>/dev/null || true
-  $WARDEN cred source create demo-slack-source --type=apikey \
-      --rotation-period=0 \
-      --config=api_url=https://slack.com/api \
-      --config=verify_endpoint=/auth.test \
-      --config=verify_method=POST
-  $WARDEN cred spec create hygiene-poster-spec --source demo-slack-source \
-      --config api_key="$SLACK_TOKEN"
+  $WARDEN cred source create demo-slack-source -type=apikey \
+      -rotation-period=0 \
+      -config=api_url=https://slack.com/api \
+      -config=verify_endpoint=/auth.test \
+      -config=verify_method=POST
+  $WARDEN cred spec create hygiene-poster-spec -source demo-slack-source \
+      -config api_key="$SLACK_TOKEN"
 
   $WARDEN write auth/jwt/role/hygiene-poster \
       description="Post hygiene canvases to ${SLACK_CHANNEL_NAME} (${SLACK_CHANNEL_ID}) via the Slack provider at /v1/tutorial-aws/slack/. Canvas create/update + one-line notify. Not for alerts or incident dispatch." \
@@ -340,5 +340,5 @@ EOF
 
   echo "warden-init: section 5 complete (namespace=tutorial-aws, Slack delivery enabled)"
 else
-  echo "warden-init: section 5 complete (namespace=tutorial-aws, Slack delivery skipped — no --slack-token given)"
+  echo "warden-init: section 5 complete (namespace=tutorial-aws, Slack delivery skipped — no -slack-token given)"
 fi

--- a/docs/tutorials/vault-policy-hygiene/.forgejo/workflows/hygiene.yaml
+++ b/docs/tutorials/vault-policy-hygiene/.forgejo/workflows/hygiene.yaml
@@ -93,7 +93,7 @@ jobs:
           echo "--- providers in the namespace ---"
           warden provider list -o json -F type,description,mount_url | jq .
           echo "--- discovery skill (head) ---"
-          warden skill read discovery --raw | head -20
+          warden skill read discovery -raw | head -20
 
       - name: Run Goose hygiene audit
         env:

--- a/docs/tutorials/vault-policy-hygiene/README.md
+++ b/docs/tutorials/vault-policy-hygiene/README.md
@@ -231,7 +231,7 @@ EOF
 #!/bin/sh
 set -eu
 
-FORGEJO="forgejo --config /data/gitea/conf/app.ini"
+FORGEJO="forgejo -config /data/gitea/conf/app.ini"
 
 if $FORGEJO admin user list 2>/dev/null | awk '{print $2}' | grep -qx siteowner; then
   exit 0
@@ -276,7 +276,7 @@ Then:
      --no-interactive \
      --instance http://forgejo.local:3000 \
      --token <REGISTRATION_TOKEN> \
-     --name local-runner \
+     -name local-runner \
      --labels "docker:docker://node:20-bookworm-slim"
    ```
    Create a runner config so spawned job containers can resolve
@@ -344,7 +344,7 @@ finding the hygiene agent should surface.
 In a new shell:
 
 ```bash
-warden server --dev --dev-root-token=dev-warden-root
+warden server -dev -dev-root-token=dev-warden-root
 ```
 
 The dev listener is hard-coded to `127.0.0.1:8400`.
@@ -372,10 +372,10 @@ curl -sf "$JWKS_URI" | jq '.keys | length'   # should print >= 1
 
 ### Audit log
 
-The `warden server --dev` instance ships with zero audit devices — the
+The `warden server -dev` instance ships with zero audit devices — the
 broker fail-opens at zero, so the cluster runs unaudited until one is
 enabled. The §5 wiring script (`warden-init.sh`) calls
-`warden audit enable --type=file --file-path=./warden-audit.log audit-default`
+`warden audit enable -file-path=./warden-audit.log -path=audit-default file`
 as its first step, which writes the log to `warden-audit.log` in the
 directory you launched `warden server` from. Section 9 tails it to
 confirm every agent request flows through Warden with attributable
@@ -393,14 +393,14 @@ lives, in the admin shell with `WARDEN_ADDR` and `WARDEN_TOKEN` exported:
 
 ```bash
 ./warden-init.sh \
-    --anthropic-key=sk-... \
-    [--slack-token=xoxb-...] \
-    [--slack-channel-id=C0123456789 --slack-channel-name='#sec-hygiene']
+    -anthropic-key=sk-... \
+    [-slack-token=xoxb-...] \
+    [-slack-channel-id=C0123456789 -slack-channel-name='#sec-hygiene']
 ```
 
-`--slack-token` is optional; without it, the Slack provider/role/policy
-are skipped. When passed, both `--slack-channel-id` and
-`--slack-channel-name` are required: they're embedded into the
+`-slack-token` is optional; without it, the Slack provider/role/policy
+are skipped. When passed, both `-slack-channel-id` and
+`-slack-channel-name` are required: they're embedded into the
 `slack-ops` role's `description` so the agent extracts the channel from
 discovery rather than an env var.
 
@@ -410,7 +410,7 @@ adapt it. Skim to understand, run the script to apply.
 ### 5a. Create the tutorial namespace
 
 ```bash
-warden namespace create tutorial --metadata=auto_auth_path=auth/jwt/
+warden namespace create tutorial -metadata=auto_auth_path=auth/jwt/
 ```
 
 The discovery flow relies on two namespace-scoped mechanisms:
@@ -441,7 +441,7 @@ OIDC endpoints (the ones discovered in section 3, step 5 —
 `/api/actions/...`, not the user-login OIDC).
 
 ```bash
-warden auth enable --type=jwt
+warden auth enable jwt
 warden write auth/jwt/config \
     jwks_url=http://forgejo.local:3000/api/actions/.well-known/keys \
     bound_issuer=http://forgejo.local:3000/api/actions \
@@ -496,12 +496,12 @@ cred spec mints OpenBao tokens via the `policy-reader` token role;
 `rotation_period=24h` rotates the AppRole's `secret_id` automatically.
 
 ```bash
-warden provider enable --type=vault \
-    --description="Internal OpenBao cluster — ACL policies, mounts, identity (read-mostly)" \
-    --path=vault
+warden provider enable vault \
+    -description="Internal OpenBao cluster — ACL policies, mounts, identity (read-mostly)" \
+    -path=vault
 ```
 
-The mount path can be supplied either positionally or via `--path` —
+The mount path can be supplied either positionally or via `-path` —
 both forms work and Vault-style single-dash long flags (`-path=vault`)
 are accepted too.
 
@@ -528,9 +528,9 @@ endpoint) by default — change `anthropic_url` in `warden-init.sh` to
 `https://api.anthropic.com` if you want Claude itself.
 
 ```bash
-warden provider enable --type=anthropic \
-    --description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
-    anthropic
+warden provider enable \
+    -description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
+    -path=anthropic anthropic
 ```
 
 Note the description: it tells any agent that reads it that this leg is
@@ -544,7 +544,7 @@ else.
 
 ### 5f. Slack provider + slack-ops role (optional)
 
-If you passed `--slack-token=xoxb-...`, a third egress leg is wired up.
+If you passed `-slack-token=xoxb-...`, a third egress leg is wired up.
 The bot token lives only in Warden — agents send `$WARDEN_JWT` and
 Warden swaps it for `Authorization: Bearer xoxb-...` at the gateway.
 
@@ -557,13 +557,13 @@ warden write auth/jwt/role/slack-ops \
 ```
 
 The channel ID and name are embedded in the description by
-`warden-init.sh` from the `--slack-channel-id` and `--slack-channel-name`
+`warden-init.sh` from the `-slack-channel-id` and `-slack-channel-name`
 flags. The agent extracts both from the role description — there is no
 `SLACK_CHANNEL` env var on the runtime side.
 
 The recipe and call shape (canvas check/delete/create, chat
 notification) are documented in the `slack` provider skill, which the
-agent fetches via `warden skill read slack --raw`.
+agent fetches via `warden skill read slack -raw`.
 
 ### 5g. Decoy roles — prove the agent matches by description
 
@@ -592,7 +592,7 @@ capabilities the recipe needs, nothing more.** A wildcard like
 the recipe is meant to flag.
 
 The policies that `warden-init.sh` writes (the third, `slack-ops`, is
-only written when `--slack-token` is passed):
+only written when `-slack-token` is passed):
 
 ```hcl
 # vault-readonly — attached to the policy-scanner JWT role only
@@ -704,8 +704,8 @@ the agent has both available for cross-checks.
 ### Step 4 — `warden skill read <type>` for each chosen provider
 
 ```bash
-warden skill read vault --raw
-warden skill read slack --raw
+warden skill read vault -raw
+warden skill read slack -raw
 ```
 
 Hits `GET /v1/sys/skills/<name>`. Returns the per-provider recipe in
@@ -944,7 +944,7 @@ docker compose down -v          # stop containers + drop named volumes (forgejo-
 rm -rf bao-out runner-config    # local artefacts: AppRole creds + runner registration
 ```
 
-Stop Warden (`Ctrl-C` in its shell — `--dev` mode is in-memory, so
+Stop Warden (`Ctrl-C` in its shell — `-dev` mode is in-memory, so
 nothing to clean up on disk besides the audit log), and optionally
 remove the host mapping:
 

--- a/docs/tutorials/vault-policy-hygiene/forgejo-init.sh
+++ b/docs/tutorials/vault-policy-hygiene/forgejo-init.sh
@@ -3,7 +3,7 @@
 # Creates the 'siteowner' admin if it doesn't already exist.
 set -eu
 
-FORGEJO="forgejo --config /data/gitea/conf/app.ini"
+FORGEJO="forgejo -config /data/gitea/conf/app.ini"
 
 if $FORGEJO admin user list 2>/dev/null | awk '{print $2}' | grep -qx siteowner; then
   echo "forgejo-init: 'siteowner' already exists"

--- a/docs/tutorials/vault-policy-hygiene/policy-hygiene.yaml
+++ b/docs/tutorials/vault-policy-hygiene/policy-hygiene.yaml
@@ -5,8 +5,8 @@ description: "Audit every ACL policy on an OpenBao cluster via Warden for dead-m
 instructions: |
   You operate on Warden. To learn how, run
 
-      warden skill read foundation --raw
-      warden skill read discovery  --raw
+      warden skill read foundation -raw
+      warden skill read discovery  -raw
 
   Browse the full catalog with `warden skill list -F name,description`.
 

--- a/docs/tutorials/vault-policy-hygiene/warden-init.sh
+++ b/docs/tutorials/vault-policy-hygiene/warden-init.sh
@@ -24,19 +24,19 @@
 # Requires:
 #   - WARDEN_ADDR + WARDEN_TOKEN exported (admin shell setup from section 4)
 #   - bao-out/creds.env populated by bao-init.sh (ROLE_ID + SECRET_ID)
-#   - Anthropic API key passed via --anthropic-key=sk-... or $ANTHROPIC_API_KEY
+#   - Anthropic API key passed via -anthropic-key=sk-... or $ANTHROPIC_API_KEY
 #
 # Usage:
-#   ./warden-init.sh --anthropic-key=sk-ant-... \
-#                    [--slack-token=xoxb-...] \
-#                    [--slack-channel-id=C0123456789] \
-#                    [--slack-channel-name='#sec-hygiene']
+#   ./warden-init.sh -anthropic-key=sk-ant-... \
+#                    [-slack-token=xoxb-...] \
+#                    [-slack-channel-id=C0123456789] \
+#                    [-slack-channel-name='#sec-hygiene']
 #
-# --slack-token is optional; without it, the Slack provider/role/policy
+# -slack-token is optional; without it, the Slack provider/role/policy
 # are skipped (the agent will fail the Slack upload, but Goose's hygiene
 # work and Forgejo's actions/upload-artifact still produce the report).
-# --slack-channel-id and --slack-channel-name are required when
-# --slack-token is given; they end up in the slack-ops role's description
+# -slack-channel-id and -slack-channel-name are required when
+# -slack-token is given; they end up in the slack-ops role's description
 # so the agent extracts the channel from discovery, not from env vars.
 set -euo pipefail
 
@@ -46,21 +46,21 @@ SLACK_CHANNEL_ID="${SLACK_CHANNEL_ID:-}"
 SLACK_CHANNEL_NAME="${SLACK_CHANNEL_NAME:-}"
 for arg in "$@"; do
   case $arg in
-    --anthropic-key=*)       ANTHROPIC_KEY="${arg#--anthropic-key=}" ;;
-    --slack-token=*)         SLACK_TOKEN="${arg#--slack-token=}" ;;
-    --slack-channel-id=*)    SLACK_CHANNEL_ID="${arg#--slack-channel-id=}" ;;
-    --slack-channel-name=*)  SLACK_CHANNEL_NAME="${arg#--slack-channel-name=}" ;;
+    --anthropic-key=*|-anthropic-key=*)           ANTHROPIC_KEY="${arg#*=}" ;;
+    --slack-token=*|-slack-token=*)               SLACK_TOKEN="${arg#*=}" ;;
+    --slack-channel-id=*|-slack-channel-id=*)     SLACK_CHANNEL_ID="${arg#*=}" ;;
+    --slack-channel-name=*|-slack-channel-name=*) SLACK_CHANNEL_NAME="${arg#*=}" ;;
     *) echo "unknown arg: $arg" >&2; exit 1 ;;
   esac
 done
 
 if [ -z "$ANTHROPIC_KEY" ]; then
-  echo "ERROR: pass --anthropic-key=sk-... or set ANTHROPIC_API_KEY" >&2
+  echo "ERROR: pass -anthropic-key=sk-... or set ANTHROPIC_API_KEY" >&2
   exit 1
 fi
 
 if [ -n "$SLACK_TOKEN" ] && { [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$SLACK_CHANNEL_NAME" ]; }; then
-  echo "ERROR: --slack-token requires --slack-channel-id=C... and --slack-channel-name=#..." >&2
+  echo "ERROR: -slack-token requires -slack-channel-id=C... and -slack-channel-name=#..." >&2
   exit 1
 fi
 
@@ -81,7 +81,7 @@ command -v "$WARDEN" >/dev/null 2>&1 || { [ -x ./warden ] && WARDEN=./warden; } 
 # README tails this file to verify identity-attribution; without this
 # step the file never exists.
 if ! "$WARDEN" audit list 2>/dev/null | grep -q "^audit-default/"; then
-  "$WARDEN" audit enable --type=file --file-path=./warden-audit.log audit-default
+  "$WARDEN" audit enable -file-path=./warden-audit.log -path=audit-default file
 fi
 
 # 5a. Create the shared tutorial namespace.
@@ -93,7 +93,7 @@ fi
 # which auth mount to use for implicit authentication on those calls;
 # without it, every sys/* call returns 401. Idempotent — future
 # tutorials reuse this namespace rather than each creating their own.
-$WARDEN namespace create tutorial --metadata=auto_auth_path=auth/jwt/ 2>/dev/null || true
+$WARDEN namespace create tutorial -metadata=auto_auth_path=auth/jwt/ 2>/dev/null || true
 export WARDEN_NAMESPACE=tutorial
 
 # 5b. JWT auth pointed at Forgejo's Actions OIDC.
@@ -101,7 +101,7 @@ export WARDEN_NAMESPACE=tutorial
 # default_role=discovery-baseline is the fallback when the URL has no
 # role segment (i.e. /v1/sys/* calls). It carries just enough policy
 # for the agent to run the discovery loop.
-$WARDEN auth enable --type=jwt 2>/dev/null || true
+$WARDEN auth enable jwt 2>/dev/null || true
 $WARDEN write auth/jwt/config \
     jwks_url=http://forgejo.local:3000/api/actions/.well-known/keys \
     bound_issuer=http://forgejo.local:3000/api/actions \
@@ -139,9 +139,9 @@ $WARDEN write auth/jwt/role/discovery-baseline \
     token_policies=discovery-baseline
 
 # 5d. Vault provider → OpenBao (AppRole login via the bao-init creds).
-$WARDEN provider enable --type=vault \
-    --description="Internal OpenBao cluster — ACL policies, mounts, identity (read-mostly)" \
-    vault 2>/dev/null || true
+$WARDEN provider enable \
+    -description="Internal OpenBao cluster — ACL policies, mounts, identity (read-mostly)" \
+    -path=vault vault 2>/dev/null || true
 $WARDEN write vault/config \
     vault_address=http://127.0.0.1:8200 \
     auto_auth_path=auth/jwt/
@@ -149,18 +149,18 @@ $WARDEN write vault/config \
 # Order matters: delete spec before source (spec depends on source).
 $WARDEN cred spec delete -f policy-scanner 2>/dev/null || true
 $WARDEN cred source delete -f openbao-root 2>/dev/null || true
-$WARDEN cred source create openbao-root --type=hvault \
-    --rotation-period=24h \
-    --config=vault_address=http://127.0.0.1:8200 \
-    --config=auth_method=approle \
-    --config=approle_mount=approle/ \
-    --config=role_name=warden-policy-scanner \
-    --config=role_id="$ROLE_ID" \
-    --config=secret_id="$SECRET_ID"
-$WARDEN cred spec create policy-scanner --source openbao-root \
-    --config mint_method=vault_token \
-    --config token_role=policy-reader \
-    --config ttl=1h
+$WARDEN cred source create openbao-root -type=hvault \
+    -rotation-period=24h \
+    -config=vault_address=http://127.0.0.1:8200 \
+    -config=auth_method=approle \
+    -config=approle_mount=approle/ \
+    -config=role_name=warden-policy-scanner \
+    -config=role_id="$ROLE_ID" \
+    -config=secret_id="$SECRET_ID"
+$WARDEN cred spec create policy-scanner -source openbao-root \
+    -config mint_method=vault_token \
+    -config token_role=policy-reader \
+    -config ttl=1h
 
 # policy-scanner role — dense description embedding the upstream mount.
 # The agent reads this verbatim from `warden role list` and pairs it
@@ -177,9 +177,9 @@ $WARDEN write auth/jwt/role/policy-scanner \
 # (configured via ANTHROPIC_HOST + ANTHROPIC_API_KEY in the workflow).
 # The agent does not "discover" this leg — the runtime wires it
 # in before the agent starts. See docs/agent-flow.md §1.
-$WARDEN provider enable --type=anthropic \
-    --description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
-    anthropic 2>/dev/null || true
+$WARDEN provider enable \
+    -description="Anthropic-compatible LLM endpoint (default: DeepSeek). Internal — used by Goose runtime, not chosen by agents." \
+    -path=anthropic anthropic 2>/dev/null || true
 $WARDEN write anthropic/config \
     anthropic_url=https://api.deepseek.com/anthropic \
     auto_auth_path=auth/jwt/ \
@@ -187,15 +187,15 @@ $WARDEN write anthropic/config \
 
 $WARDEN cred spec delete -f anthropic-ops 2>/dev/null || true
 $WARDEN cred source delete -f anthropic-src 2>/dev/null || true
-$WARDEN cred source create anthropic-src --type=apikey \
-    --rotation-period=0 \
-    --config=api_url=https://api.deepseek.com \
-    --config=verify_endpoint=/v1/models \
-    --config=auth_header_type=custom_header \
-    --config=auth_header_name=x-api-key \
-    --config=extra_headers=anthropic-version:2023-06-01
-$WARDEN cred spec create anthropic-ops --source anthropic-src \
-    --config api_key="$ANTHROPIC_KEY"
+$WARDEN cred source create anthropic-src -type=apikey \
+    -rotation-period=0 \
+    -config=api_url=https://api.deepseek.com \
+    -config=verify_endpoint=/v1/models \
+    -config=auth_header_type=custom_header \
+    -config=auth_header_name=x-api-key \
+    -config=extra_headers=anthropic-version:2023-06-01
+$WARDEN cred spec create anthropic-ops -source anthropic-src \
+    -config api_key="$ANTHROPIC_KEY"
 
 $WARDEN write auth/jwt/role/anthropic-ops \
     description="LLM inference for the hygiene auditor agent. Used internally by Goose — agents do not call this role directly." \
@@ -234,22 +234,22 @@ path "anthropic/role/anthropic-ops/gateway/v1/models"   { capabilities = ["read"
 EOF
 $WARDEN policy write anthropic-ops /tmp/anthropic-ops.hcl
 
-# 5h. Slack provider → slack.com/api (optional — skip if no --slack-token).
+# 5h. Slack provider → slack.com/api (optional — skip if no -slack-token).
 if [ -n "$SLACK_TOKEN" ]; then
-  $WARDEN provider enable --type=slack \
-      --description="Slack workspace for security-team notifications and canvas reports" \
-      slack 2>/dev/null || true
+  $WARDEN provider enable \
+      -description="Slack workspace for security-team notifications and canvas reports" \
+      -path=slack slack 2>/dev/null || true
   $WARDEN write slack/config slack_url=https://slack.com/api auto_auth_path=auth/jwt/
 
   $WARDEN cred spec delete -f slack-ops 2>/dev/null || true
   $WARDEN cred source delete -f slack-src 2>/dev/null || true
-  $WARDEN cred source create slack-src --type=apikey \
-      --rotation-period=0 \
-      --config=api_url=https://slack.com/api \
-      --config=verify_endpoint=/auth.test \
-      --config=verify_method=POST
-  $WARDEN cred spec create slack-ops --source slack-src \
-      --config api_key="$SLACK_TOKEN"
+  $WARDEN cred source create slack-src -type=apikey \
+      -rotation-period=0 \
+      -config=api_url=https://slack.com/api \
+      -config=verify_endpoint=/auth.test \
+      -config=verify_method=POST
+  $WARDEN cred spec create slack-ops -source slack-src \
+      -config api_key="$SLACK_TOKEN"
 
   # slack-ops role description embeds the destination channel (name + id)
   # so the agent extracts them from discovery rather than from env vars.
@@ -287,5 +287,5 @@ EOF
 
   echo "warden-init: section 5 complete (namespace=tutorial, Slack delivery enabled)"
 else
-  echo "warden-init: section 5 complete (namespace=tutorial, Slack delivery skipped — no --slack-token given)"
+  echo "warden-init: section 5 complete (namespace=tutorial, Slack delivery skipped — no -slack-token given)"
 fi

--- a/e2e/audit/json_payload_test.go
+++ b/e2e/audit/json_payload_test.go
@@ -9,8 +9,8 @@ import (
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
 
-// TestJSON_AuditEnableDryRun exercises `warden audit enable --json` with
-// --dry-run. We dry-run instead of really enabling because:
+// TestJSON_AuditEnableDryRun exercises `warden audit enable -json` with
+// -dry-run. We dry-run instead of really enabling because:
 //
 //   - audit-enable opens a file handle on the configured path and the
 //     node's filesystem won't necessarily allow that under the e2e
@@ -23,7 +23,8 @@ func TestJSON_AuditEnableDryRun(t *testing.T) {
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "audit", "enable", "e2e-json-audit",
+	}, "audit", "enable", "file",
+		"-path", "e2e-json-audit",
 		"--json", `{"type":"file","description":"e2e --json audit","config":{"file_path":"/tmp/e2e-json-audit.log","format":"json"}}`,
 		"--dry-run",
 		"-o", "json")

--- a/e2e/auth/json_payload_test.go
+++ b/e2e/auth/json_payload_test.go
@@ -9,10 +9,9 @@ import (
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
 
-// TestJSON_AuthEnableWithJSON covers `warden auth enable --json` end-to-end.
-// Mounts a JWT auth method at a unique path with a payload-derived path
-// (no positional argument), then verifies via the API that the mount
-// landed.
+// TestJSON_AuthEnableWithJSON covers `warden auth enable -json` end-to-end.
+// Mounts a JWT auth method at a custom path (via -path) with a JSON payload,
+// then verifies via the API that the mount landed.
 func TestJSON_AuthEnableWithJSON(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
@@ -24,8 +23,9 @@ func TestJSON_AuthEnableWithJSON(t *testing.T) {
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "auth", "enable", path,
-		"--json", `{"type":"jwt","description":"e2e --json auth enable"}`,
+	}, "auth", "enable", "jwt",
+		"-path", path,
+		"-json", `{"type":"jwt","description":"e2e -json auth enable"}`,
 		"-o", "json")
 	if err != nil {
 		t.Fatalf("auth enable --json failed: %v\nOutput:\n%s", err, out)
@@ -50,10 +50,9 @@ func TestJSON_AuthEnableWithJSON(t *testing.T) {
 	}
 }
 
-// TestJSON_AuthEnableWithPathFlag verifies that -path works as an
-// alternative to the positional PATH argument. Uses Vault-style single-dash
-// long flags so this test also exercises the flag-normalization layer
-// against the newly-added -path flag.
+// TestJSON_AuthEnableWithPathFlag verifies that -path overrides the default
+// mount path (which defaults to TYPE). Uses Vault-style single-dash long
+// flags throughout to exercise the flag-normalization layer.
 func TestJSON_AuthEnableWithPathFlag(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
@@ -66,9 +65,9 @@ func TestJSON_AuthEnableWithPathFlag(t *testing.T) {
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
 	}, "auth", "enable",
-		"-type", "jwt",
 		"-path", path,
-		"-o", "json")
+		"-o", "json",
+		"jwt")
 	if err != nil {
 		t.Fatalf("auth enable -path failed: %v\nOutput:\n%s", err, out)
 	}
@@ -85,39 +84,41 @@ func TestJSON_AuthEnableWithPathFlag(t *testing.T) {
 	}
 }
 
-// TestJSON_AuthEnableRejectsPathAndPositionalConflict pins the conflict
-// rule: supplying both -path and a positional PATH must fail with a
-// usage error (not silently prefer one).
-func TestJSON_AuthEnableRejectsPathAndPositionalConflict(t *testing.T) {
+// TestJSON_AuthEnableRejectsPayloadTypeMismatch pins the conflict rule:
+// when the JSON payload's "type" field disagrees with the TYPE positional,
+// the CLI must fail with a usage error.
+func TestJSON_AuthEnableRejectsPayloadTypeMismatch(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "auth", "enable", "positional-path",
-		"-type", "jwt",
-		"-path", "flag-path",
+	}, "auth", "enable", "jwt",
+		"-json", `{"type":"oidc"}`,
 		"-o", "json")
 	if err == nil {
-		t.Fatalf("expected non-zero exit for -path + positional PATH; got success.\nOutput:\n%s", out)
+		t.Fatalf("expected non-zero exit for TYPE/payload mismatch; got success.\nOutput:\n%s", out)
 	}
 }
 
-// TestJSON_AuthEnableDerivesPathFromPayloadType verifies the no-positional-arg
-// path-resolution: when the agent omits the positional PATH, the mount
-// path is derived from payload["type"] (e.g. "jwt" → "jwt/").
-func TestJSON_AuthEnableDerivesPathFromPayloadType(t *testing.T) {
+// TestJSON_AuthEnableDryRunWithMatchingType pins the happy path: TYPE
+// positional + a -json payload whose "type" field matches, plus -dry-run.
+// Dry-run is needed because "jwt" is already mounted by setup.sh; the test
+// confirms the CLI plumbing (cobra arg parsing, type-mismatch check, schema
+// fetch, payload validation) all wire together without actually mounting.
+// The dry-run envelope reports the path TEMPLATE (sys/auth/{path}) rather
+// than the resolved mount path, so we verify the template — a regression
+// in the template would surface here.
+func TestJSON_AuthEnableDryRunWithMatchingType(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
-	// "jwt" is already mounted by setup.sh, so we use a custom path that
-	// matches the type. Using --dry-run avoids the conflict.
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "auth", "enable",
-		"--json", `{"type":"jwt"}`,
-		"--dry-run",
+	}, "auth", "enable", "jwt",
+		"-json", `{"type":"jwt"}`,
+		"-dry-run",
 		"-o", "json")
 	if err != nil {
-		t.Fatalf("auth enable --json --dry-run failed: %v\nOutput:\n%s", err, out)
+		t.Fatalf("auth enable -json -dry-run failed: %v\nOutput:\n%s", err, out)
 	}
 
 	var resp map[string]any
@@ -126,5 +127,8 @@ func TestJSON_AuthEnableDerivesPathFromPayloadType(t *testing.T) {
 	}
 	if resp["dry_run"] != true || resp["validated"] != true {
 		t.Errorf("expected dry_run=true and validated=true; got %v", resp)
+	}
+	if resp["path"] != "sys/auth/{path}" {
+		t.Errorf("expected path template sys/auth/{path}; got %v", resp["path"])
 	}
 }

--- a/e2e/credential/json_payload_test.go
+++ b/e2e/credential/json_payload_test.go
@@ -90,11 +90,11 @@ func TestJSON_RejectsCombiningWithTypedFlags(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected non-zero exit when --type and --json both set; got success.\nOutput:\n%s", out)
 	}
-	if !strings.Contains(out, "--json") {
-		t.Errorf("expected error to mention --json; got:\n%s", out)
+	if !strings.Contains(out, "-json") {
+		t.Errorf("expected error to mention -json; got:\n%s", out)
 	}
-	if !strings.Contains(out, "--type") {
-		t.Errorf("expected error to mention --type; got:\n%s", out)
+	if !strings.Contains(out, "-type") {
+		t.Errorf("expected error to mention -type; got:\n%s", out)
 	}
 }
 

--- a/e2e/provider/json_payload_test.go
+++ b/e2e/provider/json_payload_test.go
@@ -9,17 +9,18 @@ import (
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
 
-// TestJSON_ProviderEnableDryRun exercises `warden provider enable --json`
-// with --dry-run. Real-mount tests would conflict with the `vault`
-// provider already configured by setup.sh; dry-run verifies the CLI
-// plumbing (schema fetch, payload validation, exclusivity check) without
-// touching mount-table state.
+// TestJSON_ProviderEnableDryRun exercises `warden provider enable -json`
+// with -dry-run. Real-mount tests would conflict with the `vault` provider
+// already configured by setup.sh; dry-run verifies the CLI plumbing
+// (schema fetch, payload validation, exclusivity check) without touching
+// mount-table state.
 func TestJSON_ProviderEnableDryRun(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "provider", "enable", "e2e-json-provider",
+	}, "provider", "enable", "vault",
+		"-path", "e2e-json-provider",
 		"--json", `{"type":"vault","description":"e2e --json provider"}`,
 		"--dry-run",
 		"-o", "json")
@@ -36,16 +37,16 @@ func TestJSON_ProviderEnableDryRun(t *testing.T) {
 	}
 }
 
-// TestJSON_ProviderEnableRejectsTypedFlagConflict pins the mutual-exclusivity
-// rule at the provider command — agents that mix --type with --json should
-// fail fast with a usage error.
-func TestJSON_ProviderEnableRejectsTypedFlagConflict(t *testing.T) {
+// TestJSON_ProviderEnableRejectsDescriptionWithJSON pins the mutual-
+// exclusivity rule — agents that mix -description with -json should fail
+// fast with a usage error.
+func TestJSON_ProviderEnableRejectsDescriptionWithJSON(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "provider", "enable", "e2e-conflict",
-		"--type", "vault",
+	}, "provider", "enable", "vault",
+		"-description", "should-not-be-allowed",
 		"--json", `{"type":"vault"}`,
 		"-o", "json")
 	if err == nil {
@@ -53,20 +54,19 @@ func TestJSON_ProviderEnableRejectsTypedFlagConflict(t *testing.T) {
 	}
 }
 
-// TestJSON_ProviderEnableWithPathFlagDryRun verifies that -path works on
-// provider enable. Uses Vault-style single-dash long flags so this test
-// also exercises the flag-normalization layer against the newly-added
-// -path flag.
+// TestJSON_ProviderEnableWithPathFlagDryRun verifies that -path overrides
+// the default mount path. Uses Vault-style single-dash long flags so this
+// test also exercises the flag-normalization layer against the -path flag.
 func TestJSON_ProviderEnableWithPathFlagDryRun(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
 	}, "provider", "enable",
-		"-type", "vault",
 		"-path", "e2e-pathflag-provider",
 		"-dry-run",
-		"-o", "json")
+		"-o", "json",
+		"vault")
 	if err != nil {
 		t.Fatalf("provider enable -path -dry-run failed: %v\nOutput:\n%s", err, out)
 	}
@@ -80,19 +80,18 @@ func TestJSON_ProviderEnableWithPathFlagDryRun(t *testing.T) {
 	}
 }
 
-// TestJSON_ProviderEnableRejectsPathAndPositionalConflict pins the conflict
-// rule: supplying both -path and a positional PATH must fail with a usage
-// error.
-func TestJSON_ProviderEnableRejectsPathAndPositionalConflict(t *testing.T) {
+// TestJSON_ProviderEnableRejectsPayloadTypeMismatch pins the conflict rule:
+// when the JSON payload's "type" field disagrees with the TYPE positional,
+// the CLI must fail with a usage error.
+func TestJSON_ProviderEnableRejectsPayloadTypeMismatch(t *testing.T) {
 	port := h.GetLeaderPort(t)
 
 	out, err := h.WardenCLIWithPort(t, port, map[string]string{
 		"WARDEN_TOKEN": h.RootToken(t),
-	}, "provider", "enable", "positional-path",
-		"-type", "vault",
-		"-path", "flag-path",
+	}, "provider", "enable", "vault",
+		"--json", `{"type":"aws"}`,
 		"-o", "json")
 	if err == nil {
-		t.Fatalf("expected non-zero exit for -path + positional PATH; got success.\nOutput:\n%s", out)
+		t.Fatalf("expected non-zero exit for TYPE/payload mismatch; got success.\nOutput:\n%s", out)
 	}
 }

--- a/e2e/skill/cli_test.go
+++ b/e2e/skill/cli_test.go
@@ -189,7 +189,7 @@ func TestCLI_SkillCreate_JSONFlagsExclusivity(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for --name + --json, got success.\noutput: %s", out)
 	}
-	if !strings.Contains(out, "--json cannot be combined with") {
+	if !strings.Contains(out, "-json cannot be combined with") {
 		t.Errorf("output does not mention the exclusivity error; got:\n%s", out)
 	}
 }

--- a/provider/alicloud/README.md
+++ b/provider/alicloud/README.md
@@ -38,7 +38,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -55,13 +55,13 @@ warden write auth/jwt/role/alicloud-user \
 Enable the Alicloud provider at the default path:
 
 ```bash
-warden provider enable --type=alicloud
+warden provider enable alicloud
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=alicloud alicloud-prod
+warden provider enable -path=alicloud-prod alicloud
 ```
 
 Verify the provider is enabled:
@@ -102,23 +102,23 @@ The `alicloud` source requires a *management* access key that Warden uses to cal
 
 Create an `alicloud` source holding a *management* access key with permissions to call `sts:AssumeRole`. Warden calls Alicloud's STS API per request and hands clients short-lived credentials, so even a compromised session window is bounded.
 
-The example below also enables [management key rotation](#management-key-rotation) via `--rotation-period=720h` (30 days). The `management_user_name` config key is the RAM user that owns the management key — required for rotation to work.
+The example below also enables [management key rotation](#management-key-rotation) via `-rotation-period=720h` (30 days). The `management_user_name` config key is the RAM user that owns the management key — required for rotation to work.
 
 ```bash
 warden cred source create alicloud-src \
-  --type=alicloud \
-  --rotation-period=720h \
-  --config access_key_id=LTAI-mgmt-key \
-  --config access_key_secret=mgmt-secret \
-  --config management_user_name=warden-management
+  -type=alicloud \
+  -rotation-period=720h \
+  -config access_key_id=LTAI-mgmt-key \
+  -config access_key_secret=mgmt-secret \
+  -config management_user_name=warden-management
 
 warden cred spec create alicloud-ops \
-  --source alicloud-src \
-  --type=alicloud_keys \
-  --config mint_method=assume_role \
-  --config role_arn=acs:ram::123456789012:role/warden-ops \
-  --config role_session_name=warden-session \
-  --config duration_seconds=1h
+  -source alicloud-src \
+  -type=alicloud_keys \
+  -config mint_method=assume_role \
+  -config role_arn=acs:ram::123456789012:role/warden-ops \
+  -config role_session_name=warden-session \
+  -config duration_seconds=1h
 ```
 
 The RAM role's trust policy must allow the management user to assume it, and the source's management key needs `AliyunSTSAssumeRoleAccess` (or an equivalent custom policy). See [Alicloud: Use STS to grant an access to a RAM role](https://www.alibabacloud.com/help/en/ram/user-guide/use-sts-tokens-to-access-resources) for setup.
@@ -127,12 +127,12 @@ Optionally pass an inline `policy` to further restrict the issued session:
 
 ```bash
 warden cred spec create alicloud-readonly \
-  --source alicloud-src \
-  --type=alicloud_keys \
-  --config mint_method=assume_role \
-  --config role_arn=acs:ram::123456789012:role/warden-ops \
-  --config duration_seconds=15m \
-  --config 'policy={"Version":"1","Statement":[{"Effect":"Allow","Action":"ecs:Describe*","Resource":"*"}]}'
+  -source alicloud-src \
+  -type=alicloud_keys \
+  -config mint_method=assume_role \
+  -config role_arn=acs:ram::123456789012:role/warden-ops \
+  -config duration_seconds=15m \
+  -config 'policy={"Version":"1","Statement":[{"Effect":"Allow","Action":"ecs:Describe*","Resource":"*"}]}'
 ```
 
 ### Option B: Vault/OpenBao KV v2 source
@@ -147,21 +147,21 @@ The `hvault` source also supports rotation — it rotates its own AppRole `secre
 
 ```bash
 warden cred source create alicloud-vault-src \
-  --type=hvault \
-  --rotation-period=24h \
-  --config vault_address=https://vault.example.com \
-  --config auth_method=approle \
-  --config role_id=your-role-id \
-  --config secret_id=your-secret-id \
-  --config approle_mount=approle \
-  --config role_name=warden-role
+  -type=hvault \
+  -rotation-period=24h \
+  -config vault_address=https://vault.example.com \
+  -config auth_method=approle \
+  -config role_id=your-role-id \
+  -config secret_id=your-secret-id \
+  -config approle_mount=approle \
+  -config role_name=warden-role
 
 warden cred spec create alicloud-ops \
-  --source alicloud-vault-src \
-  --type=alicloud_keys \
-  --config mint_method=static_alicloud \
-  --config kv2_mount=secret \
-  --config secret_path=alicloud/prod/keys
+  -source alicloud-vault-src \
+  -type=alicloud_keys \
+  -config mint_method=static_alicloud \
+  -config kv2_mount=secret \
+  -config secret_path=alicloud/prod/keys
 ```
 
 The KV v2 secret at `secret/alicloud/prod/keys` must contain `access_key_id` and `access_key_secret` fields.
@@ -347,14 +347,14 @@ Warden extracts the JWT from `X-Amz-Security-Token` (it starts with `eyJ`), auth
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -434,7 +434,7 @@ The `alicloud` source supports only dynamic mint methods. When the keys already 
 
 ### Alicloud source configuration
 
-Fields on the `alicloud` source, passed as `--config key=value` to `warden cred source create`:
+Fields on the `alicloud` source, passed as `-config key=value` to `warden cred source create`:
 
 | Key | Default | Description |
 |---|---|---|
@@ -447,16 +447,16 @@ Fields on the `alicloud` source, passed as `--config key=value` to `warden cred 
 | `ca_data` | — | Base64-encoded PEM CA bundle for custom/self-signed CAs. |
 | `tls_skip_verify` | false | Skip TLS verification (development only). |
 
-In addition to `--config` fields, `warden cred source create` accepts two top-level flags that are **not** part of the driver's config map:
+In addition to `-config` fields, `warden cred source create` accepts two top-level flags that are **not** part of the driver's config map:
 
 | Flag | Default | Description |
 |---|---|---|
-| `--rotation-period` | — (rotation disabled) | How often Warden rotates the source's management access key. Requires `management_user_name` to also be set. Example: `--rotation-period=720h` (30 days). See [Management key rotation](#management-key-rotation). |
-| `--type` | — | Driver type. Use `--type=alicloud`. |
+| `-rotation-period` | — (rotation disabled) | How often Warden rotates the source's management access key. Requires `management_user_name` to also be set. Example: `-rotation-period=720h` (30 days). See [Management key rotation](#management-key-rotation). |
+| `-type` | — | Driver type. Use `-type=alicloud`. |
 
 ### Spec configuration
 
-Fields on the `alicloud_keys` spec (passed as `--config key=value` to `warden cred spec create`):
+Fields on the `alicloud_keys` spec (passed as `-config key=value` to `warden cred spec create`):
 
 | Key | Mint methods | Description |
 |---|---|---|
@@ -469,21 +469,21 @@ Fields on the `alicloud_keys` spec (passed as `--config key=value` to `warden cr
 
 ### Management key rotation
 
-The `alicloud` source implements Warden's `Rotatable` interface, so the management access key stored on the source can be rotated automatically without downtime. Rotation is driven by the source's `--rotation-period` flag and runs through Warden's rotation manager.
+The `alicloud` source implements Warden's `Rotatable` interface, so the management access key stored on the source can be rotated automatically without downtime. Rotation is driven by the source's `-rotation-period` flag and runs through Warden's rotation manager.
 
 **Enable rotation** with two pieces:
 
-- `--rotation-period` on `warden cred source create` — tells Warden's rotation manager how often to rotate (e.g., `720h` for 30 days). Without this flag the source is never rotated, even if everything else is configured.
-- `--config management_user_name=<ram-user>` — the RAM user that owns the management access key. Without it, `SupportsRotation()` returns false and the rotation manager skips the source even when `--rotation-period` is set.
+- `-rotation-period` on `warden cred source create` — tells Warden's rotation manager how often to rotate (e.g., `720h` for 30 days). Without this flag the source is never rotated, even if everything else is configured.
+- `-config management_user_name=<ram-user>` — the RAM user that owns the management access key. Without it, `SupportsRotation()` returns false and the rotation manager skips the source even when `-rotation-period` is set.
 
 ```bash
 warden cred source create alicloud-src \
-  --type=alicloud \
-  --rotation-period=720h \
-  --config access_key_id=LTAI-mgmt-key \
-  --config access_key_secret=mgmt-secret \
-  --config management_user_name=warden-management \
-  --config activation_delay=5m
+  -type=alicloud \
+  -rotation-period=720h \
+  -config access_key_id=LTAI-mgmt-key \
+  -config access_key_secret=mgmt-secret \
+  -config management_user_name=warden-management \
+  -config activation_delay=5m
 ```
 
 `activation_delay` is optional (defaults to 5 minutes) — the wait between minting the new key and using it, to let RAM eventual consistency propagate.

--- a/provider/ansible_tower/README.md
+++ b/provider/ansible_tower/README.md
@@ -51,7 +51,7 @@ The Ansible Tower provider enables proxied access to the Ansible Tower (AWX / Re
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -69,7 +69,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -86,13 +86,13 @@ warden write auth/jwt/role/ansible-tower-user \
 Enable the Ansible Tower provider at a path of your choice:
 
 ```bash
-warden provider enable --type=ansible_tower
+warden provider enable ansible_tower
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=ansible_tower ansible-tower-prod
+warden provider enable -path=ansible-tower-prod ansible_tower
 ```
 
 Verify the provider is enabled:
@@ -149,20 +149,20 @@ Save the token from the response, then create the Warden credential source and s
 
 ```bash
 warden cred source create ansible-tower-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://tower.example.com \
-  --config=verify_endpoint=/api/v2/ping/ \
-  --config=auth_header_type=bearer \
-  --config=display_name=Ansible\ Tower
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://tower.example.com \
+  -config=verify_endpoint=/api/v2/ping/ \
+  -config=auth_header_type=bearer \
+  -config=display_name=Ansible\ Tower
 ```
 
 Create a credential spec that references the credential source. The spec carries the PAT and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create ansible-tower-ops \
-  --source ansible-tower-src \
-  --config api_key=your-ansible-tower-pat
+  -source ansible-tower-src \
+  -config api_key=your-ansible-tower-pat
 ```
 
 The PAT is validated at creation time via a `GET /api/v2/ping/` call to the Ansible Tower API (SpecVerifier). If the token is invalid, spec creation will fail.
@@ -178,24 +178,24 @@ Instead of storing PATs directly in Warden, you can store them in a Vault/OpenBa
 ```bash
 # Create a Vault credential source
 warden cred source create ansible-tower-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create ansible-tower-ops \
-  --source ansible-tower-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=ansible-tower/ops
+  -source ansible-tower-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=ansible-tower/ops
 ```
 
 The KV v2 secret at `secret/ansible-tower/ops` should contain an `api_key` field with the Ansible Tower PAT. Warden fetches the secret from Vault on each credential request.
@@ -384,14 +384,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-3 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 1 and 5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -547,7 +547,7 @@ The token value is returned only once in the response. Store it securely.
 2. Update the credential spec:
    ```bash
    warden cred spec update ansible-tower-ops \
-     --config api_key=your-new-pat
+     -config api_key=your-new-pat
    ```
 3. Delete the old token in Ansible Tower:
    ```bash

--- a/provider/anthropic/README.md
+++ b/provider/anthropic/README.md
@@ -50,7 +50,7 @@ The Anthropic provider enables proxied access to the Anthropic API through Warde
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -84,13 +84,13 @@ warden write auth/jwt/role/anthropic-user \
 Enable the Anthropic provider at a path of your choice:
 
 ```bash
-warden provider enable --type=anthropic
+warden provider enable anthropic
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=anthropic anthropic-prod
+warden provider enable -path=anthropic-prod anthropic
 ```
 
 Verify the provider is enabled:
@@ -124,15 +124,15 @@ The credential source holds only connection info (`api_url`). The API key is sto
 
 ```bash
 warden cred source create anthropic-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.anthropic.com \
-  --config=verify_endpoint=/v1/models \
-  --config=auth_header_type=custom_header \
-  --config=auth_header_name=x-api-key \
-  --config=extra_headers=anthropic-version:2023-06-01 \
-  --config=optional_metadata=organization_id \
-  --config=display_name=Anthropic
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.anthropic.com \
+  -config=verify_endpoint=/v1/models \
+  -config=auth_header_type=custom_header \
+  -config=auth_header_name=x-api-key \
+  -config=extra_headers=anthropic-version:2023-06-01 \
+  -config=optional_metadata=organization_id \
+  -config=display_name=Anthropic
 ```
 
 Verify the source was created:
@@ -145,8 +145,8 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create anthropic-ops \
-  --source anthropic-src \
-  --config api_key=<your-anthropic-api-key>
+  -source anthropic-src \
+  -config api_key=<your-anthropic-api-key>
 ```
 
 The API key is validated at creation time via a `GET /v1/models` call to the Anthropic API (SpecVerifier). If the key is invalid, spec creation will fail.
@@ -168,21 +168,21 @@ Instead of storing the API key directly in Warden, you can store it in a Vault/O
 ```bash
 # Create a Vault credential source
 warden cred source create anthropic-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 # Create a credential spec using the static_apikey mint method
 warden cred spec create anthropic-ops \
-  --source anthropic-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=anthropic/ops
+  -source anthropic-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=anthropic/ops
 ```
 
 The KV v2 secret at `secret/anthropic/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -420,14 +420,14 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -538,6 +538,6 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update anthropic-ops \
-     --config api_key=<new-api-key>
+     -config api_key=<new-api-key>
    ```
 3. Delete the old key from the Anthropic console

--- a/provider/atlassian/README.md
+++ b/provider/atlassian/README.md
@@ -52,7 +52,7 @@ The Atlassian provider enables proxied access to all Atlassian Cloud and Data Ce
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -70,7 +70,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -87,7 +87,7 @@ warden write auth/jwt/role/atlassian-user \
 Enable the Atlassian provider at a path of your choice:
 
 ```bash
-warden provider enable --type=atlassian jira
+warden provider enable -path=jira atlassian
 ```
 
 Verify the provider is enabled:
@@ -125,19 +125,19 @@ Generate an API token at [id.atlassian.com/manage-profile/security/api-tokens](h
 
 ```bash
 warden cred source create atlassian-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=display_name=Atlassian \
-  --config=optional_metadata=email
+  -type=apikey \
+  -rotation-period=0 \
+  -config=display_name=Atlassian \
+  -config=optional_metadata=email
 ```
 
 Create a credential spec with both `email` and `api_key`:
 
 ```bash
 warden cred spec create atlassian-ops \
-  --source atlassian-src \
-  --config email=fred@example.com \
-  --config api_key=ATATT3xFfGF0your-api-token
+  -source atlassian-src \
+  -config email=fred@example.com \
+  -config api_key=ATATT3xFfGF0your-api-token
 ```
 
 ### Option B: Personal Access Token (Data Center)
@@ -146,17 +146,17 @@ Atlassian Data Center (Jira DC 8.14+, Confluence DC 7.9+, Bitbucket DC 5.5+) sup
 
 ```bash
 warden cred source create atlassian-dc-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=display_name=AtlassianDC
+  -type=apikey \
+  -rotation-period=0 \
+  -config=display_name=AtlassianDC
 ```
 
 Create a credential spec with only `api_key`:
 
 ```bash
 warden cred spec create atlassian-ops \
-  --source atlassian-dc-src \
-  --config api_key=your-personal-access-token
+  -source atlassian-dc-src \
+  -config api_key=your-personal-access-token
 ```
 
 For older Data Center versions without PAT support, fall back to Basic Auth by adding `optional_metadata=email` to the source and including both `email` and `api_key` (the account password) on the spec.
@@ -184,20 +184,20 @@ Then create the Warden credential source and spec:
 
 ```bash
 warden cred source create atlassian-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 warden cred spec create atlassian-ops \
-  --source atlassian-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=atlassian/ops
+  -source atlassian-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=atlassian/ops
 ```
 
 Warden reads all keys from the KV secret and populates credential data directly. For Cloud, the `email` key triggers Basic Auth injection automatically — no `optional_metadata` config is needed on the Vault source.
@@ -294,7 +294,7 @@ Mount one instance of the Atlassian provider per product. Each product has its o
 ### Confluence
 
 ```bash
-warden provider enable --type=atlassian confluence
+warden provider enable -path=confluence atlassian
 
 warden write confluence/config <<EOF
 {
@@ -331,7 +331,7 @@ curl -s -X POST "${CONFLUENCE_ENDPOINT}/pages" \
 ### Jira Service Management
 
 ```bash
-warden provider enable --type=atlassian jira-servicedesk
+warden provider enable -path=jira-servicedesk atlassian
 
 warden write jira-servicedesk/config <<EOF
 {
@@ -365,7 +365,7 @@ curl -s -X POST "${JSM_ENDPOINT}/request" \
 Bitbucket Cloud uses **app passwords** instead of personal API tokens. Create one at [bitbucket.org/account/settings/app-passwords](https://bitbucket.org/account/settings/app-passwords). Use your Bitbucket username as `email` and the app password as `api_key`.
 
 ```bash
-warden provider enable --type=atlassian bitbucket
+warden provider enable -path=bitbucket atlassian
 
 warden write bitbucket/config <<EOF
 {
@@ -376,15 +376,15 @@ warden write bitbucket/config <<EOF
 EOF
 
 warden cred source create bitbucket-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=display_name=Bitbucket \
-  --config=optional_metadata=email
+  -type=apikey \
+  -rotation-period=0 \
+  -config=display_name=Bitbucket \
+  -config=optional_metadata=email
 
 warden cred spec create bitbucket-ops \
-  --source bitbucket-src \
-  --config email=your-bitbucket-username \
-  --config api_key=your-app-password
+  -source bitbucket-src \
+  -config email=your-bitbucket-username \
+  -config api_key=your-app-password
 ```
 
 ```bash
@@ -404,7 +404,7 @@ curl -s "${BITBUCKET_ENDPOINT}/repositories/your-workspace" \
 The Admin API uses **org API keys** (not personal tokens), which are injected as Bearer tokens. Generate one at [admin.atlassian.com](https://admin.atlassian.com) under **Settings > API keys**. No `email` field is needed.
 
 ```bash
-warden provider enable --type=atlassian atlassian-admin
+warden provider enable -path=atlassian-admin atlassian
 
 warden write atlassian-admin/config <<EOF
 {
@@ -415,13 +415,13 @@ warden write atlassian-admin/config <<EOF
 EOF
 
 warden cred source create atlassian-admin-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=display_name=AtlassianAdmin
+  -type=apikey \
+  -rotation-period=0 \
+  -config=display_name=AtlassianAdmin
 
 warden cred spec create atlassian-admin-ops \
-  --source atlassian-admin-src \
-  --config api_key=your-org-api-key
+  -source atlassian-admin-src \
+  -config api_key=your-org-api-key
 ```
 
 ## Data Center and Self-Hosted
@@ -429,7 +429,7 @@ warden cred spec create atlassian-admin-ops \
 Atlassian Data Center (Jira DC 8.14+, Confluence DC 7.9+, Bitbucket DC 5.5+) supports **Personal Access Tokens (PATs)** as Bearer tokens. The credential source and spec setup follows [Option B in Step 3](#option-b-personal-access-token-data-center). Only the provider mount and URL differ:
 
 ```bash
-warden provider enable --type=atlassian jira-dc
+warden provider enable -path=jira-dc atlassian
 
 warden write jira-dc/config <<EOF
 {
@@ -446,12 +446,12 @@ For older Data Center versions without PAT support, use Basic Auth the same way 
 
 Steps 1 and 5 use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. Steps 2-4 (provider, credential, and policy setup) are identical regardless of the auth method.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener. In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener. In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA

--- a/provider/aws/README.md
+++ b/provider/aws/README.md
@@ -54,7 +54,7 @@ The AWS provider enables proxied access to AWS services through Warden. Clients 
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -155,7 +155,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -172,13 +172,13 @@ warden write auth/jwt/role/aws-user \
 Enable the AWS provider at a path of your choice:
 
 ```bash
-warden provider enable --type=aws
+warden provider enable aws
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=aws aws-prod
+warden provider enable -path=aws-prod aws
 ```
 
 Verify the provider is enabled:
@@ -218,14 +218,14 @@ The credential source tells Warden how to authenticate to AWS and where the base
 
 ```bash
 warden cred source create my-aws-source \
-  --type aws \
-  --rotation-period 24h \
-  --config access_key_id=<AccessKeyId> \
-  --config secret_access_key=<SecretAccessKey> \
-  --config region=us-east-1
+  -type aws \
+  -rotation-period 24h \
+  -config access_key_id=<AccessKeyId> \
+  -config secret_access_key=<SecretAccessKey> \
+  -config region=us-east-1
 ```
 
-The `--rotation-period` controls how often Warden rotates the base IAM access keys. Since the IAM user can only manage its own keys and assume roles (no direct resource access), longer periods are acceptable (e.g., `720h` / 30 days). For stricter environments, use shorter periods (e.g., `12h`-`24h`).
+The `-rotation-period` controls how often Warden rotates the base IAM access keys. Since the IAM user can only manage its own keys and assume roles (no direct resource access), longer periods are acceptable (e.g., `720h` / 30 days). For stricter environments, use shorter periods (e.g., `12h`-`24h`).
 
 Verify:
 
@@ -238,30 +238,30 @@ A credential spec defines what temporary credentials Warden mints for consumers.
 ```bash
 # Spec for developers — read-only access, short TTL
 warden cred spec create developer \
-  --source my-aws-source \
-  --config mint_method=sts_assume_role \
-  --config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-readonly-role \
-  --config ttl=1h \
-  --min-ttl 600s \
-  --max-ttl 2h
+  -source my-aws-source \
+  -config mint_method=sts_assume_role \
+  -config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-readonly-role \
+  -config ttl=1h \
+  -min-ttl 600s \
+  -max-ttl 2h
 
 # Spec for CI/CD pipelines — deploy permissions
 warden cred spec create deployer \
-  --source my-aws-source \
-  --config mint_method=sts_assume_role \
-  --config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-deploy-role \
-  --config ttl=30m \
-  --min-ttl 600s \
-  --max-ttl 1h
+  -source my-aws-source \
+  -config mint_method=sts_assume_role \
+  -config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-deploy-role \
+  -config ttl=30m \
+  -min-ttl 600s \
+  -max-ttl 1h
 
 # Spec for operators — full access, longer TTL
 warden cred spec create operator \
-  --source my-aws-source \
-  --config mint_method=sts_assume_role \
-  --config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-operator-role \
-  --config ttl=2h \
-  --min-ttl 600s \
-  --max-ttl 4h
+  -source my-aws-source \
+  -config mint_method=sts_assume_role \
+  -config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/devops-operator-role \
+  -config ttl=2h \
+  -min-ttl 600s \
+  -max-ttl 4h
 ```
 
 Each spec points to a different `role_arn`, so the IAM user's `AssumeRoles` policy must allow assuming all of them (the `devops-*` wildcard in the [AssumeRoles policy](#attach-iam-policies) covers this).
@@ -277,14 +277,14 @@ Instead of storing AWS credentials directly in Warden, you can store them in a V
 ```bash
 # Create a Vault credential source
 warden cred source create aws-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=<role-id> \
-  --config=secret_id=<secret-id> \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=<role-id> \
+  -config=secret_id=<secret-id> \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 #### static_aws — fetch static credentials from KV v2
@@ -293,12 +293,12 @@ The KV v2 secret must contain `access_key_id` and `secret_access_key` fields.
 
 ```bash
 warden cred spec create developer \
-  --source aws-vault-src \
-  --config mint_method=static_aws \
-  --config kv2_mount=secret \
-  --config secret_path=aws/creds \
-  --min-ttl 600s \
-  --max-ttl 2h
+  -source aws-vault-src \
+  -config mint_method=static_aws \
+  -config kv2_mount=secret \
+  -config secret_path=aws/creds \
+  -min-ttl 600s \
+  -max-ttl 2h
 ```
 
 #### dynamic_aws — generate credentials via Vault AWS secrets engine
@@ -307,13 +307,13 @@ Vault generates temporary AWS credentials using its [AWS secrets engine](https:/
 
 ```bash
 warden cred spec create developer \
-  --source aws-vault-src \
-  --config mint_method=dynamic_aws \
-  --config aws_mount=aws \
-  --config role_name=my-vault-aws-role \
-  --config ttl=1h \
-  --min-ttl 600s \
-  --max-ttl 2h
+  -source aws-vault-src \
+  -config mint_method=dynamic_aws \
+  -config aws_mount=aws \
+  -config role_name=my-vault-aws-role \
+  -config ttl=1h \
+  -min-ttl 600s \
+  -max-ttl 2h
 ```
 
 ## Step 4: Create a Policy
@@ -404,7 +404,7 @@ Warden detects the JWT in the `X-Amz-Security-Token` header, authenticates it ag
 
 For workloads that already have X.509 certificates (Kubernetes pods with cert-manager, VMs with machine certificates, SPIFFE X.509-SVIDs), Warden can authenticate using TLS client certificates instead of JWTs.
 
-> **Prerequisite:** TLS must be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** TLS must be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 #### Set up cert auth and configure the provider
 
@@ -412,7 +412,7 @@ Replace Step 1 with cert auth setup, and update the provider's `auto_auth_path`:
 
 ```bash
 # Enable cert auth
-warden auth enable --type=cert
+warden auth enable cert
 
 # Configure trusted CA
 warden write auth/cert/config \
@@ -651,8 +651,8 @@ For HTTPS, you'll need a **wildcard SSL certificate** (`*.warden.yourdomain.com`
 
 ### TTL Bounds
 
-- `--min-ttl`: Minimum credential TTL. Requests for shorter TTLs are clamped up.
-- `--max-ttl`: Maximum credential TTL. Requests for longer TTLs are clamped down.
+- `-min-ttl`: Minimum credential TTL. Requests for shorter TTLs are clamped up.
+- `-max-ttl`: Maximum credential TTL. Requests for longer TTLs are clamped down.
 
 ## Supported AWS Services
 

--- a/provider/aws/e2e_test/README.md
+++ b/provider/aws/e2e_test/README.md
@@ -29,7 +29,7 @@ This directory contains Terraform-based end-to-end tests for the Warden AWS prov
 ### 1. Start Warden Server
 
 ```bash
-./warden server --config=warden.local.hcl
+./warden server -config=warden.local.hcl
 ```
 
 ### 2. Configure Warden Namespaces and Authentication
@@ -48,41 +48,41 @@ EOF
 
 # Configure Vault as credential source
 ./warden -n PROD/SEC cred source create vault \
-  --type hvault \
-  --config vault_address=http://127.0.0.1:8200 \
-  --config auth_method=approle \
-  --config role_id=c0ae884e-b55e-1736-3710-bb1d88d76182 \
-  --config secret_id=e0b8f9b8-6b32-5478-9a73-196e50734c2f \
-  --config approle_mount=warden_approle
+  -type hvault \
+  -config vault_address=http://127.0.0.1:8200 \
+  -config auth_method=approle \
+  -config role_id=c0ae884e-b55e-1736-3710-bb1d88d76182 \
+  -config secret_id=e0b8f9b8-6b32-5478-9a73-196e50734c2f \
+  -config approle_mount=warden_approle
 
 # Create credential specifications
 ./warden -n PROD/SEC cred spec create aws_local \
-  --type aws_access_keys \
-  --source local \
-  --config access_key_id=test \
-  --config secret_access_key=test
+  -type aws_access_keys \
+  -source local \
+  -config access_key_id=test \
+  -config secret_access_key=test
 
 ./warden -n PROD/SEC cred spec create aws_static \
-  --type aws_access_keys \
-  --source vault \
-  --config mint_method=static_aws \
-  --config kv2_mount=kv_static_secret \
-  --config secret_path=aws/prod
+  -type aws_access_keys \
+  -source vault \
+  -config mint_method=static_aws \
+  -config kv2_mount=kv_static_secret \
+  -config secret_path=aws/prod
 
 ./warden -n PROD/SEC cred spec create aws_dynamic \
-  --type aws_access_keys \
-  --source vault \
-  --config mint_method=dynamic_aws \
-  --config aws_mount=aws \
-  --config role_name=terraform \
-  --config ttl=900s \
-  --config role_session_name=warden \
-  --config role_arn=arn:aws:iam::905418489750:role/terraform-role-warden \
-  --min-ttl 600s \
-  --max-ttl 8h
+  -type aws_access_keys \
+  -source vault \
+  -config mint_method=dynamic_aws \
+  -config aws_mount=aws \
+  -config role_name=terraform \
+  -config ttl=900s \
+  -config role_session_name=warden \
+  -config role_arn=arn:aws:iam::905418489750:role/terraform-role-warden \
+  -min-ttl 600s \
+  -max-ttl 8h
 
 # Enable JWT authentication
-./warden -n PROD/SEC auth enable --type=jwt --description="jwt test auth method"
+./warden -n PROD/SEC auth enable jwt -description="jwt test auth method"
 ./warden -n PROD/SEC write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create JWT roles
@@ -99,7 +99,7 @@ EOF
     token_ttl=1h
 
 # Enable AWS provider
-./warden -n PROD/SEC provider enable --type=aws --description="aws provider"
+./warden -n PROD/SEC provider enable aws -description="aws provider"
 ./warden -n PROD/SEC write aws/config proxy_domains="localhost,warden"
 ```
 
@@ -113,7 +113,7 @@ export JWT=$(curl -s -X POST http://localhost:4444/oauth2/token \
   | jq -r '.access_token')
 
 # Login to Warden and extract credentials
-LOGIN_OUTPUT=$(./warden -n PROD/SEC login --method=jwt --token=$JWT --role=aws-kv)
+LOGIN_OUTPUT=$(./warden -n PROD/SEC login -method=jwt -token=$JWT -role=aws-kv)
 export AWS_ACCESS_KEY_ID=$(echo "$LOGIN_OUTPUT" | grep "| data" | sed 's/.*access_key_id=\([^,]*\).*/\1/')
 export AWS_SECRET_ACCESS_KEY=$(echo "$LOGIN_OUTPUT" | grep "| data" | sed 's/.*secret_access_key=\([^ |]*\).*/\1/')
 

--- a/provider/azure/README.md
+++ b/provider/azure/README.md
@@ -51,7 +51,7 @@ The Azure provider enables proxied access to Azure APIs through Warden. It manag
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -116,7 +116,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -133,13 +133,13 @@ warden write auth/jwt/role/azure-user \
 Enable the Azure provider at a path of your choice:
 
 ```bash
-warden provider enable --type=azure
+warden provider enable azure
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=azure azure-prod
+warden provider enable -path=azure-prod azure
 ```
 
 Verify the provider is enabled:
@@ -172,12 +172,12 @@ The credential source holds the Microsoft Entra ID service principal credentials
 
 ```bash
 warden cred source create azure-src \
-  --type=azure \
-  --rotation-period=720h \
-  --config=tenant_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-  --config=client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-  --config=client_secret=your-client-secret \
-  --config=subscription_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  -type=azure \
+  -rotation-period=720h \
+  -config=tenant_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -config=client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -config=client_secret=your-client-secret \
+  -config=subscription_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 Verify the source was created:
@@ -194,11 +194,11 @@ Mints an Microsoft Entra ID Bearer token using the client credentials flow:
 
 ```bash
 warden cred spec create azure-ops \
-  --source azure-src \
-  --config auth_method=bearer_token \
-  --config client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-  --config client_secret=workload-sp-client-secret \
-  --config resource_uri=https://management.azure.com/
+  -source azure-src \
+  -config auth_method=bearer_token \
+  -config client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -config client_secret=workload-sp-client-secret \
+  -config resource_uri=https://management.azure.com/
 ```
 
 ### Option B: Key Vault Secret
@@ -207,12 +207,12 @@ Fetches a secret directly from Azure Key Vault:
 
 ```bash
 warden cred spec create azure-kv \
-  --source azure-src \
-  --config auth_method=key_vault_secret \
-  --config client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-  --config client_secret=workload-sp-client-secret \
-  --config vault_name=my-key-vault \
-  --config secret_name=my-secret
+  -source azure-src \
+  -config auth_method=key_vault_secret \
+  -config client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -config client_secret=workload-sp-client-secret \
+  -config vault_name=my-key-vault \
+  -config secret_name=my-secret
 ```
 
 Verify:
@@ -371,14 +371,14 @@ Warden supports automatic rotation of Azure service principal credentials via th
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA

--- a/provider/cloudflare/README.md
+++ b/provider/cloudflare/README.md
@@ -56,7 +56,7 @@ The Cloudflare provider enables proxied access to Cloudflare APIs through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -74,7 +74,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -91,13 +91,13 @@ warden write auth/jwt/role/cloudflare-user \
 Enable the Cloudflare provider at a path of your choice:
 
 ```bash
-warden provider enable --type=cloudflare
+warden provider enable cloudflare
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=cloudflare cloudflare-prod
+warden provider enable -path=cloudflare-prod cloudflare
 ```
 
 Verify the provider is enabled:
@@ -150,36 +150,36 @@ Create a Cloudflare credential source and spec. You can configure both modes or 
 
 ```bash
 warden cred source create cloudflare-src \
-  --type=local
+  -type=local
 
 warden cred spec create cloudflare-ops \
-  --source cloudflare-src \
-  --type=cloudflare_keys \
-  --config mint_method=static_keys \
-  --config access_key_id=your-r2-access-key-id \
-  --config secret_access_key=your-r2-secret-access-key \
-  --config api_token=your-cloudflare-api-token
+  -source cloudflare-src \
+  -type=cloudflare_keys \
+  -config mint_method=static_keys \
+  -config access_key_id=your-r2-access-key-id \
+  -config secret_access_key=your-r2-secret-access-key \
+  -config api_token=your-cloudflare-api-token
 ```
 
 **API-only (no R2):**
 
 ```bash
 warden cred spec create cloudflare-api-only \
-  --source cloudflare-src \
-  --type=cloudflare_keys \
-  --config mint_method=static_keys \
-  --config api_token=your-cloudflare-api-token
+  -source cloudflare-src \
+  -type=cloudflare_keys \
+  -config mint_method=static_keys \
+  -config api_token=your-cloudflare-api-token
 ```
 
 **R2-only (no API):**
 
 ```bash
 warden cred spec create cloudflare-r2-only \
-  --source cloudflare-src \
-  --type=cloudflare_keys \
-  --config mint_method=static_keys \
-  --config access_key_id=your-r2-access-key-id \
-  --config secret_access_key=your-r2-secret-access-key
+  -source cloudflare-src \
+  -type=cloudflare_keys \
+  -config mint_method=static_keys \
+  -config access_key_id=your-r2-access-key-id \
+  -config secret_access_key=your-r2-secret-access-key
 ```
 
 ### Option B: Vault/OpenBao as Credential Source
@@ -192,21 +192,21 @@ Store your Cloudflare credentials in a Vault/OpenBao KV v2 secret engine and hav
 
 ```bash
 warden cred source create cloudflare-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 warden cred spec create cloudflare-ops \
-  --source cloudflare-vault-src \
-  --type=cloudflare_keys \
-  --config mint_method=static_cloudflare \
-  --config kv2_mount=secret \
-  --config secret_path=cloudflare/prod
+  -source cloudflare-vault-src \
+  -type=cloudflare_keys \
+  -config mint_method=static_cloudflare \
+  -config kv2_mount=secret \
+  -config secret_path=cloudflare/prod
 ```
 
 The KV v2 secret at `secret/cloudflare/prod` should contain at least `api_token` (for API mode) and/or `access_key_id` + `secret_access_key` (for R2 mode).
@@ -411,14 +411,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -540,17 +540,17 @@ At least one mode must be configured: `api_token` for the REST API, or `access_k
    ```bash
    # Dual-mode
    warden cred spec update cloudflare-ops \
-     --config access_key_id=new-access-key-id \
-     --config secret_access_key=new-secret-access-key \
-     --config api_token=new-api-token
+     -config access_key_id=new-access-key-id \
+     -config secret_access_key=new-secret-access-key \
+     -config api_token=new-api-token
 
    # API-only
    warden cred spec update cloudflare-api-only \
-     --config api_token=new-api-token
+     -config api_token=new-api-token
 
    # R2-only
    warden cred spec update cloudflare-r2-only \
-     --config access_key_id=new-access-key-id \
-     --config secret_access_key=new-secret-access-key
+     -config access_key_id=new-access-key-id \
+     -config secret_access_key=new-secret-access-key
    ```
 3. Revoke the old credentials in the Cloudflare Dashboard

--- a/provider/cloudflare/e2e_test/README.md
+++ b/provider/cloudflare/e2e_test/README.md
@@ -71,7 +71,7 @@ docker compose -f deploy/docker-compose.quickstart.yml up -d
 ### 2. Start Warden (dev mode)
 
 ```bash
-warden server --dev --dev-root-token=root
+warden server -dev -dev-root-token=root
 ```
 
 ### 3. Configure Warden
@@ -81,7 +81,7 @@ export WARDEN_ADDR="http://127.0.0.1:8400"
 export WARDEN_TOKEN="root"
 
 # Enable JWT auth
-warden auth enable --type=jwt
+warden auth enable jwt
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create role
@@ -91,7 +91,7 @@ warden write auth/jwt/role/cloudflare-user \
     cred_spec_name=cloudflare-ops
 
 # Enable Cloudflare provider
-warden provider enable --type=cloudflare
+warden provider enable cloudflare
 
 # Configure provider (account_id required for R2)
 warden write cloudflare/config <<EOF
@@ -105,16 +105,16 @@ EOF
 
 # Create credential source
 warden cred source create cloudflare-src \
-  --type=local
+  -type=local
 
 # Create credential spec with Cloudflare keys (dual-mode)
 warden cred spec create cloudflare-ops \
-  --source cloudflare-src \
-  --type=cloudflare_keys \
-  --config mint_method=static_keys \
-  --config access_key_id=<your-r2-access-key-id> \
-  --config secret_access_key=<your-r2-secret-access-key> \
-  --config api_token=<your-cloudflare-api-token>
+  -source cloudflare-src \
+  -type=cloudflare_keys \
+  -config mint_method=static_keys \
+  -config access_key_id=<your-r2-access-key-id> \
+  -config secret_access_key=<your-r2-secret-access-key> \
+  -config api_token=<your-cloudflare-api-token>
 
 # Create policy
 warden policy write cloudflare-access - <<EOF

--- a/provider/cohere/README.md
+++ b/provider/cohere/README.md
@@ -50,7 +50,7 @@ The Cohere provider enables proxied access to the Cohere API through Warden. It 
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/cohere-user \
 Enable the Cohere provider at a path of your choice:
 
 ```bash
-warden provider enable --type=cohere
+warden provider enable cohere
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=cohere cohere-prod
+warden provider enable -path=cohere-prod cohere
 ```
 
 Verify the provider is enabled:
@@ -127,21 +127,21 @@ The credential source holds only connection info (`api_url`). The API key is sto
 
 ```bash
 warden cred source create cohere-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.cohere.com \
-  --config=verify_endpoint=/v1/check-api-key \
-  --config=verify_method=POST \
-  --config=auth_header_type=bearer \
-  --config=display_name=Cohere
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.cohere.com \
+  -config=verify_endpoint=/v1/check-api-key \
+  -config=verify_method=POST \
+  -config=auth_header_type=bearer \
+  -config=display_name=Cohere
 ```
 
 Create a credential spec that references the credential source. The spec carries the API key and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create cohere-prod \
-  --source cohere-src \
-  --config api_key=your-cohere-api-key
+  -source cohere-src \
+  -config api_key=your-cohere-api-key
 ```
 
 The API key is validated at creation time via a `POST /v1/check-api-key` call to the Cohere API (SpecVerifier). If the key is invalid, spec creation will fail.
@@ -157,24 +157,24 @@ Instead of storing API keys directly in Warden, you can store them in a Vault/Op
 ```bash
 # Create a Vault credential source
 warden cred source create cohere-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create cohere-prod \
-  --source cohere-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=cohere/prod
+  -source cohere-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=cohere/prod
 ```
 
 The KV v2 secret at `secret/cohere/prod` should contain an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -395,14 +395,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -519,6 +519,6 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update cohere-prod \
-     --config api_key=your-new-api-key
+     -config api_key=your-new-api-key
    ```
 3. Delete the old key in the Cohere dashboard

--- a/provider/datadog/README.md
+++ b/provider/datadog/README.md
@@ -50,7 +50,7 @@ The Datadog provider enables proxied access to the Datadog REST API through Ward
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/datadog-user \
 Enable the Datadog provider at a path of your choice:
 
 ```bash
-warden provider enable --type=datadog
+warden provider enable datadog
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=datadog datadog-prod
+warden provider enable -path=datadog-prod datadog
 ```
 
 Verify the provider is enabled:
@@ -139,22 +139,22 @@ The credential source holds only connection info (`api_url`). The API key and ap
 
 ```bash
 warden cred source create datadog-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.datadoghq.com \
-  --config=verify_endpoint=/api/v1/validate \
-  --config=auth_header_type=custom_header \
-  --config=auth_header_name=DD-API-KEY \
-  --config=display_name=Datadog
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.datadoghq.com \
+  -config=verify_endpoint=/api/v1/validate \
+  -config=auth_header_type=custom_header \
+  -config=auth_header_name=DD-API-KEY \
+  -config=display_name=Datadog
 ```
 
 Create a credential spec that references the credential source. The spec carries the API key (and optionally an application key) and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create datadog-ops \
-  --source datadog-src \
-  --config api_key=your-datadog-api-key \
-  --config application_key=your-datadog-application-key
+  -source datadog-src \
+  -config api_key=your-datadog-api-key \
+  -config application_key=your-datadog-application-key
 ```
 
 The API key is validated at creation time via a `GET /api/v1/validate` call to the Datadog API (SpecVerifier). If the key is invalid, spec creation will fail.
@@ -172,24 +172,24 @@ Instead of storing API keys directly in Warden, you can store them in a Vault/Op
 ```bash
 # Create a Vault credential source
 warden cred source create datadog-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create datadog-ops \
-  --source datadog-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=datadog/ops
+  -source datadog-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=datadog/ops
 ```
 
 The KV v2 secret at `secret/datadog/ops` should contain an `api_key` field and optionally an `application_key` field. Warden fetches the secret from Vault on each credential request.
@@ -379,14 +379,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -504,7 +504,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update datadog-ops \
-     --config api_key=your-new-api-key \
-     --config application_key=your-new-application-key
+     -config api_key=your-new-api-key \
+     -config application_key=your-new-application-key
    ```
 3. Revoke the old keys in Datadog

--- a/provider/dynatrace/README.md
+++ b/provider/dynatrace/README.md
@@ -52,7 +52,7 @@ The Dynatrace provider enables proxied access to the Dynatrace REST API through 
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -70,7 +70,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -87,13 +87,13 @@ warden write auth/jwt/role/dynatrace-user \
 Enable the Dynatrace provider at a path of your choice:
 
 ```bash
-warden provider enable --type=dynatrace
+warden provider enable dynatrace
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=dynatrace dynatrace-prod
+warden provider enable -path=dynatrace-prod dynatrace
 ```
 
 Verify the provider is enabled:
@@ -131,23 +131,23 @@ The credential source holds only connection info. The API token is stored on the
 
 ```bash
 warden cred source create dynatrace-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://abc12345.live.dynatrace.com \
-  --config=verify_endpoint=/api/v2/tokens/lookup \
-  --config=verify_method=POST \
-  --config=auth_header_type=custom_header \
-  --config=auth_header_name=Authorization \
-  --config=extra_headers=Authorization:Api-Token \
-  --config=display_name=Dynatrace
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://abc12345.live.dynatrace.com \
+  -config=verify_endpoint=/api/v2/tokens/lookup \
+  -config=verify_method=POST \
+  -config=auth_header_type=custom_header \
+  -config=auth_header_name=Authorization \
+  -config=extra_headers=Authorization:Api-Token \
+  -config=display_name=Dynatrace
 ```
 
 Create a credential spec that references the credential source. The spec carries the API token and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create dynatrace-env \
-  --source dynatrace-src \
-  --config api_key=dt0c01.XXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+  -source dynatrace-src \
+  -config api_key=dt0c01.XXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
 ```
 
 > **Note:** Dynatrace API tokens follow the format `dt0c01.{token-id}.{secret}`. You can create tokens in Dynatrace under Access tokens with specific scopes.
@@ -158,22 +158,22 @@ For Dynatrace Platform API access, use OAuth2 client credentials. This is recomm
 
 ```bash
 warden cred source create dynatrace-oauth-src \
-  --type=oauth2 \
-  --rotation-period=0 \
-  --config=client_id=dt0s02.XXXXXXXX \
-  --config=client_secret=dt0s02.XXXXXXXX.YYYYYYYYYYYYYYYYYYYY \
-  --config=token_url=https://sso.dynatrace.com/sso/oauth2/token \
-  --config=default_scopes="storage:buckets:read app-engine:apps:run" \
-  --config=token_param.resource=urn:dtaccount:your-account-uuid \
-  --config=display_name=Dynatrace
+  -type=oauth2 \
+  -rotation-period=0 \
+  -config=client_id=dt0s02.XXXXXXXX \
+  -config=client_secret=dt0s02.XXXXXXXX.YYYYYYYYYYYYYYYYYYYY \
+  -config=token_url=https://sso.dynatrace.com/sso/oauth2/token \
+  -config=default_scopes="storage:buckets:read app-engine:apps:run" \
+  -config=token_param.resource=urn:dtaccount:your-account-uuid \
+  -config=display_name=Dynatrace
 ```
 
 Create a credential spec (scope can be overridden per spec):
 
 ```bash
 warden cred spec create dynatrace-platform \
-  --source dynatrace-oauth-src \
-  --config scope="storage:buckets:read storage:logs:read"
+  -source dynatrace-oauth-src \
+  -config scope="storage:buckets:read storage:logs:read"
 ```
 
 > **Note:** The `token_param.resource` on the source config injects the `resource` form parameter into the OAuth2 token exchange, as required by Dynatrace SSO. OAuth2 tokens are valid for 5 minutes; when a token expires, Warden transparently re-mints a fresh one on the next request.
@@ -201,24 +201,24 @@ Instead of storing API tokens directly in Warden, you can store them in a Vault/
 ```bash
 # Create a Vault credential source
 warden cred source create dynatrace-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create dynatrace-env \
-  --source dynatrace-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=dynatrace/env
+  -source dynatrace-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=dynatrace/env
 ```
 
 The KV v2 secret at `secret/dynatrace/env` should contain an `api_key` field with the Dynatrace API token.
@@ -381,14 +381,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -524,7 +524,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update dynatrace-env \
-     --config api_key=dt0c01.NEW_TOKEN_ID.NEW_TOKEN_SECRET
+     -config api_key=dt0c01.NEW_TOKEN_ID.NEW_TOKEN_SECRET
    ```
 3. Revoke the old token in Dynatrace
 

--- a/provider/elastic/README.md
+++ b/provider/elastic/README.md
@@ -50,7 +50,7 @@ The Elastic provider enables proxied access to Elasticsearch REST APIs through W
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/elastic-user \
 Enable the Elastic provider at a path of your choice:
 
 ```bash
-warden provider enable --type=elastic
+warden provider enable elastic
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=elastic elastic-prod
+warden provider enable -path=elastic-prod elastic
 ```
 
 Verify the provider is enabled:
@@ -131,21 +131,21 @@ Elasticsearch API keys use the format `base64(id:api_key)`. When you create an A
 
 ```bash
 warden cred source create elastic-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
-  --config=verify_endpoint=/ \
-  --config=auth_header_type=custom_header \
-  --config=auth_header_name=Authorization \
-  --config=display_name=Elastic
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
+  -config=verify_endpoint=/ \
+  -config=auth_header_type=custom_header \
+  -config=auth_header_name=Authorization \
+  -config=display_name=Elastic
 ```
 
 Create a credential spec that references the credential source. The spec carries the pre-encoded API key.
 
 ```bash
 warden cred spec create elastic-ops \
-  --source elastic-src \
-  --config api_key=your-base64-encoded-api-key
+  -source elastic-src \
+  -config api_key=your-base64-encoded-api-key
 ```
 
 > **Tip:** To get the encoded API key from Elasticsearch:
@@ -162,10 +162,10 @@ The Elasticsearch driver creates API keys programmatically via `POST /_security/
 
 ```bash
 warden cred source create elastic-src \
-  --type=elastic \
-  --config=elastic_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
-  --config=api_key=your-base64-encoded-source-api-key \
-  --rotation-period=72h
+  -type=elastic \
+  -config=elastic_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
+  -config=api_key=your-base64-encoded-source-api-key \
+  -rotation-period=72h
 ```
 
 The source API key must have sufficient privileges to create and invalidate API keys. To create such a key:
@@ -188,23 +188,23 @@ Create a credential spec. The driver mints a new API key for each spec:
 
 ```bash
 warden cred spec create elastic-ops \
-  --source elastic-src
+  -source elastic-src
 ```
 
 Optionally restrict the minted key's permissions via `role_descriptors`:
 
 ```bash
 warden cred spec create elastic-readonly \
-  --source elastic-src \
-  --config 'role_descriptors={"reader":{"indices":[{"names":["my-index-*"],"privileges":["read"]}]}}'
+  -source elastic-src \
+  -config 'role_descriptors={"reader":{"indices":[{"names":["my-index-*"],"privileges":["read"]}]}}'
 ```
 
 Set an expiration on minted keys:
 
 ```bash
 warden cred spec create elastic-temp \
-  --source elastic-src \
-  --config expiration=1h
+  -source elastic-src \
+  -config expiration=1h
 ```
 
 ### Option C: Vault/OpenBao as Credential Source
@@ -218,24 +218,24 @@ Store the Elasticsearch API key in a Vault/OpenBao KV v2 secret and have Warden 
 ```bash
 # Create a Vault credential source
 warden cred source create elastic-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create elastic-ops \
-  --source elastic-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=elastic/ops
+  -source elastic-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=elastic/ops
 ```
 
 Verify:
@@ -380,14 +380,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -520,7 +520,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update elastic-ops \
-     --config api_key=your-new-base64-encoded-api-key
+     -config api_key=your-new-base64-encoded-api-key
    ```
 3. Invalidate the old key in Elasticsearch:
    ```bash

--- a/provider/gcp/README.md
+++ b/provider/gcp/README.md
@@ -50,7 +50,7 @@ The GCP provider enables proxied access to Google Cloud Platform APIs through Wa
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -81,7 +81,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -98,13 +98,13 @@ warden write auth/jwt/role/gcp-user \
 Enable the GCP provider at a path of your choice:
 
 ```bash
-warden provider enable --type=gcp
+warden provider enable gcp
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=gcp gcp-prod
+warden provider enable -path=gcp-prod gcp
 ```
 
 Verify the provider is enabled:
@@ -137,10 +137,10 @@ The credential source holds the service account key used to authenticate with GC
 
 ```bash
 warden cred source create gcp-sa \
-  --type=gcp_access_token \
-  --rotation-period=720h \
-  --config=source=gcp \
-  --config=service_account_key=@/path/to/service-account-key.json
+  -type=gcp_access_token \
+  -rotation-period=720h \
+  -config=source=gcp \
+  -config=service_account_key=@/path/to/service-account-key.json
 ```
 
 The `@` prefix reads the file contents into the config value.
@@ -159,11 +159,11 @@ Mint OAuth2 access tokens using the source service account directly:
 
 ```bash
 warden cred spec create gcp-cloud-platform \
-  --source=gcp-sa \
-  --min-ttl=5m \
-  --max-ttl=1h \
-  --config=mint_method=access_token \
-  --config=scopes=https://www.googleapis.com/auth/cloud-platform
+  -source=gcp-sa \
+  -min-ttl=5m \
+  -max-ttl=1h \
+  -config=mint_method=access_token \
+  -config=scopes=https://www.googleapis.com/auth/cloud-platform
 ```
 
 ### Option B: Impersonated Access Token
@@ -172,13 +172,13 @@ Mint tokens on behalf of another service account:
 
 ```bash
 warden cred spec create gcp-impersonated \
-  --source=gcp-sa \
-  --min-ttl=5m \
-  --max-ttl=1h \
-  --config=mint_method=impersonated_access_token \
-  --config=target_service_account=target@my-project.iam.gserviceaccount.com \
-  --config=scopes=https://www.googleapis.com/auth/cloud-platform \
-  --config=lifetime=3600s
+  -source=gcp-sa \
+  -min-ttl=5m \
+  -max-ttl=1h \
+  -config=mint_method=impersonated_access_token \
+  -config=target_service_account=target@my-project.iam.gserviceaccount.com \
+  -config=scopes=https://www.googleapis.com/auth/cloud-platform \
+  -config=lifetime=3600s
 ```
 
 ### Option C: Vault/OpenBao GCP Secret Engine
@@ -192,29 +192,29 @@ Instead of storing a service account key in Warden, you can use the Vault GCP se
 ```bash
 # Create a Vault credential source
 warden cred source create gcp-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 # Create a credential spec using the dynamic_gcp mint method (roleset)
 warden cred spec create gcp-cloud-platform \
-  --source gcp-vault-src \
-  --config mint_method=dynamic_gcp \
-  --config gcp_mount=gcp \
-  --config role_name=my-roleset
+  -source gcp-vault-src \
+  -config mint_method=dynamic_gcp \
+  -config gcp_mount=gcp \
+  -config role_name=my-roleset
 
 # Or using a static account instead of a roleset
 warden cred spec create gcp-static \
-  --source gcp-vault-src \
-  --config mint_method=dynamic_gcp \
-  --config gcp_mount=gcp \
-  --config role_name=my-static-account \
-  --config role_type=static-account
+  -source gcp-vault-src \
+  -config mint_method=dynamic_gcp \
+  -config gcp_mount=gcp \
+  -config role_name=my-static-account \
+  -config role_type=static-account
 ```
 
 Verify:
@@ -379,14 +379,14 @@ When the source key rotates, all credential specs sharing that source automatica
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -52,7 +52,7 @@ The GitHub provider enables proxied access to the GitHub REST API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -70,7 +70,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -87,13 +87,13 @@ warden write auth/jwt/role/github-user \
 Enable the GitHub provider at a path of your choice:
 
 ```bash
-warden provider enable --type=github
+warden provider enable github
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=github github-prod
+warden provider enable -path=github-prod github
 ```
 
 Verify the provider is enabled:
@@ -127,9 +127,9 @@ The credential source holds only connection info. Auth credentials (PAT, App pri
 
 ```bash
 warden cred source create github-src \
-  --type=github \
-  --rotation-period=0 \
-  --config=github_url=https://api.github.com
+  -type=github \
+  -rotation-period=0 \
+  -config=github_url=https://api.github.com
 ```
 
 Verify the source was created:
@@ -149,20 +149,20 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create github-ops \
-  --source github-src \
-  --config auth_method=app \
-  --config app_id=<your-app-id> \
-  --config private_key=@/path/to/private-key.pem \
-  --config installation_id=<your-installation-id>
+  -source github-src \
+  -config auth_method=app \
+  -config app_id=<your-app-id> \
+  -config private_key=@/path/to/private-key.pem \
+  -config installation_id=<your-installation-id>
 ```
 
 ### Option B: Personal Access Token
 
 ```bash
 warden cred spec create github-ops \
-  --source github-src \
-  --config auth_method=pat \
-  --config token=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  -source github-src \
+  -config auth_method=pat \
+  -config token=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 Verify:
@@ -338,14 +338,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -54,7 +54,7 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -72,7 +72,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -89,13 +89,13 @@ warden write auth/jwt/role/gitlab-user \
 Enable the GitLab provider at a path of your choice:
 
 ```bash
-warden provider enable --type=gitlab
+warden provider enable gitlab
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=gitlab gitlab-prod
+warden provider enable -path=gitlab-prod gitlab
 ```
 
 Verify the provider is enabled:
@@ -134,12 +134,12 @@ The credential source holds the connection info and auth credentials for GitLab.
 
 ```bash
 warden cred source create gitlab-oauth \
-  --type=gitlab \
-  --rotation-period=720h \
-  --config=gitlab_address=https://gitlab.com \
-  --config=auth_method=oauth2 \
-  --config=application_id=<your-application-id> \
-  --config=application_secret=<your-application-secret>
+  -type=gitlab \
+  -rotation-period=720h \
+  -config=gitlab_address=https://gitlab.com \
+  -config=auth_method=oauth2 \
+  -config=application_id=<your-application-id> \
+  -config=application_secret=<your-application-secret>
 ```
 
 ### Option B: Personal Access Token
@@ -149,11 +149,11 @@ warden cred source create gitlab-oauth \
 
 ```bash
 warden cred source create gitlab-pat \
-  --type=gitlab \
-  --rotation-period=720h \
-  --config=gitlab_address=https://gitlab.com \
-  --config=auth_method=pat \
-  --config=personal_access_token=glpat-xxxxxxxxxxxxxxxxxxxx
+  -type=gitlab \
+  -rotation-period=720h \
+  -config=gitlab_address=https://gitlab.com \
+  -config=auth_method=pat \
+  -config=personal_access_token=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
 Verify the source was created:
@@ -168,28 +168,28 @@ Create a credential spec that references the credential source. The spec defines
 
 ```bash
 warden cred spec create gitlab-project-token \
-  --source=gitlab-pat \
-  --min-ttl=1h \
-  --max-ttl=24h \
-  --config=mint_method=project_access_token \
-  --config=project_id=123 \
-  --config=token_name=warden-minted \
-  --config=scopes=api,read_api \
-  --config=access_level=30
+  -source=gitlab-pat \
+  -min-ttl=1h \
+  -max-ttl=24h \
+  -config=mint_method=project_access_token \
+  -config=project_id=123 \
+  -config=token_name=warden-minted \
+  -config=scopes=api,read_api \
+  -config=access_level=30
 ```
 
 ### Group Access Token
 
 ```bash
 warden cred spec create gitlab-group-token \
-  --source=gitlab-pat \
-  --min-ttl=1h \
-  --max-ttl=24h \
-  --config=mint_method=group_access_token \
-  --config=group_id=79644309 \
-  --config=token_name=warden-minted \
-  --config=scopes=api \
-  --config=access_level=30
+  -source=gitlab-pat \
+  -min-ttl=1h \
+  -max-ttl=24h \
+  -config=mint_method=group_access_token \
+  -config=group_id=79644309 \
+  -config=token_name=warden-minted \
+  -config=scopes=api \
+  -config=access_level=30
 ```
 
 Verify:
@@ -364,14 +364,14 @@ The default activation delay is **1 minute** (configurable via `activation_delay
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA

--- a/provider/grafana/README.md
+++ b/provider/grafana/README.md
@@ -53,7 +53,7 @@ A single provider type supports all Grafana services. Mount multiple instances w
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -71,7 +71,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -88,13 +88,13 @@ warden write auth/jwt/role/grafana-user \
 Enable the Grafana provider at a path of your choice:
 
 ```bash
-warden provider enable --type=grafana
+warden provider enable grafana
 ```
 
 To mount at a custom path (useful for multi-service setups):
 
 ```bash
-warden provider enable --type=grafana grafana-loki
+warden provider enable -path=grafana-loki grafana
 ```
 
 Verify the provider is enabled:
@@ -134,19 +134,19 @@ Create a service account in Grafana:
 
 ```bash
 warden cred source create grafana-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://mystack.grafana.net/api \
-  --config=verify_endpoint=/org \
-  --config=display_name=Grafana
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://mystack.grafana.net/api \
+  -config=verify_endpoint=/org \
+  -config=display_name=Grafana
 ```
 
 Create a credential spec that references the credential source:
 
 ```bash
 warden cred spec create grafana-ops \
-  --source grafana-src \
-  --config api_key=glsa_your-service-account-token
+  -source grafana-src \
+  -config api_key=glsa_your-service-account-token
 ```
 
 ### Option B: Dynamic Tokens via Grafana Source Driver
@@ -156,19 +156,19 @@ The Grafana source driver uses an admin service account token to programmaticall
 ```bash
 # Create a Grafana credential source with admin token
 warden cred source create grafana-dynamic-src \
-  --type=grafana \
-  --config=grafana_url=https://mystack.grafana.net \
-  --config=admin_token=glsa_your-admin-token
+  -type=grafana \
+  -config=grafana_url=https://mystack.grafana.net \
+  -config=admin_token=glsa_your-admin-token
 ```
 
 Create a credential spec for dynamic token minting:
 
 ```bash
 warden cred spec create grafana-ops \
-  --source grafana-dynamic-src \
-  --config role=Viewer \
-  --config token_expiry=1h \
-  --config name_prefix=warden-
+  -source grafana-dynamic-src \
+  -config role=Viewer \
+  -config token_expiry=1h \
+  -config name_prefix=warden-
 ```
 
 ### Option C: Vault/OpenBao as Credential Source
@@ -177,24 +177,24 @@ Store the Grafana token in Vault/OpenBao KV v2 and have Warden fetch it at runti
 
 ```bash
 warden cred source create grafana-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create grafana-ops \
-  --source grafana-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=grafana/ops
+  -source grafana-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=grafana/ops
 ```
 
 ## Step 4: Create a Policy
@@ -299,7 +299,7 @@ Mount multiple instances of the Grafana provider for different ecosystem service
 ### Loki (Logs)
 
 ```bash
-warden provider enable --type=grafana grafana-loki
+warden provider enable -path=grafana-loki grafana
 
 warden write grafana-loki/config <<EOF
 {
@@ -330,7 +330,7 @@ curl -s "${LOKI_ENDPOINT}/loki/api/v1/labels" \
 ### Mimir (Metrics)
 
 ```bash
-warden provider enable --type=grafana grafana-mimir
+warden provider enable -path=grafana-mimir grafana
 
 warden write grafana-mimir/config <<EOF
 {
@@ -357,7 +357,7 @@ curl -s "${MIMIR_ENDPOINT}/prometheus/api/v1/query_range?query=up&start=16094592
 ### Tempo (Traces)
 
 ```bash
-warden provider enable --type=grafana grafana-tempo
+warden provider enable -path=grafana-tempo grafana
 
 warden write grafana-tempo/config <<EOF
 {
@@ -381,14 +381,14 @@ curl -s "${TEMPO_ENDPOINT}/api/search?q={resource.service.name=\"myapp\"}" \
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -502,7 +502,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update grafana-ops \
-     --config api_key=glsa_your-new-token
+     -config api_key=glsa_your-new-token
    ```
 3. Delete the old token in Grafana
 

--- a/provider/honeycomb/README.md
+++ b/provider/honeycomb/README.md
@@ -52,7 +52,7 @@ The Honeycomb provider enables proxied access to the Honeycomb API through Warde
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -70,7 +70,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -87,13 +87,13 @@ warden write auth/jwt/role/honeycomb-user \
 Enable the Honeycomb provider at a path of your choice:
 
 ```bash
-warden provider enable --type=honeycomb
+warden provider enable honeycomb
 ```
 
 To mount at a custom path (e.g., for the EU region):
 
 ```bash
-warden provider enable --type=honeycomb honeycomb-eu
+warden provider enable -path=honeycomb-eu honeycomb
 ```
 
 Verify the provider is enabled:
@@ -141,18 +141,18 @@ Use this when you already have a Honeycomb ingest or configuration key and want 
 
 ```bash
 warden cred source create honeycomb-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.honeycomb.io \
-  --config=display_name=Honeycomb
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.honeycomb.io \
+  -config=display_name=Honeycomb
 ```
 
 Create a credential spec with your API key:
 
 ```bash
 warden cred spec create honeycomb-ops \
-  --source honeycomb-src \
-  --config api_key=your-honeycomb-api-key
+  -source honeycomb-src \
+  -config api_key=your-honeycomb-api-key
 ```
 
 ### Option B: Dynamic API Keys (Honeycomb Source Driver)
@@ -168,35 +168,35 @@ Create a credential source backed by the Honeycomb API:
 
 ```bash
 warden cred source create honeycomb-src \
-  --type=honeycomb \
-  --rotation-period=24h \
-  --config=management_key_id=hcxmk_01abc123 \
-  --config=management_key_secret=your-management-key-secret \
-  --config=team_slug=my-team \
-  --config=honeycomb_url=https://api.honeycomb.io
+  -type=honeycomb \
+  -rotation-period=24h \
+  -config=management_key_id=hcxmk_01abc123 \
+  -config=management_key_secret=your-management-key-secret \
+  -config=team_slug=my-team \
+  -config=honeycomb_url=https://api.honeycomb.io
 ```
 
 Create a credential spec that mints ingest keys:
 
 ```bash
 warden cred spec create honeycomb-ops \
-  --source honeycomb-src \
-  --config environment_id=your-environment-id \
-  --config key_type=ingest \
-  --config key_name_prefix=warden- \
-  --config key_ttl=24h
+  -source honeycomb-src \
+  -config environment_id=your-environment-id \
+  -config key_type=ingest \
+  -config key_name_prefix=warden- \
+  -config key_ttl=24h
 ```
 
 For configuration keys with specific permissions:
 
 ```bash
 warden cred spec create honeycomb-config \
-  --source honeycomb-src \
-  --config environment_id=your-environment-id \
-  --config key_type=configuration \
-  --config key_name_prefix=warden- \
-  --config key_ttl=24h \
-  --config 'permissions={"send_events":true,"create_datasets":true,"run_queries":true}'
+  -source honeycomb-src \
+  -config environment_id=your-environment-id \
+  -config key_type=configuration \
+  -config key_name_prefix=warden- \
+  -config key_ttl=24h \
+  -config 'permissions={"send_events":true,"create_datasets":true,"run_queries":true}'
 ```
 
 ### Option C: Vault/OpenBao as Credential Source
@@ -210,24 +210,24 @@ Instead of storing the API key directly in Warden, you can store it in a Vault/O
 ```bash
 # Create a Vault credential source
 warden cred source create honeycomb-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create honeycomb-ops \
-  --source honeycomb-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=honeycomb/ops
+  -source honeycomb-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=honeycomb/ops
 ```
 
 The KV v2 secret at `secret/honeycomb/ops` must contain an `api_key` field with your Honeycomb ingest or configuration key.
@@ -381,14 +381,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-4 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -524,7 +524,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update honeycomb-ops \
-     --config api_key=your-new-api-key
+     -config api_key=your-new-api-key
    ```
 3. Delete the old key in Honeycomb
 
@@ -534,7 +534,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential source:
    ```bash
    warden cred source update honeycomb-src \
-     --config management_key_id=new-key-id \
-     --config management_key_secret=new-key-secret
+     -config management_key_id=new-key-id \
+     -config management_key_secret=new-key-secret
    ```
 3. Delete the old management key in Honeycomb

--- a/provider/ibmcloud/README.md
+++ b/provider/ibmcloud/README.md
@@ -81,7 +81,7 @@ Only hosts matching the `allowed_host_suffixes` list (default: `.cloud.ibm.com`,
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -99,7 +99,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -116,13 +116,13 @@ warden write auth/jwt/role/ibmcloud-user \
 Enable the IBM Cloud provider at a path of your choice:
 
 ```bash
-warden provider enable --type=ibmcloud
+warden provider enable ibmcloud
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=ibmcloud ibmcloud-prod
+warden provider enable -path=ibmcloud-prod ibmcloud
 ```
 
 Verify the provider is enabled:
@@ -175,24 +175,24 @@ The IBM driver exchanges your API key for a short-lived IAM token and combines i
 
 ```bash
 warden cred source create ibmcloud-src \
-  --type=ibm \
-  --config=api_key=your-ibm-api-key
+  -type=ibm \
+  -config=api_key=your-ibm-api-key
 
 warden cred spec create ibmcloud-ops \
-  --source ibmcloud-src \
-  --type=ibmcloud_keys \
-  --config mint_method=iam_with_cos \
-  --config access_key_id=your-cos-access-key-id \
-  --config secret_access_key=your-cos-secret-access-key
+  -source ibmcloud-src \
+  -type=ibmcloud_keys \
+  -config mint_method=iam_with_cos \
+  -config access_key_id=your-cos-access-key-id \
+  -config secret_access_key=your-cos-secret-access-key
 ```
 
 **API-only (no COS):**
 
 ```bash
 warden cred spec create ibmcloud-api-only \
-  --source ibmcloud-src \
-  --type=ibmcloud_keys \
-  --config mint_method=iam_with_cos
+  -source ibmcloud-src \
+  -type=ibmcloud_keys \
+  -config mint_method=iam_with_cos
 ```
 
 ### Option B: Vault/OpenBao — Dynamic IBM Secrets Engine
@@ -201,23 +201,23 @@ Use Vault's IBM secrets engine to generate dynamic API keys with automatic lease
 
 ```bash
 warden cred source create ibmcloud-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 warden cred spec create ibmcloud-ops \
-  --source ibmcloud-vault-src \
-  --type=ibmcloud_keys \
-  --config mint_method=dynamic_ibm \
-  --config ibm_mount=ibmcloud \
-  --config role_name=my-ibm-role \
-  --config access_key_id=your-cos-access-key-id \
-  --config secret_access_key=your-cos-secret-access-key
+  -source ibmcloud-vault-src \
+  -type=ibmcloud_keys \
+  -config mint_method=dynamic_ibm \
+  -config ibm_mount=ibmcloud \
+  -config role_name=my-ibm-role \
+  -config access_key_id=your-cos-access-key-id \
+  -config secret_access_key=your-cos-secret-access-key
 ```
 
 Warden calls the Vault IBM secrets engine to get a dynamic API key, exchanges it for an IAM token, and optionally merges static COS HMAC keys from the spec config.
@@ -517,7 +517,7 @@ Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA

--- a/provider/kubernetes/README.md
+++ b/provider/kubernetes/README.md
@@ -33,7 +33,7 @@ The Kubernetes provider enables proxied access to Kubernetes API servers through
 >
 > **2. Start Warden in dev mode:**
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 
 ## Step 1: Configure JWT Auth and Create a Role
@@ -42,7 +42,7 @@ Enable JWT auth and create a role bound to a Warden policy:
 
 ```bash
 # Enable JWT auth (if not already enabled)
-warden auth enable --type=jwt --path=auth/jwt/
+warden auth enable jwt -path=auth/jwt/
 
 # Configure JWT auth with your OIDC provider
 warden write auth/jwt/config \
@@ -60,7 +60,7 @@ warden write auth/jwt/role/k8s-user \
 
 ```bash
 # Enable the Kubernetes provider
-warden provider enable --type=kubernetes
+warden provider enable kubernetes
 
 # Configure the provider with your cluster's API server URL
 warden write kubernetes/config \
@@ -101,28 +101,28 @@ SOURCE_TOKEN=$(kubectl create token warden-token-creator -n warden --duration=24
 
 # Create the credential source with automatic token rotation
 warden cred source create k8s-source \
-  --type=kubernetes \
-  --rotation-period=12h \
-  --config=kubernetes_url=https://my-cluster.example.com:6443 \
-  --config=token=$SOURCE_TOKEN \
-  --config=ca_data=$CA_DATA \
-  --config=source_service_account=warden-token-creator \
-  --config=source_namespace=warden \
-  --config=source_token_ttl=24h
+  -type=kubernetes \
+  -rotation-period=12h \
+  -config=kubernetes_url=https://my-cluster.example.com:6443 \
+  -config=token=$SOURCE_TOKEN \
+  -config=ca_data=$CA_DATA \
+  -config=source_service_account=warden-token-creator \
+  -config=source_namespace=warden \
+  -config=source_token_ttl=24h
 ```
 
 For development clusters with self-signed certificates:
 
 ```bash
 warden cred source create k8s-source-dev \
-  --type=kubernetes \
-  --rotation-period=12h \
-  --config=kubernetes_url=https://localhost:6443 \
-  --config=token=$SOURCE_TOKEN \
-  --config=tls_skip_verify=true \
-  --config=source_service_account=warden-token-creator \
-  --config=source_namespace=warden \
-  --config=source_token_ttl=24h
+  -type=kubernetes \
+  -rotation-period=12h \
+  -config=kubernetes_url=https://localhost:6443 \
+  -config=token=$SOURCE_TOKEN \
+  -config=tls_skip_verify=true \
+  -config=source_service_account=warden-token-creator \
+  -config=source_namespace=warden \
+  -config=source_token_ttl=24h
 ```
 
 > **How rotation works:** `source_service_account` and `source_namespace` tell the driver
@@ -152,11 +152,11 @@ kubectl wait --for=jsonpath='{.data.token}' secret/warden-token-creator-token -n
 SOURCE_TOKEN=$(kubectl get secret warden-token-creator-token -n warden -o jsonpath='{.data.token}' | base64 -d)
 
 warden cred source create k8s-source \
-  --type=kubernetes \
-  --rotation-period=0 \
-  --config=kubernetes_url=https://my-cluster.example.com:6443 \
-  --config=token=$SOURCE_TOKEN \
-  --config=ca_data=$CA_DATA
+  -type=kubernetes \
+  -rotation-period=0 \
+  -config=kubernetes_url=https://my-cluster.example.com:6443 \
+  -config=token=$SOURCE_TOKEN \
+  -config=ca_data=$CA_DATA
 ```
 
 </details>
@@ -202,30 +202,30 @@ roleRef:
 ```bash
 # Read-only spec — tokens inherit the "pod-reader" Role
 warden cred spec create k8s-app-reader \
-  --source k8s-source \
-  --config service_account=app-reader \
-  --config namespace=default \
-  --config ttl=1h
+  -source k8s-source \
+  -config service_account=app-reader \
+  -config namespace=default \
+  -config ttl=1h
 ```
 
 ```bash
 # Different spec for a different access level (e.g., an admin SA with broader permissions)
 warden cred spec create k8s-app-admin \
-  --source k8s-source \
-  --config service_account=app-admin \
-  --config namespace=default \
-  --config ttl=30m
+  -source k8s-source \
+  -config service_account=app-admin \
+  -config namespace=default \
+  -config ttl=30m
 ```
 
 With custom audiences:
 
 ```bash
 warden cred spec create k8s-api-consumer \
-  --source k8s-source \
-  --config service_account=api-consumer \
-  --config namespace=production \
-  --config audiences=https://my-app.example.com,https://api.example.com \
-  --config ttl=30m
+  -source k8s-source \
+  -config service_account=api-consumer \
+  -config namespace=production \
+  -config audiences=https://my-app.example.com,https://api.example.com \
+  -config ttl=30m
 ```
 
 ## Step 4: Create a Policy
@@ -402,10 +402,10 @@ If rotation is not configured (no `source_service_account`/`source_namespace`), 
 ```bash
 SOURCE_TOKEN=$(kubectl create token warden-token-creator -n warden --duration=24h)
 warden cred source create k8s-source \
-  --type=kubernetes \
-  --rotation-period=0 \
-  --config=kubernetes_url=https://my-cluster.example.com:6443 \
-  --config=token=$SOURCE_TOKEN
+  -type=kubernetes \
+  -rotation-period=0 \
+  -config=kubernetes_url=https://my-cluster.example.com:6443 \
+  -config=token=$SOURCE_TOKEN
 ```
 
 ## Troubleshooting

--- a/provider/mistral/README.md
+++ b/provider/mistral/README.md
@@ -50,7 +50,7 @@ The Mistral provider enables proxied access to the Mistral AI API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/mistral-user \
 Enable the Mistral provider at a path of your choice:
 
 ```bash
-warden provider enable --type=mistral
+warden provider enable mistral
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=mistral mistral-prod
+warden provider enable -path=mistral-prod mistral
 ```
 
 Verify the provider is enabled:
@@ -125,12 +125,12 @@ The credential source holds only connection info (`api_url`). The API key is sto
 
 ```bash
 warden cred source create mistral-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.mistral.ai \
-  --config=verify_endpoint=/v1/models \
-  --config=optional_metadata=organization_id \
-  --config=display_name=Mistral
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.mistral.ai \
+  -config=verify_endpoint=/v1/models \
+  -config=optional_metadata=organization_id \
+  -config=display_name=Mistral
 ```
 
 Verify the source was created:
@@ -143,17 +143,17 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create mistral-ops \
-  --source mistral-src \
-  --config api_key=<your-mistral-api-key>
+  -source mistral-src \
+  -config api_key=<your-mistral-api-key>
 ```
 
 Optionally include an organization ID:
 
 ```bash
 warden cred spec create mistral-ops \
-  --source mistral-src \
-  --config api_key=<your-mistral-api-key> \
-  --config organization_id=<your-org-id>
+  -source mistral-src \
+  -config api_key=<your-mistral-api-key> \
+  -config organization_id=<your-org-id>
 ```
 
 The API key is validated at creation time via a `GET /v1/models` call to the Mistral API (SpecVerifier). If the key is invalid, spec creation will fail.
@@ -175,21 +175,21 @@ Instead of storing the API key directly in Warden, you can store it in a Vault/O
 ```bash
 # Create a Vault credential source
 warden cred source create mistral-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 # Create a credential spec using the static_apikey mint method
 warden cred spec create mistral-ops \
-  --source mistral-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=mistral/ops
+  -source mistral-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=mistral/ops
 ```
 
 The KV v2 secret at `secret/mistral/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -358,14 +358,14 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -472,6 +472,6 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update mistral-ops \
-     --config api_key=<new-api-key>
+     -config api_key=<new-api-key>
    ```
 3. Delete the old key from the Mistral console

--- a/provider/newrelic/README.md
+++ b/provider/newrelic/README.md
@@ -50,7 +50,7 @@ The New Relic provider enables proxied access to the New Relic REST API v2 and N
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/newrelic-user \
 Enable the New Relic provider at a path of your choice:
 
 ```bash
-warden provider enable --type=newrelic
+warden provider enable newrelic
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=newrelic newrelic-prod
+warden provider enable -path=newrelic-prod newrelic
 ```
 
 Verify the provider is enabled:
@@ -134,12 +134,12 @@ The credential source holds only connection info (`api_url`). The User API key i
 
 ```bash
 warden cred source create newrelic-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.newrelic.com \
-  --config=auth_header_type=custom_header \
-  --config=auth_header_name=Api-Key \
-  --config=display_name=New\ Relic
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.newrelic.com \
+  -config=auth_header_type=custom_header \
+  -config=auth_header_name=Api-Key \
+  -config=display_name=New\ Relic
 ```
 
 > **Note on verification:** New Relic's NerdGraph endpoint (`/graphql`) requires a POST with a GraphQL body, which the static API key driver's simple GET-based verifier does not support. Therefore `verify_endpoint` is omitted and key validation is skipped at spec creation time. The key will be validated on the first proxied request to New Relic.
@@ -148,8 +148,8 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create newrelic-ops \
-  --source newrelic-src \
-  --config api_key=NRAK-XXXXXXXXXXXXXXXXXXXX
+  -source newrelic-src \
+  -config api_key=NRAK-XXXXXXXXXXXXXXXXXXXX
 ```
 
 ### Option B: Vault/OpenBao as Credential Source
@@ -163,24 +163,24 @@ Instead of storing API keys directly in Warden, you can store them in a Vault/Op
 ```bash
 # Create a Vault credential source
 warden cred source create newrelic-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create newrelic-ops \
-  --source newrelic-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=newrelic/ops
+  -source newrelic-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=newrelic/ops
 ```
 
 The KV v2 secret at `secret/newrelic/ops` should contain an `api_key` field with the New Relic User API key. Warden fetches the secret from Vault on each credential request.
@@ -369,14 +369,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -508,7 +508,7 @@ New Relic does not have an atomic key rotation API. Rotation follows a create-th
 2. **Update** the credential spec in Warden:
    ```bash
    warden cred spec update newrelic-ops \
-     --config api_key=NRAK-YYYYYYYYYYYYYYYYYYYY
+     -config api_key=NRAK-YYYYYYYYYYYYYYYYYYYY
    ```
 3. **Verify** requests are working with the new key
 4. **Delete** the old key in New Relic (UI or via NerdGraph `apiAccessDeleteKeys` mutation)

--- a/provider/openai/README.md
+++ b/provider/openai/README.md
@@ -50,7 +50,7 @@ The OpenAI provider enables proxied access to the OpenAI API through Warden. It 
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/openai-user \
 Enable the OpenAI provider at a path of your choice:
 
 ```bash
-warden provider enable --type=openai
+warden provider enable openai
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=openai openai-prod
+warden provider enable -path=openai-prod openai
 ```
 
 Verify the provider is enabled:
@@ -125,12 +125,12 @@ The credential source holds only connection info (`api_url`). The API key is sto
 
 ```bash
 warden cred source create openai-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.openai.com \
-  --config=verify_endpoint=/v1/models \
-  --config=optional_metadata=organization_id,project_id \
-  --config=display_name=OpenAI
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.openai.com \
+  -config=verify_endpoint=/v1/models \
+  -config=optional_metadata=organization_id,project_id \
+  -config=display_name=OpenAI
 ```
 
 Verify the source was created:
@@ -143,18 +143,18 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create openai-ops \
-  --source openai-src \
-  --config api_key=<your-openai-api-key>
+  -source openai-src \
+  -config api_key=<your-openai-api-key>
 ```
 
 Optionally include an organization ID and/or project ID:
 
 ```bash
 warden cred spec create openai-ops \
-  --source openai-src \
-  --config api_key=<your-openai-api-key> \
-  --config organization_id=<your-org-id> \
-  --config project_id=<your-project-id>
+  -source openai-src \
+  -config api_key=<your-openai-api-key> \
+  -config organization_id=<your-org-id> \
+  -config project_id=<your-project-id>
 ```
 
 The API key is validated at creation time via a `GET /v1/models` call to the OpenAI API (SpecVerifier). If the key is invalid, spec creation will fail.
@@ -176,21 +176,21 @@ Instead of storing the API key directly in Warden, you can store it in a Vault/O
 ```bash
 # Create a Vault credential source
 warden cred source create openai-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 # Create a credential spec using the static_apikey mint method
 warden cred spec create openai-ops \
-  --source openai-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=openai/ops
+  -source openai-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=openai/ops
 ```
 
 The KV v2 secret at `secret/openai/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -372,14 +372,14 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -487,6 +487,6 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update openai-ops \
-     --config api_key=<new-api-key>
+     -config api_key=<new-api-key>
    ```
 3. Delete the old key from the OpenAI dashboard

--- a/provider/ovh/README.md
+++ b/provider/ovh/README.md
@@ -56,7 +56,7 @@ The OVH provider enables proxied access to OVHcloud APIs through Warden. It supp
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -74,7 +74,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -91,13 +91,13 @@ warden write auth/jwt/role/ovh-user \
 Enable the OVH provider at a path of your choice:
 
 ```bash
-warden provider enable --type=ovh
+warden provider enable ovh
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=ovh ovh-prod
+warden provider enable -path=ovh-prod ovh
 ```
 
 Verify the provider is enabled:
@@ -133,12 +133,12 @@ Create an OVH credential source using an OAuth2 service account. Warden automati
 
 ```bash
 warden cred source create ovh-src \
-  --type=ovh \
-  --config client_id=your-client-id \
-  --config client_secret=your-client-secret \
-  --config ovh_endpoint=ovh-eu \
-  --config project_id=your-cloud-project-id \
-  --config user_id=your-cloud-user-id
+  -type=ovh \
+  -config client_id=your-client-id \
+  -config client_secret=your-client-secret \
+  -config ovh_endpoint=ovh-eu \
+  -config project_id=your-cloud-project-id \
+  -config user_id=your-cloud-user-id
 ```
 
 The `project_id` and `user_id` are only needed for S3 credential management (`dynamic_s3` and `oauth2_token_and_s3` mint methods). They can be omitted if you only need API tokens, or overridden per-spec for multi-tenant S3 access.
@@ -147,27 +147,27 @@ The `project_id` and `user_id` are only needed for S3 credential management (`dy
 
 ```bash
 warden cred spec create ovh-api \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=oauth2_token
+  -source ovh-src \
+  -type=ovh_keys \
+  -config mint_method=oauth2_token
 ```
 
 **S3-only mode** (dynamic S3 credentials, ~1h TTL, revoked and re-created on expiry):
 
 ```bash
 warden cred spec create ovh-s3 \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=dynamic_s3
+  -source ovh-src \
+  -type=ovh_keys \
+  -config mint_method=dynamic_s3
 ```
 
 **Dual mode** (OAuth2 token + S3 credentials):
 
 ```bash
 warden cred spec create ovh-dual \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=oauth2_token_and_s3
+  -source ovh-src \
+  -type=ovh_keys \
+  -config mint_method=oauth2_token_and_s3
 ```
 
 **Multi-tenant S3 access** — override `project_id` and `user_id` per-spec to target different S3 users:
@@ -175,19 +175,19 @@ warden cred spec create ovh-dual \
 ```bash
 # Read-only S3 user
 warden cred spec create ovh-s3-reader \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=dynamic_s3 \
-  --config project_id=my-project \
-  --config user_id=reader-user-id
+  -source ovh-src \
+  -type=ovh_keys \
+  -config mint_method=dynamic_s3 \
+  -config project_id=my-project \
+  -config user_id=reader-user-id
 
 # Read-write S3 user
 warden cred spec create ovh-s3-writer \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=dynamic_s3 \
-  --config project_id=my-project \
-  --config user_id=writer-user-id
+  -source ovh-src \
+  -type=ovh_keys \
+  -config mint_method=dynamic_s3 \
+  -config project_id=my-project \
+  -config user_id=writer-user-id
 ```
 
 Verify:
@@ -403,14 +403,14 @@ S3 Object Storage regions are independent of the API region and are auto-detecte
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -528,7 +528,7 @@ aws s3 ls s3://my-bucket/ \
 2. Update the credential source:
    ```bash
    warden cred source update ovh-src \
-     --config client_id=new-client-id \
-     --config client_secret=new-client-secret
+     -config client_id=new-client-id \
+     -config client_secret=new-client-secret
    ```
 3. Revoke the old service account in OVHcloud IAM

--- a/provider/ovh/e2e_test/README.md
+++ b/provider/ovh/e2e_test/README.md
@@ -60,7 +60,7 @@ All permissions are **read-only**. No write operations are performed on the OVH 
 
 ### OVH Credential Setup
 
-The OVH provider uses an OVH source (`--type=ovh`) with an OAuth2 service account to automatically mint bearer tokens and S3 credentials.
+The OVH provider uses an OVH source (`-type=ovh`) with an OAuth2 service account to automatically mint bearer tokens and S3 credentials.
 
 | Field | Purpose | How to Obtain |
 |-------|---------|---------------|
@@ -154,7 +154,7 @@ docker compose -f deploy/docker-compose.quickstart.yml up -d
 ### 2. Start Warden (dev mode)
 
 ```bash
-warden server --dev --dev-root-token=root
+warden server -dev -dev-root-token=root
 ```
 
 ### 3. Configure Warden
@@ -164,7 +164,7 @@ export WARDEN_ADDR="http://127.0.0.1:8400"
 export WARDEN_TOKEN="root"
 
 # Enable JWT auth
-warden auth enable --type=jwt
+warden auth enable jwt
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create role
@@ -174,7 +174,7 @@ warden write auth/jwt/role/ovh-user \
     cred_spec_name=ovh-ops
 
 # Enable OVH provider
-warden provider enable --type=ovh
+warden provider enable ovh
 
 # Configure provider
 warden write ovh/config <<EOF
@@ -189,18 +189,18 @@ EOF
 ```bash
 # Create OVH credential source with OAuth2 service account
 warden cred source create ovh-src \
-  --type=ovh \
-  --config client_id=<your-client-id> \
-  --config client_secret=<your-client-secret> \
-  --config ovh_endpoint=ovh-eu \
-  --config project_id=<your-cloud-project-id> \
-  --config user_id=<your-cloud-user-id>
+  -type=ovh \
+  -config client_id=<your-client-id> \
+  -config client_secret=<your-client-secret> \
+  -config ovh_endpoint=ovh-eu \
+  -config project_id=<your-cloud-project-id> \
+  -config user_id=<your-cloud-user-id>
 
 # Create credential spec — dual mode (auto-minted API token + dynamic S3 keys)
 warden cred spec create ovh-ops \
-  --source ovh-src \
-  --type=ovh_keys \
-  --config mint_method=oauth2_token_and_s3
+  -source ovh-src \
+  -type=ovh_keys \
+  -config mint_method=oauth2_token_and_s3
 ```
 
 Other mint methods: `oauth2_token` (API only), `dynamic_s3` (S3 only).

--- a/provider/pagerduty/README.md
+++ b/provider/pagerduty/README.md
@@ -51,7 +51,7 @@ The PagerDuty provider enables proxied access to the PagerDuty REST API v2 throu
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -69,7 +69,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -86,13 +86,13 @@ warden write auth/jwt/role/pagerduty-user \
 Enable the PagerDuty provider at a path of your choice:
 
 ```bash
-warden provider enable --type=pagerduty
+warden provider enable pagerduty
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=pagerduty pagerduty-prod
+warden provider enable -path=pagerduty-prod pagerduty
 ```
 
 Verify the provider is enabled:
@@ -128,19 +128,19 @@ The credential source holds only connection info (`api_url`). The API token is s
 
 ```bash
 warden cred source create pagerduty-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://api.pagerduty.com \
-  --config=verify_endpoint=/users/me \
-  --config=display_name=PagerDuty
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://api.pagerduty.com \
+  -config=verify_endpoint=/users/me \
+  -config=display_name=PagerDuty
 ```
 
 Create a credential spec that references the credential source. The spec carries the API token and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create pagerduty-ops \
-  --source pagerduty-src \
-  --config api_key=your-pagerduty-api-token
+  -source pagerduty-src \
+  -config api_key=your-pagerduty-api-token
 ```
 
 The API token is validated at creation time via a `GET /users/me` call to the PagerDuty API (SpecVerifier). If the token is invalid, spec creation will fail.
@@ -160,24 +160,24 @@ Instead of storing the API token directly in Warden, you can store it in a Vault
 ```bash
 # Create a Vault credential source
 warden cred source create pagerduty-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create pagerduty-ops \
-  --source pagerduty-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=pagerduty/ops
+  -source pagerduty-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=pagerduty/ops
 ```
 
 The KV v2 secret at `secret/pagerduty/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -186,10 +186,10 @@ You can also use the `oauth2` mint method if you have an OAuth2 plugin (openbao-
 
 ```bash
 warden cred spec create pagerduty-ops \
-  --source pagerduty-vault-src \
-  --config mint_method=oauth2 \
-  --config oauth2_mount=oauth2 \
-  --config credential_name=pagerduty
+  -source pagerduty-vault-src \
+  -config mint_method=oauth2 \
+  -config oauth2_mount=oauth2 \
+  -config credential_name=pagerduty
 ```
 
 Verify:
@@ -358,13 +358,13 @@ The source holds the OAuth2 app credentials (`client_id`, `client_secret`). Toke
 
 ```bash
 warden cred source create pagerduty-oauth-src \
-  --type=oauth2 \
-  --rotation-period=0 \
-  --config=client_id=your-client-id \
-  --config=client_secret=your-client-secret \
-  --config=token_url=https://identity.pagerduty.com/oauth/token \
-  --config=verify_url=https://api.pagerduty.com/users/me \
-  --config=display_name=PagerDuty
+  -type=oauth2 \
+  -rotation-period=0 \
+  -config=client_id=your-client-id \
+  -config=client_secret=your-client-secret \
+  -config=token_url=https://identity.pagerduty.com/oauth/token \
+  -config=verify_url=https://api.pagerduty.com/users/me \
+  -config=display_name=PagerDuty
 ```
 
 ### Create an OAuth2 Credential Spec
@@ -373,8 +373,8 @@ The spec optionally specifies the OAuth2 scope. If omitted, the default scope fr
 
 ```bash
 warden cred spec create pagerduty-ops \
-  --source pagerduty-oauth-src \
-  --config scope="read write"
+  -source pagerduty-oauth-src \
+  -config scope="read write"
 ```
 
 The spec is validated at creation time: Warden mints a test token and verifies it by calling `GET /users/me` on the PagerDuty API. If the credentials are invalid, spec creation will fail.
@@ -396,14 +396,14 @@ All gateway requests work identically — Warden transparently injects the minte
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -546,7 +546,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update pagerduty-ops \
-     --config api_key=your-new-api-token
+     -config api_key=your-new-api-token
    ```
 3. Revoke the old token in PagerDuty
 
@@ -567,7 +567,7 @@ Bearer tokens are minted on demand and cached for their TTL. When a token expire
 2. Update the credential source:
    ```bash
    warden cred source update pagerduty-oauth-src \
-     --config=client_id=new-client-id \
-     --config=client_secret=new-client-secret
+     -config=client_id=new-client-id \
+     -config=client_secret=new-client-secret
    ```
 3. Revoke the old credentials in PagerDuty

--- a/provider/prometheus/README.md
+++ b/provider/prometheus/README.md
@@ -52,7 +52,7 @@ The Prometheus provider enables proxied access to the Prometheus HTTP API throug
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -70,7 +70,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -87,13 +87,13 @@ warden write auth/jwt/role/prometheus-user \
 Enable the Prometheus provider at a path of your choice:
 
 ```bash
-warden provider enable --type=prometheus
+warden provider enable prometheus
 ```
 
 To mount at a custom path (e.g., for a specific cluster or environment):
 
 ```bash
-warden provider enable --type=prometheus prometheus-prod
+warden provider enable -path=prometheus-prod prometheus
 ```
 
 Verify the provider is enabled:
@@ -129,18 +129,18 @@ Use this for Grafana Mimir, Amazon Managed Prometheus, Thanos, Cortex, or Victor
 
 ```bash
 warden cred source create prometheus-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://prometheus.example.com \
-  --config=display_name=Prometheus
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://prometheus.example.com \
+  -config=display_name=Prometheus
 ```
 
 Create a credential spec with your bearer token:
 
 ```bash
 warden cred spec create prometheus-ops \
-  --source prometheus-src \
-  --config api_key=your-bearer-token
+  -source prometheus-src \
+  -config api_key=your-bearer-token
 ```
 
 ### Option B: Basic Auth (Self-hosted Prometheus)
@@ -158,20 +158,20 @@ Create a credential source with `optional_metadata=auth_type` to allow the auth 
 
 ```bash
 warden cred source create prometheus-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://prometheus.example.com \
-  --config=optional_metadata=auth_type \
-  --config=display_name=Prometheus
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://prometheus.example.com \
+  -config=optional_metadata=auth_type \
+  -config=display_name=Prometheus
 ```
 
 Create a credential spec with the base64-encoded credentials and `auth_type=basic`:
 
 ```bash
 warden cred spec create prometheus-ops \
-  --source prometheus-src \
-  --config api_key=${ENCODED} \
-  --config auth_type=basic
+  -source prometheus-src \
+  -config api_key=${ENCODED} \
+  -config auth_type=basic
 ```
 
 ### Option C: Vault/OpenBao as Credential Source
@@ -185,24 +185,24 @@ Instead of storing the token directly in Warden, you can store it in a Vault/Ope
 ```bash
 # Create a Vault credential source
 warden cred source create prometheus-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create prometheus-ops \
-  --source prometheus-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=prometheus/ops
+  -source prometheus-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=prometheus/ops
 ```
 
 The KV v2 secret at `secret/prometheus/ops` must contain at minimum an `api_key` field. For basic auth, also include `auth_type=basic`.
@@ -372,14 +372,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1–4 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -500,5 +500,5 @@ curl --cert client.pem --key client-key.pem \
 3. Update the credential spec:
    ```bash
    warden cred spec update prometheus-ops \
-     --config api_key=${ENCODED}
+     -config api_key=${ENCODED}
    ```

--- a/provider/rds/README.md
+++ b/provider/rds/README.md
@@ -152,7 +152,7 @@ Each database user name must match the `db_user` in its corresponding credential
 Set up JWT auth for workload authentication. The auth role does **not** need a `cred_spec_name` — the RDS provider resolves credentials via path-based provider grants instead.
 
 ```bash
-warden auth enable --type=jwt
+warden auth enable jwt
 
 warden write auth/jwt/config \
     jwks_url=http://localhost:4444/.well-known/jwks.json \
@@ -197,7 +197,7 @@ Setting `default_role=db-user` means workloads don't need to pass `?role=` — t
 ## Step 2: Mount and Configure the RDS Provider
 
 ```bash
-warden provider enable --type=rds
+warden provider enable rds
 ```
 
 Workloads authenticate with their JWT directly — no explicit Warden login required:
@@ -220,62 +220,62 @@ Create an AWS credential source with the service user's access keys and automati
 
 ```bash
 warden cred source create aws-prod \
-  --type=aws \
-  --rotation-period=24h \
-  --config access_key_id=<SERVICE_USER_ACCESS_KEY_ID> \
-  --config secret_access_key=<SERVICE_USER_SECRET_ACCESS_KEY> \
-  --config region=us-east-1
+  -type=aws \
+  -rotation-period=24h \
+  -config access_key_id=<SERVICE_USER_ACCESS_KEY_ID> \
+  -config secret_access_key=<SERVICE_USER_SECRET_ACCESS_KEY> \
+  -config region=us-east-1
 ```
 
-> Set `--rotation-period=0` to disable rotation (not recommended for production). The IAM permissions for rotation are included in the prerequisite policy on the service user.
+> Set `-rotation-period=0` to disable rotation (not recommended for production). The IAM permissions for rotation are included in the prerequisite policy on the service user.
 
 Create credential specs for each database user / permission level. The `role_arn` points to the database IAM role from the prerequisites:
 
 ```bash
 # Read-only spec
 warden cred spec create rds-readonly \
-  --source aws-prod \
-  --config mint_method=rds_iam_token \
-  --config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
-  --config db_user=app_readonly \
-  --config db_engine=postgres \
-  --config region=us-east-1 \
-  --config role_arn=arn:aws:iam::123456789:role/warden-rds-connect
+  -source aws-prod \
+  -config mint_method=rds_iam_token \
+  -config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
+  -config db_user=app_readonly \
+  -config db_engine=postgres \
+  -config region=us-east-1 \
+  -config role_arn=arn:aws:iam::123456789:role/warden-rds-connect
 
 # Read-write spec
 warden cred spec create rds-readwrite \
-  --source aws-prod \
-  --config mint_method=rds_iam_token \
-  --config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
-  --config db_user=app_readwrite \
-  --config db_engine=postgres \
-  --config region=us-east-1 \
-  --config role_arn=arn:aws:iam::123456789:role/warden-rds-connect
+  -source aws-prod \
+  -config mint_method=rds_iam_token \
+  -config db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
+  -config db_user=app_readwrite \
+  -config db_engine=postgres \
+  -config region=us-east-1 \
+  -config role_arn=arn:aws:iam::123456789:role/warden-rds-connect
 ```
 
 For Aurora, use the cluster or reader endpoint:
 
 ```bash
 warden cred spec create aurora-readonly \
-  --source aws-prod \
-  --config mint_method=rds_iam_token \
-  --config db_endpoint=mydb.cluster-ro-abc123.us-east-1.rds.amazonaws.com \
-  --config db_user=app_readonly \
-  --config db_engine=postgres \
-  --config region=us-east-1
+  -source aws-prod \
+  -config mint_method=rds_iam_token \
+  -config db_endpoint=mydb.cluster-ro-abc123.us-east-1.rds.amazonaws.com \
+  -config db_user=app_readonly \
+  -config db_engine=postgres \
+  -config region=us-east-1
 ```
 
 For cross-account access, add `role_arn`:
 
 ```bash
 warden cred spec create rds-cross-account \
-  --source aws-prod \
-  --config mint_method=rds_iam_token \
-  --config db_endpoint=mydb.xyz789.eu-west-1.rds.amazonaws.com \
-  --config db_user=app_readonly \
-  --config db_engine=postgres \
-  --config region=eu-west-1 \
-  --config role_arn=arn:aws:iam::987654321:role/rds-cross-account
+  -source aws-prod \
+  -config mint_method=rds_iam_token \
+  -config db_endpoint=mydb.xyz789.eu-west-1.rds.amazonaws.com \
+  -config db_user=app_readonly \
+  -config db_engine=postgres \
+  -config region=eu-west-1 \
+  -config role_arn=arn:aws:iam::987654321:role/rds-cross-account
 ```
 
 ## Step 4: Create Grants on the Provider

--- a/provider/redshift/README.md
+++ b/provider/redshift/README.md
@@ -155,7 +155,7 @@ Warden controls which workload gets a token for which IAM identity; Redshift con
 Set up JWT auth for workload authentication. The auth role does **not** need a `cred_spec_name` — the Redshift provider resolves credentials via path-based provider grants instead.
 
 ```bash
-warden auth enable --type=jwt
+warden auth enable jwt
 
 warden write auth/jwt/config \
     jwks_url=http://localhost:4444/.well-known/jwks.json \
@@ -169,7 +169,7 @@ warden write auth/jwt/role/db-user \
 ## Step 2: Mount and Configure the Redshift Provider
 
 ```bash
-warden provider enable --type=redshift
+warden provider enable redshift
 
 warden write redshift/config \
     auto_auth_path=auth/jwt/
@@ -190,12 +190,12 @@ Create an AWS credential source with the service user's access keys and automati
 
 ```bash
 warden cred source create aws-prod \
-  --type=aws \
-  --rotation-period=24h \
-  --config access_key_id=<SERVICE_USER_ACCESS_KEY_ID> \
-  --config secret_access_key=<SERVICE_USER_SECRET_ACCESS_KEY> \
-  --config region=us-east-1 \
-  --config assume_role_arn=arn:aws:iam::123456789:role/warden-redshift-connect
+  -type=aws \
+  -rotation-period=24h \
+  -config access_key_id=<SERVICE_USER_ACCESS_KEY_ID> \
+  -config secret_access_key=<SERVICE_USER_SECRET_ACCESS_KEY> \
+  -config region=us-east-1 \
+  -config assume_role_arn=arn:aws:iam::123456789:role/warden-redshift-connect
 ```
 
 > The `assume_role_arn` on the source is what makes Warden call AWS as the database role rather than as the service user. Without it, the service user itself needs `redshift:GetClusterCredentialsWithIAM` permission.
@@ -204,24 +204,24 @@ warden cred source create aws-prod \
 
 ```bash
 warden cred spec create redshift-readonly \
-  --source aws-prod \
-  --config mint_method=redshift_iam_token \
-  --config cluster_identifier=my-redshift-cluster \
-  --config db_endpoint=my-redshift-cluster.abc123.us-east-1.redshift.amazonaws.com \
-  --config db_name=analytics \
-  --config region=us-east-1
+  -source aws-prod \
+  -config mint_method=redshift_iam_token \
+  -config cluster_identifier=my-redshift-cluster \
+  -config db_endpoint=my-redshift-cluster.abc123.us-east-1.redshift.amazonaws.com \
+  -config db_name=analytics \
+  -config region=us-east-1
 ```
 
 ### Serverless workgroup spec
 
 ```bash
 warden cred spec create redshift-serverless-readonly \
-  --source aws-prod \
-  --config mint_method=redshift_iam_token \
-  --config workgroup_name=my-workgroup \
-  --config db_endpoint=my-workgroup.123456789.us-east-1.redshift-serverless.amazonaws.com \
-  --config db_name=analytics \
-  --config region=us-east-1
+  -source aws-prod \
+  -config mint_method=redshift_iam_token \
+  -config workgroup_name=my-workgroup \
+  -config db_endpoint=my-workgroup.123456789.us-east-1.redshift-serverless.amazonaws.com \
+  -config db_name=analytics \
+  -config region=us-east-1
 ```
 
 ### Longer token TTL
@@ -230,13 +230,13 @@ The default token TTL is 900 seconds (15 minutes). To extend it up to 3600 secon
 
 ```bash
 warden cred spec create redshift-long-running \
-  --source aws-prod \
-  --config mint_method=redshift_iam_token \
-  --config cluster_identifier=my-redshift-cluster \
-  --config db_endpoint=my-redshift-cluster.abc123.us-east-1.redshift.amazonaws.com \
-  --config db_name=analytics \
-  --config region=us-east-1 \
-  --config duration_seconds=3600
+  -source aws-prod \
+  -config mint_method=redshift_iam_token \
+  -config cluster_identifier=my-redshift-cluster \
+  -config db_endpoint=my-redshift-cluster.abc123.us-east-1.redshift.amazonaws.com \
+  -config db_name=analytics \
+  -config region=us-east-1 \
+  -config duration_seconds=3600
 ```
 
 ## Step 4: Create Grants on the Provider

--- a/provider/scaleway/README.md
+++ b/provider/scaleway/README.md
@@ -54,7 +54,7 @@ The Scaleway provider enables proxied access to Scaleway APIs through Warden. It
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -72,7 +72,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -89,13 +89,13 @@ warden write auth/jwt/role/scaleway-user \
 Enable the Scaleway provider at a path of your choice:
 
 ```bash
-warden provider enable --type=scaleway
+warden provider enable scaleway
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=scaleway scaleway-prod
+warden provider enable -path=scaleway-prod scaleway
 ```
 
 Verify the provider is enabled:
@@ -131,21 +131,21 @@ Create a Scaleway credential source and spec with your API key pair. The spec is
 
 ```bash
 warden cred source create scaleway-src \
-  --type=scaleway \
-  --config=scaleway_url=https://api.scaleway.com
+  -type=scaleway \
+  -config=scaleway_url=https://api.scaleway.com
 
 warden cred spec create scaleway-ops \
-  --source scaleway-src \
-  --config mint_method=static_keys \
-  --config access_key=SCWXXXXXXXXXXXXXXXXX \
-  --config secret_key=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  -source scaleway-src \
+  -config mint_method=static_keys \
+  -config access_key=SCWXXXXXXXXXXXXXXXXX \
+  -config secret_key=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 ### Option B: Dynamic API Keys (Recommended)
 
 Have Warden create short-lived API keys on demand via the Scaleway IAM API. Keys are automatically revoked when they expire. No long-lived secrets are stored in credential specs.
 
-> **Note:** The Scaleway IAM API is currently `v1alpha1`. While it has been stable in practice (used by the CLI, Terraform, and all SDKs), Scaleway may introduce breaking changes without a deprecation period. If the API version changes, update the `iam_api_path` config on the credential source (e.g., `--config=iam_api_path=/iam/v2`). No code changes required.
+> **Note:** The Scaleway IAM API is currently `v1alpha1`. While it has been stable in practice (used by the CLI, Terraform, and all SDKs), Scaleway may introduce breaking changes without a deprecation period. If the API version changes, update the `iam_api_path` config on the credential source (e.g., `-config=iam_api_path=/iam/v2`). No code changes required.
 
 **Prerequisites:**
 - A **management API key** with IAM permissions to create and delete API keys
@@ -153,19 +153,19 @@ Have Warden create short-lived API keys on demand via the Scaleway IAM API. Keys
 
 ```bash
 warden cred source create scaleway-dynamic-src \
-  --type=scaleway \
-  --rotation-period=24h \
-  --config=scaleway_url=https://api.scaleway.com \
-  --config=management_secret_key=your-management-secret-key \
-  --config=management_access_key=SCWXXXXXXXXXXXXXXXXX
+  -type=scaleway \
+  -rotation-period=24h \
+  -config=scaleway_url=https://api.scaleway.com \
+  -config=management_secret_key=your-management-secret-key \
+  -config=management_access_key=SCWXXXXXXXXXXXXXXXXX
 
 warden cred spec create scaleway-ops \
-  --source scaleway-dynamic-src \
-  --config mint_method=dynamic_keys \
-  --config application_id=your-iam-application-id \
-  --config default_project_id=your-project-id \
-  --config ttl=1h \
-  --config description=warden-managed
+  -source scaleway-dynamic-src \
+  -config mint_method=dynamic_keys \
+  -config application_id=your-iam-application-id \
+  -config default_project_id=your-project-id \
+  -config ttl=1h \
+  -config description=warden-managed
 ```
 
 Each credential request creates a fresh API key via `POST /iam/v1alpha1/api-keys` with the configured TTL. When the lease expires, Warden revokes the key via `DELETE /iam/v1alpha1/api-keys/{access_key}`.
@@ -180,21 +180,21 @@ Store your Scaleway keys in a Vault/OpenBao KV v2 secret engine and have Warden 
 
 ```bash
 warden cred source create scaleway-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 warden cred spec create scaleway-ops \
-  --source scaleway-vault-src \
-  --type=scaleway_keys \
-  --config mint_method=static_scaleway \
-  --config kv2_mount=secret \
-  --config secret_path=scaleway/prod
+  -source scaleway-vault-src \
+  -type=scaleway_keys \
+  -config mint_method=static_scaleway \
+  -config kv2_mount=secret \
+  -config secret_path=scaleway/prod
 ```
 
 The KV v2 secret at `secret/scaleway/prod` should contain `access_key` and `secret_key` fields.
@@ -413,14 +413,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -558,8 +558,8 @@ aws s3 ls s3://my-bucket/ \
 2. Update the credential spec:
    ```bash
    warden cred spec update scaleway-ops \
-     --config access_key=SCWNEWKEYXXXXXXXXXX \
-     --config secret_key=new-uuid-secret-key
+     -config access_key=SCWNEWKEYXXXXXXXXXX \
+     -config secret_key=new-uuid-secret-key
    ```
 3. Delete the old API key in Scaleway Console
 
@@ -579,11 +579,11 @@ When both `management_secret_key` and `management_access_key` are configured on 
 
 ```bash
 warden cred source create scaleway-dynamic-src \
-  --type=scaleway \
-  --rotation-period=24h \
-  --config=scaleway_url=https://api.scaleway.com \
-  --config=management_secret_key=your-management-secret-key \
-  --config=management_access_key=SCWXXXXXXXXXXXXXXXXX
+  -type=scaleway \
+  -rotation-period=24h \
+  -config=scaleway_url=https://api.scaleway.com \
+  -config=management_secret_key=your-management-secret-key \
+  -config=management_access_key=SCWXXXXXXXXXXXXXXXXX
 ```
 
 The rotation flow:
@@ -602,7 +602,7 @@ If automatic rotation is not configured, rotate manually:
 2. Update the credential source:
    ```bash
    warden cred source update scaleway-dynamic-src \
-     --config=management_secret_key=new-management-secret-key \
-     --config=management_access_key=SCWNEWKEYXXXXXXXXXX
+     -config=management_secret_key=new-management-secret-key \
+     -config=management_access_key=SCWNEWKEYXXXXXXXXXX
    ```
 3. Delete the old management API key in Scaleway Console

--- a/provider/scaleway/e2e_test/README.md
+++ b/provider/scaleway/e2e_test/README.md
@@ -77,7 +77,7 @@ docker compose -f deploy/docker-compose.quickstart.yml up -d
 ### 2. Start Warden (dev mode)
 
 ```bash
-warden server --dev --dev-root-token=root
+warden server -dev -dev-root-token=root
 ```
 
 ### 3. Configure Warden
@@ -87,7 +87,7 @@ export WARDEN_ADDR="http://127.0.0.1:8400"
 export WARDEN_TOKEN="root"
 
 # Enable JWT auth
-warden auth enable --type=jwt
+warden auth enable jwt
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create role
@@ -97,7 +97,7 @@ warden write auth/jwt/role/scaleway-user \
     cred_spec_name=scaleway-ops
 
 # Enable Scaleway provider
-warden provider enable --type=scaleway
+warden provider enable scaleway
 
 # Configure provider
 warden write scaleway/config <<EOF
@@ -110,18 +110,18 @@ EOF
 
 # Create credential source with management app keys (Application 1)
 warden cred source create scaleway-src \
-  --type=scaleway \
-  --rotation-period=24h \
-  --config=management_secret_key=<warden-management-secret-key> \
-  --config=management_access_key=<warden-management-access-key>
+  -type=scaleway \
+  -rotation-period=24h \
+  -config=management_secret_key=<warden-management-secret-key> \
+  -config=management_access_key=<warden-management-access-key>
 
 # Create credential spec pointing to workload app (Application 2)
 warden cred spec create scaleway-ops \
-  --source scaleway-src \
-  --config mint_method=dynamic_keys \
-  --config application_id=<warden-workload-application-id> \
-  --config default_project_id=<your-project-id> \
-  --config ttl=1h
+  -source scaleway-src \
+  -config mint_method=dynamic_keys \
+  -config application_id=<warden-workload-application-id> \
+  -config default_project_id=<your-project-id> \
+  -config ttl=1h
 
 # Create policy
 warden policy write scaleway-access - <<EOF

--- a/provider/sdk/dbaccess/README.md
+++ b/provider/sdk/dbaccess/README.md
@@ -84,7 +84,7 @@ providers = map[string]wardenlogical.Factory{
 
 That's it. Your provider supports:
 
-- `warden provider enable --type=myprovider`
+- `warden provider enable myprovider`
 - `warden write myprovider/config auto_auth_path=auth/jwt/`
 - `warden write myprovider/grants/analytics credential_spec=prod-readonly db_name=analytics`
 - `warden read myprovider/access/analytics` — returns the formatted connection string

--- a/provider/sdk/dualgateway/README.md
+++ b/provider/sdk/dualgateway/README.md
@@ -78,7 +78,7 @@ providers = map[string]wardenlogical.Factory{
 
 That's it. Your provider supports:
 
-- `warden provider enable --type=myprovider`
+- `warden provider enable myprovider`
 - `warden write myprovider/config myprovider_url=https://api.myprovider.com auto_auth_path=auth/jwt/`
 - API mode: `POST /v1/myprovider/gateway/some/api/path` (header injected, request forwarded)
 - API mode with role: `POST /v1/myprovider/role/{role}/gateway/some/api/path`

--- a/provider/sdk/httpproxy/README.md
+++ b/provider/sdk/httpproxy/README.md
@@ -68,7 +68,7 @@ providers = map[string]wardenlogical.Factory{
 ```
 
 That's it. Your provider supports:
-- `warden provider enable --type=myprovider`
+- `warden provider enable myprovider`
 - `warden write myprovider/config myprovider_url=... auto_auth_path=auth/jwt/`
 - `POST /myprovider/gateway/v1/some/endpoint` (role provided via `X-Warden-Role` header)
 - `POST /myprovider/role/{role}/gateway/v1/some/endpoint` (role embedded in URL path)

--- a/provider/sentry/README.md
+++ b/provider/sentry/README.md
@@ -50,7 +50,7 @@ The Sentry provider enables proxied access to the Sentry REST API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/sentry-user \
 Enable the Sentry provider at a path of your choice:
 
 ```bash
-warden provider enable --type=sentry
+warden provider enable sentry
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=sentry sentry-prod
+warden provider enable -path=sentry-prod sentry
 ```
 
 Verify the provider is enabled:
@@ -133,19 +133,19 @@ First, create an Internal Integration in Sentry:
 
 ```bash
 warden cred source create sentry-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://sentry.io/api/0 \
-  --config=verify_endpoint=/ \
-  --config=display_name=Sentry
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://sentry.io/api/0 \
+  -config=verify_endpoint=/ \
+  -config=display_name=Sentry
 ```
 
 Create a credential spec that references the credential source. The spec carries the auth token and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create sentry-ops \
-  --source sentry-src \
-  --config api_key=your-sentry-internal-integration-token
+  -source sentry-src \
+  -config api_key=your-sentry-internal-integration-token
 ```
 
 The token is validated at creation time via a `GET /` call to the Sentry API (SpecVerifier). If the token is invalid, spec creation will fail.
@@ -161,24 +161,24 @@ Instead of storing the auth token directly in Warden, you can store it in a Vaul
 ```bash
 # Create a Vault credential source
 warden cred source create sentry-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create sentry-ops \
-  --source sentry-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=sentry/ops
+  -source sentry-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=sentry/ops
 ```
 
 The KV v2 secret at `secret/sentry/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -328,14 +328,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -450,6 +450,6 @@ Sentry does not support OAuth2 client credentials flow. For machine-to-machine a
 2. Update the credential spec:
    ```bash
    warden cred spec update sentry-ops \
-     --config api_key=your-new-token
+     -config api_key=your-new-token
    ```
 3. Revoke the old token in Sentry

--- a/provider/servicenow/README.md
+++ b/provider/servicenow/README.md
@@ -52,7 +52,7 @@ The ServiceNow provider enables proxied access to a ServiceNow instance REST API
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -70,7 +70,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -87,13 +87,13 @@ warden write auth/jwt/role/servicenow-user \
 Enable the ServiceNow provider at a path of your choice:
 
 ```bash
-warden provider enable --type=servicenow
+warden provider enable servicenow
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=servicenow servicenow-prod
+warden provider enable -path=servicenow-prod servicenow
 ```
 
 Verify the provider is enabled:
@@ -129,19 +129,19 @@ The credential source holds only connection info (`api_url`). The API token is s
 
 ```bash
 warden cred source create servicenow-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://mycompany.service-now.com \
-  --config=verify_endpoint=/api/now/table/sys_user?sysparm_limit=1 \
-  --config=display_name=ServiceNow
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://mycompany.service-now.com \
+  -config=verify_endpoint=/api/now/table/sys_user?sysparm_limit=1 \
+  -config=display_name=ServiceNow
 ```
 
 Create a credential spec that references the credential source. The spec carries the API token and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create servicenow-ops \
-  --source servicenow-src \
-  --config api_key=your-servicenow-api-token
+  -source servicenow-src \
+  -config api_key=your-servicenow-api-token
 ```
 
 The API token is validated at creation time via a `GET /api/now/table/sys_user?sysparm_limit=1` call to the ServiceNow API (SpecVerifier). If the token is invalid, spec creation will fail.
@@ -161,24 +161,24 @@ Instead of storing the API token directly in Warden, you can store it in a Vault
 ```bash
 # Create a Vault credential source
 warden cred source create servicenow-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create servicenow-ops \
-  --source servicenow-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=servicenow/ops
+  -source servicenow-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=servicenow/ops
 ```
 
 The KV v2 secret at `secret/servicenow/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -187,10 +187,10 @@ You can also use the `oauth2` mint method if you have an OAuth2 plugin (openbao-
 
 ```bash
 warden cred spec create servicenow-ops \
-  --source servicenow-vault-src \
-  --config mint_method=oauth2 \
-  --config oauth2_mount=oauth2 \
-  --config credential_name=servicenow
+  -source servicenow-vault-src \
+  -config mint_method=oauth2 \
+  -config oauth2_mount=oauth2 \
+  -config credential_name=servicenow
 ```
 
 Verify:
@@ -367,13 +367,13 @@ The source holds the OAuth2 app credentials (`client_id`, `client_secret`). Toke
 
 ```bash
 warden cred source create servicenow-oauth-src \
-  --type=oauth2 \
-  --rotation-period=0 \
-  --config=client_id=your-client-id \
-  --config=client_secret=your-client-secret \
-  --config=token_url=https://mycompany.service-now.com/oauth_token.do \
-  --config=verify_url=https://mycompany.service-now.com/api/now/table/sys_user?sysparm_limit=1 \
-  --config=display_name=ServiceNow
+  -type=oauth2 \
+  -rotation-period=0 \
+  -config=client_id=your-client-id \
+  -config=client_secret=your-client-secret \
+  -config=token_url=https://mycompany.service-now.com/oauth_token.do \
+  -config=verify_url=https://mycompany.service-now.com/api/now/table/sys_user?sysparm_limit=1 \
+  -config=display_name=ServiceNow
 ```
 
 ### Create an OAuth2 Credential Spec
@@ -382,8 +382,8 @@ The spec optionally specifies the OAuth2 scope. If omitted, the `default_scopes`
 
 ```bash
 warden cred spec create servicenow-ops \
-  --source servicenow-oauth-src \
-  --config scope="useraccount"
+  -source servicenow-oauth-src \
+  -config scope="useraccount"
 ```
 
 The spec is validated at creation time: Warden mints a test token and verifies it by calling `GET /api/now/table/sys_user?sysparm_limit=1` on the ServiceNow API. If the credentials are invalid, spec creation will fail.
@@ -405,14 +405,14 @@ All gateway requests work identically — Warden transparently injects the minte
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -555,7 +555,7 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update servicenow-ops \
-     --config api_key=your-new-api-token
+     -config api_key=your-new-api-token
    ```
 3. Revoke the old credentials in ServiceNow
 
@@ -576,8 +576,8 @@ Bearer tokens are minted on demand and cached for their TTL. When a token expire
 2. Update the credential source:
    ```bash
    warden cred source update servicenow-oauth-src \
-     --config=client_id=new-client-id \
-     --config=client_secret=new-client-secret
+     -config=client_id=new-client-id \
+     -config=client_secret=new-client-secret
    ```
 3. Revoke the old credentials in ServiceNow
 

--- a/provider/slack/README.md
+++ b/provider/slack/README.md
@@ -50,7 +50,7 @@ The Slack provider enables proxied access to the Slack Web API through Warden. I
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -68,7 +68,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -85,13 +85,13 @@ warden write auth/jwt/role/slack-user \
 Enable the Slack provider at a path of your choice:
 
 ```bash
-warden provider enable --type=slack
+warden provider enable slack
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=slack slack-prod
+warden provider enable -path=slack-prod slack
 ```
 
 Verify the provider is enabled:
@@ -125,12 +125,12 @@ The credential source holds only connection info (`api_url`). The bot token is s
 
 ```bash
 warden cred source create slack-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://slack.com/api \
-  --config=verify_endpoint=/auth.test \
-  --config=verify_method=POST \
-  --config=display_name=Slack
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://slack.com/api \
+  -config=verify_endpoint=/auth.test \
+  -config=verify_method=POST \
+  -config=display_name=Slack
 ```
 
 Verify the source was created:
@@ -143,8 +143,8 @@ Create a credential spec that references the credential source. The spec carries
 
 ```bash
 warden cred spec create slack-ops \
-  --source slack-src \
-  --config api_key=xoxb-your-bot-token
+  -source slack-src \
+  -config api_key=xoxb-your-bot-token
 ```
 
 The bot token is validated at creation time via a `POST /auth.test` call to the Slack API (SpecVerifier). If the token is invalid, spec creation will fail.
@@ -166,21 +166,21 @@ Instead of storing the bot token directly in Warden, you can store it in a Vault
 ```bash
 # Create a Vault credential source
 warden cred source create slack-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 
 # Create a credential spec using the static_apikey mint method
 warden cred spec create slack-ops \
-  --source slack-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=slack/ops
+  -source slack-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=slack/ops
 ```
 
 The KV v2 secret at `secret/slack/ops` should contain at minimum an `api_key` field. Warden fetches the secret from Vault on each credential request.
@@ -390,14 +390,14 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -503,6 +503,6 @@ curl --cert client.pem --key client-key.pem \
 2. Update the credential spec:
    ```bash
    warden cred spec update slack-ops \
-     --config api_key=xoxb-new-bot-token
+     -config api_key=xoxb-new-bot-token
    ```
 3. Revoke the old token from the Slack App settings if needed

--- a/provider/splunk/README.md
+++ b/provider/splunk/README.md
@@ -51,7 +51,7 @@ The Splunk provider enables proxied access to the Splunk REST API through Warden
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -69,7 +69,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -86,13 +86,13 @@ warden write auth/jwt/role/splunk-user \
 Enable the Splunk provider at a path of your choice:
 
 ```bash
-warden provider enable --type=splunk
+warden provider enable splunk
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=splunk splunk-prod
+warden provider enable -path=splunk-prod splunk
 ```
 
 Verify the provider is enabled:
@@ -149,20 +149,20 @@ Save the token from the response, then create the Warden credential source and s
 
 ```bash
 warden cred source create splunk-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://splunk.example.com:8089 \
-  --config=verify_endpoint=/services/server/info \
-  --config=auth_header_type=bearer \
-  --config=display_name=Splunk
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://splunk.example.com:8089 \
+  -config=verify_endpoint=/services/server/info \
+  -config=auth_header_type=bearer \
+  -config=display_name=Splunk
 ```
 
 Create a credential spec that references the credential source. The spec carries the bearer token and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create splunk-ops \
-  --source splunk-src \
-  --config api_key=your-splunk-bearer-token
+  -source splunk-src \
+  -config api_key=your-splunk-bearer-token
 ```
 
 The bearer token is validated at creation time via a `GET /services/server/info` call to the Splunk API (SpecVerifier). If the token is invalid, spec creation will fail.
@@ -178,24 +178,24 @@ Instead of storing bearer tokens directly in Warden, you can store them in a Vau
 ```bash
 # Create a Vault credential source
 warden cred source create splunk-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create splunk-ops \
-  --source splunk-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=splunk/ops
+  -source splunk-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=splunk/ops
 ```
 
 The KV v2 secret at `secret/splunk/ops` should contain an `api_key` field with the Splunk bearer token. Warden fetches the secret from Vault on each credential request.
@@ -372,14 +372,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -542,7 +542,7 @@ curl -k -u admin:password -X POST \
 2. Update the credential spec:
    ```bash
    warden cred spec update splunk-ops \
-     --config api_key=your-new-bearer-token
+     -config api_key=your-new-bearer-token
    ```
 3. Delete the old token in Splunk:
    ```bash

--- a/provider/tfe/README.md
+++ b/provider/tfe/README.md
@@ -51,7 +51,7 @@ The TFE provider enables proxied access to the Terraform Enterprise (TFE) and HC
 >
 > **4. Start the Warden server** in dev mode:
 > ```bash
-> warden server --dev --dev-root-token=root
+> warden server -dev -dev-root-token=root
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -69,7 +69,7 @@ Set up a JWT auth method and create a role that binds the credential spec and po
 
 ```bash
 # Enable JWT auth if not already enabled
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -86,13 +86,13 @@ warden write auth/jwt/role/tfe-user \
 Enable the TFE provider at a path of your choice:
 
 ```bash
-warden provider enable --type=tfe
+warden provider enable tfe
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=tfe tfe-prod
+warden provider enable -path=tfe-prod tfe
 ```
 
 Verify the provider is enabled:
@@ -143,26 +143,26 @@ Save the token (it is only displayed once), then create the Warden credential so
 
 ```bash
 warden cred source create tfe-src \
-  --type=apikey \
-  --rotation-period=0 \
-  --config=api_url=https://app.terraform.io/api/v2 \
-  --config=verify_endpoint=/account/details \
-  --config=auth_header_type=bearer \
-  --config=display_name=TFE \
-  --config=extra_headers=Content-Type:application/vnd.api+json
+  -type=apikey \
+  -rotation-period=0 \
+  -config=api_url=https://app.terraform.io/api/v2 \
+  -config=verify_endpoint=/account/details \
+  -config=auth_header_type=bearer \
+  -config=display_name=TFE \
+  -config=extra_headers=Content-Type:application/vnd.api+json
 ```
 
 Create a credential spec that references the credential source. The spec carries the API token and gets associated with tokens at login time.
 
 ```bash
 warden cred spec create tfe-ops \
-  --source tfe-src \
-  --config api_key=your-tfe-api-token
+  -source tfe-src \
+  -config api_key=your-tfe-api-token
 ```
 
 The API token is validated at creation time via a `GET /account/details` call to the TFE API (SpecVerifier). If the token is invalid, spec creation will fail.
 
-> **Note:** Organization tokens cannot access `/account/details`. For organization tokens, use `--config=verify_endpoint=/organizations` instead.
+> **Note:** Organization tokens cannot access `/account/details`. For organization tokens, use `-config=verify_endpoint=/organizations` instead.
 
 ### Option B: Vault/OpenBao as Credential Source
 
@@ -175,24 +175,24 @@ Instead of storing API tokens directly in Warden, you can store them in a Vault/
 ```bash
 # Create a Vault credential source
 warden cred source create tfe-vault-src \
-  --type=hvault \
-  --config=vault_address=https://vault.example.com \
-  --config=auth_method=approle \
-  --config=role_id=your-role-id \
-  --config=secret_id=your-secret-id \
-  --config=approle_mount=approle \
-  --config=role_name=warden-role \
-  --rotation-period=24h
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=your-role-id \
+  -config=secret_id=your-secret-id \
+  -config=approle_mount=approle \
+  -config=role_name=warden-role \
+  -rotation-period=24h
 ```
 
 Create a credential spec using the `static_apikey` mint method:
 
 ```bash
 warden cred spec create tfe-ops \
-  --source tfe-vault-src \
-  --config mint_method=static_apikey \
-  --config kv2_mount=secret \
-  --config secret_path=tfe/ops
+  -source tfe-vault-src \
+  -config mint_method=static_apikey \
+  -config kv2_mount=secret \
+  -config secret_path=tfe/ops
 ```
 
 The KV v2 secret at `secret/tfe/ops` should contain an `api_key` field with the TFE API token. Warden fetches the secret from Vault on each credential request.
@@ -359,14 +359,14 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-3 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `--dev-tls` to enable TLS with auto-generated certificates, or provide your own with `--dev-tls-cert-file`, `--dev-tls-key-file`, and `--dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
 ### Enable Cert Auth
 
 ```bash
-warden auth enable --type=cert
+warden auth enable cert
 ```
 
 ### Configure Trusted CA
@@ -505,7 +505,7 @@ TFE enforces a rate limit of **30 requests per second** per authenticated user. 
 2. Update the credential spec:
    ```bash
    warden cred spec update tfe-ops \
-     --config api_key=your-new-api-token
+     -config api_key=your-new-api-token
    ```
 3. Revoke the old token in TFE
 

--- a/provider/vault/README.md
+++ b/provider/vault/README.md
@@ -75,11 +75,11 @@ The Vault provider enables proxied access to HashiCorp Vault (or OpenBao) throug
 >
 > **4. Start the Warden server** in dev mode with TLS and mTLS:
 > ```bash
-> warden server --dev --dev-root-token=root \
->     --dev-tls-cert-file=$CERT_DIR/server.pem \
->     --dev-tls-key-file=$CERT_DIR/server.key \
->     --dev-tls-ca-cert-file=$CERT_DIR/ca.pem \
->     --dev-tls-require-client-cert
+> warden server -dev -dev-root-token=root \
+>     -dev-tls-cert-file=$CERT_DIR/server.pem \
+>     -dev-tls-key-file=$CERT_DIR/server.key \
+>     -dev-tls-ca-cert-file=$CERT_DIR/ca.pem \
+>     -dev-tls-require-client-cert
 > ```
 >
 > **5. In another terminal window**, export the environment variables for the CLI:
@@ -200,7 +200,7 @@ Set up a TLS certificate auth method and create a role that binds the credential
 
 ```bash
 # Enable cert auth
-warden auth enable --type=cert
+warden auth enable cert
 
 # Configure with the CA that signs client certificates
 warden write auth/cert/config \
@@ -221,13 +221,13 @@ The `allowed_common_names` field supports glob patterns. The client certificate 
 Enable the Vault provider at a path of your choice:
 
 ```bash
-warden provider enable --type=vault
+warden provider enable vault
 ```
 
 To mount at a custom path:
 
 ```bash
-warden provider enable --type=vault vault-prod
+warden provider enable -path=vault-prod vault
 ```
 
 Verify the provider is enabled:
@@ -261,34 +261,34 @@ The credential source tells Warden how to authenticate to Vault using the AppRol
 
 ```bash
 warden cred source create vault-prod \
-  --type hvault \
-  --rotation-period 24h \
-  --config vault_address=http://127.0.0.1:8200 \
-  --config auth_method=approle \
-  --config role_id=<role-id> \
-  --config secret_id=<secret-id> \
-  --config secret_id_accessor=<accessor> \
-  --config approle_mount=warden_approle \
-  --config role_name=warden-source
+  -type hvault \
+  -rotation-period 24h \
+  -config vault_address=http://127.0.0.1:8200 \
+  -config auth_method=approle \
+  -config role_id=<role-id> \
+  -config secret_id=<secret-id> \
+  -config secret_id_accessor=<accessor> \
+  -config approle_mount=warden_approle \
+  -config role_name=warden-source
 ```
 
 For Vault Enterprise/HCP Vault with namespaces or OpenBao, add `vault_namespace` to scope all Warden API calls (AppRole auth, credential minting) to that namespace:
 
 ```bash
 warden cred source create vault-prod \
-  --type hvault \
-  --rotation-period 24h \
-  --config vault_address=https://vault.example.com:8200 \
-  --config auth_method=approle \
-  --config role_id=<role-id> \
-  --config secret_id=<secret-id> \
-  --config secret_id_accessor=<accessor> \
-  --config approle_mount=warden_approle \
-  --config role_name=warden-source \
-  --config vault_namespace=admin/team-a
+  -type hvault \
+  -rotation-period 24h \
+  -config vault_address=https://vault.example.com:8200 \
+  -config auth_method=approle \
+  -config role_id=<role-id> \
+  -config secret_id=<secret-id> \
+  -config secret_id_accessor=<accessor> \
+  -config approle_mount=warden_approle \
+  -config role_name=warden-source \
+  -config vault_namespace=admin/team-a
 ```
 
-The `--rotation-period` controls how often Warden rotates the AppRole `secret_id`. During rotation, Warden generates a new `secret_id`, verifies it works, persists the new config, then destroys the old one. Both credentials remain valid during the transition — there is no downtime.
+The `-rotation-period` controls how often Warden rotates the AppRole `secret_id`. During rotation, Warden generates a new `secret_id`, verifies it works, persists the new config, then destroys the old one. Both credentials remain valid during the transition — there is no downtime.
 
 Set to `0` to disable rotation (not recommended for production).
 
@@ -303,20 +303,20 @@ The Vault provider gateway requires a credential spec of type `vault_token`. War
 ```bash
 # Read-only Vault token
 warden cred spec create vault-reader \
-  --source vault-prod \
-  --config mint_method=vault_token \
-  --config token_role=reader \
-  --min-ttl 600s \
-  --max-ttl 2h
+  -source vault-prod \
+  -config mint_method=vault_token \
+  -config token_role=reader \
+  -min-ttl 600s \
+  -max-ttl 2h
 
 # Admin Vault token with custom TTL
 warden cred spec create vault-admin \
-  --source vault-prod \
-  --config mint_method=vault_token \
-  --config token_role=admin \
-  --config ttl=4h \
-  --min-ttl 1h \
-  --max-ttl 8h
+  -source vault-prod \
+  -config mint_method=vault_token \
+  -config token_role=admin \
+  -config ttl=4h \
+  -min-ttl 1h \
+  -max-ttl 8h
 ```
 
 ## Step 5: Create a Policy
@@ -548,7 +548,7 @@ Steps 1, 3-5 (provider setup) are identical. Replace Steps 2 and 6 with the foll
 
 ```bash
 # Enable JWT auth
-warden auth enable --type=jwt
+warden auth enable jwt
 
 # Configure JWT with the identity provider's JWKS endpoint
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
@@ -695,8 +695,8 @@ docker compose -f docker-compose.quickstart.yml down -v
 
 ### TTL Bounds
 
-- `--min-ttl`: Minimum credential TTL. Requests for shorter TTLs are clamped up.
-- `--max-ttl`: Maximum credential TTL. Requests for longer TTLs are clamped down.
+- `-min-ttl`: Minimum credential TTL. Requests for shorter TTLs are clamped up.
+- `-max-ttl`: Maximum credential TTL. Requests for longer TTLs are clamped down.
 
 ### Cert Auth Config
 


### PR DESCRIPTION
…to single-dash flags

Vault parity for enable commands and Vault-style flag conventions in docs:

  - `auth enable`, `provider enable`, `audit enable` now take TYPE as a required positional argument; the `-type` flag is gone. Mount path still defaults to TYPE; override it with `-path=<mount>` (Vault's exact form). Migration: `--type=jwt jwt-prod` → `-path=jwt-prod jwt`; `--type=aws` → `aws`. In `-json` mode, if the payload carries a `type` field it must match the TYPE positional or the CLI rejects with a usage error. Trailing slashes on the positional are stripped so `enable jwt/` works.

  - All operator-facing documentation switched to single-dash long flags: READMEs, CHANGELOG, tutorial scripts, provider docs, and cobra Long/ Example help text now consistently spell flags as `-config`, `-output`, `-path`, etc. — matching the Vault muscle memory the binary's flag normalizer (cmd/warden.go) was built for. Flag *registrations* in code remain `--foo` (cobra/pflag canonical), so `warden --help` still prints `--`. The binary already accepts both forms; this is a docs/UX cleanup, not a behavior change.

  - Tutorial scripts (warden-init.sh) accept both `--anthropic-key=` and `-anthropic-key=` argument forms so docs can use single-dash safely.

  - Removed unused helpers.MountPathFromArgOrPayload + its test.