### PR TITLE
feat(auth/kubernetes): TokenReview-based auth method

### DIFF
--- a/auth/helper/token_type.go
+++ b/auth/helper/token_type.go
@@ -1,17 +1,23 @@
 package helper
 
-// BackendJWT and BackendCert identify the auth backend type for token type resolution.
+// BackendJWT, BackendCert, BackendKubernetes identify the auth backend type
+// for token type resolution.
 const (
-	BackendJWT  = "jwt"
-	BackendCert = "cert"
+	BackendJWT        = "jwt"
+	BackendCert       = "cert"
+	BackendKubernetes = "kubernetes"
 )
 
 // DefaultTokenType returns the default token type for the given auth backend.
 func DefaultTokenType(backend string) string {
-	if backend == BackendCert {
+	switch backend {
+	case BackendCert:
 		return "cert_role"
+	case BackendKubernetes:
+		return "kubernetes_role"
+	default:
+		return "jwt_role"
 	}
-	return "jwt_role"
 }
 
 // DisplayTokenType maps an internal token type name to its user-facing alias.

--- a/auth/method/kubernetes/backend.go
+++ b/auth/method/kubernetes/backend.go
@@ -1,0 +1,191 @@
+// Package kubernetes implements the Warden auth method that validates
+// workload tokens by calling the Kubernetes TokenReview API on the
+// issuing kube-apiserver. Removes the JWKS-on-spoke requirement that
+// hardened distros (Talos default, CIS-baseline) make awkward, and
+// matches the auth/kubernetes shape Vault and OpenBao operators already
+// know.
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/helper/httputil"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// KubernetesAuthConfig is the per-mount configuration for the kubernetes
+// auth method. Operator-authored via POST /config; persisted as JSON.
+type KubernetesAuthConfig struct {
+	// KubernetesHost is the kube-apiserver base URL, e.g. https://10.0.0.1:6443.
+	// Required.
+	KubernetesHost string `json:"kubernetes_host"`
+
+	// KubernetesCACert is the PEM-encoded CA bundle Warden uses to validate
+	// the kube-apiserver's TLS cert. Required unless TLSSkipVerify is true.
+	KubernetesCACert string `json:"kubernetes_ca_cert,omitempty"`
+
+	// TokenReviewerJWT is an optional hub-side service-account JWT used as
+	// the Authorization: Bearer for TokenReview calls. When unset, the
+	// auth method falls back to self-reviewing mode (the workload's own
+	// JWT is used as the bearer; requires the workload SA to have
+	// system:auth-delegator on the spoke cluster).
+	//
+	// Treated as a secret — masked on GET /config.
+	TokenReviewerJWT string `json:"token_reviewer_jwt,omitempty"`
+
+	// TLSSkipVerify disables TLS validation on TokenReview calls. Dev only.
+	TLSSkipVerify bool `json:"tls_skip_verify,omitempty"`
+
+	// Issuer, if set, gates login on the workload JWT's `iss` claim
+	// matching this value (cheap unverified parse, before the TokenReview
+	// round-trip). Per-mount issuer pinning is the right place to do this
+	// — the introspect aggregator stays config-agnostic.
+	Issuer string `json:"issuer,omitempty"`
+
+	// DisableIssValidation lets operators opt out of the `iss` pre-filter
+	// even when Issuer is non-empty.
+	DisableIssValidation bool `json:"disable_iss_validation,omitempty"`
+
+	// TokenTTL is the default TTL for issued Warden tokens; per-role
+	// TokenTTL overrides this.
+	TokenTTL time.Duration `json:"token_ttl" default:"1h"`
+
+	// DefaultRole, if set, is used by transparent-mode flows when the
+	// caller doesn't specify a role.
+	DefaultRole string `json:"default_role,omitempty"`
+
+	// Internal runtime state — derived from the stored config on Initialize.
+	httpClient *http.Client `json:"-"`
+}
+
+// kubernetesAuthBackend is the framework-based kubernetes auth method.
+type kubernetesAuthBackend struct {
+	*framework.Backend
+	config      *KubernetesAuthConfig
+	configMu    sync.RWMutex
+	logger      *logger.GatedLogger
+	storageView sdklogical.Storage
+}
+
+var _ logical.Factory = Factory
+
+// Factory creates a new kubernetes auth backend per the logical.Factory pattern.
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &kubernetesAuthBackend{
+		logger:      conf.Logger,
+		storageView: conf.StorageView,
+	}
+
+	b.Backend = &framework.Backend{
+		Help:         kubernetesAuthHelp,
+		BackendType:  "kubernetes",
+		BackendClass: logical.ClassAuth,
+		PathsSpecial: &logical.Paths{
+			Unauthenticated: []string{
+				"login",
+				"introspect/roles",
+			},
+		},
+		Paths: []*framework.Path{
+			b.pathLogin(),
+			b.pathConfig(),
+			b.pathRole(),
+			b.pathRoleList(),
+			b.pathIntrospect(),
+		},
+	}
+
+	if err := b.Backend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	if len(conf.Config) > 0 {
+		if err := b.setupConfig(ctx, conf.Config); err != nil {
+			return nil, fmt.Errorf("failed to setup kubernetes config: %w", err)
+		}
+	}
+
+	return b, nil
+}
+
+// setupConfig parses the operator-supplied config map, builds the HTTP
+// client used for TokenReview calls, validates required fields, and
+// installs the resulting KubernetesAuthConfig under the backend mutex.
+func (b *kubernetesAuthBackend) setupConfig(_ context.Context, conf map[string]any) error {
+	cfg, err := mapToKubernetesAuthConfig(conf)
+	if err != nil {
+		return err
+	}
+
+	if cfg.KubernetesHost == "" {
+		return fmt.Errorf("kubernetes_host is required")
+	}
+	if cfg.KubernetesCACert == "" && !cfg.TLSSkipVerify {
+		return fmt.Errorf("kubernetes_ca_cert is required unless tls_skip_verify is true")
+	}
+
+	client, err := buildKubernetesClient(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to build kubernetes HTTP client: %w", err)
+	}
+	cfg.httpClient = client
+
+	b.configMu.Lock()
+	b.config = cfg
+	b.configMu.Unlock()
+	return nil
+}
+
+// Initialize loads persisted config from storage and re-runs setupConfig
+// so the in-memory HTTP client is rebuilt after a restart.
+func (b *kubernetesAuthBackend) Initialize(ctx context.Context) error {
+	if b.storageView == nil {
+		return nil
+	}
+	entry, err := b.storageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry == nil {
+		return nil
+	}
+	var configMap map[string]any
+	if err := entry.DecodeJSON(&configMap); err != nil {
+		return fmt.Errorf("failed to decode config: %w", err)
+	}
+	if err := b.setupConfig(ctx, configMap); err != nil {
+		return fmt.Errorf("failed to setup kubernetes config from storage: %w", err)
+	}
+	return nil
+}
+
+// SensitiveConfigFields returns the config fields that should be masked
+// on GET /config. token_reviewer_jwt is a hub-side service-account token
+// and is treated as a secret; CA certs and host URLs are public material.
+func (b *kubernetesAuthBackend) SensitiveConfigFields() []string {
+	return []string{"token_reviewer_jwt"}
+}
+
+// buildKubernetesClient constructs the *http.Client used for TokenReview
+// calls. Reuses helper/httputil so the TLS handling is consistent across
+// HTTP-talking auth methods and credential drivers; accepts raw PEM
+// directly (auth-method config is operator-authored, no base64 transport).
+func buildKubernetesClient(cfg *KubernetesAuthConfig) (*http.Client, error) {
+	return httputil.BuildHTTPClient([]byte(cfg.KubernetesCACert), cfg.TLSSkipVerify, defaultHTTPTimeout)
+}
+
+const kubernetesAuthHelp = `
+The "kubernetes" auth method validates workload service-account tokens
+by calling the Kubernetes TokenReview API on the issuing kube-apiserver.
+
+Configure: kubernetes_host, kubernetes_ca_cert, optionally token_reviewer_jwt.
+Roles bind to bound_service_account_names and bound_service_account_namespaces.
+`

--- a/auth/method/kubernetes/backend_test.go
+++ b/auth/method/kubernetes/backend_test.go
@@ -1,0 +1,112 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+func TestFactory_BasicCreation(t *testing.T) {
+	be, err := Factory(context.Background(), &logical.BackendConfig{Logger: testLogger()})
+	require.NoError(t, err)
+	require.NotNil(t, be)
+}
+
+func TestFactory_WithEmptyConfig(t *testing.T) {
+	be, err := Factory(context.Background(), &logical.BackendConfig{
+		Logger: testLogger(),
+		Config: map[string]any{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, be)
+}
+
+func TestFactory_BackendType(t *testing.T) {
+	be, err := Factory(context.Background(), &logical.BackendConfig{Logger: testLogger()})
+	require.NoError(t, err)
+	assert.Equal(t, "kubernetes", be.Type())
+}
+
+func TestFactory_SpecialPathsUnauthenticated(t *testing.T) {
+	be, err := Factory(context.Background(), &logical.BackendConfig{Logger: testLogger()})
+	require.NoError(t, err)
+	paths := be.SpecialPaths()
+	require.NotNil(t, paths)
+	assert.Contains(t, paths.Unauthenticated, "login")
+	assert.Contains(t, paths.Unauthenticated, "introspect/roles")
+}
+
+func TestFactory_SensitiveConfigFields(t *testing.T) {
+	be, err := Factory(context.Background(), &logical.BackendConfig{Logger: testLogger()})
+	require.NoError(t, err)
+	provider, ok := be.(logical.SensitiveFieldsProvider)
+	require.True(t, ok, "kubernetes backend must implement SensitiveFieldsProvider")
+	assert.Equal(t, []string{"token_reviewer_jwt"}, provider.SensitiveConfigFields())
+}
+
+func TestSetupConfig_RequiresKubernetesHost(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	err := b.setupConfig(ctx, map[string]any{
+		"kubernetes_ca_cert": "PEM",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kubernetes_host is required")
+}
+
+func TestSetupConfig_RequiresCAUnlessSkipVerify(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	err := b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": "https://kube",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kubernetes_ca_cert is required")
+
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": "https://kube",
+		"tls_skip_verify": true,
+	}))
+}
+
+func TestInitialize_RoundTripsConfigFromStorage(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	// Write config directly to storage (the persisted shape produced by
+	// handleConfigWrite: token_ttl as string, all fields populated).
+	stored := map[string]any{
+		"kubernetes_host":    "https://kube.example.com",
+		"tls_skip_verify":    true,
+		"token_reviewer_jwt": "reviewer-jwt",
+		"issuer":             "https://kubernetes.default.svc",
+		"token_ttl":          "45m",
+		"default_role":       "ops-reader",
+	}
+	entry, err := sdklogical.StorageEntryJSON("config", stored)
+	require.NoError(t, err)
+	require.NoError(t, b.storageView.Put(ctx, entry))
+
+	// Drop in-memory config and reload via Initialize.
+	b.configMu.Lock()
+	b.config = nil
+	b.configMu.Unlock()
+	require.NoError(t, b.Initialize(ctx))
+	require.NotNil(t, b.config)
+	assert.Equal(t, "https://kube.example.com", b.config.KubernetesHost)
+	assert.True(t, b.config.TLSSkipVerify)
+	assert.Equal(t, "reviewer-jwt", b.config.TokenReviewerJWT)
+	assert.Equal(t, "https://kubernetes.default.svc", b.config.Issuer)
+	assert.Equal(t, "ops-reader", b.config.DefaultRole)
+	assert.NotNil(t, b.config.httpClient, "Initialize must rebuild the HTTP client")
+}
+
+func TestInitialize_NoStoredConfigIsNotAnError(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	// Fresh backend with empty storage — Initialize should succeed and
+	// leave b.config nil (the kubernetes auth method is "not configured yet").
+	require.NoError(t, b.Initialize(ctx))
+	assert.Nil(t, b.config)
+}

--- a/auth/method/kubernetes/helper.go
+++ b/auth/method/kubernetes/helper.go
@@ -1,0 +1,75 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// errAuthFailed is the generic error returned for all authentication
+// failures to prevent information leakage about which specific check
+// failed (bound SA mismatch vs. expired token vs. issuer mismatch, etc.).
+// Mirrors the same pattern used by the JWT auth method.
+var errAuthFailed = fmt.Errorf("authentication failed")
+
+// serviceAccountUsernamePrefix is the mandatory prefix Kubernetes uses
+// for ServiceAccount-issued tokens in TokenReview.Status.User.Username.
+// Format: "system:serviceaccount:<namespace>:<sa-name>".
+const serviceAccountUsernamePrefix = "system:serviceaccount:"
+
+// parseSAUsername splits a TokenReview status.user.username into the
+// namespace and service account name. Returns false if the username
+// doesn't start with the mandatory prefix or is otherwise malformed
+// (e.g. system:anonymous, system:node:..., or an OIDC user).
+func parseSAUsername(username string) (namespace, name string, ok bool) {
+	rest, found := strings.CutPrefix(username, serviceAccountUsernamePrefix)
+	if !found {
+		return "", "", false
+	}
+	parts := strings.SplitN(rest, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// matchBoundList returns true if want is in the bound list, or if the
+// list contains "*" (wildcard). Empty bound list rejects everything —
+// the caller is responsible for refusing role configs with both
+// bound_service_account_names and bound_service_account_namespaces empty.
+func matchBoundList(bound []string, want string) bool {
+	for _, b := range bound {
+		if b == "*" || b == want {
+			return true
+		}
+	}
+	return false
+}
+
+// matchRoleBindings returns nil if the (namespace, name) pair satisfies
+// the role's bound_service_account_namespaces and bound_service_account_names.
+// Returns a descriptive error for server-side logging; callers should
+// return errAuthFailed to clients.
+func matchRoleBindings(role *KubernetesRole, namespace, name string) error {
+	if !matchBoundList(role.BoundServiceAccountNamespaces, namespace) {
+		return fmt.Errorf("service account namespace %q not in role's bound list", namespace)
+	}
+	if !matchBoundList(role.BoundServiceAccountNames, name) {
+		return fmt.Errorf("service account name %q not in role's bound list", name)
+	}
+	return nil
+}
+
+// audienceMatches returns true if want is empty (role declared no
+// audience requirement) or want appears in the TokenReview's returned
+// status.audiences slice.
+func audienceMatches(want string, got []string) bool {
+	if want == "" {
+		return true
+	}
+	for _, a := range got {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/auth/method/kubernetes/helper_test.go
+++ b/auth/method/kubernetes/helper_test.go
@@ -1,0 +1,149 @@
+package kubernetes
+
+import "testing"
+
+func TestParseSAUsername(t *testing.T) {
+	t.Run("valid SA username", func(t *testing.T) {
+		ns, name, ok := parseSAUsername("system:serviceaccount:default:myapp")
+		if !ok || ns != "default" || name != "myapp" {
+			t.Fatalf("got ns=%q name=%q ok=%v", ns, name, ok)
+		}
+	})
+	t.Run("namespace with hyphens", func(t *testing.T) {
+		ns, name, ok := parseSAUsername("system:serviceaccount:kube-system:coredns")
+		if !ok || ns != "kube-system" || name != "coredns" {
+			t.Fatalf("got ns=%q name=%q ok=%v", ns, name, ok)
+		}
+	})
+	t.Run("missing prefix", func(t *testing.T) {
+		if _, _, ok := parseSAUsername("system:anonymous"); ok {
+			t.Fatal("should reject non-SA username")
+		}
+	})
+	t.Run("missing namespace", func(t *testing.T) {
+		if _, _, ok := parseSAUsername("system:serviceaccount::myapp"); ok {
+			t.Fatal("should reject empty namespace")
+		}
+	})
+	t.Run("missing name", func(t *testing.T) {
+		if _, _, ok := parseSAUsername("system:serviceaccount:default:"); ok {
+			t.Fatal("should reject empty name")
+		}
+	})
+	t.Run("missing colon between ns and name", func(t *testing.T) {
+		if _, _, ok := parseSAUsername("system:serviceaccount:default"); ok {
+			t.Fatal("should reject malformed (no second colon)")
+		}
+	})
+	t.Run("empty string", func(t *testing.T) {
+		if _, _, ok := parseSAUsername(""); ok {
+			t.Fatal("should reject empty input")
+		}
+	})
+}
+
+func TestMatchBoundList(t *testing.T) {
+	t.Run("empty list rejects", func(t *testing.T) {
+		if matchBoundList(nil, "anything") {
+			t.Fatal("empty list must reject")
+		}
+	})
+	t.Run("exact match", func(t *testing.T) {
+		if !matchBoundList([]string{"a", "b"}, "b") {
+			t.Fatal("expected exact match")
+		}
+	})
+	t.Run("wildcard matches any", func(t *testing.T) {
+		if !matchBoundList([]string{"*"}, "anything") {
+			t.Fatal("wildcard should match")
+		}
+	})
+	t.Run("no match", func(t *testing.T) {
+		if matchBoundList([]string{"a", "b"}, "c") {
+			t.Fatal("no element should match")
+		}
+	})
+}
+
+func TestMatchRoleBindings(t *testing.T) {
+	role := &KubernetesRole{
+		BoundServiceAccountNamespaces: []string{"default", "prod"},
+		BoundServiceAccountNames:      []string{"myapp"},
+	}
+	t.Run("matches", func(t *testing.T) {
+		if err := matchRoleBindings(role, "default", "myapp"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("namespace mismatch", func(t *testing.T) {
+		if err := matchRoleBindings(role, "other", "myapp"); err == nil {
+			t.Fatal("expected namespace mismatch error")
+		}
+	})
+	t.Run("name mismatch", func(t *testing.T) {
+		if err := matchRoleBindings(role, "default", "otherapp"); err == nil {
+			t.Fatal("expected name mismatch error")
+		}
+	})
+	t.Run("wildcard namespace allows any", func(t *testing.T) {
+		r := &KubernetesRole{
+			BoundServiceAccountNamespaces: []string{"*"},
+			BoundServiceAccountNames:      []string{"myapp"},
+		}
+		if err := matchRoleBindings(r, "anywhere", "myapp"); err != nil {
+			t.Fatalf("wildcard ns should accept any namespace: %v", err)
+		}
+	})
+}
+
+func TestAudienceMatches(t *testing.T) {
+	t.Run("empty want matches anything (no audience binding)", func(t *testing.T) {
+		if !audienceMatches("", nil) {
+			t.Fatal("empty want should match")
+		}
+		if !audienceMatches("", []string{"x"}) {
+			t.Fatal("empty want should match even with audiences present")
+		}
+	})
+	t.Run("want present in got", func(t *testing.T) {
+		if !audienceMatches("api", []string{"api", "internal"}) {
+			t.Fatal("want should match when present")
+		}
+	})
+	t.Run("want not present in got", func(t *testing.T) {
+		if audienceMatches("api", []string{"internal"}) {
+			t.Fatal("want should not match when absent")
+		}
+	})
+	t.Run("want present but got is empty", func(t *testing.T) {
+		if audienceMatches("api", nil) {
+			t.Fatal("want should not match against empty audiences")
+		}
+	})
+}
+
+func TestOnlyWildcardOrEmpty(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		if !onlyWildcardOrEmpty(nil) {
+			t.Fatal("empty should return true")
+		}
+	})
+	t.Run("only wildcard", func(t *testing.T) {
+		if !onlyWildcardOrEmpty([]string{"*"}) {
+			t.Fatal("only wildcard should return true")
+		}
+	})
+	t.Run("multiple wildcards (degenerate)", func(t *testing.T) {
+		if !onlyWildcardOrEmpty([]string{"*", "*"}) {
+			t.Fatal("all wildcards should return true")
+		}
+	})
+	t.Run("has concrete value", func(t *testing.T) {
+		if onlyWildcardOrEmpty([]string{"myapp"}) {
+			t.Fatal("concrete value should return false")
+		}
+		if onlyWildcardOrEmpty([]string{"*", "myapp"}) {
+			t.Fatal("wildcard+concrete should return false")
+		}
+	})
+}

--- a/auth/method/kubernetes/parser.go
+++ b/auth/method/kubernetes/parser.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// mapToKubernetesAuthConfig converts an operator-supplied config map
+// (from the framework field schema or persisted storage) into a typed
+// KubernetesAuthConfig. Duration handling normalizes the various source
+// representations (string, int seconds from TypeDurationSecond, float64
+// from JSON, native time.Duration) into time.Duration before unmarshal.
+func mapToKubernetesAuthConfig(data map[string]any) (*KubernetesAuthConfig, error) {
+	dataCopy := make(map[string]any, len(data))
+	for k, v := range data {
+		dataCopy[k] = v
+	}
+
+	switch ttl := dataCopy["token_ttl"].(type) {
+	case string:
+		if d, err := time.ParseDuration(ttl); err == nil {
+			dataCopy["token_ttl"] = d
+		}
+	case int:
+		dataCopy["token_ttl"] = time.Duration(ttl) * time.Second
+	case float64:
+		dataCopy["token_ttl"] = time.Duration(int64(ttl)) * time.Second
+	case time.Duration:
+		// Already a duration, keep as-is.
+	}
+
+	jsonData, err := json.Marshal(dataCopy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config map: %w", err)
+	}
+
+	var config KubernetesAuthConfig
+	if err := json.Unmarshal(jsonData, &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal to KubernetesAuthConfig: %w", err)
+	}
+
+	if config.TokenTTL == 0 {
+		config.TokenTTL = 1 * time.Hour
+	}
+
+	return &config, nil
+}

--- a/auth/method/kubernetes/parser_test.go
+++ b/auth/method/kubernetes/parser_test.go
@@ -1,0 +1,87 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMapToKubernetesAuthConfig_TokenTTLNormalization(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want time.Duration
+	}{
+		{"string", "30m", 30 * time.Minute},
+		{"int seconds (TypeDurationSecond)", 1800, 1800 * time.Second},
+		{"float64 (JSON decode)", float64(900), 900 * time.Second},
+		{"time.Duration passthrough", 2 * time.Hour, 2 * time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := mapToKubernetesAuthConfig(map[string]any{
+				"kubernetes_host":    "https://kube",
+				"kubernetes_ca_cert": "PEM",
+				"token_ttl":          tc.in,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.TokenTTL != tc.want {
+				t.Fatalf("token_ttl: got %v, want %v", cfg.TokenTTL, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapToKubernetesAuthConfig_DefaultTokenTTL(t *testing.T) {
+	cfg, err := mapToKubernetesAuthConfig(map[string]any{
+		"kubernetes_host": "https://kube",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TokenTTL != time.Hour {
+		t.Fatalf("expected default 1h, got %v", cfg.TokenTTL)
+	}
+}
+
+func TestMapToKubernetesAuthConfig_AllFieldsRoundTrip(t *testing.T) {
+	in := map[string]any{
+		"kubernetes_host":        "https://kube.example.com",
+		"kubernetes_ca_cert":     "-----BEGIN CERTIFICATE-----...",
+		"token_reviewer_jwt":     "eyJ.reviewer.jwt",
+		"tls_skip_verify":        true,
+		"issuer":                 "https://kubernetes.default.svc",
+		"disable_iss_validation": false,
+		"token_ttl":              "45m",
+		"default_role":           "ops-reader",
+	}
+	cfg, err := mapToKubernetesAuthConfig(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.KubernetesHost != in["kubernetes_host"] {
+		t.Errorf("kubernetes_host: %q", cfg.KubernetesHost)
+	}
+	if cfg.KubernetesCACert != in["kubernetes_ca_cert"] {
+		t.Errorf("kubernetes_ca_cert: %q", cfg.KubernetesCACert)
+	}
+	if cfg.TokenReviewerJWT != in["token_reviewer_jwt"] {
+		t.Errorf("token_reviewer_jwt: %q", cfg.TokenReviewerJWT)
+	}
+	if !cfg.TLSSkipVerify {
+		t.Error("tls_skip_verify should be true")
+	}
+	if cfg.Issuer != in["issuer"] {
+		t.Errorf("issuer: %q", cfg.Issuer)
+	}
+	if cfg.DisableIssValidation {
+		t.Error("disable_iss_validation should be false")
+	}
+	if cfg.TokenTTL != 45*time.Minute {
+		t.Errorf("token_ttl: %v", cfg.TokenTTL)
+	}
+	if cfg.DefaultRole != in["default_role"] {
+		t.Errorf("default_role: %q", cfg.DefaultRole)
+	}
+}

--- a/auth/method/kubernetes/path_config.go
+++ b/auth/method/kubernetes/path_config.go
@@ -1,0 +1,157 @@
+package kubernetes
+
+import (
+	"context"
+	"net/http"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+const maskedSecret = "*************"
+
+// pathConfig returns the /config path definition.
+func (b *kubernetesAuthBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"kubernetes_host": {
+				Type:        framework.TypeString,
+				Description: "kube-apiserver base URL, e.g. https://10.0.0.1:6443. Required.",
+			},
+			"kubernetes_ca_cert": {
+				Type:        framework.TypeString,
+				Description: "PEM-encoded CA bundle for kube-apiserver TLS validation. Required unless tls_skip_verify=true.",
+			},
+			"token_reviewer_jwt": {
+				Type:        framework.TypeString,
+				Description: "Optional hub-side service-account JWT used as the Authorization: Bearer for TokenReview calls. When unset, the workload's own JWT is used (self-reviewing mode; requires the workload SA to have system:auth-delegator).",
+			},
+			"tls_skip_verify": {
+				Type:        framework.TypeBool,
+				Description: "Disable TLS validation on TokenReview calls. Dev only.",
+			},
+			"issuer": {
+				Type:        framework.TypeString,
+				Description: "If set, login pre-filters on the workload JWT's iss claim matching this value before calling TokenReview.",
+			},
+			"disable_iss_validation": {
+				Type:        framework.TypeBool,
+				Description: "Skip the iss claim pre-filter even when issuer is non-empty.",
+			},
+			"token_ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Default TTL for issued tokens (default: 1h). Per-role token_ttl overrides this.",
+			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Default role for transparent operations when no role is specified.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read kubernetes auth configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure kubernetes authentication",
+			},
+		},
+		HelpSynopsis:    "Configure the kubernetes auth method",
+		HelpDescription: `Configures the connection to the kube-apiserver used for TokenReview calls, plus optional issuer pinning and default-role for transparent mode. The token_reviewer_jwt is masked on read.`,
+	}
+}
+
+// handleConfigRead returns the current configuration with token_reviewer_jwt
+// masked. Fields not yet set are returned as their zero values.
+func (b *kubernetesAuthBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	b.configMu.RLock()
+	defer b.configMu.RUnlock()
+
+	if b.config == nil {
+		return &logical.Response{StatusCode: http.StatusOK, Data: map[string]any{}}, nil
+	}
+
+	maskedReviewer := ""
+	if b.config.TokenReviewerJWT != "" {
+		maskedReviewer = maskedSecret
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"kubernetes_host":        b.config.KubernetesHost,
+			"kubernetes_ca_cert":     b.config.KubernetesCACert,
+			"token_reviewer_jwt":     maskedReviewer,
+			"tls_skip_verify":        b.config.TLSSkipVerify,
+			"issuer":                 b.config.Issuer,
+			"disable_iss_validation": b.config.DisableIssValidation,
+			"token_ttl":              b.config.TokenTTL.String(),
+			"default_role":           b.config.DefaultRole,
+		},
+	}, nil
+}
+
+// handleConfigWrite merges the request fields with the existing config,
+// runs setupConfig (which validates + rebuilds the HTTP client), then
+// persists the normalized form to storage.
+func (b *kubernetesAuthBackend) handleConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	conf := make(map[string]any)
+
+	b.configMu.RLock()
+	if b.config != nil {
+		conf["kubernetes_host"] = b.config.KubernetesHost
+		conf["kubernetes_ca_cert"] = b.config.KubernetesCACert
+		conf["token_reviewer_jwt"] = b.config.TokenReviewerJWT
+		conf["tls_skip_verify"] = b.config.TLSSkipVerify
+		conf["issuer"] = b.config.Issuer
+		conf["disable_iss_validation"] = b.config.DisableIssValidation
+		conf["token_ttl"] = b.config.TokenTTL
+		conf["default_role"] = b.config.DefaultRole
+	}
+	b.configMu.RUnlock()
+
+	for key := range d.Schema {
+		if val, ok := d.GetOk(key); ok {
+			conf[key] = val
+		}
+	}
+
+	if err := b.setupConfig(ctx, conf); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        err,
+		}, nil
+	}
+
+	if b.storageView != nil {
+		b.configMu.RLock()
+		normalized := map[string]any{
+			"kubernetes_host":        b.config.KubernetesHost,
+			"kubernetes_ca_cert":     b.config.KubernetesCACert,
+			"token_reviewer_jwt":     b.config.TokenReviewerJWT,
+			"tls_skip_verify":        b.config.TLSSkipVerify,
+			"issuer":                 b.config.Issuer,
+			"disable_iss_validation": b.config.DisableIssValidation,
+			"token_ttl":              b.config.TokenTTL.String(),
+			"default_role":           b.config.DefaultRole,
+		}
+		b.configMu.RUnlock()
+
+		entry, err := sdklogical.StorageEntryJSON("config", normalized)
+		if err != nil {
+			return &logical.Response{StatusCode: http.StatusInternalServerError, Err: err}, nil
+		}
+		if err := b.storageView.Put(ctx, entry); err != nil {
+			return &logical.Response{StatusCode: http.StatusInternalServerError, Err: err}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"message": "configuration updated"},
+	}, nil
+}

--- a/auth/method/kubernetes/path_config_test.go
+++ b/auth/method/kubernetes/path_config_test.go
@@ -1,0 +1,156 @@
+package kubernetes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+func TestPathConfig_Pattern(t *testing.T) {
+	b, _ := newTestBackend(t)
+	p := b.pathConfig()
+	assert.Equal(t, "config", p.Pattern)
+}
+
+func TestPathConfig_FieldsPresent(t *testing.T) {
+	b, _ := newTestBackend(t)
+	p := b.pathConfig()
+	for _, name := range []string{
+		"kubernetes_host", "kubernetes_ca_cert", "token_reviewer_jwt",
+		"tls_skip_verify", "issuer", "disable_iss_validation",
+		"token_ttl", "default_role",
+	} {
+		_, ok := p.Fields[name]
+		assert.True(t, ok, "expected field %q", name)
+	}
+}
+
+func TestHandleConfigRead_EmptyConfigReturnsEmptyData(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	// b.config is nil by default for a freshly-constructed backend.
+	d := &framework.FieldData{Raw: map[string]any{}, Schema: b.pathConfig().Fields}
+	resp, err := b.handleConfigRead(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Data)
+}
+
+func TestHandleConfigRead_MasksTokenReviewerJWT(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host":    "https://kube",
+		"tls_skip_verify":    true,
+		"token_reviewer_jwt": "super-secret-reviewer-jwt",
+	}))
+
+	d := &framework.FieldData{Raw: map[string]any{}, Schema: b.pathConfig().Fields}
+	resp, err := b.handleConfigRead(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "https://kube", resp.Data["kubernetes_host"])
+	assert.Equal(t, maskedSecret, resp.Data["token_reviewer_jwt"],
+		"token_reviewer_jwt must be masked, never returned in plaintext")
+	assert.NotContains(t, resp.Data["token_reviewer_jwt"], "super-secret",
+		"raw secret must not appear in the masked response")
+}
+
+func TestHandleConfigRead_EmptyReviewerJWTReturnsEmptyString(t *testing.T) {
+	// When token_reviewer_jwt is unset (self-reviewing mode), the field
+	// should be empty, not masked — operators need to see that no
+	// reviewer JWT is configured.
+	b, ctx := newTestBackend(t)
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": "https://kube",
+		"tls_skip_verify": true,
+	}))
+
+	d := &framework.FieldData{Raw: map[string]any{}, Schema: b.pathConfig().Fields}
+	resp, err := b.handleConfigRead(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Data["token_reviewer_jwt"])
+}
+
+func TestHandleConfigWrite_BasicWriteThenReadRoundTrip(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	// tls_skip_verify=true so we don't have to mint a real PEM bundle
+	// just to exercise the config-roundtrip plumbing.
+	d := &framework.FieldData{
+		Raw: map[string]any{
+			"kubernetes_host":    "https://kube.example.com",
+			"tls_skip_verify":    true,
+			"token_reviewer_jwt": "reviewer-jwt-value",
+			"issuer":             "https://kubernetes.default.svc",
+		},
+		Schema: b.pathConfig().Fields,
+	}
+	resp, err := b.handleConfigWrite(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Err, "unexpected validation error: %v", resp.Err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read it back.
+	rd := &framework.FieldData{Raw: map[string]any{}, Schema: b.pathConfig().Fields}
+	rResp, err := b.handleConfigRead(ctx, &logical.Request{}, rd)
+	require.NoError(t, err)
+	assert.Equal(t, "https://kube.example.com", rResp.Data["kubernetes_host"])
+	assert.Equal(t, true, rResp.Data["tls_skip_verify"])
+	assert.Equal(t, maskedSecret, rResp.Data["token_reviewer_jwt"])
+	assert.Equal(t, "https://kubernetes.default.svc", rResp.Data["issuer"])
+}
+
+func TestHandleConfigWrite_RejectsMissingKubernetesHost(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := &framework.FieldData{
+		Raw:    map[string]any{"kubernetes_ca_cert": "PEM"},
+		Schema: b.pathConfig().Fields,
+	}
+	resp, err := b.handleConfigWrite(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, resp.Err.Error(), "kubernetes_host is required")
+}
+
+func TestHandleConfigWrite_PartialUpdate_PreservesUnsetFields(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	// Initial config with all fields set.
+	d := &framework.FieldData{
+		Raw: map[string]any{
+			"kubernetes_host":    "https://initial",
+			"tls_skip_verify":    true,
+			"token_reviewer_jwt": "reviewer-initial",
+			"issuer":             "https://initial-issuer",
+		},
+		Schema: b.pathConfig().Fields,
+	}
+	resp, err := b.handleConfigWrite(ctx, nil, d)
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "unexpected validation error on initial write: %v", resp.Err)
+
+	// Partial update: only change the host. Reviewer JWT + issuer must persist.
+	d2 := &framework.FieldData{
+		Raw:    map[string]any{"kubernetes_host": "https://updated"},
+		Schema: b.pathConfig().Fields,
+	}
+	resp2, err := b.handleConfigWrite(ctx, nil, d2)
+	require.NoError(t, err)
+	require.Nil(t, resp2.Err, "unexpected validation error on partial update: %v", resp2.Err)
+
+	rd := &framework.FieldData{Raw: map[string]any{}, Schema: b.pathConfig().Fields}
+	rResp, err := b.handleConfigRead(ctx, &logical.Request{}, rd)
+	require.NoError(t, err)
+	assert.Equal(t, "https://updated", rResp.Data["kubernetes_host"])
+	assert.Equal(t, true, rResp.Data["tls_skip_verify"],
+		"unset tls_skip_verify in update should preserve prior value")
+	assert.Equal(t, maskedSecret, rResp.Data["token_reviewer_jwt"])
+	assert.Equal(t, "https://initial-issuer", rResp.Data["issuer"])
+}

--- a/auth/method/kubernetes/path_introspect.go
+++ b/auth/method/kubernetes/path_introspect.go
@@ -1,0 +1,153 @@
+package kubernetes
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	authhelper "github.com/stephnangue/warden/auth/helper"
+	"github.com/stephnangue/warden/framework"
+	lgr "github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathIntrospect returns the introspection path definition. Mirrors the
+// JWT auth method: unauthenticated, takes the workload JWT from Bearer
+// or req.ClientToken, returns the set of roles this token could assume.
+func (b *kubernetesAuthBackend) pathIntrospect() *framework.Path {
+	return &framework.Path{
+		Pattern: "introspect/roles",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleIntrospectRoles,
+				Summary:  "List roles this Kubernetes SA token is allowed to assume",
+			},
+		},
+		HelpSynopsis:    "Discover roles assumable by the presented SA token",
+		HelpDescription: "Returns the roles within this mount whose bound service-account + audience constraints are satisfied by the JWT in the Authorization header (or req.ClientToken).",
+	}
+}
+
+// introspectedRole is the per-role payload returned by introspection.
+type introspectedRole struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// handleIntrospectRoles returns the subset of this mount's roles that
+// the presented K8s SA token could assume.
+//
+// Design constraint: JWT introspect can run the local JWKS validator N
+// times cheaply; kubernetes can't — each TokenReview is an HTTP
+// round-trip. Calling TokenReview per role would amplify apiserver
+// load. We make ONE TokenReview without audience binding to learn the
+// token's natural audiences + identity, then filter roles locally by
+// SA name/namespace and (per-role) audience membership. Login always
+// re-runs TokenReview with audience binding, so the actual security
+// check still happens there — introspect is a discovery hint, not an
+// authorization decision (same trade-off the JWT method makes).
+func (b *kubernetesAuthBackend) handleIntrospectRoles(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	b.configMu.RLock()
+	cfg := b.config
+	b.configMu.RUnlock()
+
+	if cfg == nil {
+		return introspectEmpty(), nil
+	}
+
+	jwtToken := extractJWTFromRequest(req)
+	if jwtToken == "" {
+		return introspectEmpty(), nil
+	}
+
+	// Per-mount issuer pinning: if the mount has an issuer pinned,
+	// short-circuit when the token's iss doesn't match. Keeps the
+	// aggregator decoupled from per-mount config.
+	if cfg.Issuer != "" && !cfg.DisableIssValidation {
+		claims, _ := authhelper.ParseJWTClaimsUnverified(jwtToken)
+		if claims == nil {
+			return introspectEmpty(), nil
+		}
+		issClaim, _ := claims["iss"].(string)
+		if issClaim != cfg.Issuer {
+			return introspectEmpty(), nil
+		}
+	}
+
+	// Bearer for the TokenReview call: prefer the configured reviewer
+	// JWT (standard Vault path); fall back to the workload's JWT in
+	// self-reviewing mode.
+	bearer := cfg.TokenReviewerJWT
+	if bearer == "" {
+		bearer = jwtToken
+	}
+
+	// One TokenReview with no audience binding. Response status.audiences
+	// gives us the token's natural audiences for per-role filtering.
+	status, err := reviewToken(ctx, cfg.httpClient, cfg.KubernetesHost, bearer, jwtToken, nil)
+	if err != nil {
+		b.logger.Warn("introspect: TokenReview call failed", lgr.Err(err))
+		return introspectEmpty(), nil
+	}
+	if !status.Authenticated || status.Error != "" {
+		return introspectEmpty(), nil
+	}
+
+	saNamespace, saName, ok := parseSAUsername(status.User.Username)
+	if !ok {
+		return introspectEmpty(), nil
+	}
+
+	roleNames, err := b.listRoles(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	matches := make([]introspectedRole, 0, len(roleNames))
+	for _, name := range roleNames {
+		role, err := b.getRole(ctx, name)
+		if err != nil {
+			b.logger.Warn("introspect: failed to load role", lgr.String("role", name), lgr.Err(err))
+			continue
+		}
+		if role == nil {
+			continue
+		}
+		if matchRoleBindings(role, saNamespace, saName) != nil {
+			continue
+		}
+		if !audienceMatches(role.Audience, status.Audiences) {
+			continue
+		}
+		matches = append(matches, introspectedRole{
+			Name:        role.Name,
+			Description: role.Description,
+		})
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"roles": matches},
+	}, nil
+}
+
+func introspectEmpty() *logical.Response {
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"roles": []introspectedRole{}},
+	}
+}
+
+// extractJWTFromRequest pulls a JWT off an introspect request. Two paths
+// (mirrors the JWT auth method):
+//  1. Direct HTTP call — Authorization: Bearer <jwt>.
+//  2. In-process call from the sys/introspect/roles aggregator — the
+//     aggregator places the raw JWT in req.ClientToken before dispatch.
+func extractJWTFromRequest(req *logical.Request) string {
+	if req.HTTPRequest != nil {
+		if auth := req.HTTPRequest.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+			return strings.TrimPrefix(auth, "Bearer ")
+		}
+	}
+	return req.ClientToken
+}

--- a/auth/method/kubernetes/path_introspect_test.go
+++ b/auth/method/kubernetes/path_introspect_test.go
@@ -1,0 +1,227 @@
+package kubernetes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// introspectRequest builds a logical.Request carrying the JWT in the
+// Authorization header — the path the production aggregator uses.
+func introspectRequest(t *testing.T, jwt string) *logical.Request {
+	t.Helper()
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/auth/kubernetes/introspect/roles", nil)
+	httpReq.Header.Set("Authorization", "Bearer "+jwt)
+	return &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "introspect/roles",
+		HTTPRequest: httpReq,
+	}
+}
+
+// introspectSetup builds a backend wired to a fake apiserver and seeds
+// the roles the aggregator should pick from.
+func introspectSetup(t *testing.T, status tokenReviewStatus) (*kubernetesAuthBackend, *fakeAPIServer) {
+	t.Helper()
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{Response: status})
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+	}))
+	return b, fake
+}
+
+func TestIntrospect_ReturnsEmptyWhenNoJWT(t *testing.T) {
+	b, _ := introspectSetup(t, tokenReviewStatus{Authenticated: true})
+	resp, err := b.handleIntrospectRoles(t.Context(), &logical.Request{}, &framework.FieldData{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles, "missing JWT should produce empty list, not an error")
+}
+
+func TestIntrospect_ReturnsEmptyWhenBackendNotConfigured(t *testing.T) {
+	b, _ := newTestBackend(t)
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleIntrospectRoles(t.Context(), introspectRequest(t, jwt), &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}
+
+func TestIntrospect_ReturnsEmptyOnTokenReviewDenial(t *testing.T) {
+	b, _ := introspectSetup(t, tokenReviewStatus{
+		Authenticated: false,
+		Error:         "token rejected",
+	})
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleIntrospectRoles(t.Context(), introspectRequest(t, jwt), &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}
+
+func TestIntrospect_OnlyOneTokenReviewRegardlessOfRoleCount(t *testing.T) {
+	b, fake := introspectSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		Audiences:     []string{"https://kubernetes.default.svc"},
+	})
+	ctx := t.Context()
+
+	// Seed 5 roles, all matching the same SA. The design pins one
+	// TokenReview call total, not one per role — that's the whole
+	// point of the introspect design constraint.
+	for _, name := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+			"name":                             name,
+			"bound_service_account_names":      []string{"myapp"},
+			"bound_service_account_namespaces": []string{"default"},
+		}))
+	}
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleIntrospectRoles(ctx, introspectRequest(t, jwt), &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Len(t, roles, 5)
+	assert.Equal(t, int32(1), fake.Calls,
+		"introspect must make exactly ONE TokenReview call regardless of role count")
+}
+
+func TestIntrospect_TokenReviewSentWithoutAudienceBinding(t *testing.T) {
+	b, fake := introspectSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		Audiences:     []string{"https://kubernetes.default.svc"},
+	})
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	_, _ = b.handleIntrospectRoles(t.Context(), introspectRequest(t, jwt), &framework.FieldData{})
+
+	// Introspect must NOT request a specific audience — the trade-off
+	// is that we learn the token's natural audiences instead, and filter
+	// per-role locally.
+	assert.Empty(t, fake.AudsSeen,
+		"introspect must call TokenReview without audience binding")
+}
+
+func TestIntrospect_FiltersByRoleSABindings(t *testing.T) {
+	b, _ := introspectSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+	})
+	ctx := t.Context()
+
+	// myapp role matches; other-app role doesn't.
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "myapp-role",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+	}))
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "other-role",
+		"bound_service_account_names":      []string{"other-app"},
+		"bound_service_account_namespaces": []string{"default"},
+	}))
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleIntrospectRoles(ctx, introspectRequest(t, jwt), &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "myapp-role", roles[0].Name)
+}
+
+func TestIntrospect_FiltersByAudience(t *testing.T) {
+	b, _ := introspectSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		Audiences:     []string{"https://allowed-aud", "https://kubernetes.default.svc"},
+	})
+	ctx := t.Context()
+
+	// Role pinned to an audience the token DOES have → included.
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "allowed",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"audience":                         "https://allowed-aud",
+	}))
+	// Role pinned to an audience the token does NOT have → excluded.
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "forbidden",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"audience":                         "https://other-aud",
+	}))
+	// Role with no audience binding → included regardless.
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "unbound",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+	}))
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleIntrospectRoles(ctx, introspectRequest(t, jwt), &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	names := make([]string, 0, len(roles))
+	for _, r := range roles {
+		names = append(names, r.Name)
+	}
+	assert.ElementsMatch(t, []string{"allowed", "unbound"}, names,
+		"only roles whose audience binding is satisfied (or unbound) should appear")
+}
+
+func TestIntrospect_IssuerPinShortCircuitsBeforeTokenReview(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{Authenticated: true},
+	})
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+		"issuer":          "https://cluster-a.svc",
+	}))
+
+	// Token from wrong cluster.
+	jwt := mintK8sSAJWT("https://cluster-b.svc", "default", "myapp")
+	resp, err := b.handleIntrospectRoles(ctx, introspectRequest(t, jwt), &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+	assert.Equal(t, int32(0), fake.Calls,
+		"issuer pin must reject before the TokenReview round-trip")
+}
+
+func TestIntrospect_AcceptsJWTFromReqClientToken(t *testing.T) {
+	// In-process callers (the sys/introspect/roles aggregator) stash the
+	// JWT on req.ClientToken instead of the Authorization header.
+	b, _ := introspectSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+	})
+	_, _ = b.handleRoleCreate(t.Context(), nil, roleFieldData(t, b, map[string]any{
+		"name":                             "viaclient",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+	}))
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	req := &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "introspect/roles",
+		ClientToken: jwt,
+	}
+	resp, err := b.handleIntrospectRoles(t.Context(), req, &framework.FieldData{})
+	require.NoError(t, err)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Len(t, roles, 1)
+}

--- a/auth/method/kubernetes/path_login.go
+++ b/auth/method/kubernetes/path_login.go
@@ -1,0 +1,207 @@
+package kubernetes
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	authhelper "github.com/stephnangue/warden/auth/helper"
+	"github.com/stephnangue/warden/framework"
+	lgr "github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathLogin returns the /login path definition.
+func (b *kubernetesAuthBackend) pathLogin() *framework.Path {
+	return &framework.Path{
+		Pattern: "login",
+		Fields: map[string]*framework.FieldSchema{
+			"jwt": {
+				Type:        framework.TypeString,
+				Description: "Kubernetes ServiceAccount JWT (workload identity token).",
+				Required:    true,
+			},
+			"role": {
+				Type:        framework.TypeString,
+				Description: "Name of the role to authenticate against. Falls back to config.default_role if unset.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleLogin,
+				Summary:  "Authenticate using a Kubernetes ServiceAccount JWT",
+			},
+		},
+		HelpSynopsis: "Authenticate using a Kubernetes ServiceAccount JWT",
+		HelpDescription: `Validates the workload's JWT by calling TokenReview on the configured
+kube-apiserver, matches the resolved SA against the role's bound
+service-account names and namespaces, and issues a token bound to the
+role's policies.`,
+	}
+}
+
+// handleLogin runs the TokenReview-based login flow:
+//  1. extract JWT and resolve role (with default_role fallback)
+//  2. cheap issuer pre-filter (unverified iss claim) if configured
+//  3. TokenReview against the kube-apiserver
+//  4. parse the returned system:serviceaccount:<ns>:<name> username
+//  5. match against role's bound_service_account_names/namespaces
+//  6. enforce role.max_age if configured (against iat claim)
+//  7. compute effective TTL = min(role.TokenTTL, jwt-exp-derived-TTL)
+//  8. return auth response with PrincipalID + role + policies
+//
+// All authentication failures collapse to errAuthFailed in the response
+// to prevent leaking which check failed; detailed reasons are logged
+// server-side via the gated logger.
+func (b *kubernetesAuthBackend) handleLogin(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Snapshot config under lock so concurrent /config writes don't block
+	// the TokenReview HTTP round-trip.
+	b.configMu.RLock()
+	cfg := b.config
+	b.configMu.RUnlock()
+
+	if cfg == nil {
+		return logical.ErrorResponse(logical.ErrBadRequest("kubernetes auth method is not configured (POST /config first)")), nil
+	}
+
+	jwtToken, _ := d.GetOk("jwt")
+	jwtStr, _ := jwtToken.(string)
+	if jwtStr == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("jwt is required")), nil
+	}
+
+	roleName, _ := d.GetOk("role")
+	roleStr, _ := roleName.(string)
+	if roleStr == "" {
+		roleStr = cfg.DefaultRole
+	}
+	if roleStr == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("role is required (no default_role configured)")), nil
+	}
+
+	role, err := b.getRole(ctx, roleStr)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if role == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("role %q not found", roleStr)), nil
+	}
+
+	// Cheap issuer pre-filter: parse-unverified, check iss matches the
+	// mount's configured issuer. Cuts noise before the TokenReview round-trip
+	// for tokens from the wrong cluster.
+	claims, _ := authhelper.ParseJWTClaimsUnverified(jwtStr)
+	if cfg.Issuer != "" && !cfg.DisableIssValidation {
+		if claims == nil {
+			b.logger.Warn("kubernetes login: failed to parse JWT for issuer pre-filter")
+			return logical.ErrorResponse(errAuthFailed), nil
+		}
+		issClaim, _ := claims["iss"].(string)
+		if issClaim != cfg.Issuer {
+			b.logger.Warn("kubernetes login: iss mismatch",
+				lgr.String("role", roleStr),
+				lgr.String("got_iss", issClaim),
+				lgr.String("want_iss", cfg.Issuer))
+			return logical.ErrorResponse(errAuthFailed), nil
+		}
+	}
+
+	// TokenReview call. Bearer is the operator-configured token_reviewer_jwt
+	// when set, otherwise the workload's own JWT (self-reviewing mode).
+	bearer := cfg.TokenReviewerJWT
+	if bearer == "" {
+		bearer = jwtStr
+	}
+	var audiences []string
+	if role.Audience != "" {
+		audiences = []string{role.Audience}
+	}
+	status, err := reviewToken(ctx, cfg.httpClient, cfg.KubernetesHost, bearer, jwtStr, audiences)
+	if err != nil {
+		b.logger.Warn("kubernetes login: TokenReview call failed",
+			lgr.String("role", roleStr),
+			lgr.Err(err))
+		return logical.ErrorResponse(errAuthFailed), nil
+	}
+	if !status.Authenticated || status.Error != "" {
+		b.logger.Warn("kubernetes login: TokenReview rejected token",
+			lgr.String("role", roleStr),
+			lgr.String("tokenreview_error", status.Error))
+		return logical.ErrorResponse(errAuthFailed), nil
+	}
+
+	// Username must be a SA token: "system:serviceaccount:<ns>:<name>".
+	// Anything else (system:anonymous, OIDC users, node identities) is
+	// out of scope for this auth method.
+	saNamespace, saName, ok := parseSAUsername(status.User.Username)
+	if !ok {
+		b.logger.Warn("kubernetes login: username is not a service account",
+			lgr.String("role", roleStr),
+			lgr.String("username", status.User.Username))
+		return logical.ErrorResponse(errAuthFailed), nil
+	}
+
+	if err := matchRoleBindings(role, saNamespace, saName); err != nil {
+		b.logger.Warn("kubernetes login: SA binding mismatch",
+			lgr.String("role", roleStr),
+			lgr.String("sa", saName),
+			lgr.String("namespace", saNamespace),
+			lgr.Err(err))
+		return logical.ErrorResponse(errAuthFailed), nil
+	}
+
+	// Optional freshness check via the iat claim. The TokenReview already
+	// rejects expired tokens; max_age adds a stricter bound (e.g. only
+	// accept tokens issued in the last 5 minutes).
+	if role.MaxAge != "" && claims != nil {
+		maxAge, parseErr := role.ParseMaxAge()
+		if parseErr == nil && maxAge > 0 {
+			if iat, ok := claims["iat"].(float64); ok {
+				if time.Since(time.Unix(int64(iat), 0)) > maxAge {
+					b.logger.Warn("kubernetes login: token older than role.max_age",
+						lgr.String("role", roleStr),
+						lgr.Float64("iat", iat))
+					return logical.ErrorResponse(errAuthFailed), nil
+				}
+			}
+		}
+	}
+
+	// Effective TTL: min(role.TokenTTL, jwt-exp-derived). If the JWT has
+	// no exp claim or it's already expired, only use role.TokenTTL.
+	roleTTL, _ := role.ParseTokenTTL()
+	effectiveTTL := roleTTL
+	if claims != nil {
+		if exp, ok := claims["exp"].(float64); ok {
+			until := time.Until(time.Unix(int64(exp), 0))
+			if until > 0 && until < effectiveTTL {
+				effectiveTTL = until
+			}
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Auth: &logical.Auth{
+			PrincipalID:    status.User.Username,
+			RoleName:       roleStr,
+			Policies:       role.TokenPolicies,
+			CredentialSpec: role.CredSpecName,
+			TokenType:      role.TokenType,
+			TokenTTL:       effectiveTTL,
+			ClientIP:       req.ClientIP,
+			// ClientToken carries the raw JWT so LoginCreateToken can pass
+			// it to KubernetesRoleTokenType.Generate(), which hashes
+			// (mountAccessor + JWT + role) into the deterministic cache ID
+			// used for transparent-mode lookups.
+			ClientToken: jwtStr,
+		},
+		Data: map[string]any{
+			"principal_id":              status.User.Username,
+			"role":                      roleStr,
+			"service_account_uid":       status.User.UID,
+			"service_account_namespace": saNamespace,
+			"service_account_name":      saName,
+		},
+	}, nil
+}

--- a/auth/method/kubernetes/path_login_test.go
+++ b/auth/method/kubernetes/path_login_test.go
@@ -1,0 +1,333 @@
+package kubernetes
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// loginSetup builds a backend wired to a fake apiserver returning the
+// given TokenReview status, plus a role with sensible defaults. Returns
+// the backend, ctx, fake apiserver handle, and the role's name.
+func loginSetup(t *testing.T, status tokenReviewStatus, configOverrides map[string]any) (*kubernetesAuthBackend, *fakeAPIServer) {
+	t.Helper()
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{Response: status})
+
+	cfg := map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+	}
+	for k, v := range configOverrides {
+		cfg[k] = v
+	}
+	require.NoError(t, b.setupConfig(ctx, cfg))
+
+	// Default role: bound to default/myapp.
+	_, err := b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "myrole",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"token_policies":                   []string{"default"},
+	}))
+	require.NoError(t, err)
+	return b, fake
+}
+
+func loginFieldData(t *testing.T, b *kubernetesAuthBackend, jwt, role string) *framework.FieldData {
+	t.Helper()
+	return &framework.FieldData{
+		Raw:    map[string]any{"jwt": jwt, "role": role},
+		Schema: b.pathLogin().Fields,
+	}
+}
+
+func TestHandleLogin_HappyPath_SelfReviewingMode(t *testing.T) {
+	b, fake := loginSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp", UID: "uid-1"},
+	}, nil)
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	ctx := t.Context()
+	resp, err := b.handleLogin(ctx, &logical.Request{ClientIP: "10.0.0.1"}, loginFieldData(t, b, jwt, "myrole"))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Err, "unexpected login error: %v", resp.Err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, resp.Auth)
+	assert.Equal(t, "system:serviceaccount:default:myapp", resp.Auth.PrincipalID)
+	assert.Equal(t, "myrole", resp.Auth.RoleName)
+	assert.Equal(t, "kubernetes_role", resp.Auth.TokenType)
+	assert.Equal(t, []string{"default"}, resp.Auth.Policies)
+	assert.Equal(t, jwt, resp.Auth.ClientToken, "ClientToken must be the raw workload JWT for transparent-mode cache lookups")
+
+	// In self-reviewing mode the workload JWT IS the Authorization bearer.
+	assert.Equal(t, "Bearer "+jwt, fake.BearerSeen)
+
+	// Metadata surfaces the parsed SA fields for audit consumers.
+	assert.Equal(t, "default", resp.Data["service_account_namespace"])
+	assert.Equal(t, "myapp", resp.Data["service_account_name"])
+	assert.Equal(t, "uid-1", resp.Data["service_account_uid"])
+}
+
+func TestHandleLogin_UsesTokenReviewerJWTAsBearerWhenConfigured(t *testing.T) {
+	b, fake := loginSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+	}, map[string]any{
+		"token_reviewer_jwt": "hub-reviewer-jwt",
+	})
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	_, _ = b.handleLogin(t.Context(), &logical.Request{}, loginFieldData(t, b, jwt, "myrole"))
+
+	assert.Equal(t, "Bearer hub-reviewer-jwt", fake.BearerSeen,
+		"configured token_reviewer_jwt must be used as the Authorization bearer")
+	assert.Equal(t, jwt, fake.TokenSeen, "workload JWT goes in spec.token regardless of bearer choice")
+}
+
+func TestHandleLogin_RejectsWhenTokenReviewSaysUnauthenticated(t *testing.T) {
+	b, _ := loginSetup(t, tokenReviewStatus{
+		Authenticated: false,
+		Error:         "token signature invalid",
+	}, nil)
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleLogin(t.Context(), &logical.Request{}, loginFieldData(t, b, jwt, "myrole"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Equal(t, errAuthFailed.Error(), resp.Err.Error(),
+		"all auth failures must collapse to errAuthFailed (no info leak)")
+}
+
+func TestHandleLogin_RejectsNonServiceAccountUsername(t *testing.T) {
+	b, _ := loginSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:anonymous"},
+	}, nil)
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	resp, err := b.handleLogin(t.Context(), &logical.Request{}, loginFieldData(t, b, jwt, "myrole"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Equal(t, errAuthFailed.Error(), resp.Err.Error())
+}
+
+func TestHandleLogin_RejectsSANotInRoleBindings(t *testing.T) {
+	b, _ := loginSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:other-ns:myapp"},
+	}, nil)
+
+	jwt := mintK8sSAJWT("https://kube", "other-ns", "myapp")
+	resp, err := b.handleLogin(t.Context(), &logical.Request{}, loginFieldData(t, b, jwt, "myrole"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Equal(t, errAuthFailed.Error(), resp.Err.Error())
+}
+
+func TestHandleLogin_IssuerPreFilter_RejectsMismatchedIss(t *testing.T) {
+	b, fake := loginSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+	}, map[string]any{
+		"issuer": "https://cluster-a.svc",
+	})
+
+	// Token from a different cluster.
+	jwt := mintK8sSAJWT("https://cluster-b.svc", "default", "myapp")
+	resp, err := b.handleLogin(t.Context(), &logical.Request{}, loginFieldData(t, b, jwt, "myrole"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Equal(t, errAuthFailed.Error(), resp.Err.Error())
+	assert.Equal(t, int32(0), fake.Calls,
+		"issuer pre-filter must reject before the TokenReview round-trip")
+}
+
+func TestHandleLogin_IssuerPreFilter_AcceptsMatchingIss(t *testing.T) {
+	b, fake := loginSetup(t, tokenReviewStatus{
+		Authenticated: true,
+		User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+	}, map[string]any{
+		"issuer": "https://cluster-a.svc",
+	})
+
+	jwt := mintK8sSAJWT("https://cluster-a.svc", "default", "myapp")
+	resp, err := b.handleLogin(t.Context(), &logical.Request{}, loginFieldData(t, b, jwt, "myrole"))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err)
+	assert.Equal(t, int32(1), fake.Calls, "matching iss should not block TokenReview")
+}
+
+func TestHandleLogin_PassesRoleAudienceToTokenReview(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: true,
+			User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		},
+	})
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+	}))
+	// Role pins audience.
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "audrole",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"audience":                         "https://my-api",
+	}))
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	_, _ = b.handleLogin(ctx, &logical.Request{}, loginFieldData(t, b, jwt, "audrole"))
+
+	assert.Equal(t, []string{"https://my-api"}, fake.AudsSeen,
+		"role.audience must be passed through as spec.audiences")
+}
+
+func TestHandleLogin_TTLClampsToJWTExp(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: true,
+			User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		},
+	})
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+	}))
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "ttltest",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"token_ttl":                        3600, // 1h
+	}))
+
+	// JWT expires in 10 minutes — effective TTL should clamp to that, not 1h.
+	exp := time.Now().Add(10 * time.Minute).Unix()
+	jwt := mintJWT(map[string]any{
+		"iss": "https://kube",
+		"sub": "system:serviceaccount:default:myapp",
+		"exp": float64(exp),
+	})
+
+	resp, err := b.handleLogin(ctx, &logical.Request{}, loginFieldData(t, b, jwt, "ttltest"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Auth)
+	// Allow ±30s wiggle around the 10m expectation.
+	assert.InDelta(t, (10 * time.Minute).Seconds(), resp.Auth.TokenTTL.Seconds(), 30,
+		"TTL should clamp to JWT exp when sooner than role.token_ttl")
+}
+
+func TestHandleLogin_RejectsTokenOlderThanMaxAge(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: true,
+			User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		},
+	})
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+	}))
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "maxagerole",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"max_age":                          "5m",
+	}))
+
+	// Token issued 10 minutes ago, max_age=5m → rejected.
+	iat := time.Now().Add(-10 * time.Minute).Unix()
+	jwt := mintJWT(map[string]any{
+		"iss": "https://kube",
+		"sub": "system:serviceaccount:default:myapp",
+		"iat": float64(iat),
+	})
+
+	resp, err := b.handleLogin(ctx, &logical.Request{}, loginFieldData(t, b, jwt, "maxagerole"))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Equal(t, errAuthFailed.Error(), resp.Err.Error())
+	_ = fake
+}
+
+func TestHandleLogin_DefaultRoleFallback(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: true,
+			User:          tokenReviewUser{Username: "system:serviceaccount:default:myapp"},
+		},
+	})
+	require.NoError(t, b.setupConfig(ctx, map[string]any{
+		"kubernetes_host": fake.URL,
+		"tls_skip_verify": true,
+		"default_role":    "fallback",
+	}))
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "fallback",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+	}))
+
+	jwt := mintK8sSAJWT("https://kube", "default", "myapp")
+	// Note: no role in the request.
+	d := &framework.FieldData{Raw: map[string]any{"jwt": jwt}, Schema: b.pathLogin().Fields}
+	resp, err := b.handleLogin(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	require.Nil(t, resp.Err)
+	assert.Equal(t, "fallback", resp.Auth.RoleName)
+}
+
+func TestHandleLogin_BasicValidation(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	t.Run("missing jwt", func(t *testing.T) {
+		require.NoError(t, b.setupConfig(ctx, map[string]any{
+			"kubernetes_host": "https://kube",
+			"tls_skip_verify": true,
+		}))
+		d := &framework.FieldData{Raw: map[string]any{"role": "x"}, Schema: b.pathLogin().Fields}
+		resp, err := b.handleLogin(ctx, &logical.Request{}, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "jwt is required")
+	})
+
+	t.Run("missing role and no default", func(t *testing.T) {
+		d := &framework.FieldData{Raw: map[string]any{"jwt": mintK8sSAJWT("https://kube", "default", "x")}, Schema: b.pathLogin().Fields}
+		resp, err := b.handleLogin(ctx, &logical.Request{}, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "role is required")
+	})
+
+	t.Run("role not found", func(t *testing.T) {
+		d := &framework.FieldData{Raw: map[string]any{"jwt": mintK8sSAJWT("https://kube", "default", "x"), "role": "ghost"}, Schema: b.pathLogin().Fields}
+		resp, err := b.handleLogin(ctx, &logical.Request{}, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "not found")
+	})
+
+	t.Run("backend not configured", func(t *testing.T) {
+		fresh, freshCtx := newTestBackend(t)
+		d := &framework.FieldData{Raw: map[string]any{"jwt": "x", "role": "y"}, Schema: fresh.pathLogin().Fields}
+		resp, err := fresh.handleLogin(freshCtx, &logical.Request{}, d)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "not configured")
+	})
+}

--- a/auth/method/kubernetes/path_role.go
+++ b/auth/method/kubernetes/path_role.go
@@ -1,0 +1,353 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+const rolePrefix = "role/"
+
+// pathRole returns the role CRUD path definition.
+func (b *kubernetesAuthBackend) pathRole() *framework.Path {
+	return &framework.Path{
+		Pattern: "role/" + framework.GenericNameRegex("name"),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of the role",
+				Required:    true,
+			},
+			"description": {
+				Type:        framework.TypeString,
+				Description: "Human-readable description, surfaced via introspection so agents can select an appropriate role",
+			},
+			"bound_service_account_names": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: `List of service account names the workload's SA must match. "*" matches any. At least one of bound_service_account_names or bound_service_account_namespaces must be a concrete value (refusing both as ["*"]).`,
+			},
+			"bound_service_account_namespaces": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: `List of namespaces the workload's SA must live in. "*" matches any. At least one of bound_service_account_names or bound_service_account_namespaces must be a concrete value.`,
+			},
+			"audience": {
+				Type:        framework.TypeString,
+				Description: "If set, sent as spec.audiences in the TokenReview request. The workload JWT must declare this audience or the kube-apiserver rejects the review.",
+			},
+			"token_policies": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "List of policies attached to issued tokens",
+			},
+			"token_ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Token TTL (default: 1h). Overrides the auth method's config token_ttl.",
+				Default:     3600,
+			},
+			"cred_spec_name": {
+				Type:        framework.TypeString,
+				Description: "Credential spec name for implicit auth flows",
+			},
+			"max_age": {
+				Type:        framework.TypeString,
+				Description: `Maximum elapsed time since the JWT was issued (iat). Rejects JWTs older than this. Example: "30m", "1h"`,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.handleRoleCreate,
+				Summary:  "Create a new role",
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleRoleRead,
+				Summary:  "Read role configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleRoleUpdate,
+				Summary:  "Update role configuration",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.handleRoleDelete,
+				Summary:  "Delete a role",
+			},
+		},
+		HelpSynopsis:    "Manage kubernetes auth roles",
+		HelpDescription: "Create, read, update, and delete roles for kubernetes authentication.",
+	}
+}
+
+// pathRoleList returns the role list path definition.
+func (b *kubernetesAuthBackend) pathRoleList() *framework.Path {
+	return &framework.Path{
+		Pattern: "role/?$",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.handleRoleList,
+				Summary:  "List all roles",
+			},
+		},
+		HelpSynopsis:    "List kubernetes auth roles",
+		HelpDescription: "List all configured roles for kubernetes authentication.",
+	}
+}
+
+func (b *kubernetesAuthBackend) handleRoleCreate(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	existing, err := b.getRole(ctx, name)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if existing != nil {
+		return logical.ErrorResponse(logical.ErrConflictf("role %q already exists", name)), nil
+	}
+
+	role := b.buildRoleFromFieldData(name, d)
+
+	if err := b.validateRole(role); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+
+	if err := b.setRole(ctx, role); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusCreated,
+		Data: map[string]any{
+			"name":    role.Name,
+			"message": fmt.Sprintf("Successfully created role %s", name),
+		},
+	}, nil
+}
+
+func (b *kubernetesAuthBackend) handleRoleRead(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	role, err := b.getRole(ctx, name)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if role == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("role %q not found", name)), nil
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"name":                             role.Name,
+			"description":                      role.Description,
+			"bound_service_account_names":      role.BoundServiceAccountNames,
+			"bound_service_account_namespaces": role.BoundServiceAccountNamespaces,
+			"audience":                         role.Audience,
+			"token_policies":                   role.TokenPolicies,
+			"token_ttl":                        role.TokenTTL,
+			"cred_spec_name":                   role.CredSpecName,
+			"max_age":                          role.MaxAge,
+		},
+	}, nil
+}
+
+func (b *kubernetesAuthBackend) handleRoleUpdate(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	role, err := b.getRole(ctx, name)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	isCreate := role == nil
+	if isCreate {
+		role = b.buildRoleFromFieldData(name, d)
+	} else {
+		// Update existing role — only touch fields explicitly provided.
+		if v, ok := d.GetOk("description"); ok {
+			role.Description = v.(string)
+		}
+		if v, ok := d.GetOk("bound_service_account_names"); ok {
+			role.BoundServiceAccountNames = v.([]string)
+		}
+		if v, ok := d.GetOk("bound_service_account_namespaces"); ok {
+			role.BoundServiceAccountNamespaces = v.([]string)
+		}
+		if v, ok := d.GetOk("audience"); ok {
+			role.Audience = v.(string)
+		}
+		if v, ok := d.GetOk("token_policies"); ok {
+			role.TokenPolicies = v.([]string)
+		}
+		if v, ok := d.GetOk("token_ttl"); ok {
+			role.TokenTTL = (time.Duration(v.(int)) * time.Second).String()
+		}
+		if v, ok := d.GetOk("cred_spec_name"); ok {
+			role.CredSpecName = v.(string)
+		}
+		if v, ok := d.GetOk("max_age"); ok {
+			role.MaxAge = v.(string)
+		}
+	}
+
+	if err := b.validateRole(role); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+
+	if err := b.setRole(ctx, role); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	statusCode := http.StatusOK
+	action := "updated"
+	if isCreate {
+		statusCode = http.StatusCreated
+		action = "created"
+	}
+
+	return &logical.Response{
+		StatusCode: statusCode,
+		Data: map[string]any{
+			"name":    role.Name,
+			"message": fmt.Sprintf("Successfully %s role %s", action, name),
+		},
+	}, nil
+}
+
+func (b *kubernetesAuthBackend) handleRoleDelete(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	if err := b.deleteRole(ctx, name); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"message": fmt.Sprintf("Successfully deleted role %s", name)},
+	}, nil
+}
+
+func (b *kubernetesAuthBackend) handleRoleList(ctx context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	roles, err := b.listRoles(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"keys": roles},
+	}, nil
+}
+
+// validateRole validates role fields and sets defaults. TokenType is
+// always pinned to "kubernetes_role" so operators can't override it.
+func (b *kubernetesAuthBackend) validateRole(role *KubernetesRole) error {
+	role.TokenType = "kubernetes_role"
+
+	if role.TokenTTL == "" {
+		role.TokenTTL = time.Hour.String()
+	}
+	if _, err := role.ParseTokenTTL(); err != nil {
+		return logical.ErrBadRequestf("invalid token_ttl: %v", err)
+	}
+
+	// At least one of names/namespaces must be a concrete value. Both empty
+	// or both ["*"] would let any K8s workload that can reach the spoke get
+	// this role — refuse it (defense in depth, matches Vault's behavior).
+	if onlyWildcardOrEmpty(role.BoundServiceAccountNames) && onlyWildcardOrEmpty(role.BoundServiceAccountNamespaces) {
+		return logical.ErrBadRequest("at least one of bound_service_account_names or bound_service_account_namespaces must contain a concrete value (not empty, not only \"*\")")
+	}
+
+	if role.MaxAge != "" {
+		maxAge, err := role.ParseMaxAge()
+		if err != nil {
+			return logical.ErrBadRequestf("invalid max_age: %v", err)
+		}
+		if maxAge <= 0 {
+			return logical.ErrBadRequest("max_age must be a positive duration")
+		}
+	}
+
+	return nil
+}
+
+// onlyWildcardOrEmpty returns true if the list is empty or contains only
+// "*" entries. Used by validateRole to refuse roles bound to nothing
+// concrete.
+func onlyWildcardOrEmpty(list []string) bool {
+	if len(list) == 0 {
+		return true
+	}
+	for _, v := range list {
+		if v != "*" {
+			return false
+		}
+	}
+	return true
+}
+
+// buildRoleFromFieldData creates a KubernetesRole from request field data.
+func (b *kubernetesAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldData) *KubernetesRole {
+	role := &KubernetesRole{Name: name}
+
+	if v, ok := d.GetOk("description"); ok {
+		role.Description = v.(string)
+	}
+	if v, ok := d.GetOk("bound_service_account_names"); ok {
+		role.BoundServiceAccountNames = v.([]string)
+	}
+	if v, ok := d.GetOk("bound_service_account_namespaces"); ok {
+		role.BoundServiceAccountNamespaces = v.([]string)
+	}
+	if v, ok := d.GetOk("audience"); ok {
+		role.Audience = v.(string)
+	}
+	if v, ok := d.GetOk("token_policies"); ok {
+		role.TokenPolicies = v.([]string)
+	}
+	if v, ok := d.GetOk("token_ttl"); ok {
+		role.TokenTTL = (time.Duration(v.(int)) * time.Second).String()
+	}
+	if v, ok := d.GetOk("cred_spec_name"); ok {
+		role.CredSpecName = v.(string)
+	}
+	if v, ok := d.GetOk("max_age"); ok {
+		role.MaxAge = v.(string)
+	}
+
+	return role
+}
+
+// Storage helpers — JSON-encoded under role/<name>.
+
+func (b *kubernetesAuthBackend) getRole(ctx context.Context, name string) (*KubernetesRole, error) {
+	entry, err := b.storageView.Get(ctx, rolePrefix+name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var role KubernetesRole
+	if err := entry.DecodeJSON(&role); err != nil {
+		return nil, err
+	}
+	return &role, nil
+}
+
+func (b *kubernetesAuthBackend) setRole(ctx context.Context, role *KubernetesRole) error {
+	entry, err := sdklogical.StorageEntryJSON(rolePrefix+role.Name, role)
+	if err != nil {
+		return err
+	}
+	return b.storageView.Put(ctx, entry)
+}
+
+func (b *kubernetesAuthBackend) deleteRole(ctx context.Context, name string) error {
+	return b.storageView.Delete(ctx, rolePrefix+name)
+}
+
+func (b *kubernetesAuthBackend) listRoles(ctx context.Context) ([]string, error) {
+	return b.storageView.List(ctx, rolePrefix)
+}

--- a/auth/method/kubernetes/path_role_test.go
+++ b/auth/method/kubernetes/path_role_test.go
@@ -1,0 +1,253 @@
+package kubernetes
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// roleFieldData builds a FieldData targeting the role path schema with
+// the given raw values. The "name" key is the role name; other keys
+// match the field schema in path_role.go.
+func roleFieldData(t *testing.T, b *kubernetesAuthBackend, raw map[string]any) *framework.FieldData {
+	t.Helper()
+	return &framework.FieldData{Raw: raw, Schema: b.pathRole().Fields}
+}
+
+func TestHandleRoleCreate_Basic(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "myapp",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default"},
+		"token_policies":                   []string{"default"},
+		"token_ttl":                        3600,
+	})
+	resp, err := b.handleRoleCreate(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Err, "unexpected validation error: %v", resp.Err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "myapp", resp.Data["name"])
+}
+
+func TestHandleRoleCreate_DuplicateConflicts(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "dup",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"default"},
+	})
+	_, _ = b.handleRoleCreate(ctx, nil, d)
+
+	// Second create with same name should 409 conflict.
+	resp, err := b.handleRoleCreate(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "already exists")
+}
+
+func TestHandleRoleCreate_RefusesBothWildcards(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "wildwild",
+		"bound_service_account_names":      []string{"*"},
+		"bound_service_account_namespaces": []string{"*"},
+	})
+	resp, err := b.handleRoleCreate(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err, "must refuse */* binding")
+	assert.Contains(t, resp.Err.Error(), "at least one of bound_service_account_names")
+}
+
+func TestHandleRoleCreate_RefusesBothEmpty(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := roleFieldData(t, b, map[string]any{
+		"name": "noboundings",
+	})
+	resp, err := b.handleRoleCreate(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err, "must refuse empty bindings")
+	assert.Contains(t, resp.Err.Error(), "at least one of bound_service_account_names")
+}
+
+func TestHandleRoleCreate_PinsTokenType(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "pinned",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"default"},
+	})
+	_, _ = b.handleRoleCreate(ctx, nil, d)
+
+	role, err := b.getRole(ctx, "pinned")
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	assert.Equal(t, "kubernetes_role", role.TokenType,
+		"TokenType must always be pinned to kubernetes_role regardless of operator input")
+}
+
+func TestHandleRoleCreate_DefaultsTokenTTLToOneHour(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "defaultttl",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"default"},
+	})
+	_, _ = b.handleRoleCreate(ctx, nil, d)
+
+	role, err := b.getRole(ctx, "defaultttl")
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	ttl, err := role.ParseTokenTTL()
+	require.NoError(t, err)
+	assert.Equal(t, time.Hour, ttl)
+}
+
+func TestHandleRoleRead_Roundtrip(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	createData := roleFieldData(t, b, map[string]any{
+		"name":                             "roundtrip",
+		"description":                      "round-trip test",
+		"bound_service_account_names":      []string{"myapp"},
+		"bound_service_account_namespaces": []string{"default", "prod"},
+		"audience":                         "api",
+		"token_policies":                   []string{"reader", "writer"},
+	})
+	_, _ = b.handleRoleCreate(ctx, nil, createData)
+
+	resp, err := b.handleRoleRead(ctx, nil, roleFieldData(t, b, map[string]any{"name": "roundtrip"}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Err)
+	assert.Equal(t, "roundtrip", resp.Data["name"])
+	assert.Equal(t, "round-trip test", resp.Data["description"])
+	assert.Equal(t, []string{"myapp"}, resp.Data["bound_service_account_names"])
+	assert.Equal(t, []string{"default", "prod"}, resp.Data["bound_service_account_namespaces"])
+	assert.Equal(t, "api", resp.Data["audience"])
+	assert.Equal(t, []string{"reader", "writer"}, resp.Data["token_policies"])
+}
+
+func TestHandleRoleRead_NotFound(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	resp, err := b.handleRoleRead(ctx, nil, roleFieldData(t, b, map[string]any{"name": "ghost"}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "not found")
+}
+
+func TestHandleRoleUpdate_CreatesIfMissing(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "upsert",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"default"},
+	})
+	resp, err := b.handleRoleUpdate(ctx, nil, d)
+	require.NoError(t, err)
+	require.Nil(t, resp.Err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestHandleRoleUpdate_PatchesExistingFields(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "patch",
+		"description":                      "before",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"default"},
+		"token_policies":                   []string{"default"},
+	}))
+
+	// Update only the description; SA bindings and policies must persist.
+	resp, err := b.handleRoleUpdate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":        "patch",
+		"description": "after",
+	}))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	role, err := b.getRole(ctx, "patch")
+	require.NoError(t, err)
+	assert.Equal(t, "after", role.Description)
+	assert.Equal(t, []string{"app"}, role.BoundServiceAccountNames)
+	assert.Equal(t, []string{"default"}, role.BoundServiceAccountNamespaces)
+	assert.Equal(t, []string{"default"}, role.TokenPolicies)
+}
+
+func TestHandleRoleDelete(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+		"name":                             "deleteme",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"default"},
+	}))
+
+	resp, err := b.handleRoleDelete(ctx, nil, roleFieldData(t, b, map[string]any{"name": "deleteme"}))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Confirm gone.
+	role, err := b.getRole(ctx, "deleteme")
+	require.NoError(t, err)
+	assert.Nil(t, role)
+}
+
+func TestHandleRoleList(t *testing.T) {
+	b, ctx := newTestBackend(t)
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		_, _ = b.handleRoleCreate(ctx, nil, roleFieldData(t, b, map[string]any{
+			"name":                             name,
+			"bound_service_account_names":      []string{"app"},
+			"bound_service_account_namespaces": []string{"default"},
+		}))
+	}
+
+	resp, err := b.handleRoleList(ctx, &logical.Request{}, &framework.FieldData{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	keys, ok := resp.Data["keys"].([]string)
+	require.True(t, ok, "list response should contain []string keys")
+	assert.ElementsMatch(t, []string{"alpha", "beta", "gamma"}, keys)
+}
+
+func TestValidateRole_BadMaxAge(t *testing.T) {
+	b, _ := newTestBackend(t)
+	tests := []struct {
+		max string
+		msg string
+	}{
+		{"not-a-duration", "invalid max_age"},
+		{"-5m", "max_age must be a positive duration"},
+		{"0s", "max_age must be a positive duration"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.max, func(t *testing.T) {
+			err := b.validateRole(&KubernetesRole{
+				BoundServiceAccountNames:      []string{"app"},
+				BoundServiceAccountNamespaces: []string{"default"},
+				MaxAge:                        tc.max,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.msg)
+		})
+	}
+}
+
+func TestValidateRole_AcceptsValidMaxAge(t *testing.T) {
+	b, _ := newTestBackend(t)
+	err := b.validateRole(&KubernetesRole{
+		BoundServiceAccountNames:      []string{"app"},
+		BoundServiceAccountNamespaces: []string{"default"},
+		MaxAge:                        "5m",
+	})
+	require.NoError(t, err)
+}

--- a/auth/method/kubernetes/role.go
+++ b/auth/method/kubernetes/role.go
@@ -1,0 +1,54 @@
+package kubernetes
+
+import "time"
+
+// KubernetesRole represents a role configuration for the kubernetes auth
+// method. Used for both runtime evaluation and on-disk storage; durations
+// are stored as strings for JSON readability.
+type KubernetesRole struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+
+	// BoundServiceAccountNames is the list of service account names this
+	// role accepts. "*" matches any. Validation refuses ("*",...) paired
+	// with ("*",...) for BoundServiceAccountNamespaces — at least one of
+	// the two must be a concrete value.
+	BoundServiceAccountNames []string `json:"bound_service_account_names"`
+
+	// BoundServiceAccountNamespaces is the list of namespaces the workload
+	// SA must live in. "*" matches any (subject to the same validation).
+	BoundServiceAccountNamespaces []string `json:"bound_service_account_namespaces"`
+
+	// Audience is sent as spec.audiences in the TokenReview request.
+	// The workload JWT must declare this audience or the kube-apiserver
+	// rejects the review. Empty = no audience binding for this role
+	// (TokenReview will accept the token's natural audiences).
+	Audience string `json:"audience,omitempty"`
+
+	TokenPolicies []string `json:"token_policies"`
+	TokenTTL      string   `json:"token_ttl"`
+	TokenType     string   `json:"token_type,omitempty"`
+	CredSpecName  string   `json:"cred_spec_name,omitempty"`
+
+	// MaxAge optionally caps the elapsed time since the JWT's iat claim.
+	// Empty = no freshness check. Same shape as JWTRole.MaxAge.
+	MaxAge string `json:"max_age,omitempty"`
+}
+
+// ParseTokenTTL parses the TokenTTL string to a time.Duration.
+// Returns 1h when empty (mirrors JWT method default).
+func (r *KubernetesRole) ParseTokenTTL() (time.Duration, error) {
+	if r.TokenTTL == "" {
+		return time.Hour, nil
+	}
+	return time.ParseDuration(r.TokenTTL)
+}
+
+// ParseMaxAge parses the MaxAge string to a time.Duration.
+// Returns 0 (no check) if MaxAge is not set.
+func (r *KubernetesRole) ParseMaxAge() (time.Duration, error) {
+	if r.MaxAge == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(r.MaxAge)
+}

--- a/auth/method/kubernetes/testing_test.go
+++ b/auth/method/kubernetes/testing_test.go
@@ -1,0 +1,201 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+)
+
+// =============================================================================
+// Logger
+// =============================================================================
+
+func testLogger() *logger.GatedLogger {
+	cfg := &logger.Config{
+		Level:   logger.ErrorLevel,
+		Format:  logger.JSONFormat,
+		Outputs: []io.Writer{io.Discard},
+	}
+	gl, _ := logger.NewGatedLogger(cfg, logger.GatedWriterConfig{Underlying: io.Discard})
+	return gl
+}
+
+// =============================================================================
+// Inmem storage
+// =============================================================================
+
+type inmemStorage struct {
+	mu   sync.RWMutex
+	data map[string]*sdklogical.StorageEntry
+}
+
+func newInmemStorage() *inmemStorage {
+	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
+}
+
+func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			keys = append(keys, k[len(prefix):])
+		}
+	}
+	return keys, nil
+}
+
+func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key], nil
+}
+
+func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[entry.Key] = entry
+	return nil
+}
+
+func (s *inmemStorage) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *inmemStorage) ListPage(ctx context.Context, prefix string, _ string, _ int) ([]string, error) {
+	return s.List(ctx, prefix)
+}
+
+var _ sdklogical.Storage = (*inmemStorage)(nil)
+
+// =============================================================================
+// Backend constructor
+// =============================================================================
+
+// newTestBackend builds a kubernetesAuthBackend with inmem storage and
+// no upstream apiserver configured. Use newTestBackendWithFakeAPI when
+// the test actually exercises TokenReview.
+func newTestBackend(t *testing.T) (*kubernetesAuthBackend, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	storage := newInmemStorage()
+	be, err := Factory(ctx, &logical.BackendConfig{
+		Logger:      testLogger(),
+		StorageView: storage,
+	})
+	require.NoError(t, err)
+	return be.(*kubernetesAuthBackend), ctx
+}
+
+// =============================================================================
+// Fake kube-apiserver — httptest.Server returning canned TokenReview responses
+// =============================================================================
+
+// fakeAPIServerOpts configures a single test apiserver.
+type fakeAPIServerOpts struct {
+	// Response is the canned status payload returned for any TokenReview
+	// request. Authenticated/User/Audiences/Error fields drive test
+	// assertions about login outcomes.
+	Response tokenReviewStatus
+
+	// ResponseStatus overrides the HTTP status code; defaults to 201.
+	ResponseStatus int
+
+	// Failures: number of leading requests that should fail with status
+	// FailWithStatus (drives retry tests). After Failures responses are
+	// returned, subsequent requests get the canned Response.
+	Failures       int
+	FailWithStatus int // default 500
+}
+
+// fakeAPIServer is the test handle returned by newFakeAPIServer. Exposes
+// the server URL + records what bearer was used + the spec.token /
+// spec.audiences seen by the apiserver.
+type fakeAPIServer struct {
+	URL         string
+	Calls       int32
+	BearerSeen  string
+	TokenSeen   string
+	AudsSeen    []string
+	RawBodySeen []byte
+}
+
+// newFakeAPIServer spins up an httptest.Server that responds to TokenReview
+// POSTs at /apis/authentication.k8s.io/v1/tokenreviews. Records the
+// authorization bearer + spec for inspection in tests.
+func newFakeAPIServer(t *testing.T, opts fakeAPIServerOpts) *fakeAPIServer {
+	t.Helper()
+	fake := &fakeAPIServer{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&fake.Calls, 1)
+		fake.BearerSeen = r.Header.Get("Authorization")
+
+		body, _ := io.ReadAll(r.Body)
+		fake.RawBodySeen = body
+		var req tokenReviewRequest
+		_ = json.Unmarshal(body, &req)
+		fake.TokenSeen = req.Spec.Token
+		fake.AudsSeen = req.Spec.Audiences
+
+		// Failure injection for retry tests.
+		if opts.Failures > 0 && int32(opts.Failures) >= n {
+			status := opts.FailWithStatus
+			if status == 0 {
+				status = http.StatusInternalServerError
+			}
+			w.WriteHeader(status)
+			return
+		}
+
+		respStatus := opts.ResponseStatus
+		if respStatus == 0 {
+			respStatus = http.StatusCreated
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(respStatus)
+		_ = json.NewEncoder(w).Encode(tokenReviewResponse{Status: opts.Response})
+	}))
+	t.Cleanup(srv.Close)
+	fake.URL = srv.URL
+	return fake
+}
+
+// =============================================================================
+// JWT mint — produces well-formed (unsigned) JWTs for unverified-parse tests
+// =============================================================================
+
+// mintJWT returns a JWT with the given payload claims and a dummy
+// signature. ParseJWTClaimsUnverified accepts these because it doesn't
+// verify signatures; TokenReview-based login also accepts them because
+// the kube-apiserver (real or our fake) is the only signature authority.
+func mintJWT(claims map[string]any) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	payloadEnc := base64.RawURLEncoding.EncodeToString(payload)
+	signature := base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature"))
+	return header + "." + payloadEnc + "." + signature
+}
+
+// mintK8sSAJWT returns a K8s SA-shaped JWT with the standard sub claim.
+// Useful for the issuer-pin and shape-detection paths.
+func mintK8sSAJWT(issuer, namespace, name string) string {
+	return mintJWT(map[string]any{
+		"iss": issuer,
+		"sub": "system:serviceaccount:" + namespace + ":" + name,
+	})
+}

--- a/auth/method/kubernetes/tokenreview.go
+++ b/auth/method/kubernetes/tokenreview.go
@@ -1,0 +1,118 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stephnangue/warden/helper/httputil"
+)
+
+// TokenReview request/response shapes from authentication.k8s.io/v1.
+// Locally typed rather than importing k8s.io/api to keep the dependency
+// surface small — TokenReview is a stable, narrow API and the four
+// structs below are all we need to (de)serialize.
+type tokenReviewRequest struct {
+	APIVersion string          `json:"apiVersion"`
+	Kind       string          `json:"kind"`
+	Spec       tokenReviewSpec `json:"spec"`
+}
+
+type tokenReviewSpec struct {
+	Token     string   `json:"token"`
+	Audiences []string `json:"audiences,omitempty"`
+}
+
+type tokenReviewResponse struct {
+	Status tokenReviewStatus `json:"status"`
+}
+
+type tokenReviewStatus struct {
+	Authenticated bool            `json:"authenticated"`
+	User          tokenReviewUser `json:"user,omitempty"`
+	Audiences     []string        `json:"audiences,omitempty"`
+	Error         string          `json:"error,omitempty"`
+}
+
+type tokenReviewUser struct {
+	Username string   `json:"username"`
+	UID      string   `json:"uid"`
+	Groups   []string `json:"groups,omitempty"`
+}
+
+const (
+	tokenReviewPath  = "/apis/authentication.k8s.io/v1/tokenreviews"
+	tokenReviewKind  = "TokenReview"
+	tokenReviewAPIv1 = "authentication.k8s.io/v1"
+
+	// defaultHTTPTimeout caps each TokenReview round-trip. Generous enough
+	// to tolerate a cold apiserver but short enough that a workload's
+	// login latency stays bounded.
+	defaultHTTPTimeout = 10 * time.Second
+)
+
+// reviewToken POSTs a TokenReview to the kube-apiserver and returns the
+// authenticated status. Uses bearerJWT as the Authorization header —
+// when the operator configured token_reviewer_jwt this is that
+// hub-side service account token (standard Vault path); otherwise it
+// is the workload's own JWT (self-reviewing mode, requires the
+// workload SA to have system:auth-delegator).
+//
+// audiences is passed through to spec.audiences; if non-empty, the
+// kube-apiserver rejects the review if the token's natural audiences
+// do not include all requested values. For login, callers pass the
+// role's required audience; for introspection, callers pass nil to
+// learn the token's natural audiences from the response.
+func reviewToken(
+	ctx context.Context,
+	client *http.Client,
+	kubernetesHost string,
+	bearerJWT string,
+	workloadJWT string,
+	audiences []string,
+) (*tokenReviewStatus, error) {
+	body, err := json.Marshal(tokenReviewRequest{
+		APIVersion: tokenReviewAPIv1,
+		Kind:       tokenReviewKind,
+		Spec: tokenReviewSpec{
+			Token:     workloadJWT,
+			Audiences: audiences,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal tokenreview request: %w", err)
+	}
+
+	req := httputil.HTTPRequest{
+		Method: http.MethodPost,
+		URL:    kubernetesHost + tokenReviewPath,
+		Body:   body,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + bearerJWT,
+			"Content-Type":  "application/json",
+			"Accept":        "application/json",
+		},
+		// TokenReview returns 201 Created on success in some apiserver
+		// versions, 200 OK in others — both signal a valid review.
+		OKStatuses: []int{http.StatusOK, http.StatusCreated},
+	}
+
+	retry := httputil.DefaultHTTPRetryConfig()
+	// Retry on transient apiserver 5xx errors in addition to the default
+	// 429 (rate limit). 5xx during auth typically means the apiserver is
+	// briefly unavailable — retrying is the right call.
+	retry.RetryableStatuses = []int{http.StatusTooManyRequests, 500}
+
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, client, req, retry)
+	if err != nil {
+		return nil, fmt.Errorf("tokenreview call to %s failed (status %d): %w", kubernetesHost, status, err)
+	}
+
+	var resp tokenReviewResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal tokenreview response: %w", err)
+	}
+	return &resp.Status, nil
+}

--- a/auth/method/kubernetes/tokenreview_test.go
+++ b/auth/method/kubernetes/tokenreview_test.go
@@ -1,0 +1,129 @@
+package kubernetes
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/helper/httputil"
+)
+
+func TestReviewToken_AuthenticatedHappyPath(t *testing.T) {
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: true,
+			User: tokenReviewUser{
+				Username: "system:serviceaccount:default:myapp",
+				UID:      "abc-uid",
+			},
+			Audiences: []string{"https://kubernetes.default.svc"},
+		},
+	})
+
+	client, err := httputil.BuildHTTPClient(nil, false, 0)
+	require.NoError(t, err)
+
+	status, err := reviewToken(context.Background(), client, fake.URL,
+		"reviewer-jwt", "workload-jwt", []string{"https://kubernetes.default.svc"})
+	require.NoError(t, err)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, "system:serviceaccount:default:myapp", status.User.Username)
+	assert.Equal(t, "abc-uid", status.User.UID)
+	assert.Contains(t, fake.AudsSeen, "https://kubernetes.default.svc")
+	assert.Equal(t, "workload-jwt", fake.TokenSeen)
+	assert.Equal(t, "Bearer reviewer-jwt", fake.BearerSeen,
+		"reviewer JWT should be the Authorization bearer when supplied")
+}
+
+func TestReviewToken_SelfReviewingMode_UsesWorkloadJWTAsBearer(t *testing.T) {
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{Authenticated: true, User: tokenReviewUser{Username: "system:serviceaccount:default:app"}},
+	})
+	client, _ := httputil.BuildHTTPClient(nil, false, 0)
+
+	// Caller passes the workload JWT as the bearer (production path
+	// sets bearer = workloadJWT when TokenReviewerJWT is empty).
+	_, err := reviewToken(context.Background(), client, fake.URL,
+		"workload-jwt", "workload-jwt", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer workload-jwt", fake.BearerSeen)
+}
+
+func TestReviewToken_DeniedTokenIsNotAnError(t *testing.T) {
+	// TokenReview returning authenticated=false is a normal response,
+	// not an HTTP error. reviewToken must surface it cleanly so the
+	// caller can apply errAuthFailed without leaking the spoke's reason.
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: false,
+			Error:         "token expired",
+		},
+	})
+	client, _ := httputil.BuildHTTPClient(nil, false, 0)
+
+	status, err := reviewToken(context.Background(), client, fake.URL, "bearer", "workload", nil)
+	require.NoError(t, err)
+	assert.False(t, status.Authenticated)
+	assert.Equal(t, "token expired", status.Error)
+}
+
+func TestReviewToken_RetriesOn5xxThenSucceeds(t *testing.T) {
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Failures:       2, // 500 twice, then succeed
+		FailWithStatus: http.StatusInternalServerError,
+		Response:       tokenReviewStatus{Authenticated: true, User: tokenReviewUser{Username: "system:serviceaccount:default:app"}},
+	})
+	client, _ := httputil.BuildHTTPClient(nil, false, 0)
+
+	status, err := reviewToken(context.Background(), client, fake.URL, "bearer", "workload", nil)
+	require.NoError(t, err)
+	assert.True(t, status.Authenticated)
+	assert.Equal(t, int32(3), fake.Calls, "expected two retries before the third call succeeds")
+}
+
+func TestReviewToken_FailsAfterMaxRetries(t *testing.T) {
+	// Default retry config is 3 attempts; fake fails 5 times so all attempts fail.
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Failures:       5,
+		FailWithStatus: http.StatusInternalServerError,
+	})
+	client, _ := httputil.BuildHTTPClient(nil, false, 0)
+
+	_, err := reviewToken(context.Background(), client, fake.URL, "bearer", "workload", nil)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "tokenreview call"), "error should mention the call: %v", err)
+}
+
+func TestReviewToken_SpecAudiencesArePassedThrough(t *testing.T) {
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{Authenticated: true, User: tokenReviewUser{Username: "system:serviceaccount:default:app"}},
+	})
+	client, _ := httputil.BuildHTTPClient(nil, false, 0)
+
+	_, err := reviewToken(context.Background(), client, fake.URL, "bearer", "workload", []string{"api", "internal"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"api", "internal"}, fake.AudsSeen)
+}
+
+func TestReviewToken_NilAudiencesOmittedFromRequest(t *testing.T) {
+	// audiences=nil should produce no spec.audiences field (omitempty),
+	// which TokenReview interprets as "any audience the token has".
+	fake := newFakeAPIServer(t, fakeAPIServerOpts{
+		Response: tokenReviewStatus{
+			Authenticated: true,
+			Audiences:     []string{"https://kubernetes.default.svc"},
+			User:          tokenReviewUser{Username: "system:serviceaccount:default:app"},
+		},
+	})
+	client, _ := httputil.BuildHTTPClient(nil, false, 0)
+
+	status, err := reviewToken(context.Background(), client, fake.URL, "bearer", "workload", nil)
+	require.NoError(t, err)
+	assert.Empty(t, fake.AudsSeen, "no audiences should be sent when nil is passed")
+	assert.Equal(t, []string{"https://kubernetes.default.svc"}, status.Audiences,
+		"response audiences are the token's natural set")
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stephnangue/warden/audit"
 	"github.com/stephnangue/warden/auth/method/cert"
 	"github.com/stephnangue/warden/auth/method/jwt"
+	authk8s "github.com/stephnangue/warden/auth/method/kubernetes"
 	"github.com/stephnangue/warden/config"
 	"github.com/stephnangue/warden/core"
 	wardenseal "github.com/stephnangue/warden/core/seal"
@@ -201,8 +202,9 @@ Usage: warden server [options]
 	}
 
 	authMethods = map[string]wardenlogical.Factory{
-		"jwt":  jwt.Factory,
-		"cert": cert.Factory,
+		"jwt":        jwt.Factory,
+		"cert":       cert.Factory,
+		"kubernetes": authk8s.Factory,
 	}
 
 	storageBackends = map[string]physical.Factory{

--- a/core/token_store.go
+++ b/core/token_store.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	TypeWardenToken = "warden_token"
-	TypeJWTRole     = "jwt_role"
-	TypeCertRole    = "cert_role"
+	TypeWardenToken    = "warden_token"
+	TypeJWTRole        = "jwt_role"
+	TypeCertRole       = "cert_role"
+	TypeKubernetesRole = "kubernetes_role"
 )
 
 // Storage path constants for token store organization
@@ -308,6 +309,7 @@ func (s *TokenStore) registerBuiltinTypes() error {
 		&WardenTokenType{},
 		&JWTRoleTokenType{},
 		&CertRoleTokenType{},
+		&KubernetesRoleTokenType{},
 	}
 
 	for _, tokenType := range builtinTypes {

--- a/core/token_type_kubernetes.go
+++ b/core/token_type_kubernetes.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+// KubernetesRoleTokenType implements Kubernetes ServiceAccount JWT handling
+// with role binding. Used for implicit authentication where clients present
+// a K8s SA JWT directly and Warden authenticates them by calling TokenReview
+// on the issuing kube-apiserver (no JWKS fetch needed on the hub side).
+//
+// The (mountAccessor, JWT, role) tuple is the lookup value; its hash becomes
+// the token ID. mountAccessor prevents cache contamination across two
+// kubernetes mounts that share a role name and an SA token (e.g. workloads
+// in different spoke clusters that happen to use identical role names).
+type KubernetesRoleTokenType struct{}
+
+func (t *KubernetesRoleTokenType) Metadata() TokenTypeMetadata {
+	return TokenTypeMetadata{
+		Name:        TypeKubernetesRole,
+		IDPrefix:    "kubr_",
+		ValuePrefix: "", // MUST be empty: K8s SA tokens are JWTs (eyJ...) but
+		// JWTRoleTokenType owns that prefix in the registry. K8s tokens reach
+		// LookupTransparentTokenWithRole via performImplicitAuth's mount-type
+		// dispatch, not via prefix-based DetectType.
+		Description:    "Kubernetes ServiceAccount token validated via TokenReview, bound to a role",
+		DefaultTTL:     1 * time.Hour,
+		AuthMethodType: "kubernetes",
+	}
+}
+
+func (t *KubernetesRoleTokenType) Generate(_ context.Context, authData *AuthData, entry *TokenEntry) (map[string]string, error) {
+	// K8s SA tokens come from the workload (just like generic JWTs); Warden
+	// does not mint them. We store a hash of (mountAccessor, JWT, role)
+	// rather than the raw JWT for:
+	// - Security: SA tokens may carry sensitive bound-claim information.
+	// - ID computation: ComputeID() uses this to derive the token ID.
+	// - Mount isolation: cache entries cannot collide across mounts.
+	if authData == nil {
+		return entry.Data, nil
+	}
+	jwt := authData.TokenValue
+	if jwt == "" {
+		return entry.Data, nil
+	}
+	entry.Data["jwt"] = t.LookupValue(jwt, authData.MountAccessor, authData.RoleName)
+	return entry.Data, nil
+}
+
+func (t *KubernetesRoleTokenType) ValidateValue(tokenValue string) bool {
+	// Same JWT shape check as JWTRoleTokenType — three base64url segments
+	// separated by dots, starting with the standard JWT header prefix.
+	if !strings.HasPrefix(tokenValue, "eyJ") {
+		return false
+	}
+	parts := strings.Split(tokenValue, ".")
+	return len(parts) == 3 && len(parts[0]) > 0 && len(parts[1]) > 0 && len(parts[2]) > 0
+}
+
+func (t *KubernetesRoleTokenType) ComputeID(lookupValue string) string {
+	h := sha256.New()
+	h.Write([]byte(lookupValue))
+	hash := hex.EncodeToString(h.Sum(nil))[:32]
+	return t.Metadata().IDPrefix + hash
+}
+
+func (t *KubernetesRoleTokenType) LookupKey() string {
+	return "jwt"
+}
+
+// LookupValue computes the SHA-256 hash of (mountAccessor, jwt, role) that
+// ComputeID hashes into the byID-cache key. Same shape as
+// JWTRoleTokenType.LookupValue and CertRoleTokenType.LookupValue.
+func (t *KubernetesRoleTokenType) LookupValue(jwt, mountAccessor, role string) string {
+	h := sha256.Sum256([]byte(mountAccessor + ":" + jwt + ":" + role))
+	return hex.EncodeToString(h[:])
+}
+
+// IsTransparent always returns true; opts KubernetesRoleTokenType into the
+// transparent-auth family behaviors (cache-only persistence, the
+// explicit-login guard, the "transparent" display alias, deterministic-ID
+// collision handling) via the registry.
+func (t *KubernetesRoleTokenType) IsTransparent() bool { return true }
+
+// CredentialFormat reports "k8s_sa_jwt" — same wire shape as a generic JWT
+// (Authorization: Bearer eyJ...), but a distinct discovery-level kind so
+// the introspect aggregator only fans K8s SA tokens out to kubernetes
+// mounts (avoiding TokenReview round-trips against spokes that cannot
+// authenticate the token). performImplicitAuth groups "jwt" and
+// "k8s_sa_jwt" into a shared extraction case since the wire-level parse
+// is identical.
+func (t *KubernetesRoleTokenType) CredentialFormat() string { return "k8s_sa_jwt" }
+
+var _ TransparentTokenType = (*KubernetesRoleTokenType)(nil)

--- a/core/token_type_kubernetes_test.go
+++ b/core/token_type_kubernetes_test.go
@@ -1,0 +1,199 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleK8sSAJWT = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpteWFwcCJ9.sig"
+
+func TestKubernetesRoleTokenType_Metadata(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+	meta := kt.Metadata()
+
+	assert.Equal(t, "kubernetes_role", meta.Name)
+	assert.Equal(t, TypeKubernetesRole, meta.Name, "constant must match metadata name")
+	assert.Equal(t, "kubr_", meta.IDPrefix)
+	assert.Equal(t, "", meta.ValuePrefix,
+		"ValuePrefix MUST be empty - jwt_role owns the eyJ prefix in the registry; "+
+			"the kubernetes type reaches the cache via performImplicitAuth's mount-type dispatch, "+
+			"not via prefix-based DetectType")
+	assert.Equal(t, "kubernetes", meta.AuthMethodType,
+		"AuthMethodType wires this TokenType to mounts of type 'kubernetes' via the registry")
+}
+
+func TestKubernetesRoleTokenType_ImplementsTransparentTokenType(t *testing.T) {
+	// Compile-time assertion lives in token_type_kubernetes.go; this is
+	// the runtime equivalent so a test failure surfaces the contract.
+	var tt TransparentTokenType = &KubernetesRoleTokenType{}
+	assert.True(t, tt.IsTransparent(),
+		"KubernetesRoleTokenType must opt into transparent-family behaviors via IsTransparent()")
+	assert.Equal(t, "k8s_sa_jwt", tt.CredentialFormat(),
+		"CredentialFormat must be 'k8s_sa_jwt' (distinct from generic 'jwt') so the "+
+			"introspect aggregator only fans K8s SA tokens out to kubernetes mounts")
+}
+
+func TestKubernetesRoleTokenType_ValidateValue(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+
+	t.Run("valid 3-segment JWT", func(t *testing.T) {
+		assert.True(t, kt.ValidateValue(sampleK8sSAJWT))
+	})
+	t.Run("missing eyJ prefix", func(t *testing.T) {
+		assert.False(t, kt.ValidateValue("AAA.BBB.CCC"))
+	})
+	t.Run("two segments only", func(t *testing.T) {
+		assert.False(t, kt.ValidateValue("eyJhdr.eyJsig"))
+	})
+	t.Run("empty segment", func(t *testing.T) {
+		assert.False(t, kt.ValidateValue("eyJ..sig"))
+	})
+}
+
+func TestKubernetesRoleTokenType_LookupValue_IncludesMountAccessor(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+
+	// Same JWT + same role, different mount accessors → different hashes.
+	// This is the load-bearing property: two kubernetes mounts (e.g. two
+	// spokes) with the same workload SA token + same role name must not
+	// share a cache entry.
+	h1 := kt.LookupValue(sampleK8sSAJWT, "accessor-A", "deploy")
+	h2 := kt.LookupValue(sampleK8sSAJWT, "accessor-B", "deploy")
+	assert.NotEqual(t, h1, h2,
+		"mount accessor must namespace the cache key")
+}
+
+func TestKubernetesRoleTokenType_LookupValue_DifferentRolesProduceDifferentHashes(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+	h1 := kt.LookupValue(sampleK8sSAJWT, "acc1", "role1")
+	h2 := kt.LookupValue(sampleK8sSAJWT, "acc1", "role2")
+	assert.NotEqual(t, h1, h2)
+}
+
+func TestKubernetesRoleTokenType_LookupValue_IsDeterministic(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+	h1 := kt.LookupValue(sampleK8sSAJWT, "acc1", "deploy")
+	h2 := kt.LookupValue(sampleK8sSAJWT, "acc1", "deploy")
+	assert.Equal(t, h1, h2)
+}
+
+func TestKubernetesRoleTokenType_LookupValue_HashShapeMatchesProductionExpectation(t *testing.T) {
+	// performImplicitAuth (and the singleflight key) build the same
+	// (mountAccessor + ":" + credential + ":" + role) shape. Pin the
+	// exact format here so the dispatch code and the TokenType stay in
+	// agreement; if either side changes the hash input shape without
+	// the other, transparent-mode cache lookups silently miss.
+	kt := &KubernetesRoleTokenType{}
+	expected := sha256.Sum256([]byte("accX:" + sampleK8sSAJWT + ":role-Y"))
+	assert.Equal(t, hex.EncodeToString(expected[:]), kt.LookupValue(sampleK8sSAJWT, "accX", "role-Y"))
+}
+
+func TestKubernetesRoleTokenType_LookupValue_DoesNotCollideWithJWTRoleTokenType(t *testing.T) {
+	// Defense in depth: even with the per-type IDPrefix ("jwtr_" vs
+	// "kubr_") making the final cache IDs disjoint, the underlying
+	// hash inputs should also differ. Same JWT + accessor + role hashed
+	// by two different transparent types must not collide on LookupValue.
+	jwtType := &JWTRoleTokenType{}
+	k8sType := &KubernetesRoleTokenType{}
+	assert.Equal(t, jwtType.LookupValue(sampleK8sSAJWT, "acc", "r"),
+		k8sType.LookupValue(sampleK8sSAJWT, "acc", "r"),
+		"hash inputs are identical (both shapes are mountAccessor+cred+role); "+
+			"separation comes from ComputeID's per-type IDPrefix")
+
+	jwtID := jwtType.ComputeID(jwtType.LookupValue(sampleK8sSAJWT, "acc", "r"))
+	k8sID := k8sType.ComputeID(k8sType.LookupValue(sampleK8sSAJWT, "acc", "r"))
+	assert.NotEqual(t, jwtID, k8sID,
+		"cache IDs must differ across TokenTypes even for identical hash inputs")
+	assert.True(t, strings.HasPrefix(jwtID, "jwtr_"))
+	assert.True(t, strings.HasPrefix(k8sID, "kubr_"))
+}
+
+func TestKubernetesRoleTokenType_Generate_StoresHashedLookupValueUnderJWTKey(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+	entry := &TokenEntry{Data: make(map[string]string)}
+	auth := &AuthData{
+		TokenValue:    sampleK8sSAJWT,
+		MountAccessor: "acc-1",
+		RoleName:      "deploy",
+	}
+	data, err := kt.Generate(context.Background(), auth, entry)
+	require.NoError(t, err)
+
+	stored, ok := data[kt.LookupKey()]
+	require.True(t, ok, "Generate must populate entry.Data[\"jwt\"]")
+	expected := kt.LookupValue(sampleK8sSAJWT, "acc-1", "deploy")
+	assert.Equal(t, expected, stored,
+		"stored value must match what LookupTransparentTokenWithRole will compute")
+}
+
+func TestKubernetesRoleTokenType_Generate_NoOpOnNilOrEmpty(t *testing.T) {
+	kt := &KubernetesRoleTokenType{}
+	t.Run("nil authData", func(t *testing.T) {
+		entry := &TokenEntry{Data: map[string]string{"existing": "preserved"}}
+		out, err := kt.Generate(context.Background(), nil, entry)
+		require.NoError(t, err)
+		_, ok := out[kt.LookupKey()]
+		assert.False(t, ok, "should not populate jwt key when authData is nil")
+		assert.Equal(t, "preserved", out["existing"])
+	})
+	t.Run("empty TokenValue", func(t *testing.T) {
+		entry := &TokenEntry{Data: make(map[string]string)}
+		_, err := kt.Generate(context.Background(), &AuthData{TokenValue: ""}, entry)
+		require.NoError(t, err)
+	})
+}
+
+func TestKubernetesRoleTokenType_RegisteredInBuiltinTypes(t *testing.T) {
+	registry := NewTokenTypeRegistry()
+	require.NoError(t, registry.Register(&KubernetesRoleTokenType{}))
+
+	// Lookup by name.
+	tt, err := registry.GetByName("kubernetes_role")
+	require.NoError(t, err)
+	assert.Equal(t, "kubernetes_role", tt.Metadata().Name)
+
+	// Lookup by auth-method type (the PR1+PR2 dispatch path).
+	tt2 := registry.GetTransparentTokenTypeForAuthMethod("kubernetes")
+	require.NotNil(t, tt2, "registry must index kubernetes_role under AuthMethodType=kubernetes")
+	assert.Equal(t, "k8s_sa_jwt", tt2.CredentialFormat())
+
+	// IsTransparent reports true so the explicit-login guard and cache-only
+	// persistence opt in via the registry.
+	assert.True(t, registry.IsTransparent("kubernetes_role"))
+}
+
+// TestTokenStore_KubernetesRoleEnrolledInGuard_AndDispatch pins the
+// end-to-end registration via a real TokenStore (the path Core uses).
+// All three transparent role types must report IsTransparentType=true
+// so the explicit-login guard at request_handler.go:638 rejects external
+// POST /auth/<mount>/login attempts uniformly. Verifying this through
+// the TokenStore (not just the registry directly) catches breakage in
+// the registerBuiltinTypes() wiring.
+func TestTokenStore_KubernetesRoleEnrolledInGuard_AndDispatch(t *testing.T) {
+	core := createTestCore(t)
+	require.NotNil(t, core.tokenStore, "test core must have a token store")
+
+	// All transparent types report true.
+	for _, name := range []string{"jwt_role", "cert_role", "kubernetes_role"} {
+		assert.True(t, core.tokenStore.IsTransparentType(name),
+			"%s must be classified as transparent so the explicit-login guard fires", name)
+	}
+	// Non-transparent type reports false.
+	assert.False(t, core.tokenStore.IsTransparentType("warden_token"),
+		"warden_token is a persisted bearer token, not transparent")
+	// Unknown type reports false.
+	assert.False(t, core.tokenStore.IsTransparentType("nonexistent_role"))
+
+	// Mount-type → TransparentTokenType lookup must round-trip for
+	// kubernetes mounts (PR2's dispatch depends on this).
+	tt := core.tokenStore.GetTransparentTokenTypeForAuthMethod("kubernetes")
+	require.NotNil(t, tt, "GetTransparentTokenTypeForAuthMethod(\"kubernetes\") must return KubernetesRoleTokenType")
+	assert.Equal(t, "kubernetes_role", tt.Metadata().Name)
+	assert.Equal(t, "k8s_sa_jwt", tt.CredentialFormat())
+}


### PR DESCRIPTION
## Summary

Adds the **kubernetes** auth method — the third (after jwt and cert) and first cloud-native member of the transparent-auth family. Validates workload service-account tokens by calling **TokenReview** on the issuing kube-apiserver, removing the JWKS-on-spoke requirement that hardened K8s distros (Talos default, CIS-baseline) make awkward. Matches the `auth/kubernetes` shape Vault and OpenBao operators already know.

### Inherits the foundations from prior PRs

Each prior refactor pays off here in the obvious way:

| From | What it gave kubernetes |
|---|---|
| #262 (transparent-auth foundations) | `KubernetesRoleTokenType` returns `IsTransparent=true` and auto-enrolls in cache-only persistence, the explicit-login guard, the `transparent` display alias, and deterministic-ID collision handling. **Zero edits** to the four legacy `TypeJWTRole \|\| TypeCertRole` sites in `token_store.go` or the guard at `request_handler.go:638`. |
| #263 (mount-driven dispatch) | `KubernetesRoleTokenType.CredentialFormat() == "k8s_sa_jwt"` reuses the existing `case "jwt", "k8s_sa_jwt":` JWT-bearer extraction in `performImplicitAuth`. **Zero new dispatch cases.** The introspect aggregator's exact-match filter routes K8s SA tokens only to kubernetes mounts (no wasted TokenReview round-trips against spokes that can't authenticate them). |
| #264 (helper/httputil) | TokenReview's HTTP client reuses `httputil.BuildHTTPClient` (raw PEM) + `httputil.ExecuteWithRetry` (default 429 + 5xx retries). |

### Backend layout (mirrors `auth/method/jwt`)

- `backend.go` — Factory, `KubernetesAuthConfig`, `setupConfig` / `Initialize`
- `path_config.go` — `POST/GET /config`, `token_reviewer_jwt` masked on read
- `path_role.go` — CRUD + LIST on `role/<name>`, refuses `*/*` binding
- `path_login.go` — TokenReview call, SA name/namespace binding, optional `iss` pre-filter, optional `max_age`, `min(role.TokenTTL, jwt-exp-derived)` clamp
- `path_introspect.go` — **one** TokenReview without audience binding, per-role local filter (SA + audience)
- `tokenreview.go` — locally typed request/response shapes, **no `k8s.io/api` dependency**
- `role.go` / `helper.go` / `parser.go` — schema + shared helpers

### Security-relevant choices

- **All authentication failures collapse to `errAuthFailed`** — no information leakage about which check failed. Detailed reasons logged server-side via the gated logger.
- **`token_reviewer_jwt` is a secret.** `SensitiveConfigFields` reports it for the framework's `sys/auth/<mount>` masking; `handleConfigRead` masks it directly with the same 13-asterisk placeholder. When unset, the auth method falls back to **self-reviewing mode** (workload JWT also serves as the Authorization bearer; requires the workload SA to have `system:auth-delegator`).
- **Roles refuse `*/*` binding** — at least one of `bound_service_account_names` or `bound_service_account_namespaces` must be a concrete value (defense in depth, matches Vault).
- **`TokenType` always pinned to `kubernetes_role`** — operators can't override it via the role-create field; pinned by `validateRole`.
- **Login response carries** `service_account_uid`, `service_account_namespace`, `service_account_name` — flows into audit logs under `response.data` for SA-level attribution.

### What's intentionally out of scope (follow-ups)

- `token_reviewer_jwt_path` field for file-based auto-rotation (kubelet-rotated projected SA tokens).
- E2E test against a real / mocked kube-apiserver in `e2e/auth/` — needs infra work.
- `skill.md` for the kubernetes auth method (no auth method ships one today).
- Operator docs under `docs/auth-methods/`.
- Deleting `jwt_validation_pubkeys` from the JWT method's schema (now obsoleted by kubernetes).
- Typed mount-table accessors (`MountTable.AuthMountsInNamespace`) — captured in the plan as a separate follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 49 packages OK, 0 FAIL. New `auth/method/kubernetes` package + extended `core/` suite are green.
- [x] `make test-e2e` — 213 tests across 14 packages, 0 fail, 0 skip (3-node HA cluster + Vault + Hydra).
- [x] `go vet ./...` — only pre-existing lock-copy warnings; no new issues.
- [x] `gofmt -l` — all new files clean. `cmd/server/server.go` is flagged but the issue is pre-existing on `main` (verified) and orthogonal to the one-line registration I added.
- [x] **Coverage:** 8 unit-test files (~1850 lines) plus a shared `testing_test.go` with an httptest-based fake apiserver. Exercises: SA binding hits + misses, both bearer modes (configured `token_reviewer_jwt` vs self-reviewing), issuer pre-filter pre-empts TokenReview round-trip, TTL clamp to JWT `exp`, `max_age` rejection, error-string uniformity, introspect one-TokenReview-call invariant + per-role audience filtering + `iss` pin short-circuit.
- [x] **Core-level test** (`core/token_type_kubernetes_test.go`) pins `KubernetesRoleTokenType`'s `TransparentTokenType` interface compliance, cache-key shape (mount-accessor namespaced), and end-to-end registry wiring (`IsTransparentType("kubernetes_role")` returns true via the real `TokenStore`; the explicit-login guard at `request_handler.go:638` fires for it identically to `jwt_role`/`cert_role`).
