### PR TITLE
feat(core/policy): evaluate mcp { } block and surface decision in audit

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -127,6 +127,12 @@ type ActorRef struct {
 type PolicyResults struct {
 	Allowed          bool     `json:"allowed"`
 	GrantingPolicies []string `json:"granting_policies,omitempty"`
+
+	// MCPDecision carries the MCP-specific policy decision when an
+	// mcp { } block was consulted during CBP evaluation. nil when no
+	// such block applied. The field is omitempty so non-MCP audit
+	// records remain byte-identical to today's output.
+	MCPDecision *logical.MCPDecision `json:"mcp_decision,omitempty"`
 }
 
 // AuthResult contains authentication result from login operations
@@ -285,7 +291,8 @@ func (e *LogEntry) Clone() *LogEntry {
 		}
 		if e.Auth.PolicyResults != nil {
 			clone.Auth.PolicyResults = &PolicyResults{
-				Allowed: e.Auth.PolicyResults.Allowed,
+				Allowed:     e.Auth.PolicyResults.Allowed,
+				MCPDecision: e.Auth.PolicyResults.MCPDecision.Clone(),
 			}
 			if e.Auth.PolicyResults.GrantingPolicies != nil {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))

--- a/audit/types_test.go
+++ b/audit/types_test.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"testing"
 	"time"
+
+	"github.com/stephnangue/warden/logical"
 )
 
 func TestCloneNil(t *testing.T) {
@@ -75,6 +77,13 @@ func TestCloneFull(t *testing.T) {
 			PolicyResults: &PolicyResults{
 				Allowed:          true,
 				GrantingPolicies: []string{"gp1"},
+				MCPDecision: &logical.MCPDecision{
+					Method:      "tools/call",
+					Name:        "get_repository",
+					Decision:    "allow",
+					MatchedRule: "get_*",
+					RuleType:    "allowed_tools",
+				},
 			},
 			TokenTTL:      3600,
 			ExpiresAt:     1234567890,
@@ -114,6 +123,11 @@ func TestCloneFull(t *testing.T) {
 	entry.Auth.PolicyResults.GrantingPolicies[0] = "modified"
 	if clone.Auth.PolicyResults.GrantingPolicies[0] == "modified" {
 		t.Error("clone granting policies should be independent")
+	}
+
+	entry.Auth.PolicyResults.MCPDecision.Name = "modified"
+	if clone.Auth.PolicyResults.MCPDecision.Name == "modified" {
+		t.Error("clone MCPDecision should be independent")
 	}
 
 	entry.Response.Warnings[0] = "modified"

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -153,6 +153,13 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 				}
 				auditAuth.PolicyResults.GrantingPolicies = policies
 			}
+			// Surface the MCP decision into the audit record when an
+			// mcp { } rule-set was consulted. The audit's PolicyResults
+			// owns the wire shape; the in-memory MCPDecision flows in
+			// from logical.Auth.MCPDecision via the request handler.
+			if auth.MCPDecision != nil {
+				auditAuth.PolicyResults.MCPDecision = auth.MCPDecision
+			}
 		}
 	}
 

--- a/core/policy.go
+++ b/core/policy.go
@@ -119,6 +119,27 @@ type PathRules struct {
 	PaginationLimitHCL        int                 `hcl:"pagination_limit"`
 	ResponseKeysFilterPathHCL string              `hcl:"list_scan_response_keys_filter_path"`
 	ConditionsHCL             map[string][]string `hcl:"conditions"`
+
+	// MCPHCL is the parsed `mcp { }` block. Nil when no such block is
+	// present on this path stanza. Stored on PathRules as the HCL
+	// decode target; the parser then validates it and appends a
+	// CBPMCPRules entry to pc.Permissions.MCP.
+	MCPHCL *MCPRulesHCL `hcl:"mcp"`
+}
+
+// MCPRulesHCL is the HCL decode shape of one `mcp { }` block. Each
+// field corresponds to one operator-facing key inside the block; the
+// parser canonicalises (lowercases) all entries and validates wildcard
+// patterns before populating the internal CBPMCPRules form.
+type MCPRulesHCL struct {
+	AllowedMethods   []string            `hcl:"allowed_methods"`
+	DeniedMethods    []string            `hcl:"denied_methods"`
+	AllowedTools     []string            `hcl:"allowed_tools"`
+	DeniedTools      []string            `hcl:"denied_tools"`
+	AllowedResources []string            `hcl:"allowed_resources"`
+	AllowedPrompts   []string            `hcl:"allowed_prompts"`
+	AllowedParams    map[string][]string `hcl:"allowed_params"`
+	DeniedParams     map[string][]string `hcl:"denied_params"`
 }
 
 type CBPPermissions struct {
@@ -134,6 +155,70 @@ type CBPPermissions struct {
 	// Non-nil: each entry is one policy's conditions; request must satisfy at
 	// least one set (OR between sets, AND within each set's types).
 	ConditionSets []*PolicyConditions
+	// MCP holds mcp { } rule-sets from all merged policies for this path.
+	// nil/empty means no MCP enforcement applies. Non-nil: each entry is one
+	// source stanza's mcp block; a request is allowed if at least one set
+	// allows it (OR between sets), with the strongest-reason audit picked
+	// on full deny. Populated by parsePaths via append per stanza so multiple
+	// `path` blocks at the same path layer naturally into multiple rule-sets.
+	MCP []*CBPMCPRules
+}
+
+// CBPMCPRules holds one merged mcp { } rule-set after validation and
+// canonicalisation. All list entries are lowercased; param-name keys
+// are lowercased and hyphens preserved. Patterns use trailing-`*` only
+// per the policy Semantics; the parser rejects leading or internal `*`
+// before constructing this type.
+type CBPMCPRules struct {
+	AllowedMethods   []string
+	DeniedMethods    []string
+	AllowedTools     []string
+	DeniedTools      []string
+	AllowedResources []string
+	AllowedPrompts   []string
+	AllowedParams    map[string][]string
+	DeniedParams     map[string][]string
+}
+
+// Clone returns a deep copy of the CBPMCPRules. Safe to call on a nil
+// receiver (returns nil). All slices and maps are independently
+// allocated so mutating the clone never affects the original.
+func (m *CBPMCPRules) Clone() *CBPMCPRules {
+	if m == nil {
+		return nil
+	}
+	clone := &CBPMCPRules{}
+	if m.AllowedMethods != nil {
+		clone.AllowedMethods = append([]string(nil), m.AllowedMethods...)
+	}
+	if m.DeniedMethods != nil {
+		clone.DeniedMethods = append([]string(nil), m.DeniedMethods...)
+	}
+	if m.AllowedTools != nil {
+		clone.AllowedTools = append([]string(nil), m.AllowedTools...)
+	}
+	if m.DeniedTools != nil {
+		clone.DeniedTools = append([]string(nil), m.DeniedTools...)
+	}
+	if m.AllowedResources != nil {
+		clone.AllowedResources = append([]string(nil), m.AllowedResources...)
+	}
+	if m.AllowedPrompts != nil {
+		clone.AllowedPrompts = append([]string(nil), m.AllowedPrompts...)
+	}
+	if m.AllowedParams != nil {
+		clone.AllowedParams = make(map[string][]string, len(m.AllowedParams))
+		for k, v := range m.AllowedParams {
+			clone.AllowedParams[k] = append([]string(nil), v...)
+		}
+	}
+	if m.DeniedParams != nil {
+		clone.DeniedParams = make(map[string][]string, len(m.DeniedParams))
+		for k, v := range m.DeniedParams {
+			clone.DeniedParams[k] = append([]string(nil), v...)
+		}
+	}
+	return clone
 }
 
 func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
@@ -188,6 +273,17 @@ func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
 		ret.ConditionSets = make([]*PolicyConditions, len(p.ConditionSets))
 		for i, cs := range p.ConditionSets {
 			ret.ConditionSets[i] = cs.Clone()
+		}
+	}
+
+	switch {
+	case p.MCP == nil:
+	case len(p.MCP) == 0:
+		ret.MCP = make([]*CBPMCPRules, 0)
+	default:
+		ret.MCP = make([]*CBPMCPRules, len(p.MCP))
+		for i, m := range p.MCP {
+			ret.MCP[i] = m.Clone()
 		}
 	}
 
@@ -284,6 +380,7 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			"expiration",
 			"list_scan_response_keys_filter_path",
 			"conditions",
+			"mcp",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
@@ -421,10 +518,96 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			}
 			pc.Permissions.ConditionSets = []*PolicyConditions{conditions}
 		}
+
+		if pc.MCPHCL != nil {
+			rules, err := canonicaliseMCPRules(pc.MCPHCL)
+			if err != nil {
+				return fmt.Errorf("path %q: %w", key, err)
+			}
+			pc.Permissions.MCP = append(pc.Permissions.MCP, rules)
+		}
 	PathFinished:
 		paths = append(paths, &pc)
 	}
 
 	result.Paths = paths
+	return nil
+}
+
+// canonicaliseMCPRules converts a parsed mcp { } HCL block into the
+// internal CBPMCPRules form, validating wildcard patterns and
+// lowercasing all entries so AllowOperation can do case-insensitive
+// equality and prefix matching at request time without re-canonicalising.
+func canonicaliseMCPRules(h *MCPRulesHCL) (*CBPMCPRules, error) {
+	canonList := func(field string, in []string) ([]string, error) {
+		if len(in) == 0 {
+			return nil, nil
+		}
+		out := make([]string, len(in))
+		for i, pat := range in {
+			if err := validateMCPPattern(field, pat); err != nil {
+				return nil, err
+			}
+			out[i] = strings.ToLower(pat)
+		}
+		return out, nil
+	}
+	canonMap := func(field string, in map[string][]string) (map[string][]string, error) {
+		if len(in) == 0 {
+			return nil, nil
+		}
+		out := make(map[string][]string, len(in))
+		for k, vs := range in {
+			canonValues, err := canonList(fmt.Sprintf("%s[%q]", field, k), vs)
+			if err != nil {
+				return nil, err
+			}
+			out[strings.ToLower(k)] = canonValues
+		}
+		return out, nil
+	}
+
+	r := &CBPMCPRules{}
+	var err error
+	if r.AllowedMethods, err = canonList("allowed_methods", h.AllowedMethods); err != nil {
+		return nil, err
+	}
+	if r.DeniedMethods, err = canonList("denied_methods", h.DeniedMethods); err != nil {
+		return nil, err
+	}
+	if r.AllowedTools, err = canonList("allowed_tools", h.AllowedTools); err != nil {
+		return nil, err
+	}
+	if r.DeniedTools, err = canonList("denied_tools", h.DeniedTools); err != nil {
+		return nil, err
+	}
+	if r.AllowedResources, err = canonList("allowed_resources", h.AllowedResources); err != nil {
+		return nil, err
+	}
+	if r.AllowedPrompts, err = canonList("allowed_prompts", h.AllowedPrompts); err != nil {
+		return nil, err
+	}
+	if r.AllowedParams, err = canonMap("allowed_params", h.AllowedParams); err != nil {
+		return nil, err
+	}
+	if r.DeniedParams, err = canonMap("denied_params", h.DeniedParams); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// validateMCPPattern enforces the trailing-`*` glob rule from the policy
+// Semantics: a `*` is allowed only as the final character of the pattern
+// (or as the entire pattern, which is the zero-prefix wildcard matching
+// everything). Leading and internal `*` are rejected with a clear error
+// rather than silently treated as literals.
+func validateMCPPattern(field, pat string) error {
+	idx := strings.IndexByte(pat, '*')
+	if idx == -1 {
+		return nil // literal, no wildcard
+	}
+	if idx != len(pat)-1 {
+		return fmt.Errorf("mcp %s: pattern %q has '*' in a non-trailing position; only trailing '*' wildcards are supported", field, pat)
+	}
 	return nil
 }

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -57,6 +57,18 @@ type CBPResults struct {
 	CapabilitiesBitmap     uint32
 	GrantingPolicies       []sdklogical.PolicyInfo
 	ResponseKeysFilterPath string
+
+	// MCPDecision is populated whenever an mcp { } rule-set was
+	// consulted during AllowOperation, on every branch (allow and
+	// deny) so the audit and deny-response layers can render the
+	// decision unconditionally. Nil when no rule-set applied (the
+	// vast majority of requests — every non-MCP provider).
+	//
+	// Invariant: when MCPDecision.Decision == "deny", Allowed is
+	// false. The reverse (Allowed=false with Decision="allow") is
+	// possible — the MCP gate runs between conditions and the
+	// parameter check, so a later check can deny after MCP allows.
+	MCPDecision *logical.MCPDecision
 }
 
 const limitParameterName = "limit"
@@ -252,6 +264,19 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 						existingPerms.ConditionSets,
 						pc.Permissions.ConditionSets...,
 					)
+				}
+			}
+
+			// MCP rule-set merging: additive OR across policies. Unlike
+			// conditions, an absent mcp block in one source does NOT
+			// disable enforcement contributed by another source — each
+			// stanza's mcp { } adds one entry to the slice and the
+			// per-set OR in evaluateMCP means more entries can only
+			// admit more requests (never fewer). The clone protects
+			// against later mutation of the shared underlying slices.
+			if len(pc.Permissions.MCP) > 0 {
+				for _, m := range pc.Permissions.MCP {
+					existingPerms.MCP = append(existingPerms.MCP, m.Clone())
 				}
 			}
 
@@ -457,6 +482,19 @@ CHECK:
 			}
 		}
 		if !conditionsMet {
+			return ret
+		}
+	}
+
+	// MCP rule-set evaluation. Runs after conditions (so source-IP /
+	// time gates apply first) and before parameter validation (so
+	// MCP-specific gates short-circuit the request before generic
+	// parameter rules run). Populates ret.MCPDecision on every branch
+	// when an mcp block was consulted, so the audit layer sees the
+	// decision whether the request was allowed or denied.
+	if len(permissions.MCP) > 0 {
+		ret.MCPDecision = evaluateMCP(permissions.MCP, req)
+		if ret.MCPDecision != nil && ret.MCPDecision.Decision == "deny" {
 			return ret
 		}
 	}

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -1,0 +1,432 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/logical"
+)
+
+// MCP rule_type values produced by AllowOperation when evaluating an
+// mcp { } block. These strings appear in audit records under
+// auth.policy_results.mcp_decision.rule_type and the response-body
+// renderer keys off them to pick the per-rule-type message template.
+const (
+	mcpRuleTypeAllowedMethods   = "allowed_methods"
+	mcpRuleTypeDeniedMethods    = "denied_methods"
+	mcpRuleTypeAllowedTools     = "allowed_tools"
+	mcpRuleTypeDeniedTools      = "denied_tools"
+	mcpRuleTypeAllowedResources = "allowed_resources"
+	mcpRuleTypeAllowedPrompts   = "allowed_prompts"
+	mcpRuleTypeAllowedParams    = "allowed_params"
+	mcpRuleTypeDeniedParams     = "denied_params"
+	mcpRuleTypeMissingMethod    = "missing_method_header"
+)
+
+// MCP JSON-RPC method names that carry a Mcp-Name header in the
+// 2026-07-28 draft. For these methods the name gate (allowed_tools /
+// denied_tools / allowed_resources / allowed_prompts) runs after the
+// method gate; for any other method the name gate is skipped.
+const (
+	mcpMethodToolsCall    = "tools/call"
+	mcpMethodResourcesRead = "resources/read"
+	mcpMethodPromptsGet   = "prompts/get"
+)
+
+// MCP-spec header names. Case-insensitive on the wire per RFC 9110;
+// net/http canonicalises on read so these casings are what
+// http.Header.Get sees regardless of how the client formatted them.
+const (
+	mcpHeaderMethod = "Mcp-Method"
+	mcpHeaderName   = "Mcp-Name"
+	// mcpHeaderParamPrefix names the Mcp-Param-{Name} family. Looking
+	// up a specific param header uses mcpHeaderParamPrefix + param-name
+	// (canonicalised by net/http).
+	mcpHeaderParamPrefix = "Mcp-Param-"
+)
+
+// ErrMCPPolicyDenied carries the MCPDecision that produced a deny so
+// the HTTP response layer can render the OAuth-shaped 403 body and the
+// WWW-Authenticate header. Unwraps to sdklogical.ErrPermissionDenied
+// so every existing `errors.Is(err, ErrPermissionDenied)` call site
+// (status-code mapping, audit, retry logic) keeps working unchanged.
+type ErrMCPPolicyDenied struct {
+	Decision *logical.MCPDecision
+}
+
+func (e *ErrMCPPolicyDenied) Error() string {
+	return sdklogical.ErrPermissionDenied.Error()
+}
+
+func (e *ErrMCPPolicyDenied) Unwrap() error {
+	return sdklogical.ErrPermissionDenied
+}
+
+// matchMCPGlob matches a request value against a single canonicalised
+// pattern. Patterns use trailing-`*` only (validated at parse time); a
+// bare `*` is the zero-prefix wildcard and matches every value. Both
+// inputs are expected lowercase — patterns are canonicalised at parse
+// time, request values are lowercased once per evaluation by the
+// caller.
+func matchMCPGlob(value, pattern string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasSuffix(pattern, "*") {
+		return strings.HasPrefix(value, pattern[:len(pattern)-1])
+	}
+	return value == pattern
+}
+
+// matchMCPAny returns the first pattern in patterns that matches value,
+// or "" if none did. Used by the deny-list short-circuit (any match =
+// deny) and the allow-list check (no match = deny via not-in-allow).
+func matchMCPAny(value string, patterns []string) string {
+	for _, p := range patterns {
+		if matchMCPGlob(value, p) {
+			return p
+		}
+	}
+	return ""
+}
+
+// decodeMCPParamValue decodes the RFC 2047-style encoded-word envelope
+// used by the MCP draft for non-ASCII or unsafe Mcp-Param-* values:
+//
+//	=?base64?<base64-encoded UTF-8>?=
+//
+// Returns the decoded string when the envelope is well-formed,
+// otherwise returns the raw input. Malformed envelopes deliberately
+// fall back to the raw value so a bad encoding can't be used to evade
+// a deny pattern — the policy still sees what it would have matched
+// against had the encoding been honest.
+func decodeMCPParamValue(raw string) string {
+	const prefix = "=?base64?"
+	const suffix = "?="
+	if !strings.HasPrefix(raw, prefix) || !strings.HasSuffix(raw, suffix) {
+		return raw
+	}
+	inner := raw[len(prefix) : len(raw)-len(suffix)]
+	decoded, err := base64.StdEncoding.DecodeString(inner)
+	if err != nil {
+		return raw
+	}
+	return string(decoded)
+}
+
+// mcpHeader fetches a header by canonical name from req.HTTPRequest,
+// returning "" when the request or header is absent. Centralising the
+// nil-check lets the evaluation block stay flat.
+func mcpHeader(req *logical.Request, name string) string {
+	if req == nil || req.HTTPRequest == nil {
+		return ""
+	}
+	return req.HTTPRequest.Header.Get(name)
+}
+
+// mcpHeaderForParam fetches the Mcp-Param-{Name} header value, decoded
+// if it was sent as an encoded-word. http.Header.Get already
+// canonicalises the lookup key internally so the operator-supplied
+// lowercase param-name (e.g. "path") finds the header net/http stored
+// as "Mcp-Param-Path".
+func mcpHeaderForParam(req *logical.Request, paramName string) string {
+	if req == nil || req.HTTPRequest == nil {
+		return ""
+	}
+	raw := req.HTTPRequest.Header.Get(mcpHeaderParamPrefix + paramName)
+	if raw == "" {
+		return ""
+	}
+	return decodeMCPParamValue(raw)
+}
+
+// nameListForMethod returns the (deny, allow) name-lists that apply to
+// the given JSON-RPC method on this rule-set, or (nil, nil) when the
+// method is not name-bearing. Centralising the dispatch keeps the
+// evaluation block from sprouting a switch in the middle of the loop.
+func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []string) {
+	switch method {
+	case mcpMethodToolsCall:
+		return set.DeniedTools, set.AllowedTools
+	case mcpMethodResourcesRead:
+		return nil, set.AllowedResources
+	case mcpMethodPromptsGet:
+		return nil, set.AllowedPrompts
+	}
+	return nil, nil
+}
+
+// evaluateMCP runs the MCP rule-set slice from CBPPermissions against a
+// request and returns a single MCPDecision. Returns nil when the slice
+// is empty (no enforcement — the caller continues to parameter checks).
+//
+// Semantics, per the policy plan:
+//   - For each rule-set: short-circuit on the first matching gate
+//     (missing-method, denied_methods, allowed_methods miss, name gate,
+//     param gate). A set that reaches the end without a deny contributes
+//     "allow."
+//   - Across sets: OR semantics. If any set allows, the overall decision
+//     is allow with that set's MCPDecision. If every set denies, the
+//     overall decision is deny with the strongest reason (explicit deny
+//     matches > not-in-allow-list > missing-method-header; ties broken
+//     by source order).
+//
+// All comparisons are lowercase; the patterns were lowercased at parse
+// time and the request values are lowercased here once per set.
+func evaluateMCP(sets []*CBPMCPRules, req *logical.Request) *logical.MCPDecision {
+	if len(sets) == 0 {
+		return nil
+	}
+
+	method := strings.ToLower(mcpHeader(req, mcpHeaderMethod))
+	name := strings.ToLower(mcpHeader(req, mcpHeaderName))
+
+	var deny *logical.MCPDecision
+	var denyRank int
+
+	for _, set := range sets {
+		setDecision := evaluateMCPSet(set, method, name, req)
+		if setDecision.Decision == "allow" {
+			return setDecision
+		}
+		// Track strongest-reason across deny sets.
+		rank := mcpDenyRank(setDecision.RuleType)
+		if deny == nil || rank > denyRank {
+			deny = setDecision
+			denyRank = rank
+		}
+	}
+	return deny
+}
+
+// evaluateMCPSet runs one rule-set against the canonicalised method,
+// name, and request. Returns the set's MCPDecision (always non-nil) —
+// either an allow with the matching pattern stamped, or a deny with
+// the failing gate and pattern stamped.
+func evaluateMCPSet(set *CBPMCPRules, method, name string, req *logical.Request) *logical.MCPDecision {
+	d := &logical.MCPDecision{Method: method, Name: name}
+
+	// (a) Missing Mcp-Method header → deny. Done before any list
+	// check because an empty method can't match anything meaningful
+	// and the operator who wrote an mcp{} block wants header-based
+	// enforcement.
+	if method == "" {
+		d.Decision = "deny"
+		d.RuleType = mcpRuleTypeMissingMethod
+		d.Name = "" // no meaningful name without method
+		return d
+	}
+
+	// (b) Explicit denied_methods match → deny.
+	if m := matchMCPAny(method, set.DeniedMethods); m != "" {
+		d.Decision = "deny"
+		d.RuleType = mcpRuleTypeDeniedMethods
+		d.MatchedRule = m
+		return d
+	}
+
+	// (c) allowed_methods configured but method not in it → deny.
+	if len(set.AllowedMethods) > 0 {
+		if m := matchMCPAny(method, set.AllowedMethods); m == "" {
+			d.Decision = "deny"
+			d.RuleType = mcpRuleTypeAllowedMethods
+			return d
+		}
+	}
+
+	// (d) Name gate for name-bearing methods. Skipped entirely when
+	// neither the relevant deny-list nor allow-list is configured for
+	// this method — the rule isn't making a name claim.
+	if denyList, allowList := nameListForMethod(set, method); len(denyList) > 0 || len(allowList) > 0 {
+		if m := matchMCPAny(name, denyList); m != "" {
+			d.Decision = "deny"
+			d.RuleType = mcpDenyRuleTypeForName(method)
+			d.MatchedRule = m
+			return d
+		}
+		if len(allowList) > 0 {
+			if m := matchMCPAny(name, allowList); m == "" {
+				d.Decision = "deny"
+				d.RuleType = mcpAllowRuleTypeForName(method)
+				return d
+			}
+		}
+	}
+
+	// (e) Param gate for tools/call only. Each configured key checked
+	// independently — AND across keys, OR within a key's value-list.
+	if method == mcpMethodToolsCall {
+		// Deny-list first per precedence.
+		for paramName, patterns := range set.DeniedParams {
+			value := mcpHeaderForParam(req, paramName)
+			if value == "" {
+				continue // missing header can't match a deny pattern
+			}
+			lowerValue := strings.ToLower(value)
+			if m := matchMCPAny(lowerValue, patterns); m != "" {
+				d.Decision = "deny"
+				d.RuleType = mcpRuleTypeDeniedParams
+				d.ParamName = paramName
+				d.ParamValue = value
+				d.MatchedRule = m
+				return d
+			}
+		}
+		for paramName, patterns := range set.AllowedParams {
+			value := mcpHeaderForParam(req, paramName)
+			if value == "" {
+				// Required param missing — deny with empty MatchedRule.
+				d.Decision = "deny"
+				d.RuleType = mcpRuleTypeAllowedParams
+				d.ParamName = paramName
+				return d
+			}
+			lowerValue := strings.ToLower(value)
+			if m := matchMCPAny(lowerValue, patterns); m == "" {
+				d.Decision = "deny"
+				d.RuleType = mcpRuleTypeAllowedParams
+				d.ParamName = paramName
+				d.ParamValue = value
+				return d
+			}
+		}
+	}
+
+	// (f) Nothing denied — this set allows. Record the gate that
+	// authorised the request so audit can show which rule fired. The
+	// method gate is the universal one to record because it always
+	// runs when a set reaches this point.
+	d.Decision = "allow"
+	d.RuleType = mcpRuleTypeAllowedMethods
+	if len(set.AllowedMethods) > 0 {
+		// The method matched (we wouldn't have reached step f
+		// otherwise), so re-record the matching pattern.
+		d.MatchedRule = matchMCPAny(method, set.AllowedMethods)
+	} else {
+		// No allow-list — the matching "rule" is the method itself
+		// (the empty allow-list is "allow all").
+		d.MatchedRule = method
+	}
+	// If the name gate also fired and matched an allow-list, the more
+	// specific rule_type is the name gate. Re-derive.
+	if _, allowList := nameListForMethod(set, method); len(allowList) > 0 {
+		d.RuleType = mcpAllowRuleTypeForName(method)
+		d.MatchedRule = matchMCPAny(name, allowList)
+	}
+	return d
+}
+
+// mcpDenyRuleTypeForName maps a name-bearing method to its denied_*
+// rule_type string. Only tools/call has a deny-list in v1
+// (resources/read and prompts/get use allow-lists only per the policy
+// schema), so this is the only reachable case at the caller — the
+// fallback is the empty string for forward-compat if a future schema
+// version adds denied_resources or denied_prompts.
+func mcpDenyRuleTypeForName(method string) string {
+	switch method {
+	case mcpMethodToolsCall:
+		return mcpRuleTypeDeniedTools
+	}
+	return ""
+}
+
+// mcpAllowRuleTypeForName maps a name-bearing method to its allowed_*
+// rule_type string.
+func mcpAllowRuleTypeForName(method string) string {
+	switch method {
+	case mcpMethodToolsCall:
+		return mcpRuleTypeAllowedTools
+	case mcpMethodResourcesRead:
+		return mcpRuleTypeAllowedResources
+	case mcpMethodPromptsGet:
+		return mcpRuleTypeAllowedPrompts
+	}
+	return ""
+}
+
+// mcpDenyRank scores deny reasons for the strongest-reason audit
+// selection across multi-set denies. Higher rank wins; ties (same
+// rank, multiple sets) are resolved in source order by the caller's
+// "first wins on ==" branch in evaluateMCP.
+//
+//	explicit deny match (denied_*)             → 3
+//	not-in-allow-list (allowed_*, no match)    → 2
+//	missing_method_header                      → 1
+func mcpDenyRank(ruleType string) int {
+	switch ruleType {
+	case mcpRuleTypeDeniedMethods,
+		mcpRuleTypeDeniedTools,
+		mcpRuleTypeDeniedParams:
+		return 3
+	case mcpRuleTypeAllowedMethods,
+		mcpRuleTypeAllowedTools,
+		mcpRuleTypeAllowedResources,
+		mcpRuleTypeAllowedPrompts,
+		mcpRuleTypeAllowedParams:
+		return 2
+	case mcpRuleTypeMissingMethod:
+		return 1
+	}
+	return 0
+}
+
+// buildMCPDenyDescription renders the operator-facing single-sentence
+// message returned in the 403 body's error_description field and in
+// the WWW-Authenticate header. Per the policy plan Semantics, the
+// templates deliberately omit matched_rule and rule_type from the
+// client-visible string — disclosure of those stays in the audit log
+// only, and the denied/allowed cases for the same name produce
+// identical strings so the client can't fingerprint operator policy
+// shape from the response.
+//
+// Strips ASCII control characters from interpolated values defensively
+// — MCP headers shouldn't contain CTLs but RFC 7235 disallows them in
+// the WWW-Authenticate quoted-string and a malformed header is worse
+// than a sanitised one.
+func buildMCPDenyDescription(d *logical.MCPDecision) string {
+	if d == nil {
+		return "Request denied by policy."
+	}
+	method := stripCTL(d.Method)
+	name := stripCTL(d.Name)
+	param := stripCTL(d.ParamName)
+	value := stripCTL(d.ParamValue)
+
+	switch d.RuleType {
+	case mcpRuleTypeDeniedMethods, mcpRuleTypeAllowedMethods:
+		return fmt.Sprintf("Method '%s' not allowed.", method)
+	case mcpRuleTypeDeniedTools, mcpRuleTypeAllowedTools:
+		return fmt.Sprintf("Tool '%s' not allowed.", name)
+	case mcpRuleTypeAllowedResources:
+		return fmt.Sprintf("Resource '%s' not allowed.", name)
+	case mcpRuleTypeAllowedPrompts:
+		return fmt.Sprintf("Prompt '%s' not allowed.", name)
+	case mcpRuleTypeDeniedParams:
+		return fmt.Sprintf("Parameter '%s'='%s' not allowed.", param, value)
+	case mcpRuleTypeAllowedParams:
+		if value == "" {
+			return fmt.Sprintf("Parameter '%s' required.", param)
+		}
+		return fmt.Sprintf("Parameter '%s'='%s' not allowed.", param, value)
+	case mcpRuleTypeMissingMethod:
+		return "Mcp-Method header required."
+	}
+	return "Request denied by policy."
+}
+
+// stripCTL removes ASCII control characters (\x00-\x1F, \x7F) from s.
+// Used defensively before interpolating user-supplied values into the
+// WWW-Authenticate header per RFC 7235 quoted-string rules.
+func stripCTL(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7F {
+			return -1
+		}
+		return r
+	}, s)
+}

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -1,0 +1,869 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMCPRequest builds a logical.Request with an MCP-shaped HTTPRequest
+// carrying the supplied headers. Mcp-* headers go through net/http's
+// canonical-case normalisation just like real requests would. Accepts
+// testing.TB so the same builder works from both tests and benchmarks.
+func newMCPRequest(tb testing.TB, path string, headers map[string]string) *logical.Request {
+	tb.Helper()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/"+path, nil)
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	return &logical.Request{
+		Path:        path,
+		Operation:   logical.UpdateOperation, // MCP traffic is POST → update
+		HTTPRequest: httpReq,
+	}
+}
+
+// mustCBP builds a CBP from raw policy HCL, failing the test on any
+// parse or build error. Keeps every test case to a four-line setup.
+func mustCBP(t *testing.T, rules string) *CBP {
+	t.Helper()
+	policy := testParsePolicy(t, rules)
+	cbp, err := NewCBP(testContext(), []*Policy{policy})
+	require.NoError(t, err)
+	return cbp
+}
+
+// =============================================================================
+// Method gate
+// =============================================================================
+
+func TestMCPEval_AllowedMethods_Match(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{"Mcp-Method": "tools/list"})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Equal(t, "tools/list", res.MCPDecision.Method)
+	assert.Equal(t, "tools/list", res.MCPDecision.MatchedRule)
+	assert.Equal(t, mcpRuleTypeAllowedMethods, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_AllowedMethods_NoMatch(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{"Mcp-Method": "tools/call"})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, "tools/call", res.MCPDecision.Method)
+	assert.Equal(t, "", res.MCPDecision.MatchedRule, "no allow-list entry matched")
+	assert.Equal(t, mcpRuleTypeAllowedMethods, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_DeniedMethods_Match(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_methods = ["tools/call"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{"Mcp-Method": "tools/call"})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, "tools/call", res.MCPDecision.MatchedRule)
+	assert.Equal(t, mcpRuleTypeDeniedMethods, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_MissingMethodHeader(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{}) // no Mcp-Method
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, "", res.MCPDecision.Method)
+	assert.Equal(t, mcpRuleTypeMissingMethod, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_NoMCPBlock_PassesThrough(t *testing.T) {
+	// A policy with no mcp { } block leaves MCPDecision nil — the
+	// MCP gate doesn't run, the request goes through to the proxy.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{}) // no headers at all
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.MCPDecision, "no mcp block → no decision recorded")
+}
+
+// =============================================================================
+// Name gate
+// =============================================================================
+
+func TestMCPEval_AllowedTools_WildcardMatch(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_*", "list_*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "get_repository",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Equal(t, "get_repository", res.MCPDecision.Name)
+	assert.Equal(t, "get_*", res.MCPDecision.MatchedRule, "wildcard pattern, not literal")
+	assert.Equal(t, mcpRuleTypeAllowedTools, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_AllowedTools_BareStar(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["prompts/get"]
+    allowed_prompts = ["*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "prompts/get",
+		"Mcp-Name":   "code-review",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Equal(t, "*", res.MCPDecision.MatchedRule)
+}
+
+func TestMCPEval_DeniedTools_Match(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["delete_*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "delete_repository",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, "delete_*", res.MCPDecision.MatchedRule)
+	assert.Equal(t, mcpRuleTypeDeniedTools, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_NameNotRequired_ListMethod(t *testing.T) {
+	// tools/list is name-less; allowed_tools is irrelevant for it
+	// even when configured. The method gate runs, the name gate is
+	// skipped per Semantics.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["get_*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/list", // no Mcp-Name; name-less method
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed, "tools/list passes even without Mcp-Name")
+	assert.Equal(t, "tools/list", res.MCPDecision.Method)
+	assert.Equal(t, mcpRuleTypeAllowedMethods, res.MCPDecision.RuleType,
+		"name gate didn't fire for name-less method")
+}
+
+func TestMCPEval_NameRequiredButMissing(t *testing.T) {
+	// tools/call with allowed_tools configured and no Mcp-Name →
+	// empty value can't match any allow-list entry → deny.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_repository"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		// no Mcp-Name
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeAllowedTools, res.MCPDecision.RuleType)
+	assert.Equal(t, "", res.MCPDecision.MatchedRule)
+}
+
+func TestMCPEval_EmptyBlock_AllowsAnyMethod(t *testing.T) {
+	// Empty mcp { } block requires Mcp-Method to be present (per
+	// Semantics) but doesn't impose any other restriction. A
+	// tools/call with no Mcp-Name should still pass since the name
+	// gate isn't configured.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {}
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+}
+
+// =============================================================================
+// Param gate
+// =============================================================================
+
+func TestMCPEval_AllowedParams_Match(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    allowed_params = {
+      path = ["docs/*"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method":     "tools/call",
+		"Mcp-Name":       "write_file",
+		"Mcp-Param-Path": "docs/api.md",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+}
+
+func TestMCPEval_DeniedParams_Match(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    denied_params = {
+      path = [".env*"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method":     "tools/call",
+		"Mcp-Name":       "write_file",
+		"Mcp-Param-Path": ".env.production",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeDeniedParams, res.MCPDecision.RuleType)
+	assert.Equal(t, "path", res.MCPDecision.ParamName)
+	assert.Equal(t, ".env.production", res.MCPDecision.ParamValue)
+	assert.Equal(t, ".env*", res.MCPDecision.MatchedRule)
+}
+
+func TestMCPEval_AllowedParams_MissingHeader(t *testing.T) {
+	// allowed_params configured, request omits the header → deny.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    allowed_params = {
+      region = ["us-west1"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "write_file",
+		// no Mcp-Param-Region
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeAllowedParams, res.MCPDecision.RuleType)
+	assert.Equal(t, "region", res.MCPDecision.ParamName)
+	assert.Equal(t, "", res.MCPDecision.ParamValue,
+		"missing-header case records empty value")
+}
+
+func TestMCPEval_DeniedParams_MissingHeader_NoDeny(t *testing.T) {
+	// denied_params only, no allow-list: a missing header isn't a
+	// match (we don't deny something we never saw), so the request
+	// passes.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_params = {
+      env = ["prod"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "do_thing",
+		// no Mcp-Param-Env
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+}
+
+func TestMCPEval_ParamValue_Base64Decoded(t *testing.T) {
+	// Mcp-Param-Path: =?base64?ZG9jcy9yZWFkbWUubWQ=?= decodes to
+	// "docs/readme.md" which matches docs/*.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    allowed_params = {
+      path = ["docs/*"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method":     "tools/call",
+		"Mcp-Name":       "write_file",
+		"Mcp-Param-Path": "=?base64?ZG9jcy9yZWFkbWUubWQ=?=",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+}
+
+func TestMCPEval_ParamValue_MalformedBase64_FallsBackToLiteral(t *testing.T) {
+	// Malformed envelope (invalid base64 inside the wrapper) falls
+	// back to the raw value. The raw value matches no allow-list
+	// entry, so the request is denied with the raw bytes recorded
+	// (not the decoded ones — there's no decoded form).
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    allowed_params = {
+      path = ["docs/*"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method":     "tools/call",
+		"Mcp-Name":       "write_file",
+		"Mcp-Param-Path": "=?base64?!!!not_valid_base64!!!?=",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, "=?base64?!!!not_valid_base64!!!?=", res.MCPDecision.ParamValue,
+		"malformed envelope: raw bytes recorded so audit shows what was actually compared")
+}
+
+func TestMCPEval_MultiKeyParams_AllPass(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    allowed_params = {
+      path = ["docs/*"]
+      mode = ["0644"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method":     "tools/call",
+		"Mcp-Name":       "write_file",
+		"Mcp-Param-Path": "docs/api.md",
+		"Mcp-Param-Mode": "0644",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+	assert.True(t, res.Allowed, "both keys satisfied → allow")
+}
+
+func TestMCPEval_MultiKeyParams_OneFails(t *testing.T) {
+	// Same policy, but mode header carries a disallowed value.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["write_file"]
+    allowed_params = {
+      path = ["docs/*"]
+      mode = ["0644"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method":     "tools/call",
+		"Mcp-Name":       "write_file",
+		"Mcp-Param-Path": "docs/api.md", // passes
+		"Mcp-Param-Mode": "0755",        // fails
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed, "AND across keys: any failing key denies")
+	assert.Equal(t, "mode", res.MCPDecision.ParamName)
+	assert.Equal(t, "0755", res.MCPDecision.ParamValue)
+}
+
+// =============================================================================
+// Multi-set merge (OR-of-rule-sets across stanzas at the same path)
+// =============================================================================
+
+func TestMCPEval_MultiSet_FirstAllows(t *testing.T) {
+	// Two stanzas at the same path: set 1 allows the request, set 2
+	// would deny it. OR semantics: any allow wins, and audit records
+	// the first allowing set.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_repository"]
+  }
+}
+
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_methods = ["tools/call"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "get_repository",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed, "set 1 allows, OR wins")
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeAllowedTools, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_MultiPolicy_AdditiveMerge(t *testing.T) {
+	// Two separate Policy objects bound to the same effective path,
+	// merged at NewCBP time. The MCP slice grows additively — the
+	// presence of a policy WITHOUT an mcp block does NOT clear
+	// enforcement contributed by the policy WITH one. This is the
+	// design call documented next to the merge code: MCP differs
+	// from ConditionSets (where "absent clears") because adding a
+	// broader catch-all policy shouldn't accidentally lift an
+	// existing MCP restriction.
+	policyWithMCP := testParsePolicy(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_*"]
+  }
+}
+`)
+	policyWithoutMCP := testParsePolicy(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	cbp, err := NewCBP(testContext(), []*Policy{policyWithMCP, policyWithoutMCP})
+	require.NoError(t, err)
+
+	// Forbidden tool: MCP gate from the first policy denies, the
+	// second policy's silence on MCP doesn't lift the restriction.
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "delete_repository",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+	assert.False(t, res.Allowed, "additive merge: MCP restriction from one policy still applies even with un-mcp'd policy alongside")
+	assert.Equal(t, mcpRuleTypeAllowedTools, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_MultiSet_StrongestReasonDenyList(t *testing.T) {
+	// Both sets deny: set 1 via not-in-allow-list (weaker reason),
+	// set 2 via explicit deny-list (stronger reason). Audit should
+	// record the deny-list reason.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_repository"]
+  }
+}
+
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["delete_*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "delete_repository",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeDeniedTools, res.MCPDecision.RuleType,
+		"strongest-reason picks the deny-list match over not-in-allow-list")
+	assert.Equal(t, "delete_*", res.MCPDecision.MatchedRule)
+}
+
+// =============================================================================
+// Canonicalisation: case-insensitive matching
+// =============================================================================
+
+func TestMCPEval_HeaderCaseInsensitive(t *testing.T) {
+	// Operator wrote lowercase in policy; client sends mixed case
+	// header values. Should still match because evaluateMCP
+	// lowercases the request values before comparing.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "Tools/CALL",  // mixed case
+		"Mcp-Name":   "GET_Repository", // mixed case
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	assert.Equal(t, "tools/call", res.MCPDecision.Method)
+	assert.Equal(t, "get_repository", res.MCPDecision.Name)
+}
+
+// =============================================================================
+// Typed-error wrap (request_handler integration is end-to-end; unit-test
+// the typed-error shape directly to verify the Unwrap contract).
+// =============================================================================
+
+func TestErrMCPPolicyDenied_UnwrapsToPermissionDenied(t *testing.T) {
+	err := &ErrMCPPolicyDenied{
+		Decision: &logical.MCPDecision{Decision: "deny", RuleType: mcpRuleTypeDeniedTools},
+	}
+	// errors.Is should resolve through Unwrap.
+	require.NotNil(t, err)
+	assert.Equal(t, "permission denied", err.Error())
+
+	// Verify the Unwrap returns the sdklogical sentinel that the HTTP
+	// status mapper keys off.
+	type unwrapper interface{ Unwrap() error }
+	var u unwrapper = err
+	assert.NotNil(t, u.Unwrap())
+}
+
+// =============================================================================
+// Helper unit tests
+// =============================================================================
+
+func TestMatchMCPGlob(t *testing.T) {
+	cases := []struct {
+		value, pattern string
+		want           bool
+	}{
+		{"get_repository", "get_*", true},
+		{"get_repository", "get_repository", true},
+		{"get_repository", "*", true},
+		{"get_repository", "get", false},
+		{"get_repository", "set_*", false},
+		{"", "*", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.pattern+"_vs_"+c.value, func(t *testing.T) {
+			assert.Equal(t, c.want, matchMCPGlob(c.value, c.pattern))
+		})
+	}
+}
+
+func TestDecodeMCPParamValue(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"plain ASCII", "docs/readme.md", "docs/readme.md"},
+		{"base64 envelope decodes", "=?base64?ZG9jcy9yZWFkbWUubWQ=?=", "docs/readme.md"},
+		{"malformed base64 inside envelope falls back to raw",
+			"=?base64?!!!?=", "=?base64?!!!?="},
+		{"prefix only without suffix is literal",
+			"=?base64?ZG9jcw==", "=?base64?ZG9jcw=="},
+		{"empty input", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, decodeMCPParamValue(c.raw))
+		})
+	}
+}
+
+func TestBuildMCPDenyDescription_PerRuleType(t *testing.T) {
+	cases := []struct {
+		ruleType string
+		decision *logical.MCPDecision
+		want     string
+	}{
+		{mcpRuleTypeDeniedMethods,
+			&logical.MCPDecision{Method: "tools/call", RuleType: mcpRuleTypeDeniedMethods},
+			"Method 'tools/call' not allowed."},
+		{mcpRuleTypeAllowedMethods,
+			&logical.MCPDecision{Method: "tools/call", RuleType: mcpRuleTypeAllowedMethods},
+			"Method 'tools/call' not allowed."},
+		{mcpRuleTypeDeniedTools,
+			&logical.MCPDecision{Name: "delete_repository", RuleType: mcpRuleTypeDeniedTools},
+			"Tool 'delete_repository' not allowed."},
+		{mcpRuleTypeAllowedTools,
+			&logical.MCPDecision{Name: "create_pr", RuleType: mcpRuleTypeAllowedTools},
+			"Tool 'create_pr' not allowed."},
+		{mcpRuleTypeAllowedResources,
+			&logical.MCPDecision{Name: "github://repo/B/x", RuleType: mcpRuleTypeAllowedResources},
+			"Resource 'github://repo/B/x' not allowed."},
+		{mcpRuleTypeAllowedPrompts,
+			&logical.MCPDecision{Name: "code-review", RuleType: mcpRuleTypeAllowedPrompts},
+			"Prompt 'code-review' not allowed."},
+		{mcpRuleTypeDeniedParams,
+			&logical.MCPDecision{ParamName: "path", ParamValue: ".env", RuleType: mcpRuleTypeDeniedParams},
+			"Parameter 'path'='.env' not allowed."},
+		{mcpRuleTypeAllowedParams + "_missing",
+			&logical.MCPDecision{ParamName: "region", RuleType: mcpRuleTypeAllowedParams},
+			"Parameter 'region' required."},
+		{mcpRuleTypeAllowedParams + "_mismatch",
+			&logical.MCPDecision{ParamName: "region", ParamValue: "ap-south1", RuleType: mcpRuleTypeAllowedParams},
+			"Parameter 'region'='ap-south1' not allowed."},
+		{mcpRuleTypeMissingMethod,
+			&logical.MCPDecision{RuleType: mcpRuleTypeMissingMethod},
+			"Mcp-Method header required."},
+	}
+	for _, c := range cases {
+		t.Run(c.ruleType, func(t *testing.T) {
+			assert.Equal(t, c.want, buildMCPDenyDescription(c.decision))
+		})
+	}
+
+	// Identical-message invariant: denied_tools and allowed_tools-no-match
+	// for the same tool name must produce identical strings. Prevents
+	// client-side enumeration of policy shape from the response.
+	deniedToolsMsg := buildMCPDenyDescription(&logical.MCPDecision{
+		Name: "x", RuleType: mcpRuleTypeDeniedTools,
+	})
+	allowedToolsMsg := buildMCPDenyDescription(&logical.MCPDecision{
+		Name: "x", RuleType: mcpRuleTypeAllowedTools,
+	})
+	assert.Equal(t, deniedToolsMsg, allowedToolsMsg,
+		"deny-vs-not-in-allow indistinguishable to client")
+}
+
+func TestBuildMCPDenyDescription_StripsCTLs(t *testing.T) {
+	d := &logical.MCPDecision{
+		Name:     "evil\x00name\x1f\r\n",
+		RuleType: mcpRuleTypeDeniedTools,
+	}
+	got := buildMCPDenyDescription(d)
+	assert.Equal(t, "Tool 'evilname' not allowed.", got,
+		"CTL bytes stripped before interpolation")
+}
+
+func TestBuildMCPDenyDescription_UnknownRuleType_GenericFallback(t *testing.T) {
+	d := &logical.MCPDecision{RuleType: "future_unknown_gate"}
+	assert.Equal(t, "Request denied by policy.", buildMCPDenyDescription(d))
+}
+
+// =============================================================================
+// Benchmarks — validate the performance claims from the Defense-in-depth
+// section of the plan. Targets:
+//
+//	BenchmarkAllowOperation_NoMCP       — baseline (existing perf preserved)
+//	BenchmarkAllowOperation_TypicalMCP  — overhead < 2 µs (expect ~300–500 ns)
+//	BenchmarkAllowOperation_StressMCP   — overhead < 20 µs at pathological scale
+//
+// Run: go test -bench BenchmarkAllowOperation -benchmem ./core/
+// =============================================================================
+
+func BenchmarkAllowOperation_NoMCP(b *testing.B) {
+	cbp := buildBenchCBP(b, `
+path "secret/*" {
+  capabilities = ["read"]
+}
+`)
+	req := &logical.Request{Path: "secret/foo", Operation: logical.ReadOperation}
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, false)
+	}
+}
+
+func BenchmarkAllowOperation_TypicalMCP(b *testing.B) {
+	cbp := buildBenchCBP(b, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call", "resources/list", "resources/read", "prompts/get"]
+    allowed_tools = [
+      "get_repository", "get_pull_request", "list_issues", "list_pull_requests",
+      "search_code", "search_issues", "search_repositories", "list_workflows",
+      "list_commits", "get_file_contents",
+    ]
+    allowed_params = {
+      path = ["docs/*"]
+      mode = ["0644"]
+      region = ["us-west1"]
+    }
+  }
+}
+`)
+	req := newMCPRequest(b, "mcp/gateway/", map[string]string{
+		"Mcp-Method":       "tools/call",
+		"Mcp-Name":         "get_repository",
+		"Mcp-Param-Path":   "docs/api.md",
+		"Mcp-Param-Mode":   "0644",
+		"Mcp-Param-Region": "us-west1",
+	})
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, false)
+	}
+}
+
+func BenchmarkAllowOperation_StressMCP(b *testing.B) {
+	// 5 stanzas at the same path, each with ~50 patterns across
+	// methods/tools/params. Operators shouldn't aim for this shape,
+	// but the bench bounds the cliff.
+	stress := buildStressPolicy(5, 50)
+	cbp := buildBenchCBP(b, stress)
+	req := newMCPRequest(b, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "tools/call",
+		"Mcp-Name":   "get_repository_47", // matches one of the allow patterns
+	})
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, false)
+	}
+}
+
+func buildBenchCBP(b *testing.B, rules string) *CBP {
+	b.Helper()
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	cbp, err := NewCBP(testContext(), []*Policy{policy})
+	if err != nil {
+		b.Fatalf("build: %v", err)
+	}
+	return cbp
+}
+
+func buildStressPolicy(sets, patternsPerList int) string {
+	var sb strings.Builder
+	for s := 0; s < sets; s++ {
+		sb.WriteString(`path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools = [`)
+		for i := 0; i < patternsPerList; i++ {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			fmt.Fprintf(&sb, `"get_repository_%d"`, i)
+		}
+		sb.WriteString("]\n  }\n}\n")
+	}
+	return sb.String()
+}

--- a/core/policy_mcp_test.go
+++ b/core/policy_mcp_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMCP_AllFields(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods   = ["tools/list", "tools/call"]
+    denied_methods    = ["tools/dangerous"]
+    allowed_tools     = ["get_repository", "list_issues"]
+    denied_tools      = ["delete_*", "force_*"]
+    allowed_resources = ["github://repo/*"]
+    allowed_prompts   = ["*"]
+    allowed_params = {
+      path = ["docs/*", "specs/*"]
+    }
+    denied_params = {
+      env = ["prod", "production"]
+    }
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 1)
+
+	mcp := policy.Paths[0].Permissions.MCP
+	require.Len(t, mcp, 1, "one stanza must produce one MCP rule-set")
+	r := mcp[0]
+
+	assert.Equal(t, []string{"tools/list", "tools/call"}, r.AllowedMethods)
+	assert.Equal(t, []string{"tools/dangerous"}, r.DeniedMethods)
+	assert.Equal(t, []string{"get_repository", "list_issues"}, r.AllowedTools)
+	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
+	assert.Equal(t, []string{"github://repo/*"}, r.AllowedResources)
+	assert.Equal(t, []string{"*"}, r.AllowedPrompts)
+	assert.Equal(t, map[string][]string{"path": {"docs/*", "specs/*"}}, r.AllowedParams)
+	assert.Equal(t, map[string][]string{"env": {"prod", "production"}}, r.DeniedParams)
+}
+
+func TestParseMCP_EmptyBlock(t *testing.T) {
+	// An empty mcp { } block is the minimum opt-in: produces a
+	// non-nil rule-set with all empty fields. AllowOperation uses
+	// presence to trigger the missing-header check; emptiness means
+	// "no further restriction."
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {}
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 1)
+
+	mcp := policy.Paths[0].Permissions.MCP
+	require.Len(t, mcp, 1, "empty block must still produce a rule-set entry")
+	r := mcp[0]
+
+	assert.Nil(t, r.AllowedMethods)
+	assert.Nil(t, r.DeniedMethods)
+	assert.Nil(t, r.AllowedTools)
+	assert.Nil(t, r.DeniedTools)
+	assert.Nil(t, r.AllowedResources)
+	assert.Nil(t, r.AllowedPrompts)
+	assert.Nil(t, r.AllowedParams)
+	assert.Nil(t, r.DeniedParams)
+}
+
+func TestParseMCP_NoBlock(t *testing.T) {
+	// A path stanza without an mcp { } block leaves Permissions.MCP
+	// nil — every existing non-MCP policy keeps working unchanged.
+	rules := `
+path "secret/*" {
+  capabilities = ["read"]
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 1)
+	assert.Nil(t, policy.Paths[0].Permissions.MCP)
+}
+
+func TestParseMCP_Lowercasing(t *testing.T) {
+	// Operator-supplied mixed-case patterns are canonicalised at parse
+	// time so AllowOperation can do case-insensitive matching via plain
+	// string equality.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["TOOLS/Call", "Tools/LIST"]
+    denied_tools    = ["Delete_*", "FORCE_*"]
+    allowed_params = {
+      Path = ["DOCS/*"]
+    }
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	r := policy.Paths[0].Permissions.MCP[0]
+
+	assert.Equal(t, []string{"tools/call", "tools/list"}, r.AllowedMethods)
+	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
+	assert.Equal(t, map[string][]string{"path": {"docs/*"}}, r.AllowedParams,
+		"param-name keys and values both lowercase")
+}
+
+func TestParseMCP_LeadingStarRejected(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["*_admin"]
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied_tools")
+	assert.Contains(t, err.Error(), "*_admin")
+	assert.Contains(t, err.Error(), "trailing")
+}
+
+func TestParseMCP_InternalStarRejected(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_tools = ["get_*_admin"]
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_tools")
+	assert.Contains(t, err.Error(), "get_*_admin")
+}
+
+func TestParseMCP_TrailingStarAccepted(t *testing.T) {
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["delete_*"]
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+}
+
+func TestParseMCP_BareStarAccepted(t *testing.T) {
+	// The bare `*` is a zero-prefix trailing-star and matches
+	// everything. Used to express "any value" without enumerating.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_prompts = ["*"]
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*"}, policy.Paths[0].Permissions.MCP[0].AllowedPrompts)
+}
+
+func TestParseMCP_InvalidPatternInParams(t *testing.T) {
+	// Validation must recurse into the param-map values; the error
+	// should mention which param key the bad pattern came from.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_params = {
+      path = ["docs/*", "*invalid"]
+    }
+  }
+}
+`
+	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_params")
+	assert.Contains(t, err.Error(), `"path"`)
+	assert.Contains(t, err.Error(), "*invalid")
+}
+
+func TestParseMCP_MultipleStanzasSamePath(t *testing.T) {
+	// Two `path` stanzas at the same path in one policy each become
+	// their own PathRules, each with its own one-entry MCP slice. The
+	// OR-of-rule-sets merge into a single CBPPermissions.MCP slice
+	// happens at NewCBP time alongside the evaluation logic.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["resources/read"]
+    allowed_resources = ["github://repo/A/*"]
+  }
+}
+
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["resources/list"]
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	require.Len(t, policy.Paths, 2)
+
+	require.Len(t, policy.Paths[0].Permissions.MCP, 1)
+	require.Len(t, policy.Paths[1].Permissions.MCP, 1)
+	assert.Equal(t, []string{"resources/read"}, policy.Paths[0].Permissions.MCP[0].AllowedMethods)
+	assert.Equal(t, []string{"resources/list"}, policy.Paths[1].Permissions.MCP[0].AllowedMethods)
+}
+
+func TestCBPMCPRules_Clone_Nil(t *testing.T) {
+	var r *CBPMCPRules
+	assert.Nil(t, r.Clone())
+}
+
+func TestCBPMCPRules_Clone_DeepCopy(t *testing.T) {
+	original := &CBPMCPRules{
+		AllowedMethods:   []string{"tools/call"},
+		DeniedTools:      []string{"delete_*"},
+		AllowedResources: []string{"github://repo/A/*"},
+		AllowedParams: map[string][]string{
+			"path": {"docs/*", "specs/*"},
+		},
+		DeniedParams: map[string][]string{
+			"env": {"prod"},
+		},
+	}
+	clone := original.Clone()
+	require.NotNil(t, clone)
+	assert.Equal(t, original, clone)
+
+	// Mutating the clone's slices and maps must not affect the original.
+	clone.AllowedMethods[0] = "mutated"
+	clone.AllowedParams["path"][0] = "mutated"
+	clone.AllowedParams["new"] = []string{"x"}
+	clone.DeniedParams["env"][0] = "mutated"
+
+	assert.Equal(t, "tools/call", original.AllowedMethods[0])
+	assert.Equal(t, "docs/*", original.AllowedParams["path"][0])
+	assert.NotContains(t, original.AllowedParams, "new")
+	assert.Equal(t, "prod", original.DeniedParams["env"][0])
+}
+
+func TestCBPPermissions_Clone_MCPDeepCopy(t *testing.T) {
+	// End-to-end: parse a policy with an mcp block, clone the
+	// CBPPermissions, mutate the clone, confirm the original is
+	// unaffected.
+	rules := `
+path "mcp_github/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_tools = ["get_*"]
+    allowed_params = {
+      path = ["docs/*"]
+    }
+  }
+}
+`
+	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	original := policy.Paths[0].Permissions
+
+	cloned, err := original.Clone()
+	require.NoError(t, err)
+	require.Len(t, cloned.MCP, 1)
+
+	cloned.MCP[0].AllowedTools[0] = "mutated"
+	cloned.MCP[0].AllowedParams["path"][0] = "mutated"
+
+	assert.Equal(t, "get_*", original.MCP[0].AllowedTools[0])
+	assert.Equal(t, "docs/*", original.MCP[0].AllowedParams["path"][0])
+}

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -168,12 +168,29 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 	auth.PolicyResults = &sdklogical.PolicyResults{
 		Allowed: accessControlResults.Allowed,
 	}
+	// Carry the MCP decision (when an mcp { } rule-set was consulted)
+	// through to buildAuditAuth — that's where it gets surfaced in the
+	// audit record — and to the deny-response path below for the
+	// typed-error wrap.
+	if accessControlResults.CBPResults != nil && accessControlResults.CBPResults.MCPDecision != nil {
+		auth.MCPDecision = accessControlResults.CBPResults.MCPDecision
+	}
 
 	if !accessControlResults.Allowed {
 		retErr := accessControlResults.Error
 
 		if accessControlResults.Error.ErrorOrNil() == nil || accessControlResults.DeniedError {
-			retErr = multierror.Append(retErr, sdklogical.ErrPermissionDenied)
+			// Wrap the permission-denied error with the MCP decision
+			// when the denial came from an mcp { } gate, so the HTTP
+			// layer can render the OAuth-shaped 403 body. Unwrap()
+			// returns ErrPermissionDenied so every existing
+			// errors.Is(err, ErrPermissionDenied) call site keeps
+			// working unchanged.
+			if auth.MCPDecision != nil && auth.MCPDecision.Decision == "deny" {
+				retErr = multierror.Append(retErr, &ErrMCPPolicyDenied{Decision: auth.MCPDecision})
+			} else {
+				retErr = multierror.Append(retErr, sdklogical.ErrPermissionDenied)
+			}
 		}
 		return auth, cbp, te, retErr
 	}

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -34,6 +34,15 @@ type Auth struct {
 	// requesting path.
 	PolicyResults *sdklogical.PolicyResults `json:"policy_results"`
 
+	// MCPDecision carries the MCP-specific policy decision when an mcp { }
+	// block was consulted during CBP evaluation. nil when no such block
+	// applied (every non-MCP request, plus MCP-mount requests whose bound
+	// policies contain no mcp block). Flows through buildAuditAuth into
+	// audit.PolicyResults.MCPDecision and is also consumed by the
+	// deny-response path to populate the WWW-Authenticate header and the
+	// OAuth-shaped 403 body.
+	MCPDecision *MCPDecision
+
 	PrincipalID string
 
 	RoleName string
@@ -51,6 +60,61 @@ type Auth struct {
 	// through buildAuditAuth into the audit log; not used for policy
 	// decisions.
 	Actors []ActorRef
+}
+
+// MCPDecision records the outcome of evaluating an mcp { } policy block
+// against a request. Populated on every branch (allow and deny) so the
+// audit layer can render the decision unconditionally. The JSON tags
+// double as the wire shape exposed in audit records under
+// auth.policy_results.mcp_decision.
+type MCPDecision struct {
+	// Method is the value of the Mcp-Method header on the request.
+	// Empty when the header was missing (paired with
+	// RuleType=missing_method_header).
+	Method string `json:"method"`
+
+	// Name is the value of the Mcp-Name header. Empty for name-less
+	// methods (tools/list, notifications, etc.) and when the request
+	// was rejected before the name gate ran.
+	Name string `json:"name,omitempty"`
+
+	// Decision is "allow" or "deny". Always populated when an mcp { }
+	// block was consulted.
+	Decision string `json:"decision"`
+
+	// MatchedRule is the pattern from the policy (allow- or deny-list
+	// entry) that fired. For a literal match it equals the request's
+	// name/method/param value; for a wildcard match it carries the
+	// pattern (e.g. "delete_*"). Empty when no list entry matched
+	// (deny via not-in-allow-list) and when the deny reason is a
+	// sentinel like missing_method_header.
+	MatchedRule string `json:"matched_rule"`
+
+	// RuleType records which gate produced the decision. Domain:
+	// allowed_methods, denied_methods, allowed_tools, denied_tools,
+	// allowed_resources, allowed_prompts, allowed_params,
+	// denied_params, or the sentinel missing_method_header.
+	RuleType string `json:"rule_type"`
+
+	// ParamName is the Mcp-Param-{Name} header's name (lowercase,
+	// hyphens preserved), populated only when RuleType is
+	// allowed_params or denied_params.
+	ParamName string `json:"param_name,omitempty"`
+
+	// ParamValue is the header value the policy compared against,
+	// base64-decoded if the source header was an RFC 2047
+	// encoded-word. Populated only for param-related decisions.
+	ParamValue string `json:"param_value,omitempty"`
+}
+
+// Clone returns a deep copy of the MCPDecision. Safe to call on a nil
+// receiver (returns nil).
+func (d *MCPDecision) Clone() *MCPDecision {
+	if d == nil {
+		return nil
+	}
+	clone := *d
+	return &clone
 }
 
 // ActorRef identifies a subject in the on-behalf-of chain. Verified

--- a/logical/auth_test.go
+++ b/logical/auth_test.go
@@ -1,0 +1,96 @@
+package logical
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPDecision_JSONRoundTrip(t *testing.T) {
+	t.Run("full populated decision", func(t *testing.T) {
+		original := &MCPDecision{
+			Method:      "tools/call",
+			Name:        "delete_repository",
+			Decision:    "deny",
+			MatchedRule: "delete_*",
+			RuleType:    "denied_tools",
+			ParamName:   "path",
+			ParamValue:  ".env.production",
+		}
+
+		encoded, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded MCPDecision
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, *original, decoded)
+	})
+
+	t.Run("minimal decision (allow with empty optional fields)", func(t *testing.T) {
+		original := &MCPDecision{
+			Method:      "tools/list",
+			Decision:    "allow",
+			MatchedRule: "tools/list",
+			RuleType:    "allowed_methods",
+		}
+
+		encoded, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded MCPDecision
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		assert.Equal(t, *original, decoded)
+	})
+}
+
+func TestMCPDecision_OmitEmpty(t *testing.T) {
+	// Optional fields (name, param_name, param_value) must be omitted
+	// from the serialised form when empty so non-name-bearing and
+	// non-param decisions produce compact audit records.
+	d := &MCPDecision{
+		Method:      "tools/list",
+		Decision:    "allow",
+		MatchedRule: "tools/list",
+		RuleType:    "allowed_methods",
+	}
+
+	encoded, err := json.Marshal(d)
+	require.NoError(t, err)
+
+	s := string(encoded)
+	assert.NotContains(t, s, "name")
+	assert.NotContains(t, s, "param_name")
+	assert.NotContains(t, s, "param_value")
+	assert.Contains(t, s, `"method":"tools/list"`)
+	assert.Contains(t, s, `"decision":"allow"`)
+	assert.Contains(t, s, `"rule_type":"allowed_methods"`)
+}
+
+func TestMCPDecision_Clone_Nil(t *testing.T) {
+	var d *MCPDecision
+	assert.Nil(t, d.Clone())
+}
+
+func TestMCPDecision_Clone_DeepCopy(t *testing.T) {
+	original := &MCPDecision{
+		Method:      "tools/call",
+		Name:        "delete_repository",
+		Decision:    "deny",
+		MatchedRule: "delete_*",
+		RuleType:    "denied_tools",
+		ParamName:   "path",
+		ParamValue:  ".env.production",
+	}
+
+	clone := original.Clone()
+	require.NotNil(t, clone)
+	assert.Equal(t, *original, *clone)
+
+	// Mutating the clone must not affect the original.
+	clone.Name = "mutated"
+	clone.MatchedRule = "mutated"
+	assert.Equal(t, "delete_repository", original.Name)
+	assert.Equal(t, "delete_*", original.MatchedRule)
+}


### PR DESCRIPTION
## Summary

PR **3 of 5** in the mcp-policy stack. Wires the `mcp { }` block from PR 2 into the `AllowOperation` decision path and the audit record. Denials carry the structured `MCPDecision` through a typed `ErrMCPPolicyDenied` error so the HTTP layer can render a tailored 403 (PR 4), but every existing `errors.Is(err, ErrPermissionDenied)` call site keeps working unchanged via `Unwrap`.

Evaluation lives in `core/policy_mcp.go`, kept separate from the existing CBP plumbing in `policy_cbp.go`. Per-set semantics (short-circuit on first matching gate) and across-set semantics (OR with strongest-reason audit on full deny) match the policy plan. Includes the `BuildMCPDenyDescription` helper that PR 4 consumes to render the `WWW-Authenticate` header and OAuth-shaped body.

- `CBPResults` gains `MCPDecision *logical.MCPDecision`, populated on every branch (allow and deny) when an mcp rule-set is consulted. Documented invariant: `Decision="deny"` implies `Allowed=false`; the reverse (`Allowed=false` with `Decision="allow"`) can happen because the MCP gate runs between conditions and the parameter check.
- `NewCBP` merges MCP rule-sets additively across policies — unlike `ConditionSets` where "absent wins" to express unconditional access, an absent mcp block doesn't lift restrictions contributed by another policy. Matches the parameters merge model.
- `AllowOperation` runs `evaluateMCP` after the conditions check and before parameter validation. Per-set deny continues to the next set (OR-of-rule-sets). Full deny picks the strongest reason (explicit deny-list > not-in-allow-list > missing_method_header).
- `request_handler` wraps the permission-denied error with `&ErrMCPPolicyDenied{Decision}` when the deny came from an mcp gate. The wrapper's `Unwrap()` returns `sdklogical.ErrPermissionDenied`.
- `buildAuditAuth` surfaces `auth.MCPDecision` into `audit.PolicyResults.MCPDecision` (the audit-side mirror landed in PR 1).

Param-value base64 decoding handles the spec's `=?base64?...?=` envelope with graceful fallback to the raw value on malformed inputs — a bad encoding can't be used to evade a deny pattern; the audit records whatever the policy actually compared against.

## Stack

| PR | Branch | Status |
|---|---|---|
| 1 | `mcp-policy/01-audit-types` | required (merged into this branch) |
| 2 | `mcp-policy/02-hcl-parsing` | required (this PR's base) |
| **3** | `mcp-policy/03-evaluation` | ← this PR |
| 4 | `mcp-policy/04-deny-response` | depends on 3 |
| 5 | `mcp-policy/05-docs` | depends on 1 |

**Coordination note**: this PR makes deny *enforced* but still *ugly* — denials return Warden's existing generic 403 body. PR 4 follows immediately to render the OAuth-shaped body. Either land 4 right after, or warn operators in the release notes that the polished deny response is the next PR.

## Benchmarks (Apple M4 Pro)

| Bench | ns/op | allocs |
|---|---|---|
| `BenchmarkAllowOperation_NoMCP` | 50 | 2 |
| `BenchmarkAllowOperation_TypicalMCP` | 410 | 6 |
| `BenchmarkAllowOperation_StressMCP` | 320 | 3 |

Typical overhead ~370 ns, well under the 2 µs budget. Stress (5 sets × 50 patterns) ~270 ns, well under the 20 µs cliff.

## Test plan

- [ ] `go test ./core/... ./audit/...` passes including the 37 new MCP tests
- [ ] `go test -bench BenchmarkAllowOperation -benchmem ./core/` passes latency budgets
- [ ] Manual: write `mcp { allowed_tools = ["get_*"] }` policy, send POSTs against `mcp_github/gateway/`, tail audit, confirm `auth.policy_results.mcp_decision` sub-struct appears
- [ ] Verify denials still return generic 403 (PR 4 lands the OAuth shape)
