### PR TITLE
refactor(core): typed class-filtered accessors on MountTable

### DIFF
--- a/core/mount.go
+++ b/core/mount.go
@@ -167,6 +167,46 @@ func (t *MountTable) findAllNamespaceMounts(ctx context.Context) ([]*MountEntry,
 	return mounts, nil
 }
 
+// findAllAuthMountsInNamespace returns every auth-class mount belonging to the
+// namespace carried in ctx. Caller must hold mountsLock (R or W); the accessor
+// does no locking of its own so it composes inside larger critical sections.
+//
+// Prefer this to raw iteration over Entries when the caller wants only auth-
+// class mounts — the class filter lives in one place instead of every handler
+// having to remember it.
+func (t *MountTable) findAllAuthMountsInNamespace(ctx context.Context) ([]*MountEntry, error) {
+	return t.findAllMountsInNamespaceOfClass(ctx, mountClassAuth)
+}
+
+// findAllProviderMountsInNamespace is the provider-class twin of
+// findAllAuthMountsInNamespace. Same locking and return-shape contract.
+func (t *MountTable) findAllProviderMountsInNamespace(ctx context.Context) ([]*MountEntry, error) {
+	return t.findAllMountsInNamespaceOfClass(ctx, mountClassProvider)
+}
+
+// findAllMountsInNamespaceOfClass is the shared body of the class-specific
+// accessors. Unexported so callers go through the typed wrappers — that keeps
+// the class set a closed enum (adding audit support, for example, lands as a
+// new wrapper, not a generic call against an internal-only class string).
+func (t *MountTable) findAllMountsInNamespaceOfClass(ctx context.Context, class string) ([]*MountEntry, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*MountEntry, 0)
+	for _, entry := range t.Entries {
+		if entry.Class != class {
+			continue
+		}
+		if entry.Namespace().ID != ns.ID {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
 func (t *MountTable) find(ctx context.Context, predicate func(*MountEntry) bool) (*MountEntry, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {

--- a/core/mount_test.go
+++ b/core/mount_test.go
@@ -603,3 +603,155 @@ func TestCore_MountEntryView(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// mixedClassTable builds a MountTable containing entries of every class so the
+// accessor tests can confirm the filter is correct in both directions
+// (returns the right entries; doesn't return the wrong ones).
+func mixedClassTable(t *testing.T) *MountTable {
+	t.Helper()
+	table := NewMountTable()
+	table.Entries = []*MountEntry{
+		{
+			Path: "jwt/", Type: "jwt", Class: mountClassAuth, UUID: "auth-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "cert/", Type: "cert", Class: mountClassAuth, UUID: "auth-2",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "vault/", Type: "vault", Class: mountClassProvider, UUID: "prov-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "aws/", Type: "aws", Class: mountClassProvider, UUID: "prov-2",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "sys/", Type: "system", Class: mountClassSystem, UUID: "sys-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+	}
+	return table
+}
+
+func TestMountTable_findAllAuthMountsInNamespace_returnsAuthOnly(t *testing.T) {
+	table := mixedClassTable(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	got, err := table.findAllAuthMountsInNamespace(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Order matches insertion order; assert by UUID for stability.
+	assert.Equal(t, "auth-1", got[0].UUID)
+	assert.Equal(t, "auth-2", got[1].UUID)
+	for _, e := range got {
+		assert.Equal(t, mountClassAuth, e.Class,
+			"accessor must return only auth-class entries (got %s)", e.Class)
+	}
+}
+
+func TestMountTable_findAllAuthMountsInNamespace_namespaceFiltered(t *testing.T) {
+	otherNs := &namespace.Namespace{ID: "ns-other", Path: "other/"}
+	table := NewMountTable()
+	table.Entries = []*MountEntry{
+		{
+			Path: "jwt/", Type: "jwt", Class: mountClassAuth, UUID: "root-auth",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "jwt/", Type: "jwt", Class: mountClassAuth, UUID: "other-auth",
+			NamespaceID: otherNs.ID, namespace: otherNs,
+		},
+	}
+
+	rootCtx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	got, err := table.findAllAuthMountsInNamespace(rootCtx)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "root namespace should see only its own auth mount")
+	assert.Equal(t, "root-auth", got[0].UUID)
+
+	otherCtx := namespace.ContextWithNamespace(context.Background(), otherNs)
+	got, err = table.findAllAuthMountsInNamespace(otherCtx)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "other namespace should see only its own auth mount")
+	assert.Equal(t, "other-auth", got[0].UUID)
+}
+
+func TestMountTable_findAllAuthMountsInNamespace_emptyResult(t *testing.T) {
+	// Table holds provider + system entries only; auth accessor returns empty.
+	table := NewMountTable()
+	table.Entries = []*MountEntry{
+		{
+			Path: "vault/", Class: mountClassProvider, UUID: "prov-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "sys/", Class: mountClassSystem, UUID: "sys-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+	}
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	got, err := table.findAllAuthMountsInNamespace(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, got, "must return non-nil empty slice (callers may JSON-marshal)")
+	assert.Empty(t, got)
+}
+
+func TestMountTable_findAllAuthMountsInNamespace_emptyTable(t *testing.T) {
+	table := NewMountTable()
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	got, err := table.findAllAuthMountsInNamespace(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestMountTable_findAllAuthMountsInNamespace_missingNamespaceContext(t *testing.T) {
+	table := mixedClassTable(t)
+	// Background context carries no namespace — accessor surfaces the
+	// namespace-extraction error.
+	_, err := table.findAllAuthMountsInNamespace(context.Background())
+	assert.Error(t, err)
+}
+
+func TestMountTable_findAllProviderMountsInNamespace_returnsProviderOnly(t *testing.T) {
+	table := mixedClassTable(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	got, err := table.findAllProviderMountsInNamespace(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "prov-1", got[0].UUID)
+	assert.Equal(t, "prov-2", got[1].UUID)
+	for _, e := range got {
+		assert.Equal(t, mountClassProvider, e.Class)
+	}
+}
+
+func TestMountTable_findAllProviderMountsInNamespace_doesNotReturnAuth(t *testing.T) {
+	// Defense in depth: even with paths that look like they could collide
+	// (jwt/ as both an auth method and a hypothetical provider mount name),
+	// the provider accessor must never return auth entries.
+	table := NewMountTable()
+	table.Entries = []*MountEntry{
+		{
+			Path: "jwt/", Class: mountClassAuth, UUID: "auth-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+		{
+			Path: "jwt/", Class: mountClassProvider, UUID: "prov-1",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		},
+	}
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	got, err := table.findAllProviderMountsInNamespace(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "prov-1", got[0].UUID)
+	assert.Equal(t, mountClassProvider, got[0].Class)
+}

--- a/core/sys_auth.go
+++ b/core/sys_auth.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/stephnangue/warden/framework"
-	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
@@ -206,19 +205,13 @@ func (b *SystemBackend) handleAuthList(ctx context.Context, req *logical.Request
 	b.core.mountsLock.RLock()
 	defer b.core.mountsLock.RUnlock()
 
-	mounts := make(map[string]any)
-
-	ns, err := namespace.FromContext(ctx)
+	entries, err := b.core.mounts.findAllAuthMountsInNamespace(ctx)
 	if err != nil {
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
 	}
 
-	for _, entry := range b.core.mounts.Entries {
-		// Only return entries of class auth in the specified namespace
-		if entry.Class != mountClassAuth || entry.NamespaceID != ns.ID {
-			continue
-		}
-
+	mounts := make(map[string]any, len(entries))
+	for _, entry := range entries {
 		// Deep copy config
 		entry.configMu.RLock()
 		config := make(map[string]any)

--- a/core/sys_introspect.go
+++ b/core/sys_introspect.go
@@ -14,7 +14,6 @@ import (
 
 	authhelper "github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/framework"
-	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/listener"
 	lgr "github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -98,11 +97,6 @@ func (b *SystemBackend) handleIntrospectRoles(ctx context.Context, req *logical.
 		}, nil
 	}
 
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
-	}
-
 	// Snapshot matching mount entries under the lock, then release before
 	// dispatching so that concurrent mount writes are not blocked on our
 	// in-process fan-out. The filter asks the registry "what TokenType
@@ -111,11 +105,13 @@ func (b *SystemBackend) handleIntrospectRoles(ctx context.Context, req *logical.
 	// to a kubernetes mount (which would burn a TokenReview round-trip)
 	// and vice versa.
 	b.core.mountsLock.RLock()
-	matching := make([]*MountEntry, 0)
-	for _, entry := range b.core.mounts.Entries {
-		if entry.Class != mountClassAuth || entry.NamespaceID != ns.ID {
-			continue
-		}
+	authMounts, err := b.core.mounts.findAllAuthMountsInNamespace(ctx)
+	if err != nil {
+		b.core.mountsLock.RUnlock()
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	matching := make([]*MountEntry, 0, len(authMounts))
+	for _, entry := range authMounts {
 		tt := b.core.tokenStore.GetTransparentTokenTypeForAuthMethod(entry.Type)
 		if tt == nil || tt.CredentialFormat() != credFormat {
 			continue

--- a/core/sys_providers.go
+++ b/core/sys_providers.go
@@ -207,19 +207,18 @@ func (b *SystemBackend) handleProviderList(ctx context.Context, req *logical.Req
 	b.core.mountsLock.RLock()
 	defer b.core.mountsLock.RUnlock()
 
-	mounts := make(map[string]any)
-
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
 	}
 
-	for _, entry := range b.core.mounts.Entries {
-		// Only return entries of class provider in the specified namespace
-		if entry.Class != mountClassProvider || entry.NamespaceID != ns.ID {
-			continue
-		}
+	entries, err := b.core.mounts.findAllProviderMountsInNamespace(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
 
+	mounts := make(map[string]any, len(entries))
+	for _, entry := range entries {
 		// Deep copy config
 		entry.configMu.RLock()
 		config := make(map[string]any)


### PR DESCRIPTION
## Summary
- Adds `findAllAuthMountsInNamespace` and `findAllProviderMountsInNamespace` typed accessors on `MountTable`, sharing an unexported `findAllMountsInNamespaceOfClass` helper.
- Refactors `handleAuthList` ([core/sys_auth.go](core/sys_auth.go)), `handleProviderList` ([core/sys_providers.go](core/sys_providers.go)), and `handleIntrospectRoles` ([core/sys_introspect.go](core/sys_introspect.go)) to use the accessors instead of inlining the same `entry.Class != … || entry.NamespaceID != ns.ID` filter three times.
- Behavior is identical pre/post — the class+namespace filter is preserved, just moved into one place where missing it isn't possible.

## Why
The three handlers above are textbook copy-paste duplication of the class+namespace filter. A fourth handler that forgot the class check would silently surface entries of the wrong class in its response. The typed accessors make that bug impossible by name.

This is also the foundation PR for a follow-up that splits `c.mounts` into `c.mounts` (provider+system) + `c.auth` (auth methods only). After the split, the accessor signatures are compatible with the post-split class-pure auth table, so the follow-up PR's consumer edits collapse to a one-token substitution per call site.

## Test plan
- [x] `go build ./...` — clean.
- [x] `go test ./core/ -run 'TestMountTable_findAll' -v` — 7 new accessor tests pass (mixed-class isolation, namespace filtering, empty result, empty table, missing-namespace error, provider-only, cross-class defense).
- [x] `go test ./core/ -run 'TestSystemBackend_HandleAuthList|TestSystemBackend_HandleProviderList|TestSystemBackend_Introspect|TestDetectIntrospectCredentialFormat'` — existing handler tests pass unchanged.
- [x] `go test -race -count=1 ./core/...` — full core suite passes under race detector.
- [x] `go test -count=1 ./...` — full repo suite passes.
