### PR TITLE
feat(oauth2): authorization-code flow driver methods

### DIFF
--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
@@ -26,14 +28,23 @@ const (
 
 // auth_method selects the OAuth2 flow. It is read spec-over-source and defaults
 // to client_credentials so existing sources keep working unchanged.
-const oauth2AuthMethodClientCredentials = "client_credentials"
+const (
+	oauth2AuthMethodClientCredentials = "client_credentials"
+	oauth2AuthMethodAuthorizationCode = "authorization_code"
+)
 
 // OAuth2 grant types sent in the token request.
-const oauth2GrantClientCredentials = "client_credentials"
+const (
+	oauth2GrantClientCredentials = "client_credentials"
+	oauth2GrantAuthorizationCode = "authorization_code"
+	oauth2GrantRefreshToken      = "refresh_token"
+)
 
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*OAuth2Driver)(nil)
 var _ credential.SpecVerifier = (*OAuth2Driver)(nil)
+var _ credential.SpecConnector = (*OAuth2Driver)(nil)
+var _ credential.OAuth2Authorizer = (*OAuth2Driver)(nil)
 
 // OAuth2Driver exchanges OAuth2 credentials for bearer tokens.
 //
@@ -74,7 +85,7 @@ func (f *OAuth2DriverFactory) ValidateConfig(config map[string]string) error {
 		credential.StringField("token_url").
 			Required().
 			Custom(func(v string) error {
-				return validateOAuth2HTTPSURL(v, "token_url", credential.GetBool(config, "tls_skip_verify", false))
+				return validateOAuth2SafeURL(v, "token_url", credential.GetBool(config, "tls_skip_verify", false))
 			}).
 			Describe("OAuth2 token endpoint (HTTPS)").
 			Example("https://identity.pagerduty.com/oauth/token"),
@@ -98,7 +109,7 @@ func (f *OAuth2DriverFactory) ValidateConfig(config map[string]string) error {
 				if v == "" {
 					return nil
 				}
-				return validateOAuth2HTTPSURL(v, "verify_url", credential.GetBool(config, "tls_skip_verify", false))
+				return validateOAuth2SafeURL(v, "verify_url", credential.GetBool(config, "tls_skip_verify", false))
 			}).
 			Describe("Endpoint to verify minted tokens (skip if empty)").
 			Example("https://api.pagerduty.com/users/me"),
@@ -196,10 +207,15 @@ func (d *OAuth2Driver) displayName() string {
 
 // oauth2TokenResponse is the standard OAuth2 token endpoint response.
 type oauth2TokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
-	Scope       string `json:"scope"`
+	AccessToken           string `json:"access_token"`
+	TokenType             string `json:"token_type"`
+	ExpiresIn             int    `json:"expires_in"`
+	Scope                 string `json:"scope"`
+	RefreshToken          string `json:"refresh_token"`
+	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in"`
+	// Some providers (notably GitHub) report failures as HTTP 200 with an error body.
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
 }
 
 // resolve returns spec.Config[key] when set, else the source config value, else def.
@@ -222,6 +238,8 @@ func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.Cred
 	switch authMethod {
 	case oauth2AuthMethodClientCredentials:
 		return d.mintFromClientCredentials(ctx, spec)
+	case oauth2AuthMethodAuthorizationCode:
+		return d.mintFromRefreshToken(ctx, spec)
 	default:
 		return nil, 0, "", fmt.Errorf("%s OAuth2 unsupported auth_method %q", d.displayName(), authMethod)
 	}
@@ -256,6 +274,167 @@ func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *cred
 		form.Set(k, v)
 	}
 
+	tokenResp, err := d.postTokenRequest(ctx, d.tokenURL(), form)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, err)
+	}
+	if tokenResp.AccessToken == "" {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 token response missing access_token", name)
+	}
+
+	return accessTokenRawData(tokenResp), ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
+}
+
+// mintFromRefreshToken exchanges the sealed refresh token for a fresh access
+// token (grant_type=refresh_token). Providers that issue no refresh token seal a
+// static access token at connect time, which is returned directly. When the
+// provider rotates the refresh token, the new value is surfaced under the reserved
+// rawData key for the minting layer to persist.
+func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	name := d.displayName()
+
+	refreshToken := credential.GetString(spec.Config, "refresh_token", "")
+	if refreshToken == "" {
+		// No-refresh-token providers seal a static access token at connect time.
+		if staticToken := credential.GetString(spec.Config, "access_token", ""); staticToken != "" {
+			return map[string]interface{}{"api_key": staticToken}, staticTokenTTL(spec), "", nil
+		}
+		return nil, 0, "", fmt.Errorf("%s OAuth2 spec %q is not connected — run `warden cred spec connect %s`", name, spec.Name, spec.Name)
+	}
+
+	clientID := d.resolve(spec, "client_id", "")
+	clientSecret := d.resolve(spec, "client_secret", "")
+	if clientID == "" || clientSecret == "" {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 spec missing client_id or client_secret", name)
+	}
+
+	form := url.Values{
+		"grant_type":    {oauth2GrantRefreshToken},
+		"refresh_token": {refreshToken},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+
+	tokenResp, err := d.postTokenRequest(ctx, d.tokenURL(), form)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w", name, err)
+	}
+	if tokenResp.AccessToken == "" {
+		return nil, 0, "", fmt.Errorf("%s OAuth2 refresh response missing access_token", name)
+	}
+
+	rawData := accessTokenRawData(tokenResp)
+	// Surface a rotated refresh token for the minting layer to persist (§5).
+	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
+		rawData[credential.RawRotatedRefreshTokenKey] = tokenResp.RefreshToken
+	}
+	return rawData, ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
+}
+
+// ExchangeAuthorizationCode exchanges an authorization code for tokens using the
+// client secret the server holds, and returns the spec-config keys to seal.
+func (d *OAuth2Driver) ExchangeAuthorizationCode(ctx context.Context, spec *credential.CredSpec, code, redirectURI, codeVerifier string) (map[string]string, error) {
+	name := d.displayName()
+
+	clientID := d.resolve(spec, "client_id", "")
+	clientSecret := d.resolve(spec, "client_secret", "")
+	if clientID == "" || clientSecret == "" {
+		return nil, fmt.Errorf("%s OAuth2 spec missing client_id or client_secret", name)
+	}
+
+	form := url.Values{
+		"grant_type":    {oauth2GrantAuthorizationCode},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+	if codeVerifier != "" {
+		form.Set("code_verifier", codeVerifier)
+	}
+
+	tokenResp, err := d.postTokenRequest(ctx, d.tokenURL(), form)
+	if err != nil {
+		return nil, fmt.Errorf("%s OAuth2 authorization-code exchange failed: %w", name, err)
+	}
+
+	sealed := map[string]string{}
+	switch {
+	case tokenResp.RefreshToken != "":
+		sealed["refresh_token"] = tokenResp.RefreshToken
+		if tokenResp.RefreshTokenExpiresIn > 0 {
+			sealed["refresh_token_expires_at"] = expiresAt(tokenResp.RefreshTokenExpiresIn)
+		}
+	case tokenResp.AccessToken != "":
+		// No-refresh-token provider: seal the access token. Record its expiry when
+		// the provider returns one so mint can lease it correctly (otherwise it is
+		// treated as non-expiring).
+		sealed["access_token"] = tokenResp.AccessToken
+		if tokenResp.ExpiresIn > 0 {
+			sealed["access_token_expires_at"] = expiresAt(tokenResp.ExpiresIn)
+		}
+	default:
+		return nil, fmt.Errorf("%s OAuth2 authorization-code exchange returned neither refresh_token nor access_token", name)
+	}
+	return sealed, nil
+}
+
+// BuildAuthorizeURL assembles the provider authorize URL. Scopes are read as
+// already-normalized (space-separated) but commas are tolerated defensively.
+func (d *OAuth2Driver) BuildAuthorizeURL(spec *credential.CredSpec, redirectURI, state, codeChallenge string) (string, error) {
+	authURL := credential.GetString(d.credSource.Config, "auth_url", "")
+	if authURL == "" {
+		return "", fmt.Errorf("%s OAuth2 source missing auth_url (required for authorization_code)", d.displayName())
+	}
+	clientID := d.resolve(spec, "client_id", "")
+	if clientID == "" {
+		return "", fmt.Errorf("%s OAuth2 spec missing client_id", d.displayName())
+	}
+
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid auth_url: %w", err)
+	}
+
+	q := parsed.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	if state != "" {
+		q.Set("state", state)
+	}
+	if scope := normalizeOAuth2Scopes(d.resolve(spec, "scopes", "")); scope != "" {
+		q.Set("scope", scope)
+	}
+	// PKCE is on by default; honor an explicit pkce=false to omit the challenge.
+	if codeChallenge != "" && pkceEnabled(d.resolve(spec, "pkce", "")) {
+		q.Set("code_challenge", codeChallenge)
+		q.Set("code_challenge_method", "S256")
+	}
+	parsed.RawQuery = q.Encode()
+	return parsed.String(), nil
+}
+
+// RequiresConnect reports whether the spec uses the authorization_code flow,
+// which needs a one-time `cred spec connect` before it can mint.
+func (d *OAuth2Driver) RequiresConnect(spec *credential.CredSpec) bool {
+	return d.resolve(spec, "auth_method", oauth2AuthMethodClientCredentials) == oauth2AuthMethodAuthorizationCode
+}
+
+// IsConnected reports whether the spec has been connected — a refresh token or a
+// static access token has been sealed into it.
+func (d *OAuth2Driver) IsConnected(spec *credential.CredSpec) bool {
+	if spec == nil {
+		return false
+	}
+	return credential.GetString(spec.Config, "refresh_token", "") != "" ||
+		credential.GetString(spec.Config, "access_token", "") != ""
+}
+
+// postTokenRequest POSTs a form-encoded token request and decodes the response,
+// treating a body that carries an "error" field (some providers, notably GitHub,
+// report failures as HTTP 200 with an error body) as a failure.
+func (d *OAuth2Driver) postTokenRequest(ctx context.Context, tokenURL string, form url.Values) (*oauth2TokenResponse, error) {
 	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       oauth2MaxRetryAttempts,
 		MaxBodySize:       httputil.DefaultMaxBodySize,
@@ -263,10 +442,9 @@ func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *cred
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}
-
 	httpReq := httputil.HTTPRequest{
 		Method: http.MethodPost,
-		URL:    d.resolve(spec, "token_url", ""),
+		URL:    tokenURL,
 		Body:   []byte(form.Encode()),
 		Headers: map[string]string{
 			"Content-Type": "application/x-www-form-urlencoded",
@@ -276,34 +454,92 @@ func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *cred
 
 	body, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, err)
+		return nil, err
 	}
 
 	var tokenResp oauth2TokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to decode %s OAuth2 token response: %w", name, err)
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
 	}
+	if tokenResp.Error != "" {
+		if tokenResp.ErrorDescription != "" {
+			return nil, fmt.Errorf("token endpoint error %q: %s", tokenResp.Error, tokenResp.ErrorDescription)
+		}
+		return nil, fmt.Errorf("token endpoint error %q", tokenResp.Error)
+	}
+	return &tokenResp, nil
+}
 
-	if tokenResp.AccessToken == "" {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 token response missing access_token", name)
+// accessTokenRawData builds the rawData map returned to the credential parser.
+func accessTokenRawData(resp *oauth2TokenResponse) map[string]interface{} {
+	rawData := map[string]interface{}{"api_key": resp.AccessToken}
+	if resp.Scope != "" {
+		rawData["scope"] = resp.Scope
 	}
+	if resp.TokenType != "" {
+		rawData["token_type"] = resp.TokenType
+	}
+	return rawData
+}
 
-	rawData := map[string]interface{}{
-		"api_key": tokenResp.AccessToken,
+// ttlFromExpiresIn converts an expires_in (seconds) into a lease TTL (0 if absent).
+func ttlFromExpiresIn(expiresIn int) time.Duration {
+	if expiresIn > 0 {
+		return time.Duration(expiresIn) * time.Second
 	}
-	if tokenResp.Scope != "" {
-		rawData["scope"] = tokenResp.Scope
-	}
-	if tokenResp.TokenType != "" {
-		rawData["token_type"] = tokenResp.TokenType
-	}
+	return 0
+}
 
-	var ttl time.Duration
-	if tokenResp.ExpiresIn > 0 {
-		ttl = time.Duration(tokenResp.ExpiresIn) * time.Second
-	}
+// expiresAt returns an RFC3339 UTC timestamp expiresIn seconds from now.
+func expiresAt(expiresIn int) string {
+	return time.Now().Add(time.Duration(expiresIn) * time.Second).UTC().Format(time.RFC3339)
+}
 
-	return rawData, ttl, "", nil
+// normalizeOAuth2Scopes returns scopes space-separated, tolerating comma- or
+// whitespace-separated input.
+func normalizeOAuth2Scopes(raw string) string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	return strings.Join(fields, " ")
+}
+
+// tokenURL returns the source-level token endpoint. It is deliberately read from
+// the source only (not spec-overridable) so the SSRF-validated source endpoint
+// can't be bypassed by a spec-level token_url.
+func (d *OAuth2Driver) tokenURL() string {
+	return credential.GetString(d.credSource.Config, "token_url", "")
+}
+
+// staticTokenTTL returns the remaining lease for a sealed static access token, or
+// 0 (treated as non-expiring) when no access_token_expires_at is set or it is
+// already past / unparseable.
+func staticTokenTTL(spec *credential.CredSpec) time.Duration {
+	raw := credential.GetString(spec.Config, "access_token_expires_at", "")
+	if raw == "" {
+		return 0
+	}
+	exp, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return 0
+	}
+	if remaining := time.Until(exp); remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+
+// pkceEnabled reports whether PKCE should be sent, defaulting to true unless the
+// spec explicitly sets pkce=false.
+func pkceEnabled(raw string) bool {
+	if raw == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return true
+	}
+	return enabled
 }
 
 // Revoke is a no-op for OAuth2 bearer tokens — they expire naturally.

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -109,6 +110,16 @@ func TestOAuth2DriverFactory_ValidateConfig(t *testing.T) {
 			config: map[string]string{
 				"token_url": "https://auth.example.com/oauth/token",
 				"auth_url":  "https://169.254.169.254/latest/meta-data/",
+			},
+			wantErr: true,
+			errMsg:  "must not target a loopback/private/link-local address",
+		},
+		{
+			// token_url is server-fetched (the client secret is POSTed there),
+			// so it must be SSRF-guarded too.
+			name: "token_url SSRF-blocked (private address)",
+			config: map[string]string{
+				"token_url": "https://10.0.0.5/oauth/token",
 			},
 			wantErr: true,
 			errMsg:  "must not target a loopback/private/link-local address",
@@ -848,4 +859,262 @@ func TestValidateOAuth2HTTPSURL_TLSSkipVerify(t *testing.T) {
 	require.NoError(t, validateOAuth2HTTPSURL("https://auth.local/token", "token_url", true))
 	// FTP still rejected
 	require.Error(t, validateOAuth2HTTPSURL("ftp://auth.local/token", "token_url", true))
+}
+
+func TestValidateOAuth2SafeURL_SSRF(t *testing.T) {
+	// Public hostnames pass.
+	require.NoError(t, validateOAuth2SafeURL("https://github.com/login/oauth/authorize", "auth_url", false))
+	// IP literals in blocked ranges are rejected in production.
+	for _, blocked := range []string{
+		"https://127.0.0.1/x", "https://10.0.0.1/x", "https://192.168.1.1/x",
+		"https://169.254.169.254/latest/meta-data/", "https://[::1]/x",
+	} {
+		require.Error(t, validateOAuth2SafeURL(blocked, "auth_url", false), blocked)
+	}
+	// tls_skip_verify allows loopback for dev/test.
+	require.NoError(t, validateOAuth2SafeURL("https://127.0.0.1/x", "auth_url", true))
+}
+
+// =============================================================================
+// Authorization-code flow
+// =============================================================================
+
+func TestOAuth2Driver_ExchangeAuthorizationCode(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		assert.Equal(t, "the-code", r.Form.Get("code"))
+		assert.Equal(t, "http://127.0.0.1:8765/callback", r.Form.Get("redirect_uri"))
+		assert.Equal(t, "cid", r.Form.Get("client_id"))
+		assert.Equal(t, "csecret", r.Form.Get("client_secret"))
+		assert.Equal(t, "the-verifier", r.Form.Get("code_verifier"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":             "at-1",
+			"refresh_token":            "rt-1",
+			"expires_in":               28800,
+			"refresh_token_expires_in": 15897600,
+			"token_type":               "bearer",
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeOAuth2, Config: map[string]string{"token_url": server.URL}},
+		httpClient: server.Client(),
+	}
+	spec := &credential.CredSpec{
+		Name:   "gh",
+		Type:   credential.TypeOAuthBearerToken,
+		Config: map[string]string{"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret"},
+	}
+
+	sealed, err := d.ExchangeAuthorizationCode(context.Background(), spec, "the-code", "http://127.0.0.1:8765/callback", "the-verifier")
+	require.NoError(t, err)
+	assert.Equal(t, "rt-1", sealed["refresh_token"])
+	exp, perr := time.Parse(time.RFC3339, sealed["refresh_token_expires_at"])
+	require.NoError(t, perr)
+	assert.True(t, exp.After(time.Now()))
+}
+
+func TestOAuth2Driver_ExchangeAuthorizationCode_ProviderError(t *testing.T) {
+	// GitHub reports failures as HTTP 200 with an error body.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "bad_verification_code",
+			"error_description": "The code passed is incorrect or expired.",
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"client_id": "cid", "client_secret": "csecret"}}
+
+	_, err := d.ExchangeAuthorizationCode(context.Background(), spec, "bad", "http://127.0.0.1:1/cb", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad_verification_code")
+	assert.Contains(t, err.Error(), "incorrect or expired")
+}
+
+func TestOAuth2Driver_ExchangeAuthorizationCode_NoRefreshToken(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "static-at", "token_type": "bearer"})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"client_id": "cid", "client_secret": "csecret"}}
+
+	sealed, err := d.ExchangeAuthorizationCode(context.Background(), spec, "c", "http://127.0.0.1:1/cb", "")
+	require.NoError(t, err)
+	assert.Equal(t, "static-at", sealed["access_token"])
+	assert.Empty(t, sealed["refresh_token"])
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_Rotating(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		assert.Equal(t, "rt-old", r.Form.Get("refresh_token"))
+		assert.Equal(t, "cid", r.Form.Get("client_id"))
+		assert.Equal(t, "csecret", r.Form.Get("client_secret"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  "at-new",
+			"refresh_token": "rt-new", // rotated
+			"expires_in":    28800,
+			"token_type":    "bearer",
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-old",
+	}}
+
+	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "at-new", rawData["api_key"])
+	assert.Equal(t, 28800*time.Second, ttl)
+	// Rotated token is surfaced under the reserved key for the minting layer.
+	assert.Equal(t, "rt-new", rawData[credential.RawRotatedRefreshTokenKey])
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_NonRotating(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No refresh_token in the response → stable token, no write-back.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "at-1", "expires_in": 3600})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "g", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-stable",
+	}}
+
+	rawData, _, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "at-1", rawData["api_key"])
+	_, has := rawData[credential.RawRotatedRefreshTokenKey]
+	assert.False(t, has)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_NotConnected(t *testing.T) {
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": "https://example.invalid/token"}}, httpClient: http.DefaultClient}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret"}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_StaticAccessToken(t *testing.T) {
+	// No refresh_token but a sealed static access_token (no-refresh provider): no HTTP call.
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": "https://example.invalid/token"}}, httpClient: http.DefaultClient}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"auth_method": "authorization_code", "access_token": "static-token"}}
+
+	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "static-token", rawData["api_key"])
+	assert.Equal(t, time.Duration(0), ttl)
+}
+
+func TestOAuth2Driver_BuildAuthorizeURL(t *testing.T) {
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{
+		"auth_url": "https://github.com/login/oauth/authorize",
+	}}}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "scopes": "repo,read:org",
+	}}
+
+	raw, err := d.BuildAuthorizeURL(spec, "http://127.0.0.1:8765/callback", "the-state", "the-challenge")
+	require.NoError(t, err)
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "github.com", u.Host)
+	q := u.Query()
+	assert.Equal(t, "code", q.Get("response_type"))
+	assert.Equal(t, "cid", q.Get("client_id"))
+	assert.Equal(t, "http://127.0.0.1:8765/callback", q.Get("redirect_uri"))
+	assert.Equal(t, "the-state", q.Get("state"))
+	assert.Equal(t, "repo read:org", q.Get("scope")) // comma normalized to space
+	assert.Equal(t, "the-challenge", q.Get("code_challenge"))
+	assert.Equal(t, "S256", q.Get("code_challenge_method"))
+}
+
+func TestOAuth2Driver_BuildAuthorizeURL_MissingAuthURL(t *testing.T) {
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{}}}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"client_id": "cid"}}
+
+	_, err := d.BuildAuthorizeURL(spec, "http://127.0.0.1:1/cb", "s", "c")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth_url")
+}
+
+func TestOAuth2Driver_BuildAuthorizeURL_PKCEDisabled(t *testing.T) {
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{
+		"auth_url": "https://github.com/login/oauth/authorize",
+	}}}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "pkce": "false",
+	}}
+
+	raw, err := d.BuildAuthorizeURL(spec, "http://127.0.0.1:8765/callback", "s", "the-challenge")
+	require.NoError(t, err)
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	// pkce=false omits the challenge even when one is passed.
+	assert.Empty(t, u.Query().Get("code_challenge"))
+	assert.Empty(t, u.Query().Get("code_challenge_method"))
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_StaticAccessToken_Expiring(t *testing.T) {
+	exp := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": "https://example.invalid/token"}}, httpClient: http.DefaultClient}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "access_token": "static-token", "access_token_expires_at": exp,
+	}}
+
+	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "static-token", rawData["api_key"])
+	// TTL derived from access_token_expires_at (not the hardcoded 0).
+	assert.InDelta(t, (2 * time.Hour).Seconds(), ttl.Seconds(), 60)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_MissingClientCreds(t *testing.T) {
+	// A connected spec (refresh_token sealed) but no client credentials must fail
+	// fast with a clear error instead of a wasted token-endpoint round-trip.
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": "https://example.invalid/token"}}, httpClient: http.DefaultClient}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "refresh_token": "rt",
+	}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing client_id or client_secret")
+}
+
+func TestOAuth2Driver_RequiresConnect_IsConnected(t *testing.T) {
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{}}}
+
+	cc := &credential.CredSpec{Config: map[string]string{}} // default client_credentials
+	assert.False(t, d.RequiresConnect(cc))
+
+	ac := &credential.CredSpec{Config: map[string]string{"auth_method": "authorization_code"}}
+	assert.True(t, d.RequiresConnect(ac))
+	assert.False(t, d.IsConnected(ac)) // empty spec, not connected yet
+
+	withRefresh := &credential.CredSpec{Config: map[string]string{"auth_method": "authorization_code", "refresh_token": "rt"}}
+	assert.True(t, d.IsConnected(withRefresh))
+
+	withStatic := &credential.CredSpec{Config: map[string]string{"auth_method": "authorization_code", "access_token": "at"}}
+	assert.True(t, d.IsConnected(withStatic))
 }

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -202,3 +202,39 @@ type SpecRotatable interface {
 	// Returns error if cleanup fails. The RotationManager will retry with backoff.
 	CleanupSpecRotation(ctx context.Context, cleanupConfig map[string]string) error
 }
+
+// RawRotatedRefreshTokenKey is a reserved key the OAuth2 driver may set in the
+// rawData returned by MintCredential to surface a refresh token that the provider
+// rotated during a refresh. The minting layer consumes and strips it (persisting
+// the new token) before the credential is parsed, so it never reaches the
+// credential's Data map.
+const RawRotatedRefreshTokenKey = "__rotated_refresh_token"
+
+// SpecConnector is an optional interface for drivers whose specs require a
+// one-time interactive connect step (e.g. OAuth2 authorization_code) before they
+// can mint credentials. ValidateSpec skips its test-mint for a spec that requires
+// connecting but is not connected yet.
+type SpecConnector interface {
+	// RequiresConnect reports whether this spec uses a connect-gated flow.
+	RequiresConnect(spec *CredSpec) bool
+
+	// IsConnected reports whether the one-time connect has completed (e.g. a
+	// refresh token or static access token has been sealed into the spec).
+	IsConnected(spec *CredSpec) bool
+}
+
+// OAuth2Authorizer is an optional interface for drivers that support an OAuth2
+// authorization-code consent flow. The CLI captures only the authorization code
+// on a loopback redirect; the server builds the authorize URL and performs the
+// code→token exchange using the client secret it holds, then seals the returned
+// keys into the spec.
+type OAuth2Authorizer interface {
+	// BuildAuthorizeURL assembles the provider authorize URL for the given spec,
+	// loopback redirect URI, CSRF state and (optional) PKCE code challenge.
+	BuildAuthorizeURL(spec *CredSpec, redirectURI, state, codeChallenge string) (string, error)
+
+	// ExchangeAuthorizationCode exchanges an authorization code for tokens and
+	// returns the spec-config keys to seal (notably "refresh_token", or a static
+	// "access_token" for providers that do not issue refresh tokens).
+	ExchangeAuthorizationCode(ctx context.Context, spec *CredSpec, code, redirectURI, codeVerifier string) (map[string]string, error)
+}

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -47,12 +47,47 @@ func NewOAuthBearerTokenCredType() *OAuthBearerTokenCredType {
 }
 
 // ConfigSchema returns the declarative schema for OAuth bearer token spec config.
-// The spec holds only the scope — the driver mints the token dynamically.
 func (t *OAuthBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("scope").
-			Describe("OAuth2 scope to request").
+			Describe("OAuth2 scope to request (client_credentials)").
 			Example("read write"),
+
+		// OAuth2 source - authorization_code / client_credentials fields.
+		credential.StringField("auth_method").
+			OneOf("client_credentials", "authorization_code").
+			Describe("OAuth2 flow for an oauth2 source (default client_credentials)").
+			Example("authorization_code"),
+
+		credential.StringField("client_id").
+			Describe("OAuth2 client ID (per-spec for authorization_code)").
+			Example("aBcD3FgHiJkLmN0pQ"),
+
+		credential.StringField("client_secret").
+			Describe("OAuth2 client secret (per-spec for authorization_code; sealed)").
+			Example("@/path/to/client_secret"),
+
+		credential.StringField("scopes").
+			Describe("OAuth2 scopes for authorization_code (comma- or space-separated)").
+			Example("repo,read:org"),
+
+		credential.StringField("redirect_uri").
+			Describe("Pinned loopback redirect for connect, when the provider requires an exact callback match (e.g. GitHub)").
+			Example("http://127.0.0.1:8765/callback"),
+
+		credential.BoolField("pkce").
+			Describe("Send PKCE on connect (default true)").
+			Example("true"),
+
+		// Sealed by `cred spec connect`; not operator-set.
+		credential.StringField("refresh_token").
+			Describe("Sealed at connect time — not operator-set"),
+		credential.StringField("access_token").
+			Describe("Sealed at connect time for providers without refresh tokens — not operator-set"),
+		credential.StringField("refresh_token_expires_at").
+			Describe("Sealed at connect time (RFC3339) — not operator-set"),
+		credential.StringField("access_token_expires_at").
+			Describe("Sealed at connect time for an expiring static access token (RFC3339) — not operator-set"),
 
 		// Vault source - OAuth2 plugin fields
 		credential.StringField("mint_method").
@@ -113,6 +148,9 @@ func (t *OAuthBearerTokenCredType) RequiresSpecRotation() bool {
 }
 
 // SensitiveConfigFields returns spec config keys that should be masked in output.
+// For authorization_code specs these secrets live on the spec (resolved
+// spec-over-source), so they are masked here in addition to the source-level
+// masking the driver factory applies.
 func (t *OAuthBearerTokenCredType) SensitiveConfigFields() []string {
-	return nil
+	return []string{"client_secret", "refresh_token", "access_token"}
 }

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -252,7 +252,10 @@ func TestOAuthBearerTokenCredType_RequiresSpecRotation(t *testing.T) {
 
 func TestOAuthBearerTokenCredType_SensitiveConfigFields(t *testing.T) {
 	ct := NewOAuthBearerTokenCredType()
-	assert.Nil(t, ct.SensitiveConfigFields())
+	assert.ElementsMatch(t,
+		[]string{"client_secret", "refresh_token", "access_token"},
+		ct.SensitiveConfigFields(),
+	)
 }
 
 func TestOAuthBearerTokenCredType_FieldSchemas(t *testing.T) {


### PR DESCRIPTION
Add SpecConnector and OAuth2Authorizer interfaces and implement them on the
OAuth2 driver: BuildAuthorizeURL (honors pkce=false), ExchangeAuthorizationCode
(handles GitHub HTTP-200 error bodies; seals access_token_expires_at for
expiring no-refresh tokens), and mintFromRefreshToken (grant_type=refresh_token;
fails fast on missing client creds; surfaces a rotated refresh token under a
reserved rawData key for the minting layer). Share a postTokenRequest helper and
extend oauth2TokenResponse.

Harden SSRF: validate the server-fetched token_url/verify_url (not just
auth_url), and read token_url/auth_url from the source only so a spec cannot
override them.

Declare the authorization_code spec fields and mask
client_secret/refresh_token/access_token in the oauth_bearer_token type.

Not yet wired to spec creation/connect (PR3+); methods are unit-tested in
isolation.

---
Part 2/9 of the OAuth2 authorization-code series (stacked). Base: `feat/oauth2-driver-foundations`. Merge bottom-up.