### PR TITLE
docs(github): factor Git smart-HTTP into README intro and policy

### DIFF
--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -1,6 +1,6 @@
 # GitHub Provider
 
-The GitHub provider enables proxied access to the GitHub REST API through Warden. It supports both **GitHub App** and **Personal Access Token (PAT)** authentication, and works with GitHub.com and GitHub Enterprise Server.
+The GitHub provider enables proxied access to both the GitHub REST API and Git smart-HTTP (clone, fetch, push) through Warden. It supports both **GitHub App** and **Personal Access Token (PAT)** authentication, and works with GitHub.com and GitHub Enterprise Server.
 
 ## Table of Contents
 
@@ -178,7 +178,17 @@ Create a policy that grants access to the GitHub provider gateway. Note that thi
 
 ```bash
 warden policy write github-access - <<EOF
+# Role taken from the URL path (/v1/github/role/<role>/gateway/...).
+# Used when callers pin the role per request via the URL.
 path "github/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+
+# Role taken from the Basic Auth username (git clone), the X-Warden-Role
+# header, or the mount's default_role. URL has no /role/<role>/ segment.
+# Both REST and Git smart-HTTP can land on either rule — the distinction
+# is the URL shape, not the protocol.
+path "github/gateway/*" {
   capabilities = ["create", "read", "update", "delete", "patch"]
 }
 EOF


### PR DESCRIPTION
The intro sentence advertised REST-only access even though the provider
has proxied Git smart-HTTP (clone, fetch, push) since #249. Updated to
name both capabilities so readers scanning the first paragraph get the
full picture.

The Step-4 policy example only granted github/role/+/gateway*, which
denied any request whose URL didn't embed the role in the path — git
clone (role in Basic Auth username), the X-Warden-Provider header
form, and any REST caller using default_role or X-Warden-Role on a
roleless URL. Added a github/gateway/* rule with HCL comments that
describe each rule by where the role comes from (URL path vs. header /
Basic Auth / default_role) — not by protocol, because both REST and
Git smart-HTTP can land on either rule depending on URL shape.

The secondary "tighter control" example at lines 187-204 is unchanged;
it illustrates conditions on the path-routed shape and a follow-up
should decide whether to parallelise it for git-shape paths or just
add a caveat sentence.
