### PR TITLE
feat(http): render MCP policy denials as OAuth-shaped 403 responses

### DIFF
--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -375,20 +375,22 @@ func mcpDenyRank(ruleType string) int {
 	return 0
 }
 
-// buildMCPDenyDescription renders the operator-facing single-sentence
+// BuildMCPDenyDescription renders the operator-facing single-sentence
 // message returned in the 403 body's error_description field and in
-// the WWW-Authenticate header. Per the policy plan Semantics, the
-// templates deliberately omit matched_rule and rule_type from the
-// client-visible string — disclosure of those stays in the audit log
-// only, and the denied/allowed cases for the same name produce
-// identical strings so the client can't fingerprint operator policy
-// shape from the response.
+// the WWW-Authenticate header. Exported so the HTTP response layer
+// (http package) can consume it without duplicating the template
+// table. Per the policy plan Semantics, the templates deliberately
+// omit matched_rule and rule_type from the client-visible string —
+// disclosure of those stays in the audit log only, and the
+// denied/allowed cases for the same name produce identical strings
+// so the client can't fingerprint operator policy shape from the
+// response.
 //
 // Strips ASCII control characters from interpolated values defensively
 // — MCP headers shouldn't contain CTLs but RFC 7235 disallows them in
 // the WWW-Authenticate quoted-string and a malformed header is worse
 // than a sanitised one.
-func buildMCPDenyDescription(d *logical.MCPDecision) string {
+func BuildMCPDenyDescription(d *logical.MCPDecision) string {
 	if d == nil {
 		return "Request denied by policy."
 	}

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -729,17 +729,17 @@ func TestBuildMCPDenyDescription_PerRuleType(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.ruleType, func(t *testing.T) {
-			assert.Equal(t, c.want, buildMCPDenyDescription(c.decision))
+			assert.Equal(t, c.want, BuildMCPDenyDescription(c.decision))
 		})
 	}
 
 	// Identical-message invariant: denied_tools and allowed_tools-no-match
 	// for the same tool name must produce identical strings. Prevents
 	// client-side enumeration of policy shape from the response.
-	deniedToolsMsg := buildMCPDenyDescription(&logical.MCPDecision{
+	deniedToolsMsg := BuildMCPDenyDescription(&logical.MCPDecision{
 		Name: "x", RuleType: mcpRuleTypeDeniedTools,
 	})
-	allowedToolsMsg := buildMCPDenyDescription(&logical.MCPDecision{
+	allowedToolsMsg := BuildMCPDenyDescription(&logical.MCPDecision{
 		Name: "x", RuleType: mcpRuleTypeAllowedTools,
 	})
 	assert.Equal(t, deniedToolsMsg, allowedToolsMsg,
@@ -751,14 +751,14 @@ func TestBuildMCPDenyDescription_StripsCTLs(t *testing.T) {
 		Name:     "evil\x00name\x1f\r\n",
 		RuleType: mcpRuleTypeDeniedTools,
 	}
-	got := buildMCPDenyDescription(d)
+	got := BuildMCPDenyDescription(d)
 	assert.Equal(t, "Tool 'evilname' not allowed.", got,
 		"CTL bytes stripped before interpolation")
 }
 
 func TestBuildMCPDenyDescription_UnknownRuleType_GenericFallback(t *testing.T) {
 	d := &logical.MCPDecision{RuleType: "future_unknown_gate"}
-	assert.Equal(t, "Request denied by policy.", buildMCPDenyDescription(d))
+	assert.Equal(t, "Request denied by policy.", BuildMCPDenyDescription(d))
 }
 
 // =============================================================================

--- a/http/logical.go
+++ b/http/logical.go
@@ -49,6 +49,21 @@ func handleLogical(c *core.Core, log *logger.GatedLogger, forwarder *standbyForw
 			}
 
 			statusCode := errorToStatusCode(err)
+
+			// MCP-flavoured policy denials carry the structured
+			// MCPDecision via a typed error wrapper from
+			// core/request_handler.go. Render the OAuth-shaped 403
+			// body and the WWW-Authenticate header. Non-MCP denials
+			// (and every other error category) fall through to the
+			// generic Warden error body unchanged. The typed error
+			// Unwraps to sdklogical.ErrPermissionDenied so the status
+			// code is still 403 from errorToStatusCode above.
+			var mcpErr *core.ErrMCPPolicyDenied
+			if errors.As(err, &mcpErr) {
+				respondMCPDeny(w, statusCode, mcpErr.Decision)
+				return
+			}
+
 			respondError(w, statusCode, err.Error())
 			return
 		}

--- a/http/util.go
+++ b/http/util.go
@@ -2,7 +2,11 @@ package http
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+
+	"github.com/stephnangue/warden/core"
+	"github.com/stephnangue/warden/logical"
 )
 
 // ErrorResponse represents a JSON error response
@@ -30,4 +34,43 @@ func respondOk(w http.ResponseWriter, data any) {
 	if data != nil {
 		json.NewEncoder(w).Encode(data)
 	}
+}
+
+// mcpDenyResponse is the OAuth-conventional JSON body shape returned by
+// respondMCPDeny. Matches the MCP Python reference SDK's deny shape so
+// any RFC 6750-aware client surfaces it the same way it would surface
+// an OAuth insufficient-permissions error from any other MCP server.
+type mcpDenyResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// respondMCPDeny renders an MCP policy denial as an HTTP 403 with the
+// RFC 6750-shaped WWW-Authenticate header and an OAuth-conventional
+// JSON body. Body and header carry the same error_description text so
+// SDKs that surface one or the other see identical messages.
+//
+// The MCP spec handles permission denial at the HTTP layer (not in-band
+// JSON-RPC), so this body is NOT a JSON-RPC envelope — no jsonrpc
+// field, no error.code, no id. The error value is
+// "insufficient_permissions" (Cloudflare-style RFC 6750 extension) to
+// distinguish from "insufficient_scope" which implies an OAuth scope
+// the client could go fetch — this isn't an OAuth scope mismatch,
+// it's a gateway policy decision.
+//
+// Description templates per RuleType live in core/policy_mcp.go's
+// BuildMCPDenyDescription so the wire shape and the audit JSON tags
+// stay in lockstep.
+func respondMCPDeny(w http.ResponseWriter, status int, d *logical.MCPDecision) {
+	desc := core.BuildMCPDenyDescription(d)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate",
+		fmt.Sprintf(`Bearer error="insufficient_permissions", error_description=%q`, desc))
+	w.WriteHeader(status)
+
+	resp := &mcpDenyResponse{
+		Error:            "insufficient_permissions",
+		ErrorDescription: desc,
+	}
+	json.NewEncoder(w).Encode(resp)
 }

--- a/http/util_test.go
+++ b/http/util_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -315,6 +317,97 @@ func TestErrorResponse_NilErrors(t *testing.T) {
 
 	// Nil slice is marshaled as null in JSON
 	assert.Contains(t, string(data), `"errors":null`)
+}
+
+// =============================================================================
+// respondMCPDeny Tests
+// =============================================================================
+
+func TestRespondMCPDeny_DeniedTools(t *testing.T) {
+	w := httptest.NewRecorder()
+	d := &logical.MCPDecision{
+		Method:      "tools/call",
+		Name:        "delete_repository",
+		Decision:    "deny",
+		MatchedRule: "delete_*",
+		RuleType:    "denied_tools",
+	}
+
+	respondMCPDeny(w, http.StatusForbidden, d)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	auth := w.Header().Get("WWW-Authenticate")
+	assert.Contains(t, auth, `Bearer error="insufficient_permissions"`)
+	assert.Contains(t, auth, `error_description="Tool 'delete_repository' not allowed."`)
+	assert.NotContains(t, auth, "scope=", "no scope= attribute per deliberate non-disclosure design")
+	assert.NotContains(t, auth, "delete_*", "matched_rule must not leak into the client-visible WWW-Authenticate")
+	assert.NotContains(t, auth, "denied_tools", "rule_type must not leak into the client-visible WWW-Authenticate")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "insufficient_permissions", body["error"])
+	assert.Equal(t, "Tool 'delete_repository' not allowed.", body["error_description"])
+	assert.NotContains(t, body, "jsonrpc", "no JSON-RPC envelope")
+	assert.NotContains(t, body, "id", "no JSON-RPC id field")
+	assert.NotContains(t, body, "matched_rule", "matched_rule stays audit-only")
+	assert.NotContains(t, body, "rule_type", "rule_type stays audit-only")
+}
+
+func TestRespondMCPDeny_DescriptionMatchesHeaderAndBody(t *testing.T) {
+	// Invariant: the error_description text in the WWW-Authenticate
+	// header and the JSON body must be byte-identical so SDKs that
+	// surface one or the other show the same message to the agent.
+	cases := []*logical.MCPDecision{
+		{Method: "tools/call", Name: "x", Decision: "deny", RuleType: "denied_tools"},
+		{Method: "tools/call", Name: "y", Decision: "deny", RuleType: "allowed_tools"},
+		{Method: "resources/read", Name: "uri", Decision: "deny", RuleType: "allowed_resources"},
+		{RuleType: "missing_method_header", Decision: "deny"},
+		{ParamName: "path", ParamValue: ".env", RuleType: "denied_params", Decision: "deny"},
+		{ParamName: "region", RuleType: "allowed_params", Decision: "deny"},
+	}
+	for _, d := range cases {
+		t.Run(d.RuleType, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			respondMCPDeny(w, http.StatusForbidden, d)
+
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			bodyDesc, _ := body["error_description"].(string)
+			require.NotEmpty(t, bodyDesc)
+
+			// Extract the header's error_description value (between
+			// the first `error_description="` and the closing `"`).
+			auth := w.Header().Get("WWW-Authenticate")
+			const marker = `error_description="`
+			start := strings.Index(auth, marker)
+			require.GreaterOrEqual(t, start, 0, "header should contain error_description")
+			headerDesc := auth[start+len(marker) : len(auth)-1] // strip trailing "
+
+			assert.Equal(t, bodyDesc, headerDesc, "header and body descriptions must be byte-identical")
+		})
+	}
+}
+
+func TestRespondMCPDeny_DeniedAndAllowedToolsProduceIdenticalResponse(t *testing.T) {
+	// Disclosure-resistance invariant from the policy plan: a deny
+	// from denied_tools and a deny from allowed_tools-no-match for
+	// the same tool name must produce byte-identical responses so
+	// the client can't fingerprint operator policy shape.
+	w1 := httptest.NewRecorder()
+	w2 := httptest.NewRecorder()
+	respondMCPDeny(w1, http.StatusForbidden, &logical.MCPDecision{
+		Method: "tools/call", Name: "delete_repository", Decision: "deny", RuleType: "denied_tools", MatchedRule: "delete_*",
+	})
+	respondMCPDeny(w2, http.StatusForbidden, &logical.MCPDecision{
+		Method: "tools/call", Name: "delete_repository", Decision: "deny", RuleType: "allowed_tools",
+	})
+
+	assert.Equal(t, w1.Body.String(), w2.Body.String(),
+		"deny-vs-not-in-allow indistinguishable in response body")
+	assert.Equal(t, w1.Header().Get("WWW-Authenticate"), w2.Header().Get("WWW-Authenticate"),
+		"deny-vs-not-in-allow indistinguishable in WWW-Authenticate")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

PR **4 of 5** in the mcp-policy stack. Wires the typed `ErrMCPPolicyDenied` from PR 3 into a tailored HTTP response. MCP denials now return HTTP 403 with:

- `WWW-Authenticate: Bearer error="insufficient_permissions", error_description="..."` (RFC 6750-shaped)
- JSON body `{"error":"insufficient_permissions","error_description":"..."}` (OAuth-conventional)

The MCP draft handles permission denial at the HTTP transport layer (not in-band JSON-RPC), so the response deliberately is **not** a JSON-RPC envelope — no `jsonrpc`/`code`/`id` fields. The error value `insufficient_permissions` is a Cloudflare-style RFC 6750 extension, distinct from `insufficient_scope` which would imply a fetchable OAuth scope — this is a gateway policy decision, not a scope mismatch.

Description templates per `RuleType` (one-sentence subject+verdict) live in `BuildMCPDenyDescription` (exported in this PR so the http package can reuse them rather than duplicate the table). Templates deliberately omit `matched_rule` and `rule_type` from the client-visible string — disclosure stays in audit only, and denied-vs-not-in-allow for the same name produce identical strings so the client can't fingerprint operator policy shape.

- `http/logical.go`: three-line `errors.As` dispatch just before the existing `respondError` fallthrough. The typed error's `Unwrap` returns `ErrPermissionDenied` so the status code is still 403 from `errorToStatusCode`; non-MCP denials take the unchanged `respondError` path.
- `http/util.go`: `respondMCPDeny` next to `respondError`. Header value uses `fmt.Sprintf` with `%q` so embedded quotes/backslashes round-trip safely through RFC 7235 quoted-string. Body shape via a small `mcpDenyResponse` struct.
- `core/policy_mcp.go`: `BuildMCPDenyDescription` exported (was unexported in PR 3).

Three new tests in `http/util_test.go` cover the wire format end-to-end:
- denied_tools shape (asserts no `matched_rule`/`rule_type`/`scope=` leak into the client-visible header or body)
- header-vs-body description byte-identity across every `RuleType`
- denied-tools-vs-allowed-tools-no-match identical-response invariant (the by-design disclosure-resistance check)

## Stack

| PR | Branch | Status |
|---|---|---|
| 1 | `mcp-policy/01-audit-types` | required |
| 2 | `mcp-policy/02-hcl-parsing` | required |
| 3 | `mcp-policy/03-evaluation` | required (this PR's base) |
| **4** | `mcp-policy/04-deny-response` | ← this PR |
| 5 | `mcp-policy/05-docs` | independent |

## Test plan

- [ ] `go test ./http/...` passes (3 new wire-format tests)
- [ ] Manual: cURL a denied request, confirm the JSON body matches templates byte-exact and `WWW-Authenticate` round-trips
- [ ] Confirm the `denied_tools`-vs-`allowed_tools`-no-match symmetry (identical `error_description` strings for the same tool name) in a manual probe
- [ ] Non-MCP denials still return the existing Warden error body
