### PR TITLE
feat(cert): remove spiffe_id principal claim

### DIFF
--- a/auth/method/cert/README.md
+++ b/auth/method/cert/README.md
@@ -69,7 +69,7 @@ warden write auth/cert/config \
 
 `trusted_ca_pem` accepts a concatenated PEM bundle — multiple `-----BEGIN CERTIFICATE-----` blocks back-to-back are all loaded. The mount validates the bundle at write time and rejects PEM with no valid certificates.
 
-When `principal_claim` is omitted, the mount defaults to `cn` (the certificate Subject's CommonName). For SPIFFE-issued certificates, set it to `spiffe_id`; for service-mesh certs, `uri_san` or `dns_san` is often the right pick. See [Principal Claim Selection](#principal-claim-selection) for the full list.
+When `principal_claim` is omitted, the mount defaults to `cn` (the certificate Subject's CommonName). For service-mesh or SPIFFE certificates, `uri_san` or `dns_san` is often the right pick. See [Principal Claim Selection](#principal-claim-selection) for the full list.
 
 ## Step 2: Enable Revocation Checking (Optional)
 
@@ -165,8 +165,7 @@ The first request with a given (certificate fingerprint, role) tuple triggers a 
 | `cn` | `Subject.CommonName` | Default. Operator-issued certs with a meaningful CN per workload. |
 | `dns_san` | First DNS SAN | Service-mesh certs where the SAN is the service name. Returns the first DNS SAN; if you have multiple and need stable picks, narrow via `allowed_dns_sans`. |
 | `email_san` | First email SAN | Operator certs where the identity is a person, not a service. |
-| `uri_san` | First URI SAN | Any URI-typed identity (SPIFFE is the common case, but works for any URI scheme). |
-| `spiffe_id` | First URI SAN starting with `spiffe://` | SPIFFE SVIDs specifically. Differs from `uri_san` in that it filters to SPIFFE URIs — useful when the cert carries multiple URI SANs and only the SPIFFE one is the identity. |
+| `uri_san` | First URI SAN | Any URI-typed identity, including a SPIFFE ID carried in the URI SAN. Note this is a plain string read — it does **not** validate the certificate as a SPIFFE SVID. |
 | `serial` | `SerialNumber` (decimal string) | When the issuing CA assigns one cert per workload and the serial is the registry key. |
 
 Pick the field whose value is **stable for the lifetime of the workload**. The principal flows into audit logs and policy decisions; you don't want it to change across cert rotations of the same workload identity.
@@ -178,7 +177,7 @@ For SPIFFE X.509 SVIDs, the workload identity lives in the certificate's URI SAN
 ```bash
 warden write auth/cert/role/api-frontend \
   allowed_uri_sans="spiffe://prod.example.org/api/frontend/*" \
-  principal_claim="spiffe_id" \
+  principal_claim="uri_san" \
   token_policies="api-read"
 ```
 
@@ -252,7 +251,7 @@ Per-mount introspection (`auth/<mount>/introspect/roles`) exists too — the agg
 | Field | Required | Description |
 |---|---|---|
 | `trusted_ca_pem` | Yes (unless every role sets its own `certificate`) | PEM-encoded CA bundle that signs accepted client certificates. Multiple `-----BEGIN CERTIFICATE-----` blocks may be concatenated. |
-| `principal_claim` | No (default `cn`) | Which certificate field becomes the principal identity. One of `cn`, `dns_san`, `email_san`, `uri_san`, `spiffe_id`, `serial`. |
+| `principal_claim` | No (default `cn`) | Which certificate field becomes the principal identity. One of `cn`, `dns_san`, `email_san`, `uri_san`, `serial`. |
 | `token_ttl` | No (default `1h`) | Default TTL for issued Warden auth tokens; per-role `token_ttl` overrides; capped further by the certificate's `NotAfter`. |
 | `revocation_mode` | No (default `none`) | Revocation check mode. One of `none`, `ocsp`, `crl`, `best_effort`. |
 | `crl_cache_ttl` | No (default `1h`) | How long a fetched CRL is cached per distribution-point URL. Example: `30m`, `2h`. |

--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -85,7 +85,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 var validRevocationModes = []string{"", "none", "crl", "ocsp", "best_effort"}
 
 // validPrincipalClaims lists the allowed values for principal_claim.
-var validPrincipalClaims = []string{"cn", "dns_san", "email_san", "uri_san", "spiffe_id", "serial"}
+var validPrincipalClaims = []string{"cn", "dns_san", "email_san", "uri_san", "serial"}
 
 func (b *certAuthBackend) setupCertConfig(_ context.Context, conf map[string]any) error {
 	config, err := mapToCertAuthConfig(conf)
@@ -98,6 +98,15 @@ func (b *certAuthBackend) setupCertConfig(_ context.Context, conf map[string]any
 	}
 	if config.PrincipalClaim == "" {
 		config.PrincipalClaim = "cn"
+	}
+	// Backward compatibility: the "spiffe_id" principal claim was removed because
+	// it pulled a spiffe:// URI from the certificate without validating it as an
+	// SVID. A persisted value is coerced to "uri_san" (identical result for a
+	// single-URI SVID) so existing mounts keep loading; real SPIFFE validation
+	// now lives in a mount configured with mode=spiffe.
+	if config.PrincipalClaim == "spiffe_id" {
+		b.logger.Warn("principal_claim \"spiffe_id\" is deprecated and does not validate SPIFFE SVIDs; coercing to \"uri_san\" (use a mount with mode=spiffe for SPIFFE validation)")
+		config.PrincipalClaim = "uri_san"
 	}
 	if !isValidPrincipalClaim(config.PrincipalClaim) {
 		return fmt.Errorf("invalid principal_claim %q; must be one of: %v", config.PrincipalClaim, validPrincipalClaims)

--- a/auth/method/cert/helpers_test.go
+++ b/auth/method/cert/helpers_test.go
@@ -18,7 +18,7 @@ func TestIsValidPrincipalClaim(t *testing.T) {
 		{"dns_san", true},
 		{"email_san", true},
 		{"uri_san", true},
-		{"spiffe_id", true},
+		{"spiffe_id", false},
 		{"serial", true},
 		{"invalid", false},
 		{"CN", false},

--- a/auth/method/cert/path_config.go
+++ b/auth/method/cert/path_config.go
@@ -2,6 +2,7 @@ package cert
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -21,7 +22,7 @@ func (b *certAuthBackend) pathConfig() *framework.Path {
 			},
 			"principal_claim": {
 				Type:          framework.TypeString,
-				Description:   "Identity source from certificate: cn (default), spiffe_id, dns_san, email_san, uri_san, serial",
+				Description:   "Identity source from certificate: cn (default), dns_san, email_san, uri_san, serial",
 				Default:       "cn",
 				AllowedValues: principalClaimAllowedValues(),
 			},
@@ -102,6 +103,17 @@ func (b *certAuthBackend) handleConfigRead(ctx context.Context, req *logical.Req
 
 // handleConfigWrite handles writing the configuration
 func (b *certAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	// Reject the removed "spiffe_id" principal claim on new writes. A persisted
+	// legacy value is coerced to "uri_san" on load instead (see setupCertConfig).
+	if v, ok := d.GetOk("principal_claim"); ok {
+		if claim, _ := v.(string); claim == "spiffe_id" {
+			return &logical.Response{
+				StatusCode: http.StatusBadRequest,
+				Err:        fmt.Errorf("principal_claim \"spiffe_id\" is no longer supported; configure a mount with mode=spiffe for SPIFFE SVID validation"),
+			}, nil
+		}
+	}
+
 	// Build config map from field data
 	conf := make(map[string]any)
 

--- a/auth/method/cert/path_login.go
+++ b/auth/method/cert/path_login.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/auth/helper"
@@ -131,6 +130,11 @@ func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request,
 	}
 	if principalClaim == "" {
 		principalClaim = "cn"
+	}
+	// Legacy roles may still carry the removed "spiffe_id" claim; treat it as
+	// "uri_san" (identical result for a single-URI SVID).
+	if principalClaim == "spiffe_id" {
+		principalClaim = "uri_san"
 	}
 
 	// Extract principal identity from the certificate
@@ -281,12 +285,6 @@ func extractPrincipal(cert *x509.Certificate, claim string) string {
 	case "uri_san":
 		if len(cert.URIs) > 0 {
 			return cert.URIs[0].String()
-		}
-	case "spiffe_id":
-		for _, u := range cert.URIs {
-			if strings.HasPrefix(u.String(), "spiffe://") {
-				return u.String()
-			}
 		}
 	case "serial":
 		return cert.SerialNumber.String()

--- a/auth/method/cert/path_login_test.go
+++ b/auth/method/cert/path_login_test.go
@@ -328,7 +328,7 @@ func TestExtractPrincipal(t *testing.T) {
 		{"dns_san", "agent.example.com"},
 		{"email_san", "agent@example.com"},
 		{"uri_san", "spiffe://example.com/agent"},
-		{"spiffe_id", "spiffe://example.com/agent"},
+		{"spiffe_id", ""}, // removed claim — now treated as unknown, yields empty
 		{"serial", cert.SerialNumber.String()},
 		{"unknown", ""},
 	}

--- a/auth/method/cert/path_role.go
+++ b/auth/method/cert/path_role.go
@@ -72,7 +72,7 @@ func (b *certAuthBackend) pathRole() *framework.Path {
 			},
 			"principal_claim": {
 				Type:          framework.TypeString,
-				Description:   "Identity source from certificate (overrides global config): cn, dns_san, email_san, uri_san, spiffe_id, serial",
+				Description:   "Identity source from certificate (overrides global config): cn, dns_san, email_san, uri_san, serial",
 				AllowedValues: principalClaimAllowedValues(),
 			},
 		},

--- a/auth/method/cert/principal_claim_migration_test.go
+++ b/auth/method/cert/principal_claim_migration_test.go
@@ -1,0 +1,100 @@
+package cert
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The "spiffe_id" principal claim was removed because it read a spiffe:// URI
+// from the certificate without validating it as an SVID. These tests pin the
+// migration behavior: persisted/legacy values are coerced to "uri_san", while
+// new writes are rejected.
+
+func TestSetupCertConfig_CoercesSpiffeIDToURISAN(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	err := b.setupCertConfig(ctx, map[string]any{
+		"principal_claim": "spiffe_id",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "uri_san", b.config.PrincipalClaim)
+}
+
+func TestInitialize_CoercesPersistedSpiffeID(t *testing.T) {
+	b, ctx := createTestBackend(t)
+
+	// Simulate a config persisted by an older version that still allowed spiffe_id.
+	entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+		"principal_claim": "spiffe_id",
+		"token_ttl":       "1h",
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.storageView.Put(ctx, entry))
+
+	require.NoError(t, b.Initialize(ctx))
+	require.NotNil(t, b.config)
+	assert.Equal(t, "uri_san", b.config.PrincipalClaim)
+}
+
+func TestHandleConfigWrite_RejectsSpiffeID(t *testing.T) {
+	b, ctx := createTestBackend(t)
+
+	d := &framework.FieldData{
+		Raw:    map[string]any{"principal_claim": "spiffe_id"},
+		Schema: b.pathConfig().Fields,
+	}
+
+	resp, err := b.handleConfigWrite(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "spiffe_id")
+}
+
+// A role persisted before the removal may still carry principal_claim=spiffe_id.
+// Login must coerce it to uri_san so the workload keeps authenticating with the
+// same principal value (the single SPIFFE URI SAN).
+func TestHandleLogin_LegacyRoleSpiffeIDClaimCoerced(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	caCert, caKey, caPEM := testCA(t)
+
+	b.config = &CertAuthConfig{
+		TrustedCAPEM:   caPEM,
+		PrincipalClaim: "cn",
+		TokenTTL:       time.Hour,
+	}
+	b.config.caPool, _ = buildCAPool(caPEM)
+
+	// setRole bypasses validateRole, mimicking a value stored by an older version.
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:               "legacy",
+		AllowedCommonNames: []string{"*"},
+		PrincipalClaim:     "spiffe_id",
+		TokenTTL:           "1h",
+	}))
+
+	clientCert := testClientCert(t, caCert, caKey, "agent", func(tmpl *x509.Certificate) {
+		u, _ := url.Parse("spiffe://example.com/ns/default/sa/agent")
+		tmpl.URIs = append(tmpl.URIs, u)
+	})
+
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, clientCert)}
+	d := &framework.FieldData{
+		Raw:    map[string]any{"role": "legacy"},
+		Schema: b.pathLogin().Fields,
+	}
+
+	resp, err := b.handleLogin(ctx, req, d)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, resp.Auth)
+	assert.Equal(t, "spiffe://example.com/ns/default/sa/agent", resp.Auth.PrincipalID)
+}


### PR DESCRIPTION
## What

Removes the `spiffe_id` value from the certificate auth method's `principal_claim`.

`principal_claim=spiffe_id` pulled a `spiffe://` URI out of a certificate **without** validating it as an SVID or binding its trust domain — "fake SPIFFE" sitting next to real X.509 auth. It is removed ahead of a first-class `mode=spiffe` trust model (later PRs in this stack).

## Changes

- Drop `spiffe_id` from the valid principal claims and from `extractPrincipal`.
- Reject new `principal_claim=spiffe_id` writes with a message pointing at `mode=spiffe`.
- Graceful migration: a value persisted by an older version is coerced to `uri_san` on config load and at login (identical principal for a single-URI SVID), with a deprecation warning — so existing mounts keep working.
- Docs updated (principal-claim table, examples, config reference).

## Tests

`auth/method/cert/principal_claim_migration_test.go` covers coercion-on-load (direct and via `Initialize`), new-write rejection, legacy-role coercion at login, plus an x509 login regression. `go test ./auth/method/cert/...`, `go vet`, and `go build ./...` are clean.

## Notes

First of a 6-PR stack delivering full SPIFFE support (SVID validation → spiffe mount mode → enforcement → federation). This is the only breaking change in the stack and is handled gracefully.
