### PR TITLE
feat(mcp_aws): opt into mcp { } body-authoritative policy enforcement

### DIFF
--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -21,6 +21,9 @@ var headersToStrip = []string{
 	"X-Warden-Provider",
 	"X-Warden-Role",
 	"X-Warden-On-Behalf-Of",
+	// Cookie carries client session identity that AWS will ignore but that
+	// would otherwise bleed across the trust boundary. Strip explicitly —
+	// sigv4.NormalizeRequest doesn't touch it.
 	"Cookie",
 }
 

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -16,6 +16,52 @@ import (
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
+// Compile-time assertion: mcp_aws opts into CBP `mcp { }` body-authoritative
+// policy enforcement. Without this assertion the core's request handler type-
+// asserts to logical.MCPPolicyEnforced, fails silently, skips body extraction,
+// and any mcp { } block bound to an mcp_aws path becomes a no-op. The unit
+// test in provider_test.go also asserts this at the type level so an
+// accidental refactor that drops the method surfaces as a compile error in
+// the test, not as a quiet over-permission at runtime.
+var _ logical.MCPPolicyEnforced = (*mcpAWSBackend)(nil)
+
+// ShouldEnforceMCPPolicy reports whether this request is subject to mcp { }
+// body-authoritative policy enforcement. The gate matches mcp_github exactly:
+// JSON-RPC POSTs only. GET (SSE reconnect) and DELETE (session close), and
+// any non-JSON Content-Type, decline and pass through under credential-scope-
+// only enforcement (IAM here, PAT scopes for mcp_github).
+//
+// The body cap returned is the backend's MaxBodySize as of THIS call, read
+// through snapshot() to match the rest of the hot path. A config-write that
+// lands between this call and the SigV4 read in handleGateway may produce
+// different caps for the same request; both caps lead to the same correct
+// decision under any operator-set value, so the brief inconsistency is
+// harmless. The lock protects against tearing a torn-read of a partial
+// int64 — not against config-write atomicity across the whole request.
+func (b *mcpAWSBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int64) {
+	if req == nil || req.HTTPRequest == nil {
+		return false, 0
+	}
+	r := req.HTTPRequest
+	if r.Method != http.MethodPost {
+		return false, 0
+	}
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		return false, 0
+	}
+	// Strip a charset / boundary parameter (e.g. "application/json; charset=utf-8")
+	// before comparing to the bare media type.
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.TrimSpace(strings.ToLower(ct))
+	if ct != "application/json" {
+		return false, 0
+	}
+	return true, b.snapshot().maxBody
+}
+
 // DefaultMCPAWSURL is the GA endpoint for AWS's hosted MCP Server.
 const DefaultMCPAWSURL = "https://aws-mcp.us-east-1.api.aws/mcp"
 

--- a/provider/mcp_aws/provider_test.go
+++ b/provider/mcp_aws/provider_test.go
@@ -2,6 +2,7 @@ package mcp_aws
 
 import (
 	"context"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -241,6 +242,119 @@ func TestConfigWrite_StaleRegionUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "eu-frankfurt-1", b.region, "region must follow the URL change")
+}
+
+// --- MCPPolicyEnforced opt-in ---
+//
+// The compile-time interface satisfaction is asserted at package scope in
+// provider.go; a duplicate test-side assertion would not catch anything the
+// package-scope one doesn't already catch.
+
+// mustGateReq returns a logical.Request whose HTTPRequest carries the given
+// method and Content-Type. URL and body are arbitrary — the gate only reads
+// method + Content-Type.
+func mustGateReq(method, contentType string) *logical.Request {
+	r, _ := http.NewRequest(method, "https://warden.example.com/v1/mcp_aws/gateway/", nil)
+	if contentType != "" {
+		r.Header.Set("Content-Type", contentType)
+	}
+	return &logical.Request{HTTPRequest: r}
+}
+
+// TestShouldEnforceMCPPolicy_CapReflectsConfiguredMaxBody drives a non-default
+// max_body_size through handleConfigWrite and asserts the cap returned by
+// ShouldEnforceMCPPolicy follows. Catches a refactor that returns a stale
+// snapshot, a default constant, or any value other than the live config.
+func TestShouldEnforceMCPPolicy_CapReflectsConfiguredMaxBody(t *testing.T) {
+	const customMax int64 = 7 * 1024 * 1024
+	b := setupBackend(t)
+	path := b.pathConfig()
+	fd := makeFieldData(path, map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+		"auto_auth_path": "auth/jwt/",
+		"max_body_size":  customMax,
+	})
+	resp, err := b.handleConfigWrite(context.Background(), nil, fd)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	enforce, capBytes := b.ShouldEnforceMCPPolicy(mustGateReq("POST", "application/json"))
+	assert.True(t, enforce)
+	assert.Equal(t, customMax, capBytes, "cap must follow the configured max_body_size, not a snapshotted default")
+}
+
+func TestShouldEnforceMCPPolicy_AcceptsJSONWithCharset(t *testing.T) {
+	b := setupBackend(t)
+	enforce, _ := b.ShouldEnforceMCPPolicy(mustGateReq("POST", "application/json; charset=utf-8"))
+	assert.True(t, enforce, "charset parameter on Content-Type must not disqualify")
+}
+
+func TestShouldEnforceMCPPolicy_DeclinesNonPOST(t *testing.T) {
+	b := setupBackend(t)
+	for _, method := range []string{"GET", "DELETE", "PUT", "PATCH", "HEAD", "OPTIONS"} {
+		t.Run(method, func(t *testing.T) {
+			enforce, capBytes := b.ShouldEnforceMCPPolicy(mustGateReq(method, "application/json"))
+			assert.False(t, enforce)
+			assert.Equal(t, int64(0), capBytes)
+		})
+	}
+}
+
+func TestShouldEnforceMCPPolicy_DeclinesNonJSON(t *testing.T) {
+	b := setupBackend(t)
+	for _, ct := range []string{"", "text/plain", "application/octet-stream", "text/event-stream", "application/x-www-form-urlencoded"} {
+		t.Run(ct, func(t *testing.T) {
+			enforce, capBytes := b.ShouldEnforceMCPPolicy(mustGateReq("POST", ct))
+			assert.False(t, enforce)
+			assert.Equal(t, int64(0), capBytes, "declined requests must return cap=0; a later behavior change that returned MaxBodySize on decline would mislead core")
+		})
+	}
+}
+
+func TestShouldEnforceMCPPolicy_NilSafe(t *testing.T) {
+	b := setupBackend(t)
+	enforce, _ := b.ShouldEnforceMCPPolicy(nil)
+	assert.False(t, enforce, "nil request must not panic, must decline")
+	enforce, _ = b.ShouldEnforceMCPPolicy(&logical.Request{})
+	assert.False(t, enforce, "nil HTTPRequest must not panic, must decline")
+}
+
+// TestShouldEnforceMCPPolicy_ConcurrentReadDuringConfigWrite spins one
+// goroutine calling the gate while another writes config repeatedly. Without
+// -race + the snapshot()-mediated RLock, this would flag tearing the
+// MaxBodySize read. Catches an accidental future drop of the RLock.
+func TestShouldEnforceMCPPolicy_ConcurrentReadDuringConfigWrite(t *testing.T) {
+	b := setupBackend(t)
+	path := b.pathConfig()
+	// Seed with a valid base config so the writer's partial updates have
+	// auto_auth_path already set.
+	{
+		fd := makeFieldData(path, map[string]any{
+			"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+			"auto_auth_path": "auth/jwt/",
+		})
+		resp, err := b.handleConfigWrite(context.Background(), nil, fd)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+	}
+
+	const iterations = 200
+	done := make(chan struct{})
+
+	go func() {
+		req := mustGateReq("POST", "application/json")
+		for i := 0; i < iterations; i++ {
+			_, _ = b.ShouldEnforceMCPPolicy(req)
+		}
+		close(done)
+	}()
+
+	for i := 0; i < iterations; i++ {
+		max := int64(1<<20) + int64(i)
+		fd := makeFieldData(path, map[string]any{"max_body_size": max})
+		_, _ = b.handleConfigWrite(context.Background(), nil, fd)
+	}
+	<-done
 }
 
 func TestConfigWrite_ExplicitRegionWins(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the `logical.MCPPolicyEnforced` interface implementation directly on `mcpAWSBackend` (not via the httpproxy spec wrapper that mcp_github uses, since mcp_aws is a custom backend). The gate is byte-for-byte equivalent to mcp_github's `shouldEnforceMCPPolicy` — JSON-RPC POSTs only; GET / DELETE / non-JSON Content-Types decline and pass through under credential-scope-only enforcement.

The body cap returned to core's MCP extractor is read through `snapshot()` under the same `RWMutex` that protects every other gateway-hot-path field, so a concurrent config-write cannot tear the `MaxBodySize` int64 read. A config-write that lands between this gate and `handleGateway`'s SigV4 body read may produce different caps for the same request, but both lead to the same correct decision under any operator-set value.

Without the package-scope compile-time assertion, core's type assertion in `extractMCPDescriptor` would silently fall through and any `mcp { }` block bound to an mcp_aws path would become a no-op — over-permission, not under-permission, so operators wouldn't notice.

After #289 (tri-state MCPDescriptor + conditional allowed_params), this gate is the only mcp_aws-side opt-in needed; the framework handles the non-POST skip and the conditional param semantics automatically.

## Test plan

- [x] `go test ./provider/mcp_aws/... -race -count=1` green
- [x] Tests:
  - **Cap-reflects-configured-max-body** — drives a non-default `max_body_size` through `handleConfigWrite` and asserts the gate's cap follows; catches a refactor that returns a stale snapshot or a default constant.
  - **Accepts JSON POST** with and without charset/boundary parameter.
  - **Declines non-POST methods and non-JSON content types** (both assert `cap == 0`, so a future bug returning `MaxBodySize` on decline gets flagged).
  - **Nil-safe** for nil request and request with nil HTTPRequest.
  - **Concurrent reader + writer for 200 iterations under `-race`** — pins the `snapshot()`-mediated RLock as the regression bench against an accidental future drop.

Stacks on #292.
