### PR TITLE
feat(httpproxy): add Dispatch + ResolveUpstream + role-extractor hooks

### DIFF
--- a/provider/sdk/httpproxy/gateway.go
+++ b/provider/sdk/httpproxy/gateway.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stephnangue/warden/logical"
 )
 
+// defaultAcceptJSON is the Accept value injected when no spec or dispatch
+// override is in force and Accept defaulting is not suppressed.
+const defaultAcceptJSON = "application/json"
+
 func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	// Snapshot mutable fields under read lock to avoid races with config writes
 	b.mu.RLock()
@@ -20,6 +24,23 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	providerURL := b.providerURL
 	proxy := b.Proxy
 	b.mu.RUnlock()
+
+	credExtractor := b.spec.ExtractCredentials
+	var dispatch Dispatch
+	if b.spec.ResolveUpstream != nil {
+		if d, ok := b.spec.ResolveUpstream(req.HTTPRequest, providerURL); ok {
+			dispatch = d
+			if d.UpstreamURL != "" {
+				providerURL = d.UpstreamURL
+			}
+			if d.ExtractCredentials != nil {
+				credExtractor = d.ExtractCredentials
+			}
+			if d.MaxBodySize > 0 {
+				maxBody = d.MaxBodySize
+			}
+		}
+	}
 
 	// Apply timeout if configured
 	if timeout > 0 {
@@ -36,7 +57,7 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	req.HTTPRequest.Body = http.MaxBytesReader(req.ResponseWriter, req.HTTPRequest.Body, maxBody)
 
 	// Extract credentials using provider-specific extractor
-	credHeaders, err := b.spec.ExtractCredentials(req)
+	credHeaders, err := credExtractor(req)
 	if err != nil {
 		b.Logger.Warn("Failed to get credentials", logger.Err(err))
 		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
@@ -64,7 +85,7 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	r.RequestURI = "" // Required for outgoing requests
 
 	// Clean headers and inject credentials
-	b.prepareHeaders(r, credHeaders)
+	b.prepareHeaders(r, credHeaders, dispatch)
 
 	b.Logger.Trace("Proxying request",
 		logger.String("provider", b.spec.Name),
@@ -95,8 +116,31 @@ func buildTargetURL(providerURL, path, rawQuery string) (string, error) {
 	return providerURL + apiPath, nil
 }
 
+// resolveAcceptDefault returns the Accept value to inject when the client did
+// not set one. Empty string means "do not inject anything."
+//
+// Precedence:
+//  1. dispatch.Accept (non-empty) wins.
+//  2. Otherwise, if dispatch.SkipDefaultAccept is set, suppress.
+//  3. Otherwise, fall through to specDefault, defaulting to defaultAcceptJSON
+//     when specDefault is empty.
+func resolveAcceptDefault(specDefault string, dispatch Dispatch) string {
+	if dispatch.Accept != "" {
+		return dispatch.Accept
+	}
+	if dispatch.SkipDefaultAccept {
+		return ""
+	}
+	if specDefault != "" {
+		return specDefault
+	}
+	return defaultAcceptJSON
+}
+
 // prepareHeaders removes unwanted headers and injects credential + provider headers.
-func (b *proxyBackend) prepareHeaders(r *http.Request, credHeaders map[string]string) {
+// The dispatch carries per-request overrides for Accept defaulting and dynamic-header
+// injection; zero values mean "use the spec defaults."
+func (b *proxyBackend) prepareHeaders(r *http.Request, credHeaders map[string]string, dispatch Dispatch) {
 	// Read Connection header before removing it
 	conn := r.Header.Get("Connection")
 
@@ -131,8 +175,8 @@ func (b *proxyBackend) prepareHeaders(r *http.Request, credHeaders map[string]st
 
 	// Inject dynamic headers as fallbacks — only set if the client didn't already
 	// provide them. This differs from DefaultHeaders and credential headers which
-	// always override.
-	if b.spec.DynamicHeaders != nil {
+	// always override. SkipDynamicHeaders lets per-request dispatches opt out.
+	if b.spec.DynamicHeaders != nil && !dispatch.SkipDynamicHeaders {
 		b.mu.RLock()
 		state := b.extraState
 		b.mu.RUnlock()
@@ -143,13 +187,10 @@ func (b *proxyBackend) prepareHeaders(r *http.Request, credHeaders map[string]st
 		}
 	}
 
-	// Set Accept header if not already set
-	accept := "application/json"
-	if b.spec.DefaultAccept != "" {
-		accept = b.spec.DefaultAccept
-	}
 	if r.Header.Get("Accept") == "" {
-		r.Header.Set("Accept", accept)
+		if accept := resolveAcceptDefault(b.spec.DefaultAccept, dispatch); accept != "" {
+			r.Header.Set("Accept", accept)
+		}
 	}
 
 	// Set User-Agent if not already set

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -2,6 +2,7 @@ package httpproxy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -857,7 +858,7 @@ func TestPrepareHeaders(t *testing.T) {
 		req.Header.Set("X-Custom-Remove", "should-go")
 		req.Header.Set("X-Keep", "keep-me")
 
-		pb.prepareHeaders(req, map[string]string{"Authorization": "Bearer real-key"})
+		pb.prepareHeaders(req, map[string]string{"Authorization": "Bearer real-key"}, Dispatch{})
 
 		assert.Equal(t, "Bearer real-key", req.Header.Get("Authorization"))
 		assert.Empty(t, req.Header.Get("X-Warden-Token"))
@@ -867,7 +868,7 @@ func TestPrepareHeaders(t *testing.T) {
 
 	t.Run("sets default and static headers", func(t *testing.T) {
 		req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
-		pb.prepareHeaders(req, map[string]string{"Authorization": "Bearer key"})
+		pb.prepareHeaders(req, map[string]string{"Authorization": "Bearer key"}, Dispatch{})
 
 		assert.Equal(t, "val", req.Header.Get("X-Default"))
 		assert.Equal(t, "text/plain", req.Header.Get("Accept"))
@@ -877,7 +878,7 @@ func TestPrepareHeaders(t *testing.T) {
 	t.Run("preserves client-set Accept", func(t *testing.T) {
 		req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
 		req.Header.Set("Accept", "text/event-stream")
-		pb.prepareHeaders(req, map[string]string{})
+		pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 		assert.Equal(t, "text/event-stream", req.Header.Get("Accept"))
 	})
 
@@ -886,7 +887,7 @@ func TestPrepareHeaders(t *testing.T) {
 		req.Header.Set("Connection", "keep-alive")
 		req.Header.Set("Transfer-Encoding", "chunked")
 		req.Header.Set("Proxy-Authorization", "Basic abc")
-		pb.prepareHeaders(req, map[string]string{})
+		pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 		assert.Empty(t, req.Header.Get("Connection"))
 		assert.Empty(t, req.Header.Get("Transfer-Encoding"))
 		assert.Empty(t, req.Header.Get("Proxy-Authorization"))
@@ -896,7 +897,7 @@ func TestPrepareHeaders(t *testing.T) {
 		req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
 		req.Header.Set("Connection", "X-Custom-Hop")
 		req.Header.Set("X-Custom-Hop", "should-be-removed")
-		pb.prepareHeaders(req, map[string]string{})
+		pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 		assert.Empty(t, req.Header.Get("X-Custom-Hop"))
 	})
 
@@ -905,7 +906,7 @@ func TestPrepareHeaders(t *testing.T) {
 		req.Header.Set("X-Forwarded-For", "10.0.0.1")
 		req.Header.Set("X-Real-Ip", "10.0.0.1")
 		req.Header.Set("Forwarded", "for=10.0.0.1")
-		pb.prepareHeaders(req, map[string]string{})
+		pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 		assert.Empty(t, req.Header.Get("X-Forwarded-For"))
 		assert.Empty(t, req.Header.Get("X-Real-Ip"))
 		assert.Empty(t, req.Header.Get("Forwarded"))
@@ -927,7 +928,7 @@ func TestPrepareHeaders_DynamicHeaders(t *testing.T) {
 	pb.extraState["version"] = "v2"
 
 	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
-	pb.prepareHeaders(req, map[string]string{})
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 	assert.Equal(t, "v2", req.Header.Get("X-Api-Version"))
 }
 
@@ -942,7 +943,7 @@ func TestPrepareHeaders_DynamicHeaders_NotOverrideClient(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
 	req.Header.Set("X-Api-Version", "client-v1")
-	pb.prepareHeaders(req, map[string]string{})
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 	assert.Equal(t, "client-v1", req.Header.Get("X-Api-Version"))
 }
 
@@ -954,6 +955,304 @@ func TestPrepareHeaders_DefaultUserAgent(t *testing.T) {
 	pb := b.(*proxyBackend)
 
 	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
-	pb.prepareHeaders(req, map[string]string{})
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{})
 	assert.Equal(t, "warden-testprovider-proxy", req.Header.Get("User-Agent"))
+}
+
+// --- Dispatch tests (per-request override hooks) ---
+
+func TestPrepareHeaders_Dispatch_SkipDynamicHeaders(t *testing.T) {
+	spec := testSpec()
+	spec.DynamicHeaders = func(state map[string]any) map[string]string {
+		return map[string]string{"X-Api-Version": "v2"}
+	}
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{SkipDynamicHeaders: true})
+	assert.Empty(t, req.Header.Get("X-Api-Version"),
+		"dynamic headers must not be injected when dispatch.SkipDynamicHeaders is set")
+}
+
+func TestPrepareHeaders_Dispatch_AcceptOverride(t *testing.T) {
+	spec := testSpec()
+	spec.DefaultAccept = "text/plain"
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{Accept: "application/x-git-upload-pack-result"})
+	assert.Equal(t, "application/x-git-upload-pack-result", req.Header.Get("Accept"),
+		"dispatch.Accept must override spec.DefaultAccept")
+}
+
+func TestPrepareHeaders_Dispatch_SkipDefaultAccept(t *testing.T) {
+	// SkipDefaultAccept + empty dispatch.Accept = "do not inject any Accept default."
+	// Required for protocols that negotiate their own Accept.
+	spec := testSpec()
+	spec.DefaultAccept = "application/json"
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{SkipDefaultAccept: true})
+	assert.Empty(t, req.Header.Get("Accept"),
+		"Accept must not be injected when dispatch.SkipDefaultAccept is set with empty dispatch.Accept")
+}
+
+func TestPrepareHeaders_Dispatch_SkipDynamicHeaders_KeepsAcceptDefault(t *testing.T) {
+	// SkipDynamicHeaders alone must NOT suppress Accept defaulting — that's
+	// SkipDefaultAccept's job. The two fields are independent.
+	spec := testSpec()
+	spec.DefaultAccept = "application/json"
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{SkipDynamicHeaders: true})
+	assert.Equal(t, "application/json", req.Header.Get("Accept"),
+		"SkipDynamicHeaders must not affect Accept defaulting")
+}
+
+func TestPrepareHeaders_Dispatch_Zero_PreservesSpecDefaults(t *testing.T) {
+	// A zero Dispatch{} must produce identical behaviour to the pre-Dispatch
+	// world: spec.DefaultAccept applies, spec.DynamicHeaders injects.
+	spec := testSpec()
+	spec.DefaultAccept = "text/plain"
+	spec.DynamicHeaders = func(state map[string]any) map[string]string {
+		return map[string]string{"X-Api-Version": "v2"}
+	}
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
+	pb.prepareHeaders(req, map[string]string{}, Dispatch{})
+	assert.Equal(t, "text/plain", req.Header.Get("Accept"))
+	assert.Equal(t, "v2", req.Header.Get("X-Api-Version"))
+}
+
+// --- TransparentAuthRoleExtractor delegation tests ---
+
+func TestGetAuthRoleFromRequest_HookNil_DefaultsTransparentEmpty(t *testing.T) {
+	spec := testSpec() // no GetAuthRoleFromRequest set
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	role, ok := pb.GetAuthRoleFromRequest(httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, "", role)
+	assert.True(t, ok,
+		"with hook unset, proxyBackend must report transparent=true / role=empty so the core flow falls back to default_role")
+}
+
+func TestGetAuthRoleFromRequest_HookReturnsRole(t *testing.T) {
+	spec := testSpec()
+	spec.GetAuthRoleFromRequest = func(r *http.Request) (string, bool) {
+		return "from-hook", true
+	}
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	role, ok := pb.GetAuthRoleFromRequest(httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, "from-hook", role)
+	assert.True(t, ok)
+}
+
+func TestGetAuthRoleFromRequest_HookReturnsNonTransparent(t *testing.T) {
+	spec := testSpec()
+	spec.GetAuthRoleFromRequest = func(r *http.Request) (string, bool) {
+		return "", false
+	}
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	role, ok := pb.GetAuthRoleFromRequest(httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, "", role)
+	assert.False(t, ok,
+		"hook returning ok=false signals non-transparent — core flow should fall back to explicit auth")
+}
+
+// --- ResolveUpstream tests (via handleGateway) ---
+
+func TestHandleGateway_ResolveUpstream_OverridesUpstreamURL(t *testing.T) {
+	// Stand up two upstream servers; one is the spec default, the other is what
+	// ResolveUpstream returns. Assert the request lands on the override.
+	defaultUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Hit", "default")
+		w.WriteHeader(200)
+	}))
+	defer defaultUpstream.Close()
+
+	overrideUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Hit", "override")
+		w.WriteHeader(200)
+	}))
+	defer overrideUpstream.Close()
+
+	spec := testSpec()
+	spec.DefaultURL = defaultUpstream.URL
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		return map[string]string{"Authorization": "Bearer test"}, nil
+	}
+	spec.ResolveUpstream = func(r *http.Request, providerURL string) (Dispatch, bool) {
+		return Dispatch{UpstreamURL: overrideUpstream.URL}, true
+	}
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.providerURL = defaultUpstream.URL
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httpReq,
+		ResponseWriter: rec,
+	})
+
+	assert.Equal(t, "override", rec.Header().Get("X-Hit"),
+		"request should land on the override upstream, not the spec default")
+}
+
+func TestHandleGateway_ResolveUpstream_OverridesCredentialExtractor(t *testing.T) {
+	// Default extractor returns one Authorization; override returns another.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Auth", r.Header.Get("Authorization"))
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	spec := testSpec()
+	spec.DefaultURL = upstream.URL
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		return map[string]string{"Authorization": "Bearer default-cred"}, nil
+	}
+	spec.ResolveUpstream = func(r *http.Request, providerURL string) (Dispatch, bool) {
+		return Dispatch{
+			ExtractCredentials: func(req *logical.Request) (map[string]string, error) {
+				return map[string]string{"Authorization": "Basic override-cred"}, nil
+			},
+		}, true
+	}
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.providerURL = upstream.URL
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httpReq,
+		ResponseWriter: rec,
+	})
+
+	assert.Equal(t, "Basic override-cred", rec.Header().Get("X-Got-Auth"))
+}
+
+func TestHandleGateway_ResolveUpstream_MaxBodySizeOverride(t *testing.T) {
+	// Cap is enforced by http.MaxBytesReader — sending body > cap fails the read.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("X-Got-Bytes", fmt.Sprintf("%d", len(body)))
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	spec := testSpec()
+	spec.DefaultURL = upstream.URL
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		return map[string]string{"Authorization": "Bearer test"}, nil
+	}
+	spec.ResolveUpstream = func(r *http.Request, providerURL string) (Dispatch, bool) {
+		return Dispatch{MaxBodySize: 1024}, true // tight cap for this request
+	}
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.providerURL = upstream.URL
+	pb.MaxBodySize = 10 * 1024 * 1024 // 10MB default
+
+	// Body of 100 bytes — under the dispatch cap, should reach upstream.
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(strings.Repeat("x", 100))
+	httpReq := httptest.NewRequest("POST", "/v1/test/gateway/foo", body)
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httpReq,
+		ResponseWriter: rec,
+	})
+
+	assert.Equal(t, "100", rec.Header().Get("X-Got-Bytes"))
+}
+
+func TestHandleGateway_ResolveUpstream_FallthroughOnFalse(t *testing.T) {
+	// When ResolveUpstream returns ok=false, all spec defaults must apply.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Auth", r.Header.Get("Authorization"))
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	spec := testSpec()
+	spec.DefaultURL = upstream.URL
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		return map[string]string{"Authorization": "Bearer default-cred"}, nil
+	}
+	resolveCalled := false
+	spec.ResolveUpstream = func(r *http.Request, providerURL string) (Dispatch, bool) {
+		resolveCalled = true
+		return Dispatch{}, false
+	}
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.providerURL = upstream.URL
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httpReq,
+		ResponseWriter: rec,
+	})
+
+	assert.True(t, resolveCalled, "ResolveUpstream should have been consulted")
+	assert.Equal(t, "Bearer default-cred", rec.Header().Get("X-Got-Auth"),
+		"with ok=false, default credentials must be used")
+}
+
+func TestHandleGateway_NoResolveUpstream_UsesDefaults(t *testing.T) {
+	// Existing providers (no ResolveUpstream set) must behave exactly as before.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Auth", r.Header.Get("Authorization"))
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	spec := testSpec()
+	spec.DefaultURL = upstream.URL
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		return map[string]string{"Authorization": "Bearer default-cred"}, nil
+	}
+	// spec.ResolveUpstream intentionally nil
+
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.providerURL = upstream.URL
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httpReq,
+		ResponseWriter: rec,
+	})
+
+	assert.Equal(t, "Bearer default-cred", rec.Header().Get("X-Got-Auth"))
 }

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -17,6 +17,38 @@ import (
 // TokenExtractorFunc extracts the Warden session token from an incoming HTTP request.
 type TokenExtractorFunc func(r *http.Request) string
 
+// Dispatch carries per-request overrides returned by ProviderSpec.ResolveUpstream.
+// Zero values mean "fall through to the spec/mount default." Used by providers
+// that carry multiple protocols on the same mount and need different upstreams,
+// credential formats, header policies, or size caps depending on the path.
+type Dispatch struct {
+	// UpstreamURL overrides providerURL for this request.
+	UpstreamURL string
+
+	// ExtractCredentials overrides Spec.ExtractCredentials for this request.
+	ExtractCredentials CredentialExtractor
+
+	// Accept overrides Spec.DefaultAccept for this request. When empty, the
+	// spec default applies unless SkipDefaultAccept is also set.
+	Accept string
+
+	// SkipDefaultAccept suppresses Accept injection entirely when Accept is
+	// empty: no header is set and the client's own Accept negotiation is
+	// preserved. Required for protocols whose clients negotiate their own
+	// Accept and would be broken by a JSON default.
+	SkipDefaultAccept bool
+
+	// SkipDynamicHeaders disables Spec.DynamicHeaders injection for this
+	// request. Used when the request targets a surface where the dynamic
+	// headers are irrelevant or harmful.
+	SkipDynamicHeaders bool
+
+	// MaxBodySize overrides the per-mount max_body_size for this request when > 0.
+	// Used by protocols that legitimately need larger caps than the REST default
+	// (e.g. uploading large binary payloads). When 0, falls through to b.MaxBodySize.
+	MaxBodySize int64
+}
+
 // ProviderSpec fully describes an HTTP proxy provider.
 // All shared behavior is handled by the httpproxy package; only provider-specific
 // differences are captured here.
@@ -87,6 +119,27 @@ type ProviderSpec struct {
 	// Returns the transport and a shutdown function.
 	// If nil, DefaultNewTransport is used.
 	NewTransport func() (*http.Transport, func())
+
+	// ResolveUpstream optionally returns per-request overrides for upstream
+	// URL, credential extraction, header policy, and body cap. When nil — or
+	// when the call returns ok=false — the spec/mount defaults apply unchanged.
+	// Used by providers that carry multiple protocols on the same mount and
+	// need to route a subset of paths to a different upstream surface.
+	ResolveUpstream func(r *http.Request, providerURL string) (Dispatch, bool)
+
+	// GetAuthRoleFromRequest optionally extracts the auth role from request
+	// context. The shared httpproxy backend wires this into the core's
+	// TransparentAuthRoleExtractor flow, so the spec hook is consulted only
+	// when the path-based role lookup is empty and BEFORE the X-Warden-Role
+	// header override.
+	//
+	// Return ("", true) for "transparent yes, no role contribution — fall back
+	// to default_role"; this is also the default behaviour when the hook is
+	// unset. Return (role, true) to supply a role. Return ("", false) only if
+	// the provider wants to mark the request as non-transparent (rare; used by
+	// providers whose transparent auth requires a specific authorization
+	// scheme that is absent on this request).
+	GetAuthRoleFromRequest func(r *http.Request) (string, bool)
 }
 
 // proxyBackend is the concrete backend type created by NewFactory.
@@ -357,4 +410,20 @@ func (b *proxyBackend) handleTransparentGatewayStreaming(ctx context.Context, re
 // SensitiveConfigFields returns the list of config fields that should be masked in output.
 func (b *proxyBackend) SensitiveConfigFields() []string {
 	return []string{"ca_data"}
+}
+
+// Compile-time assertion that proxyBackend satisfies the role-extractor
+// interface. The implementation delegates to spec.GetAuthRoleFromRequest;
+// providers that leave the hook nil get ("", true) — observationally
+// equivalent to not implementing the interface, since the core's
+// transparent-auth flow only acts on isTransparent==false or a non-empty role.
+var _ logical.TransparentAuthRoleExtractor = (*proxyBackend)(nil)
+
+// GetAuthRoleFromRequest delegates to the optional spec hook. See
+// ProviderSpec.GetAuthRoleFromRequest for the contract.
+func (b *proxyBackend) GetAuthRoleFromRequest(r *http.Request) (string, bool) {
+	if b.spec.GetAuthRoleFromRequest == nil {
+		return "", true
+	}
+	return b.spec.GetAuthRoleFromRequest(r)
 }


### PR DESCRIPTION
## Summary

Adds three additive extension points to `ProviderSpec` for providers that carry multiple protocols on the same mount and need different upstreams, credential formats, header policies, or size caps depending on the path.

**`ProviderSpec` gains:**
- `ResolveUpstream(r, providerURL) (Dispatch, bool)` — consulted in `handleGateway` before URL/credential/body-cap/header decisions; `ok=false` or nil hook means "use spec defaults."
- `GetAuthRoleFromRequest(r) (role, ok)` — wired through `proxyBackend` so it satisfies `logical.TransparentAuthRoleExtractor`. Consulted by core role resolution only when path-based lookup is empty and BEFORE the `X-Warden-Role` override. Same hook AWS and Alicloud already use for SigV4 role extraction; nil-hook default returns `("", true)` so observable behaviour for non-opting providers is unchanged.

**`Dispatch` fields:**
- `UpstreamURL`, `ExtractCredentials`, `MaxBodySize` override the per-mount/per-spec defaults inline in `handleGateway`.
- `Accept` overrides `Spec.DefaultAccept`.
- `SkipDefaultAccept` suppresses `Accept` injection entirely (for protocols that negotiate their own `Accept`).
- `SkipDynamicHeaders` suppresses `Spec.DynamicHeaders` injection.

`Accept` resolution moves out of `prepareHeaders` into a small `resolveAcceptDefault` helper with documented precedence: `dispatch.Accept` > `SkipDefaultAccept` > `spec.DefaultAccept` > `defaultAcceptJSON`.

All fields are optional. No other provider in-tree opts in; this PR is pure scaffolding for a follow-up that lights up a real use case.

## Test plan

- [x] `go build ./...`
- [x] `go test ./provider/sdk/httpproxy/...` — existing tests pass unchanged + 12 new unit tests for the hooks
- [x] `go test ./provider/... ./core/...` — no regressions in providers that consume the SDK
- [ ] Verify in a follow-up PR that a real provider can opt into both hooks without further SDK changes