### PR TITLE
fix(framework,sigv4): log client cancellation at debug, not error

### DIFF
--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -7,6 +7,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -701,6 +702,18 @@ func (b *StreamingBackend) InitProxy(transport http.RoundTripper) {
 		Director:  func(req *http.Request) {},
 		Transport: swap,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			// Client-side cancellation isn't a Warden error. Common
+			// shapes: MCP Streamable HTTP's GET notification stream
+			// the client opens then disconnects, or a long tool-call
+			// the user cancelled mid-flight. Log at Debug, skip the
+			// 502 — the connection is already gone.
+			if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
+				b.Logger.Debug("proxy aborted: client closed connection",
+					logger.Err(err),
+					logger.String("target_url", r.URL.String()),
+				)
+				return
+			}
 			b.Logger.Error("proxy error",
 				logger.Err(err),
 				logger.String("target_url", r.URL.String()),

--- a/provider/sdk/sigv4/sigv4.go
+++ b/provider/sdk/sigv4/sigv4.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -472,6 +473,19 @@ func ForwardDirect(log *logger.GatedLogger, w http.ResponseWriter, r *http.Reque
 
 	resp, err := transport.RoundTrip(outReq)
 	if err != nil {
+		// Client-side cancellation (the inbound r.Context was canceled
+		// before the upstream answered) is not a Warden error. Common
+		// shapes: MCP Streamable HTTP's GET notification stream that
+		// the client opens then disconnects, or a tool-call the user
+		// cancelled mid-flight. Log at Debug and don't write 502 —
+		// the connection is gone, no one's reading the response.
+		if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
+			log.Debug("forward aborted: client closed connection",
+				logger.Err(err),
+				logger.String("request_id", middleware.GetReqID(r.Context())),
+			)
+			return
+		}
 		log.Error("direct forward failed", logger.Err(err))
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		return


### PR DESCRIPTION
## Summary

Two cosmetic-noise sites were logging `context.Canceled` at **Error** and writing `502 Bad Gateway` on a connection that was already gone:

- `framework/streaming_backend.go` — the `httputil.ReverseProxy.ErrorHandler` used by every httpproxy-based provider (mcp_github, github, gitlab, openai, anthropic, atlassian, etc.).
- `provider/sdk/sigv4/sigv4.go` — the `ForwardDirect` path used by alicloud, mcp_aws, and sdk/dualgateway.

Both now detect `errors.Is(err, context.Canceled) || r.Context().Err() != nil` and:

- log at **Debug** with `target_url` / `request_id`,
- skip the `http.Error(w, ..., 502)` call (no one's reading the response — writing is a no-op at best, a misleading audit trail at worst).

No behavior change for real upstream failures (DNS, TCP reset, TLS, 5xx from upstream): those still log at Error and respond `502`.

### Why this surfaces now

Two common MCP-shaped triggers:

1. **MCP Streamable HTTP's GET notification stream** — the client opens a long-lived GET on `/gateway`, then disconnects on shutdown. The inbound context cancels, the in-flight `RoundTrip` returns `context.Canceled`.
2. **Tool-call cancellation** — the user `Ctrl-C`s a slow `tools/call` in Claude. Same shape.

Before this PR, every disconnect produced one `ERR` line per provider per session. With dual mcp_aws + mcp_github setups it was easy to mistake the noise for an actual failure.

### Audit trail

The audit log already records the request and response with `streamed: true` and the correct `status_code` for non-cancelled paths. Client-cancelled requests don't need an additional `Error`-level entry in the operator log — the audit log is the source of truth.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./framework/... ./provider/sdk/sigv4/... -count=1` — green
- [x] End-to-end: run mcp_aws + mcp_github with Claude Code, observe disappearance of `ERR direct forward failed error="context canceled"` and `ERR proxy error error="context canceled"` from the operator log. Successful calls still log/audit identically.
