### PR TITLE
feat(core): return path in LIST /sys/providers for X-Warden-Provider

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -188,7 +188,11 @@ type MountInput struct {
 }
 
 type MountOutput struct {
-	Type        string         `json:"type"`
+	Type string `json:"type"`
+	// Path is the mount path with trailing slash (e.g. "github/"). Agents
+	// pass it as X-Warden-Provider for header-routed calls; see the
+	// per-provider skill for when that applies.
+	Path        string         `json:"path" mapstructure:"path"`
 	Description string         `json:"description"`
 	Accessor    string         `json:"accessor"`
 	Config      map[string]any `json:"config" mapstructure:"config"`

--- a/api/sys_mounts_test.go
+++ b/api/sys_mounts_test.go
@@ -25,6 +25,7 @@ func TestSys_ListMounts(t *testing.T) {
 				"mounts": {
 					"secret/": {
 						"type": "kv",
+						"path": "secret/",
 						"description": "Key-Value secrets engine",
 						"accessor": "kv_accessor_123",
 						"config": {
@@ -35,6 +36,7 @@ func TestSys_ListMounts(t *testing.T) {
 					},
 					"database/": {
 						"type": "database",
+						"path": "database/",
 						"description": "Database secrets engine",
 						"accessor": "database_accessor_456",
 						"config": {
@@ -83,6 +85,10 @@ func TestSys_ListMounts(t *testing.T) {
 
 		if secretMount.Accessor != "kv_accessor_123" {
 			t.Errorf("expected accessor kv_accessor_123, got %s", secretMount.Accessor)
+		}
+
+		if secretMount.Path != "secret/" {
+			t.Errorf("expected path secret/, got %s", secretMount.Path)
 		}
 
 		databaseMount, ok := mounts["database/"]
@@ -221,6 +227,7 @@ func TestSys_ListMountsWithContext(t *testing.T) {
 				"mounts": {
 					"secret/": {
 						"type": "kv",
+						"path": "secret/",
 						"description": "Key-Value secrets engine",
 						"accessor": "kv_accessor_123"
 					}

--- a/cmd/providers/list.go
+++ b/cmd/providers/list.go
@@ -54,7 +54,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	for _, path := range paths {
 		mount := mounts[path]
 		items = append(items, map[string]any{
-			"path":        path,
+			"path":        mount.Path,
 			"type":        mount.Type,
 			"accessor":    mount.Accessor,
 			"description": mount.Description,

--- a/core/seed/skills/discovery.md
+++ b/core/seed/skills/discovery.md
@@ -55,17 +55,17 @@ match to your task.
 ## Step 3 — list providers in this namespace
 
 ```bash
-warden provider list -o json -F type,description,mount_url
+warden provider list -o json -F type,path,description,mount_url
 ```
 
 Returns one record per mounted provider:
 
 ```json
 [
-  {"type": "aws",    "description": "Production AWS account 1234",     "mount_url": "/v1/team-data/aws/"},
-  {"type": "openai", "description": "OpenAI API for embeddings + chat", "mount_url": "/v1/team-data/openai/"},
-  {"type": "rds",    "description": "RDS PostgreSQL — analytics",      "mount_url": "/v1/team-data/rds-pg/"},
-  {"type": "vault",  "description": "Internal Vault — secrets/, pki/", "mount_url": "/v1/team-data/vault/"}
+  {"type": "aws",    "path": "aws/",    "description": "Production AWS account 1234",     "mount_url": "/v1/team-data/aws/"},
+  {"type": "openai", "path": "openai/", "description": "OpenAI API for embeddings + chat", "mount_url": "/v1/team-data/openai/"},
+  {"type": "rds",    "path": "rds-pg/", "description": "RDS PostgreSQL — analytics",      "mount_url": "/v1/team-data/rds-pg/"},
+  {"type": "vault",  "path": "vault/",  "description": "Internal Vault — secrets/, pki/", "mount_url": "/v1/team-data/vault/"}
 ]
 ```
 
@@ -79,6 +79,10 @@ provider's skill to build the full upstream URL.
 Concatenating `$WARDEN_NAMESPACE` separately produces a double-
 namespaced path that doesn't route (e.g.
 `/v1/tutorial/tutorial/vault/...` → `no route found`).
+
+`path` is the bare mount path (with trailing slash). Some provider
+skills tell agents to pass it as `X-Warden-Provider` for header-routed
+calls — follow the per-provider skill for when that applies.
 
 Listing providers requires capabilities granted by your role's
 policy — by convention this is included in the namespace's default

--- a/core/sys_providers.go
+++ b/core/sys_providers.go
@@ -231,6 +231,7 @@ func (b *SystemBackend) handleProviderList(ctx context.Context, req *logical.Req
 
 		mounts[entry.Path] = map[string]any{
 			"type":        entry.Type,
+			"path":        entry.Path,
 			"description": entry.Description,
 			"accessor":    entry.Accessor,
 			"config":      maskedConfig,

--- a/core/sys_providers_test.go
+++ b/core/sys_providers_test.go
@@ -232,11 +232,15 @@ func TestSystemBackend_HandleProviderList(t *testing.T) {
 	assert.Len(t, mounts, 2)
 
 	// Every entry must carry a mount_url that agents can prepend
-	// $WARDEN_ADDR to without further string manipulation.
+	// $WARDEN_ADDR to without further string manipulation, and a
+	// `path` field that mirrors the map key so JSON-streaming
+	// consumers can hand it straight to X-Warden-Provider.
 	for path, entry := range mounts {
 		em, ok := entry.(map[string]any)
 		require.True(t, ok)
 		assert.Equal(t, "/v1/"+path, em["mount_url"],
 			"mount_url for %q should be /v1/%s", path, path)
+		assert.Equal(t, path, em["path"],
+			"path field for %q should equal the map key", path)
 	}
 }

--- a/provider/github/skill.md
+++ b/provider/github/skill.md
@@ -86,13 +86,21 @@ dispatches per-request based on path shape — `.git/info/refs`,
 `.git/git-upload-pack`, and `.git/git-receive-pack` route to the Git
 host with HTTP Basic Auth instead of the REST `Authorization: token`.
 
+(All examples below assume `mount_url = /v1/github/`; substitute yours
+from `warden provider list`.)
+
 ### Clone
 
 The clone URL carries the Warden role as the Basic Auth username and
 the Warden JWT as the password. Substitute `<role>` and the mount URL:
 
+Git embeds Basic Auth between scheme and host in the clone URL, so
+split `$WARDEN_ADDR` (the canonical env var from the `foundation`
+skill) — `${WARDEN_ADDR%%://*}` is the scheme, `${WARDEN_ADDR#*://}`
+is the host (and port if present):
+
 ```bash
-git clone "https://<role>:${WARDEN_TOKEN}@$WARDEN_HOST/v1/github/gateway/<owner>/<repo>.git"
+git clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/v1/github/gateway/<owner>/<repo>.git"
 ```
 
 Git's credential helpers cache on URL+username, so each role gets a
@@ -107,13 +115,20 @@ git config --global credential.helper "cache --timeout=900"
 
 ### Header-routed alternative
 
-If you prefer a clone URL that looks like a real Git URL, set
-`X-Warden-Provider: github` via `http.extraheader` instead:
+If you prefer a clone URL that looks like a real Git URL, pass the
+mount path as `X-Warden-Provider` via `http.extraheader` instead. Use
+the `path` field from `warden provider list` (trailing-slash form;
+the server accepts either):
 
 ```bash
-git -c http.extraheader="X-Warden-Provider: github" \
-    clone "https://<role>:${WARDEN_TOKEN}@$WARDEN_HOST/<owner>/<repo>.git"
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="github") | .path')
+git -c http.extraheader="X-Warden-Provider: $path" \
+    clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/<owner>/<repo>.git"
 ```
+
+When more than one `github` mount exists, pick the entry whose
+`description` matches the upstream you want — `path` alone doesn't
+tell you which GitHub host or org the mount fronts.
 
 `http.extraheader` persists into `.git/config` at clone time, so the
 header carries through to follow-up operations automatically.


### PR DESCRIPTION
## Summary

- Adds `path` to each entry in the `LIST /sys/providers` response (mirroring `handleProviderRead`) so agents can hand it straight to the `X-Warden-Provider` header for header-routed Git smart-HTTP calls — no re-deriving it from the map key or parsing `mount_url`.
- Exposes `Path` on `api.MountOutput` so typed Go consumers (CLI, embedders) see the field, with a doc comment parallel to `MountURL`'s.
- Teaches the field in the agent skills: `discovery.md` now shows `path` in the provider-list example and the `-F` selector; `provider/github/skill.md` anchors the header-routed clone snippet on the discovered `path` and adds a description-based multi-mount disambiguation rule.
- Side cleanups in the github skill: clone examples now use the canonical `$WARDEN_ADDR` (scheme-agnostic via bash parameter expansion) instead of the undocumented `$WARDEN_HOST`, and `cmd/providers/list.go` reads `mount.Path` from the typed struct rather than the iterated map key.

## Test plan

- [x] `go test ./core/ ./api/` — both pass (core 11.1s, api 35.3s)
- [x] `go build ./...` — clean
- [x] `gofmt -d` on all changed Go files — clean
- [x] `go vet` — no new warnings (8 pre-existing on main)
- [x] e2e `TestProviderList_IncludesMountURL` backward-compatible (only asserts on `mount_url`, new field is additive)
- [ ] Manual smoke against an HA cluster: `warden provider list -o json -F path,type,description,mount_url` returns non-empty `path` per entry
- [ ] Manual smoke for the new agent flow: `git -c http.extraheader="X-Warden-Provider: $(warden provider list -o json | jq -r '.[0].path')" clone …` routes the same as the existing hard-coded `X-Warden-Provider: github` form
