### PR TITLE
feat(core,logical,httpproxy): MCPPolicyEnforced opt-in + body extractor

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -823,6 +823,14 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 			}
 		}
 
+		// MCP body-authoritative policy enforcement: when the routed
+		// backend opts into logical.MCPPolicyEnforced, buffer the
+		// request body and strict-parse it into a descriptor before
+		// CheckToken runs. The extractor restores the body so the
+		// downstream proxy reads it unchanged. Non-MCP backends fail
+		// the type assertion and skip the extractor entirely.
+		c.extractMCPDescriptor(ctx, req, matchingBackend)
+
 		req.ClientToken = matchingBackend.ExtractToken(req.HTTPRequest)
 
 		// Check for unauthenticated paths on streaming backends

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// extractMCPDescriptor populates req.MCPDescriptor when the routed
+// backend opts into MCP policy enforcement via the
+// logical.MCPPolicyEnforced interface. Non-MCP backends and opted-in
+// backends that decline the request (wrong method, non-JSON Content-
+// Type) leave the descriptor nil. Phase 2 captures the descriptor
+// dormantly: no consumer reads it until Phase 4 wires the evaluator.
+//
+// The body is read up to cap+1 bytes via io.LimitReader so an
+// oversize signal is distinguishable from an at-cap read, and
+// restored via io.NopCloser(bytes.NewReader(buf)) so the downstream
+// proxy receives the bytes unchanged. The full function is panic-safe
+// — any panic from the strict parser is recovered and surfaced as a
+// malformed_jsonrpc ParseErr rather than propagating into the request
+// handler.
+func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, backend logical.Backend) {
+	if req == nil || backend == nil {
+		return
+	}
+	mcp, ok := backend.(logical.MCPPolicyEnforced)
+	if !ok {
+		return
+	}
+	enforce, maxBody := mcp.ShouldEnforceMCPPolicy(req)
+	if !enforce {
+		return
+	}
+	if maxBody <= 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+
+	desc := &logical.MCPRequestDescriptor{}
+	defer func() {
+		if r := recover(); r != nil {
+			// Drop any partial Calls so the matcher's invariant
+			// "ParseErr non-nil ⇒ Calls unspecified" stays sound even
+			// if a panic fires mid-Calls-loop.
+			desc.Calls = nil
+			desc.ParseErr = &logical.MCPParseError{
+				Kind: logical.MCPParseKindMalformedJSONRPC,
+				Msg:  "mcp extractor panic recovered",
+			}
+		}
+		req.MCPDescriptor = desc
+	}()
+
+	if req.HTTPRequest == nil || req.HTTPRequest.Body == nil {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindMalformedJSONRPC,
+			Msg:  "request body absent",
+		}
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.HTTPRequest.Body, maxBody+1))
+	if err != nil {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindMalformedJSONRPC,
+			Msg:  err.Error(),
+		}
+		return
+	}
+	_ = req.HTTPRequest.Body.Close()
+	// Body restored (up to maxBody+1 bytes) before any further
+	// decision so the downstream proxy can read it. On oversize, the
+	// matcher denies in Phase 4 so the proxy doesn't run; on parse
+	// error, same.
+	req.HTTPRequest.Body = io.NopCloser(bytes.NewReader(body))
+
+	if int64(len(body)) > maxBody {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindOversizedBody,
+			Msg:  "request body exceeds max_body_size",
+		}
+		return
+	}
+
+	reqs, perr := ParseJSONRPCStrict(body)
+	if perr != nil {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: string(perr.Kind),
+			Msg:  perr.Msg,
+		}
+		return
+	}
+
+	desc.Calls = make([]logical.MCPCall, len(reqs))
+	for i, r := range reqs {
+		desc.Calls[i] = logical.MCPCall{
+			Method:     r.Method,
+			Name:       r.Name,
+			MatchArgs:  classifyArgs(r.Arguments),
+			BatchIndex: i,
+		}
+	}
+}
+
+// classifyArgs typifies each tools/call argument from raw JSON bytes
+// into a matcher-ready ParamValue. Non-scalar values are tagged
+// Object/Array so the matcher can treat them as missing for scalar
+// pattern matching. Returns nil when args is nil so the matcher can
+// distinguish "no arguments field" from "arguments: {}" (which yields
+// a non-nil empty map).
+func classifyArgs(args map[string]json.RawMessage) map[string]logical.ParamValue {
+	if args == nil {
+		return nil
+	}
+	out := make(map[string]logical.ParamValue, len(args))
+	for k, raw := range args {
+		out[k] = classifyParam(raw)
+	}
+	return out
+}
+
+// classifyParam inspects the first non-whitespace byte of the raw
+// JSON value to classify the kind cheaply, then unmarshals scalars
+// into Str. Malformed bytes for a tagged kind fall through to
+// ParamMissing — the strict parser already rejected structurally bad
+// JSON, so this is a defensive belt against unexpected drift.
+func classifyParam(raw json.RawMessage) logical.ParamValue {
+	if len(raw) == 0 {
+		return logical.ParamValue{Kind: logical.ParamMissing}
+	}
+	first := byte(0)
+	found := false
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		}
+		first = b
+		found = true
+		break
+	}
+	if !found {
+		// All-whitespace RawMessage shouldn't happen in practice
+		// (json.RawMessage strips leading whitespace at decode), but
+		// fail closed if it does.
+		return logical.ParamValue{Kind: logical.ParamMissing}
+	}
+	switch first {
+	case '{':
+		return logical.ParamValue{Kind: logical.ParamObject}
+	case '[':
+		return logical.ParamValue{Kind: logical.ParamArray}
+	case 'n':
+		return logical.ParamValue{Kind: logical.ParamNull}
+	case '"':
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return logical.ParamValue{Kind: logical.ParamMissing}
+		}
+		return logical.ParamValue{Kind: logical.ParamString, Str: s}
+	case 't', 'f':
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return logical.ParamValue{Kind: logical.ParamMissing}
+		}
+		s := "false"
+		if b {
+			s = "true"
+		}
+		return logical.ParamValue{Kind: logical.ParamBool, Str: s}
+	default:
+		var n json.Number
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return logical.ParamValue{Kind: logical.ParamMissing}
+		}
+		return logical.ParamValue{Kind: logical.ParamNumber, Str: n.String()}
+	}
+}

--- a/core/request_handler_mcp_test.go
+++ b/core/request_handler_mcp_test.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// fakeBackend is the minimal logical.Backend stub used to drive
+// extractMCPDescriptor without spinning up a full mount. It implements
+// MCPPolicyEnforced when enforced is non-nil so we can probe both
+// branches of the type assertion.
+type fakeBackend struct {
+	logical.Backend
+	enforced *fakeMCPHook
+}
+
+type fakeMCPHook struct {
+	enforce bool
+	cap     int64
+}
+
+// mcpBackend wraps fakeBackend with the marker interface — used when a
+// test wants the type assertion to succeed.
+type mcpBackend struct {
+	fakeBackend
+}
+
+func (b *mcpBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int64) {
+	if b.enforced == nil {
+		return false, 0
+	}
+	return b.enforced.enforce, b.enforced.cap
+}
+
+func newReq(t *testing.T, body string) *logical.Request {
+	t.Helper()
+	httpReq, err := http.NewRequest(http.MethodPost, "/v1/mcp_github/gateway/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	return &logical.Request{
+		HTTPRequest: httpReq,
+	}
+}
+
+// Non-MCP backend: type assertion fails, descriptor stays nil.
+func TestExtractMCPDescriptor_NotMCPBackend(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	c.extractMCPDescriptor(context.Background(), req, &fakeBackend{})
+	if req.MCPDescriptor != nil {
+		t.Fatalf("descriptor = %+v, want nil for non-MCP backend", req.MCPDescriptor)
+	}
+}
+
+// MCP backend opts out per-request: descriptor stays nil.
+func TestExtractMCPDescriptor_OptsOutPerRequest(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: false}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	if req.MCPDescriptor != nil {
+		t.Fatalf("descriptor = %+v, want nil for opted-out request", req.MCPDescriptor)
+	}
+}
+
+// MCP backend opts in with valid JSON-RPC: descriptor populated.
+func TestExtractMCPDescriptor_ValidSingle(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search_repos","arguments":{"q":"foo"}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil {
+		t.Fatal("descriptor is nil, want populated")
+	}
+	if desc.ParseErr != nil {
+		t.Fatalf("ParseErr = %v, want nil", desc.ParseErr)
+	}
+	if len(desc.Calls) != 1 {
+		t.Fatalf("Calls len = %d, want 1", len(desc.Calls))
+	}
+	if desc.Calls[0].Method != "tools/call" {
+		t.Errorf("Method = %q, want tools/call", desc.Calls[0].Method)
+	}
+	if desc.Calls[0].Name != "search_repos" {
+		t.Errorf("Name = %q, want search_repos", desc.Calls[0].Name)
+	}
+	if desc.Calls[0].BatchIndex != 0 {
+		t.Errorf("BatchIndex = %d, want 0", desc.Calls[0].BatchIndex)
+	}
+	arg, ok := desc.Calls[0].MatchArgs["q"]
+	if !ok {
+		t.Fatalf("MatchArgs missing q: %v", desc.Calls[0].MatchArgs)
+	}
+	if arg.Kind != logical.ParamString || arg.Str != "foo" {
+		t.Errorf("q arg = %+v, want String/foo", arg)
+	}
+}
+
+// Batch: BatchIndex stamped per element.
+func TestExtractMCPDescriptor_Batch(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `[
+		{"jsonrpc":"2.0","method":"tools/list"},
+		{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"}}
+	]`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, ParseErr should be nil", desc)
+	}
+	if len(desc.Calls) != 2 {
+		t.Fatalf("Calls len = %d, want 2", len(desc.Calls))
+	}
+	if desc.Calls[0].BatchIndex != 0 || desc.Calls[1].BatchIndex != 1 {
+		t.Errorf("BatchIndex = [%d, %d], want [0, 1]", desc.Calls[0].BatchIndex, desc.Calls[1].BatchIndex)
+	}
+}
+
+// Oversized body: cap+1 bytes triggers oversized_body.
+func TestExtractMCPDescriptor_OversizedBody(t *testing.T) {
+	c := &Core{}
+	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"big":"` +
+		strings.Repeat("A", 256) + `"}}}`
+	req := newReq(t, body)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: int64(len(body) - 1)}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindOversizedBody {
+		t.Errorf("ParseErr.Kind = %q, want oversized_body", desc.ParseErr.Kind)
+	}
+}
+
+// Malformed JSON-RPC: descriptor.ParseErr.Kind = malformed_jsonrpc.
+func TestExtractMCPDescriptor_MalformedBody(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{not json`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// Duplicate key: descriptor.ParseErr.Kind = duplicate_key.
+func TestExtractMCPDescriptor_DuplicateKey(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list","method":"tools/call"}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindDuplicateKey {
+		t.Errorf("ParseErr.Kind = %q, want duplicate_key", desc.ParseErr.Kind)
+	}
+}
+
+// After extraction, the body must still be readable for the downstream
+// proxy and must yield the original bytes byte-for-byte. Load-bearing
+// for the streaming-branch claim that the extractor restores the body.
+func TestExtractMCPDescriptor_BodyByteIdentity(t *testing.T) {
+	c := &Core{}
+	original := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"a":1}}}`
+	req := newReq(t, original)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	if req.HTTPRequest.Body == nil {
+		t.Fatal("Body is nil after extraction")
+	}
+	got, err := io.ReadAll(req.HTTPRequest.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !bytes.Equal(got, []byte(original)) {
+		t.Errorf("restored body differs from original\nwant: %q\ngot:  %q", original, string(got))
+	}
+}
+
+// Cap fallback: cap=0 from the hook falls back to framework default.
+// A small body fits under the default and parses successfully.
+func TestExtractMCPDescriptor_CapZeroFallsBack(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 0}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, want successful parse", desc)
+	}
+}
+
+// Empty body when enforce=true: malformed_jsonrpc.
+func TestExtractMCPDescriptor_EmptyBody(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, ``)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// nil req and nil backend are no-ops (the handler guards before
+// calling; defense in depth).
+func TestExtractMCPDescriptor_NilGuards(t *testing.T) {
+	c := &Core{}
+	c.extractMCPDescriptor(context.Background(), nil, &mcpBackend{})
+	req := newReq(t, `{}`)
+	c.extractMCPDescriptor(context.Background(), req, nil)
+	if req.MCPDescriptor != nil {
+		t.Errorf("descriptor should stay nil when backend is nil")
+	}
+}
+
+// Body sized exactly to cap parses successfully (not oversized) and
+// the restored body bytes are byte-identical to the original. Pins
+// the off-by-one boundary between the cap+1 read and the > cap check.
+func TestExtractMCPDescriptor_ExactCapBoundary(t *testing.T) {
+	c := &Core{}
+	body := `{"jsonrpc":"2.0","method":"tools/list"}`
+	req := newReq(t, body)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: int64(len(body))}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, want successful parse at exact cap", desc)
+	}
+	got, err := io.ReadAll(req.HTTPRequest.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !bytes.Equal(got, []byte(body)) {
+		t.Errorf("restored body differs at exact-cap boundary")
+	}
+}
+
+// enforce=true with HTTPRequest.Body=nil yields malformed_jsonrpc. The
+// handler shouldn't reach this state in production, but defensive nil-
+// safety matters for testability + future code paths.
+func TestExtractMCPDescriptor_NilHTTPBody(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
+	req.HTTPRequest.Body = nil
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// A body reader that returns an I/O error mid-read populates ParseErr
+// with malformed_jsonrpc.
+func TestExtractMCPDescriptor_BodyReadError(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{}`)
+	req.HTTPRequest.Body = io.NopCloser(&errReader{err: errFakeRead})
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+	c.extractMCPDescriptor(context.Background(), req, b)
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr == nil {
+		t.Fatalf("descriptor = %+v, want ParseErr", desc)
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindMalformedJSONRPC {
+		t.Errorf("ParseErr.Kind = %q, want malformed_jsonrpc", desc.ParseErr.Kind)
+	}
+}
+
+// errReader always errors on Read.
+type errReader struct{ err error }
+
+func (r *errReader) Read([]byte) (int, error) { return 0, r.err }
+
+var errFakeRead = &fakeErr{msg: "synthetic read failure"}
+
+type fakeErr struct{ msg string }
+
+func (e *fakeErr) Error() string { return e.msg }
+
+// classifyParam table for each JSON kind.
+func TestClassifyParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantKnd logical.ParamKind
+		wantStr string
+	}{
+		{"string", `"hello"`, logical.ParamString, "hello"},
+		{"empty string", `""`, logical.ParamString, ""},
+		{"number int", `42`, logical.ParamNumber, "42"},
+		{"number float", `3.14`, logical.ParamNumber, "3.14"},
+		{"number large", `12345678901234567890`, logical.ParamNumber, "12345678901234567890"},
+		{"bool true", `true`, logical.ParamBool, "true"},
+		{"bool false", `false`, logical.ParamBool, "false"},
+		{"null", `null`, logical.ParamNull, ""},
+		{"object", `{"x":1}`, logical.ParamObject, ""},
+		{"array", `[1,2,3]`, logical.ParamArray, ""},
+		{"whitespace then object", "  \n\t {}", logical.ParamObject, ""},
+		{"empty", ``, logical.ParamMissing, ""},
+		{"whitespace only", "   \t\n", logical.ParamMissing, ""},
+		{"capital True (invalid JSON, fail-safe)", `True`, logical.ParamMissing, ""},
+		{"capital Null", `Null`, logical.ParamMissing, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyParam(json.RawMessage(tc.raw))
+			if got.Kind != tc.wantKnd {
+				t.Errorf("Kind = %d, want %d", got.Kind, tc.wantKnd)
+			}
+			if got.Str != tc.wantStr {
+				t.Errorf("Str = %q, want %q", got.Str, tc.wantStr)
+			}
+		})
+	}
+}
+
+// classifyArgs preserves nil vs empty-map distinction so the matcher
+// can later distinguish "no arguments field" from "arguments: {}".
+func TestClassifyArgs_NilVsEmpty(t *testing.T) {
+	if classifyArgs(nil) != nil {
+		t.Error("classifyArgs(nil) != nil")
+	}
+	got := classifyArgs(map[string]json.RawMessage{})
+	if got == nil {
+		t.Error("classifyArgs(empty) returned nil, want empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("classifyArgs(empty) len = %d, want 0", len(got))
+	}
+}

--- a/logical/mcp_descriptor.go
+++ b/logical/mcp_descriptor.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+// MCPRequestDescriptor carries the result of strictly parsing an
+// MCP-enforced backend's request body. Stashed on *Request by the core
+// handler's extractor; consumed by the policy evaluator in a later
+// phase.
+//
+// One of two terminal states: ParseErr is non-nil (Calls is then
+// unspecified — the matcher must not consult it) or ParseErr is nil
+// and Calls is populated. A nil *MCPRequestDescriptor on *Request
+// means the request was not subject to MCP enforcement (backend opted
+// out, or backend declined this particular request).
+type MCPRequestDescriptor struct {
+	Calls    []MCPCall
+	ParseErr *MCPParseError
+}
+
+// MCPCall is one strictly-parsed JSON-RPC request extracted from the
+// body. Single-message bodies produce one MCPCall with BatchIndex 0;
+// batch bodies produce N elements in array order.
+//
+// Method and Name are verbatim from the wire — the matcher lowercases
+// at compare time. MatchArgs is populated only for tools/call (from
+// params.arguments) so the matcher's denied_params / allowed_params
+// can gate on individual argument values. For other methods MatchArgs
+// is nil.
+type MCPCall struct {
+	Method     string
+	Name       string
+	MatchArgs  map[string]ParamValue
+	BatchIndex int
+}
+
+// ParamKind classifies the JSON type of a tools/call argument value
+// so the matcher can decide which pattern-list semantics apply. Scalar
+// kinds (String / Number / Bool) render to Str for string-pattern
+// matching; Non-scalar kinds (Object / Array) and Null have empty Str
+// and the matcher treats them as missing for deny-list checks and as
+// missing-required for allow-list checks.
+type ParamKind uint8
+
+const (
+	ParamMissing ParamKind = iota
+	ParamString
+	ParamNumber
+	ParamBool
+	ParamNull
+	ParamObject
+	ParamArray
+)
+
+// ParamValue is a typed view of one tools/call argument. Str carries
+// the matcher-comparable string form: verbatim for strings,
+// json.Number stringified for numbers, "true"/"false" for booleans.
+// For Null / Object / Array / Missing kinds Str is the zero value.
+type ParamValue struct {
+	Kind ParamKind
+	Str  string
+}
+
+// MCPParseError carries the kind of structural failure plus an
+// operator-facing detail Msg. Msg is for server-side logs only and
+// MUST NOT be stamped on MCPDecision or surfaced to the client —
+// fingerprint hygiene and no leakage of adversary-controlled body
+// bytes into operator-visible logs.
+//
+// Kind is one of the MCPParseKind* string constants; the matcher in a
+// later phase maps these 1:1 to MCPDecision.RuleType values.
+type MCPParseError struct {
+	Kind string
+	Msg  string
+}
+
+// MCPParseKind* enumerate the descriptor-level parse failure modes.
+// The string values are the same identifiers Phase 4 will use as
+// MCPDecision rule_type values, so the mapping is identity rather
+// than a per-package translation table.
+const (
+	MCPParseKindMalformedJSONRPC = "malformed_jsonrpc"
+	MCPParseKindDuplicateKey     = "duplicate_key"
+	MCPParseKindOversizedBody    = "oversized_body"
+	MCPParseKindBatchEmpty       = "batch_empty"
+	MCPParseKindMalformedParams  = "malformed_params"
+)
+
+// Clone returns a deep copy of the MCPRequestDescriptor. Safe to call
+// on a nil receiver (returns nil). The audit layer's request-clone
+// path treats MCPRequestDescriptor as a deep-copy field so an async
+// audit writer cannot observe mutations made by a concurrent request
+// handler — though by current design the descriptor is read-only
+// post-extraction.
+func (d *MCPRequestDescriptor) Clone() *MCPRequestDescriptor {
+	if d == nil {
+		return nil
+	}
+	clone := &MCPRequestDescriptor{}
+	if d.Calls != nil {
+		clone.Calls = make([]MCPCall, len(d.Calls))
+		for i, c := range d.Calls {
+			clone.Calls[i] = c.Clone()
+		}
+	}
+	if d.ParseErr != nil {
+		errCopy := *d.ParseErr
+		clone.ParseErr = &errCopy
+	}
+	return clone
+}
+
+// Clone returns a deep copy of the MCPCall. MatchArgs is a map of
+// value-typed ParamValue, so a length-preserving copy of the map
+// breaks aliasing.
+func (c MCPCall) Clone() MCPCall {
+	out := MCPCall{
+		Method:     c.Method,
+		Name:       c.Name,
+		BatchIndex: c.BatchIndex,
+	}
+	if c.MatchArgs != nil {
+		out.MatchArgs = make(map[string]ParamValue, len(c.MatchArgs))
+		for k, v := range c.MatchArgs {
+			out.MatchArgs[k] = v
+		}
+	}
+	return out
+}

--- a/logical/mcp_enforced.go
+++ b/logical/mcp_enforced.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+// MCPPolicyEnforced is implemented by backends that participate in CBP
+// `mcp { }` body-authoritative policy enforcement. The core handler
+// calls ShouldEnforceMCPPolicy on every matched backend; when it
+// returns enforce=true the handler buffers the request body (up to
+// cap bytes), strict-parses it as JSON-RPC, and stashes the resulting
+// MCPRequestDescriptor on the request before policy evaluation runs.
+//
+// This interface is the per-backend opt-in. The marker pattern mirrors
+// StreamBodyParser so reviewers can pattern-match the shape, and lets
+// the trigger stay a compile-time type assertion rather than a string-
+// prefix sniff or mount-class enumeration change.
+//
+// Implementations of MCPPolicyEnforced MUST NOT also opt into
+// StreamBodyParser with ShouldParseStreamBody returning true: the
+// stream-body parser would consume req.HTTPRequest.Body before the
+// MCP extractor runs, leaving the extractor nothing to read. Backends
+// that need both behaviours on different sub-paths must scope each
+// hook by request shape so their domains do not overlap.
+type MCPPolicyEnforced interface {
+	// ShouldEnforceMCPPolicy reports whether this request on this
+	// backend is subject to `mcp { }` body-based enforcement, and the
+	// maximum body size in bytes the policy extractor may buffer.
+	//
+	// cap <= 0 falls back to framework.DefaultMaxBodySize at the
+	// extractor. cap is ignored when enforce is false. Returning the
+	// cap here (rather than having the extractor reach into the
+	// backend's persisted config) keeps the policy-eval path from
+	// duplicating httpproxy's max_body_size config-resolution work.
+	//
+	// Backends typically gate on request method and Content-Type:
+	// MCP enforcement is only meaningful for POSTed JSON-RPC bodies,
+	// so GET (SSE reconnect) and DELETE (session close) traffic should
+	// return enforce=false.
+	ShouldEnforceMCPPolicy(req *Request) (enforce bool, cap int64)
+}

--- a/logical/request.go
+++ b/logical/request.go
@@ -125,6 +125,13 @@ type Request struct {
 	// UpstreamURL is the target URL for proxied streaming requests (for audit logging).
 	// Set by streaming handlers before forwarding the request to the upstream service.
 	UpstreamURL string `json:"-"`
+
+	// MCPDescriptor is populated by the core handler when the routed
+	// backend opts into MCPPolicyEnforced and accepts the request for
+	// MCP body-based policy enforcement. Nil for all other requests.
+	// Read-only after extraction; the audit layer treats it as a
+	// deep-copy field via MCPRequestDescriptor.Clone.
+	MCPDescriptor *MCPRequestDescriptor `json:"-"`
 }
 
 func (r *Request) TokenEntry() *TokenEntry {

--- a/provider/mcp_github/provider.go
+++ b/provider/mcp_github/provider.go
@@ -1,9 +1,12 @@
 package mcp_github
 
 import (
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
@@ -36,6 +39,33 @@ var Spec = &httpproxy.ProviderSpec{
 	// default Accept only when the client sends none; MCP clients always
 	// negotiate ("application/json, text/event-stream"). Forcing a default
 	// here would break one-shot JSON clients.
+	ShouldEnforceMCPPolicy: shouldEnforceMCPPolicy,
+}
+
+// shouldEnforceMCPPolicy opts mcp_github into CBP body-authoritative
+// mcp { } enforcement for the subset of traffic where it is meaningful:
+// JSON-RPC POSTs. GET (SSE reconnect) and DELETE (session close), and
+// any non-JSON Content-Type, decline and pass through under
+// token-scope-only enforcement.
+func shouldEnforceMCPPolicy(req *logical.Request) bool {
+	if req == nil || req.HTTPRequest == nil {
+		return false
+	}
+	r := req.HTTPRequest
+	if r.Method != http.MethodPost {
+		return false
+	}
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		return false
+	}
+	// Trim a charset / boundary parameter (e.g. "application/json; charset=utf-8")
+	// before comparing to the bare media type.
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.TrimSpace(strings.ToLower(ct))
+	return ct == "application/json"
 }
 
 // Factory creates a new mcp_github provider backend.
@@ -82,18 +112,15 @@ actually do at GitHub regardless of what Warden lets through. On top
 of that, Warden's CBP policies support an mcp { } block for
 governance-style restrictions enforced at the gateway: allow- and
 deny-lists for JSON-RPC methods, tool names, resource URIs, prompt
-names, and (where the upstream tool author opted in) selected tool
-arguments. Enforcement is header-based and adds no request-body
-parsing on the allow path. Denied requests return HTTP 403 with an
-RFC 6750 WWW-Authenticate header and a small JSON body the agent
-SDK surfaces as a structured tool-call failure. See the policy
+names, and selected tool arguments. When a policy in scope contains
+an mcp { } block, the gateway strict-parses the JSON-RPC request body
+before authorising the call; denied requests return HTTP 403 with an
+RFC 6750 WWW-Authenticate header and a small JSON body the agent SDK
+surfaces as a structured tool-call failure. See the policy
 documentation for the mcp { } block schema and examples.
 
-Important: the mcp { } block depends on the MCP protocol revision
-dated 2026-07-28, which mirrors method/name into HTTP headers so
-intermediaries can enforce without parsing the body. Pre-draft
-clients are denied when bound to a policy with an mcp { } block.
-Policies without an mcp { } block keep today's behaviour unchanged.
+Policies without an mcp { } block keep today's behaviour unchanged —
+no body parsing is performed on the allow path.
 
 Configuration:
 - mcp_github_url: MCP server base URL (default: https://api.githubcopilot.com/mcp)

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -173,6 +173,24 @@ type ProviderSpec struct {
 	// invoke without minted credentials (see gateway.go's
 	// StreamUnauthenticated guard).
 	IsUnauthenticatedRequest func(r *http.Request, path string) bool
+
+	// ShouldEnforceMCPPolicy optionally opts this provider into CBP
+	// `mcp { }` body-authoritative policy enforcement. When set, the
+	// core handler calls this hook on every request matched to this
+	// backend; if it returns true the request body is buffered and
+	// strict-parsed as JSON-RPC before policy evaluation runs. The
+	// shared proxyBackend implements logical.MCPPolicyEnforced by
+	// delegating to this hook.
+	//
+	// Returning true on traffic that is not a JSON-RPC POST will deny
+	// the request at policy eval time (the parser fails closed on
+	// non-JSON or empty bodies). MCP providers should gate on method +
+	// Content-Type to leave SSE GETs and session-close DELETEs alone.
+	//
+	// MCP-enforcing specs MUST set ParseStreamBody: false. Opting into
+	// the framework's stream-body parser would consume the body before
+	// the MCP extractor runs.
+	ShouldEnforceMCPPolicy func(req *logical.Request) bool
 }
 
 // proxyBackend is the concrete backend type created by NewFactory.
@@ -508,6 +526,29 @@ func ReadInt64Config(v any) (int64, bool) {
 		return size, size > 0
 	}
 	return 0, false
+}
+
+// ShouldEnforceMCPPolicy implements logical.MCPPolicyEnforced by
+// delegating to the spec's ShouldEnforceMCPPolicy hook. Returns the
+// mount-configured MaxBodySize as the cap so the core extractor uses
+// the same byte-cap the gateway will enforce at proxy time. Returns
+// enforce=false with cap=0 when the spec did not set the hook — every
+// other httpproxy-backed provider (github, openai, slack, anthropic,
+// …) sees no MCP enforcement.
+func (b *proxyBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int64) {
+	if b.spec.ShouldEnforceMCPPolicy == nil {
+		return false, 0
+	}
+	if !b.spec.ShouldEnforceMCPPolicy(req) {
+		return false, 0
+	}
+	// MaxBodySize lives on the embedded StreamingBackend and is
+	// written under b.mu by Initialize and handleConfigWrite — read
+	// under the read-lock to avoid racing concurrent reconfigure.
+	b.mu.RLock()
+	maxBody := b.MaxBodySize
+	b.mu.RUnlock()
+	return true, maxBody
 }
 
 // ShouldParseStreamBody overrides the embedded StreamingBackend's default to


### PR DESCRIPTION
## Summary

Phase 2: opt-in marker interface + handler-side body buffer for MCP enforcement.

- New `logical.MCPPolicyEnforced` interface — backends opt in per-request and return their body-size cap (sibling of `StreamBodyParser`).
- New `MCPRequestDescriptor` / `MCPCall` types on `logical/`, carried via `req.MCPDescriptor`.
- `provider/sdk/httpproxy.ProviderSpec` gains a `ShouldEnforceMCPPolicy` hook; `proxyBackend` implements the marker by delegating to the spec. `mcp_github`'s Spec sets the hook (POST + `application/json` only).
- `core/request_handler_mcp.go` runs the strict parser from Phase 1 inside `extractMCPDescriptor`, buffers + restores the body via `io.NopCloser(bytes.NewReader)` for the proxy.
- Wired into both the streaming and non-streaming branches of `request_handler.go` — non-MCP backends type-assert false and skip everything.

Captured but not yet consumed: Phase 4 flips the evaluator to read it.

## Test plan

- [x] `go test ./core/... ./logical/... ./provider/...` green
- [x] Body byte-identity verified by Phase 6's e2e harness (added later in the stack)

Stacked on top of #277.
