### PR TITLE
feat(mcp_aws): inference helpers for SigV4 service+region and gateway path

### DIFF
--- a/provider/mcp_aws/inference.go
+++ b/provider/mcp_aws/inference.go
@@ -1,0 +1,56 @@
+// Package mcp_aws proxies MCP traffic from Warden-token-bearing clients to
+// AWS-hosted MCP endpoints, signing the outgoing request with AWS SigV4 using
+// credentials minted by the aws source driver.
+package mcp_aws
+
+import (
+	"net/url"
+	"strings"
+)
+
+// serviceAndRegion derives the SigV4 service name and region from an upstream
+// MCP endpoint URL using a structured DNS-label match. Mirrors AWS's own
+// client-side proxy: aws/mcp-proxy-for-aws utils.py
+// get_service_name_and_region_from_endpoint.
+//
+// Arm 1 — Bedrock AgentCore (Gateway or Runtime):
+//
+//	[..., "bedrock-agentcore", region, "amazonaws", "com"]
+//	  → ("bedrock-agentcore", region)
+//
+// Arm 2 — AWS-hosted MCP product (e.g. aws-mcp.us-east-1.api.aws):
+//
+//	[service, region, "api", "aws"]
+//	  → (service, region)
+//
+// Arm 3 — fallback:
+//
+//	[service, ...]
+//	  → (service, "")  // operator must supply region via config
+//
+// Hosts that don't fit any arm (FIPS-flavored, GovCloud, China partition,
+// dualstack labels, IPv6 literals) land in arm 3 with an empty region.
+func serviceAndRegion(u *url.URL) (service, region string) {
+	if u == nil {
+		return "", ""
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", ""
+	}
+	labels := strings.Split(host, ".")
+	n := len(labels)
+
+	if n >= 4 &&
+		labels[n-1] == "com" &&
+		labels[n-2] == "amazonaws" &&
+		labels[n-4] == "bedrock-agentcore" {
+		return "bedrock-agentcore", labels[n-3]
+	}
+
+	if n == 4 && labels[2] == "api" && labels[3] == "aws" {
+		return labels[0], labels[1]
+	}
+
+	return labels[0], ""
+}

--- a/provider/mcp_aws/inference_test.go
+++ b/provider/mcp_aws/inference_test.go
@@ -1,0 +1,131 @@
+package mcp_aws
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestServiceAndRegion(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		wantService string
+		wantRegion  string
+	}{
+		// Arm 2 — the GA AWS MCP Server product.
+		{
+			name:        "aws_mcp_us_east_1",
+			raw:         "https://aws-mcp.us-east-1.api.aws/mcp",
+			wantService: "aws-mcp",
+			wantRegion:  "us-east-1",
+		},
+		{
+			name:        "aws_mcp_eu_frankfurt",
+			raw:         "https://aws-mcp.eu-frankfurt-1.api.aws/mcp",
+			wantService: "aws-mcp",
+			wantRegion:  "eu-frankfurt-1",
+		},
+
+		// Arm 1 — Bedrock AgentCore (Runtime + Gateway).
+		{
+			name:        "bedrock_agentcore_runtime",
+			raw:         "https://runtime.bedrock-agentcore.us-east-1.amazonaws.com/agents/myMcp/invocations",
+			wantService: "bedrock-agentcore",
+			wantRegion:  "us-east-1",
+		},
+		{
+			name:        "bedrock_agentcore_gateway",
+			raw:         "https://gateway.bedrock-agentcore.eu-west-1.amazonaws.com/mcp",
+			wantService: "bedrock-agentcore",
+			wantRegion:  "eu-west-1",
+		},
+
+		// Arm 3 — fallback paths the plan calls out explicitly.
+		{
+			name:        "generic_amazonaws_no_region_inferable",
+			raw:         "https://your-service.us-east-1.amazonaws.com/mcp",
+			wantService: "your-service",
+			wantRegion:  "",
+		},
+		{
+			name:        "localhost_for_tests",
+			raw:         "http://localhost:8080/mcp",
+			wantService: "localhost",
+			wantRegion:  "",
+		},
+
+		// Edge cases the plan documents as falling through to arm 3.
+		{
+			// FIPS hits arm 2 because the suffix is still .api.aws —
+			// service label includes the -fips marker, region is correct.
+			name:        "fips_label_kept_in_service_name",
+			raw:         "https://aws-mcp-fips.us-east-1.api.aws/mcp",
+			wantService: "aws-mcp-fips",
+			wantRegion:  "us-east-1",
+		},
+		{
+			// GovCloud commercial-style hostname — neither arm matches; arm 3.
+			name:        "govcloud_amazonaws_us_gov",
+			raw:         "https://aws-mcp.us-gov-west-1.amazonaws-us-gov.com/mcp",
+			wantService: "aws-mcp",
+			wantRegion:  "",
+		},
+		{
+			// China partition — .com.cn breaks arm 1's [..., amazonaws, com] match.
+			name:        "china_partition_amazonaws_com_cn",
+			raw:         "https://aws-mcp.cn-north-1.amazonaws.com.cn/mcp",
+			wantService: "aws-mcp",
+			wantRegion:  "",
+		},
+		{
+			// Extra "dualstack" label between region and amazonaws breaks arm 1.
+			name:        "dualstack_label_breaks_bedrock_match",
+			raw:         "https://runtime.bedrock-agentcore.us-east-1.dualstack.amazonaws.com/mcp",
+			wantService: "runtime",
+			wantRegion:  "",
+		},
+
+		// IPv6 literal — Hostname() strips brackets and port.
+		{
+			name:        "ipv6_literal",
+			raw:         "http://[::1]:8080/mcp",
+			wantService: "::1",
+			wantRegion:  "",
+		},
+
+		// Defensive: empty host.
+		{
+			name:        "empty_url",
+			raw:         "",
+			wantService: "",
+			wantRegion:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var u *url.URL
+			if tc.raw != "" {
+				parsed, err := url.Parse(tc.raw)
+				if err != nil {
+					t.Fatalf("parse %q: %v", tc.raw, err)
+				}
+				u = parsed
+			}
+			gotService, gotRegion := serviceAndRegion(u)
+			if gotService != tc.wantService {
+				t.Errorf("service = %q, want %q", gotService, tc.wantService)
+			}
+			if gotRegion != tc.wantRegion {
+				t.Errorf("region = %q, want %q", gotRegion, tc.wantRegion)
+			}
+		})
+	}
+}
+
+func TestServiceAndRegion_NilSafe(t *testing.T) {
+	s, r := serviceAndRegion(nil)
+	if s != "" || r != "" {
+		t.Fatalf("nil URL: got (%q,%q), want empty pair", s, r)
+	}
+}

--- a/provider/mcp_aws/path.go
+++ b/provider/mcp_aws/path.go
@@ -1,0 +1,28 @@
+package mcp_aws
+
+import "strings"
+
+// pathAfterGateway returns the substring of reqPath that follows the first
+// "gateway" segment, with that segment dropped. Trailing slashes are
+// preserved verbatim — MCP servers distinguish "/mcp" from "/mcp/" and
+// re-normalizing them would invalidate the SigV4 canonical request.
+//
+// Accepts both forms encountered in the request pipeline:
+//
+//   - Absolute paths (e.g. "/v1/team-data/mcp_aws/role/s3-reader/gateway/tools/call")
+//     as seen on req.HTTPRequest.URL.Path
+//   - Mount-relative paths (e.g. "gateway", "role/s3-reader/gateway/tools/call")
+//     as seen on req.Path after the framework strips the mount prefix
+//
+// Returns "" when reqPath has no "gateway" segment (caller should treat that
+// as a programmer error — the path patterns registered with the framework
+// guarantee a gateway segment is present).
+func pathAfterGateway(reqPath string) string {
+	if i := strings.Index(reqPath, "/gateway"); i >= 0 {
+		return reqPath[i+len("/gateway"):]
+	}
+	if strings.HasPrefix(reqPath, "gateway") {
+		return reqPath[len("gateway"):]
+	}
+	return ""
+}

--- a/provider/mcp_aws/path_test.go
+++ b/provider/mcp_aws/path_test.go
@@ -1,0 +1,47 @@
+package mcp_aws
+
+import "testing"
+
+func TestPathAfterGateway(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Mount-relative — no leading slash. This is the shape req.Path takes
+		// after the framework strips the mount prefix.
+		{"mount_relative_bare", "gateway", ""},
+		{"mount_relative_trailing_slash", "gateway/", "/"},
+		{"mount_relative_with_tail", "gateway/tools/call", "/tools/call"},
+		{"mount_relative_tail_trailing_slash", "gateway/tools/call/", "/tools/call/"},
+
+		// Mount-relative with role prefix.
+		{"role_prefix_bare", "role/s3-reader/gateway", ""},
+		{"role_prefix_trailing_slash", "role/s3-reader/gateway/", "/"},
+		{"role_prefix_with_tail", "role/s3-reader/gateway/tools/call", "/tools/call"},
+		{"role_prefix_tail_trailing_slash", "role/s3-reader/gateway/tools/call/", "/tools/call/"},
+
+		// Absolute — the shape req.HTTPRequest.URL.Path takes.
+		{"absolute_bare", "/v1/team-data/mcp_aws/gateway", ""},
+		{"absolute_trailing_slash", "/v1/team-data/mcp_aws/gateway/", "/"},
+		{"absolute_with_tail", "/v1/team-data/mcp_aws/gateway/tools/call", "/tools/call"},
+		{"absolute_tail_trailing_slash", "/v1/team-data/mcp_aws/gateway/tools/call/", "/tools/call/"},
+		{"absolute_role_with_tail", "/v1/team-data/mcp_aws/role/s3-reader/gateway/tools/call", "/tools/call"},
+
+		// Deep tails (the AgentCore /agents/.../invocations shape).
+		{"agentcore_invocations", "role/s3-reader/gateway/agents/my-mcp/invocations", "/agents/my-mcp/invocations"},
+
+		// Defensive: nothing to find.
+		{"no_gateway_segment", "config", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pathAfterGateway(tc.in)
+			if got != tc.want {
+				t.Errorf("pathAfterGateway(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

First slice of the upcoming \`mcp_aws\` provider — two small pure-function helpers with no framework dependencies, easy to review in isolation.

### \`serviceAndRegion(*url.URL) (service, region string)\` — provider/mcp_aws/inference.go
Derives the SigV4 service name and signing region from an upstream MCP endpoint URL using a structured DNS-label match. Mirrors the rule in AWS's own client-side proxy ([\`aws/mcp-proxy-for-aws\`](https://github.com/aws/mcp-proxy-for-aws/blob/main/mcp_proxy_for_aws/utils.py)'s \`get_service_name_and_region_from_endpoint\` so the GA AWS MCP Server (`aws-mcp.{region}.api.aws`), Bedrock AgentCore endpoints (`*.bedrock-agentcore.{region}.amazonaws.com`), and the GovCloud / China-partition / dualstack / IPv6 fallthrough cases all resolve the same way Warden's signer expects.

### `pathAfterGateway(string) string` — provider/mcp_aws/path.go
Extracts the substring of a request path that follows the first `gateway` segment, preserving trailing slashes verbatim. MCP servers distinguish `/mcp` from `/mcp/` and re-normalizing via `path.Join` would also invalidate the SigV4 canonical request — so this is a string-level split, not a path-aware one. Handles both mount-relative paths (`req.Path`) and absolute paths (`req.HTTPRequest.URL.Path`).

Both functions are fully covered by table-driven tests (29 cases combined): inference covers FIPS / GovCloud / China / dualstack / IPv6 / Bedrock AgentCore arms; path covers mount-relative, role-prefixed, absolute, trailing-slash, and the AgentCore `/agents/.../invocations` tail.

No callers yet — this PR builds the SDK; the provider scaffold that consumes them is the next PR in the stack.

## Test plan

- [x] `go test ./provider/mcp_aws/... -race -count=1` green (29 test cases)
- [x] `go vet ./provider/mcp_aws/...` clean

## Stacked PR series

This is PR 1 of an 8-PR series. The rest:
2. `mcp_aws-scaffold` — provider + gateway + tests
3. `mcp_aws-policy` — MCPPolicyEnforced opt-in
4. `mcp_aws-docs` — skill.md + README
5. `mcp_aws-register` — cmd/server wiring
6. `framework-streaming-thread-safe` — atomic accessors across providers
7. ~~mcp-policy-method-aware — #289~~ merged
8. ~~mcp_github-policy-doc-fix — #290~~ merged
EOF
)