### PR TITLE
Roll OAuth2 refresh_token_expires_at forward on rotation; fix GitHub MCP auth-code docs

### DIFF
--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -344,9 +344,14 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 	}
 
 	rawData := accessTokenRawData(tokenResp)
-	// Surface a rotated refresh token for the minting layer to persist.
+	// Surface a rotated refresh token for the minting layer to persist. A refresh
+	// resets the refresh-token window, so surface the new expiry too (when the
+	// provider returns one) to keep the persisted refresh_token_expires_at in step.
 	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
 		rawData[credential.RawRotatedRefreshTokenKey] = tokenResp.RefreshToken
+		if tokenResp.RefreshTokenExpiresIn > 0 {
+			rawData[credential.RawRotatedRefreshTokenExpiresAtKey] = expiresAt(tokenResp.RefreshTokenExpiresIn)
+		}
 	}
 	return rawData, d.extractMetadata(ctx, spec, tokenResp.AccessToken), ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
 }

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -973,10 +973,11 @@ func TestOAuth2Driver_MintFromRefreshToken_Rotating(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token":  "at-new",
-			"refresh_token": "rt-new", // rotated
-			"expires_in":    28800,
-			"token_type":    "bearer",
+			"access_token":             "at-new",
+			"refresh_token":            "rt-new", // rotated
+			"expires_in":               28800,
+			"refresh_token_expires_in": 15897600, // ~6 months, reset window
+			"token_type":               "bearer",
 		})
 	}))
 	defer server.Close()
@@ -992,6 +993,37 @@ func TestOAuth2Driver_MintFromRefreshToken_Rotating(t *testing.T) {
 	assert.Equal(t, 28800*time.Second, ttl)
 	// Rotated token is surfaced under the reserved key for the minting layer.
 	assert.Equal(t, "rt-new", rawData[credential.RawRotatedRefreshTokenKey])
+	// The reset refresh-token window is surfaced too, as a future RFC3339 expiry.
+	rotatedExp, ok := rawData[credential.RawRotatedRefreshTokenExpiresAtKey].(string)
+	require.True(t, ok, "rotated refresh-token expiry must be surfaced")
+	exp, perr := time.Parse(time.RFC3339, rotatedExp)
+	require.NoError(t, perr)
+	assert.True(t, exp.After(time.Now().Add(180*24*time.Hour-time.Hour)), "expiry should reflect the reset ~6-month window")
+}
+
+func TestOAuth2Driver_MintFromRefreshToken_RotatingWithoutExpiry(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Rotates the refresh token but returns no refresh_token_expires_in.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  "at-new",
+			"refresh_token": "rt-new",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{credSource: &credential.CredSource{Config: map[string]string{"token_url": server.URL}}, httpClient: server.Client()}
+	spec := &credential.CredSpec{Name: "gh", Config: map[string]string{
+		"auth_method": "authorization_code", "client_id": "cid", "client_secret": "csecret", "refresh_token": "rt-old",
+	}}
+
+	rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "rt-new", rawData[credential.RawRotatedRefreshTokenKey])
+	// No expiry surfaced when the provider omits refresh_token_expires_in.
+	_, hasExp := rawData[credential.RawRotatedRefreshTokenExpiresAtKey]
+	assert.False(t, hasExp)
 }
 
 func TestOAuth2Driver_MintFromRefreshToken_NonRotating(t *testing.T) {

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -316,9 +316,10 @@ func (m *Manager) issueWithWriteBack(ctx context.Context, specName string, drive
 	return cred, nil
 }
 
-// consumeRotatedRefreshToken strips the reserved rotated-token key from rawData
-// (so it never reaches the credential Data map) and persists the new refresh
-// token into the spec config. Must run before ParseAndValidate.
+// consumeRotatedRefreshToken strips the reserved rotated-token keys from rawData
+// (so they never reach the credential Data map) and persists the new refresh
+// token — and its refreshed expiry, when the provider surfaced one — into the
+// spec config. Must run before ParseAndValidate.
 //
 // A persist failure does not fail this issuance — the access token just minted
 // is valid and is returned. But it is logged at error level because the old
@@ -331,6 +332,10 @@ func (m *Manager) consumeRotatedRefreshToken(ctx context.Context, spec *CredSpec
 		return
 	}
 	delete(rawData, RawRotatedRefreshTokenKey)
+	// The rotated expiry travels under its own reserved key; strip it unconditionally
+	// so it never lands in the credential Data, and apply it below if present.
+	rotatedExpiry, hasExpiry := rawData[RawRotatedRefreshTokenExpiresAtKey]
+	delete(rawData, RawRotatedRefreshTokenExpiresAtKey)
 	newToken, isString := rotated.(string)
 	if !isString || newToken == "" {
 		// The only producer sets a non-empty string; a different shape means a
@@ -353,6 +358,12 @@ func (m *Manager) consumeRotatedRefreshToken(ctx context.Context, spec *CredSpec
 		updated.Config[k] = v
 	}
 	updated.Config["refresh_token"] = newToken
+	// Keep refresh_token_expires_at in step with the rotated token when the provider
+	// returned a fresh expiry. If it rotated the token without one, leave the prior
+	// value untouched rather than assert an expiry we no longer know.
+	if exp, isStr := rotatedExpiry.(string); hasExpiry && isStr && exp != "" {
+		updated.Config["refresh_token_expires_at"] = exp
+	}
 	if err := m.configStore.PersistRotatedSpec(ctx, updated); err != nil {
 		m.log.Error("failed to persist rotated refresh token; spec must be reconnected if mints start failing",
 			logger.String("spec", spec.Name), logger.Err(err))

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -777,20 +777,49 @@ func TestManager_WriteBack_StripsReservedKeyAndPersists(t *testing.T) {
 	addRefreshSpecAndSource(configStore, "rt-old")
 
 	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, nil, time.Hour, "", nil
+		return map[string]interface{}{
+			"api_key":                          "at-new",
+			RawRotatedRefreshTokenKey:          "rt-new",
+			RawRotatedRefreshTokenExpiresAtKey: "2030-01-01T00:00:00Z",
+		}, nil, time.Hour, "", nil
 	}
 
 	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
 	require.NoError(t, err)
 
-	// The reserved rotated-token key must be stripped before parsing.
+	// The reserved rotated-token keys must be stripped before parsing.
 	_, leaked := cred.Data[RawRotatedRefreshTokenKey]
 	assert.False(t, leaked, "reserved rotated-token key must not reach credential Data")
+	_, leakedExp := cred.Data[RawRotatedRefreshTokenExpiresAtKey]
+	assert.False(t, leakedExp, "reserved rotated-expiry key must not reach credential Data")
 	assert.Equal(t, "at-new", cred.Data["api_key"])
 
-	// The rotated token is persisted into a fresh spec copy.
+	// The rotated token and its refreshed expiry are persisted into a fresh spec copy.
 	require.Len(t, configStore.persisted, 1)
 	assert.Equal(t, "rt-new", configStore.persisted[0].Config["refresh_token"])
+	assert.Equal(t, "2030-01-01T00:00:00Z", configStore.persisted[0].Config["refresh_token_expires_at"])
+}
+
+func TestManager_WriteBack_RotatingWithoutExpiry_KeepsPriorExpiry(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+	configStore.AddSource(&CredSource{Name: "src", Type: SourceTypeLocal, Config: map[string]string{}})
+	configStore.AddSpec(&CredSpec{Name: "gh", Type: TypeVaultToken, Source: "src", Config: map[string]string{
+		"auth_method": "authorization_code", "refresh_token": "rt-old", "refresh_token_expires_at": "2027-01-01T00:00:00Z",
+	}})
+
+	// Rotates the token but surfaces no new expiry.
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, nil, time.Hour, "", nil
+	}
+
+	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	require.NoError(t, err)
+
+	require.Len(t, configStore.persisted, 1)
+	assert.Equal(t, "rt-new", configStore.persisted[0].Config["refresh_token"])
+	// The prior expiry is left untouched rather than dropped or overwritten.
+	assert.Equal(t, "2027-01-01T00:00:00Z", configStore.persisted[0].Config["refresh_token_expires_at"])
 }
 
 func TestManager_WriteBack_NonRotating_NoPersist(t *testing.T) {

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -211,6 +211,15 @@ type SpecRotatable interface {
 // credential's Data map.
 const RawRotatedRefreshTokenKey = "__rotated_refresh_token"
 
+// RawRotatedRefreshTokenExpiresAtKey is a reserved key the OAuth2 driver may set
+// in rawData alongside RawRotatedRefreshTokenKey to surface the rotated refresh
+// token's new expiry (RFC3339). Providers that rotate the refresh token reset its
+// lifetime on each refresh, so the connect-time refresh_token_expires_at goes
+// stale. The minting layer consumes and strips this key, updating the spec's
+// refresh_token_expires_at so it tracks the rotated token, before the credential
+// is parsed — so it never reaches the credential's Data map.
+const RawRotatedRefreshTokenExpiresAtKey = "__rotated_refresh_token_expires_at"
+
 // OAuth2Authorizer is an optional interface for drivers that support an OAuth2
 // authorization-code consent flow. The CLI captures only the authorization code
 // on a loopback redirect; the server builds the authorize URL and performs the

--- a/provider/mcp_github/README.md
+++ b/provider/mcp_github/README.md
@@ -45,7 +45,7 @@ warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.jso
 warden write auth/jwt/role/mcp-user \
     token_policies="mcp-github-access" \
     user_claim=sub \
-    cred_spec_name=github-ops
+    cred_spec_name=github-oauth
 ```
 
 ## Step 2: Mount and Configure the Provider
@@ -143,19 +143,29 @@ warden cred spec read github-ops
 ### Option C: OAuth2 Authorization Code Flow (acting as a GitHub user)
 
 The App and PAT flows act as an application or a static token. To instead have an
-agent act **as a specific GitHub user** — with a token scoped to exactly what that
-user consented to — use the OAuth2 authorization-code flow. A human authorizes
-once in the browser; Warden seals the resulting refresh token and mints a fresh
-access token on each request. The agent never sees the client secret or the token.
+agent act **as a specific GitHub user** — with access limited to the intersection
+of the app's permissions and what that user consented to — use the OAuth2
+authorization-code flow. A human authorizes once in the browser; Warden seals the
+resulting refresh token and mints a fresh access token on each request. The agent
+never sees the client secret or the token.
 
 This flow uses its own `oauth2` credential source (not the `github` source created
 at the start of Step 3).
 
-1. Register an **OAuth App** under **Settings > Developer settings > OAuth Apps**
-   (this is distinct from a GitHub App). Note the **Client ID** and generate a
-   **Client Secret**.
-2. Set the app's **Authorization callback URL** to a fixed loopback address —
-   GitHub matches it exactly — for example `http://127.0.0.1:8765/callback`.
+Refresh tokens in this flow come only from a **GitHub App** with user-token
+expiration enabled. A classic OAuth App issues a non-expiring user token and no
+refresh token, so it cannot drive the refresh-on-demand model below.
+
+1. Use a **GitHub App** — the one from Option A works, or create a new one under
+   **Settings > Developer settings > GitHub Apps**. Enable **Expire user
+   authorization tokens** in its settings so GitHub returns a refresh token. Note
+   the **Client ID** and generate a **client secret** (this is the app's OAuth
+   client secret, distinct from the private key used in Option A).
+2. Set the app's **Callback URL** to a fixed loopback address — GitHub validates
+   the redirect against it — for example `http://127.0.0.1:8765/callback`.
+
+The user's effective access is the app's configured **permissions** intersected
+with what the user grants at consent time; there is no separate scope list to set.
 
 Create the source pointing at GitHub's authorize and token endpoints:
 
@@ -168,8 +178,8 @@ warden cred source create github-oauth-src \
 ```
 
 Create the spec — it starts empty, with no token until consent — carrying the
-OAuth App's credentials, the scopes you need, and the pinned callback from step 2.
-The client secret is read from a file so it never lands in shell history:
+app's OAuth client credentials and the pinned callback from step 2. The client
+secret is read from a file so it never lands in shell history:
 
 ```bash
 warden cred spec create github-oauth \
@@ -177,7 +187,6 @@ warden cred spec create github-oauth \
   -config auth_method=authorization_code \
   -config client_id=<your-client-id> \
   -config client_secret=@/path/to/client-secret \
-  -config scopes=repo,read:org \
   -config redirect_uri=http://127.0.0.1:8765/callback
 ```
 
@@ -190,9 +199,9 @@ warden cred spec connect github-oauth
 ```
 
 Re-run `connect` whenever you need to re-authorize — after revoking the grant,
-widening scopes, or rotating the secret. Add `-force` to replace a live
-authorization without the confirmation prompt, or `-no-browser` on a headless host
-to print the URL to open elsewhere. Bind this spec to the role from Step 1 with
+changing the app's permissions, or rotating the secret. Add `-force` to replace a
+live authorization without the confirmation prompt, or `-no-browser` on a headless
+host to print the URL to open elsewhere. Bind this spec to the role from Step 1 with
 `cred_spec_name=github-oauth`; Warden then injects the user's access token as
 `Authorization: Bearer <token>` on each MCP request, refreshing it from the sealed
 refresh token as needed.
@@ -405,6 +414,43 @@ For Claude Code, Cursor, Continue, Cline, Goose, and other clients that accept S
 ```
 
 > **Heads-up on `${VAR}` in headers.** MCP clients vary in what they substitute in `.mcp.json`. Claude Code and Cursor expand `${VAR}` in stdio `env` blocks and in the `url` field, but **HTTP-transport `headers` values are a known gap** — the literal `${JWT_TOKEN}` string ships on the wire. For the `Authorization` header (and the routing headers in the next example), paste the actual values instead of `${...}` placeholders, or run the JSON through `envsubst` at deploy time.
+
+#### Claude Code (CLI)
+
+Add the server straight from the command line instead of hand-editing the JSON.
+The shell expands `$JWT_TOKEN` when the command runs, so the token is written into
+the config as a literal value — sidestepping the header-substitution gap noted
+above:
+
+```bash
+claude mcp add --transport http github \
+  "${WARDEN_ADDR}/v1/mcp_github/role/mcp-user/gateway/" \
+  --header "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+This writes a `local`-scope entry (visible only to you, only in this directory) by
+default. Add `--scope project` to write a shared `.mcp.json` you can commit, or
+`--scope user` to make it available across all your projects.
+
+Confirm Claude Code registered it and completes the MCP handshake — this is where a
+missing lifecycle method in your policy (see Step 4) would surface as a hang:
+
+```bash
+claude mcp list
+```
+
+Then just ask Claude to use it; it discovers whatever tools your policy and the
+bound token allow:
+
+```
+> List the open issues in myorg/myrepo and summarize the three highest-priority ones.
+```
+
+The `role` segment in the URL selects which credential spec backs the calls: point
+at a role bound to `github-ops` to act as the App or PAT identity, or at a role
+bound to `github-oauth` (Option C) to act as the consenting GitHub user. The Hydra
+JWT is short-lived — when it expires, refresh it, then `claude mcp remove github`
+and re-add with the new token.
 
 #### Header-routed alternative
 


### PR DESCRIPTION
## Summary

Two related changes to the OAuth2 authorization-code path for the GitHub MCP provider:

1. **Bug fix** — keep the persisted `refresh_token_expires_at` in step with a rotated refresh token.
2. **Docs** — correct the `mcp_github` authorization-code setup (it pointed at the wrong kind of GitHub app) and add a Claude Code usage example.

## The bug

For a refresh-token-backed spec, when the provider rotates the refresh token during a mint, the new token was persisted but its expiry was not — `refresh_token_expires_at` stayed pinned to the value sealed at `connect` time. GitHub (and other rotating providers) reset the refresh-token window on every refresh, so the persisted expiry drifted increasingly stale. It is write-only today (nothing reads it yet), so this is a correctness/observability bug — a misleading timestamp on `cred spec read` and a landmine for any future "refresh token expiring soon" logic.

## The fix

- New reserved rawData key `RawRotatedRefreshTokenExpiresAtKey`, mirroring the existing rotated-token key.
- The OAuth2 driver surfaces the rotated token's new expiry alongside the rotated token, only when the provider returns `refresh_token_expires_in`.
- The minting layer strips that key from the credential `Data` and persists it into the spec's `refresh_token_expires_at`. A rotation **without** a new expiry leaves the prior value untouched rather than asserting an expiry we no longer know.

## Docs

- The authorization-code section described a refresh-token flow but told operators to register a classic **OAuth App**, which issues non-expiring user tokens and no refresh token. Corrected to a **GitHub App** with user-token expiration enabled; dropped the misleading `scopes` config (App user-to-server tokens derive access from the app's permissions, not the `scope` param); framed effective access as app permissions intersected with user consent.
- Added a **Claude Code (CLI)** subsection to Step 5: `claude mcp add` with HTTP transport + Authorization header, `--scope` options, the `claude mcp list` handshake check, a natural-language usage example, and the role→spec mapping for acting as the App/PAT identity or the consenting GitHub user.

## Testing

- Extended the rotating-driver test to assert the reset window is surfaced as a future RFC3339 expiry; added a rotating-without-expiry case.
- Extended the manager write-back test to assert the expiry is persisted and that neither reserved key leaks into credential `Data`; added a case preserving the prior expiry when none is returned.
- `go test ./credential/...` and `go vet ./credential/...` pass.
