### PR TITLE
docs(mcp_aws): skill markdown and operator README

### DIFF
--- a/provider/mcp_aws/README.md
+++ b/provider/mcp_aws/README.md
@@ -1,0 +1,580 @@
+# AWS MCP Provider
+
+The `mcp_aws` provider enables proxied access to AWS-hosted MCP (Model Context Protocol) servers through Warden. MCP clients (Claude Code, Cursor, Continue, Cline, Goose, ...) point at Warden instead of the AWS MCP endpoint; Warden authenticates the caller, mints short-lived STS credentials bound to the chosen role, signs the upstream request with AWS SigV4, and streams JSON or SSE responses back unchanged. Agents never hold an IAM access key.
+
+The same provider fronts both **AWS's hosted MCP Server** (the GA product reached at `aws-mcp.{region}.api.aws/mcp`, which exposes a single `call_aws` tool that gives agents access to every AWS API) and **customer-owned MCP servers hosted on Bedrock AgentCore Runtime or Gateway** (where the tools and their argument shapes are whatever the customer's server exposes). One mount per upstream — describe each mount so operators and agents can pick the right one.
+
+## Why use Warden in front of this?
+
+AWS ships its own client-side helper, `mcp-proxy-for-aws`, that signs MCP requests with SigV4 using credentials it reads from the local AWS configuration (env vars, profile, IMDS, process provider). Running it works, but it pushes the security boundary all the way down to every agent host: an `~/.aws/credentials` file on each laptop, each container, each CI runner. Compromise one host, leak whatever IAM that profile holds.
+
+With Warden in front:
+
+- **Clients present an identity Warden recognizes, never IAM credentials.** That identity is whatever the operator's chosen Warden auth method accepts — a short-lived JWT (issued by an OIDC provider, or a Kubernetes cluster), or a TLS client certificate presented during the mTLS handshake (cert-manager, SPIFFE, machine certificates). No IAM access keys on the agent host. No `~/.aws/credentials`, no `AWS_ACCESS_KEY_ID`, no profile.
+- **STS credentials are minted per request** by the `aws` source driver and live inside the Warden server only. They never leave the broker.
+- **Revocation is "delete the role"**, not "rotate keys on N machines". The next request mints fresh credentials under the new policy; nothing on the agent side changes.
+- **Every signed call lands in CloudTrail** tied to the assumed-role identity and (via Warden's audit log) to the originating Warden session. The audit trail joins both sides.
+
+For a single developer with a laptop and personal AWS creds, `mcp-proxy-for-aws` is fine. For a fleet of agents — production workflows, CI runners, shared dev environments — having Warden broker the credentials is the difference between credential hygiene that scales and a sprawling credential surface.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Point an MCP Client at Warden](#step-5-point-an-mcp-client-at-warden)
+- [TLS Certificate Authentication](#tls-certificate-authentication)
+- [Configuration Reference](#configuration-reference)
+- [IAM Permissions and Tool Availability](#iam-permissions-and-tool-availability)
+
+## Prerequisites
+
+- Docker and Docker Compose installed and running
+- An AWS account with:
+  - An IAM role the broker can assume on the agent's behalf (with permissions covering the AWS operations the agent will make), and
+  - Permanent IAM credentials (access key + secret) for an identity that has `sts:AssumeRole` on the target role — these stay inside Warden's credential source and never reach the agent
+- An MCP client that supports remote MCP servers over HTTP (Claude Code, Cursor, Continue, Cline, Goose, ...)
+
+> **New to Warden?** Follow the standard quickstart flow used by the other provider READMEs: deploy the quickstart compose, install the binary, export `WARDEN_ADDR` and `WARDEN_TOKEN`, then return here.
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/s3-reader \
+    token_policies="mcp-aws-s3-readonly" \
+    user_claim=sub \
+    cred_spec_name=aws-s3-reader
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the `mcp_aws` provider at a path of your choice:
+
+```bash
+warden provider enable mcp_aws
+```
+
+To mount at a custom path — useful when you intend to mount more than one (one per AWS deployment pattern, or one per region):
+
+```bash
+warden provider enable -path=aws-mcp -description "AWS MCP Server (us-east-1) — S3+DynamoDB reach" mcp_aws
+```
+
+Verify the provider is enabled:
+
+```bash
+warden provider list
+```
+
+Configure the provider. For the GA AWS MCP Server, the default URL resolves the signing region automatically; for Bedrock AgentCore or non-standard hosts, you may need to set `region` explicitly.
+
+```bash
+warden write mcp_aws/config <<EOF
+{
+  "mcp_aws_url": "https://aws-mcp.us-east-1.api.aws/mcp",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "10m",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+For a customer-owned MCP server on Bedrock AgentCore Runtime:
+
+```bash
+warden write mcp_aws/config <<EOF
+{
+  "mcp_aws_url": "https://runtime.bedrock-agentcore.us-east-1.amazonaws.com/agents/myMcp/invocations",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "10m",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+For hosts where the signing region cannot be inferred from the URL (GovCloud, China partition, custom test hosts), set `region` explicitly:
+
+```bash
+warden write mcp_aws/config <<EOF
+{
+  "mcp_aws_url": "https://my-mcp.example.com/mcp",
+  "region": "us-west-2",
+  "auto_auth_path": "auth/jwt/",
+  "timeout": "10m",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+Verify the configuration:
+
+```bash
+warden read mcp_aws/config
+```
+
+## Step 3: Create a Credential Source and Spec
+
+If you already configured an `aws` credential source for another provider (the [`aws` REST provider's README](../aws/README.md) walks through the IAM-user setup in full), you can reuse it here unchanged — `mcp_aws` consumes the same source-and-spec shape. Skip to Step 4 if so.
+
+The credential source holds the permanent IAM access key Warden uses to call STS; credential specs on top of it define which role each Warden role assumes. The agent never sees either the source's permanent keys or the minted STS credentials.
+
+```bash
+warden cred source create aws-src \
+  -type aws \
+  -rotation-period 24h \
+  -config access_key_id=<AccessKeyId> \
+  -config secret_access_key=<SecretAccessKey> \
+  -config region=us-east-1
+```
+
+`-rotation-period` is how often Warden rotates the source's IAM access keys. Longer periods are acceptable when the IAM user only has `sts:AssumeRole` (no direct resource access); shorter periods (`12h`-`24h`) suit stricter environments. See the [`aws` provider README](../aws/README.md) for a full discussion of the IAM-user policy shape required here.
+
+Verify:
+
+```bash
+warden cred source read aws-src
+```
+
+Create a credential spec that assumes a target IAM role via STS. The role's permissions are what gate which AWS calls the agent can actually make:
+
+```bash
+warden cred spec create aws-s3-reader \
+  -source aws-src \
+  -config mint_method=sts_assume_role \
+  -config role_arn=arn:aws:iam::<ACCOUNT_ID>:role/s3-reader-role \
+  -config ttl=1h \
+  -min-ttl 600s \
+  -max-ttl 2h
+```
+
+Each request mints a fresh STS session bound to the target role. The session lives `ttl` (clamped by `-min-ttl` / `-max-ttl`); subsequent requests mint new sessions. SigV4 imposes a separate 15-minute clock on the signed request itself — see the "Quirks" section of the skill for what that means for long-running tool calls.
+
+The source's IAM user must have `sts:AssumeRole` permission on every `role_arn` any spec built on top of the source references. Multiple specs over the same source give different Warden roles different reach — e.g. one spec per assumed-role ARN, one Warden role bound to each spec.
+
+Verify:
+
+```bash
+warden cred spec read aws-s3-reader
+```
+
+## Step 4: Create a Policy
+
+MCP traffic passes through two complementary layers of authorization. The IAM role's permissions are the security boundary — they bound what the agent can actually do at AWS regardless of what Warden lets through. On top of that, Warden's CBP policies support an `mcp { }` block for governance-style restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs, prompt names, and selected tool arguments.
+
+Enforcement is **body-authoritative**. When a policy in scope contains an `mcp { }` block, Warden strict-parses the JSON-RPC request body and matches against the parsed body. The parser fails closed on any structural problem and the matcher denies with a specific `rule_type`:
+
+| `rule_type` | Trigger |
+|---|---|
+| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
+| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
+| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
+| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
+| `denied_params` / `allowed_params` | A `tools/call` argument (`params.arguments.<key>`) matches a deny pattern, or — when present — fails an allow-list pattern. Both rules are conditional on presence: missing arguments don't trigger either, matching Vault's `allowed_parameters` semantics. Tools whose argument shape doesn't include the gated key pass through unaffected. |
+| `missing_body` | Request body absent on a path the backend opted into MCP enforcement for. POST/JSON-RPC traffic that fails to parse triggers this; non-POST verbs (GET for the SSE notification stream, DELETE for session terminate) silently skip `mcp { }` evaluation — the body-authoritative gate doesn't apply to body-less verbs. |
+| `malformed_jsonrpc` | Body is not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, etc.) |
+| `duplicate_key` | Duplicate object key detected anywhere in the body — Warden rejects ambiguity that Go's standard JSON parser silently last-wins-resolves |
+| `oversized_body` | Body exceeds the mount's `max_body_size` |
+| `batch_empty` | JSON-RPC batch is `[]` |
+| `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
+
+All examples below use `capabilities = ["create", "read", "delete"]`. MCP Streamable HTTP uses three HTTP verbs on the same `/gateway` URL: POST for JSON-RPC requests (mapped by Warden to `create`), GET for the optional server → client SSE notification stream (`read`), and DELETE for session terminate (`delete`). All three need to be in the cap list or off-spec MCP clients fail to connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip body-authoritative evaluation automatically.
+
+The `allowed_methods` examples below list the MCP **protocol** methods every spec-compliant client uses in its handshake — `initialize`, `notifications/initialized`, `ping` — alongside the data-plane methods (`tools/list`, `tools/call`). Omitting the lifecycle methods makes `claude mcp list` (and similar client health checks) hang on connect.
+
+The simplest policy grants the gateway and leans on IAM for everything:
+
+```bash
+warden policy write mcp-aws-access - <<EOF
+path "mcp_aws/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+}
+EOF
+```
+
+A policy that restricts the agent to the `call_aws` tool but only against a vetted set of AWS services. The AWS MCP Server prefixes every tool name with `aws___` (three underscores) — confirm via `tools/list` on the live server. The tool takes `service_name`, `operation_name`, and `region_name` arguments — `allowed_params` keys match those argument names directly:
+
+```bash
+warden policy write mcp-aws-s3-readonly - <<EOF
+path "mcp_aws/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+  mcp {
+    allowed_methods = [
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+      "tools/call",
+      "ping"
+    ]
+    allowed_tools   = ["aws___call_aws"]
+    allowed_params = {
+      service_name = ["s3", "dynamodb"]
+    }
+  }
+}
+EOF
+```
+
+A complementary deny-list shape — permissive by default, blocks dangerous operations regardless of which service they target. `mcp { }` patterns support a trailing `*` only (literals otherwise), so list the prefix you want to block and any one-off exact names separately:
+
+```bash
+warden policy write mcp-aws-safe - <<EOF
+path "mcp_aws/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+  mcp {
+    denied_params = {
+      operation_name = [
+        "delete_*",
+        "terminate_*",
+        "put_bucket_policy",
+        "put_role_policy",
+        "put_user_policy",
+      ]
+    }
+  }
+}
+EOF
+```
+
+Argument-level gates restrict the *values* passed to `tools/call`. Combine `allowed_params` and `denied_params` to constrain both which services may be called and within what regions:
+
+```bash
+warden policy write mcp-aws-us-only - <<EOF
+path "mcp_aws/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+  mcp {
+    allowed_methods = [
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+      "tools/call",
+      "ping"
+    ]
+    allowed_tools   = ["aws___call_aws"]
+    allowed_params = {
+      service_name = ["s3", "dynamodb", "lambda"]
+      region_name  = ["us-east-1", "us-east-2", "us-west-2"]
+    }
+  }
+}
+EOF
+```
+
+The `mcp { }` block composes with runtime conditions so you can layer environment guards on top of tool-level restrictions:
+
+```bash
+warden policy write mcp-aws-business-hours - <<EOF
+path "mcp_aws/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+  conditions {
+    source_ip   = ["10.0.0.0/8"]
+    time_window = ["08:00-18:00 UTC"]
+    day_of_week = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+  }
+  mcp {
+    allowed_methods = [
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+      "tools/call",
+      "ping"
+    ]
+    allowed_tools   = ["aws___call_aws"]
+  }
+}
+EOF
+```
+
+When a request hits the `mcp { }` gate and is denied, Warden returns HTTP 403 with a structured JSON body and an RFC 6750 `WWW-Authenticate` header; MCP client SDKs surface this to the agent as a tool-call failure with an actionable message. The audit log records the matched rule and the offending tool/parameter so operators can debug policy decisions centrally.
+
+These Warden-level denials are **distinct** from AWS-side `AccessDeniedException` errors. The latter come from the upstream MCP server when the IAM role lacks a required permission; they stream back as native AWS error responses inside the tool-call result. Operators debugging permission issues should check `error_description` (or the response body shape) to tell the two layers apart.
+
+Policies that omit the `mcp { }` block keep the simplest behavior: Warden passes the request through to AWS unchanged and the IAM role alone enforces authorization.
+
+## Step 5: Point an MCP Client at Warden
+
+Get a JWT from Hydra using one of the quickstart clients:
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+Configure your MCP client to point at the Warden mount. The URL pattern is:
+
+```
+${WARDEN_ADDR}/v1/mcp_aws/role/{role}/gateway
+```
+
+**Note no trailing slash on `gateway`.** AWS's hosted MCP Server (and Bedrock AgentCore) lives at exactly `/mcp` and rejects `/mcp/` with a JSON-RPC `-32600 Invalid request path`. This is the opposite convention from `mcp_github`, where the trailing slash is mandatory.
+
+For Claude Code, Cursor, Continue, Cline, Goose, and other clients that accept Streamable HTTP MCP servers via a JSON config block:
+
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "type": "http",
+      "url": "${WARDEN_ADDR}/v1/mcp_aws/role/s3-reader/gateway",
+      "headers": {
+        "Authorization": "Bearer ${JWT_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+> **Heads-up on `${VAR}` in headers.** MCP clients vary in what they substitute in `.mcp.json`. Claude Code and Cursor expand `${VAR}` in stdio `env` blocks and in the `url` field, but **HTTP-transport `headers` values are a known gap** — the literal `${JWT_TOKEN}` string ships on the wire. For the `Authorization` header (and the routing headers in the next example), paste the actual values instead of `${...}` placeholders, or run the JSON through `envsubst` at deploy time.
+
+#### Header-routed alternative
+
+Some MCP clients dislike long URLs, or you want one base URL to mux several Warden providers. Pass the mount path as `X-Warden-Provider`, the namespace as `X-Warden-Namespace`, and the role as `X-Warden-Role` instead — Warden synthesises the canonical gateway path from the headers. Look up the mount path first:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_aws") | .path' | head -1)
+```
+
+When more than one `mcp_aws` mount exists, replace `head -1` with a `select(.description=="...")` matching the mount you want — the `path` alone doesn't tell you which IAM role or region the mount fronts.
+
+The `path` is what `warden provider list` returns (e.g., `mcp_aws/`, `team-data/aws-mcp/`), **not** the literal string `mcp_aws` — Warden routes on the mount path, not the provider type.
+
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "type": "http",
+      "url": "${WARDEN_ADDR}/",
+      "headers": {
+        "Authorization": "Bearer ${JWT_TOKEN}",
+        "X-Warden-Provider": "mcp_aws/",
+        "X-Warden-Namespace": "<namespace>",
+        "X-Warden-Role": "s3-reader"
+      }
+    }
+  }
+}
+```
+
+The same caveat applies here as above: paste the actual mount path, namespace, role, and (if you're not handing the file to `envsubst`) JWT in the `headers` map — `${VAR}` placeholders in HTTP-transport headers don't get expanded by the major clients today.
+
+### Smoke-test with curl
+
+List the tools the server exposes:
+
+```bash
+curl -X POST "${WARDEN_ADDR}/v1/mcp_aws/role/s3-reader/gateway" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Call a tool. For AWS's hosted MCP Server, every AWS API call goes through the single `call_aws` tool — the JSON-RPC arguments select the service, operation, and target region:
+
+```bash
+curl -X POST "${WARDEN_ADDR}/v1/mcp_aws/role/s3-reader/gateway" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call_aws","arguments":{"service_name":"s3","operation_name":"list_buckets","region_name":"us-east-1","parameters":{}}}}'
+```
+
+The `region_name` inside the tool arguments selects which AWS region's API to call. This is independent of the mount's signing region — a single mount fronting `aws-mcp.us-east-1.api.aws` already serves agents operating against any AWS region's APIs, as long as the bound IAM role's permissions cover those operations.
+
+For a Bedrock AgentCore-hosted MCP server, the available tools and their argument shapes come from whatever the customer's server exposes — discover them via `tools/list`.
+
+The **absence** of a trailing slash on `gateway` matters — Warden composes the upstream URL as the mount's configured base + whatever follows `gateway` in the inbound path. For AWS's hosted MCP Server and Bedrock AgentCore, `/mcp/` returns JSON-RPC `-32600 Invalid request path`; only `/mcp` is accepted. This is the opposite convention from `mcp_github`, where the trailing slash is required.
+
+## TLS Certificate Authentication
+
+Steps 1 and 5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
+
+> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Steps 2-4 (provider mount, credential source and spec, policy) are identical — the `mcp-aws-access` policy from Step 4 works for either auth method. Replace Steps 1 and 5 with the following.
+
+### Enable Cert Auth
+
+```bash
+warden auth enable cert
+```
+
+### Configure Trusted CA
+
+Provide the PEM-encoded CA certificate that signs your client certificates:
+
+```bash
+warden write auth/cert/config \
+    trusted_ca_pem=@/path/to/ca.pem \
+    default_role=s3-reader
+```
+
+### Create a Cert Role
+
+Create a role that binds allowed certificate identities to a credential spec and policy:
+
+```bash
+warden write auth/cert/role/s3-reader \
+    allowed_common_names="agent-*" \
+    token_policies="mcp-aws-access" \
+    cred_spec_name=aws-s3-reader
+```
+
+The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+
+### Configure Provider for Cert Auth
+
+Update the provider config to point at the cert auth mount:
+
+```bash
+warden write mcp_aws/config <<EOF
+{
+  "mcp_aws_url": "https://aws-mcp.us-east-1.api.aws/mcp",
+  "auto_auth_path": "auth/cert/",
+  "timeout": "10m",
+  "max_body_size": 10485760
+}
+EOF
+```
+
+### Make Requests with Certificates
+
+`curl` smoke test, role from the URL path:
+
+```bash
+curl --cert client.pem --key client-key.pem \
+    --cacert warden-ca.pem \
+    -X POST "https://warden.internal/v1/mcp_aws/role/s3-reader/gateway" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+#### MCP Client JSON Config (cert auth)
+
+**State of mTLS in MCP clients today.** The MCP specification does not standardize a client-side TLS configuration block, and the major IDE clients (Claude Code, Cursor, Continue) do not currently expose first-class fields for client certificate / key paths in their HTTP server configuration. Until that lands, two portable patterns work — both using header-routed mode so the MCP client only needs to set headers, never a deep URL.
+
+Look up the mount path and namespace first:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_aws") | .path' | head -1)
+namespace=$WARDEN_NAMESPACE   # whatever your default namespace is
+```
+
+The `path` is the mount path Warden returns from `warden provider list` (e.g., `mcp_aws/`, `team-data/aws-mcp/`), **not** the literal string `mcp_aws`. Same gotcha as the JWT header-routed flow in the skill.
+
+**Pattern A: Local mTLS-terminating sidecar (recommended).** Run a sidecar (Envoy, nginx, stunnel, `mtls-proxy`) on the agent host that holds the client cert/key and the trusted CA. The MCP client talks plain HTTP over loopback to the sidecar; the sidecar terminates client TLS, validates Warden's server cert, and forwards the request over mTLS with the validated client certificate attached as `X-SSL-Client-Cert` (URL-encoded PEM) or `X-Forwarded-Client-Cert`. Warden trusts the forwarded header when the listener is configured to do so.
+
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "type": "http",
+      "url": "http://127.0.0.1:9443/",
+      "headers": {
+        "X-Warden-Provider": "mcp_aws/",
+        "X-Warden-Namespace": "<namespace>",
+        "X-Warden-Role": "s3-reader"
+      }
+    }
+  }
+}
+```
+
+Substitute `mcp_aws/` with your mount's actual `path` and `<namespace>` with your namespace before saving — see the env-var caveat in Step 5: `${VAR}` placeholders in HTTP-transport `headers` are not expanded by the major MCP clients today. Drop the `X-Warden-Role` header when cert auth's `default_role` already covers the binding.
+
+**Pattern B: `mcp-remote` as a Node-based bridge.** Many MCP installations already use `mcp-remote` (an npx-launched HTTP-to-stdio bridge) for transport-shape reasons. It runs in Node.js, so Node's TLS environment variables flow through: `NODE_EXTRA_CA_CERTS=/path/to/warden-ca.pem` for a custom CA. Client certificate handling via `mcp-remote` requires a custom Node TLS context and is not as turnkey — for most deployments Pattern A is simpler. A typical CA-only setup (Warden's server cert validated by a private CA; mTLS still requires Pattern A) looks like:
+
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://warden.internal/",
+        "--transport", "http-only",
+        "--header", "X-Warden-Provider: mcp_aws/",
+        "--header", "X-Warden-Namespace: <namespace>",
+        "--header", "X-Warden-Role: s3-reader"
+      ],
+      "env": {
+        "NODE_EXTRA_CA_CERTS": "/path/to/warden-ca.pem"
+      }
+    }
+  }
+}
+```
+
+`--header` accepts repeated values for adding custom headers; consult your `mcp-remote` version's docs if it differs. This authenticates Warden's server cert against a private CA but does **not** supply a client cert.
+
+#### Selecting the role with a certificate
+
+With cert auth, the role is resolved (in priority order):
+
+1. `X-Warden-Role` header on the request — what the JSON examples above set
+2. `/role/<role>/` segment in the URL path — not used in header-routed mode, but available when an MCP client cannot send custom headers
+3. `default_role` set on the cert auth method's config — useful when one cert maps 1:1 to one role; the JSON config can drop `X-Warden-Role` entirely
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mcp_aws_url` | string | `https://aws-mcp.us-east-1.api.aws/mcp` | MCP server base URL (must be HTTPS). Drives the SigV4 service and signing-region inference. |
+| `region` | string | inferred from URL | SigV4 signing region. Required when the host doesn't yield one via DNS-label inference (e.g. GovCloud, China partition, custom test hosts). Independent of which AWS region the agent's API calls actually target. |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `10m` | Session timeout. Raise for long agent sessions that keep an SSE stream open across many tool calls. |
+| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (development only) |
+| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
+| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | — | Fallback role when not specified in URL |
+
+### Region behavior
+
+The mount's `region` is the **SigV4 signing region for the upstream MCP endpoint**, not a restriction on which AWS region the agent's API calls target. AWS's MCP Server makes API calls in any region; the agent picks the target region via `region_name` inside the tool arguments. One mount fronting `aws-mcp.us-east-1.api.aws/mcp` already serves agents operating against every AWS region's APIs.
+
+A second mount is only needed when the operator specifically wants the MCP server itself in another region — for latency, data sovereignty, or failover.
+
+## IAM Permissions and Tool Availability
+
+The upstream MCP server enforces permissions per call against the assumed-role identity. The set of operations available through a given mount is determined by the **bound IAM role's policy**, not by Warden policy. An `AccessDeniedException` from a `tools/call` request typically means the bound role lacks a required permission.
+
+Provision the IAM role with permissions covering the intended operation surface, and bind one credential spec per Warden role to give different agents different reach.
+
+Common patterns:
+
+| Role's intent | IAM policy shape |
+|---------------|-------------------|
+| Read-only S3 reach | `s3:ListBucket`, `s3:GetObject`, `s3:GetBucketLocation` on the target buckets |
+| DynamoDB query / scan | `dynamodb:Query`, `dynamodb:Scan`, `dynamodb:GetItem` on the target tables |
+| Lambda invocation | `lambda:InvokeFunction` on the target functions |
+| EC2 inventory | `ec2:Describe*` (read-only inventory of regions and instances) |
+| CloudWatch logs read | `logs:DescribeLogGroups`, `logs:GetLogEvents` on the target log groups |
+
+The CloudTrail entry for each AWS API call captures both the assumed-role identity and (via Warden's audit log linkage) the originating Warden session. Treat the IAM role as the security boundary and the `mcp { }` block as governance over which JSON-RPC shapes ever reach AWS.
+
+**Rotate** the source's permanent credentials by updating the source config:
+
+```bash
+warden cred source update aws-src \
+  -config=access_key_id=AKIA-new... \
+  -config=secret_access_key=...
+```
+
+Then revoke the old access key from the IAM console. STS sessions minted before the rotation continue to work until they expire (per `ttl` on the spec); new sessions use the new source credentials.

--- a/provider/mcp_aws/skill.go
+++ b/provider/mcp_aws/skill.go
@@ -1,0 +1,14 @@
+package mcp_aws
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the mcp_aws provider.
+// The content is seeded into the global skill registry the first time an
+// mcp_aws provider is mounted in the cluster; subsequent mounts are no-ops
+// and operator edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/mcp_aws/skill.md
+++ b/provider/mcp_aws/skill.md
@@ -1,0 +1,229 @@
+---
+name: mcp_aws
+description: "Talk to AWS-hosted MCP through Warden — without holding IAM keys. Use any MCP client (Claude Code, Cursor, ...) by pointing it at Warden; tools and JSON/SSE responses pass through unchanged. Fronts both AWS's hosted MCP Server (aws-mcp.{region}.api.aws) and customer-owned MCP servers on Bedrock AgentCore."
+category: provider-guide
+provider: mcp_aws
+requires: [foundation, discovery]
+upstream: AWS-hosted MCP servers — the GA AWS MCP Server (aws-mcp.{region}.api.aws/mcp) and Bedrock AgentCore Runtime/Gateway endpoints
+---
+
+# AWS MCP through Warden
+
+## What it does
+
+Warden proxies MCP traffic to an AWS-hosted MCP endpoint, signing each
+outgoing request with AWS SigV4 using IAM credentials minted by the
+`aws` source driver. The MCP client calls a Warden URL; Warden
+authenticates the caller (JWT/cert), looks up the IAM role bound to the
+chosen Warden role, mints short-lived STS credentials, signs the
+upstream request with SigV4, and streams the response (JSON or SSE)
+back unchanged. The agent **never holds IAM credentials** — no
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` on the agent host, no
+`~/.aws/credentials`, no profile to leak.
+
+## Pick the right mount
+
+A single `mcp_aws` mount fronts exactly one upstream — either AWS's
+hosted MCP Server product, or a customer-owned MCP server on Bedrock
+AgentCore Runtime / Gateway. When more than one `mcp_aws` mount exists,
+**match by the operator-set mount description**, not by inspecting the
+upstream URL. The description reflects what the operator intends the
+mount to be used for (which IAM role, which region, which AgentCore
+server); the URL is a backend detail that may change without semantic
+meaning.
+
+```bash
+warden provider list -o json | jq -r '.[] | select(.type=="mcp_aws") | "\(.path)\t\(.description)"'
+```
+
+Pick the mount whose description matches your task. If none of the
+descriptions cover what you need, ask the operator to mount one — do
+not pick the first mcp_aws mount by URL pattern alone.
+
+## Configure the MCP client
+
+`<mount-url>` and `<role>` below come from the discovery flow:
+- `<mount-url>` is the chosen provider's `mount_url` from
+  `warden provider list` (e.g. `/v1/mcp_aws/`,
+  `/v1/team-data/mcp_aws/`). Warden has already baked the namespace
+  and mount path in.
+- `<role>` is the role you picked from `warden role list` to perform
+  this task — it goes in the URL path.
+
+```
+MCP server URL : $WARDEN_ADDR<mount-url>role/<role>/gateway
+Auth header    : Authorization: Bearer $WARDEN_TOKEN
+```
+
+Note **no trailing slash** on `gateway` — this is the opposite of
+`mcp_github`. AWS's hosted MCP Server lives at exactly `/mcp` and
+rejects requests to `/mcp/` with a JSON-RPC `-32600 Invalid request
+path` error. Bedrock AgentCore endpoints follow the same convention.
+
+For MCP client configuration files, the entry looks like (Claude Code
+/ Cursor / Continue / Cline / Goose all accept this shape):
+
+```json
+{
+  "type": "http",
+  "url": "$WARDEN_ADDR<mount-url>role/<role>/gateway",
+  "headers": {
+    "Authorization": "Bearer $WARDEN_TOKEN"
+  }
+}
+```
+
+Substitute `$WARDEN_ADDR`, `<mount-url>`, `<role>`, and `$WARDEN_TOKEN`
+before saving — most MCP clients do not expand environment variables
+inside config files.
+
+## Examples
+
+(All examples below assume `mount_url = /v1/mcp_aws/` and role
+`s3-reader`; substitute yours from `warden provider list`.)
+
+List the tools the server exposes:
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  $WARDEN_ADDR/v1/mcp_aws/role/s3-reader/gateway
+```
+
+Call a tool (the operator must grant a role whose IAM permissions cover
+the requested AWS operation — see Quirks below). For AWS's hosted MCP
+Server, every AWS API call goes through a single `call_aws` tool whose
+arguments select the service, operation, and target region:
+
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call_aws","arguments":{"service_name":"s3","operation_name":"list_buckets","region_name":"us-east-1","parameters":{}}}}' \
+  $WARDEN_ADDR/v1/mcp_aws/role/s3-reader/gateway
+```
+
+The `region_name` inside the tool arguments selects which AWS region's
+API to call — this is **independent** of the mount's signing region.
+A mount fronting `aws-mcp.us-east-1.api.aws/mcp` can still reach
+`eu-west-1` S3, `ap-southeast-2` DynamoDB, etc., as long as the bound
+IAM role's permissions cover those operations.
+
+For a Bedrock AgentCore-hosted MCP server, the available tools depend
+on what the customer's server exposes — discover them via `tools/list`
+and call them with their published argument shapes.
+
+The **absence** of a trailing slash on `gateway` matters — Warden
+composes the upstream URL as the mount's configured base + whatever
+follows `gateway` in the request. AWS's hosted MCP Server requires
+`/mcp` exactly; `/mcp/` returns JSON-RPC `-32600 Invalid request path`.
+(This is the opposite convention from `mcp_github`, where GitHub's MCP
+server requires the trailing slash on `/mcp/`.)
+
+## Header-routed alternative
+
+If you prefer an MCP server URL that is just `$WARDEN_ADDR/` (some MCP
+clients dislike long paths, or you want to mux several MCP providers
+under one base URL), pass the mount path as `X-Warden-Provider` and the
+namespace as `X-Warden-Namespace`:
+
+```bash
+path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_aws" and .description=="<the description you want>") | .path' | head -1)
+
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "X-Warden-Provider: $path" \
+  -H "X-Warden-Namespace: $WARDEN_NAMESPACE" \
+  -H "X-Warden-Role: s3-reader" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  $WARDEN_ADDR/
+```
+
+For an MCP client config:
+
+```json
+{
+  "type": "http",
+  "url": "$WARDEN_ADDR/",
+  "headers": {
+    "Authorization": "Bearer $WARDEN_TOKEN",
+    "X-Warden-Provider": "<path-from-warden-provider-list>",
+    "X-Warden-Namespace": "<namespace>",
+    "X-Warden-Role": "<role>"
+  }
+}
+```
+
+When more than one `mcp_aws` mount exists, the `jq` filter above keys
+on `.description` — the same rule as "Pick the right mount" above.
+
+## Quirks
+
+- **The injected auth is AWS SigV4, not Bearer.** Unlike `mcp_github`
+  which injects `Authorization: Bearer <pat>`, mcp_aws builds an
+  `Authorization: AWS4-HMAC-SHA256 Credential=…/{date}/{region}/{service}/aws4_request,SignedHeaders=…,Signature=…`
+  header per request along with `X-Amz-Date`, `X-Amz-Content-Sha256`,
+  and (for STS-minted credentials) `X-Amz-Security-Token`. The signing
+  service and region are derived from the upstream URL host — agents
+  don't need to know either.
+- **IAM permissions determine which calls succeed.** The bound IAM
+  role's policy is the security boundary. A `403` or
+  `AccessDeniedException` from the upstream means the role lacks the
+  required permission for the target service / action / resource.
+  Operators provision IAM roles whose permissions cover the intended
+  toolset; agents hitting `AccessDenied` should ask the operator to
+  widen the role's policy, not try a different Warden role unless one
+  exists.
+- **Warden policy can gate tools too — body-authoritative.** Operators
+  may bind a policy with an `mcp { }` block that restricts JSON-RPC
+  methods, tool names, resource URIs, prompt names, and `tools/call`
+  arguments (including the `service_name` / `operation_name` /
+  `region_name` keys the AWS MCP Server's `call_aws` tool reads).
+  Warden strict-parses the JSON-RPC request body and matches against
+  the parsed body — no client-side opt-in or header mirroring required.
+  A deny shows up as HTTP 403 with an RFC 6750
+  `WWW-Authenticate: Bearer error="insufficient_permissions", error_description="..."`
+  header and a small JSON body of the same shape; the description
+  names the offending method/tool/parameter. This is **independent**
+  of IAM `AccessDenied` errors, which surface as native AWS error
+  responses streamed back from the upstream — read the
+  `error_description` to tell the two apart. The strict parser also
+  fails closed on structural problems (malformed JSON-RPC, duplicate
+  keys, oversized body, etc.) with a specific `rule_type` in the audit
+  log. See the README's "Create a Policy" section for the full
+  rule_type table.
+- **Streamable HTTP / SSE flows through transparently.** Send
+  `Accept: application/json, text/event-stream` and the server's
+  choice of framing comes back unchanged. The `Mcp-Session-Id`
+  response header round-trips automatically; subsequent client
+  requests carrying it reach the same upstream session.
+- **Session timeout is mount-wide.** The mount's `timeout` config
+  caps an entire SSE session (default 10 minutes). For longer agent
+  sessions, ask the operator to raise it.
+- **The mount's region is the *signing* region, not a restriction on
+  AWS region of API calls.** AWS's MCP Server can call any region's
+  APIs; the agent picks the target region via `region_name` inside
+  the tool arguments. A second mount is only needed when the operator
+  specifically wants the MCP server itself in another region — for
+  latency, data sovereignty, or failover.
+- **AgentCore-hosted MCP servers expose different tool shapes.** When
+  the upstream is `*.bedrock-agentcore.{region}.amazonaws.com`, the
+  available tools and their argument schemas come from whatever the
+  customer-owned server exposes — discover via `tools/list`. The
+  `call_aws` example above is specific to AWS's hosted MCP Server
+  product.
+- **STS credentials are short-lived.** The bound IAM role's STS
+  session duration caps how long any individual MCP request can take
+  end-to-end on the signing side. The signed request is valid for 15
+  minutes from `X-Amz-Date`; long-running tool calls beyond that
+  window will fail with a SigV4 expiration error rather than a token
+  refresh. Restart the MCP session for very long operations.
+- **Rate limits propagate from AWS.** Warden does not retry; back off
+  when you see `ThrottlingException` / `RequestLimitExceeded` from
+  AWS. CloudTrail captures every call for audit.
+- **Not in scope**: OAuth flows (Dynamic Client Registration, PRM
+  discovery), stdio transport, and any path that requires running
+  AWS's `mcp-proxy-for-aws` on the client side. Warden replaces that
+  proxy; the client just speaks plain Streamable HTTP MCP to Warden.


### PR DESCRIPTION
## Summary

skill.md (agent-facing) + README.md (operator-facing) + skill.go embed wrapper for the `mcp_aws` provider. ~820 lines of docs, one squashed commit.

The docs already incorporate every learning from the end-to-end testing session that surfaced four real architectural collisions between MCP Streamable HTTP and Warden's `mcp { }` block (most of them inherited from mcp_github's examples, which #290 fixed in parallel):

- **No trailing slash on `gateway`** — opposite of mcp_github. AWS's hosted MCP Server (and Bedrock AgentCore) returns JSON-RPC `-32600 Invalid request path` on `/mcp/`.
- **`capabilities = ["create", "read", "delete"]`** in every policy example — MCP Streamable HTTP uses POST + GET + DELETE on the same URL.
- **MCP lifecycle methods** (`initialize`, `notifications/initialized`, `ping`) listed in every `allowed_methods` example alongside data-plane methods — every spec-compliant client does the handshake before any `tools/*` call.
- **Tool name prefix `aws___`** — the actual AWS MCP Server prefix; the GA blog hint that tools were named `call_aws` was misleading.
- **`rule_type` table** reflects #289's contract: non-POST verbs silently skip `mcp { }` evaluation, and `allowed_params` is conditional on presence.

### Skill.md highlights

- "Pick the right mount" section: agents identify mcp_aws mounts by operator-set description, not by URL sniffing — since one provider type fronts both AWS's hosted MCP Server *and* Bedrock AgentCore.
- Adapted from mcp_github's structure; same shape, AWS-specific quirks called out where they differ.

### README.md highlights

- "Why use Warden in front of this?" section that names the security posture wins over running AWS's own client-side `mcp-proxy-for-aws` (clients hold an identity Warden recognizes — JWT or TLS cert, never IAM keys; STS minted per-request; revocation is delete-the-role).
- Step 3 cross-references the `aws` REST provider's README for IAM-user setup, using the actual `aws_driver.go` field names (`role_arn` on the spec, `ttl` with separate CLI flags `-min-ttl`/`-max-ttl`, `-rotation-period` on the source).
- Step 4 reproduces the full `rule_type` table from mcp_github and includes the conditional-`allowed_params` semantic from #289.
- TLS Certificate Authentication covers the sidecar-terminator pattern most MCP clients need today.

## Stacks on

#293 (mcp_aws-policy / MCPPolicyEnforced opt-in).
