### PR TITLE
feat(providers): add tune endpoint to update a mount description

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 )
@@ -98,13 +99,13 @@ func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config map[
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
+	// Trim a trailing slash so a normalized mount path ("aws/") doesn't
+	// produce a double slash before the "/tune" suffix.
+	path = strings.TrimSuffix(path, "/")
 	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/providers/%s/tune", path))
 
-	// Wrap config in the expected request body structure
-	body := map[string]any{
-		"config": config,
-	}
-	if err := r.SetJSONBody(body); err != nil {
+	// Tunable fields (currently just "description") are sent at the top level.
+	if err := r.SetJSONBody(config); err != nil {
 		return err
 	}
 

--- a/cmd/providers/providers.go
+++ b/cmd/providers/providers.go
@@ -31,4 +31,5 @@ func init() {
 	ProvidersCmd.AddCommand(DisableCmd)
 	ProvidersCmd.AddCommand(ListCmd)
 	ProvidersCmd.AddCommand(ReadCmd)
+	ProvidersCmd.AddCommand(TuneCmd)
 }

--- a/cmd/providers/tune.go
+++ b/cmd/providers/tune.go
@@ -1,0 +1,120 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	tuneDescription string
+	tunePath        string
+	tuneJSON        string
+
+	TuneCmd = &cobra.Command{
+		Use:           "tune [PATH]",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Update a provider's description",
+		Long: `
+Usage: warden provider tune [options] [PATH]
+
+  Update the description of a provider enabled at PATH. The PATH may be
+  supplied either positionally or via -path (pick one — combining both is
+  rejected). Two input modes:
+
+    Typed flag (human-friendly):
+
+      $ warden provider tune aws/ -description="Production AWS"
+
+    Full JSON payload (agent-friendly):
+
+      $ warden provider tune aws/ -json @tune.json
+      $ echo '{"description":"Production AWS"}' | warden provider tune aws/ -json -
+
+  Tuning is a partial update: omitting -description leaves the current
+  description unchanged, while -description="" clears it. -json is mutually
+  exclusive with -description. Combine with -dry-run to preview the request
+  without applying it.
+`,
+		RunE: runTune,
+	}
+)
+
+func init() {
+	TuneCmd.Flags().StringVar(&tuneDescription, "description", "", "New description for the provider")
+	TuneCmd.Flags().StringVar(&tunePath, "path", "", "Mount path (alternative to the positional PATH argument)")
+	TuneCmd.Flags().StringVarP(&tuneJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -description)")
+}
+
+func runTune(cmd *cobra.Command, args []string) error {
+	path, err := helpers.RequirePath(args, tunePath)
+	if err != nil {
+		return err
+	}
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+	if err := helpers.ValidatePath(path); err != nil {
+		return err
+	}
+
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	jsonPayload, err := helpers.ResolveJSONInput(tuneJSON)
+	if err != nil {
+		return err
+	}
+
+	if jsonPayload != nil {
+		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
+			"-description": cmd.Flags().Changed("description"),
+		}); err != nil {
+			return err
+		}
+		if helpers.ResolveDryRun() {
+			return helpers.DryRun(c, "POST", "sys/providers/{path}/tune", jsonPayload)
+		}
+		resource, err := c.Operator().Post("sys/providers/"+path+"tune", jsonPayload)
+		if err != nil {
+			return fmt.Errorf("error tuning provider: %w", err)
+		}
+		data := map[string]any{}
+		var resData map[string]any
+		if resource != nil {
+			resData = resource.Data
+		}
+		helpers.MergeServerResponseInto(data, resData, map[string]any{
+			"path":  path,
+			"tuned": true,
+		})
+		return helpers.RenderMap(data, func() {
+			fmt.Printf("Success! Tuned provider at: %s\n", path)
+		})
+	}
+
+	// Typed-flag mode. Send "description" only when the operator actually set
+	// the flag, so a bare `tune` is a no-op rather than clearing the field.
+	data := map[string]any{}
+	if cmd.Flags().Changed("description") {
+		data["description"] = tuneDescription
+	}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "POST", "sys/providers/{path}/tune", data)
+	}
+
+	if err := c.Sys().TuneMount(path, data); err != nil {
+		return fmt.Errorf("error tuning provider: %w", err)
+	}
+
+	return helpers.RenderMap(map[string]any{"path": path, "tuned": true}, func() {
+		fmt.Printf("Success! Tuned provider at: %s\n", path)
+	})
+}

--- a/core/sys_providers.go
+++ b/core/sys_providers.go
@@ -16,6 +16,41 @@ import (
 func (b *SystemBackend) pathProviders() []*framework.Path {
 	return []*framework.Path{
 		{
+			// Must be registered before the generic "providers/{path}"
+			// path below: routing is first-match in slice order and both
+			// patterns match "providers/<path>/tune". The "/tune" suffix
+			// here disambiguates only because this entry is tried first.
+			//
+			// Inherent limitation: the path capture is greedy and spans
+			// slashes, so a provider whose own mount path ends in a "tune"
+			// segment (e.g. "foo/tune/") is shadowed — "providers/foo/tune"
+			// always resolves here, so such a mount cannot be created, read,
+			// or deleted via the generic path. Mount paths ending in "tune"
+			// are effectively unsupported. Routing runs before mount-path
+			// validation, so this can't be rejected at create time; closing
+			// it would require a different endpoint shape.
+			Pattern: "providers/" + framework.MatchAllRegex("path") + "/tune",
+			Fields: map[string]*framework.FieldSchema{
+				"path": {
+					Type:        framework.TypeString,
+					Description: "The path of the provider to tune",
+					Required:    true,
+				},
+				"description": {
+					Type:        framework.TypeString,
+					Description: "Human-readable description",
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.handleProviderTune,
+					Summary:  "Tune a provider mount's description",
+				},
+			},
+			HelpSynopsis:    "Tune a provider mount",
+			HelpDescription: "Update the description of an existing provider mount.",
+		},
+		{
 			Pattern: "providers/" + framework.MatchAllRegex("path"),
 			Fields: map[string]*framework.FieldSchema{
 				"path": {
@@ -185,6 +220,51 @@ func (b *SystemBackend) handleProviderRead(ctx context.Context, req *logical.Req
 		"accessor":    entry.Accessor,
 		"config":      maskedConfig,
 		"mount_url":   mountURL(entry.Namespace(), entry.Path),
+	}), nil
+}
+
+// handleProviderTune handles POST /sys/providers/{path}/tune. It updates the
+// mount-level description of an existing provider in place. The description is
+// the only tunable field today; the body is a partial update, so an omitted
+// description leaves the current value untouched while an explicit empty
+// string clears it.
+func (b *SystemBackend) handleProviderTune(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	path := d.Get("path").(string)
+
+	// Exclusive lock: we mutate the entry and rewrite its persisted record,
+	// so we must exclude the RLock readers in handleProviderRead/List.
+	b.core.mountsLock.Lock()
+	defer b.core.mountsLock.Unlock()
+
+	// Normalize path
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+
+	entry, err := b.core.mounts.findByPath(ctx, path)
+	if err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+	if entry == nil {
+		return logical.ErrorResponse(logical.ErrNotFound("mount not found")), nil
+	}
+
+	// Only touch the description when the caller actually sent the field.
+	if v, ok := d.GetOk("description"); ok {
+		entry.Description = v.(string)
+	}
+
+	// The router holds a pointer to this same entry, so the in-memory change
+	// is already live; persist it so it survives a restart or failover.
+	if err := b.core.persistMounts(ctx, nil, b.core.mounts, entry.UUID); err != nil {
+		b.logger.Error("failed to persist tuned mount", logger.Err(err))
+		return logical.ErrorResponse(logical.ErrInternal("failed to persist mount")), nil
+	}
+
+	return b.respondSuccess(map[string]any{
+		"path":        entry.Path,
+		"description": entry.Description,
+		"message":     fmt.Sprintf("Successfully tuned %s", entry.Path),
 	}), nil
 }
 

--- a/core/sys_providers_test.go
+++ b/core/sys_providers_test.go
@@ -55,17 +55,23 @@ func TestSystemBackend_PathProviders(t *testing.T) {
 	backend, _, _ := setupTestSystemBackend(t)
 
 	paths := backend.pathProviders()
-	require.Len(t, paths, 2)
+	require.Len(t, paths, 3)
+
+	// Check providers/{path}/tune path — must be first so it wins routing
+	// against the generic providers/{path} pattern.
+	assert.Equal(t, "providers/"+framework.MatchAllRegex("path")+"/tune", paths[0].Pattern)
+	assert.Contains(t, paths[0].Fields, "path")
+	assert.Contains(t, paths[0].Fields, "description")
 
 	// Check providers/{path} path
-	assert.Equal(t, "providers/"+framework.MatchAllRegex("path"), paths[0].Pattern)
-	assert.Contains(t, paths[0].Fields, "path")
-	assert.Contains(t, paths[0].Fields, "type")
-	assert.Contains(t, paths[0].Fields, "description")
-	assert.Contains(t, paths[0].Fields, "config")
+	assert.Equal(t, "providers/"+framework.MatchAllRegex("path"), paths[1].Pattern)
+	assert.Contains(t, paths[1].Fields, "path")
+	assert.Contains(t, paths[1].Fields, "type")
+	assert.Contains(t, paths[1].Fields, "description")
+	assert.Contains(t, paths[1].Fields, "config")
 
 	// Check providers/ list path
-	assert.Equal(t, "providers/?$", paths[1].Pattern)
+	assert.Equal(t, "providers/?$", paths[2].Pattern)
 }
 
 func TestSystemBackend_HandleProviderCreate(t *testing.T) {
@@ -74,7 +80,7 @@ func TestSystemBackend_HandleProviderCreate(t *testing.T) {
 	// Register mock provider factory
 	core.providers["mock"] = MockProviderFactory
 
-	schema := backend.pathProviders()[0].Fields
+	schema := backend.pathProviders()[1].Fields
 	raw := map[string]interface{}{
 		"path":        "test-provider",
 		"type":        "mock",
@@ -96,7 +102,7 @@ func TestSystemBackend_HandleProviderCreate(t *testing.T) {
 func TestSystemBackend_HandleProviderCreate_InvalidPath(t *testing.T) {
 	backend, ctx, _ := setupTestSystemBackend(t)
 
-	schema := backend.pathProviders()[0].Fields
+	schema := backend.pathProviders()[1].Fields
 	raw := map[string]interface{}{
 		"path": "sys/invalid", // Reserved path
 		"type": "mock",
@@ -127,7 +133,7 @@ func TestSystemBackend_HandleProviderRead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now read it
-	schema := backend.pathProviders()[0].Fields
+	schema := backend.pathProviders()[1].Fields
 	raw := map[string]interface{}{
 		"path": "test-provider",
 	}
@@ -149,7 +155,7 @@ func TestSystemBackend_HandleProviderRead(t *testing.T) {
 func TestSystemBackend_HandleProviderRead_NotFound(t *testing.T) {
 	backend, ctx, _ := setupTestSystemBackend(t)
 
-	schema := backend.pathProviders()[0].Fields
+	schema := backend.pathProviders()[1].Fields
 	raw := map[string]interface{}{
 		"path": "nonexistent",
 	}
@@ -179,7 +185,7 @@ func TestSystemBackend_HandleProviderDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now delete it
-	schema := backend.pathProviders()[0].Fields
+	schema := backend.pathProviders()[1].Fields
 	raw := map[string]interface{}{
 		"path": "test-provider",
 	}
@@ -216,7 +222,7 @@ func TestSystemBackend_HandleProviderList(t *testing.T) {
 	require.NoError(t, core.mount(ctx, entry2))
 
 	// List provider mounts
-	schema := backend.pathProviders()[1].Fields
+	schema := backend.pathProviders()[2].Fields
 	raw := map[string]interface{}{}
 
 	req := createTestRequest(logical.ListOperation, "providers/", raw)
@@ -243,4 +249,104 @@ func TestSystemBackend_HandleProviderList(t *testing.T) {
 		assert.Equal(t, path, em["path"],
 			"path field for %q should equal the map key", path)
 	}
+}
+
+func TestSystemBackend_HandleProviderTune(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	core.providers["mock"] = MockProviderFactory
+
+	entry := &MountEntry{
+		Class:       mountClassProvider,
+		Type:        "mock",
+		Path:        "test-provider/",
+		Description: "old description",
+	}
+	require.NoError(t, core.mount(ctx, entry))
+
+	// paths[0] is the tune schema (path + description).
+	tuneSchema := backend.pathProviders()[0].Fields
+	raw := map[string]interface{}{
+		"path":        "test-provider",
+		"description": "new description",
+	}
+	req := createTestRequest(logical.CreateOperation, "providers/test-provider/tune", raw)
+	resp, err := backend.handleProviderTune(ctx, req, createFieldData(tuneSchema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "new description", resp.Data["description"])
+
+	// The change must be visible to a subsequent read.
+	readSchema := backend.pathProviders()[1].Fields
+	readRaw := map[string]interface{}{"path": "test-provider"}
+	readReq := createTestRequest(logical.ReadOperation, "providers/test-provider", readRaw)
+	readResp, err := backend.handleProviderRead(ctx, readReq, createFieldData(readSchema, readRaw))
+	require.NoError(t, err)
+	assert.Equal(t, "new description", readResp.Data["description"])
+}
+
+func TestSystemBackend_HandleProviderTune_NotFound(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	tuneSchema := backend.pathProviders()[0].Fields
+	raw := map[string]interface{}{
+		"path":        "nonexistent",
+		"description": "x",
+	}
+	req := createTestRequest(logical.CreateOperation, "providers/nonexistent/tune", raw)
+	resp, err := backend.handleProviderTune(ctx, req, createFieldData(tuneSchema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestSystemBackend_HandleProviderTune_OmittedDescriptionNoOp(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	core.providers["mock"] = MockProviderFactory
+
+	entry := &MountEntry{
+		Class:       mountClassProvider,
+		Type:        "mock",
+		Path:        "test-provider/",
+		Description: "keep me",
+	}
+	require.NoError(t, core.mount(ctx, entry))
+
+	// No "description" key: the existing value must survive untouched.
+	tuneSchema := backend.pathProviders()[0].Fields
+	raw := map[string]interface{}{
+		"path": "test-provider",
+	}
+	req := createTestRequest(logical.CreateOperation, "providers/test-provider/tune", raw)
+	resp, err := backend.handleProviderTune(ctx, req, createFieldData(tuneSchema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "keep me", resp.Data["description"])
+}
+
+func TestSystemBackend_HandleProviderTune_ClearDescription(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	core.providers["mock"] = MockProviderFactory
+
+	entry := &MountEntry{
+		Class:       mountClassProvider,
+		Type:        "mock",
+		Path:        "test-provider/",
+		Description: "remove me",
+	}
+	require.NoError(t, core.mount(ctx, entry))
+
+	// An explicit empty description clears the field.
+	tuneSchema := backend.pathProviders()[0].Fields
+	raw := map[string]interface{}{
+		"path":        "test-provider",
+		"description": "",
+	}
+	req := createTestRequest(logical.CreateOperation, "providers/test-provider/tune", raw)
+	resp, err := backend.handleProviderTune(ctx, req, createFieldData(tuneSchema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "", resp.Data["description"])
 }


### PR DESCRIPTION
## Summary

Provider mount descriptions were set only at creation time and were otherwise immutable — correcting a wrong description meant unmounting and remounting. This adds a `providers/<path>/tune` endpoint (POST) that updates the description in place and persists it, exposed end-to-end (server + API client + CLI).

This matters for discovery: a multi-product skill identifies a provider by its operator-set mount description, so operators need a way to fix a description without destroying the mount.

## What's included

- **Server** (`core/sys_providers.go`): new `providers/<path>/tune` path + `handleProviderTune`. Partial update — omitting `description` is a no-op, an explicit empty string clears it. Mutates the `MountEntry` under `mountsLock` and persists via `persistMounts`.
- **API client** (`api/sys_mounts.go`): sends tune fields at the top level (not wrapped under `config`), and trims a trailing slash so a normalized path doesn't produce a double slash before `/tune`.
- **CLI** (`cmd/providers/tune.go`): `warden provider tune <path> -description=...`, with `-json` and `-dry-run`, mirroring `provider enable`.

## Design notes

- **Routing order:** the tune path is registered *before* the generic `providers/<path>` path. Routing is first-match-in-order with `^…$`-anchored patterns, so both match `providers/aws/tune`; ordering is what disambiguates.
- **Partial-update semantics:** `GetOk` presence detection on the server and `cmd.Flags().Changed` on the CLI, so a bare `tune` never blanks an existing description while `-description=""` explicitly clears it.
- **Known limitation (documented in code):** the path capture spans slashes, so a provider whose own mount path ends in a `tune` segment (e.g. `foo/tune/`) is shadowed by this route — it can't be created/read/deleted via the generic path. This is inherent to the suffix-over-matchall routing; closing it would require a different endpoint shape.

## Test plan

- **Unit** (`core/sys_providers_test.go`): tune updates description; not-found → 404; omitted-description no-op; explicit-empty clear; plus updated path-registration assertions. `go test ./core/... ./api/...` green; `go build`/`go vet` clean.
- **Manual end-to-end** against a dev server: enable → read → tune → read → no-op → clear → 404 → dry-run all behaved as expected; nested `a/b/` tuned correctly; `foo/tune/` confirmed shadowed.
