### PR TITLE
feat(audit,logical): add MCPDecision type for MCP policy decisions

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -127,6 +127,12 @@ type ActorRef struct {
 type PolicyResults struct {
 	Allowed          bool     `json:"allowed"`
 	GrantingPolicies []string `json:"granting_policies,omitempty"`
+
+	// MCPDecision carries the MCP-specific policy decision when an
+	// mcp { } block was consulted during CBP evaluation. nil when no
+	// such block applied. The field is omitempty so non-MCP audit
+	// records remain byte-identical to today's output.
+	MCPDecision *logical.MCPDecision `json:"mcp_decision,omitempty"`
 }
 
 // AuthResult contains authentication result from login operations
@@ -285,7 +291,8 @@ func (e *LogEntry) Clone() *LogEntry {
 		}
 		if e.Auth.PolicyResults != nil {
 			clone.Auth.PolicyResults = &PolicyResults{
-				Allowed: e.Auth.PolicyResults.Allowed,
+				Allowed:     e.Auth.PolicyResults.Allowed,
+				MCPDecision: e.Auth.PolicyResults.MCPDecision.Clone(),
 			}
 			if e.Auth.PolicyResults.GrantingPolicies != nil {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))

--- a/audit/types_test.go
+++ b/audit/types_test.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"testing"
 	"time"
+
+	"github.com/stephnangue/warden/logical"
 )
 
 func TestCloneNil(t *testing.T) {
@@ -75,6 +77,13 @@ func TestCloneFull(t *testing.T) {
 			PolicyResults: &PolicyResults{
 				Allowed:          true,
 				GrantingPolicies: []string{"gp1"},
+				MCPDecision: &logical.MCPDecision{
+					Method:      "tools/call",
+					Name:        "get_repository",
+					Decision:    "allow",
+					MatchedRule: "get_*",
+					RuleType:    "allowed_tools",
+				},
 			},
 			TokenTTL:      3600,
 			ExpiresAt:     1234567890,
@@ -114,6 +123,11 @@ func TestCloneFull(t *testing.T) {
 	entry.Auth.PolicyResults.GrantingPolicies[0] = "modified"
 	if clone.Auth.PolicyResults.GrantingPolicies[0] == "modified" {
 		t.Error("clone granting policies should be independent")
+	}
+
+	entry.Auth.PolicyResults.MCPDecision.Name = "modified"
+	if clone.Auth.PolicyResults.MCPDecision.Name == "modified" {
+		t.Error("clone MCPDecision should be independent")
 	}
 
 	entry.Response.Warnings[0] = "modified"

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -34,6 +34,15 @@ type Auth struct {
 	// requesting path.
 	PolicyResults *sdklogical.PolicyResults `json:"policy_results"`
 
+	// MCPDecision carries the MCP-specific policy decision when an mcp { }
+	// block was consulted during CBP evaluation. nil when no such block
+	// applied (every non-MCP request, plus MCP-mount requests whose bound
+	// policies contain no mcp block). Flows through buildAuditAuth into
+	// audit.PolicyResults.MCPDecision and is also consumed by the
+	// deny-response path to populate the WWW-Authenticate header and the
+	// OAuth-shaped 403 body.
+	MCPDecision *MCPDecision
+
 	PrincipalID string
 
 	RoleName string
@@ -51,6 +60,61 @@ type Auth struct {
 	// through buildAuditAuth into the audit log; not used for policy
 	// decisions.
 	Actors []ActorRef
+}
+
+// MCPDecision records the outcome of evaluating an mcp { } policy block
+// against a request. Populated on every branch (allow and deny) so the
+// audit layer can render the decision unconditionally. The JSON tags
+// double as the wire shape exposed in audit records under
+// auth.policy_results.mcp_decision.
+type MCPDecision struct {
+	// Method is the value of the Mcp-Method header on the request.
+	// Empty when the header was missing (paired with
+	// RuleType=missing_method_header).
+	Method string `json:"method"`
+
+	// Name is the value of the Mcp-Name header. Empty for name-less
+	// methods (tools/list, notifications, etc.) and when the request
+	// was rejected before the name gate ran.
+	Name string `json:"name,omitempty"`
+
+	// Decision is "allow" or "deny". Always populated when an mcp { }
+	// block was consulted.
+	Decision string `json:"decision"`
+
+	// MatchedRule is the pattern from the policy (allow- or deny-list
+	// entry) that fired. For a literal match it equals the request's
+	// name/method/param value; for a wildcard match it carries the
+	// pattern (e.g. "delete_*"). Empty when no list entry matched
+	// (deny via not-in-allow-list) and when the deny reason is a
+	// sentinel like missing_method_header.
+	MatchedRule string `json:"matched_rule"`
+
+	// RuleType records which gate produced the decision. Domain:
+	// allowed_methods, denied_methods, allowed_tools, denied_tools,
+	// allowed_resources, allowed_prompts, allowed_params,
+	// denied_params, or the sentinel missing_method_header.
+	RuleType string `json:"rule_type"`
+
+	// ParamName is the Mcp-Param-{Name} header's name (lowercase,
+	// hyphens preserved), populated only when RuleType is
+	// allowed_params or denied_params.
+	ParamName string `json:"param_name,omitempty"`
+
+	// ParamValue is the header value the policy compared against,
+	// base64-decoded if the source header was an RFC 2047
+	// encoded-word. Populated only for param-related decisions.
+	ParamValue string `json:"param_value,omitempty"`
+}
+
+// Clone returns a deep copy of the MCPDecision. Safe to call on a nil
+// receiver (returns nil).
+func (d *MCPDecision) Clone() *MCPDecision {
+	if d == nil {
+		return nil
+	}
+	clone := *d
+	return &clone
 }
 
 // ActorRef identifies a subject in the on-behalf-of chain. Verified

--- a/logical/auth_test.go
+++ b/logical/auth_test.go
@@ -1,0 +1,96 @@
+package logical
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPDecision_JSONRoundTrip(t *testing.T) {
+	t.Run("full populated decision", func(t *testing.T) {
+		original := &MCPDecision{
+			Method:      "tools/call",
+			Name:        "delete_repository",
+			Decision:    "deny",
+			MatchedRule: "delete_*",
+			RuleType:    "denied_tools",
+			ParamName:   "path",
+			ParamValue:  ".env.production",
+		}
+
+		encoded, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded MCPDecision
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, *original, decoded)
+	})
+
+	t.Run("minimal decision (allow with empty optional fields)", func(t *testing.T) {
+		original := &MCPDecision{
+			Method:      "tools/list",
+			Decision:    "allow",
+			MatchedRule: "tools/list",
+			RuleType:    "allowed_methods",
+		}
+
+		encoded, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded MCPDecision
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, *original, decoded)
+	})
+}
+
+func TestMCPDecision_OmitEmpty(t *testing.T) {
+	// Optional fields (name, param_name, param_value) must be omitted
+	// from the serialised form when empty so non-name-bearing and
+	// non-param decisions produce compact audit records.
+	d := &MCPDecision{
+		Method:      "tools/list",
+		Decision:    "allow",
+		MatchedRule: "tools/list",
+		RuleType:    "allowed_methods",
+	}
+
+	encoded, err := json.Marshal(d)
+	require.NoError(t, err)
+
+	s := string(encoded)
+	assert.NotContains(t, s, "name")
+	assert.NotContains(t, s, "param_name")
+	assert.NotContains(t, s, "param_value")
+	assert.Contains(t, s, `"method":"tools/list"`)
+	assert.Contains(t, s, `"decision":"allow"`)
+	assert.Contains(t, s, `"rule_type":"allowed_methods"`)
+}
+
+func TestMCPDecision_Clone_Nil(t *testing.T) {
+	var d *MCPDecision
+	assert.Nil(t, d.Clone())
+}
+
+func TestMCPDecision_Clone_DeepCopy(t *testing.T) {
+	original := &MCPDecision{
+		Method:      "tools/call",
+		Name:        "delete_repository",
+		Decision:    "deny",
+		MatchedRule: "delete_*",
+		RuleType:    "denied_tools",
+		ParamName:   "path",
+		ParamValue:  ".env.production",
+	}
+
+	clone := original.Clone()
+	require.NotNil(t, clone)
+	assert.Equal(t, *original, *clone)
+
+	// Mutating the clone must not affect the original.
+	clone.Name = "mutated"
+	clone.MatchedRule = "mutated"
+	assert.Equal(t, "delete_repository", original.Name)
+	assert.Equal(t, "delete_*", original.MatchedRule)
+}


### PR DESCRIPTION
## Summary

PR **1 of 5** in the mcp-policy stack. Adds the `logical.MCPDecision` type and the audit-record carrier path the rest of the stack consumes — types only, no behaviour change yet.

- `logical.MCPDecision` records method, name, decision, matched_rule, rule_type, optional param_name/param_value. Nil-safe `Clone()`.
- `logical.Auth` gains an `MCPDecision` carrier field so the CBP evaluation result flows through `buildAuditAuth` into the audit record.
- `audit.PolicyResults` gains `MCPDecision` with `mcp_decision` JSON tag and `omitempty` so non-MCP audit records are byte-identical to today.
- `LogEntry.Clone()` deep-copies the new field via `MCPDecision.Clone()`.

`MCPDecision` lives in the `logical` package (not `audit`) to avoid a circular import: `audit/types.go` already imports `logical` for `logical.Backend`, so defining the type in `audit` and referencing it from `logical.Auth` would cycle.

## Stack

| PR | Branch | Status |
|---|---|---|
| **1** | `mcp-policy/01-audit-types` | ← this PR |
| 2 | `mcp-policy/02-hcl-parsing` | independent, can land in parallel |
| 3 | `mcp-policy/03-evaluation` | depends on 1 and 2 |
| 4 | `mcp-policy/04-deny-response` | depends on 3 |
| 5 | `mcp-policy/05-docs` | depends on 1 (for behaviour to document) |

## Test plan

- [ ] \`go test ./audit/... ./logical/...\` passes locally
- [ ] \`go build ./...\` clean
- [ ] \`go vet\` clean on touched packages
- [ ] Existing audit records remain byte-identical (omitempty on the pointer)
- [ ] Snapshot test on a sample audit golden file (if one exists), otherwise manual diff