### PR TITLE
feat(mcp_github): add transparent proxy to GitHub's hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Warden supports multiple methods for verifying caller identity.
 | **JWT** | Signed JWT token or SPIFFE JWT-SVID | The **same JWT** goes in whichever credential slot the upstream SDK natively expects (`AWS_SECRET_ACCESS_KEY`, `OPENAI_API_KEY`, `X-Vault-Token`, `Authorization: Bearer`, …). Warden detects it, validates the identity, and swaps in the real upstream credential. Existing SDK code keeps working — only the base URL changes. |
 | **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Identity is proven at the TLS handshake (or forwarded by a TLS-terminating proxy via `X-SSL-Client-Cert`). The SDK's credential slot is filled with any placeholder value — Warden ignores it once cert auth has proven the identity. Role selection follows the same per-provider conventions as JWT mode. |
 
-This is the design property that makes Warden a *drop-in* layer rather than a rewrite tax: a pre-existing boto3, openai-python, Vault CLI, or curl-against-GitHub script becomes Warden-mediated by setting the base URL to Warden and putting the JWT where the secret used to go. It also separates Warden from MCP (which adds a protocol the agent host must speak) and from dedicated auth proxies (which typically require client libraries).
+This is the design property that makes Warden a *drop-in* layer rather than a rewrite tax: a pre-existing boto3, openai-python, Vault CLI, or curl-against-GitHub script becomes Warden-mediated by setting the base URL to Warden and putting the JWT where the secret used to go. It also separates Warden from dedicated auth proxies (which typically require client libraries).
 
 ## Tutorials
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -56,6 +56,7 @@ import (
 	"github.com/stephnangue/warden/provider/honeycomb"
 	"github.com/stephnangue/warden/provider/ibmcloud"
 	"github.com/stephnangue/warden/provider/kubernetes"
+	mcp_github "github.com/stephnangue/warden/provider/mcp_github"
 	"github.com/stephnangue/warden/provider/mistral"
 	"github.com/stephnangue/warden/provider/newrelic"
 	"github.com/stephnangue/warden/provider/openai"
@@ -161,6 +162,7 @@ Usage: warden server [options]
 		"ibmcloud":      ibmcloud.Factory,
 		"github":        github.Factory,
 		"gitlab":        gitlab.Factory,
+		"mcp_github":    mcp_github.Factory,
 		"mistral":       mistral.Factory,
 		"newrelic":      newrelic.Factory,
 		"openai":        openai.Factory,
@@ -190,6 +192,7 @@ Usage: warden server [options]
 		"aws":           aws.Skill(),
 		"github":        github.Skill(),
 		"gitlab":        gitlab.Skill(),
+		"mcp_github":    mcp_github.Skill(),
 		"openai":        openai.Skill(),
 		"rds":           rds.Skill(),
 		"scaleway":      scaleway.Skill(),

--- a/provider/mcp_github/README.md
+++ b/provider/mcp_github/README.md
@@ -1,0 +1,440 @@
+# GitHub MCP Provider
+
+The `mcp_github` provider enables proxied access to GitHub's hosted MCP (Model Context Protocol) server through Warden. MCP clients (Claude Code, Cursor, Continue, Cline, Goose, ...) point at Warden instead of `api.githubcopilot.com`; Warden authenticates the caller, injects a GitHub token bound to the chosen role as `Authorization: Bearer <token>`, and streams JSON or SSE responses back unchanged. Agents never hold a GitHub credential.
+
+It supports both **GitHub App** and **Personal Access Token (PAT)** authentication. The same credential spec used by the `github` REST provider works here unchanged — one role binding grants both REST and MCP reach.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Point an MCP Client at Warden](#step-5-point-an-mcp-client-at-warden)
+- [TLS Certificate Authentication](#tls-certificate-authentication)
+- [Configuration Reference](#configuration-reference)
+- [Auth Method Comparison](#auth-method-comparison)
+- [Token Scopes and Tool Availability](#token-scopes-and-tool-availability)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- One of the following:
+  - **GitHub App** with a private key and installation ID (recommended — short-lived tokens, auto-refreshed), OR
+  - **Personal Access Token** (classic or fine-grained) with the scopes covering the MCP tools you want to expose (e.g., `repo`, `issues`, `pull_requests`)
+- An MCP client that supports remote MCP servers over HTTP (Claude Code, Cursor, Continue, Cline, Goose, ...)
+
+> **New to Warden?** Follow the standard quickstart flow used by the other provider READMEs (the `github` and `slack` READMEs cover it step by step): deploy the quickstart compose, install the binary, export `WARDEN_ADDR` and `WARDEN_TOKEN`, then return here.
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/mcp-user \
+    token_policies="mcp-github-access" \
+    user_claim=sub \
+    cred_spec_name=github-ops
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the `mcp_github` provider at a path of your choice:
+
+```bash
+warden provider enable mcp_github
+```
+
+To mount at a custom path:
+
+```bash
+warden provider enable -path=copilot-mcp mcp_github
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider with `auto_auth_path`. The default `timeout` is 10 minutes — raise it for agent sessions that keep an SSE stream open across many tool calls:
+
+```bash
+warden write mcp_github/config <<EOF
+{
+  "mcp_github_url": "https://api.githubcopilot.com/mcp",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "10m",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read mcp_github/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+If you already configured a credential source and spec for the `github` REST provider, you can reuse them here unchanged — the same App or PAT works for both flows. Skip to Step 4.
+
+The credential source holds only connection info (`github_url`). Auth credentials (App private key + installation ID, or PAT) live on the credential spec, allowing multiple specs with different identities to share one source.
+
+```bash
+warden cred source create github-src \
+  -type=github \
+  -rotation-period=0 \
+  -config=github_url=https://api.github.com
+```
+
+Verify the source was created:
+
+```bash
+warden cred source read github-src
+```
+
+### Option A: GitHub App (Recommended)
+
+1. Go to **Settings > Developer settings > GitHub Apps** and create a new app.
+2. Note the **App ID** from the app settings page.
+3. Generate a **private key** (RSA, PEM format) and download it.
+4. Install the app on your organization or account and note the **Installation ID** from the URL.
+5. Grant the app the permissions covering the MCP tools you intend to use (e.g., `Contents: Read`, `Issues: Read/Write`, `Pull requests: Read/Write`).
+
+```bash
+warden cred spec create github-ops \
+  -source github-src \
+  -config auth_method=app \
+  -config app_id=<your-app-id> \
+  -config private_key=@/path/to/private-key.pem \
+  -config installation_id=<your-installation-id>
+```
+
+Warden mints a short-lived (1 hour) installation token at request time and auto-refreshes before expiry. The agent never sees the private key or the installation token.
+
+### Option B: Personal Access Token
+
+```bash
+warden cred spec create github-ops \
+  -source github-src \
+  -config auth_method=pat \
+  -config token=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Verify:
+
+```bash
+warden cred spec read github-ops
+```
+
+## Step 4: Create a Policy
+
+The `mcp_github` provider runs in opaque pass-through mode — request bodies are not parsed for policy evaluation. This is by design: MCP traffic is JSON-RPC, and tool-level authorization belongs in the PAT's scopes rather than Warden policy. Grant access to the gateway and rely on the PAT's GitHub scopes for fine-grained authorization:
+
+```bash
+warden policy write mcp-github-access - <<EOF
+path "mcp_github/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+For coarser control over which roles can reach the MCP gateway at all, combine with runtime conditions:
+
+```bash
+warden policy write mcp-github-business-hours - <<EOF
+path "mcp_github/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+}
+EOF
+```
+
+## Step 5: Point an MCP Client at Warden
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+Configure your MCP client to point at the Warden mount. The URL pattern is:
+
+```
+${WARDEN_ADDR}/v1/mcp_github/role/{role}/gateway/
+```
+
+For Claude Code, Cursor, Continue, Cline, Goose, and other clients that accept Streamable HTTP MCP servers via a JSON config block:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "${WARDEN_ADDR}/v1/mcp_github/role/mcp-user/gateway/",
+      "headers": {
+        "Authorization": "Bearer ${JWT_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+> **Heads-up on `${VAR}` in headers.** MCP clients vary in what they substitute in `.mcp.json`. Claude Code and Cursor expand `${VAR}` in stdio `env` blocks and in the `url` field, but **HTTP-transport `headers` values are a known gap** — the literal `${JWT_TOKEN}` string ships on the wire. For the `Authorization` header (and the routing headers in the next example), paste the actual values instead of `${...}` placeholders, or run the JSON through `envsubst` at deploy time.
+
+#### Header-routed alternative
+
+Some MCP clients dislike long URLs, or you want one base URL to mux several Warden providers. Pass the mount path as `X-Warden-Provider`, the namespace as `X-Warden-Namespace`, and the role as `X-Warden-Role` instead — Warden synthesises the canonical gateway path from the headers. Look up the mount path first:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_github") | .path' | head -1)
+```
+
+The `path` is what `warden provider list` returns (e.g., `mcp_github/`, `team-data/copilot-mcp/`), **not** the literal string `mcp_github` — Warden routes on the mount path, not the provider type.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "${WARDEN_ADDR}/",
+      "headers": {
+        "Authorization": "Bearer ${JWT_TOKEN}",
+        "X-Warden-Provider": "mcp_github/",
+        "X-Warden-Namespace": "<namespace>",
+        "X-Warden-Role": "mcp-user"
+      }
+    }
+  }
+}
+```
+
+The same caveat applies here as above: paste the actual mount path, namespace, role, and (if you're not handing the file to `envsubst`) JWT in the `headers` map — `${VAR}` placeholders in HTTP-transport headers don't get expanded by the major clients today.
+
+### Smoke-test with curl
+
+List the tools the server exposes:
+
+```bash
+curl -X POST "${WARDEN_ADDR}/v1/mcp_github/role/mcp-user/gateway/" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Call a tool:
+
+```bash
+curl -X POST "${WARDEN_ADDR}/v1/mcp_github/role/mcp-user/gateway/" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_issues","arguments":{"owner":"myorg","repo":"myrepo"}}}'
+```
+
+The trailing slash on `gateway/` matters — GitHub's MCP server lives at exactly one path, and Warden composes the upstream URL as the mount's configured upstream URL plus the gateway suffix.
+
+## TLS Certificate Authentication
+
+Steps 1 and 5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 2-4 (provider mount, credential source and spec, policy) are identical — the `mcp-github-access` policy from Step 4 works for either auth method. Replace Steps 1 and 5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=mcp-user
+```
+
+### Create a Cert Role
+
+Create a role that binds allowed certificate identities to a credential spec and policy:
+
+```bash
+warden write auth/cert/role/mcp-user \
+    allowed_common_names="agent-*" \
+    token_policies="mcp-github-access" \
+    cred_spec_name=github-ops
+```
+
+The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+
+### Configure Provider for Cert Auth
+
+Update the provider config to point at the cert auth mount:
+
+```bash
+warden write mcp_github/config <<EOF
+{
+  "mcp_github_url": "https://api.githubcopilot.com/mcp",
+  "auto_auth_path": "auth/cert/",
+  "timeout": "10m",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+`curl` smoke test, role from the URL path:
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -X POST "https://warden.internal/v1/mcp_github/role/mcp-user/gateway/" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+#### MCP Client JSON Config (cert auth)
+
+**State of mTLS in MCP clients today.** The MCP specification does not standardize a client-side TLS configuration block, and the major IDE clients (Claude Code, Cursor, Continue) do not currently expose first-class fields for client certificate / key paths in their HTTP server configuration. Until that lands, two portable patterns work — both using header-routed mode so the MCP client only needs to set headers, never a deep URL.
+
+Look up the mount path and namespace first:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_github") | .path' | head -1)
+namespace=$WARDEN_NAMESPACE   # whatever your default namespace is
+```
+
+The `path` is the mount path Warden returns from `warden provider list` (e.g., `mcp_github/`, `team-data/copilot-mcp/`), **not** the literal string `mcp_github`. Same gotcha as the JWT header-routed flow in the skill.
+
+**Pattern A: Local mTLS-terminating sidecar (recommended).** Run a sidecar (Envoy, nginx, stunnel, `mtls-proxy`) on the agent host that holds the client cert/key and the trusted CA. The MCP client talks plain HTTP over loopback to the sidecar; the sidecar terminates client TLS, validates Warden's server cert, and forwards the request over mTLS with the validated client certificate attached as `X-SSL-Client-Cert` (URL-encoded PEM) or `X-Forwarded-Client-Cert`. Warden trusts the forwarded header when the listener is configured to do so.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "http://127.0.0.1:9443/",
+      "headers": {
+        "X-Warden-Provider": "mcp_github/",
+        "X-Warden-Namespace": "<namespace>",
+        "X-Warden-Role": "mcp-user"
+      }
+    }
+  }
+}
+```
+
+Substitute `mcp_github/` with your mount's actual `path` and `<namespace>` with your namespace before saving — see the env-var caveat in Step 5: `${VAR}` placeholders in HTTP-transport `headers` are not expanded by the major MCP clients today. Drop the `X-Warden-Role` header when cert auth's `default_role` already covers the binding.
+
+**Pattern B: `mcp-remote` as a Node-based bridge.** Many MCP installations already use `mcp-remote` (an npx-launched HTTP-to-stdio bridge) for transport-shape reasons. It runs in Node.js, so Node's TLS environment variables flow through: `NODE_EXTRA_CA_CERTS=/path/to/warden-ca.pem` for a custom CA. Client certificate handling via `mcp-remote` requires a custom Node TLS context and is not as turnkey — for most deployments Pattern A is simpler. A typical CA-only setup (Warden's server cert validated by a private CA; mTLS still requires Pattern A) looks like:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://warden.internal/",
+        "--transport", "http-only",
+        "--header", "X-Warden-Provider: mcp_github/",
+        "--header", "X-Warden-Namespace: <namespace>",
+        "--header", "X-Warden-Role: mcp-user"
+      ],
+      "env": {
+        "NODE_EXTRA_CA_CERTS": "/path/to/warden-ca.pem"
+      }
+    }
+  }
+}
+```
+
+`--header` accepts repeated values for adding custom headers; consult your `mcp-remote` version's docs if it differs. This authenticates Warden's server cert against a private CA but does **not** supply a client cert.
+
+#### Selecting the role with a certificate
+
+With cert auth, the role is resolved (in priority order):
+
+1. `X-Warden-Role` header on the request — what the JSON examples above set
+2. `/role/<role>/` segment in the URL path — not used in header-routed mode, but available when an MCP client cannot send custom headers
+3. `default_role` set on the cert auth method's config (`auth/cert/config`, shown in [Configure Trusted CA](#configure-trusted-ca) above) — useful when one cert maps 1:1 to one role; the JSON config can drop `X-Warden-Role` entirely
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mcp_github_url` | string | `https://api.githubcopilot.com/mcp` | MCP server base URL (must be HTTPS) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `10m` | Session timeout. Raise for long agent sessions that keep an SSE stream open across many tool calls |
+| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (development only) |
+| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
+| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+## Auth Method Comparison
+
+| Method | Credentials | Token Lifetime | Rotation |
+|--------|-------------|----------------|----------|
+| **App** | Installation token (auto-minted) | 1 hour (auto-refreshed) | Not needed — tokens are ephemeral |
+| **PAT** | Static personal access token | No expiration | Not supported — manage PAT lifecycle on GitHub |
+
+**GitHub App** is recommended because:
+- Tokens are short-lived (1 hour) and automatically refreshed
+- Fine-grained permissions scoped to the app installation
+- No long-lived secrets stored after initial setup
+- Audit trail tied to the app identity
+
+## Token Scopes and Tool Availability
+
+GitHub's MCP server enforces upstream permissions per tool. The set of MCP tools available through a given mount is determined by the **bound token's permissions**, not by Warden policy. A `403` or `tool not available` response from a `tools/call` request typically means the bound token lacks a required scope.
+
+Common mappings:
+
+| Tool family | GitHub App permission | PAT scope |
+|-------------|------------------------|-----------|
+| Repository read | `Contents: Read` | `repo` (classic) or `Contents: Read` (fine-grained) |
+| Issues | `Issues: Read/Write` | `repo` or `Issues: Read/Write` |
+| Pull requests | `Pull requests: Read/Write` | `repo` or `Pull requests: Read/Write` |
+| Actions | `Actions: Read/Write` | `workflow` |
+| Secrets | `Secrets: Read/Write` | `repo` plus organization secret access |
+
+Provision the App or PAT with permissions covering the intended tool surface, and bind one credential spec per role to give different agents different reach.
+
+**Rotate a PAT** by updating the credential spec:
+
+```bash
+warden cred spec update github-ops \
+  -config token=ghp-new-personal-access-token
+```
+
+Then revoke the old PAT from the [GitHub PAT settings](https://github.com/settings/tokens).
+
+**GitHub App tokens do not require rotation** — installation tokens are auto-minted and expire after 1 hour. To rotate the App's private key, generate a new key in the GitHub App settings, update the spec with `private_key=@/path/to/new-key.pem`, and delete the old key from GitHub.

--- a/provider/mcp_github/provider.go
+++ b/provider/mcp_github/provider.go
@@ -1,0 +1,86 @@
+package mcp_github
+
+import (
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+)
+
+// DefaultMCPGitHubURL is the default URL for GitHub's hosted MCP server.
+const DefaultMCPGitHubURL = "https://api.githubcopilot.com/mcp"
+
+// DefaultMCPGitHubTimeout caps a single MCP session. MCP responses can stream
+// over SSE for many tool calls, so the default sits well above the per-request
+// shapes that govern REST providers; operators raise this for longer sessions.
+const DefaultMCPGitHubTimeout = 10 * time.Minute
+
+// Spec defines the mcp_github provider configuration for the httpproxy framework.
+//
+// The provider transparently proxies traffic to GitHub's hosted MCP server,
+// injecting a GitHub token as Authorization: Bearer <pat>. Bodies and Accept
+// negotiation pass through unchanged so Streamable HTTP (JSON or SSE) works
+// without any MCP-specific framework support.
+var Spec = &httpproxy.ProviderSpec{
+	Name:            "mcp_github",
+	DefaultURL:      DefaultMCPGitHubURL,
+	URLConfigKey:    "mcp_github_url",
+	DefaultTimeout:  DefaultMCPGitHubTimeout,
+	ParseStreamBody: false,
+	UserAgent:       "warden-mcp-github-proxy",
+	HelpText:        mcpGitHubBackendHelp,
+	ExtractCredentials: httpproxy.TypedTokenExtractor(
+		credential.TypeGitHubToken, "token", "Authorization", "Bearer ",
+	),
+	// DefaultAccept intentionally unset. The httpproxy framework injects a
+	// default Accept only when the client sends none; MCP clients always
+	// negotiate ("application/json, text/event-stream"). Forcing a default
+	// here would break one-shot JSON clients.
+}
+
+// Factory creates a new mcp_github provider backend.
+var Factory = httpproxy.NewFactory(Spec)
+
+const mcpGitHubBackendHelp = `
+The mcp_github provider proxies requests to GitHub's hosted MCP server
+with automatic credential management. Warden performs implicit
+authentication on every request, mints a GitHub token from the
+credential manager, and injects it as Authorization: Bearer <token>.
+Clients never hold a PAT.
+
+The gateway path format is:
+  /mcp_github/gateway/{mcp-path}
+
+The MCP server exposes a single endpoint; an empty suffix routes to the
+canonical server URL. Examples:
+
+  POST /mcp_github/gateway/    → POST https://api.githubcopilot.com/mcp/
+  GET  /mcp_github/gateway/    → GET  https://api.githubcopilot.com/mcp/
+
+JSON-RPC bodies, the Accept header, and the Mcp-Session-Id header pass
+through unchanged. Streamable HTTP responses (JSON or SSE) are streamed
+without buffering.
+
+The role can be provided via the X-Warden-Role header, or embedded in
+the URL path:
+  /mcp_github/role/{role}/gateway/
+
+Header-routed alternative: clients that prefer a base URL without the
+/v1/mcp_github/gateway/ prefix can send the mount path as
+X-Warden-Provider (and the namespace as X-Warden-Namespace) and let
+Warden synthesise the canonical gateway path. The X-Warden-Provider
+value is the mount path from 'warden provider list', not the literal
+provider type — see the skill markdown for the exact command.
+
+The same TypeGitHubToken credspec used for the github REST provider works
+here unchanged — binding one to a role grants both REST and MCP reach.
+
+Configuration:
+- mcp_github_url: MCP server base URL (default: https://api.githubcopilot.com/mcp)
+- max_body_size: Maximum request body size (default: 10MB, max: 100MB)
+- timeout: Session timeout (default: 10m). Raise for long agent sessions
+    that keep an SSE stream open across many tool calls.
+- auto_auth_path: Auth mount path for implicit authentication (e.g.,
+    'auth/jwt/')
+- default_role: Fallback role when not specified by header or URL path
+`

--- a/provider/mcp_github/skill.go
+++ b/provider/mcp_github/skill.go
@@ -1,0 +1,14 @@
+package mcp_github
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the mcp_github provider.
+// The content is seeded into the global skill registry the first time an
+// mcp_github provider is mounted in the cluster; subsequent mounts are no-ops
+// and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/mcp_github/skill.md
+++ b/provider/mcp_github/skill.md
@@ -1,0 +1,148 @@
+---
+name: mcp_github
+description: "Talk to GitHub's hosted MCP server through Warden — without holding a GitHub PAT. Use any MCP client (Claude Code, Cursor, ...) by pointing it at Warden; tools and JSON/SSE responses pass through unchanged."
+category: provider-guide
+provider: mcp_github
+requires: [foundation, discovery]
+upstream: GitHub's hosted MCP server (api.githubcopilot.com/mcp)
+---
+
+# GitHub MCP through Warden
+
+## What it does
+
+Warden proxies traffic to GitHub's hosted MCP server. The MCP client
+calls a Warden URL; Warden authenticates the caller (JWT/cert), looks
+up the GitHub PAT bound to the chosen role, injects it as
+`Authorization: Bearer <pat>`, and streams the response (JSON or SSE)
+back unchanged. The agent **never holds a PAT**.
+
+The same PAT that backs the `github` REST provider also backs this
+mount — a single role binding grants both REST and MCP reach.
+
+## Configure the MCP client
+
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/mcp_github/`,
+  `/v1/team-data/mcp_github/`). Warden has already baked the namespace
+  and mount path in.
+- `<role>` is the role you picked from `warden role list` to perform
+  this task — it goes in the URL path.
+
+```
+MCP server URL : $WARDEN_ADDR<mount-url>role/<role>/gateway/
+Auth header    : Authorization: Bearer $WARDEN_TOKEN
+```
+
+For MCP client configuration files, the entry looks like (Claude Code
+/ Cursor / Continue / Cline / Goose all accept this shape):
+
+```json
+{
+  "type": "http",
+  "url": "$WARDEN_ADDR<mount-url>role/<role>/gateway/",
+  "headers": {
+    "Authorization": "Bearer $WARDEN_TOKEN"
+  }
+}
+```
+
+Substitute `$WARDEN_ADDR`, `<mount-url>`, `<role>`, and `$WARDEN_TOKEN`
+before saving — most MCP clients do not expand environment variables
+inside config files.
+
+## Examples
+
+(All examples below assume `mount_url = /v1/mcp_github/` and role
+`mcp-reader`; substitute yours from `warden provider list`.)
+
+List the tools the server exposes:
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  $WARDEN_ADDR/v1/mcp_github/role/mcp-reader/gateway/
+```
+
+Call a tool (the operator must grant a role with a PAT scoped for the
+tool — see Quirks below):
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_issues","arguments":{"owner":"myorg","repo":"myrepo"}}}' \
+  $WARDEN_ADDR/v1/mcp_github/role/mcp-reader/gateway/
+```
+
+The trailing slash on `gateway/` matters — GitHub's MCP server lives at
+exactly one path, and Warden composes the upstream URL as the mount's
+upstream-URL config + the gateway suffix.
+
+## Header-routed alternative
+
+If you prefer an MCP server URL that is just `$WARDEN_ADDR/` (some MCP
+clients dislike long paths, or you want to mux several MCP providers
+under one base URL), pass the mount path as `X-Warden-Provider` and the
+namespace as `X-Warden-Namespace`:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_github") | .path' | head -1)
+
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "X-Warden-Provider: $path" \
+  -H "X-Warden-Namespace: $WARDEN_NAMESPACE" \
+  -H "X-Warden-Role: mcp-reader" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  $WARDEN_ADDR/
+```
+
+For an MCP client config:
+
+```json
+{
+  "type": "http",
+  "url": "$WARDEN_ADDR/",
+  "headers": {
+    "Authorization": "Bearer $WARDEN_TOKEN",
+    "X-Warden-Provider": "<path-from-warden-provider-list>",
+    "X-Warden-Namespace": "<namespace>",
+    "X-Warden-Role": "<role>"
+  }
+}
+```
+
+When more than one `mcp_github` mount exists, replace `head -1` with a
+`select(.description=="...")` matching the mount you want — `path`
+alone doesn't tell you which PAT or scope set the mount fronts.
+
+## Quirks
+
+- **The injected header is `Authorization: Bearer <pat>`** — the same
+  Bearer prefix the GitHub MCP docs document. This is the opposite of
+  the `github` REST provider, which uses `Authorization: token <pat>`.
+  The same `TypeGitHubToken` credspec works for both; only the wire
+  format differs.
+- **PAT scopes determine which tools resolve.** GitHub's MCP server
+  enforces upstream scopes per tool. A `403` or `tool not available`
+  response usually means the bound PAT lacks a required scope (e.g.
+  `repo`, `issues`, `pull_requests`). Operators provision PATs with
+  scopes covering the intended toolset; agents that hit scope errors
+  should ask the operator to widen the binding, not request a different
+  Warden role unless one exists.
+- **Streamable HTTP / SSE flows through transparently.** Send
+  `Accept: application/json, text/event-stream` and the server's
+  choice of framing comes back unchanged. The `Mcp-Session-Id`
+  response header round-trips automatically; subsequent client
+  requests carrying it reach the same upstream session.
+- **Session timeout is mount-wide.** The mount's `timeout` config
+  caps an entire SSE session (default 10 minutes). For longer agent
+  sessions, ask the operator to raise it.
+- **Rate limits propagate from GitHub**. Warden does not retry; back
+  off when you see GitHub-side rate limit responses.
+- **Not in scope**: OAuth flows (Dynamic Client Registration, PRM
+  discovery, `.well-known/oauth-protected-resource`), stdio transport,
+  and legacy split-endpoint HTTP+SSE. Use the PAT path.


### PR DESCRIPTION
## Summary

- Adds `mcp_github` — a transparent proxy to GitHub's hosted MCP server at `https://api.githubcopilot.com/mcp/`. First of a planned per-MCP-server family (`mcp_linear`, `mcp_sentry`, ...).
- Reuses `credential.TypeGitHubToken` so an operator-bound credspec used by the `github` REST provider grants both REST and MCP reach. Injects `Authorization: Bearer <pat>` per GitHub's MCP docs.
- Minimal `httpproxy.ProviderSpec`: opaque pass-through of JSON-RPC bodies, 10m default timeout for SSE sessions, no MCP-specific framework code. SSE flows through Go's `httputil.ReverseProxy` `text/event-stream` special-case under `FlushInterval=0`.
- Skill markdown documents both path-routed and header-routed agent UX.
- Operator README covers JWT and TLS-cert auth, GitHub App (recommended) and PAT credential options, and current MCP-client mTLS limitations (sidecar / `mcp-remote` patterns).
- Drops the "separates Warden from MCP" clause from the root README (line 124) — inconsistent now that Warden ships an MCP provider. Keeps the credential-in-env framing on line 42, which is the problem this provider solves.

## Test plan

- [x] `go build ./...` and `go vet ./provider/mcp_github/... ./cmd/server/...` (already passing locally)
- [x] `warden provider enable mcp_github` and confirm it appears in `warden provider list`
- [x] `warden read sys/skills/mcp_github` returns the seeded markdown
- [x] Bind a `TypeGitHubToken` credspec (App or PAT) to a test role
- [x] Path-routed smoke test: `POST .../v1/mcp_github/role/<role>/gateway/` with a `tools/list` JSON-RPC body returns valid tool listing
- [x] Header-routed smoke test: same body with `X-Warden-Provider: <mount-path>`, `X-Warden-Namespace`, `X-Warden-Role` headers against `$WARDEN_ADDR/`
- [ ] SSE smoke test: `tools/call` with `Accept: text/event-stream` via `curl --no-buffer -N` — events arrive incrementally, connection persists
- [ ] Audit log shows the request with the PAT redacted
- [ ] `Mcp-Session-Id` response header round-trips to subsequent client requests
