### PR TITLE
feat(httpproxy): per-request IsUnauthenticatedRequest spec hook + StreamUnauthenticated handler guard

### DIFF
--- a/logical/request.go
+++ b/logical/request.go
@@ -100,10 +100,20 @@ type Request struct {
 	// requests are cache-only, not persisted to storage.
 	Transparent bool `json:"-"`
 
-	// StreamUnauthenticated indicates this streaming request is accessing
-	// an unauthenticated path (e.g., PKI certificate PEM files for Vault provider)
-	// and should be allowed without a token. This works regardless of whether
-	// transparent mode is enabled.
+	// StreamUnauthenticated marks this streaming request for upstream
+	// pass-through without Warden authentication. Set by core when a
+	// TransparentModeProvider's IsUnauthenticatedPath returns true —
+	// either path-only (the static UnauthenticatedPaths list, e.g. Vault
+	// PKI certificate PEM files) or request-aware (a provider hook that
+	// inspects headers, e.g. Git smart-HTTP's first probe with no
+	// Authorization header). Works regardless of whether transparent
+	// mode is enabled.
+	//
+	// When true the core skips CheckToken, audit emission, credential
+	// minting, and implicit auth. The streaming handler still runs but
+	// receives req.Credential == nil, so handlers that previously assumed
+	// a credential is always present must guard accordingly (see e.g.
+	// the httpproxy gateway handler's StreamUnauthenticated guard).
 	StreamUnauthenticated bool `json:"-"`
 
 	// AuditPath is the normalized path used for audit logging. For streaming requests,

--- a/provider/sdk/httpproxy/gateway.go
+++ b/provider/sdk/httpproxy/gateway.go
@@ -59,12 +59,21 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	}
 	req.HTTPRequest.Body = http.MaxBytesReader(req.ResponseWriter, req.HTTPRequest.Body, maxBody)
 
-	// Extract credentials using provider-specific extractor
-	credHeaders, err := credExtractor(req)
-	if err != nil {
-		b.Logger.Warn("Failed to get credentials", logger.Err(err))
-		http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
-		return
+	// Extract credentials using provider-specific extractor.
+	// Skip on stream-unauthenticated requests: core skipped credential
+	// minting, so req.Credential is nil — the extractor would 401 a probe
+	// that the backend has explicitly cleared for upstream pass-through
+	// (e.g. Git smart-HTTP first probe → upstream WWW-Authenticate →
+	// client retry with Basic Auth).
+	var credHeaders map[string]string
+	if !req.StreamUnauthenticated {
+		var err error
+		credHeaders, err = credExtractor(req)
+		if err != nil {
+			b.Logger.Warn("Failed to get credentials", logger.Err(err))
+			http.Error(req.ResponseWriter, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 	}
 
 	// Build target URL

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -741,6 +741,94 @@ func TestHandleGateway_NoCredential(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
+func TestHandleGateway_StreamUnauthenticated_BypassesCredExtractor(t *testing.T) {
+	var sawAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.Header().Set("WWW-Authenticate", "Basic realm=upstream")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	spec := testSpec()
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		t.Fatal("credential extractor must not be called on StreamUnauthenticated requests")
+		return nil, nil
+	}
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.providerURL = upstream.URL
+	pb.StreamingBackend.InitProxy(upstream.Client().Transport)
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("GET", "/test/gateway/owner/repo.git/info/refs", nil)
+	httpReq.URL, _ = url.Parse(upstream.URL + "/test/gateway/owner/repo.git/info/refs")
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:           httpReq,
+		ResponseWriter:        rec,
+		StreamUnauthenticated: true,
+	})
+
+	assert.Empty(t, sawAuth, "no Authorization may be injected on unauthenticated pass-through")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, "Basic realm=upstream", rec.Header().Get("WWW-Authenticate"),
+		"upstream's WWW-Authenticate must propagate so the client knows to retry")
+}
+
+func TestProxyBackend_IsUnauthenticatedPath_ConsultsSpecHook(t *testing.T) {
+	spec := testSpec()
+	spec.IsUnauthenticatedRequest = func(r *http.Request, path string) bool {
+		return r != nil && r.Header.Get("X-Probe") == "1"
+	}
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+
+	r := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+	r.Header.Set("X-Probe", "1")
+	assert.True(t, pb.IsUnauthenticatedPath(r, "gateway/foo"),
+		"spec hook returning true short-circuits to true")
+
+	r2 := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+	assert.False(t, pb.IsUnauthenticatedPath(r2, "gateway/foo"),
+		"spec hook returning false does NOT veto — falls through to (empty) static list")
+}
+
+func TestProxyBackend_IsUnauthenticatedPath_FallsThroughToStaticList(t *testing.T) {
+	spec := testSpec()
+	spec.IsUnauthenticatedRequest = func(r *http.Request, path string) bool { return false }
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.StreamingBackend.UnauthenticatedPaths = []string{"v1/+/ca/pem"}
+	pb.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{}) // resets cache
+
+	r := httptest.NewRequest("GET", "/v1/test/gateway/v1/pki/ca/pem", nil)
+	assert.True(t, pb.IsUnauthenticatedPath(r, "gateway/v1/pki/ca/pem"),
+		"hook=false must fall through to static list — both mechanisms compose")
+}
+
+func TestProxyBackend_IsUnauthenticatedPath_NoHook_UsesStaticList(t *testing.T) {
+	spec := testSpec() // IsUnauthenticatedRequest intentionally nil
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	pb.StreamingBackend.UnauthenticatedPaths = []string{"v1/+/ca/pem"}
+	pb.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
+
+	r := httptest.NewRequest("GET", "/v1/test/gateway/v1/pki/ca/pem", nil)
+	assert.True(t, pb.IsUnauthenticatedPath(r, "gateway/v1/pki/ca/pem"))
+	assert.False(t, pb.IsUnauthenticatedPath(r, "gateway/v1/secret/data/k"))
+}
+
+func TestProxyBackend_IsUnauthenticatedPath_HookFalse_NoMatchInList(t *testing.T) {
+	spec := testSpec()
+	spec.IsUnauthenticatedRequest = func(r *http.Request, path string) bool { return false }
+	b := setupBackend(t, spec)
+	pb := b.(*proxyBackend)
+	// No UnauthenticatedPaths set
+	r := httptest.NewRequest("GET", "/v1/test/gateway/foo", nil)
+	assert.False(t, pb.IsUnauthenticatedPath(r, "gateway/foo"))
+}
+
 func TestHandleGateway_InvalidGatewayPath(t *testing.T) {
 	spec := testSpec()
 	b := setupBackend(t, spec)

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -152,6 +152,27 @@ type ProviderSpec struct {
 	// this is also the default behaviour when the hook is unset. Return a
 	// non-empty role to supply a role for this request.
 	GetAuthRoleFromRequest func(r *http.Request) string
+
+	// IsUnauthenticatedRequest optionally lets the provider declare that a
+	// specific request should bypass authentication and pass through to the
+	// upstream. Consulted by the shared httpproxy backend's
+	// IsUnauthenticatedPath implementation; if the hook returns true the
+	// request is treated as unauthenticated. If it returns false (or the hook
+	// is unset), the static StreamingBackend.UnauthenticatedPaths list still
+	// applies as a fallback — providers can rely on both mechanisms.
+	//
+	// Used by providers whose mount carries a protocol that probes for auth
+	// (Git smart-HTTP first probe → upstream WWW-Authenticate → client retry
+	// with Basic Auth) where the same path is "unauth" on the probe and
+	// "auth-required" on the retry. The hook receives the parsed HTTP
+	// request and the mount-relative path so it can correlate headers and
+	// path shape.
+	//
+	// The handler still runs for unauthenticated requests; req.Credential
+	// will be nil, so providers must ensure their gateway path is safe to
+	// invoke without minted credentials (see gateway.go's
+	// StreamUnauthenticated guard).
+	IsUnauthenticatedRequest func(r *http.Request, path string) bool
 }
 
 // proxyBackend is the concrete backend type created by NewFactory.
@@ -423,6 +444,13 @@ func (b *proxyBackend) SensitiveConfigFields() []string {
 // not implementing the interface.
 var _ logical.TransparentAuthRoleExtractor = (*proxyBackend)(nil)
 
+// Compile-time assertion that proxyBackend satisfies TransparentModeProvider.
+// Satisfaction is inherited from the embedded StreamingBackend, but the
+// override on IsUnauthenticatedPath shadows the embedded method — this
+// assertion catches regressions where someone changes the override
+// signature in a way that breaks interface satisfaction.
+var _ logical.TransparentModeProvider = (*proxyBackend)(nil)
+
 // GetAuthRoleFromRequest delegates to the optional spec hook. See
 // ProviderSpec.GetAuthRoleFromRequest for the contract.
 func (b *proxyBackend) GetAuthRoleFromRequest(r *http.Request) string {
@@ -430,6 +458,19 @@ func (b *proxyBackend) GetAuthRoleFromRequest(r *http.Request) string {
 		return ""
 	}
 	return b.spec.GetAuthRoleFromRequest(r)
+}
+
+// IsUnauthenticatedPath consults the spec's IsUnauthenticatedRequest hook
+// (request-aware) before falling through to the static UnauthenticatedPaths
+// list on the embedded StreamingBackend. Both mechanisms compose: a
+// request that the hook declines (false) can still match the static list,
+// preserving the invariant that any path in UnauthenticatedPaths is always
+// unauth-passable.
+func (b *proxyBackend) IsUnauthenticatedPath(r *http.Request, path string) bool {
+	if b.spec.IsUnauthenticatedRequest != nil && b.spec.IsUnauthenticatedRequest(r, path) {
+		return true
+	}
+	return b.StreamingBackend.IsUnauthenticatedPath(r, path)
 }
 
 // cloneExtraState returns a shallow copy of the given extraState map. Used


### PR DESCRIPTION
Adds the request-aware hook providers need to declare that a specific
request — not just a path — should bypass auth and pass through to the
upstream. Layered on top of the existing static UnauthenticatedPaths
list: the hook can only ADD to the unauth set, never SUBTRACT, so the
static list remains a load-bearing audit-able invariant.

The gateway handler's credential-extractor call is now guarded on
req.StreamUnauthenticated. Required for unauth probes to reach the
upstream: core skips credential minting on these requests, so the
extractor would have returned 401 for them. Inert for current consumers
— no existing httpproxy spec populates UnauthenticatedPaths or the new
hook.

Also refreshes the StreamUnauthenticated doc comment in logical/request.go
to reflect the broadened semantics: the field can now be set via either
path-only static matching or request-aware hooks, and handlers receive
req.Credential == nil so they must guard accordingly.

Motivation: Git smart-HTTP's first probe ships no Authorization header
and needs the upstream's WWW-Authenticate: Basic challenge to know to
retry with credentials. Warden's bare 401 today breaks that negotiation.
A follow-up PR wires this hook in the github provider to fix it.
