### PR TITLE
feat(framework): pass request to StreamBodyParser.ShouldParseStreamBody

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -787,7 +787,7 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		// Backends that implement StreamBodyParser and return true get req.Data
 		// populated before policy evaluation. The body is restored after parsing
 		// so the streaming handler can still read it.
-		if parser, ok := matchingBackend.(logical.StreamBodyParser); ok && parser.ShouldParseStreamBody() {
+		if parser, ok := matchingBackend.(logical.StreamBodyParser); ok && parser.ShouldParseStreamBody(req.HTTPRequest) {
 			if err := c.parseRequestBody(req); err != nil {
 				return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
 			}

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1427,7 +1427,7 @@ type mockStreamBodyParserBackend struct {
 	parseStreamBody bool
 }
 
-func (m *mockStreamBodyParserBackend) ShouldParseStreamBody() bool {
+func (m *mockStreamBodyParserBackend) ShouldParseStreamBody(_ *http.Request) bool {
 	return m.parseStreamBody
 }
 

--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -652,8 +652,9 @@ func (b *StreamingBackend) IsUnauthenticatedPath(path string) bool {
 	return false
 }
 
-// ShouldParseStreamBody implements logical.StreamBodyParser.
-func (b *StreamingBackend) ShouldParseStreamBody() bool {
+// ShouldParseStreamBody implements logical.StreamBodyParser. Subtypes may
+// override to inspect the request.
+func (b *StreamingBackend) ShouldParseStreamBody(_ *http.Request) bool {
 	return b.ParseStreamBody
 }
 

--- a/framework/streaming_backend_test.go
+++ b/framework/streaming_backend_test.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -456,11 +457,13 @@ func BenchmarkIsUnauthenticatedPath_NoMatch(b *testing.B) {
 }
 
 func TestShouldParseStreamBody(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/test/gateway/foo", nil)
+
 	t.Run("returns false by default", func(t *testing.T) {
 		b := &StreamingBackend{
 			Backend: &Backend{BackendType: "test"},
 		}
-		assert.False(t, b.ShouldParseStreamBody())
+		assert.False(t, b.ShouldParseStreamBody(r))
 	})
 
 	t.Run("returns true when enabled", func(t *testing.T) {
@@ -468,6 +471,15 @@ func TestShouldParseStreamBody(t *testing.T) {
 			ParseStreamBody: true,
 			Backend:         &Backend{BackendType: "test"},
 		}
-		assert.True(t, b.ShouldParseStreamBody())
+		assert.True(t, b.ShouldParseStreamBody(r))
+	})
+
+	t.Run("ignores request shape", func(t *testing.T) {
+		b := &StreamingBackend{
+			ParseStreamBody: true,
+			Backend:         &Backend{BackendType: "test"},
+		}
+		// Per-request behaviour belongs in subtypes that override the method.
+		assert.True(t, b.ShouldParseStreamBody(httptest.NewRequest("GET", "/v1/test/gateway/anything.bin", nil)))
 	})
 }

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -147,9 +147,15 @@ type TransparentAuthRoleExtractor interface {
 // buffering large payloads. Backends that need req.Data for ACL/policy checks
 // (e.g., Vault) should implement this interface and return true.
 //
+// The request is passed so backends carrying multiple protocols on the same
+// mount can inspect the path/headers and disable parsing for the subset of
+// requests where parsing would be wasteful or harmful (e.g. binary upload
+// protocols). Implementations that don't need per-request behaviour ignore
+// the argument and return a static per-backend value.
+//
 // When enabled, the core parses application/json and application/x-www-form-urlencoded
 // bodies (up to maxRequestBodySize), restores the body for the provider to re-read,
 // and populates req.Data before CheckToken runs.
 type StreamBodyParser interface {
-	ShouldParseStreamBody() bool
+	ShouldParseStreamBody(r *http.Request) bool
 }

--- a/logical/paths.go
+++ b/logical/paths.go
@@ -16,7 +16,7 @@ type Paths struct {
 	// Stream is a list of paths that handle streaming requests.
 	// For these paths, the core does two things during processing:
 	//  1) does NOT parse request body into req.Data, unless the backend
-	//     implements StreamBodyParser and returns true from ShouldParseStreamBody().
+	//     implements StreamBodyParser and returns true from ShouldParseStreamBody.
 	//     In that case, JSON and form-urlencoded bodies are parsed and restored
 	//     for the streaming handler to re-read.
 	//  2) mints and injects credential into logical request


### PR DESCRIPTION
## Summary

Changes the `StreamBodyParser` interface signature from `ShouldParseStreamBody() bool` to `ShouldParseStreamBody(r *http.Request) bool` so backends carrying multiple protocols on the same mount can decide per-request whether to parse the body, rather than only per-backend.

The default `StreamingBackend` implementation ignores the new argument and returns the static `ParseStreamBody` flag — every existing backend behaves exactly as before. The core caller now passes `req.HTTPRequest`; the test mock and the stale doc comment in `logical/paths.go` are updated to match.

This is pure scaffolding for a follow-up provider that needs to opt out of body parsing on a subset of paths without affecting the rest of its mount.

## Test plan

- [x] `go build ./...`
- [x] `go test ./framework/... ./core/... ./provider/...` — no regressions
- [x] New sub-test `TestShouldParseStreamBody/ignores_request_shape` locks in that the default impl does not differentiate by request shape
- [ ] Follow-up PR exercises the per-request branch via an override on a real provider