### PR TITLE
fix(core/policy): make mcp { } gate method-aware

### DIFF
--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -335,11 +335,13 @@ func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.
 		for paramName, patterns := range set.AllowedParams {
 			value := callMatchArgString(call, paramName)
 			if value == "" {
-				// Required param missing — deny with empty MatchedRule.
-				d.Decision = "deny"
-				d.RuleType = mcpRuleTypeAllowedParams
-				d.ParamName = paramName
-				return d
+				// Param not present in the call — no constraint applies.
+				// Matches Vault's allowed_parameters convention: the
+				// gate is "IF present, must match", not "must be
+				// present". Tools that don't take this argument at
+				// all (or for which the agent omitted it) pass through;
+				// tools that do take it get the value-list check.
+				continue
 			}
 			lowerValue := strings.ToLower(value)
 			if m := matchMCPAny(lowerValue, patterns); m == "" {

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -122,17 +122,34 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 
 // decideMCP is the production entry point called from
 // AllowOperation when the matched permissions carry a non-empty
-// mcp { } rule-set slice. It bridges req.MCPDescriptor's three
-// terminal states to MCPDecision:
+// mcp { } rule-set slice. It bridges req.MCPDescriptor's four
+// terminal states to MCPDecision (see extractMCPDescriptor for how
+// each state is produced):
 //
-//   - nil descriptor (backend didn't opt into MCPPolicyEnforced or
-//     declined this request) ⇒ deny missing_body. Bound mcp{} to a
-//     non-MCP path? Fail closed here.
-//   - descriptor.ParseErr non-nil (strict JSON-RPC parse failed) ⇒
-//     deny with the mapped rule_type. The ParseErr.Msg is operator-
-//     facing only and never copied into the decision.
-//   - descriptor.Calls populated ⇒ delegate to evaluateMCPDescriptor
-//     for body-driven gate evaluation.
+//   - Nil descriptor — no MCP-aware backend handled this request.
+//     If an operator bound mcp{} to a non-MCP path, that's a misconfig
+//     and we fail closed with missing_body. This is the safety net.
+//
+//   - Non-nil, empty descriptor (Calls nil, ParseErr nil) — the
+//     backend is MCP-aware but ShouldEnforceMCPPolicy declined for
+//     this request (typically a non-POST verb, or a non-JSON
+//     Content-Type). The mcp{} block is body-authoritative; a verb
+//     with no body cannot be governed by method/tool/param allow-
+//     lists, so we return nil to skip mcp{} evaluation and let the
+//     cap-level check decide. This is what makes MCP Streamable
+//     HTTP's GET (notification SSE stream) and DELETE (session
+//     terminate) work on the same URL that POST gates.
+//
+//   - descriptor.ParseErr non-nil — strict JSON-RPC parse failed.
+//     Deny with the typed rule_type (malformed_jsonrpc, duplicate_key,
+//     oversized_body, etc). ParseErr.Msg is operator-facing only and
+//     never copied into the decision.
+//
+//   - descriptor.Calls populated — body parsed cleanly. Delegate to
+//     evaluateMCPDescriptor for body-driven gate evaluation.
+//
+// A nil return from decideMCP means "this policy layer has no opinion
+// — fall through to the next check". A non-nil deny is binding.
 //
 // Every returned decision passes through sanitizeMCPDecision so
 // adversary-controlled bytes don't leak into audit or response
@@ -149,6 +166,12 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request) *logical.MCPDecision {
 			Decision: "deny",
 			RuleType: mcpRuleTypeMissingBody,
 		}
+	case desc.Calls == nil && desc.ParseErr == nil:
+		// Backend opted out of MCP enforcement for this specific
+		// request shape (e.g. non-POST verb on a multi-method MCP
+		// endpoint). The mcp{} block doesn't apply to body-less
+		// verbs; return nil so the cap-level check decides.
+		return nil
 	case desc.ParseErr != nil:
 		d = &logical.MCPDecision{
 			Decision: "deny",
@@ -159,10 +182,12 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request) *logical.MCPDecision {
 		if d == nil {
 			// Defence in depth: evaluateMCPDescriptor returns nil
 			// only for empty sets (handled above) or for a non-nil
-			// descriptor with zero calls. The extractor's invariant
-			// rules the latter out, but decideMCP is the policy-
-			// layer boundary and cannot trust its input. Fail
-			// closed.
+			// descriptor with zero calls (the extractor's invariant
+			// for the "populated" arm rules this out — Calls is
+			// always non-empty when ParseErr is nil and the empty
+			// sentinel is intercepted above). decideMCP is the
+			// policy-layer boundary and cannot trust its input.
+			// Fail closed.
 			d = &logical.MCPDecision{
 				Decision: "deny",
 				RuleType: mcpRuleTypeMissingBody,

--- a/core/policy_mcp_body_test.go
+++ b/core/policy_mcp_body_test.go
@@ -87,26 +87,31 @@ func TestDecideMCP_DescriptorMatcherAllows(t *testing.T) {
 	assert.Equal(t, "allow", d.Decision)
 }
 
-// Defence in depth: a non-nil descriptor with empty Calls and nil
-// ParseErr violates the extractor's invariant. decideMCP must NOT
-// fail open in that case — it synthesises a missing_body deny rather
-// than returning nil (which would let AllowOperation skip the deny
-// gate and allow the request).
-func TestDecideMCP_DescriptorWithEmptyCallsFailsClosed(t *testing.T) {
+// The empty-but-non-nil descriptor is the deliberate sentinel an
+// MCP-aware backend installs via extractMCPDescriptor when
+// ShouldEnforceMCPPolicy declines for a specific request (typically a
+// non-POST verb on a multi-method MCP endpoint). decideMCP must
+// return nil (skip evaluation) for this shape so the cap-level check
+// can decide — the mcp{} block is body-authoritative and can't
+// meaningfully gate a verb the backend declared body-less.
+//
+// This is what lets MCP Streamable HTTP's GET (notification SSE
+// stream) and DELETE (session terminate) share the same URL as the
+// POST that mcp{} gates without the multi-method path tripping
+// missing_body. The nil-descriptor case (genuine misconfig: mcp{}
+// bound to a non-MCP backend) still fails closed, covered by
+// TestDecideMCP_DescriptorMissingFailsClosed.
+func TestDecideMCP_EmptyDescriptorSkipsEvaluation(t *testing.T) {
 	sets := []*CBPMCPRules{{
 		AllowedMethods: []string{"tools/list"},
 	}}
 	req := &logical.Request{
 		MCPDescriptor: &logical.MCPRequestDescriptor{
-			// Calls explicitly nil; ParseErr nil. Invariant-violating
-			// shape that the production extractor cannot produce, but
-			// decideMCP must still fail closed.
+			// Calls nil, ParseErr nil — the per-request opt-out sentinel.
 		},
 	}
 	d := decideMCP(sets, req)
-	require.NotNil(t, d, "decideMCP must not return nil on invariant-violating descriptor")
-	assert.Equal(t, "deny", d.Decision)
-	assert.Equal(t, mcpRuleTypeMissingBody, d.RuleType)
+	assert.Nil(t, d, "decideMCP must return nil for the per-request opt-out sentinel so the cap-level check decides")
 }
 
 // Empty sets — no mcp{} block in scope — returns nil. The

--- a/core/policy_mcp_descriptor_test.go
+++ b/core/policy_mcp_descriptor_test.go
@@ -65,8 +65,8 @@ func TestEvaluateMCPDescriptor_NumericParamMatches(t *testing.T) {
 }
 
 // Object-typed argument values can never match a string pattern: the
-// matcher treats them as missing for deny-list checks (skip) and as
-// missing-required for allow-list checks (deny). Pins both halves.
+// matcher treats them as missing for both deny-list and allow-list
+// checks, and missing is conditional (skip) for both. Pins both halves.
 func TestEvaluateMCPDescriptor_NonScalarParamTreatedAsMissing(t *testing.T) {
 	t.Run("deny list skips object", func(t *testing.T) {
 		sets := []*CBPMCPRules{{
@@ -90,7 +90,10 @@ func TestEvaluateMCPDescriptor_NonScalarParamTreatedAsMissing(t *testing.T) {
 			t.Fatalf("decision = %+v, want allow (object value skipped by deny gate)", d)
 		}
 	})
-	t.Run("allow list denies object as missing-required", func(t *testing.T) {
+	t.Run("allow list skips object as missing", func(t *testing.T) {
+		// allowed_params is conditional ("IF present, must match"):
+		// a non-scalar argument is treated as missing by the matcher,
+		// and missing means "no constraint applies" — request passes.
 		sets := []*CBPMCPRules{{
 			AllowedMethods: []string{"tools/call"},
 			AllowedTools:   []string{"x"},
@@ -108,11 +111,8 @@ func TestEvaluateMCPDescriptor_NonScalarParamTreatedAsMissing(t *testing.T) {
 			}},
 		}
 		d := evaluateMCPDescriptor(sets, desc)
-		if d == nil || d.Decision != "deny" {
-			t.Fatalf("decision = %+v, want deny (object value can't satisfy allow-list)", d)
-		}
-		if d.RuleType != mcpRuleTypeAllowedParams || d.ParamName != "cfg" {
-			t.Errorf("decision = %+v, want allowed_params cfg", d)
+		if d == nil || d.Decision != "allow" {
+			t.Fatalf("decision = %+v, want allow (object value treated as missing; conditional skip)", d)
 		}
 	})
 }

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -242,9 +242,10 @@ path "mcp/gateway/*" {
 }
 
 // Object-typed argument can never match a string pattern; the matcher
-// treats it as missing. For an allow-list this means missing-required
-// (deny); for a deny-list it would skip. Pins the non-scalar contract
-// through the production pipeline.
+// treats it as missing. Under the conditional-allow semantics, missing
+// means "no constraint applies" — the request passes (the operator who
+// wants to forbid non-scalar values must use denied_params or a tighter
+// allowed_tools list, not allowed_params).
 func TestMCPE2E_NonScalarArgumentTreatedAsMissing(t *testing.T) {
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
@@ -271,9 +272,8 @@ path "mcp/gateway/*" {
 
 	res := cbp.AllowOperation(testContext(), req, false)
 
-	assert.False(t, res.Allowed)
-	assert.Equal(t, mcpRuleTypeAllowedParams, res.MCPDecision.RuleType)
-	assert.Equal(t, "cfg", res.MCPDecision.ParamName)
+	assert.True(t, res.Allowed,
+		"non-scalar argument is treated as missing; missing is a conditional skip under the allow-list, not a deny")
 }
 
 func TestMCPE2E_BatchDenyStampsBatchIndex(t *testing.T) {

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -436,11 +436,14 @@ path "mcp/gateway/*" {
 // =============================================================================
 
 // Backend opts out per-request (ShouldEnforceMCPPolicy returns false)
-// and mcp{} is in scope → deny missing_body. The most likely real-
-// world trigger: a non-POST request reaches a path with mcp{} bound,
-// the backend's hook declines, the descriptor stays nil, the matcher
-// fails closed.
-func TestMCPE2E_PerRequestOptOut_WithMCPBlock_DeniesMissingBody(t *testing.T) {
+// and mcp{} is in scope → request passes through. This is the canonical
+// MCP Streamable HTTP shape: GET on the same /gateway URL as the POST
+// that mcp{} gates. The body-authoritative block can't meaningfully
+// apply to a verb the backend declared body-less, so decideMCP skips
+// evaluation and the cap-level check decides. Without this behavior,
+// every MCP-spec-compliant client that opens an SSE notification
+// stream would hit missing_body.
+func TestMCPE2E_PerRequestOptOut_WithMCPBlock_PassesThrough(t *testing.T) {
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -452,18 +455,24 @@ path "mcp/gateway/*" {
 	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
 	runExtract(req, &mcpMockBackend{enforce: false, cap: 0})
 
-	require.Nil(t, req.MCPDescriptor,
-		"opt-out leaves descriptor nil")
+	require.NotNil(t, req.MCPDescriptor,
+		"opt-out installs the empty sentinel so decideMCP can distinguish per-request opt-out from misconfig")
+	require.Nil(t, req.MCPDescriptor.Calls,
+		"sentinel descriptor must have Calls nil")
+	require.Nil(t, req.MCPDescriptor.ParseErr,
+		"sentinel descriptor must have ParseErr nil")
 
 	res := cbp.AllowOperation(testContext(), req, false)
 
-	assert.False(t, res.Allowed)
-	assert.Equal(t, mcpRuleTypeMissingBody, res.MCPDecision.RuleType)
+	assert.True(t, res.Allowed)
+	assert.Nil(t, res.MCPDecision,
+		"empty sentinel skips mcp{} evaluation; cap-level check decides")
 }
 
 // Same opt-out, no mcp{} in scope → matcher never runs, request
-// passes through cleanly. Operators who don't bind mcp{} to non-POST
-// paths see no friction.
+// passes through cleanly. Symmetry with the mcp{}-in-scope test: the
+// empty sentinel is installed either way, and decideMCP isn't even
+// called because permissions.MCP is empty.
 func TestMCPE2E_PerRequestOptOut_NoMCPBlock_PassesThrough(t *testing.T) {
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
@@ -473,8 +482,10 @@ path "mcp/gateway/*" {
 	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
 	runExtract(req, &mcpMockBackend{enforce: false, cap: 0})
 
-	require.Nil(t, req.MCPDescriptor,
-		"opt-out leaves descriptor nil (symmetry with the mcp{}-in-scope test)")
+	require.NotNil(t, req.MCPDescriptor,
+		"opt-out installs the empty sentinel regardless of whether mcp{} is in scope")
+	require.Nil(t, req.MCPDescriptor.Calls)
+	require.Nil(t, req.MCPDescriptor.ParseErr)
 
 	res := cbp.AllowOperation(testContext(), req, false)
 

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -469,9 +469,14 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_AllowedParams_MissingArgument(t *testing.T) {
-	// allowed_params configured, body's arguments omit the required
-	// key → deny with allowed_params (the matcher's "required param
-	// missing" branch).
+	// allowed_params configured, body's arguments omit the gated
+	// key → request passes. allowed_params is a conditional check
+	// ("IF this argument is present, its value must match"), not a
+	// required-argument check. Matches Vault's allowed_parameters
+	// convention and lets one mcp{} block cover a server with
+	// multiple tools that share a JSON-RPC method but take different
+	// argument shapes — a tool that doesn't take `region` at all
+	// shouldn't be blocked because the policy mentions `region`.
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -495,11 +500,8 @@ path "mcp/gateway/*" {
 	}`)
 	res := cbp.AllowOperation(testContext(), req, false)
 
-	assert.False(t, res.Allowed)
-	assert.Equal(t, mcpRuleTypeAllowedParams, res.MCPDecision.RuleType)
-	assert.Equal(t, "region", res.MCPDecision.ParamName)
-	assert.Equal(t, "", res.MCPDecision.ParamValue,
-		"missing-argument case records empty value")
+	assert.True(t, res.Allowed,
+		"missing argument is not a constraint violation under conditional semantics")
 }
 
 func TestMCPEval_DeniedParams_MissingArgument_NoDeny(t *testing.T) {

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -13,31 +13,54 @@ import (
 	"github.com/stephnangue/warden/logical"
 )
 
-// extractMCPDescriptor populates req.MCPDescriptor when the routed
-// backend opts into MCP policy enforcement via the
-// logical.MCPPolicyEnforced interface. Non-MCP backends and opted-in
-// backends that decline the request (wrong method, non-JSON Content-
-// Type) leave the descriptor nil. The matcher in decideMCP reads the
-// descriptor and produces an MCPDecision; if the descriptor is nil
-// when an mcp{} block is in scope, the matcher fails closed.
+// extractMCPDescriptor populates req.MCPDescriptor based on whether
+// the routed backend opts into MCP policy enforcement via the
+// logical.MCPPolicyEnforced interface. The descriptor has three
+// terminal shapes consumed by decideMCP — see decideMCP's doc for the
+// tri-state contract:
+//
+//  1. Nil — backend does not implement MCPPolicyEnforced at all. If an
+//     mcp{} block is bound to such a path that's an operator misconfig
+//     and decideMCP fails closed with missing_body.
+//
+//  2. Non-nil, empty (Calls nil, ParseErr nil) — backend implements
+//     the interface but ShouldEnforceMCPPolicy returned enforce=false
+//     for THIS request (typically a non-POST verb on a multi-method
+//     MCP endpoint, or a non-JSON Content-Type). mcp{} is body-
+//     authoritative and cannot meaningfully gate a body-less request,
+//     so decideMCP skips evaluation and lets the cap-level policy
+//     decide. This is the path that lets MCP Streamable HTTP's GET
+//     (notification SSE stream) and DELETE (session terminate) verbs
+//     share the same URL with the POST that carries JSON-RPC.
+//
+//  3. Non-nil with Calls or ParseErr populated — backend opted in and
+//     extraction either succeeded (Calls) or failed in a typed way
+//     (ParseErr). decideMCP runs the body-authoritative matcher.
 //
 // The body is read up to cap+1 bytes via io.LimitReader so an
 // oversize signal is distinguishable from an at-cap read, and
 // restored via io.NopCloser(bytes.NewReader(buf)) so the downstream
-// proxy receives the bytes unchanged. The full function is panic-safe
-// — any panic from the strict parser is recovered and surfaced as a
-// malformed_jsonrpc ParseErr rather than propagating into the request
-// handler.
+// proxy receives the bytes unchanged. The full extraction path is
+// panic-safe — any panic from the strict parser is recovered and
+// surfaced as a malformed_jsonrpc ParseErr rather than propagating
+// into the request handler.
 func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, backend logical.Backend) {
 	if req == nil || backend == nil {
 		return
 	}
 	mcp, ok := backend.(logical.MCPPolicyEnforced)
 	if !ok {
-		return
+		return // Shape 1: leave descriptor nil.
 	}
 	enforce, maxBody := mcp.ShouldEnforceMCPPolicy(req)
 	if !enforce {
+		// Shape 2: install the empty sentinel so decideMCP can tell
+		// "backend declined for this request" apart from "no MCP-aware
+		// backend handled this request at all". Without this branch,
+		// MCP Streamable HTTP's GET/DELETE on the same URL as POST
+		// would deny with missing_body, breaking the SSE notification
+		// stream every spec-compliant MCP client opens.
+		req.MCPDescriptor = &logical.MCPRequestDescriptor{}
 		return
 	}
 	if maxBody <= 0 {

--- a/core/request_handler_mcp_test.go
+++ b/core/request_handler_mcp_test.go
@@ -64,15 +64,22 @@ func TestExtractMCPDescriptor_NotMCPBackend(t *testing.T) {
 	}
 }
 
-// MCP backend opts out per-request: descriptor stays nil.
+// MCP backend opts out per-request: descriptor is the empty sentinel
+// (non-nil, no Calls, no ParseErr). decideMCP uses this to distinguish
+// "backend declined for this request shape" from "no MCP-aware backend
+// at all", which lets MCP Streamable HTTP's GET/DELETE share the URL
+// with the POST that mcp{} gates.
 func TestExtractMCPDescriptor_OptsOutPerRequest(t *testing.T) {
 	c := &Core{}
 	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)
 	b := &mcpBackend{}
 	b.enforced = &fakeMCPHook{enforce: false}
 	c.extractMCPDescriptor(context.Background(), req, b)
-	if req.MCPDescriptor != nil {
-		t.Fatalf("descriptor = %+v, want nil for opted-out request", req.MCPDescriptor)
+	if req.MCPDescriptor == nil {
+		t.Fatalf("descriptor = nil, want empty sentinel for opted-out request")
+	}
+	if req.MCPDescriptor.Calls != nil || req.MCPDescriptor.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, want empty sentinel (Calls nil, ParseErr nil) for opted-out request", req.MCPDescriptor)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related changes to how `core/policy` evaluates `mcp { }` blocks, surfaced while testing the upcoming `mcp_aws` provider end-to-end with Claude Code.

### 1. Tri-state MCPDescriptor — mcp { } skips non-POST verbs

MCP Streamable HTTP (the wire protocol the latest spec mandates) uses three HTTP verbs on the same URL: POST for JSON-RPC requests, GET for the optional server → client SSE notification stream, DELETE for session terminate. Every spec-compliant MCP client opens the GET stream as part of its \`initialize\` handshake.

Before this change, an operator binding \`mcp { }\` to an MCP \`/gateway\` path made the handshake fail with \`missing_body\`: the backend's \`ShouldEnforceMCPPolicy\` correctly returned \`(false, 0)\` for the GET, the extractor left \`req.MCPDescriptor\` nil, and \`decideMCP\` collapsed the nil into a fail-closed deny. The previous doc note tried to deflect this onto the operator (\"don't bind mcp{} to non-POST paths\" but MCP-spec compliance leaves no choice — the verbs share a URL.

The fix distinguishes:
- nil descriptor → no MCP-aware backend handled this request (genuine misconfig; fail closed, behavior preserved)
- non-nil, empty descriptor → backend implements MCPPolicyEnforced but declined for this request (per-request opt-out; **new**: decideMCP returns nil, cap-level check decides)
- populated descriptor → evaluate as before

### 2. allowed_params is conditional, not required

Pre-existing wrong behavior: `allowed_params = { region = ["us-west1"] }` required EVERY `tools/call` to include a `region` argument — even tools that didn't take one. An MCP server with multiple tools that share `tools/call` but take different argument shapes (like AWS's hosted MCP Server: `aws___call_aws`, `aws___query_aws_documentation`, ...) would have tools blocked because the policy mentions a key those tools don't carry.

This change makes `allowed_params` conditional on presence — "IF this argument is present, its value must match" — matching Vault's `allowed_parameters` convention. `denied_params` already had this behavior; only `allowed_params` needed the alignment.

## Test plan

- [x] `go test ./core/... -race -count=1` green (existing tests that pinned the old behavior were updated to pin the new contract)
- [x] End-to-end with mcp_aws + Claude Code: handshake → tools/list → tools/call → S3 bucket list returned successfully
- [x] Audit log confirms `mcp_decision: null` on GETs (empty-sentinel skip) and `matched_rule` on POSTs

## Follow-ups

- docs(mcp_github): align policy examples — separate PR
- docs(mcp_aws): align policy examples — separate PR (lands with the mcp_aws stack)
EOF
)