### PR TITLE
feat(gitlab): add Git smart-HTTP support via provider/sdk/githttp

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -189,6 +189,7 @@ Usage: warden server [options]
 		"atlassian":     atlassian.Skill(),
 		"aws":           aws.Skill(),
 		"github":        github.Skill(),
+		"gitlab":        gitlab.Skill(),
 		"openai":        openai.Skill(),
 		"rds":           rds.Skill(),
 		"scaleway":      scaleway.Skill(),

--- a/provider/gitlab/README.md
+++ b/provider/gitlab/README.md
@@ -10,6 +10,7 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
 - [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
 - [Step 4: Create a Policy](#step-4-create-a-policy)
 - [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [Git over HTTPS](#git-over-https)
 - [Minting Project and Group Access Tokens](#minting-project-and-group-access-tokens)
 - [Authentication Methods](#authentication-methods)
 - [Credential Rotation](#credential-rotation)
@@ -311,6 +312,74 @@ curl "${GITLAB_ENDPOINT}/api/v4/projects/123/repository/branches" \
   -H "Authorization: Bearer ${JWT_TOKEN}"
 ```
 
+## Git over HTTPS
+
+The same mount also proxies Git smart-HTTP (`clone`, `fetch`, `push`) to the configured `gitlab_address` — no separate config field needed, since GitLab serves both REST (`/api/v4/...`) and Git (`/<group>/<repo>.git/...`) off the same host root. The provider dispatches per-request: paths ending in `.git/info/refs`, `.git/git-upload-pack`, or `.git/git-receive-pack` route to GitLab with HTTP Basic Auth carrying `oauth2:<access-token>` as the credential; everything else continues to route as REST with the existing `Authorization: Bearer` flow.
+
+### Clone, fetch, push (path-routed form)
+
+The clone URL carries the Warden role as the Basic Auth username and the Warden JWT as the password. Git's credential helpers cache on URL + username, so each role gets a distinct cache entry — switching roles does not invalidate the other's cache. Subsequent `pull`/`push` against the cloned remote re-use the same role automatically.
+
+```bash
+git clone "https://<role>:${JWT_TOKEN}@${WARDEN_HOST}/v1/gitlab/gateway/<group>/<repo>.git"
+```
+
+Note the path shape: `/v1/gitlab/gateway/<group>/<repo>.git`. Unlike REST (which goes under `/v1/gitlab/gateway/api/v4/...`), Git smart-HTTP paths sit directly under `gateway/` — no `/api/v4` prefix, since Git and REST are separate protocols on the same mount.
+
+To keep the JWT out of shell history and `.git/config`:
+
+```bash
+git config --global credential.helper "store"
+# or, better, a short-lived in-memory cache:
+git config --global credential.helper "cache --timeout=900"
+```
+
+### Header-routed form (`X-Warden-Provider` + `X-Warden-Namespace`)
+
+Operators who want a clone URL that looks like a real Git URL (no Warden-specific path prefix) can use header routing instead. Set `X-Warden-Provider` via Git's `http.extraheader` config, carrying the mount path from `warden provider list`:
+
+```bash
+git -c http.extraheader="X-Warden-Provider: gitlab" \
+    clone "https://<role>:${JWT_TOKEN}@${WARDEN_HOST}/<group>/<repo>.git"
+```
+
+For mounts in a non-root namespace, add `X-Warden-Namespace` as a second `http.extraheader` carrying the namespace path (the same value used in `WARDEN_NAMESPACE`):
+
+```bash
+git -c http.extraheader="X-Warden-Provider: gitlab" \
+    -c http.extraheader="X-Warden-Namespace: team-a/data" \
+    clone "https://<role>:${JWT_TOKEN}@${WARDEN_HOST}/<group>/<repo>.git"
+```
+
+Both headers persist into `.git/config` at clone time, so follow-up `pull`/`push` against the cloned remote carry them automatically. Warden synthesises the canonical `gitlab/gateway/<group>/<repo>.git/...` path under the resolved namespace before mount lookup, so the dispatch and credential flows behave identically to the path-routed form.
+
+### Cert-auth clients
+
+Cert-auth clients (mTLS or `X-SSL-Client-Cert` from a TLS-terminating proxy) still need to populate Git's password slot because the Git protocol requires it. Any placeholder works — the gitlab provider's token extractor skips the Basic Auth password when `X-SSL-Client-Cert` is set, so the placeholder is never sent to the JWT validator:
+
+```bash
+git clone "https://<role>:cert@${WARDEN_HOST}/v1/gitlab/gateway/<group>/<repo>.git"
+```
+
+Mixing a malformed cert with a valid JWT in the Basic Auth password is intentionally not a fallback path: if cert auth fails the request fails with a clear cert-auth error rather than silently switching schemes.
+
+### Role precedence
+
+Role resolution follows core ordering, with the Basic Auth username consulted after path/header roles but before `default_role`:
+
+1. `X-Warden-Role` header
+2. Path-embedded role (`/v1/gitlab/role/<role>/gateway/...`)
+3. **Basic Auth username** (Git smart-HTTP only)
+4. `default_role` from the mount config
+
+So `git clone https://<role>:$JWT@<host>/...` resolves to the username even when a mount-level `default_role` is configured; the default is used only when none of the higher-precedence sources contribute. REST callers are unaffected — the Basic Auth username is consulted only on Git smart-HTTP paths.
+
+### Sizing `git_max_body_size` and `timeout`
+
+- **`git_max_body_size`** caps Git request bodies in bytes. Default 2 GiB; valid range 1 MiB to 10 GiB. The existing `max_body_size` field controls REST POST bodies separately (default 10 MiB, 100 MiB ceiling) — do not raise `max_body_size` to accommodate Git pushes, that is what `git_max_body_size` is for.
+- **Do not crank `git_max_body_size` to the 10 GiB ceiling reflexively.** The ceiling is a sanity cap, not a recommended value. Bodies stream through Warden chunk-by-chunk so memory is fine, but each accepted request pins one goroutine, one outbound socket, and 2× the body's bandwidth (ingress + egress to the Git host) for the duration of the transfer. Size to your actual largest expected push, not the maximum theoretical push.
+- **Tune `timeout` for the longest expected push.** The mount-level `timeout` controls how long Warden will wait for the full request/response cycle. The default suits REST API calls, not multi-minute Git pushes. Rough heuristic: `timeout ≥ (git_max_body_size / smallest expected client bandwidth) × 2`, rounded up generously. Example: a 2 GiB cap with clients on a 100 Mbps link needs at least 320 s — set `timeout = 600s`. Too-tight `timeout` shows up as half-uploaded pushes that fail at the same byte count, which is a confusing failure mode.
+
 ## Cleanup
 
 To stop Warden and the identity provider:
@@ -433,8 +502,9 @@ curl --cert client.pem --key client-key.pem \
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `gitlab_address` | string | — | GitLab instance URL (required, e.g., `https://gitlab.com`) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`) |
+| `git_max_body_size` | int | 2147483648 (2 GiB) | Maximum request body size for Git smart-HTTP requests in bytes (range: 1 MiB to 10 GiB) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size for REST requests in bytes (max 100 MB) |
+| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`); raise for large Git pushes — see [Git over HTTPS](#git-over-https) |
 | `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
 | `default_role` | string | — | Fallback role when not specified in URL |
 

--- a/provider/gitlab/git_test.go
+++ b/provider/gitlab/git_test.go
@@ -1,0 +1,197 @@
+package gitlab
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/githttp"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractToken(t *testing.T) {
+	t.Run("PRIVATE-TOKEN wins over everything", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+		r.Header.Set("PRIVATE-TOKEN", "private-token-value")
+		r.Header.Set("Authorization", "Bearer bearer-token")
+		r.Header.Set("X-Warden-Token", "warden-token")
+		assert.Equal(t, "private-token-value", extractToken(r))
+	})
+
+	t.Run("Bearer wins over X-Warden-Token and Basic password", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+		r.Header.Set("Authorization", "Bearer bearer-token")
+		r.Header.Set("X-Warden-Token", "warden-token")
+		assert.Equal(t, "bearer-token", extractToken(r))
+	})
+
+	t.Run("X-Warden-Token wins over Basic password", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+		r.Header.Set("X-Warden-Token", "warden-token")
+		r.SetBasicAuth("role-name", "basic-password")
+		// SetBasicAuth writes Authorization: Basic ...; extractToken sees
+		// no Bearer, then checks X-Warden-Token before falling through to
+		// Basic.
+		assert.Equal(t, "warden-token", extractToken(r))
+	})
+
+	t.Run("Basic password returned without cert and without higher-precedence headers", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
+		r.SetBasicAuth("role-name", "jwt-as-password")
+		assert.Equal(t, "jwt-as-password", extractToken(r))
+	})
+
+	t.Run("Basic password skipped when X-SSL-Client-Cert set", func(t *testing.T) {
+		// Cert-auth case: Git protocol forces a placeholder password slot,
+		// but the cert is the real credential.
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
+		r.SetBasicAuth("role-name", "placeholder")
+		r.Header.Set("X-SSL-Client-Cert", "<pem>")
+		assert.Empty(t, extractToken(r))
+	})
+
+	t.Run("empty Basic password → empty (no token extracted)", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
+		r.SetBasicAuth("role-name", "")
+		assert.Empty(t, extractToken(r))
+	})
+
+	t.Run("no auth → empty", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+		assert.Empty(t, extractToken(r))
+	})
+}
+
+// TestSpec_ResolveUpstream covers the GitLab dispatch surface through the
+// public Spec interface — confirms gitHooks is wired with identity URL
+// derivation and the GitLab credential type. SDK-level behaviour (suffix
+// detection, body-size defaults, credential format) is exercised directly
+// in provider/sdk/githttp.
+func TestSpec_ResolveUpstream(t *testing.T) {
+	t.Run("git path → identity-derived upstream with overridden body cap", func(t *testing.T) {
+		state := map[string]any{"git_max_body_size": int64(3 * 1024 * 1024 * 1024)}
+		r := httptest.NewRequest("POST", "/v1/gitlab/gateway/group/repo.git/git-upload-pack", nil)
+		d, ok := Spec.ResolveUpstream(r, "https://gitlab.com", state)
+		require.True(t, ok)
+		assert.Equal(t, "https://gitlab.com", d.UpstreamURL)
+		assert.NotNil(t, d.ExtractCredentials)
+		assert.True(t, d.SkipDefaultAccept)
+		assert.True(t, d.SkipDynamicHeaders)
+		assert.True(t, d.BypassBodyParsing)
+		assert.Equal(t, int64(3*1024*1024*1024), d.MaxBodySize)
+	})
+
+	t.Run("git path with empty state uses default cap from SDK", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/v1/gitlab/gateway/group/repo.git/git-receive-pack", nil)
+		d, ok := Spec.ResolveUpstream(r, "https://gitlab.com", map[string]any{})
+		require.True(t, ok)
+		assert.Equal(t, githttp.DefaultMaxBodySize, d.MaxBodySize)
+	})
+
+	t.Run("self-hosted host: REST URL = Git URL (identity derivation)", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
+		d, ok := Spec.ResolveUpstream(r, "https://gitlab.example.com", map[string]any{})
+		require.True(t, ok)
+		assert.Equal(t, "https://gitlab.example.com", d.UpstreamURL)
+	})
+
+	t.Run("REST path → ok=false, spec defaults apply", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/projects", nil)
+		d, ok := Spec.ResolveUpstream(r, "https://gitlab.com", map[string]any{})
+		assert.False(t, ok)
+		assert.Equal(t, httpproxy.Dispatch{}, d)
+	})
+}
+
+// TestSpec_DispatchExtractorRoundTrip verifies the credential extractor
+// returned by Spec.ResolveUpstream produces "Basic oauth2:<token>" —
+// proving the GitLab-specific BasicAuthUsername is wired through the SDK
+// closure.
+func TestSpec_DispatchExtractorRoundTrip(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/gitlab/gateway/group/repo.git/git-upload-pack", nil)
+	d, ok := Spec.ResolveUpstream(r, "https://gitlab.com", map[string]any{})
+	require.True(t, ok)
+
+	headers, err := d.ExtractCredentials(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeGitLabAccessToken,
+			Data: map[string]string{"access_token": "glpat_test"},
+		},
+	})
+	require.NoError(t, err)
+
+	auth := headers["Authorization"]
+	require.True(t, len(auth) > 6 && auth[:6] == "Basic ", "expected Basic auth, got %q", auth)
+	decoded, err := base64.StdEncoding.DecodeString(auth[6:])
+	require.NoError(t, err)
+	assert.Equal(t, "oauth2:glpat_test", string(decoded))
+}
+
+func TestSpec_DispatchExtractor_NilCredentialRejected(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/gitlab/gateway/group/repo.git/git-upload-pack", nil)
+	d, ok := Spec.ResolveUpstream(r, "https://gitlab.com", map[string]any{})
+	require.True(t, ok)
+	_, err := d.ExtractCredentials(&logical.Request{})
+	assert.ErrorContains(t, err, "no credential available")
+}
+
+func TestSpec_DispatchExtractor_WrongTypeRejected(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/gitlab/gateway/group/repo.git/git-upload-pack", nil)
+	d, ok := Spec.ResolveUpstream(r, "https://gitlab.com", map[string]any{})
+	require.True(t, ok)
+	_, err := d.ExtractCredentials(&logical.Request{
+		Credential: &credential.Credential{Type: credential.TypeGitHubToken},
+	})
+	assert.ErrorContains(t, err, "unsupported credential type")
+}
+
+func TestSpec_GetAuthRoleFromRequest(t *testing.T) {
+	t.Run("git path with Basic Auth user → returns role", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
+		r.SetBasicAuth("contributor", "jwt-or-placeholder")
+		assert.Equal(t, "contributor", Spec.GetAuthRoleFromRequest(r))
+	})
+
+	t.Run("REST path with Basic Auth user → empty (username not consumed for REST)", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+		r.SetBasicAuth("contributor", "jwt")
+		assert.Empty(t, Spec.GetAuthRoleFromRequest(r))
+	})
+}
+
+func TestSpec_IsUnauthenticatedRequest(t *testing.T) {
+	t.Run("git probe without Authorization → true", func(t *testing.T) {
+		p := "gateway/group/repo.git/info/refs"
+		assert.True(t, Spec.IsUnauthenticatedRequest(httptest.NewRequest("GET", "/"+p, nil), p))
+	})
+
+	t.Run("git path with Basic Authorization → false (retry, not probe)", func(t *testing.T) {
+		p := "gateway/group/repo.git/info/refs"
+		r := httptest.NewRequest("GET", "/"+p, nil)
+		r.SetBasicAuth("role", "jwt")
+		assert.False(t, Spec.IsUnauthenticatedRequest(r, p))
+	})
+
+	t.Run("REST path → false", func(t *testing.T) {
+		p := "gateway/api/v4/projects"
+		assert.False(t, Spec.IsUnauthenticatedRequest(httptest.NewRequest("GET", "/"+p, nil), p))
+	})
+}
+
+// TestSpec_WiringSanity asserts the spec carries the three git hooks and
+// that the dispatch is opt-in (REST paths return ok=false).
+func TestSpec_WiringSanity(t *testing.T) {
+	assert.NotNil(t, Spec.ResolveUpstream, "Spec.ResolveUpstream must be set so git smart-HTTP can dispatch")
+	assert.NotNil(t, Spec.GetAuthRoleFromRequest, "Spec.GetAuthRoleFromRequest must be set so Basic Auth user becomes role")
+	assert.NotNil(t, Spec.IsUnauthenticatedRequest, "Spec.IsUnauthenticatedRequest must be set so the first Git smart-HTTP probe bypasses auth")
+
+	r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+	_, ok := Spec.ResolveUpstream(r, "https://gitlab.com", map[string]any{})
+	assert.False(t, ok, "REST path must NOT trigger the git dispatch")
+
+	var _ *httpproxy.ProviderSpec = Spec
+}

--- a/provider/gitlab/provider.go
+++ b/provider/gitlab/provider.go
@@ -7,10 +7,21 @@ import (
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/provider/sdk/githttp"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
-// extractToken extracts Warden token from PRIVATE-TOKEN, Authorization: Bearer, or X-Warden-Token headers.
+// extractToken extracts the Warden session token from one of:
+//  1. PRIVATE-TOKEN header (GitLab's REST API convention)
+//  2. Authorization: Bearer <token>
+//  3. X-Warden-Token header
+//  4. HTTP Basic Auth password (Git smart-HTTP carries the JWT this way)
+//
+// The Basic Auth branch is suppressed when X-SSL-Client-Cert is present:
+// cert-based implicit auth takes precedence in the core flow, and the Git
+// protocol requires a placeholder password slot that the JWT validator
+// would otherwise reject. Reading the placeholder would actively harm
+// correctness for cert-authenticated clients.
 func extractToken(r *http.Request) string {
 	if token := r.Header.Get("PRIVATE-TOKEN"); token != "" {
 		return token
@@ -22,8 +33,28 @@ func extractToken(r *http.Request) string {
 	if token := r.Header.Get("X-Warden-Token"); token != "" {
 		return token
 	}
+	if r.Header.Get("X-SSL-Client-Cert") == "" {
+		if _, pwd, ok := r.BasicAuth(); ok && pwd != "" {
+			return pwd
+		}
+	}
 	return ""
 }
+
+// gitHooks bundles the three ProviderSpec hooks the mount wires for git
+// smart-HTTP. GitLab serves REST under /api/v4/* and git under
+// /<group>/<repo>.git, both off the same host root, so the configured
+// gitlab_address works for both — git URL derivation is identity, which
+// BuildHooks supplies automatically when DeriveGitURL is nil.
+//
+// "oauth2" is GitLab's published Basic Auth username convention: required
+// for OAuth2-minted tokens and accepted for personal/project/group access
+// tokens. Parallels GitHub's "x-access-token".
+var gitHooks = githttp.BuildHooks(githttp.Options{
+	BasicAuthUsername: "oauth2",
+	CredentialType:    credential.TypeGitLabAccessToken,
+	TokenField:        "access_token",
+})
 
 // Spec defines the GitLab provider configuration for the httpproxy framework.
 var Spec = &httpproxy.ProviderSpec{
@@ -37,6 +68,24 @@ var Spec = &httpproxy.ProviderSpec{
 	ExtractCredentials:   httpproxy.TypedTokenExtractor(credential.TypeGitLabAccessToken, "access_token", "Authorization", "Bearer "),
 	ExtractToken:         extractToken,
 	ExtraHeadersToRemove: []string{"PRIVATE-TOKEN"},
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"git_max_body_size": githttp.MaxBodySizeField(),
+	},
+	OnConfigRead: func(state map[string]any) map[string]any {
+		return map[string]any{
+			"git_max_body_size": githttp.ReadMaxBodySize(state),
+		}
+	},
+	OnConfigWrite: func(d *framework.FieldData, state map[string]any) (map[string]any, error) {
+		if err := githttp.WriteMaxBodySize(d, state); err != nil {
+			return nil, err
+		}
+		return state, nil
+	},
+	OnInitialize: func(config map[string]any, state map[string]any) map[string]any {
+		githttp.InitializeMaxBodySize(config, state)
+		return state
+	},
 	ValidateExtraConfig: func(conf map[string]any) error {
 		addr, ok := conf["gitlab_address"].(string)
 		if !ok || addr == "" {
@@ -44,50 +93,83 @@ var Spec = &httpproxy.ProviderSpec{
 		}
 		return nil
 	},
+	ResolveUpstream:          gitHooks.ResolveUpstream,
+	GetAuthRoleFromRequest:   gitHooks.GetAuthRoleFromRequest,
+	IsUnauthenticatedRequest: gitHooks.IsUnauthenticatedRequest,
 }
 
 // Factory creates a new GitLab provider backend.
 var Factory = httpproxy.NewFactory(Spec)
 
 const gitlabBackendHelp = `
-The GitLab provider enables proxying requests to GitLab (SaaS or self-hosted)
-with automatic credential management and access token injection.
+The GitLab provider proxies both the GitLab REST API and Git smart-HTTP
+(clone/fetch/push) with automatic credential management. The mount
+dispatches per-request based on path shape:
+
+  REST paths (/api/v4/...) → gitlab_address with Authorization: Bearer
+    <access-token> on the outgoing call. Incoming requests may carry
+    the Warden JWT via Authorization: Bearer, PRIVATE-TOKEN, or
+    X-Warden-Token.
+
+  Git smart-HTTP paths (<group>/<repo>.git/info/refs,
+    .git/git-upload-pack, .git/git-receive-pack) → gitlab_address with
+    HTTP Basic Auth carrying oauth2:<access-token> as the credential.
 
 Warden performs implicit authentication on every request and obtains a
-GitLab access token from the credential manager — either a personal access
-token (PAT) or an OAuth2 token depending on the source configuration — and
-injects it as an Authorization: Bearer header in the proxied request. This
-allows Warden to broker GitLab access without distributing long-lived tokens
-to clients.
+GitLab access token from the credential manager — either a personal
+access token (PAT) or an OAuth2 token depending on the source
+configuration. Clients never hold a long-lived token.
 
-Unlike multi-host providers (AWS, GCP), the GitLab provider targets a single
-GitLab instance configured via gitlab_address. All gateway requests are
-forwarded to that instance.
-
-The gateway path format is:
+The REST gateway path format is:
   /gitlab/gateway/{api-path}
-
-The {api-path} is appended to the configured gitlab_address and forwarded
-over HTTPS (or HTTP for development instances).
 
 Examples:
   /gitlab/gateway/api/v4/projects
   /gitlab/gateway/api/v4/projects/123/repository/branches
   /gitlab/gateway/api/v4/groups/my-group/projects
   /gitlab/gateway/api/v4/projects/123/merge_requests
-  /gitlab/gateway/api/v4/projects/123/pipelines
 
-The role can be provided via the X-Warden-Role header, or embedded in
-the URL path:
-  /gitlab/role/{role}/gateway/{api-path}
+The Git clone URL carries the Warden role in the Basic Auth username
+and the Warden JWT in the password:
 
-Self-hosted GitLab instances are supported by setting gitlab_address to the
-instance URL (e.g., "https://gitlab.example.com").
+  git clone https://<role>:$JWT@<warden-addr>/v1/gitlab/gateway/<group>/<repo>.git
+
+Git's credential helpers cache on URL + username, so each role gets a
+distinct credential entry. Cert-auth clients pass any placeholder in
+the password slot; the token extractor skips the placeholder when
+X-SSL-Client-Cert is present.
+
+Self-hosted GitLab instances are supported by setting gitlab_address to
+the instance URL (e.g., "https://gitlab.example.com"). REST and Git
+paths share the same base — no separate Git host field is needed.
+
+The role can be provided via the X-Warden-Role header, embedded in the
+URL path (/gitlab/role/{role}/gateway/{api-path}), carried in the Basic
+Auth username (Git smart-HTTP requests only), or defaulted by
+default_role. Precedence: X-Warden-Role > path role > Basic Auth
+username > default_role.
+
+Header-routed alternative: clients that want a URL without the
+/v1/gitlab/gateway/ prefix can send X-Warden-Provider: gitlab (and
+optionally X-Warden-Namespace) via http.extraheader at clone time:
+
+  git -c http.extraheader="X-Warden-Provider: gitlab" \
+      clone https://<role>:$JWT@<warden-addr>/<group>/<repo>.git
+
+http.extraheader persists into .git/config, so subsequent fetch/pull/push
+carry the header automatically.
 
 Configuration:
-- gitlab_address: Base URL of the GitLab instance (required, e.g., "https://gitlab.com")
-- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
-- timeout: Request timeout duration (e.g., '30s', '5m')
-- auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')
-- default_role: Fallback role when not specified in the URL path
+- gitlab_address: Base URL of the GitLab instance (required, e.g.,
+    "https://gitlab.com")
+- git_max_body_size: Cap on Git request bodies in bytes
+    (default: 2 GiB, range: 1 MiB to 10 GiB)
+- max_body_size: Cap on REST request bodies (default: 10MB, max: 100MB).
+    Do not raise to accommodate Git pushes — git_max_body_size is the
+    knob for that.
+- timeout: Request timeout duration (e.g., '30s', '5m'). Tune up for
+    large Git pushes.
+- auto_auth_path: Auth mount path for implicit authentication (e.g.,
+    'auth/jwt/')
+- default_role: Fallback role when not specified by header or URL path
 `

--- a/provider/gitlab/skill.go
+++ b/provider/gitlab/skill.go
@@ -1,0 +1,12 @@
+package gitlab
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing markdown for the gitlab provider, seeded
+// into the global skill registry on first mount.
+func Skill() string {
+	return skillMD
+}

--- a/provider/gitlab/skill.md
+++ b/provider/gitlab/skill.md
@@ -1,0 +1,167 @@
+---
+name: gitlab
+description: "Call the GitLab REST API or clone/push Git repos through Warden — without holding a GitLab access token. Covers REST (read projects, manage issues, trigger pipelines) and Git smart-HTTP (clone, fetch, push)."
+category: provider-guide
+provider: gitlab
+requires: [foundation, discovery]
+upstream: GitLab REST API (gitlab.com/api/v4 or self-hosted /api/v4) and Git smart-HTTP (same host)
+---
+
+# GitLab through Warden
+
+## What it does
+
+Warden proxies GitLab REST API requests. The agent calls a Warden
+URL; Warden authenticates the caller (JWT/cert), looks up the GitLab
+access token bound to the chosen role, injects it as
+`Authorization: Bearer <token>`, and forwards to GitLab. The agent
+**never holds an access token**.
+
+## Configure the CLI/SDK
+
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/gitlab/`, `/v1/team-data/gitlab-self-hosted/`).
+  Warden has already baked the namespace + mount path in.
+- `<role>` is the role you picked from `warden role list` to perform this
+  task — it goes in the URL path.
+
+```bash
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/api/v4/<gitlab-api-path>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
+```
+
+Unlike GitHub (which proxies REST off the host root), GitLab's REST
+API lives under `/api/v4/`, so the gateway path includes `api/v4/`
+**after** the `gateway/` segment.
+
+For `curl` or any HTTP client: rewrite the GitLab host (including
+`/api/v4`) to `$WARDEN_ADDR<mount-url>role/<role>/gateway/api/v4` and
+add the bearer token.
+
+## Examples
+
+(All examples assume `mount_url = /v1/gitlab/` and role `repo-reader`;
+substitute yours.)
+
+List projects you're a member of:
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/gitlab/role/repo-reader/gateway/api/v4/projects?membership=true
+```
+
+Read a specific project's issues:
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  "$WARDEN_ADDR/v1/gitlab/role/repo-reader/gateway/api/v4/projects/<id>/issues"
+```
+
+Open an issue (operator must grant a write-capable role):
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Bug","description":"..."}' \
+  "$WARDEN_ADDR/v1/gitlab/role/issue-writer/gateway/api/v4/projects/<id>/issues"
+```
+
+For the python-gitlab client: configure `gitlab.Gitlab(url=...)` with
+`$WARDEN_ADDR<mount-url>role/<role>/gateway` (no `/api/v4` suffix — the
+client appends it) and use `oauth_token=$WARDEN_TOKEN` for auth.
+
+## Quirks
+
+- **The injected header is `Authorization: Bearer <token>`** —
+  Warden swaps your `Authorization: Bearer $WARDEN_TOKEN` (incoming)
+  for the credential token (outgoing). GitLab accepts the same Bearer
+  shape for OAuth2 tokens, personal access tokens, and project/group
+  access tokens.
+- **`PRIVATE-TOKEN` header on incoming requests works too** — if your
+  client prefers GitLab's native auth header, send the JWT there
+  instead of `Authorization`. Warden strips it before proxying.
+- **Self-hosted instances** point Warden at the instance URL (e.g.
+  `https://gitlab.example.com`); check `warden read gitlab/config` to
+  confirm which. The same `gitlab_address` covers both REST and Git.
+- **Rate limits propagate from GitLab**. Warden does not retry; back
+  off when you see `429 Too Many Requests`.
+
+## Git
+
+The same mount also proxies Git smart-HTTP (`git clone`, `fetch`, `push`)
+to the configured `gitlab_address`. REST and Git share the mount; the
+provider dispatches per-request based on path shape — `.git/info/refs`,
+`.git/git-upload-pack`, and `.git/git-receive-pack` route to GitLab
+with HTTP Basic Auth instead of the REST `Authorization: Bearer`.
+
+(All examples below assume `mount_url = /v1/gitlab/`; substitute yours
+from `warden provider list`.)
+
+### Clone
+
+The clone URL carries the Warden role as the Basic Auth username and
+the Warden JWT as the password. Substitute `<role>` and the mount URL:
+
+Git embeds Basic Auth between scheme and host in the clone URL, so
+split `$WARDEN_ADDR` (the canonical env var from the `foundation`
+skill) — `${WARDEN_ADDR%%://*}` is the scheme, `${WARDEN_ADDR#*://}`
+is the host (and port if present):
+
+```bash
+git clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/v1/gitlab/gateway/<group>/<repo>.git"
+```
+
+Note: Git smart-HTTP paths use `<group>/<repo>.git` directly off the
+mount's `gateway/` segment — no `/api/v4/` here, since Git is a
+separate protocol from REST.
+
+Git's credential helpers cache on URL+username, so each role gets a
+distinct cache entry — switching roles does not invalidate the other's
+cache. Subsequent `pull`/`push` against the cloned remote re-use the
+same role automatically.
+
+To keep the JWT out of shell history and `.git/config`:
+```bash
+git config --global credential.helper "cache --timeout=900"
+```
+
+### Header-routed alternative
+
+If you prefer a clone URL that looks like a real Git URL, pass the
+mount path as `X-Warden-Provider` and the namespace as
+`X-Warden-Namespace` via `http.extraheader` instead. `path` comes
+from `warden provider list`; `$WARDEN_NAMESPACE` is in your
+environment:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="gitlab") | .path' | head -1)
+git -c http.extraheader="X-Warden-Provider: $path" \
+    -c http.extraheader="X-Warden-Namespace: $WARDEN_NAMESPACE" \
+    clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/<group>/<repo>.git"
+```
+
+When more than one `gitlab` mount exists, replace `head -1` with a
+`select(.description=="...")` matching the upstream you want — `path`
+alone doesn't tell you which GitLab instance the mount fronts.
+
+`http.extraheader` persists into `.git/config` at clone time, so both
+headers carry through to follow-up operations automatically.
+
+### Quirks
+
+- **Basic Auth username is `oauth2`** on the upstream call — Warden
+  formats the credential as `Basic base64(oauth2:<access-token>)`,
+  which is GitLab's published convention for OAuth2 tokens and also
+  accepted for personal/project/group access tokens. The username slot
+  on your **clone URL** is still the Warden role; Warden re-encodes it
+  on the upstream side.
+- **Role precedence**: `X-Warden-Role` header > path-embedded
+  `/role/<r>/` > Basic Auth username (Git smart-HTTP only) >
+  `default_role`. Per-clone role selection via the username works even
+  when a mount-level `default_role` is set.
+- **Cert-auth clients** still need a non-empty Basic Auth password
+  (Git protocol requirement). Any placeholder works; the placeholder is
+  never sent to the JWT validator when `X-SSL-Client-Cert` is present.
+- **Body size**: large pushes need `git_max_body_size` raised on the
+  mount (default 2 GiB, max 10 GiB), and the mount `timeout` raised to
+  match. See the provider README for sizing guidance.
+- **Not in scope**: LFS, partial clone, submodules with embedded
+  credentials.


### PR DESCRIPTION
## Summary

- Wire the gitlab provider as the second consumer of the `provider/sdk/githttp` SDK extracted in #259. The same mount now proxies both REST (under `/api/v4/`) and Git smart-HTTP (`.git/info/refs`, `.git/git-upload-pack`, `.git/git-receive-pack`) to the configured `gitlab_address`. No separate git URL field is needed: GitLab serves both protocols off the same host root, so `DeriveGitURL` is omitted and the SDK falls through to its identity default.
- `extractToken` extends with a Basic Auth password fallback (with the same `X-SSL-Client-Cert` guard the github provider uses), preserving the existing PRIVATE-TOKEN → Bearer → X-Warden-Token precedence. `git_max_body_size` joins `ExtraConfigFields`; `OnConfigRead/Write/Initialize` delegate to the SDK helpers. The three SDK hooks (`ResolveUpstream`, `GetAuthRoleFromRequest`, `IsUnauthenticatedRequest`) are attached to `Spec`.
- New agent skill (`provider/gitlab/skill.md` + `skill.go`) mirrors the github skill structure with GitLab specifics: `/api/v4/` REST examples, `oauth2` Basic Auth username, PRIVATE-TOKEN incoming header documented. Header-routed Git example includes `X-Warden-Namespace` alongside `X-Warden-Provider`. Registered in `cmd/server/server.go`'s `providerSkills` map.

## Design notes

- **Basic Auth username is `oauth2`** on the upstream call — GitLab's published convention that works for OAuth2 tokens, personal access tokens, and project/group access tokens. Parallels GitHub's `x-access-token`.
- **`gitHooks` is inline in `provider.go`, not a separate `git.go`** — GitLab has no host-specific git scaffolding (identity URL derivation, no helpers), so a marker file would hold one declaration. GitHub keeps `git.go` because `deriveGitURL` lives there. Honest asymmetry: GitHub has host-specific URL derivation; GitLab doesn't.
- **No `gitlab_git_address` override field** — adding a hypothetical knob with no use case would repeat the dead `git_url` mistake from the github provider that #259 just removed. Can be added later if a concrete need surfaces.

## Test plan

- [x] `go test ./provider/gitlab/...` — gitlab tests pass (extractToken precedence including the new Basic-Auth and empty-password subtests, `Spec.ResolveUpstream` dispatch, round-trip `oauth2:<token>` format, credential-extractor error paths, role extraction, unauthenticated probe, wiring sanity)
- [x] `go test ./provider/sdk/githttp/...` — SDK tests still pass (no SDK changes, but second consumer validates the API shape in practice)
- [x] `go test ./provider/github/...` — github regression (first consumer still works)
- [x] `go vet ./provider/... ./cmd/server/...` — clean
- [x] `go build ./...` — clean
- [ ] Manual smoke clone against gitlab.com via a local Warden — verify `info/refs` probe → `WWW-Authenticate: Basic` → retry with `<role>:<JWT>` works end-to-end
- [ ] Verify the header-routed form with `X-Warden-Namespace` works for a mount in a non-root namespace
- [ ] Verify `warden write gitlab/config git_max_body_size=...` round-trips through config read

## Closes the two-PR series

This is PR2 of two. PR1 (#259) extracted the SDK that this PR consumes. With this merged, the SDK has two consumers and the extraction-on-second-use pattern (matching `dbaccess` and `dualgateway` precedents) is complete.
