### PR TITLE
docs(mcp_github): document the mcp { } policy block and 2026-07-28 dependency

### DIFF
--- a/provider/mcp_github/README.md
+++ b/provider/mcp_github/README.md
@@ -141,30 +141,71 @@ warden cred spec read github-ops
 
 ## Step 4: Create a Policy
 
-The `mcp_github` provider runs in opaque pass-through mode — request bodies are not parsed for policy evaluation. This is by design: MCP traffic is JSON-RPC, and tool-level authorization belongs in the PAT's scopes rather than Warden policy. Grant access to the gateway and rely on the PAT's GitHub scopes for fine-grained authorization:
+MCP traffic passes through two complementary layers of authorization. The minted GitHub token is the security boundary — its scopes bound what the agent can actually do at GitHub regardless of what Warden lets through. On top of that, Warden's CBP policies support an `mcp { }` block for governance-style restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs, prompt names, and (where the upstream tool author opted in) selected tool arguments. Enforcement is header-based; the allow path does no request-body parsing.
+
+> **Important — MCP draft 2026-07-28 dependency.** The `mcp { }` block relies on the next MCP protocol revision (draft dated 2026-07-28), which mirrors the JSON-RPC method and selected fields into HTTP headers so intermediaries can inspect without parsing the body. Until your MCP client adopts the draft, those headers are absent — and a policy with an `mcp { }` block bound to its path will **deny every request** from a pre-draft client. For mixed fleets, stage the rollout: start with the gateway-only policy below, verify clients send the new headers, then promote roles to policies with the `mcp { }` block. Policies without an `mcp { }` block continue to behave exactly as today.
+>
+> Tool-argument constraints (`allowed_params` / `denied_params`) carry an additional dependency: the upstream tool author has to opt into the per-argument header mirror via `x-mcp-header` in the tool's input schema. Until GitHub's MCP server ships that opt-in, `allowed_params` rules silently no-op for those tools and the PAT scopes remain the only argument-level guard.
+
+All examples below use `capabilities = ["update"]`. MCP traffic is HTTP POST and Warden maps POST to the `update` operation; the 2026-07-28 draft removed the GET stream endpoint entirely, so no other capabilities are needed.
+
+The simplest policy grants the gateway and leans on PAT scopes for everything:
 
 ```bash
 warden policy write mcp-github-access - <<EOF
 path "mcp_github/role/+/gateway*" {
-  capabilities = ["create", "read", "update", "delete", "patch"]
+  capabilities = ["update"]
 }
 EOF
 ```
 
-For coarser control over which roles can reach the MCP gateway at all, combine with runtime conditions:
+A policy that restricts the agent to a vetted set of GitHub tools (requires draft-2026-07-28 clients — see disclaimer above):
+
+```bash
+warden policy write mcp-github-readonly - <<EOF
+path "mcp_github/role/+/gateway*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call", "resources/list", "resources/read"]
+    allowed_tools   = ["get_repository", "get_pull_request", "list_issues", "search_code"]
+  }
+}
+EOF
+```
+
+A complementary deny-list shape — permissive by default, blocks dangerous tools:
+
+```bash
+warden policy write mcp-github-safe - <<EOF
+path "mcp_github/role/+/gateway*" {
+  capabilities = ["update"]
+  mcp {
+    denied_tools = ["delete_*", "force_*", "merge_pull_request"]
+  }
+}
+EOF
+```
+
+The `mcp { }` block composes with runtime conditions so you can layer environment guards on top of tool-level restrictions:
 
 ```bash
 warden policy write mcp-github-business-hours - <<EOF
 path "mcp_github/role/+/gateway*" {
-  capabilities = ["create", "read", "update", "delete", "patch"]
+  capabilities = ["update"]
   conditions {
     source_ip   = ["10.0.0.0/8"]
     time_window = ["08:00-18:00 UTC"]
     day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
   }
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["get_*", "list_*", "create_issue_comment"]
+  }
 }
 EOF
 ```
+
+When a request hits the `mcp { }` gate and is denied, Warden returns HTTP 403 with a structured JSON body and an RFC 6750 `WWW-Authenticate` header; MCP client SDKs surface this to the agent as a tool-call failure with an actionable message. The audit log records the matched rule and the offending tool/parameter so operators can debug policy decisions centrally. Policies that omit the `mcp { }` block keep today's behaviour: Warden passes the request through to GitHub unchanged and the PAT's scopes alone enforce authorization.
 
 ## Step 5: Point an MCP Client at Warden
 

--- a/provider/mcp_github/provider.go
+++ b/provider/mcp_github/provider.go
@@ -75,6 +75,26 @@ provider type — see the skill markdown for the exact command.
 The same TypeGitHubToken credspec used for the github REST provider works
 here unchanged — binding one to a role grants both REST and MCP reach.
 
+Policy:
+Two layers of authorization apply to MCP traffic. The minted GitHub
+token is the security boundary — its scopes bound what the agent can
+actually do at GitHub regardless of what Warden lets through. On top
+of that, Warden's CBP policies support an mcp { } block for
+governance-style restrictions enforced at the gateway: allow- and
+deny-lists for JSON-RPC methods, tool names, resource URIs, prompt
+names, and (where the upstream tool author opted in) selected tool
+arguments. Enforcement is header-based and adds no request-body
+parsing on the allow path. Denied requests return HTTP 403 with an
+RFC 6750 WWW-Authenticate header and a small JSON body the agent
+SDK surfaces as a structured tool-call failure. See the policy
+documentation for the mcp { } block schema and examples.
+
+Important: the mcp { } block depends on the MCP protocol revision
+dated 2026-07-28, which mirrors method/name into HTTP headers so
+intermediaries can enforce without parsing the body. Pre-draft
+clients are denied when bound to a policy with an mcp { } block.
+Policies without an mcp { } block keep today's behaviour unchanged.
+
 Configuration:
 - mcp_github_url: MCP server base URL (default: https://api.githubcopilot.com/mcp)
 - max_body_size: Maximum request body size (default: 10MB, max: 100MB)

--- a/provider/mcp_github/skill.md
+++ b/provider/mcp_github/skill.md
@@ -133,6 +133,15 @@ alone doesn't tell you which PAT or scope set the mount fronts.
   scopes covering the intended toolset; agents that hit scope errors
   should ask the operator to widen the binding, not request a different
   Warden role unless one exists.
+- **Warden policy can gate tools too** (requires MCP draft 2026-07-28
+  on the client side). Operators may bind a policy with an `mcp { }`
+  block that restricts which methods, tool names, resource URIs, or
+  prompt names the role can call. A deny shows up as HTTP 403 with an
+  RFC 6750 `WWW-Authenticate: Bearer error="insufficient_permissions",
+  error_description="..."` header and a small JSON body of the same
+  shape; the description names the offending method/tool/parameter.
+  This is independent of PAT scope errors — read the `error_description`
+  to tell the two apart. See the README's "Create a Policy" section.
 - **Streamable HTTP / SSE flows through transparently.** Send
   `Accept: application/json, text/event-stream` and the server's
   choice of framing comes back unchanged. The `Mcp-Session-Id`


### PR DESCRIPTION
## Summary

PR **5 of 5** in the mcp-policy stack. Operator-facing documentation for the new `mcp { }` policy block in CBP.

- **README Step 4 ("Create a Policy")** rewritten to explain the two layers of authorization (PAT scopes as the security boundary; `mcp { }` as governance at the gateway), with three example shapes (vetted allow-list, dangerous-tool deny-list, conditions + mcp composition).
- **Important disclaimer**: the README explicitly warns about the MCP draft 2026-07-28 dependency — pre-draft clients bound to a policy with an `mcp { }` block are **denied on every request** because the required headers are absent. For mixed fleets, operators should stage the rollout (gateway-only policy first, verify clients send the new headers, then promote to mcp{} policies).
- **All policy examples narrowed** from `capabilities = ["create", "read", "update", "delete", "patch"]` to `capabilities = ["update"]`. MCP traffic is HTTP POST → update; the 2026-07-28 draft removed the GET stream endpoint so no other capabilities are needed. The previous broad list was over-permissive defensive coding.
- **Tool-argument constraints** (`allowed_params` / `denied_params`) carry an additional dependency on the upstream tool author opting into `x-mcp-header` in the tool input schema — documented so operators don't expect those rules to fire against tools whose schemas haven't been updated.
- `provider.go` HelpText gains a Policy section with the same two-layer framing and the same draft-2026-07-28 disclaimer, sized for the briefer CLI-help context.
- `skill.md` gains one bullet under Quirks pointing agents at the new deny shape (RFC 6750 `WWW-Authenticate` + JSON body) so a prompt-injected agent that sees an `insufficient_permissions` error can tell it apart from a PAT-scope error.

No code change. No test change. No behaviour change.

## Stack

| PR | Branch | Status |
|---|---|---|
| 1 | `mcp-policy/01-audit-types` | this docs PR depends on it (for behaviour to document) |
| 2 | `mcp-policy/02-hcl-parsing` | docs reference the HCL block from this PR |
| 3 | `mcp-policy/03-evaluation` | docs describe enforcement behaviour from this PR |
| 4 | `mcp-policy/04-deny-response` | docs describe the 403 response shape from this PR |
| **5** | `mcp-policy/05-docs` | ← this PR (off main, can land any time after 4) |

## Test plan

- [ ] README renders correctly on GitHub
- [ ] `warden help mcp_github` shows the new Policy section
- [ ] Skill markdown renders correctly in any tooling that consumes it
- [ ] Cross-references to "Create a Policy" section in the README are intact
