### PR TITLE
feat(core/policy): mcp { } HCL symmetry — denied_resources, denied_prompts

### DIFF
--- a/core/policy.go
+++ b/core/policy.go
@@ -137,7 +137,9 @@ type MCPRulesHCL struct {
 	AllowedTools     []string            `hcl:"allowed_tools"`
 	DeniedTools      []string            `hcl:"denied_tools"`
 	AllowedResources []string            `hcl:"allowed_resources"`
+	DeniedResources  []string            `hcl:"denied_resources"`
 	AllowedPrompts   []string            `hcl:"allowed_prompts"`
+	DeniedPrompts    []string            `hcl:"denied_prompts"`
 	AllowedParams    map[string][]string `hcl:"allowed_params"`
 	DeniedParams     map[string][]string `hcl:"denied_params"`
 }
@@ -175,7 +177,9 @@ type CBPMCPRules struct {
 	AllowedTools     []string
 	DeniedTools      []string
 	AllowedResources []string
+	DeniedResources  []string
 	AllowedPrompts   []string
+	DeniedPrompts    []string
 	AllowedParams    map[string][]string
 	DeniedParams     map[string][]string
 }
@@ -203,8 +207,14 @@ func (m *CBPMCPRules) Clone() *CBPMCPRules {
 	if m.AllowedResources != nil {
 		clone.AllowedResources = append([]string(nil), m.AllowedResources...)
 	}
+	if m.DeniedResources != nil {
+		clone.DeniedResources = append([]string(nil), m.DeniedResources...)
+	}
 	if m.AllowedPrompts != nil {
 		clone.AllowedPrompts = append([]string(nil), m.AllowedPrompts...)
+	}
+	if m.DeniedPrompts != nil {
+		clone.DeniedPrompts = append([]string(nil), m.DeniedPrompts...)
 	}
 	if m.AllowedParams != nil {
 		clone.AllowedParams = make(map[string][]string, len(m.AllowedParams))
@@ -584,7 +594,13 @@ func canonicaliseMCPRules(h *MCPRulesHCL) (*CBPMCPRules, error) {
 	if r.AllowedResources, err = canonList("allowed_resources", h.AllowedResources); err != nil {
 		return nil, err
 	}
+	if r.DeniedResources, err = canonList("denied_resources", h.DeniedResources); err != nil {
+		return nil, err
+	}
 	if r.AllowedPrompts, err = canonList("allowed_prompts", h.AllowedPrompts); err != nil {
+		return nil, err
+	}
+	if r.DeniedPrompts, err = canonList("denied_prompts", h.DeniedPrompts); err != nil {
 		return nil, err
 	}
 	if r.AllowedParams, err = canonMap("allowed_params", h.AllowedParams); err != nil {

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -35,7 +35,9 @@ const (
 	mcpRuleTypeAllowedTools     = "allowed_tools"
 	mcpRuleTypeDeniedTools      = "denied_tools"
 	mcpRuleTypeAllowedResources = "allowed_resources"
+	mcpRuleTypeDeniedResources  = "denied_resources"
 	mcpRuleTypeAllowedPrompts   = "allowed_prompts"
+	mcpRuleTypeDeniedPrompts    = "denied_prompts"
 	mcpRuleTypeAllowedParams    = "allowed_params"
 	mcpRuleTypeDeniedParams     = "denied_params"
 	mcpRuleTypeMissingMethod    = "missing_method_header"
@@ -136,9 +138,9 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 	case mcpMethodToolsCall:
 		return set.DeniedTools, set.AllowedTools
 	case mcpMethodResourcesRead:
-		return nil, set.AllowedResources
+		return set.DeniedResources, set.AllowedResources
 	case mcpMethodPromptsGet:
-		return nil, set.AllowedPrompts
+		return set.DeniedPrompts, set.AllowedPrompts
 	}
 	return nil, nil
 }
@@ -388,15 +390,15 @@ func callMatchArgString(call *logical.MCPCall, paramName string) string {
 }
 
 // mcpDenyRuleTypeForName maps a name-bearing method to its denied_*
-// rule_type string. Only tools/call has a deny-list in v1
-// (resources/read and prompts/get use allow-lists only per the policy
-// schema), so this is the only reachable case at the caller — the
-// fallback is the empty string for forward-compat if a future schema
-// version adds denied_resources or denied_prompts.
+// rule_type string.
 func mcpDenyRuleTypeForName(method string) string {
 	switch method {
 	case mcpMethodToolsCall:
 		return mcpRuleTypeDeniedTools
+	case mcpMethodResourcesRead:
+		return mcpRuleTypeDeniedResources
+	case mcpMethodPromptsGet:
+		return mcpRuleTypeDeniedPrompts
 	}
 	return ""
 }
@@ -442,6 +444,8 @@ func mcpDenyRank(ruleType string) int {
 		return 4
 	case mcpRuleTypeDeniedMethods,
 		mcpRuleTypeDeniedTools,
+		mcpRuleTypeDeniedResources,
+		mcpRuleTypeDeniedPrompts,
 		mcpRuleTypeDeniedParams:
 		return 3
 	case mcpRuleTypeAllowedMethods,
@@ -491,9 +495,9 @@ func BuildMCPDenyDescription(d *logical.MCPDecision) string {
 		return fmt.Sprintf("Method '%s' not allowed.", method)
 	case mcpRuleTypeDeniedTools, mcpRuleTypeAllowedTools:
 		return fmt.Sprintf("Tool '%s' not allowed.", name)
-	case mcpRuleTypeAllowedResources:
+	case mcpRuleTypeDeniedResources, mcpRuleTypeAllowedResources:
 		return fmt.Sprintf("Resource '%s' not allowed.", name)
-	case mcpRuleTypeAllowedPrompts:
+	case mcpRuleTypeDeniedPrompts, mcpRuleTypeAllowedPrompts:
 		return fmt.Sprintf("Prompt '%s' not allowed.", name)
 	case mcpRuleTypeDeniedParams:
 		return fmt.Sprintf("Parameter '%s'='%s' not allowed.", param, value)

--- a/core/policy_mcp_body_test.go
+++ b/core/policy_mcp_body_test.go
@@ -240,6 +240,8 @@ func TestMCPDenyRank_StructuralFailuresOutrankExplicitDeny(t *testing.T) {
 		{mcpRuleTypeMalformedParams, 4},
 		{mcpRuleTypeDeniedMethods, 3},
 		{mcpRuleTypeDeniedTools, 3},
+		{mcpRuleTypeDeniedResources, 3},
+		{mcpRuleTypeDeniedPrompts, 3},
 		{mcpRuleTypeDeniedParams, 3},
 		{mcpRuleTypeAllowedMethods, 2},
 		{mcpRuleTypeAllowedTools, 2},

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -266,6 +266,104 @@ path "mcp/gateway/*" {
 	assert.Equal(t, mcpRuleTypeDeniedTools, res.MCPDecision.RuleType)
 }
 
+func TestMCPEval_DeniedResources_Match(t *testing.T) {
+	// resources/read with a denied_resources pattern that matches the
+	// requested URI → deny with rule_type denied_resources. Mirrors
+	// denied_tools but on the resources/read name gate.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods   = ["resources/read"]
+    denied_resources  = ["github://secrets/*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "resources/read",
+		"Mcp-Name":   "github://secrets/api-key",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, "github://secrets/*", res.MCPDecision.MatchedRule)
+	assert.Equal(t, mcpRuleTypeDeniedResources, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_DeniedPrompts_Match(t *testing.T) {
+	// prompts/get with a denied_prompts pattern that matches → deny
+	// with rule_type denied_prompts.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["prompts/get"]
+    denied_prompts  = ["sudo_*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "prompts/get",
+		"Mcp-Name":   "sudo_admin",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, "sudo_*", res.MCPDecision.MatchedRule)
+	assert.Equal(t, mcpRuleTypeDeniedPrompts, res.MCPDecision.RuleType)
+}
+
+// denied_resources alone (no allowed_resources) — a name that does
+// NOT match the deny pattern passes through the name gate.
+// Pre-Phase-5 the matcher returned (nil, allowList) for resources/read
+// so this code path didn't exist; pinning it here.
+func TestMCPEval_DeniedResources_Only_NonMatchingAllowed(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods  = ["resources/read"]
+    denied_resources = ["github://secrets/*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "resources/read",
+		"Mcp-Name":   "github://repo/readme.md", // does not match denied_resources
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+}
+
+// Deny-list precedence on resources/read: when the same name matches
+// both allow and deny lists, the deny wins per evaluateMCPSetForCall
+// step (d) (deny-list scanned before allow-list).
+func TestMCPEval_DeniedResources_BeatsAllowedResources(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods   = ["resources/read"]
+    allowed_resources = ["github://*"]
+    denied_resources  = ["github://secrets/*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", map[string]string{
+		"Mcp-Method": "resources/read",
+		"Mcp-Name":   "github://secrets/api-key",
+	})
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeDeniedResources, res.MCPDecision.RuleType)
+}
+
 func TestMCPEval_NameNotRequired_ListMethod(t *testing.T) {
 	// tools/list is name-less; allowed_tools is irrelevant for it
 	// even when configured. The method gate runs, the name gate is
@@ -765,9 +863,15 @@ func TestBuildMCPDenyDescription_PerRuleType(t *testing.T) {
 		{mcpRuleTypeAllowedResources,
 			&logical.MCPDecision{Name: "github://repo/B/x", RuleType: mcpRuleTypeAllowedResources},
 			"Resource 'github://repo/B/x' not allowed."},
+		{mcpRuleTypeDeniedResources,
+			&logical.MCPDecision{Name: "github://secrets/api-key", RuleType: mcpRuleTypeDeniedResources},
+			"Resource 'github://secrets/api-key' not allowed."},
 		{mcpRuleTypeAllowedPrompts,
 			&logical.MCPDecision{Name: "code-review", RuleType: mcpRuleTypeAllowedPrompts},
 			"Prompt 'code-review' not allowed."},
+		{mcpRuleTypeDeniedPrompts,
+			&logical.MCPDecision{Name: "sudo_admin", RuleType: mcpRuleTypeDeniedPrompts},
+			"Prompt 'sudo_admin' not allowed."},
 		{mcpRuleTypeDeniedParams,
 			&logical.MCPDecision{ParamName: "path", ParamValue: ".env", RuleType: mcpRuleTypeDeniedParams},
 			"Parameter 'path'='.env' not allowed."},

--- a/core/policy_mcp_test.go
+++ b/core/policy_mcp_test.go
@@ -21,7 +21,9 @@ path "mcp_github/gateway/*" {
     allowed_tools     = ["get_repository", "list_issues"]
     denied_tools      = ["delete_*", "force_*"]
     allowed_resources = ["github://repo/*"]
+    denied_resources  = ["github://secrets/*"]
     allowed_prompts   = ["*"]
+    denied_prompts    = ["sudo_*"]
     allowed_params = {
       path = ["docs/*", "specs/*"]
     }
@@ -44,7 +46,9 @@ path "mcp_github/gateway/*" {
 	assert.Equal(t, []string{"get_repository", "list_issues"}, r.AllowedTools)
 	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
 	assert.Equal(t, []string{"github://repo/*"}, r.AllowedResources)
+	assert.Equal(t, []string{"github://secrets/*"}, r.DeniedResources)
 	assert.Equal(t, []string{"*"}, r.AllowedPrompts)
+	assert.Equal(t, []string{"sudo_*"}, r.DeniedPrompts)
 	assert.Equal(t, map[string][]string{"path": {"docs/*", "specs/*"}}, r.AllowedParams)
 	assert.Equal(t, map[string][]string{"env": {"prod", "production"}}, r.DeniedParams)
 }
@@ -73,7 +77,9 @@ path "mcp_github/gateway/*" {
 	assert.Nil(t, r.AllowedTools)
 	assert.Nil(t, r.DeniedTools)
 	assert.Nil(t, r.AllowedResources)
+	assert.Nil(t, r.DeniedResources)
 	assert.Nil(t, r.AllowedPrompts)
+	assert.Nil(t, r.DeniedPrompts)
 	assert.Nil(t, r.AllowedParams)
 	assert.Nil(t, r.DeniedParams)
 }
@@ -239,6 +245,8 @@ func TestCBPMCPRules_Clone_DeepCopy(t *testing.T) {
 		AllowedMethods:   []string{"tools/call"},
 		DeniedTools:      []string{"delete_*"},
 		AllowedResources: []string{"github://repo/A/*"},
+		DeniedResources:  []string{"github://repo/A/secrets/*"},
+		DeniedPrompts:    []string{"sudo_*"},
 		AllowedParams: map[string][]string{
 			"path": {"docs/*", "specs/*"},
 		},
@@ -255,11 +263,15 @@ func TestCBPMCPRules_Clone_DeepCopy(t *testing.T) {
 	clone.AllowedParams["path"][0] = "mutated"
 	clone.AllowedParams["new"] = []string{"x"}
 	clone.DeniedParams["env"][0] = "mutated"
+	clone.DeniedResources[0] = "mutated"
+	clone.DeniedPrompts[0] = "mutated"
 
 	assert.Equal(t, "tools/call", original.AllowedMethods[0])
 	assert.Equal(t, "docs/*", original.AllowedParams["path"][0])
 	assert.NotContains(t, original.AllowedParams, "new")
 	assert.Equal(t, "prod", original.DeniedParams["env"][0])
+	assert.Equal(t, "github://repo/A/secrets/*", original.DeniedResources[0])
+	assert.Equal(t, "sudo_*", original.DeniedPrompts[0])
 }
 
 func TestCBPPermissions_Clone_MCPDeepCopy(t *testing.T) {

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -99,8 +99,9 @@ type MCPDecision struct {
 
 	// RuleType records which gate produced the decision. Domain:
 	//   gate-driven: allowed_methods, denied_methods, allowed_tools,
-	//     denied_tools, allowed_resources, allowed_prompts,
-	//     allowed_params, denied_params
+	//     denied_tools, allowed_resources, denied_resources,
+	//     allowed_prompts, denied_prompts, allowed_params,
+	//     denied_params
 	//   structural failure (body could not be evaluated):
 	//     missing_body, malformed_jsonrpc, duplicate_key,
 	//     oversized_body, batch_empty, malformed_params


### PR DESCRIPTION
## Summary

Phase 5: HCL symmetry for the `mcp { }` block — add `denied_resources` and `denied_prompts` alongside the existing allow-list counterparts.

- `MCPRulesHCL` and `CBPMCPRules` gain the new fields; both reuse `validateMCPPattern` (trailing-`*` only) and `canonicaliseMCPRules`.
- `nameListForMethod` exposes the new deny-lists to `resources/read` and `prompts/get`.
- `mcpDenyRuleTypeForName` extended to cover the new methods.

Additive — existing policies parse unchanged.

## Test plan

- [x] `go test ./core/...` green; new parser + evaluator test coverage for both fields

Stacked on top of #280.
