### PR TITLE
feat(cert): add spiffe mount mode and trust-domain config plane (enforcement gated)

### DIFF
--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 
 	"github.com/stephnangue/warden/framework"
@@ -19,6 +21,7 @@ import (
 
 // CertAuthConfig represents certificate authentication configuration
 type CertAuthConfig struct {
+	Mode           string        `json:"mode,omitempty"`            // "x509" (default) or "spiffe"
 	TrustedCAPEM   string        `json:"trusted_ca_pem"`            // PEM-encoded trusted CA certs
 	PrincipalClaim string        `json:"principal_claim,omitempty"` // "cn" (default), "dns_san", "email_san", "uri_san", "serial"
 	TokenTTL       time.Duration `json:"token_ttl" default:"1h"`    // Default token TTL
@@ -38,7 +41,18 @@ type certAuthBackend struct {
 	logger            *logger.GatedLogger
 	storageView       sdklogical.Storage
 	revocationChecker *revocationChecker
+
+	// spiffeBundleSet holds the per-trust-domain X.509 authorities used to verify
+	// SVIDs in spiffe mode. Guarded by spiffeMu, separate from configMu.
+	spiffeBundleSet *x509bundle.Set
+	spiffeMu        sync.RWMutex
 }
+
+// Auth mount modes. A mount operates in exactly one mode, fixed on its config.
+const (
+	modeX509   = "x509"   // classic PKI: CA pool + field matching
+	modeSPIFFE = "spiffe" // SPIFFE X.509-SVID relying party
+)
 
 var _ logical.Factory = Factory
 
@@ -65,6 +79,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathRole(),
 			b.pathRoleList(),
 			b.pathIntrospect(),
+			b.pathSPIFFETrustDomain(),
+			b.pathSPIFFETrustDomainList(),
 		},
 	}
 
@@ -91,6 +107,13 @@ func (b *certAuthBackend) setupCertConfig(_ context.Context, conf map[string]any
 	config, err := mapToCertAuthConfig(conf)
 	if err != nil {
 		return err
+	}
+
+	if config.Mode == "" {
+		config.Mode = modeX509
+	}
+	if config.Mode != modeX509 && config.Mode != modeSPIFFE {
+		return fmt.Errorf("invalid mode %q; must be one of: %s, %s", config.Mode, modeX509, modeSPIFFE)
 	}
 
 	if config.TokenTTL == 0 {
@@ -197,7 +220,25 @@ func (b *certAuthBackend) Initialize(ctx context.Context) error {
 			return fmt.Errorf("failed to setup cert config from storage: %w", err)
 		}
 	}
+
+	// In spiffe mode, load the configured trust-domain bundles. Fail closed: if
+	// the bundles cannot be loaded, the mount must not serve SPIFFE logins.
+	if b.mountMode() == modeSPIFFE {
+		if err := b.rebuildBundleSet(ctx); err != nil {
+			return fmt.Errorf("failed to load SPIFFE trust bundles: %w", err)
+		}
+	}
 	return nil
+}
+
+// mountMode returns the configured mount mode, defaulting to x509 when unset.
+func (b *certAuthBackend) mountMode() string {
+	b.configMu.RLock()
+	defer b.configMu.RUnlock()
+	if b.config != nil && b.config.Mode != "" {
+		return b.config.Mode
+	}
+	return modeX509
 }
 
 // SensitiveConfigFields returns the list of config fields that should be masked

--- a/auth/method/cert/path_config.go
+++ b/auth/method/cert/path_config.go
@@ -16,9 +16,15 @@ func (b *certAuthBackend) pathConfig() *framework.Path {
 	return &framework.Path{
 		Pattern: "config",
 		Fields: map[string]*framework.FieldSchema{
+			"mode": {
+				Type:          framework.TypeString,
+				Description:   "Trust model for this mount: x509 (default, classic PKI) or spiffe (SPIFFE X.509-SVID).",
+				Default:       modeX509,
+				AllowedValues: []interface{}{modeX509, modeSPIFFE},
+			},
 			"trusted_ca_pem": {
 				Type:        framework.TypeString,
-				Description: "PEM-encoded trusted CA certificates",
+				Description: "PEM-encoded trusted CA certificates (x509 mode only)",
 			},
 			"principal_claim": {
 				Type:          framework.TypeString,
@@ -63,9 +69,11 @@ func (b *certAuthBackend) pathConfig() *framework.Path {
 		HelpSynopsis: "Configure certificate authentication",
 		HelpDescription: `This endpoint configures the certificate authentication method.
 
-Set 'trusted_ca_pem' to PEM-encoded CA certificates that sign client certificates.
-Use 'principal_claim' to control which certificate field identifies the principal
-(cn, dns_san, email_san, uri_san, or serial).`,
+Set 'mode' to choose the trust model: x509 (default, classic PKI) or spiffe
+(SPIFFE X.509-SVID). In x509 mode, set 'trusted_ca_pem' to the CA bundle that
+signs client certificates and 'principal_claim' to the identity field
+(cn, dns_san, email_san, uri_san, or serial). In spiffe mode, register trust
+domains under spiffe/trust-domain/ instead; those PKI fields are not used.`,
 	}
 }
 
@@ -81,24 +89,34 @@ func (b *certAuthBackend) handleConfigRead(ctx context.Context, req *logical.Req
 		}, nil
 	}
 
-	certCount := 0
-	if b.config.TrustedCAPEM != "" {
-		certCount = parsePEMCertificates(b.config.TrustedCAPEM)
+	mode := b.config.Mode
+	if mode == "" {
+		mode = modeX509
 	}
 
-	return &logical.Response{
-		StatusCode: http.StatusOK,
-		Data: map[string]any{
-			"trusted_ca_pem":   b.config.TrustedCAPEM,
-			"principal_claim":  b.config.PrincipalClaim,
-			"token_ttl":        b.config.TokenTTL.String(),
-			"revocation_mode":  b.config.RevocationMode,
-			"crl_cache_ttl":    b.config.CRLCacheTTL,
-			"ocsp_timeout":     b.config.OCSPTimeout,
-			"default_role":     b.config.DefaultRole,
-			"trusted_ca_count": certCount,
-		},
-	}, nil
+	// Fields common to both modes.
+	data := map[string]any{
+		"mode":            mode,
+		"token_ttl":       b.config.TokenTTL.String(),
+		"revocation_mode": b.config.RevocationMode,
+		"crl_cache_ttl":   b.config.CRLCacheTTL,
+		"ocsp_timeout":    b.config.OCSPTimeout,
+		"default_role":    b.config.DefaultRole,
+	}
+
+	// x509-only fields are surfaced only in x509 mode; in spiffe mode trust
+	// domains are managed and listed under spiffe/trust-domain/.
+	if mode == modeX509 {
+		certCount := 0
+		if b.config.TrustedCAPEM != "" {
+			certCount = parsePEMCertificates(b.config.TrustedCAPEM)
+		}
+		data["trusted_ca_pem"] = b.config.TrustedCAPEM
+		data["principal_claim"] = b.config.PrincipalClaim
+		data["trusted_ca_count"] = certCount
+	}
+
+	return &logical.Response{StatusCode: http.StatusOK, Data: data}, nil
 }
 
 // handleConfigWrite handles writing the configuration
@@ -114,12 +132,56 @@ func (b *certAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 		}
 	}
 
+	// Resolve current vs requested mode and enforce mode coherence.
+	b.configMu.RLock()
+	currentMode := modeX509
+	if b.config != nil && b.config.Mode != "" {
+		currentMode = b.config.Mode
+	}
+	b.configMu.RUnlock()
+
+	effectiveMode := currentMode
+	if v, ok := d.GetOk("mode"); ok {
+		if requested, _ := v.(string); requested != "" {
+			effectiveMode = requested
+			if requested != currentMode {
+				// Switching mode would orphan existing roles/trust domains into an
+				// incompatible mount; require a clean slate.
+				roles, err := b.listRoles(ctx)
+				if err != nil {
+					return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+				}
+				tds, err := b.listTrustDomains(ctx)
+				if err != nil {
+					return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+				}
+				if len(roles) > 0 || len(tds) > 0 {
+					return &logical.Response{
+						StatusCode: http.StatusBadRequest,
+						Err:        fmt.Errorf("cannot change mode while roles or trust domains exist; delete them first or use a new mount"),
+					}, nil
+				}
+			}
+		}
+	}
+
+	// PKI-only config fields are not accepted in spiffe mode.
+	if effectiveMode == modeSPIFFE {
+		if _, ok := d.GetOk("trusted_ca_pem"); ok {
+			return &logical.Response{StatusCode: http.StatusBadRequest, Err: fmt.Errorf("trusted_ca_pem is not allowed in spiffe mode; configure trust domains via spiffe/trust-domain/<name>")}, nil
+		}
+		if _, ok := d.GetOk("principal_claim"); ok {
+			return &logical.Response{StatusCode: http.StatusBadRequest, Err: fmt.Errorf("principal_claim is not allowed in spiffe mode; the principal is the verified SVID ID")}, nil
+		}
+	}
+
 	// Build config map from field data
 	conf := make(map[string]any)
 
 	// Copy existing config if present
 	b.configMu.RLock()
 	if b.config != nil {
+		conf["mode"] = b.config.Mode
 		conf["trusted_ca_pem"] = b.config.TrustedCAPEM
 		conf["principal_claim"] = b.config.PrincipalClaim
 		conf["token_ttl"] = b.config.TokenTTL
@@ -137,6 +199,13 @@ func (b *certAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 		}
 	}
 
+	// In spiffe mode, drop any carried-over PKI-only fields so the persisted
+	// config stays coherent with the mode.
+	if effectiveMode == modeSPIFFE {
+		delete(conf, "trusted_ca_pem")
+		delete(conf, "principal_claim")
+	}
+
 	// Setup new config
 	if err := b.setupCertConfig(ctx, conf); err != nil {
 		return &logical.Response{
@@ -151,6 +220,7 @@ func (b *certAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Re
 	if b.storageView != nil {
 		b.configMu.RLock()
 		normalized := map[string]any{
+			"mode":            b.config.Mode,
 			"trusted_ca_pem":  b.config.TrustedCAPEM,
 			"principal_claim": b.config.PrincipalClaim,
 			"token_ttl":       b.config.TokenTTL.String(),

--- a/auth/method/cert/path_introspect.go
+++ b/auth/method/cert/path_introspect.go
@@ -47,6 +47,12 @@ func (b *certAuthBackend) handleIntrospectRoles(ctx context.Context, req *logica
 		return introspectEmpty(), nil
 	}
 
+	// SPIFFE-mode introspection is not yet implemented; return no matches rather
+	// than evaluate x509 trust logic against spiffe roles.
+	if b.config != nil && b.config.Mode == modeSPIFFE {
+		return introspectEmpty(), nil
+	}
+
 	roleNames, err := b.listRoles(ctx)
 	if err != nil {
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil

--- a/auth/method/cert/path_login.go
+++ b/auth/method/cert/path_login.go
@@ -54,6 +54,16 @@ func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse(logical.ErrBadRequest("no client certificate provided")), nil
 	}
 
+	// SPIFFE mode can be configured (trust domains, roles) but SVID enforcement
+	// is not yet wired in this build. Fail closed rather than fall through to
+	// x509 verification, which would be the wrong trust model.
+	if b.config != nil && b.config.Mode == modeSPIFFE {
+		return &logical.Response{
+			StatusCode: http.StatusNotImplemented,
+			Err:        fmt.Errorf("SPIFFE SVID authentication is not yet enabled on this mount"),
+		}, nil
+	}
+
 	// Get role name — fall back to default_role if configured
 	roleName := d.Get("role").(string)
 	if roleName == "" && b.config != nil && b.config.DefaultRole != "" {

--- a/auth/method/cert/path_role.go
+++ b/auth/method/cert/path_role.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/framework"
@@ -55,7 +57,15 @@ func (b *certAuthBackend) pathRole() *framework.Path {
 			},
 			"certificate": {
 				Type:        framework.TypeString,
-				Description: "Role-specific CA PEM (overrides global trusted CAs)",
+				Description: "Role-specific CA PEM (overrides global trusted CAs). x509 mode only.",
+			},
+			"trust_domain": {
+				Type:        framework.TypeString,
+				Description: "SPIFFE trust domain this role authenticates (e.g. prod.example.org). Required in spiffe mode; not valid in x509 mode.",
+			},
+			"allowed_spiffe_ids": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "Optional SPIFFE ID segment-wildcard patterns restricting the path within the trust domain (e.g. spiffe://prod.example.org/ns/*/sa/*). spiffe mode only.",
 			},
 			"token_policies": {
 				Type:        framework.TypeCommaStringSlice,
@@ -161,24 +171,31 @@ func (b *certAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse(logical.ErrNotFoundf("role %q not found", name)), nil
 	}
 
-	return &logical.Response{
-		StatusCode: http.StatusOK,
-		Data: map[string]any{
-			"name":                         role.Name,
-			"description":                  role.Description,
-			"allowed_common_names":         role.AllowedCommonNames,
-			"allowed_dns_sans":             role.AllowedDNSSANs,
-			"allowed_email_sans":           role.AllowedEmailSANs,
-			"allowed_uri_sans":             role.AllowedURISANs,
-			"allowed_organizational_units": role.AllowedOrganizationalUnits,
-			"allowed_organizations":        role.AllowedOrganizations,
-			"certificate":                  role.Certificate,
-			"token_policies":               role.TokenPolicies,
-			"token_ttl":                    role.TokenTTL,
-			"cred_spec_name":               role.CredSpecName,
-			"principal_claim":              role.PrincipalClaim,
-		},
-	}, nil
+	// Fields common to both modes.
+	data := map[string]any{
+		"name":           role.Name,
+		"description":    role.Description,
+		"token_policies": role.TokenPolicies,
+		"token_ttl":      role.TokenTTL,
+		"cred_spec_name": role.CredSpecName,
+	}
+
+	// Surface only the fields relevant to the mount's mode.
+	if b.mountMode() == modeSPIFFE {
+		data["trust_domain"] = role.TrustDomain
+		data["allowed_spiffe_ids"] = role.AllowedSPIFFEIDs
+	} else {
+		data["allowed_common_names"] = role.AllowedCommonNames
+		data["allowed_dns_sans"] = role.AllowedDNSSANs
+		data["allowed_email_sans"] = role.AllowedEmailSANs
+		data["allowed_uri_sans"] = role.AllowedURISANs
+		data["allowed_organizational_units"] = role.AllowedOrganizationalUnits
+		data["allowed_organizations"] = role.AllowedOrganizations
+		data["certificate"] = role.Certificate
+		data["principal_claim"] = role.PrincipalClaim
+	}
+
+	return &logical.Response{StatusCode: http.StatusOK, Data: data}, nil
 }
 
 // handleRoleUpdate updates an existing role or creates it if it doesn't exist (upsert pattern).
@@ -218,6 +235,12 @@ func (b *certAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Req
 		}
 		if v, ok := d.GetOk("certificate"); ok {
 			role.Certificate = v.(string)
+		}
+		if v, ok := d.GetOk("trust_domain"); ok {
+			role.TrustDomain = v.(string)
+		}
+		if v, ok := d.GetOk("allowed_spiffe_ids"); ok {
+			role.AllowedSPIFFEIDs = v.([]string)
 		}
 		if v, ok := d.GetOk("token_policies"); ok {
 			role.TokenPolicies = v.([]string)
@@ -290,7 +313,8 @@ func (b *certAuthBackend) handleRoleList(ctx context.Context, req *logical.Reque
 	}, nil
 }
 
-// validateRole validates role fields and sets defaults
+// validateRole validates role fields and sets defaults, dispatching to the
+// mode-specific validator for the mount.
 func (b *certAuthBackend) validateRole(role *CertRole) error {
 	// Token type is always cert_role for cert auth backends
 	role.TokenType = "cert_role"
@@ -302,6 +326,19 @@ func (b *certAuthBackend) validateRole(role *CertRole) error {
 	// Validate the TTL parses
 	if _, err := role.ParseTokenTTL(); err != nil {
 		return logical.ErrBadRequestf("invalid token_ttl: %v", err)
+	}
+
+	if b.mountMode() == modeSPIFFE {
+		return validateSPIFFERole(role)
+	}
+	return validateX509Role(role)
+}
+
+// validateX509Role validates a role on an x509-mode mount: at least one PKI
+// constraint, valid patterns, and no SPIFFE-only fields.
+func validateX509Role(role *CertRole) error {
+	if role.TrustDomain != "" || len(role.AllowedSPIFFEIDs) > 0 {
+		return logical.ErrBadRequest("trust_domain and allowed_spiffe_ids are only valid in spiffe mode")
 	}
 
 	// Require at least one certificate constraint to prevent overly permissive roles
@@ -354,6 +391,36 @@ func (b *certAuthBackend) validateRole(role *CertRole) error {
 	return nil
 }
 
+// validateSPIFFERole validates a role on a spiffe-mode mount: a required, valid
+// trust_domain, optional SPIFFE-ID patterns, and no PKI-only fields. The trust
+// domain need not already be registered — it is resolved (fail-closed) at login.
+func validateSPIFFERole(role *CertRole) error {
+	if role.TrustDomain == "" {
+		return logical.ErrBadRequest("trust_domain is required in spiffe mode")
+	}
+	if _, err := spiffeid.TrustDomainFromString(role.TrustDomain); err != nil {
+		return logical.ErrBadRequestf("invalid trust_domain %q: %v", role.TrustDomain, err)
+	}
+	for _, p := range role.AllowedSPIFFEIDs {
+		if err := helper.ValidatePattern(p); err != nil {
+			return logical.ErrBadRequestf("invalid allowed_spiffe_ids pattern: %v", err)
+		}
+	}
+
+	if len(role.AllowedCommonNames) > 0 ||
+		len(role.AllowedDNSSANs) > 0 ||
+		len(role.AllowedEmailSANs) > 0 ||
+		len(role.AllowedURISANs) > 0 ||
+		len(role.AllowedOrganizationalUnits) > 0 ||
+		len(role.AllowedOrganizations) > 0 ||
+		role.Certificate != "" ||
+		role.PrincipalClaim != "" {
+		return logical.ErrBadRequest("allowed_common_names, allowed_dns_sans, allowed_email_sans, allowed_uri_sans, allowed_organizational_units, allowed_organizations, certificate, and principal_claim are not valid in spiffe mode")
+	}
+
+	return nil
+}
+
 // buildRoleFromFieldData creates a CertRole from request field data
 func (b *certAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldData) *CertRole {
 	role := &CertRole{
@@ -383,6 +450,12 @@ func (b *certAuthBackend) buildRoleFromFieldData(name string, d *framework.Field
 	}
 	if v, ok := d.GetOk("certificate"); ok {
 		role.Certificate = v.(string)
+	}
+	if v, ok := d.GetOk("trust_domain"); ok {
+		role.TrustDomain = v.(string)
+	}
+	if v, ok := d.GetOk("allowed_spiffe_ids"); ok {
+		role.AllowedSPIFFEIDs = v.([]string)
 	}
 	if v, ok := d.GetOk("token_policies"); ok {
 		role.TokenPolicies = v.([]string)

--- a/auth/method/cert/path_spiffe.go
+++ b/auth/method/cert/path_spiffe.go
@@ -1,0 +1,247 @@
+package cert
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+const spiffeTrustDomainPrefix = "spiffe/trust-domain/"
+
+// pathSPIFFETrustDomain manages a SPIFFE trust domain and the X.509 authorities
+// that are authoritative for it. These paths are only meaningful in spiffe mode.
+func (b *certAuthBackend) pathSPIFFETrustDomain() *framework.Path {
+	return &framework.Path{
+		Pattern: "spiffe/trust-domain/" + framework.GenericNameRegex("name"),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "SPIFFE trust domain name (e.g. prod.example.org)",
+				Required:    true,
+			},
+			"bundle_pem": {
+				Type:        framework.TypeString,
+				Description: "PEM-encoded X.509 authorities (CA certificates) for the trust domain",
+			},
+			"bundle_json": {
+				Type:        framework.TypeString,
+				Description: "SPIFFE trust-bundle (JWKS) document; only its X.509 authorities are used",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{Callback: b.handleTrustDomainWrite, Summary: "Register a SPIFFE trust domain bundle"},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.handleTrustDomainWrite, Summary: "Update a SPIFFE trust domain bundle"},
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.handleTrustDomainRead, Summary: "Read a SPIFFE trust domain"},
+			logical.DeleteOperation: &framework.PathOperation{Callback: b.handleTrustDomainDelete, Summary: "Delete a SPIFFE trust domain"},
+		},
+		HelpSynopsis:    "Manage SPIFFE trust domains and their X.509 bundles",
+		HelpDescription: "Register the X.509 authorities authoritative for a SPIFFE trust domain. Only available when the mount is configured with mode=spiffe.",
+	}
+}
+
+// pathSPIFFETrustDomainList lists the configured SPIFFE trust domains.
+func (b *certAuthBackend) pathSPIFFETrustDomainList() *framework.Path {
+	return &framework.Path{
+		Pattern: "spiffe/trust-domain/?$",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{Callback: b.handleTrustDomainList, Summary: "List SPIFFE trust domains"},
+		},
+		HelpSynopsis:    "List SPIFFE trust domains",
+		HelpDescription: "List the configured SPIFFE trust domains. Only available when the mount is configured with mode=spiffe.",
+	}
+}
+
+// requireSPIFFEMode returns a 400 response when the mount is not in spiffe mode.
+func (b *certAuthBackend) requireSPIFFEMode() *logical.Response {
+	if b.mountMode() != modeSPIFFE {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("trust domains are only available when the mount is configured with mode=spiffe"),
+		}
+	}
+	return nil
+}
+
+func (b *certAuthBackend) handleTrustDomainWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if resp := b.requireSPIFFEMode(); resp != nil {
+		return resp, nil
+	}
+	name := d.Get("name").(string)
+
+	td, err := spiffeid.TrustDomainFromString(name)
+	if err != nil {
+		return &logical.Response{StatusCode: http.StatusBadRequest, Err: fmt.Errorf("invalid trust domain %q: %w", name, err)}, nil
+	}
+	canonical := td.Name()
+
+	bundlePEM, _ := d.Get("bundle_pem").(string)
+	bundleJSON, _ := d.Get("bundle_json").(string)
+
+	// Validate the bundle parses into at least one X.509 authority before storing.
+	if _, err := parseTrustDomainAuthorities(td, bundlePEM, bundleJSON); err != nil {
+		return &logical.Response{StatusCode: http.StatusBadRequest, Err: err}, nil
+	}
+
+	if err := b.setTrustDomain(ctx, &SPIFFETrustDomain{Name: canonical, BundlePEM: bundlePEM, BundleJSON: bundleJSON}); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	// Refresh the in-memory verification set so the change takes effect at once.
+	if err := b.rebuildBundleSet(ctx); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"name": canonical, "message": fmt.Sprintf("Successfully configured trust domain %s", canonical)},
+	}, nil
+}
+
+func (b *certAuthBackend) handleTrustDomainRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if resp := b.requireSPIFFEMode(); resp != nil {
+		return resp, nil
+	}
+	name := d.Get("name").(string)
+	if td, err := spiffeid.TrustDomainFromString(name); err == nil {
+		name = td.Name()
+	}
+
+	entry, err := b.getTrustDomain(ctx, name)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if entry == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("trust domain %q not found", name)), nil
+	}
+
+	// Trust bundles are public CA material, but the read returns a summary
+	// (count + subjects) rather than the raw bytes, matching the config-read style.
+	source := "bundle_pem"
+	if entry.BundleJSON != "" {
+		source = "bundle_json"
+	}
+	subjects := []string{}
+	count := 0
+	if td, err := spiffeid.TrustDomainFromString(entry.Name); err == nil {
+		if authorities, err := parseTrustDomainAuthorities(td, entry.BundlePEM, entry.BundleJSON); err == nil {
+			count = len(authorities)
+			for _, a := range authorities {
+				subjects = append(subjects, a.Subject.String())
+			}
+		}
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data: map[string]any{
+			"name":                    entry.Name,
+			"bundle_source":           source,
+			"x509_authority_count":    count,
+			"x509_authority_subjects": subjects,
+		},
+	}, nil
+}
+
+func (b *certAuthBackend) handleTrustDomainDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if resp := b.requireSPIFFEMode(); resp != nil {
+		return resp, nil
+	}
+	name := d.Get("name").(string)
+	if td, err := spiffeid.TrustDomainFromString(name); err == nil {
+		name = td.Name()
+	}
+
+	if err := b.deleteTrustDomain(ctx, name); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if err := b.rebuildBundleSet(ctx); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	return &logical.Response{StatusCode: http.StatusOK, Data: map[string]any{"message": fmt.Sprintf("Successfully deleted trust domain %s", name)}}, nil
+}
+
+func (b *certAuthBackend) handleTrustDomainList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if resp := b.requireSPIFFEMode(); resp != nil {
+		return resp, nil
+	}
+	names, err := b.listTrustDomains(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	return &logical.Response{StatusCode: http.StatusOK, Data: map[string]any{"keys": names}}, nil
+}
+
+// --- storage + bundle-set helpers ---
+
+func (b *certAuthBackend) getTrustDomain(ctx context.Context, name string) (*SPIFFETrustDomain, error) {
+	entry, err := b.storageView.Get(ctx, spiffeTrustDomainPrefix+name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var td SPIFFETrustDomain
+	if err := entry.DecodeJSON(&td); err != nil {
+		return nil, err
+	}
+	return &td, nil
+}
+
+func (b *certAuthBackend) setTrustDomain(ctx context.Context, td *SPIFFETrustDomain) error {
+	entry, err := sdklogical.StorageEntryJSON(spiffeTrustDomainPrefix+td.Name, td)
+	if err != nil {
+		return err
+	}
+	return b.storageView.Put(ctx, entry)
+}
+
+func (b *certAuthBackend) deleteTrustDomain(ctx context.Context, name string) error {
+	return b.storageView.Delete(ctx, spiffeTrustDomainPrefix+name)
+}
+
+func (b *certAuthBackend) listTrustDomains(ctx context.Context) ([]string, error) {
+	return b.storageView.List(ctx, spiffeTrustDomainPrefix)
+}
+
+func (b *certAuthBackend) listTrustDomainEntries(ctx context.Context) ([]*SPIFFETrustDomain, error) {
+	names, err := b.listTrustDomains(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]*SPIFFETrustDomain, 0, len(names))
+	for _, name := range names {
+		td, err := b.getTrustDomain(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if td != nil {
+			entries = append(entries, td)
+		}
+	}
+	return entries, nil
+}
+
+// rebuildBundleSet loads every configured trust-domain bundle from storage and
+// atomically replaces the in-memory verification set.
+func (b *certAuthBackend) rebuildBundleSet(ctx context.Context) error {
+	entries, err := b.listTrustDomainEntries(ctx)
+	if err != nil {
+		return err
+	}
+	set, err := buildBundleSet(entries)
+	if err != nil {
+		return err
+	}
+	b.spiffeMu.Lock()
+	b.spiffeBundleSet = set
+	b.spiffeMu.Unlock()
+	return nil
+}

--- a/auth/method/cert/role.go
+++ b/auth/method/cert/role.go
@@ -13,7 +13,9 @@ type CertRole struct {
 	AllowedURISANs             []string `json:"allowed_uri_sans,omitempty"`
 	AllowedOrganizationalUnits []string `json:"allowed_organizational_units,omitempty"`
 	AllowedOrganizations       []string `json:"allowed_organizations,omitempty"`
-	Certificate                string   `json:"certificate,omitempty"` // Role-specific CA PEM (overrides global)
+	Certificate                string   `json:"certificate,omitempty"`        // Role-specific CA PEM (overrides global) — x509 mode
+	TrustDomain                string   `json:"trust_domain,omitempty"`       // SPIFFE trust domain this role binds to — spiffe mode
+	AllowedSPIFFEIDs           []string `json:"allowed_spiffe_ids,omitempty"` // optional SPIFFE ID segment patterns — spiffe mode
 	TokenPolicies              []string `json:"token_policies"`
 	TokenTTL                   string   `json:"token_ttl"`
 	TokenType                  string   `json:"token_type,omitempty"`

--- a/auth/method/cert/spiffe_mode_test.go
+++ b/auth/method/cert/spiffe_mode_test.go
@@ -1,0 +1,272 @@
+package cert
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// mode config
+// =============================================================================
+
+func TestSetupCertConfig_ModeDefaultAndValidation(t *testing.T) {
+	b, ctx := createTestBackend(t)
+
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{}))
+	assert.Equal(t, modeX509, b.config.Mode)
+
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+	assert.Equal(t, modeSPIFFE, b.config.Mode)
+
+	err := b.setupCertConfig(ctx, map[string]any{"mode": "bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+func TestHandleConfigWrite_SpiffeModeRejectsPKIFields(t *testing.T) {
+	_, _, caPEM := testCA(t)
+
+	t.Run("trusted_ca_pem", func(t *testing.T) {
+		b, ctx := createTestBackend(t)
+		d := &framework.FieldData{
+			Raw:    map[string]any{"mode": "spiffe", "trusted_ca_pem": caPEM},
+			Schema: b.pathConfig().Fields,
+		}
+		resp, err := b.handleConfigWrite(ctx, &logical.Request{}, d)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Contains(t, resp.Err.Error(), "trusted_ca_pem is not allowed in spiffe mode")
+	})
+
+	t.Run("principal_claim", func(t *testing.T) {
+		b, ctx := createTestBackend(t)
+		d := &framework.FieldData{
+			Raw:    map[string]any{"mode": "spiffe", "principal_claim": "cn"},
+			Schema: b.pathConfig().Fields,
+		}
+		resp, err := b.handleConfigWrite(ctx, &logical.Request{}, d)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Contains(t, resp.Err.Error(), "principal_claim is not allowed in spiffe mode")
+	})
+}
+
+func TestHandleConfigWrite_ModeChangeGuard(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	// Register a trust domain so the mount is no longer a clean slate.
+	resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+		Raw:    map[string]any{"name": "example.org", "bundle_pem": caPEM},
+		Schema: b.pathSPIFFETrustDomain().Fields,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Switching mode now must be rejected.
+	resp, err = b.handleConfigWrite(ctx, &logical.Request{}, &framework.FieldData{
+		Raw:    map[string]any{"mode": "x509"},
+		Schema: b.pathConfig().Fields,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, resp.Err.Error(), "cannot change mode")
+}
+
+// =============================================================================
+// trust-domain CRUD + bundle-set wiring
+// =============================================================================
+
+func TestTrustDomainCRUD(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	tdSchema := b.pathSPIFFETrustDomain().Fields
+
+	// Write.
+	resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+		Raw:    map[string]any{"name": "prod.example.org", "bundle_pem": caPEM},
+		Schema: tdSchema,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The in-memory verification set is rebuilt and resolves the trust domain.
+	require.NotNil(t, b.spiffeBundleSet)
+	bundle, err := b.spiffeBundleSet.GetX509BundleForTrustDomain(mustTD(t, "prod.example.org"))
+	require.NoError(t, err)
+	assert.Len(t, bundle.X509Authorities(), 1)
+
+	// Read returns a summary, not raw PEM.
+	readData := &framework.FieldData{Raw: map[string]any{"name": "prod.example.org"}, Schema: tdSchema}
+	resp, err = b.handleTrustDomainRead(ctx, &logical.Request{}, readData)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, resp.Data["x509_authority_count"])
+	assert.Equal(t, "bundle_pem", resp.Data["bundle_source"])
+	_, hasRawPEM := resp.Data["bundle_pem"]
+	assert.False(t, hasRawPEM, "raw bundle must not be echoed")
+
+	// List.
+	listResp, err := b.handleTrustDomainList(ctx, &logical.Request{}, &framework.FieldData{})
+	require.NoError(t, err)
+	assert.Contains(t, listResp.Data["keys"], "prod.example.org")
+
+	// Delete, then it is gone from storage.
+	resp, err = b.handleTrustDomainDelete(ctx, &logical.Request{}, readData)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	got, err := b.getTrustDomain(ctx, "prod.example.org")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestTrustDomain_RejectedInX509Mode(t *testing.T) {
+	b, ctx := createTestBackend(t) // config nil -> x509 mode
+
+	resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+		Raw:    map[string]any{"name": "example.org", "bundle_pem": "x"},
+		Schema: b.pathSPIFFETrustDomain().Fields,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, resp.Err.Error(), "mode=spiffe")
+}
+
+func TestTrustDomainWrite_Validation(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+	tdSchema := b.pathSPIFFETrustDomain().Fields
+
+	t.Run("invalid name", func(t *testing.T) {
+		resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+			Raw:    map[string]any{"name": "Bad.Domain", "bundle_pem": caPEM},
+			Schema: tdSchema,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("invalid bundle", func(t *testing.T) {
+		resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+			Raw:    map[string]any{"name": "example.org", "bundle_pem": "garbage"},
+			Schema: tdSchema,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+// =============================================================================
+// role validation gating
+// =============================================================================
+
+func TestValidateRole_ModeGating(t *testing.T) {
+	b, ctx := createTestBackend(t)
+
+	// x509 mode (default): SPIFFE-only fields are rejected.
+	err := b.validateRole(&CertRole{Name: "r", TrustDomain: "example.org"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only valid in spiffe mode")
+
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	// spiffe mode: trust_domain required.
+	err = b.validateRole(&CertRole{Name: "r"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust_domain is required")
+
+	// spiffe mode: valid role.
+	require.NoError(t, b.validateRole(&CertRole{
+		Name:             "r",
+		TrustDomain:      "example.org",
+		AllowedSPIFFEIDs: []string{"spiffe://example.org/ns/*"},
+	}))
+
+	// spiffe mode: PKI fields rejected.
+	err = b.validateRole(&CertRole{Name: "r", TrustDomain: "example.org", AllowedCommonNames: []string{"x"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid in spiffe mode")
+}
+
+// =============================================================================
+// enforcement gate (PR3: spiffe data plane not yet enabled)
+// =============================================================================
+
+func TestHandleLogin_SpiffeModeGated(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	clientCert := testClientCert(t, caCert, caKey, "agent")
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, clientCert)}
+	d := &framework.FieldData{Raw: map[string]any{"role": "api"}, Schema: b.pathLogin().Fields}
+
+	resp, err := b.handleLogin(ctx, req, d)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	assert.Contains(t, resp.Err.Error(), "not yet enabled")
+}
+
+func TestHandleIntrospect_SpiffeModeEmpty(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	clientCert := testClientCert(t, caCert, caKey, "agent")
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, clientCert)}
+
+	resp, err := b.handleIntrospectRoles(ctx, req, &framework.FieldData{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	roles := resp.Data["roles"].([]introspectedRole)
+	assert.Empty(t, roles)
+}
+
+// =============================================================================
+// mode-aware read output
+// =============================================================================
+
+func TestHandleConfigRead_SpiffeModeOmitsX509Fields(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	resp, err := b.handleConfigRead(ctx, &logical.Request{}, &framework.FieldData{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, modeSPIFFE, resp.Data["mode"])
+	for _, k := range []string{"trusted_ca_pem", "principal_claim", "trusted_ca_count"} {
+		_, present := resp.Data[k]
+		assert.False(t, present, "x509-only field %q must not appear in spiffe mode", k)
+	}
+}
+
+func TestHandleRoleRead_SpiffeModeShowsSpiffeFields(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:             "api",
+		TrustDomain:      "example.org",
+		AllowedSPIFFEIDs: []string{"spiffe://example.org/api/*"},
+		TokenTTL:         "1h",
+	}))
+
+	fd := &framework.FieldData{
+		Raw:    map[string]any{"name": "api"},
+		Schema: map[string]*framework.FieldSchema{"name": {Type: framework.TypeString}},
+	}
+	resp, err := b.handleRoleRead(ctx, &logical.Request{}, fd)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "example.org", resp.Data["trust_domain"])
+	_, hasCN := resp.Data["allowed_common_names"]
+	assert.False(t, hasCN, "x509-only field must not appear for a spiffe role")
+}


### PR DESCRIPTION
## What

Introduces `mode=x509|spiffe` on the certificate auth mount plus the full SPIFFE config plane, with enforcement deliberately **gated off** — operators can stage a spiffe mount, but logins fail closed until the next PR turns enforcement on.

## Changes

- config: `mode` field (default `x509`), validated; reject `trusted_ca_pem`/`principal_claim` in spiffe mode; guard against changing mode while roles or trust domains exist; reads surface only the active mode's fields.
- `spiffe/trust-domain/<name>` CRUD + list paths, gated to spiffe mode; bundles validated and stored; read returns a summary (public CA material, not raw PEM).
- backend: per-trust-domain `x509bundle.Set` rebuilt on write/delete, loaded fail-closed at `Initialize`, guarded by a dedicated mutex.
- roles: `trust_domain` + `allowed_spiffe_ids`; `validateRole` dispatches by mode (spiffe requires `trust_domain` and rejects PKI fields, and vice versa).
- login/introspection: in spiffe mode, fail closed / return no matches until enforcement lands in the next PR.

## Tests

Mode validation + mode-change guard, trust-domain CRUD + set rebuild, role-validation gating both ways, and the gated login/introspection behaviour. x509 mounts unaffected.

## Notes

#3 of the SPIFFE stack, rebased onto current `main`.
