### PR TITLE
refactor(core): mount-driven dispatch for implicit auth

### DIFF
--- a/auth/helper/jwt_unverified.go
+++ b/auth/helper/jwt_unverified.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// ParseJWTClaimsUnverified decodes a JWT's payload segment and returns its
+// claims as a map. **No signature verification.** Intended for cheap
+// shape-sniffing on incoming requests — e.g. distinguishing a Kubernetes
+// SA token (sub starts with "system:serviceaccount:") from a generic JWT,
+// or pre-filtering by issuer claim before doing a full validator round-trip.
+//
+// Callers must NOT use the returned claims for authorization decisions;
+// they have not been cryptographically validated. Use a full validator
+// (JWKS, TokenReview, etc.) for any security-relevant check.
+//
+// Returns an error if the token is not a well-formed JWT (three segments)
+// or the payload is not valid base64url JSON.
+func ParseJWTClaimsUnverified(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("not a JWT: expected three dot-separated segments")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, errors.New("JWT payload is not valid base64url")
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, errors.New("JWT payload is not valid JSON")
+	}
+	return claims, nil
+}

--- a/auth/helper/jwt_unverified_test.go
+++ b/auth/helper/jwt_unverified_test.go
@@ -1,0 +1,76 @@
+package helper
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// mintJWT returns a JWT with the given JSON payload and a fixed bogus
+// signature. Header is the standard {"alg":"RS256","typ":"JWT"} encoded.
+// Signature is not validated by ParseJWTClaimsUnverified.
+func mintJWT(payloadJSON string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature"))
+	return header + "." + payload + "." + signature
+}
+
+func TestParseJWTClaimsUnverified(t *testing.T) {
+	t.Run("kubernetes SA token shape", func(t *testing.T) {
+		tok := mintJWT(`{"iss":"https://kubernetes.default.svc","sub":"system:serviceaccount:default:myapp","aud":["api"]}`)
+		claims, err := ParseJWTClaimsUnverified(tok)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, _ := claims["iss"].(string); got != "https://kubernetes.default.svc" {
+			t.Fatalf("iss: got %q", got)
+		}
+		if got, _ := claims["sub"].(string); got != "system:serviceaccount:default:myapp" {
+			t.Fatalf("sub: got %q", got)
+		}
+	})
+
+	t.Run("generic OIDC JWT shape", func(t *testing.T) {
+		tok := mintJWT(`{"iss":"https://accounts.google.com","sub":"1234567890","email":"u@example.com"}`)
+		claims, err := ParseJWTClaimsUnverified(tok)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, _ := claims["sub"].(string); got != "1234567890" {
+			t.Fatalf("sub: got %q", got)
+		}
+		if strings.HasPrefix(claims["sub"].(string), "system:serviceaccount:") {
+			t.Fatal("generic JWT must not look like a K8s SA token")
+		}
+	})
+
+	t.Run("not three segments", func(t *testing.T) {
+		_, err := ParseJWTClaimsUnverified("not.a.jwt.four.segments")
+		if err == nil {
+			t.Fatal("expected error for wrong segment count")
+		}
+	})
+
+	t.Run("payload not base64url", func(t *testing.T) {
+		_, err := ParseJWTClaimsUnverified("header.!!!.signature")
+		if err == nil {
+			t.Fatal("expected error for invalid base64 payload")
+		}
+	})
+
+	t.Run("payload not JSON", func(t *testing.T) {
+		tok := "header." + base64.RawURLEncoding.EncodeToString([]byte("not json")) + ".signature"
+		_, err := ParseJWTClaimsUnverified(tok)
+		if err == nil {
+			t.Fatal("expected error for non-JSON payload")
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, err := ParseJWTClaimsUnverified("")
+		if err == nil {
+			t.Fatal("expected error for empty token")
+		}
+	})
+}

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1318,22 +1318,33 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 	return c.performImplicitAuth(ctx, req, autoAuthPath, authRole)
 }
 
-// performImplicitAuth performs implicit authentication by detecting the credential type
-// (JWT bearer token or TLS client certificate), looking up cached tokens, and performing
-// login if needed. Used by both gateway requests and transparent operations.
+// performImplicitAuth performs implicit authentication by routing through the
+// auth mount the caller's namespace/provider points at, looking up cached
+// tokens, and performing login if needed. Used by both gateway requests and
+// transparent operations.
 //
 // Transparent mode precedence rules:
 //
-//	Credential (first match wins):
-//	  1. X-Warden-Token header → explicit auth, implicit auth skipped entirely
-//	  2. TLS client certificate (via X-SSL-Client-Cert) → implicit cert auth
-//	  3. Authorization: Bearer eyJ... → implicit JWT auth
+//	Outer (handled before this function):
+//	  - X-Warden-Token header → explicit auth, implicit auth skipped entirely.
 //
-//	Auth path (config only, no per-request override):
+//	Auth path (config only, no per-request override — resolved before calling):
 //	  - Gateway: provider auto_auth_path config
 //	  - Operations: namespace auto_auth_path metadata
 //
-//	Auth role (first match wins):
+//	Inside this function:
+//	  1. Resolve the mount at autoAuthPath. Reject if no mount is registered.
+//	  2. Look up the TransparentTokenType registered for that mount's type
+//	     (via the TokenStore registry). Reject if no transparent type serves
+//	     this mount type — that means the mount doesn't support implicit auth.
+//	  3. Dispatch on the TokenType's CredentialFormat() to extract the
+//	     credential the mount expects (TLS client cert vs JWT bearer). Reject
+//	     with a specific error if the caller didn't present that credential.
+//	  4. Compute a deterministic cache key from (mountAccessor + credential
+//	     + role) via the TokenType's LookupValue, look up the cached token,
+//	     fall through to an internal login on miss.
+//
+//	Auth role (first match wins, resolved before calling):
 //	  1. X-Warden-Role header
 //	  2. Request-encoded role: URL path /role/{name}/gateway/... (streaming
 //	     backends) or ?role= query param (access backends)
@@ -1358,38 +1369,44 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		ctx = context.WithValue(ctx, logical.ClientIPKey, req.ClientIP)
 	}
 
-	// Resolve the auth mount once so transparent token types can fold the
-	// stable mount accessor into their cache key. Without this, two mounts
-	// of the same auth type with overlapping role names + the same credential
-	// would silently share a cache entry.
+	// Resolve the auth mount once. mountEntry tells us which TransparentTokenType
+	// serves this mount (via the registry) and supplies the stable mount accessor
+	// that transparent types fold into their cache key.
 	authMountEntry := c.router.MatchingMountEntry(ctx, autoAuthPath)
-	var mountAccessor string
-	if authMountEntry != nil {
-		mountAccessor = authMountEntry.Accessor
+	if authMountEntry == nil {
+		return fmt.Errorf("no auth mount registered at %q for implicit auth", autoAuthPath)
+	}
+	mountAccessor := authMountEntry.Accessor
+
+	// Look up the TransparentTokenType registered for this mount type. If the
+	// mount type isn't a transparent auth method (or isn't registered at all),
+	// reject the request explicitly rather than silently falling back to
+	// credential-format sniffing.
+	ttype := c.tokenStore.GetTransparentTokenTypeForAuthMethod(authMountEntry.Type)
+	if ttype == nil {
+		return fmt.Errorf("auth method %q at %q does not support implicit auth", authMountEntry.Type, autoAuthPath)
 	}
 
-	// Detect credential type: client certificate or JWT bearer token
 	var singleflightKey string
 	var lookupFunc func() (*TokenEntry, error)
 	var loginData map[string]any
 	var credKey string // fingerprint or JWT — used for post-login lookup with resolved role
 
-	// Check for client certificate first (forwarded from LB or direct TLS)
-	clientCert := extractTransparentClientCert(req)
-
-	// Per-credential TransparentTokenType: cert credentials are served by
-	// CertRoleTokenType, JWT-bearer credentials by JWTRoleTokenType. PR2
-	// will replace this credential-format sniff with a registry lookup on
-	// mountEntry.Type so adding a new transparent auth method does not
-	// require touching this switch.
-	var ttype TransparentTokenType
-
-	switch {
-	case clientCert != nil:
-		// Certificate-based transparent auth
+	// Dispatch by the credential's wire-extraction shape. Cases group by what
+	// the credential looks like on the wire (cert vs JWT bearer), not by the
+	// discovery-level CredentialFormat subtype — JWTRoleTokenType ("jwt") and
+	// KubernetesRoleTokenType ("k8s_sa_jwt") both arrive as JWTs in the
+	// Authorization header and share the same parse path. The right TokenType
+	// is selected upstream via mountEntry.Type, so the cache key remains
+	// type-specific even when two formats share an extraction case.
+	switch ttype.CredentialFormat() {
+	case "cert":
+		clientCert := extractTransparentClientCert(req)
+		if clientCert == nil {
+			return fmt.Errorf("auth method %q at %q requires a TLS client certificate", authMountEntry.Type, autoAuthPath)
+		}
 		hash := sha256.Sum256(clientCert.Raw)
 		fingerprint := hex.EncodeToString(hash[:])
-		ttype = &CertRoleTokenType{}
 		sfHash := sha256.Sum256([]byte("cert:" + mountAccessor + ":" + fingerprint + ":" + authRole))
 		singleflightKey = hex.EncodeToString(sfHash[:])
 		loginData = map[string]any{"role": authRole}
@@ -1398,12 +1415,13 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 			return c.LookupTransparentTokenWithRole(ctx, ttype, fingerprint, mountAccessor, authRole)
 		}
 
-	case strings.HasPrefix(req.ClientToken, "eyJ"):
-		// JWT-based transparent auth
+	case "jwt", "k8s_sa_jwt":
 		clientToken := req.ClientToken
-		ttype = &JWTRoleTokenType{}
-		jwtHash := sha256.Sum256([]byte("jwt:" + mountAccessor + ":" + clientToken + ":" + authRole))
-		singleflightKey = hex.EncodeToString(jwtHash[:])
+		if !strings.HasPrefix(clientToken, "eyJ") {
+			return fmt.Errorf("auth method %q at %q requires a JWT bearer token", authMountEntry.Type, autoAuthPath)
+		}
+		sfHash := sha256.Sum256([]byte("jwt:" + mountAccessor + ":" + clientToken + ":" + authRole))
+		singleflightKey = hex.EncodeToString(sfHash[:])
 		loginData = map[string]any{"jwt": clientToken, "role": authRole}
 		credKey = clientToken
 		lookupFunc = func() (*TokenEntry, error) {
@@ -1411,7 +1429,7 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		}
 
 	default:
-		return fmt.Errorf("no valid credential for implicit auth (need JWT bearer token or TLS client certificate)")
+		return fmt.Errorf("auth method %q has unsupported credential format %q for implicit auth", authMountEntry.Type, ttype.CredentialFormat())
 	}
 
 	// Step 1: Try cached lookup

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1372,6 +1372,7 @@ func TestIsTransparentRequest(t *testing.T) {
 func TestHandleTransparentAuth(t *testing.T) {
 	core := createTestCore(t)
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	jwtMount := mountStubAuthMethod(t, core, "jwt/", "jwt")
 
 	t.Run("returns error when no credential provided", func(t *testing.T) {
 		backend := &mockTransparentModeProvider{
@@ -1384,7 +1385,7 @@ func TestHandleTransparentAuth(t *testing.T) {
 
 		err := core.handleTransparentAuth(ctx, req, backend, "terraform")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no valid credential")
+		assert.Contains(t, err.Error(), "requires a JWT bearer token")
 	})
 
 	t.Run("returns error for non-JWT non-cert token", func(t *testing.T) {
@@ -1398,15 +1399,18 @@ func TestHandleTransparentAuth(t *testing.T) {
 
 		err := core.handleTransparentAuth(ctx, req, backend, "terraform")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no valid credential")
+		assert.Contains(t, err.Error(), "requires a JWT bearer token")
 	})
 
 	t.Run("uses existing JWT token when found in cache", func(t *testing.T) {
-		// Create a JWT token using GenerateToken with the jwt_role type
+		// Create a JWT token using GenerateToken with the jwt_role type.
+		// MountAccessor must match the mount's accessor so the cache write and
+		// the subsequent transparent-auth lookup hash to the same key.
 		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.test-sig"
 
 		authData := &AuthData{
 			TokenValue:     sampleJWT,
+			MountAccessor:  jwtMount.Accessor,
 			RoleName:       "terraform",
 			PrincipalID:    "test-user",
 			ExpireAt:       time.Now().Add(24 * time.Hour),
@@ -1431,10 +1435,10 @@ func TestHandleTransparentAuth(t *testing.T) {
 		assert.Equal(t, te.ID, req.TokenEntry().ID)
 	})
 
-	t.Run("returns error when implicit auth fails - auth backend not mounted", func(t *testing.T) {
+	t.Run("returns error when implicit auth fails - unmounted auth path", func(t *testing.T) {
 		backend := &mockTransparentModeProvider{
 			transparentMode: true,
-			autoAuthPath:    "auth/jwt/",
+			autoAuthPath:    "auth/never-mounted/",
 		}
 		// Use a JWT that won't be found in the token store
 		req := &logical.Request{
@@ -1443,8 +1447,9 @@ func TestHandleTransparentAuth(t *testing.T) {
 		}
 
 		err := core.handleTransparentAuth(ctx, req, backend, "terraform")
-		// Should fail because the auth backend is not mounted
+		// Should fail with the new mount-existence guard
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no auth mount registered")
 	})
 }
 
@@ -1453,12 +1458,15 @@ func TestHandleTransparentAuth(t *testing.T) {
 func TestHandleTransparentAuth_Singleflight(t *testing.T) {
 	core := createTestCore(t)
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	jwtMount := mountStubAuthMethod(t, core, "jwt/", "jwt")
 
-	// Create a JWT token using GenerateToken
+	// Create a JWT token using GenerateToken. Must use the mount's accessor
+	// so the cache key matches what the transparent-auth lookup will compute.
 	sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzaW5nbGVmbGlnaHQtdXNlciJ9.test-sig"
 
 	authData := &AuthData{
 		TokenValue:     sampleJWT,
+		MountAccessor:  jwtMount.Accessor,
 		RoleName:       "terraform",
 		PrincipalID:    "test-user-singleflight",
 		ExpireAt:       time.Now().Add(24 * time.Hour),
@@ -1811,6 +1819,8 @@ func TestHandleRequest_ConcurrentWithRootToken(t *testing.T) {
 func TestTransparentOps_NonStreamingPath(t *testing.T) {
 	core := createTestCore(t)
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	jwtMount := mountStubAuthMethod(t, core, "jwt/", "jwt")
+	_ = mountStubAuthMethod(t, core, "cert/", "cert")
 
 	t.Run("X-Warden-Token skips transparent ops", func(t *testing.T) {
 		// When X-Warden-Token is set, transparent ops should be skipped entirely,
@@ -1887,10 +1897,12 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 
 	t.Run("JWT transparent ops with cached token succeeds", func(t *testing.T) {
 		// Pre-create a cached token in root namespace, then verify transparent ops finds it.
+		// The cache must be populated with the mount's accessor so the lookup hash matches.
 		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjYWNoZWQtdXNlciJ9.cached-sig"
 
 		authData := &AuthData{
 			TokenValue:     sampleJWT,
+			MountAccessor:  jwtMount.Accessor,
 			RoleName:       "ops-reader",
 			PrincipalID:    "cached-user",
 			ExpireAt:       time.Now().Add(24 * time.Hour),
@@ -1927,7 +1939,9 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 	})
 
 	t.Run("no credential with auto_auth_path returns auth error", func(t *testing.T) {
-		// No JWT, no cert — namespace has auto_auth_path but no credential
+		// No JWT, no cert — namespace points at a mounted cert auth method
+		// but no client cert was forwarded, so transparent-auth bails with
+		// the credential-mismatch error from the mount-type-keyed dispatch.
 		ns := &namespace.Namespace{
 			ID:   "test-ns-nocred",
 			Path: "nocred/",
@@ -1936,6 +1950,7 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 			},
 		}
 		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+		_ = mountStubAuthMethodInNamespace(t, core, "cert/", "cert", ns)
 
 		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
 		httpReq.Header.Set("X-Warden-Role", "agent")
@@ -1949,7 +1964,7 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.True(t, req.Transparent)
 		assert.NotNil(t, resp.Err)
-		assert.Contains(t, resp.Err.Error(), "no valid credential")
+		assert.Contains(t, resp.Err.Error(), "requires a TLS client certificate")
 	})
 
 	t.Run("namespace auto_auth_path triggers transparent ops", func(t *testing.T) {
@@ -1981,10 +1996,26 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 	t.Run("role query param takes precedence over X-Warden-Role header", func(t *testing.T) {
 		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJwcmVjLXVzZXIifQ.prec-sig"
 
-		// Pre-create cached tokens for both roles
+		// Use a non-root namespace with auto_auth_path metadata + mount the
+		// jwt auth method in that namespace so the router resolves it.
+		ns := &namespace.Namespace{
+			ID:   "test-ns-prec",
+			Path: "prec/",
+			CustomMetadata: map[string]string{
+				"auto_auth_path": "auth/jwt/",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+		precMount := mountStubAuthMethodInNamespace(t, core, "jwt/", "jwt", ns)
+
+		// Pre-create cached tokens for both roles. Token namespace is root
+		// (the fake `prec/` namespace isn't in the namespace store, so token
+		// resolution would fail), but the cache key uses the per-mount
+		// accessor — which is what performImplicitAuth threads in.
 		for _, roleName := range []string{"from-query", "from-header"} {
 			authData := &AuthData{
 				TokenValue:     sampleJWT,
+				MountAccessor:  precMount.Accessor,
 				RoleName:       roleName,
 				PrincipalID:    "prec-user",
 				ExpireAt:       time.Now().Add(24 * time.Hour),
@@ -1994,15 +2025,6 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 			_, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, authData)
 			require.NoError(t, err)
 		}
-
-		ns := &namespace.Namespace{
-			ID:   "test-ns-prec",
-			Path: "prec/",
-			CustomMetadata: map[string]string{
-				"auto_auth_path": "auth/jwt/",
-			},
-		}
-		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
 
 		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources?role=from-query", nil)
 		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)
@@ -2022,17 +2044,6 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 	t.Run("X-Warden-Role header used when no role query param", func(t *testing.T) {
 		sampleJWT := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWxsYmFjay11c2VyIn0.fallback-sig"
 
-		authData := &AuthData{
-			TokenValue:     sampleJWT,
-			RoleName:       "from-header",
-			PrincipalID:    "fallback-user",
-			ExpireAt:       time.Now().Add(24 * time.Hour),
-			Policies:       []string{"default"},
-			CredentialSpec: "test-spec",
-		}
-		_, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, authData)
-		require.NoError(t, err)
-
 		ns := &namespace.Namespace{
 			ID:   "test-ns-fallback",
 			Path: "fallback/",
@@ -2041,6 +2052,21 @@ func TestTransparentOps_NonStreamingPath(t *testing.T) {
 			},
 		}
 		nsCtx := namespace.ContextWithNamespace(context.Background(), ns)
+		fallbackMount := mountStubAuthMethodInNamespace(t, core, "jwt/", "jwt", ns)
+
+		authData := &AuthData{
+			TokenValue:     sampleJWT,
+			MountAccessor:  fallbackMount.Accessor,
+			RoleName:       "from-header",
+			PrincipalID:    "fallback-user",
+			ExpireAt:       time.Now().Add(24 * time.Hour),
+			Policies:       []string{"default"},
+			CredentialSpec: "test-spec",
+		}
+		// Token namespace is root (the fake `fallback/` namespace isn't in
+		// the namespace store); cache key uses the per-mount accessor.
+		_, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, authData)
+		require.NoError(t, err)
 
 		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/cred/sources", nil)
 		httpReq.Header.Set("Authorization", "Bearer "+sampleJWT)

--- a/core/sys_introspect.go
+++ b/core/sys_introspect.go
@@ -12,6 +12,7 @@ import (
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"golang.org/x/sync/errgroup"
 
+	authhelper "github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/listener"
@@ -24,9 +25,15 @@ import (
 const aggregateIntrospectConcurrency = 10
 
 // pathIntrospectRoles exposes GET /v1/sys/introspect/roles.
-// The endpoint detects the caller's identity type (JWT or cert), finds
-// every auth mount of that type in the caller's namespace, fans out an
-// `introspect/roles` call to each, and aggregates the union.
+// The endpoint detects the caller's credential format (TLS client cert,
+// generic JWT, or Kubernetes SA JWT) and fans out an `introspect/roles`
+// call to every auth mount in the caller's namespace whose registered
+// TokenType reports a matching CredentialFormat. Results are merged into
+// a single roles[] union, with per-mount failures collected into warnings[].
+//
+// Exact-match filtering is deliberate: a generic JWT never fans out to
+// kubernetes mounts (which would burn a TokenReview round-trip the spoke
+// cannot satisfy), and a K8s SA token never fans out to generic JWT mounts.
 //
 // Autonomous agents present their identity vehicle with each request and
 // must specify a role so Warden's transparent auth can resolve a cred
@@ -69,7 +76,7 @@ func (b *SystemBackend) pathIntrospectRoles() []*framework.Path {
 				},
 			},
 			HelpSynopsis:    "Discover roles the presented identity can assume",
-			HelpDescription: "Fans out to every auth mount of the detected identity type (JWT or cert) in the current namespace and returns the union of roles each mount reports the identity can assume.",
+			HelpDescription: "Fans out to every auth mount in the current namespace whose registered TokenType matches the caller's credential format (cert, jwt, or k8s_sa_jwt) and returns the union of roles each mount reports the identity can assume.",
 		},
 	}
 }
@@ -83,8 +90,8 @@ type aggregatedRole struct {
 }
 
 func (b *SystemBackend) handleIntrospectRoles(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	credType := detectIntrospectCredType(req)
-	if credType == "" {
+	credFormat := detectIntrospectCredentialFormat(req)
+	if credFormat == "" {
 		return &logical.Response{
 			StatusCode: http.StatusUnauthorized,
 			Err:        fmt.Errorf("introspection requires a JWT bearer token or TLS client certificate"),
@@ -98,11 +105,19 @@ func (b *SystemBackend) handleIntrospectRoles(ctx context.Context, req *logical.
 
 	// Snapshot matching mount entries under the lock, then release before
 	// dispatching so that concurrent mount writes are not blocked on our
-	// in-process fan-out.
+	// in-process fan-out. The filter asks the registry "what TokenType
+	// serves this mount, and does its CredentialFormat exactly match what
+	// the caller presented?" — exact-match so a generic JWT never fans out
+	// to a kubernetes mount (which would burn a TokenReview round-trip)
+	// and vice versa.
 	b.core.mountsLock.RLock()
 	matching := make([]*MountEntry, 0)
 	for _, entry := range b.core.mounts.Entries {
-		if entry.Class != mountClassAuth || entry.NamespaceID != ns.ID || entry.Type != credType {
+		if entry.Class != mountClassAuth || entry.NamespaceID != ns.ID {
+			continue
+		}
+		tt := b.core.tokenStore.GetTransparentTokenTypeForAuthMethod(entry.Type)
+		if tt == nil || tt.CredentialFormat() != credFormat {
 			continue
 		}
 		matching = append(matching, entry)
@@ -226,18 +241,33 @@ func (b *SystemBackend) introspectMount(ctx context.Context, parent *logical.Req
 	return out, nil
 }
 
-// detectIntrospectCredType mirrors the identity-type detection in
-// performImplicitAuth: client cert takes precedence, then JWT via
-// Authorization: Bearer. Returns "" if neither is present.
-func detectIntrospectCredType(req *logical.Request) string {
+// detectIntrospectCredentialFormat returns the discovery-level credential
+// kind the caller presented: "cert" for a forwarded TLS client certificate,
+// "k8s_sa_jwt" for a Kubernetes service-account JWT (recognized by its
+// mandatory `sub: system:serviceaccount:*` claim), or "jwt" for any other
+// JWT bearer token. Returns "" if neither cert nor bearer JWT was sent.
+//
+// The K8s subtype is detected via an unverified claims parse — signature
+// validation happens later, inside the mount that the aggregator fans out
+// to. Using the subtype here lets the aggregator route K8s SA tokens only
+// to kubernetes mounts and avoid burning a TokenReview round-trip against
+// the spoke for a token it cannot authenticate.
+func detectIntrospectCredentialFormat(req *logical.Request) string {
 	if req.HTTPRequest == nil {
 		return ""
 	}
 	if cert := listener.ForwardedClientCert(req.HTTPRequest.Context()); cert != nil {
 		return "cert"
 	}
-	if auth := req.HTTPRequest.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
-		return "jwt"
+	auth := req.HTTPRequest.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return ""
 	}
-	return ""
+	jwt := strings.TrimPrefix(auth, "Bearer ")
+	if claims, err := authhelper.ParseJWTClaimsUnverified(jwt); err == nil {
+		if sub, _ := claims["sub"].(string); strings.HasPrefix(sub, "system:serviceaccount:") {
+			return "k8s_sa_jwt"
+		}
+	}
+	return "jwt"
 }

--- a/core/sys_introspect_test.go
+++ b/core/sys_introspect_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -88,7 +89,7 @@ func (b *introspectMockBackend) SpecialPaths() *logical.Paths        { return ni
 func (b *introspectMockBackend) ExtractToken(r *http.Request) string { return "" }
 
 // jwtRequest builds a system-backend request with an Authorization: Bearer
-// header, which the aggregator interprets as credType = "jwt".
+// header, which the aggregator interprets as CredentialFormat = "jwt".
 func jwtRequest(t *testing.T) *logical.Request {
 	t.Helper()
 	httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/introspect/roles", nil)
@@ -102,7 +103,7 @@ func jwtRequest(t *testing.T) *logical.Request {
 
 // certRequest builds a system-backend request carrying a forwarded
 // client certificate in the HTTP request context, which the aggregator
-// interprets as credType = "cert".
+// interprets as CredentialFormat = "cert".
 func certRequest(t *testing.T) *logical.Request {
 	t.Helper()
 	cert := &x509.Certificate{
@@ -119,19 +120,31 @@ func certRequest(t *testing.T) *logical.Request {
 	}
 }
 
-func TestDetectIntrospectCredType(t *testing.T) {
+func TestDetectIntrospectCredentialFormat(t *testing.T) {
 	t.Run("no HTTP request returns empty", func(t *testing.T) {
-		assert.Equal(t, "", detectIntrospectCredType(&logical.Request{}))
+		assert.Equal(t, "", detectIntrospectCredentialFormat(&logical.Request{}))
 	})
-	t.Run("Authorization: Bearer returns jwt", func(t *testing.T) {
+	t.Run("Authorization: Bearer with non-parseable JWT returns jwt (default)", func(t *testing.T) {
 		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
 		httpReq.Header.Set("Authorization", "Bearer eyJ.abc.def")
-		assert.Equal(t, "jwt", detectIntrospectCredType(&logical.Request{HTTPRequest: httpReq}))
+		assert.Equal(t, "jwt", detectIntrospectCredentialFormat(&logical.Request{HTTPRequest: httpReq}))
+	})
+	t.Run("generic JWT (sub is opaque) returns jwt", func(t *testing.T) {
+		jwt := mintK8sJWT(`{"iss":"https://accounts.google.com","sub":"1234567890"}`)
+		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+jwt)
+		assert.Equal(t, "jwt", detectIntrospectCredentialFormat(&logical.Request{HTTPRequest: httpReq}))
+	})
+	t.Run("K8s SA token (sub starts with system:serviceaccount:) returns k8s_sa_jwt", func(t *testing.T) {
+		jwt := mintK8sJWT(`{"iss":"https://kubernetes.default.svc","sub":"system:serviceaccount:default:myapp"}`)
+		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
+		httpReq.Header.Set("Authorization", "Bearer "+jwt)
+		assert.Equal(t, "k8s_sa_jwt", detectIntrospectCredentialFormat(&logical.Request{HTTPRequest: httpReq}))
 	})
 	t.Run("no Bearer prefix returns empty", func(t *testing.T) {
 		httpReq := httptest.NewRequest(http.MethodGet, "/x", nil)
 		httpReq.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
-		assert.Equal(t, "", detectIntrospectCredType(&logical.Request{HTTPRequest: httpReq}))
+		assert.Equal(t, "", detectIntrospectCredentialFormat(&logical.Request{HTTPRequest: httpReq}))
 	})
 	t.Run("forwarded client cert returns cert (takes precedence over JWT)", func(t *testing.T) {
 		cert := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "c"}}
@@ -139,8 +152,17 @@ func TestDetectIntrospectCredType(t *testing.T) {
 		httpReq.Header.Set("Authorization", "Bearer eyJ.abc.def")
 		ctx := listener.WithForwardedClientCert(httpReq.Context(), cert)
 		httpReq = httpReq.WithContext(ctx)
-		assert.Equal(t, "cert", detectIntrospectCredType(&logical.Request{HTTPRequest: httpReq}))
+		assert.Equal(t, "cert", detectIntrospectCredentialFormat(&logical.Request{HTTPRequest: httpReq}))
 	})
+}
+
+// mintK8sJWT returns a well-formed (but unsigned) JWT with the given payload.
+// Used by the format-detection tests to exercise the unverified claims-parse path.
+func mintK8sJWT(payloadJSON string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature"))
+	return header + "." + payload + "." + signature
 }
 
 func TestSystemBackend_Introspect_Unauthenticated(t *testing.T) {
@@ -233,6 +255,41 @@ func TestSystemBackend_Introspect_FilterByCredType(t *testing.T) {
 	require.Len(t, roles, 1)
 	assert.Equal(t, "cert-role", roles[0].Name)
 	assert.Equal(t, "cert-mount/", roles[0].AuthPath)
+}
+
+// TestSystemBackend_Introspect_K8sSAToken_DoesNotFanOutToJWTMounts pins the
+// granular CredentialFormat behavior introduced with PR2: a Kubernetes SA
+// JWT (sub starts with system:serviceaccount:) is detected as "k8s_sa_jwt"
+// and must NOT fan out to generic JWT mounts (whose CredentialFormat is
+// "jwt"). Without this, a workload presenting an EKS SA token would force
+// every JWT mount in the namespace to do a JWKS validation against a token
+// it cannot authenticate.
+//
+// The mirror case (k8s_sa_jwt → kubernetes mounts) lands with PR3 when
+// KubernetesRoleTokenType is registered with AuthMethodType="kubernetes"
+// and CredentialFormat="k8s_sa_jwt".
+func TestSystemBackend_Introspect_K8sSAToken_DoesNotFanOutToJWTMounts(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	core.authMethods["jwt"] = ctrl.factory()
+	require.NoError(t, core.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "jwt-mount/"}))
+	ctrl.rolesByMount["auth/jwt-mount/"] = []map[string]any{{"name": "jwt-role"}}
+
+	// Build a request carrying a Kubernetes SA JWT.
+	k8sJWT := mintK8sJWT(`{"iss":"https://kubernetes.default.svc","sub":"system:serviceaccount:default:myapp"}`)
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/introspect/roles", nil)
+	httpReq.Header.Set("Authorization", "Bearer "+k8sJWT)
+	req := &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "introspect/roles",
+		HTTPRequest: httpReq,
+	}
+
+	resp, err := backend.handleIntrospectRoles(ctx, req, nil)
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]aggregatedRole)
+	assert.Empty(t, roles, "K8s SA token must not fan out to generic JWT mounts")
 }
 
 func TestSystemBackend_Introspect_MountError_AppearsInWarnings(t *testing.T) {

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -11,8 +11,11 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/hashicorp/go-uuid"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stephnangue/warden/audit"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/credential/drivers"
@@ -585,4 +588,55 @@ func createTestCore(t *testing.T) *Core {
 	_ = core.setupMounts(ctx)
 
 	return core
+}
+
+// mountStubAuthMethod registers a stub auth mount at the given mountPath
+// (e.g. "jwt/") with the given mountType (e.g. "jwt", "cert") in the root
+// namespace. See mountStubAuthMethodInNamespace for non-root mounts.
+//
+// The mount has no backend — it exists only so router lookups
+// (MatchingMountEntry) succeed and tests can exercise code paths that
+// need a real MountEntry (mount accessor, entry.Type) without spinning
+// up the full auth-method factory. Returns the created MountEntry.
+//
+// The router path becomes authRoutePrefix + mountPath ("auth/jwt/"). Pass
+// the same value to tests that drive performImplicitAuth via autoAuthPath.
+func mountStubAuthMethod(t *testing.T, c *Core, mountPath, mountType string) *MountEntry {
+	t.Helper()
+	return mountStubAuthMethodInNamespace(t, c, mountPath, mountType, namespace.RootNamespace)
+}
+
+// mountStubAuthMethodInNamespace is the namespace-aware variant of
+// mountStubAuthMethod. The router prefix becomes ns.Path + "auth/" + mountPath
+// so MatchingMountEntry called with a request context in the same namespace
+// will resolve it.
+func mountStubAuthMethodInNamespace(t *testing.T, c *Core, mountPath, mountType string, ns *namespace.Namespace) *MountEntry {
+	t.Helper()
+
+	accessor, err := c.generateMountAccessor(mountType)
+	require.NoError(t, err)
+	backendUUID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	mountUUID, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	entry := &MountEntry{
+		Class:            mountClassAuth,
+		Path:             mountPath,
+		Type:             mountType,
+		UUID:             mountUUID,
+		Accessor:         accessor,
+		BackendAwareUUID: backendUUID,
+		NamespaceID:      ns.ID,
+		namespace:        ns,
+	}
+
+	view := NewBarrierView(c.barrier, "auth/"+entry.UUID+"/")
+	require.NoError(t, c.router.Mount(authRoutePrefix+mountPath, nil, entry, view))
+
+	c.mountsLock.Lock()
+	c.mounts.Entries = append(c.mounts.Entries, entry)
+	c.mountsLock.Unlock()
+
+	return entry
 }


### PR DESCRIPTION
## Summary

- Replaces credential-format sniffing in `performImplicitAuth` (cert vs `eyJ` prefix) with mount-type-driven dispatch through the `TransparentTokenType` registry from the prior PR. Per-mount actionable errors replace the generic "no valid credential" catch-all.
- Fixes the same antipattern in `handleIntrospectRoles` + `detectIntrospectCredentialFormat` (renamed from `detectIntrospectCredType`). New detection distinguishes Kubernetes SA tokens (`k8s_sa_jwt`) from generic JWTs via an unverified `sub` claim parse; new filter uses registry-aware `tt.CredentialFormat() != detected` exact-match.
- Closes the latent bug where the introspect aggregator would silently fan out a K8s SA token to JWT mounts (burning JWKS validation against a token the spoke can't authenticate) and never reach kubernetes mounts.

New helper `auth/helper/ParseJWTClaimsUnverified` for cheap shape-sniffing without signature verification. The kubernetes auth method's `iss` pre-filter (next PR in the stack) will reuse it.

Test helpers `mountStubAuthMethod` / `mountStubAuthMethodInNamespace` let tests register real `MountEntry` objects for the router without spinning up auth-method factories. New test pins the K8s-SA-token-does-not-fan-out-to-JWT-mounts behavior.

**Stacked on top of the transparent-auth foundations PR** — review that one first. Third PR in the stack (`kubernetes` auth method) coming next.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full unit suite green
- [x] `make test-e2e` — 3-node HA cluster green (213 tests across 14 e2e packages)
- [x] Bug-for-bug parity verified for JWT/cert transparent auth
- [x] New test: `TestSystemBackend_Introspect_K8sSAToken_DoesNotFanOutToJWTMounts`
