### PR TITLE
feat(mcp_aws): register provider and skill in server

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -57,6 +57,7 @@ import (
 	"github.com/stephnangue/warden/provider/honeycomb"
 	"github.com/stephnangue/warden/provider/ibmcloud"
 	"github.com/stephnangue/warden/provider/kubernetes"
+	mcp_aws "github.com/stephnangue/warden/provider/mcp_aws"
 	mcp_github "github.com/stephnangue/warden/provider/mcp_github"
 	"github.com/stephnangue/warden/provider/mistral"
 	"github.com/stephnangue/warden/provider/newrelic"
@@ -163,6 +164,7 @@ Usage: warden server [options]
 		"ibmcloud":      ibmcloud.Factory,
 		"github":        github.Factory,
 		"gitlab":        gitlab.Factory,
+		"mcp_aws":       mcp_aws.Factory,
 		"mcp_github":    mcp_github.Factory,
 		"mistral":       mistral.Factory,
 		"newrelic":      newrelic.Factory,
@@ -193,6 +195,7 @@ Usage: warden server [options]
 		"aws":           aws.Skill(),
 		"github":        github.Skill(),
 		"gitlab":        gitlab.Skill(),
+		"mcp_aws":       mcp_aws.Skill(),
 		"mcp_github":    mcp_github.Skill(),
 		"openai":        openai.Skill(),
 		"rds":           rds.Skill(),


### PR DESCRIPTION
## Summary

Three-line wiring in `cmd/server/server.go` — mirrors mcp_github's registration sites exactly so a `warden provider enable mcp_aws` resolves to the Factory built across #291 / #292 / #293, and a first mount seeds `skill.md` into the global skill registry per the convention introduced by the embedded `//go:embed` in #294.

- `import mcp_aws "github.com/stephnangue/warden/provider/mcp_aws"`
- `"mcp_aws": mcp_aws.Factory` in the providers map (next to `"mcp_github"`)
- `"mcp_aws": mcp_aws.Skill()` in the skills map

No e2e test in this PR. The plan called for one that drives a stub upstream and verifies the canonical SigV4 request, but `TestHandleGateway_ThroughConfigWrite` in #292 already exercises the production `handleConfigWrite` → `handleGateway` path against an `httptest.NewServer` stub that records the signed headers. That covers the wire-correctness invariant the e2e test would have checked — without LocalStack hosting an MCP server (it doesn't), an e2e test in the cluster would just duplicate the unit-level coverage against the same stub. Sibling provider mcp_github also ships without an e2e test for the same reason.

## End-to-end verification

The pipeline was verified end-to-end against the live AWS MCP Server with Claude Code as the client (cluster running this binary, real AWS account, real S3 buckets returned to Claude). The session surfaced four real architectural collisions between MCP Streamable HTTP and Warden's mcp { } block — all four were fixed in #289 (framework: tri-state MCPDescriptor + conditional allowed_params) and #290 / #294 (docs that match the new semantics).

## Stacks on

#294 (mcp_aws-docs).
