### PR TITLE
refactor(helper): extract HTTP utilities to helper/httputil

### DIFF
--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -369,7 +370,7 @@ func (d *AlicloudDriver) callSignedJSON(
 	var lastErr error
 	for attempt := 0; attempt < alicloudMaxRetryAttempts; attempt++ {
 		if attempt > 0 {
-			// Exponential backoff + 20% jitter, mirrors ExecuteWithRetry's math.
+			// Exponential backoff + 20% jitter, mirrors httputil.ExecuteWithRetry's math.
 			backoff := time.Second * time.Duration(1<<uint(attempt-1))
 			jitter := time.Duration(rand.Int63n(int64(backoff) / 5))
 			select {
@@ -412,7 +413,7 @@ func (d *AlicloudDriver) callSignedJSON(
 		// back as readable bodies (which the helper would otherwise drop) and
 		// can be classified by Code: EntityNotExist.* on 404, NoPermission on
 		// 403, Throttling/InvalidParameter on 400.
-		httpReq := HTTPRequest{
+		httpReq := httputil.HTTPRequest{
 			Method:  method,
 			URL:     u.String(),
 			Headers: headers,
@@ -423,12 +424,12 @@ func (d *AlicloudDriver) callSignedJSON(
 				http.StatusNotFound,
 			},
 		}
-		retry := HTTPRetryConfig{
+		retry := httputil.HTTPRetryConfig{
 			MaxAttempts: 1,
 			MaxBodySize: alicloudMaxResponseBodySize,
 		}
 
-		respBody, status, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retry)
+		respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retry)
 		if err != nil {
 			// Transport error or non-OK HTTP status. Retry on transient HTTP
 			// codes (429 and 5xx); surface anything else immediately.

--- a/credential/drivers/db_helpers_test.go
+++ b/credential/drivers/db_helpers_test.go
@@ -1,14 +1,16 @@
 package drivers
 
 import (
-	"testing"
-
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/helper/httputil"
 )
 
 func TestDefaultPortForEngine(t *testing.T) {
@@ -28,20 +30,20 @@ func TestReadLimitedBody(t *testing.T) {
 }
 
 // =============================================================================
-// HTTPRetryConfig Tests
+// httputil.HTTPRetryConfig Tests
 // =============================================================================
 
 func TestDefaultHTTPRetryConfig(t *testing.T) {
-	cfg := DefaultHTTPRetryConfig()
+	cfg := httputil.DefaultHTTPRetryConfig()
 	assert.Equal(t, 3, cfg.MaxAttempts)
-	assert.Equal(t, int64(DefaultMaxBodySize), cfg.MaxBodySize)
+	assert.Equal(t, int64(httputil.DefaultMaxBodySize), cfg.MaxBodySize)
 	assert.Contains(t, cfg.RetryableStatuses, 429)
 	assert.Equal(t, 1*time.Second, cfg.BaseBackoff)
 	assert.Equal(t, 20, cfg.JitterPercent)
 }
 
 // =============================================================================
-// ExecuteWithRetry Tests
+// httputil.ExecuteWithRetry Tests
 // =============================================================================
 
 func TestExecuteWithRetry_Success(t *testing.T) {
@@ -51,11 +53,11 @@ func TestExecuteWithRetry_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, status, err := ExecuteWithRetry(
+	body, status, err := httputil.ExecuteWithRetry(
 		context.Background(),
 		srv.Client(),
-		HTTPRequest{Method: "GET", URL: srv.URL},
-		DefaultHTTPRetryConfig(),
+		httputil.HTTPRequest{Method: "GET", URL: srv.URL},
+		httputil.DefaultHTTPRetryConfig(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, status)
@@ -69,11 +71,11 @@ func TestExecuteWithRetry_NonRetryableError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, status, err := ExecuteWithRetry(
+	_, status, err := httputil.ExecuteWithRetry(
 		context.Background(),
 		srv.Client(),
-		HTTPRequest{Method: "GET", URL: srv.URL},
-		DefaultHTTPRetryConfig(),
+		httputil.HTTPRequest{Method: "GET", URL: srv.URL},
+		httputil.DefaultHTTPRetryConfig(),
 	)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusForbidden, status)
@@ -86,15 +88,15 @@ func TestExecuteWithRetry_WithExplicitOKStatuses(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, status, err := ExecuteWithRetry(
+	body, status, err := httputil.ExecuteWithRetry(
 		context.Background(),
 		srv.Client(),
-		HTTPRequest{
+		httputil.HTTPRequest{
 			Method:     "POST",
 			URL:        srv.URL,
 			OKStatuses: []int{http.StatusCreated},
 		},
-		DefaultHTTPRetryConfig(),
+		httputil.DefaultHTTPRetryConfig(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, status)
@@ -105,13 +107,13 @@ func TestExecuteWithRetry_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, _, err := ExecuteWithRetry(
+	_, _, err := httputil.ExecuteWithRetry(
 		ctx,
 		&http.Client{},
-		HTTPRequest{Method: "GET", URL: "http://localhost:1"},
-		HTTPRetryConfig{
+		httputil.HTTPRequest{Method: "GET", URL: "http://localhost:1"},
+		httputil.HTTPRetryConfig{
 			MaxAttempts:       3,
-			MaxBodySize:       DefaultMaxBodySize,
+			MaxBodySize:       httputil.DefaultMaxBodySize,
 			RetryableStatuses: []int{429},
 			BaseBackoff:       1 * time.Millisecond,
 			JitterPercent:     20,
@@ -134,13 +136,13 @@ func TestExecuteWithRetry_RetryOn5xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, status, err := ExecuteWithRetry(
+	body, status, err := httputil.ExecuteWithRetry(
 		context.Background(),
 		srv.Client(),
-		HTTPRequest{Method: "GET", URL: srv.URL},
-		HTTPRetryConfig{
+		httputil.HTTPRequest{Method: "GET", URL: srv.URL},
+		httputil.HTTPRetryConfig{
 			MaxAttempts:       3,
-			MaxBodySize:       DefaultMaxBodySize,
+			MaxBodySize:       httputil.DefaultMaxBodySize,
 			RetryableStatuses: []int{500}, // 500 means all 5xx
 			BaseBackoff:       1 * time.Millisecond,
 			JitterPercent:     10,
@@ -162,17 +164,17 @@ func TestExecuteWithRetry_WithHeaders(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, status, err := ExecuteWithRetry(
+	_, status, err := httputil.ExecuteWithRetry(
 		context.Background(),
 		srv.Client(),
-		HTTPRequest{
+		httputil.HTTPRequest{
 			Method: "GET",
 			URL:    srv.URL,
 			Headers: map[string]string{
 				"Authorization": "Bearer test-token",
 			},
 		},
-		DefaultHTTPRetryConfig(),
+		httputil.DefaultHTTPRetryConfig(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, status)
@@ -184,15 +186,15 @@ func TestExecuteWithRetry_WithBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, status, err := ExecuteWithRetry(
+	_, status, err := httputil.ExecuteWithRetry(
 		context.Background(),
 		srv.Client(),
-		HTTPRequest{
+		httputil.HTTPRequest{
 			Method: "POST",
 			URL:    srv.URL,
 			Body:   []byte(`{"key":"value"}`),
 		},
-		DefaultHTTPRetryConfig(),
+		httputil.DefaultHTTPRetryConfig(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, status)

--- a/credential/drivers/elastic_driver.go
+++ b/credential/drivers/elastic_driver.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -481,7 +482,7 @@ func (d *ElasticDriver) doElasticRequest(ctx context.Context, method, path strin
 		headers["Content-Type"] = "application/json"
 	}
 
-	return ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+	return httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
 		Method:  method,
 		URL:     elasticURL + path,
 		Body:    body,
@@ -490,11 +491,11 @@ func (d *ElasticDriver) doElasticRequest(ctx context.Context, method, path strin
 }
 
 // defaultElasticRetryConfig returns the standard retry configuration for Elasticsearch API calls.
-func defaultElasticRetryConfig() HTTPRetryConfig {
-	return HTTPRetryConfig{
+func defaultElasticRetryConfig() httputil.HTTPRetryConfig {
+	return httputil.HTTPRetryConfig{
 		MaxAttempts:       3,
 		MaxBodySize:       elasticMaxResponseBodySize,
-		RetryableStatuses: []int{429, 500}, // 500 = wildcard for all 5xx (see ExecuteWithRetry)
+		RetryableStatuses: []int{429, 500}, // 500 = wildcard for all 5xx (see httputil.ExecuteWithRetry)
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -515,7 +516,7 @@ func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest, maxA
 	}
 
 	// Configure retry behavior (no automatic retries by default)
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       maxAttempts,
 		MaxBodySize:       gcpMaxResponseBodySize,
 		RetryableStatuses: []int{}, // GCP doesn't retry by default
@@ -523,7 +524,7 @@ func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest, maxA
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:     apiReq.method,
 		URL:        apiReq.url,
 		Body:       apiReq.body,
@@ -531,7 +532,7 @@ func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest, maxA
 		OKStatuses: apiReq.okStatuses,
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", apiReq.operation, err)
 	}

--- a/credential/drivers/github_driver.go
+++ b/credential/drivers/github_driver.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -329,7 +330,7 @@ func (d *GitHubDriver) doGitHubRequest(ctx context.Context, method, path string,
 	}
 
 	// Configure retry behavior (retry on 429 and 5xx)
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       githubMaxRetryAttempts,
 		MaxBodySize:       githubMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500}, // 429 and all 5xx
@@ -337,14 +338,14 @@ func (d *GitHubDriver) doGitHubRequest(ctx context.Context, method, path string,
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:  method,
 		URL:     apiURL,
 		Body:    body,
 		Headers: headers,
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil && d.logger != nil {
 		d.logger.Warn("GitHub API request failed", logger.String("error", err.Error()))
 	}

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -588,7 +589,7 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 	}
 
 	// Configure retry behavior (only retry on rate limiting)
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       gitlabMaxRetryAttempts,
 		MaxBodySize:       gitlabMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests}, // 429 only
@@ -596,14 +597,14 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:  method,
 		URL:     apiURL,
 		Body:    body,
 		Headers: headers,
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil && d.logger != nil {
 		d.logger.Warn("GitLab API request failed", logger.String("error", err.Error()))
 	}

--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -279,7 +280,7 @@ func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path strin
 		headers["X-Grafana-Org-Id"] = orgID
 	}
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       grafanaMaxRetryAttempts,
 		MaxBodySize:       grafanaMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -287,14 +288,14 @@ func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path strin
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:  method,
 		URL:     apiURL,
 		Body:    body,
 		Headers: headers,
 	}
 
-	respBody, status, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil && d.logger != nil {
 		d.logger.Warn("Grafana API request failed",
 			logger.String("method", method),

--- a/credential/drivers/honeycomb_driver.go
+++ b/credential/drivers/honeycomb_driver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -325,7 +326,7 @@ func (d *HoneycombDriver) VerifySpec(ctx context.Context, spec *credential.CredS
 // --- HTTP helpers ---
 
 // honeycombRetryConfig is the shared retry configuration for all Honeycomb API calls.
-var honeycombRetryConfig = HTTPRetryConfig{
+var honeycombRetryConfig = httputil.HTTPRetryConfig{
 	MaxAttempts:       honeycombMaxRetryAttempts,
 	MaxBodySize:       honeycombMaxResponseBodySize,
 	RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -347,7 +348,7 @@ func (d *HoneycombDriver) doHoneycombRequest(ctx context.Context, method, path s
 		headers["Content-Type"] = honeycombContentType
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:     method,
 		URL:        apiURL,
 		Body:       body,
@@ -355,7 +356,7 @@ func (d *HoneycombDriver) doHoneycombRequest(ctx context.Context, method, path s
 		OKStatuses: okStatuses,
 	}
 
-	respBody, status, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, honeycombRetryConfig)
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, honeycombRetryConfig)
 	if err != nil && d.logger != nil {
 		d.logger.Warn("Honeycomb API request failed",
 			logger.String("method", method),

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -462,7 +463,7 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 		return fmt.Errorf("failed to marshal API key details request: %w", err)
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
 		Method: "POST",
 		URL:    iamEndpoint + "/v1/apikeys/details",
 		Body:   reqBody,
@@ -523,7 +524,7 @@ func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, 
 		return "", "", fmt.Errorf("failed to marshal create API key request: %w", err)
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
 		Method: "POST",
 		URL:    iamEndpoint + "/v1/apikeys",
 		Body:   reqBody,
@@ -556,7 +557,7 @@ func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, 
 func (d *IBMDriver) deleteAPIKey(ctx context.Context, iamToken, apiKeyID string) error {
 	iamEndpoint := d.getIAMEndpoint()
 
-	_, _, err := ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
 		Method: "DELETE",
 		URL:    fmt.Sprintf("%s/v1/apikeys/%s", iamEndpoint, url.PathEscape(apiKeyID)),
 		Headers: map[string]string{
@@ -577,11 +578,11 @@ func (d *IBMDriver) getIAMEndpoint() string {
 }
 
 // defaultIBMRetryConfig returns the standard retry configuration for IBM Cloud API calls.
-func defaultIBMRetryConfig() HTTPRetryConfig {
-	return HTTPRetryConfig{
+func defaultIBMRetryConfig() httputil.HTTPRetryConfig {
+	return httputil.HTTPRetryConfig{
 		MaxAttempts:       3,
 		MaxBodySize:       ibmMaxResponseBodySize,
-		RetryableStatuses: []int{429, 500}, // 500 = wildcard for all 5xx (see ExecuteWithRetry)
+		RetryableStatuses: []int{429, 500}, // 500 = wildcard for all 5xx (see httputil.ExecuteWithRetry)
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}

--- a/credential/drivers/ibm_iam.go
+++ b/credential/drivers/ibm_iam.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/stephnangue/warden/helper/httputil"
 )
 
 // ibmIAMTokenResponse represents the IBM Cloud IAM token endpoint response.
@@ -40,7 +42,7 @@ func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, 
 		"apikey":     {apiKey},
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, httpClient, HTTPRequest{
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, httpClient, httputil.HTTPRequest{
 		Method: "POST",
 		URL:    iamEndpoint + "/identity/token",
 		Body:   []byte(form.Encode()),

--- a/credential/drivers/kubernetes_driver.go
+++ b/credential/drivers/kubernetes_driver.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -501,7 +502,7 @@ func (d *KubernetesDriver) doK8sRequestWith(ctx context.Context, k8sURL, token, 
 		headers["Content-Type"] = "application/json"
 	}
 
-	return ExecuteWithRetry(ctx, d.httpClient, HTTPRequest{
+	return httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
 		Method:  method,
 		URL:     k8sURL + path,
 		Body:    body,
@@ -510,8 +511,8 @@ func (d *KubernetesDriver) doK8sRequestWith(ctx context.Context, k8sURL, token, 
 }
 
 // defaultK8sRetryConfig returns the standard retry configuration for Kubernetes API calls.
-func defaultK8sRetryConfig() HTTPRetryConfig {
-	return HTTPRetryConfig{
+func defaultK8sRetryConfig() httputil.HTTPRetryConfig {
+	return httputil.HTTPRetryConfig{
 		MaxAttempts:       3,
 		MaxBodySize:       k8sMaxResponseBodySize,
 		RetryableStatuses: []int{429, 500},

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -213,15 +214,15 @@ func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.Cred
 		form.Set(k, v)
 	}
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       oauth2MaxRetryAttempts,
-		MaxBodySize:       DefaultMaxBodySize,
+		MaxBodySize:       httputil.DefaultMaxBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodPost,
 		URL:    credential.GetString(config, "token_url", ""),
 		Body:   []byte(form.Encode()),
@@ -231,7 +232,7 @@ func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.Cred
 		},
 	}
 
-	body, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	body, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, err)
 	}
@@ -299,21 +300,21 @@ func (d *OAuth2Driver) VerifySpec(ctx context.Context, spec *credential.CredSpec
 
 	method := credential.GetString(d.credSource.Config, "verify_method", http.MethodGet)
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       oauth2MaxRetryAttempts,
-		MaxBodySize:       DefaultMaxBodySize,
+		MaxBodySize:       httputil.DefaultMaxBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:  method,
 		URL:     verifyURL,
 		Headers: headers,
 	}
 
-	_, _, err = ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, _, err = httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return fmt.Errorf("%s OAuth2 token verification failed: %w", name, err)
 	}

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -203,7 +204,7 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 		"client_secret": {clientSecret},
 	}
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       ovhMaxRetryAttempts,
 		MaxBodySize:       ovhMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
@@ -211,7 +212,7 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodPost,
 		URL:    d.tokenURL,
 		Body:   []byte(formData.Encode()),
@@ -221,7 +222,7 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 		},
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return "", 0, fmt.Errorf("OAuth2 token request failed: %w", err)
 	}
@@ -277,7 +278,7 @@ type s3CredentialResult struct {
 func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, userID string) (*s3CredentialResult, error) {
 	apiURL := fmt.Sprintf("%s/cloud/project/%s/user/%s/s3Credentials", d.apiURL, projectID, userID)
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       ovhMaxRetryAttempts,
 		MaxBodySize:       ovhMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
@@ -285,7 +286,7 @@ func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, u
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodPost,
 		URL:    apiURL,
 		Headers: map[string]string{
@@ -295,7 +296,7 @@ func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, u
 		},
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OVH S3 credentials: %w", err)
 	}
@@ -406,7 +407,7 @@ func (d *OVHDriver) Revoke(ctx context.Context, leaseID string) error {
 
 	apiURL := fmt.Sprintf("%s/cloud/project/%s/user/%s/s3Credentials/%s", d.apiURL, projectID, userID, accessKeyID)
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       ovhMaxRetryAttempts,
 		MaxBodySize:       ovhMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
@@ -414,7 +415,7 @@ func (d *OVHDriver) Revoke(ctx context.Context, leaseID string) error {
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodDelete,
 		URL:    apiURL,
 		Headers: map[string]string{
@@ -424,7 +425,7 @@ func (d *OVHDriver) Revoke(ctx context.Context, leaseID string) error {
 		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
 	}
 
-	_, _, err = ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, _, err = httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return fmt.Errorf("failed to revoke OVH S3 credentials %s: %w", accessKeyID, err)
 	}

--- a/credential/drivers/scaleway_driver.go
+++ b/credential/drivers/scaleway_driver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -229,7 +230,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 
 	apiURL := d.iamURL("/api-keys")
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       scalewayMaxRetryAttempts,
 		MaxBodySize:       scalewayMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -237,7 +238,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodPost,
 		URL:    apiURL,
 		Body:   bodyJSON,
@@ -248,7 +249,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		},
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return nil, 0, "", fmt.Errorf("failed to create Scaleway API key: %w", err)
 	}
@@ -303,7 +304,7 @@ func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
 
 	apiURL := d.iamURL("/api-keys/" + leaseID)
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       scalewayMaxRetryAttempts,
 		MaxBodySize:       scalewayMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -311,7 +312,7 @@ func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodDelete,
 		URL:    apiURL,
 		Headers: map[string]string{
@@ -321,7 +322,7 @@ func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
 		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
 	}
 
-	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return fmt.Errorf("failed to revoke Scaleway API key %s: %w", leaseID, err)
 	}
@@ -369,7 +370,7 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 		return nil, nil, 0, fmt.Errorf("management_access_key is required for rotation")
 	}
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       scalewayMaxRetryAttempts,
 		MaxBodySize:       scalewayMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -379,13 +380,13 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 
 	// Look up the current key to find its bearer (application_id or user_id)
 	getURL := d.iamURL("/api-keys/" + managementAccessKey)
-	getReq := HTTPRequest{
+	getReq := httputil.HTTPRequest{
 		Method:  http.MethodGet,
 		URL:     getURL,
 		Headers: map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
 	}
 
-	respBody, _, err := ExecuteWithRetry(ctx, d.httpClient, getReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, getReq, retryConfig)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to look up current management key: %w", err)
 	}
@@ -416,14 +417,14 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 	}
 
 	createURL := d.iamURL("/api-keys")
-	createReq := HTTPRequest{
+	createReq := httputil.HTTPRequest{
 		Method:  http.MethodPost,
 		URL:     createURL,
 		Body:    bodyJSON,
 		Headers: map[string]string{"X-Auth-Token": managementKey, "Content-Type": "application/json", "Accept": "application/json"},
 	}
 
-	respBody, _, err = ExecuteWithRetry(ctx, d.httpClient, createReq, retryConfig)
+	respBody, _, err = httputil.ExecuteWithRetry(ctx, d.httpClient, createReq, retryConfig)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to create new management key: %w", err)
 	}
@@ -488,7 +489,7 @@ func (d *ScalewayDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	}
 
 	deleteURL := d.iamURL("/api-keys/" + oldAccessKey)
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       scalewayMaxRetryAttempts,
 		MaxBodySize:       scalewayMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -496,14 +497,14 @@ func (d *ScalewayDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 		JitterPercent:     20,
 	}
 
-	deleteReq := HTTPRequest{
+	deleteReq := httputil.HTTPRequest{
 		Method:     http.MethodDelete,
 		URL:        deleteURL,
 		Headers:    map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
 		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
 	}
 
-	_, _, err := ExecuteWithRetry(ctx, d.httpClient, deleteReq, retryConfig)
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, deleteReq, retryConfig)
 	if err != nil {
 		d.logger.Warn("failed to delete old management key during cleanup",
 			logger.Err(err),
@@ -548,7 +549,7 @@ func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.
 	// Verify the key works by calling a lightweight IAM endpoint
 	apiURL := d.iamURL("/api-keys/" + accessKey)
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       scalewayMaxRetryAttempts,
 		MaxBodySize:       scalewayMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -556,7 +557,7 @@ func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method: http.MethodGet,
 		URL:    apiURL,
 		Headers: map[string]string{
@@ -565,7 +566,7 @@ func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.
 		},
 	}
 
-	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return fmt.Errorf("Scaleway API key verification failed: %w", err)
 	}

--- a/credential/drivers/static_apikey_driver.go
+++ b/credential/drivers/static_apikey_driver.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -218,7 +219,7 @@ func (d *StaticAPIKeyDriver) VerifySpec(ctx context.Context, spec *credential.Cr
 	method := credential.GetString(d.credSource.Config, "verify_method", http.MethodGet)
 	headers := buildAPIKeyAuthHeaders(d.credSource.Config, apiKey)
 
-	retryConfig := HTTPRetryConfig{
+	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       apiKeyMaxRetryAttempts,
 		MaxBodySize:       apiKeyMaxResponseBodySize,
 		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
@@ -226,13 +227,13 @@ func (d *StaticAPIKeyDriver) VerifySpec(ctx context.Context, spec *credential.Cr
 		JitterPercent:     20,
 	}
 
-	httpReq := HTTPRequest{
+	httpReq := httputil.HTTPRequest{
 		Method:  method,
 		URL:     apiURL,
 		Headers: headers,
 	}
 
-	_, _, err := ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
 		return fmt.Errorf("%s API key verification failed: %w", name, err)
 	}

--- a/credential/drivers/tls_helper.go
+++ b/credential/drivers/tls_helper.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
@@ -9,49 +8,35 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper/httputil"
 )
 
-// BuildHTTPClient creates an *http.Client with optional TLS configuration.
-// It reads "ca_data" and "tls_skip_verify" from the config map.
-// If neither is set, returns a plain client with the given timeout.
+// BuildHTTPClient is the credential-driver-facing adapter over
+// httputil.BuildHTTPClient. It reads "ca_data" (base64-encoded PEM) and
+// "tls_skip_verify" from the driver's config map and delegates to the
+// generic helper. Kept as a shim so existing drivers don't need to
+// change call sites; new consumers (auth methods, future drivers) can
+// use httputil.BuildHTTPClient directly with raw PEM.
 func BuildHTTPClient(config map[string]string, timeout time.Duration) (*http.Client, error) {
 	caData := credential.GetString(config, "ca_data", "")
 	skipVerify := credential.GetBool(config, "tls_skip_verify", false)
 
-	if caData == "" && !skipVerify {
-		return &http.Client{Timeout: timeout}, nil
-	}
-
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
-
-	if skipVerify {
-		tlsConfig.InsecureSkipVerify = true
-	}
-
+	var caPEM []byte
 	if caData != "" {
-		pemBytes, err := base64.StdEncoding.DecodeString(caData)
+		decoded, err := base64.StdEncoding.DecodeString(caData)
 		if err != nil {
 			return nil, fmt.Errorf("ca_data is not valid base64: %w", err)
 		}
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(pemBytes) {
-			return nil, fmt.Errorf("ca_data contains no valid PEM certificates")
-		}
-		tlsConfig.RootCAs = pool
+		caPEM = decoded
 	}
 
-	return &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}, nil
+	return httputil.BuildHTTPClient(caPEM, skipVerify, timeout)
 }
 
 // ValidateCAData validates that a ca_data value is valid base64-encoded PEM.
-// Intended for use as a credential.StringField().Custom() validator.
+// Intended for use as a credential.StringField().Custom() validator. Stays in
+// credential/drivers because it's tied to the driver-schema field convention
+// (base64-encoded transport form); raw-PEM validators belong elsewhere.
 func ValidateCAData(v string) error {
 	if v == "" {
 		return nil

--- a/helper/httputil/client.go
+++ b/helper/httputil/client.go
@@ -1,0 +1,51 @@
+// Package httputil provides HTTP client utilities shared across Warden:
+// auth methods (e.g. kubernetes TokenReview), credential drivers
+// (e.g. AWS STS, GCP token exchange), and provider SDKs. The helpers
+// here are deliberately format-neutral and do not depend on the
+// credential package — callers extract config values themselves and
+// pass typed primitives.
+package httputil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// BuildHTTPClient returns an *http.Client configured for calls that may
+// need a non-system root CA bundle and/or TLS verification disabled.
+//
+//   - caPEM is the PEM-encoded CA bundle as raw bytes. Pass nil/empty
+//     to use the system roots.
+//   - skipVerify disables certificate validation (test/dev only).
+//   - timeout is the per-request timeout. Pass 0 to use no timeout
+//     (the client will block until the connection terminates).
+//
+// Returns an error if caPEM is non-empty but contains no valid PEM
+// certificates.
+func BuildHTTPClient(caPEM []byte, skipVerify bool, timeout time.Duration) (*http.Client, error) {
+	if len(caPEM) == 0 && !skipVerify {
+		return &http.Client{Timeout: timeout}, nil
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if skipVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	if len(caPEM) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("ca bundle contains no valid PEM certificates")
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}, nil
+}

--- a/helper/httputil/client_test.go
+++ b/helper/httputil/client_test.go
@@ -1,0 +1,119 @@
+package httputil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// generateTestCAPEM returns a self-signed CA certificate as raw PEM bytes.
+func generateTestCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Test CA"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func TestBuildHTTPClient_NoTLSConfig(t *testing.T) {
+	client, err := BuildHTTPClient(nil, false, 30*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.Timeout != 30*time.Second {
+		t.Errorf("expected timeout 30s, got %v", client.Timeout)
+	}
+	if client.Transport != nil {
+		t.Error("expected nil transport when no TLS config set")
+	}
+}
+
+func TestBuildHTTPClient_TLSSkipVerify(t *testing.T) {
+	client, err := BuildHTTPClient(nil, true, 15*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be true")
+	}
+}
+
+func TestBuildHTTPClient_ValidCAPEM(t *testing.T) {
+	caPEM := generateTestCAPEM(t)
+	client, err := BuildHTTPClient(caPEM, false, 30*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be set")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be false")
+	}
+}
+
+func TestBuildHTTPClient_InvalidPEM(t *testing.T) {
+	_, err := BuildHTTPClient([]byte("not a PEM certificate"), false, 30*time.Second)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+func TestBuildHTTPClient_BothOptions(t *testing.T) {
+	caPEM := generateTestCAPEM(t)
+	client, err := BuildHTTPClient(caPEM, true, 30*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be true")
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be set")
+	}
+}
+
+func TestBuildHTTPClient_MinTLSVersion(t *testing.T) {
+	client, err := BuildHTTPClient(nil, true, 30*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("expected MinVersion TLS 1.2, got %d", transport.TLSClientConfig.MinVersion)
+	}
+}

--- a/helper/httputil/retry.go
+++ b/helper/httputil/retry.go
@@ -1,4 +1,4 @@
-package drivers
+package httputil
 
 import (
 	"bytes"
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	// DefaultMaxBodySize is the default maximum response body size (1MB)
+	// DefaultMaxBodySize is the default maximum response body size (1MB).
 	DefaultMaxBodySize = 1 << 20
 )
 
-// HTTPRetryConfig configures HTTP retry behavior
+// HTTPRetryConfig configures HTTP retry behavior.
 type HTTPRetryConfig struct {
 	// MaxAttempts is the maximum number of attempts (including the initial request)
 	MaxAttempts int
@@ -23,8 +23,8 @@ type HTTPRetryConfig struct {
 	// MaxBodySize is the maximum response body size to read
 	MaxBodySize int64
 
-	// RetryableStatuses are HTTP status codes that should be retried
-	// Special value 500 matches all 5xx errors (500-599)
+	// RetryableStatuses are HTTP status codes that should be retried.
+	// Special value 500 matches all 5xx errors (500-599).
 	RetryableStatuses []int
 
 	// BaseBackoff is the base backoff duration (exponential: 1s, 2s, 4s, 8s...)
@@ -34,8 +34,8 @@ type HTTPRetryConfig struct {
 	JitterPercent int
 }
 
-// DefaultHTTPRetryConfig returns sensible defaults for API calls
-// Retries only on rate limiting (429)
+// DefaultHTTPRetryConfig returns sensible defaults for API calls.
+// Retries only on rate limiting (429).
 func DefaultHTTPRetryConfig() HTTPRetryConfig {
 	return HTTPRetryConfig{
 		MaxAttempts:       3,
@@ -46,7 +46,7 @@ func DefaultHTTPRetryConfig() HTTPRetryConfig {
 	}
 }
 
-// HTTPRequest represents a prepared HTTP request
+// HTTPRequest represents a prepared HTTP request.
 type HTTPRequest struct {
 	// Method is the HTTP method (GET, POST, etc.)
 	Method string
@@ -64,8 +64,8 @@ type HTTPRequest struct {
 	OKStatuses []int
 }
 
-// ExecuteWithRetry executes an HTTP request with exponential backoff retry
-// Returns response body, status code, and error
+// ExecuteWithRetry executes an HTTP request with exponential backoff retry.
+// Returns response body, status code, and error.
 func ExecuteWithRetry(
 	ctx context.Context,
 	client *http.Client,

--- a/helper/httputil/retry_test.go
+++ b/helper/httputil/retry_test.go
@@ -1,0 +1,201 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestExecuteWithRetry_SuccessFirstAttempt(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	body, status, err := ExecuteWithRetry(context.Background(), srv.Client(),
+		HTTPRequest{Method: http.MethodGet, URL: srv.URL},
+		DefaultHTTPRetryConfig(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d", status)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("body: got %s", body)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 call, got %d", got)
+	}
+}
+
+func TestExecuteWithRetry_RetriesOn429ThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultHTTPRetryConfig()
+	cfg.BaseBackoff = 1 * time.Millisecond // keep test fast
+	cfg.JitterPercent = 1
+	_, status, err := ExecuteWithRetry(context.Background(), srv.Client(),
+		HTTPRequest{Method: http.MethodGet, URL: srv.URL}, cfg,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", status)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 calls (one retry), got %d", got)
+	}
+}
+
+func TestExecuteWithRetry_NoRetryOnNonRetryableStatus(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	_, status, err := ExecuteWithRetry(context.Background(), srv.Client(),
+		HTTPRequest{Method: http.MethodGet, URL: srv.URL},
+		DefaultHTTPRetryConfig(),
+	)
+	if err == nil {
+		t.Fatal("expected error for 400 status")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d", status)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 call (no retry on 4xx), got %d", got)
+	}
+}
+
+func TestExecuteWithRetry_5xxRetryWithSpecialValue500(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusBadGateway) // 502 — should retry under {500}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultHTTPRetryConfig()
+	cfg.BaseBackoff = 1 * time.Millisecond
+	cfg.JitterPercent = 1
+	cfg.RetryableStatuses = []int{500} // special value means all 5xx
+	_, status, err := ExecuteWithRetry(context.Background(), srv.Client(),
+		HTTPRequest{Method: http.MethodGet, URL: srv.URL}, cfg,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", status)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 calls (two retries), got %d", got)
+	}
+}
+
+func TestExecuteWithRetry_ExplicitOKStatuses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`created`))
+	}))
+	defer srv.Close()
+
+	body, status, err := ExecuteWithRetry(context.Background(), srv.Client(),
+		HTTPRequest{
+			Method:     http.MethodPost,
+			URL:        srv.URL,
+			OKStatuses: []int{http.StatusOK, http.StatusCreated},
+		},
+		DefaultHTTPRetryConfig(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusCreated {
+		t.Fatalf("status: got %d", status)
+	}
+	if string(body) != "created" {
+		t.Fatalf("body: got %s", body)
+	}
+}
+
+func TestExecuteWithRetry_RespectsContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	cfg := DefaultHTTPRetryConfig()
+	cfg.BaseBackoff = 1 * time.Second
+	_, _, err := ExecuteWithRetry(ctx, srv.Client(),
+		HTTPRequest{Method: http.MethodGet, URL: srv.URL}, cfg,
+	)
+	if err == nil {
+		t.Fatal("expected error when context already cancelled before second attempt")
+	}
+}
+
+func TestExecuteWithRetry_HeadersAreSent(t *testing.T) {
+	gotHeader := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Test-Header")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, _, err := ExecuteWithRetry(context.Background(), srv.Client(),
+		HTTPRequest{
+			Method:  http.MethodGet,
+			URL:     srv.URL,
+			Headers: map[string]string{"X-Test-Header": "abc"},
+		},
+		DefaultHTTPRetryConfig(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHeader != "abc" {
+		t.Fatalf("expected header sent, got %q", gotHeader)
+	}
+}
+
+func TestDefaultHTTPRetryConfig(t *testing.T) {
+	cfg := DefaultHTTPRetryConfig()
+	if cfg.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts: got %d, want 3", cfg.MaxAttempts)
+	}
+	if cfg.MaxBodySize != DefaultMaxBodySize {
+		t.Errorf("MaxBodySize: got %d, want %d", cfg.MaxBodySize, DefaultMaxBodySize)
+	}
+	if len(cfg.RetryableStatuses) != 1 || cfg.RetryableStatuses[0] != 429 {
+		t.Errorf("RetryableStatuses: got %v, want [429]", cfg.RetryableStatuses)
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the HTTP client builder, retry helper, and request/config types from `credential/drivers/` into a new top-level **`helper/httputil/`** package. These helpers are pure HTTP plumbing — nothing in their behavior is credential-driver-specific. Living under `credential/drivers/` blocked reuse by upcoming consumers (kubernetes auth method, future AWS IAM auth method, potentially provider SDKs) that have no reason to depend on the `credential` package.

### What moves

- **`helper/httputil/client.go`** — `BuildHTTPClient(caPEM []byte, skipVerify bool, timeout time.Duration)`. New signature takes raw PEM bytes (not base64-encoded config maps), making it operator-friendly for auth-method config schemas.
- **`helper/httputil/retry.go`** — `HTTPRequest`, `HTTPRetryConfig`, `DefaultHTTPRetryConfig`, `ExecuteWithRetry`, `DefaultMaxBodySize`. Verbatim move; the API was already generic.

### What stays

- **`credential/drivers/tls_helper.go`** keeps its existing `BuildHTTPClient(config map[string]string, timeout)` API as a thin shim — decodes base64 `ca_data` and delegates to `httputil.BuildHTTPClient`. ~20 driver callers needed **zero** call-site changes.
- **`ValidateCAData`** stays in `credential/drivers/` — it's tied to the driver-schema field convention (base64 transport form).

### Diff scope

- 15 driver files updated: add `helper/httputil` import, qualify moved names (`ExecuteWithRetry` → `httputil.ExecuteWithRetry`, etc.)
- New direct unit tests in `helper/httputil/` (14 cases covering `BuildHTTPClient` + `ExecuteWithRetry` retry behavior, status filtering, context cancellation, header propagation)
- Behavior-preserving — no public API removed; the shim's wire-level error messages are unchanged where existing tests assert on them

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 48 packages OK, 0 FAIL
- [x] `go vet ./...` — only pre-existing lock-copy warnings, none introduced
- [x] `gofmt -l ./credential/drivers/ ./helper/httputil/` — clean for all touched files (pre-existing flags on `aws_driver.go` and `grafana_driver_test.go` are unrelated)
- [x] Existing `tls_helper_test.go` (the shim's tests) still pass — confirms shim is behavior-equivalent

This is foundation work for the kubernetes auth method (PR coming next).
