### PR TITLE
refactor(credential): trim non-secret descriptive fields from rawData

### DIFF
--- a/credential/drivers/azure_driver.go
+++ b/credential/drivers/azure_driver.go
@@ -345,10 +345,6 @@ func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.Cred
 
 	rawData := map[string]interface{}{
 		"access_token": token,
-		"resource_uri": resourceURI,
-		"tenant_id":    tenantID,
-		"client_id":    clientID,
-		"token_type":   "Bearer",
 	}
 
 	metadata := azureBearerTokenMetadata(clientID, tenantID, resourceURI, ttl, time.Now())

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -239,17 +239,10 @@ func (d *GCPDriver) mintAccessToken(ctx context.Context, spec *credential.CredSp
 	}
 
 	saKey, _ := d.parseServiceAccountKey()
-	projectID := ""
-	if saKey != nil {
-		projectID = saKey.ProjectID
-	}
 
 	ttl := time.Until(expiry)
 	rawData := map[string]interface{}{
 		"access_token": token,
-		"project_id":   projectID,
-		"scopes":       scopesStr,
-		"token_type":   "Bearer",
 	}
 
 	if d.logger != nil {
@@ -333,17 +326,9 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 	}
 
 	saKey, _ := d.parseServiceAccountKey()
-	projectID := ""
-	if saKey != nil {
-		projectID = saKey.ProjectID
-	}
 
 	rawData := map[string]interface{}{
-		"access_token":           tokenResp.AccessToken,
-		"project_id":             projectID,
-		"scopes":                 scopesStr,
-		"token_type":             "Bearer",
-		"target_service_account": targetSA,
+		"access_token": tokenResp.AccessToken,
 	}
 
 	if d.logger != nil {

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -191,9 +191,7 @@ func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec)
 
 	ttl := time.Until(expiry)
 	rawData := map[string]interface{}{
-		"api_key":      token,
 		"access_token": token,
-		"token_type":   "Bearer",
 	}
 
 	if d.logger != nil {

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -307,10 +307,7 @@ func TestIBMDriver_MintIAMToken(t *testing.T) {
 	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, rawData["api_key"])
 	assert.NotEmpty(t, rawData["access_token"])
-	assert.Equal(t, "Bearer", rawData["token_type"])
-	assert.Equal(t, rawData["api_key"], rawData["access_token"])
 	assert.True(t, ttl > 0)
 	assert.Empty(t, leaseID, "IAM tokens should have no lease ID")
 }

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -532,14 +532,7 @@ func isRefreshTokenRejection(err error) bool {
 
 // accessTokenRawData builds the rawData map returned to the credential parser.
 func accessTokenRawData(resp *oauth2TokenResponse) map[string]interface{} {
-	rawData := map[string]interface{}{"api_key": resp.AccessToken}
-	if resp.Scope != "" {
-		rawData["scope"] = resp.Scope
-	}
-	if resp.TokenType != "" {
-		rawData["token_type"] = resp.TokenType
-	}
-	return rawData
+	return map[string]interface{}{"api_key": resp.AccessToken}
 }
 
 // ttlFromExpiresIn converts an expires_in (seconds) into a lease TTL (0 if absent).

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -380,8 +380,6 @@ func TestOAuth2Driver_MintCredential(t *testing.T) {
 	rawData, _, ttl, leaseID, err := d.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "eyJ-test-access-token", rawData["api_key"])
-	assert.Equal(t, "Bearer", rawData["token_type"])
-	assert.Equal(t, "read write", rawData["scope"])
 	assert.Equal(t, 3600*time.Second, ttl)
 	assert.Empty(t, leaseID)
 }


### PR DESCRIPTION
## Summary

Several drivers put **descriptive** fields into `rawData` (which becomes `Credential.Data`) that no provider/gateway ever reads, and that the credential type's `Parse` either drops or keeps-but-nobody-consumes. In audit they're just HMAC-salted noise; the descriptive identity now lives in `Credential.Metadata`. This trims each affected mint down to the secret the gateway actually injects.

| Driver / mint | Removed from rawData | Kept |
|---|---|---|
| Azure `bearer_token` | `resource_uri`, `tenant_id`, `client_id`, `token_type` | `access_token` |
| GCP `access_token` | `project_id`, `scopes`, `token_type` | `access_token` |
| GCP `impersonated_access_token` | `project_id`, `scopes`, `token_type`, `target_service_account` | `access_token` |
| IBM IAM | `api_key`, `token_type` | `access_token` |
| OAuth2 | `scope`, `token_type` | `api_key` |

## Why this is safe (verified, not assumed)

- Provider/gateway reads of `Credential.Data[...]` were enumerated across `provider/`; none read the removed keys. Azure/GCP gateways read only `access_token`; IBM's extractor uses `access_token` (`CredentialField: "access_token"`); OAuth2-backed providers read `api_key`/`access_token`.
- `BaseTokenType.Parse` copies only `PrimaryField`+`OptionalFields` into `Data`; `IBMCloudKeys.Parse` keeps only `access_token`/`access_key_id`/`secret_access_key` — so IBM's `api_key`/`token_type` were already dropped.

## Out of scope (unchanged)

AWS `sts_assume_role` (its `cred_source` has a `Parse` side-effect → `SourceType`; `session_token`/`security_token` are consumed), AWS `rds_iam_token`, AWS `redshift_iam_token`, and every other driver. Credential **type** schemas are left intact (the optional fields simply won't be populated).

## Testing

- `go build ./...`, `go vet ./credential/...`, `go test ./credential/... ./provider/...` — all pass.
- Updated two driver-test assertions that checked the removed keys (`ibm_driver_test.go`, `oauth2_driver_test.go`).
