### PR TITLE
framework: pass request to TransparentModeProvider.IsUnauthenticatedPath

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -802,7 +802,7 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 				if req.MountPoint != "" {
 					relativePath = strings.TrimPrefix(req.Path, req.MountPoint)
 				}
-				if tmp.IsUnauthenticatedPath(relativePath) {
+				if tmp.IsUnauthenticatedPath(req.HTTPRequest, relativePath) {
 					req.StreamUnauthenticated = true
 					c.logger.Trace("unauthenticated streaming request",
 						logger.String("path", req.Path),

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1054,7 +1054,7 @@ func (m *mockTransparentModeProvider) IsTransparentPath(path string) bool {
 	return strings.HasPrefix(path, "gateway") || strings.Contains(path, "/gateway")
 }
 
-func (m *mockTransparentModeProvider) IsUnauthenticatedPath(path string) bool {
+func (m *mockTransparentModeProvider) IsUnauthenticatedPath(_ *http.Request, _ string) bool {
 	return false
 }
 

--- a/framework/access_backend.go
+++ b/framework/access_backend.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -98,7 +99,7 @@ func (b *AccessBackend) IsTransparentPath(path string) bool {
 }
 
 // IsUnauthenticatedPath returns false — all access paths require authentication.
-func (b *AccessBackend) IsUnauthenticatedPath(path string) bool {
+func (b *AccessBackend) IsUnauthenticatedPath(_ *http.Request, _ string) bool {
 	return false
 }
 

--- a/framework/access_backend_test.go
+++ b/framework/access_backend_test.go
@@ -138,8 +138,8 @@ func TestAccessBackend_IsTransparentPath_CustomPrefix(t *testing.T) {
 
 func TestAccessBackend_IsUnauthenticatedPath(t *testing.T) {
 	b := setupAccessBackend(t)
-	assert.False(t, b.IsUnauthenticatedPath("access/readonly"))
-	assert.False(t, b.IsUnauthenticatedPath("config"))
+	assert.False(t, b.IsUnauthenticatedPath(nil, "access/readonly"))
+	assert.False(t, b.IsUnauthenticatedPath(nil, "config"))
 }
 
 func TestAccessBackend_ConfigPersistence(t *testing.T) {

--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -619,8 +619,9 @@ func (b *StreamingBackend) IsTransparentPath(path string) bool {
 }
 
 // IsUnauthenticatedPath checks if the path matches an unauthenticated pattern.
-// Uses radix tree for O(log n) lookup with wildcard fallback.
-func (b *StreamingBackend) IsUnauthenticatedPath(path string) bool {
+// Uses radix tree for O(log n) lookup with wildcard fallback. Subtypes may
+// override to inspect the request.
+func (b *StreamingBackend) IsUnauthenticatedPath(_ *http.Request, path string) bool {
 	b.unauthPathsOnce.Do(b.initUnauthPaths)
 
 	if b.unauthPaths == nil {

--- a/framework/streaming_backend_test.go
+++ b/framework/streaming_backend_test.go
@@ -129,7 +129,7 @@ func TestIsUnauthenticatedPath(t *testing.T) {
 				UnauthenticatedPaths: tt.paths,
 			}
 
-			result := b.IsUnauthenticatedPath(tt.testPath)
+			result := b.IsUnauthenticatedPath(nil, tt.testPath)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -264,7 +264,7 @@ func TestIsUnauthenticatedPath_PathsContainingKeywords(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := b.IsUnauthenticatedPath(tt.path)
+			result := b.IsUnauthenticatedPath(nil, tt.path)
 			assert.Equal(t, tt.expected, result, "path: %s", tt.path)
 		})
 	}
@@ -318,10 +318,24 @@ func TestIsUnauthenticatedPath_VaultPKIPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			result := b.IsUnauthenticatedPath(tt.path)
+			result := b.IsUnauthenticatedPath(nil, tt.path)
 			assert.Equal(t, tt.expected, result, "path: %s", tt.path)
 		})
 	}
+}
+
+func TestIsUnauthenticatedPath_IgnoresRequestShape(t *testing.T) {
+	b := &StreamingBackend{UnauthenticatedPaths: []string{"v1/+/ca/pem"}}
+	path := "role/test/gateway/v1/pki/ca/pem"
+
+	// Default impl is path-only; request is plumbed for subtypes that override.
+	assert.True(t, b.IsUnauthenticatedPath(httptest.NewRequest("GET", "/"+path, nil), path))
+	assert.True(t, b.IsUnauthenticatedPath(httptest.NewRequest("POST", "/"+path, nil), path))
+	r := httptest.NewRequest("GET", "/"+path, nil)
+	r.Header.Set("Authorization", "Bearer xyz")
+	assert.True(t, b.IsUnauthenticatedPath(r, path))
+	assert.True(t, b.IsUnauthenticatedPath(nil, path),
+		"default impl tolerates nil request — subtypes opt in to using it")
 }
 
 func TestMatchWildcardSegments(t *testing.T) {
@@ -390,11 +404,11 @@ func TestSetUnauthenticatedPaths_ResetsCache(t *testing.T) {
 	}
 
 	// Initialize the unauthPaths by calling IsUnauthenticatedPath
-	result1 := b.IsUnauthenticatedPath("role/test/gateway/v1/pki/ca/pem")
+	result1 := b.IsUnauthenticatedPath(nil, "role/test/gateway/v1/pki/ca/pem")
 	assert.True(t, result1, "should match initial pattern")
 
 	// This should NOT match with the initial config
-	result2 := b.IsUnauthenticatedPath("role/test/gateway/v1/pki/issuer/abc/pem")
+	result2 := b.IsUnauthenticatedPath(nil, "role/test/gateway/v1/pki/issuer/abc/pem")
 	assert.False(t, result2, "should not match issuer pattern initially")
 
 	// Now update UnauthenticatedPaths directly and call SetTransparentConfig to reset cache
@@ -402,7 +416,7 @@ func TestSetUnauthenticatedPaths_ResetsCache(t *testing.T) {
 	b.SetTransparentConfig(&TransparentConfig{}) // This resets the unauthPaths cache
 
 	// The issuer pattern should now match
-	result3 := b.IsUnauthenticatedPath("role/test/gateway/v1/pki/issuer/abc/pem")
+	result3 := b.IsUnauthenticatedPath(nil, "role/test/gateway/v1/pki/issuer/abc/pem")
 	assert.True(t, result3, "should match issuer pattern after config update")
 }
 
@@ -423,11 +437,11 @@ func BenchmarkIsUnauthenticatedPath(b *testing.B) {
 	}
 
 	// Initialize
-	backend.IsUnauthenticatedPath("warmup")
+	backend.IsUnauthenticatedPath(nil, "warmup")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		backend.IsUnauthenticatedPath("role/provisionner/gateway/v1/pki/issuer/abc123/pem")
+		backend.IsUnauthenticatedPath(nil, "role/provisionner/gateway/v1/pki/issuer/abc123/pem")
 	}
 }
 
@@ -448,11 +462,11 @@ func BenchmarkIsUnauthenticatedPath_NoMatch(b *testing.B) {
 	}
 
 	// Initialize
-	backend.IsUnauthenticatedPath("warmup")
+	backend.IsUnauthenticatedPath(nil, "warmup")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		backend.IsUnauthenticatedPath("role/provisionner/gateway/v1/secret/data/mykey")
+		backend.IsUnauthenticatedPath(nil, "role/provisionner/gateway/v1/secret/data/mykey")
 	}
 }
 

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -128,10 +128,26 @@ type TransparentModeProvider interface {
 	// TransparentAuthRoleExtractor hook both returned "". Returns "" if unset.
 	GetDefaultAuthRole() string
 
-	// IsUnauthenticatedPath checks if a path can be accessed without authentication.
-	// Used for read-only endpoints that clients may access
-	// without sending tokens (e.g., PKI certificate PEM files).
-	IsUnauthenticatedPath(path string) bool
+	// IsUnauthenticatedPath checks if a request can be served without
+	// authentication. Used for read-only endpoints that clients may access
+	// without sending tokens (e.g., PKI certificate PEM files) and for
+	// protocol probes that need to reach the upstream to negotiate auth
+	// (e.g., Git smart-HTTP's initial /info/refs request, which expects the
+	// upstream's WWW-Authenticate header so the client knows to retry with
+	// credentials).
+	//
+	// The request is passed so backends carrying multiple protocols on the
+	// same mount can inspect headers (e.g., presence of Authorization) and
+	// decide per-request whether to bypass auth, rather than only per-path.
+	// Implementations that don't need per-request behaviour ignore the
+	// argument and return a static path-based decision.
+	//
+	// When this returns true the core sets req.StreamUnauthenticated, which
+	// short-circuits CheckToken, audit emission, credential minting, and
+	// implicit auth. The request reaches the streaming handler with
+	// req.Credential == nil — handlers that previously assumed a credential
+	// is always present must guard accordingly.
+	IsUnauthenticatedPath(r *http.Request, path string) bool
 
 	// IsTransparentPath checks if the given path (relative to mount) should trigger
 	// transparent authentication. Streaming backends match gateway paths;

--- a/provider/sdk/dbaccess/provider_test.go
+++ b/provider/sdk/dbaccess/provider_test.go
@@ -209,8 +209,8 @@ func TestTransparentModeProvider(t *testing.T) {
 	})
 
 	t.Run("IsUnauthenticatedPath always false", func(t *testing.T) {
-		assert.False(t, b.IsUnauthenticatedPath("access/readonly"))
-		assert.False(t, b.IsUnauthenticatedPath("config"))
+		assert.False(t, b.IsUnauthenticatedPath(nil, "access/readonly"))
+		assert.False(t, b.IsUnauthenticatedPath(nil, "config"))
 	})
 }
 


### PR DESCRIPTION
Mirrors commit d9bf41b (StreamBodyParser.ShouldParseStreamBody) — same
evolution, same rationale: backends carrying multiple protocols on one
mount need to make per-request unauth decisions, not just per-path. The
default StreamingBackend and AccessBackend implementations ignore the
new argument and keep current behaviour, so every existing provider
(openai, anthropic, vault PKI paths, ...) is byte-identical.

A follow-up PR adds the matching hook on httpproxy.ProviderSpec; another
wires github to use it for Git smart-HTTP probe passthrough.
