### PR TITLE
feat(credential): driver-returned credential metadata for audit

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -441,6 +441,32 @@ func (f *JSONFormat) saltCredentialField(ctx context.Context, cred *Credential, 
 				cred.Data[key] = salted
 			}
 		}
+	case "metadata":
+		// Metadata logs in clear by default; salting is opt-in via salt_fields
+		// (response.credential.metadata salts every key, .subject one key).
+		if cred.Metadata == nil {
+			return nil
+		}
+		if len(parts) == 1 {
+			for key, value := range cred.Metadata {
+				if value != "" {
+					salted, err := f.saltFn(ctx, value)
+					if err != nil {
+						return err
+					}
+					cred.Metadata[key] = salted
+				}
+			}
+		} else if len(parts) >= 2 {
+			key := parts[1]
+			if value, ok := cred.Metadata[key]; ok && value != "" {
+				salted, err := f.saltFn(ctx, value)
+				if err != nil {
+					return err
+				}
+				cred.Metadata[key] = salted
+			}
+		}
 	}
 
 	return nil
@@ -685,6 +711,12 @@ func (f *JSONFormat) omitCredentialField(cred *Credential, parts []string) {
 			cred.Data = nil
 		} else if len(parts) >= 2 && cred.Data != nil {
 			delete(cred.Data, parts[1])
+		}
+	case "metadata":
+		if len(parts) == 1 {
+			cred.Metadata = nil
+		} else if len(parts) >= 2 && cred.Metadata != nil {
+			delete(cred.Metadata, parts[1])
 		}
 	}
 }

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -1317,3 +1317,76 @@ func TestOmitResponseFields(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONFormatCredentialMetadata(t *testing.T) {
+	mockSaltFunc := func(ctx context.Context, data string) (string, error) {
+		return "hmac-sha256:" + data, nil
+	}
+
+	newEntry := func() *LogEntry {
+		return &LogEntry{
+			Timestamp: time.Now(),
+			Response: &Response{
+				StatusCode: 200,
+				Credential: &Credential{
+					CredentialID: "cred-1",
+					Type:         "oauth_bearer_token",
+					TokenID:      "tok-1",
+					Data:         map[string]string{"api_key": "secret-token"},
+					Metadata:     map[string]string{"subject": "alice@example.com", "subject_verified": "true"},
+				},
+			},
+		}
+	}
+
+	format := func(saltFields []string, entry *LogEntry) Credential {
+		f := NewJSONFormat(WithSaltFunc(mockSaltFunc), WithSaltFields(saltFields))
+		out, err := f.FormatResponse(context.Background(), entry)
+		if err != nil {
+			t.Fatalf("FormatResponse: %v", err)
+		}
+		var got LogEntry
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return *got.Response.Credential
+	}
+
+	t.Run("clear by default; data salted", func(t *testing.T) {
+		entry := newEntry()
+		c := format([]string{"response.credential.data"}, entry)
+		if c.Metadata["subject"] != "alice@example.com" {
+			t.Errorf("subject should be in clear, got %q", c.Metadata["subject"])
+		}
+		if !containsBytes([]byte(c.Data["api_key"]), "hmac-sha256:") {
+			t.Error("data api_key should be salted")
+		}
+		// The original entry must be untouched (Clone deep-copy).
+		if entry.Response.Credential.Metadata["subject"] != "alice@example.com" {
+			t.Error("original metadata mutated by salting (Clone deep-copy missing)")
+		}
+		if entry.Response.Credential.Data["api_key"] != "secret-token" {
+			t.Error("original data mutated by salting")
+		}
+	})
+
+	t.Run("salt one metadata key", func(t *testing.T) {
+		c := format([]string{"response.credential.metadata.subject"}, newEntry())
+		if !containsBytes([]byte(c.Metadata["subject"]), "hmac-sha256:") {
+			t.Errorf("subject should be salted, got %q", c.Metadata["subject"])
+		}
+		if c.Metadata["subject_verified"] != "true" {
+			t.Errorf("subject_verified should stay clear, got %q", c.Metadata["subject_verified"])
+		}
+	})
+
+	t.Run("salt whole metadata map", func(t *testing.T) {
+		c := format([]string{"response.credential.metadata"}, newEntry())
+		if !containsBytes([]byte(c.Metadata["subject"]), "hmac-sha256:") {
+			t.Error("subject should be salted")
+		}
+		if !containsBytes([]byte(c.Metadata["subject_verified"]), "hmac-sha256:") {
+			t.Error("subject_verified should be salted")
+		}
+	})
+}

--- a/audit/types.go
+++ b/audit/types.go
@@ -170,6 +170,11 @@ type Credential struct {
 	// Credential data (sensitive - will be HMAC salted by the format layer)
 	// Contains the actual credential values like access_key, secret_key, password, etc.
 	Data map[string]string `json:"data,omitempty"`
+
+	// Metadata holds non-secret, descriptive attributes (e.g. the forwarded
+	// token's subject). Logged in clear by default; salt-able per key via
+	// salt_fields (response.credential.metadata[.key]).
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // EntryType defines the type of audit entry
@@ -253,6 +258,12 @@ func (e *LogEntry) Clone() *LogEntry {
 				clone.Response.Credential.Data = make(map[string]string, len(e.Response.Credential.Data))
 				for k, v := range e.Response.Credential.Data {
 					clone.Response.Credential.Data[k] = v
+				}
+			}
+			if e.Response.Credential.Metadata != nil {
+				clone.Response.Credential.Metadata = make(map[string]string, len(e.Response.Credential.Metadata))
+				for k, v := range e.Response.Credential.Metadata {
+					clone.Response.Credential.Metadata[k] = v
 				}
 			}
 		}

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -232,6 +232,15 @@ func buildAuditCredential(cred *credential.Credential) *audit.Credential {
 		}
 	}
 
+	// Non-secret metadata (e.g. subject) — logged in clear unless an operator
+	// opts a key into salt_fields.
+	if cred.Metadata != nil {
+		auditCred.Metadata = make(map[string]string, len(cred.Metadata))
+		for k, v := range cred.Metadata {
+			auditCred.Metadata[k] = v
+		}
+	}
+
 	return auditCred
 }
 

--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -894,7 +894,7 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				}
 
 				if runTestMint {
-					if _, _, _, err := driver.MintCredential(ctx, testSpec); err != nil {
+					if _, _, _, _, err := driver.MintCredential(ctx, testSpec); err != nil {
 						return logical.ErrBadRequestf("credential test failed for spec type '%s': %s", spec.Type, err.Error())
 					}
 

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -715,8 +715,8 @@ func (d *testDriver) Type() string {
 	return "test_driver"
 }
 
-func (d *testDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
-	return nil, 0, "", nil
+func (d *testDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", nil
 }
 
 func (d *testDriver) Revoke(ctx context.Context, leaseID string) error {
@@ -863,7 +863,7 @@ func (t *testCredentialType) ValidateConfig(config map[string]string, sourceName
 	return nil
 }
 
-func (t *testCredentialType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *testCredentialType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	// Convert map[string]interface{} to map[string]string for Data field
 	dataStr := make(map[string]string)
 	for k, v := range rawData {
@@ -1086,7 +1086,7 @@ func (t *validatingCredentialType) ValidateConfig(config map[string]string, sour
 	return nil
 }
 
-func (t *validatingCredentialType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *validatingCredentialType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	dataStr := make(map[string]string)
 	for k, v := range rawData {
 		if str, ok := v.(string); ok {
@@ -1358,8 +1358,8 @@ func (f *connectGatedDriverFactory) InferCredentialType(_ map[string]string) (st
 type connectGatedDriver struct{}
 
 func (d *connectGatedDriver) Type() string { return "connect_driver" }
-func (d *connectGatedDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
-	return nil, 0, "", fmt.Errorf("mint must not run for an unconnected spec")
+func (d *connectGatedDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", fmt.Errorf("mint must not run for an unconnected spec")
 }
 func (d *connectGatedDriver) Revoke(ctx context.Context, leaseID string) error { return nil }
 func (d *connectGatedDriver) Cleanup(ctx context.Context) error                { return nil }

--- a/core/rotation_test.go
+++ b/core/rotation_test.go
@@ -30,8 +30,8 @@ type mockRotatableDriver struct {
 	failUntilAttempt int32         // fail PrepareRotation until this many calls
 }
 
-func (d *mockRotatableDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
-	return map[string]interface{}{"key": "value"}, time.Hour, "lease-123", nil
+func (d *mockRotatableDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return map[string]interface{}{"key": "value"}, nil, time.Hour, "lease-123", nil
 }
 
 func (d *mockRotatableDriver) Revoke(ctx context.Context, leaseID string) error {

--- a/credential/credential.go
+++ b/credential/credential.go
@@ -18,11 +18,11 @@ const (
 	TypeDBAuthToken       = "db_auth_token"
 	TypeOAuthBearerToken  = "oauth_bearer_token"
 	TypeKubernetesToken   = "kubernetes_token"
-	TypeScalewayKeys     = "scaleway_keys"
-	TypeOVHKeys          = "ovh_keys"
-	TypeCloudflareKeys   = "cloudflare_keys"
-	TypeIBMCloudKeys     = "ibmcloud_keys"
-	TypeAlicloudKeys     = "alicloud_keys"
+	TypeScalewayKeys      = "scaleway_keys"
+	TypeOVHKeys           = "ovh_keys"
+	TypeCloudflareKeys    = "cloudflare_keys"
+	TypeIBMCloudKeys      = "ibmcloud_keys"
+	TypeAlicloudKeys      = "alicloud_keys"
 )
 
 // Source type constants
@@ -86,7 +86,7 @@ type Credential struct {
 	TokenID  string        // Session token this credential is bound to
 	IssuedAt time.Time     // When the credential was issued
 
-	// Data
+	// The secret part of the credential
 	Data map[string]string // Type-specific credential data
 
 	// Metadata
@@ -94,6 +94,11 @@ type Credential struct {
 	SourceType string // Type of the driver that issued this credential
 	Revocable  bool   // Whether this credential can be revoked
 	SpecName   string // Which spec created this credential (for tracking/audit)
+
+	// Metadata holds non-secret, descriptive attributes about the credential
+	// (e.g. "subject", "subject_verified") that audit logs in clear. Never put
+	// secret material here — that belongs in Data, which audit HMAC-salts.
+	Metadata map[string]string
 }
 
 // IsExpired checks if the credential has expired

--- a/credential/credential_parser.go
+++ b/credential/credential_parser.go
@@ -51,6 +51,7 @@ func NewCredentialParser(typeRegistry *TypeRegistry, logger *logger.GatedLogger)
 //   - ctx: Context with namespace information
 //   - spec: The CredSpec defining the credential type and source
 //   - rawData: Raw credential data from driver.MintCredential()
+//   - metadata: credential metadata from driver.MintCredential()
 //   - leaseTTL: Time-to-live for the credential
 //   - leaseID: Lease identifier for revocation at source
 //   - driver: The source driver that minted the credential (for Type() method)
@@ -60,6 +61,7 @@ func (p *CredentialParser) ParseAndValidate(
 	ctx context.Context,
 	spec *CredSpec,
 	rawData map[string]interface{},
+	metadata map[string]interface{},
 	leaseTTL time.Duration,
 	leaseID string,
 	driver SourceDriver,
@@ -70,8 +72,8 @@ func (p *CredentialParser) ParseAndValidate(
 		return nil, fmt.Errorf("credential type '%s' not found: %w", spec.Type, err)
 	}
 
-	// Step 2: Parse raw data into structured credential
-	cred, err := credType.Parse(rawData, leaseTTL, leaseID)
+	// Step 2: Parse raw data and its metadata into structured credential
+	cred, err := credType.Parse(rawData, metadata, leaseTTL, leaseID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse credential: %w", err)
 	}

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -180,26 +180,26 @@ func (d *AlicloudDriver) ramEndpoint() string {
 }
 
 // MintCredential returns Alicloud credentials for the given spec.
-func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "assume_role":
 		return d.mintAssumeRole(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported or missing mint_method: %q (only assume_role is supported by the alicloud source)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported or missing mint_method: %q (only assume_role is supported by the alicloud source)", mintMethod)
 	}
 }
 
 // mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
-func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mgmtID, mgmtSecret := d.mgmtAccessKey()
 	if mgmtID == "" || mgmtSecret == "" {
-		return nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
+		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
 	}
 
 	roleARN := credential.GetString(spec.Config, "role_arn", "")
 	if roleARN == "" {
-		return nil, 0, "", fmt.Errorf("role_arn is required for assume_role")
+		return nil, nil, 0, "", fmt.Errorf("role_arn is required for assume_role")
 	}
 	sessionName := credential.GetString(spec.Config, "role_session_name", "warden-session")
 	duration := credential.GetDuration(spec.Config, "duration_seconds", time.Hour)
@@ -223,7 +223,7 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 
 	respBody, err := d.callSignedJSON(ctx, http.MethodPost, d.stsEndpoint(), params, mgmtID, mgmtSecret, "")
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("STS AssumeRole failed: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed: %w", err)
 	}
 
 	var resp struct {
@@ -235,10 +235,10 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		} `json:"Credentials"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, 0, "", fmt.Errorf("parse STS response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("parse STS response: %w", err)
 	}
 	if resp.Credentials.AccessKeyID == "" || resp.Credentials.AccessKeySecret == "" {
-		return nil, 0, "", fmt.Errorf("STS returned empty credentials")
+		return nil, nil, 0, "", fmt.Errorf("STS returned empty credentials")
 	}
 
 	d.logger.Info("issued STS temporary credentials",
@@ -251,7 +251,7 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		"access_key_id":     resp.Credentials.AccessKeyID,
 		"access_key_secret": resp.Credentials.AccessKeySecret,
 		"security_token":    resp.Credentials.SecurityToken,
-	}, duration, "", nil // STS tokens are self-expiring; no leaseID
+	}, nil, duration, "", nil // STS tokens are self-expiring; no leaseID
 }
 
 // Revoke is a no-op: the driver's only supported mint method (assume_role)

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -87,7 +87,7 @@ func TestAlicloudDriverFactory_Create(t *testing.T) {
 func TestAlicloudDriver_StaticKeysRejected(t *testing.T) {
 	f := &AlicloudDriverFactory{}
 	d, _ := f.Create(map[string]string{}, createAlicloudTestLogger())
-	_, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
 		Config: map[string]string{
 			"mint_method":       "static_keys",
 			"access_key_id":     "x",
@@ -101,7 +101,7 @@ func TestAlicloudDriver_StaticKeysRejected(t *testing.T) {
 func TestAlicloudDriver_UnsupportedMintMethod(t *testing.T) {
 	f := &AlicloudDriverFactory{}
 	d, _ := f.Create(map[string]string{}, createAlicloudTestLogger())
-	_, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
 		Config: map[string]string{"mint_method": "bogus"},
 	})
 	assert.Error(t, err)
@@ -111,7 +111,7 @@ func TestAlicloudDriver_UnsupportedMintMethod(t *testing.T) {
 func TestAlicloudDriver_MissingMintMethod(t *testing.T) {
 	f := &AlicloudDriverFactory{}
 	d, _ := f.Create(map[string]string{}, createAlicloudTestLogger())
-	_, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
 		Config: map[string]string{},
 	})
 	assert.Error(t, err)
@@ -157,7 +157,7 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 		},
 	}
 
-	raw, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
+	raw, _, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "STS.tempid", raw["access_key_id"])
 	assert.Equal(t, "tempsecret", raw["access_key_secret"])
@@ -179,7 +179,7 @@ func TestAlicloudDriver_MintAssumeRole_MissingRoleArn(t *testing.T) {
 		"access_key_secret": "mgmt-secret",
 	}, createAlicloudTestLogger())
 
-	_, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
 		Config: map[string]string{"mint_method": "assume_role"},
 	})
 	assert.Error(t, err)
@@ -189,7 +189,7 @@ func TestAlicloudDriver_MintAssumeRole_MissingRoleArn(t *testing.T) {
 func TestAlicloudDriver_MintAssumeRole_MissingManagementKey(t *testing.T) {
 	f := &AlicloudDriverFactory{}
 	d, _ := f.Create(map[string]string{}, createAlicloudTestLogger())
-	_, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
 		Config: map[string]string{
 			"mint_method": "assume_role",
 			"role_arn":    "acs:ram::123:role/x",
@@ -214,7 +214,7 @@ func TestAlicloudDriver_DynamicKeysRejected(t *testing.T) {
 		"access_key_id":     "LTAI-mgmt",
 		"access_key_secret": "mgmt-secret",
 	}, createAlicloudTestLogger())
-	_, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
 		Config: map[string]string{
 			"mint_method":   "dynamic_keys",
 			"ram_user_name": "warden-svc",

--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -44,13 +44,13 @@ type AWSDriver struct {
 	authMu         sync.Mutex
 
 	// AWS clients (rebuilt on auth changes)
-	stsClient                  *sts.Client
-	secretsManagerClient       *secretsmanager.Client
-	iamClient                  *iam.Client
-	redshiftClient             *redshift.Client
-	redshiftServerlessClient   *redshiftserverless.Client
-	region                     string
-	baseCredsVerified          bool
+	stsClient                *sts.Client
+	secretsManagerClient     *secretsmanager.Client
+	iamClient                *iam.Client
+	redshiftClient           *redshift.Client
+	redshiftServerlessClient *redshiftserverless.Client
+	region                   string
+	baseCredsVerified        bool
 }
 
 // AWSDriverFactory creates AWSDriver instances
@@ -238,10 +238,10 @@ func (d *AWSDriver) buildClients(creds aws.CredentialsProvider) {
 }
 
 // MintCredential mints credentials using AWS based on credential spec
-func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	// Re-authenticate if needed
 	if err := d.authenticate(ctx); err != nil {
-		return nil, 0, "", fmt.Errorf("authentication failed: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("authentication failed: %w", err)
 	}
 
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
@@ -256,15 +256,15 @@ func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	case "redshift_iam_token":
 		return d.mintViaRedshiftIAMToken(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role', 'secrets_manager', 'rds_iam_token', or 'redshift_iam_token'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role', 'secrets_manager', 'rds_iam_token', or 'redshift_iam_token'", mintMethod)
 	}
 }
 
 // mintViaSTSAssumeRole mints temporary credentials via STS AssumeRole
-func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	roleArn, err := credential.GetStringRequired(spec.Config, "role_arn")
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
@@ -272,15 +272,15 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 	ttlStr := credential.GetString(spec.Config, "ttl", "1h")
 	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("invalid ttl '%s': %w", ttlStr, err)
+		return nil, nil, 0, "", fmt.Errorf("invalid ttl '%s': %w", ttlStr, err)
 	}
 
 	// Validate TTL against spec bounds
 	if spec.MinTTL > 0 && ttl < spec.MinTTL {
-		return nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", ttl, spec.MinTTL)
+		return nil, nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", ttl, spec.MinTTL)
 	}
 	if spec.MaxTTL > 0 && ttl > spec.MaxTTL {
-		return nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", ttl, spec.MaxTTL)
+		return nil, nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", ttl, spec.MaxTTL)
 	}
 
 	input := &sts.AssumeRoleInput{
@@ -298,7 +298,7 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 
 	result, err := d.stsClient.AssumeRole(ctx, input)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("STS AssumeRole failed for %s: %w", roleArn, err)
+		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed for %s: %w", roleArn, err)
 	}
 
 	creds := result.Credentials
@@ -306,7 +306,7 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 
 	// Validate lease TTL is positive (guards against clock skew or cached responses)
 	if leaseTTL <= 0 {
-		return nil, 0, "", fmt.Errorf("STS credentials already expired or have invalid expiration time")
+		return nil, nil, 0, "", fmt.Errorf("STS credentials already expired or have invalid expiration time")
 	}
 
 	// Synthetic lease ID for tracking (STS creds can't be revoked)
@@ -328,14 +328,14 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 		)
 	}
 
-	return rawData, leaseTTL, leaseID, nil
+	return rawData, nil, leaseTTL, leaseID, nil
 }
 
 // mintViaSecretsManager fetches a secret from AWS Secrets Manager
-func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	secretID, err := credential.GetStringRequired(spec.Config, "secret_id")
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	input := &secretsmanager.GetSecretValueInput{
@@ -350,16 +350,16 @@ func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.
 
 	result, err := d.secretsManagerClient.GetSecretValue(ctx, input)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to get secret '%s': %w", secretID, err)
+		return nil, nil, 0, "", fmt.Errorf("failed to get secret '%s': %w", secretID, err)
 	}
 
 	if result.SecretString == nil {
-		return nil, 0, "", fmt.Errorf("secret '%s' has no string value (binary secrets not supported)", secretID)
+		return nil, nil, 0, "", fmt.Errorf("secret '%s' has no string value (binary secrets not supported)", secretID)
 	}
 
 	var secretData map[string]interface{}
 	if err := json.Unmarshal([]byte(*result.SecretString), &secretData); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse secret JSON: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse secret JSON: %w", err)
 	}
 
 	// Apply json_key_map if provided (remap keys)
@@ -376,7 +376,7 @@ func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.
 	}
 
 	// Secrets Manager secrets are static (no lease TTL)
-	return secretData, 0, "", nil
+	return secretData, nil, 0, "", nil
 }
 
 // applyKeyMap remaps keys in data according to a comma-separated "srcKey=destKey" map
@@ -399,14 +399,14 @@ func applyKeyMap(data map[string]interface{}, keyMapStr string) map[string]inter
 // mintViaRDSIAMToken generates a short-lived IAM authentication token for RDS.
 // The token is a pre-signed STS GetCallerIdentity URL that RDS accepts as a password.
 // This is a local SigV4 signing operation — no network call to RDS.
-func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	dbEndpoint, err := credential.GetStringRequired(spec.Config, "db_endpoint")
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 	dbUser, err := credential.GetStringRequired(spec.Config, "db_user")
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	dbEngine := credential.GetString(spec.Config, "db_engine", "postgres")
@@ -417,7 +417,7 @@ func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.Cre
 
 	token, err := rdsauth.BuildAuthToken(ctx, endpoint, region, dbUser, d.baseCreds)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to build RDS IAM auth token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to build RDS IAM auth token: %w", err)
 	}
 
 	rawData := map[string]interface{}{
@@ -440,7 +440,7 @@ func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.Cre
 	}
 
 	// RDS IAM tokens are valid for 15 minutes
-	return rawData, 15 * time.Minute, "", nil
+	return rawData, nil, 15 * time.Minute, "", nil
 }
 
 // mintViaRedshiftIAMToken generates a short-lived IAM authentication token for
@@ -451,19 +451,19 @@ func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.Cre
 //
 // Both APIs return a database user (mapped 1:1 to the source IAM identity for
 // provisioned, workgroup-scoped for serverless) and a temporary password.
-func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	dbEndpoint, err := credential.GetStringRequired(spec.Config, "db_endpoint")
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	clusterID := credential.GetString(spec.Config, "cluster_identifier", "")
 	workgroup := credential.GetString(spec.Config, "workgroup_name", "")
 	if clusterID == "" && workgroup == "" {
-		return nil, 0, "", fmt.Errorf("redshift_iam_token requires either 'cluster_identifier' (provisioned) or 'workgroup_name' (serverless)")
+		return nil, nil, 0, "", fmt.Errorf("redshift_iam_token requires either 'cluster_identifier' (provisioned) or 'workgroup_name' (serverless)")
 	}
 	if clusterID != "" && workgroup != "" {
-		return nil, 0, "", fmt.Errorf("redshift_iam_token requires exactly one of 'cluster_identifier' or 'workgroup_name', not both")
+		return nil, nil, 0, "", fmt.Errorf("redshift_iam_token requires exactly one of 'cluster_identifier' or 'workgroup_name', not both")
 	}
 
 	dbName := credential.GetString(spec.Config, "db_name", "")
@@ -472,7 +472,7 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credentia
 
 	durationSeconds := credential.GetInt(spec.Config, "duration_seconds", 900)
 	if durationSeconds < 900 || durationSeconds > 3600 {
-		return nil, 0, "", fmt.Errorf("duration_seconds must be between 900 and 3600 (got %d)", durationSeconds)
+		return nil, nil, 0, "", fmt.Errorf("duration_seconds must be between 900 and 3600 (got %d)", durationSeconds)
 	}
 
 	var (
@@ -492,10 +492,10 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credentia
 		}
 		out, err := d.redshiftClient.GetClusterCredentialsWithIAM(ctx, input)
 		if err != nil {
-			return nil, 0, "", fmt.Errorf("Redshift GetClusterCredentialsWithIAM failed for cluster %s: %w", clusterID, err)
+			return nil, nil, 0, "", fmt.Errorf("Redshift GetClusterCredentialsWithIAM failed for cluster %s: %w", clusterID, err)
 		}
 		if out.DbUser == nil || out.DbPassword == nil {
-			return nil, 0, "", fmt.Errorf("Redshift GetClusterCredentialsWithIAM returned empty credentials for cluster %s", clusterID)
+			return nil, nil, 0, "", fmt.Errorf("Redshift GetClusterCredentialsWithIAM returned empty credentials for cluster %s", clusterID)
 		}
 		dbUser = *out.DbUser
 		dbPassword = *out.DbPassword
@@ -511,10 +511,10 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credentia
 		}
 		out, err := d.redshiftServerlessClient.GetCredentials(ctx, input)
 		if err != nil {
-			return nil, 0, "", fmt.Errorf("Redshift Serverless GetCredentials failed for workgroup %s: %w", workgroup, err)
+			return nil, nil, 0, "", fmt.Errorf("Redshift Serverless GetCredentials failed for workgroup %s: %w", workgroup, err)
 		}
 		if out.DbUser == nil || out.DbPassword == nil {
-			return nil, 0, "", fmt.Errorf("Redshift Serverless GetCredentials returned empty credentials for workgroup %s", workgroup)
+			return nil, nil, 0, "", fmt.Errorf("Redshift Serverless GetCredentials returned empty credentials for workgroup %s", workgroup)
 		}
 		dbUser = *out.DbUser
 		dbPassword = *out.DbPassword
@@ -550,7 +550,7 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credentia
 		)
 	}
 
-	return rawData, leaseTTL, "", nil
+	return rawData, nil, leaseTTL, "", nil
 }
 
 // Revoke attempts to revoke a credential (best-effort)

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -254,7 +254,7 @@ func TestAWSDriver_MintCredential_InvalidMethod(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method")
 }
@@ -285,7 +285,7 @@ func TestAWSDriver_MintCredential_TTLBelowMinimum(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "below minimum")
 }
@@ -316,7 +316,7 @@ func TestAWSDriver_MintCredential_TTLExceedsMaximum(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
@@ -380,7 +380,7 @@ func TestAWSDriver_MintCredential_RedshiftIAMToken_MissingEndpoint(t *testing.T)
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "db_endpoint")
 }
@@ -397,7 +397,7 @@ func TestAWSDriver_MintCredential_RedshiftIAMToken_NoClusterOrWorkgroup(t *testi
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cluster_identifier")
 	assert.Contains(t, err.Error(), "workgroup_name")
@@ -417,7 +417,7 @@ func TestAWSDriver_MintCredential_RedshiftIAMToken_BothClusterAndWorkgroup(t *te
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one")
 }
@@ -437,7 +437,7 @@ func TestAWSDriver_MintCredential_RedshiftIAMToken_DurationOutOfRange(t *testing
 					"duration_seconds":   d,
 				},
 			}
-			_, _, _, err := driver.MintCredential(context.TODO(), spec)
+			_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "duration_seconds")
 		})
@@ -457,7 +457,7 @@ func TestAWSDriver_MintCredential_UnsupportedMethodMessage_IncludesRedshift(t *t
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "redshift_iam_token")
 }

--- a/credential/drivers/azure_driver.go
+++ b/credential/drivers/azure_driver.go
@@ -310,7 +310,7 @@ func (f *AzureDriverFactory) Create(config map[string]string, log *logger.GatedL
 
 // MintCredential mints credentials based on the spec's mint_method.
 // Credentials are minted using the SP credentials stored in the spec (not the source).
-func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "bearer_token")
 
 	switch mintMethod {
@@ -319,12 +319,12 @@ func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	case "key_vault_secret":
 		return d.fetchKeyVaultSecret(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Azure driver; use 'bearer_token' or 'key_vault_secret'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Azure driver; use 'bearer_token' or 'key_vault_secret'", mintMethod)
 	}
 }
 
 // mintBearerToken exchanges spec's SP credentials for an Azure AD bearer token
-func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	// Get SP credentials from spec config (pre-provisioned)
 	tenantID := credential.GetString(spec.Config, "tenant_id", d.getTenantID())
 	clientID := credential.GetString(spec.Config, "client_id", "")
@@ -332,13 +332,13 @@ func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.Cred
 	resourceURI := credential.GetString(spec.Config, "resource_uri", "https://management.azure.com/")
 
 	if clientID == "" || clientSecret == "" {
-		return nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'client_secret' for bearer_token mint method")
+		return nil, nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'client_secret' for bearer_token mint method")
 	}
 
 	// Exchange for bearer token
 	token, expiresIn, err := d.acquireToken(ctx, tenantID, clientID, clientSecret, resourceURI)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to acquire Azure AD token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire Azure AD token: %w", err)
 	}
 
 	ttl := time.Duration(expiresIn) * time.Second
@@ -360,11 +360,11 @@ func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.Cred
 	}
 
 	// No leaseID - bearer tokens expire naturally and cannot be revoked
-	return rawData, ttl, "", nil
+	return rawData, nil, ttl, "", nil
 }
 
 // fetchKeyVaultSecret fetches a secret from Azure Key Vault
-func (d *AzureDriver) fetchKeyVaultSecret(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *AzureDriver) fetchKeyVaultSecret(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	// Get SP credentials from spec config
 	tenantID := credential.GetString(spec.Config, "tenant_id", d.getTenantID())
 	clientID := credential.GetString(spec.Config, "client_id", "")
@@ -374,16 +374,16 @@ func (d *AzureDriver) fetchKeyVaultSecret(ctx context.Context, spec *credential.
 	secretVersion := credential.GetString(spec.Config, "secret_version", "")
 
 	if clientID == "" || clientSecret == "" {
-		return nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'client_secret' for key_vault_secret mint method")
+		return nil, nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'client_secret' for key_vault_secret mint method")
 	}
 	if vaultName == "" || secretName == "" {
-		return nil, 0, "", fmt.Errorf("spec config must contain 'vault_name' and 'secret_name' for key_vault_secret mint method")
+		return nil, nil, 0, "", fmt.Errorf("spec config must contain 'vault_name' and 'secret_name' for key_vault_secret mint method")
 	}
 
 	// Get bearer token for Key Vault
 	kvToken, _, err := d.acquireToken(ctx, tenantID, clientID, clientSecret, "https://vault.azure.net/")
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to acquire Key Vault token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire Key Vault token: %w", err)
 	}
 
 	// Build Key Vault URL
@@ -402,7 +402,7 @@ func (d *AzureDriver) fetchKeyVaultSecret(ctx context.Context, spec *credential.
 		operation:   "fetchKeyVaultSecret",
 	}, nil, 1)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	var secretResp struct {
@@ -410,7 +410,7 @@ func (d *AzureDriver) fetchKeyVaultSecret(ctx context.Context, spec *credential.
 		ID    string `json:"id"`
 	}
 	if err := json.Unmarshal(respBody, &secretResp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to decode Key Vault response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to decode Key Vault response: %w", err)
 	}
 
 	// Try to parse as JSON for structured secrets
@@ -429,7 +429,7 @@ func (d *AzureDriver) fetchKeyVaultSecret(ctx context.Context, spec *credential.
 	}
 
 	// Key Vault secrets are static - no TTL, no lease
-	return rawData, 0, "", nil
+	return rawData, nil, 0, "", nil
 }
 
 // Revoke is a no-op for Azure credentials (they expire naturally)

--- a/credential/drivers/azure_driver_test.go
+++ b/credential/drivers/azure_driver_test.go
@@ -189,7 +189,7 @@ func TestAzureDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 			"mint_method": "invalid_method",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method 'invalid_method'")
 }
@@ -206,7 +206,7 @@ func TestAzureDriver_MintCredential_BearerToken_MissingCredentials(t *testing.T)
 			"client_secret": "test-secret",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "'client_id' and 'client_secret'")
 
@@ -219,7 +219,7 @@ func TestAzureDriver_MintCredential_BearerToken_MissingCredentials(t *testing.T)
 			"client_id":   "test-client",
 		},
 	}
-	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	_, _, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "'client_id' and 'client_secret'")
 }
@@ -238,7 +238,7 @@ func TestAzureDriver_MintCredential_KeyVaultSecret_MissingConfig(t *testing.T) {
 			"secret_name":   "test-secret",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "'vault_name' and 'secret_name'")
 
@@ -253,7 +253,7 @@ func TestAzureDriver_MintCredential_KeyVaultSecret_MissingConfig(t *testing.T) {
 			"vault_name":    "test-vault",
 		},
 	}
-	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	_, _, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "'vault_name' and 'secret_name'")
 }

--- a/credential/drivers/elastic_driver.go
+++ b/credential/drivers/elastic_driver.go
@@ -171,7 +171,7 @@ func (f *ElasticDriverFactory) Create(config map[string]string, log *logger.Gate
 //   - key_name: Override for the generated key name (optional)
 //   - role_descriptors: JSON string of role descriptors (optional)
 //   - expiration: Key expiration duration, e.g. "30d" (optional)
-func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	prefix := credential.GetString(d.credSource.Config, "key_name_prefix", "warden")
 	keyName := credential.GetString(spec.Config, "key_name", fmt.Sprintf("%s-%s-%d", prefix, spec.Name, time.Now().Unix()))
 	expiration := credential.GetString(spec.Config, "expiration", "1h")
@@ -188,7 +188,7 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 	if rdJSON := credential.GetString(spec.Config, "role_descriptors", ""); rdJSON != "" {
 		var roleDescriptors map[string]interface{}
 		if err := json.Unmarshal([]byte(rdJSON), &roleDescriptors); err != nil {
-			return nil, 0, "", fmt.Errorf("invalid role_descriptors JSON: %w", err)
+			return nil, nil, 0, "", fmt.Errorf("invalid role_descriptors JSON: %w", err)
 		}
 		reqBody["role_descriptors"] = roleDescriptors
 	}
@@ -199,12 +199,12 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal create API key request: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal create API key request: %w", err)
 	}
 
 	respBody, _, err := d.doElasticRequest(ctx, http.MethodPost, "/_security/api_key", body)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create Elasticsearch API key: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create Elasticsearch API key: %w", err)
 	}
 
 	var createResp struct {
@@ -215,11 +215,11 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		Expiration *int64 `json:"expiration"`
 	}
 	if err := json.Unmarshal(respBody, &createResp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to decode create API key response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to decode create API key response: %w", err)
 	}
 
 	if createResp.Encoded == "" || createResp.ID == "" {
-		return nil, 0, "", fmt.Errorf("create API key response missing encoded or id field")
+		return nil, nil, 0, "", fmt.Errorf("create API key response missing encoded or id field")
 	}
 
 	rawData := map[string]interface{}{
@@ -246,7 +246,7 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		)
 	}
 
-	return rawData, ttl, leaseID, nil
+	return rawData, nil, ttl, leaseID, nil
 }
 
 // Revoke invalidates an Elasticsearch API key via DELETE /_security/api_key.

--- a/credential/drivers/elastic_driver_test.go
+++ b/credential/drivers/elastic_driver_test.go
@@ -317,7 +317,7 @@ func TestElasticDriver_MintCredential(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	rawData, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rawData["api_key"], "should return encoded API key")
@@ -338,7 +338,7 @@ func TestElasticDriver_MintCredential_WithExpiration(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rawData["api_key"])
@@ -359,7 +359,7 @@ func TestElasticDriver_MintCredential_WithRoleDescriptors(t *testing.T) {
 		},
 	}
 
-	rawData, _, _, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 	assert.NotEmpty(t, rawData["api_key"])
 }
@@ -377,7 +377,7 @@ func TestElasticDriver_MintCredential_InvalidRoleDescriptors(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid role_descriptors JSON")
 }
@@ -415,7 +415,7 @@ func TestElasticDriver_MintCredential_WithCustomKeyName(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "my-custom-key", receivedName)
 }
@@ -651,7 +651,7 @@ func TestElasticDriver_FullRotationLifecycle(t *testing.T) {
 
 	// Verify the driver still works after rotation
 	spec := &credential.CredSpec{Name: "post-rotation", Config: map[string]string{}}
-	rawData, _, _, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 	assert.NotEmpty(t, rawData["api_key"])
 }
@@ -773,7 +773,7 @@ func TestElasticDriver_RequestIncludesApiKeyHeader(t *testing.T) {
 	}
 
 	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
 	assert.Equal(t, "ApiKey "+apiKey, receivedAuth)
@@ -826,7 +826,7 @@ func TestElasticDriver_ConcurrentMintCredential(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		go func() {
 			spec := &credential.CredSpec{Name: "concurrent-spec", Config: map[string]string{}}
-			_, _, _, err := d.MintCredential(context.TODO(), spec)
+			_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 			errs <- err
 		}()
 	}

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -173,7 +173,7 @@ func (f *GCPDriverFactory) Create(config map[string]string, log *logger.GatedLog
 }
 
 // MintCredential mints credentials based on the spec's mint_method.
-func (d *GCPDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GCPDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "access_token")
 
 	switch mintMethod {
@@ -182,18 +182,18 @@ func (d *GCPDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	case "impersonated_access_token":
 		return d.mintImpersonatedAccessToken(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GCP driver; use 'access_token' or 'impersonated_access_token'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GCP driver; use 'access_token' or 'impersonated_access_token'", mintMethod)
 	}
 }
 
 // mintAccessToken exchanges the source SA key for an OAuth2 access token
-func (d *GCPDriver) mintAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GCPDriver) mintAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	scopesStr := credential.GetString(spec.Config, "scopes", "https://www.googleapis.com/auth/cloud-platform")
 	scopes := splitScopes(scopesStr)
 
 	token, expiry, err := d.getSourceToken(ctx, scopes)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to acquire GCP access token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire GCP access token: %w", err)
 	}
 
 	saKey, _ := d.parseServiceAccountKey()
@@ -219,14 +219,14 @@ func (d *GCPDriver) mintAccessToken(ctx context.Context, spec *credential.CredSp
 	}
 
 	// No leaseID - access tokens expire naturally and cannot be revoked
-	return rawData, ttl, "", nil
+	return rawData, nil, ttl, "", nil
 }
 
 // mintImpersonatedAccessToken impersonates another service account via IAM Credentials API
-func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	targetSA := credential.GetString(spec.Config, "target_service_account", "")
 	if targetSA == "" {
-		return nil, 0, "", fmt.Errorf("target_service_account is required for impersonated_access_token mint method")
+		return nil, nil, 0, "", fmt.Errorf("target_service_account is required for impersonated_access_token mint method")
 	}
 
 	scopesStr := credential.GetString(spec.Config, "scopes", "https://www.googleapis.com/auth/cloud-platform")
@@ -236,7 +236,7 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 	// Get source token with IAM scope for impersonation
 	sourceToken, _, err := d.getSourceToken(ctx, []string{"https://www.googleapis.com/auth/iam"})
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to get source token for impersonation: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to get source token for impersonation: %w", err)
 	}
 
 	// Call IAM Credentials API to generate an access token for the target SA
@@ -249,7 +249,7 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal impersonation request: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal impersonation request: %w", err)
 	}
 
 	respBody, err := d.doGCPRequest(ctx, gcpAPIRequest{
@@ -262,7 +262,7 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		operation:   "generateAccessToken",
 	}, 1)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	var tokenResp struct {
@@ -270,11 +270,11 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		ExpireTime  string `json:"expireTime"` // RFC3339
 	}
 	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to decode impersonation response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to decode impersonation response: %w", err)
 	}
 
 	if tokenResp.AccessToken == "" {
-		return nil, 0, "", fmt.Errorf("impersonation response missing accessToken")
+		return nil, nil, 0, "", fmt.Errorf("impersonation response missing accessToken")
 	}
 
 	// Parse expiry time
@@ -310,7 +310,7 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		)
 	}
 
-	return rawData, ttl, "", nil
+	return rawData, nil, ttl, "", nil
 }
 
 // Revoke is a no-op for GCP credentials (they expire naturally)

--- a/credential/drivers/gcp_driver_test.go
+++ b/credential/drivers/gcp_driver_test.go
@@ -123,7 +123,7 @@ func TestGCPDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method")
 }
@@ -144,7 +144,7 @@ func TestGCPDriver_MintCredential_ImpersonationMissingTarget(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "target_service_account")
 }

--- a/credential/drivers/github_driver.go
+++ b/credential/drivers/github_driver.go
@@ -132,7 +132,7 @@ func (d *GitHubDriver) getGitHubURL() string {
 
 // MintCredential returns a GitHub token for the given spec.
 // Auth credentials are read from spec.Config, not from the source.
-func (d *GitHubDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GitHubDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	authMethod := credential.GetString(spec.Config, "auth_method", "app")
 	switch authMethod {
 	case "app":
@@ -140,12 +140,12 @@ func (d *GitHubDriver) MintCredential(ctx context.Context, spec *credential.Cred
 	case "pat":
 		return d.mintPATCredential(spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported auth_method '%s'", authMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported auth_method '%s'", authMethod)
 	}
 }
 
 // mintAppCredential mints a GitHub App installation access token using spec config
-func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	d.appTokenMu.Lock()
 	defer d.appTokenMu.Unlock()
 
@@ -156,14 +156,14 @@ func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.C
 			"expires_at": cached.expiresAt.Format(time.RFC3339),
 		}
 		ttl := time.Until(cached.expiresAt)
-		return rawData, ttl, "", nil
+		return rawData, nil, ttl, "", nil
 	}
 
 	// Parse private key from spec config
 	keyPEM := credential.GetString(spec.Config, "private_key", "")
 	key, err := parseRSAPrivateKey(keyPEM)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse private key from spec: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse private key from spec: %w", err)
 	}
 
 	appID := credential.GetString(spec.Config, "app_id", "")
@@ -172,7 +172,7 @@ func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.C
 	// Mint a fresh installation token
 	token, expiresAt, err := d.mintInstallationToken(ctx, key, appID, installationID)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to mint installation token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to mint installation token: %w", err)
 	}
 
 	// Cache per spec
@@ -195,14 +195,14 @@ func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.C
 		)
 	}
 
-	return rawData, ttl, "", nil
+	return rawData, nil, ttl, "", nil
 }
 
 // mintPATCredential returns the PAT from spec config as a credential
-func (d *GitHubDriver) mintPATCredential(spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GitHubDriver) mintPATCredential(spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	token := credential.GetString(spec.Config, "token", "")
 	if token == "" {
-		return nil, 0, "", fmt.Errorf("no GitHub PAT configured in spec")
+		return nil, nil, 0, "", fmt.Errorf("no GitHub PAT configured in spec")
 	}
 
 	rawData := map[string]interface{}{
@@ -210,7 +210,7 @@ func (d *GitHubDriver) mintPATCredential(spec *credential.CredSpec) (map[string]
 	}
 
 	// PATs are static - no TTL, no lease
-	return rawData, 0, "", nil
+	return rawData, nil, 0, "", nil
 }
 
 // mintInstallationToken creates a new installation access token via the GitHub API

--- a/credential/drivers/github_driver_test.go
+++ b/credential/drivers/github_driver_test.go
@@ -167,7 +167,7 @@ func TestGitHubDriver_MintPATCredential(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "ghp_test123", rawData["token"])
 	assert.Equal(t, time.Duration(0), ttl)
@@ -192,7 +192,7 @@ func TestGitHubDriver_MintPATCredential_EmptyToken(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no GitHub PAT configured")
 }
@@ -214,7 +214,7 @@ func TestGitHubDriver_MintCredential_UnsupportedAuthMethod(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported auth_method")
 }
@@ -258,7 +258,7 @@ func TestGitHubDriver_MintAppCredential(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "ghs_installation_token_123", rawData["token"])
 	assert.NotEmpty(t, rawData["expires_at"])
@@ -301,13 +301,13 @@ func TestGitHubDriver_MintAppCredential_Cached(t *testing.T) {
 	}
 
 	// First call mints
-	rawData1, _, _, err := driver.MintCredential(context.Background(), spec)
+	rawData1, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "ghs_cached_token", rawData1["token"])
 	assert.Equal(t, 1, callCount)
 
 	// Second call should use cache (no additional HTTP call)
-	rawData2, _, _, err := driver.MintCredential(context.Background(), spec)
+	rawData2, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "ghs_cached_token", rawData2["token"])
 	assert.Equal(t, 1, callCount, "should use cached token, not call API again")
@@ -359,17 +359,17 @@ func TestGitHubDriver_MintAppCredential_PerSpecCache(t *testing.T) {
 	}
 
 	// Mint for spec A
-	_, _, _, err := driver.MintCredential(context.Background(), specA)
+	_, _, _, _, err := driver.MintCredential(context.Background(), specA)
 	require.NoError(t, err)
 	assert.Equal(t, 1, callCount)
 
 	// Mint for spec B — should call API again (different spec)
-	_, _, _, err = driver.MintCredential(context.Background(), specB)
+	_, _, _, _, err = driver.MintCredential(context.Background(), specB)
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount, "different specs should not share cache")
 
 	// Mint for spec A again — should use cache
-	_, _, _, err = driver.MintCredential(context.Background(), specA)
+	_, _, _, _, err = driver.MintCredential(context.Background(), specA)
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount, "same spec should use cached token")
 }
@@ -403,7 +403,7 @@ func TestGitHubDriver_MintInstallationToken_APIError(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to mint installation token")
 }
@@ -440,7 +440,7 @@ func TestGitHubDriver_MintInstallationToken_EmptyToken(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty token")
 }

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -196,7 +196,7 @@ func (d *GitLabDriver) verifyAuth(ctx context.Context) error {
 }
 
 // MintCredential mints credentials based on the spec's mint_method
-func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
@@ -205,12 +205,12 @@ func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.Cred
 	case "group_access_token":
 		return d.mintGroupAccessToken(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GitLab driver; use 'project_access_token' or 'group_access_token'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GitLab driver; use 'project_access_token' or 'group_access_token'", mintMethod)
 	}
 }
 
 // mintProjectAccessToken creates a project access token via the GitLab API
-func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	projectID := credential.GetString(spec.Config, "project_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -233,13 +233,13 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
 	path := fmt.Sprintf("/api/v4/projects/%s/access_tokens", url.PathEscape(projectID))
 	respBody, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create project access token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create project access token: %w", err)
 	}
 
 	var result struct {
@@ -247,11 +247,11 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 		Token string `json:"token"`
 	}
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	if result.Token == "" {
-		return nil, 0, "", fmt.Errorf("GitLab API returned empty token")
+		return nil, nil, 0, "", fmt.Errorf("GitLab API returned empty token")
 	}
 
 	tokenIDStr := strconv.Itoa(result.ID)
@@ -272,11 +272,11 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 		)
 	}
 
-	return rawData, ttl, leaseID, nil
+	return rawData, nil, ttl, leaseID, nil
 }
 
 // mintGroupAccessToken creates a group access token via the GitLab API
-func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	groupID := credential.GetString(spec.Config, "group_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -298,13 +298,13 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
 	path := fmt.Sprintf("/api/v4/groups/%s/access_tokens", url.PathEscape(groupID))
 	respBody, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create group access token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create group access token: %w", err)
 	}
 
 	var result struct {
@@ -312,11 +312,11 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 		Token string `json:"token"`
 	}
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	if result.Token == "" {
-		return nil, 0, "", fmt.Errorf("GitLab API returned empty token")
+		return nil, nil, 0, "", fmt.Errorf("GitLab API returned empty token")
 	}
 
 	tokenIDStr := strconv.Itoa(result.ID)
@@ -337,7 +337,7 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 		)
 	}
 
-	return rawData, ttl, leaseID, nil
+	return rawData, nil, ttl, leaseID, nil
 }
 
 // Revoke revokes a previously minted access token

--- a/credential/drivers/gitlab_driver_test.go
+++ b/credential/drivers/gitlab_driver_test.go
@@ -202,7 +202,7 @@ func TestGitLabDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 			"mint_method": "invalid_method",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method 'invalid_method'")
 }
@@ -215,7 +215,7 @@ func TestGitLabDriver_MintCredential_MissingMintMethod(t *testing.T) {
 		Type:   credential.TypeGitLabAccessToken,
 		Config: map[string]string{},
 	}
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method")
 }
@@ -300,7 +300,7 @@ func TestGitLabDriver_MintProjectAccessToken(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "glpat-minted-token", rawData["access_token"])
 	assert.Equal(t, "99", rawData["token_id"])
@@ -345,7 +345,7 @@ func TestGitLabDriver_MintGroupAccessToken(t *testing.T) {
 		},
 	}
 
-	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, _, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "glpat-group-token", rawData["access_token"])
 	assert.Equal(t, "77", rawData["token_id"])
@@ -434,7 +434,7 @@ func TestGitLabDriver_MintProjectAccessToken_EmptyToken(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty token")
 }
@@ -470,7 +470,7 @@ func TestGitLabDriver_MintProjectAccessToken_APIError(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create project access token")
 }

--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -126,7 +126,7 @@ func (d *GrafanaDriver) getAdminToken() string {
 //  3. Return {"api_key": "<token>"} with TTL matching token expiry
 //
 // The leaseID is the service account ID, used for cleanup on Revoke.
-func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	role := credential.GetString(spec.Config, "role", grafanaDefaultRole)
 	namePrefix := credential.GetString(spec.Config, "name_prefix", grafanaDefaultNamePrefix)
 	tokenExpiry := credential.GetDuration(spec.Config, "token_expiry", grafanaDefaultTokenExpiry)
@@ -136,7 +136,7 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 	switch role {
 	case "Viewer", "Editor", "Admin":
 	default:
-		return nil, 0, "", fmt.Errorf("invalid role '%s': must be Viewer, Editor, or Admin", role)
+		return nil, nil, 0, "", fmt.Errorf("invalid role '%s': must be Viewer, Editor, or Admin", role)
 	}
 
 	// Step 1: Create a service account
@@ -147,22 +147,22 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		"isDisabled": false,
 	})
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal service account request: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal service account request: %w", err)
 	}
 
 	saResp, _, err := d.doGrafanaRequest(ctx, http.MethodPost, "/api/serviceaccounts", saBody, orgID)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create service account: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create service account: %w", err)
 	}
 
 	var saResult struct {
 		ID int64 `json:"id"`
 	}
 	if err := json.Unmarshal(saResp, &saResult); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse service account response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse service account response: %w", err)
 	}
 	if saResult.ID == 0 {
-		return nil, 0, "", fmt.Errorf("Grafana API returned service account with ID 0")
+		return nil, nil, 0, "", fmt.Errorf("Grafana API returned service account with ID 0")
 	}
 
 	// Step 2: Create a token for the service account
@@ -172,7 +172,7 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		"secondsToLive": secondsToLive,
 	})
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal token request: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal token request: %w", err)
 	}
 
 	tokenPath := fmt.Sprintf("/api/serviceaccounts/%d/tokens", saResult.ID)
@@ -180,7 +180,7 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 	if err != nil {
 		// Best-effort cleanup: delete the service account we just created
 		d.deleteServiceAccount(ctx, saResult.ID, orgID)
-		return nil, 0, "", fmt.Errorf("failed to create service account token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create service account token: %w", err)
 	}
 
 	var tokenResult struct {
@@ -188,11 +188,11 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 	}
 	if err := json.Unmarshal(tokenResp, &tokenResult); err != nil {
 		d.deleteServiceAccount(ctx, saResult.ID, orgID)
-		return nil, 0, "", fmt.Errorf("failed to parse token response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse token response: %w", err)
 	}
 	if tokenResult.Key == "" {
 		d.deleteServiceAccount(ctx, saResult.ID, orgID)
-		return nil, 0, "", fmt.Errorf("Grafana API returned empty token key")
+		return nil, nil, 0, "", fmt.Errorf("Grafana API returned empty token key")
 	}
 
 	// Return credential as api_key for BearerAPIKeyExtractor compatibility
@@ -218,7 +218,7 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		)
 	}
 
-	return rawData, tokenExpiry, leaseID, nil
+	return rawData, nil, tokenExpiry, leaseID, nil
 }
 
 // Revoke deletes the service account (and all its tokens) identified by leaseID.

--- a/credential/drivers/grafana_driver_test.go
+++ b/credential/drivers/grafana_driver_test.go
@@ -213,7 +213,7 @@ func TestGrafanaDriver_MintCredential(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "glsa_minted_token_123", rawData["api_key"])
 	assert.Equal(t, grafanaDefaultTokenExpiry, ttl)
@@ -275,7 +275,7 @@ func TestGrafanaDriver_MintCredential_CustomConfig(t *testing.T) {
 		},
 	}
 
-	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, _, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "glsa_custom", rawData["api_key"])
 	assert.Equal(t, "99:100", leaseID)
@@ -301,7 +301,7 @@ func TestGrafanaDriver_MintCredential_InvalidRole(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid role")
 }
@@ -330,7 +330,7 @@ func TestGrafanaDriver_MintCredential_SACreateFails(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create service account")
 }
@@ -375,7 +375,7 @@ func TestGrafanaDriver_MintCredential_TokenCreateFails_CleansUpSA(t *testing.T) 
 		Config: map[string]string{},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create service account token")
 	assert.Equal(t, int32(1), deleteCalled.Load(), "should cleanup service account on token create failure")
@@ -421,7 +421,7 @@ func TestGrafanaDriver_MintCredential_EmptyTokenKey(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty token key")
 	assert.Equal(t, int32(1), deleteCalled.Load(), "should cleanup on empty token key")
@@ -606,7 +606,7 @@ func TestGrafanaDriver_MintCredential_SAZeroID(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ID 0")
 }
@@ -638,9 +638,9 @@ func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
 
 func TestParseGrafanaLeaseID(t *testing.T) {
 	tests := []struct {
-		leaseID       string
-		wantSAID      string
-		wantOrgID     string
+		leaseID   string
+		wantSAID  string
+		wantOrgID string
 	}{
 		{"1337", "1337", ""},
 		{"42:1337", "1337", "42"},

--- a/credential/drivers/honeycomb_driver.go
+++ b/credential/drivers/honeycomb_driver.go
@@ -152,7 +152,7 @@ func (d *HoneycombDriver) getTeamSlug() string {
 //
 // The leaseID is the Honeycomb key ID (e.g., "hcxik_..."), used for revocation.
 // The key secret is only available at creation time.
-func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	keyType := credential.GetString(spec.Config, "key_type", honeycombDefaultKeyType)
 	namePrefix := credential.GetString(spec.Config, "key_name_prefix", honeycombDefaultKeyNamePrefix)
 	environmentID := credential.GetString(spec.Config, "environment_id", "")
@@ -163,11 +163,11 @@ func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.C
 	switch keyType {
 	case "ingest", "configuration":
 	default:
-		return nil, 0, "", fmt.Errorf("invalid key_type '%s': must be 'ingest' or 'configuration'", keyType)
+		return nil, nil, 0, "", fmt.Errorf("invalid key_type '%s': must be 'ingest' or 'configuration'", keyType)
 	}
 
 	if environmentID == "" {
-		return nil, 0, "", fmt.Errorf("environment_id is required in spec config")
+		return nil, nil, 0, "", fmt.Errorf("environment_id is required in spec config")
 	}
 
 	// Build key name
@@ -182,11 +182,11 @@ func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.C
 	// Parse and add permissions if specified (configuration keys only)
 	if permissionsJSON != "" {
 		if keyType != "configuration" {
-			return nil, 0, "", fmt.Errorf("permissions can only be set for configuration keys, not %s keys", keyType)
+			return nil, nil, 0, "", fmt.Errorf("permissions can only be set for configuration keys, not %s keys", keyType)
 		}
 		var permissions map[string]interface{}
 		if err := json.Unmarshal([]byte(permissionsJSON), &permissions); err != nil {
-			return nil, 0, "", fmt.Errorf("invalid permissions JSON: %w", err)
+			return nil, nil, 0, "", fmt.Errorf("invalid permissions JSON: %w", err)
 		}
 		attributes["permissions"] = permissions
 	}
@@ -208,7 +208,7 @@ func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.C
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal API key request: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal API key request: %w", err)
 	}
 
 	// Create the API key
@@ -216,7 +216,7 @@ func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.C
 	path := fmt.Sprintf("/2/teams/%s/api-keys", url.PathEscape(teamSlug))
 	respBody, _, err := d.doHoneycombRequest(ctx, http.MethodPost, path, bodyBytes)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create API key: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create API key: %w", err)
 	}
 
 	// Parse response — JSON:API format
@@ -229,13 +229,13 @@ func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.C
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse API key response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse API key response: %w", err)
 	}
 	if resp.Data.ID == "" {
-		return nil, 0, "", fmt.Errorf("Honeycomb API returned key with empty ID")
+		return nil, nil, 0, "", fmt.Errorf("Honeycomb API returned key with empty ID")
 	}
 	if resp.Data.Attributes.Secret == "" {
-		return nil, 0, "", fmt.Errorf("Honeycomb API returned key with empty secret")
+		return nil, nil, 0, "", fmt.Errorf("Honeycomb API returned key with empty secret")
 	}
 
 	rawData := map[string]interface{}{
@@ -256,7 +256,7 @@ func (d *HoneycombDriver) MintCredential(ctx context.Context, spec *credential.C
 		)
 	}
 
-	return rawData, keyTTL, leaseID, nil
+	return rawData, nil, keyTTL, leaseID, nil
 }
 
 // Revoke deletes the API key identified by leaseID.

--- a/credential/drivers/honeycomb_driver_test.go
+++ b/credential/drivers/honeycomb_driver_test.go
@@ -256,7 +256,7 @@ func TestHoneycombDriver_MintCredential(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "secret-ingest-key-value", rawData["api_key"])
 	assert.Equal(t, "ingest", rawData["key_type"])
@@ -316,7 +316,7 @@ func TestHoneycombDriver_MintCredential_ConfigurationKey(t *testing.T) {
 		},
 	}
 
-	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, _, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "secret-config-key", rawData["api_key"])
 	assert.Equal(t, "configuration", rawData["key_type"])
@@ -373,7 +373,7 @@ func TestHoneycombDriver_MintCredential_CustomConfig(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "secret-custom", rawData["api_key"])
 	assert.Equal(t, "ingest", rawData["key_type"])
@@ -403,7 +403,7 @@ func TestHoneycombDriver_MintCredential_InvalidPermissionsJSON(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid permissions JSON")
 }
@@ -442,7 +442,7 @@ func TestHoneycombDriver_MintCredential_EmptyID(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty ID")
 }
@@ -469,7 +469,7 @@ func TestHoneycombDriver_MintCredential_InvalidKeyType(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid key_type")
 }
@@ -493,7 +493,7 @@ func TestHoneycombDriver_MintCredential_MissingEnvironmentID(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "environment_id is required")
 }
@@ -521,7 +521,7 @@ func TestHoneycombDriver_MintCredential_PermissionsOnIngestKey(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "permissions can only be set for configuration keys")
 }
@@ -553,7 +553,7 @@ func TestHoneycombDriver_MintCredential_APIError(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create API key")
 }
@@ -592,7 +592,7 @@ func TestHoneycombDriver_MintCredential_EmptySecret(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty secret")
 }

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -169,7 +169,7 @@ func (f *IBMDriverFactory) Create(config map[string]string, log *logger.GatedLog
 // ============================================================================
 
 // MintCredential mints credentials based on the spec's mint_method.
-func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token")
 
 	switch mintMethod {
@@ -178,15 +178,15 @@ func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	case "iam_with_cos":
 		return d.mintIAMWithCOS(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for IBM driver; use 'iam_token' or 'iam_with_cos'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for IBM driver; use 'iam_token' or 'iam_with_cos'", mintMethod)
 	}
 }
 
 // mintIAMToken exchanges the source API key for an IAM bearer token
-func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	token, expiry, err := d.getIAMToken(ctx)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
 	}
 
 	ttl := time.Until(expiry)
@@ -204,14 +204,14 @@ func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec)
 	}
 
 	// No leaseID — IAM tokens expire naturally and cannot be revoked
-	return rawData, ttl, "", nil
+	return rawData, nil, ttl, "", nil
 }
 
 // mintIAMWithCOS mints an IAM bearer token and combines it with static COS HMAC keys from spec config.
-func (d *IBMDriver) mintIAMWithCOS(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *IBMDriver) mintIAMWithCOS(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	token, expiry, err := d.getIAMToken(ctx)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
 	}
 
 	ttl := time.Until(expiry)
@@ -236,7 +236,7 @@ func (d *IBMDriver) mintIAMWithCOS(ctx context.Context, spec *credential.CredSpe
 		)
 	}
 
-	return rawData, ttl, "", nil
+	return rawData, nil, ttl, "", nil
 }
 
 // Revoke is a no-op for IBM credentials (IAM tokens expire naturally)

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -154,7 +154,7 @@ func TestIBMDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method")
 }
@@ -304,7 +304,7 @@ func TestIBMDriver_MintIAMToken(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rawData["api_key"])
@@ -326,7 +326,7 @@ func TestIBMDriver_MintIAMToken_DefaultMintMethod(t *testing.T) {
 		Config: map[string]string{}, // no mint_method = defaults to iam_token
 	}
 
-	rawData, _, _, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 	assert.NotEmpty(t, rawData["access_token"])
 }
@@ -346,7 +346,7 @@ func TestIBMDriver_MintIAMToken_InvalidKey(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "IBM IAM token")
 }
@@ -546,7 +546,7 @@ func TestIBMDriver_MintIAMWithCOS_DualMode(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rawData["access_token"])
@@ -569,7 +569,7 @@ func TestIBMDriver_MintIAMWithCOS_APIOnly(t *testing.T) {
 		},
 	}
 
-	rawData, _, _, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, rawData["access_token"])
@@ -594,7 +594,7 @@ func TestIBMDriver_MintIAMWithCOS_InvalidKey(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := d.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to acquire IBM IAM token")
 }

--- a/credential/drivers/kubernetes_driver.go
+++ b/credential/drivers/kubernetes_driver.go
@@ -161,17 +161,17 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 //   - namespace: Target namespace (required)
 //   - audiences: Comma-separated token audiences (optional)
 //   - ttl: Token TTL duration, e.g. "1h" (optional, default: 1h)
-func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	sa := credential.GetString(spec.Config, "service_account", "")
 	namespace := credential.GetString(spec.Config, "namespace", "")
 	audiencesStr := credential.GetString(spec.Config, "audiences", "")
 	ttl := credential.GetDuration(spec.Config, "ttl", 1*time.Hour)
 
 	if sa == "" {
-		return nil, 0, "", fmt.Errorf("service_account is required in spec config")
+		return nil, nil, 0, "", fmt.Errorf("service_account is required in spec config")
 	}
 	if namespace == "" {
-		return nil, 0, "", fmt.Errorf("namespace is required in spec config")
+		return nil, nil, 0, "", fmt.Errorf("namespace is required in spec config")
 	}
 
 	// Build audiences list
@@ -189,7 +189,7 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 
 	body, err := buildTokenRequestBody(expirationSeconds, audiences)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal TokenRequest: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal TokenRequest: %w", err)
 	}
 
 	path := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token",
@@ -197,7 +197,7 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 
 	respBody, statusCode, err := d.doK8sRequest(ctx, http.MethodPost, path, body)
 	if err != nil {
-		return nil, 0, "", d.mapError(err, statusCode, sa, namespace)
+		return nil, nil, 0, "", d.mapError(err, statusCode, sa, namespace)
 	}
 
 	// Parse TokenRequest response
@@ -208,11 +208,11 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 		} `json:"status"`
 	}
 	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to decode TokenRequest response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to decode TokenRequest response: %w", err)
 	}
 
 	if tokenResp.Status.Token == "" {
-		return nil, 0, "", fmt.Errorf("TokenRequest response missing token")
+		return nil, nil, 0, "", fmt.Errorf("TokenRequest response missing token")
 	}
 
 	// Compute TTL from expiration timestamp
@@ -256,7 +256,7 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 		)
 	}
 
-	return rawData, computedTTL, "", nil
+	return rawData, nil, computedTTL, "", nil
 }
 
 // Revoke is a no-op for Kubernetes ServiceAccount tokens.

--- a/credential/drivers/kubernetes_driver_test.go
+++ b/credential/drivers/kubernetes_driver_test.go
@@ -302,7 +302,7 @@ func TestKubernetesDriver_MintCredential_Success(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	rawData, ttl, leaseID, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "my-sa",
@@ -324,7 +324,7 @@ func TestKubernetesDriver_MintCredential_DefaultTTL(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	rawData, ttl, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	rawData, _, ttl, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "my-sa",
@@ -344,7 +344,7 @@ func TestKubernetesDriver_MintCredential_CustomAudiences(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	rawData, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	rawData, _, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "my-sa",
@@ -362,7 +362,7 @@ func TestKubernetesDriver_MintCredential_MissingServiceAccount(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	_, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"namespace": "default",
@@ -378,7 +378,7 @@ func TestKubernetesDriver_MintCredential_MissingNamespace(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	_, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "my-sa",
@@ -394,7 +394,7 @@ func TestKubernetesDriver_MintCredential_SANotFound(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	_, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "not-found-sa",
@@ -411,7 +411,7 @@ func TestKubernetesDriver_MintCredential_Forbidden(t *testing.T) {
 
 	d := newTestK8sDriver(t, server.URL)
 
-	_, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "forbidden-sa",
@@ -718,7 +718,7 @@ func TestKubernetesDriver_MintCredential_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	_, _, _, err := d.MintCredential(ctx, &credential.CredSpec{
+	_, _, _, _, err := d.MintCredential(ctx, &credential.CredSpec{
 		Name: "test-spec",
 		Config: map[string]string{
 			"service_account": "my-sa",
@@ -751,7 +751,7 @@ func TestKubernetesDriver_ConcurrentMintAndRotation(t *testing.T) {
 	go func() {
 		defer func() { done <- struct{}{} }()
 		for i := 0; i < 10; i++ {
-			_, _, _, _ = d.MintCredential(context.Background(), &credential.CredSpec{
+			_, _, _, _, _ = d.MintCredential(context.Background(), &credential.CredSpec{
 				Name: "test-spec",
 				Config: map[string]string{
 					"service_account": "my-sa",

--- a/credential/drivers/local_driver.go
+++ b/credential/drivers/local_driver.go
@@ -46,7 +46,7 @@ func (f *LocalDriverFactory) InferCredentialType(_ map[string]string) (string, e
 }
 
 // MintCredential retrieves static credential data from the spec's SourceParams
-func (d *LocalDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *LocalDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	// Local credentials are always static (no TTL, no lease)
 	rawData := make(map[string]interface{})
 
@@ -67,7 +67,7 @@ func (d *LocalDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	// - leaseTTL: 0 (static credentials have no TTL)
 	// - leaseID: "" (static credentials have no lease)
 	// - error: nil
-	return rawData, 0, "", nil
+	return rawData, nil, 0, "", nil
 }
 
 // Revoke is a no-op for static credentials

--- a/credential/drivers/local_driver_test.go
+++ b/credential/drivers/local_driver_test.go
@@ -70,7 +70,7 @@ func TestLocalDriver_MintCredential(t *testing.T) {
 		},
 	}
 
-	data, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	data, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "admin", data["username"])
 	assert.Equal(t, "secret", data["password"])

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -233,7 +233,7 @@ func (d *OAuth2Driver) resolve(spec *credential.CredSpec, key, def string) strin
 
 // MintCredential mints a bearer token using the flow selected by auth_method
 // (default client_credentials).
-func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	authMethod := d.resolve(spec, "auth_method", oauth2AuthMethodClientCredentials)
 	switch authMethod {
 	case oauth2AuthMethodClientCredentials:
@@ -241,19 +241,19 @@ func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.Cred
 	case oauth2AuthMethodAuthorizationCode:
 		return d.mintFromRefreshToken(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("%s OAuth2 unsupported auth_method %q", d.displayName(), authMethod)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 unsupported auth_method %q", d.displayName(), authMethod)
 	}
 }
 
 // mintFromClientCredentials exchanges client credentials for a bearer token.
-func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	config := d.credSource.Config
 	name := d.displayName()
 
 	clientID := d.resolve(spec, "client_id", "")
 	clientSecret := d.resolve(spec, "client_secret", "")
 	if clientID == "" || clientSecret == "" {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 source missing client_id or client_secret", name)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 source missing client_id or client_secret", name)
 	}
 
 	defaultScopes := credential.GetString(config, "default_scopes", "")
@@ -276,13 +276,13 @@ func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *cred
 
 	tokenResp, err := d.postTokenRequest(ctx, d.tokenURL(), form)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, err)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, err)
 	}
 	if tokenResp.AccessToken == "" {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 token response missing access_token", name)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 token response missing access_token", name)
 	}
 
-	return accessTokenRawData(tokenResp), ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
+	return accessTokenRawData(tokenResp), nil, ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
 }
 
 // mintFromRefreshToken exchanges the sealed refresh token for a fresh access
@@ -290,22 +290,22 @@ func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *cred
 // static access token at connect time, which is returned directly. When the
 // provider rotates the refresh token, the new value is surfaced under the reserved
 // rawData key for the minting layer to persist.
-func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	name := d.displayName()
 
 	refreshToken := credential.GetString(spec.Config, "refresh_token", "")
 	if refreshToken == "" {
 		// No-refresh-token providers seal a static access token at connect time.
 		if staticToken := credential.GetString(spec.Config, "access_token", ""); staticToken != "" {
-			return map[string]interface{}{"api_key": staticToken}, staticTokenTTL(spec), "", nil
+			return map[string]interface{}{"api_key": staticToken}, nil, staticTokenTTL(spec), "", nil
 		}
-		return nil, 0, "", fmt.Errorf("%s OAuth2 spec %q is not connected — run `warden cred spec connect %s`", name, spec.Name, spec.Name)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 spec %q is not connected — run `warden cred spec connect %s`", name, spec.Name, spec.Name)
 	}
 
 	clientID := d.resolve(spec, "client_id", "")
 	clientSecret := d.resolve(spec, "client_secret", "")
 	if clientID == "" || clientSecret == "" {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 spec missing client_id or client_secret", name)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 spec missing client_id or client_secret", name)
 	}
 
 	form := url.Values{
@@ -320,12 +320,12 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 		if isRefreshTokenRejection(err) {
 			// Signal the minting layer to re-read the spec and retry once (the
 			// token may have been rotated by another node).
-			return nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w: %w", name, credential.ErrRefreshTokenRejected, err)
+			return nil, nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w: %w", name, credential.ErrRefreshTokenRejected, err)
 		}
-		return nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w", name, err)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 refresh failed: %w", name, err)
 	}
 	if tokenResp.AccessToken == "" {
-		return nil, 0, "", fmt.Errorf("%s OAuth2 refresh response missing access_token", name)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 refresh response missing access_token", name)
 	}
 
 	rawData := accessTokenRawData(tokenResp)
@@ -333,7 +333,7 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		rawData[credential.RawRotatedRefreshTokenKey] = tokenResp.RefreshToken
 	}
-	return rawData, ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
+	return rawData, nil, ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
 }
 
 // ExchangeAuthorizationCode exchanges an authorization code for tokens using the
@@ -603,7 +603,7 @@ func (d *OAuth2Driver) Cleanup(_ context.Context) error {
 func (d *OAuth2Driver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
 	name := d.displayName()
 
-	rawData, _, _, err := d.MintCredential(ctx, spec)
+	rawData, _, _, _, err := d.MintCredential(ctx, spec)
 	if err != nil {
 		return fmt.Errorf("%s OAuth2 spec verification failed: %w", name, err)
 	}

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -369,7 +369,7 @@ func TestOAuth2Driver_MintCredential(t *testing.T) {
 		Config: map[string]string{"scope": "read write"},
 	}
 
-	rawData, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "eyJ-test-access-token", rawData["api_key"])
 	assert.Equal(t, "Bearer", rawData["token_type"])
@@ -412,7 +412,7 @@ func TestOAuth2Driver_MintCredential_DefaultScope(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "test-token", rawData["api_key"])
 	assert.Equal(t, 1800*time.Second, ttl)
@@ -460,7 +460,7 @@ func TestOAuth2Driver_MintCredential_ExtraTokenParams(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	rawData, _, _, err := d.MintCredential(context.Background(), spec)
+	rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "test-token", rawData["api_key"])
 }
@@ -492,7 +492,7 @@ func TestOAuth2Driver_MintCredential_NoExpiresIn(t *testing.T) {
 		Config: map[string]string{},
 	}
 
-	_, ttl, _, err := d.MintCredential(context.Background(), spec)
+	_, _, ttl, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, time.Duration(0), ttl)
 }
@@ -506,7 +506,7 @@ func TestOAuth2Driver_MintCredential_MissingCredentials(t *testing.T) {
 	}
 
 	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing client_id or client_secret")
 }
@@ -531,7 +531,7 @@ func TestOAuth2Driver_MintCredential_TokenEndpointError(t *testing.T) {
 	}
 
 	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token exchange failed")
 }
@@ -559,7 +559,7 @@ func TestOAuth2Driver_MintCredential_EmptyAccessToken(t *testing.T) {
 	}
 
 	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing access_token")
 }
@@ -584,7 +584,7 @@ func TestOAuth2Driver_MintCredential_MalformedJSON(t *testing.T) {
 	}
 
 	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode")
 }
@@ -600,7 +600,7 @@ func TestOAuth2Driver_MintCredential_DisplayName(t *testing.T) {
 	}
 
 	spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "PagerDuty OAuth2 source missing")
 }
@@ -978,7 +978,7 @@ func TestOAuth2Driver_MintFromRefreshToken_Rotating(t *testing.T) {
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-old",
 	}}
 
-	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "at-new", rawData["api_key"])
 	assert.Equal(t, 28800*time.Second, ttl)
@@ -999,7 +999,7 @@ func TestOAuth2Driver_MintFromRefreshToken_NonRotating(t *testing.T) {
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-stable",
 	}}
 
-	rawData, _, _, err := d.MintCredential(context.Background(), spec)
+	rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "at-1", rawData["api_key"])
 	_, has := rawData[credential.RawRotatedRefreshTokenKey]
@@ -1010,7 +1010,7 @@ func TestOAuth2Driver_MintFromRefreshToken_NotConnected(t *testing.T) {
 	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": "https://example.invalid/token"}}, httpClient: http.DefaultClient}
 	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret"}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not connected")
 }
@@ -1020,7 +1020,7 @@ func TestOAuth2Driver_MintFromRefreshToken_StaticAccessToken(t *testing.T) {
 	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": "https://example.invalid/token"}}, httpClient: http.DefaultClient}
 	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{"auth_method": "authorization_code", "access_token": "static-token"}}
 
-	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "static-token", rawData["api_key"])
 	assert.Equal(t, time.Duration(0), ttl)
@@ -1040,7 +1040,7 @@ func TestOAuth2Driver_MintFromRefreshToken_InvalidGrant_HTTP400(t *testing.T) {
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-dead",
 	}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, credential.ErrRefreshTokenRejected), "expected ErrRefreshTokenRejected, got %v", err)
 }
@@ -1058,7 +1058,7 @@ func TestOAuth2Driver_MintFromRefreshToken_InvalidGrant_HTTP200(t *testing.T) {
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-dead",
 	}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, credential.ErrRefreshTokenRejected), "expected ErrRefreshTokenRejected, got %v", err)
 }
@@ -1077,7 +1077,7 @@ func TestOAuth2Driver_MintFromRefreshToken_NonGrantError_NotRejection(t *testing
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt",
 	}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, credential.ErrRefreshTokenRejected), "non-grant error must not be a rejection: %v", err)
 }
@@ -1097,7 +1097,7 @@ func TestOAuth2Driver_MintFromRefreshToken_InvalidClient_NotRejection(t *testing
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "wrong", "refresh_token": "rt",
 	}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, credential.ErrRefreshTokenRejected), "invalid_client must not be a refresh-token rejection: %v", err)
 }
@@ -1117,7 +1117,7 @@ func TestOAuth2Driver_MintFromRefreshToken_SlowDown400_NotRejection(t *testing.T
 		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt",
 	}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, credential.ErrRefreshTokenRejected), "slow_down 400 must not be a refresh-token rejection: %v", err)
 }
@@ -1179,7 +1179,7 @@ func TestOAuth2Driver_MintFromRefreshToken_StaticAccessToken_Expiring(t *testing
 		"auth_method": "authorization_code", "access_token": "static-token", "access_token_expires_at": exp,
 	}}
 
-	rawData, ttl, _, err := d.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "static-token", rawData["api_key"])
 	// TTL derived from access_token_expires_at (not the hardcoded 0).
@@ -1194,7 +1194,7 @@ func TestOAuth2Driver_MintFromRefreshToken_MissingClientCreds(t *testing.T) {
 		"auth_method": "authorization_code", "refresh_token": "rt",
 	}}
 
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing client_id or client_secret")
 }

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -143,7 +143,7 @@ func (d *OVHDriver) Type() string {
 }
 
 // MintCredential returns OVH credentials for the given spec.
-func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "oauth2_token":
@@ -153,7 +153,7 @@ func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	case "oauth2_token_and_s3":
 		return d.mintOAuth2TokenAndS3(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected oauth2_token, dynamic_s3, or oauth2_token_and_s3)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected oauth2_token, dynamic_s3, or oauth2_token_and_s3)", mintMethod)
 	}
 }
 
@@ -249,10 +249,10 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 }
 
 // mintOAuth2Token mints a bearer token via the OAuth2 client_credentials grant.
-func (d *OVHDriver) mintOAuth2Token(ctx context.Context) (map[string]interface{}, time.Duration, string, error) {
+func (d *OVHDriver) mintOAuth2Token(ctx context.Context) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	token, ttl, err := d.fetchOAuth2Token(ctx)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	d.logger.Info("minted OVH OAuth2 bearer token",
@@ -263,7 +263,7 @@ func (d *OVHDriver) mintOAuth2Token(ctx context.Context) (map[string]interface{}
 		"api_token": token,
 	}
 
-	return rawData, ttl, "", nil // No leaseID — token expires naturally
+	return rawData, nil, ttl, "", nil // No leaseID — token expires naturally
 }
 
 // s3CredentialResult holds the result of an S3 credential creation call.
@@ -323,20 +323,20 @@ func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, u
 // mintDynamicS3 creates S3 credentials via the OVH cloud API.
 // The TTL is derived from the OAuth2 token used for API auth — S3 keys are
 // revoked and re-created when the credential lease expires (~1h).
-func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	token, tokenTTL, err := d.fetchOAuth2Token(ctx)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to get OAuth2 token for S3 credential creation: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to get OAuth2 token for S3 credential creation: %w", err)
 	}
 
 	projectID, userID, err := d.resolveProjectAndUser(spec)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	s3, err := d.createS3Credentials(ctx, token, projectID, userID)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	d.logger.Info("created dynamic OVH S3 credentials",
@@ -350,24 +350,24 @@ func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec
 		"secret_key": s3.secretKey,
 	}
 
-	return rawData, tokenTTL, s3.leaseID, nil
+	return rawData, nil, tokenTTL, s3.leaseID, nil
 }
 
 // mintOAuth2TokenAndS3 mints both a bearer token and S3 credentials.
-func (d *OVHDriver) mintOAuth2TokenAndS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *OVHDriver) mintOAuth2TokenAndS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	token, tokenTTL, err := d.fetchOAuth2Token(ctx)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to mint OAuth2 token for dual-mode credential: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to mint OAuth2 token for dual-mode credential: %w", err)
 	}
 
 	projectID, userID, err := d.resolveProjectAndUser(spec)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	s3, err := d.createS3Credentials(ctx, token, projectID, userID)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 
 	d.logger.Info("minted OVH dual-mode credentials (OAuth2 token + S3)",
@@ -383,7 +383,7 @@ func (d *OVHDriver) mintOAuth2TokenAndS3(ctx context.Context, spec *credential.C
 	}
 
 	// TTL = token TTL (shorter-lived governs refresh; S3 keys are revoked on refresh)
-	return rawData, tokenTTL, s3.leaseID, nil
+	return rawData, nil, tokenTTL, s3.leaseID, nil
 }
 
 // Revoke deletes dynamically created S3 credentials.

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -213,7 +213,7 @@ func TestOVHDriver_MintOAuth2Token(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "eyJhbGciOiJSUzI1NiIs.test-token", rawData["api_token"])
 	assert.Equal(t, 3599*time.Second, ttl)
@@ -238,7 +238,7 @@ func TestOVHDriver_MintOAuth2Token_EmptyResponse(t *testing.T) {
 		Config: map[string]string{"mint_method": "oauth2_token"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty access_token")
 }
@@ -282,7 +282,7 @@ func TestOVHDriver_MintDynamicS3(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "s3-access-key-123", rawData["access_key"])
 	assert.Equal(t, "s3-secret-key-456", rawData["secret_key"])
@@ -329,7 +329,7 @@ func TestOVHDriver_MintDynamicS3_SpecOverridesSource(t *testing.T) {
 		},
 	}
 
-	rawData, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, _, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "s3-key", rawData["access_key"])
 	assert.Equal(t, "spec-proj/spec-user/s3-key", leaseID)
@@ -356,7 +356,7 @@ func TestOVHDriver_MintDynamicS3_MissingProjectID(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "project_id")
 }
@@ -382,7 +382,7 @@ func TestOVHDriver_MintDynamicS3_MissingUserID(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "user_id")
 }
@@ -425,7 +425,7 @@ func TestOVHDriver_MintOAuth2TokenAndS3(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "dual-token", rawData["api_token"])
 	assert.Equal(t, "dual-s3-key", rawData["access_key"])
@@ -446,7 +446,7 @@ func TestOVHDriver_MintCredential_UnsupportedMethod(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method")
 }
@@ -557,7 +557,7 @@ func TestOVHDriver_MintOAuth2Token_ServerError(t *testing.T) {
 		Config: map[string]string{"mint_method": "oauth2_token"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OAuth2 token request failed")
 }
@@ -575,7 +575,7 @@ func TestOVHDriver_MintOAuth2Token_MalformedJSON(t *testing.T) {
 		Config: map[string]string{"mint_method": "oauth2_token"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse OAuth2 token response")
 }
@@ -597,7 +597,7 @@ func TestOVHDriver_MintOAuth2Token_MissingExpiresIn(t *testing.T) {
 		Config: map[string]string{"mint_method": "oauth2_token"},
 	}
 
-	rawData, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "valid-token", rawData["api_token"])
 	assert.Equal(t, 1*time.Hour, ttl) // fallback TTL
@@ -632,7 +632,7 @@ func TestOVHDriver_MintDynamicS3_EmptySecret(t *testing.T) {
 		Config: map[string]string{"mint_method": "dynamic_s3"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty S3 access or secret key")
 }
@@ -662,7 +662,7 @@ func TestOVHDriver_MintDynamicS3_APIError(t *testing.T) {
 		Config: map[string]string{"mint_method": "dynamic_s3"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create OVH S3 credentials")
 }
@@ -704,7 +704,7 @@ func TestOVHDriver_MintOAuth2TokenAndS3_CallCount(t *testing.T) {
 		Config: map[string]string{"mint_method": "oauth2_token_and_s3"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, 1, tokenCalls, "should make exactly 1 token call")
 	assert.Equal(t, 1, s3Calls, "should make exactly 1 S3 credential call")
@@ -735,7 +735,7 @@ func TestOVHDriver_MintOAuth2TokenAndS3_S3APIError(t *testing.T) {
 		Config: map[string]string{"mint_method": "oauth2_token_and_s3"},
 	}
 
-	_, _, _, err := driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create OVH S3 credentials")
 }

--- a/credential/drivers/scaleway_driver.go
+++ b/credential/drivers/scaleway_driver.go
@@ -164,7 +164,7 @@ func (d *ScalewayDriver) iamURL(subpath string) string {
 }
 
 // MintCredential returns Scaleway credentials for the given spec.
-func (d *ScalewayDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *ScalewayDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "static_keys")
 	switch mintMethod {
 	case "static_keys":
@@ -172,19 +172,19 @@ func (d *ScalewayDriver) MintCredential(ctx context.Context, spec *credential.Cr
 	case "dynamic_keys":
 		return d.mintDynamicCredential(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected static_keys or dynamic_keys)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected static_keys or dynamic_keys)", mintMethod)
 	}
 }
 
 // mintStaticCredential reads access_key and secret_key from spec config.
-func (d *ScalewayDriver) mintStaticCredential(spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *ScalewayDriver) mintStaticCredential(spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	accessKey := credential.GetString(spec.Config, "access_key", "")
 	if accessKey == "" {
-		return nil, 0, "", fmt.Errorf("no access_key configured in spec")
+		return nil, nil, 0, "", fmt.Errorf("no access_key configured in spec")
 	}
 	secretKey := credential.GetString(spec.Config, "secret_key", "")
 	if secretKey == "" {
-		return nil, 0, "", fmt.Errorf("no secret_key configured in spec")
+		return nil, nil, 0, "", fmt.Errorf("no secret_key configured in spec")
 	}
 
 	rawData := map[string]interface{}{
@@ -192,21 +192,21 @@ func (d *ScalewayDriver) mintStaticCredential(spec *credential.CredSpec) (map[st
 		"secret_key": secretKey,
 	}
 
-	return rawData, 0, "", nil // Static — no TTL, no lease
+	return rawData, nil, 0, "", nil // Static — no TTL, no lease
 }
 
 // mintDynamicCredential creates a new API key via the Scaleway IAM API.
-func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	d.configMu.RLock()
 	managementKey := d.getManagementSecretKeyLocked()
 	d.configMu.RUnlock()
 	if managementKey == "" {
-		return nil, 0, "", fmt.Errorf("management_secret_key is required on source for dynamic_keys mint method")
+		return nil, nil, 0, "", fmt.Errorf("management_secret_key is required on source for dynamic_keys mint method")
 	}
 
 	applicationID := credential.GetString(spec.Config, "application_id", "")
 	if applicationID == "" {
-		return nil, 0, "", fmt.Errorf("application_id is required for dynamic_keys mint method")
+		return nil, nil, 0, "", fmt.Errorf("application_id is required for dynamic_keys mint method")
 	}
 
 	ttl := credential.GetDuration(spec.Config, "ttl", 1*time.Hour)
@@ -225,7 +225,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 
 	bodyJSON, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
 	apiURL := d.iamURL("/api-keys")
@@ -251,7 +251,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 
 	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create Scaleway API key: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create Scaleway API key: %w", err)
 	}
 
 	// Parse response
@@ -264,11 +264,11 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		ExpiresAt        string `json:"expires_at"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, 0, "", fmt.Errorf("failed to parse Scaleway API response: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse Scaleway API response: %w", err)
 	}
 
 	if resp.AccessKey == "" || resp.SecretKey == "" {
-		return nil, 0, "", fmt.Errorf("Scaleway API returned empty access_key or secret_key")
+		return nil, nil, 0, "", fmt.Errorf("Scaleway API returned empty access_key or secret_key")
 	}
 
 	d.logger.Info("created dynamic Scaleway API key",
@@ -283,7 +283,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 	}
 
 	// LeaseID is the access_key — used by Revoke to delete the key
-	return rawData, ttl, resp.AccessKey, nil
+	return rawData, nil, ttl, resp.AccessKey, nil
 }
 
 // Revoke deletes a dynamically created API key via DELETE /iam/v1alpha1/api-keys/{access_key}.

--- a/credential/drivers/scaleway_driver_test.go
+++ b/credential/drivers/scaleway_driver_test.go
@@ -106,7 +106,7 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 			},
 		}
 
-		rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+		rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 		require.NoError(t, err)
 		assert.Equal(t, "SCWXXXXXXXXXXXXXXXXX", rawData["access_key"])
 		assert.Equal(t, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", rawData["secret_key"])
@@ -123,7 +123,7 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 			},
 		}
 
-		rawData, _, _, err := driver.MintCredential(context.Background(), spec)
+		rawData, _, _, _, err := driver.MintCredential(context.Background(), spec)
 		require.NoError(t, err)
 		assert.Equal(t, "SCWXXXXXXXXXXXXXXXXX", rawData["access_key"])
 	})
@@ -137,7 +137,7 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 			},
 		}
 
-		_, _, _, err := driver.MintCredential(context.Background(), spec)
+		_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "access_key")
 	})
@@ -151,7 +151,7 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 			},
 		}
 
-		_, _, _, err := driver.MintCredential(context.Background(), spec)
+		_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secret_key")
 	})
@@ -164,7 +164,7 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 			},
 		}
 
-		_, _, _, err := driver.MintCredential(context.Background(), spec)
+		_, _, _, _, err := driver.MintCredential(context.Background(), spec)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported mint_method")
 	})
@@ -225,7 +225,7 @@ func TestScalewayDriver_MintDynamicCredential(t *testing.T) {
 		},
 	}
 
-	rawData, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "SCWNEWKEYXXXXXXXXXX", rawData["access_key"])
 	assert.Equal(t, "new-uuid-secret-key", rawData["secret_key"])
@@ -248,7 +248,7 @@ func TestScalewayDriver_MintDynamicCredential_MissingManagementKey(t *testing.T)
 		},
 	}
 
-	_, _, _, err = driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err = driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "management_secret_key")
 }
@@ -269,7 +269,7 @@ func TestScalewayDriver_MintDynamicCredential_MissingApplicationID(t *testing.T)
 		},
 	}
 
-	_, _, _, err = driver.MintCredential(context.Background(), spec)
+	_, _, _, _, err = driver.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "application_id")
 }

--- a/credential/drivers/static_apikey_driver.go
+++ b/credential/drivers/static_apikey_driver.go
@@ -163,10 +163,10 @@ func (d *StaticAPIKeyDriver) getAPIURL() string {
 
 // MintCredential returns the API key from spec config.
 // The key is static — no TTL, no lease.
-func (d *StaticAPIKeyDriver) MintCredential(_ context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *StaticAPIKeyDriver) MintCredential(_ context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	apiKey := credential.GetString(spec.Config, "api_key", "")
 	if apiKey == "" {
-		return nil, 0, "", fmt.Errorf("no %s API key configured in spec", d.displayName())
+		return nil, nil, 0, "", fmt.Errorf("no %s API key configured in spec", d.displayName())
 	}
 
 	rawData := map[string]interface{}{
@@ -180,7 +180,7 @@ func (d *StaticAPIKeyDriver) MintCredential(_ context.Context, spec *credential.
 		}
 	}
 
-	return rawData, 0, "", nil // Static — no TTL, no lease
+	return rawData, nil, 0, "", nil // Static — no TTL, no lease
 }
 
 // Revoke is a no-op for static API keys.

--- a/credential/drivers/static_apikey_driver_test.go
+++ b/credential/drivers/static_apikey_driver_test.go
@@ -185,7 +185,7 @@ func TestStaticAPIKeyDriver_MintCredential(t *testing.T) {
 		Type:   credential.TypeAPIKey,
 		Config: map[string]string{"api_key": "sk-test-key-123"},
 	}
-	rawData, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
+	rawData, _, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "sk-test-key-123", rawData["api_key"])
 	assert.Equal(t, time.Duration(0), ttl)
@@ -199,7 +199,7 @@ func TestStaticAPIKeyDriver_MintCredential_EmptyKey(t *testing.T) {
 		Type:   credential.TypeAPIKey,
 		Config: map[string]string{"api_key": ""},
 	}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OpenAI API key")
 }
@@ -210,7 +210,7 @@ func TestStaticAPIKeyDriver_MintCredential_DisplayName(t *testing.T) {
 		Name:   "test",
 		Config: map[string]string{},
 	}
-	_, _, _, err := d.MintCredential(context.Background(), spec)
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "API Key") // default display name
 }
@@ -247,7 +247,7 @@ func TestStaticAPIKeyDriver_MintCredential_OptionalMetadata(t *testing.T) {
 				"project_id":      "proj-789",
 			},
 		}
-		rawData, _, _, err := d.MintCredential(context.Background(), spec)
+		rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
 		require.NoError(t, err)
 		assert.Equal(t, "org-456", rawData["organization_id"])
 		assert.Equal(t, "proj-789", rawData["project_id"])
@@ -261,7 +261,7 @@ func TestStaticAPIKeyDriver_MintCredential_OptionalMetadata(t *testing.T) {
 			Name:   "test",
 			Config: map[string]string{"api_key": "sk-test"},
 		}
-		rawData, _, _, err := d.MintCredential(context.Background(), spec)
+		rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
 		require.NoError(t, err)
 		assert.Nil(t, rawData["organization_id"])
 	})
@@ -275,7 +275,7 @@ func TestStaticAPIKeyDriver_MintCredential_OptionalMetadata(t *testing.T) {
 				"organization_id": "org-123",
 			},
 		}
-		rawData, _, _, err := d.MintCredential(context.Background(), spec)
+		rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
 		require.NoError(t, err)
 		assert.Nil(t, rawData["organization_id"])
 	})

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -278,10 +278,10 @@ func (d *VaultDriver) loginViaApprole(ctx context.Context) error {
 }
 
 // MintCredential mints credential using Hashicorp Vault based on mint_method
-func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	// Re-authenticate if needed
 	if err := d.authenticate(ctx); err != nil {
-		return nil, 0, "", fmt.Errorf("authentication failed: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("authentication failed: %w", err)
 	}
 
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
@@ -300,26 +300,26 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	case "oauth2":
 		return d.fetchOAuth2Creds(ctx, spec)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2'", mintMethod)
 	}
 }
 
 // fetchStaticKVSecret fetches static secrets from Vault KV v2
-func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	kv2Mount := credential.GetString(spec.Config, "kv2_mount", "")
 	secretPath := credential.GetString(spec.Config, "secret_path", "")
 
 	if kv2Mount == "" || secretPath == "" {
-		return nil, 0, "", fmt.Errorf("kv2_mount and secret_path are required for static KV credentials")
+		return nil, nil, 0, "", fmt.Errorf("kv2_mount and secret_path are required for static KV credentials")
 	}
 
 	secret, err := d.vault.KVv2(kv2Mount).Get(ctx, secretPath)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to read KV secret: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to read KV secret: %w", err)
 	}
 
 	if secret == nil || secret.Data == nil {
-		return nil, 0, "", fmt.Errorf("no secret found at path '%s' on mount '%s'", secretPath, kv2Mount)
+		return nil, nil, 0, "", fmt.Errorf("no secret found at path '%s' on mount '%s'", secretPath, kv2Mount)
 	}
 
 	if d.logger != nil {
@@ -331,16 +331,16 @@ func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, spec *credential.
 	}
 
 	// Return raw data (static, no lease)
-	return secret.Data, 0, "", nil
+	return secret.Data, nil, 0, "", nil
 }
 
 // fetchDynamicAWSCreds fetches dynamic AWS credentials from Vault AWS engine
-func (d *VaultDriver) fetchDynamicAWSCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchDynamicAWSCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	awsMount := credential.GetString(spec.Config, "aws_mount", "")
 	roleName := credential.GetString(spec.Config, "role_name", "")
 
 	if awsMount == "" || roleName == "" {
-		return nil, 0, "", fmt.Errorf("aws_mount and role_name are required for dynamic AWS credentials")
+		return nil, nil, 0, "", fmt.Errorf("aws_mount and role_name are required for dynamic AWS credentials")
 	}
 
 	// Build request path and data
@@ -361,15 +361,15 @@ func (d *VaultDriver) fetchDynamicAWSCreds(ctx context.Context, spec *credential
 		// Parse and validate TTL against min/max bounds
 		parsedTTL, err := time.ParseDuration(ttl)
 		if err != nil {
-			return nil, 0, "", fmt.Errorf("invalid ttl format '%s': %w", ttl, err)
+			return nil, nil, 0, "", fmt.Errorf("invalid ttl format '%s': %w", ttl, err)
 		}
 
 		// Validate TTL against spec bounds
 		if spec.MinTTL > 0 && parsedTTL < spec.MinTTL {
-			return nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", parsedTTL, spec.MinTTL)
+			return nil, nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", parsedTTL, spec.MinTTL)
 		}
 		if spec.MaxTTL > 0 && parsedTTL > spec.MaxTTL {
-			return nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", parsedTTL, spec.MaxTTL)
+			return nil, nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", parsedTTL, spec.MaxTTL)
 		}
 
 		data["ttl"] = parsedTTL.String()
@@ -387,18 +387,18 @@ func (d *VaultDriver) fetchDynamicAWSCreds(ctx context.Context, spec *credential
 	}
 
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to generate AWS credentials: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to generate AWS credentials: %w", err)
 	}
 
 	if secret == nil || secret.Data == nil {
-		return nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, awsMount)
+		return nil, nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, awsMount)
 	}
 
 	leaseTTL := time.Duration(secret.LeaseDuration) * time.Second
 
 	// Validate lease TTL is positive
 	if leaseTTL <= 0 {
-		return nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for AWS credentials on mount '%s'", awsMount)
+		return nil, nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for AWS credentials on mount '%s'", awsMount)
 	}
 
 	// Add credential source
@@ -418,16 +418,16 @@ func (d *VaultDriver) fetchDynamicAWSCreds(ctx context.Context, spec *credential
 		)
 	}
 
-	return rawData, leaseTTL, secret.LeaseID, nil
+	return rawData, nil, leaseTTL, secret.LeaseID, nil
 }
 
 // fetchDynamicGCPCreds fetches dynamic GCP credentials from Vault GCP secret engine
-func (d *VaultDriver) fetchDynamicGCPCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchDynamicGCPCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	gcpMount := credential.GetString(spec.Config, "gcp_mount", "")
 	roleName := credential.GetString(spec.Config, "role_name", "")
 
 	if gcpMount == "" || roleName == "" {
-		return nil, 0, "", fmt.Errorf("gcp_mount and role_name are required for dynamic GCP credentials")
+		return nil, nil, 0, "", fmt.Errorf("gcp_mount and role_name are required for dynamic GCP credentials")
 	}
 
 	// Build path based on role_type (roleset or static-account)
@@ -439,16 +439,16 @@ func (d *VaultDriver) fetchDynamicGCPCreds(ctx context.Context, spec *credential
 	case "static-account":
 		path = fmt.Sprintf("%s/static-account/%s/token", gcpMount, roleName)
 	default:
-		return nil, 0, "", fmt.Errorf("unsupported role_type '%s'; use 'roleset' or 'static-account'", roleType)
+		return nil, nil, 0, "", fmt.Errorf("unsupported role_type '%s'; use 'roleset' or 'static-account'", roleType)
 	}
 
 	secret, err := d.vault.Logical().ReadWithContext(ctx, path)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to generate GCP credentials: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to generate GCP credentials: %w", err)
 	}
 
 	if secret == nil || secret.Data == nil {
-		return nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, gcpMount)
+		return nil, nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, gcpMount)
 	}
 
 	leaseTTL := time.Duration(secret.LeaseDuration) * time.Second
@@ -481,27 +481,27 @@ func (d *VaultDriver) fetchDynamicGCPCreds(ctx context.Context, spec *credential
 		)
 	}
 
-	return rawData, leaseTTL, secret.LeaseID, nil
+	return rawData, nil, leaseTTL, secret.LeaseID, nil
 }
 
 // fetchOAuth2Creds fetches OAuth2 credentials from an OpenBao/Vault OAuth2 secret engine
 // (compatible with openbao-plugin-secrets-oauthapp)
-func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	oauth2Mount := credential.GetString(spec.Config, "oauth2_mount", "")
 	credentialName := credential.GetString(spec.Config, "credential_name", "")
 
 	if oauth2Mount == "" || credentialName == "" {
-		return nil, 0, "", fmt.Errorf("oauth2_mount and credential_name are required for oauth2 credentials")
+		return nil, nil, 0, "", fmt.Errorf("oauth2_mount and credential_name are required for oauth2 credentials")
 	}
 
 	path := fmt.Sprintf("%s/creds/%s", oauth2Mount, credentialName)
 	secret, err := d.vault.Logical().ReadWithContext(ctx, path)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to fetch OAuth2 credentials: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to fetch OAuth2 credentials: %w", err)
 	}
 
 	if secret == nil || secret.Data == nil {
-		return nil, 0, "", fmt.Errorf("no credentials returned for '%s' on mount '%s'", credentialName, oauth2Mount)
+		return nil, nil, 0, "", fmt.Errorf("no credentials returned for '%s' on mount '%s'", credentialName, oauth2Mount)
 	}
 
 	// Compute TTL from expire_time if available (RFC3339 timestamp from oauthapp plugin)
@@ -529,17 +529,17 @@ func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, spec *credential.Cre
 		)
 	}
 
-	return rawData, leaseTTL, secret.LeaseID, nil
+	return rawData, nil, leaseTTL, secret.LeaseID, nil
 }
 
 // fetchDynamicIBMCreds fetches dynamic IBM Cloud credentials from Vault IBM secrets engine,
 // exchanges the API key for an IAM bearer token, and optionally includes COS HMAC keys.
-func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	ibmMount := credential.GetString(spec.Config, "ibm_mount", "")
 	roleName := credential.GetString(spec.Config, "role_name", "")
 
 	if ibmMount == "" || roleName == "" {
-		return nil, 0, "", fmt.Errorf("ibm_mount and role_name are required for dynamic IBM credentials")
+		return nil, nil, 0, "", fmt.Errorf("ibm_mount and role_name are required for dynamic IBM credentials")
 	}
 
 	// Step 1: Fetch dynamic API key from Vault IBM secrets engine
@@ -550,13 +550,13 @@ func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential
 	if ttl != "" {
 		parsedTTL, err := time.ParseDuration(ttl)
 		if err != nil {
-			return nil, 0, "", fmt.Errorf("invalid ttl format '%s': %w", ttl, err)
+			return nil, nil, 0, "", fmt.Errorf("invalid ttl format '%s': %w", ttl, err)
 		}
 		if spec.MinTTL > 0 && parsedTTL < spec.MinTTL {
-			return nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", parsedTTL, spec.MinTTL)
+			return nil, nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", parsedTTL, spec.MinTTL)
 		}
 		if spec.MaxTTL > 0 && parsedTTL > spec.MaxTTL {
-			return nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", parsedTTL, spec.MaxTTL)
+			return nil, nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", parsedTTL, spec.MaxTTL)
 		}
 		data["ttl"] = parsedTTL.String()
 	}
@@ -569,16 +569,16 @@ func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential
 		secret, err = d.vault.Logical().ReadWithContext(ctx, path)
 	}
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to generate IBM credentials from Vault: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to generate IBM credentials from Vault: %w", err)
 	}
 	if secret == nil || secret.Data == nil {
-		return nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, ibmMount)
+		return nil, nil, 0, "", fmt.Errorf("no credentials returned for role '%s' on mount '%s'", roleName, ibmMount)
 	}
 
 	// Extract API key from Vault response
 	apiKey, _ := secret.Data["api_key"].(string)
 	if apiKey == "" {
-		return nil, 0, "", fmt.Errorf("Vault IBM engine did not return an api_key for role '%s'", roleName)
+		return nil, nil, 0, "", fmt.Errorf("Vault IBM engine did not return an api_key for role '%s'", roleName)
 	}
 
 	vaultLeaseTTL := time.Duration(secret.LeaseDuration) * time.Second
@@ -600,7 +600,7 @@ func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential
 			}
 			cancel()
 		}
-		return nil, 0, "", fmt.Errorf("failed to exchange IBM API key for IAM token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to exchange IBM API key for IAM token: %w", err)
 	}
 
 	// Step 3: Build result with IAM token
@@ -623,7 +623,7 @@ func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential
 		leaseTTL = iamTTL
 	}
 	if leaseTTL <= 0 {
-		return nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for IBM credentials on mount '%s'", ibmMount)
+		return nil, nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for IBM credentials on mount '%s'", ibmMount)
 	}
 
 	if d.logger != nil {
@@ -638,15 +638,15 @@ func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, spec *credential
 		)
 	}
 
-	return rawData, leaseTTL, secret.LeaseID, nil
+	return rawData, nil, leaseTTL, secret.LeaseID, nil
 }
 
 // fetchDynamicVaultToken generates a Vault token via auth/token/create/{role}
-func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	tokenRole := credential.GetString(spec.Config, "token_role", "")
 
 	if tokenRole == "" {
-		return nil, 0, "", fmt.Errorf("token_role is required for dynamic Vault token generation")
+		return nil, nil, 0, "", fmt.Errorf("token_role is required for dynamic Vault token generation")
 	}
 
 	// Build request path
@@ -660,15 +660,15 @@ func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credenti
 	if ttl != "" {
 		parsedTTL, err := time.ParseDuration(ttl)
 		if err != nil {
-			return nil, 0, "", fmt.Errorf("invalid ttl format '%s': %w", ttl, err)
+			return nil, nil, 0, "", fmt.Errorf("invalid ttl format '%s': %w", ttl, err)
 		}
 
 		// Validate TTL against spec bounds
 		if spec.MinTTL > 0 && parsedTTL < spec.MinTTL {
-			return nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", parsedTTL, spec.MinTTL)
+			return nil, nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", parsedTTL, spec.MinTTL)
 		}
 		if spec.MaxTTL > 0 && parsedTTL > spec.MaxTTL {
-			return nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", parsedTTL, spec.MaxTTL)
+			return nil, nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", parsedTTL, spec.MaxTTL)
 		}
 
 		data["ttl"] = parsedTTL.String()
@@ -689,11 +689,11 @@ func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credenti
 	// Create the token
 	secret, err := d.vault.Logical().WriteWithContext(ctx, path, data)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create Vault token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create Vault token: %w", err)
 	}
 
 	if secret == nil || secret.Auth == nil {
-		return nil, 0, "", fmt.Errorf("no token returned for role '%s'", tokenRole)
+		return nil, nil, 0, "", fmt.Errorf("no token returned for role '%s'", tokenRole)
 	}
 
 	// Extract token TTL from auth response
@@ -701,7 +701,7 @@ func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credenti
 
 	// Validate lease TTL is positive
 	if leaseTTL <= 0 {
-		return nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for token role '%s'", tokenRole)
+		return nil, nil, 0, "", fmt.Errorf("Vault returned invalid lease duration for token role '%s'", tokenRole)
 	}
 
 	// Build raw data with token
@@ -725,7 +725,7 @@ func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credenti
 
 	// Vault tokens don't have a lease ID in the traditional sense
 	// The token itself is the credential; revocation is done via token/revoke
-	return rawData, leaseTTL, secret.Auth.Accessor, nil
+	return rawData, nil, leaseTTL, secret.Auth.Accessor, nil
 }
 
 // Revoke revokes a Vault lease or token accessor

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -264,7 +264,7 @@ func TestVaultDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 		Type:   credential.TypeAWSAccessKeys,
 		Config: map[string]string{},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method ''")
 
@@ -276,7 +276,7 @@ func TestVaultDriver_MintCredential_UnsupportedMintMethod(t *testing.T) {
 			"mint_method": "invalid",
 		},
 	}
-	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	_, _, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported mint_method 'invalid'")
 }
@@ -299,7 +299,7 @@ func TestVaultDriver_MintCredential_StaticRouting(t *testing.T) {
 			"mint_method": "static_aws",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kv2_mount and secret_path are required")
 
@@ -311,7 +311,7 @@ func TestVaultDriver_MintCredential_StaticRouting(t *testing.T) {
 			"mint_method": "static_apikey",
 		},
 	}
-	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	_, _, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kv2_mount and secret_path are required")
 }
@@ -334,7 +334,7 @@ func TestVaultDriver_MintCredential_AWSRouting(t *testing.T) {
 			"mint_method": "static_aws",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kv2_mount and secret_path are required")
 
@@ -347,7 +347,7 @@ func TestVaultDriver_MintCredential_AWSRouting(t *testing.T) {
 			"aws_mount":   "aws",
 		},
 	}
-	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	_, _, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "aws_mount and role_name are required")
 }
@@ -370,7 +370,7 @@ func TestVaultDriver_MintCredential_VaultTokenRouting(t *testing.T) {
 			"mint_method": "vault_token",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token_role is required")
 }
@@ -393,7 +393,7 @@ func TestVaultDriver_MintCredential_DynamicGCPRouting(t *testing.T) {
 			"mint_method": "dynamic_gcp",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gcp_mount and role_name are required")
 
@@ -408,7 +408,7 @@ func TestVaultDriver_MintCredential_DynamicGCPRouting(t *testing.T) {
 			"role_type":   "invalid",
 		},
 	}
-	_, _, _, err = driver.MintCredential(context.TODO(), spec2)
+	_, _, _, _, err = driver.MintCredential(context.TODO(), spec2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported role_type")
 }
@@ -431,7 +431,7 @@ func TestVaultDriver_MintCredential_DynamicIBMRouting(t *testing.T) {
 			"mint_method": "dynamic_ibm",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ibm_mount and role_name are required")
 }
@@ -454,7 +454,7 @@ func TestVaultDriver_MintCredential_OAuth2Routing(t *testing.T) {
 			"mint_method": "oauth2",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "oauth2_mount and credential_name are required")
 }
@@ -512,7 +512,7 @@ func TestVaultDriver_FetchDynamicAWSCreds_InvalidTTL(t *testing.T) {
 			"ttl":         "not-a-duration",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ttl format")
 }
@@ -536,7 +536,7 @@ func TestVaultDriver_FetchDynamicVaultToken_InvalidTTL(t *testing.T) {
 			"ttl":         "bad",
 		},
 	}
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ttl format")
 }
@@ -645,7 +645,7 @@ func TestVaultDriver_FetchDynamicAWSCreds_TTLBelowMinimum(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "below minimum")
 }
@@ -672,7 +672,7 @@ func TestVaultDriver_FetchDynamicAWSCreds_TTLExceedsMaximum(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
@@ -698,7 +698,7 @@ func TestVaultDriver_FetchDynamicVaultToken_TTLBelowMinimum(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "below minimum")
 }
@@ -724,7 +724,7 @@ func TestVaultDriver_FetchDynamicVaultToken_TTLExceedsMaximum(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := driver.MintCredential(context.TODO(), spec)
+	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -252,9 +252,9 @@ func (m *Manager) issueCredential(ctx context.Context, specName string) (*Creden
 // failure. This is the simple path for specs that do not rotate a refresh token.
 func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver SourceDriver) (*Credential, error) {
 	var cred *Credential
-	err := m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+	err := m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 		var parseErr error
-		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, leaseTTL, leaseID, driver)
+		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
 		return parseErr
 	})
 	if err != nil {
@@ -293,10 +293,10 @@ func (m *Manager) issueWithWriteBack(ctx context.Context, specName string, drive
 			return err
 		}
 		cred = nil
-		return m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+		return m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 			m.consumeRotatedRefreshToken(ctx, spec, rawData)
 			var parseErr error
-			cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, leaseTTL, leaseID, driver)
+			cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
 			return parseErr
 		})
 	}

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -117,7 +117,7 @@ func (m *mockConfigStore) rotateOnOtherNode(name, refreshToken string) {
 // mockSourceDriver implements SourceDriver for testing
 type mockSourceDriver struct {
 	driverType   string
-	mintFunc     func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error)
+	mintFunc     func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
 	revokeFunc   func(ctx context.Context, leaseID string) error
 	revokeCalls  atomic.Int32
 	mintCalls    atomic.Int32
@@ -128,11 +128,11 @@ type mockSourceDriver struct {
 func newMockSourceDriver(driverType string) *mockSourceDriver {
 	return &mockSourceDriver{
 		driverType: driverType,
-		mintFunc: func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+		mintFunc: func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 			return map[string]interface{}{
 				"username": "test-user",
 				"password": "test-pass",
-			}, time.Hour, "lease-123", nil
+			}, nil, time.Hour, "lease-123", nil
 		},
 		revokeFunc: func(ctx context.Context, leaseID string) error {
 			return nil
@@ -140,7 +140,7 @@ func newMockSourceDriver(driverType string) *mockSourceDriver {
 	}
 }
 
-func (d *mockSourceDriver) MintCredential(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+func (d *mockSourceDriver) MintCredential(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	d.mintCalls.Add(1)
 	return d.mintFunc(ctx, spec)
 }
@@ -221,7 +221,7 @@ func (t *mockCredentialType) ValidateConfig(config map[string]string, sourceType
 	return nil
 }
 
-func (t *mockCredentialType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*Credential, error) {
+func (t *mockCredentialType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*Credential, error) {
 	data := make(map[string]string)
 	for k, v := range rawData {
 		if s, ok := v.(string); ok {
@@ -632,15 +632,15 @@ func TestManager_IssueCredential_Timeout(t *testing.T) {
 	})
 
 	// Configure driver to block longer than timeout
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 		select {
 		case <-ctx.Done():
-			return nil, 0, "", ctx.Err()
+			return nil, nil, 0, "", ctx.Err()
 		case <-time.After(200 * time.Millisecond):
 			return map[string]interface{}{
 				"username": "test-user",
 				"password": "test-pass",
-			}, time.Hour, "lease-123", nil
+			}, nil, time.Hour, "lease-123", nil
 		}
 	}
 
@@ -672,15 +672,15 @@ func TestManager_IssueCredential_ErrorNotCached(t *testing.T) {
 
 	// First call fails
 	callCount := 0
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 		callCount++
 		if callCount == 1 {
-			return nil, 0, "", errors.New("transient error")
+			return nil, nil, 0, "", errors.New("transient error")
 		}
 		return map[string]interface{}{
 			"username": "test-user",
 			"password": "test-pass",
-		}, time.Hour, "lease-123", nil
+		}, nil, time.Hour, "lease-123", nil
 	}
 
 	// First request should fail
@@ -776,8 +776,8 @@ func TestManager_WriteBack_StripsReservedKeyAndPersists(t *testing.T) {
 	defer manager.Stop()
 	addRefreshSpecAndSource(configStore, "rt-old")
 
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
-		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, time.Hour, "", nil
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, nil, time.Hour, "", nil
 	}
 
 	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
@@ -799,8 +799,8 @@ func TestManager_WriteBack_NonRotating_NoPersist(t *testing.T) {
 	addRefreshSpecAndSource(configStore, "rt-stable")
 
 	// No reserved key → stable token, no write-back.
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
-		return map[string]interface{}{"api_key": "at-1"}, time.Hour, "", nil
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-1"}, nil, time.Hour, "", nil
 	}
 
 	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
@@ -818,15 +818,15 @@ func TestManager_InvalidGrant_RetriesOnceWithReloadedSpec(t *testing.T) {
 	// storage WITHOUT touching this node's cache. The retry must reload from
 	// storage (not the cache) to pick up rt-fresh.
 	var attempts int32
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 		n := atomic.AddInt32(&attempts, 1)
 		if n == 1 {
 			assert.Equal(t, "rt-stale", spec.Config["refresh_token"])
 			configStore.rotateOnOtherNode("gh", "rt-fresh") // storage advances; cache stays stale
-			return nil, 0, "", ErrRefreshTokenRejected
+			return nil, nil, 0, "", ErrRefreshTokenRejected
 		}
 		assert.Equal(t, "rt-fresh", spec.Config["refresh_token"], "retry must reload from storage, bypassing the stale cache")
-		return map[string]interface{}{"api_key": "at-ok"}, time.Hour, "", nil
+		return map[string]interface{}{"api_key": "at-ok"}, nil, time.Hour, "", nil
 	}
 
 	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
@@ -841,9 +841,9 @@ func TestManager_InvalidGrant_RetryFailsOnce_SurfacesError(t *testing.T) {
 	addRefreshSpecAndSource(configStore, "rt-dead")
 
 	var attempts int32
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 		atomic.AddInt32(&attempts, 1)
-		return nil, 0, "", ErrRefreshTokenRejected // never recovers
+		return nil, nil, 0, "", ErrRefreshTokenRejected // never recovers
 	}
 
 	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
@@ -858,8 +858,8 @@ func TestManager_WriteBack_PersistError_DoesNotFailIssuance(t *testing.T) {
 	addRefreshSpecAndSource(configStore, "rt-old")
 
 	configStore.persistFn = func(spec *CredSpec) error { return errors.New("storage down") }
-	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error) {
-		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, time.Hour, "", nil
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, nil, time.Hour, "", nil
 	}
 
 	// A persist failure must not fail issuance — the access token is still valid.

--- a/credential/minting_service.go
+++ b/credential/minting_service.go
@@ -60,10 +60,10 @@ func (s *MintingService) MintWithCleanup(
 	ctx context.Context,
 	driver SourceDriver,
 	spec *CredSpec,
-	onSuccess func(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) error,
+	onSuccess func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error,
 ) error {
 	// Step 1: Mint credential from driver
-	rawData, leaseTTL, leaseID, err := driver.MintCredential(ctx, spec)
+	rawData, metadata, leaseTTL, leaseID, err := driver.MintCredential(ctx, spec)
 	if err != nil {
 		return fmt.Errorf("failed to fetch credential: %w", err)
 	}
@@ -79,7 +79,7 @@ func (s *MintingService) MintWithCleanup(
 
 	// Step 3: Call success handler to process minted data
 	// This typically involves parsing and validating the credential
-	if err := onSuccess(rawData, leaseTTL, leaseID); err != nil {
+	if err := onSuccess(rawData, metadata, leaseTTL, leaseID); err != nil {
 		return err // Deferred cleanup will revoke the lease
 	}
 

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -68,10 +68,11 @@ type SourceDriver interface {
 	// Takes a CredSpec as input
 	// Returns:
 	//   - rawData: map of credential fields
+	//   - metadata: map of fields about the credentials, such as the subject
 	//   - leaseTTL: duration of the lease (0 for static credentials)
 	//   - leaseID: identifier for revocation (empty for static)
 	//   - error: any error encountered
-	MintCredential(ctx context.Context, spec *CredSpec) (map[string]interface{}, time.Duration, string, error)
+	MintCredential(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
 
 	// Revoke attempts to revoke a lease/credential (best-effort)
 	// Returns nil if revocation is not supported or succeeds

--- a/credential/type.go
+++ b/credential/type.go
@@ -67,9 +67,10 @@ type Type interface {
 
 	// Parse converts raw credential data from source into structured Credential
 	// rawData contains the source-specific credential fields
+	// metadata contains the metadata about the credential
 	// leaseTTL is the lease duration from the source (0 for static)
 	// leaseID is the lease identifier for revocation (empty for static)
-	Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*Credential, error)
+	Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*Credential, error)
 
 	// Validate checks if credential data is well-formed
 	Validate(cred *Credential) error

--- a/credential/types/alicloud_keys.go
+++ b/credential/types/alicloud_keys.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // AlicloudKeysCredType handles Alibaba Cloud (Alicloud) API key credentials.
@@ -111,7 +112,7 @@ func (t *AlicloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 }
 
 // Parse converts raw credential data from source into structured Credential
-func (t *AlicloudKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *AlicloudKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	accessKeyID, ok := rawData["access_key_id"].(string)
 	if !ok || accessKeyID == "" {
 		return nil, fmt.Errorf("%w: missing or invalid access_key_id", credential.ErrInvalidCredential)
@@ -131,6 +132,11 @@ func (t *AlicloudKeysCredType) Parse(rawData map[string]interface{}, leaseTTL ti
 		data["security_token"] = securityToken
 	}
 
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	return &credential.Credential{
 		Type:      credential.TypeAlicloudKeys,
 		Category:  credential.CategoryCloudIAM,
@@ -139,6 +145,7 @@ func (t *AlicloudKeysCredType) Parse(rawData map[string]interface{}, leaseTTL ti
 		IssuedAt:  time.Now(),
 		Revocable: leaseTTL > 0,
 		Data:      data,
+		Metadata:  meta,
 	}, nil
 }
 

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -172,6 +172,7 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 	tests := []struct {
 		name     string
 		rawData  map[string]interface{}
+		metadata map[string]interface{}
 		leaseTTL time.Duration
 		leaseID  string
 		wantErr  bool
@@ -182,6 +183,7 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 			rawData: map[string]interface{}{
 				"api_key": "sk-xxxxxxxxxxxxxxxxxxxx",
 			},
+			metadata: nil,
 			leaseTTL: 0,
 			leaseID:  "",
 			wantErr:  false,
@@ -194,6 +196,7 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 				"key_name":        "production-key",
 				"organization_id": "org-456",
 			},
+			metadata: nil,
 			leaseTTL: 0,
 			leaseID:  "",
 			wantErr:  false,
@@ -201,6 +204,7 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 		{
 			name:     "missing api_key",
 			rawData:  map[string]interface{}{},
+			metadata: map[string]interface{}{},
 			leaseTTL: 0,
 			leaseID:  "",
 			wantErr:  true,
@@ -211,6 +215,7 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 			rawData: map[string]interface{}{
 				"api_key": "",
 			},
+			metadata: nil,
 			leaseTTL: 0,
 			leaseID:  "",
 			wantErr:  true,
@@ -220,7 +225,7 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, tt.metadata, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
@@ -244,6 +249,8 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 func TestAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
 	ct := NewAPIKeyCredType()
 
+	// The static-API-key driver places these descriptive fields in rawData; the
+	// api_key type's OptionalFields copy them into cred.Data (matching production).
 	rawData := map[string]interface{}{
 		"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
 		"key_id":          "key-123",
@@ -252,7 +259,7 @@ func TestAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
 		"project_id":      "proj-789",
 	}
 
-	cred, err := ct.Parse(rawData, 0, "")
+	cred, err := ct.Parse(rawData, nil, 0, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "sk-xxxxxxxxxxxxxxxxxxxx", cred.Data["api_key"])

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // AWSIAMAccessKeysCredType handles AWS IAM access keys (static and STS temporary)
@@ -201,7 +202,7 @@ func (t *AWSIAMAccessKeysCredType) validateAWSConfig(config map[string]string) e
 }
 
 // Parse converts raw credential data from source into structured Credential
-func (t *AWSIAMAccessKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *AWSIAMAccessKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	// Extract access_key_id (may be named "access_key" from Vault AWS engine)
 	accessKeyID, ok := rawData["access_key_id"].(string)
 	if !ok || accessKeyID == "" {
@@ -222,6 +223,11 @@ func (t *AWSIAMAccessKeysCredType) Parse(rawData map[string]interface{}, leaseTT
 		}
 	}
 
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	cred := &credential.Credential{
 		Type:      credential.TypeAWSAccessKeys,
 		Category:  credential.CategoryCloudIAM,
@@ -233,6 +239,7 @@ func (t *AWSIAMAccessKeysCredType) Parse(rawData map[string]interface{}, leaseTT
 			"access_key_id":     accessKeyID,
 			"secret_access_key": secretAccessKey,
 		},
+		Metadata: meta,
 	}
 
 	// Extract optional session token (for STS temporary credentials)

--- a/credential/types/aws_iam_keys_test.go
+++ b/credential/types/aws_iam_keys_test.go
@@ -299,7 +299,7 @@ func TestAWSIAMAccessKeysCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errMsg != "" {

--- a/credential/types/azure_bearer_token_test.go
+++ b/credential/types/azure_bearer_token_test.go
@@ -127,6 +127,7 @@ func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 	tests := []struct {
 		name     string
 		rawData  map[string]interface{}
+		metadata map[string]interface{}
 		leaseTTL time.Duration
 		leaseID  string
 		wantErr  bool
@@ -141,6 +142,7 @@ func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 				"client_id":    "test-client",
 				"token_type":   "Bearer",
 			},
+			metadata: nil,
 			leaseTTL: 1 * time.Hour,
 			leaseID:  "",
 			wantErr:  false,
@@ -150,6 +152,7 @@ func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 			rawData: map[string]interface{}{
 				"access_token": "test-token",
 			},
+			metadata: nil,
 			leaseTTL: 30 * time.Minute,
 			leaseID:  "",
 			wantErr:  false,
@@ -159,6 +162,7 @@ func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 			rawData: map[string]interface{}{
 				"resource_uri": "https://management.azure.com/",
 			},
+			metadata: nil,
 			leaseTTL: 1 * time.Hour,
 			wantErr:  true,
 			errMsg:   "access_token",
@@ -168,6 +172,7 @@ func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 			rawData: map[string]interface{}{
 				"access_token": "",
 			},
+			metadata: map[string]interface{}{},
 			leaseTTL: 1 * time.Hour,
 			wantErr:  true,
 			errMsg:   "access_token",
@@ -176,7 +181,7 @@ func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := credType.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := credType.Parse(tt.rawData, tt.metadata, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)

--- a/credential/types/base_token_type.go
+++ b/credential/types/base_token_type.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // TokenFieldConfig describes how to extract and validate token fields from raw data
@@ -41,7 +42,7 @@ func (t *BaseTokenType) Metadata() credential.TypeMetadata {
 }
 
 // Parse converts raw credential data from source into structured Credential
-func (t *BaseTokenType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *BaseTokenType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	// Extract primary token field
 	var token string
 	var found bool
@@ -76,6 +77,11 @@ func (t *BaseTokenType) Parse(rawData map[string]interface{}, leaseTTL time.Dura
 		}
 	}
 
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	cred := &credential.Credential{
 		Type:      t.TypeMetadata.Name,
 		Category:  t.TypeMetadata.Category,
@@ -84,6 +90,7 @@ func (t *BaseTokenType) Parse(rawData map[string]interface{}, leaseTTL time.Dura
 		IssuedAt:  time.Now(),
 		Revocable: t.Revocable && leaseID != "",
 		Data:      data,
+		Metadata:  meta,
 	}
 
 	return cred, nil

--- a/credential/types/cloudflare_keys.go
+++ b/credential/types/cloudflare_keys.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // CloudflareKeysCredType handles Cloudflare cloud credentials.
@@ -99,7 +100,7 @@ func (t *CloudflareKeysCredType) ValidateConfig(config map[string]string, source
 
 // Parse converts raw credential data from source into structured Credential.
 // At least one mode must be present: api_token (API) or access_key_id+secret_access_key (R2).
-func (t *CloudflareKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *CloudflareKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	accessKeyID, _ := rawData["access_key_id"].(string)
 	secretAccessKey, _ := rawData["secret_access_key"].(string)
 	apiToken, _ := rawData["api_token"].(string)
@@ -127,6 +128,11 @@ func (t *CloudflareKeysCredType) Parse(rawData map[string]interface{}, leaseTTL 
 		data["secret_access_key"] = secretAccessKey
 	}
 
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	return &credential.Credential{
 		Type:      credential.TypeCloudflareKeys,
 		Category:  credential.CategoryCloudIAM,
@@ -135,6 +141,7 @@ func (t *CloudflareKeysCredType) Parse(rawData map[string]interface{}, leaseTTL 
 		IssuedAt:  time.Now(),
 		Revocable: leaseTTL > 0,
 		Data:      data,
+		Metadata:  meta,
 	}, nil
 }
 

--- a/credential/types/cloudflare_keys_test.go
+++ b/credential/types/cloudflare_keys_test.go
@@ -237,7 +237,7 @@ func TestCloudflareKeysCredType_Parse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)

--- a/credential/types/db_auth_token_test.go
+++ b/credential/types/db_auth_token_test.go
@@ -20,6 +20,8 @@ func TestDBAuthTokenCredType_Metadata(t *testing.T) {
 func TestDBAuthTokenCredType_Parse(t *testing.T) {
 	ct := NewDBAuthTokenCredType()
 
+	// The DB-auth drivers place these descriptive fields in rawData; the type's
+	// OptionalFields copy them into cred.Data (matching production).
 	rawData := map[string]interface{}{
 		"auth_token": "my-iam-token-xyz",
 		"db_host":    "mydb.abc123.us-east-1.rds.amazonaws.com",
@@ -30,7 +32,7 @@ func TestDBAuthTokenCredType_Parse(t *testing.T) {
 		"region":     "us-east-1",
 	}
 
-	cred, err := ct.Parse(rawData, 15*time.Minute, "")
+	cred, err := ct.Parse(rawData, nil, 15*time.Minute, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, credential.TypeDBAuthToken, cred.Type)
@@ -53,7 +55,7 @@ func TestDBAuthTokenCredType_Parse_MissingToken(t *testing.T) {
 		"db_host": "mydb.rds.amazonaws.com",
 	}
 
-	_, err := ct.Parse(rawData, 15*time.Minute, "")
+	_, err := ct.Parse(rawData, nil, 15*time.Minute, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "auth_token")
 }

--- a/credential/types/gcp_access_token_test.go
+++ b/credential/types/gcp_access_token_test.go
@@ -115,7 +115,7 @@ func TestGCPAccessTokenCredType_Parse(t *testing.T) {
 			"target_service_account": "target@project.iam.gserviceaccount.com",
 		}
 
-		cred, err := ct.Parse(rawData, 1*time.Hour, "")
+		cred, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 		require.NoError(t, err)
 		assert.Equal(t, credential.TypeGCPAccessToken, cred.Type)
 		assert.Equal(t, credential.CategoryCloudIAM, cred.Category)
@@ -131,7 +131,7 @@ func TestGCPAccessTokenCredType_Parse(t *testing.T) {
 			"project_id": "my-project",
 		}
 
-		_, err := ct.Parse(rawData, 1*time.Hour, "")
+		_, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "access_token")
 	})
@@ -141,7 +141,7 @@ func TestGCPAccessTokenCredType_Parse(t *testing.T) {
 			"access_token": "",
 		}
 
-		_, err := ct.Parse(rawData, 1*time.Hour, "")
+		_, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 		require.Error(t, err)
 	})
 }

--- a/credential/types/github_token_test.go
+++ b/credential/types/github_token_test.go
@@ -252,7 +252,7 @@ func TestGitHubTokenCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
@@ -285,7 +285,7 @@ func TestGitHubTokenCredType_Parse_OptionalFields(t *testing.T) {
 		"permissions": `{"contents":"read"}`,
 	}
 
-	cred, err := ct.Parse(rawData, 1*time.Hour, "")
+	cred, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "ghs_test", cred.Data["token"])

--- a/credential/types/gitlab_access_token_test.go
+++ b/credential/types/gitlab_access_token_test.go
@@ -194,7 +194,7 @@ func TestGitLabAccessTokenCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
@@ -228,7 +228,7 @@ func TestGitLabAccessTokenCredType_Parse_OptionalFields(t *testing.T) {
 		"scopes":       "api,read_api",
 	}
 
-	cred, err := ct.Parse(rawData, 24*time.Hour, "lease-1")
+	cred, err := ct.Parse(rawData, nil, 24*time.Hour, "lease-1")
 	require.NoError(t, err)
 
 	assert.Equal(t, "glpat-test", cred.Data["access_token"])

--- a/credential/types/ibmcloud_keys.go
+++ b/credential/types/ibmcloud_keys.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // IBMCloudKeysCredType handles IBM Cloud credentials.
@@ -101,7 +102,7 @@ func (t *IBMCloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 
 // Parse converts raw credential data from source into structured Credential.
 // At least one mode must be present: access_token (API) or access_key_id+secret_access_key (COS).
-func (t *IBMCloudKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *IBMCloudKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	accessKeyID, _ := rawData["access_key_id"].(string)
 	secretAccessKey, _ := rawData["secret_access_key"].(string)
 	accessToken, _ := rawData["access_token"].(string)
@@ -129,6 +130,11 @@ func (t *IBMCloudKeysCredType) Parse(rawData map[string]interface{}, leaseTTL ti
 		data["secret_access_key"] = secretAccessKey
 	}
 
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	return &credential.Credential{
 		Type:      credential.TypeIBMCloudKeys,
 		Category:  credential.CategoryCloudIAM,
@@ -137,6 +143,7 @@ func (t *IBMCloudKeysCredType) Parse(rawData map[string]interface{}, leaseTTL ti
 		IssuedAt:  time.Now(),
 		Revocable: leaseTTL > 0,
 		Data:      data,
+		Metadata:  meta,
 	}, nil
 }
 

--- a/credential/types/ibmcloud_keys_test.go
+++ b/credential/types/ibmcloud_keys_test.go
@@ -41,8 +41,8 @@ func TestIBMCloudKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
 			name: "dynamic_ibm with COS keys",
 			config: map[string]string{
 				"mint_method":       "dynamic_ibm",
-				"ibm_mount":        "ibmcloud",
-				"role_name":        "my-role",
+				"ibm_mount":         "ibmcloud",
+				"role_name":         "my-role",
 				"access_key_id":     "cos-access-key",
 				"secret_access_key": "cos-secret-key",
 			},
@@ -237,7 +237,7 @@ func TestIBMCloudKeysCredType_Parse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)

--- a/credential/types/kubernetes_token_test.go
+++ b/credential/types/kubernetes_token_test.go
@@ -29,7 +29,7 @@ func TestKubernetesTokenCredType_Parse_Valid(t *testing.T) {
 		"audiences":       "https://my-app.example.com",
 	}
 
-	cred, err := ct.Parse(rawData, 1*time.Hour, "")
+	cred, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 	require.NoError(t, err)
 	assert.Equal(t, credential.TypeKubernetesToken, cred.Type)
 	assert.Equal(t, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test", cred.Data["token"])
@@ -46,7 +46,7 @@ func TestKubernetesTokenCredType_Parse_MissingToken(t *testing.T) {
 		"service_account": "my-sa",
 	}
 
-	_, err := ct.Parse(rawData, 1*time.Hour, "")
+	_, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing")
 }
@@ -58,7 +58,7 @@ func TestKubernetesTokenCredType_Revocable(t *testing.T) {
 		"token": "test-token",
 	}
 
-	cred, err := ct.Parse(rawData, 1*time.Hour, "some-lease-id")
+	cred, err := ct.Parse(rawData, nil, 1*time.Hour, "some-lease-id")
 	require.NoError(t, err)
 	assert.False(t, cred.Revocable)
 }

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -141,7 +141,7 @@ func TestOAuthBearerTokenCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
@@ -170,7 +170,7 @@ func TestOAuthBearerTokenCredType_Parse_OptionalFields(t *testing.T) {
 		"token_type": "Bearer",
 	}
 
-	cred, err := ct.Parse(rawData, 1*time.Hour, "")
+	cred, err := ct.Parse(rawData, nil, 1*time.Hour, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "test-token", cred.Data["api_key"])

--- a/credential/types/ovh_keys.go
+++ b/credential/types/ovh_keys.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // OVHKeysCredType handles OVH cloud credentials.
@@ -65,7 +66,7 @@ func (t *OVHKeysCredType) ValidateConfig(config map[string]string, sourceType st
 }
 
 // Parse converts raw credential data from source into structured Credential
-func (t *OVHKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *OVHKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	accessKey, _ := rawData["access_key"].(string)
 	secretKey, _ := rawData["secret_key"].(string)
 	apiToken, _ := rawData["api_token"].(string)
@@ -95,6 +96,11 @@ func (t *OVHKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Du
 		data["api_token"] = apiToken
 	}
 
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	return &credential.Credential{
 		Type:      credential.TypeOVHKeys,
 		Category:  credential.CategoryCloudIAM,
@@ -103,6 +109,7 @@ func (t *OVHKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Du
 		IssuedAt:  time.Now(),
 		Revocable: leaseTTL > 0,
 		Data:      data,
+		Metadata:  meta,
 	}, nil
 }
 

--- a/credential/types/ovh_keys_test.go
+++ b/credential/types/ovh_keys_test.go
@@ -94,7 +94,7 @@ func TestOVHKeysCredType_Parse(t *testing.T) {
 			"access_key": "test-access-key",
 			"secret_key": "test-secret-key",
 			"api_token":  "test-api-token",
-		}, 0, "")
+		}, nil, 0, "")
 		require.NoError(t, err)
 		assert.Equal(t, credential.TypeOVHKeys, cred.Type)
 		assert.Equal(t, "test-access-key", cred.Data["access_key"])
@@ -106,7 +106,7 @@ func TestOVHKeysCredType_Parse(t *testing.T) {
 	t.Run("valid: api_token only (API mode)", func(t *testing.T) {
 		cred, err := ct.Parse(map[string]interface{}{
 			"api_token": "test-api-token",
-		}, 0, "")
+		}, nil, 0, "")
 		require.NoError(t, err)
 		assert.Equal(t, "test-api-token", cred.Data["api_token"])
 		assert.Len(t, cred.Data, 1)
@@ -118,7 +118,7 @@ func TestOVHKeysCredType_Parse(t *testing.T) {
 		cred, err := ct.Parse(map[string]interface{}{
 			"access_key": "test-access-key",
 			"secret_key": "test-secret-key",
-		}, 0, "")
+		}, nil, 0, "")
 		require.NoError(t, err)
 		assert.Equal(t, "test-access-key", cred.Data["access_key"])
 		assert.Equal(t, "test-secret-key", cred.Data["secret_key"])
@@ -132,7 +132,7 @@ func TestOVHKeysCredType_Parse(t *testing.T) {
 			"access_key": "test-access-key",
 			"secret_key": "test-secret-key",
 			"api_token":  "test-api-token",
-		}, 1*time.Hour, "lease-123")
+		}, nil, 1*time.Hour, "lease-123")
 		require.NoError(t, err)
 		assert.Equal(t, 1*time.Hour, cred.LeaseTTL)
 		assert.Equal(t, "lease-123", cred.LeaseID)
@@ -142,7 +142,7 @@ func TestOVHKeysCredType_Parse(t *testing.T) {
 	t.Run("invalid: access_key without secret_key", func(t *testing.T) {
 		_, err := ct.Parse(map[string]interface{}{
 			"access_key": "test-access-key",
-		}, 0, "")
+		}, nil, 0, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secret_key")
 	})
@@ -150,13 +150,13 @@ func TestOVHKeysCredType_Parse(t *testing.T) {
 	t.Run("invalid: secret_key without access_key", func(t *testing.T) {
 		_, err := ct.Parse(map[string]interface{}{
 			"secret_key": "test-secret-key",
-		}, 0, "")
+		}, nil, 0, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "access_key")
 	})
 
 	t.Run("invalid: empty raw data", func(t *testing.T) {
-		_, err := ct.Parse(map[string]interface{}{}, 0, "")
+		_, err := ct.Parse(map[string]interface{}{}, nil, 0, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least one mode")
 	})

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 )
 
 // ScalewayKeysCredType handles Scaleway API key credentials.
@@ -123,7 +124,7 @@ func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceTy
 }
 
 // Parse converts raw credential data from source into structured Credential
-func (t *ScalewayKeysCredType) Parse(rawData map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+func (t *ScalewayKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
 	accessKey, ok := rawData["access_key"].(string)
 	if !ok || accessKey == "" {
 		return nil, fmt.Errorf("%w: missing or invalid access_key", credential.ErrInvalidCredential)
@@ -132,6 +133,11 @@ func (t *ScalewayKeysCredType) Parse(rawData map[string]interface{}, leaseTTL ti
 	secretKey, ok := rawData["secret_key"].(string)
 	if !ok || secretKey == "" {
 		return nil, fmt.Errorf("%w: missing or invalid secret_key", credential.ErrInvalidCredential)
+	}
+
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
 	}
 
 	return &credential.Credential{
@@ -145,6 +151,7 @@ func (t *ScalewayKeysCredType) Parse(rawData map[string]interface{}, leaseTTL ti
 			"access_key": accessKey,
 			"secret_key": secretKey,
 		},
+		Metadata: meta,
 	}, nil
 }
 

--- a/credential/types/scaleway_keys_test.go
+++ b/credential/types/scaleway_keys_test.go
@@ -275,7 +275,7 @@ func TestScalewayKeysCredType_Parse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)

--- a/credential/types/vault_token_test.go
+++ b/credential/types/vault_token_test.go
@@ -148,7 +148,7 @@ func TestVaultTokenCredType_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred, err := ct.Parse(tt.rawData, tt.leaseTTL, tt.leaseID)
+			cred, err := ct.Parse(tt.rawData, nil, tt.leaseTTL, tt.leaseID)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errMsg != "" {

--- a/helper/general.go
+++ b/helper/general.go
@@ -1,0 +1,20 @@
+package helper
+
+import "fmt"
+
+func ToStringMap(src map[string]interface{}) (map[string]string, error) {
+	if src == nil {
+		return nil, nil
+	}
+	dst := make(map[string]string, len(src))
+
+	for k, v := range src {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("key %q contains %T, expected string", k, v)
+		}
+		dst[k] = s
+	}
+
+	return dst, nil
+}


### PR DESCRIPTION
Generalize how non-secret, descriptive attributes about a credential reach the
audit log. A SourceDriver now returns a second map from MintCredential —
metadata — alongside the raw credential data, and Type.Parse carries it into a
new non-secret Credential.Metadata map that audit records in clear (the operator
can salt any key via salt_fields; secret material still belongs in Data, which
is HMAC-salted by default).

This replaces the earlier manager-side subject injection: the driver is the
authority on what its credential represents, metadata flows through the same
mint -> Parse path as the raw data, and BaseTokenType handles it once for the
token types. The plumbing is inert in this change — every driver returns nil
metadata; a later change wires the OAuth2 driver to populate it.

Audit records the metadata uniformly at the single buildAuditCredential
chokepoint (deep-copied in LogEntry.Clone), and the JSON format layer supports
salting/omitting response.credential.metadata[.key] (clear by default).

---
Part 7/9 of the OAuth2 authorization-code series (stacked). Base: `feat/oauth2-refresh-writeback`. Merge bottom-up.