### PR TITLE
ci: trigger CI on pull_request.edited so retargets fire a run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Include `edited` so retargeting a stacked PR's base to `main`
+    # triggers CI. Without it, GitHub fires pull_request.edited but the
+    # default subscription ignores that event, leaving the retargeted PR
+    # with no run queued until a force-push or close+reopen.
+    types: [opened, synchronize, reopened, edited]
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## Summary

Add `edited` to the `pull_request:` trigger types so CI runs automatically when a stacked PR's base is retargeted to `main`.

The default `pull_request:` subscription is `[opened, synchronize, reopened]`. Retargeting a PR's base produces a `pull_request.edited` event, which isn't in the default list. The result, observed across the recent #277/#286/#279/#280/#281/#282/#283/#284 stack: every retarget left the PR with no run queued until someone close+reopened it or force-pushed an unrelated change.

The change is one block in `.github/workflows/ci.yml`:

```yaml
pull_request:
  branches: [main]
  types: [opened, synchronize, reopened, edited]
```

No effect on the existing trigger paths — push to main, regular pull_request open/synchronize, and `workflow_call` are unchanged.

## Test plan

- [x] CI runs on this very PR (proves the trigger config still parses + works for the default events)
- [ ] On the next stacked PR retarget, confirm a new run is queued without close+reopen
