### PR TITLE
feat(core/policy): parse and validate the mcp { } block in CBP HCL

### DIFF
--- a/core/policy.go
+++ b/core/policy.go
@@ -119,6 +119,27 @@ type PathRules struct {
 	PaginationLimitHCL        int                 `hcl:"pagination_limit"`
 	ResponseKeysFilterPathHCL string              `hcl:"list_scan_response_keys_filter_path"`
 	ConditionsHCL             map[string][]string `hcl:"conditions"`
+
+	// MCPHCL is the parsed `mcp { }` block. Nil when no such block is
+	// present on this path stanza. Stored on PathRules as the HCL
+	// decode target; the parser then validates it and appends a
+	// CBPMCPRules entry to pc.Permissions.MCP.
+	MCPHCL *MCPRulesHCL `hcl:"mcp"`
+}
+
+// MCPRulesHCL is the HCL decode shape of one `mcp { }` block. Each
+// field corresponds to one operator-facing key inside the block; the
+// parser canonicalises (lowercases) all entries and validates wildcard
+// patterns before populating the internal CBPMCPRules form.
+type MCPRulesHCL struct {
+	AllowedMethods   []string            `hcl:"allowed_methods"`
+	DeniedMethods    []string            `hcl:"denied_methods"`
+	AllowedTools     []string            `hcl:"allowed_tools"`
+	DeniedTools      []string            `hcl:"denied_tools"`
+	AllowedResources []string            `hcl:"allowed_resources"`
+	AllowedPrompts   []string            `hcl:"allowed_prompts"`
+	AllowedParams    map[string][]string `hcl:"allowed_params"`
+	DeniedParams     map[string][]string `hcl:"denied_params"`
 }
 
 type CBPPermissions struct {
@@ -134,6 +155,70 @@ type CBPPermissions struct {
 	// Non-nil: each entry is one policy's conditions; request must satisfy at
 	// least one set (OR between sets, AND within each set's types).
 	ConditionSets []*PolicyConditions
+	// MCP holds mcp { } rule-sets from all merged policies for this path.
+	// nil/empty means no MCP enforcement applies. Non-nil: each entry is one
+	// source stanza's mcp block; a request is allowed if at least one set
+	// allows it (OR between sets), with the strongest-reason audit picked
+	// on full deny. Populated by parsePaths via append per stanza so multiple
+	// `path` blocks at the same path layer naturally into multiple rule-sets.
+	MCP []*CBPMCPRules
+}
+
+// CBPMCPRules holds one merged mcp { } rule-set after validation and
+// canonicalisation. All list entries are lowercased; param-name keys
+// are lowercased and hyphens preserved. Patterns use trailing-`*` only
+// per the policy Semantics; the parser rejects leading or internal `*`
+// before constructing this type.
+type CBPMCPRules struct {
+	AllowedMethods   []string
+	DeniedMethods    []string
+	AllowedTools     []string
+	DeniedTools      []string
+	AllowedResources []string
+	AllowedPrompts   []string
+	AllowedParams    map[string][]string
+	DeniedParams     map[string][]string
+}
+
+// Clone returns a deep copy of the CBPMCPRules. Safe to call on a nil
+// receiver (returns nil). All slices and maps are independently
+// allocated so mutating the clone never affects the original.
+func (m *CBPMCPRules) Clone() *CBPMCPRules {
+	if m == nil {
+		return nil
+	}
+	clone := &CBPMCPRules{}
+	if m.AllowedMethods != nil {
+		clone.AllowedMethods = append([]string(nil), m.AllowedMethods...)
+	}
+	if m.DeniedMethods != nil {
+		clone.DeniedMethods = append([]string(nil), m.DeniedMethods...)
+	}
+	if m.AllowedTools != nil {
+		clone.AllowedTools = append([]string(nil), m.AllowedTools...)
+	}
+	if m.DeniedTools != nil {
+		clone.DeniedTools = append([]string(nil), m.DeniedTools...)
+	}
+	if m.AllowedResources != nil {
+		clone.AllowedResources = append([]string(nil), m.AllowedResources...)
+	}
+	if m.AllowedPrompts != nil {
+		clone.AllowedPrompts = append([]string(nil), m.AllowedPrompts...)
+	}
+	if m.AllowedParams != nil {
+		clone.AllowedParams = make(map[string][]string, len(m.AllowedParams))
+		for k, v := range m.AllowedParams {
+			clone.AllowedParams[k] = append([]string(nil), v...)
+		}
+	}
+	if m.DeniedParams != nil {
+		clone.DeniedParams = make(map[string][]string, len(m.DeniedParams))
+		for k, v := range m.DeniedParams {
+			clone.DeniedParams[k] = append([]string(nil), v...)
+		}
+	}
+	return clone
 }
 
 func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
@@ -188,6 +273,17 @@ func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
 		ret.ConditionSets = make([]*PolicyConditions, len(p.ConditionSets))
 		for i, cs := range p.ConditionSets {
 			ret.ConditionSets[i] = cs.Clone()
+		}
+	}
+
+	switch {
+	case p.MCP == nil:
+	case len(p.MCP) == 0:
+		ret.MCP = make([]*CBPMCPRules, 0)
+	default:
+		ret.MCP = make([]*CBPMCPRules, len(p.MCP))
+		for i, m := range p.MCP {
+			ret.MCP[i] = m.Clone()
 		}
 	}
 
@@ -284,6 +380,7 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			"expiration",
 			"list_scan_response_keys_filter_path",
 			"conditions",
+			"mcp",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
@@ -421,10 +518,96 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			}
 			pc.Permissions.ConditionSets = []*PolicyConditions{conditions}
 		}
+
+		if pc.MCPHCL != nil {
+			rules, err := canonicaliseMCPRules(pc.MCPHCL)
+			if err != nil {
+				return fmt.Errorf("path %q: %w", key, err)
+			}
+			pc.Permissions.MCP = append(pc.Permissions.MCP, rules)
+		}
 	PathFinished:
 		paths = append(paths, &pc)
 	}
 
 	result.Paths = paths
+	return nil
+}
+
+// canonicaliseMCPRules converts a parsed mcp { } HCL block into the
+// internal CBPMCPRules form, validating wildcard patterns and
+// lowercasing all entries so AllowOperation can do case-insensitive
+// equality and prefix matching at request time without re-canonicalising.
+func canonicaliseMCPRules(h *MCPRulesHCL) (*CBPMCPRules, error) {
+	canonList := func(field string, in []string) ([]string, error) {
+		if len(in) == 0 {
+			return nil, nil
+		}
+		out := make([]string, len(in))
+		for i, pat := range in {
+			if err := validateMCPPattern(field, pat); err != nil {
+				return nil, err
+			}
+			out[i] = strings.ToLower(pat)
+		}
+		return out, nil
+	}
+	canonMap := func(field string, in map[string][]string) (map[string][]string, error) {
+		if len(in) == 0 {
+			return nil, nil
+		}
+		out := make(map[string][]string, len(in))
+		for k, vs := range in {
+			canonValues, err := canonList(fmt.Sprintf("%s[%q]", field, k), vs)
+			if err != nil {
+				return nil, err
+			}
+			out[strings.ToLower(k)] = canonValues
+		}
+		return out, nil
+	}
+
+	r := &CBPMCPRules{}
+	var err error
+	if r.AllowedMethods, err = canonList("allowed_methods", h.AllowedMethods); err != nil {
+		return nil, err
+	}
+	if r.DeniedMethods, err = canonList("denied_methods", h.DeniedMethods); err != nil {
+		return nil, err
+	}
+	if r.AllowedTools, err = canonList("allowed_tools", h.AllowedTools); err != nil {
+		return nil, err
+	}
+	if r.DeniedTools, err = canonList("denied_tools", h.DeniedTools); err != nil {
+		return nil, err
+	}
+	if r.AllowedResources, err = canonList("allowed_resources", h.AllowedResources); err != nil {
+		return nil, err
+	}
+	if r.AllowedPrompts, err = canonList("allowed_prompts", h.AllowedPrompts); err != nil {
+		return nil, err
+	}
+	if r.AllowedParams, err = canonMap("allowed_params", h.AllowedParams); err != nil {
+		return nil, err
+	}
+	if r.DeniedParams, err = canonMap("denied_params", h.DeniedParams); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// validateMCPPattern enforces the trailing-`*` glob rule from the policy
+// Semantics: a `*` is allowed only as the final character of the pattern
+// (or as the entire pattern, which is the zero-prefix wildcard matching
+// everything). Leading and internal `*` are rejected with a clear error
+// rather than silently treated as literals.
+func validateMCPPattern(field, pat string) error {
+	idx := strings.IndexByte(pat, '*')
+	if idx == -1 {
+		return nil // literal, no wildcard
+	}
+	if idx != len(pat)-1 {
+		return fmt.Errorf("mcp %s: pattern %q has '*' in a non-trailing position; only trailing '*' wildcards are supported", field, pat)
+	}
 	return nil
 }

--- a/core/policy_mcp_test.go
+++ b/core/policy_mcp_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMCP_AllFields(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods   = ["tools/list", "tools/call"]
+    denied_methods    = ["tools/dangerous"]
+    allowed_tools     = ["get_repository", "list_issues"]
+    denied_tools      = ["delete_*", "force_*"]
+    allowed_resources = ["github://repo/*"]
+    allowed_prompts   = ["*"]
+    allowed_params = {
+      path = ["docs/*", "specs/*"]
+    }
+    denied_params = {
+      env = ["prod", "production"]
+    }
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 1)
+
+	mcp := policy.Paths[0].Permissions.MCP
+	require.Len(t, mcp, 1, "one stanza must produce one MCP rule-set")
+	r := mcp[0]
+
+	assert.Equal(t, []string{"tools/list", "tools/call"}, r.AllowedMethods)
+	assert.Equal(t, []string{"tools/dangerous"}, r.DeniedMethods)
+	assert.Equal(t, []string{"get_repository", "list_issues"}, r.AllowedTools)
+	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
+	assert.Equal(t, []string{"github://repo/*"}, r.AllowedResources)
+	assert.Equal(t, []string{"*"}, r.AllowedPrompts)
+	assert.Equal(t, map[string][]string{"path": {"docs/*", "specs/*"}}, r.AllowedParams)
+	assert.Equal(t, map[string][]string{"env": {"prod", "production"}}, r.DeniedParams)
+}
+
+func TestParseMCP_EmptyBlock(t *testing.T) {
+	// An empty mcp { } block is the minimum opt-in: produces a
+	// non-nil rule-set with all empty fields. AllowOperation uses
+	// presence to trigger the missing-header check; emptiness means
+	// "no further restriction."
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {}
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 1)
+
+	mcp := policy.Paths[0].Permissions.MCP
+	require.Len(t, mcp, 1, "empty block must still produce a rule-set entry")
+	r := mcp[0]
+
+	assert.Nil(t, r.AllowedMethods)
+	assert.Nil(t, r.DeniedMethods)
+	assert.Nil(t, r.AllowedTools)
+	assert.Nil(t, r.DeniedTools)
+	assert.Nil(t, r.AllowedResources)
+	assert.Nil(t, r.AllowedPrompts)
+	assert.Nil(t, r.AllowedParams)
+	assert.Nil(t, r.DeniedParams)
+}
+
+func TestParseMCP_NoBlock(t *testing.T) {
+	// A path stanza without an mcp { } block leaves Permissions.MCP
+	// nil — every existing non-MCP policy keeps working unchanged.
+	rules := `
+path "secret/*" {
+  capabilities = ["read"]
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 1)
+	assert.Nil(t, policy.Paths[0].Permissions.MCP)
+}
+
+func TestParseMCP_Lowercasing(t *testing.T) {
+	// Operator-supplied mixed-case patterns are canonicalised at parse
+	// time so AllowOperation can do case-insensitive matching via plain
+	// string equality.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["TOOLS/Call", "Tools/LIST"]
+    denied_tools    = ["Delete_*", "FORCE_*"]
+    allowed_params = {
+      Path = ["DOCS/*"]
+    }
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	r := policy.Paths[0].Permissions.MCP[0]
+
+	assert.Equal(t, []string{"tools/call", "tools/list"}, r.AllowedMethods)
+	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
+	assert.Equal(t, map[string][]string{"path": {"docs/*"}}, r.AllowedParams,
+		"param-name keys and values both lowercase")
+}
+
+func TestParseMCP_LeadingStarRejected(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["*_admin"]
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied_tools")
+	assert.Contains(t, err.Error(), "*_admin")
+	assert.Contains(t, err.Error(), "trailing")
+}
+
+func TestParseMCP_InternalStarRejected(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_tools = ["get_*_admin"]
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_tools")
+	assert.Contains(t, err.Error(), "get_*_admin")
+}
+
+func TestParseMCP_TrailingStarAccepted(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["delete_*"]
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+}
+
+func TestParseMCP_BareStarAccepted(t *testing.T) {
+	// The bare `*` is a zero-prefix trailing-star and matches
+	// everything. Used to express "any value" without enumerating.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_prompts = ["*"]
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*"}, policy.Paths[0].Permissions.MCP[0].AllowedPrompts)
+}
+
+func TestParseMCP_InvalidPatternInParams(t *testing.T) {
+	// Validation must recurse into the param-map values; the error
+	// should mention which param key the bad pattern came from.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_params = {
+      path = ["docs/*", "*invalid"]
+    }
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_params")
+	assert.Contains(t, err.Error(), `"path"`)
+	assert.Contains(t, err.Error(), "*invalid")
+}
+
+func TestParseMCP_MultipleStanzasSamePath(t *testing.T) {
+	// Two `path` stanzas at the same path in one policy each become
+	// their own PathRules, each with its own one-entry MCP slice. The
+	// OR-of-rule-sets merge into a single CBPPermissions.MCP slice
+	// happens at NewCBP time alongside the evaluation logic.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["resources/read"]
+    allowed_resources = ["github://repo/A/*"]
+  }
+}
+
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["resources/list"]
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 2)
+
+	require.Len(t, policy.Paths[0].Permissions.MCP, 1)
+	require.Len(t, policy.Paths[1].Permissions.MCP, 1)
+	assert.Equal(t, []string{"resources/read"}, policy.Paths[0].Permissions.MCP[0].AllowedMethods)
+	assert.Equal(t, []string{"resources/list"}, policy.Paths[1].Permissions.MCP[0].AllowedMethods)
+}
+
+func TestCBPMCPRules_Clone_Nil(t *testing.T) {
+	var r *CBPMCPRules
+	assert.Nil(t, r.Clone())
+}
+
+func TestCBPMCPRules_Clone_DeepCopy(t *testing.T) {
+	original := &CBPMCPRules{
+		AllowedMethods:   []string{"tools/call"},
+		DeniedTools:      []string{"delete_*"},
+		AllowedResources: []string{"github://repo/A/*"},
+		AllowedParams: map[string][]string{
+			"path": {"docs/*", "specs/*"},
+		},
+		DeniedParams: map[string][]string{
+			"env": {"prod"},
+		},
+	}
+	clone := original.Clone()
+	require.NotNil(t, clone)
+	assert.Equal(t, original, clone)
+
+	// Mutating the clone's slices and maps must not affect the original.
+	clone.AllowedMethods[0] = "mutated"
+	clone.AllowedParams["path"][0] = "mutated"
+	clone.AllowedParams["new"] = []string{"x"}
+	clone.DeniedParams["env"][0] = "mutated"
+
+	assert.Equal(t, "tools/call", original.AllowedMethods[0])
+	assert.Equal(t, "docs/*", original.AllowedParams["path"][0])
+	assert.NotContains(t, original.AllowedParams, "new")
+	assert.Equal(t, "prod", original.DeniedParams["env"][0])
+}
+
+func TestCBPPermissions_Clone_MCPDeepCopy(t *testing.T) {
+	// End-to-end: parse a policy with an mcp block, clone the
+	// CBPPermissions, mutate the clone, confirm the original is
+	// unaffected.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_tools = ["get_*"]
+    allowed_params = {
+      path = ["docs/*"]
+    }
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	original := policy.Paths[0].Permissions
+
+	cloned, err := original.Clone()
+	require.NoError(t, err)
+	require.Len(t, cloned.MCP, 1)
+
+	cloned.MCP[0].AllowedTools[0] = "mutated"
+	cloned.MCP[0].AllowedParams["path"][0] = "mutated"
+
+	assert.Equal(t, "get_*", original.MCP[0].AllowedTools[0])
+	assert.Equal(t, "docs/*", original.MCP[0].AllowedParams["path"][0])
+}


### PR DESCRIPTION
## Summary

PR **2 of 5** in the mcp-policy stack. Adds HCL parsing for a new `mcp { }` block inside `path` rules, covering method/name/resource/prompt list gates and tool-argument param gates. Policies with `mcp { }` blocks parse, validate, store, and load round-trip — but `AllowOperation` doesn't yet consult them. The stored data is dead until PR 3 lands.

- `PathRules` gains `MCPHCL *MCPRulesHCL` (HCL-tagged decode target).
- `MCPRulesHCL` holds the six string-list fields (allowed/denied methods/tools, allowed resources/prompts) plus two `map[string][]string` fields for allowed/denied params.
- `CBPPermissions.MCP []*CBPMCPRules` is the canonicalised internal form; one entry per source stanza (append per stanza in `parsePaths`).
- `CBPMCPRules.Clone()` deep-copies slices and maps independently.
- `CBPPermissions.Clone()` extended to deep-copy the new MCP slice via the per-element `Clone()`, mirroring the existing `ConditionSets` pattern.

Canonicalisation lowercases every pattern and param key at parse time so the upcoming `AllowOperation` evaluation can do case-insensitive matching via plain string equality (and `HasPrefix` for trailing-`*` globs).

Validation enforces the trailing-`*` rule from the policy semantics: leading or internal `*` is rejected with a clear error mentioning the field path (including param key for nested maps) and the offending pattern. Bare `*` is the zero-prefix wildcard and is accepted.

## Stack

| PR | Branch | Status |
|---|---|---|
| 1 | `mcp-policy/01-audit-types` | independent, can land in parallel |
| **2** | `mcp-policy/02-hcl-parsing` | ← this PR |
| 3 | `mcp-policy/03-evaluation` | depends on 1 and 2 |
| 4 | `mcp-policy/04-deny-response` | depends on 3 |
| 5 | `mcp-policy/05-docs` | depends on 1 (for behaviour to document) |

## Test plan

- [ ] `go test ./core/...` passes (existing tests unchanged + 13 new MCP HCL tests)
- [ ] `warden policy write` against a sample `mcp { }` policy succeeds
- [ ] `warden policy read` returns the policy unchanged (HCL round-trip)
- [ ] Patterns with leading/internal `*` rejected with helpful errors
- [ ] Bare `*` (zero-prefix wildcard) accepted
