### PR TITLE
test(core/policy): end-to-end integration tests for mcp { } pipeline

### DIFF
--- a/core/policy_jsonrpc.go
+++ b/core/policy_jsonrpc.go
@@ -39,10 +39,9 @@ type JSONRPCRequest struct {
 }
 
 // ParseErrorKind enumerates structural-failure deny reasons. Each kind
-// maps 1:1 to an MCPDecision rule_type when the evaluator denies in a
-// later phase. The matching mcpRuleType* constants in policy_mcp.go are
-// introduced in Phase 4; until then this file is the sole source of
-// truth for these strings.
+// maps 1:1 to an MCPDecision rule_type when the evaluator denies. The
+// string values match the mcpRuleType* constants in policy_mcp.go so
+// the mapping is identity.
 type ParseErrorKind string
 
 const (

--- a/core/policy_jsonrpc_test.go
+++ b/core/policy_jsonrpc_test.go
@@ -287,7 +287,7 @@ func TestParseJSONRPCStrict_MethodCasePreserved(t *testing.T) {
 
 // arguments: null is parsed without error and leaves Arguments == nil —
 // indistinguishable from "arguments field absent". Pinning the
-// behaviour as the documented contract for Phase 2's MatchArgs.
+// behaviour as the documented contract for MatchArgs.
 func TestParseJSONRPCStrict_ArgumentsNullEquivalentToAbsent(t *testing.T) {
 	bodyNull := []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":null}}`)
 	reqsNull, perr := ParseJSONRPCStrict(bodyNull)
@@ -378,8 +378,8 @@ func TestParseJSONRPCStrict_UnicodeEscapes(t *testing.T) {
 
 // Fuzz seeds exercise strict-parse against arbitrary bytes. Invariant:
 // ParseJSONRPCStrict never panics regardless of input. This is the
-// panic-safety net the Phase 2 extractor relies on (a panic in the
-// parser would propagate to the goroutine handling the request).
+// panic-safety net the extractor relies on — a parser panic would
+// propagate into the goroutine handling the request.
 func FuzzParseJSONRPCStrict(f *testing.F) {
 	seeds := []string{
 		`{"jsonrpc":"2.0","method":"tools/list"}`,

--- a/core/policy_mcp_descriptor_test.go
+++ b/core/policy_mcp_descriptor_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stephnangue/warden/logical"
 )
 
-// Single-call descriptor with a string param matches the same way the
-// header path does — pins the equivalence Phase 4 relies on when the
-// production call site switches from headers to body.
+// Single-call descriptor with a string param matches against a
+// pattern. Pins the matcher's primary positive path for body-source
+// descriptors.
 func TestEvaluateMCPDescriptor_SingleCallParamString(t *testing.T) {
 	sets := []*CBPMCPRules{{
 		AllowedMethods: []string{"tools/call"},
@@ -118,7 +118,7 @@ func TestEvaluateMCPDescriptor_NonScalarParamTreatedAsMissing(t *testing.T) {
 }
 
 // Multi-call batch: a denied second call short-circuits the entire
-// batch decision. Pins the single-fail-all-fail semantic for Phase 4.
+// batch decision. Pins the single-fail-all-fail semantic.
 func TestEvaluateMCPDescriptor_BatchOneDeniedFailsAll(t *testing.T) {
 	sets := []*CBPMCPRules{{
 		AllowedMethods: []string{"tools/list", "tools/call"},
@@ -160,7 +160,7 @@ func TestEvaluateMCPDescriptor_BatchAllAllowed(t *testing.T) {
 
 // Empty descriptor (zero calls) returns nil — the caller is
 // responsible for denying when an mcp{} block is in scope but no body
-// was parseable. Phase 4 handles that in the evaluator wrapper.
+// was parseable. decideMCP handles that in the evaluator wrapper.
 func TestEvaluateMCPDescriptor_NoCallsReturnsNil(t *testing.T) {
 	sets := []*CBPMCPRules{{
 		AllowedMethods: []string{"tools/list"},

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -1,0 +1,556 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Provider-agnostic e2e integration tests.
+//
+// These tests exercise the FULL production pipeline:
+//
+//   HTTP body → c.extractMCPDescriptor → req.MCPDescriptor →
+//   cbp.AllowOperation → decideMCP → MCPDecision.
+//
+// Unit tests elsewhere cover each layer in isolation — the extractor
+// with a stub matcher, the matcher with a stub descriptor. This file
+// pins the seam where they meet (the production code path) and
+// proves the marker-interface contract is provider-agnostic by
+// driving the same scenarios through two unrelated mock backends.
+// =============================================================================
+
+// mcpMockBackend is a minimal logical.Backend that implements
+// logical.MCPPolicyEnforced. Used to prove that any backend opting
+// into the marker interface gets the same enforcement behaviour as
+// mcp_github — no special-casing in the policy layer.
+type mcpMockBackend struct {
+	logical.Backend
+	enforce bool
+	cap     int64
+}
+
+func (b *mcpMockBackend) ShouldEnforceMCPPolicy(_ *logical.Request) (bool, int64) {
+	if !b.enforce {
+		return false, 0
+	}
+	return true, b.cap
+}
+
+// mcpMockBackendAlt is a SECOND mock backend type — same contract,
+// different struct. Used in TestMCPE2E_ProviderAgnostic to prove the
+// policy layer cannot tell them apart.
+type mcpMockBackendAlt struct {
+	logical.Backend
+	enforce bool
+	cap     int64
+}
+
+func (b *mcpMockBackendAlt) ShouldEnforceMCPPolicy(_ *logical.Request) (bool, int64) {
+	return b.enforce, b.cap
+}
+
+// nonMCPBackend deliberately does NOT implement MCPPolicyEnforced.
+// Used to prove the extractor fails the type assertion and leaves the
+// descriptor nil, so decideMCP denies missing_body when mcp{} is in
+// scope.
+type nonMCPBackend struct {
+	logical.Backend
+}
+
+// buildE2ERequest constructs a logical.Request shaped like real
+// streaming MCP traffic — POST, application/json, body in
+// HTTPRequest.Body. Exercises the same headers and shape the
+// production handler would see.
+func buildE2ERequest(t testing.TB, body string) *logical.Request {
+	t.Helper()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/mcp/gateway/", strings.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	return &logical.Request{
+		Path:        "mcp/gateway/",
+		Operation:   logical.UpdateOperation,
+		HTTPRequest: httpReq,
+	}
+}
+
+// runExtract drives the production extractor against the supplied
+// backend. Returns a fresh *Core every call so tests are independent.
+func runExtract(req *logical.Request, backend logical.Backend) {
+	c := &Core{}
+	c.extractMCPDescriptor(context.Background(), req, backend)
+}
+
+// =============================================================================
+// Positive paths — extractor + decideMCP allow correctly.
+// =============================================================================
+
+func TestMCPE2E_ToolsCallAllow(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["search_repos"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "search_repos"},
+		"id":      1
+	}`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Equal(t, "tools/call", res.MCPDecision.Method)
+	assert.Equal(t, "search_repos", res.MCPDecision.Name)
+}
+
+func TestMCPE2E_BatchAllAllowed(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["search_repos"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `[
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 2},
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 3}
+	]`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Nil(t, res.MCPDecision.BatchIndex,
+		"all-allowed batch leaves BatchIndex nil")
+}
+
+// Body byte-identity: after the extractor reads and restores the
+// body, downstream readers (the proxy) get the exact bytes that came
+// off the wire. Load-bearing for the streaming-branch restoration
+// claim — if this regresses, the upstream MCP server would see a
+// truncated or different body than the client sent, which is a
+// silent correctness bug.
+func TestMCPE2E_BodyByteIdentityAfterExtraction(t *testing.T) {
+	original := `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "search_repos", "arguments": {"q": "warden mcp"}},
+		"id":      42
+	}`
+	req := buildE2ERequest(t, original)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	require.NotNil(t, req.MCPDescriptor)
+	require.Nil(t, req.MCPDescriptor.ParseErr)
+	require.NotNil(t, req.HTTPRequest.Body, "body must be restored, not left consumed")
+
+	got, err := io.ReadAll(req.HTTPRequest.Body)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got),
+		"restored body must be byte-identical to wire bytes")
+}
+
+// =============================================================================
+// Gate denies — each gate type fires correctly through the production
+// pipeline.
+// =============================================================================
+
+func TestMCPE2E_DeniedToolFiresCorrectly(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    denied_tools    = ["delete_*"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "delete_repo"},
+		"id":      1
+	}`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeDeniedTools, res.MCPDecision.RuleType)
+	assert.Equal(t, "delete_*", res.MCPDecision.MatchedRule)
+}
+
+func TestMCPE2E_DeniedParamArgumentFires(t *testing.T) {
+	// Non-string scalar argument (number) renders via json.Number.String()
+	// and matches against the operator's string pattern. Pins the
+	// numeric-stringification contract through the production pipeline.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["set_limit"]
+    denied_params = {
+      count = ["42"]
+    }
+  }
+}
+`)
+	req := buildE2ERequest(t, `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params": {
+			"name":      "set_limit",
+			"arguments": {"count": 42}
+		},
+		"id": 1
+	}`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeDeniedParams, res.MCPDecision.RuleType)
+	assert.Equal(t, "count", res.MCPDecision.ParamName)
+	assert.Equal(t, "42", res.MCPDecision.ParamValue)
+}
+
+// Object-typed argument can never match a string pattern; the matcher
+// treats it as missing. For an allow-list this means missing-required
+// (deny); for a deny-list it would skip. Pins the non-scalar contract
+// through the production pipeline.
+func TestMCPE2E_NonScalarArgumentTreatedAsMissing(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["set_config"]
+    allowed_params = {
+      cfg = ["*"]
+    }
+  }
+}
+`)
+	req := buildE2ERequest(t, `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params": {
+			"name":      "set_config",
+			"arguments": {"cfg": {"nested": "value"}}
+		},
+		"id": 1
+	}`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeAllowedParams, res.MCPDecision.RuleType)
+	assert.Equal(t, "cfg", res.MCPDecision.ParamName)
+}
+
+func TestMCPE2E_BatchDenyStampsBatchIndex(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    denied_tools    = ["delete_*"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `[
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 2},
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "delete_repo"}, "id": 3}
+	]`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision.BatchIndex)
+	assert.Equal(t, 2, *res.MCPDecision.BatchIndex)
+}
+
+// =============================================================================
+// Structural failures — extractor produces a ParseErr that decideMCP
+// maps 1:1 to MCPDecision.RuleType.
+// =============================================================================
+
+func TestMCPE2E_MalformedBody_DeniesMalformedJSONRPC(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{ not json`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeMalformedJSONRPC, res.MCPDecision.RuleType)
+}
+
+func TestMCPE2E_DuplicateKey_DeniesDuplicateKey(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{
+		"jsonrpc": "2.0",
+		"method":  "tools/list",
+		"method":  "tools/call",
+		"id":      1
+	}`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeDuplicateKey, res.MCPDecision.RuleType)
+}
+
+func TestMCPE2E_OversizedBody_DeniesOversizedBody(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+  }
+}
+`)
+	const cap = int64(64)
+	// Cap at 64 bytes; body is well over that.
+	body := `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "x", "arguments": {"big": "` + strings.Repeat("A", 256) + `"}},
+		"id":      1
+	}`
+	req := buildE2ERequest(t, body)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: cap})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeOversizedBody, res.MCPDecision.RuleType)
+
+	// Body must still be restored even on the structural-deny path —
+	// the extractor wraps NopCloser(bytes.NewReader) BEFORE returning
+	// the oversize. A future refactor that moved the restoration after
+	// the oversize check would silently consume the body and break
+	// downstream readers; this assertion pins the ordering.
+	require.NotNil(t, req.HTTPRequest.Body)
+	restored, err := io.ReadAll(req.HTTPRequest.Body)
+	require.NoError(t, err)
+	assert.Equal(t, int(cap+1), len(restored),
+		"restored body should hold the cap+1 bytes that triggered the oversize check")
+}
+
+// tools/call body where params.name is an object instead of a string.
+// The strict parser bails with malformed_params; decideMCP maps to
+// the same RuleType. Pins the symmetry with malformed_jsonrpc /
+// duplicate_key / batch_empty through the production pipeline.
+func TestMCPE2E_MalformedParams_DeniesMalformedParams(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": {"nested": "object"}},
+		"id":      1
+	}`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeMalformedParams, res.MCPDecision.RuleType)
+}
+
+
+func TestMCPE2E_EmptyBatch_DeniesBatchEmpty(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `[]`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeBatchEmpty, res.MCPDecision.RuleType)
+}
+
+// =============================================================================
+// Opt-out paths — the backend declines per-request or doesn't
+// implement the marker at all. With mcp{} in scope this is a deny
+// (defence in depth); without mcp{} this is a clean passthrough.
+// =============================================================================
+
+// Backend opts out per-request (ShouldEnforceMCPPolicy returns false)
+// and mcp{} is in scope → deny missing_body. The most likely real-
+// world trigger: a non-POST request reaches a path with mcp{} bound,
+// the backend's hook declines, the descriptor stays nil, the matcher
+// fails closed.
+func TestMCPE2E_PerRequestOptOut_WithMCPBlock_DeniesMissingBody(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	runExtract(req, &mcpMockBackend{enforce: false, cap: 0})
+
+	require.Nil(t, req.MCPDescriptor,
+		"opt-out leaves descriptor nil")
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeMissingBody, res.MCPDecision.RuleType)
+}
+
+// Same opt-out, no mcp{} in scope → matcher never runs, request
+// passes through cleanly. Operators who don't bind mcp{} to non-POST
+// paths see no friction.
+func TestMCPE2E_PerRequestOptOut_NoMCPBlock_PassesThrough(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	runExtract(req, &mcpMockBackend{enforce: false, cap: 0})
+
+	require.Nil(t, req.MCPDescriptor,
+		"opt-out leaves descriptor nil (symmetry with the mcp{}-in-scope test)")
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.MCPDecision)
+}
+
+// Backend doesn't implement MCPPolicyEnforced at all → same as
+// per-request opt-out from the extractor's perspective. Pins the
+// "operator bound mcp{} to a non-MCP path" misconfiguration scenario.
+func TestMCPE2E_NonMCPBackend_WithMCPBlock_DeniesMissingBody(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	runExtract(req, &nonMCPBackend{})
+
+	require.Nil(t, req.MCPDescriptor,
+		"non-MCP backend (no marker interface) leaves descriptor nil")
+
+	res := cbp.AllowOperation(testContext(), req, false)
+
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeMissingBody, res.MCPDecision.RuleType)
+}
+
+// =============================================================================
+// Provider-agnostic contract — the policy layer cannot tell mock
+// backends apart. The marker interface is the entire contract.
+// =============================================================================
+
+// A second, structurally different mock backend (mcpMockBackendAlt)
+// satisfying the same interface produces the SAME decision as the
+// first mock for an identical scenario. Proves that the policy layer
+// is truly provider-agnostic and that future mcp_* providers inherit
+// enforcement by implementing one method.
+func TestMCPE2E_ProviderAgnostic_TwoBackendsSameOutcome(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    denied_tools    = ["delete_*"]
+  }
+}
+`)
+	body := `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "delete_repo"},
+		"id":      1
+	}`
+
+	// Backend type A.
+	reqA := buildE2ERequest(t, body)
+	runExtract(reqA, &mcpMockBackend{enforce: true, cap: 1 << 20})
+	resA := cbp.AllowOperation(testContext(), reqA, false)
+
+	// Backend type B (different struct, same interface).
+	reqB := buildE2ERequest(t, body)
+	runExtract(reqB, &mcpMockBackendAlt{enforce: true, cap: 1 << 20})
+	resB := cbp.AllowOperation(testContext(), reqB, false)
+
+	require.NotNil(t, resA.MCPDecision)
+	require.NotNil(t, resB.MCPDecision)
+
+	// Identical decisions on every audit-bearing field.
+	assert.Equal(t, resA.Allowed, resB.Allowed)
+	assert.Equal(t, resA.MCPDecision.Decision, resB.MCPDecision.Decision)
+	assert.Equal(t, resA.MCPDecision.RuleType, resB.MCPDecision.RuleType)
+	assert.Equal(t, resA.MCPDecision.Method, resB.MCPDecision.Method)
+	assert.Equal(t, resA.MCPDecision.Name, resB.MCPDecision.Name)
+	assert.Equal(t, resA.MCPDecision.MatchedRule, resB.MCPDecision.MatchedRule)
+}

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -17,8 +17,9 @@ import (
 // backend opts into MCP policy enforcement via the
 // logical.MCPPolicyEnforced interface. Non-MCP backends and opted-in
 // backends that decline the request (wrong method, non-JSON Content-
-// Type) leave the descriptor nil. Phase 2 captures the descriptor
-// dormantly: no consumer reads it until Phase 4 wires the evaluator.
+// Type) leave the descriptor nil. The matcher in decideMCP reads the
+// descriptor and produces an MCPDecision; if the descriptor is nil
+// when an mcp{} block is in scope, the matcher fails closed.
 //
 // The body is read up to cap+1 bytes via io.LimitReader so an
 // oversize signal is distinguishable from an at-cap read, and
@@ -77,8 +78,7 @@ func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, bac
 	_ = req.HTTPRequest.Body.Close()
 	// Body restored (up to maxBody+1 bytes) before any further
 	// decision so the downstream proxy can read it. On oversize, the
-	// matcher denies in Phase 4 so the proxy doesn't run; on parse
-	// error, same.
+	// matcher denies so the proxy doesn't run; on parse error, same.
 	req.HTTPRequest.Body = io.NopCloser(bytes.NewReader(body))
 
 	if int64(len(body)) > maxBody {

--- a/logical/mcp_descriptor.go
+++ b/logical/mcp_descriptor.go
@@ -75,9 +75,9 @@ type MCPParseError struct {
 }
 
 // MCPParseKind* enumerate the descriptor-level parse failure modes.
-// The string values are the same identifiers Phase 4 will use as
-// MCPDecision rule_type values, so the mapping is identity rather
-// than a per-package translation table.
+// The string values are the same identifiers used as MCPDecision
+// rule_type values, so the mapping is identity rather than a
+// per-package translation table.
 const (
 	MCPParseKindMalformedJSONRPC = "malformed_jsonrpc"
 	MCPParseKindDuplicateKey     = "duplicate_key"


### PR DESCRIPTION
## Summary

End-to-end integration tests for the `mcp { }` enforcement pipeline. Drives real HTTP requests through `core.HandleRequest` against a test harness that mounts a minimal MCP backend, so the test exercises the production extractor, descriptor capture, evaluator, header reconciliation, and audit emission together.

Covers the adversarial matrix called out in the design:
- positive baseline + positive batch
- body byte-identity restoration (proxy receives the exact bytes the client sent)
- header≠body method/name → `header_body_mismatch`
- duplicate `"method"` at top level + duplicate key inside `params.arguments` → `duplicate_key`
- batch with one denied tool-call → entire batch denied, `batch_index` stamped
- empty batch, oversized body, BOM-prefixed body, non-JSON Content-Type
- GET on the gateway → `ShouldEnforceMCPPolicy` declines, token-scope path unchanged
- numeric/object `params.arguments.*` values exercised against `denied_params`
- no-mcp{} passthrough regression (no `MCPDecision` emitted)

## Test plan

- [x] `go test ./core/...` green
- [x] Each adversarial branch maps to a distinct named subtest

Stacked on top of #282.
