### PR TITLE
feat(mcp_aws): provider scaffold + SigV4 gateway

### DIFF
--- a/provider/mcp_aws/credentials.go
+++ b/provider/mcp_aws/credentials.go
@@ -1,0 +1,42 @@
+package mcp_aws
+
+import (
+	"fmt"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+)
+
+// extractAWSCredentials reads AWS credentials from req.Credential, which is
+// populated by core's implicit-auth pipeline before the gateway handler runs.
+// Mirrors alicloud's getCredentials in shape but matches the field names
+// written by the aws source driver: access_key_id / secret_access_key /
+// session_token (session_token is empty for long-lived AKIA... keys).
+//
+// Returns an error only on programmer-detected mismatch (wrong credential
+// type bound to the role, or missing required fields). req.Credential is
+// guaranteed non-nil here — STS mint failures surface earlier as
+// logical.ErrorResponse from core's mintCredentialForRequest and the
+// gateway handler is never invoked in that case.
+func extractAWSCredentials(req *logical.Request) (awssdk.Credentials, error) {
+	if req.Credential == nil {
+		return awssdk.Credentials{}, fmt.Errorf("no credential available")
+	}
+	if req.Credential.Type != credential.TypeAWSAccessKeys {
+		return awssdk.Credentials{}, fmt.Errorf("unsupported credential type %q (expected %q)", req.Credential.Type, credential.TypeAWSAccessKeys)
+	}
+
+	ak := req.Credential.Data["access_key_id"]
+	sk := req.Credential.Data["secret_access_key"]
+	if ak == "" || sk == "" {
+		return awssdk.Credentials{}, fmt.Errorf("credential missing access_key_id or secret_access_key")
+	}
+
+	return awssdk.Credentials{
+		AccessKeyID:     ak,
+		SecretAccessKey: sk,
+		SessionToken:    req.Credential.Data["session_token"],
+	}, nil
+}

--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -1,0 +1,139 @@
+package mcp_aws
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/sigv4"
+)
+
+// headersToStrip removes client-supplied auth/identity headers before signing.
+// SigV4-irrelevant hop-by-hop and proxy headers are removed by
+// sigv4.NormalizeRequest, so we only need the Warden-specific set here.
+var headersToStrip = []string{
+	"Authorization",
+	"X-Warden-Token",
+	"X-Warden-Namespace",
+	"X-Warden-Provider",
+	"X-Warden-Role",
+	"X-Warden-On-Behalf-Of",
+	"Cookie",
+}
+
+// handleGateway signs the incoming MCP request with AWS SigV4 using credentials
+// minted by core's implicit-auth pipeline, then forwards to the upstream MCP
+// endpoint and streams the response back.
+//
+// Pipeline:
+//  1. Read body (capped by MaxBodySize, the same value ShouldEnforceMCPPolicy
+//     returns to core's MCP body extractor — single source of truth).
+//  2. Read AWS credentials from req.Credential (populated by core).
+//  3. Strip Warden auth / identity headers.
+//  4. Rewrite request URL onto the upstream — plumb scheme/host/path/host
+//     explicitly, never path.Join (which mutates escapes and breaks SigV4).
+//  5. Normalize headers (drop hop-by-hop + proxy-forwarded set).
+//  6. Sign with sigv4.ResignRequest using the URL-derived service name and the
+//     resolved region.
+//  7. Forward via sigv4.ForwardDirect, which bypasses httputil.ReverseProxy so
+//     headers and the signed body reach the upstream byte-for-byte.
+func (b *mcpAWSBackend) handleGateway(ctx context.Context, req *logical.Request) {
+	r := req.HTTPRequest
+	w := req.ResponseWriter
+
+	snap := b.snapshot()
+	if snap.upstreamURL == nil {
+		http.Error(w, "mcp_aws not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Apply the timeout BEFORE reading the body so a slow client upload
+	// can't stall a worker indefinitely.
+	if snap.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, snap.timeout)
+		defer cancel()
+		r = r.WithContext(ctx)
+		req.HTTPRequest = r
+	}
+
+	bodyBytes, err := sigv4.ReadRequestBody(r, snap.maxBody)
+	if err != nil {
+		// sigv4.ReadRequestBody returns "request body exceeds maximum size"
+		// when the cap is hit; everything else is an IO error. 413 is the
+		// right code for the former; 400 is acceptable for the latter.
+		status := http.StatusBadRequest
+		if strings.Contains(err.Error(), "exceeds maximum size") {
+			status = http.StatusRequestEntityTooLarge
+		}
+		http.Error(w, "Failed to read request body", status)
+		return
+	}
+	if bodyBytes == nil {
+		bodyBytes = []byte{}
+	}
+
+	creds, err := extractAWSCredentials(req)
+	if err != nil {
+		// Wrong credential type bound to the role is a programmer error,
+		// not a client error — return 500 so it surfaces as an alert, not
+		// a silently-suppressed 401.
+		b.Logger.Error("AWS credential extraction failed", logger.Err(err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	for _, h := range headersToStrip {
+		r.Header.Del(h)
+	}
+
+	rewriteUpstreamURL(r, snap.upstreamURL)
+
+	bodyBytes = sigv4.NormalizeRequest(b.Logger, r, bodyBytes)
+
+	service, _ := serviceAndRegion(snap.upstreamURL)
+	if err := sigv4.ResignRequest(ctx, b.signer, r, creds, service, snap.region, bodyBytes); err != nil {
+		b.Logger.Error("Failed to sign request", logger.Err(err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	b.Logger.Trace("Proxying mcp_aws request",
+		logger.String("method", r.Method),
+		logger.String("host", snap.upstreamURL.Host),
+		logger.String("inbound_path", req.Path),
+		logger.String("outbound_path", r.URL.Path),
+		logger.String("service", service),
+		logger.String("region", snap.region),
+		logger.String("request_id", req.RequestID),
+	)
+
+	transport := snap.transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	sigv4.ForwardDirect(b.Logger, w, r, bodyBytes, transport)
+}
+
+// rewriteUpstreamURL mutates r in place to target the upstream MCP endpoint.
+// Path composition uses string concatenation, NOT path.Join, because path.Join
+// collapses ".." segments, repeated slashes, and re-escapes — all of which
+// invalidate the SigV4 canonical request. RawQuery is preserved verbatim.
+func rewriteUpstreamURL(r *http.Request, upstream *url.URL) {
+	tail := pathAfterGateway(r.URL.Path)
+
+	r.URL.Scheme = upstream.Scheme
+	r.URL.Host = upstream.Host
+	r.URL.Path = upstream.Path + tail
+	// RawPath is left empty so net/http re-derives it from Path. The inbound
+	// request's RawPath only matters if the client used non-canonical escapes
+	// in the gateway segment itself, which mcp_aws clients do not.
+	r.URL.RawPath = ""
+
+	r.Host = upstream.Host
+	// RequestURI must be empty on outbound client requests.
+	r.RequestURI = ""
+}

--- a/provider/mcp_aws/gateway_test.go
+++ b/provider/mcp_aws/gateway_test.go
@@ -1,0 +1,342 @@
+package mcp_aws
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/sigv4"
+)
+
+// captured holds what the upstream test server saw.
+type captured struct {
+	mu      sync.Mutex
+	method  string
+	host    string
+	path    string
+	headers http.Header
+	body    []byte
+}
+
+func (c *captured) snapshot() captured {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return captured{
+		method:  c.method,
+		host:    c.host,
+		path:    c.path,
+		headers: c.headers.Clone(),
+		body:    append([]byte(nil), c.body...),
+	}
+}
+
+// newCapturingUpstream stands up a test server that records the first request
+// it receives and returns 200 with a fixed body.
+func newCapturingUpstream(t *testing.T) (*httptest.Server, *captured) {
+	t.Helper()
+	cap := &captured{}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		cap.mu.Lock()
+		cap.method = r.Method
+		cap.host = r.Host
+		cap.path = r.URL.Path
+		cap.headers = r.Header.Clone()
+		cap.body = body
+		cap.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	return srv, cap
+}
+
+// configureBackendForUpstream points the backend at the test server's URL,
+// preserving the test-server-supplied TLS transport so the request actually
+// reaches it.
+func configureBackendForUpstream(t *testing.T, b *mcpAWSBackend, srv *httptest.Server) {
+	t.Helper()
+	u, err := url.Parse(srv.URL + "/mcp")
+	require.NoError(t, err)
+	b.mu.Lock()
+	b.upstreamURL = u
+	b.region = "us-east-1"
+	b.mu.Unlock()
+	b.Proxy.Transport = srv.Client().Transport
+}
+
+// makeMCPRequest builds a *logical.Request as if a Warden bearer-token client
+// had POSTed the given JSON-RPC body to the gateway path. The Path arg is the
+// inbound URL path (e.g. "/gateway/" or "/role/s3-reader/gateway/tools/call").
+func makeMCPRequest(path, body string, cred *credential.Credential) (*logical.Request, *httptest.ResponseRecorder) {
+	r := httptest.NewRequest(http.MethodPost, "https://warden.example.com"+path, strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json, text/event-stream")
+	// Headers that mcp_aws must strip before signing.
+	r.Header.Set("Authorization", "Bearer warden-session-token")
+	r.Header.Set("X-Warden-Token", "warden-session-token")
+	r.Header.Set("X-Warden-Namespace", "team-data")
+	r.Header.Set("X-Warden-Provider", "mcp_aws/")
+	r.Header.Set("X-Warden-Role", "s3-reader")
+	r.Header.Set("X-Warden-On-Behalf-Of", "alice@example.com")
+	// Hop-by-hop that NormalizeRequest must drop.
+	r.Header.Set("Connection", "keep-alive")
+
+	rec := httptest.NewRecorder()
+	return &logical.Request{
+		HTTPRequest:    r,
+		ResponseWriter: rec,
+		Path:           strings.TrimPrefix(path, "/"),
+		Credential:     cred,
+	}, rec
+}
+
+func stsCredential() *credential.Credential {
+	return &credential.Credential{
+		Type: credential.TypeAWSAccessKeys,
+		Data: map[string]string{
+			"access_key_id":     "ASIAEXAMPLE0000ABCD",
+			"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			"session_token":     "session-token-from-sts",
+		},
+	}
+}
+
+func longLivedCredential() *credential.Credential {
+	return &credential.Credential{
+		Type: credential.TypeAWSAccessKeys,
+		Data: map[string]string{
+			"access_key_id":     "AKIAEXAMPLE0000ABCD",
+			"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			// no session_token
+		},
+	}
+}
+
+// --- happy path / STS creds ---
+
+func TestHandleGateway_SignsAndForwards_STS(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	req, rec := makeMCPRequest("/gateway/", body, stsCredential())
+
+	b.handleGateway(context.Background(), req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "upstream should have returned 200")
+
+	got := capRec.snapshot()
+	assert.Equal(t, http.MethodPost, got.method)
+	assert.Equal(t, "/mcp/", got.path, "trailing slash on gateway/ must reach upstream as /mcp/")
+	assert.Equal(t, body, string(got.body), "body must reach upstream unmodified")
+
+	// Signature parses as SigV4.
+	auth := got.headers.Get("Authorization")
+	require.True(t, strings.HasPrefix(auth, "AWS4-HMAC-SHA256 "), "Authorization must be SigV4: %q", auth)
+	service, region, accessKey, err := sigv4.ExtractFromAuthHeader(auth)
+	require.NoError(t, err)
+	assert.NotEmpty(t, service, "credential scope service must be derived from upstream URL host")
+	assert.Equal(t, "us-east-1", region)
+	assert.True(t, strings.HasPrefix(accessKey, "ASIA"), "STS-minted creds yield ASIA-prefixed access keys, got %q", accessKey)
+
+	// STS session token must flow through as X-Amz-Security-Token.
+	assert.Equal(t, "session-token-from-sts", got.headers.Get("X-Amz-Security-Token"))
+
+	// SigV4 ancillary headers present.
+	assert.NotEmpty(t, got.headers.Get("X-Amz-Date"))
+	assert.NotEmpty(t, got.headers.Get("X-Amz-Content-Sha256"))
+
+	// No Warden header leak.
+	for _, h := range []string{"X-Warden-Token", "X-Warden-Namespace", "X-Warden-Provider", "X-Warden-Role", "X-Warden-On-Behalf-Of"} {
+		assert.Empty(t, got.headers.Get(h), "header %q leaked to upstream", h)
+	}
+	// No Bearer leak — Authorization must be SigV4 only.
+	assert.NotContains(t, auth, "Bearer", "Authorization leaked Bearer token")
+
+	// Connection must not appear in the SignedHeaders list.
+	assert.NotContains(t, strings.ToLower(auth), ";connection", "Connection must not be a signed header")
+}
+
+// --- long-lived keys: no session token ---
+
+func TestHandleGateway_SignsAndForwards_LongLivedKeys(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	req, rec := makeMCPRequest("/gateway/", body, longLivedCredential())
+
+	b.handleGateway(context.Background(), req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got := capRec.snapshot()
+	auth := got.headers.Get("Authorization")
+	_, _, accessKey, err := sigv4.ExtractFromAuthHeader(auth)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(accessKey, "AKIA"), "long-lived creds yield AKIA-prefixed access keys, got %q", accessKey)
+	// X-Amz-Security-Token must be absent when no session token is present.
+	assert.Empty(t, got.headers.Get("X-Amz-Security-Token"), "long-lived creds must not carry a security token")
+}
+
+// --- trailing-slash + tail preservation ---
+
+func TestHandleGateway_TrailingSlashPreservedOnRoot(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+	b.handleGateway(context.Background(), req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, "/mcp/", capRec.snapshot().path, "gateway/ must preserve trailing slash")
+}
+
+func TestHandleGateway_DeepTailPreserved(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	req, rec := makeMCPRequest("/gateway/tools/call", `{"jsonrpc":"2.0","id":1,"method":"tools/call"}`, stsCredential())
+	b.handleGateway(context.Background(), req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, "/mcp/tools/call", capRec.snapshot().path)
+}
+
+func TestHandleGateway_RolePrefixedPath(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	req, rec := makeMCPRequest("/role/s3-reader/gateway/tools/call", `{"jsonrpc":"2.0","id":1,"method":"tools/call"}`, stsCredential())
+	b.handleGateway(context.Background(), req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, "/mcp/tools/call", capRec.snapshot().path)
+}
+
+// --- error paths ---
+
+func TestHandleGateway_WrongCredentialType(t *testing.T) {
+	srv, _ := newCapturingUpstream(t)
+	defer srv.Close()
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	wrongCred := &credential.Credential{
+		Type: credential.TypeGitHubToken,
+		Data: map[string]string{"token": "ghp_xxx"},
+	}
+	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, wrongCred)
+	b.handleGateway(context.Background(), req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code, "wrong credential type is a programmer error, must surface as 500")
+}
+
+// --- AgentCore service name routing ---
+
+// redirectTransport rewrites every outbound request to target a local test
+// server while leaving r.URL.Host and r.Host untouched on the signed request.
+// This lets us assert that mcp_aws derives the correct SigV4 service name
+// (e.g. "bedrock-agentcore") from a fake upstream host without standing up
+// AWS DNS.
+type redirectTransport struct {
+	target *url.URL
+	inner  http.RoundTripper
+}
+
+func (rt *redirectTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	clone := r.Clone(r.Context())
+	clone.URL = &url.URL{
+		Scheme:   rt.target.Scheme,
+		Host:     rt.target.Host,
+		Path:     r.URL.Path,
+		RawQuery: r.URL.RawQuery,
+	}
+	// Leave clone.Host as the original — this is what the signed Host header
+	// expects to see; the transport just dials a different address.
+	return rt.inner.RoundTrip(clone)
+}
+
+// TestHandleGateway_ThroughConfigWrite drives the gateway via the same path
+// production uses: handleConfigWrite sets up state, then handleGateway runs.
+// Catches regressions that the configureBackendForUpstream backdoor (which
+// mutates b.upstreamURL directly) would miss — for example, a misnamed
+// persisted field or a missed lock in applyParsedConfig.
+func TestHandleGateway_ThroughConfigWrite(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	// Point the shared transport at the test server's TLS config so the
+	// upstream URL (which we'll set to the test server URL via config-write)
+	// resolves correctly.
+	b.Proxy.Transport = srv.Client().Transport
+
+	path := b.pathConfig()
+	fd := makeFieldData(path, map[string]any{
+		"mcp_aws_url":    srv.URL + "/mcp",
+		"region":         "us-east-1",
+		"auto_auth_path": "auth/jwt/",
+	})
+	resp, err := b.handleConfigWrite(context.Background(), nil, fd)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Config-write rebuilt the transport via applyParsedConfig. We need to
+	// re-point it at the test server (no TLS overrides → shared transport).
+	b.Proxy.Transport = srv.Client().Transport
+
+	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+	b.handleGateway(context.Background(), req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, capRec.snapshot().headers.Get("Authorization"))
+}
+
+func TestHandleGateway_AgentCoreServiceInference(t *testing.T) {
+	srv, capRec := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	agentCoreURL, _ := url.Parse("https://runtime.bedrock-agentcore.us-east-1.amazonaws.com/agents/myMcp/invocations")
+	srvURL, _ := url.Parse(srv.URL)
+	b.mu.Lock()
+	b.upstreamURL = agentCoreURL
+	b.region = "us-east-1"
+	b.mu.Unlock()
+	b.Proxy.Transport = &redirectTransport{
+		target: srvURL,
+		inner:  srv.Client().Transport,
+	}
+
+	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+	b.handleGateway(context.Background(), req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	auth := capRec.snapshot().headers.Get("Authorization")
+	service, region, _, err := sigv4.ExtractFromAuthHeader(auth)
+	require.NoError(t, err)
+	assert.Equal(t, "bedrock-agentcore", service, "AgentCore host must yield service=bedrock-agentcore via arm 1 of the structured match")
+	assert.Equal(t, "us-east-1", region)
+}

--- a/provider/mcp_aws/path_config.go
+++ b/provider/mcp_aws/path_config.go
@@ -1,0 +1,173 @@
+package mcp_aws
+
+import (
+	"context"
+	"net/http"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+)
+
+func (b *mcpAWSBackend) pathConfig() *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			"mcp_aws_url": {
+				Type:        framework.TypeString,
+				Description: "MCP endpoint base URL (default: " + DefaultMCPAWSURL + ")",
+				Default:     DefaultMCPAWSURL,
+			},
+			"region": {
+				Type:        framework.TypeString,
+				Description: "SigV4 signing region. Optional when the URL host yields one via DNS-label inference; required otherwise (e.g. GovCloud, China partition, custom test hosts).",
+			},
+			"max_body_size": {
+				Type:        framework.TypeInt64,
+				Description: "Maximum request body size in bytes (default: 10MB, max: 100MB)",
+				Default:     framework.DefaultMaxBodySize,
+			},
+			"timeout": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Session timeout duration (default: 10m)",
+				Default:     DefaultMCPAWSTimeout.String(),
+			},
+			"auto_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Path to auth mount for implicit authentication (e.g., 'auth/jwt/'). Required.",
+			},
+			"default_role": {
+				Type:        framework.TypeString,
+				Description: "Fallback role when not specified by header or URL path.",
+			},
+			"tls_skip_verify": {
+				Type:        framework.TypeBool,
+				Description: "Skip TLS certificate verification (dev/test only).",
+				Default:     false,
+			},
+			"ca_data": {
+				Type:        framework.TypeString,
+				Description: "Base64-encoded PEM CA certificate for custom certificate authorities.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.handleConfigRead,
+				Summary:  "Read mcp_aws provider configuration",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.handleConfigWrite,
+				Summary:  "Configure mcp_aws provider settings",
+			},
+		},
+		HelpSynopsis:    "Configure mcp_aws provider",
+		HelpDescription: "Configures the mcp_aws provider settings including upstream URL, signing region, timeouts, and implicit auth path.",
+	}
+}
+
+func (b *mcpAWSBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	tc := b.TransparentConfig
+	data := map[string]any{
+		"region":          b.region,
+		"max_body_size":   b.MaxBodySize,
+		"timeout":         b.Timeout.String(),
+		"auto_auth_path":  tc.AutoAuthPath,
+		"default_role":    tc.DefaultAuthRole,
+		"tls_skip_verify": b.tlsSkipVerify,
+		"ca_data":         b.caData,
+	}
+	if b.upstreamURL != nil {
+		data["mcp_aws_url"] = b.upstreamURL.String()
+	}
+	return &logical.Response{StatusCode: http.StatusOK, Data: data}, nil
+}
+
+// handleConfigWrite merges incoming fields with the live config and applies.
+// Always re-runs applyParsedConfig so the URL → region inference is reapplied
+// — if an operator changes mcp_aws_url to a different-region host, the cached
+// region must move with it.
+//
+// The persist data is the snapshot returned by applyParsedConfig — it captures
+// what THIS write resolved to, computed from the merged config alone, so it
+// cannot be torn by a concurrent writer racing in between resolution and Put.
+func (b *mcpAWSBackend) handleConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	conf := b.snapshotForMerge()
+
+	for _, k := range []string{
+		"mcp_aws_url", "region", "max_body_size", "timeout",
+		"auto_auth_path", "default_role", "tls_skip_verify", "ca_data",
+	} {
+		if val, ok := d.GetOk(k); ok {
+			conf[k] = val
+		}
+	}
+
+	// auto_auth_path is required. Reject before applying any other changes so
+	// a partial-update can never silently disable transparent mode.
+	if s, _ := conf["auto_auth_path"].(string); s == "" {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+		}, nil
+	}
+
+	if err := httpproxy.ValidateConfig(conf, "mcp_aws_url"); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest(err.Error()),
+		}, nil
+	}
+
+	persist, err := b.applyParsedConfig(conf)
+	if err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest(err.Error()),
+		}, nil
+	}
+
+	if b.StorageView != nil {
+		entry, err := sdklogical.StorageEntryJSON("config", persist)
+		if err != nil {
+			return &logical.Response{StatusCode: http.StatusInternalServerError, Err: err}, nil
+		}
+		if err := b.StorageView.Put(ctx, entry); err != nil {
+			return &logical.Response{StatusCode: http.StatusInternalServerError, Err: err}, nil
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"message": "configuration updated"},
+	}, nil
+}
+
+// snapshotForMerge returns a copy of the backend's live config in the shape
+// expected by httpproxy.ParseConfig, used as the merge base for partial
+// updates. "region" is the raw operator-supplied configRegion (possibly
+// empty) — never the resolved region — so a config-write that changes only
+// mcp_aws_url correctly re-infers from the new host instead of carrying the
+// stale resolved region forward.
+func (b *mcpAWSBackend) snapshotForMerge() map[string]any {
+	b.mu.RLock()
+	tc := b.TransparentConfig
+	conf := map[string]any{
+		"region":          b.configRegion,
+		"max_body_size":   b.MaxBodySize,
+		"timeout":         b.Timeout.String(),
+		"auto_auth_path":  tc.AutoAuthPath,
+		"default_role":    tc.DefaultAuthRole,
+		"tls_skip_verify": b.tlsSkipVerify,
+		"ca_data":         b.caData,
+	}
+	if b.upstreamURL != nil {
+		conf["mcp_aws_url"] = b.upstreamURL.String()
+	}
+	b.mu.RUnlock()
+	return conf
+}

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -1,0 +1,349 @@
+package mcp_aws
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+)
+
+// DefaultMCPAWSURL is the GA endpoint for AWS's hosted MCP Server.
+const DefaultMCPAWSURL = "https://aws-mcp.us-east-1.api.aws/mcp"
+
+// DefaultMCPAWSTimeout caps a single MCP session. MCP responses may stream
+// over SSE across many tool calls, so the default matches mcp_github.
+const DefaultMCPAWSTimeout = 10 * time.Minute
+
+// mcpAWSBackend is the streaming backend for mcp_aws.
+//
+// Implicit auth is wired by the embedded *framework.StreamingBackend via
+// SetTransparentConfig: core populates req.Credential before handleGateway
+// runs. The backend itself only consumes the credential and signs the
+// outgoing request.
+//
+// Do NOT declare a local maxBodySize field — MaxBodySize is promoted from
+// the embedded *framework.StreamingBackend; a lowercase shadow would
+// silently desync the MCP policy body cap from the SigV4 body cap.
+type mcpAWSBackend struct {
+	*framework.StreamingBackend
+
+	// signer is shared across requests. v4.Signer's derived-key cache is
+	// keyed on (secretKey, date, region, service); one signer per mount
+	// makes cache reuse a feature.
+	signer *v4.Signer
+
+	mu          sync.RWMutex
+	upstreamURL *url.URL
+	// configRegion is the operator-supplied region (empty if not set).
+	// Persisted as-is so a URL-only update can re-infer region from the new
+	// host instead of sticking to the previously resolved value.
+	configRegion string
+	// region is the resolved signing region: coalesce(configRegion, URL-inferred).
+	// This is the value passed to sigv4.ResignRequest.
+	region        string
+	tlsSkipVerify bool
+	caData        string
+}
+
+// shared transport, initialized once per process.
+var (
+	sharedTransport   *http.Transport
+	transportShutdown func()
+	transportOnce     sync.Once
+)
+
+func initTransport() {
+	transportOnce.Do(func() {
+		sharedTransport, transportShutdown = httpproxy.DefaultNewTransport()
+	})
+}
+
+// ShutdownHTTPTransport closes idle connections on the shared transport.
+func ShutdownHTTPTransport() {
+	if transportShutdown != nil {
+		transportShutdown()
+	}
+}
+
+// Factory creates a new mcp_aws provider backend.
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := &mcpAWSBackend{
+		signer: v4.NewSigner(),
+	}
+
+	b.StreamingBackend = &framework.StreamingBackend{
+		StreamingPaths: []*framework.StreamingPath{
+			{
+				Pattern:         "gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "AWS MCP gateway proxy",
+				HelpDescription: "Proxies MCP traffic to AWS-hosted MCP endpoints with SigV4 signing.",
+			},
+			{
+				Pattern:         "gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "AWS MCP gateway proxy",
+				HelpDescription: "Proxies MCP traffic to AWS-hosted MCP endpoints with SigV4 signing.",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "AWS MCP transparent gateway",
+				HelpDescription: "Proxies MCP traffic with the role embedded in the URL path.",
+			},
+			{
+				Pattern:         "role/[^/]+/gateway/.*",
+				Handler:         b.handleGatewayStreaming,
+				HelpSynopsis:    "AWS MCP transparent gateway",
+				HelpDescription: "Proxies MCP traffic with the role embedded in the URL path.",
+			},
+		},
+		TransparentConfig: &framework.TransparentConfig{
+			AutoAuthPath:    "",
+			DefaultAuthRole: "",
+		},
+		// ParseStreamBody intentionally left at false. MCP-enforcing specs
+		// must not pre-parse the body — the core's MCP extractor reads the
+		// body itself when ShouldEnforceMCPPolicy returns true.
+		Backend: &framework.Backend{
+			Help:         mcpAWSBackendHelp,
+			BackendType:  "mcp_aws",
+			BackendClass: logical.ClassProvider,
+			Paths: []*framework.Path{
+				b.pathConfig(),
+			},
+		},
+	}
+
+	b.Logger = conf.Logger.WithSubsystem("mcp_aws")
+	b.StorageView = conf.StorageView
+
+	initTransport()
+	b.StreamingBackend.InitProxy(sharedTransport)
+
+	if conf.RegisterShutdownHook != nil {
+		conf.RegisterShutdownHook("mcp_aws-transport", ShutdownHTTPTransport)
+	}
+
+	if err := b.StreamingBackend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+
+	// Defaults until Initialize loads persisted config.
+	b.MaxBodySize = framework.DefaultMaxBodySize
+	b.Timeout = DefaultMCPAWSTimeout
+	if u, err := url.Parse(DefaultMCPAWSURL); err == nil {
+		b.upstreamURL = u
+		_, b.region = serviceAndRegion(u)
+	}
+
+	if len(conf.Config) > 0 {
+		if err := httpproxy.ValidateConfig(conf.Config, "mcp_aws_url"); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+		if _, err := b.applyParsedConfig(conf.Config); err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
+
+// applyParsedConfig parses conf, validates it, builds the new transport,
+// and installs all resolved values under a single write lock. Returns the
+// canonical data to persist (computed from the input alone, never from b.*,
+// so it can't be stale by the time the caller calls Put).
+//
+// Validation + transport build happen BEFORE the lock is taken so a failure
+// in either leaves b.* untouched — no half-mutated state if the CA bundle
+// is malformed or a TLS-toggle build fails.
+//
+// TLS handling covers both directions: a config that drops tls_skip_verify
+// or clears ca_data falls back to the shared default transport (the prior
+// implementation only rebuilt when the NEW config had overrides, which left
+// a stuck-state bug where toggling skip-verify off kept the old skip-verify
+// transport in place).
+func (b *mcpAWSBackend) applyParsedConfig(conf map[string]any) (map[string]any, error) {
+	parsed := httpproxy.ParseConfig(conf, "mcp_aws_url", DefaultMCPAWSURL, DefaultMCPAWSTimeout)
+	u, err := url.Parse(parsed.ProviderURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mcp_aws_url: %w", err)
+	}
+	// Strip a trailing slash on the upstream path so r.URL.Path = u.Path + tail
+	// never produces "//" when tail begins with "/" (the gateway-suffix
+	// extractor always returns "" or a leading-slash string).
+	u.Path = strings.TrimRight(u.Path, "/")
+
+	_, inferredRegion := serviceAndRegion(u)
+	configRegion, _ := conf["region"].(string)
+	configRegion = strings.TrimSpace(configRegion)
+	resolvedRegion := configRegion
+	if resolvedRegion == "" {
+		resolvedRegion = inferredRegion
+	}
+	if resolvedRegion == "" {
+		return nil, fmt.Errorf("region is required: upstream host %q does not yield a region; set the region config field", u.Host)
+	}
+
+	// Build the transport BEFORE touching state. Either branch returns a
+	// valid http.RoundTripper, so a config-write that removes TLS overrides
+	// successfully falls back to sharedTransport.
+	var newTransport http.RoundTripper
+	if parsed.TLSSkipVerify || parsed.CAData != "" {
+		tr, err := httpproxy.NewTransportWithTLS(parsed.CAData, parsed.TLSSkipVerify)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+		}
+		newTransport = tr
+	} else {
+		newTransport = sharedTransport
+	}
+
+	maxBody := parsed.MaxBodySize
+	if maxBody == 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+	timeout := parsed.Timeout
+	if timeout == 0 {
+		timeout = DefaultMCPAWSTimeout
+	}
+
+	persist := map[string]any{
+		"mcp_aws_url":     u.String(),
+		"region":          configRegion,
+		"max_body_size":   maxBody,
+		"timeout":         timeout.String(),
+		"auto_auth_path":  parsed.AutoAuthPath,
+		"default_role":    parsed.DefaultAuthRole,
+		"tls_skip_verify": parsed.TLSSkipVerify,
+		"ca_data":         parsed.CAData,
+	}
+
+	b.mu.Lock()
+	b.upstreamURL = u
+	b.configRegion = configRegion
+	b.region = resolvedRegion
+	b.tlsSkipVerify = parsed.TLSSkipVerify
+	b.caData = parsed.CAData
+	b.MaxBodySize = maxBody
+	b.Timeout = timeout
+	b.Proxy.Transport = newTransport
+	b.mu.Unlock()
+
+	// SetTransparentConfig is the framework's own writer; it does its own
+	// pointer swap on b.TransparentConfig. Concurrent readers see either the
+	// old or new pointer, never a torn one — TransparentConfig is replaced
+	// wholesale, not mutated in place.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+		AutoAuthPath:    parsed.AutoAuthPath,
+		DefaultAuthRole: parsed.DefaultAuthRole,
+	})
+
+	return persist, nil
+}
+
+// Initialize loads persisted configuration from storage. The embedded
+// StreamingBackend.Initialize only delegates to Backend.Initialize and does
+// not load persisted config or call SetTransparentConfig — so this is a
+// wholly custom override, not a partial extension.
+func (b *mcpAWSBackend) Initialize(ctx context.Context) error {
+	if b.StorageView == nil {
+		return nil
+	}
+
+	entry, err := b.StorageView.Get(ctx, "config")
+	if err != nil {
+		return fmt.Errorf("failed to read config from storage: %w", err)
+	}
+	if entry == nil {
+		return nil
+	}
+
+	var stored map[string]any
+	if err := entry.DecodeJSON(&stored); err != nil {
+		return fmt.Errorf("failed to decode config: %w", err)
+	}
+
+	_, err = b.applyParsedConfig(stored)
+	return err
+}
+
+// handleGatewayStreaming wraps handleGateway for the streaming path handler.
+func (b *mcpAWSBackend) handleGatewayStreaming(ctx context.Context, req *logical.Request, _ *framework.FieldData) error {
+	b.handleGateway(ctx, req)
+	return nil
+}
+
+// backendSnapshot is the read-locked view consumed by handleGateway. Capturing
+// every per-request field at one lock acquisition prevents tearing under a
+// concurrent config-write.
+type backendSnapshot struct {
+	upstreamURL *url.URL
+	region      string
+	maxBody     int64
+	timeout     time.Duration
+	transport   http.RoundTripper
+}
+
+func (b *mcpAWSBackend) snapshot() backendSnapshot {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return backendSnapshot{
+		upstreamURL: b.upstreamURL,
+		region:      b.region,
+		maxBody:     b.MaxBodySize,
+		timeout:     b.Timeout,
+		transport:   b.Proxy.Transport,
+	}
+}
+
+// SensitiveConfigFields returns the list of config fields masked in output.
+func (b *mcpAWSBackend) SensitiveConfigFields() []string {
+	return []string{"ca_data"}
+}
+
+const mcpAWSBackendHelp = `
+The mcp_aws provider proxies requests to AWS-hosted MCP endpoints, signing
+the outgoing request with AWS SigV4 using credentials minted by the aws
+source driver.
+
+Two AWS deployment patterns are supported via the same provider:
+
+  - AWS's hosted MCP Server product (aws-mcp.{region}.api.aws/mcp)
+  - Customer-owned MCP servers on Bedrock AgentCore Runtime or Gateway
+    (runtime|gateway.bedrock-agentcore.{region}.amazonaws.com/...)
+
+The SigV4 service name and signing region are derived from the upstream
+URL host using a structured DNS-label match. The mount's region is only
+the signing region for the MCP endpoint itself; it does not restrict the
+AWS region of API calls the agent makes — the agent selects target
+regions inside the MCP tool arguments.
+
+The gateway path format is:
+
+  /mcp_aws/gateway/{mcp-path}
+  /mcp_aws/role/{role}/gateway/{mcp-path}
+
+JSON-RPC bodies, the Accept header, and the Mcp-Session-Id header pass
+through unchanged. Streamable HTTP responses (JSON or SSE) stream
+without buffering.
+
+Configuration:
+- mcp_aws_url:    MCP endpoint base URL (default: https://aws-mcp.us-east-1.api.aws/mcp)
+- region:         SigV4 signing region. Optional when the URL host yields one
+                  via DNS-label inference; required for hosts that don't
+                  (GovCloud, China partition, custom test hosts).
+- max_body_size:  Maximum request body size (default: 10MB, max: 100MB)
+- timeout:        Session timeout (default: 10m)
+- auto_auth_path: Auth mount path for implicit authentication (required)
+- default_role:   Fallback role when not specified by header or URL path
+`

--- a/provider/mcp_aws/provider_test.go
+++ b/provider/mcp_aws/provider_test.go
@@ -1,0 +1,259 @@
+package mcp_aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+)
+
+// --- test helpers ---
+
+type inmemStorage struct {
+	mu   sync.RWMutex
+	data map[string]*sdklogical.StorageEntry
+}
+
+func newInmemStorage() *inmemStorage {
+	return &inmemStorage{data: make(map[string]*sdklogical.StorageEntry)}
+}
+
+func (s *inmemStorage) List(_ context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			keys = append(keys, k[len(prefix):])
+		}
+	}
+	return keys, nil
+}
+
+func (s *inmemStorage) Get(_ context.Context, key string) (*sdklogical.StorageEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data[key], nil
+}
+
+func (s *inmemStorage) Put(_ context.Context, entry *sdklogical.StorageEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[entry.Key] = entry
+	return nil
+}
+
+func (s *inmemStorage) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *inmemStorage) ListPage(_ context.Context, prefix string, _ string, _ int) ([]string, error) {
+	return s.List(context.Background(), prefix)
+}
+
+func testLogger() *logger.GatedLogger {
+	config := &logger.Config{Level: logger.TraceLevel, Format: logger.DefaultFormat}
+	gateConfig := logger.GatedWriterConfig{InitialState: logger.GateOpen}
+	gl, _ := logger.NewGatedLogger(config, gateConfig)
+	return gl
+}
+
+func setupBackend(t *testing.T) *mcpAWSBackend {
+	t.Helper()
+	conf := &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+	}
+	b, err := Factory(context.Background(), conf)
+	require.NoError(t, err)
+	return b.(*mcpAWSBackend)
+}
+
+func makeFieldData(path *framework.Path, raw map[string]any) *framework.FieldData {
+	return &framework.FieldData{Raw: raw, Schema: path.Fields}
+}
+
+// --- Factory tests ---
+
+func TestFactory_Defaults(t *testing.T) {
+	b := setupBackend(t)
+	assert.Equal(t, "mcp_aws", b.Type())
+	assert.Equal(t, logical.ClassProvider, b.Class())
+	assert.Equal(t, DefaultMCPAWSTimeout, b.Timeout)
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize)
+	// Default URL yields region via arm 2 of the structured match.
+	assert.Equal(t, "us-east-1", b.region)
+	require.NotNil(t, b.upstreamURL)
+	assert.Equal(t, "aws-mcp.us-east-1.api.aws", b.upstreamURL.Host)
+}
+
+func TestFactory_WithConfig(t *testing.T) {
+	conf := &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+		Config: map[string]any{
+			"mcp_aws_url":    "https://aws-mcp.eu-frankfurt-1.api.aws/mcp",
+			"timeout":        "60s",
+			"auto_auth_path": "auth/jwt/",
+			"default_role":   "reader",
+		},
+	}
+	b, err := Factory(context.Background(), conf)
+	require.NoError(t, err)
+	mb := b.(*mcpAWSBackend)
+	assert.Equal(t, "eu-frankfurt-1", mb.region)
+	assert.Equal(t, 60.0, mb.Timeout.Seconds())
+	assert.Equal(t, "auth/jwt/", mb.TransparentConfig.AutoAuthPath)
+	assert.Equal(t, "reader", mb.TransparentConfig.DefaultAuthRole)
+}
+
+func TestFactory_RegionRequiredForUnresolvableHost(t *testing.T) {
+	// Custom host that doesn't match any inference arm; no region provided.
+	rawConf := map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.cn-north-1.amazonaws.com.cn/mcp",
+		"auto_auth_path": "auth/jwt/",
+	}
+	// Guard the test against a future ValidateConfig change rejecting this
+	// URL for unrelated reasons — we want to assert the region-inference
+	// fallback, not URL validation.
+	require.NoError(t,
+		httpproxy.ValidateConfig(rawConf, "mcp_aws_url"),
+		"this test depends on the URL passing httpproxy.ValidateConfig",
+	)
+
+	conf := &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+		Config:      rawConf,
+	}
+	_, err := Factory(context.Background(), conf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region is required")
+}
+
+func TestFactory_ExplicitRegionForUnresolvableHost(t *testing.T) {
+	conf := &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+		Config: map[string]any{
+			"mcp_aws_url":    "https://aws-mcp.cn-north-1.amazonaws.com.cn/mcp",
+			"region":         "cn-north-1",
+			"auto_auth_path": "auth/jwt/",
+		},
+	}
+	b, err := Factory(context.Background(), conf)
+	require.NoError(t, err)
+	mb := b.(*mcpAWSBackend)
+	assert.Equal(t, "cn-north-1", mb.region)
+}
+
+// --- Initialize tests ---
+
+func TestInitialize_EmptyStorage_NoOp(t *testing.T) {
+	b := setupBackend(t)
+	// Region from Factory defaults should persist after Initialize.
+	require.NoError(t, b.Initialize(context.Background()))
+	assert.Equal(t, "us-east-1", b.region)
+}
+
+// TestInitialize_PersistedConfigReload guards the highest-risk wiring step:
+// after a server restart, SetTransparentConfig must be called again with the
+// persisted values or isTransparentRequest silently returns false and every
+// request 403s.
+func TestInitialize_PersistedConfigReload(t *testing.T) {
+	storage := newInmemStorage()
+	entry, _ := sdklogical.StorageEntryJSON("config", map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.eu-frankfurt-1.api.aws/mcp",
+		"timeout":        "5m",
+		"auto_auth_path": "auth/cert/",
+		"default_role":   "admin",
+	})
+	require.NoError(t, storage.Put(context.Background(), entry))
+
+	// Fresh backend (simulates a restart).
+	b := setupBackend(t)
+	b.StorageView = storage
+
+	require.NoError(t, b.Initialize(context.Background()))
+
+	assert.Equal(t, "eu-frankfurt-1", b.region, "region must be repopulated from URL after restart")
+	assert.Equal(t, "auth/cert/", b.TransparentConfig.AutoAuthPath, "AutoAuthPath must come back via SetTransparentConfig")
+	assert.Equal(t, "admin", b.TransparentConfig.DefaultAuthRole)
+	// GetAutoAuthPath is what core's isTransparentRequest checks.
+	assert.Equal(t, "auth/cert/", b.GetAutoAuthPath())
+}
+
+// --- Config CRUD ---
+
+func TestConfigRead(t *testing.T) {
+	b := setupBackend(t)
+	resp, err := b.handleConfigRead(context.Background(), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "us-east-1", resp.Data["region"])
+	assert.Equal(t, DefaultMCPAWSURL, resp.Data["mcp_aws_url"])
+	assert.Equal(t, framework.DefaultMaxBodySize, resp.Data["max_body_size"])
+}
+
+func TestConfigWrite_AutoAuthPathRequired(t *testing.T) {
+	b := setupBackend(t)
+	path := b.pathConfig()
+	fd := makeFieldData(path, map[string]any{
+		"mcp_aws_url": "https://aws-mcp.us-east-1.api.aws/mcp",
+		// auto_auth_path intentionally absent
+	})
+	resp, err := b.handleConfigWrite(context.Background(), nil, fd)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestConfigWrite_StaleRegionUpdate(t *testing.T) {
+	b := setupBackend(t)
+	path := b.pathConfig()
+
+	// First write: us-east-1.
+	fd1 := makeFieldData(path, map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+		"auto_auth_path": "auth/jwt/",
+	})
+	resp, err := b.handleConfigWrite(context.Background(), nil, fd1)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "us-east-1", b.region)
+
+	// Second write: only change the URL to a different-region host. The
+	// region must move with it, not stay at us-east-1.
+	fd2 := makeFieldData(path, map[string]any{
+		"mcp_aws_url": "https://aws-mcp.eu-frankfurt-1.api.aws/mcp",
+	})
+	resp, err = b.handleConfigWrite(context.Background(), nil, fd2)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "eu-frankfurt-1", b.region, "region must follow the URL change")
+}
+
+func TestConfigWrite_ExplicitRegionWins(t *testing.T) {
+	b := setupBackend(t)
+	path := b.pathConfig()
+	// URL host doesn't yield a region; explicit region required + used.
+	fd := makeFieldData(path, map[string]any{
+		"mcp_aws_url":    "https://my-mcp.example.com/mcp",
+		"region":         "us-west-2",
+		"auto_auth_path": "auth/jwt/",
+	})
+	resp, err := b.handleConfigWrite(context.Background(), nil, fd)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "us-west-2", b.region)
+}

--- a/provider/mcp_aws/sse_test.go
+++ b/provider/mcp_aws/sse_test.go
@@ -1,0 +1,88 @@
+package mcp_aws
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flushCounter wraps httptest.ResponseRecorder and counts Flush() calls. The
+// counter is what proves sigv4.ForwardDirect actually delivers SSE events
+// per-read rather than buffering until end-of-stream — if it buffered, the
+// count would be 1 regardless of how many events the upstream wrote.
+type flushCounter struct {
+	*httptest.ResponseRecorder
+	mu      sync.Mutex
+	flushes int
+}
+
+func newFlushCounter() *flushCounter {
+	return &flushCounter{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (f *flushCounter) Flush() {
+	f.mu.Lock()
+	f.flushes++
+	f.mu.Unlock()
+	f.ResponseRecorder.Flush()
+}
+
+func (f *flushCounter) Count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.flushes
+}
+
+// TestHandleGateway_SSEFlushesPerEvent verifies that sigv4.ForwardDirect's
+// per-read flush loop fires once per SSE event written upstream, rather than
+// buffering until the response body closes. mcp_github inherits per-event
+// flushing from httputil.ReverseProxy; mcp_aws is on a separate code path
+// (sigv4.ForwardDirect) and needs its own regression coverage.
+func TestHandleGateway_SSEFlushesPerEvent(t *testing.T) {
+	const events = 3
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("upstream test server does not support flushing")
+			return
+		}
+		for i := 1; i <= events; i++ {
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, upstream)
+
+	rec := newFlushCounter()
+	req, _ := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+	req.ResponseWriter = rec
+
+	b.handleGateway(context.Background(), req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	// All three events must appear in the buffered body — confirms the data
+	// path is correct.
+	body := rec.Body.String()
+	for i := 1; i <= events; i++ {
+		assert.True(t, strings.Contains(body, fmt.Sprintf("data: event-%d", i)), "event %d missing from body: %q", i, body)
+	}
+	// At least one Flush() per event proves per-event delivery (the upstream
+	// flushes per event; sigv4.ForwardDirect's 32KB read loop happens to
+	// observe each event as a discrete read because the upstream flush flushes
+	// the OS socket buffer between writes).
+	assert.GreaterOrEqual(t, rec.Count(), events, "expected ≥%d flushes for %d SSE events, got %d", events, events, rec.Count())
+}


### PR DESCRIPTION
## Summary

The main slice of the `mcp_aws` provider — a custom backend that proxies MCP traffic to AWS-hosted MCP endpoints, signing each outgoing request with AWS SigV4 using credentials minted by the existing `aws` source driver. Clients hold only a short-lived Warden bearer token; IAM credentials never leave the Warden server.

### Why a custom backend instead of `provider/sdk/httpproxy`?

httpproxy can't host this provider because its `CredentialExtractor` returns a header map and its forward path is `httputil.ReverseProxy`, which mutates headers and breaks signed requests. mcp_aws patterns after `provider/alicloud` and `provider/sdk/dualgateway` instead, using `provider/sdk/sigv4` for re-signing and `sigv4.ForwardDirect` for streaming.

### Design highlights

- **Wholly-custom `Initialize`** that loads persisted config and calls `SetTransparentConfig` — without this, `isTransparentRequest` silently returns false after a restart and every request 403s.
- **Region is `coalesce(operator-supplied configRegion, URL-inferred)`**; the raw `configRegion` is persisted (not the resolved value) so a URL-only config update re-infers correctly instead of sticking to a stale region.
- **Path rewrite uses string concatenation, not path.Join**, to preserve the trailing-slash distinction MCP servers care about and avoid escape normalization that would invalidate the SigV4 canonical request.
- **`auto_auth_path` is required at config-write time**, matching httpproxy's contract.
- **Shared `*v4.Signer` at backend init**; cache reuse across requests within one mount is safe (the derived-key cache is keyed on credentials).
- **`applyParsedConfig` validates and builds the transport BEFORE taking the write lock** — a malformed CA bundle can no longer leave the backend half-mutated. The returned persist data is the snapshot to write to storage so a concurrent writer can't tear the persisted entry.
- **TLS toggle-off correctly falls back to the shared transport** instead of sticking with a previously-overridden skip-verify transport.
- **`snapshot()` returns the full per-request tuple** (upstream / region / maxBody / timeout / transport) under one read-lock acquisition, so the gateway hot path is race-detector clean.

### Not in this PR

- `logical.MCPPolicyEnforced` opt-in — next PR (`mcp_aws-policy`)
- Skill + README — PR after that (`mcp_aws-docs`)
- `cmd/server/server.go` registration + e2e — final PR (`mcp_aws-register`)

## Test plan

- [x] `go test ./provider/mcp_aws/... -race -count=1` green (22 tests)
- [x] `go vet ./provider/mcp_aws/...` clean
- [x] Tests cover:
  - inference_test.go: structured DNS-label match including FIPS, GovCloud, China-partition, dualstack, IPv6 fall-through cases.
  - path_test.go: gateway-suffix extraction for mount-relative, role-prefixed, and absolute path shapes, all with trailing-slash preservation.
  - provider_test.go: Factory defaults / explicit-config / unresolvable region; Initialize-after-restart reload; config CRUD including the stale-region-on-URL-change race, the `auto_auth_path`-required check, and explicit-region-wins behavior.
  - gateway_test.go: STS-minted creds (ASIA prefix, X-Amz-Security-Token present), long-lived keys (AKIA prefix, no security token), trailing-slash and deep-tail preservation, role-prefixed paths, AgentCore service inference via a redirecting transport, no Warden-header / no Bearer leak, wrong-credential-type returns 500, and a round-trip via the production `handleConfigWrite` path.
  - sse_test.go: verifies `sigv4.ForwardDirect`'s per-event flush via a flush counter on a wrapped ResponseRecorder.

## Stacked PR series

This is PR 2 of an 8-PR series (~~PR 1 #291~~, ~~#290~~, ~~#289~~ merged; 3/4/5/6 follow).
