### PR TITLE
feat(cert): SPIFFE X.509-SVID verification primitives

### DIFF
--- a/auth/method/cert/spiffe.go
+++ b/auth/method/cert/spiffe.go
@@ -1,0 +1,131 @@
+package cert
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+
+	"github.com/stephnangue/warden/auth/helper"
+)
+
+// SPIFFETrustDomain is a configured SPIFFE trust domain together with the X.509
+// authorities that are authoritative for it. It is stored as JSON under the
+// spiffe/trust-domain/<name> storage prefix.
+//
+// Exactly one of BundlePEM or BundleJSON carries the trust material:
+//   - BundlePEM:  one or more concatenated CERTIFICATE PEM blocks.
+//   - BundleJSON: a SPIFFE trust-bundle (JWKS) document. Only its X.509
+//     authorities are consumed; JWT authorities are ignored.
+//
+// The struct is intentionally minimal but kept extensible: federation (remote
+// bundle endpoints and periodic refresh) will add fields here in a later change.
+type SPIFFETrustDomain struct {
+	Name       string `json:"name"`
+	BundlePEM  string `json:"bundle_pem,omitempty"`
+	BundleJSON string `json:"bundle_json,omitempty"`
+}
+
+// parseTrustDomainAuthorities parses the configured bundle into the X.509
+// authorities for the trust domain. It accepts a PEM bundle or a SPIFFE-JWKS
+// document, but not both, and requires at least one X.509 authority.
+func parseTrustDomainAuthorities(td spiffeid.TrustDomain, bundlePEM, bundleJSON string) ([]*x509.Certificate, error) {
+	switch {
+	case bundlePEM != "" && bundleJSON != "":
+		return nil, fmt.Errorf("provide either bundle_pem or bundle_json, not both")
+
+	case bundlePEM != "":
+		certs, err := parsePEMCertChain([]byte(bundlePEM))
+		if err != nil {
+			return nil, err
+		}
+		if len(certs) == 0 {
+			return nil, fmt.Errorf("bundle_pem contains no valid certificates")
+		}
+		return certs, nil
+
+	case bundleJSON != "":
+		// spiffebundle parses the JWKS form and exposes only its X.509 authorities.
+		b, err := spiffebundle.Parse(td, []byte(bundleJSON))
+		if err != nil {
+			return nil, fmt.Errorf("invalid bundle_json: %w", err)
+		}
+		authorities := b.X509Authorities()
+		if len(authorities) == 0 {
+			return nil, fmt.Errorf("bundle_json contains no X.509 authorities")
+		}
+		return authorities, nil
+
+	default:
+		return nil, fmt.Errorf("a bundle is required (set bundle_pem or bundle_json)")
+	}
+}
+
+// parsePEMCertChain decodes every CERTIFICATE block in a PEM bundle. Non-certificate
+// blocks are skipped; a block that fails to parse is an error.
+func parsePEMCertChain(pemData []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	rest := pemData
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
+}
+
+// buildBundleSet assembles the X.509 verification source from all configured
+// trust domains. The returned Set maps each trust domain to its authorities and
+// is the source consumed by verifySPIFFE.
+func buildBundleSet(domains []*SPIFFETrustDomain) (*x509bundle.Set, error) {
+	bundles := make([]*x509bundle.Bundle, 0, len(domains))
+	for _, d := range domains {
+		td, err := spiffeid.TrustDomainFromString(d.Name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid trust domain %q: %w", d.Name, err)
+		}
+		authorities, err := parseTrustDomainAuthorities(td, d.BundlePEM, d.BundleJSON)
+		if err != nil {
+			return nil, fmt.Errorf("trust domain %q: %w", d.Name, err)
+		}
+		bundles = append(bundles, x509bundle.FromX509Authorities(td, authorities))
+	}
+	return x509bundle.NewSet(bundles...), nil
+}
+
+// verifySPIFFE validates that certs (leaf first, optional intermediates) form a
+// spec-compliant X.509-SVID and binds it to a role's trust domain.
+//
+// It delegates the SVID rules to go-spiffe's x509svid.Verify — exactly one URI
+// SAN holding a valid SPIFFE ID, a non-CA leaf without certificate/CRL signing
+// usage, and a chain to the X.509 authorities of the SVID's own trust domain in
+// set — then additionally requires the SVID's trust domain to equal expectedTD
+// and, when allowedIDs is non-empty, its SPIFFE ID to match one of the patterns.
+// It returns the verified SPIFFE ID and the verified chains.
+func verifySPIFFE(set *x509bundle.Set, certs []*x509.Certificate, expectedTD spiffeid.TrustDomain, allowedIDs []string) (spiffeid.ID, [][]*x509.Certificate, error) {
+	id, chains, err := x509svid.Verify(certs, set)
+	if err != nil {
+		return spiffeid.ID{}, nil, err
+	}
+	if !id.MemberOf(expectedTD) {
+		return spiffeid.ID{}, nil, fmt.Errorf("SVID trust domain %q does not match role trust domain %q", id.TrustDomain().Name(), expectedTD.Name())
+	}
+	if len(allowedIDs) > 0 && !helper.MatchAny(id.String(), allowedIDs) {
+		return spiffeid.ID{}, nil, fmt.Errorf("SPIFFE ID %q not allowed by role", id.String())
+	}
+	return id, chains, nil
+}

--- a/auth/method/cert/spiffe_test.go
+++ b/auth/method/cert/spiffe_test.go
@@ -1,0 +1,240 @@
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"net/url"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testSVID mints an X.509-SVID: a leaf signed by the given CA carrying exactly
+// one URI SAN set to spiffeID. Extra opts can mutate the template (e.g. to make
+// it a CA cert or add a second URI SAN) for negative cases.
+func testSVID(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, spiffeID string, opts ...func(*x509.Certificate)) *x509.Certificate {
+	t.Helper()
+	setURI := func(tmpl *x509.Certificate) {
+		u, err := url.Parse(spiffeID)
+		require.NoError(t, err)
+		tmpl.URIs = []*url.URL{u}
+	}
+	return testClientCert(t, caCert, caKey, "", append([]func(*x509.Certificate){setURI}, opts...)...)
+}
+
+func mustTD(t *testing.T, s string) spiffeid.TrustDomain {
+	t.Helper()
+	td, err := spiffeid.TrustDomainFromString(s)
+	require.NoError(t, err)
+	return td
+}
+
+// =============================================================================
+// parseTrustDomainAuthorities
+// =============================================================================
+
+func TestParseTrustDomainAuthorities_PEM(t *testing.T) {
+	caCert, _, caPEM := testCA(t)
+	td := mustTD(t, "example.org")
+
+	authorities, err := parseTrustDomainAuthorities(td, caPEM, "")
+	require.NoError(t, err)
+	require.Len(t, authorities, 1)
+	assert.Equal(t, caCert.Raw, authorities[0].Raw)
+}
+
+func TestParseTrustDomainAuthorities_JWKS(t *testing.T) {
+	caCert, _, _ := testCA(t)
+	td := mustTD(t, "example.org")
+
+	// Generate a valid SPIFFE trust-bundle (JWKS) document from the CA cert.
+	jwks, err := spiffebundle.FromX509Authorities(td, []*x509.Certificate{caCert}).Marshal()
+	require.NoError(t, err)
+
+	authorities, err := parseTrustDomainAuthorities(td, "", string(jwks))
+	require.NoError(t, err)
+	require.Len(t, authorities, 1)
+	assert.Equal(t, caCert.Raw, authorities[0].Raw)
+}
+
+func TestParseTrustDomainAuthorities_Errors(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	td := mustTD(t, "example.org")
+
+	t.Run("both provided", func(t *testing.T) {
+		_, err := parseTrustDomainAuthorities(td, caPEM, "{}")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+	t.Run("neither provided", func(t *testing.T) {
+		_, err := parseTrustDomainAuthorities(td, "", "")
+		require.Error(t, err)
+	})
+	t.Run("invalid pem", func(t *testing.T) {
+		_, err := parseTrustDomainAuthorities(td, "not a pem", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid certificates")
+	})
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := parseTrustDomainAuthorities(td, "", "not json")
+		require.Error(t, err)
+	})
+}
+
+// =============================================================================
+// buildBundleSet
+// =============================================================================
+
+func TestBuildBundleSet(t *testing.T) {
+	_, _, pemA := testCA(t)
+	_, _, pemB := testCA(t)
+
+	set, err := buildBundleSet([]*SPIFFETrustDomain{
+		{Name: "a.example.org", BundlePEM: pemA},
+		{Name: "b.example.org", BundlePEM: pemB},
+	})
+	require.NoError(t, err)
+
+	// Both trust domains resolve to a bundle with one authority.
+	for _, name := range []string{"a.example.org", "b.example.org"} {
+		b, err := set.GetX509BundleForTrustDomain(mustTD(t, name))
+		require.NoError(t, err, name)
+		assert.Len(t, b.X509Authorities(), 1, name)
+	}
+}
+
+func TestBuildBundleSet_InvalidTrustDomain(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	// Trust domain names must be lowercase; an uppercase letter is rejected.
+	_, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "Example.org", BundlePEM: caPEM}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid trust domain")
+}
+
+func TestBuildBundleSet_BadBundle(t *testing.T) {
+	_, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: "garbage"}})
+	require.Error(t, err)
+}
+
+// =============================================================================
+// verifySPIFFE
+// =============================================================================
+
+func TestVerifySPIFFE_ValidSVID(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: caPEM}})
+	require.NoError(t, err)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://example.org/ns/default/sa/foo")
+
+	id, chains, err := verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "example.org"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "spiffe://example.org/ns/default/sa/foo", id.String())
+	assert.NotEmpty(t, chains)
+}
+
+func TestVerifySPIFFE_UnknownTrustDomain(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	// Set only knows example.org; the SVID and expected TD are other.org.
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: caPEM}})
+	require.NoError(t, err)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://other.org/foo")
+
+	_, _, err = verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "other.org"), nil)
+	require.Error(t, err)
+}
+
+func TestVerifySPIFFE_TrustDomainMismatch(t *testing.T) {
+	_, _, pemA := testCA(t)
+	caB, keyB, pemB := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{
+		{Name: "example.org", BundlePEM: pemA},
+		{Name: "other.org", BundlePEM: pemB},
+	})
+	require.NoError(t, err)
+
+	// A genuine other.org SVID (in the set) but the role pins example.org.
+	svid := testSVID(t, caB, keyB, "spiffe://other.org/foo")
+
+	_, _, err = verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "example.org"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match role trust domain")
+}
+
+func TestVerifySPIFFE_TwoURISANs(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: caPEM}})
+	require.NoError(t, err)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://example.org/foo", func(tmpl *x509.Certificate) {
+		extra, _ := url.Parse("spiffe://example.org/bar")
+		tmpl.URIs = append(tmpl.URIs, extra)
+	})
+
+	_, _, err = verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "example.org"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than one URI SAN")
+}
+
+func TestVerifySPIFFE_CALeafRejected(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: caPEM}})
+	require.NoError(t, err)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://example.org/foo", func(tmpl *x509.Certificate) {
+		tmpl.IsCA = true
+		tmpl.BasicConstraintsValid = true
+	})
+
+	_, _, err = verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "example.org"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CA flag")
+}
+
+func TestVerifySPIFFE_WrongCA(t *testing.T) {
+	_, _, pemA := testCA(t)
+	caB, keyB, _ := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: pemA}})
+	require.NoError(t, err)
+
+	// URI claims example.org, but the SVID is signed by an authority not in that bundle.
+	svid := testSVID(t, caB, keyB, "spiffe://example.org/foo")
+
+	_, _, err = verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "example.org"), nil)
+	require.Error(t, err)
+}
+
+func TestVerifySPIFFE_NonSpiffeURIRejected(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: caPEM}})
+	require.NoError(t, err)
+
+	svid := testSVID(t, caCert, caKey, "https://example.org/not-spiffe")
+
+	_, _, err = verifySPIFFE(set, []*x509.Certificate{svid}, mustTD(t, "example.org"), nil)
+	require.Error(t, err)
+}
+
+func TestVerifySPIFFE_AllowedSPIFFEIDs(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	set, err := buildBundleSet([]*SPIFFETrustDomain{{Name: "example.org", BundlePEM: caPEM}})
+	require.NoError(t, err)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://example.org/ns/default/sa/api")
+	td := mustTD(t, "example.org")
+
+	t.Run("match", func(t *testing.T) {
+		id, _, err := verifySPIFFE(set, []*x509.Certificate{svid}, td, []string{"spiffe://example.org/ns/+/sa/*"})
+		require.NoError(t, err)
+		assert.Equal(t, "spiffe://example.org/ns/default/sa/api", id.String())
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		_, _, err := verifySPIFFE(set, []*x509.Certificate{svid}, td, []string{"spiffe://example.org/ns/other/*"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not allowed by role")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.9
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
## What

Adds the SPIFFE X.509-SVID verification primitives and the `go-spiffe/v2` dependency. **No wiring into the request path yet** — nothing outside tests calls this, so the crypto-critical logic can be reviewed in isolation with zero behavior change.

## Changes

- Add `github.com/spiffe/go-spiffe/v2`.
- `SPIFFETrustDomain`: a trust domain plus its X.509 authorities, from a PEM bundle or a SPIFFE trust-bundle (JWKS) document (JWT authorities ignored).
- `parseTrustDomainAuthorities` / `buildBundleSet`: assemble the per-trust-domain `x509bundle.Set` used as the verification source.
- `verifySPIFFE`: wraps go-spiffe `x509svid.Verify` (enforces exactly one URI SAN, a non-CA leaf with no certificate/CRL-signing usage, and a chain to the SVID's own trust-domain authorities) and adds the role trust-domain binding + SPIFFE-ID pattern checks.

## Tests

`spiffe_test.go` exhaustively covers verify accept/reject (unknown trust domain, trust-domain mismatch, two URI SANs, CA leaf, wrong CA, allowed-id mismatch) and PEM + JWKS bundle parsing. Build/vet/test clean.

## Notes

#2 of the SPIFFE stack (follows the now-merged spiffe_id removal). The next PR builds on this branch.
