### PR TITLE
fix(github): proxy first git smart-HTTP probe so upstream challenges with WWW-Authenticate

### DIFF
--- a/provider/github/git.go
+++ b/provider/github/git.go
@@ -139,3 +139,40 @@ func roleFromBasicAuthUser(r *http.Request) string {
 	user, _, _ := r.BasicAuth()
 	return user
 }
+
+// isUnauthenticatedGitProbe is the Spec.IsUnauthenticatedRequest hook.
+// It reports whether r is a Git smart-HTTP probe that should pass
+// through to github.com without Warden authentication.
+//
+// Git's smart-HTTP protocol always probes <repo>.git/info/refs once
+// without an Authorization header; it requires the server's
+// WWW-Authenticate response to know that it must retry with Basic Auth.
+// A bare 401 from Warden breaks the negotiation because clients never
+// learn what credential scheme to use. Letting the probe reach github
+// lets github return its own WWW-Authenticate: Basic challenge; git
+// then retries with <role>:<JWT>, which lands on the second-pass code
+// path where extractToken pulls the JWT from the Basic password slot
+// and normal Warden auth runs.
+//
+// Returns false (so normal auth runs) when r is nil, when r carries any
+// Authorization header, or when the path is not a Git smart-HTTP
+// endpoint. Cert-auth clients (X-SSL-Client-Cert) typically also have
+// no Authorization header on the probe; the retry's cert flow handles
+// credential resolution.
+//
+// The Authorization-header check looks redundant — core only consults
+// IsUnauthenticatedPath when ClientToken == "", which already implies
+// extractToken found no usable credential. But several edge cases reach
+// here with Authorization set yet ClientToken empty: malformed Bearer
+// ("Bearer " with no token), Basic with an empty password slot,
+// Negotiate (Kerberos) and other unrecognised schemes, and Basic when
+// X-SSL-Client-Cert is also present (extractToken deliberately skips
+// Basic in that case). Without this guard those all silently get
+// probe-passthrough; with it they fall through to implicit-auth-fail
+// → 401, which is the honest answer.
+func isUnauthenticatedGitProbe(r *http.Request, path string) bool {
+	if r == nil || r.Header.Get("Authorization") != "" {
+		return false
+	}
+	return isGitSmartHTTPPath(pathAfterGateway(path))
+}

--- a/provider/github/git_test.go
+++ b/provider/github/git_test.go
@@ -193,6 +193,55 @@ func TestRoleFromBasicAuthUser(t *testing.T) {
 	})
 }
 
+func TestIsUnauthenticatedGitProbe(t *testing.T) {
+	// Production callers pass mount-relative paths.
+	gitPath := "gateway/owner/repo.git/info/refs"
+	roleGitPath := "role/admin/gateway/owner/repo.git/info/refs"
+
+	t.Run("mount-relative git path without Authorization → true", func(t *testing.T) {
+		assert.True(t, isUnauthenticatedGitProbe(httptest.NewRequest("GET", "/"+gitPath, nil), gitPath))
+	})
+	t.Run("mount-relative role/X/gateway git path without Authorization → true", func(t *testing.T) {
+		assert.True(t, isUnauthenticatedGitProbe(httptest.NewRequest("GET", "/"+roleGitPath, nil), roleGitPath))
+	})
+	t.Run("git path with Basic Authorization → false (retry, not probe)", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/"+gitPath, nil)
+		r.SetBasicAuth("role", "jwt")
+		assert.False(t, isUnauthenticatedGitProbe(r, gitPath))
+	})
+	t.Run("git path with Bearer → false", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/"+gitPath, nil)
+		r.Header.Set("Authorization", "Bearer xyz")
+		assert.False(t, isUnauthenticatedGitProbe(r, gitPath))
+	})
+	t.Run("git path with empty Basic password → false (edge case)", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/"+gitPath, nil)
+		r.SetBasicAuth("role", "") // extractToken returns "" yet Authorization is set
+		assert.False(t, isUnauthenticatedGitProbe(r, gitPath))
+	})
+	t.Run("non-git mount-relative path → false", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/gateway/user", nil)
+		assert.False(t, isUnauthenticatedGitProbe(r, "gateway/user"))
+	})
+	t.Run("nil request → false", func(t *testing.T) {
+		assert.False(t, isUnauthenticatedGitProbe(nil, gitPath))
+	})
+	t.Run("git-upload-pack endpoint → true", func(t *testing.T) {
+		p := "gateway/owner/repo.git/git-upload-pack"
+		assert.True(t, isUnauthenticatedGitProbe(httptest.NewRequest("POST", "/"+p, nil), p))
+	})
+	t.Run("git-receive-pack endpoint → true", func(t *testing.T) {
+		p := "gateway/owner/repo.git/git-receive-pack"
+		assert.True(t, isUnauthenticatedGitProbe(httptest.NewRequest("POST", "/"+p, nil), p))
+	})
+	t.Run("URL-shape path also works (shape-robust)", func(t *testing.T) {
+		// Not how callers invoke us, but the helper must not regress if a future
+		// caller passes a URL-shaped path. Documents the suffix check's robustness.
+		urlPath := "/v1/github/gateway/owner/repo.git/info/refs"
+		assert.True(t, isUnauthenticatedGitProbe(httptest.NewRequest("GET", urlPath, nil), urlPath))
+	})
+}
+
 func TestResolveGitUpstream(t *testing.T) {
 	state := map[string]any{
 		"git_max_body_size": int64(3 * 1024 * 1024 * 1024), // 3 GiB
@@ -266,10 +315,11 @@ func TestResolveGitUpstream_DispatchExtractorRoundTrip(t *testing.T) {
 	assert.Equal(t, "x-access-token:ghp_test", string(decoded))
 }
 
-// Compile-time sanity: spec wires both hooks.
+// Compile-time sanity: spec wires all three git-related hooks.
 func TestSpec_WiringSanity(t *testing.T) {
 	assert.NotNil(t, Spec.ResolveUpstream, "Spec.ResolveUpstream must be set so git smart-HTTP can dispatch")
 	assert.NotNil(t, Spec.GetAuthRoleFromRequest, "Spec.GetAuthRoleFromRequest must be set so Basic Auth user becomes role")
+	assert.NotNil(t, Spec.IsUnauthenticatedRequest, "Spec.IsUnauthenticatedRequest must be set so the first Git smart-HTTP probe bypasses auth")
 	// Sanity: the dispatch returned for a non-git path must be ok=false so REST
 	// callers see no behaviour change.
 	r := httptest.NewRequest("GET", "/v1/github/gateway/user", nil)

--- a/provider/github/provider.go
+++ b/provider/github/provider.go
@@ -138,8 +138,9 @@ var Spec = &httpproxy.ProviderSpec{
 		}
 		return state
 	},
-	ResolveUpstream:        resolveGitUpstream,
-	GetAuthRoleFromRequest: roleFromBasicAuthUser,
+	ResolveUpstream:          resolveGitUpstream,
+	GetAuthRoleFromRequest:   roleFromBasicAuthUser,
+	IsUnauthenticatedRequest: isUnauthenticatedGitProbe,
 }
 
 // Factory creates a new GitHub provider backend.


### PR DESCRIPTION
Git's smart-HTTP protocol probes <repo>.git/info/refs once with no
Authorization header and requires the server's WWW-Authenticate response
to know it must retry with Basic Auth. Warden returned a bare 401 on
that probe, so embedded-credential clones (the canonical form already
in the README) failed with "Authentication failed" — git never tried
the credentials it had in the URL.

Wire the IsUnauthenticatedRequest hook added in the previous PR to
declare the first probe as unauthenticated. The probe passes through
to github.com which responds with WWW-Authenticate: Basic realm="GitHub";
git retries with Authorization: Basic <role>:<JWT>; extractToken pulls
the JWT out of the Basic password slot; normal Warden auth runs on the
retry.

The header-presence guard ensures only probes (no Authorization) are
treated as unauth — the retry takes the normal flow. Edge cases
(malformed Bearer, empty Basic password, Negotiate scheme, Basic with
X-SSL-Client-Cert) all correctly fall through to implicit-auth-fail.

The first probe is intentionally not audited (mirrors PKI public-paths
behaviour in core); the retry that carries credentials is fully audited.
