### PR TITLE
feat(core/policy): strict JSON-RPC body parser for mcp { } enforcement

### DIFF
--- a/core/policy_jsonrpc.go
+++ b/core/policy_jsonrpc.go
@@ -1,0 +1,417 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// maxJSONDepth bounds the recursion of the strict JSON-RPC body walker
+// so a pathologically nested payload cannot exhaust the goroutine
+// stack. The bound applies inside `params` (one level deep at the start
+// of the walk), so a tools/call with arguments nested up to 31 levels
+// is still accepted.
+const maxJSONDepth = 32
+
+// JSONRPCRequest is one strictly-parsed JSON-RPC 2.0 request extracted
+// from a body by ParseJSONRPCStrict. Single-message bodies produce a
+// one-element slice; batch bodies produce N elements in array order.
+//
+// Method is the verbatim string from the body — callers lowercase
+// before matching. Name is method-derived: tools/call → params.name,
+// resources/read → params.uri, prompts/get → params.name. It is empty
+// for other methods. Arguments is the parsed params.arguments map for
+// tools/call only (raw bytes per argument key so callers can do their
+// own type discrimination); nil for any other method.
+//
+// RawParams retains the verbatim params bytes for matcher-internal use.
+// It is descriptor-only and MUST NOT be copied to MCPDecision, the
+// audit record, or the client response.
+type JSONRPCRequest struct {
+	Method    string
+	Name      string
+	Arguments map[string]json.RawMessage
+	RawParams json.RawMessage
+}
+
+// ParseErrorKind enumerates structural-failure deny reasons. Each kind
+// maps 1:1 to an MCPDecision rule_type when the evaluator denies in a
+// later phase. The matching mcpRuleType* constants in policy_mcp.go are
+// introduced in Phase 4; until then this file is the sole source of
+// truth for these strings.
+type ParseErrorKind string
+
+const (
+	ErrKindMalformedJSONRPC ParseErrorKind = "malformed_jsonrpc"
+	ErrKindDuplicateKey     ParseErrorKind = "duplicate_key"
+	ErrKindOversizedBody    ParseErrorKind = "oversized_body"
+	ErrKindBatchEmpty       ParseErrorKind = "batch_empty"
+	ErrKindMalformedParams  ParseErrorKind = "malformed_params"
+)
+
+// ParseError carries the kind of structural failure plus an
+// operator-facing detail Msg. Msg is for server-side logs only and
+// MUST NOT be stamped on MCPDecision or surfaced to the client —
+// fingerprint hygiene and no leakage of adversary-controlled body
+// bytes into operator-visible logs.
+type ParseError struct {
+	Kind ParseErrorKind
+	Msg  string
+}
+
+func (e *ParseError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Kind) + ": " + e.Msg
+}
+
+// ParseJSONRPCStrict strictly parses a JSON-RPC 2.0 single-message or
+// batch request body and returns the extracted requests. Fails CLOSED
+// on any deviation from a well-formed JSON-RPC envelope:
+//
+//   - UTF-8 BOM prefix.
+//   - Top-level value other than an object or an array.
+//   - Empty batch ([]).
+//   - Trailing data after the top-level value.
+//   - Duplicate keys at any depth, in the request object or anywhere in
+//     params (Go's encoding/json silently last-wins on duplicates; this
+//     parser scans tokens with a per-object seen-set to reject them).
+//   - jsonrpc field absent or != "2.0".
+//   - method field absent, empty, or non-string.
+//   - Unknown top-level keys outside {jsonrpc, method, params, id}.
+//   - Nesting deeper than maxJSONDepth inside params.
+//   - method-specific shape mismatches: tools/call without params.name
+//     or with non-object params.arguments, resources/read without
+//     params.uri, prompts/get without params.name.
+//
+// Callers are responsible for bounding the input size (Content-Length
+// and io.LimitReader at the handler boundary) — this function does NOT
+// itself enforce a body cap; ErrKindOversizedBody is enumerated for
+// callers that need to map their own size-cap failure into the same
+// rule_type vocabulary.
+func ParseJSONRPCStrict(body []byte) ([]JSONRPCRequest, *ParseError) {
+	if hasUTF8BOM(body) {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "body has UTF-8 BOM"}
+	}
+
+	first, ok := firstNonWS(body)
+	if !ok {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "empty body"}
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+
+	var requests []JSONRPCRequest
+
+	switch first {
+	case '{':
+		req, perr := parseJSONRPCRequest(dec)
+		if perr != nil {
+			return nil, perr
+		}
+		requests = []JSONRPCRequest{*req}
+	case '[':
+		// Consume the opening '['.
+		if _, err := dec.Token(); err != nil {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+		for dec.More() {
+			req, perr := parseJSONRPCRequest(dec)
+			if perr != nil {
+				return nil, perr
+			}
+			requests = append(requests, *req)
+		}
+		// Consume the closing ']'.
+		if _, err := dec.Token(); err != nil {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+		if len(requests) == 0 {
+			return nil, &ParseError{Kind: ErrKindBatchEmpty, Msg: "empty batch"}
+		}
+	default:
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "top-level value must be object or array"}
+	}
+
+	// No trailing data after the top-level value. dec.Token() returning
+	// io.EOF means clean end; anything else (including a successful
+	// token read) is trailing data.
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "trailing data after JSON-RPC payload"}
+	}
+
+	return requests, nil
+}
+
+// parseJSONRPCRequest parses one JSON-RPC request object from the
+// decoder's current position. The decoder is positioned immediately
+// before the opening '{' of the request.
+func parseJSONRPCRequest(dec *json.Decoder) (*JSONRPCRequest, *ParseError) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "request must be a JSON object"}
+	}
+
+	req := &JSONRPCRequest{}
+	seen := map[string]struct{}{}
+	var jsonrpcSeen, methodSeen bool
+
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "non-string object key"}
+		}
+		if _, dup := seen[key]; dup {
+			return nil, &ParseError{Kind: ErrKindDuplicateKey, Msg: "duplicate key in request object"}
+		}
+		seen[key] = struct{}{}
+
+		switch key {
+		case "jsonrpc":
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "jsonrpc must be a string"}
+			}
+			if s != "2.0" {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: `jsonrpc must be "2.0"`}
+			}
+			jsonrpcSeen = true
+		case "method":
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "method must be a string"}
+			}
+			if s == "" {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "method must be non-empty"}
+			}
+			req.Method = s
+			methodSeen = true
+		case "params":
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			if perr := validateJSONValue(v, 1); perr != nil {
+				return nil, perr
+			}
+			req.RawParams = v
+		case "id":
+			// JSON-RPC 2.0 permits string, number, or null. We don't
+			// inspect the id; just consume the next value to advance
+			// the decoder. validateJSONValue ensures structural
+			// soundness if the id happens to be a complex value (some
+			// MCP clients have been seen wrapping ids in objects —
+			// reject those uniformly).
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			if perr := validateJSONValue(v, 1); perr != nil {
+				return nil, perr
+			}
+		default:
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "unknown top-level key"}
+		}
+	}
+
+	// Consume the closing '}'.
+	if _, err := dec.Token(); err != nil {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+	}
+
+	if !jsonrpcSeen {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "missing jsonrpc field"}
+	}
+	if !methodSeen {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "missing method field"}
+	}
+
+	if perr := extractMethodShape(req); perr != nil {
+		return nil, perr
+	}
+
+	return req, nil
+}
+
+// extractMethodShape populates Name and (for tools/call) Arguments
+// from RawParams based on the request method. Unrecognised methods
+// leave Name and Arguments zero — the matcher will treat them as
+// name-less.
+func extractMethodShape(req *JSONRPCRequest) *ParseError {
+	switch req.Method {
+	case "tools/call":
+		return extractToolsCall(req)
+	case "resources/read":
+		return extractByParamKey(req, "uri")
+	case "prompts/get":
+		return extractByParamKey(req, "name")
+	}
+	return nil
+}
+
+// extractToolsCall populates Name from params.name (required, non-empty
+// string) and Arguments from params.arguments (optional, must be an
+// object when present).
+func extractToolsCall(req *JSONRPCRequest) *ParseError {
+	if len(req.RawParams) == 0 {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call missing params"}
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params must be an object"}
+	}
+
+	nameRaw, ok := top["name"]
+	if !ok {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call missing params.name"}
+	}
+	var name string
+	if err := json.Unmarshal(nameRaw, &name); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.name must be a string"}
+	}
+	if name == "" {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.name must be non-empty"}
+	}
+	req.Name = name
+
+	if argsRaw, ok := top["arguments"]; ok {
+		var args map[string]json.RawMessage
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.arguments must be an object"}
+		}
+		req.Arguments = args
+	}
+
+	return nil
+}
+
+// extractByParamKey extracts Name from the named top-level params key
+// (required, non-empty string). Used for resources/read (key = "uri")
+// and prompts/get (key = "name").
+func extractByParamKey(req *JSONRPCRequest, key string) *ParseError {
+	if len(req.RawParams) == 0 {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " missing params"}
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params must be an object"}
+	}
+
+	raw, ok := top[key]
+	if !ok {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " missing params." + key}
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params." + key + " must be a string"}
+	}
+	if s == "" {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params." + key + " must be non-empty"}
+	}
+	req.Name = s
+	return nil
+}
+
+// validateJSONValue recursively walks a json.RawMessage looking for
+// duplicate keys at every object level and bounding recursion depth.
+// It does not inspect primitive values beyond confirming they tokenise.
+// The caller passes the starting depth (typically 1 — params sits one
+// level below the request object).
+func validateJSONValue(raw json.RawMessage, startDepth int) *ParseError {
+	if len(raw) == 0 {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return walkJSONValue(dec, startDepth)
+}
+
+func walkJSONValue(dec *json.Decoder, depth int) *ParseError {
+	if depth > maxJSONDepth {
+		return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "nested too deep"}
+	}
+	tok, err := dec.Token()
+	if err != nil {
+		return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+	}
+	delim, isDelim := tok.(json.Delim)
+	if !isDelim {
+		// Primitive (string, number, bool, null) — Token() already
+		// consumed it; nothing more to walk.
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]struct{}{}
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			key, ok := keyTok.(string)
+			if !ok {
+				return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "non-string object key"}
+			}
+			if _, dup := seen[key]; dup {
+				return &ParseError{Kind: ErrKindDuplicateKey, Msg: "duplicate key in nested object"}
+			}
+			seen[key] = struct{}{}
+			if perr := walkJSONValue(dec, depth+1); perr != nil {
+				return perr
+			}
+		}
+		if _, err := dec.Token(); err != nil {
+			return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+	case '[':
+		for dec.More() {
+			if perr := walkJSONValue(dec, depth+1); perr != nil {
+				return perr
+			}
+		}
+		if _, err := dec.Token(); err != nil {
+			return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+	default:
+		return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "unexpected delimiter"}
+	}
+	return nil
+}
+
+func hasUTF8BOM(body []byte) bool {
+	return len(body) >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF
+}
+
+// firstNonWS returns the first non-whitespace byte of body and whether
+// such a byte was found. Whitespace per RFC 8259: SP, HT, LF, CR.
+func firstNonWS(body []byte) (byte, bool) {
+	for _, b := range body {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return b, true
+		}
+	}
+	return 0, false
+}

--- a/core/policy_jsonrpc_test.go
+++ b/core/policy_jsonrpc_test.go
@@ -1,0 +1,514 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseJSONRPCStrict_ValidSingle(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	if reqs[0].Method != "tools/list" {
+		t.Errorf("Method = %q, want tools/list", reqs[0].Method)
+	}
+	if reqs[0].Name != "" {
+		t.Errorf("Name = %q, want empty (tools/list has no name)", reqs[0].Name)
+	}
+}
+
+func TestParseJSONRPCStrict_ValidBatch(t *testing.T) {
+	body := []byte(`[
+		{"jsonrpc":"2.0","method":"tools/list","id":1},
+		{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_repos"},"id":2},
+		{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"repo://foo"},"id":3}
+	]`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(reqs) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(reqs))
+	}
+	if reqs[1].Name != "search_repos" {
+		t.Errorf("reqs[1].Name = %q, want search_repos", reqs[1].Name)
+	}
+	if reqs[2].Name != "repo://foo" {
+		t.Errorf("reqs[2].Name = %q, want repo://foo", reqs[2].Name)
+	}
+}
+
+func TestParseJSONRPCStrict_ValidToolsCallWithArgs(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/foo","count":5}},"id":1}`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if reqs[0].Name != "read_file" {
+		t.Errorf("Name = %q, want read_file", reqs[0].Name)
+	}
+	if reqs[0].Arguments == nil {
+		t.Fatalf("Arguments is nil, want populated")
+	}
+	if got := string(reqs[0].Arguments["path"]); got != `"/tmp/foo"` {
+		t.Errorf("arguments.path = %s, want %q", got, `"/tmp/foo"`)
+	}
+	if got := string(reqs[0].Arguments["count"]); got != "5" {
+		t.Errorf("arguments.count = %s, want 5", got)
+	}
+}
+
+// Adversarial / fail-closed table. Every case must yield the named
+// ParseErrorKind. These are the bytes a compromised agent could send.
+func TestParseJSONRPCStrict_Adversarial(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want ParseErrorKind
+	}{
+		{"empty body", "", ErrKindMalformedJSONRPC},
+		{"whitespace only", "   \n\t  ", ErrKindMalformedJSONRPC},
+		{"utf-8 bom", "\xEF\xBB\xBF" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"non-object non-array top level", `"hello"`, ErrKindMalformedJSONRPC},
+		{"top-level number", `42`, ErrKindMalformedJSONRPC},
+		{"trailing data after object", `{"jsonrpc":"2.0","method":"tools/list"}garbage`, ErrKindMalformedJSONRPC},
+		{"trailing data after batch", `[{"jsonrpc":"2.0","method":"tools/list"}]extra`, ErrKindMalformedJSONRPC},
+		{"empty batch", `[]`, ErrKindBatchEmpty},
+		{"missing jsonrpc", `{"method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"missing method", `{"jsonrpc":"2.0","id":1}`, ErrKindMalformedJSONRPC},
+		{"jsonrpc wrong version", `{"jsonrpc":"1.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"jsonrpc number not string", `{"jsonrpc":2.0,"method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"method empty string", `{"jsonrpc":"2.0","method":""}`, ErrKindMalformedJSONRPC},
+		{"method is number", `{"jsonrpc":"2.0","method":42}`, ErrKindMalformedJSONRPC},
+		{"method is object", `{"jsonrpc":"2.0","method":{"x":1}}`, ErrKindMalformedJSONRPC},
+		{"unknown top-level key", `{"jsonrpc":"2.0","method":"tools/list","extra":1}`, ErrKindMalformedJSONRPC},
+		{"duplicate top-level key", `{"jsonrpc":"2.0","method":"tools/list","method":"tools/call"}`, ErrKindDuplicateKey},
+		{"duplicate jsonrpc", `{"jsonrpc":"2.0","jsonrpc":"2.0","method":"tools/list"}`, ErrKindDuplicateKey},
+		{"duplicate nested key in params", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"a","name":"b"}}`, ErrKindDuplicateKey},
+		{"duplicate key in arguments", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"path":"a","path":"b"}}}`, ErrKindDuplicateKey},
+		{"duplicate deeply nested", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"cfg":{"a":1,"a":2}}}}`, ErrKindDuplicateKey},
+
+		// tools/call shape requirements.
+		{"tools/call missing params", `{"jsonrpc":"2.0","method":"tools/call"}`, ErrKindMalformedParams},
+		{"tools/call params is array", `{"jsonrpc":"2.0","method":"tools/call","params":["a"]}`, ErrKindMalformedParams},
+		{"tools/call params is string", `{"jsonrpc":"2.0","method":"tools/call","params":"x"}`, ErrKindMalformedParams},
+		{"tools/call missing params.name", `{"jsonrpc":"2.0","method":"tools/call","params":{}}`, ErrKindMalformedParams},
+		{"tools/call params.name is object", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":{"x":1}}}`, ErrKindMalformedParams},
+		{"tools/call params.name is number", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":42}}`, ErrKindMalformedParams},
+		{"tools/call params.name empty", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":""}}`, ErrKindMalformedParams},
+		{"tools/call arguments is array", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":["a"]}}`, ErrKindMalformedParams},
+		{"tools/call arguments is string", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":"y"}}`, ErrKindMalformedParams},
+
+		// resources/read shape.
+		{"resources/read missing params", `{"jsonrpc":"2.0","method":"resources/read"}`, ErrKindMalformedParams},
+		{"resources/read missing params.uri", `{"jsonrpc":"2.0","method":"resources/read","params":{}}`, ErrKindMalformedParams},
+		{"resources/read uri is array", `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":["x"]}}`, ErrKindMalformedParams},
+		{"resources/read uri empty", `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":""}}`, ErrKindMalformedParams},
+
+		// prompts/get shape.
+		{"prompts/get missing params", `{"jsonrpc":"2.0","method":"prompts/get"}`, ErrKindMalformedParams},
+		{"prompts/get missing params.name", `{"jsonrpc":"2.0","method":"prompts/get","params":{}}`, ErrKindMalformedParams},
+		{"prompts/get name is null", `{"jsonrpc":"2.0","method":"prompts/get","params":{"name":null}}`, ErrKindMalformedParams},
+
+		// Batch.
+		{"batch one entry malformed", `[{"jsonrpc":"2.0","method":"tools/list"},{"jsonrpc":"2.0"}]`, ErrKindMalformedJSONRPC},
+		{"batch with empty batch element", `[[]]`, ErrKindMalformedJSONRPC},
+		{"batch with primitive entry", `[1]`, ErrKindMalformedJSONRPC},
+		{"batch with string entry", `["x"]`, ErrKindMalformedJSONRPC},
+		{"batch with null entry", `[null]`, ErrKindMalformedJSONRPC},
+		{"batch dup key in one element", `[{"jsonrpc":"2.0","method":"tools/list"},{"jsonrpc":"2.0","method":"a","method":"b"}]`, ErrKindDuplicateKey},
+
+		// params: null for name-bearing methods — currently denied via
+		// the "missing params.<key>" path; pinning the contract.
+		{"tools/call params null", `{"jsonrpc":"2.0","method":"tools/call","params":null}`, ErrKindMalformedParams},
+		{"resources/read params null", `{"jsonrpc":"2.0","method":"resources/read","params":null}`, ErrKindMalformedParams},
+		{"prompts/get params null", `{"jsonrpc":"2.0","method":"prompts/get","params":null}`, ErrKindMalformedParams},
+
+		// Leading bytes that aren't JSON whitespace (RFC 8259 set is
+		// only SP/HT/LF/CR). VT and FF look like whitespace in some
+		// contexts but JSON rejects them as leading bytes.
+		{"vertical tab leading", "\x0b" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"form feed leading", "\x0c" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"utf-16 le bom prefix", "\xff\xfe" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+
+		// Trailing whitespace then garbage.
+		{"trailing whitespace then garbage", `{"jsonrpc":"2.0","method":"tools/list"}` + "   garbage", ErrKindMalformedJSONRPC},
+
+		// Duplicate key directly inside id-as-object.
+		{"id object with duplicate keys", `{"jsonrpc":"2.0","method":"tools/list","id":{"a":1,"a":2}}`, ErrKindDuplicateKey},
+
+		// id permits primitives only; complex ids carrying dup keys are rejected by the walker.
+		{"id is array of dup keys", `{"jsonrpc":"2.0","method":"tools/list","id":[{"a":1,"a":2}]}`, ErrKindDuplicateKey},
+
+		// Malformed JSON.
+		{"malformed JSON unclosed", `{"jsonrpc":"2.0","method":"tools/list"`, ErrKindMalformedJSONRPC},
+		{"malformed JSON garbage", `{`, ErrKindMalformedJSONRPC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqs, perr := ParseJSONRPCStrict([]byte(tc.body))
+			if perr == nil {
+				t.Fatalf("expected ParseError of kind %q, got nil (reqs=%v)", tc.want, reqs)
+			}
+			if perr.Kind != tc.want {
+				t.Errorf("ParseError.Kind = %q, want %q (msg=%q)", perr.Kind, tc.want, perr.Msg)
+			}
+		})
+	}
+}
+
+// Methods outside the name-bearing trio leave Name empty and accept
+// any params shape (including array-style by-position params).
+func TestParseJSONRPCStrict_NonNameMethodsAcceptArrayParams(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"initialize","params":[1,2,3],"id":1}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("expected no error, got %v", perr)
+	}
+	if reqs[0].Name != "" {
+		t.Errorf("Name = %q, want empty for initialize", reqs[0].Name)
+	}
+	if reqs[0].Arguments != nil {
+		t.Errorf("Arguments populated for non-tools/call: %v", reqs[0].Arguments)
+	}
+}
+
+// Notifications (no id) parse cleanly. The parser does not differentiate
+// them; the matcher gates them like any other request.
+func TestParseJSONRPCStrict_Notification(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/cancelled"}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("expected no error, got %v", perr)
+	}
+	if reqs[0].Method != "notifications/cancelled" {
+		t.Errorf("Method = %q", reqs[0].Method)
+	}
+}
+
+// JSON-RPC ids may be string, number, or null. All accepted; none
+// inspected.
+func TestParseJSONRPCStrict_IDShapes(t *testing.T) {
+	for _, idLit := range []string{`"abc"`, `42`, `null`, `0`, `-1`} {
+		body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":` + idLit + `}`)
+		if _, perr := ParseJSONRPCStrict(body); perr != nil {
+			t.Errorf("id=%s: expected no error, got %v", idLit, perr)
+		}
+	}
+}
+
+// Depth bound: at the limit accepts, one over rejects. params occupies
+// depth 1; arguments adds depth 2; each x-wrapper adds one more.
+// maxJSONDepth = 32, so 30 x-wrappers reach the deepest acceptable
+// level and 31 wrappers exceed it.
+func TestParseJSONRPCStrict_DepthBound(t *testing.T) {
+	build := func(n int) string {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteString(`{"x":`)
+		}
+		sb.WriteString(`0`)
+		for i := 0; i < n; i++ {
+			sb.WriteString(`}`)
+		}
+		return sb.String()
+	}
+	pass := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":` + build(30) + `}}`
+	if _, perr := ParseJSONRPCStrict([]byte(pass)); perr != nil {
+		t.Errorf("at depth limit: expected accept, got %v", perr)
+	}
+	fail := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":` + build(31) + `}}`
+	_, perr := ParseJSONRPCStrict([]byte(fail))
+	if perr == nil {
+		t.Fatalf("over depth limit: expected ParseError, got nil")
+	}
+	if perr.Kind != ErrKindMalformedJSONRPC {
+		t.Errorf("over depth limit: kind = %q, want malformed_jsonrpc", perr.Kind)
+	}
+}
+
+// Leading whitespace is fine (JSON allows it); trailing whitespace
+// after the value is also fine (encoding/json tolerates it before EOF).
+func TestParseJSONRPCStrict_Whitespace(t *testing.T) {
+	body := []byte("\n\t   " + `{"jsonrpc":"2.0","method":"tools/list"}` + "\n  ")
+	if _, perr := ParseJSONRPCStrict(body); perr != nil {
+		t.Errorf("whitespace-padded body rejected: %v", perr)
+	}
+}
+
+// RawParams captures the verbatim params bytes for matcher-internal
+// use. Must be non-empty for any request that had a params field.
+func TestParseJSONRPCStrict_RawParamsCaptured(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1}}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("unexpected error: %v", perr)
+	}
+	if len(reqs[0].RawParams) == 0 {
+		t.Errorf("RawParams empty, want verbatim bytes")
+	}
+	var v any
+	if err := json.Unmarshal(reqs[0].RawParams, &v); err != nil {
+		t.Errorf("RawParams not valid JSON: %v", err)
+	}
+}
+
+// Method is preserved verbatim (NOT lowercased) on the descriptor;
+// callers lowercase only at match time. This contract matters because
+// MCPDecision.Method in later phases is lowercased once at the matcher
+// boundary, not at the parser boundary — keeping the descriptor faithful
+// to the wire lets reconciliation diagnose case-mismatch attacks.
+func TestParseJSONRPCStrict_MethodCasePreserved(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"Tools/Call","params":{"name":"X"}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("unexpected error: %v", perr)
+	}
+	if reqs[0].Method != "Tools/Call" {
+		t.Errorf("Method = %q, want verbatim Tools/Call", reqs[0].Method)
+	}
+	// The method-specific shape extraction matches verbatim too, so a
+	// capitalised method does NOT trigger the tools/call params.name
+	// requirement: it routes through extractMethodShape's default case.
+	if reqs[0].Name != "" {
+		t.Errorf("Name = %q, want empty (capitalised method is not name-bearing)", reqs[0].Name)
+	}
+}
+
+// arguments: null is parsed without error and leaves Arguments == nil —
+// indistinguishable from "arguments field absent". Pinning the
+// behaviour as the documented contract for Phase 2's MatchArgs.
+func TestParseJSONRPCStrict_ArgumentsNullEquivalentToAbsent(t *testing.T) {
+	bodyNull := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":null}}`)
+	reqsNull, perr := ParseJSONRPCStrict(bodyNull)
+	if perr != nil {
+		t.Fatalf("arguments:null: unexpected error: %v", perr)
+	}
+	if reqsNull[0].Arguments != nil {
+		t.Errorf("arguments:null produced Arguments=%v, want nil", reqsNull[0].Arguments)
+	}
+
+	bodyAbsent := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"}}`)
+	reqsAbsent, perr := ParseJSONRPCStrict(bodyAbsent)
+	if perr != nil {
+		t.Fatalf("arguments absent: unexpected error: %v", perr)
+	}
+	if reqsAbsent[0].Arguments != nil {
+		t.Errorf("arguments absent produced Arguments=%v, want nil", reqsAbsent[0].Arguments)
+	}
+
+	bodyEmpty := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{}}}`)
+	reqsEmpty, perr := ParseJSONRPCStrict(bodyEmpty)
+	if perr != nil {
+		t.Fatalf("arguments:{}: unexpected error: %v", perr)
+	}
+	if reqsEmpty[0].Arguments == nil {
+		t.Errorf("arguments:{} produced Arguments=nil, want non-nil empty map")
+	}
+	if len(reqsEmpty[0].Arguments) != 0 {
+		t.Errorf("arguments:{} produced Arguments=%v, want empty", reqsEmpty[0].Arguments)
+	}
+}
+
+// id may be a complex value (object/array) as long as the value itself
+// is structurally sound (no duplicate keys at any depth). Strict JSON-RPC
+// 2.0 §4 restricts id to string/number/null; we accept more leniently
+// because id is not consulted for policy and rejecting it would break
+// MCP clients that have been observed wrapping ids. Strict-dup-key
+// detection inside complex ids still applies — see Adversarial.
+func TestParseJSONRPCStrict_LenientComplexID(t *testing.T) {
+	for _, body := range []string{
+		`{"jsonrpc":"2.0","method":"tools/list","id":{}}`,
+		`{"jsonrpc":"2.0","method":"tools/list","id":{"trace":"x"}}`,
+		`{"jsonrpc":"2.0","method":"tools/list","id":[1,2]}`,
+	} {
+		if _, perr := ParseJSONRPCStrict([]byte(body)); perr != nil {
+			t.Errorf("body=%s: unexpected error: %v", body, perr)
+		}
+	}
+}
+
+// Numeric ids preserve precision via json.Number — Decode into
+// RawMessage never coerces to float64. A 19-digit integer would lose
+// precision under default decoding.
+func TestParseJSONRPCStrict_LargeNumericIDPreserved(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":12345678901234567890}`)
+	if _, perr := ParseJSONRPCStrict(body); perr != nil {
+		t.Errorf("large numeric id rejected: %v", perr)
+	}
+}
+
+// Notifications can carry params per JSON-RPC 2.0 §4.1. The parser
+// doesn't differentiate notifications from id-bearing requests; only
+// the matcher cares.
+func TestParseJSONRPCStrict_NotificationWithParams(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/progress","params":{"token":"abc","value":50}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("notification with params rejected: %v", perr)
+	}
+	if reqs[0].Method != "notifications/progress" {
+		t.Errorf("Method = %q", reqs[0].Method)
+	}
+}
+
+// Unicode escapes in method strings decode correctly (Go normalises
+// during Token()). The matcher's lowercase compare sees the post-
+// decode runes, matching the upstream MCP server's view.
+func TestParseJSONRPCStrict_UnicodeEscapes(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("unicode-escaped method rejected: %v", perr)
+	}
+	if reqs[0].Method != "tools/call" {
+		t.Errorf("Method = %q, want tools/call", reqs[0].Method)
+	}
+}
+
+// Fuzz seeds exercise strict-parse against arbitrary bytes. Invariant:
+// ParseJSONRPCStrict never panics regardless of input. This is the
+// panic-safety net the Phase 2 extractor relies on (a panic in the
+// parser would propagate to the goroutine handling the request).
+func FuzzParseJSONRPCStrict(f *testing.F) {
+	seeds := []string{
+		`{"jsonrpc":"2.0","method":"tools/list"}`,
+		`[{"jsonrpc":"2.0","method":"tools/list"}]`,
+		`{}`,
+		`[`,
+		`{"a":1,"a":2}`,
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1}}}`,
+		string([]byte{0xEF, 0xBB, 0xBF, '{', '}'}),
+		``,
+		`{"jsonrpc":"2.0","method":"tools/list","id":null,"id":1}`,
+		`{"jsonrpc":"2.0","method":"tools/call","params":[]}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, body []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("parser panicked on input %q: %v", body, r)
+			}
+		}()
+		_, _ = ParseJSONRPCStrict(body)
+	})
+}
+
+// ---------- benchmarks ----------
+
+// Typical single-request body: tools/list with id. Tiny — measures
+// per-request overhead floor.
+func BenchmarkParseJSONRPCStrict_Small(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Typical tools/call with a handful of scalar arguments. Closest to
+// the median production payload size.
+func BenchmarkParseJSONRPCStrict_ToolsCall(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/foo","encoding":"utf-8","limit":1024,"offset":0}},"id":42}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Larger arguments object: still bounded but exercises the per-object
+// duplicate-key seen-set growth and the recursive walker on a non-
+// trivial structure.
+func BenchmarkParseJSONRPCStrict_LargeArguments(b *testing.B) {
+	var args strings.Builder
+	args.WriteString(`{`)
+	for i := 0; i < 64; i++ {
+		if i > 0 {
+			args.WriteString(`,`)
+		}
+		fmt.Fprintf(&args, `"key_%02d":"value_%02d"`, i, i)
+	}
+	args.WriteString(`}`)
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"big_tool","arguments":` + args.String() + `},"id":1}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Batch of 16 mixed-shape requests. Exercises the batch loop and
+// allocates a request slice.
+func BenchmarkParseJSONRPCStrict_Batch16(b *testing.B) {
+	const one = `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_repos","arguments":{"q":"foo"}},"id":1}`
+	var sb strings.Builder
+	sb.WriteString(`[`)
+	for i := 0; i < 16; i++ {
+		if i > 0 {
+			sb.WriteString(`,`)
+		}
+		sb.WriteString(one)
+	}
+	sb.WriteString(`]`)
+	body := []byte(sb.String())
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Deny-path: duplicate key in nested arguments. Measures the cost of
+// the failure path (matters because adversarial traffic might saturate
+// it).
+func BenchmarkParseJSONRPCStrict_DuplicateKey(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1,"a":2}}}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err == nil {
+			b.Fatal("expected ParseError")
+		}
+	}
+}
+
+// Deny-path: malformed JSON-RPC envelope (unknown top-level key).
+// Cheapest deny — single field validation before bail.
+func BenchmarkParseJSONRPCStrict_UnknownTopLevel(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","unexpected":42}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err == nil {
+			b.Fatal("expected ParseError")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the body-authoritative `mcp { }` enforcement work. Adds `core/policy_jsonrpc.go` with `ParseJSONRPCStrict([]byte) ([]JSONRPCRequest, *ParseError)` and a table-driven test suite + fuzz seed corpus. Strict parser rejects duplicate keys, trailing data, non-`"2.0"` JSON-RPC versions, missing/wrong-type `method`, unknown top-level keys, empty batches, UTF-8 BOM, and bounds recursion at depth 32.

Not wired into production yet — Phase 2 builds the extractor that calls this, Phase 4 flips the production switch. Mergeable alone; the parser is dead code on `main` until Phase 2.

See the commit message for the full set of parse errors and canonicalisation choices.

## Test plan

- [x] `go test ./core/...` — table tests cover all reject codes
- [x] `go test -fuzz=. -fuzztime=30s ./core/...` — seed corpus stable
