### PR TITLE
feat(core,logical,httpproxy): MCPPolicyEnforced opt-in + body extractor

### DIFF
--- a/core/policy_jsonrpc.go
+++ b/core/policy_jsonrpc.go
@@ -1,0 +1,417 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// maxJSONDepth bounds the recursion of the strict JSON-RPC body walker
+// so a pathologically nested payload cannot exhaust the goroutine
+// stack. The bound applies inside `params` (one level deep at the start
+// of the walk), so a tools/call with arguments nested up to 31 levels
+// is still accepted.
+const maxJSONDepth = 32
+
+// JSONRPCRequest is one strictly-parsed JSON-RPC 2.0 request extracted
+// from a body by ParseJSONRPCStrict. Single-message bodies produce a
+// one-element slice; batch bodies produce N elements in array order.
+//
+// Method is the verbatim string from the body — callers lowercase
+// before matching. Name is method-derived: tools/call → params.name,
+// resources/read → params.uri, prompts/get → params.name. It is empty
+// for other methods. Arguments is the parsed params.arguments map for
+// tools/call only (raw bytes per argument key so callers can do their
+// own type discrimination); nil for any other method.
+//
+// RawParams retains the verbatim params bytes for matcher-internal use.
+// It is descriptor-only and MUST NOT be copied to MCPDecision, the
+// audit record, or the client response.
+type JSONRPCRequest struct {
+	Method    string
+	Name      string
+	Arguments map[string]json.RawMessage
+	RawParams json.RawMessage
+}
+
+// ParseErrorKind enumerates structural-failure deny reasons. Each kind
+// maps 1:1 to an MCPDecision rule_type when the evaluator denies in a
+// later phase. The matching mcpRuleType* constants in policy_mcp.go are
+// introduced in Phase 4; until then this file is the sole source of
+// truth for these strings.
+type ParseErrorKind string
+
+const (
+	ErrKindMalformedJSONRPC ParseErrorKind = "malformed_jsonrpc"
+	ErrKindDuplicateKey     ParseErrorKind = "duplicate_key"
+	ErrKindOversizedBody    ParseErrorKind = "oversized_body"
+	ErrKindBatchEmpty       ParseErrorKind = "batch_empty"
+	ErrKindMalformedParams  ParseErrorKind = "malformed_params"
+)
+
+// ParseError carries the kind of structural failure plus an
+// operator-facing detail Msg. Msg is for server-side logs only and
+// MUST NOT be stamped on MCPDecision or surfaced to the client —
+// fingerprint hygiene and no leakage of adversary-controlled body
+// bytes into operator-visible logs.
+type ParseError struct {
+	Kind ParseErrorKind
+	Msg  string
+}
+
+func (e *ParseError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Kind) + ": " + e.Msg
+}
+
+// ParseJSONRPCStrict strictly parses a JSON-RPC 2.0 single-message or
+// batch request body and returns the extracted requests. Fails CLOSED
+// on any deviation from a well-formed JSON-RPC envelope:
+//
+//   - UTF-8 BOM prefix.
+//   - Top-level value other than an object or an array.
+//   - Empty batch ([]).
+//   - Trailing data after the top-level value.
+//   - Duplicate keys at any depth, in the request object or anywhere in
+//     params (Go's encoding/json silently last-wins on duplicates; this
+//     parser scans tokens with a per-object seen-set to reject them).
+//   - jsonrpc field absent or != "2.0".
+//   - method field absent, empty, or non-string.
+//   - Unknown top-level keys outside {jsonrpc, method, params, id}.
+//   - Nesting deeper than maxJSONDepth inside params.
+//   - method-specific shape mismatches: tools/call without params.name
+//     or with non-object params.arguments, resources/read without
+//     params.uri, prompts/get without params.name.
+//
+// Callers are responsible for bounding the input size (Content-Length
+// and io.LimitReader at the handler boundary) — this function does NOT
+// itself enforce a body cap; ErrKindOversizedBody is enumerated for
+// callers that need to map their own size-cap failure into the same
+// rule_type vocabulary.
+func ParseJSONRPCStrict(body []byte) ([]JSONRPCRequest, *ParseError) {
+	if hasUTF8BOM(body) {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "body has UTF-8 BOM"}
+	}
+
+	first, ok := firstNonWS(body)
+	if !ok {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "empty body"}
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+
+	var requests []JSONRPCRequest
+
+	switch first {
+	case '{':
+		req, perr := parseJSONRPCRequest(dec)
+		if perr != nil {
+			return nil, perr
+		}
+		requests = []JSONRPCRequest{*req}
+	case '[':
+		// Consume the opening '['.
+		if _, err := dec.Token(); err != nil {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+		for dec.More() {
+			req, perr := parseJSONRPCRequest(dec)
+			if perr != nil {
+				return nil, perr
+			}
+			requests = append(requests, *req)
+		}
+		// Consume the closing ']'.
+		if _, err := dec.Token(); err != nil {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+		if len(requests) == 0 {
+			return nil, &ParseError{Kind: ErrKindBatchEmpty, Msg: "empty batch"}
+		}
+	default:
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "top-level value must be object or array"}
+	}
+
+	// No trailing data after the top-level value. dec.Token() returning
+	// io.EOF means clean end; anything else (including a successful
+	// token read) is trailing data.
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "trailing data after JSON-RPC payload"}
+	}
+
+	return requests, nil
+}
+
+// parseJSONRPCRequest parses one JSON-RPC request object from the
+// decoder's current position. The decoder is positioned immediately
+// before the opening '{' of the request.
+func parseJSONRPCRequest(dec *json.Decoder) (*JSONRPCRequest, *ParseError) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "request must be a JSON object"}
+	}
+
+	req := &JSONRPCRequest{}
+	seen := map[string]struct{}{}
+	var jsonrpcSeen, methodSeen bool
+
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "non-string object key"}
+		}
+		if _, dup := seen[key]; dup {
+			return nil, &ParseError{Kind: ErrKindDuplicateKey, Msg: "duplicate key in request object"}
+		}
+		seen[key] = struct{}{}
+
+		switch key {
+		case "jsonrpc":
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "jsonrpc must be a string"}
+			}
+			if s != "2.0" {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: `jsonrpc must be "2.0"`}
+			}
+			jsonrpcSeen = true
+		case "method":
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "method must be a string"}
+			}
+			if s == "" {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "method must be non-empty"}
+			}
+			req.Method = s
+			methodSeen = true
+		case "params":
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			if perr := validateJSONValue(v, 1); perr != nil {
+				return nil, perr
+			}
+			req.RawParams = v
+		case "id":
+			// JSON-RPC 2.0 permits string, number, or null. We don't
+			// inspect the id; just consume the next value to advance
+			// the decoder. validateJSONValue ensures structural
+			// soundness if the id happens to be a complex value (some
+			// MCP clients have been seen wrapping ids in objects —
+			// reject those uniformly).
+			var v json.RawMessage
+			if err := dec.Decode(&v); err != nil {
+				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			if perr := validateJSONValue(v, 1); perr != nil {
+				return nil, perr
+			}
+		default:
+			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "unknown top-level key"}
+		}
+	}
+
+	// Consume the closing '}'.
+	if _, err := dec.Token(); err != nil {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+	}
+
+	if !jsonrpcSeen {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "missing jsonrpc field"}
+	}
+	if !methodSeen {
+		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "missing method field"}
+	}
+
+	if perr := extractMethodShape(req); perr != nil {
+		return nil, perr
+	}
+
+	return req, nil
+}
+
+// extractMethodShape populates Name and (for tools/call) Arguments
+// from RawParams based on the request method. Unrecognised methods
+// leave Name and Arguments zero — the matcher will treat them as
+// name-less.
+func extractMethodShape(req *JSONRPCRequest) *ParseError {
+	switch req.Method {
+	case "tools/call":
+		return extractToolsCall(req)
+	case "resources/read":
+		return extractByParamKey(req, "uri")
+	case "prompts/get":
+		return extractByParamKey(req, "name")
+	}
+	return nil
+}
+
+// extractToolsCall populates Name from params.name (required, non-empty
+// string) and Arguments from params.arguments (optional, must be an
+// object when present).
+func extractToolsCall(req *JSONRPCRequest) *ParseError {
+	if len(req.RawParams) == 0 {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call missing params"}
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params must be an object"}
+	}
+
+	nameRaw, ok := top["name"]
+	if !ok {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call missing params.name"}
+	}
+	var name string
+	if err := json.Unmarshal(nameRaw, &name); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.name must be a string"}
+	}
+	if name == "" {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.name must be non-empty"}
+	}
+	req.Name = name
+
+	if argsRaw, ok := top["arguments"]; ok {
+		var args map[string]json.RawMessage
+		if err := json.Unmarshal(argsRaw, &args); err != nil {
+			return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.arguments must be an object"}
+		}
+		req.Arguments = args
+	}
+
+	return nil
+}
+
+// extractByParamKey extracts Name from the named top-level params key
+// (required, non-empty string). Used for resources/read (key = "uri")
+// and prompts/get (key = "name").
+func extractByParamKey(req *JSONRPCRequest, key string) *ParseError {
+	if len(req.RawParams) == 0 {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " missing params"}
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params must be an object"}
+	}
+
+	raw, ok := top[key]
+	if !ok {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " missing params." + key}
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params." + key + " must be a string"}
+	}
+	if s == "" {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params." + key + " must be non-empty"}
+	}
+	req.Name = s
+	return nil
+}
+
+// validateJSONValue recursively walks a json.RawMessage looking for
+// duplicate keys at every object level and bounding recursion depth.
+// It does not inspect primitive values beyond confirming they tokenise.
+// The caller passes the starting depth (typically 1 — params sits one
+// level below the request object).
+func validateJSONValue(raw json.RawMessage, startDepth int) *ParseError {
+	if len(raw) == 0 {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return walkJSONValue(dec, startDepth)
+}
+
+func walkJSONValue(dec *json.Decoder, depth int) *ParseError {
+	if depth > maxJSONDepth {
+		return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "nested too deep"}
+	}
+	tok, err := dec.Token()
+	if err != nil {
+		return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+	}
+	delim, isDelim := tok.(json.Delim)
+	if !isDelim {
+		// Primitive (string, number, bool, null) — Token() already
+		// consumed it; nothing more to walk.
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]struct{}{}
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			}
+			key, ok := keyTok.(string)
+			if !ok {
+				return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "non-string object key"}
+			}
+			if _, dup := seen[key]; dup {
+				return &ParseError{Kind: ErrKindDuplicateKey, Msg: "duplicate key in nested object"}
+			}
+			seen[key] = struct{}{}
+			if perr := walkJSONValue(dec, depth+1); perr != nil {
+				return perr
+			}
+		}
+		if _, err := dec.Token(); err != nil {
+			return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+	case '[':
+		for dec.More() {
+			if perr := walkJSONValue(dec, depth+1); perr != nil {
+				return perr
+			}
+		}
+		if _, err := dec.Token(); err != nil {
+			return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+		}
+	default:
+		return &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "unexpected delimiter"}
+	}
+	return nil
+}
+
+func hasUTF8BOM(body []byte) bool {
+	return len(body) >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF
+}
+
+// firstNonWS returns the first non-whitespace byte of body and whether
+// such a byte was found. Whitespace per RFC 8259: SP, HT, LF, CR.
+func firstNonWS(body []byte) (byte, bool) {
+	for _, b := range body {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return b, true
+		}
+	}
+	return 0, false
+}

--- a/core/policy_jsonrpc_test.go
+++ b/core/policy_jsonrpc_test.go
@@ -1,0 +1,514 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseJSONRPCStrict_ValidSingle(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	if reqs[0].Method != "tools/list" {
+		t.Errorf("Method = %q, want tools/list", reqs[0].Method)
+	}
+	if reqs[0].Name != "" {
+		t.Errorf("Name = %q, want empty (tools/list has no name)", reqs[0].Name)
+	}
+}
+
+func TestParseJSONRPCStrict_ValidBatch(t *testing.T) {
+	body := []byte(`[
+		{"jsonrpc":"2.0","method":"tools/list","id":1},
+		{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_repos"},"id":2},
+		{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"repo://foo"},"id":3}
+	]`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(reqs) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(reqs))
+	}
+	if reqs[1].Name != "search_repos" {
+		t.Errorf("reqs[1].Name = %q, want search_repos", reqs[1].Name)
+	}
+	if reqs[2].Name != "repo://foo" {
+		t.Errorf("reqs[2].Name = %q, want repo://foo", reqs[2].Name)
+	}
+}
+
+func TestParseJSONRPCStrict_ValidToolsCallWithArgs(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/foo","count":5}},"id":1}`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if reqs[0].Name != "read_file" {
+		t.Errorf("Name = %q, want read_file", reqs[0].Name)
+	}
+	if reqs[0].Arguments == nil {
+		t.Fatalf("Arguments is nil, want populated")
+	}
+	if got := string(reqs[0].Arguments["path"]); got != `"/tmp/foo"` {
+		t.Errorf("arguments.path = %s, want %q", got, `"/tmp/foo"`)
+	}
+	if got := string(reqs[0].Arguments["count"]); got != "5" {
+		t.Errorf("arguments.count = %s, want 5", got)
+	}
+}
+
+// Adversarial / fail-closed table. Every case must yield the named
+// ParseErrorKind. These are the bytes a compromised agent could send.
+func TestParseJSONRPCStrict_Adversarial(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want ParseErrorKind
+	}{
+		{"empty body", "", ErrKindMalformedJSONRPC},
+		{"whitespace only", "   \n\t  ", ErrKindMalformedJSONRPC},
+		{"utf-8 bom", "\xEF\xBB\xBF" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"non-object non-array top level", `"hello"`, ErrKindMalformedJSONRPC},
+		{"top-level number", `42`, ErrKindMalformedJSONRPC},
+		{"trailing data after object", `{"jsonrpc":"2.0","method":"tools/list"}garbage`, ErrKindMalformedJSONRPC},
+		{"trailing data after batch", `[{"jsonrpc":"2.0","method":"tools/list"}]extra`, ErrKindMalformedJSONRPC},
+		{"empty batch", `[]`, ErrKindBatchEmpty},
+		{"missing jsonrpc", `{"method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"missing method", `{"jsonrpc":"2.0","id":1}`, ErrKindMalformedJSONRPC},
+		{"jsonrpc wrong version", `{"jsonrpc":"1.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"jsonrpc number not string", `{"jsonrpc":2.0,"method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"method empty string", `{"jsonrpc":"2.0","method":""}`, ErrKindMalformedJSONRPC},
+		{"method is number", `{"jsonrpc":"2.0","method":42}`, ErrKindMalformedJSONRPC},
+		{"method is object", `{"jsonrpc":"2.0","method":{"x":1}}`, ErrKindMalformedJSONRPC},
+		{"unknown top-level key", `{"jsonrpc":"2.0","method":"tools/list","extra":1}`, ErrKindMalformedJSONRPC},
+		{"duplicate top-level key", `{"jsonrpc":"2.0","method":"tools/list","method":"tools/call"}`, ErrKindDuplicateKey},
+		{"duplicate jsonrpc", `{"jsonrpc":"2.0","jsonrpc":"2.0","method":"tools/list"}`, ErrKindDuplicateKey},
+		{"duplicate nested key in params", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"a","name":"b"}}`, ErrKindDuplicateKey},
+		{"duplicate key in arguments", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"path":"a","path":"b"}}}`, ErrKindDuplicateKey},
+		{"duplicate deeply nested", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"cfg":{"a":1,"a":2}}}}`, ErrKindDuplicateKey},
+
+		// tools/call shape requirements.
+		{"tools/call missing params", `{"jsonrpc":"2.0","method":"tools/call"}`, ErrKindMalformedParams},
+		{"tools/call params is array", `{"jsonrpc":"2.0","method":"tools/call","params":["a"]}`, ErrKindMalformedParams},
+		{"tools/call params is string", `{"jsonrpc":"2.0","method":"tools/call","params":"x"}`, ErrKindMalformedParams},
+		{"tools/call missing params.name", `{"jsonrpc":"2.0","method":"tools/call","params":{}}`, ErrKindMalformedParams},
+		{"tools/call params.name is object", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":{"x":1}}}`, ErrKindMalformedParams},
+		{"tools/call params.name is number", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":42}}`, ErrKindMalformedParams},
+		{"tools/call params.name empty", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":""}}`, ErrKindMalformedParams},
+		{"tools/call arguments is array", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":["a"]}}`, ErrKindMalformedParams},
+		{"tools/call arguments is string", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":"y"}}`, ErrKindMalformedParams},
+
+		// resources/read shape.
+		{"resources/read missing params", `{"jsonrpc":"2.0","method":"resources/read"}`, ErrKindMalformedParams},
+		{"resources/read missing params.uri", `{"jsonrpc":"2.0","method":"resources/read","params":{}}`, ErrKindMalformedParams},
+		{"resources/read uri is array", `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":["x"]}}`, ErrKindMalformedParams},
+		{"resources/read uri empty", `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":""}}`, ErrKindMalformedParams},
+
+		// prompts/get shape.
+		{"prompts/get missing params", `{"jsonrpc":"2.0","method":"prompts/get"}`, ErrKindMalformedParams},
+		{"prompts/get missing params.name", `{"jsonrpc":"2.0","method":"prompts/get","params":{}}`, ErrKindMalformedParams},
+		{"prompts/get name is null", `{"jsonrpc":"2.0","method":"prompts/get","params":{"name":null}}`, ErrKindMalformedParams},
+
+		// Batch.
+		{"batch one entry malformed", `[{"jsonrpc":"2.0","method":"tools/list"},{"jsonrpc":"2.0"}]`, ErrKindMalformedJSONRPC},
+		{"batch with empty batch element", `[[]]`, ErrKindMalformedJSONRPC},
+		{"batch with primitive entry", `[1]`, ErrKindMalformedJSONRPC},
+		{"batch with string entry", `["x"]`, ErrKindMalformedJSONRPC},
+		{"batch with null entry", `[null]`, ErrKindMalformedJSONRPC},
+		{"batch dup key in one element", `[{"jsonrpc":"2.0","method":"tools/list"},{"jsonrpc":"2.0","method":"a","method":"b"}]`, ErrKindDuplicateKey},
+
+		// params: null for name-bearing methods — currently denied via
+		// the "missing params.<key>" path; pinning the contract.
+		{"tools/call params null", `{"jsonrpc":"2.0","method":"tools/call","params":null}`, ErrKindMalformedParams},
+		{"resources/read params null", `{"jsonrpc":"2.0","method":"resources/read","params":null}`, ErrKindMalformedParams},
+		{"prompts/get params null", `{"jsonrpc":"2.0","method":"prompts/get","params":null}`, ErrKindMalformedParams},
+
+		// Leading bytes that aren't JSON whitespace (RFC 8259 set is
+		// only SP/HT/LF/CR). VT and FF look like whitespace in some
+		// contexts but JSON rejects them as leading bytes.
+		{"vertical tab leading", "\x0b" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"form feed leading", "\x0c" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+		{"utf-16 le bom prefix", "\xff\xfe" + `{"jsonrpc":"2.0","method":"tools/list"}`, ErrKindMalformedJSONRPC},
+
+		// Trailing whitespace then garbage.
+		{"trailing whitespace then garbage", `{"jsonrpc":"2.0","method":"tools/list"}` + "   garbage", ErrKindMalformedJSONRPC},
+
+		// Duplicate key directly inside id-as-object.
+		{"id object with duplicate keys", `{"jsonrpc":"2.0","method":"tools/list","id":{"a":1,"a":2}}`, ErrKindDuplicateKey},
+
+		// id permits primitives only; complex ids carrying dup keys are rejected by the walker.
+		{"id is array of dup keys", `{"jsonrpc":"2.0","method":"tools/list","id":[{"a":1,"a":2}]}`, ErrKindDuplicateKey},
+
+		// Malformed JSON.
+		{"malformed JSON unclosed", `{"jsonrpc":"2.0","method":"tools/list"`, ErrKindMalformedJSONRPC},
+		{"malformed JSON garbage", `{`, ErrKindMalformedJSONRPC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqs, perr := ParseJSONRPCStrict([]byte(tc.body))
+			if perr == nil {
+				t.Fatalf("expected ParseError of kind %q, got nil (reqs=%v)", tc.want, reqs)
+			}
+			if perr.Kind != tc.want {
+				t.Errorf("ParseError.Kind = %q, want %q (msg=%q)", perr.Kind, tc.want, perr.Msg)
+			}
+		})
+	}
+}
+
+// Methods outside the name-bearing trio leave Name empty and accept
+// any params shape (including array-style by-position params).
+func TestParseJSONRPCStrict_NonNameMethodsAcceptArrayParams(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"initialize","params":[1,2,3],"id":1}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("expected no error, got %v", perr)
+	}
+	if reqs[0].Name != "" {
+		t.Errorf("Name = %q, want empty for initialize", reqs[0].Name)
+	}
+	if reqs[0].Arguments != nil {
+		t.Errorf("Arguments populated for non-tools/call: %v", reqs[0].Arguments)
+	}
+}
+
+// Notifications (no id) parse cleanly. The parser does not differentiate
+// them; the matcher gates them like any other request.
+func TestParseJSONRPCStrict_Notification(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/cancelled"}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("expected no error, got %v", perr)
+	}
+	if reqs[0].Method != "notifications/cancelled" {
+		t.Errorf("Method = %q", reqs[0].Method)
+	}
+}
+
+// JSON-RPC ids may be string, number, or null. All accepted; none
+// inspected.
+func TestParseJSONRPCStrict_IDShapes(t *testing.T) {
+	for _, idLit := range []string{`"abc"`, `42`, `null`, `0`, `-1`} {
+		body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":` + idLit + `}`)
+		if _, perr := ParseJSONRPCStrict(body); perr != nil {
+			t.Errorf("id=%s: expected no error, got %v", idLit, perr)
+		}
+	}
+}
+
+// Depth bound: at the limit accepts, one over rejects. params occupies
+// depth 1; arguments adds depth 2; each x-wrapper adds one more.
+// maxJSONDepth = 32, so 30 x-wrappers reach the deepest acceptable
+// level and 31 wrappers exceed it.
+func TestParseJSONRPCStrict_DepthBound(t *testing.T) {
+	build := func(n int) string {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteString(`{"x":`)
+		}
+		sb.WriteString(`0`)
+		for i := 0; i < n; i++ {
+			sb.WriteString(`}`)
+		}
+		return sb.String()
+	}
+	pass := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":` + build(30) + `}}`
+	if _, perr := ParseJSONRPCStrict([]byte(pass)); perr != nil {
+		t.Errorf("at depth limit: expected accept, got %v", perr)
+	}
+	fail := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":` + build(31) + `}}`
+	_, perr := ParseJSONRPCStrict([]byte(fail))
+	if perr == nil {
+		t.Fatalf("over depth limit: expected ParseError, got nil")
+	}
+	if perr.Kind != ErrKindMalformedJSONRPC {
+		t.Errorf("over depth limit: kind = %q, want malformed_jsonrpc", perr.Kind)
+	}
+}
+
+// Leading whitespace is fine (JSON allows it); trailing whitespace
+// after the value is also fine (encoding/json tolerates it before EOF).
+func TestParseJSONRPCStrict_Whitespace(t *testing.T) {
+	body := []byte("\n\t   " + `{"jsonrpc":"2.0","method":"tools/list"}` + "\n  ")
+	if _, perr := ParseJSONRPCStrict(body); perr != nil {
+		t.Errorf("whitespace-padded body rejected: %v", perr)
+	}
+}
+
+// RawParams captures the verbatim params bytes for matcher-internal
+// use. Must be non-empty for any request that had a params field.
+func TestParseJSONRPCStrict_RawParamsCaptured(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1}}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("unexpected error: %v", perr)
+	}
+	if len(reqs[0].RawParams) == 0 {
+		t.Errorf("RawParams empty, want verbatim bytes")
+	}
+	var v any
+	if err := json.Unmarshal(reqs[0].RawParams, &v); err != nil {
+		t.Errorf("RawParams not valid JSON: %v", err)
+	}
+}
+
+// Method is preserved verbatim (NOT lowercased) on the descriptor;
+// callers lowercase only at match time. This contract matters because
+// MCPDecision.Method in later phases is lowercased once at the matcher
+// boundary, not at the parser boundary — keeping the descriptor faithful
+// to the wire lets reconciliation diagnose case-mismatch attacks.
+func TestParseJSONRPCStrict_MethodCasePreserved(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"Tools/Call","params":{"name":"X"}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("unexpected error: %v", perr)
+	}
+	if reqs[0].Method != "Tools/Call" {
+		t.Errorf("Method = %q, want verbatim Tools/Call", reqs[0].Method)
+	}
+	// The method-specific shape extraction matches verbatim too, so a
+	// capitalised method does NOT trigger the tools/call params.name
+	// requirement: it routes through extractMethodShape's default case.
+	if reqs[0].Name != "" {
+		t.Errorf("Name = %q, want empty (capitalised method is not name-bearing)", reqs[0].Name)
+	}
+}
+
+// arguments: null is parsed without error and leaves Arguments == nil —
+// indistinguishable from "arguments field absent". Pinning the
+// behaviour as the documented contract for Phase 2's MatchArgs.
+func TestParseJSONRPCStrict_ArgumentsNullEquivalentToAbsent(t *testing.T) {
+	bodyNull := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":null}}`)
+	reqsNull, perr := ParseJSONRPCStrict(bodyNull)
+	if perr != nil {
+		t.Fatalf("arguments:null: unexpected error: %v", perr)
+	}
+	if reqsNull[0].Arguments != nil {
+		t.Errorf("arguments:null produced Arguments=%v, want nil", reqsNull[0].Arguments)
+	}
+
+	bodyAbsent := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"}}`)
+	reqsAbsent, perr := ParseJSONRPCStrict(bodyAbsent)
+	if perr != nil {
+		t.Fatalf("arguments absent: unexpected error: %v", perr)
+	}
+	if reqsAbsent[0].Arguments != nil {
+		t.Errorf("arguments absent produced Arguments=%v, want nil", reqsAbsent[0].Arguments)
+	}
+
+	bodyEmpty := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{}}}`)
+	reqsEmpty, perr := ParseJSONRPCStrict(bodyEmpty)
+	if perr != nil {
+		t.Fatalf("arguments:{}: unexpected error: %v", perr)
+	}
+	if reqsEmpty[0].Arguments == nil {
+		t.Errorf("arguments:{} produced Arguments=nil, want non-nil empty map")
+	}
+	if len(reqsEmpty[0].Arguments) != 0 {
+		t.Errorf("arguments:{} produced Arguments=%v, want empty", reqsEmpty[0].Arguments)
+	}
+}
+
+// id may be a complex value (object/array) as long as the value itself
+// is structurally sound (no duplicate keys at any depth). Strict JSON-RPC
+// 2.0 §4 restricts id to string/number/null; we accept more leniently
+// because id is not consulted for policy and rejecting it would break
+// MCP clients that have been observed wrapping ids. Strict-dup-key
+// detection inside complex ids still applies — see Adversarial.
+func TestParseJSONRPCStrict_LenientComplexID(t *testing.T) {
+	for _, body := range []string{
+		`{"jsonrpc":"2.0","method":"tools/list","id":{}}`,
+		`{"jsonrpc":"2.0","method":"tools/list","id":{"trace":"x"}}`,
+		`{"jsonrpc":"2.0","method":"tools/list","id":[1,2]}`,
+	} {
+		if _, perr := ParseJSONRPCStrict([]byte(body)); perr != nil {
+			t.Errorf("body=%s: unexpected error: %v", body, perr)
+		}
+	}
+}
+
+// Numeric ids preserve precision via json.Number — Decode into
+// RawMessage never coerces to float64. A 19-digit integer would lose
+// precision under default decoding.
+func TestParseJSONRPCStrict_LargeNumericIDPreserved(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":12345678901234567890}`)
+	if _, perr := ParseJSONRPCStrict(body); perr != nil {
+		t.Errorf("large numeric id rejected: %v", perr)
+	}
+}
+
+// Notifications can carry params per JSON-RPC 2.0 §4.1. The parser
+// doesn't differentiate notifications from id-bearing requests; only
+// the matcher cares.
+func TestParseJSONRPCStrict_NotificationWithParams(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/progress","params":{"token":"abc","value":50}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("notification with params rejected: %v", perr)
+	}
+	if reqs[0].Method != "notifications/progress" {
+		t.Errorf("Method = %q", reqs[0].Method)
+	}
+}
+
+// Unicode escapes in method strings decode correctly (Go normalises
+// during Token()). The matcher's lowercase compare sees the post-
+// decode runes, matching the upstream MCP server's view.
+func TestParseJSONRPCStrict_UnicodeEscapes(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"}}`)
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		t.Fatalf("unicode-escaped method rejected: %v", perr)
+	}
+	if reqs[0].Method != "tools/call" {
+		t.Errorf("Method = %q, want tools/call", reqs[0].Method)
+	}
+}
+
+// Fuzz seeds exercise strict-parse against arbitrary bytes. Invariant:
+// ParseJSONRPCStrict never panics regardless of input. This is the
+// panic-safety net the Phase 2 extractor relies on (a panic in the
+// parser would propagate to the goroutine handling the request).
+func FuzzParseJSONRPCStrict(f *testing.F) {
+	seeds := []string{
+		`{"jsonrpc":"2.0","method":"tools/list"}`,
+		`[{"jsonrpc":"2.0","method":"tools/list"}]`,
+		`{}`,
+		`[`,
+		`{"a":1,"a":2}`,
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1}}}`,
+		string([]byte{0xEF, 0xBB, 0xBF, '{', '}'}),
+		``,
+		`{"jsonrpc":"2.0","method":"tools/list","id":null,"id":1}`,
+		`{"jsonrpc":"2.0","method":"tools/call","params":[]}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, body []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("parser panicked on input %q: %v", body, r)
+			}
+		}()
+		_, _ = ParseJSONRPCStrict(body)
+	})
+}
+
+// ---------- benchmarks ----------
+
+// Typical single-request body: tools/list with id. Tiny — measures
+// per-request overhead floor.
+func BenchmarkParseJSONRPCStrict_Small(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Typical tools/call with a handful of scalar arguments. Closest to
+// the median production payload size.
+func BenchmarkParseJSONRPCStrict_ToolsCall(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/foo","encoding":"utf-8","limit":1024,"offset":0}},"id":42}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Larger arguments object: still bounded but exercises the per-object
+// duplicate-key seen-set growth and the recursive walker on a non-
+// trivial structure.
+func BenchmarkParseJSONRPCStrict_LargeArguments(b *testing.B) {
+	var args strings.Builder
+	args.WriteString(`{`)
+	for i := 0; i < 64; i++ {
+		if i > 0 {
+			args.WriteString(`,`)
+		}
+		fmt.Fprintf(&args, `"key_%02d":"value_%02d"`, i, i)
+	}
+	args.WriteString(`}`)
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"big_tool","arguments":` + args.String() + `},"id":1}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Batch of 16 mixed-shape requests. Exercises the batch loop and
+// allocates a request slice.
+func BenchmarkParseJSONRPCStrict_Batch16(b *testing.B) {
+	const one = `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_repos","arguments":{"q":"foo"}},"id":1}`
+	var sb strings.Builder
+	sb.WriteString(`[`)
+	for i := 0; i < 16; i++ {
+		if i > 0 {
+			sb.WriteString(`,`)
+		}
+		sb.WriteString(one)
+	}
+	sb.WriteString(`]`)
+	body := []byte(sb.String())
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Deny-path: duplicate key in nested arguments. Measures the cost of
+// the failure path (matters because adversarial traffic might saturate
+// it).
+func BenchmarkParseJSONRPCStrict_DuplicateKey(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1,"a":2}}}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err == nil {
+			b.Fatal("expected ParseError")
+		}
+	}
+}
+
+// Deny-path: malformed JSON-RPC envelope (unknown top-level key).
+// Cheapest deny — single field validation before bail.
+func BenchmarkParseJSONRPCStrict_UnknownTopLevel(b *testing.B) {
+	body := []byte(`{"jsonrpc":"2.0","method":"tools/list","unexpected":42}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseJSONRPCStrict(body); err == nil {
+			b.Fatal("expected ParseError")
+		}
+	}
+}

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -823,6 +823,14 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 			}
 		}
 
+		// MCP body-authoritative policy enforcement: when the routed
+		// backend opts into logical.MCPPolicyEnforced, buffer the
+		// request body and strict-parse it into a descriptor before
+		// CheckToken runs. The extractor restores the body so the
+		// downstream proxy reads it unchanged. Non-MCP backends fail
+		// the type assertion and skip the extractor entirely.
+		c.extractMCPDescriptor(ctx, req, matchingBackend)
+
 		req.ClientToken = matchingBackend.ExtractToken(req.HTTPRequest)
 
 		// Check for unauthenticated paths on streaming backends

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// extractMCPDescriptor populates req.MCPDescriptor when the routed
+// backend opts into MCP policy enforcement via the
+// logical.MCPPolicyEnforced interface. Non-MCP backends and opted-in
+// backends that decline the request (wrong method, non-JSON Content-
+// Type) leave the descriptor nil. Phase 2 captures the descriptor
+// dormantly: no consumer reads it until Phase 4 wires the evaluator.
+//
+// The body is read up to cap+1 bytes via io.LimitReader so an
+// oversize signal is distinguishable from an at-cap read, and
+// restored via io.NopCloser(bytes.NewReader(buf)) so the downstream
+// proxy receives the bytes unchanged. The full function is panic-safe
+// — any panic from the strict parser is recovered and surfaced as a
+// malformed_jsonrpc ParseErr rather than propagating into the request
+// handler.
+func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, backend logical.Backend) {
+	if req == nil || backend == nil {
+		return
+	}
+	mcp, ok := backend.(logical.MCPPolicyEnforced)
+	if !ok {
+		return
+	}
+	enforce, maxBody := mcp.ShouldEnforceMCPPolicy(req)
+	if !enforce {
+		return
+	}
+	if maxBody <= 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+
+	desc := &logical.MCPRequestDescriptor{}
+	defer func() {
+		if r := recover(); r != nil {
+			// Drop any partial Calls so the matcher's invariant
+			// "ParseErr non-nil ⇒ Calls unspecified" stays sound even
+			// if a panic fires mid-Calls-loop.
+			desc.Calls = nil
+			desc.ParseErr = &logical.MCPParseError{
+				Kind: logical.MCPParseKindMalformedJSONRPC,
+				Msg:  "mcp extractor panic recovered",
+			}
+		}
+		req.MCPDescriptor = desc
+	}()
+
+	if req.HTTPRequest == nil || req.HTTPRequest.Body == nil {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindMalformedJSONRPC,
+			Msg:  "request body absent",
+		}
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.HTTPRequest.Body, maxBody+1))
+	if err != nil {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindMalformedJSONRPC,
+			Msg:  err.Error(),
+		}
+		return
+	}
+	_ = req.HTTPRequest.Body.Close()
+	// Body restored (up to maxBody+1 bytes) before any further
+	// decision so the downstream proxy can read it. On oversize, the
+	// matcher denies in Phase 4 so the proxy doesn't run; on parse
+	// error, same.
+	req.HTTPRequest.Body = io.NopCloser(bytes.NewReader(body))
+
+	if int64(len(body)) > maxBody {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindOversizedBody,
+			Msg:  "request body exceeds max_body_size",
+		}
+		return
+	}
+
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: string(perr.Kind),
+			Msg:  perr.Msg,
+		}
+		return
+	}
+
+	desc.Calls = make([]logical.MCPCall, len(reqs))
+	for i, r := range reqs {
+		desc.Calls[i] = logical.MCPCall{
+			Method:     r.Method,
+			Name:       r.Name,
+			MatchArgs:  classifyArgs(r.Arguments),
+			BatchIndex: i,
+		}
+	}
+}
+
+// classifyArgs typifies each tools/call argument from raw JSON bytes
+// into a matcher-ready ParamValue. Non-scalar values are tagged
+// Object/Array so the matcher can treat them as missing for scalar
+// pattern matching. Returns nil when args is nil so the matcher can
+// distinguish "no arguments field" from "arguments: {}" (which yields
+// a non-nil empty map).
+func classifyArgs(args map[string]json.RawMessage) map[string]logical.ParamValue {
+	if args == nil {
+		return nil
+	}
+	out := make(map[string]logical.ParamValue, len(args))
+	for k, raw := range args {
+		out[k] = classifyParam(raw)
+	}
+	return out
+}
+
+// classifyParam inspects the first non-whitespace byte of the raw
+// JSON value to classify the kind cheaply, then unmarshals scalars
+// into Str. Malformed bytes for a tagged kind fall through to
+// ParamMissing — the strict parser already rejected structurally bad
+// JSON, so this is a defensive belt against unexpected drift.
+func classifyParam(raw json.RawMessage) logical.ParamValue {
+	if len(raw) == 0 {
+		return logical.ParamValue{Kind: logical.ParamMissing}
+	}
+	first := byte(0)
+	found := false
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		}
+		first = b
+		found = true
+		break
+	}
+	if !found {
+		// All-whitespace RawMessage shouldn't happen in practice
+		// (json.RawMessage strips leading whitespace at decode), but
+		// fail closed if it does.
+		return logical.ParamValue{Kind: logical.ParamMissing}
+	}
+	switch first {
+	case '{':
+		return logical.ParamValue{Kind: logical.ParamObject}
+	case '[':
+		return logical.ParamValue{Kind: logical.ParamArray}
+	case 'n':
+		return logical.ParamValue{Kind: logical.ParamNull}
+	case '"':
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return logical.ParamValue{Kind: logical.ParamMissing}
+		}
+		return logical.ParamValue{Kind: logical.ParamString, Str: s}
+	case 't', 'f':
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return logical.ParamValue{Kind: logical.ParamMissing}
+		}
+		s := "false"
+		if b {
+			s = "true"
+		}
+		return logical.ParamValue{Kind: logical.ParamBool, Str: s}
+	default:
+		var n json.Number
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return logical.ParamValue{Kind: logical.ParamMissing}
+		}
+		return logical.ParamValue{Kind: logical.ParamNumber, Str: n.String()}
+	}
+}

--- a/core/request_handler_mcp_test.go
+++ b/core/request_handler_mcp_test.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// fakeBackend is the minimal logical.Backend stub used to drive
+// extractMCPDescriptor without spinning up a full mount. It implements
+// MCPPolicyEnforced when enforced is non-nil so we can probe both
+// branches of the type assertion.
+type fakeBackend struct {
+	logical.Backend
+	enforced *fakeMCPHook
+}
+
+type fakeMCPHook struct {
+	enforce bool
+	cap     int64
+}
+
+// mcpBackend wraps fakeBackend with the marker interface — used when a
+// test wants the type assertion to succeed.
+type mcpBackend struct {
+	fakeBackend
+}
+
+func (b *mcpBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int64) {
+	if b.enforced == nil {
+		return false, 0
+	}
+	return b.enforced.enforce, b.enforced.cap
+}
+
+func newReq(t *testing.T, body string) *logical.Request {
+	t.Helper()
+	httpReq, err := http.NewRequest(http.MethodPost, "/v1/mcp_github/gateway/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	return &logical.Request{
+		HTTPRequest: httpReq,
+	}
+}
+
+// Non-MCP backend: type assertion fails, descriptor stays nil.
+func TestExtractMCPDescriptor_NotMCPBackend(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	c.extractMCPDescriptor(context.Background(), req, &fakeBackend{})
+	if req.MCPDescriptor != nil {
+		t.Fatalf("descriptor = %+v, want nil for non-MCP backend", req.MCPDescriptor)
+	}
+}
+
+// MCP backend opts out per-request: descriptor stays nil.
+func TestExtractMCPDescriptor_OptsOutPerRequest(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: false}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	if req.MCPDescriptor != nil {
+		t.Fatalf("descriptor = %+v, want nil for opted-out request", req.MCPDescriptor)
+	}
+}
+
+// MCP backend opts in with valid JSON-RPC: descriptor populated.
+func TestExtractMCPDescriptor_ValidSingle(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_repos","arguments":{"q":"foo"}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil {
+		t.Fatal("descriptor is nil, want populated")
+	}
+	if desc.ParseErr != nil {
+		t.Fatalf("ParseErr = %v, want nil", desc.ParseErr)
+	}
+	if len(desc.Calls) != 1 {
+		t.Fatalf("Calls len = %d, want 1", len(desc.Calls))
+	}
+	if desc.Calls[0].Method != "tools/call" {
+		t.Errorf("Method = %q, want tools/call", desc.Calls[0].Method)
+	}
+	if desc.Calls[0].Name != "search_repos" {
+		t.Errorf("Name = %q, want search_repos", desc.Calls[0].Name)
+	}
+	if desc.Calls[0].BatchIndex != 0 {
+		t.Errorf("BatchIndex = %d, want 0", desc.Calls[0].BatchIndex)
+	}
+	arg, ok := desc.Calls[0].MatchArgs["q"]
+	if !ok {
+		t.Fatalf("MatchArgs missing q: %v", desc.Calls[0].MatchArgs)
+	}
+	if arg.Kind != logical.ParamString || arg.Str != "foo" {
+		t.Errorf("q arg = %+v, want String/foo", arg)
+	}
+}
+
+// Batch: BatchIndex stamped per element.
+func TestExtractMCPDescriptor_Batch(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `[
+		{"jsonrpc":"2.0","method":"tools/list"},
+		{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"}}
+	]`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, ParseErr should be nil", desc)
+	}
+	if len(desc.Calls) != 2 {
+		t.Fatalf("Calls len = %d, want 2", len(desc.Calls))
+	}
+	if desc.Calls[0].BatchIndex != 0 || desc.Calls[1].BatchIndex != 1 {
+		t.Errorf("BatchIndex = [%d, %d], want [0, 1]", desc.Calls[0].BatchIndex, desc.Calls[1].BatchIndex)
+	}
+}
+
+// Oversized body: cap+1 bytes triggers oversized_body.
+func TestExtractMCPDescriptor_OversizedBody(t *testing.T) {
+	c := &Core{}
+	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"big":"` +
+		strings.Repeat("A", 256) + `"}}}`
+	req := newReq(t, body)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: int64(len(body) - 1)}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindOversizedBody {
+		t.Errorf("ParseErr.Kind = %q, want oversized_body", desc.ParseErr.Kind)
+	}
+}
+
+// Malformed JSON-RPC: descriptor.ParseErr.Kind = malformed_jsonrpc.
+func TestExtractMCPDescriptor_MalformedBody(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{not json`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// Duplicate key: descriptor.ParseErr.Kind = duplicate_key.
+func TestExtractMCPDescriptor_DuplicateKey(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list","method":"tools/call"}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindDuplicateKey {
+		t.Errorf("ParseErr.Kind = %q, want duplicate_key", desc.ParseErr.Kind)
+	}
+}
+
+// After extraction, the body must still be readable for the downstream
+// proxy and must yield the original bytes byte-for-byte. Load-bearing
+// for the streaming-branch claim that the extractor restores the body.
+func TestExtractMCPDescriptor_BodyByteIdentity(t *testing.T) {
+	c := &Core{}
+	original := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1}}}`
+	req := newReq(t, original)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	if req.HTTPRequest.Body == nil {
+		t.Fatal("Body is nil after extraction")
+	}
+	got, err := io.ReadAll(req.HTTPRequest.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !bytes.Equal(got, []byte(original)) {
+		t.Errorf("restored body differs from original\nwant: %q\ngot:  %q", original, string(got))
+	}
+}
+
+// Cap fallback: cap=0 from the hook falls back to framework default.
+// A small body fits under the default and parses successfully.
+func TestExtractMCPDescriptor_CapZeroFallsBack(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 0}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, want successful parse", desc)
+	}
+}
+
+// Empty body when enforce=true: malformed_jsonrpc.
+func TestExtractMCPDescriptor_EmptyBody(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, ``)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// nil req and nil backend are no-ops (the handler guards before
+// calling; defense in depth).
+func TestExtractMCPDescriptor_NilGuards(t *testing.T) {
+	c := &Core{}
+	c.extractMCPDescriptor(context.Background(), nil, &mcpBackend{})
+	req := newReq(t, `{}`)
+	c.extractMCPDescriptor(context.Background(), req, nil)
+	if req.MCPDescriptor != nil {
+		t.Errorf("descriptor should stay nil when backend is nil")
+	}
+}
+
+// Body sized exactly to cap parses successfully (not oversized) and
+// the restored body bytes are byte-identical to the original. Pins
+// the off-by-one boundary between the cap+1 read and the > cap check.
+func TestExtractMCPDescriptor_ExactCapBoundary(t *testing.T) {
+	c := &Core{}
+	body := `{"jsonrpc":"2.0","method":"tools/list"}`
+	req := newReq(t, body)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: int64(len(body))}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, want successful parse at exact cap", desc)
+	}
+	got, err := io.ReadAll(req.HTTPRequest.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !bytes.Equal(got, []byte(body)) {
+		t.Errorf("restored body differs at exact-cap boundary")
+	}
+}
+
+// enforce=true with HTTPRequest.Body=nil yields malformed_jsonrpc. The
+// handler shouldn't reach this state in production, but defensive nil-
+// safety matters for testability + future code paths.
+func TestExtractMCPDescriptor_NilHTTPBody(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	req.HTTPRequest.Body = nil
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// A body reader that returns an I/O error mid-read populates ParseErr
+// with malformed_jsonrpc.
+func TestExtractMCPDescriptor_BodyReadError(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{}`)
+	req.HTTPRequest.Body = io.NopCloser(&errReader{err: errFakeRead})
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// errReader always errors on Read.
+type errReader struct{ err error }
+
+func (r *errReader) Read([]byte) (int, error) { return 0, r.err }
+
+var errFakeRead = &fakeErr{msg: "synthetic read failure"}
+
+type fakeErr struct{ msg string }
+
+func (e *fakeErr) Error() string { return e.msg }
+
+// classifyParam table for each JSON kind.
+func TestClassifyParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantKnd logical.ParamKind
+		wantStr string
+	}{
+		{"string", `"hello"`, logical.ParamString, "hello"},
+		{"empty string", `""`, logical.ParamString, ""},
+		{"number int", `42`, logical.ParamNumber, "42"},
+		{"number float", `3.14`, logical.ParamNumber, "3.14"},
+		{"number large", `12345678901234567890`, logical.ParamNumber, "12345678901234567890"},
+		{"bool true", `true`, logical.ParamBool, "true"},
+		{"bool false", `false`, logical.ParamBool, "false"},
+		{"null", `null`, logical.ParamNull, ""},
+		{"object", `{"x":1}`, logical.ParamObject, ""},
+		{"array", `[1,2,3]`, logical.ParamArray, ""},
+		{"whitespace then object", "  \n\t {}", logical.ParamObject, ""},
+		{"empty", ``, logical.ParamMissing, ""},
+		{"whitespace only", "   \t\n", logical.ParamMissing, ""},
+		{"capital True (invalid JSON, fail-safe)", `True`, logical.ParamMissing, ""},
+		{"capital Null", `Null`, logical.ParamMissing, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyParam(json.RawMessage(tc.raw))
+			if got.Kind != tc.wantKnd {
+				t.Errorf("Kind = %d, want %d", got.Kind, tc.wantKnd)
+			}
+			if got.Str != tc.wantStr {
+				t.Errorf("Str = %q, want %q", got.Str, tc.wantStr)
+			}
+		})
+	}
+}
+
+// classifyArgs preserves nil vs empty-map distinction so the matcher
+// can later distinguish "no arguments field" from "arguments: {}".
+func TestClassifyArgs_NilVsEmpty(t *testing.T) {
+	if classifyArgs(nil) != nil {
+		t.Error("classifyArgs(nil) != nil")
+	}
+	got := classifyArgs(map[string]json.RawMessage{})
+	if got == nil {
+		t.Error("classifyArgs(empty) returned nil, want empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("classifyArgs(empty) len = %d, want 0", len(got))
+	}
+}

--- a/logical/mcp_descriptor.go
+++ b/logical/mcp_descriptor.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+// MCPRequestDescriptor carries the result of strictly parsing an
+// MCP-enforced backend's request body. Stashed on *Request by the core
+// handler's extractor; consumed by the policy evaluator in a later
+// phase.
+//
+// One of two terminal states: ParseErr is non-nil (Calls is then
+// unspecified — the matcher must not consult it) or ParseErr is nil
+// and Calls is populated. A nil *MCPRequestDescriptor on *Request
+// means the request was not subject to MCP enforcement (backend opted
+// out, or backend declined this particular request).
+type MCPRequestDescriptor struct {
+	Calls    []MCPCall
+	ParseErr *MCPParseError
+}
+
+// MCPCall is one strictly-parsed JSON-RPC request extracted from the
+// body. Single-message bodies produce one MCPCall with BatchIndex 0;
+// batch bodies produce N elements in array order.
+//
+// Method and Name are verbatim from the wire — the matcher lowercases
+// at compare time. MatchArgs is populated only for tools/call (from
+// params.arguments) so the matcher's denied_params / allowed_params
+// can gate on individual argument values. For other methods MatchArgs
+// is nil.
+type MCPCall struct {
+	Method     string
+	Name       string
+	MatchArgs  map[string]ParamValue
+	BatchIndex int
+}
+
+// ParamKind classifies the JSON type of a tools/call argument value
+// so the matcher can decide which pattern-list semantics apply. Scalar
+// kinds (String / Number / Bool) render to Str for string-pattern
+// matching; Non-scalar kinds (Object / Array) and Null have empty Str
+// and the matcher treats them as missing for deny-list checks and as
+// missing-required for allow-list checks.
+type ParamKind uint8
+
+const (
+	ParamMissing ParamKind = iota
+	ParamString
+	ParamNumber
+	ParamBool
+	ParamNull
+	ParamObject
+	ParamArray
+)
+
+// ParamValue is a typed view of one tools/call argument. Str carries
+// the matcher-comparable string form: verbatim for strings,
+// json.Number stringified for numbers, "true"/"false" for booleans.
+// For Null / Object / Array / Missing kinds Str is the zero value.
+type ParamValue struct {
+	Kind ParamKind
+	Str  string
+}
+
+// MCPParseError carries the kind of structural failure plus an
+// operator-facing detail Msg. Msg is for server-side logs only and
+// MUST NOT be stamped on MCPDecision or surfaced to the client —
+// fingerprint hygiene and no leakage of adversary-controlled body
+// bytes into operator-visible logs.
+//
+// Kind is one of the MCPParseKind* string constants; the matcher in a
+// later phase maps these 1:1 to MCPDecision.RuleType values.
+type MCPParseError struct {
+	Kind string
+	Msg  string
+}
+
+// MCPParseKind* enumerate the descriptor-level parse failure modes.
+// The string values are the same identifiers Phase 4 will use as
+// MCPDecision rule_type values, so the mapping is identity rather
+// than a per-package translation table.
+const (
+	MCPParseKindMalformedJSONRPC = "malformed_jsonrpc"
+	MCPParseKindDuplicateKey     = "duplicate_key"
+	MCPParseKindOversizedBody    = "oversized_body"
+	MCPParseKindBatchEmpty       = "batch_empty"
+	MCPParseKindMalformedParams  = "malformed_params"
+)
+
+// Clone returns a deep copy of the MCPRequestDescriptor. Safe to call
+// on a nil receiver (returns nil). The audit layer's request-clone
+// path treats MCPRequestDescriptor as a deep-copy field so an async
+// audit writer cannot observe mutations made by a concurrent request
+// handler — though by current design the descriptor is read-only
+// post-extraction.
+func (d *MCPRequestDescriptor) Clone() *MCPRequestDescriptor {
+	if d == nil {
+		return nil
+	}
+	clone := &MCPRequestDescriptor{}
+	if d.Calls != nil {
+		clone.Calls = make([]MCPCall, len(d.Calls))
+		for i, c := range d.Calls {
+			clone.Calls[i] = c.Clone()
+		}
+	}
+	if d.ParseErr != nil {
+		errCopy := *d.ParseErr
+		clone.ParseErr = &errCopy
+	}
+	return clone
+}
+
+// Clone returns a deep copy of the MCPCall. MatchArgs is a map of
+// value-typed ParamValue, so a length-preserving copy of the map
+// breaks aliasing.
+func (c MCPCall) Clone() MCPCall {
+	out := MCPCall{
+		Method:     c.Method,
+		Name:       c.Name,
+		BatchIndex: c.BatchIndex,
+	}
+	if c.MatchArgs != nil {
+		out.MatchArgs = make(map[string]ParamValue, len(c.MatchArgs))
+		for k, v := range c.MatchArgs {
+			out.MatchArgs[k] = v
+		}
+	}
+	return out
+}

--- a/logical/mcp_enforced.go
+++ b/logical/mcp_enforced.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+// MCPPolicyEnforced is implemented by backends that participate in CBP
+// `mcp { }` body-authoritative policy enforcement. The core handler
+// calls ShouldEnforceMCPPolicy on every matched backend; when it
+// returns enforce=true the handler buffers the request body (up to
+// cap bytes), strict-parses it as JSON-RPC, and stashes the resulting
+// MCPRequestDescriptor on the request before policy evaluation runs.
+//
+// This interface is the per-backend opt-in. The marker pattern mirrors
+// StreamBodyParser so reviewers can pattern-match the shape, and lets
+// the trigger stay a compile-time type assertion rather than a string-
+// prefix sniff or mount-class enumeration change.
+//
+// Implementations of MCPPolicyEnforced MUST NOT also opt into
+// StreamBodyParser with ShouldParseStreamBody returning true: the
+// stream-body parser would consume req.HTTPRequest.Body before the
+// MCP extractor runs, leaving the extractor nothing to read. Backends
+// that need both behaviours on different sub-paths must scope each
+// hook by request shape so their domains do not overlap.
+type MCPPolicyEnforced interface {
+	// ShouldEnforceMCPPolicy reports whether this request on this
+	// backend is subject to `mcp { }` body-based enforcement, and the
+	// maximum body size in bytes the policy extractor may buffer.
+	//
+	// cap <= 0 falls back to framework.DefaultMaxBodySize at the
+	// extractor. cap is ignored when enforce is false. Returning the
+	// cap here (rather than having the extractor reach into the
+	// backend's persisted config) keeps the policy-eval path from
+	// duplicating httpproxy's max_body_size config-resolution work.
+	//
+	// Backends typically gate on request method and Content-Type:
+	// MCP enforcement is only meaningful for POSTed JSON-RPC bodies,
+	// so GET (SSE reconnect) and DELETE (session close) traffic should
+	// return enforce=false.
+	ShouldEnforceMCPPolicy(req *Request) (enforce bool, cap int64)
+}

--- a/logical/request.go
+++ b/logical/request.go
@@ -125,6 +125,13 @@ type Request struct {
 	// UpstreamURL is the target URL for proxied streaming requests (for audit logging).
 	// Set by streaming handlers before forwarding the request to the upstream service.
 	UpstreamURL string `json:"-"`
+
+	// MCPDescriptor is populated by the core handler when the routed
+	// backend opts into MCPPolicyEnforced and accepts the request for
+	// MCP body-based policy enforcement. Nil for all other requests.
+	// Read-only after extraction; the audit layer treats it as a
+	// deep-copy field via MCPRequestDescriptor.Clone.
+	MCPDescriptor *MCPRequestDescriptor `json:"-"`
 }
 
 func (r *Request) TokenEntry() *TokenEntry {

--- a/provider/mcp_github/provider.go
+++ b/provider/mcp_github/provider.go
@@ -1,9 +1,12 @@
 package mcp_github
 
 import (
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
@@ -36,6 +39,33 @@ var Spec = &httpproxy.ProviderSpec{
 	// default Accept only when the client sends none; MCP clients always
 	// negotiate ("application/json, text/event-stream"). Forcing a default
 	// here would break one-shot JSON clients.
+	ShouldEnforceMCPPolicy: shouldEnforceMCPPolicy,
+}
+
+// shouldEnforceMCPPolicy opts mcp_github into CBP body-authoritative
+// mcp { } enforcement for the subset of traffic where it is meaningful:
+// JSON-RPC POSTs. GET (SSE reconnect) and DELETE (session close), and
+// any non-JSON Content-Type, decline and pass through under
+// token-scope-only enforcement.
+func shouldEnforceMCPPolicy(req *logical.Request) bool {
+	if req == nil || req.HTTPRequest == nil {
+		return false
+	}
+	r := req.HTTPRequest
+	if r.Method != http.MethodPost {
+		return false
+	}
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		return false
+	}
+	// Trim a charset / boundary parameter (e.g. "application/json; charset=utf-8")
+	// before comparing to the bare media type.
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.TrimSpace(strings.ToLower(ct))
+	return ct == "application/json"
 }
 
 // Factory creates a new mcp_github provider backend.
@@ -82,18 +112,15 @@ actually do at GitHub regardless of what Warden lets through. On top
 of that, Warden's CBP policies support an mcp { } block for
 governance-style restrictions enforced at the gateway: allow- and
 deny-lists for JSON-RPC methods, tool names, resource URIs, prompt
-names, and (where the upstream tool author opted in) selected tool
-arguments. Enforcement is header-based and adds no request-body
-parsing on the allow path. Denied requests return HTTP 403 with an
-RFC 6750 WWW-Authenticate header and a small JSON body the agent
-SDK surfaces as a structured tool-call failure. See the policy
+names, and selected tool arguments. When a policy in scope contains
+an mcp { } block, the gateway strict-parses the JSON-RPC request body
+before authorising the call; denied requests return HTTP 403 with an
+RFC 6750 WWW-Authenticate header and a small JSON body the agent SDK
+surfaces as a structured tool-call failure. See the policy
 documentation for the mcp { } block schema and examples.
 
-Important: the mcp { } block depends on the MCP protocol revision
-dated 2026-07-28, which mirrors method/name into HTTP headers so
-intermediaries can enforce without parsing the body. Pre-draft
-clients are denied when bound to a policy with an mcp { } block.
-Policies without an mcp { } block keep today's behaviour unchanged.
+Policies without an mcp { } block keep today's behaviour unchanged —
+no body parsing is performed on the allow path.
 
 Configuration:
 - mcp_github_url: MCP server base URL (default: https://api.githubcopilot.com/mcp)

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -173,6 +173,24 @@ type ProviderSpec struct {
 	// invoke without minted credentials (see gateway.go's
 	// StreamUnauthenticated guard).
 	IsUnauthenticatedRequest func(r *http.Request, path string) bool
+
+	// ShouldEnforceMCPPolicy optionally opts this provider into CBP
+	// `mcp { }` body-authoritative policy enforcement. When set, the
+	// core handler calls this hook on every request matched to this
+	// backend; if it returns true the request body is buffered and
+	// strict-parsed as JSON-RPC before policy evaluation runs. The
+	// shared proxyBackend implements logical.MCPPolicyEnforced by
+	// delegating to this hook.
+	//
+	// Returning true on traffic that is not a JSON-RPC POST will deny
+	// the request at policy eval time (the parser fails closed on
+	// non-JSON or empty bodies). MCP providers should gate on method +
+	// Content-Type to leave SSE GETs and session-close DELETEs alone.
+	//
+	// MCP-enforcing specs MUST set ParseStreamBody: false. Opting into
+	// the framework's stream-body parser would consume the body before
+	// the MCP extractor runs.
+	ShouldEnforceMCPPolicy func(req *logical.Request) bool
 }
 
 // proxyBackend is the concrete backend type created by NewFactory.
@@ -508,6 +526,29 @@ func ReadInt64Config(v any) (int64, bool) {
 		return size, size > 0
 	}
 	return 0, false
+}
+
+// ShouldEnforceMCPPolicy implements logical.MCPPolicyEnforced by
+// delegating to the spec's ShouldEnforceMCPPolicy hook. Returns the
+// mount-configured MaxBodySize as the cap so the core extractor uses
+// the same byte-cap the gateway will enforce at proxy time. Returns
+// enforce=false with cap=0 when the spec did not set the hook — every
+// other httpproxy-backed provider (github, openai, slack, anthropic,
+// …) sees no MCP enforcement.
+func (b *proxyBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int64) {
+	if b.spec.ShouldEnforceMCPPolicy == nil {
+		return false, 0
+	}
+	if !b.spec.ShouldEnforceMCPPolicy(req) {
+		return false, 0
+	}
+	// MaxBodySize lives on the embedded StreamingBackend and is
+	// written under b.mu by Initialize and handleConfigWrite — read
+	// under the read-lock to avoid racing concurrent reconfigure.
+	b.mu.RLock()
+	maxBody := b.MaxBodySize
+	b.mu.RUnlock()
+	return true, maxBody
 }
 
 // ShouldParseStreamBody overrides the embedded StreamingBackend's default to


### PR DESCRIPTION
## Summary

Phase 2: opt-in marker interface + handler-side body buffer for MCP enforcement.

- New `logical.MCPPolicyEnforced` interface — backends opt in per-request and return their body-size cap (sibling of `StreamBodyParser`).
- New `MCPRequestDescriptor` / `MCPCall` types on `logical/`, carried via `req.MCPDescriptor`.
- `provider/sdk/httpproxy.ProviderSpec` gains a `ShouldEnforceMCPPolicy` hook; `proxyBackend` implements the marker by delegating to the spec. `mcp_github`'s Spec sets the hook (POST + `application/json` only).
- `core/request_handler_mcp.go` runs the strict parser from Phase 1 inside `extractMCPDescriptor`, buffers + restores the body via `io.NopCloser(bytes.NewReader)` for the proxy.
- Wired into both the streaming and non-streaming branches of `request_handler.go` — non-MCP backends type-assert false and skip everything.

Captured but not yet consumed: Phase 4 flips the evaluator to read it.

## Test plan

- [x] `go test ./core/... ./logical/... ./provider/...` green
- [x] Body byte-identity verified by Phase 6's e2e harness (added later in the stack)

Stacked on top of #277.
