### PR TITLE
feat(core,api): add OAuth2 connect endpoints for the authorization-code flow

### DIFF
--- a/api/sys_credential_specs.go
+++ b/api/sys_credential_specs.go
@@ -333,3 +333,123 @@ func (c *Sys) DeleteCredentialSpecWithContext(ctx context.Context, name string) 
 
 	return nil
 }
+
+// AuthorizeCredentialSpecInput is the input for building a connect authorize URL.
+type AuthorizeCredentialSpecInput struct {
+	RedirectURI   string `json:"redirect_uri"`
+	State         string `json:"state,omitempty"`
+	CodeChallenge string `json:"code_challenge,omitempty"`
+}
+
+// AuthorizeCredentialSpecOutput carries the provider authorize URL.
+type AuthorizeCredentialSpecOutput struct {
+	Name         string `json:"name"`
+	AuthorizeURL string `json:"authorize_url"`
+}
+
+// ConnectCredentialSpecInput is the input for completing the connect flow.
+type ConnectCredentialSpecInput struct {
+	Code         string `json:"code"`
+	RedirectURI  string `json:"redirect_uri"`
+	CodeVerifier string `json:"code_verifier,omitempty"`
+}
+
+// ConnectCredentialSpecOutput carries the connect result.
+type ConnectCredentialSpecOutput struct {
+	Name        string `json:"name"`
+	Connected   bool   `json:"connected"`
+	Reconnected bool   `json:"reconnected"`
+	Message     string `json:"message"`
+}
+
+// AuthorizeCredentialSpec builds the provider authorize URL for a spec's connect flow.
+func (c *Sys) AuthorizeCredentialSpec(name string, input *AuthorizeCredentialSpecInput) (*AuthorizeCredentialSpecOutput, error) {
+	return c.AuthorizeCredentialSpecWithContext(context.Background(), name, input)
+}
+
+// AuthorizeCredentialSpecWithContext builds the authorize URL with context.
+func (c *Sys) AuthorizeCredentialSpecWithContext(ctx context.Context, name string, input *AuthorizeCredentialSpecInput) (*AuthorizeCredentialSpecOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	if input == nil {
+		return nil, errors.New("input cannot be nil")
+	}
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/cred/specs/%s/authorize", name))
+	if err := r.SetJSONBody(input); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	resource, err := ParseResource(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resource == nil || resource.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	output := &AuthorizeCredentialSpecOutput{}
+	if v, ok := resource.Data["name"].(string); ok {
+		output.Name = v
+	}
+	if v, ok := resource.Data["authorize_url"].(string); ok {
+		output.AuthorizeURL = v
+	}
+	return output, nil
+}
+
+// ConnectCredentialSpec completes the connect flow by exchanging the authorization code.
+func (c *Sys) ConnectCredentialSpec(name string, input *ConnectCredentialSpecInput) (*ConnectCredentialSpecOutput, error) {
+	return c.ConnectCredentialSpecWithContext(context.Background(), name, input)
+}
+
+// ConnectCredentialSpecWithContext completes the connect flow with context.
+func (c *Sys) ConnectCredentialSpecWithContext(ctx context.Context, name string, input *ConnectCredentialSpecInput) (*ConnectCredentialSpecOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	if input == nil {
+		return nil, errors.New("input cannot be nil")
+	}
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/cred/specs/%s/connect", name))
+	if err := r.SetJSONBody(input); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	resource, err := ParseResource(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resource == nil || resource.Data == nil {
+		return nil, errors.New("data from server response is empty")
+	}
+
+	output := &ConnectCredentialSpecOutput{}
+	if v, ok := resource.Data["name"].(string); ok {
+		output.Name = v
+	}
+	if v, ok := resource.Data["connected"].(bool); ok {
+		output.Connected = v
+	}
+	if v, ok := resource.Data["reconnected"].(bool); ok {
+		output.Reconnected = v
+	}
+	if v, ok := resource.Data["message"].(string); ok {
+		output.Message = v
+	}
+	return output, nil
+}

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
@@ -143,6 +144,41 @@ func (b *SystemBackend) pathCredentials() []*framework.Path {
 			},
 			HelpSynopsis:    "List credential specs",
 			HelpDescription: "List all credential specs in the current namespace.",
+		},
+		// OAuth2 authorization-code connect flow (stateless two-call handshake).
+		{
+			Pattern: "cred/specs/" + framework.GenericNameRegex("name") + "/authorize",
+			Fields: map[string]*framework.FieldSchema{
+				"name":           {Type: framework.TypeString, Required: true},
+				"redirect_uri":   {Type: framework.TypeString, Required: true},
+				"state":          {Type: framework.TypeString},
+				"code_challenge": {Type: framework.TypeString},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.handleCredentialSpecAuthorize,
+					Summary:  "Build the OAuth2 authorize URL for a spec's connect flow",
+				},
+			},
+			HelpSynopsis:    "Build the authorize URL for cred spec connect",
+			HelpDescription: "Returns the provider authorize URL. The server holds no state between this call and /connect; the CLI supplies state and the PKCE code_challenge.",
+		},
+		{
+			Pattern: "cred/specs/" + framework.GenericNameRegex("name") + "/connect",
+			Fields: map[string]*framework.FieldSchema{
+				"name":          {Type: framework.TypeString, Required: true},
+				"code":          {Type: framework.TypeString, Required: true},
+				"redirect_uri":  {Type: framework.TypeString, Required: true},
+				"code_verifier": {Type: framework.TypeString},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.handleCredentialSpecConnect,
+					Summary:  "Exchange an authorization code and seal the credential",
+				},
+			},
+			HelpSynopsis:    "Complete cred spec connect by exchanging the authorization code",
+			HelpDescription: "Exchanges the authorization code for tokens using the client secret the server holds, then seals the result into the spec.",
 		},
 	}
 }
@@ -599,7 +635,14 @@ func (b *SystemBackend) handleCredentialSpecUpdate(ctx context.Context, req *log
 	}
 
 	// Update via credential config store
-	if err := b.core.credConfigStore.UpdateSpec(ctx, updatedSpec); err != nil {
+	// For a connected connect-gated spec (e.g. OAuth2 authorization_code), skip the
+	// validation test-mint: it would consume/rotate the sealed refresh token on an
+	// unrelated edit. Re-run `cred spec connect` to re-verify.
+	var opts []UpdateSpecOptions
+	if b.specRequiresConnect(updatedSpec) && b.specIsConnected(updatedSpec) {
+		opts = append(opts, UpdateSpecOptions{SkipVerification: true})
+	}
+	if err := b.core.credConfigStore.UpdateSpec(ctx, updatedSpec, opts...); err != nil {
 		return logical.ErrorResponse(err), nil
 	}
 
@@ -607,6 +650,177 @@ func (b *SystemBackend) handleCredentialSpecUpdate(ctx context.Context, req *log
 		"name":    updatedSpec.Name,
 		"message": fmt.Sprintf("Successfully updated credential spec %s", name),
 	}), nil
+}
+
+// handleCredentialSpecAuthorize handles POST /sys/cred/specs/{name}/authorize.
+// It returns the provider authorize URL for the spec's OAuth2 connect flow.
+func (b *SystemBackend) handleCredentialSpecAuthorize(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	redirectURI := d.Get("redirect_uri").(string)
+	state := d.Get("state").(string)
+	codeChallenge := d.Get("code_challenge").(string)
+
+	spec, authorizer, errResp := b.oauth2SpecAuthorizer(ctx, name)
+	if errResp != nil {
+		return errResp, nil
+	}
+	if err := validateConnectRedirectURI(spec, redirectURI); err != nil {
+		return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+	}
+
+	authorizeURL, err := authorizer.BuildAuthorizeURL(spec, redirectURI, state, codeChallenge)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+	}
+
+	return b.respondSuccess(map[string]any{
+		"name":          name,
+		"authorize_url": authorizeURL,
+	}), nil
+}
+
+// handleCredentialSpecConnect handles POST /sys/cred/specs/{name}/connect. It
+// exchanges the authorization code (using the client secret the server holds) and
+// seals the returned tokens into the spec. Re-runnable to re-authorize.
+func (b *SystemBackend) handleCredentialSpecConnect(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	code := d.Get("code").(string)
+	redirectURI := d.Get("redirect_uri").(string)
+	codeVerifier := d.Get("code_verifier").(string)
+
+	if code == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("code is required")), nil
+	}
+
+	spec, authorizer, errResp := b.oauth2SpecAuthorizer(ctx, name)
+	if errResp != nil {
+		return errResp, nil
+	}
+	if err := validateConnectRedirectURI(spec, redirectURI); err != nil {
+		return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+	}
+
+	reconnected := b.specIsConnected(spec)
+
+	sealed, err := authorizer.ExchangeAuthorizationCode(ctx, spec, code, redirectURI, codeVerifier)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+	}
+
+	// Seal the returned keys into a copy of the spec config.
+	updated := &credential.CredSpec{
+		Name:           spec.Name,
+		Type:           spec.Type,
+		Source:         spec.Source,
+		MinTTL:         spec.MinTTL,
+		MaxTTL:         spec.MaxTTL,
+		RotationPeriod: spec.RotationPeriod,
+		Config:         make(map[string]string, len(spec.Config)+len(sealed)),
+	}
+	for k, v := range spec.Config {
+		updated.Config[k] = v
+	}
+	for k, v := range sealed {
+		updated.Config[k] = v
+	}
+
+	// Skip verification: the exchange is itself the verification, and re-minting
+	// would consume/rotate the just-sealed refresh token.
+	if err := b.core.credConfigStore.UpdateSpec(ctx, updated, UpdateSpecOptions{SkipVerification: true}); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+
+	msg := fmt.Sprintf("Successfully connected credential spec %s", name)
+	if reconnected {
+		msg = fmt.Sprintf("Successfully re-connected credential spec %s (replaced the existing authorization)", name)
+	}
+	return b.respondSuccess(map[string]any{
+		"name":        name,
+		"connected":   true,
+		"reconnected": reconnected,
+		"message":     msg,
+	}), nil
+}
+
+// oauth2SpecAuthorizer loads a connect-gated spec and its OAuth2Authorizer driver,
+// returning an error response if the spec is missing, isn't connect-gated, or the
+// source driver doesn't support the authorization-code flow.
+func (b *SystemBackend) oauth2SpecAuthorizer(ctx context.Context, name string) (*credential.CredSpec, credential.OAuth2Authorizer, *logical.Response) {
+	spec, err := b.core.credConfigStore.GetSpec(ctx, name)
+	if err != nil {
+		if errors.Is(err, ErrSpecNotFound) {
+			return nil, nil, logical.ErrorResponse(logical.ErrNotFoundf("credential spec %q not found", name))
+		}
+		return nil, nil, logical.ErrorResponse(err)
+	}
+	if !b.specRequiresConnect(spec) {
+		return nil, nil, logical.ErrorResponse(logical.ErrBadRequestf("credential spec %q does not use an interactive connect flow", name))
+	}
+	driver, err := b.core.credentialManager.GetOrCreateDriver(ctx, spec.Source)
+	if err != nil {
+		return nil, nil, logical.ErrorResponse(err)
+	}
+	authorizer, ok := driver.(credential.OAuth2Authorizer)
+	if !ok {
+		return nil, nil, logical.ErrorResponse(logical.ErrBadRequestf("source %q does not support the OAuth2 authorization-code flow", spec.Source))
+	}
+	return spec, authorizer, nil
+}
+
+// specRequiresConnect / specIsConnected query the credential type's optional
+// ConnectGated interface.
+func (b *SystemBackend) specRequiresConnect(spec *credential.CredSpec) bool {
+	if cg := b.connectGatedType(spec.Type); cg != nil {
+		return cg.RequiresConnect(spec.Config)
+	}
+	return false
+}
+
+func (b *SystemBackend) specIsConnected(spec *credential.CredSpec) bool {
+	if cg := b.connectGatedType(spec.Type); cg != nil {
+		return cg.IsConnected(spec.Config)
+	}
+	return false
+}
+
+func (b *SystemBackend) connectGatedType(specType string) credential.ConnectGated {
+	if b.core.credentialTypeRegistry == nil {
+		return nil
+	}
+	ct, err := b.core.credentialTypeRegistry.GetByName(specType)
+	if err != nil {
+		return nil
+	}
+	cg, _ := ct.(credential.ConnectGated)
+	return cg
+}
+
+// validateConnectRedirectURI enforces the loopback redirect: if the spec pins a
+// redirect_uri, require an exact match; otherwise require a 127.0.0.1/::1 loopback
+// URL (any port — the ephemeral case).
+func validateConnectRedirectURI(spec *credential.CredSpec, redirectURI string) error {
+	if redirectURI == "" {
+		return fmt.Errorf("redirect_uri is required")
+	}
+	if pinned := spec.Config["redirect_uri"]; pinned != "" {
+		if redirectURI != pinned {
+			return fmt.Errorf("redirect_uri %q does not match the spec's pinned redirect_uri", redirectURI)
+		}
+		return nil
+	}
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		return fmt.Errorf("invalid redirect_uri: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("redirect_uri must use the http or https scheme")
+	}
+	switch u.Hostname() {
+	case "127.0.0.1", "::1":
+		return nil
+	default:
+		return fmt.Errorf("redirect_uri must be a 127.0.0.1 or ::1 loopback address")
+	}
 }
 
 // handleCredentialSpecDelete handles DELETE /sys/cred/specs/{name}

--- a/core/sys_credentials_test.go
+++ b/core/sys_credentials_test.go
@@ -2,7 +2,10 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stephnangue/warden/framework"
@@ -40,7 +43,7 @@ func TestSystemBackend_PathCredentials(t *testing.T) {
 	backend, _, _ := setupTestSystemBackend(t)
 
 	paths := backend.pathCredentials()
-	require.Len(t, paths, 4) // sources CRUD, sources list, specs CRUD, specs list
+	require.Len(t, paths, 6) // sources CRUD, sources list, specs CRUD, specs list, specs authorize, specs connect
 
 	// Check sources/{name} path
 	assert.Equal(t, "cred/sources/"+framework.GenericNameRegex("name"), paths[0].Pattern)
@@ -53,6 +56,10 @@ func TestSystemBackend_PathCredentials(t *testing.T) {
 
 	// Check specs/ list path
 	assert.Equal(t, "cred/specs/?$", paths[3].Pattern)
+
+	// Check specs connect-flow paths
+	assert.Equal(t, "cred/specs/"+framework.GenericNameRegex("name")+"/authorize", paths[4].Pattern)
+	assert.Equal(t, "cred/specs/"+framework.GenericNameRegex("name")+"/connect", paths[5].Pattern)
 }
 
 func TestSystemBackend_HandleCredentialSourceCreate(t *testing.T) {
@@ -522,4 +529,196 @@ func TestSystemBackend_HandleCredentialSpecList(t *testing.T) {
 	specs, ok := resp.Data["specs"].([]map[string]any)
 	require.True(t, ok)
 	assert.Len(t, specs, 3)
+}
+
+// =============================================================================
+// OAuth2 connect endpoints
+// =============================================================================
+
+// createOAuth2Source creates an oauth2 source with the given auth/token URLs.
+func createOAuth2Source(t *testing.T, backend *SystemBackend, ctx context.Context, name, authURL, tokenURL string, tlsSkipVerify bool) {
+	t.Helper()
+	cfg := map[string]interface{}{"auth_url": authURL, "token_url": tokenURL}
+	if tlsSkipVerify {
+		cfg["tls_skip_verify"] = "true"
+	}
+	raw := map[string]interface{}{"name": name, "type": "oauth2", "config": cfg, "rotation_period": 0}
+	schema := backend.pathCredentials()[0].Fields
+	resp, err := backend.handleCredentialSourceCreate(ctx, createTestRequest(logical.CreateOperation, "cred/sources/"+name, raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "source create: %+v", resp.Data)
+}
+
+// createAuthCodeSpec creates an empty authorization_code spec.
+func createAuthCodeSpec(t *testing.T, backend *SystemBackend, ctx context.Context, name, source string, extraConfig map[string]string) {
+	t.Helper()
+	cfg := map[string]interface{}{"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret"}
+	for k, v := range extraConfig {
+		cfg[k] = v
+	}
+	raw := map[string]interface{}{"name": name, "type": "oauth_bearer_token", "source": source, "config": cfg}
+	schema := backend.pathCredentials()[2].Fields
+	resp, err := backend.handleCredentialSpecCreate(ctx, createTestRequest(logical.CreateOperation, "cred/specs/"+name, raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "spec create: %+v", resp.Data)
+}
+
+func TestSystemBackend_HandleCredentialSpecAuthorize(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "gh-src", "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token", false)
+	createAuthCodeSpec(t, backend, ctx, "gh", "gh-src", map[string]string{"scopes": "repo,read:org"})
+
+	schema := backend.pathCredentials()[4].Fields // .../authorize
+	raw := map[string]interface{}{
+		"name":           "gh",
+		"redirect_uri":   "http://127.0.0.1:8765/callback",
+		"state":          "the-state",
+		"code_challenge": "the-challenge",
+	}
+	resp, err := backend.handleCredentialSpecAuthorize(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/authorize", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Err, "authorize error: %+v", resp.Data)
+
+	authorizeURL, _ := resp.Data["authorize_url"].(string)
+	u, err := url.Parse(authorizeURL)
+	require.NoError(t, err)
+	assert.Equal(t, "github.com", u.Host)
+	q := u.Query()
+	assert.Equal(t, "code", q.Get("response_type"))
+	assert.Equal(t, "cid", q.Get("client_id"))
+	assert.Equal(t, "http://127.0.0.1:8765/callback", q.Get("redirect_uri"))
+	assert.Equal(t, "the-state", q.Get("state"))
+	assert.Equal(t, "repo read:org", q.Get("scope"))
+	assert.Equal(t, "the-challenge", q.Get("code_challenge"))
+}
+
+func TestSystemBackend_HandleCredentialSpecAuthorize_NotConnectGated(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "cc-src", "https://idp/authorize", "https://idp/token", false)
+	// A client_credentials spec is not connect-gated.
+	raw := map[string]interface{}{"name": "cc", "type": "oauth_bearer_token", "source": "cc-src", "config": map[string]interface{}{"client_id": "x", "client_secret": "y"}}
+	createResp, err := backend.handleCredentialSpecCreate(ctx, createTestRequest(logical.CreateOperation, "cred/specs/cc", raw), createFieldData(backend.pathCredentials()[2].Fields, raw))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode, "%+v", createResp.Data)
+
+	schema := backend.pathCredentials()[4].Fields
+	areq := map[string]interface{}{"name": "cc", "redirect_uri": "http://127.0.0.1:1/callback"}
+	resp, err := backend.handleCredentialSpecAuthorize(ctx, createTestRequest(logical.CreateOperation, "cred/specs/cc/authorize", areq), createFieldData(schema, areq))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "does not use an interactive connect flow")
+}
+
+func TestSystemBackend_HandleCredentialSpecAuthorize_BadRedirectURI(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "gh-src", "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token", false)
+	createAuthCodeSpec(t, backend, ctx, "gh", "gh-src", nil)
+
+	schema := backend.pathCredentials()[4].Fields
+	raw := map[string]interface{}{"name": "gh", "redirect_uri": "https://evil.example.com/callback"} // not loopback
+	resp, err := backend.handleCredentialSpecAuthorize(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/authorize", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "loopback")
+}
+
+func TestSystemBackend_HandleCredentialSpecConnect(t *testing.T) {
+	// Mock token endpoint returns a refresh token.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		assert.Equal(t, "the-code", r.Form.Get("code"))
+		assert.Equal(t, "csecret", r.Form.Get("client_secret")) // server holds the secret
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "at", "refresh_token": "rt-sealed", "expires_in": 28800})
+	}))
+	defer server.Close()
+
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "gh-src", "https://github.com/login/oauth/authorize", server.URL, true)
+	createAuthCodeSpec(t, backend, ctx, "gh", "gh-src", nil)
+
+	schema := backend.pathCredentials()[5].Fields // .../connect
+	raw := map[string]interface{}{
+		"name":          "gh",
+		"code":          "the-code",
+		"redirect_uri":  "http://127.0.0.1:8765/callback",
+		"code_verifier": "the-verifier",
+	}
+	resp, err := backend.handleCredentialSpecConnect(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/connect", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "connect error: %+v", resp.Data)
+	assert.Equal(t, true, resp.Data["connected"])
+	assert.Equal(t, false, resp.Data["reconnected"])
+
+	// The refresh token is sealed into the spec.
+	spec, err := backend.core.credConfigStore.GetSpec(ctx, "gh")
+	require.NoError(t, err)
+	assert.Equal(t, "rt-sealed", spec.Config["refresh_token"])
+
+	// Re-running reports reconnected=true.
+	resp2, err := backend.handleCredentialSpecConnect(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/connect", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Nil(t, resp2.Err)
+	assert.Equal(t, true, resp2.Data["reconnected"])
+}
+
+func TestSystemBackend_HandleCredentialSpecConnect_MissingCode(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "gh-src", "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token", false)
+	createAuthCodeSpec(t, backend, ctx, "gh", "gh-src", nil)
+
+	schema := backend.pathCredentials()[5].Fields
+	raw := map[string]interface{}{"name": "gh", "redirect_uri": "http://127.0.0.1:8765/callback"} // no code
+	resp, err := backend.handleCredentialSpecConnect(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/connect", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "code is required")
+}
+
+func TestSystemBackend_HandleCredentialSpecConnect_ExchangeError(t *testing.T) {
+	// Provider rejects the code (GitHub-style HTTP 200 with an error body).
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "bad_verification_code", "error_description": "The code passed is incorrect or expired."})
+	}))
+	defer server.Close()
+
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "gh-src", "https://github.com/login/oauth/authorize", server.URL, true)
+	createAuthCodeSpec(t, backend, ctx, "gh", "gh-src", nil)
+
+	schema := backend.pathCredentials()[5].Fields
+	raw := map[string]interface{}{"name": "gh", "code": "stale-code", "redirect_uri": "http://127.0.0.1:8765/callback"}
+	resp, err := backend.handleCredentialSpecConnect(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/connect", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err, "exchange failure must surface as an error response")
+
+	// The spec must NOT be marked connected after a failed exchange.
+	spec, err := backend.core.credConfigStore.GetSpec(ctx, "gh")
+	require.NoError(t, err)
+	assert.Empty(t, spec.Config["refresh_token"])
+}
+
+func TestSystemBackend_HandleCredentialSpecAuthorize_PinnedRedirectURI(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "gh-src", "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token", false)
+	// Pin a fixed loopback redirect_uri on the spec.
+	createAuthCodeSpec(t, backend, ctx, "gh", "gh-src", map[string]string{"redirect_uri": "http://127.0.0.1:8765/callback"})
+
+	schema := backend.pathCredentials()[4].Fields
+
+	// Matching redirect_uri is accepted.
+	ok := map[string]interface{}{"name": "gh", "redirect_uri": "http://127.0.0.1:8765/callback", "state": "s"}
+	resp, err := backend.handleCredentialSpecAuthorize(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/authorize", ok), createFieldData(schema, ok))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "pinned match must succeed: %+v", resp.Data)
+
+	// A different loopback port is rejected even though it is loopback.
+	bad := map[string]interface{}{"name": "gh", "redirect_uri": "http://127.0.0.1:9999/callback", "state": "s"}
+	resp, err = backend.handleCredentialSpecAuthorize(ctx, createTestRequest(logical.CreateOperation, "cred/specs/gh/authorize", bad), createFieldData(schema, bad))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "does not match")
 }

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -323,7 +323,7 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 	}
 
 	rawData := accessTokenRawData(tokenResp)
-	// Surface a rotated refresh token for the minting layer to persist (§5).
+	// Surface a rotated refresh token for the minting layer to persist.
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		rawData[credential.RawRotatedRefreshTokenKey] = tokenResp.RefreshToken
 	}


### PR DESCRIPTION
Add two stateless server endpoints that let an operator complete the OAuth2
authorization-code consent for a credential spec:

- cred/specs/{name}/authorize builds the provider authorize URL (the CLI
  supplies redirect_uri, state and the PKCE challenge; the server stores
  nothing between calls).
- cred/specs/{name}/connect exchanges the authorization code using the client
  secret the server holds, then seals the returned tokens into the spec via a
  verification-skipped update (the exchange is itself the verification, and
  re-minting would consume the just-sealed refresh token). It reports whether
  the spec was already connected so the caller can warn before replacing a live
  authorization.

The update handler now skips the validation test-mint for a connected
connect-gated spec, so editing an unrelated field no longer consumes/rotates
the sealed refresh token.

redirect_uri is validated against the spec's pinned value (exact match) or,
when unpinned, restricted to an http/https 127.0.0.1/::1 loopback address. The
connect handler rejects an empty code before contacting the provider.

Add AuthorizeCredentialSpec/ConnectCredentialSpec API client methods.

---
Part 4/9 of the OAuth2 authorization-code series (stacked). Base: `feat/oauth2-spec-connect-gating`. Merge bottom-up.