### PR TITLE
feat(aws): credential metadata on STS mint + Claude Code CLI docs

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -320,6 +320,25 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 		"cred_source":       "aws_sts",
 	}
 
+	// Non-secret, descriptive attributes for clear audit logging. The secret
+	// material stays in rawData; only the principal identity goes here.
+	metadata := map[string]interface{}{
+		"subject":      roleArn, // the role the caller asked to assume
+		"session_name": sessionName,
+		"expiration":   creds.Expiration.UTC().Format(time.RFC3339),
+	}
+	if result.AssumedRoleUser != nil {
+		if arn := aws.ToString(result.AssumedRoleUser.Arn); arn != "" {
+			metadata["assumed_role_arn"] = arn
+			if acct := accountIDFromARN(arn); acct != "" {
+				metadata["account_id"] = acct
+			}
+		}
+		if id := aws.ToString(result.AssumedRoleUser.AssumedRoleId); id != "" {
+			metadata["assumed_role_id"] = id
+		}
+	}
+
 	if d.logger != nil {
 		d.logger.Debug("generated STS temporary credentials",
 			logger.String("spec", spec.Name),
@@ -328,7 +347,7 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 		)
 	}
 
-	return rawData, nil, leaseTTL, leaseID, nil
+	return rawData, metadata, leaseTTL, leaseID, nil
 }
 
 // mintViaSecretsManager fetches a secret from AWS Secrets Manager
@@ -377,6 +396,16 @@ func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.
 
 	// Secrets Manager secrets are static (no lease TTL)
 	return secretData, nil, 0, "", nil
+}
+
+// accountIDFromARN extracts the account-id segment from an ARN
+// (arn:partition:service:region:account-id:resource), or "" if malformed.
+func accountIDFromARN(arn string) string {
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) < 6 {
+		return ""
+	}
+	return parts[4]
 }
 
 // applyKeyMap remaps keys in data according to a comma-separated "srcKey=destKey" map

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -230,6 +230,41 @@ func TestApplyKeyMap(t *testing.T) {
 	}
 }
 
+func TestAccountIDFromARN(t *testing.T) {
+	tests := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "assumed role ARN",
+			arn:      "arn:aws:sts::123456789012:assumed-role/app-backend/warden-session",
+			expected: "123456789012",
+		},
+		{
+			name:     "iam role ARN",
+			arn:      "arn:aws:iam::123456789012:role/app-backend",
+			expected: "123456789012",
+		},
+		{
+			name:     "too few segments",
+			arn:      "arn:aws:iam::123456789012",
+			expected: "",
+		},
+		{
+			name:     "empty",
+			arn:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, accountIDFromARN(tt.arn))
+		})
+	}
+}
+
 func TestAWSDriver_MintCredential_InvalidMethod(t *testing.T) {
 	driver := &AWSDriver{
 		credSource: &credential.CredSource{

--- a/provider/mcp_aws/README.md
+++ b/provider/mcp_aws/README.md
@@ -340,6 +340,30 @@ For Claude Code, Cursor, Continue, Cline, Goose, and other clients that accept S
 
 > **Heads-up on `${VAR}` in headers.** MCP clients vary in what they substitute in `.mcp.json`. Claude Code and Cursor expand `${VAR}` in stdio `env` blocks and in the `url` field, but **HTTP-transport `headers` values are a known gap** — the literal `${JWT_TOKEN}` string ships on the wire. For the `Authorization` header (and the routing headers in the next example), paste the actual values instead of `${...}` placeholders, or run the JSON through `envsubst` at deploy time.
 
+#### Claude Code CLI
+
+Rather than hand-editing `.mcp.json`, Claude Code can register the server from the command line. Because the command runs in your shell, `${WARDEN_ADDR}` and `${JWT_TOKEN}` are expanded before they're written to config — sidestepping the `${VAR}`-in-headers gap above:
+
+```bash
+claude mcp add --transport http aws \
+  "${WARDEN_ADDR}/v1/mcp_aws/role/s3-reader/gateway" \
+  --header "Authorization: Bearer ${JWT_TOKEN}"
+```
+
+`--transport http` selects the Streamable HTTP transport (not the default stdio); `--header` is repeatable. Add `--scope user` to make the server available across every project (the default `local` scope binds it to the current directory). Keep the `gateway` suffix **without** a trailing slash, as in the URL-pattern note above.
+
+To use header-routed mode instead (see the next section for when), pass each routing header with its own `--header` flag against the base URL:
+
+```bash
+claude mcp add --transport http aws "${WARDEN_ADDR}/" \
+  --header "Authorization: Bearer ${JWT_TOKEN}" \
+  --header "X-Warden-Provider: mcp_aws/" \
+  --header "X-Warden-Namespace: <namespace>" \
+  --header "X-Warden-Role: s3-reader"
+```
+
+Confirm the handshake and list the exposed tools with `claude mcp list`; remove the server with `claude mcp remove aws`.
+
 #### Header-routed alternative
 
 Some MCP clients dislike long URLs, or you want one base URL to mux several Warden providers. Pass the mount path as `X-Warden-Provider`, the namespace as `X-Warden-Namespace`, and the role as `X-Warden-Role` instead — Warden synthesises the canonical gateway path from the headers. Look up the mount path first:


### PR DESCRIPTION
## Summary

Two related changes to the AWS/MCP surface:

1. **AWS driver metadata** — `mintViaSTSAssumeRole` now returns non-secret identity attributes (`subject`, `assumed_role_arn`, `assumed_role_id`, `account_id`, `session_name`, `expiration`) instead of `nil` for the metadata map. These flow into `Credential.Metadata`, which the audit layer logs **in clear** — giving auditors the "who/what was issued" context — while the actual keys/session token stay in the HMAC-salted `Data` map. All values come straight from the existing `AssumeRole` response, so there are no extra AWS API calls. Adds an `accountIDFromARN` helper with unit tests.

2. **mcp_aws README** — adds a Claude Code CLI subsection to Step 5 documenting `claude mcp add --transport http` for both URL-path and header-routed modes, and notes that shell expansion of `${WARDEN_ADDR}`/`${JWT_TOKEN}` sidesteps the `${VAR}`-in-headers gap that affects hand-edited `.mcp.json`.

## Scope notes

- Only `sts_assume_role` populates metadata; `secrets_manager`, `rds_iam_token`, and `redshift_iam_token` remain unchanged for now.
- No interface, credential-type, or parser changes — the metadata map already flows end-to-end via the existing `Parse` path.

## Testing

- `go build ./...`, `go vet ./credential/drivers/`, `go test ./credential/...` — all pass.
- New `TestAccountIDFromARN` covers well-formed ARNs, too-few-segments, and empty input.
- End-to-end audit verification (issue an `sts_assume_role` credential, confirm the `metadata` block appears in clear while `data` stays salted) is the remaining manual step.
