### PR TITLE
refactor(framework): make StreamingBackend mutable fields thread-safe

### DIFF
--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/armon/go-radix"
@@ -97,16 +98,64 @@ type StreamingPath struct {
 	HelpDescription string
 }
 
+// swappableTransport wraps an http.RoundTripper whose underlying transport
+// can be replaced atomically at runtime. ReverseProxy and custom backends
+// hold a pointer to one instance and never need to re-read Transport; the
+// swappable always dispatches to the current underlying transport.
+//
+// Uses atomic.Pointer[http.RoundTripper] (pointer to interface) rather than
+// atomic.Value because Store requires every value to have the same concrete
+// type — providers may swap an *http.Transport for an *rewritingTransport
+// from a test, which atomic.Value rejects with a panic.
+type swappableTransport struct {
+	cur atomic.Pointer[http.RoundTripper]
+}
+
+func newSwappableTransport(initial http.RoundTripper) *swappableTransport {
+	s := &swappableTransport{}
+	if initial != nil {
+		s.cur.Store(&initial)
+	}
+	return s
+}
+
+func (s *swappableTransport) load() http.RoundTripper {
+	p := s.cur.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func (s *swappableTransport) store(t http.RoundTripper) {
+	s.cur.Store(&t)
+}
+
+// RoundTrip satisfies http.RoundTripper by dispatching to the current
+// underlying transport. Falls back to http.DefaultTransport when nothing has
+// been installed yet so callers don't have to nil-check.
+func (s *swappableTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t := s.load()
+	if t == nil {
+		t = http.DefaultTransport
+	}
+	return t.RoundTrip(r)
+}
+
 // StreamingBackend implements logical.Backend for streaming/proxy operations.
 // It combines streaming paths (for proxy operations) with regular framework paths
 // (for configuration and management).
+//
+// Mutable runtime fields (MaxBodySize, Timeout, TransparentConfig, transport)
+// are held in atomic backing storage and exposed via accessor methods. Direct
+// struct-field writes to the legacy names are no longer possible (the fields
+// are unexported); use MaxBodySize() / SetMaxBodySize(), Timeout() / SetTimeout(),
+// TransparentConfig() / SetTransparentConfig(), Transport() / SetTransport().
+// This makes hot-path reads race-detector clean against concurrent config
+// writes without each provider having to coordinate its own RWMutex.
 type StreamingBackend struct {
 	// StreamingPaths are paths that handle streaming operations (e.g., gateway/*)
 	StreamingPaths []*StreamingPath
-
-	// TransparentConfig holds the implicit auth configuration
-	// When set, StreamingBackend implements logical.TransparentModeProvider
-	TransparentConfig *TransparentConfig
 
 	// UnauthenticatedPaths are paths that can be accessed without authentication.
 	// These are hardcoded by the provider for read-only endpoints that some clients
@@ -124,14 +173,10 @@ type StreamingBackend struct {
 	// Backend is the embedded standard framework backend for non-streaming paths
 	*Backend
 
-	// MaxBodySize is the maximum request body size in bytes.
-	MaxBodySize int64
-
-	// Timeout is the request timeout duration.
-	Timeout time.Duration
-
 	// Proxy is the shared reverse proxy for streaming requests.
-	// Initialized via InitProxy with a provider-specific transport.
+	// Initialized via InitProxy with a provider-specific transport. Proxy.Transport
+	// is set to the swappable transport, so subsequent SetTransport calls update
+	// both this Proxy and any custom-backend handler that reads via Transport().
 	Proxy *httputil.ReverseProxy
 
 	// Logger is the provider's scoped logger (set via conf.Logger.WithSubsystem).
@@ -140,13 +185,89 @@ type StreamingBackend struct {
 	// StorageView is the provider's storage backend for persisting configuration.
 	StorageView sdklogical.Storage
 
+	// Atomic backing storage for runtime-mutable fields. Read/write only via
+	// the typed accessor methods below.
+	maxBodySize       atomic.Int64
+	timeout           atomic.Int64 // nanoseconds
+	transparentConfig atomic.Pointer[TransparentConfig]
+	// transport is lazily-initialized via transportOnce so concurrent first
+	// SetTransport / Transport / InitProxy calls don't race on the pointer-
+	// field assignment. The same swappable lives for the lifetime of the
+	// backend; SetTransport mutates its underlying.
+	transport     *swappableTransport
+	transportOnce sync.Once
+
 	// Internal state
 	streamingPathsRe []*regexp.Regexp
 	streamingOnce    sync.Once
 
-	// unauthPaths holds the parsed unauthenticated paths (radix tree + wildcards)
+	// unauthPaths holds the parsed unauthenticated paths (radix tree + wildcards).
+	// unauthMu serializes the reset performed by SetTransparentConfig and the
+	// once-only init performed by initUnauthPaths so concurrent config writes
+	// can't race on the sync.Once or the pointer.
+	// unauthPathsOnce is a *sync.Once (not a value) so the reset in
+	// SetTransparentConfig replaces the pointer rather than copying a value —
+	// avoids go vet's -copylocks complaint about reassigning a sync.Once
+	// after first use.
+	unauthMu        sync.Mutex
 	unauthPaths     *unauthPathsEntry
-	unauthPathsOnce sync.Once
+	unauthPathsOnce *sync.Once
+}
+
+// MaxBodySize returns the maximum request body size in bytes.
+func (b *StreamingBackend) MaxBodySize() int64 { return b.maxBodySize.Load() }
+
+// SetMaxBodySize atomically updates the maximum request body size.
+func (b *StreamingBackend) SetMaxBodySize(v int64) { b.maxBodySize.Store(v) }
+
+// Timeout returns the request timeout duration.
+func (b *StreamingBackend) Timeout() time.Duration { return time.Duration(b.timeout.Load()) }
+
+// SetTimeout atomically updates the request timeout duration.
+func (b *StreamingBackend) SetTimeout(d time.Duration) { b.timeout.Store(int64(d)) }
+
+// emptyTransparentConfig is returned by TransparentConfig() when no config
+// has been installed. Sharing a single pointer avoids per-call allocation
+// on the (rare) cold path; callers must treat the returned value as read-only.
+var emptyTransparentConfig = &TransparentConfig{}
+
+// TransparentConfig returns the current implicit-auth configuration. Never
+// returns nil — when nothing has been installed yet (a freshly-constructed
+// StreamingBackend that hasn't been seeded), returns a shared empty
+// TransparentConfig so callers can safely chain field accesses. Use
+// IsTransparentMode() to distinguish "not configured" from "configured
+// with empty fields".
+func (b *StreamingBackend) TransparentConfig() *TransparentConfig {
+	if tc := b.transparentConfig.Load(); tc != nil {
+		return tc
+	}
+	return emptyTransparentConfig
+}
+
+// ensureTransport lazily initializes the swappable wrapper. Idempotent and
+// concurrency-safe via transportOnce. Callers must use this before reading
+// or writing b.transport.
+func (b *StreamingBackend) ensureTransport() *swappableTransport {
+	b.transportOnce.Do(func() {
+		b.transport = newSwappableTransport(nil)
+	})
+	return b.transport
+}
+
+// Transport returns the framework's swappable transport wrapper. The wrapper
+// itself stays stable for the lifetime of the backend; the underlying
+// http.RoundTripper changes when SetTransport / InitProxy install one. Before
+// any transport is installed, RoundTrip on the wrapper falls back to
+// http.DefaultTransport.
+func (b *StreamingBackend) Transport() http.RoundTripper {
+	return b.ensureTransport()
+}
+
+// SetTransport atomically replaces the upstream transport. The same swappable
+// dispatches for Proxy.Transport and for custom backends reading via Transport(),
+// so a single SetTransport call updates every hot-path reader.
+func (b *StreamingBackend) SetTransport(t http.RoundTripper) {
+	b.ensureTransport().store(t)
 }
 
 // Ensure StreamingBackend implements logical.Backend and logical.StreamBodyParser
@@ -493,26 +614,28 @@ func (b *StreamingBackend) ExtractToken(r *http.Request) string {
 
 // IsTransparentMode returns whether the backend has an auth config set
 func (b *StreamingBackend) IsTransparentMode() bool {
-	return b.TransparentConfig != nil
+	return b.transparentConfig.Load() != nil
 }
 
 // GetAutoAuthPath returns the auth mount path for implicit authentication
 func (b *StreamingBackend) GetAutoAuthPath() string {
-	if b.TransparentConfig == nil {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
 		return ""
 	}
-	return b.TransparentConfig.AutoAuthPath
+	return tc.AutoAuthPath
 }
 
 // GetAuthRole extracts the auth role name from the request path. Returns
 // "" when the path does not encode a role; the mount-level default_role
 // is returned separately by GetDefaultAuthRole.
 func (b *StreamingBackend) GetAuthRole(path string, _ *logical.Request) string {
-	if b.TransparentConfig == nil {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
 		return ""
 	}
 
-	pattern := b.TransparentConfig.AuthRolePattern
+	pattern := tc.AuthRolePattern
 	if pattern == nil {
 		pattern = DefaultAuthRolePattern
 	}
@@ -526,41 +649,57 @@ func (b *StreamingBackend) GetAuthRole(path string, _ *logical.Request) string {
 
 // GetDefaultAuthRole returns the mount-level default_role config value.
 func (b *StreamingBackend) GetDefaultAuthRole() string {
-	if b.TransparentConfig == nil {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
 		return ""
 	}
-	return b.TransparentConfig.DefaultAuthRole
+	return tc.DefaultAuthRole
 }
 
 // RewriteTransparentPath rewrites a transparent path to standard path
 func (b *StreamingBackend) RewriteTransparentPath(path string) string {
-	if b.TransparentConfig == nil {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
 		return path
 	}
 
-	rewriter := b.TransparentConfig.PathRewriter
+	rewriter := tc.PathRewriter
 	if rewriter == nil {
 		rewriter = DefaultPathRewriter
 	}
 	return rewriter(path)
 }
 
-// SetTransparentConfig updates the implicit auth configuration at runtime
+// SetTransparentConfig updates the implicit auth configuration at runtime.
+// The new pointer is installed atomically; readers via GetAutoAuthPath etc
+// observe either the old or new config, never a torn value.
 func (b *StreamingBackend) SetTransparentConfig(config *TransparentConfig) {
-	b.TransparentConfig = config
-	// Reset unauthPaths so it gets re-initialized with new config
-	b.unauthPathsOnce = sync.Once{}
+	b.transparentConfig.Store(config)
+	// Reset unauthPaths so it gets re-initialized with new config. Guarded
+	// by unauthMu against concurrent SetTransparentConfig + initUnauthPaths.
+	b.unauthMu.Lock()
+	b.unauthPathsOnce = &sync.Once{}
 	b.unauthPaths = nil
+	b.unauthMu.Unlock()
 }
 
-// InitProxy creates a standard reverse proxy with the given transport.
+// InitProxy creates a standard reverse proxy backed by the framework's
+// swappable transport. After this call:
+//   - b.Proxy.Transport is the swappable wrapper, so subsequent SetTransport
+//     calls update both this Proxy and any custom-backend handler that reads
+//     via Transport() — no per-provider transport re-assignment needed.
+//   - Transport() returns the same swappable, with the initial transport
+//     installed atomically.
+//
 // The proxy uses an empty Director (providers prepare requests before ServeHTTP)
 // and a standard error handler that logs and returns 502.
 // Logger must be set on the StreamingBackend before calling this method.
 func (b *StreamingBackend) InitProxy(transport http.RoundTripper) {
+	swap := b.ensureTransport()
+	swap.store(transport)
 	b.Proxy = &httputil.ReverseProxy{
 		Director:  func(req *http.Request) {},
-		Transport: transport,
+		Transport: swap,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			b.Logger.Error("proxy error",
 				logger.Err(err),
@@ -622,9 +761,17 @@ func (b *StreamingBackend) IsTransparentPath(path string) bool {
 // Uses radix tree for O(log n) lookup with wildcard fallback. Subtypes may
 // override to inspect the request.
 func (b *StreamingBackend) IsUnauthenticatedPath(_ *http.Request, path string) bool {
+	// Both the Once.Do init and the SetTransparentConfig reset serialize
+	// through unauthMu so neither tears the once+pointer pair.
+	b.unauthMu.Lock()
+	if b.unauthPathsOnce == nil {
+		b.unauthPathsOnce = &sync.Once{}
+	}
 	b.unauthPathsOnce.Do(b.initUnauthPaths)
+	paths := b.unauthPaths
+	b.unauthMu.Unlock()
 
-	if b.unauthPaths == nil {
+	if paths == nil {
 		return false
 	}
 
@@ -640,7 +787,7 @@ func (b *StreamingBackend) IsUnauthenticatedPath(_ *http.Request, path string) b
 	path = strings.TrimPrefix(path, "/")
 
 	// Check radix tree (exact and prefix matches)
-	match, raw, ok := b.unauthPaths.paths.LongestPrefix(path)
+	match, raw, ok := paths.paths.LongestPrefix(path)
 	if ok {
 		isPrefix := raw.(bool)
 		if isPrefix {
@@ -653,7 +800,7 @@ func (b *StreamingBackend) IsUnauthenticatedPath(_ *http.Request, path string) b
 
 	// Check wildcard patterns
 	pathParts := strings.Split(path, "/")
-	for _, w := range b.unauthPaths.wildcardPaths {
+	for _, w := range paths.wildcardPaths {
 		if matchWildcardSegments(pathParts, w.segments, w.isPrefix) {
 			return true
 		}

--- a/framework/streaming_backend_concurrency_test.go
+++ b/framework/streaming_backend_concurrency_test.go
@@ -1,0 +1,165 @@
+package framework
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestStreamingBackend_ConcurrentFieldAccess proves the atomic accessors
+// MaxBodySize / Timeout / TransparentConfig / Transport are race-detector
+// clean when N readers and M writers hit them concurrently. The same test
+// against the previous version of this file (exported fields, no atomics)
+// would fire the race detector immediately.
+func TestStreamingBackend_ConcurrentFieldAccess(t *testing.T) {
+	t.Parallel()
+
+	const (
+		readers    = 8
+		writers    = 4
+		iterations = 1000
+	)
+
+	sb := &StreamingBackend{}
+	sb.SetMaxBodySize(1 << 20)
+	sb.SetTimeout(30 * time.Second)
+	sb.SetTransparentConfig(&TransparentConfig{AutoAuthPath: "auth/jwt/"})
+	sb.SetTransport(http.DefaultTransport)
+
+	var wg sync.WaitGroup
+
+	// Readers: hot-path accesses on every per-request field.
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = sb.MaxBodySize()
+				_ = sb.Timeout()
+				if tc := sb.TransparentConfig(); tc != nil {
+					_ = tc.AutoAuthPath
+				}
+				_ = sb.Transport()
+			}
+		}()
+	}
+
+	// Writers: simulate config-write storms.
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				sb.SetMaxBodySize(int64(seed*1000 + j))
+				sb.SetTimeout(time.Duration(seed+j) * time.Millisecond)
+				sb.SetTransparentConfig(&TransparentConfig{
+					AutoAuthPath:    "auth/jwt/",
+					DefaultAuthRole: "role-rotate",
+				})
+				sb.SetTransport(http.DefaultTransport)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestSwappableTransport_StoreVisible verifies that a RoundTrip dispatched
+// through Transport() reaches whatever transport SetTransport installed most
+// recently. Transport() returns the stable swappable wrapper itself (not the
+// underlying), so callers always get the same object — the underlying is
+// observed via behavior, not identity.
+//
+// Without the atomic.Pointer indirection in swappableTransport, the second
+// SetTransport call with a different concrete type would panic. The test
+// uses two distinct RoundTripper implementations to exercise that path.
+func TestSwappableTransport_StoreVisible(t *testing.T) {
+	t.Parallel()
+
+	sb := &StreamingBackend{}
+	sb.InitProxy(http.DefaultTransport)
+
+	first := &countingTransport{name: "first"}
+	second := &countingTransport{name: "second"}
+
+	sb.SetTransport(first)
+	_, _ = sb.Transport().RoundTrip(&http.Request{URL: nil})
+	if first.count != 1 || second.count != 0 {
+		t.Fatalf("after first dispatch: first=%d second=%d, want 1/0", first.count, second.count)
+	}
+
+	sb.SetTransport(second)
+	_, _ = sb.Transport().RoundTrip(&http.Request{URL: nil})
+	if first.count != 1 || second.count != 1 {
+		t.Fatalf("after second dispatch: first=%d second=%d, want 1/1", first.count, second.count)
+	}
+}
+
+type countingTransport struct {
+	name  string
+	count int
+}
+
+func (c *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	c.count++
+	return nil, nil
+}
+
+// TestSwappableTransport_FirstSetTransportRace exercises the case where
+// nothing has set up the swappable yet and multiple goroutines call
+// SetTransport concurrently. Before the sync.Once-based ensureTransport,
+// the unsynchronized b.transport field assignment would race here; under
+// -race this is the regression bench.
+func TestSwappableTransport_FirstSetTransportRace(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 8
+	sb := &StreamingBackend{} // no pre-seed
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sb.SetTransport(http.DefaultTransport)
+		}()
+	}
+	wg.Wait()
+
+	// Verify the swappable was installed exactly once and dispatches correctly.
+	rec := &countingTransport{name: "rec"}
+	sb.SetTransport(rec)
+	_, _ = sb.Transport().RoundTrip(&http.Request{URL: nil})
+	if rec.count != 1 {
+		t.Fatalf("RoundTrip after concurrent SetTransport then explicit SetTransport: rec.count=%d, want 1", rec.count)
+	}
+}
+
+// TestSwappableTransport_StoreDifferentConcreteTypes exercises the path the
+// review specifically called out: SetTransport with two different concrete
+// implementations. Before atomic.Pointer (when the field was atomic.Value),
+// the second Store with a different concrete type would panic.
+func TestSwappableTransport_StoreDifferentConcreteTypes(t *testing.T) {
+	t.Parallel()
+
+	sb := &StreamingBackend{}
+
+	// First a *countingTransport (custom concrete type).
+	first := &countingTransport{name: "first"}
+	sb.SetTransport(first)
+
+	// Then *http.Transport (different concrete type — atomic.Value would panic).
+	httpTransport := &http.Transport{}
+	sb.SetTransport(httpTransport)
+
+	// Then back to a *countingTransport.
+	third := &countingTransport{name: "third"}
+	sb.SetTransport(third)
+	_, _ = sb.Transport().RoundTrip(&http.Request{URL: nil})
+	if third.count != 1 {
+		t.Fatalf("RoundTrip should reach third after three Set calls: third.count=%d", third.count)
+	}
+	if first.count != 0 {
+		t.Fatalf("first should not have been called: first.count=%d", first.count)
+	}
+}

--- a/framework/streaming_methods_test.go
+++ b/framework/streaming_methods_test.go
@@ -35,10 +35,6 @@ func testStreamingBackend() *StreamingBackend {
 				Handler: func(_ context.Context, _ *logical.Request, _ *FieldData) error { return nil },
 			},
 		},
-		TransparentConfig: &TransparentConfig{
-			AutoAuthPath:    "auth/jwt/",
-			DefaultAuthRole: "default",
-		},
 		Backend: &Backend{
 			Help:         "test streaming backend",
 			BackendType:  "test-stream",
@@ -58,6 +54,10 @@ func testStreamingBackend() *StreamingBackend {
 			},
 		},
 	}
+	sb.SetTransparentConfig(&TransparentConfig{
+		AutoAuthPath:    "auth/jwt/",
+		DefaultAuthRole: "default",
+	})
 	return sb
 }
 
@@ -257,7 +257,8 @@ func TestStreamingBackend_GetDefaultAuthRole(t *testing.T) {
 	})
 
 	t.Run("empty default returns empty", func(t *testing.T) {
-		sb := &StreamingBackend{TransparentConfig: &TransparentConfig{}}
+		sb := &StreamingBackend{}
+		sb.SetTransparentConfig(&TransparentConfig{})
 		assert.Equal(t, "", sb.GetDefaultAuthRole())
 	})
 }

--- a/provider/alicloud/handler_test.go
+++ b/provider/alicloud/handler_test.go
@@ -48,7 +48,7 @@ func TestHandleGateway_SubdomainRewrite(t *testing.T) {
 	defer upstream.Close()
 
 	b := setupBackend(t)
-	b.Proxy.Transport = upstream.Client().Transport
+	b.SetTransport(upstream.Client().Transport)
 	// Configure the proxy domain.
 	b.mu.Lock()
 	b.proxyDomains = []string{"warden.example.com"}
@@ -217,7 +217,7 @@ func TestHandleGateway_ForwardsSignedRequest(t *testing.T) {
 
 	b := setupBackend(t)
 	// Point transport at upstream's TLS (self-signed)
-	b.Proxy.Transport = upstream.Client().Transport
+	b.SetTransport(upstream.Client().Transport)
 
 	// Client signs with its role name (cert transparent)
 	body := `{"instance":"i-123"}`
@@ -266,7 +266,7 @@ func TestHandleGateway_JWTSecurityToken(t *testing.T) {
 	defer upstream.Close()
 
 	b := setupBackend(t)
-	b.Proxy.Transport = upstream.Client().Transport
+	b.SetTransport(upstream.Client().Transport)
 
 	// Client signs using a JWT as both x-acs-security-token and access_key_secret.
 	// access_key_id can be anything.

--- a/provider/alicloud/oss_test.go
+++ b/provider/alicloud/oss_test.go
@@ -75,7 +75,7 @@ func TestHandleOSS_CertTransparent_ForwardsSigned(t *testing.T) {
 
 	b := setupBackend(t)
 	upURL, _ := url.Parse(upstream.URL)
-	b.Proxy.Transport = &rewritingTransport{inner: upstream.Client().Transport, target: upURL}
+	b.SetTransport(&rewritingTransport{inner: upstream.Client().Transport, target: upURL})
 
 	// Cert transparent: client signs using role name as both keys
 	r := signOSSRequest(t, "GET", "https://oss-cn-hangzhou.aliyuncs.com/my-bucket/my-object", "", "role-reader", "role-reader", "", "cn-hangzhou")
@@ -115,7 +115,7 @@ func TestHandleOSS_JWTTransparent_ForwardsSigned(t *testing.T) {
 
 	b := setupBackend(t)
 	upURL, _ := url.Parse(upstream.URL)
-	b.Proxy.Transport = &rewritingTransport{inner: upstream.Client().Transport, target: upURL}
+	b.SetTransport(&rewritingTransport{inner: upstream.Client().Transport, target: upURL})
 
 	jwt := "eyJhbGciOiJIUzI1NiJ9.payload.sig"
 	r := signOSSRequest(t, "GET", "https://oss-cn-hangzhou.aliyuncs.com/my-bucket/key", "", "any-id", jwt, jwt, "cn-hangzhou")

--- a/provider/alicloud/path_config.go
+++ b/provider/alicloud/path_config.go
@@ -64,12 +64,12 @@ func (b *alicloudBackend) handleConfigRead(ctx context.Context, req *logical.Req
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	tc := b.TransparentConfig
+	tc := b.TransparentConfig()
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
 			"tls_skip_verify": b.tlsSkipVerify,
@@ -108,8 +108,8 @@ func (b *alicloudBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 
 	b.mu.RLock()
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
+		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
 	}
 	b.mu.RUnlock()
 
@@ -128,8 +128,8 @@ func (b *alicloudBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 	}
 
 	b.mu.Lock()
-	b.MaxBodySize = parsed.MaxBodySize
-	b.Timeout = parsed.Timeout
+	b.SetMaxBodySize(parsed.MaxBodySize)
+	b.SetTimeout(parsed.Timeout)
 	b.tlsSkipVerify = parsed.TLSSkipVerify
 	b.caData = parsed.CAData
 	b.proxyDomains = parsed.ProxyDomains
@@ -146,13 +146,13 @@ func (b *alicloudBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 				Err:        err,
 			}, nil
 		}
-		b.Proxy.Transport = transport
+		b.SetTransport(transport)
 	}
 
 	if b.StorageView != nil {
 		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
 			"tls_skip_verify": b.tlsSkipVerify,

--- a/provider/alicloud/path_config_test.go
+++ b/provider/alicloud/path_config_test.go
@@ -90,8 +90,8 @@ func TestFactory(t *testing.T) {
 	b := setupBackend(t)
 	assert.Equal(t, "alicloud", b.Type())
 	assert.Equal(t, logical.ClassProvider, b.Class())
-	assert.Equal(t, DefaultTimeout, b.Timeout)
-	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize)
+	assert.Equal(t, DefaultTimeout, b.Timeout())
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize())
 }
 
 func TestFactory_WithConfig(t *testing.T) {
@@ -108,9 +108,10 @@ func TestFactory_WithConfig(t *testing.T) {
 	b, err := Factory(context.Background(), conf)
 	require.NoError(t, err)
 	ab := b.(*alicloudBackend)
-	assert.Equal(t, 60.0, ab.Timeout.Seconds())
-	assert.Equal(t, "auth/jwt/", ab.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "reader", ab.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, 60.0, ab.Timeout().Seconds())
+	tc := ab.TransparentConfig()
+	assert.Equal(t, "auth/jwt/", tc.AutoAuthPath)
+	assert.Equal(t, "reader", tc.DefaultAuthRole)
 }
 
 func TestFactory_InvalidConfig(t *testing.T) {
@@ -155,10 +156,11 @@ func TestInitialize_ExistingConfig(t *testing.T) {
 	err := b.Initialize(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(5242880), b.MaxBodySize)
-	assert.Equal(t, 45.0, b.Timeout.Seconds())
-	assert.Equal(t, "auth/cert/", b.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "admin", b.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, int64(5242880), b.MaxBodySize())
+	assert.Equal(t, 45.0, b.Timeout().Seconds())
+	tc := b.TransparentConfig()
+	assert.Equal(t, "auth/cert/", tc.AutoAuthPath)
+	assert.Equal(t, "admin", tc.DefaultAuthRole)
 }
 
 // --- Config CRUD tests ---

--- a/provider/alicloud/path_gateway.go
+++ b/provider/alicloud/path_gateway.go
@@ -77,7 +77,7 @@ func (b *alicloudBackend) handleGateway(ctx context.Context, req *logical.Reques
 // It verifies the incoming ACS3 signature (using the client's implicit-auth
 // credentials), re-signs with real Alicloud credentials, and forwards.
 func (b *alicloudBackend) handleAPIRequest(ctx context.Context, req *logical.Request) {
-	maxBody := b.MaxBodySize
+	maxBody := b.MaxBodySize()
 	if maxBody <= 0 {
 		maxBody = 10 << 20
 	}
@@ -102,9 +102,9 @@ func (b *alicloudBackend) handleAPIRequest(ctx context.Context, req *logical.Req
 	}
 
 	// Apply timeout for verification + forwarding
-	if b.Timeout > 0 {
+	if b.Timeout() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout())
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
@@ -191,7 +191,7 @@ func (b *alicloudBackend) forward(req *logical.Request, body []byte) {
 		r.ContentLength = 0
 	}
 
-	transport := b.Proxy.Transport
+	transport := b.Transport()
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
@@ -233,7 +233,7 @@ func (b *alicloudBackend) forward(req *logical.Request, body []byte) {
 // credentials), re-signs with real Alicloud OSS credentials, and forwards to
 // the target OSS endpoint (oss-{region}.aliyuncs.com).
 func (b *alicloudBackend) handleOSSRequest(ctx context.Context, req *logical.Request) {
-	maxBody := b.MaxBodySize
+	maxBody := b.MaxBodySize()
 	if maxBody <= 0 {
 		maxBody = 10 << 20
 	}
@@ -259,9 +259,9 @@ func (b *alicloudBackend) handleOSSRequest(ctx context.Context, req *logical.Req
 	}
 
 	// Apply timeout for verification + forwarding
-	if b.Timeout > 0 {
+	if b.Timeout() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout())
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
@@ -353,7 +353,7 @@ func (b *alicloudBackend) handleOSSRequest(ctx context.Context, req *logical.Req
 	)
 
 	// Step 9: Forward directly
-	transport := b.Proxy.Transport
+	transport := b.Transport()
 	if transport == nil {
 		transport = http.DefaultTransport
 	}

--- a/provider/alicloud/provider.go
+++ b/provider/alicloud/provider.go
@@ -129,10 +129,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 				HelpDescription: "Proxies requests to Alibaba Cloud APIs with role embedded in URL path",
 			},
 		},
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "",
-			DefaultAuthRole: "",
-		},
 		Backend: &framework.Backend{
 			Help:           alicloudBackendHelp,
 			BackendType:    "alicloud",
@@ -145,6 +141,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	b.Logger = conf.Logger.WithSubsystem("alicloud")
 	b.StorageView = conf.StorageView
 
+	// Seed an empty transparent config so isTransparentRequest can route
+	// once auto_auth_path is configured via handleConfigWrite.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
+
 	initTransport()
 	b.StreamingBackend.InitProxy(sharedTransport)
 
@@ -156,16 +156,16 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		return nil, err
 	}
 
-	b.MaxBodySize = framework.DefaultMaxBodySize
-	b.Timeout = DefaultTimeout
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(DefaultTimeout)
 
 	if len(conf.Config) > 0 {
 		if err := ValidateConfig(conf.Config); err != nil {
 			return nil, fmt.Errorf("invalid configuration: %w", err)
 		}
 		parsed := parseConfig(conf.Config)
-		b.MaxBodySize = parsed.MaxBodySize
-		b.Timeout = parsed.Timeout
+		b.SetMaxBodySize(parsed.MaxBodySize)
+		b.SetTimeout(parsed.Timeout)
 		b.tlsSkipVerify = parsed.TLSSkipVerify
 		b.caData = parsed.CAData
 		b.proxyDomains = parsed.ProxyDomains
@@ -175,7 +175,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			if err != nil {
 				return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
@@ -213,14 +213,14 @@ func (b *alicloudBackend) Initialize(ctx context.Context) error {
 
 		b.mu.Lock()
 		if config.MaxBodySize > 0 {
-			b.MaxBodySize = config.MaxBodySize
+			b.SetMaxBodySize(config.MaxBodySize)
 		}
 		b.tlsSkipVerify = config.TLSSkipVerify
 		b.caData = config.CAData
 		b.proxyDomains = config.ProxyDomains
 		if config.Timeout != "" {
 			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
-				b.Timeout = timeout
+				b.SetTimeout(timeout)
 			}
 		}
 		b.mu.Unlock()
@@ -230,7 +230,7 @@ func (b *alicloudBackend) Initialize(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
@@ -239,10 +239,10 @@ func (b *alicloudBackend) Initialize(ctx context.Context) error {
 		})
 	} else {
 		// Persist defaults on first run
-		tc := b.TransparentConfig
+		tc := b.TransparentConfig()
 		defaultEntry, err := sdklogical.StorageEntryJSON("config", map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/aws/path_config.go
+++ b/provider/aws/path_config.go
@@ -64,13 +64,13 @@ func (b *awsBackend) pathConfig() *framework.Path {
 
 // handleConfigRead handles reading the AWS provider configuration
 func (b *awsBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	tc := b.TransparentConfig
+	tc := b.TransparentConfig()
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
 			"proxy_domains":   b.proxyDomains,
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
@@ -112,8 +112,8 @@ func (b *awsBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 	// Apply configuration
 	parsedConfig := parseConfig(conf)
 	b.proxyDomains = parsedConfig.ProxyDomains
-	b.MaxBodySize = parsedConfig.MaxBodySize
-	b.Timeout = parsedConfig.Timeout
+	b.SetMaxBodySize(parsedConfig.MaxBodySize)
+	b.SetTimeout(parsedConfig.Timeout)
 
 	// Update transport if TLS settings changed
 	tlsChanged := b.tlsSkipVerify != parsedConfig.TLSSkipVerify || b.caData != parsedConfig.CAData
@@ -128,10 +128,10 @@ func (b *awsBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 					Err:        logical.ErrBadRequest(err.Error()),
 				}, nil
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		} else {
 			initTransport()
-			b.Proxy.Transport = sharedTransport
+			b.SetTransport(sharedTransport)
 		}
 	}
 
@@ -140,8 +140,8 @@ func (b *awsBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 
 	// Transparent mode settings — build config from current values + overrides
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
+		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -164,8 +164,8 @@ func (b *awsBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 	if b.StorageView != nil {
 		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
 			"proxy_domains":   b.proxyDomains,
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/aws/path_config_test.go
+++ b/provider/aws/path_config_test.go
@@ -100,13 +100,12 @@ func TestPathConfig_Schema(t *testing.T) {
 
 func TestHandleConfigRead(t *testing.T) {
 	b := &awsBackend{
-		proxyDomains: []string{"example.com"},
-		StreamingBackend: &framework.StreamingBackend{
-			MaxBodySize:       framework.DefaultMaxBodySize,
-			Timeout:           30 * time.Second,
-			TransparentConfig: &framework.TransparentConfig{AutoAuthPath: "auth/jwt/", DefaultAuthRole: "reader"},
-		},
+		proxyDomains:     []string{"example.com"},
+		StreamingBackend: &framework.StreamingBackend{},
 	}
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(30 * time.Second)
+	b.SetTransparentConfig(&framework.TransparentConfig{AutoAuthPath: "auth/jwt/", DefaultAuthRole: "reader"})
 
 	resp, err := b.handleConfigRead(context.Background(), nil, nil)
 	require.NoError(t, err)
@@ -123,10 +122,10 @@ func TestHandleConfigRead(t *testing.T) {
 func TestHandleConfigWrite(t *testing.T) {
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			TransparentConfig: &framework.TransparentConfig{},
-			Logger:            createTestLogger(),
+			Logger: createTestLogger(),
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 	path := b.pathConfig()
 
 	t.Run("successful update", func(t *testing.T) {
@@ -314,10 +313,10 @@ func TestInitialize_EmptyStorage(t *testing.T) {
 	storage := newInmemStorage()
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			StorageView:       storage,
-			TransparentConfig: &framework.TransparentConfig{},
+			StorageView: storage,
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 	err := b.Initialize(context.Background())
 	assert.NoError(t, err)
 }
@@ -335,17 +334,17 @@ func TestInitialize_ExistingConfig(t *testing.T) {
 
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			StorageView:       storage,
-			TransparentConfig: &framework.TransparentConfig{},
-			Logger:            createTestLogger(),
+			StorageView: storage,
+			Logger:      createTestLogger(),
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 
 	err := b.Initialize(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"s3.amazonaws.com"}, b.proxyDomains)
-	assert.Equal(t, int64(5242880), b.MaxBodySize)
-	assert.Equal(t, 60*time.Second, b.Timeout)
+	assert.Equal(t, int64(5242880), b.MaxBodySize())
+	assert.Equal(t, 60*time.Second, b.Timeout())
 }
 
 // --- getCredentials tests ---
@@ -578,8 +577,8 @@ func TestFactory(t *testing.T) {
 	ab := b.(*awsBackend)
 	assert.Equal(t, "aws", ab.Type())
 	assert.Equal(t, logical.ClassProvider, ab.Class())
-	assert.Equal(t, framework.DefaultMaxBodySize, ab.MaxBodySize)
-	assert.Equal(t, framework.DefaultTimeout, ab.Timeout)
+	assert.Equal(t, framework.DefaultMaxBodySize, ab.MaxBodySize())
+	assert.Equal(t, framework.DefaultTimeout, ab.Timeout())
 }
 
 func TestFactory_WithConfig(t *testing.T) {
@@ -597,8 +596,8 @@ func TestFactory_WithConfig(t *testing.T) {
 	b, err := Factory(ctx, conf)
 	require.NoError(t, err)
 	ab := b.(*awsBackend)
-	assert.Equal(t, int64(5242880), ab.MaxBodySize)
-	assert.Equal(t, 60*time.Second, ab.Timeout)
+	assert.Equal(t, int64(5242880), ab.MaxBodySize())
+	assert.Equal(t, 60*time.Second, ab.Timeout())
 	assert.Equal(t, []string{"s3.amazonaws.com"}, ab.proxyDomains)
 }
 
@@ -641,10 +640,7 @@ func TestHandleGatewayStreaming(t *testing.T) {
 	// Just test it doesn't panic with minimal setup (no processor registry = error path)
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			Logger:            createTestLogger(),
-			TransparentConfig: &framework.TransparentConfig{},
-			MaxBodySize:       framework.DefaultMaxBodySize,
-			Timeout:           30 * time.Second,
+			Logger: createTestLogger(),
 		},
 		signer:   v4.NewSigner(),
 		s3Signer: v4.NewSigner(),
@@ -670,10 +666,7 @@ func TestHandleGatewayStreaming(t *testing.T) {
 func TestProcessRequest_SignatureMismatch(t *testing.T) {
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			Logger:            createTestLogger(),
-			TransparentConfig: &framework.TransparentConfig{},
-			MaxBodySize:       framework.DefaultMaxBodySize,
-			Timeout:           30 * time.Second,
+			Logger: createTestLogger(),
 		},
 		signer:   v4.NewSigner(),
 		s3Signer: v4.NewSigner(),
@@ -701,10 +694,7 @@ func TestProcessRequest_SignatureMismatch(t *testing.T) {
 func TestProcessRequest_ValidSignature_NoCredential(t *testing.T) {
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			Logger:            createTestLogger(),
-			TransparentConfig: &framework.TransparentConfig{},
-			MaxBodySize:       framework.DefaultMaxBodySize,
-			Timeout:           30 * time.Second,
+			Logger: createTestLogger(),
 		},
 		signer:       v4.NewSigner(),
 		s3Signer:     v4.NewSigner(),
@@ -752,10 +742,7 @@ func TestProcessRequest_ValidSignature_WithCredential(t *testing.T) {
 
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			Logger:            createTestLogger(),
-			TransparentConfig: &framework.TransparentConfig{},
-			MaxBodySize:       framework.DefaultMaxBodySize,
-			Timeout:           30 * time.Second,
+			Logger: createTestLogger(),
 		},
 		signer:       v4.NewSigner(),
 		s3Signer:     v4.NewSigner(),
@@ -820,7 +807,7 @@ func TestForwardDirect(t *testing.T) {
 	r.RequestURI = ""
 	rr := httptest.NewRecorder()
 
-	sigv4.ForwardDirect(b.Logger, rr, r, []byte{}, b.Proxy.Transport)
+	sigv4.ForwardDirect(b.Logger, rr, r, []byte{}, b.Transport())
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "test", rr.Header().Get("X-Custom"))
@@ -830,13 +817,12 @@ func TestForwardDirect(t *testing.T) {
 func TestProcessRequest_ExpiredSignature(t *testing.T) {
 	b := &awsBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			Logger:            createTestLogger(),
-			TransparentConfig: &framework.TransparentConfig{},
-			MaxBodySize:       framework.DefaultMaxBodySize,
+			Logger: createTestLogger(),
 		},
 		signer:   v4.NewSigner(),
 		s3Signer: v4.NewSigner(),
 	}
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
 	b.initializeProcessors()
 
 	httpReq := httptest.NewRequest(http.MethodGet, "http://s3.us-east-1.amazonaws.com/gateway/test", nil)

--- a/provider/aws/path_gateway.go
+++ b/provider/aws/path_gateway.go
@@ -18,9 +18,9 @@ import (
 
 func (b *awsBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	// Apply timeout if configured
-	if b.Timeout > 0 {
+	if b.Timeout() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout())
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
@@ -48,7 +48,7 @@ func (b *awsBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	// Forward directly via transport, bypassing httputil.ReverseProxy which
 	// modifies headers (hop-by-hop cleanup, header reordering) and breaks
 	// AWS signatures.
-	transport := b.Proxy.Transport
+	transport := b.Transport()
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
@@ -59,7 +59,7 @@ func (b *awsBackend) handleGateway(ctx context.Context, req *logical.Request) {
 // Returns the prepared request and body bytes to forward.
 func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (*http.Request, []byte, error) {
 	// Step 1: Read and buffer request body
-	bodyBytes, err := sigv4.ReadRequestBody(req.HTTPRequest, b.MaxBodySize)
+	bodyBytes, err := sigv4.ReadRequestBody(req.HTTPRequest, b.MaxBodySize())
 	if err != nil {
 		http.Error(req.ResponseWriter, "Failed to read request body", http.StatusBadRequest)
 		return nil, nil, err

--- a/provider/aws/provider.go
+++ b/provider/aws/provider.go
@@ -89,10 +89,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 				HelpDescription: "Proxies requests to AWS services with signature verification",
 			},
 		},
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "",
-			DefaultAuthRole: "",
-		},
 		Backend: &framework.Backend{
 			Help:           awsBackendHelp,
 			BackendType:    "aws",
@@ -105,6 +101,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	// Set common fields
 	b.Logger = conf.Logger.WithSubsystem("aws")
 	b.StorageView = conf.StorageView
+
+	// Seed an empty transparent config so isTransparentRequest can route
+	// once auto_auth_path is configured via handleConfigWrite.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 	// Initialize reverse proxy with AWS transport (lazily created on first use)
 	initTransport()
@@ -126,8 +126,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		}
 		parsedConfig := parseConfig(conf.Config)
 		b.proxyDomains = parsedConfig.ProxyDomains
-		b.MaxBodySize = parsedConfig.MaxBodySize
-		b.Timeout = parsedConfig.Timeout
+		b.SetMaxBodySize(parsedConfig.MaxBodySize)
+		b.SetTimeout(parsedConfig.Timeout)
 		b.tlsSkipVerify = parsedConfig.TLSSkipVerify
 		b.caData = parsedConfig.CAData
 		b.initializeProcessors()
@@ -138,16 +138,16 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			if err != nil {
 				return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 	}
 
 	// Ensure defaults are set even when no config is provided
-	if b.MaxBodySize <= 0 {
-		b.MaxBodySize = framework.DefaultMaxBodySize
+	if b.MaxBodySize() <= 0 {
+		b.SetMaxBodySize(framework.DefaultMaxBodySize)
 	}
-	if b.Timeout <= 0 {
-		b.Timeout = framework.DefaultTimeout
+	if b.Timeout() <= 0 {
+		b.SetTimeout(framework.DefaultTimeout)
 	}
 
 	return b, nil
@@ -178,12 +178,12 @@ func (b *awsBackend) Initialize(ctx context.Context) error {
 			return fmt.Errorf("failed to decode config: %w", err)
 		}
 		b.proxyDomains = config.ProxyDomains
-		b.MaxBodySize = config.MaxBodySize
+		b.SetMaxBodySize(config.MaxBodySize)
 		b.tlsSkipVerify = config.TLSSkipVerify
 		b.caData = config.CAData
 		if config.Timeout != "" {
 			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
-				b.Timeout = timeout
+				b.SetTimeout(timeout)
 			}
 		}
 		b.initializeProcessors()
@@ -194,7 +194,7 @@ func (b *awsBackend) Initialize(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{

--- a/provider/aws/transparent_test.go
+++ b/provider/aws/transparent_test.go
@@ -99,10 +99,9 @@ func TestValidateConfig_TransparentFields(t *testing.T) {
 
 func TestTransparentConfig_SetAndRead(t *testing.T) {
 	b := &awsBackend{
-		StreamingBackend: &framework.StreamingBackend{
-			TransparentConfig: &framework.TransparentConfig{},
-		},
+		StreamingBackend: &framework.StreamingBackend{},
 	}
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 		AutoAuthPath:    "auth/jwt/",

--- a/provider/azure/path_config.go
+++ b/provider/azure/path_config.go
@@ -61,12 +61,12 @@ func (b *azureBackend) pathConfig() *framework.Path {
 
 // handleConfigRead handles reading the Azure provider configuration
 func (b *azureBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	tc := b.TransparentConfig
+	tc := b.TransparentConfig()
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
@@ -79,17 +79,17 @@ func (b *azureBackend) handleConfigRead(ctx context.Context, req *logical.Reques
 func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	// For max_body_size: use provided value, or apply default if not yet set
 	if val, ok := d.GetOk("max_body_size"); ok {
-		b.MaxBodySize = val.(int64)
-	} else if b.MaxBodySize == 0 {
-		b.MaxBodySize = framework.DefaultMaxBodySize
+		b.SetMaxBodySize(val.(int64))
+	} else if b.MaxBodySize() == 0 {
+		b.SetMaxBodySize(framework.DefaultMaxBodySize)
 	}
 
 	// For timeout: use provided value, or apply default if not yet set
 	if val, ok := d.GetOk("timeout"); ok {
 		// TypeDurationSecond returns int (seconds)
-		b.Timeout = time.Duration(val.(int)) * time.Second
-	} else if b.Timeout == 0 {
-		b.Timeout = framework.DefaultTimeout
+		b.SetTimeout(time.Duration(val.(int)) * time.Second)
+	} else if b.Timeout() == 0 {
+		b.SetTimeout(framework.DefaultTimeout)
 	}
 
 	// Handle TLS settings
@@ -119,17 +119,17 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 					Err:        logical.ErrBadRequest(err.Error()),
 				}, nil
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		} else {
 			initTransport()
-			b.Proxy.Transport = sharedTransport
+			b.SetTransport(sharedTransport)
 		}
 	}
 
 	// Transparent mode settings — build new config from current values + overrides
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
+		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -151,8 +151,8 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	// Persist config to storage
 	if b.StorageView != nil {
 		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/azure/path_config_test.go
+++ b/provider/azure/path_config_test.go
@@ -94,8 +94,8 @@ func TestFactory(t *testing.T) {
 	b := setupBackend(t)
 	assert.Equal(t, "azure", b.Type())
 	assert.Equal(t, logical.ClassProvider, b.Class())
-	assert.Equal(t, framework.DefaultTimeout, b.Timeout)
-	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize)
+	assert.Equal(t, framework.DefaultTimeout, b.Timeout())
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize())
 }
 
 func TestFactory_WithConfig(t *testing.T) {
@@ -113,9 +113,10 @@ func TestFactory_WithConfig(t *testing.T) {
 	b, err := Factory(ctx, conf)
 	require.NoError(t, err)
 	ab := b.(*azureBackend)
-	assert.Equal(t, 60.0, ab.Timeout.Seconds())
-	assert.Equal(t, "auth/jwt/", ab.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "reader", ab.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, 60.0, ab.Timeout().Seconds())
+	tc := ab.TransparentConfig()
+	assert.Equal(t, "auth/jwt/", tc.AutoAuthPath)
+	assert.Equal(t, "reader", tc.DefaultAuthRole)
 }
 
 func TestFactory_InvalidConfig(t *testing.T) {
@@ -173,10 +174,11 @@ func TestInitialize_ExistingConfig(t *testing.T) {
 	err := b.Initialize(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(5242880), b.MaxBodySize)
-	assert.Equal(t, 30.0, b.Timeout.Seconds())
-	assert.Equal(t, "auth/cert/", b.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "admin", b.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, int64(5242880), b.MaxBodySize())
+	assert.Equal(t, 30.0, b.Timeout().Seconds())
+	tc := b.TransparentConfig()
+	assert.Equal(t, "auth/cert/", tc.AutoAuthPath)
+	assert.Equal(t, "admin", tc.DefaultAuthRole)
 }
 
 // --- Config CRUD tests ---

--- a/provider/azure/path_gateway.go
+++ b/provider/azure/path_gateway.go
@@ -48,15 +48,15 @@ type azureCredentialInfo struct {
 
 func (b *azureBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	// Apply timeout if configured
-	if b.Timeout > 0 {
+	if b.Timeout() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout())
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
 
 	// Enforce max body size
-	maxBody := b.MaxBodySize
+	maxBody := b.MaxBodySize()
 	if maxBody <= 0 {
 		maxBody = maxGatewayBodySize
 	}

--- a/provider/azure/provider.go
+++ b/provider/azure/provider.go
@@ -68,10 +68,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 				HelpDescription: "Proxies requests to Azure services with role embedded in URL path",
 			},
 		},
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "",
-			DefaultAuthRole: "",
-		},
 		Backend: &framework.Backend{
 			Help:           azureBackendHelp,
 			BackendType:    "azure",
@@ -84,6 +80,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	// Set common fields
 	b.Logger = conf.Logger.WithSubsystem("azure")
 	b.StorageView = conf.StorageView
+
+	// Seed an empty transparent config so isTransparentRequest can route
+	// once auto_auth_path is configured via handleConfigWrite.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 	// Initialize reverse proxy with Azure transport (lazily created on first use)
 	initTransport()
@@ -99,8 +99,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	}
 
 	// Set defaults
-	b.MaxBodySize = framework.DefaultMaxBodySize
-	b.Timeout = framework.DefaultTimeout
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(framework.DefaultTimeout)
 
 	// Apply configuration if provided
 	if len(conf.Config) > 0 {
@@ -108,8 +108,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			return nil, fmt.Errorf("invalid configuration: %w", err)
 		}
 		parsedConfig := parseConfig(conf.Config)
-		b.MaxBodySize = parsedConfig.MaxBodySize
-		b.Timeout = parsedConfig.Timeout
+		b.SetMaxBodySize(parsedConfig.MaxBodySize)
+		b.SetTimeout(parsedConfig.Timeout)
 		b.tlsSkipVerify = parsedConfig.TLSSkipVerify
 		b.caData = parsedConfig.CAData
 
@@ -119,7 +119,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			if err != nil {
 				return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
@@ -154,12 +154,12 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
 		}
-		b.MaxBodySize = config.MaxBodySize
+		b.SetMaxBodySize(config.MaxBodySize)
 		b.tlsSkipVerify = config.TLSSkipVerify
 		b.caData = config.CAData
 		if config.Timeout != "" {
 			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
-				b.Timeout = timeout
+				b.SetTimeout(timeout)
 			}
 		}
 
@@ -169,7 +169,7 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
@@ -179,10 +179,10 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 	} else {
 		// No persisted config — persist the defaults so a newly enabled
 		// Azure provider is immediately configured and readable.
-		tc := b.TransparentConfig
+		tc := b.TransparentConfig()
 		defaultEntry, err := sdklogical.StorageEntryJSON("config", map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/gcp/path_config.go
+++ b/provider/gcp/path_config.go
@@ -61,12 +61,12 @@ func (b *gcpBackend) pathConfig() *framework.Path {
 
 // handleConfigRead handles reading the GCP provider configuration
 func (b *gcpBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	tc := b.TransparentConfig
+	tc := b.TransparentConfig()
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
@@ -79,17 +79,17 @@ func (b *gcpBackend) handleConfigRead(ctx context.Context, req *logical.Request,
 func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	// For max_body_size: use provided value, or apply default if not yet set
 	if val, ok := d.GetOk("max_body_size"); ok {
-		b.MaxBodySize = val.(int64)
-	} else if b.MaxBodySize == 0 {
-		b.MaxBodySize = framework.DefaultMaxBodySize
+		b.SetMaxBodySize(val.(int64))
+	} else if b.MaxBodySize() == 0 {
+		b.SetMaxBodySize(framework.DefaultMaxBodySize)
 	}
 
 	// For timeout: use provided value, or apply default if not yet set
 	if val, ok := d.GetOk("timeout"); ok {
 		// TypeDurationSecond returns int (seconds)
-		b.Timeout = time.Duration(val.(int)) * time.Second
-	} else if b.Timeout == 0 {
-		b.Timeout = framework.DefaultTimeout
+		b.SetTimeout(time.Duration(val.(int)) * time.Second)
+	} else if b.Timeout() == 0 {
+		b.SetTimeout(framework.DefaultTimeout)
 	}
 
 	// Handle TLS settings
@@ -118,17 +118,17 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 					Err:        logical.ErrBadRequest(err.Error()),
 				}, nil
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		} else {
 			initTransport()
-			b.Proxy.Transport = sharedTransport
+			b.SetTransport(sharedTransport)
 		}
 	}
 
 	// Transparent mode settings — build new config from current values + overrides
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
+		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -150,8 +150,8 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 	// Persist config to storage
 	if b.StorageView != nil {
 		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/gcp/path_config_test.go
+++ b/provider/gcp/path_config_test.go
@@ -93,8 +93,8 @@ func TestFactory(t *testing.T) {
 	b := setupBackend(t)
 	assert.Equal(t, "gcp", b.Type())
 	assert.Equal(t, logical.ClassProvider, b.Class())
-	assert.Equal(t, framework.DefaultTimeout, b.Timeout)
-	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize)
+	assert.Equal(t, framework.DefaultTimeout, b.Timeout())
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize())
 }
 
 func TestFactory_WithConfig(t *testing.T) {
@@ -112,9 +112,10 @@ func TestFactory_WithConfig(t *testing.T) {
 	b, err := Factory(ctx, conf)
 	require.NoError(t, err)
 	gb := b.(*gcpBackend)
-	assert.Equal(t, 60.0, gb.Timeout.Seconds())
-	assert.Equal(t, "auth/jwt/", gb.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "reader", gb.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, 60.0, gb.Timeout().Seconds())
+	tc := gb.TransparentConfig()
+	assert.Equal(t, "auth/jwt/", tc.AutoAuthPath)
+	assert.Equal(t, "reader", tc.DefaultAuthRole)
 }
 
 func TestFactory_InvalidConfig(t *testing.T) {
@@ -172,10 +173,11 @@ func TestInitialize_ExistingConfig(t *testing.T) {
 	err := b.Initialize(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(5242880), b.MaxBodySize)
-	assert.Equal(t, 30.0, b.Timeout.Seconds())
-	assert.Equal(t, "auth/cert/", b.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "admin", b.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, int64(5242880), b.MaxBodySize())
+	assert.Equal(t, 30.0, b.Timeout().Seconds())
+	tc := b.TransparentConfig()
+	assert.Equal(t, "auth/cert/", tc.AutoAuthPath)
+	assert.Equal(t, "admin", tc.DefaultAuthRole)
 }
 
 // --- Config CRUD tests ---

--- a/provider/gcp/path_gateway.go
+++ b/provider/gcp/path_gateway.go
@@ -48,15 +48,15 @@ type gcpCredentialInfo struct {
 
 func (b *gcpBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	// Apply timeout if configured
-	if b.Timeout > 0 {
+	if b.Timeout() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout())
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
 
 	// Enforce max body size
-	maxBody := b.MaxBodySize
+	maxBody := b.MaxBodySize()
 	if maxBody <= 0 {
 		maxBody = maxGatewayBodySize
 	}

--- a/provider/gcp/provider.go
+++ b/provider/gcp/provider.go
@@ -68,10 +68,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 				HelpDescription: "Proxies requests to Google Cloud APIs with role embedded in URL path",
 			},
 		},
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "",
-			DefaultAuthRole: "",
-		},
 		Backend: &framework.Backend{
 			Help:           gcpBackendHelp,
 			BackendType:    "gcp",
@@ -84,6 +80,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	// Set common fields
 	b.Logger = conf.Logger.WithSubsystem("gcp")
 	b.StorageView = conf.StorageView
+
+	// Seed an empty transparent config so isTransparentRequest can route
+	// once auto_auth_path is configured via handleConfigWrite.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 	// Initialize reverse proxy with GCP transport (lazily created on first use)
 	initTransport()
@@ -99,8 +99,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	}
 
 	// Set defaults
-	b.MaxBodySize = framework.DefaultMaxBodySize
-	b.Timeout = framework.DefaultTimeout
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(framework.DefaultTimeout)
 
 	// Apply configuration if provided
 	if len(conf.Config) > 0 {
@@ -108,8 +108,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			return nil, fmt.Errorf("invalid configuration: %w", err)
 		}
 		parsedConfig := parseConfig(conf.Config)
-		b.MaxBodySize = parsedConfig.MaxBodySize
-		b.Timeout = parsedConfig.Timeout
+		b.SetMaxBodySize(parsedConfig.MaxBodySize)
+		b.SetTimeout(parsedConfig.Timeout)
 		b.tlsSkipVerify = parsedConfig.TLSSkipVerify
 		b.caData = parsedConfig.CAData
 
@@ -118,7 +118,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			if err != nil {
 				return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
@@ -153,12 +153,12 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 		if err := entry.DecodeJSON(&config); err != nil {
 			return fmt.Errorf("failed to decode config: %w", err)
 		}
-		b.MaxBodySize = config.MaxBodySize
+		b.SetMaxBodySize(config.MaxBodySize)
 		b.tlsSkipVerify = config.TLSSkipVerify
 		b.caData = config.CAData
 		if config.Timeout != "" {
 			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
-				b.Timeout = timeout
+				b.SetTimeout(timeout)
 			}
 		}
 
@@ -167,7 +167,7 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
@@ -177,10 +177,10 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 	} else {
 		// No persisted config — persist the defaults so a newly enabled
 		// GCP provider is immediately configured and readable.
-		tc := b.TransparentConfig
+		tc := b.TransparentConfig()
 		defaultEntry, err := sdklogical.StorageEntryJSON("config", map[string]any{
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/mcp_aws/gateway_test.go
+++ b/provider/mcp_aws/gateway_test.go
@@ -72,7 +72,7 @@ func configureBackendForUpstream(t *testing.T, b *mcpAWSBackend, srv *httptest.S
 	b.upstreamURL = u
 	b.region = "us-east-1"
 	b.mu.Unlock()
-	b.Proxy.Transport = srv.Client().Transport
+	b.SetTransport(srv.Client().Transport)
 }
 
 // makeMCPRequest builds a *logical.Request as if a Warden bearer-token client
@@ -292,7 +292,7 @@ func TestHandleGateway_ThroughConfigWrite(t *testing.T) {
 	// Point the shared transport at the test server's TLS config so the
 	// upstream URL (which we'll set to the test server URL via config-write)
 	// resolves correctly.
-	b.Proxy.Transport = srv.Client().Transport
+	b.SetTransport(srv.Client().Transport)
 
 	path := b.pathConfig()
 	fd := makeFieldData(path, map[string]any{
@@ -306,7 +306,7 @@ func TestHandleGateway_ThroughConfigWrite(t *testing.T) {
 
 	// Config-write rebuilt the transport via applyParsedConfig. We need to
 	// re-point it at the test server (no TLS overrides → shared transport).
-	b.Proxy.Transport = srv.Client().Transport
+	b.SetTransport(srv.Client().Transport)
 
 	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
 	b.handleGateway(context.Background(), req)
@@ -325,10 +325,10 @@ func TestHandleGateway_AgentCoreServiceInference(t *testing.T) {
 	b.upstreamURL = agentCoreURL
 	b.region = "us-east-1"
 	b.mu.Unlock()
-	b.Proxy.Transport = &redirectTransport{
+	b.SetTransport(&redirectTransport{
 		target: srvURL,
 		inner:  srv.Client().Transport,
-	}
+	})
 
 	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
 	b.handleGateway(context.Background(), req)

--- a/provider/mcp_aws/path_config.go
+++ b/provider/mcp_aws/path_config.go
@@ -68,14 +68,14 @@ func (b *mcpAWSBackend) pathConfig() *framework.Path {
 }
 
 func (b *mcpAWSBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig()
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	tc := b.TransparentConfig
 	data := map[string]any{
 		"region":          b.region,
-		"max_body_size":   b.MaxBodySize,
-		"timeout":         b.Timeout.String(),
+		"max_body_size":   b.MaxBodySize(),
+		"timeout":         b.Timeout().String(),
 		"auto_auth_path":  tc.AutoAuthPath,
 		"default_role":    tc.DefaultAuthRole,
 		"tls_skip_verify": b.tlsSkipVerify,
@@ -154,12 +154,12 @@ func (b *mcpAWSBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 // mcp_aws_url correctly re-infers from the new host instead of carrying the
 // stale resolved region forward.
 func (b *mcpAWSBackend) snapshotForMerge() map[string]any {
+	tc := b.TransparentConfig()
 	b.mu.RLock()
-	tc := b.TransparentConfig
 	conf := map[string]any{
 		"region":          b.configRegion,
-		"max_body_size":   b.MaxBodySize,
-		"timeout":         b.Timeout.String(),
+		"max_body_size":   b.MaxBodySize(),
+		"timeout":         b.Timeout().String(),
 		"auto_auth_path":  tc.AutoAuthPath,
 		"default_role":    tc.DefaultAuthRole,
 		"tls_skip_verify": b.tlsSkipVerify,

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -153,10 +153,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 				HelpDescription: "Proxies MCP traffic with the role embedded in the URL path.",
 			},
 		},
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "",
-			DefaultAuthRole: "",
-		},
 		// ParseStreamBody intentionally left at false. MCP-enforcing specs
 		// must not pre-parse the body — the core's MCP extractor reads the
 		// body itself when ShouldEnforceMCPPolicy returns true.
@@ -184,9 +180,13 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		return nil, err
 	}
 
+	// Seed an empty transparent config so isTransparentRequest can route
+	// once auto_auth_path is configured via handleConfigWrite.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
+
 	// Defaults until Initialize loads persisted config.
-	b.MaxBodySize = framework.DefaultMaxBodySize
-	b.Timeout = DefaultMCPAWSTimeout
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(DefaultMCPAWSTimeout)
 	if u, err := url.Parse(DefaultMCPAWSURL); err == nil {
 		b.upstreamURL = u
 		_, b.region = serviceAndRegion(u)
@@ -280,10 +280,12 @@ func (b *mcpAWSBackend) applyParsedConfig(conf map[string]any) (map[string]any, 
 	b.region = resolvedRegion
 	b.tlsSkipVerify = parsed.TLSSkipVerify
 	b.caData = parsed.CAData
-	b.MaxBodySize = maxBody
-	b.Timeout = timeout
-	b.Proxy.Transport = newTransport
 	b.mu.Unlock()
+
+	// Framework-side fields are atomic; no lock needed.
+	b.SetMaxBodySize(maxBody)
+	b.SetTimeout(timeout)
+	b.SetTransport(newTransport)
 
 	// SetTransparentConfig is the framework's own writer; it does its own
 	// pointer swap on b.TransparentConfig. Concurrent readers see either the
@@ -342,13 +344,16 @@ type backendSnapshot struct {
 
 func (b *mcpAWSBackend) snapshot() backendSnapshot {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	upstream := b.upstreamURL
+	region := b.region
+	b.mu.RUnlock()
+	// Framework-side fields are atomic; no lock needed.
 	return backendSnapshot{
-		upstreamURL: b.upstreamURL,
-		region:      b.region,
-		maxBody:     b.MaxBodySize,
-		timeout:     b.Timeout,
-		transport:   b.Proxy.Transport,
+		upstreamURL: upstream,
+		region:      region,
+		maxBody:     b.MaxBodySize(),
+		timeout:     b.Timeout(),
+		transport:   b.Transport(),
 	}
 }
 

--- a/provider/mcp_aws/provider_test.go
+++ b/provider/mcp_aws/provider_test.go
@@ -91,8 +91,8 @@ func TestFactory_Defaults(t *testing.T) {
 	b := setupBackend(t)
 	assert.Equal(t, "mcp_aws", b.Type())
 	assert.Equal(t, logical.ClassProvider, b.Class())
-	assert.Equal(t, DefaultMCPAWSTimeout, b.Timeout)
-	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize)
+	assert.Equal(t, DefaultMCPAWSTimeout, b.Timeout())
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize())
 	// Default URL yields region via arm 2 of the structured match.
 	assert.Equal(t, "us-east-1", b.region)
 	require.NotNil(t, b.upstreamURL)
@@ -114,9 +114,10 @@ func TestFactory_WithConfig(t *testing.T) {
 	require.NoError(t, err)
 	mb := b.(*mcpAWSBackend)
 	assert.Equal(t, "eu-frankfurt-1", mb.region)
-	assert.Equal(t, 60.0, mb.Timeout.Seconds())
-	assert.Equal(t, "auth/jwt/", mb.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "reader", mb.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, 60.0, mb.Timeout().Seconds())
+	tc := mb.TransparentConfig()
+	assert.Equal(t, "auth/jwt/", tc.AutoAuthPath)
+	assert.Equal(t, "reader", tc.DefaultAuthRole)
 }
 
 func TestFactory_RegionRequiredForUnresolvableHost(t *testing.T) {
@@ -189,8 +190,9 @@ func TestInitialize_PersistedConfigReload(t *testing.T) {
 	require.NoError(t, b.Initialize(context.Background()))
 
 	assert.Equal(t, "eu-frankfurt-1", b.region, "region must be repopulated from URL after restart")
-	assert.Equal(t, "auth/cert/", b.TransparentConfig.AutoAuthPath, "AutoAuthPath must come back via SetTransparentConfig")
-	assert.Equal(t, "admin", b.TransparentConfig.DefaultAuthRole)
+	tc := b.TransparentConfig()
+	assert.Equal(t, "auth/cert/", tc.AutoAuthPath, "AutoAuthPath must come back via SetTransparentConfig")
+	assert.Equal(t, "admin", tc.DefaultAuthRole)
 	// GetAutoAuthPath is what core's isTransparentRequest checks.
 	assert.Equal(t, "auth/cert/", b.GetAutoAuthPath())
 }

--- a/provider/sdk/dualgateway/backend.go
+++ b/provider/sdk/dualgateway/backend.go
@@ -89,10 +89,6 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 					HelpDescription: "Proxies requests to " + spec.Name + " APIs with role embedded in URL path",
 				},
 			},
-			TransparentConfig: &framework.TransparentConfig{
-				AutoAuthPath:    "",
-				DefaultAuthRole: "",
-			},
 			Backend: &framework.Backend{
 				Help:           spec.HelpText,
 				BackendType:    spec.Name,
@@ -104,6 +100,10 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 
 		b.Logger = conf.Logger.WithSubsystem(spec.Name)
 		b.StorageView = conf.StorageView
+
+		// Seed an empty transparent config so isTransparentRequest can route
+		// once auto_auth_path is configured via handleConfigWrite.
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 		initTransport()
 		b.StreamingBackend.InitProxy(sharedTransport)
@@ -122,18 +122,18 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 			}
 			parsed := parseConfig(spec, conf.Config)
 			b.providerURL = parsed.ProviderURL
-			b.MaxBodySize = parsed.MaxBodySize
-			b.Timeout = parsed.Timeout
+			b.SetMaxBodySize(parsed.MaxBodySize)
+			b.SetTimeout(parsed.Timeout)
 			if spec.OnConfigParsed != nil {
 				b.extraState = spec.OnConfigParsed(conf.Config)
 			}
 		}
 
-		if b.MaxBodySize <= 0 {
-			b.MaxBodySize = framework.DefaultMaxBodySize
+		if b.MaxBodySize() <= 0 {
+			b.SetMaxBodySize(framework.DefaultMaxBodySize)
 		}
-		if b.Timeout <= 0 {
-			b.Timeout = spec.DefaultTimeout
+		if b.Timeout() <= 0 {
+			b.SetTimeout(spec.DefaultTimeout)
 		}
 
 		return b, nil
@@ -167,12 +167,12 @@ func (b *dualgatewayBackend) Initialize(ctx context.Context) error {
 	}
 
 	if maxSize, ok := config["max_body_size"].(float64); ok && maxSize > 0 {
-		b.MaxBodySize = int64(maxSize)
+		b.SetMaxBodySize(int64(maxSize))
 	}
 
 	if timeoutStr, ok := config["timeout"].(string); ok && timeoutStr != "" {
 		if timeout, err := time.ParseDuration(timeoutStr); err == nil {
-			b.Timeout = timeout
+			b.SetTimeout(timeout)
 		}
 	}
 

--- a/provider/sdk/dualgateway/backend_test.go
+++ b/provider/sdk/dualgateway/backend_test.go
@@ -76,8 +76,8 @@ func TestNewFactory_InvalidSpec(t *testing.T) {
 func TestNewFactory_Defaults(t *testing.T) {
 	b := createBackend(t, headerAuthSpec)
 	assert.Equal(t, "https://api.test.com", b.providerURL)
-	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize)
-	assert.Equal(t, 30*time.Second, b.Timeout)
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize())
+	assert.Equal(t, 30*time.Second, b.Timeout())
 	assert.NotNil(t, b.s3Signer)
 	assert.Equal(t, headerAuthSpec, b.spec)
 }
@@ -96,7 +96,7 @@ func TestNewFactory_WithConfig(t *testing.T) {
 	require.NoError(t, err)
 	backend := b.(*dualgatewayBackend)
 	assert.Equal(t, "https://custom.test.com", backend.providerURL)
-	assert.Equal(t, int64(5242880), backend.MaxBodySize)
+	assert.Equal(t, int64(5242880), backend.MaxBodySize())
 }
 
 func TestNewFactory_InvalidConfig(t *testing.T) {

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -40,7 +40,7 @@ func (b *dualgatewayBackend) snapshotState() requestSnapshot {
 
 	return requestSnapshot{
 		providerURL: b.providerURL,
-		maxBodySize: b.MaxBodySize,
+		maxBodySize: b.MaxBodySize(),
 		extraState:  stateCopy,
 	}
 }
@@ -87,9 +87,9 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 	}
 
 	// Apply timeout for forwarding
-	if b.Timeout > 0 {
+	if t := b.Timeout(); t > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, t)
 		defer cancel()
 	}
 
@@ -163,7 +163,7 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 	)
 
 	// Forward
-	transport := b.Proxy.Transport
+	transport := b.Transport()
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
@@ -227,9 +227,9 @@ func (b *dualgatewayBackend) handleS3Request(ctx context.Context, req *logical.R
 	}
 
 	// Apply timeout for verification + forwarding
-	if b.Timeout > 0 {
+	if t := b.Timeout(); t > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, t)
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
@@ -307,7 +307,7 @@ func (b *dualgatewayBackend) handleS3Request(ctx context.Context, req *logical.R
 	}
 
 	// Step 9: Forward directly
-	transport := b.Proxy.Transport
+	transport := b.Transport()
 	if transport == nil {
 		transport = http.DefaultTransport
 	}

--- a/provider/sdk/dualgateway/path_config.go
+++ b/provider/sdk/dualgateway/path_config.go
@@ -73,12 +73,12 @@ func (b *dualgatewayBackend) pathConfig() *framework.Path {
 
 // handleConfigRead handles reading the provider configuration.
 func (b *dualgatewayBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig()
 	b.mu.RLock()
-	tc := b.TransparentConfig
 	data := map[string]any{
 		b.spec.URLConfigKey: b.providerURL,
-		"max_body_size":     b.MaxBodySize,
-		"timeout":           b.Timeout.String(),
+		"max_body_size":     b.MaxBodySize(),
+		"timeout":           b.Timeout().String(),
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
 	}
@@ -123,13 +123,12 @@ func (b *dualgatewayBackend) handleConfigWrite(ctx context.Context, req *logical
 
 	parsed := parseConfig(b.spec, conf)
 
-	// Read current transparent config under read lock
-	b.mu.RLock()
+	// Read current transparent config — TransparentConfig() is atomic, no lock needed.
+	current := b.TransparentConfig()
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    current.AutoAuthPath,
+		DefaultAuthRole: current.DefaultAuthRole,
 	}
-	b.mu.RUnlock()
 
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -145,11 +144,11 @@ func (b *dualgatewayBackend) handleConfigWrite(ctx context.Context, req *logical
 		}, nil
 	}
 
-	// All validation passed — apply changes under write lock
+	// All validation passed — apply framework-side atomics then provider-local fields under write lock.
+	b.SetMaxBodySize(parsed.MaxBodySize)
+	b.SetTimeout(parsed.Timeout)
 	b.mu.Lock()
 	b.providerURL = parsed.ProviderURL
-	b.MaxBodySize = parsed.MaxBodySize
-	b.Timeout = parsed.Timeout
 	if b.spec.OnConfigParsed != nil {
 		b.extraState = b.spec.OnConfigParsed(conf)
 	}
@@ -162,8 +161,8 @@ func (b *dualgatewayBackend) handleConfigWrite(ctx context.Context, req *logical
 		b.mu.RLock()
 		persistData := map[string]any{
 			b.spec.URLConfigKey: b.providerURL,
-			"max_body_size":     b.MaxBodySize,
-			"timeout":           b.Timeout.String(),
+			"max_body_size":     b.MaxBodySize(),
+			"timeout":           b.Timeout().String(),
 			"auto_auth_path":    tc.AutoAuthPath,
 			"default_role":      tc.DefaultAuthRole,
 		}

--- a/provider/sdk/httpproxy/gateway.go
+++ b/provider/sdk/httpproxy/gateway.go
@@ -17,10 +17,11 @@ import (
 const defaultAcceptJSON = "application/json"
 
 func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) {
-	// Snapshot mutable fields under read lock to avoid races with config writes
+	// Framework-side fields are atomic — read directly.
+	timeout := b.Timeout()
+	maxBody := b.MaxBodySize()
+	// Provider-local fields still need the RLock.
 	b.mu.RLock()
-	timeout := b.Timeout
-	maxBody := b.MaxBodySize
 	providerURL := b.providerURL
 	proxy := b.Proxy
 	b.mu.RUnlock()

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -380,7 +380,7 @@ func TestNewFactory_WithConfig(t *testing.T) {
 	require.NoError(t, err)
 	pb := b.(*proxyBackend)
 	assert.Equal(t, "https://custom.test.com", pb.providerURL)
-	assert.Equal(t, 60*time.Second, pb.Timeout)
+	assert.Equal(t, 60*time.Second, pb.Timeout())
 }
 
 func TestNewFactory_InvalidConfig(t *testing.T) {
@@ -508,10 +508,11 @@ func TestInitialize_ExistingConfig(t *testing.T) {
 
 	require.NoError(t, pb.Initialize(context.Background()))
 	assert.Equal(t, "https://saved.test.com", pb.providerURL)
-	assert.Equal(t, int64(5242880), pb.MaxBodySize)
-	assert.Equal(t, 45*time.Second, pb.Timeout)
-	assert.Equal(t, "auth/cert/", pb.TransparentConfig.AutoAuthPath)
-	assert.Equal(t, "admin", pb.TransparentConfig.DefaultAuthRole)
+	assert.Equal(t, int64(5242880), pb.MaxBodySize())
+	assert.Equal(t, 45*time.Second, pb.Timeout())
+	tc := pb.TransparentConfig()
+	assert.Equal(t, "auth/cert/", tc.AutoAuthPath)
+	assert.Equal(t, "admin", tc.DefaultAuthRole)
 }
 
 func TestInitialize_WithExtraState(t *testing.T) {
@@ -1262,7 +1263,7 @@ func TestHandleGateway_ResolveUpstream_MaxBodySizeOverride(t *testing.T) {
 	b := setupBackend(t, spec)
 	pb := b.(*proxyBackend)
 	pb.providerURL = upstream.URL
-	pb.MaxBodySize = 10 * 1024 * 1024 // 10MB default
+	pb.SetMaxBodySize(10 * 1024 * 1024) // 10MB default
 
 	// Body of 100 bytes — under the dispatch cap, should reach upstream.
 	rec := httptest.NewRecorder()

--- a/provider/sdk/httpproxy/path_config.go
+++ b/provider/sdk/httpproxy/path_config.go
@@ -74,12 +74,12 @@ func (b *proxyBackend) pathConfig() *framework.Path {
 
 // handleConfigRead handles reading the provider configuration.
 func (b *proxyBackend) handleConfigRead(_ context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	tc := b.TransparentConfig()
 	b.mu.RLock()
-	tc := b.TransparentConfig
 	data := map[string]any{
 		b.spec.URLConfigKey: b.providerURL,
-		"max_body_size":     b.MaxBodySize,
-		"timeout":           b.Timeout.String(),
+		"max_body_size":     b.MaxBodySize(),
+		"timeout":           b.Timeout().String(),
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
 		"tls_skip_verify":   b.tlsSkipVerify,
@@ -154,13 +154,12 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		hasTimeout = true
 	}
 
-	// Transparent mode settings
-	b.mu.RLock()
+	// Transparent mode settings — TransparentConfig() is atomic, no lock needed.
+	current := b.TransparentConfig()
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    current.AutoAuthPath,
+		DefaultAuthRole: current.DefaultAuthRole,
 	}
-	b.mu.RUnlock()
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
 	}
@@ -209,25 +208,29 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		}
 	}
 
-	// All validation passed — apply changes under write lock
+	// Apply framework-side fields atomically (no lock).
+	if hasMaxBodySize {
+		b.SetMaxBodySize(newMaxBodySize)
+	} else if b.MaxBodySize() == 0 {
+		b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	}
+	if hasTimeout {
+		b.SetTimeout(newTimeout)
+	} else if b.Timeout() == 0 {
+		b.SetTimeout(b.spec.DefaultTimeout)
+	}
+
+	// Apply provider-local fields under write lock.
 	b.mu.Lock()
 	if newURL != "" {
 		b.providerURL = newURL
 	}
-	if hasMaxBodySize {
-		b.MaxBodySize = newMaxBodySize
-	} else if b.MaxBodySize == 0 {
-		b.MaxBodySize = framework.DefaultMaxBodySize
-	}
-	if hasTimeout {
-		b.Timeout = newTimeout
-	} else if b.Timeout == 0 {
-		b.Timeout = b.spec.DefaultTimeout
-	}
 	if tlsChanged {
 		b.tlsSkipVerify = newSkipVerify
 		b.caData = newCAData
-		b.Proxy.Transport = newTransport
+	}
+	if tlsChanged {
+		b.SetTransport(newTransport)
 	}
 
 	b.StreamingBackend.SetTransparentConfig(tc)
@@ -251,8 +254,8 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 	// Snapshot config for persistence while still holding the lock
 	configData := map[string]any{
 		b.spec.URLConfigKey: b.providerURL,
-		"max_body_size":     b.MaxBodySize,
-		"timeout":           b.Timeout.String(),
+		"max_body_size":     b.MaxBodySize(),
+		"timeout":           b.Timeout().String(),
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
 		"tls_skip_verify":   b.tlsSkipVerify,

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -259,10 +259,6 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 				},
 			},
 			ParseStreamBody: spec.ParseStreamBody,
-			TransparentConfig: &framework.TransparentConfig{
-				AutoAuthPath:    "",
-				DefaultAuthRole: "",
-			},
 			Backend: &framework.Backend{
 				Help:           spec.HelpText,
 				BackendType:    spec.Name,
@@ -275,6 +271,10 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 		// Set common fields
 		b.Logger = conf.Logger.WithSubsystem(spec.Name)
 		b.StorageView = conf.StorageView
+
+		// Seed an empty transparent config; SetTransparentConfig below replaces it
+		// if conf.Config carries non-empty values.
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 		// Initialize reverse proxy with provider-type shared transport
 		b.StreamingBackend.InitProxy(sharedTransport)
@@ -289,8 +289,8 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 		}
 
 		// Set defaults
-		b.MaxBodySize = framework.DefaultMaxBodySize
-		b.Timeout = spec.DefaultTimeout
+		b.SetMaxBodySize(framework.DefaultMaxBodySize)
+		b.SetTimeout(spec.DefaultTimeout)
 		b.providerURL = spec.DefaultURL
 
 		// Apply configuration if provided
@@ -305,8 +305,8 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 			}
 			parsedConfig := ParseConfig(conf.Config, spec.URLConfigKey, spec.DefaultURL, spec.DefaultTimeout)
 			b.providerURL = strings.TrimRight(parsedConfig.ProviderURL, "/")
-			b.MaxBodySize = parsedConfig.MaxBodySize
-			b.Timeout = parsedConfig.Timeout
+			b.SetMaxBodySize(parsedConfig.MaxBodySize)
+			b.SetTimeout(parsedConfig.Timeout)
 
 			b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 				AutoAuthPath:    parsedConfig.AutoAuthPath,
@@ -319,7 +319,7 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 				if err != nil {
 					return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 				}
-				b.Proxy.Transport = transport
+				b.SetTransport(transport)
 				b.tlsSkipVerify = parsedConfig.TLSSkipVerify
 				b.caData = parsedConfig.CAData
 			}
@@ -358,13 +358,13 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 		// Parse max_body_size from persisted config
 		if maxSize, ok := config["max_body_size"]; ok {
 			if size, parsed := ReadInt64Config(maxSize); parsed {
-				b.MaxBodySize = size
+				b.SetMaxBodySize(size)
 			}
 		}
 
 		if timeoutStr, ok := config["timeout"].(string); ok && timeoutStr != "" {
 			if timeout, err := time.ParseDuration(timeoutStr); err == nil {
-				b.Timeout = timeout
+				b.SetTimeout(timeout)
 			}
 		}
 
@@ -384,7 +384,7 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 				b.mu.Unlock()
 				return fmt.Errorf("failed to configure TLS: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 			b.tlsSkipVerify = skipVerify
 			b.caData = caData
 		}
@@ -396,12 +396,12 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 		b.mu.Unlock()
 	} else {
 		// No persisted config — persist defaults
+		tc := b.TransparentConfig()
 		b.mu.RLock()
-		tc := b.TransparentConfig
 		configData := map[string]any{
 			b.spec.URLConfigKey: b.providerURL,
-			"max_body_size":     b.MaxBodySize,
-			"timeout":           b.Timeout.String(),
+			"max_body_size":     b.MaxBodySize(),
+			"timeout":           b.Timeout().String(),
 			"auto_auth_path":    tc.AutoAuthPath,
 			"default_role":      tc.DefaultAuthRole,
 			"tls_skip_verify":   b.tlsSkipVerify,
@@ -542,13 +542,9 @@ func (b *proxyBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int64
 	if !b.spec.ShouldEnforceMCPPolicy(req) {
 		return false, 0
 	}
-	// MaxBodySize lives on the embedded StreamingBackend and is
-	// written under b.mu by Initialize and handleConfigWrite — read
-	// under the read-lock to avoid racing concurrent reconfigure.
-	b.mu.RLock()
-	maxBody := b.MaxBodySize
-	b.mu.RUnlock()
-	return true, maxBody
+	// MaxBodySize is atomic on StreamingBackend — race-detector clean
+	// against concurrent reconfigures without holding b.mu.
+	return true, b.MaxBodySize()
 }
 
 // ShouldParseStreamBody overrides the embedded StreamingBackend's default to

--- a/provider/vault/factory_test.go
+++ b/provider/vault/factory_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"sync"
 	"testing"
 	"time"
@@ -93,8 +92,8 @@ func TestFactory(t *testing.T) {
 	vb := b.(*vaultBackend)
 	assert.Equal(t, "vault", vb.Type())
 	assert.Equal(t, logical.ClassProvider, vb.Class())
-	assert.Equal(t, framework.DefaultMaxBodySize, vb.MaxBodySize)
-	assert.Equal(t, framework.DefaultTimeout, vb.Timeout)
+	assert.Equal(t, framework.DefaultMaxBodySize, vb.MaxBodySize())
+	assert.Equal(t, framework.DefaultTimeout, vb.Timeout())
 }
 
 func TestFactory_WithConfig(t *testing.T) {
@@ -114,8 +113,8 @@ func TestFactory_WithConfig(t *testing.T) {
 	require.NoError(t, err)
 	vb := b.(*vaultBackend)
 	assert.Equal(t, "https://vault.example.com:8200", vb.vaultAddress)
-	assert.Equal(t, int64(5242880), vb.MaxBodySize)
-	assert.Equal(t, 60*time.Second, vb.Timeout)
+	assert.Equal(t, int64(5242880), vb.MaxBodySize())
+	assert.Equal(t, 60*time.Second, vb.Timeout())
 	assert.True(t, vb.tlsSkipVerify)
 }
 
@@ -150,10 +149,10 @@ func TestInitialize_EmptyStorage(t *testing.T) {
 	storage := newInmemStorage()
 	b := &vaultBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			StorageView:       storage,
-			TransparentConfig: &framework.TransparentConfig{},
+			StorageView: storage,
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 	err := b.Initialize(context.Background())
 	assert.NoError(t, err)
 }
@@ -172,17 +171,17 @@ func TestInitialize_ExistingConfig(t *testing.T) {
 
 	b := &vaultBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			StorageView:       storage,
-			TransparentConfig: &framework.TransparentConfig{},
-			Proxy:             &httputil.ReverseProxy{Transport: sharedTransport},
+			StorageView: storage,
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
+	b.InitProxy(sharedTransport)
 
 	err := b.Initialize(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "https://saved.vault.com:8200", b.vaultAddress)
-	assert.Equal(t, int64(5242880), b.MaxBodySize)
-	assert.Equal(t, 60*time.Second, b.Timeout)
+	assert.Equal(t, int64(5242880), b.MaxBodySize())
+	assert.Equal(t, 60*time.Second, b.Timeout())
 }
 
 func TestInitialize_TLSSkipVerify(t *testing.T) {
@@ -196,17 +195,18 @@ func TestInitialize_TLSSkipVerify(t *testing.T) {
 
 	b := &vaultBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			StorageView:       storage,
-			TransparentConfig: &framework.TransparentConfig{},
-			Proxy:             &httputil.ReverseProxy{Transport: sharedTransport},
+			StorageView: storage,
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
+	b.InitProxy(sharedTransport)
 
 	err := b.Initialize(context.Background())
 	require.NoError(t, err)
 	assert.True(t, b.tlsSkipVerify)
-	// Transport should be updated
-	assert.NotEqual(t, sharedTransport, b.Proxy.Transport)
+	// Transport should be updated — Proxy.Transport is now the swappable wrapper
+	// (a stable pointer); the underlying transport changed, observed via Transport().
+	assert.NotEqual(t, sharedTransport, b.Transport())
 }
 
 // --- SensitiveConfigFields ---
@@ -268,10 +268,9 @@ func TestValidateVaultAddress(t *testing.T) {
 
 func TestHandleConfigWrite_InvalidAddress(t *testing.T) {
 	b := &vaultBackend{
-		StreamingBackend: &framework.StreamingBackend{
-			TransparentConfig: &framework.TransparentConfig{},
-		},
+		StreamingBackend: &framework.StreamingBackend{},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 	path := b.pathConfig()
 	fd := &framework.FieldData{
 		Raw: map[string]interface{}{
@@ -288,10 +287,9 @@ func TestHandleConfigWrite_InvalidAddress(t *testing.T) {
 
 func TestHandleConfigWrite_MissingAutoAuthPath(t *testing.T) {
 	b := &vaultBackend{
-		StreamingBackend: &framework.StreamingBackend{
-			TransparentConfig: &framework.TransparentConfig{},
-		},
+		StreamingBackend: &framework.StreamingBackend{},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 	path := b.pathConfig()
 	fd := &framework.FieldData{
 		Raw: map[string]interface{}{
@@ -309,10 +307,10 @@ func TestHandleConfigWrite_PersistsToStorage(t *testing.T) {
 	storage := newInmemStorage()
 	b := &vaultBackend{
 		StreamingBackend: &framework.StreamingBackend{
-			StorageView:       storage,
-			TransparentConfig: &framework.TransparentConfig{},
+			StorageView: storage,
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 	path := b.pathConfig()
 	fd := &framework.FieldData{
 		Raw: map[string]interface{}{
@@ -338,10 +336,10 @@ func TestHandleGatewayStreaming_NoAddress(t *testing.T) {
 	b := &vaultBackend{
 		vaultAddress: "",
 		StreamingBackend: &framework.StreamingBackend{
-			Logger:            createTestLogger(),
-			TransparentConfig: &framework.TransparentConfig{},
+			Logger: createTestLogger(),
 		},
 	}
+	b.SetTransparentConfig(&framework.TransparentConfig{})
 
 	httpReq := httptest.NewRequest(http.MethodGet, "/v1/vault/gateway/sys/health", nil)
 	rr := httptest.NewRecorder()

--- a/provider/vault/path_config.go
+++ b/provider/vault/path_config.go
@@ -66,13 +66,13 @@ func (b *vaultBackend) pathConfig() *framework.Path {
 
 // handleConfigRead handles reading the Vault provider configuration
 func (b *vaultBackend) handleConfigRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	tc := b.TransparentConfig
+	tc := b.TransparentConfig()
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Data: map[string]any{
 			"vault_address":   b.vaultAddress,
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
@@ -97,17 +97,17 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 
 	// For max_body_size: use provided value, or apply default if not yet set
 	if val, ok := d.GetOk("max_body_size"); ok {
-		b.MaxBodySize = val.(int64)
-	} else if b.MaxBodySize == 0 {
-		b.MaxBodySize = framework.DefaultMaxBodySize
+		b.SetMaxBodySize(val.(int64))
+	} else if b.MaxBodySize() == 0 {
+		b.SetMaxBodySize(framework.DefaultMaxBodySize)
 	}
 
 	// For timeout: use provided value, or apply default if not yet set
 	if val, ok := d.GetOk("timeout"); ok {
 		// TypeDurationSecond returns int (seconds)
-		b.Timeout = time.Duration(val.(int)) * time.Second
-	} else if b.Timeout == 0 {
-		b.Timeout = framework.DefaultTimeout
+		b.SetTimeout(time.Duration(val.(int)) * time.Second)
+	} else if b.Timeout() == 0 {
+		b.SetTimeout(framework.DefaultTimeout)
 	}
 
 	tlsChanged := false
@@ -135,13 +135,13 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 				Err:        logical.ErrBadRequest(err.Error()),
 			}, nil
 		}
-		b.Proxy.Transport = transport
+		b.SetTransport(transport)
 	}
 
 	// Transparent mode settings — build new config from current values + overrides
 	tc := &framework.TransparentConfig{
-		AutoAuthPath:    b.TransparentConfig.AutoAuthPath,
-		DefaultAuthRole: b.TransparentConfig.DefaultAuthRole,
+		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
+		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -164,8 +164,8 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	if b.StorageView != nil {
 		entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
 			"vault_address":   b.vaultAddress,
-			"max_body_size":   b.MaxBodySize,
-			"timeout":         b.Timeout.String(),
+			"max_body_size":   b.MaxBodySize(),
+			"timeout":         b.Timeout().String(),
 			"tls_skip_verify": b.tlsSkipVerify,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,

--- a/provider/vault/path_config_test.go
+++ b/provider/vault/path_config_test.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"context"
 	"net/http"
-	"net/http/httputil"
 	"testing"
 	"time"
 
@@ -46,14 +45,13 @@ func TestHandleConfigRead(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &vaultBackend{
-				vaultAddress:  tt.vaultAddress,
-				tlsSkipVerify: tt.tlsSkipVerify,
-				StreamingBackend: &framework.StreamingBackend{
-					MaxBodySize:       tt.maxBodySize,
-					Timeout:           tt.timeout,
-					TransparentConfig: &framework.TransparentConfig{},
-				},
+				vaultAddress:     tt.vaultAddress,
+				tlsSkipVerify:    tt.tlsSkipVerify,
+				StreamingBackend: &framework.StreamingBackend{},
 			}
+			b.SetMaxBodySize(tt.maxBodySize)
+			b.SetTimeout(tt.timeout)
+			b.SetTransparentConfig(&framework.TransparentConfig{})
 
 			resp, err := b.handleConfigRead(context.Background(), nil, nil)
 
@@ -151,12 +149,11 @@ func TestHandleConfigWrite(t *testing.T) {
 				vaultAddress:  tt.initialVaultAddress,
 				tlsSkipVerify: tt.initialTLSSkipVerify,
 				// No storage view - config won't be persisted
-				StreamingBackend: &framework.StreamingBackend{
-					MaxBodySize:       tt.initialMaxBodySize,
-					Timeout:           tt.initialTimeout,
-					TransparentConfig: &framework.TransparentConfig{},
-				},
+				StreamingBackend: &framework.StreamingBackend{},
 			}
+			b.SetMaxBodySize(tt.initialMaxBodySize)
+			b.SetTimeout(tt.initialTimeout)
+			b.SetTransparentConfig(&framework.TransparentConfig{})
 
 			// Create field data with schema
 			schema := map[string]*framework.FieldSchema{
@@ -194,8 +191,8 @@ func TestHandleConfigWrite(t *testing.T) {
 
 			// Verify backend state was updated
 			assert.Equal(t, tt.expectedVaultAddress, b.vaultAddress)
-			assert.Equal(t, tt.expectedMaxBodySize, b.MaxBodySize)
-			assert.Equal(t, tt.expectedTimeout, b.Timeout)
+			assert.Equal(t, tt.expectedMaxBodySize, b.MaxBodySize())
+			assert.Equal(t, tt.expectedTimeout, b.Timeout())
 			assert.Equal(t, tt.expectedTLSSkipVerify, b.tlsSkipVerify)
 		})
 	}
@@ -204,18 +201,14 @@ func TestHandleConfigWrite(t *testing.T) {
 func TestHandleConfigWrite_TLSChange(t *testing.T) {
 	// This test verifies that changing tls_skip_verify updates the transport
 	b := &vaultBackend{
-		vaultAddress:  "https://vault.example.com:8200",
-		tlsSkipVerify: false,
-		StreamingBackend: &framework.StreamingBackend{
-			MaxBodySize:       framework.DefaultMaxBodySize,
-			Timeout:           framework.DefaultTimeout,
-			TransparentConfig: &framework.TransparentConfig{},
-			Proxy: &httputil.ReverseProxy{
-				Director:  func(req *http.Request) {},
-				Transport: sharedTransport,
-			},
-		},
+		vaultAddress:     "https://vault.example.com:8200",
+		tlsSkipVerify:    false,
+		StreamingBackend: &framework.StreamingBackend{},
 	}
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(framework.DefaultTimeout)
+	b.SetTransparentConfig(&framework.TransparentConfig{})
+	b.InitProxy(sharedTransport)
 
 	schema := map[string]*framework.FieldSchema{
 		"tls_skip_verify": {
@@ -241,7 +234,10 @@ func TestHandleConfigWrite_TLSChange(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, b.tlsSkipVerify)
 	// Transport should have been updated (different pointer)
-	assert.True(t, b.Proxy.Transport != sharedTransport, "transport should be a new instance")
+	// The Proxy.Transport now points at a swappable wrapper that stays stable
+	// across reconfigures; the underlying transport changes through SetTransport,
+	// observed via Transport().
+	assert.True(t, b.Transport() != sharedTransport, "transport should be a new instance")
 }
 
 func TestPathConfig_Schema(t *testing.T) {

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -50,15 +50,15 @@ func (b *vaultBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	}
 
 	// Apply timeout if configured
-	if b.Timeout > 0 {
+	if b.Timeout() > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout())
 		defer cancel()
 		req.HTTPRequest = req.HTTPRequest.WithContext(ctx)
 	}
 
 	// Enforce max body size
-	maxBody := b.MaxBodySize
+	maxBody := b.MaxBodySize()
 	if maxBody <= 0 {
 		maxBody = framework.DefaultMaxBodySize
 	}

--- a/provider/vault/provider.go
+++ b/provider/vault/provider.go
@@ -99,10 +99,6 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		},
 		UnauthenticatedPaths: vaultUnauthenticatedPaths,
 		ParseStreamBody:      true,
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "",
-			DefaultAuthRole: "",
-		},
 		Backend: &framework.Backend{
 			Help:           vaultBackendHelp,
 			BackendType:    "vault",
@@ -115,6 +111,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	// Set common fields
 	b.Logger = conf.Logger.WithSubsystem("vault")
 	b.StorageView = conf.StorageView
+
+	// Seed an empty transparent config so isTransparentRequest can route
+	// once auto_auth_path is configured via handleConfigWrite.
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 	// Initialize reverse proxy with Vault transport (lazily created on first use)
 	initTransport()
@@ -130,15 +130,15 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	}
 
 	// Set defaults
-	b.MaxBodySize = framework.DefaultMaxBodySize
-	b.Timeout = framework.DefaultTimeout
+	b.SetMaxBodySize(framework.DefaultMaxBodySize)
+	b.SetTimeout(framework.DefaultTimeout)
 
 	// Apply configuration if provided
 	if len(conf.Config) > 0 {
 		parsedConfig := parseConfig(conf.Config)
 		b.vaultAddress = parsedConfig.VaultAddress
-		b.MaxBodySize = parsedConfig.MaxBodySize
-		b.Timeout = parsedConfig.Timeout
+		b.SetMaxBodySize(parsedConfig.MaxBodySize)
+		b.SetTimeout(parsedConfig.Timeout)
 		b.tlsSkipVerify = parsedConfig.TLSSkipVerify
 		b.caData = parsedConfig.CAData
 
@@ -148,7 +148,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			if err != nil {
 				return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 	}
 
@@ -180,12 +180,12 @@ func (b *vaultBackend) Initialize(ctx context.Context) error {
 			return fmt.Errorf("failed to decode config: %w", err)
 		}
 		b.vaultAddress = config.VaultAddress
-		b.MaxBodySize = config.MaxBodySize
+		b.SetMaxBodySize(config.MaxBodySize)
 		b.tlsSkipVerify = config.TLSSkipVerify
 		b.caData = config.CAData
 		if config.Timeout != "" {
 			if timeout, err := time.ParseDuration(config.Timeout); err == nil {
-				b.Timeout = timeout
+				b.SetTimeout(timeout)
 			}
 		}
 
@@ -195,7 +195,7 @@ func (b *vaultBackend) Initialize(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("invalid TLS configuration: %w", err)
 			}
-			b.Proxy.Transport = transport
+			b.SetTransport(transport)
 		}
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{

--- a/provider/vault/provider_test.go
+++ b/provider/vault/provider_test.go
@@ -10,12 +10,11 @@ import (
 
 func TestTransparentModeProvider_ViaStreamingBackend(t *testing.T) {
 	// Create a StreamingBackend with TransparentConfig (mimics what vaultBackend uses)
-	sb := &framework.StreamingBackend{
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "auth/jwt/",
-			DefaultAuthRole: "default-role",
-		},
-	}
+	sb := &framework.StreamingBackend{}
+	sb.SetTransparentConfig(&framework.TransparentConfig{
+		AutoAuthPath:    "auth/jwt/",
+		DefaultAuthRole: "default-role",
+	})
 
 	// Test IsTransparentMode
 	t.Run("IsTransparentMode returns true when enabled", func(t *testing.T) {
@@ -39,12 +38,11 @@ func TestTransparentModeProvider_ViaStreamingBackend(t *testing.T) {
 }
 
 func TestGetAuthRole_ViaStreamingBackend(t *testing.T) {
-	sb := &framework.StreamingBackend{
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "auth/jwt/",
-			DefaultAuthRole: "default-role",
-		},
-	}
+	sb := &framework.StreamingBackend{}
+	sb.SetTransparentConfig(&framework.TransparentConfig{
+		AutoAuthPath:    "auth/jwt/",
+		DefaultAuthRole: "default-role",
+	})
 
 	tests := []struct {
 		name         string
@@ -99,12 +97,11 @@ func TestGetAuthRole_ViaStreamingBackend(t *testing.T) {
 }
 
 func TestGetAuthRole_NoDefaultAuthRole(t *testing.T) {
-	sb := &framework.StreamingBackend{
-		TransparentConfig: &framework.TransparentConfig{
-			AutoAuthPath:    "auth/jwt/",
-			DefaultAuthRole: "", // No default role
-		},
-	}
+	sb := &framework.StreamingBackend{}
+	sb.SetTransparentConfig(&framework.TransparentConfig{
+		AutoAuthPath:    "auth/jwt/",
+		DefaultAuthRole: "", // No default role
+	})
 
 	t.Run("returns empty for non-matching path without default", func(t *testing.T) {
 		result := sb.GetAuthRole("gateway/v1/secret/data/foo", nil)
@@ -118,9 +115,8 @@ func TestGetAuthRole_NoDefaultAuthRole(t *testing.T) {
 }
 
 func TestRewriteTransparentPath_ViaStreamingBackend(t *testing.T) {
-	sb := &framework.StreamingBackend{
-		TransparentConfig: &framework.TransparentConfig{},
-	}
+	sb := &framework.StreamingBackend{}
+	sb.SetTransparentConfig(&framework.TransparentConfig{})
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Converts four mutable runtime fields on `framework.StreamingBackend` from raced public-field access to lockless atomic accessors, and migrates every provider that uses them. Closes the W2 / W3 / W4 concerns surfaced during the `mcp_aws` review.

Before, `MaxBodySize int64`, `Timeout time.Duration`, `TransparentConfig *TransparentConfig`, and `Proxy.Transport` were all read on every gateway request and written from `Factory` / `Initialize` / config-write handlers across nine provider packages — guarded only by each provider's own per-instance `RWMutex` which the framework's own writes (`SetTransparentConfig` in particular) silently bypassed.

### New shape

- **`maxBodySize` and `timeout` are `atomic.Int64`** (timeout stored as nanoseconds). Accessors: `MaxBodySize() / SetMaxBodySize()`, `Timeout() / SetTimeout()`.
- **`transparentConfig` is `atomic.Pointer[TransparentConfig]`**. Accessors: `TransparentConfig()` reader (never returns nil — empty sentinel when nothing installed, so providers can safely chain field accesses), existing `SetTransparentConfig(c)` writer. `IsTransparentMode()` still reads the raw atomic to preserve its "is anything configured?" semantics.
- **Transport** is held on a new `swappableTransport` wrapper that backs both `Proxy.Transport` (for ReverseProxy-based backends) and `Transport()` (for custom backends). Backed by `atomic.Pointer[http.RoundTripper]` — NOT `atomic.Value`, which would panic when providers swap an `*http.Transport` for a different concrete RoundTripper (the alicloud OSS test exercises exactly this path). The swappable itself is installed lazily via `sync.Once`-based `ensureTransport` so concurrent first-`SetTransport` calls on a fresh backend can't race on the pointer-field assignment.

### Per-provider migration

Mechanical patterns, applied across nine packages including the newly-merged `mcp_aws`:

```
b.MaxBodySize = X            → b.SetMaxBodySize(X)
b.MaxBodySize (read)         → b.MaxBodySize()
b.Timeout = X                → b.SetTimeout(X)
b.Timeout (read)             → b.Timeout()
b.TransparentConfig (read)   → b.TransparentConfig()
b.Proxy.Transport = X        → b.SetTransport(X)
b.Proxy.Transport (read)     → b.Transport()
Struct literal TransparentConfig: → drop, call SetTransparentConfig after construction
```

Affected provider packages: `alicloud`, `aws`, `azure`, `gcp`, `mcp_aws`, `vault`, plus the `sdk/dualgateway` and `sdk/httpproxy` SDKs (which transitively cover `mcp_github`, `github`, `gitlab`, `openai`, `anthropic`, `atlassian`, `cohere`, `cloudflare`, `datadog`, `dynatrace`, `elastic`, `grafana`, `honeycomb`, `ibmcloud`, `mistral`, `newrelic`, `ovh`, `pagerduty`, `prometheus`, `rds`, `redshift`, `scaleway`, `sentry`, `servicenow`, `slack`, `splunk`, `tfe`).

### New tests

In `framework/streaming_backend_concurrency_test.go`:

- `TestStreamingBackend_ConcurrentFieldAccess` — spins N readers + M writers hitting `MaxBodySize / Timeout / TransparentConfig / Transport` for 1000 iterations each. Under `-race` this would fire immediately against the previous version of `streaming_backend.go`.
- `TestSwappableTransport_StoreVisible` — verifies `SetTransport` dispatches `RoundTrip` to the most recently installed transport.
- `TestSwappableTransport_FirstSetTransportRace` — exercises the case where nothing has installed a transport yet and multiple goroutines call `SetTransport` concurrently. Confirms the `sync.Once`-based init.
- `TestSwappableTransport_StoreDifferentConcreteTypes` — proves swapping between `*countingTransport` and `*http.Transport` doesn't panic (the `atomic.Pointer` over `atomic.Value` motivation).

The per-provider `RWMutex` stays in place for provider-specific fields (`upstreamURL`, `tlsSkipVerify`, `caData`, `proxyDomains`, etc); only the framework-side fields are now atomic.

## Test plan

- [x] `go test ./... -race -count=1` — green
- [x] `go vet ./...` — clean (no new warnings)
- [x] mcp_aws end-to-end with Claude Code — verified against AWS MCP Server with this binary in the previous PR's testing session
