### PR TITLE
feat(credential): write back rotated OAuth2 refresh tokens

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -302,6 +302,26 @@ type UpdateSpecOptions struct {
 	SkipVerification bool
 }
 
+// PersistRotatedSpec persists a spec without re-running verification, satisfying
+// credential.ConfigStoreAccessor for the refresh-token write-back. Verification
+// is skipped because re-minting would consume the just-rotated refresh token.
+func (s *CredentialConfigStore) PersistRotatedSpec(ctx context.Context, spec *credential.CredSpec) error {
+	return s.UpdateSpec(ctx, spec, UpdateSpecOptions{SkipVerification: true})
+}
+
+// ReloadSpec evicts the node-local cache entry for a spec and re-reads it,
+// forcing a load from shared storage. The refresh-token write-back uses this on
+// a rejection so a token another node rotated and persisted is actually seen
+// (the spec cache has no cross-node invalidation).
+func (s *CredentialConfigStore) ReloadSpec(ctx context.Context, name string) (*credential.CredSpec, error) {
+	ns, err := s.getNamespaceFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.specsByID.Del(s.buildSpecCacheKey(ns.UUID, name))
+	return s.GetSpec(ctx, name)
+}
+
 // UpdateSpec updates an existing spec
 func (s *CredentialConfigStore) UpdateSpec(ctx context.Context, spec *credential.CredSpec, opts ...UpdateSpecOptions) error {
 	s.mu.RLock()

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -575,6 +575,15 @@ func (b *SystemBackend) handleCredentialSpecUpdate(ctx context.Context, req *log
 
 	b.logger.Info("updating credential spec", logger.String("name", name))
 
+	// Serialize the read-modify-write against a concurrent refresh-token
+	// write-back (or /connect seal) for the same spec, so an edit can't clobber
+	// a freshly rotated refresh_token. Same per-spec lock the minting layer uses.
+	unlock, errResp := b.lockSpec(ctx, name)
+	if errResp != nil {
+		return errResp, nil
+	}
+	defer unlock()
+
 	// Get existing spec
 	spec, err := b.core.credConfigStore.GetSpec(ctx, name)
 	if err != nil {
@@ -693,6 +702,15 @@ func (b *SystemBackend) handleCredentialSpecConnect(ctx context.Context, req *lo
 		return logical.ErrorResponse(logical.ErrBadRequest("code is required")), nil
 	}
 
+	// Serialize the seal against a concurrent refresh-token write-back for the
+	// same spec, so a re-connect can't clobber an in-flight rotation (and vice
+	// versa). Same per-spec lock the minting layer uses; keyed by ns.UUID.
+	unlock, errResp := b.lockSpec(ctx, name)
+	if errResp != nil {
+		return errResp, nil
+	}
+	defer unlock()
+
 	spec, authorizer, errResp := b.oauth2SpecAuthorizer(ctx, name)
 	if errResp != nil {
 		return errResp, nil
@@ -741,6 +759,25 @@ func (b *SystemBackend) handleCredentialSpecConnect(ctx context.Context, req *lo
 		"reconnected": reconnected,
 		"message":     msg,
 	}), nil
+}
+
+// lockSpec takes the per-spec mutation lock (shared with the minting layer's
+// refresh-token write-back), keyed by ns.UUID, returning the unlock func. It
+// returns an error response if the credential manager is unavailable, the
+// namespace is missing, or the context is cancelled while waiting.
+func (b *SystemBackend) lockSpec(ctx context.Context, name string) (func(), *logical.Response) {
+	if b.core.credentialManager == nil {
+		return nil, logical.ErrorResponse(logical.ErrInternal("credential manager not initialized"))
+	}
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, logical.ErrorResponse(err)
+	}
+	unlock, err := b.core.credentialManager.LockSpec(ctx, ns.UUID, name)
+	if err != nil {
+		return nil, logical.ErrorResponse(err)
+	}
+	return unlock, nil
 }
 
 // oauth2SpecAuthorizer loads a connect-gated spec and its OAuth2Authorizer driver,

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -316,6 +317,11 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 
 	tokenResp, err := d.postTokenRequest(ctx, d.tokenURL(), form)
 	if err != nil {
+		if isRefreshTokenRejection(err) {
+			// Signal the minting layer to re-read the spec and retry once (the
+			// token may have been rotated by another node).
+			return nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w: %w", name, credential.ErrRefreshTokenRejected, err)
+		}
 		return nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w", name, err)
 	}
 	if tokenResp.AccessToken == "" {
@@ -433,24 +439,75 @@ func (d *OAuth2Driver) postTokenRequest(ctx context.Context, tokenURL string, fo
 			"Content-Type": "application/x-www-form-urlencoded",
 			"Accept":       "application/json",
 		},
+		// RFC 6749 §5.2 returns the error body on HTTP 400 (and 401 for
+		// invalid_client). Treat those as readable so the error code can be
+		// parsed and classified, rather than discarded as a transport error.
+		OKStatuses: []int{http.StatusOK, http.StatusBadRequest, http.StatusUnauthorized},
 	}
 
-	body, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	body, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
-		return nil, err
+		// Transport failure, or a status outside OKStatuses (e.g. 5xx after
+		// retries). Carry the status so callers can classify it.
+		return nil, &tokenEndpointError{status: status, err: err}
 	}
 
 	var tokenResp oauth2TokenResponse
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode token response: %w", err)
-	}
-	if tokenResp.Error != "" {
-		if tokenResp.ErrorDescription != "" {
-			return nil, fmt.Errorf("token endpoint error %q: %s", tokenResp.Error, tokenResp.ErrorDescription)
+	if jsonErr := json.Unmarshal(body, &tokenResp); jsonErr != nil {
+		if status != http.StatusOK {
+			// A non-2xx with an unparseable body (e.g. a proxy error page):
+			// classify by status alone.
+			return nil, &tokenEndpointError{status: status, err: fmt.Errorf("status %d: %s", status, string(body))}
 		}
-		return nil, fmt.Errorf("token endpoint error %q", tokenResp.Error)
+		return nil, fmt.Errorf("failed to decode token response: %w", jsonErr)
+	}
+	if status != http.StatusOK || tokenResp.Error != "" {
+		// An OAuth2 error body — carried on HTTP 400/401, or as an HTTP 200 body
+		// by providers like GitHub. Surface the parsed code for classification.
+		return nil, &tokenEndpointError{status: status, code: tokenResp.Error, description: tokenResp.ErrorDescription}
 	}
 	return &tokenResp, nil
+}
+
+// tokenEndpointError is returned by postTokenRequest when the token endpoint
+// rejects the request. It carries the HTTP status and, when the body was parsed,
+// the OAuth2 error code, so the refresh path can classify an invalid_grant
+// without fragile string matching.
+type tokenEndpointError struct {
+	status      int
+	code        string // OAuth2 error code (e.g. "invalid_grant"); "" if unparsed
+	description string
+	err         error // underlying transport/status error (when code is unparsed)
+}
+
+func (e *tokenEndpointError) Error() string {
+	if e.code != "" {
+		if e.description != "" {
+			return fmt.Sprintf("token endpoint error %q: %s", e.code, e.description)
+		}
+		return fmt.Sprintf("token endpoint error %q", e.code)
+	}
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return fmt.Sprintf("token endpoint status %d", e.status)
+}
+
+func (e *tokenEndpointError) Unwrap() error { return e.err }
+
+// isRefreshTokenRejection reports whether a postTokenRequest error indicates the
+// refresh token (grant) was rejected: an explicit invalid_grant code, or — when
+// the body carried no code — an HTTP 400/401 status (the RFC 6749 statuses for a
+// rejected grant).
+func isRefreshTokenRejection(err error) bool {
+	var tee *tokenEndpointError
+	if !errors.As(err, &tee) {
+		return false
+	}
+	if tee.code != "" {
+		return tee.code == "invalid_grant"
+	}
+	return tee.status == http.StatusBadRequest || tee.status == http.StatusUnauthorized
 }
 
 // accessTokenRawData builds the rawData map returned to the credential parser.

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1023,6 +1024,102 @@ func TestOAuth2Driver_MintFromRefreshToken_StaticAccessToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "static-token", rawData["api_key"])
 	assert.Equal(t, time.Duration(0), ttl)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_InvalidGrant_HTTP400(t *testing.T) {
+	// RFC 6749 standard rejection: HTTP 400 with an error body.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_grant", "error_description": "token expired"})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-dead",
+	}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, credential.ErrRefreshTokenRejected), "expected ErrRefreshTokenRejected, got %v", err)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_InvalidGrant_HTTP200(t *testing.T) {
+	// GitHub-style rejection: HTTP 200 with an error body.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_grant"})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-dead",
+	}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, credential.ErrRefreshTokenRejected), "expected ErrRefreshTokenRejected, got %v", err)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_NonGrantError_NotRejection(t *testing.T) {
+	// A non-grant error (HTTP 200 + a different code) must NOT be classified as a
+	// refresh-token rejection, so the minting layer does not retry it.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "temporarily_unavailable"})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt",
+	}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, credential.ErrRefreshTokenRejected), "non-grant error must not be a rejection: %v", err)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_InvalidClient_NotRejection(t *testing.T) {
+	// HTTP 401 invalid_client (wrong client_secret) must NOT be classified as a
+	// refresh-token rejection — the token is fine, the client creds are wrong.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_client"})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "wrong", "refresh_token": "rt",
+	}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, credential.ErrRefreshTokenRejected), "invalid_client must not be a refresh-token rejection: %v", err)
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_SlowDown400_NotRejection(t *testing.T) {
+	// HTTP 400 with a non-grant code (slow_down) must NOT be a rejection, even
+	// though the status is 400 — classification is by the parsed error code.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "slow_down"})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt",
+	}}
+
+	_, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, credential.ErrRefreshTokenRejected), "slow_down 400 must not be a refresh-token rejection: %v", err)
 }
 
 func TestOAuth2Driver_BuildAuthorizeURL(t *testing.T) {

--- a/credential/errors.go
+++ b/credential/errors.go
@@ -32,4 +32,10 @@ var (
 
 	// ErrSourceAlreadyExists is returned when attempting to register a source that already exists
 	ErrSourceAlreadyExists = errors.New("credential source already exists")
+
+	// ErrRefreshTokenRejected is returned when an OAuth2 provider rejects the
+	// refresh token (RFC 6749 invalid_grant). It signals the minting layer that
+	// the sealed token may have been rotated by another node, so it should
+	// re-read the latest spec and retry the refresh once.
+	ErrRefreshTokenRejected = errors.New("oauth2 refresh token rejected")
 )

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -2,7 +2,9 @@ package credential
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	ristretto "github.com/dgraph-io/ristretto/v2"
@@ -46,6 +48,13 @@ type Manager struct {
 	mintingService    *MintingService
 	credentialParser  *CredentialParser
 
+	// configStore persists rotated refresh tokens back into the spec config.
+	configStore ConfigStoreAccessor
+
+	// specLocks serializes spec-config mutations (refresh-token write-back and
+	// the /connect seal) per namespace+spec. Key: "{ns.UUID}:{specName}".
+	specLocks sync.Map
+
 	// Optional expiration registrar for timer-based TTL enforcement
 	// When set, newly issued credentials are registered for expiration
 	expirationRegistrar ExpirationRegistrar
@@ -60,6 +69,12 @@ type Manager struct {
 type ConfigStoreAccessor interface {
 	GetSpec(ctx context.Context, name string) (*CredSpec, error)
 	GetSource(ctx context.Context, name string) (*CredSource, error)
+	// PersistRotatedSpec persists a spec without re-running verification, used by
+	// the refresh-token write-back (re-minting would consume the rotated token).
+	PersistRotatedSpec(ctx context.Context, spec *CredSpec) error
+	// ReloadSpec returns the spec read from storage, bypassing the node-local
+	// cache, so a refresh token another node rotated and persisted is seen.
+	ReloadSpec(ctx context.Context, name string) (*CredSpec, error)
 }
 
 // ExpirationRegistrar defines the interface for registering credentials with an expiration manager.
@@ -98,6 +113,7 @@ func NewManager(
 		driverCoordinator: driverCoordinator,
 		mintingService:    mintingService,
 		credentialParser:  credentialParser,
+		configStore:       configStore,
 		issuanceTimeout:   DefaultIssuanceTimeout,
 	}
 
@@ -221,21 +237,156 @@ func (m *Manager) issueCredential(ctx context.Context, specName string) (*Creden
 		return nil, err
 	}
 
-	// Step 3: Mint credential with automatic cleanup, then parse and validate
-	// MintingService handles orphaned lease cleanup if parsing/validation fails
+	// A spec with a sealed refresh token (OAuth2 authorization_code) mints by
+	// exchanging that single-use token: serialize per spec, persist a rotated
+	// token, and retry once if the provider rejects it. Other specs use the
+	// simple mint path unchanged.
+	if needsRefreshTokenWriteBack(spec) {
+		return m.issueWithWriteBack(ctx, specName, driver)
+	}
+
+	return m.mintAndParse(ctx, spec, driver)
+}
+
+// mintAndParse mints a credential and parses it, with orphaned-lease cleanup on
+// failure. This is the simple path for specs that do not rotate a refresh token.
+func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver SourceDriver) (*Credential, error) {
 	var cred *Credential
-	err = m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
-		// Parse and validate the minted credential
+	err := m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 		var parseErr error
 		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, leaseTTL, leaseID, driver)
 		return parseErr
 	})
-
 	if err != nil {
 		return nil, err
 	}
-
 	return cred, nil
+}
+
+// issueWithWriteBack mints a refresh-token-backed credential under the per-spec
+// lock. It persists a rotated refresh token surfaced by the driver, and on a
+// rejection (the sealed token was already used — typically a rotation on
+// another node) it reloads the spec straight from storage, bypassing this
+// node's cache, and retries exactly once.
+func (m *Manager) issueWithWriteBack(ctx context.Context, specName string, driver SourceDriver) (*Credential, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace from context: %w", err)
+	}
+	unlock, err := m.LockSpec(ctx, ns.UUID, specName)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	var cred *Credential
+	// reload bypasses the node-local spec cache so a token another node rotated
+	// and persisted to shared storage is actually seen on the retry.
+	attempt := func(reload bool) error {
+		var spec *CredSpec
+		if reload {
+			spec, err = m.configStore.ReloadSpec(ctx, specName)
+		} else {
+			spec, err = m.specResolver.ResolveSpec(ctx, specName)
+		}
+		if err != nil {
+			return err
+		}
+		cred = nil
+		return m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+			m.consumeRotatedRefreshToken(ctx, spec, rawData)
+			var parseErr error
+			cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, leaseTTL, leaseID, driver)
+			return parseErr
+		})
+	}
+
+	err = attempt(false)
+	if err != nil && errors.Is(err, ErrRefreshTokenRejected) {
+		// The token was rejected as already-used. Reload from storage (another
+		// node may have rotated+persisted a fresh token this node hasn't cached)
+		// and retry exactly once.
+		m.log.Info("oauth2 refresh token rejected; reloading spec from storage and retrying once",
+			logger.String("spec", specName))
+		err = attempt(true)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return cred, nil
+}
+
+// consumeRotatedRefreshToken strips the reserved rotated-token key from rawData
+// (so it never reaches the credential Data map) and persists the new refresh
+// token into the spec config. Must run before ParseAndValidate.
+//
+// A persist failure does not fail this issuance — the access token just minted
+// is valid and is returned. But it is logged at error level because the old
+// refresh token is now dead at the provider: on this node the rotated token is
+// lost and future mints will fail with invalid_grant until the spec is
+// reconnected (or another node's copy is reloaded from storage).
+func (m *Manager) consumeRotatedRefreshToken(ctx context.Context, spec *CredSpec, rawData map[string]interface{}) {
+	rotated, ok := rawData[RawRotatedRefreshTokenKey]
+	if !ok {
+		return
+	}
+	delete(rawData, RawRotatedRefreshTokenKey)
+	newToken, isString := rotated.(string)
+	if !isString || newToken == "" {
+		// The only producer sets a non-empty string; a different shape means a
+		// rotated token would be silently dropped, so make it visible.
+		m.log.Warn("ignoring rotated refresh token with unexpected value",
+			logger.String("spec", spec.Name))
+		return
+	}
+	// Copy the spec (GetSpec returns a shared cached pointer) before mutating.
+	updated := &CredSpec{
+		Name:           spec.Name,
+		Type:           spec.Type,
+		Source:         spec.Source,
+		MinTTL:         spec.MinTTL,
+		MaxTTL:         spec.MaxTTL,
+		RotationPeriod: spec.RotationPeriod,
+		Config:         make(map[string]string, len(spec.Config)),
+	}
+	for k, v := range spec.Config {
+		updated.Config[k] = v
+	}
+	updated.Config["refresh_token"] = newToken
+	if err := m.configStore.PersistRotatedSpec(ctx, updated); err != nil {
+		m.log.Error("failed to persist rotated refresh token; spec must be reconnected if mints start failing",
+			logger.String("spec", spec.Name), logger.Err(err))
+	}
+}
+
+// needsRefreshTokenWriteBack reports whether a spec mints by exchanging a sealed
+// refresh token. The rotated-token reserved key can only appear for such specs.
+// Gating on the sealed token is robust to where auth_method is set; a spec that
+// retains a stale refresh_token after switching to client_credentials takes this
+// path harmlessly (the write-back is a no-op since no reserved key is surfaced).
+func needsRefreshTokenWriteBack(spec *CredSpec) bool {
+	return spec.Config["refresh_token"] != ""
+}
+
+// LockSpec serializes spec-config mutations (refresh-token write-back and the
+// /connect seal) for one namespace+spec. It is context-aware: a waiter whose
+// context is cancelled or times out returns an error rather than blocking past
+// its deadline. The key MUST use ns.UUID to match the persistence layer's spec
+// keying.
+//
+// Note: the lock map is not pruned on spec/namespace deletion. Each tiny entry
+// (a key string + a buffered channel) persists for the process lifetime; safe
+// pruning would require reference counting and is deferred.
+func (m *Manager) LockSpec(ctx context.Context, nsUUID, specName string) (unlock func(), err error) {
+	key := nsUUID + ":" + specName
+	v, _ := m.specLocks.LoadOrStore(key, make(chan struct{}, 1))
+	ch := v.(chan struct{})
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // SetExpirationRegistrar sets the expiration registrar for timer-based TTL enforcement.

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -19,28 +19,52 @@ import (
 // Mock Implementations
 // ============================================================================
 
-// mockConfigStore implements ConfigStoreAccessor for testing
+// mockConfigStore implements ConfigStoreAccessor for testing. It models the two
+// layers of the real store separately: a node-local "cache" (read by GetSpec)
+// and shared "storage" (read by ReloadSpec, written by PersistRotatedSpec). This
+// lets tests reproduce the cross-node staleness the real Ristretto-backed store
+// has: a remote node's persist updates storage but not this node's cache.
 type mockConfigStore struct {
-	specs   map[string]*CredSpec
-	sources map[string]*CredSource
+	mu        sync.Mutex
+	cache     map[string]*CredSpec // read by GetSpec (node-local)
+	storage   map[string]*CredSpec // read by ReloadSpec (shared)
+	sources   map[string]*CredSource
+	persisted []*CredSpec // specs captured by PersistRotatedSpec, in order
+	persistFn func(spec *CredSpec) error
 }
 
 func newMockConfigStore() *mockConfigStore {
 	return &mockConfigStore{
-		specs:   make(map[string]*CredSpec),
+		cache:   make(map[string]*CredSpec),
+		storage: make(map[string]*CredSpec),
 		sources: make(map[string]*CredSource),
 	}
 }
 
 func (m *mockConfigStore) GetSpec(ctx context.Context, name string) (*CredSpec, error) {
-	spec, ok := m.specs[name]
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	spec, ok := m.cache[name]
 	if !ok {
 		return nil, errors.New("spec not found")
 	}
 	return spec, nil
 }
 
+func (m *mockConfigStore) ReloadSpec(ctx context.Context, name string) (*CredSpec, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	spec, ok := m.storage[name]
+	if !ok {
+		return nil, errors.New("spec not found")
+	}
+	m.cache[name] = spec // re-reading from storage refreshes the local cache
+	return spec, nil
+}
+
 func (m *mockConfigStore) GetSource(ctx context.Context, name string) (*CredSource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	source, ok := m.sources[name]
 	if !ok {
 		return nil, errors.New("source not found")
@@ -48,12 +72,46 @@ func (m *mockConfigStore) GetSource(ctx context.Context, name string) (*CredSour
 	return source, nil
 }
 
+func (m *mockConfigStore) PersistRotatedSpec(ctx context.Context, spec *CredSpec) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.persistFn != nil {
+		if err := m.persistFn(spec); err != nil {
+			return err
+		}
+	}
+	m.persisted = append(m.persisted, spec)
+	// A same-node persist updates both storage and this node's cache.
+	m.storage[spec.Name] = spec
+	m.cache[spec.Name] = spec
+	return nil
+}
+
 func (m *mockConfigStore) AddSpec(spec *CredSpec) {
-	m.specs[spec.Name] = spec
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cache[spec.Name] = spec
+	m.storage[spec.Name] = spec
 }
 
 func (m *mockConfigStore) AddSource(source *CredSource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.sources[source.Name] = source
+}
+
+// rotateOnOtherNode simulates another HA node rotating+persisting a refresh
+// token: shared storage advances, but this node's cache stays stale.
+func (m *mockConfigStore) rotateOnOtherNode(name, refreshToken string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur := m.storage[name]
+	updated := &CredSpec{Name: cur.Name, Type: cur.Type, Source: cur.Source, Config: map[string]string{}}
+	for k, v := range cur.Config {
+		updated.Config[k] = v
+	}
+	updated.Config["refresh_token"] = refreshToken
+	m.storage[name] = updated // cache intentionally left stale
 }
 
 // mockSourceDriver implements SourceDriver for testing
@@ -700,4 +758,163 @@ func TestManager_SpecExists(t *testing.T) {
 		exists := managerWithNilStore.SpecExists(ctx, "any-spec")
 		assert.False(t, exists, "should return false when config store is nil")
 	})
+}
+
+// ============================================================================
+// Refresh-token write-back
+// ============================================================================
+
+func addRefreshSpecAndSource(configStore *mockConfigStore, refreshToken string) {
+	configStore.AddSource(&CredSource{Name: "src", Type: SourceTypeLocal, Config: map[string]string{}})
+	configStore.AddSpec(&CredSpec{Name: "gh", Type: TypeVaultToken, Source: "src", Config: map[string]string{
+		"auth_method": "authorization_code", "refresh_token": refreshToken,
+	}})
+}
+
+func TestManager_WriteBack_StripsReservedKeyAndPersists(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+	addRefreshSpecAndSource(configStore, "rt-old")
+
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, time.Hour, "", nil
+	}
+
+	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	require.NoError(t, err)
+
+	// The reserved rotated-token key must be stripped before parsing.
+	_, leaked := cred.Data[RawRotatedRefreshTokenKey]
+	assert.False(t, leaked, "reserved rotated-token key must not reach credential Data")
+	assert.Equal(t, "at-new", cred.Data["api_key"])
+
+	// The rotated token is persisted into a fresh spec copy.
+	require.Len(t, configStore.persisted, 1)
+	assert.Equal(t, "rt-new", configStore.persisted[0].Config["refresh_token"])
+}
+
+func TestManager_WriteBack_NonRotating_NoPersist(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+	addRefreshSpecAndSource(configStore, "rt-stable")
+
+	// No reserved key → stable token, no write-back.
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-1"}, time.Hour, "", nil
+	}
+
+	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	require.NoError(t, err)
+	assert.Empty(t, configStore.persisted, "non-rotating mint must not persist")
+}
+
+func TestManager_InvalidGrant_RetriesOnceWithReloadedSpec(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+	addRefreshSpecAndSource(configStore, "rt-stale")
+
+	// Cross-node rotation: attempt 1 reads this node's stale cache (rt-stale) and
+	// is rejected; meanwhile another node rotated+persisted rt-fresh to shared
+	// storage WITHOUT touching this node's cache. The retry must reload from
+	// storage (not the cache) to pick up rt-fresh.
+	var attempts int32
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			assert.Equal(t, "rt-stale", spec.Config["refresh_token"])
+			configStore.rotateOnOtherNode("gh", "rt-fresh") // storage advances; cache stays stale
+			return nil, 0, "", ErrRefreshTokenRejected
+		}
+		assert.Equal(t, "rt-fresh", spec.Config["refresh_token"], "retry must reload from storage, bypassing the stale cache")
+		return map[string]interface{}{"api_key": "at-ok"}, time.Hour, "", nil
+	}
+
+	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, "at-ok", cred.Data["api_key"])
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts), "must mint exactly twice (one retry)")
+}
+
+func TestManager_InvalidGrant_RetryFailsOnce_SurfacesError(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+	addRefreshSpecAndSource(configStore, "rt-dead")
+
+	var attempts int32
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, 0, "", ErrRefreshTokenRejected // never recovers
+	}
+
+	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRefreshTokenRejected))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts), "retry is bounded to exactly one extra attempt")
+}
+
+func TestManager_WriteBack_PersistError_DoesNotFailIssuance(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+	addRefreshSpecAndSource(configStore, "rt-old")
+
+	configStore.persistFn = func(spec *CredSpec) error { return errors.New("storage down") }
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, time.Hour, "", nil
+	}
+
+	// A persist failure must not fail issuance — the access token is still valid.
+	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, "at-new", cred.Data["api_key"])
+}
+
+func TestManager_LockSpec_Mutex(t *testing.T) {
+	manager, _, _ := createTestManager(t)
+	defer manager.Stop()
+
+	unlock, err := manager.LockSpec(context.Background(), "ns-uuid", "gh")
+	require.NoError(t, err)
+
+	// A second lock for the same key blocks until unlock.
+	locked := make(chan struct{})
+	go func() {
+		u2, e := manager.LockSpec(context.Background(), "ns-uuid", "gh")
+		if e == nil {
+			close(locked)
+			u2()
+		}
+	}()
+	select {
+	case <-locked:
+		t.Fatal("second LockSpec acquired while the first was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A different key does not block.
+	u3, err := manager.LockSpec(context.Background(), "ns-uuid", "other")
+	require.NoError(t, err)
+	u3()
+
+	unlock()
+	select {
+	case <-locked:
+	case <-time.After(time.Second):
+		t.Fatal("second LockSpec did not acquire after unlock")
+	}
+}
+
+func TestManager_LockSpec_ContextCancel(t *testing.T) {
+	manager, _, _ := createTestManager(t)
+	defer manager.Stop()
+
+	unlock, err := manager.LockSpec(context.Background(), "ns-uuid", "gh")
+	require.NoError(t, err)
+	defer unlock()
+
+	// A waiter whose context is cancelled must return an error, not block forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err = manager.LockSpec(ctx, "ns-uuid", "gh")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }


### PR DESCRIPTION
When a provider rotates the refresh token on a grant_type=refresh_token mint,
the old token is single-use and dies at the provider. The minting layer now
consumes the rotated token the driver surfaces under the reserved rawData key,
strips it before the credential is parsed (so it never lands in the credential
Data), and persists it into the spec config via a verification-skipped update.

To keep the single-use token consistent under concurrency:

- A context-aware per-spec lock (keyed by namespace UUID + spec name) serializes
  the issuance write-back, the /connect seal, and spec updates for the same
  spec, so none can clobber another's refresh_token. Waiters observe their own
  deadline instead of blocking across a slow token endpoint.
- On a rejection (the sealed token was already used — typically a rotation on
  another node), issuance reloads the spec straight from storage, bypassing the
  node-local cache, and retries exactly once. invalid_grant is distinguished
  from other token-endpoint errors (e.g. invalid_client, slow_down) by parsing
  the OAuth2 error code, so only a genuine grant rejection triggers the retry.

A persist failure does not fail the issuance (the freshly minted access token is
still returned) but is logged at error level, since the rotated token is then
lost on this node until the spec is reconnected or reloaded from storage.

Known limitations (addressed by the per-spec shared access-token cache
follow-up): the per-spec lock map is not pruned on spec deletion, and the
access-token cache is not invalidated on re-connect or rotation, so previously
issued access tokens serve until they expire.

---
Part 6/9 of the OAuth2 authorization-code series (stacked). Base: `feat/oauth2-connect-cli`. Merge bottom-up.