### PR TITLE
feat(core): connect-gating for credential specs

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -294,8 +294,16 @@ func (s *CredentialConfigStore) GetSpec(ctx context.Context, name string) (*cred
 	return spec, nil
 }
 
+// UpdateSpecOptions controls UpdateSpec behavior.
+type UpdateSpecOptions struct {
+	// SkipVerification skips the test-mint / SpecVerifier checks during validation.
+	// Used by the connect seal and refresh-token write-back, which persist a
+	// known-good token and must not re-mint (which would consume/rotate it).
+	SkipVerification bool
+}
+
 // UpdateSpec updates an existing spec
-func (s *CredentialConfigStore) UpdateSpec(ctx context.Context, spec *credential.CredSpec) error {
+func (s *CredentialConfigStore) UpdateSpec(ctx context.Context, spec *credential.CredSpec, opts ...UpdateSpecOptions) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -309,7 +317,11 @@ func (s *CredentialConfigStore) UpdateSpec(ctx context.Context, spec *credential
 	}
 
 	// Validate spec
-	if err := s.ValidateSpec(ctx, spec); err != nil {
+	var skipVerification bool
+	if len(opts) > 0 {
+		skipVerification = opts[0].SkipVerification
+	}
+	if err := s.validateSpec(ctx, spec, skipVerification); err != nil {
 		return err
 	}
 
@@ -762,8 +774,15 @@ func (s *CredentialConfigStore) ClearNamespace(ctx context.Context) error {
 // Validation
 // ============================================================================
 
-// ValidateSpec validates a spec before creation/update
+// ValidateSpec validates a spec before creation/update.
 func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credential.CredSpec) error {
+	return s.validateSpec(ctx, spec, false)
+}
+
+// validateSpec validates a spec. When skipVerification is true the test-mint and
+// SpecVerifier checks are skipped — used by the connect seal and refresh-token
+// write-back, which already hold a known-good token and must not re-mint it.
+func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credential.CredSpec, skipVerification bool) error {
 	if spec.Name == "" {
 		return logical.ErrBadRequest("spec name cannot be empty")
 	}
@@ -791,6 +810,7 @@ func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credenti
 	}
 
 	// Validate credential type exists
+	var credType credential.Type
 	if s.core.credentialTypeRegistry != nil {
 		if !s.core.credentialTypeRegistry.HasType(spec.Type) {
 			return logical.ErrBadRequestf("unknown credential type: %s (available types: %v)",
@@ -800,8 +820,11 @@ func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credenti
 
 		// Validate Config using the credential type's validation
 		// Pass the source type (not source name) to enable source-specific validation
-		credType, err := s.core.credentialTypeRegistry.GetByName(spec.Type)
-		if err == nil {
+		var typeErr error
+		credType, typeErr = s.core.credentialTypeRegistry.GetByName(spec.Type)
+		if typeErr != nil {
+			credType = nil
+		} else {
 			if err := credType.ValidateConfig(spec.Config, source.Type); err != nil {
 				return logical.ErrBadRequestf("invalid config for type '%s': %s", spec.Type, err.Error())
 			}
@@ -809,6 +832,14 @@ func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credenti
 			// Enforce rotation_period for types that embed rotatable credentials
 			if credType.RequiresSpecRotation() && spec.RotationPeriod <= 0 {
 				return logical.ErrBadRequestf("rotation_period is required for credential type '%s' which embeds rotatable credentials", spec.Type)
+			}
+
+			// Connect-gated specs (e.g. OAuth2 authorization_code) are refreshed on
+			// use, not scheduled — reject rotation_period. This is a config rule, so
+			// it runs here rather than in the test-mint block below (which can be
+			// skipped via SkipVerification or in test mode).
+			if cg, ok := credType.(credential.ConnectGated); ok && cg.RequiresConnect(spec.Config) && spec.RotationPeriod > 0 {
+				return logical.ErrBadRequestf("rotation_period is not supported for credential type '%s' (connect-gated; tokens are refreshed on use, not on a schedule)", spec.Type)
 			}
 		}
 	}
@@ -820,7 +851,7 @@ func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credenti
 	// to test source connections at creation time.
 	// Skipped for local sources where MintCredential just echoes config values.
 	// Skip credential verification in test mode (when SkipSpecVerification is true)
-	if !s.config.SkipSpecVerification && s.core.credentialDriverRegistry != nil && source.Type != credential.SourceTypeLocal {
+	if !skipVerification && !s.config.SkipSpecVerification && s.core.credentialDriverRegistry != nil && source.Type != credential.SourceTypeLocal {
 		factory, err := s.core.credentialDriverRegistry.GetFactory(source.Type)
 		if err == nil {
 			driver, err := factory.Create(source.Config, s.logger)
@@ -832,16 +863,28 @@ func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credenti
 					Source: spec.Source,
 					Config: spec.Config,
 				}
-				if _, _, _, err := driver.MintCredential(ctx, testSpec); err != nil {
-					return logical.ErrBadRequestf("credential test failed for spec type '%s': %s", spec.Type, err.Error())
+
+				// Skip the test-mint for a connect-gated spec (e.g. OAuth2
+				// authorization_code) that isn't connected yet — it cannot mint
+				// until `cred spec connect` seals a token.
+				runTestMint := true
+				if cg, ok := credType.(credential.ConnectGated); ok &&
+					cg.RequiresConnect(spec.Config) && !cg.IsConnected(spec.Config) {
+					runTestMint = false
 				}
 
-				// Run additional verification if the driver supports it.
-				// This catches cases where MintCredential doesn't call the upstream
-				// API (e.g., GitHub PAT mode just returns the token).
-				if verifier, ok := driver.(credential.SpecVerifier); ok {
-					if err := verifier.VerifySpec(ctx, testSpec); err != nil {
-						return logical.ErrBadRequestf("credential verification failed for spec type '%s': %s", spec.Type, err.Error())
+				if runTestMint {
+					if _, _, _, err := driver.MintCredential(ctx, testSpec); err != nil {
+						return logical.ErrBadRequestf("credential test failed for spec type '%s': %s", spec.Type, err.Error())
+					}
+
+					// Run additional verification if the driver supports it.
+					// This catches cases where MintCredential doesn't call the upstream
+					// API (e.g., GitHub PAT mode just returns the token).
+					if verifier, ok := driver.(credential.SpecVerifier); ok {
+						if err := verifier.VerifySpec(ctx, testSpec); err != nil {
+							return logical.ErrBadRequestf("credential verification failed for spec type '%s': %s", spec.Type, err.Error())
+						}
 					}
 				}
 			}

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -1339,3 +1339,93 @@ func TestCredentialConfigStore_ClearNamespace_Isolation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, specs2, 1)
 }
+
+// connectGatedDriver mints into an error so tests can detect whether the
+// validation test-mint ran; connect-gating itself is a credential-type property
+// (connectGatedCredType), not a driver one.
+type connectGatedDriverFactory struct{}
+
+func (f *connectGatedDriverFactory) Type() string { return "connect_driver" }
+func (f *connectGatedDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	return &connectGatedDriver{}, nil
+}
+func (f *connectGatedDriverFactory) ValidateConfig(config map[string]string) error { return nil }
+func (f *connectGatedDriverFactory) SensitiveConfigFields() []string               { return nil }
+func (f *connectGatedDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return "connect_cred", nil
+}
+
+type connectGatedDriver struct{}
+
+func (d *connectGatedDriver) Type() string { return "connect_driver" }
+func (d *connectGatedDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	return nil, 0, "", fmt.Errorf("mint must not run for an unconnected spec")
+}
+func (d *connectGatedDriver) Revoke(ctx context.Context, leaseID string) error { return nil }
+func (d *connectGatedDriver) Cleanup(ctx context.Context) error                { return nil }
+
+// connectGatedCredType implements credential.ConnectGated: authorization_code
+// specs require connecting, and count as connected once a token is sealed.
+type connectGatedCredType struct {
+	testCredentialType
+}
+
+func (t *connectGatedCredType) RequiresConnect(config map[string]string) bool {
+	return config["auth_method"] == "authorization_code"
+}
+func (t *connectGatedCredType) IsConnected(config map[string]string) bool {
+	return config["refresh_token"] != "" || config["access_token"] != ""
+}
+
+func TestCredentialConfigStore_ValidateSpec_ConnectGating(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+	require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(&connectGatedDriverFactory{}))
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+	require.NoError(t, store.core.credentialTypeRegistry.Register(&connectGatedCredType{testCredentialType{typeName: "connect_cred"}}))
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "gh-src", Type: "connect_driver"}))
+
+	// (a) An unconnected authorization_code spec creates: the test-mint is skipped
+	// even though MintCredential would error.
+	unconnected := &credential.CredSpec{
+		Name: "gh", Type: "connect_cred", Source: "gh-src",
+		Config: map[string]string{"auth_method": "authorization_code"},
+	}
+	require.NoError(t, store.CreateSpec(ctx, unconnected),
+		"unconnected authcode spec should create with the test-mint skipped")
+
+	// (b) rotation_period is rejected for a connect-gated spec.
+	err := store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gh-rot", Type: "connect_cred", Source: "gh-src",
+		Config:         map[string]string{"auth_method": "authorization_code"},
+		RotationPeriod: time.Hour,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation_period is not supported")
+
+	// (c) A connected spec runs the test-mint (which errors with this mock) — both
+	// the refresh-token and the static access-token connected states.
+	for _, connectedCfg := range []map[string]string{
+		{"auth_method": "authorization_code", "refresh_token": "rt"},
+		{"auth_method": "authorization_code", "access_token": "static"},
+	} {
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "gh-conn-" + connectedCfg["refresh_token"] + connectedCfg["access_token"],
+			Type: "connect_cred", Source: "gh-src", Config: connectedCfg,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential test failed")
+	}
+
+	// (d) Updating the unconnected spec to a connected config runs the test-mint
+	// (fails) — unless SkipVerification is set, which the connect seal / write-back use.
+	unconnected.Config["refresh_token"] = "rt"
+	err = store.UpdateSpec(ctx, unconnected)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential test failed")
+
+	require.NoError(t, store.UpdateSpec(ctx, unconnected, UpdateSpecOptions{SkipVerification: true}),
+		"UpdateSpec with SkipVerification should skip the test-mint")
+}

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -43,7 +43,6 @@ const (
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*OAuth2Driver)(nil)
 var _ credential.SpecVerifier = (*OAuth2Driver)(nil)
-var _ credential.SpecConnector = (*OAuth2Driver)(nil)
 var _ credential.OAuth2Authorizer = (*OAuth2Driver)(nil)
 
 // OAuth2Driver exchanges OAuth2 credentials for bearer tokens.
@@ -413,22 +412,6 @@ func (d *OAuth2Driver) BuildAuthorizeURL(spec *credential.CredSpec, redirectURI,
 	}
 	parsed.RawQuery = q.Encode()
 	return parsed.String(), nil
-}
-
-// RequiresConnect reports whether the spec uses the authorization_code flow,
-// which needs a one-time `cred spec connect` before it can mint.
-func (d *OAuth2Driver) RequiresConnect(spec *credential.CredSpec) bool {
-	return d.resolve(spec, "auth_method", oauth2AuthMethodClientCredentials) == oauth2AuthMethodAuthorizationCode
-}
-
-// IsConnected reports whether the spec has been connected — a refresh token or a
-// static access token has been sealed into it.
-func (d *OAuth2Driver) IsConnected(spec *credential.CredSpec) bool {
-	if spec == nil {
-		return false
-	}
-	return credential.GetString(spec.Config, "refresh_token", "") != "" ||
-		credential.GetString(spec.Config, "access_token", "") != ""
 }
 
 // postTokenRequest POSTs a form-encoded token request and decodes the response,

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -1102,19 +1102,5 @@ func TestOAuth2Driver_MintFromRefreshToken_MissingClientCreds(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing client_id or client_secret")
 }
 
-func TestOAuth2Driver_RequiresConnect_IsConnected(t *testing.T) {
-	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{}}}
-
-	cc := &credential.CredSpec{Config: map[string]string{}} // default client_credentials
-	assert.False(t, d.RequiresConnect(cc))
-
-	ac := &credential.CredSpec{Config: map[string]string{"auth_method": "authorization_code"}}
-	assert.True(t, d.RequiresConnect(ac))
-	assert.False(t, d.IsConnected(ac)) // empty spec, not connected yet
-
-	withRefresh := &credential.CredSpec{Config: map[string]string{"auth_method": "authorization_code", "refresh_token": "rt"}}
-	assert.True(t, d.IsConnected(withRefresh))
-
-	withStatic := &credential.CredSpec{Config: map[string]string{"auth_method": "authorization_code", "access_token": "at"}}
-	assert.True(t, d.IsConnected(withStatic))
-}
+// (connect-gating moved to the oauth_bearer_token credential type; see
+// credential/types/oauth_bearer_token_test.go)

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -210,19 +210,6 @@ type SpecRotatable interface {
 // credential's Data map.
 const RawRotatedRefreshTokenKey = "__rotated_refresh_token"
 
-// SpecConnector is an optional interface for drivers whose specs require a
-// one-time interactive connect step (e.g. OAuth2 authorization_code) before they
-// can mint credentials. ValidateSpec skips its test-mint for a spec that requires
-// connecting but is not connected yet.
-type SpecConnector interface {
-	// RequiresConnect reports whether this spec uses a connect-gated flow.
-	RequiresConnect(spec *CredSpec) bool
-
-	// IsConnected reports whether the one-time connect has completed (e.g. a
-	// refresh token or static access token has been sealed into the spec).
-	IsConnected(spec *CredSpec) bool
-}
-
 // OAuth2Authorizer is an optional interface for drivers that support an OAuth2
 // authorization-code consent flow. The CLI captures only the authorization code
 // on a loopback redirect; the server builds the authorize URL and performs the

--- a/credential/type.go
+++ b/credential/type.go
@@ -90,3 +90,18 @@ type Type interface {
 	// Used for masking sensitive fields in responses
 	FieldSchemas() map[string]*CredentialFieldSchema
 }
+
+// ConnectGated is an optional interface a credential Type implements when some of
+// its specs require a one-time interactive `cred spec connect` step before they
+// can mint (e.g. OAuth2 authorization_code). Connect-gating is derived from the
+// spec config, so it is modeled on the type — which owns config semantics —
+// rather than on the driver, mirroring RequiresSpecRotation. ValidateSpec rejects
+// rotation_period for a connect-gated spec and skips its test-mint until connected.
+type ConnectGated interface {
+	// RequiresConnect reports whether this spec config uses a connect-gated flow.
+	RequiresConnect(config map[string]string) bool
+
+	// IsConnected reports whether the one-time connect has completed for this spec
+	// config (e.g. a refresh token or static access token has been sealed).
+	IsConnected(config map[string]string) bool
+}

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -154,3 +154,18 @@ func (t *OAuthBearerTokenCredType) RequiresSpecRotation() bool {
 func (t *OAuthBearerTokenCredType) SensitiveConfigFields() []string {
 	return []string{"client_secret", "refresh_token", "access_token"}
 }
+
+// Compile-time assertion that the type is connect-gated for authorization_code.
+var _ credential.ConnectGated = (*OAuthBearerTokenCredType)(nil)
+
+// RequiresConnect reports whether the spec uses the authorization_code flow, which
+// needs a one-time `cred spec connect` before it can mint.
+func (t *OAuthBearerTokenCredType) RequiresConnect(config map[string]string) bool {
+	return config["auth_method"] == "authorization_code"
+}
+
+// IsConnected reports whether the spec has been connected — a refresh token or a
+// static access token has been sealed into it.
+func (t *OAuthBearerTokenCredType) IsConnected(config map[string]string) bool {
+	return config["refresh_token"] != "" || config["access_token"] != ""
+}

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -258,6 +258,23 @@ func TestOAuthBearerTokenCredType_SensitiveConfigFields(t *testing.T) {
 	)
 }
 
+func TestOAuthBearerTokenCredType_ConnectGating(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+
+	// client_credentials (default) is not connect-gated.
+	assert.False(t, ct.RequiresConnect(map[string]string{}))
+	assert.False(t, ct.RequiresConnect(map[string]string{"auth_method": "client_credentials"}))
+
+	// authorization_code is connect-gated.
+	ac := map[string]string{"auth_method": "authorization_code"}
+	assert.True(t, ct.RequiresConnect(ac))
+	assert.False(t, ct.IsConnected(ac)) // no token sealed yet
+
+	// Connected once a refresh token or static access token is sealed.
+	assert.True(t, ct.IsConnected(map[string]string{"auth_method": "authorization_code", "refresh_token": "rt"}))
+	assert.True(t, ct.IsConnected(map[string]string{"auth_method": "authorization_code", "access_token": "at"}))
+}
+
 func TestOAuthBearerTokenCredType_FieldSchemas(t *testing.T) {
 	ct := NewOAuthBearerTokenCredType()
 	schemas := ct.FieldSchemas()


### PR DESCRIPTION
Add an optional credential.ConnectGated type interface (RequiresConnect/
IsConnected, config-derived) implemented by the oauth_bearer_token type, and use
it in ValidateSpec to (a) reject rotation_period for connect-gated specs
(authorization_code) and (b) skip the test-mint until a spec is connected — so
`cred spec create` succeeds for an empty authorization_code spec. Add
UpdateSpecOptions{SkipVerification} (variadic UpdateSpec) for the connect seal /
write-back paths.

Gating lives on the credential type (like RequiresSpecRotation) rather than the
driver, so the rotation_period rule runs as a config check regardless of the
verification path. The driver-level SpecConnector from the previous commit is
removed.

---
Part 3/9 of the OAuth2 authorization-code series (stacked). Base: `feat/oauth2-authcode-driver`. Merge bottom-up.