### PR TITLE
feat(vault): subject metadata on vault_token mint

### DIFF
--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -713,6 +713,17 @@ func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credenti
 		"renewable":    secret.Auth.Renewable,
 	}
 
+	// Non-secret subject identity for clear audit logging: the token role it was
+	// minted from and the Vault entity it resolves to. The token itself stays in
+	// the HMAC-salted rawData.
+	metadata := map[string]interface{}{
+		"role": tokenRole,
+	}
+	// EntityID is empty for tokens not tied to an entity; include it only when present.
+	if secret.Auth.EntityID != "" {
+		metadata["subject"] = secret.Auth.EntityID
+	}
+
 	if d.logger != nil {
 		d.logger.Debug("generated dynamic Vault token",
 			logger.String("spec", spec.Name),
@@ -725,7 +736,7 @@ func (d *VaultDriver) fetchDynamicVaultToken(ctx context.Context, spec *credenti
 
 	// Vault tokens don't have a lease ID in the traditional sense
 	// The token itself is the credential; revocation is done via token/revoke
-	return rawData, nil, leaseTTL, secret.Auth.Accessor, nil
+	return rawData, metadata, leaseTTL, secret.Auth.Accessor, nil
 }
 
 // Revoke revokes a Vault lease or token accessor

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -2,9 +2,13 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/api"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -373,6 +377,75 @@ func TestVaultDriver_MintCredential_VaultTokenRouting(t *testing.T) {
 	_, _, _, _, err := driver.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token_role is required")
+}
+
+func TestVaultDriver_FetchDynamicVaultToken_Metadata(t *testing.T) {
+	tests := []struct {
+		name            string
+		entityID        string
+		expectSubject   bool
+		expectedSubject string
+	}{
+		{name: "with entity", entityID: "8d2c-entity-id", expectSubject: true, expectedSubject: "8d2c-entity-id"},
+		{name: "no entity", entityID: "", expectSubject: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"auth": map[string]interface{}{
+						"client_token":   "hvs.secret-token",
+						"accessor":       "hvs.accessor",
+						"policies":       []string{"default", "ci-deploy"},
+						"renewable":      true,
+						"entity_id":      tt.entityID,
+						"lease_duration": 3600,
+					},
+				})
+			}))
+			defer srv.Close()
+
+			client, err := api.NewClient(&api.Config{Address: srv.URL})
+			require.NoError(t, err)
+
+			driver := &VaultDriver{
+				vault: client,
+				credSource: &credential.CredSource{
+					Type:   credential.SourceTypeVault,
+					Config: map[string]string{"vault_address": srv.URL},
+				},
+			}
+			spec := &credential.CredSpec{
+				Name: "test-token",
+				Type: credential.TypeVaultToken,
+				Config: map[string]string{
+					"mint_method": "vault_token",
+					"token_role":  "ci-deployer",
+				},
+			}
+
+			rawData, metadata, _, leaseID, err := driver.fetchDynamicVaultToken(context.TODO(), spec)
+			require.NoError(t, err)
+
+			// Metadata carries non-secret subject identity only.
+			assert.Equal(t, "ci-deployer", metadata["role"])
+			if tt.expectSubject {
+				assert.Equal(t, tt.expectedSubject, metadata["subject"])
+			} else {
+				assert.NotContains(t, metadata, "subject")
+			}
+			// Never leak token material into the clear-logged metadata map.
+			for _, k := range []string{"token", "client_token", "accessor", "policies"} {
+				assert.NotContains(t, metadata, k)
+			}
+
+			// Secret stays in rawData; the accessor is the lease ID.
+			assert.Equal(t, "hvs.secret-token", rawData["token"])
+			assert.Equal(t, "hvs.accessor", leaseID)
+		})
+	}
 }
 
 func TestVaultDriver_MintCredential_DynamicGCPRouting(t *testing.T) {


### PR DESCRIPTION
## Summary

Populate `Credential.Metadata` for the Vault driver's `vault_token` mint method with the issued token's non-secret subject identity. Today the driver returns `nil` metadata, so a minted Vault token carries no clear audit context about who it was issued to.

`fetchDynamicVaultToken` now returns:
- `role` — the `auth/token/create/<role>` role the token was minted from
- `subject` — the Vault entity the token resolves to (`Auth.EntityID`), included only when present

These flow into `Credential.Metadata`, which the audit layer logs **in clear**, while the token itself stays in the HMAC-salted `Data` map. `subject` aligns with the same convention used by the AWS (STS) and OAuth2 drivers.

## Scope

- Only `vault_token`. The other five mint methods (`static_aws`, `static_apikey`, `dynamic_aws`, `dynamic_gcp`, `dynamic_ibm`, `oauth2`) are unchanged and continue to return `nil` metadata.
- No interface, credential-type, or parser changes — the `vault_token` type's `Parse` already threads metadata through.

## Testing

- `go build ./...`, `go vet ./credential/drivers/`, `go test ./credential/...` — all pass.
- New `TestVaultDriver_FetchDynamicVaultToken_Metadata` (table-driven, httptest Vault stub) asserts metadata carries `role`/`subject`, omits `subject` when the token has no entity, and never contains token material; confirms the secret stays in `rawData`.
