### PR TITLE
docs(mcp_github): rewrite mcp { } policy section as body-authoritative

### DIFF
--- a/provider/mcp_github/README.md
+++ b/provider/mcp_github/README.md
@@ -159,8 +159,6 @@ Enforcement is **body-authoritative**. When a policy in scope contains an `mcp {
 | `batch_empty` | JSON-RPC batch is `[]` |
 | `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
 
-Body parsing runs only for POSTs with `Content-Type: application/json`. Policies without an `mcp { }` block in scope skip the strict parser entirely — no body buffering happens on those paths.
-
 All examples below use `capabilities = ["update"]`. MCP traffic is HTTP POST and Warden maps POST to the `update` operation.
 
 The simplest policy grants the gateway and leans on PAT scopes for everything:

--- a/provider/mcp_github/README.md
+++ b/provider/mcp_github/README.md
@@ -143,7 +143,7 @@ warden cred spec read github-ops
 
 MCP traffic passes through two complementary layers of authorization. The minted GitHub token is the security boundary — its scopes bound what the agent can actually do at GitHub regardless of what Warden lets through. On top of that, Warden's CBP policies support an `mcp { }` block for governance-style restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs, prompt names, and selected tool arguments.
 
-Enforcement is **body-authoritative**. When a policy in scope contains an `mcp { }` block, Warden strict-parses the JSON-RPC request body and matches against the parsed body, never against client-supplied request headers. The parser fails closed on any structural problem and the matcher denies with a specific `rule_type`:
+Enforcement is **body-authoritative**. When a policy in scope contains an `mcp { }` block, Warden strict-parses the JSON-RPC request body and matches against the parsed body. The parser fails closed on any structural problem and the matcher denies with a specific `rule_type`:
 
 | `rule_type` | Trigger |
 |---|---|

--- a/provider/mcp_github/README.md
+++ b/provider/mcp_github/README.md
@@ -141,13 +141,27 @@ warden cred spec read github-ops
 
 ## Step 4: Create a Policy
 
-MCP traffic passes through two complementary layers of authorization. The minted GitHub token is the security boundary — its scopes bound what the agent can actually do at GitHub regardless of what Warden lets through. On top of that, Warden's CBP policies support an `mcp { }` block for governance-style restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs, prompt names, and (where the upstream tool author opted in) selected tool arguments. Enforcement is header-based; the allow path does no request-body parsing.
+MCP traffic passes through two complementary layers of authorization. The minted GitHub token is the security boundary — its scopes bound what the agent can actually do at GitHub regardless of what Warden lets through. On top of that, Warden's CBP policies support an `mcp { }` block for governance-style restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs, prompt names, and selected tool arguments.
 
-> **Important — MCP draft 2026-07-28 dependency.** The `mcp { }` block relies on the next MCP protocol revision (draft dated 2026-07-28), which mirrors the JSON-RPC method and selected fields into HTTP headers so intermediaries can inspect without parsing the body. Until your MCP client adopts the draft, those headers are absent — and a policy with an `mcp { }` block bound to its path will **deny every request** from a pre-draft client. For mixed fleets, stage the rollout: start with the gateway-only policy below, verify clients send the new headers, then promote roles to policies with the `mcp { }` block. Policies without an `mcp { }` block continue to behave exactly as today.
->
-> Tool-argument constraints (`allowed_params` / `denied_params`) carry an additional dependency: the upstream tool author has to opt into the per-argument header mirror via `x-mcp-header` in the tool's input schema. Until GitHub's MCP server ships that opt-in, `allowed_params` rules silently no-op for those tools and the PAT scopes remain the only argument-level guard.
+Enforcement is **body-authoritative**. When a policy in scope contains an `mcp { }` block, Warden strict-parses the JSON-RPC request body and matches against the parsed body, never against client-supplied request headers. The parser fails closed on any structural problem and the matcher denies with a specific `rule_type`:
 
-All examples below use `capabilities = ["update"]`. MCP traffic is HTTP POST and Warden maps POST to the `update` operation; the 2026-07-28 draft removed the GET stream endpoint entirely, so no other capabilities are needed.
+| `rule_type` | Trigger |
+|---|---|
+| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
+| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
+| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
+| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
+| `denied_params` / `allowed_params` | A `tools/call` argument (`params.arguments.<key>`) matches a deny pattern, or fails an allow-list pattern (or is missing when required) |
+| `missing_body` | Request body absent, or routed to a backend that does not opt into MCP enforcement (typically a non-POST request — operators should not bind `mcp { }` to paths that receive non-POST traffic) |
+| `malformed_jsonrpc` | Body is not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, etc.) |
+| `duplicate_key` | Duplicate object key detected anywhere in the body — Warden rejects ambiguity that Go's standard JSON parser silently last-wins-resolves |
+| `oversized_body` | Body exceeds the mount's `max_body_size` |
+| `batch_empty` | JSON-RPC batch is `[]` |
+| `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
+
+Body parsing runs only for POSTs with `Content-Type: application/json`. Policies without an `mcp { }` block in scope skip the strict parser entirely — no body buffering happens on those paths.
+
+All examples below use `capabilities = ["update"]`. MCP traffic is HTTP POST and Warden maps POST to the `update` operation.
 
 The simplest policy grants the gateway and leans on PAT scopes for everything:
 
@@ -159,7 +173,7 @@ path "mcp_github/role/+/gateway*" {
 EOF
 ```
 
-A policy that restricts the agent to a vetted set of GitHub tools (requires draft-2026-07-28 clients — see disclaimer above):
+A policy that restricts the agent to a vetted set of GitHub tools:
 
 ```bash
 warden policy write mcp-github-readonly - <<EOF
@@ -181,6 +195,22 @@ path "mcp_github/role/+/gateway*" {
   capabilities = ["update"]
   mcp {
     denied_tools = ["delete_*", "force_*", "merge_pull_request"]
+  }
+}
+EOF
+```
+
+Argument-level gates restrict the *values* passed to `tools/call`. Keys in `denied_params` / `allowed_params` match against `params.arguments.<key>` from the parsed body. The policy below permits `create_or_update_file` but never on protected branches:
+
+```bash
+warden policy write mcp-github-no-protected-branches - <<EOF
+path "mcp_github/role/+/gateway*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    denied_params = {
+      branch = ["main", "master", "production", "release/*"]
+    }
   }
 }
 EOF

--- a/provider/mcp_github/skill.md
+++ b/provider/mcp_github/skill.md
@@ -133,15 +133,20 @@ alone doesn't tell you which PAT or scope set the mount fronts.
   scopes covering the intended toolset; agents that hit scope errors
   should ask the operator to widen the binding, not request a different
   Warden role unless one exists.
-- **Warden policy can gate tools too** (requires MCP draft 2026-07-28
-  on the client side). Operators may bind a policy with an `mcp { }`
-  block that restricts which methods, tool names, resource URIs, or
-  prompt names the role can call. A deny shows up as HTTP 403 with an
-  RFC 6750 `WWW-Authenticate: Bearer error="insufficient_permissions",
+- **Warden policy can gate tools too — body-authoritative.** Operators
+  may bind a policy with an `mcp { }` block that restricts JSON-RPC
+  methods, tool names, resource URIs, prompt names, and `tools/call`
+  arguments. Warden strict-parses the JSON-RPC request body and
+  matches against the parsed body — no client-side opt-in or header
+  mirroring is required. A deny shows up as HTTP 403 with an RFC 6750
+  `WWW-Authenticate: Bearer error="insufficient_permissions",
   error_description="..."` header and a small JSON body of the same
   shape; the description names the offending method/tool/parameter.
   This is independent of PAT scope errors — read the `error_description`
-  to tell the two apart. See the README's "Create a Policy" section.
+  to tell the two apart. The parser also fails closed on structural
+  problems (malformed JSON-RPC, duplicate keys, oversized body, etc.)
+  with a specific `rule_type` in the audit log. See the README's
+  "Create a Policy" section for the full rule_type table.
 - **Streamable HTTP / SSE flows through transparently.** Send
   `Accept: application/json, text/event-stream` and the server's
   choice of framing comes back unchanged. The `Mcp-Session-Id`


### PR DESCRIPTION
## Summary

Docs-only. Rewrites the `mcp_github` operator README around body-authoritative enforcement (the actual production semantic after #280), and trims claims that no longer hold.

Three commits, scoped:
1. `d9e19ae` — rewrite the `mcp { }` policy section as body-authoritative; show all five example policy shapes (allow-list, deny-list, argument gates, condition composition, simple grant) against `mcp_github/role/+/gateway*`.
2. `8a54ade` — tighten phrasing: clarify that headers are diagnostic-only, that PAT scopes remain the primary boundary, and that the `mcp { }` gate fails closed.
3. `2294bdd` — drop an incorrect claim that the body-parsing gate would short-circuit on a missing `Content-Type` (the extractor's per-backend `ShouldEnforceMCPPolicy` does that, not the parser).

No code changes; no behaviour changes. Stacked on top of #283.

## Test plan

- [ ] Render the README on the branch and confirm the policy section reads as intended
