### PR TITLE
feat(kubernetes): subject metadata on token mint

### DIFF
--- a/credential/drivers/kubernetes_driver.go
+++ b/credential/drivers/kubernetes_driver.go
@@ -248,6 +248,8 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 		"audiences":       audiencesStr,
 	}
 
+	metadata := kubernetesTokenMetadata(sa, namespace, audiencesStr, tokenResp.Status.ExpirationTimestamp)
+
 	if d.logger != nil {
 		d.logger.Debug("minted Kubernetes ServiceAccount token",
 			logger.String("spec", spec.Name),
@@ -256,7 +258,25 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 		)
 	}
 
-	return rawData, nil, computedTTL, "", nil
+	return rawData, metadata, computedTTL, "", nil
+}
+
+// kubernetesTokenMetadata builds clear-loggable identity metadata for a minted
+// ServiceAccount token. subject is the canonical Kubernetes SA identity, matching
+// what apiserver RBAC and audit logs use. The token itself stays in rawData.
+func kubernetesTokenMetadata(sa, namespace, audiences, expiration string) map[string]interface{} {
+	meta := map[string]interface{}{
+		"subject":         fmt.Sprintf("system:serviceaccount:%s:%s", namespace, sa),
+		"service_account": sa,
+		"namespace":       namespace,
+	}
+	if audiences != "" {
+		meta["audiences"] = audiences
+	}
+	if expiration != "" {
+		meta["expiration"] = expiration
+	}
+	return meta
 }
 
 // Revoke is a no-op for Kubernetes ServiceAccount tokens.

--- a/credential/drivers/kubernetes_driver_test.go
+++ b/credential/drivers/kubernetes_driver_test.go
@@ -784,3 +784,32 @@ func TestKubernetesDriver_MapError_RateLimit(t *testing.T) {
 	err := d.mapError(fmt.Errorf("status 429"), http.StatusTooManyRequests, "my-sa", "default")
 	assert.Contains(t, err.Error(), "rate limited")
 }
+
+func TestKubernetesTokenMetadata(t *testing.T) {
+	t.Run("full", func(t *testing.T) {
+		meta := kubernetesTokenMetadata("app-backend", "default",
+			"https://app.example.com", "2026-06-09T16:04:05Z")
+
+		assert.Equal(t, "system:serviceaccount:default:app-backend", meta["subject"])
+		assert.Equal(t, "app-backend", meta["service_account"])
+		assert.Equal(t, "default", meta["namespace"])
+		assert.Equal(t, "https://app.example.com", meta["audiences"])
+		assert.Equal(t, "2026-06-09T16:04:05Z", meta["expiration"])
+
+		// Secret material never lands in the clear-logged metadata, and every
+		// value is a string (Metadata parsing rejects non-strings).
+		assert.NotContains(t, meta, "token")
+		for k, v := range meta {
+			_, ok := v.(string)
+			assert.Truef(t, ok, "metadata[%q] is %T, expected string", k, v)
+		}
+	})
+
+	t.Run("omits empty audiences and expiration", func(t *testing.T) {
+		meta := kubernetesTokenMetadata("app-backend", "default", "", "")
+
+		assert.Equal(t, "system:serviceaccount:default:app-backend", meta["subject"])
+		assert.NotContains(t, meta, "audiences")
+		assert.NotContains(t, meta, "expiration")
+	})
+}


### PR DESCRIPTION
## Summary

Populate `Credential.Metadata` for the Kubernetes driver's TokenRequest mint with the issued ServiceAccount token's non-secret subject identity. Today the driver returns `nil` metadata, so minted tokens carry no clear audit context about who was issued what.

The mint now returns:
- `subject` — the canonical `system:serviceaccount:<namespace>:<name>` identity (the exact string apiserver RBAC and audit logs use)
- `service_account`, `namespace`
- `audiences` — when set
- `expiration` — the TokenRequest `expirationTimestamp` (RFC3339), when present

These flow into `Credential.Metadata`, which the audit layer logs **in clear**, while the bearer `token` stays in the HMAC-salted `Data` map. `subject` aligns with the convention used by the AWS (STS), Vault (token), and GCP drivers.

## Sensitive data excluded

The minted `token` and the source apiserver credential never enter metadata. The cluster apiserver URL is also omitted (cluster infra detail, not subject identity).

## Design notes

- Driver-only — `TypeKubernetesToken` embeds `BaseTokenType`, whose `Parse` already threads metadata into `Credential.Metadata`. No type/parser changes.
- Metadata assembled via a small pure builder so it's unit-testable without a mock apiserver. All values are strings (the `helper.ToStringMap` invariant); `audiences`/`expiration` omitted when absent.

## Testing

- `go build ./...`, `go vet ./credential/drivers/`, `go test ./credential/...` — all pass.
- `TestKubernetesTokenMetadata` covers the full field set, the canonical subject string, omission of empty audiences/expiration, absence of the `token` secret, and the all-strings invariant.
