### PR TITLE
refactor(core): transparent-auth foundations

### DIFF
--- a/auth/helper/token_type.go
+++ b/auth/helper/token_type.go
@@ -15,12 +15,13 @@ func DefaultTokenType(backend string) string {
 }
 
 // DisplayTokenType maps an internal token type name to its user-facing alias.
-// Unknown values pass through unchanged.
-func DisplayTokenType(internal string) string {
-	switch internal {
-	case "jwt_role", "cert_role":
+// Pass isTransparent=true (as reported by the TokenStore registry) to alias
+// transparent-family token types to "transparent". This keeps auth/helper
+// decoupled from the core token registry: callers consult the registry once
+// and hand the boolean here.
+func DisplayTokenType(internal string, isTransparent bool) string {
+	if isTransparent {
 		return "transparent"
-	default:
-		return internal
 	}
+	return internal
 }

--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -40,6 +40,8 @@ type certAuthBackend struct {
 	revocationChecker *revocationChecker
 }
 
+var _ logical.Factory = Factory
+
 // Factory creates a new certificate auth backend
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b := &certAuthBackend{

--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -62,6 +62,8 @@ type jwtAuthBackend struct {
 	storageView sdklogical.Storage
 }
 
+var _ logical.Factory = Factory
+
 // Factory creates a new JWT auth backend using the logical.Factory pattern
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b := &jwtAuthBackend{

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -632,13 +632,15 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request, isI
 	resp, routeErr := c.doRouting(ctx, req)
 
 	// If the response generated an authentication, then generate the token.
-	// Transparent token types (jwt_role, cert_role) are reserved for the
-	// internal gateway auth flow — reject explicit login attempts early.
+	// Transparent token types are reserved for the internal gateway auth flow
+	// — reject explicit login attempts early. The set of transparent types is
+	// determined by the registry rather than a hardcoded list so adding a new
+	// transparent auth method does not require touching this guard.
 	if resp != nil && resp.Auth != nil {
-		if !isInternalLogin && (resp.Auth.TokenType == "jwt_role" || resp.Auth.TokenType == "cert_role") {
+		if !isInternalLogin && c.tokenStore.IsTransparentType(resp.Auth.TokenType) {
 			return logical.ErrorResponse(logical.ErrBadRequest("explicit login is not supported for roles with token_type=transparent; clients authenticate implicitly via gateway requests")), nil, nil
 		} else {
-			respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, resp)
+			respTokenCreate, errCreateToken := c.LoginCreateToken(ctx, req, resp)
 			if errCreateToken != nil {
 				return respTokenCreate, nil, errCreateToken
 			}
@@ -654,7 +656,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request, isI
 	return resp, auth, routeErr
 }
 
-func (c *Core) LoginCreateToken(ctx context.Context, resp *logical.Response) (*logical.Response, error) {
+func (c *Core) LoginCreateToken(ctx context.Context, req *logical.Request, resp *logical.Response) (*logical.Response, error) {
 	auth := resp.Auth
 
 	// Prevent internal policies from being assigned to tokens.
@@ -667,6 +669,16 @@ func (c *Core) LoginCreateToken(ctx context.Context, resp *logical.Response) (*l
 		}
 	}
 
+	// req.MountAccessor is populated by handleLoginRequest from the routed
+	// mount entry. Carry it through so transparent token types can fold it
+	// into their cache key (prevents cross-mount cache contamination when
+	// two mounts of the same auth type have overlapping role names + the
+	// same credential).
+	var mountAccessor string
+	if req != nil {
+		mountAccessor = req.MountAccessor
+	}
+
 	now := time.Now()
 	authData := logical.AuthData{
 		PrincipalID:    auth.PrincipalID,
@@ -676,6 +688,7 @@ func (c *Core) LoginCreateToken(ctx context.Context, resp *logical.Response) (*l
 		Policies:       auth.Policies,
 		ClientIP:       auth.ClientIP,
 		TokenValue:     auth.ClientToken,
+		MountAccessor:  mountAccessor,
 		Actors:         auth.Actors,
 	}
 
@@ -688,7 +701,7 @@ func (c *Core) LoginCreateToken(ctx context.Context, resp *logical.Response) (*l
 	}
 
 	data := map[string]any{
-		"token_type":     authhelper.DisplayTokenType(tokenValue.Type),
+		"token_type":     authhelper.DisplayTokenType(tokenValue.Type, c.tokenStore.IsTransparentType(tokenValue.Type)),
 		"expire_at":      tokenValue.ExpireAt,
 		"bound_ip":       tokenValue.CreatedByIP,
 		"token_id":       tokenValue.ID,
@@ -1345,40 +1358,56 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		ctx = context.WithValue(ctx, logical.ClientIPKey, req.ClientIP)
 	}
 
+	// Resolve the auth mount once so transparent token types can fold the
+	// stable mount accessor into their cache key. Without this, two mounts
+	// of the same auth type with overlapping role names + the same credential
+	// would silently share a cache entry.
+	authMountEntry := c.router.MatchingMountEntry(ctx, autoAuthPath)
+	var mountAccessor string
+	if authMountEntry != nil {
+		mountAccessor = authMountEntry.Accessor
+	}
+
 	// Detect credential type: client certificate or JWT bearer token
 	var singleflightKey string
 	var lookupFunc func() (*TokenEntry, error)
 	var loginData map[string]any
-	var credType string // "cert" or "jwt" — used for post-login lookup with resolved role
-	var credKey string  // fingerprint or JWT — used for post-login lookup with resolved role
+	var credKey string // fingerprint or JWT — used for post-login lookup with resolved role
 
 	// Check for client certificate first (forwarded from LB or direct TLS)
 	clientCert := extractTransparentClientCert(req)
+
+	// Per-credential TransparentTokenType: cert credentials are served by
+	// CertRoleTokenType, JWT-bearer credentials by JWTRoleTokenType. PR2
+	// will replace this credential-format sniff with a registry lookup on
+	// mountEntry.Type so adding a new transparent auth method does not
+	// require touching this switch.
+	var ttype TransparentTokenType
 
 	switch {
 	case clientCert != nil:
 		// Certificate-based transparent auth
 		hash := sha256.Sum256(clientCert.Raw)
 		fingerprint := hex.EncodeToString(hash[:])
-		sfHash := sha256.Sum256([]byte("cert:" + fingerprint + ":" + authRole))
+		ttype = &CertRoleTokenType{}
+		sfHash := sha256.Sum256([]byte("cert:" + mountAccessor + ":" + fingerprint + ":" + authRole))
 		singleflightKey = hex.EncodeToString(sfHash[:])
 		loginData = map[string]any{"role": authRole}
-		credType = "cert"
 		credKey = fingerprint
 		lookupFunc = func() (*TokenEntry, error) {
-			return c.LookupCertTokenWithRole(ctx, fingerprint, authRole)
+			return c.LookupTransparentTokenWithRole(ctx, ttype, fingerprint, mountAccessor, authRole)
 		}
 
 	case strings.HasPrefix(req.ClientToken, "eyJ"):
 		// JWT-based transparent auth
 		clientToken := req.ClientToken
-		jwtHash := sha256.Sum256([]byte(clientToken + ":" + authRole))
+		ttype = &JWTRoleTokenType{}
+		jwtHash := sha256.Sum256([]byte("jwt:" + mountAccessor + ":" + clientToken + ":" + authRole))
 		singleflightKey = hex.EncodeToString(jwtHash[:])
 		loginData = map[string]any{"jwt": clientToken, "role": authRole}
-		credType = "jwt"
 		credKey = clientToken
 		lookupFunc = func() (*TokenEntry, error) {
-			return c.LookupJWTTokenWithRole(ctx, clientToken, authRole)
+			return c.LookupTransparentTokenWithRole(ctx, ttype, clientToken, mountAccessor, authRole)
 		}
 
 	default:
@@ -1451,12 +1480,7 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		resolvedRole := loginResp.Auth.RoleName
 		var newTE *TokenEntry
 		var postErr error
-		switch credType {
-		case "cert":
-			newTE, postErr = c.LookupCertTokenWithRole(ctx, credKey, resolvedRole)
-		case "jwt":
-			newTE, postErr = c.LookupJWTTokenWithRole(ctx, credKey, resolvedRole)
-		}
+		newTE, postErr = c.LookupTransparentTokenWithRole(ctx, ttype, credKey, mountAccessor, resolvedRole)
 		if postErr != nil {
 			return nil, fmt.Errorf("failed to lookup created token: %w", postErr)
 		}

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -843,7 +843,7 @@ func TestLoginCreateToken(t *testing.T) {
 				Policies: []string{"root"},
 			},
 		}
-		result, err := core.LoginCreateToken(ctx, resp)
+		result, err := core.LoginCreateToken(ctx, nil, resp)
 		require.Error(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, http.StatusForbidden, result.StatusCode)
@@ -855,7 +855,7 @@ func TestLoginCreateToken(t *testing.T) {
 				Policies: []string{"response-wrapping"},
 			},
 		}
-		result, err := core.LoginCreateToken(ctx, resp)
+		result, err := core.LoginCreateToken(ctx, nil, resp)
 		require.Error(t, err)
 		require.NotNil(t, result)
 		// Should be forbidden (403) for policy rejection
@@ -1569,40 +1569,49 @@ func TestHandleTransparentAuth_JWTDifferentRoles(t *testing.T) {
 		assert.NotEqual(t, id1, id2, "Same JWT with different roles should have different token IDs")
 	})
 
-	t.Run("LookupJWTTokenWithRole returns error for non-existent token", func(t *testing.T) {
+	t.Run("LookupTransparentTokenWithRole returns error for non-existent JWT token", func(t *testing.T) {
 		sampleJWT2 := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.test"
+		jwtType := &JWTRoleTokenType{}
 
 		// Looking up a token that doesn't exist should return an error
-		_, err := core.LookupJWTTokenWithRole(ctx, sampleJWT2, "terraform")
+		_, err := core.LookupTransparentTokenWithRole(ctx, jwtType, sampleJWT2, "test-accessor", "terraform")
 		assert.Error(t, err, "Looking up non-existent JWT token should return error")
 
 		// Looking up with different role should also fail
-		_, err = core.LookupJWTTokenWithRole(ctx, sampleJWT2, "different-role")
+		_, err = core.LookupTransparentTokenWithRole(ctx, jwtType, sampleJWT2, "test-accessor", "different-role")
 		assert.Error(t, err, "Looking up with different role should not find the token")
 	})
 
-	t.Run("ComputeData and ComputeID match token creation ID", func(t *testing.T) {
+	t.Run("LookupValue and ComputeID match token creation ID", func(t *testing.T) {
 		jwtType := &JWTRoleTokenType{}
 
-		// Simulate token creation: Generate stores hash of JWT+role in entry.Data["jwt"]
+		// Simulate token creation: Generate stores hash of (accessor, JWT, role) in entry.Data["jwt"]
 		entry := &TokenEntry{
 			Data: map[string]string{},
 		}
-		authData := &AuthData{TokenValue: sampleJWT, RoleName: "terraform"}
+		authData := &AuthData{TokenValue: sampleJWT, MountAccessor: "acc1", RoleName: "terraform"}
 		jwtType.Generate(context.Background(), authData, entry)
 
-		// Verify the stored value is a hash of JWT+role (not raw value)
-		expectedHash := sha256.Sum256([]byte(sampleJWT + ":terraform"))
+		// Verify the stored value is a hash of (accessor, JWT, role) — not raw value
+		expectedHash := sha256.Sum256([]byte("acc1:" + sampleJWT + ":terraform"))
 		assert.Equal(t, hex.EncodeToString(expectedHash[:]), entry.Data["jwt"])
 
 		// Token ID is computed from the stored hash
 		tokenID := jwtType.ComputeID(entry.Data["jwt"])
 
 		// Lookup: hash first, then compute ID - should match
-		lookupHash := jwtType.ComputeData(sampleJWT, "terraform")
+		lookupHash := jwtType.LookupValue(sampleJWT, "acc1", "terraform")
 		lookupID := jwtType.ComputeID(lookupHash)
 
 		assert.Equal(t, tokenID, lookupID, "Token creation and lookup should produce same ID")
+	})
+
+	t.Run("same JWT + role on different mounts produces different token IDs", func(t *testing.T) {
+		jwtType := &JWTRoleTokenType{}
+		hashA := jwtType.LookupValue(sampleJWT, "accessor-A", "deploy")
+		hashB := jwtType.LookupValue(sampleJWT, "accessor-B", "deploy")
+		assert.NotEqual(t, hashA, hashB, "Same JWT + role on two mounts must not share a cache entry")
+		assert.NotEqual(t, jwtType.ComputeID(hashA), jwtType.ComputeID(hashB))
 	})
 }
 

--- a/core/token_registry.go
+++ b/core/token_registry.go
@@ -18,8 +18,9 @@ var (
 // TokenTypeRegistry manages registered token types
 type TokenTypeRegistry struct {
 	mu           sync.RWMutex
-	types        map[string]TokenType // name -> TokenType
-	prefixToType map[string]TokenType // valuePrefix -> TokenType
+	types        map[string]TokenType            // name -> TokenType
+	prefixToType map[string]TokenType            // valuePrefix -> TokenType
+	authMethod   map[string]TransparentTokenType // AuthMethodType -> TransparentTokenType
 }
 
 // NewTokenTypeRegistry creates a new registry
@@ -27,6 +28,7 @@ func NewTokenTypeRegistry() *TokenTypeRegistry {
 	return &TokenTypeRegistry{
 		types:        make(map[string]TokenType),
 		prefixToType: make(map[string]TokenType),
+		authMethod:   make(map[string]TransparentTokenType),
 	}
 }
 
@@ -49,7 +51,44 @@ func (r *TokenTypeRegistry) Register(tokenType TokenType) error {
 		r.prefixToType[meta.ValuePrefix] = tokenType
 	}
 
+	// Index transparent token types by AuthMethodType so callers (the
+	// implicit-auth dispatcher, the system-introspect aggregator, the
+	// explicit-login guard) can ask "what TokenType serves mounts of
+	// type X?" without a hardcoded switch.
+	if meta.AuthMethodType != "" {
+		if tt, ok := tokenType.(TransparentTokenType); ok {
+			r.authMethod[meta.AuthMethodType] = tt
+		}
+	}
+
 	return nil
+}
+
+// IsTransparent returns true if the named token type implements
+// TransparentTokenType and self-reports as transparent. Returns false for
+// unknown types and for non-transparent types (e.g. warden_token).
+func (r *TokenTypeRegistry) IsTransparent(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	tokenType, ok := r.types[name]
+	if !ok {
+		return false
+	}
+	tt, ok := tokenType.(TransparentTokenType)
+	if !ok {
+		return false
+	}
+	return tt.IsTransparent()
+}
+
+// GetTransparentTokenTypeForAuthMethod returns the TransparentTokenType
+// registered to serve mounts whose entry.Type equals the given mountType.
+// Returns nil if no transparent type is registered for that mount type.
+func (r *TokenTypeRegistry) GetTransparentTokenTypeForAuthMethod(mountType string) TransparentTokenType {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.authMethod[mountType]
 }
 
 // GetByName retrieves a token type by its name

--- a/core/token_store.go
+++ b/core/token_store.go
@@ -319,6 +319,21 @@ func (s *TokenStore) registerBuiltinTypes() error {
 	return nil
 }
 
+// IsTransparentType reports whether the named token type is registered as
+// a transparent (implicit-auth) type. Thin wrapper over the registry so
+// callers don't need direct registry access.
+func (s *TokenStore) IsTransparentType(name string) bool {
+	return s.registry.IsTransparent(name)
+}
+
+// GetTransparentTokenTypeForAuthMethod returns the TransparentTokenType
+// registered to serve mounts of the given auth method type (e.g. "jwt",
+// "cert", "kubernetes"). Returns nil if no transparent type serves that
+// mount type. Thin wrapper over the registry.
+func (s *TokenStore) GetTransparentTokenTypeForAuthMethod(mountType string) TransparentTokenType {
+	return s.registry.GetTransparentTokenTypeForAuthMethod(mountType)
+}
+
 // GenerateToken creates a new namespace-aware token
 func (s *TokenStore) GenerateToken(ctx context.Context, tokenTypeName string, authData *AuthData) (*TokenEntry, error) {
 	s.mu.Lock()
@@ -408,10 +423,11 @@ func (s *TokenStore) generateWithCollisionDetection(
 
 		// Check for existing token with same ID
 		if existingEntry, found := s.byID.Get(entry.ID); found {
-			// For JWT and cert tokens, the ID is deterministic (based on credential:role hash).
-			// Finding an existing token means this credential+role already has a valid token.
-			// Return the existing token instead of treating it as a collision.
-			if meta.Name == TypeJWTRole || meta.Name == TypeCertRole {
+			// Transparent token types use a deterministic ID (hash of credential
+			// + mountAccessor + role). Finding an existing token means this
+			// credential+mount+role already has a valid cache entry — return it
+			// instead of treating it as a collision.
+			if s.registry.IsTransparent(meta.Name) {
 				return existingEntry, nil
 			}
 
@@ -451,10 +467,10 @@ func (s *TokenStore) generateWithCollisionDetection(
 			// Don't fail the operation, token is in cache
 		}
 
-		// Register token with expiration manager for timer-based TTL enforcement
-		// Self-contained tokens (JWT, cert) are cache-only, so don't persist their expiration entries
+		// Register token with expiration manager for timer-based TTL enforcement.
+		// Transparent token types are cache-only, so don't persist their expiration entries.
 		if expMgr := s.core.GetExpirationManager(); expMgr != nil && ttl > 0 {
-			persist := entry.Type != TypeJWTRole && entry.Type != TypeCertRole
+			persist := !s.registry.IsTransparent(entry.Type)
 			if err := expMgr.RegisterToken(ctx, entry.ID, ttl, persist); err != nil {
 				s.logger.Warn("failed to register token with expiration manager",
 					logger.String("token_id", entry.ID),
@@ -1016,8 +1032,8 @@ func (s *TokenStore) ReplaceRootTokenValue(customToken string) error {
 // Uses a transaction to ensure atomicity: both token and accessor are stored together
 // or neither is stored if any operation fails
 func (s *TokenStore) persistToken(entry *TokenEntry) error {
-	// Skip persistence for self-contained tokens - they are cache-only
-	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole {
+	// Skip persistence for transparent token types — they are cache-only.
+	if s.registry.IsTransparent(entry.Type) {
 		return nil
 	}
 
@@ -1283,8 +1299,8 @@ func (s *TokenStore) loadTokenByAccessor(accessor string) (*TokenEntry, error) {
 // Uses a transaction to ensure atomicity: both token and accessor are deleted together
 // or neither is deleted if any operation fails
 func (s *TokenStore) deleteToken(entry *TokenEntry) error {
-	// Skip storage operations for self-contained tokens - they are cache-only
-	if entry.Type == TypeJWTRole || entry.Type == TypeCertRole {
+	// Skip storage operations for transparent token types — they are cache-only.
+	if s.registry.IsTransparent(entry.Type) {
 		return nil
 	}
 
@@ -1479,15 +1495,22 @@ func (c *Core) LookupToken(ctx context.Context, tokenValue string) (*TokenEntry,
 	return &entryCopy, nil
 }
 
-// LookupJWTTokenWithRole looks up a JWT token using both the JWT and role.
-// This is used for implicit auth where the same JWT with different roles
-// should produce different tokens. The composite "jwt:role" value is used
-// for ID computation and validation.
-func (c *Core) LookupJWTTokenWithRole(ctx context.Context, jwt string, role string) (*TokenEntry, error) {
+// LookupTransparentTokenWithRole looks up a cached transparent-auth token
+// keyed by (credential, mountAccessor, role). Used by performImplicitAuth
+// for both the cache-check and post-login resolution paths.
+//
+// The cache hash uses tokenType.LookupValue, so each TransparentTokenType
+// controls how its credential collapses into a deterministic cache key.
+// Mount accessor is included so two mounts of the same auth type with
+// overlapping role names + the same credential cannot share an entry.
+//
+// Returns ErrTokenNotFound on cache miss, ErrTokenNamespaceMismatch on
+// namespace boundary violation, ErrTokenExpired on TTL exhaustion,
+// ErrOriginViolation on IP binding violation.
+func (c *Core) LookupTransparentTokenWithRole(ctx context.Context, tokenType TransparentTokenType, credential, mountAccessor, role string) (*TokenEntry, error) {
 	if c.Sealed() {
 		return nil, fmt.Errorf("the core is sealed")
 	}
-
 	if c.tokenStore == nil {
 		return nil, nil
 	}
@@ -1501,22 +1524,19 @@ func (c *Core) LookupJWTTokenWithRole(ctx context.Context, jwt string, role stri
 	}
 	s.mu.RUnlock()
 
-	// Extract namespace from context
 	ns, err := namespace.FromContext(ctx)
 	if err != nil || ns == nil {
 		return nil, errors.New("namespace not found in context")
 	}
 
-	// Get JWT token type
-	jwtType := &JWTRoleTokenType{}
+	typeName := tokenType.Metadata().Name
 
-	// Compute hash of "jwt:role" - this matches what's stored in entry.Data["jwt"]
-	jwtHash := jwtType.ComputeData(jwt, role)
-	// Token ID is computed from the hash
-	tokenID := jwtType.ComputeID(jwtHash)
+	// Hash of (mountAccessor, credential, role) — matches what Generate stored.
+	lookupHash := tokenType.LookupValue(credential, mountAccessor, role)
+	tokenID := tokenType.ComputeID(lookupHash)
 
-	// Lookup token in cache only - JWT tokens are not persisted to storage
-	// On cache miss, the caller should perform implicit auth to create a new token
+	// Lookup token in cache only — transparent tokens are not persisted to storage.
+	// On cache miss the caller performs implicit auth to create a new token.
 	entry, found := s.byID.Get(tokenID)
 	if !found {
 		if s.config.EnableMetrics {
@@ -1524,7 +1544,6 @@ func (c *Core) LookupJWTTokenWithRole(ctx context.Context, jwt string, role stri
 		}
 		return nil, ErrTokenNotFound
 	}
-
 	if s.config.EnableMetrics {
 		s.metrics.IncrementCacheHits()
 	}
@@ -1532,7 +1551,8 @@ func (c *Core) LookupJWTTokenWithRole(ctx context.Context, jwt string, role stri
 	// Validate namespace binding
 	tokenNs, err := c.namespaceStore.GetNamespaceByAccessor(ctx, entry.NamespaceID)
 	if err != nil || tokenNs == nil {
-		s.logger.Warn("JWT token namespace not found",
+		s.logger.Warn("transparent token namespace not found",
+			logger.String("token_type", typeName),
 			logger.String("token_id", tokenID),
 			logger.String("token_namespace_id", entry.NamespaceID))
 		return nil, ErrTokenNamespaceMismatch
@@ -1543,133 +1563,29 @@ func (c *Core) LookupJWTTokenWithRole(ctx context.Context, jwt string, role stri
 		if s.config.EnableMetrics {
 			s.metrics.IncrementNamespaceMismatches()
 		}
-		s.logger.Warn("JWT token namespace mismatch",
+		s.logger.Warn("transparent token namespace mismatch",
+			logger.String("token_type", typeName),
 			logger.String("token_id", tokenID),
 			logger.String("token_namespace", tokenNs.Path),
 			logger.String("request_namespace", ns.Path))
 		return nil, ErrTokenNamespaceMismatch
 	}
 
-	// Validate token value matches (comparing hashes, not raw JWT)
-	// entry.Data["jwt"] stores the SHA-256 hash of the composite "jwt:role" value
-	lookupKey := jwtType.LookupKey()
+	// Validate stored hash matches recomputed hash (constant-time compare to
+	// prevent timing attacks). The stored hash lives under the type's
+	// declared LookupKey in entry.Data.
+	lookupKey := tokenType.LookupKey()
 	expectedHash, ok := entry.Data[lookupKey]
 	if !ok {
-		s.logger.Error("JWT token lookup key not found",
+		s.logger.Error("transparent token lookup key not found",
+			logger.String("token_type", typeName),
 			logger.String("token_id", tokenID),
 			logger.String("lookup_key", lookupKey))
 		return nil, ErrTokenNotFound
 	}
-	// Compare stored hash with computed hash using constant-time comparison
-	// to prevent timing attacks
-	if subtle.ConstantTimeCompare([]byte(expectedHash), []byte(jwtHash)) != 1 {
-		s.logger.Error("JWT token value mismatch",
-			logger.String("token_id", tokenID),
-			logger.String("lookup_key", lookupKey))
-		return nil, ErrTokenNotFound
-	}
-
-	// Validate expiration
-	if !entry.ExpireAt.IsZero() && time.Now().After(entry.ExpireAt) {
-		if s.config.EnableMetrics {
-			s.metrics.IncrementTokensExpired()
-		}
-		return nil, ErrTokenExpired
-	}
-
-	// Validate same-origin policy (IP binding)
-	if err := s.validateIPBinding(ctx, tokenID, entry); err != nil {
-		return nil, err
-	}
-
-	if s.config.EnableMetrics {
-		s.metrics.IncrementTokensResolved()
-	}
-
-	entryCopy := *entry
-	return &entryCopy, nil
-}
-
-// LookupCertTokenWithRole looks up a cert token using both the fingerprint and role.
-// This is used for implicit auth where the same cert with different roles
-// should produce different tokens. The composite "fingerprint:role" value is used
-// for ID computation and validation.
-func (c *Core) LookupCertTokenWithRole(ctx context.Context, certFingerprint string, role string) (*TokenEntry, error) {
-	if c.Sealed() {
-		return nil, fmt.Errorf("the core is sealed")
-	}
-
-	if c.tokenStore == nil {
-		return nil, nil
-	}
-
-	s := c.tokenStore
-
-	s.mu.RLock()
-	if s.closed {
-		s.mu.RUnlock()
-		return nil, ErrStoreClosed
-	}
-	s.mu.RUnlock()
-
-	// Extract namespace from context
-	ns, err := namespace.FromContext(ctx)
-	if err != nil || ns == nil {
-		return nil, errors.New("namespace not found in context")
-	}
-
-	certType := &CertRoleTokenType{}
-
-	// Compute hash of "fingerprint:role" - this matches what's stored in entry.Data["cert_fingerprint"]
-	certHash := certType.ComputeData(certFingerprint, role)
-	// Token ID is computed from the hash
-	tokenID := certType.ComputeID(certHash)
-
-	// Lookup token in cache only - cert tokens are not persisted to storage
-	entry, found := s.byID.Get(tokenID)
-	if !found {
-		if s.config.EnableMetrics {
-			s.metrics.IncrementCacheMisses()
-		}
-		return nil, ErrTokenNotFound
-	}
-
-	if s.config.EnableMetrics {
-		s.metrics.IncrementCacheHits()
-	}
-
-	// Validate namespace binding
-	tokenNs, err := c.namespaceStore.GetNamespaceByAccessor(ctx, entry.NamespaceID)
-	if err != nil || tokenNs == nil {
-		s.logger.Warn("cert token namespace not found",
-			logger.String("token_id", tokenID),
-			logger.String("token_namespace_id", entry.NamespaceID))
-		return nil, ErrTokenNamespaceMismatch
-	}
-
-	isValidNamespace := ns.UUID == tokenNs.UUID || ns.HasParent(tokenNs)
-	if !isValidNamespace {
-		if s.config.EnableMetrics {
-			s.metrics.IncrementNamespaceMismatches()
-		}
-		s.logger.Warn("cert token namespace mismatch",
-			logger.String("token_id", tokenID),
-			logger.String("token_namespace", tokenNs.Path),
-			logger.String("request_namespace", ns.Path))
-		return nil, ErrTokenNamespaceMismatch
-	}
-
-	// Validate token value matches (comparing hashes, not raw fingerprint)
-	lookupKey := certType.LookupKey()
-	expectedHash, ok := entry.Data[lookupKey]
-	if !ok {
-		s.logger.Error("cert token lookup key not found",
-			logger.String("token_id", tokenID),
-			logger.String("lookup_key", lookupKey))
-		return nil, ErrTokenNotFound
-	}
-	if subtle.ConstantTimeCompare([]byte(expectedHash), []byte(certHash)) != 1 {
-		s.logger.Error("cert token value mismatch",
+	if subtle.ConstantTimeCompare([]byte(expectedHash), []byte(lookupHash)) != 1 {
+		s.logger.Error("transparent token value mismatch",
+			logger.String("token_type", typeName),
 			logger.String("token_id", tokenID),
 			logger.String("lookup_key", lookupKey))
 		return nil, ErrTokenNotFound

--- a/core/token_type.go
+++ b/core/token_type.go
@@ -22,6 +22,13 @@ type TokenTypeMetadata struct {
 
 	// DefaultTTL is the recommended TTL for this token type (0 = use system default)
 	DefaultTTL time.Duration
+
+	// AuthMethodType is the mount-table entry.Type string this TokenType
+	// serves (e.g. "jwt", "cert", "kubernetes"). Empty for non-auth-method
+	// types (warden_token). Used by the registry to map a mount entry to
+	// the TransparentTokenType that handles its transparent-auth flow,
+	// without callers having to maintain a parallel switch.
+	AuthMethodType string
 }
 
 // TokenType defines the interface for pluggable token types
@@ -47,4 +54,43 @@ type TokenType interface {
 	// E.g., for warden it's "token", for jwt_role it's "token"
 	// This is used for deterministic token value validation after loading from storage
 	LookupKey() string
+}
+
+// TransparentTokenType is a TokenType that participates in transparent
+// (implicit) authentication: clients present a credential (JWT, TLS cert,
+// SA token, future cloud-native equivalents) directly with each request
+// rather than acquiring a Warden bearer token via an explicit login.
+//
+// Token types implementing this interface auto-enroll in the family of
+// transparent-auth behaviors (cache-only persistence, the explicit-login
+// guard, the "transparent" display alias, deterministic-ID collision
+// handling). The registry uses these methods so adding a new transparent
+// auth method does not require touching the call sites that enforce
+// those behaviors.
+type TransparentTokenType interface {
+	TokenType
+
+	// LookupValue produces the deterministic input that ComputeID hashes
+	// into the byID-cache key. Including mountAccessor in the input
+	// prevents cache contamination across two mounts of the same auth
+	// type with overlapping role names + the same credential.
+	LookupValue(credential, mountAccessor, role string) string
+
+	// IsTransparent always returns true; the method exists so the
+	// registry can ask "is this transparent?" without callers needing
+	// to maintain a hardcoded type list.
+	IsTransparent() bool
+
+	// CredentialFormat reports the discovery-level credential kind this
+	// type accepts. Today's values: "jwt" (generic JWT bearer, validated
+	// by JWKS/OIDC discovery), "cert" (TLS client cert), "k8s_sa_jwt"
+	// (Kubernetes SA JWT, validated by TokenReview), future "stsv4"
+	// (AWS IAM signed STS request), etc.
+	//
+	// Granularity matters: the introspect aggregator uses exact-match
+	// filtering on this value to avoid fan-out to mounts that can't
+	// authenticate the caller's credential. performImplicitAuth groups
+	// same-wire-format values (e.g. "jwt" and "k8s_sa_jwt" share JWT
+	// bearer extraction) inside its dispatch switch.
+	CredentialFormat() string
 }

--- a/core/token_type_cert.go
+++ b/core/token_type_cert.go
@@ -10,17 +10,19 @@ import (
 // CertRoleTokenType implements certificate-based token handling with role binding.
 // This token type is used for implicit authentication, where clients
 // present TLS client certificates and Warden performs implicit authentication.
-// The cert fingerprint + role combination is used as the lookup value, and its hash
-// becomes the token ID.
+// The (mountAccessor, fingerprint, role) tuple is used as the lookup value,
+// and its hash becomes the token ID — mountAccessor prevents cache
+// contamination across two cert mounts that share a role name and a cert.
 type CertRoleTokenType struct{}
 
 func (t *CertRoleTokenType) Metadata() TokenTypeMetadata {
 	return TokenTypeMetadata{
-		Name:        "cert_role",
-		IDPrefix:    "cert_",
-		ValuePrefix: "", // No bearer prefix — certs are in TLS, not headers
-		Description: "TLS client certificate with role binding",
-		DefaultTTL:  1 * time.Hour,
+		Name:           "cert_role",
+		IDPrefix:       "cert_",
+		ValuePrefix:    "", // No bearer prefix — certs are in TLS, not headers
+		Description:    "TLS client certificate with role binding",
+		DefaultTTL:     1 * time.Hour,
+		AuthMethodType: "cert",
 	}
 }
 
@@ -28,12 +30,13 @@ func (t *CertRoleTokenType) Generate(_ context.Context, authData *AuthData, entr
 	// For cert tokens, the certificate comes from the TLS connection.
 	// authData.TokenValue contains the cert fingerprint (SHA-256 of DER bytes).
 	//
-	// We store a hash of the composite "fingerprint:role" value for:
+	// We store a hash of the composite (mountAccessor, fingerprint, role)
+	// value for:
 	// - ID computation: ComputeID() uses this to derive the token ID
-	// - Validation: LookupCertTokenWithRole compares hashes
-	// The role is included because:
-	// - Same cert with different roles should produce different tokens
-	// - Each role may have different policies and credential specs
+	// - Validation: LookupTransparentTokenWithRole compares hashes
+	// The role + mountAccessor are included so:
+	// - Same cert with different roles produces different tokens
+	// - Same cert + role on two different mounts produces different tokens
 	if authData == nil {
 		return entry.Data, nil
 	}
@@ -43,8 +46,7 @@ func (t *CertRoleTokenType) Generate(_ context.Context, authData *AuthData, entr
 		return entry.Data, nil
 	}
 
-	// Store hash of composite "fingerprint:role" value
-	entry.Data["cert_fingerprint"] = t.ComputeData(fingerprint, authData.RoleName)
+	entry.Data["cert_fingerprint"] = t.LookupValue(fingerprint, authData.MountAccessor, authData.RoleName)
 
 	return entry.Data, nil
 }
@@ -65,14 +67,21 @@ func (t *CertRoleTokenType) LookupKey() string {
 	return "cert_fingerprint"
 }
 
-// ComputeData computes a SHA-256 hash of the composite "fingerprint:role" value.
-// This hash is stored in entry.Data["cert_fingerprint"] and used for both ID
-// computation and validation.
-func (t *CertRoleTokenType) ComputeData(fingerprint, role string) string {
-	lookupValue := fingerprint
-	if role != "" {
-		lookupValue = fingerprint + ":" + role
-	}
-	h := sha256.Sum256([]byte(lookupValue))
+// LookupValue computes the SHA-256 hash of (mountAccessor, fingerprint, role)
+// that ComputeID hashes into the byID-cache key. Including mountAccessor
+// prevents cache contamination across two cert mounts with overlapping role
+// names + the same client cert. Satisfies TransparentTokenType.
+func (t *CertRoleTokenType) LookupValue(fingerprint, mountAccessor, role string) string {
+	h := sha256.Sum256([]byte(mountAccessor + ":" + fingerprint + ":" + role))
 	return hex.EncodeToString(h[:])
 }
+
+// IsTransparent always returns true; opts CertRoleTokenType into the
+// transparent-auth family behaviors via the registry.
+func (t *CertRoleTokenType) IsTransparent() bool { return true }
+
+// CredentialFormat reports "cert" — TLS client certificates extracted
+// from the TLS connection (or a forwarded-cert header).
+func (t *CertRoleTokenType) CredentialFormat() string { return "cert" }
+
+var _ TransparentTokenType = (*CertRoleTokenType)(nil)

--- a/core/token_type_cert_test.go
+++ b/core/token_type_cert_test.go
@@ -20,32 +20,52 @@ func TestCertRoleTokenType_Metadata(t *testing.T) {
 	}
 }
 
-func TestCertRoleTokenType_ComputeData(t *testing.T) {
+func TestCertRoleTokenType_LookupValue(t *testing.T) {
 	ct := &CertRoleTokenType{}
 
 	// With role
-	hash1 := ct.ComputeData("fingerprint123", "admin")
-	hash2 := ct.ComputeData("fingerprint123", "admin")
+	hash1 := ct.LookupValue("fingerprint123", "acc1", "admin")
+	hash2 := ct.LookupValue("fingerprint123", "acc1", "admin")
 	if hash1 != hash2 {
-		t.Fatal("ComputeData should be deterministic")
+		t.Fatal("LookupValue should be deterministic")
 	}
 
 	// Different roles should produce different hashes
-	hash3 := ct.ComputeData("fingerprint123", "reader")
+	hash3 := ct.LookupValue("fingerprint123", "acc1", "reader")
 	if hash1 == hash3 {
 		t.Fatal("different roles should produce different hashes")
 	}
 
 	// Different fingerprints should produce different hashes
-	hash4 := ct.ComputeData("fingerprint456", "admin")
+	hash4 := ct.LookupValue("fingerprint456", "acc1", "admin")
 	if hash1 == hash4 {
 		t.Fatal("different fingerprints should produce different hashes")
 	}
 
 	// Without role
-	hash5 := ct.ComputeData("fingerprint123", "")
+	hash5 := ct.LookupValue("fingerprint123", "acc1", "")
 	if hash5 == hash1 {
 		t.Fatal("empty role should produce different hash from non-empty role")
+	}
+
+	// Mount accessor namespacing — same fingerprint + role on different mounts must not collide
+	hashMountA := ct.LookupValue("fingerprint123", "accA", "admin")
+	hashMountB := ct.LookupValue("fingerprint123", "accB", "admin")
+	if hashMountA == hashMountB {
+		t.Fatal("mount accessor must namespace the cache key")
+	}
+}
+
+func TestCertRoleTokenType_ImplementsTransparentTokenType(t *testing.T) {
+	ct := &CertRoleTokenType{}
+	if !ct.IsTransparent() {
+		t.Fatal("CertRoleTokenType.IsTransparent() should return true")
+	}
+	if ct.CredentialFormat() != "cert" {
+		t.Fatalf("expected CredentialFormat 'cert', got %q", ct.CredentialFormat())
+	}
+	if ct.Metadata().AuthMethodType != "cert" {
+		t.Fatalf("expected AuthMethodType 'cert', got %q", ct.Metadata().AuthMethodType)
 	}
 }
 
@@ -97,8 +117,9 @@ func TestCertRoleTokenType_Generate(t *testing.T) {
 	// With authData
 	entry := &TokenEntry{Data: make(map[string]string)}
 	authData := &AuthData{
-		TokenValue: "abc123fingerprint",
-		RoleName:   "agent",
+		TokenValue:    "abc123fingerprint",
+		MountAccessor: "acc1",
+		RoleName:      "agent",
 	}
 
 	result, err := ct.Generate(context.Background(), authData, entry)
@@ -114,8 +135,8 @@ func TestCertRoleTokenType_Generate(t *testing.T) {
 		t.Fatal("expected non-empty cert_fingerprint")
 	}
 
-	// Verify it matches ComputeData
-	expected := ct.ComputeData("abc123fingerprint", "agent")
+	// Verify it matches LookupValue
+	expected := ct.LookupValue("abc123fingerprint", "acc1", "agent")
 	if fingerprint != expected {
 		t.Fatalf("expected %q, got %q", expected, fingerprint)
 	}
@@ -172,11 +193,11 @@ func TestCertRoleTokenType_EndToEndIDComputation(t *testing.T) {
 	role := "agent"
 
 	// This simulates the full flow: Generate stores hash, ComputeID creates the ID
-	hash := ct.ComputeData(fingerprint, role)
+	hash := ct.LookupValue(fingerprint, "acc1", role)
 	tokenID := ct.ComputeID(hash)
 
-	// Verify the same computation in LookupCertTokenWithRole would produce the same ID
-	hash2 := ct.ComputeData(fingerprint, role)
+	// Verify the same computation in LookupTransparentTokenWithRole would produce the same ID
+	hash2 := ct.LookupValue(fingerprint, "acc1", role)
 	tokenID2 := ct.ComputeID(hash2)
 
 	if tokenID != tokenID2 {

--- a/core/token_type_jwt.go
+++ b/core/token_type_jwt.go
@@ -12,16 +12,19 @@ import (
 // This token type is used for implicit authentication, where clients
 // send requests with JWTs directly and Warden performs implicit authentication.
 // JWTs are recognized by their "eyJ" prefix (base64 encoded '{"').
-// The JWT+role combination is used as the lookup value, and its hash becomes the token ID.
+// The (mountAccessor, JWT, role) tuple is used as the lookup value, and its
+// hash becomes the token ID — mountAccessor prevents cache contamination
+// across two JWT mounts that share a role name and a credential.
 type JWTRoleTokenType struct{}
 
 func (t *JWTRoleTokenType) Metadata() TokenTypeMetadata {
 	return TokenTypeMetadata{
-		Name:        "jwt_role",
-		IDPrefix:    "jwtr_",
-		ValuePrefix: "eyJ", // Base64 encoded '{"' - JWT header start
-		Description: "JWT bearer token with role binding",
-		DefaultTTL:  1 * time.Hour,
+		Name:           "jwt_role",
+		IDPrefix:       "jwtr_",
+		ValuePrefix:    "eyJ", // Base64 encoded '{"' - JWT header start
+		Description:    "JWT bearer token with role binding",
+		DefaultTTL:     1 * time.Hour,
+		AuthMethodType: "jwt",
 	}
 }
 
@@ -29,12 +32,13 @@ func (t *JWTRoleTokenType) Generate(_ context.Context, authData *AuthData, entry
 	// For JWT tokens, we don't generate - the JWT comes from an external IdP.
 	// The JWT is passed via authData.TokenValue for implicit auth.
 	//
-	// We store a hash of the composite "jwt:role" value (not the raw JWT) for:
+	// We store a hash of the composite (mountAccessor, jwt, role) value (not
+	// the raw JWT) for:
 	// - Security: raw JWTs may contain sensitive claims
 	// - ID computation: ComputeID() uses this to derive the token ID
-	// The role is included because:
-	// - Same JWT with different roles should produce different tokens
-	// - Each role may have different policies and credential specs
+	// The role + mountAccessor are included so:
+	// - Same JWT with different roles produces different tokens
+	// - Same JWT + role on two different mounts produces different tokens
 	if authData == nil {
 		return entry.Data, nil
 	}
@@ -44,8 +48,7 @@ func (t *JWTRoleTokenType) Generate(_ context.Context, authData *AuthData, entry
 		return entry.Data, nil
 	}
 
-	// Store hash of composite "jwt:role" value using ComputeData
-	entry.Data["jwt"] = t.ComputeData(jwt, authData.RoleName)
+	entry.Data["jwt"] = t.LookupValue(jwt, authData.MountAccessor, authData.RoleName)
 
 	return entry.Data, nil
 }
@@ -71,15 +74,23 @@ func (t *JWTRoleTokenType) LookupKey() string {
 	return "jwt"
 }
 
-// ComputeData computes a SHA-256 hash of the composite "jwt:role" value.
-// This hash is stored in entry.Data["jwt"] and used for both ID computation
-// and validation. Hashing provides security (no raw JWT in storage) and
-// ensures consistent ID computation across token creation and lookup.
-func (t *JWTRoleTokenType) ComputeData(jwt, role string) string {
-	lookupValue := jwt
-	if role != "" {
-		lookupValue = jwt + ":" + role
-	}
-	h := sha256.Sum256([]byte(lookupValue))
+// LookupValue computes the SHA-256 hash of (mountAccessor, jwt, role) that
+// ComputeID hashes into the byID-cache key. Including mountAccessor
+// prevents cache contamination across two JWT mounts with overlapping role
+// names + the same credential. Satisfies TransparentTokenType.
+func (t *JWTRoleTokenType) LookupValue(jwt, mountAccessor, role string) string {
+	h := sha256.Sum256([]byte(mountAccessor + ":" + jwt + ":" + role))
 	return hex.EncodeToString(h[:])
 }
+
+// IsTransparent always returns true; opts JWTRoleTokenType into the
+// transparent-auth family behaviors via the registry.
+func (t *JWTRoleTokenType) IsTransparent() bool { return true }
+
+// CredentialFormat reports "jwt" — generic JWT bearer tokens validated
+// by JWKS/OIDC discovery. Kubernetes SA JWTs use the distinct
+// "k8s_sa_jwt" subtype so the introspect aggregator can route them only
+// to kubernetes mounts.
+func (t *JWTRoleTokenType) CredentialFormat() string { return "jwt" }
+
+var _ TransparentTokenType = (*JWTRoleTokenType)(nil)

--- a/core/token_type_jwt_test.go
+++ b/core/token_type_jwt_test.go
@@ -145,11 +145,11 @@ func TestJWTRoleTokenType_Generate(t *testing.T) {
 			Data: map[string]string{},
 		}
 
-		authData := &AuthData{TokenValue: sampleJWT, RoleName: ""}
+		authData := &AuthData{TokenValue: sampleJWT, MountAccessor: "acc1", RoleName: ""}
 		result, err := jwtType.Generate(context.Background(), authData, entry)
 		require.NoError(t, err)
-		// JWT should be stored as hash (not raw value) for security
-		expectedHash := sha256.Sum256([]byte(sampleJWT))
+		// JWT should be stored as hash of (accessor, JWT, role) for security
+		expectedHash := sha256.Sum256([]byte("acc1:" + sampleJWT + ":"))
 		assert.Equal(t, hex.EncodeToString(expectedHash[:]), result["jwt"])
 	})
 
@@ -158,37 +158,37 @@ func TestJWTRoleTokenType_Generate(t *testing.T) {
 			Data: map[string]string{},
 		}
 
-		authData := &AuthData{TokenValue: sampleJWT, RoleName: "terraform"}
+		authData := &AuthData{TokenValue: sampleJWT, MountAccessor: "acc1", RoleName: "terraform"}
 		result, err := jwtType.Generate(context.Background(), authData, entry)
 		require.NoError(t, err)
-		// JWT+role composite should be stored as hash for security
-		expectedHash := sha256.Sum256([]byte(sampleJWT + ":terraform"))
+		// (accessor, JWT, role) composite should be stored as hash for security
+		expectedHash := sha256.Sum256([]byte("acc1:" + sampleJWT + ":terraform"))
 		assert.Equal(t, hex.EncodeToString(expectedHash[:]), result["jwt"])
 	})
 }
 
-func TestJWTRoleTokenType_ComputeData(t *testing.T) {
+func TestJWTRoleTokenType_LookupValue(t *testing.T) {
 	jwtType := &JWTRoleTokenType{}
 
 	t.Run("same JWT different roles produce different hashes", func(t *testing.T) {
-		hash1 := jwtType.ComputeData(sampleJWT, "role1")
-		hash2 := jwtType.ComputeData(sampleJWT, "role2")
+		hash1 := jwtType.LookupValue(sampleJWT, "acc1", "role1")
+		hash2 := jwtType.LookupValue(sampleJWT, "acc1", "role2")
 
 		assert.NotEqual(t, hash1, hash2, "Same JWT with different roles should have different hashes")
 	})
 
-	t.Run("same JWT same role produces same hash", func(t *testing.T) {
-		hash1 := jwtType.ComputeData(sampleJWT, "terraform")
-		hash2 := jwtType.ComputeData(sampleJWT, "terraform")
+	t.Run("same JWT same role same mount produces same hash", func(t *testing.T) {
+		hash1 := jwtType.LookupValue(sampleJWT, "acc1", "terraform")
+		hash2 := jwtType.LookupValue(sampleJWT, "acc1", "terraform")
 
-		assert.Equal(t, hash1, hash2, "Same JWT with same role should have same hash")
+		assert.Equal(t, hash1, hash2, "Same inputs should produce same hash")
 	})
 
-	t.Run("empty role uses JWT only", func(t *testing.T) {
-		hashWithEmptyRole := jwtType.ComputeData(sampleJWT, "")
-		expectedHash := sha256.Sum256([]byte(sampleJWT))
+	t.Run("same JWT same role different mounts produce different hashes", func(t *testing.T) {
+		hashA := jwtType.LookupValue(sampleJWT, "accA", "deploy")
+		hashB := jwtType.LookupValue(sampleJWT, "accB", "deploy")
 
-		assert.Equal(t, hex.EncodeToString(expectedHash[:]), hashWithEmptyRole)
+		assert.NotEqual(t, hashA, hashB, "Mount accessor must namespace the cache key")
 	})
 
 	t.Run("hash and ComputeID produce consistent token IDs", func(t *testing.T) {
@@ -196,22 +196,28 @@ func TestJWTRoleTokenType_ComputeData(t *testing.T) {
 		entry := &TokenEntry{
 			Data: map[string]string{},
 		}
-		authData := &AuthData{TokenValue: sampleJWT, RoleName: "myapp"}
+		authData := &AuthData{TokenValue: sampleJWT, MountAccessor: "acc1", RoleName: "myapp"}
 		jwtType.Generate(context.Background(), authData, entry)
 
-		// The stored hash should match ComputeData
-		expectedHash := jwtType.ComputeData(sampleJWT, "myapp")
+		// The stored hash should match LookupValue
+		expectedHash := jwtType.LookupValue(sampleJWT, "acc1", "myapp")
 		assert.Equal(t, expectedHash, entry.Data["jwt"])
 
 		// Token ID is computed from the hash
 		tokenID := jwtType.ComputeID(entry.Data["jwt"])
 
 		// Lookup should compute the same ID: hash first, then ComputeID
-		lookupHash := jwtType.ComputeData(sampleJWT, "myapp")
+		lookupHash := jwtType.LookupValue(sampleJWT, "acc1", "myapp")
 		lookupID := jwtType.ComputeID(lookupHash)
 
 		assert.Equal(t, tokenID, lookupID, "Token creation and lookup should produce same ID")
 		assert.True(t, strings.HasPrefix(tokenID, "jwtr_"))
+	})
+
+	t.Run("implements TransparentTokenType", func(t *testing.T) {
+		assert.True(t, jwtType.IsTransparent())
+		assert.Equal(t, "jwt", jwtType.CredentialFormat())
+		assert.Equal(t, "jwt", jwtType.Metadata().AuthMethodType)
 	})
 }
 

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -72,6 +72,12 @@ type AuthData struct {
 	ClientIP       string
 	TokenValue     string // External token value (e.g., JWT for transparent mode)
 
+	// MountAccessor is the stable identifier of the auth mount that
+	// issued this login. Transparent token types include it in the cache
+	// key so two mounts of the same auth type with overlapping role
+	// names + the same credential cannot share a cache entry.
+	MountAccessor string
+
 	// Actors carries the verified on-behalf-of chain extracted at login
 	// (e.g. JWT "act" claim) so it can be persisted onto the issued
 	// TokenEntry for transparent-mode cache reuse.


### PR DESCRIPTION
## Summary

- Introduces a `TransparentTokenType` interface (`LookupValue`, `IsTransparent`, `CredentialFormat`) and an `AuthMethodType` field on `TokenTypeMetadata`. JWT and cert token types adopt it; the registry indexes by `AuthMethodType`.
- Folds **mount accessor** into transparent-auth cache keys via `LookupValue(credential, mountAccessor, role)`. Closes a latent cross-mount cache contamination bug where two mounts of the same auth type with the same credential + a shared role name silently shared a cache entry.
- Generic `LookupTransparentTokenWithRole` replaces the two near-clone JWT/cert lookups. Six hardcoded `TypeJWTRole || TypeCertRole` OR-chains across `token_store.go`, `request_handler.go`, and `auth/helper/token_type.go` become registry-driven via `IsTransparent`.
- Compile-time `var _ logical.Factory = Factory` assertions on jwt and cert backends — convention for future auth methods.

Operational impact zero: cache is in-memory with ~1h TTL, no persisted state to migrate; existing entries silently fall out and the next request re-runs login.

This is the first of a three-PR stack:

1. **(this PR)** transparent-auth foundations
2. mount-driven dispatch in `performImplicitAuth` and `sys/introspect/roles`
3. `kubernetes` auth method

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full unit suite green
- [x] `make test-e2e` — 3-node HA cluster + Vault + Hydra; full e2e suite green
- [x] Bug-for-bug parity verified for existing JWT/cert transparent-auth flows
