### PR TITLE
feat(cert): enforce SPIFFE X.509-SVID verification in spiffe mode

### DIFF
--- a/auth/method/cert/README.md
+++ b/auth/method/cert/README.md
@@ -1,6 +1,6 @@
 # Certificate Auth Method
 
-The certificate auth method authenticates workload identities using **TLS client certificates**. The workload presents an X.509 certificate during the TLS handshake (direct mTLS) or via a forwarding header from a trusted proxy; Warden validates the certificate chain against a configured CA bundle, applies role constraints over CN / SANs / OU / Organization, and resolves the principal from a chosen certificate field. The resolved principal flows through Warden's transparent-auth layer like any other auth method in the family.
+The certificate auth method authenticates workload identities using **TLS client certificates**. The workload presents an X.509 certificate during the TLS handshake (direct mTLS) or via a forwarding header from a trusted proxy; Warden validates the certificate, applies the matching role's constraints, and resolves a principal that flows through Warden's transparent-auth layer like any other auth method in the family. How the certificate is validated — and what the role constraints and principal are — depends on the mount's [trust mode](#trust-modes): classic PKI (`x509`) or SPIFFE X.509-SVID (`spiffe`).
 
 Two properties set certificate auth apart from the bearer-token-based methods (`jwt`, `kubernetes`):
 
@@ -11,7 +11,7 @@ This is the auth method to reach for when:
 
 - You operate **long-lived workloads** — persistent services, bare-metal or VM workloads outside an orchestrator's token-rotation lifecycle, or anything that runs for weeks to months under the same identity. The cert is rotated on the cadence of the issuing CA / mesh, not on the cadence of an IdP's token TTL.
 - You operate in **air-gapped or constrained-network environments** where reaching an external IdP per login is not an option, but a CA bundle can ship with the deployment.
-- Your workloads carry **SPIFFE X.509 SVIDs** (issued by SPIRE) and you want to bind roles to SPIFFE IDs from the certificate's URI SAN via segment-aware patterns (`spiffe://prod.example.org/ns/*`).
+- Your workloads carry **SPIFFE X.509 SVIDs** (issued by SPIRE) — enable the mount's **[spiffe mode](#spiffe-mode)** to verify each SVID against its own trust domain's bundle (full X.509-SVID validation), then bind roles to SPIFFE IDs via segment-aware patterns (`spiffe://prod.example.org/ns/+/sa/+`).
 - Your workloads carry **service-mesh-issued certificates** (Istio, Linkerd, Consul Connect) and identity flows through the cert rather than a token.
 - Your operators have already provisioned **mTLS at the network edge** and want Warden to consume that same certificate rather than layering a second credential on top.
 - You need **revocation checking** built in — CRL or OCSP — so a compromised certificate can be cut off without rotating CAs.
@@ -21,12 +21,14 @@ If your workload's identity is a Kubernetes ServiceAccount token, prefer the `ku
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
+- [Trust modes](#trust-modes)
 - [Step 1: Configure Trusted CAs](#step-1-configure-trusted-cas)
 - [Step 2: Enable Revocation Checking (Optional)](#step-2-enable-revocation-checking-optional)
 - [Step 3: Create a Role](#step-3-create-a-role)
 - [Step 4: Wire Up Transparent Auth](#step-4-wire-up-transparent-auth)
 - [Principal Claim Selection](#principal-claim-selection)
 - [SPIFFE URI Patterns](#spiffe-uri-patterns)
+- [SPIFFE mode](#spiffe-mode)
 - [How the Certificate Reaches Warden](#how-the-certificate-reaches-warden)
 - [Role-Specific CAs](#role-specific-cas)
 - [Discovering Assumable Roles](#discovering-assumable-roles)
@@ -40,6 +42,13 @@ If your workload's identity is a Kubernetes ServiceAccount token, prefer the `ku
 - A **PEM-encoded CA bundle** that issued (or transitively signed) the certificates your workloads present.
 - A way to get the workload's certificate to Warden — either direct mTLS termination at the Warden listener, or a trusted reverse proxy that terminates TLS and re-presents the certificate via a forwarding header. See [How the Certificate Reaches Warden](#how-the-certificate-reaches-warden).
 - A **role-mapping policy** in Warden that scopes what the resulting auth token can do (authenticating a certificate doesn't grant access on its own).
+
+## Trust modes
+
+A cert mount runs in one of two modes, fixed at config time; the two don't mix within a mount, so run a separate mount per model.
+
+- **`x509`** (default) — classic PKI. Warden checks the certificate chain against a configured CA bundle, matches role constraints over CN / SANs / OU / Organization, and resolves the principal from a chosen certificate field. **Steps 1–4 and the supporting sections below describe this mode** unless noted otherwise.
+- **`spiffe`** — a spec-compliant SPIFFE X.509-SVID relying party. Each trust domain has its own registered bundle, roles bind to a trust domain (optionally restricting the SPIFFE ID path), and the principal is the verified SVID ID. See [SPIFFE mode](#spiffe-mode).
 
 ## Step 1: Configure Trusted CAs
 
@@ -69,7 +78,7 @@ warden write auth/cert/config \
 
 `trusted_ca_pem` accepts a concatenated PEM bundle — multiple `-----BEGIN CERTIFICATE-----` blocks back-to-back are all loaded. The mount validates the bundle at write time and rejects PEM with no valid certificates.
 
-When `principal_claim` is omitted, the mount defaults to `cn` (the certificate Subject's CommonName). For service-mesh or SPIFFE certificates, `uri_san` or `dns_san` is often the right pick. See [Principal Claim Selection](#principal-claim-selection) for the full list.
+When `principal_claim` is omitted, the mount defaults to `cn` (the certificate Subject's CommonName). For service-mesh certificates, `uri_san` or `dns_san` is often the right pick. See [Principal Claim Selection](#principal-claim-selection) for the full list. (For SPIFFE SVIDs, use [spiffe mode](#spiffe-mode) instead — the principal is the verified SVID ID, not a `principal_claim`.)
 
 ## Step 2: Enable Revocation Checking (Optional)
 
@@ -109,7 +118,7 @@ Available constraint fields (set at least one):
 - `allowed_common_names` — glob patterns matched against `Subject.CommonName`. Standard shell globs (`?`, `*`, `[...]`); `inventory-*` matches `inventory-svc`, `inventory-cron`, etc.
 - `allowed_dns_sans` — glob patterns matched against any of the certificate's DNS SANs (any-one match accepts).
 - `allowed_email_sans` — glob patterns matched against email SANs.
-- `allowed_uri_sans` — segment-aware patterns matched against URI SANs. Right tool for SPIFFE IDs — see [SPIFFE URI Patterns](#spiffe-uri-patterns).
+- `allowed_uri_sans` — segment-aware patterns matched against URI SANs (see [SPIFFE URI Patterns](#spiffe-uri-patterns) for the syntax). Plain string matching only; for SPIFFE SVIDs use [spiffe mode](#spiffe-mode) instead.
 - `allowed_organizational_units` — exact-match list against the Subject's Organizational Unit values.
 - `allowed_organizations` — exact-match list against the Subject's Organization values.
 
@@ -172,14 +181,10 @@ Pick the field whose value is **stable for the lifetime of the workload**. The p
 
 ## SPIFFE URI Patterns
 
-For SPIFFE X.509 SVIDs, the workload identity lives in the certificate's URI SAN as a `spiffe://trust-domain/path` URI. `allowed_uri_sans` lets a role match against the SPIFFE-style URI structure with segment-aware wildcards rather than substring matches.
+SPIFFE IDs live in a certificate's URI SAN as `spiffe://trust-domain/path`. Two role fields match against that structure with the same **segment-aware** wildcards (rather than substring matches):
 
-```bash
-warden write auth/cert/role/api-frontend \
-  allowed_uri_sans="spiffe://prod.example.org/api/frontend/*" \
-  principal_claim="uri_san" \
-  token_policies="api-read"
-```
+- `allowed_spiffe_ids` in [spiffe mode](#spiffe-mode) — applied **after** the certificate is verified as an SVID against its trust domain's bundle. This is the right field for SPIFFE workloads.
+- `allowed_uri_sans` in x509 mode — a plain match against any URI SAN. It does **not** validate the certificate as an SVID, so if your workloads carry SVIDs, use spiffe mode instead of matching `spiffe://` URIs here.
 
 Pattern semantics (segment-aware, splitting on `/`):
 
@@ -191,12 +196,74 @@ Pattern semantics (segment-aware, splitting on `/`):
 
 Examples:
 
-- `spiffe://prod.example.org/api/frontend/*` matches `spiffe://prod.example.org/api/frontend/v1` and `spiffe://prod.example.org/api/frontend/v1/svc` — anything one or more segments deep under `api/frontend/`.
+- `spiffe://prod.example.org/ns/+/sa/+` matches `spiffe://prod.example.org/ns/default/sa/api` — any namespace, any service account.
 - `spiffe://+/api/frontend/svc` matches `spiffe://prod.example.org/api/frontend/svc` and `spiffe://staging.example.org/api/frontend/svc` — any trust domain, exact `api/frontend/svc` path.
 - `spiffe://+/+/+` matches any three-segment SPIFFE ID, regardless of trust domain or path.
 - `spiffe://prod.example.org/*` matches any non-empty path under `prod.example.org`.
 
-Patterns are validated at role-write time; malformed patterns (e.g. unrecognized wildcards, `+*` combinations) are rejected up front.
+Patterns are validated at role-write time; malformed patterns (e.g. a `*` in a non-trailing segment, or `+*` combinations) are rejected up front.
+
+## SPIFFE mode
+
+With `mode=spiffe` the cert method becomes a spec-compliant **SPIFFE X.509-SVID relying party**. Instead of a single global CA, each SPIFFE trust domain is registered with its own bundle, and a login is accepted only if the presented certificate is a valid SVID for the trust domain its role binds to. A mount is either `x509` or `spiffe`; set the mode before creating roles or trust domains (it can't be changed while either exists), and run the two models as separate mounts.
+
+### Step 1: Enable the mount in spiffe mode
+
+```bash
+warden auth enable -path=spiffe cert
+warden write auth/spiffe/config mode=spiffe
+```
+
+In spiffe mode `trusted_ca_pem` and `principal_claim` are rejected — trust comes from per-trust-domain bundles, and the principal is always the verified SVID ID.
+
+### Step 2: Register trust domains
+
+Register each trust domain together with the X.509 authorities (the SPIRE bundle) that sign its SVIDs:
+
+```bash
+# from a PEM bundle of CA certificates
+warden write auth/spiffe/trust-domain/prod.example.org bundle_pem=@prod-bundle.pem
+
+# …or from a SPIFFE trust-bundle (JWKS) document
+warden write auth/spiffe/trust-domain/prod.example.org bundle_json=@prod-bundle.json
+```
+
+Read back a summary (authority count and subjects — not the raw bundle), or list them:
+
+```bash
+warden read auth/spiffe/trust-domain/prod.example.org
+warden list auth/spiffe/trust-domain
+```
+
+A trust bundle may hold several authorities (e.g. old + new roots during a CA rotation). Only the X.509 authorities of a JWKS bundle are consumed; JWT authorities are ignored.
+
+### Step 3: Create a SPIFFE role
+
+A spiffe role binds to exactly one `trust_domain` and may restrict the SPIFFE ID path with the same segment-aware patterns as [SPIFFE URI Patterns](#spiffe-uri-patterns):
+
+```bash
+warden write auth/spiffe/role/api \
+  trust_domain="prod.example.org" \
+  allowed_spiffe_ids="spiffe://prod.example.org/ns/+/sa/api" \
+  token_policies="api-read" \
+  token_ttl="1h"
+```
+
+`trust_domain` is required; the PKI constraints (`allowed_common_names`, `certificate`, `principal_claim`, …) are rejected on a spiffe role. The issued token's principal is the verified SVID ID, e.g. `spiffe://prod.example.org/ns/default/sa/api`.
+
+### What is enforced
+
+On each login Warden verifies, via the SPIFFE reference library, that the certificate:
+
+- has exactly one URI SAN holding a syntactically valid SPIFFE ID;
+- is a leaf SVID (`CA=false`, no certificate- or CRL-signing key usage);
+- chains to the X.509 authorities of **its own trust domain's** bundle;
+- whose trust domain equals the role's `trust_domain`; and
+- whose SPIFFE ID matches `allowed_spiffe_ids`, when set.
+
+A certificate whose trust domain isn't configured — or differs from the role's — is rejected, even if some *other* configured bundle would have accepted it. That cross-trust-domain isolation is the property plain CA-pool matching can't provide. The transparent-auth flow behaves exactly as in x509 mode, and revocation is available too — but SVIDs are typically short-lived and carry no CRL/OCSP endpoints, so leave `revocation_mode` at `none` (a strict mode would reject an SVID that has no revocation URL).
+
+> **Chain note.** Only the leaf certificate is available on the forwarded-header path, so the registered bundle must contain the authority that directly signed the SVID (the usual SPIRE setup). **Federation note.** Bundles are configured statically or pushed by SPIRE; fetching them from SPIFFE federation endpoints with periodic refresh is not yet supported.
 
 ## How the Certificate Reaches Warden
 
@@ -250,8 +317,9 @@ Per-mount introspection (`auth/<mount>/introspect/roles`) exists too — the agg
 
 | Field | Required | Description |
 |---|---|---|
-| `trusted_ca_pem` | Yes (unless every role sets its own `certificate`) | PEM-encoded CA bundle that signs accepted client certificates. Multiple `-----BEGIN CERTIFICATE-----` blocks may be concatenated. |
-| `principal_claim` | No (default `cn`) | Which certificate field becomes the principal identity. One of `cn`, `dns_san`, `email_san`, `uri_san`, `serial`. |
+| `mode` | No (default `x509`) | Trust model for the mount: `x509` (classic PKI) or `spiffe` (SPIFFE X.509-SVID — see [SPIFFE mode](#spiffe-mode)). Cannot be changed while roles or trust domains exist. |
+| `trusted_ca_pem` | x509 mode; required unless every role sets its own `certificate` | PEM-encoded CA bundle that signs accepted client certificates. Multiple `-----BEGIN CERTIFICATE-----` blocks may be concatenated. Rejected in spiffe mode. |
+| `principal_claim` | No (default `cn`) | **x509 mode only.** Which certificate field becomes the principal identity. One of `cn`, `dns_san`, `email_san`, `uri_san`, `serial`. (In spiffe mode the principal is always the verified SVID ID.) |
 | `token_ttl` | No (default `1h`) | Default TTL for issued Warden auth tokens; per-role `token_ttl` overrides; capped further by the certificate's `NotAfter`. |
 | `revocation_mode` | No (default `none`) | Revocation check mode. One of `none`, `ocsp`, `crl`, `best_effort`. |
 | `crl_cache_ttl` | No (default `1h`) | How long a fetched CRL is cached per distribution-point URL. Example: `30m`, `2h`. |
@@ -260,19 +328,21 @@ Per-mount introspection (`auth/<mount>/introspect/roles`) exists too — the agg
 
 ### Role configuration
 
-At least one of the `allowed_*` constraint fields must be set — wide-open roles are refused at write time.
+In **x509 mode**, at least one of the `allowed_*` constraint fields must be set — wide-open roles are refused at write time. In **spiffe mode**, `trust_domain` is required and the x509-only fields below are rejected.
 
 | Field | Required | Description |
 |---|---|---|
 | `description` | No | Human-readable purpose, surfaced via introspection. |
-| `allowed_common_names` | one of six | Glob patterns matched against `Subject.CommonName`. |
-| `allowed_dns_sans` | one of six | Glob patterns matched against the certificate's DNS SANs (any-one match accepts). |
-| `allowed_email_sans` | one of six | Glob patterns matched against email SANs. |
-| `allowed_uri_sans` | one of six | Segment-aware URI patterns (see [SPIFFE URI Patterns](#spiffe-uri-patterns)). |
-| `allowed_organizational_units` | one of six | Exact-match list against `Subject.OrganizationalUnit`. |
-| `allowed_organizations` | one of six | Exact-match list against `Subject.Organization`. |
-| `certificate` | No | Role-specific CA PEM that replaces the mount's `trusted_ca_pem` for this role only. |
-| `principal_claim` | No | Per-role override of the mount's `principal_claim`. |
+| `trust_domain` | spiffe mode (required) | SPIFFE trust domain the role authenticates (e.g. `prod.example.org`). The SVID must belong to this domain and chain to its registered bundle. Rejected in x509 mode. |
+| `allowed_spiffe_ids` | No (spiffe mode) | Segment-aware SPIFFE ID patterns restricting the path within the trust domain (see [SPIFFE URI Patterns](#spiffe-uri-patterns)). |
+| `allowed_common_names` | x509: one of six | Glob patterns matched against `Subject.CommonName`. |
+| `allowed_dns_sans` | x509: one of six | Glob patterns matched against the certificate's DNS SANs (any-one match accepts). |
+| `allowed_email_sans` | x509: one of six | Glob patterns matched against email SANs. |
+| `allowed_uri_sans` | x509: one of six | Segment-aware URI patterns (see [SPIFFE URI Patterns](#spiffe-uri-patterns)). |
+| `allowed_organizational_units` | x509: one of six | Exact-match list against `Subject.OrganizationalUnit`. |
+| `allowed_organizations` | x509: one of six | Exact-match list against `Subject.Organization`. |
+| `certificate` | No (x509 mode) | Role-specific CA PEM that replaces the mount's `trusted_ca_pem` for this role only. |
+| `principal_claim` | No (x509 mode) | Per-role override of the mount's `principal_claim`. |
 | `token_policies` | No | Warden policies attached to the issued token. |
 | `token_ttl` | No (default `1h`) | TTL for issued tokens; overrides the mount-level `token_ttl`; further capped by the certificate's `NotAfter`. |
 | `cred_spec_name` | No | Credential spec name to bind to this role; downstream provider gateways use it to mint the upstream credential. |
@@ -293,13 +363,17 @@ At least one of the `allowed_*` constraint fields must be set — wide-open role
 
 **"trusted_ca_pem contains no valid certificates" at config write.** The CA bundle is empty, malformed, or contains non-CERTIFICATE PEM blocks only. Verify with `openssl crl2pkcs7 -nocrl -certfile bundle.pem | openssl pkcs7 -print_certs -noout` — every cert should print a `subject=` and `issuer=` line.
 
-**SPIFFE URI patterns reject what looks like a matching SVID.** `allowed_uri_sans` is segment-aware (split on `/`). Two easy ways to trip:
+**SPIFFE URI patterns reject what looks like a matching SVID.** `allowed_spiffe_ids` (spiffe mode) and `allowed_uri_sans` (x509 mode) are segment-aware (split on `/`). Two easy ways to trip:
 - `+` matches a single segment only — `spiffe://+/foo/bar` accepts one-segment trust domains, not nested paths.
 - `*` is a *prefix* wildcard that only works as the trailing segment — `spiffe://example.com/*` matches one or more segments after `example.com/`, but you can't put `*` in the middle of a path.
 
 Verify the role's patterns with `warden read auth/<mount>/role/<name>`, then walk through the segment match against the SVID's actual URI SAN by hand. Full pattern semantics are in the SPIFFE URI Patterns section above.
 
 **Token TTL is shorter than `token_ttl` requested.** Issued tokens are capped at `min(role.token_ttl, mount.token_ttl, time-until-cert-NotAfter)`. If the certificate is close to its `NotAfter`, the token's effective TTL collapses to whatever's left. The fix is to refresh the certificate, not to raise `token_ttl`.
+
+**`principal_claim=spiffe_id` is rejected, or a stored value now reads `uri_san`.** The `spiffe_id` principal claim was removed — it pulled a `spiffe://` URI from the certificate without validating it as an SVID. New writes are rejected; a value persisted by an older version is coerced to `uri_san` (the same string for a single-URI SVID) with a deprecation warning on load. For real SVID validation, use a [spiffe-mode](#spiffe-mode) mount.
+
+**SPIFFE login fails with "authentication failed" on a spiffe-mode mount.** Check, in order: the role's `trust_domain` has a registered bundle (`warden read auth/<mount>/trust-domain/<td>`); the SVID's trust domain matches the role's `trust_domain`; the SVID chains to *that* domain's authorities (not some other configured domain's); the SVID is a leaf (not a CA cert) with exactly one `spiffe://` URI SAN; and its path matches `allowed_spiffe_ids` when set. A role bound to an unconfigured or deleted trust domain always fails closed.
 
 **OCSP / CRL checks are slow or time out under load.** Each cache miss on revocation is a network round-trip. CRLs are cached per distribution-point URL (default 1h, raise `crl_cache_ttl` to reduce fetch frequency); OCSP isn't cached at this layer, but Warden's transparent-auth cache means most logins skip it entirely after first touch. If you're seeing consistent OCSP timeouts, raise `ocsp_timeout` (default 5s) or switch to `crl` for environments where CRLs are more reliable than the OCSP responder.
 

--- a/auth/method/cert/path_introspect.go
+++ b/auth/method/cert/path_introspect.go
@@ -5,6 +5,9 @@ import (
 	"crypto/x509"
 	"net/http"
 
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+
 	"github.com/stephnangue/warden/framework"
 	lgr "github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -47,10 +50,14 @@ func (b *certAuthBackend) handleIntrospectRoles(ctx context.Context, req *logica
 		return introspectEmpty(), nil
 	}
 
-	// SPIFFE-mode introspection is not yet implemented; return no matches rather
-	// than evaluate x509 trust logic against spiffe roles.
-	if b.config != nil && b.config.Mode == modeSPIFFE {
-		return introspectEmpty(), nil
+	// Determine the mount mode and, for spiffe mode, snapshot the bundle set once.
+	mode := modeX509
+	if b.config != nil && b.config.Mode != "" {
+		mode = b.config.Mode
+	}
+	var set *x509bundle.Set
+	if mode == modeSPIFFE {
+		set = b.snapshotBundleSet()
 	}
 
 	roleNames, err := b.listRoles(ctx)
@@ -68,17 +75,12 @@ func (b *certAuthBackend) handleIntrospectRoles(ctx context.Context, req *logica
 		if role == nil {
 			continue
 		}
-
-		if err := verifyCertForRole(cert, role, b); err != nil {
-			continue
+		if b.certSatisfiesRole(cert, role, set, mode) {
+			matches = append(matches, introspectedRole{
+				Name:        role.Name,
+				Description: role.Description,
+			})
 		}
-		if err := validateCertConstraints(cert, role); err != nil {
-			continue
-		}
-		matches = append(matches, introspectedRole{
-			Name:        role.Name,
-			Description: role.Description,
-		})
 	}
 
 	return &logical.Response{
@@ -116,4 +118,28 @@ func verifyCertForRole(cert *x509.Certificate, role *CertRole, b *certAuthBacken
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	})
 	return err
+}
+
+// certSatisfiesRole reports whether the presented certificate would be accepted
+// by the role under the mount mode — the same trust decision login makes, minus
+// the revocation check (introspection is advisory). In spiffe mode it verifies
+// the SVID against the role's trust-domain bundle; otherwise it runs the x509
+// chain + constraint checks.
+func (b *certAuthBackend) certSatisfiesRole(cert *x509.Certificate, role *CertRole, set *x509bundle.Set, mode string) bool {
+	if mode == modeSPIFFE {
+		if role.TrustDomain == "" || set == nil {
+			return false
+		}
+		expectedTD, err := spiffeid.TrustDomainFromString(role.TrustDomain)
+		if err != nil {
+			return false
+		}
+		_, _, err = verifySPIFFE(set, []*x509.Certificate{cert}, expectedTD, role.AllowedSPIFFEIDs)
+		return err == nil
+	}
+
+	if err := verifyCertForRole(cert, role, b); err != nil {
+		return false
+	}
+	return validateCertConstraints(cert, role) == nil
 }

--- a/auth/method/cert/path_login.go
+++ b/auth/method/cert/path_login.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+
 	"github.com/stephnangue/warden/auth/helper"
 	"github.com/stephnangue/warden/framework"
 	lgr "github.com/stephnangue/warden/logger"
@@ -54,14 +56,10 @@ func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request,
 		return logical.ErrorResponse(logical.ErrBadRequest("no client certificate provided")), nil
 	}
 
-	// SPIFFE mode can be configured (trust domains, roles) but SVID enforcement
-	// is not yet wired in this build. Fail closed rather than fall through to
-	// x509 verification, which would be the wrong trust model.
+	// SPIFFE mode verifies the certificate as an X.509-SVID against the role's
+	// trust-domain bundle, a distinct trust model from x509 mode.
 	if b.config != nil && b.config.Mode == modeSPIFFE {
-		return &logical.Response{
-			StatusCode: http.StatusNotImplemented,
-			Err:        fmt.Errorf("SPIFFE SVID authentication is not yet enabled on this mount"),
-		}, nil
+		return b.handleSPIFFELogin(ctx, req, d, cert)
 	}
 
 	// Get role name — fall back to default_role if configured
@@ -177,6 +175,81 @@ func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request,
 			TokenTTL:       effectiveTTL,
 			ClientIP:       req.ClientIP,
 			ClientToken:    fingerprint, // Cert fingerprint for token type caching
+		},
+		Data: map[string]any{
+			"principal_id": principalID,
+			"role":         roleName,
+			"fingerprint":  fingerprint,
+		},
+	}, nil
+}
+
+// handleSPIFFELogin authenticates a client X.509-SVID in spiffe mode. It verifies
+// the certificate against the role's trust-domain bundle (SVID rules + chain +
+// trust-domain binding + optional SPIFFE-ID patterns) and issues a token whose
+// principal is the verified SPIFFE ID. Called with configMu held by handleLogin.
+func (b *certAuthBackend) handleSPIFFELogin(ctx context.Context, req *logical.Request, d *framework.FieldData, cert *x509.Certificate) (*logical.Response, error) {
+	// Resolve the role — fall back to default_role if configured.
+	roleName := d.Get("role").(string)
+	if roleName == "" && b.config != nil && b.config.DefaultRole != "" {
+		roleName = b.config.DefaultRole
+	}
+	if roleName == "" {
+		return logical.ErrorResponse(logical.ErrBadRequest("missing role")), nil
+	}
+
+	role, err := b.getRole(ctx, roleName)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if role == nil || role.TrustDomain == "" {
+		b.logger.Warn("login failed: role not found or not bound to a trust domain", lgr.String("role", roleName))
+		return &logical.Response{StatusCode: http.StatusUnauthorized, Err: errCertAuthFailed}, nil
+	}
+
+	expectedTD, err := spiffeid.TrustDomainFromString(role.TrustDomain)
+	if err != nil {
+		b.logger.Warn("login failed: role has invalid trust_domain", lgr.Err(err), lgr.String("role", roleName))
+		return &logical.Response{StatusCode: http.StatusUnauthorized, Err: errCertAuthFailed}, nil
+	}
+
+	// Fail closed if no trust bundles are loaded.
+	set := b.snapshotBundleSet()
+	if set == nil {
+		b.logger.Warn("login failed: no SPIFFE trust bundles loaded", lgr.String("role", roleName))
+		return &logical.Response{StatusCode: http.StatusUnauthorized, Err: errCertAuthFailed}, nil
+	}
+
+	id, chains, err := verifySPIFFE(set, []*x509.Certificate{cert}, expectedTD, role.AllowedSPIFFEIDs)
+	if err != nil {
+		b.logger.Warn("login failed: SVID verification", lgr.Err(err), lgr.String("role", roleName))
+		return &logical.Response{StatusCode: http.StatusUnauthorized, Err: errCertAuthFailed}, nil
+	}
+
+	// Reuse the standard revocation check against the verified chains.
+	if b.revocationChecker != nil && b.config != nil &&
+		b.config.RevocationMode != "" && b.config.RevocationMode != "none" {
+		if err := b.revocationChecker.checkRevocation(cert, chains, b.config.RevocationMode); err != nil {
+			b.logger.Warn("login failed: SVID revocation check", lgr.Err(err), lgr.String("role", roleName))
+			return &logical.Response{StatusCode: http.StatusUnauthorized, Err: errCertAuthFailed}, nil
+		}
+	}
+
+	principalID := id.String()
+	effectiveTTL := b.calculateTTL(cert, role)
+	fingerprint := certFingerprint(cert)
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Auth: &logical.Auth{
+			PrincipalID:    principalID,
+			RoleName:       roleName,
+			Policies:       role.TokenPolicies,
+			CredentialSpec: role.CredSpecName,
+			TokenType:      "cert_role",
+			TokenTTL:       effectiveTTL,
+			ClientIP:       req.ClientIP,
+			ClientToken:    fingerprint,
 		},
 		Data: map[string]any{
 			"principal_id": principalID,

--- a/auth/method/cert/path_spiffe.go
+++ b/auth/method/cert/path_spiffe.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -13,13 +14,16 @@ import (
 	"github.com/stephnangue/warden/logical"
 )
 
+// spiffeTrustDomainPrefix is the internal storage-key prefix for trust-domain
+// entries (namespaced away from role/ and config). It is independent of the
+// API route, which is "trust-domain/<name>".
 const spiffeTrustDomainPrefix = "spiffe/trust-domain/"
 
 // pathSPIFFETrustDomain manages a SPIFFE trust domain and the X.509 authorities
 // that are authoritative for it. These paths are only meaningful in spiffe mode.
 func (b *certAuthBackend) pathSPIFFETrustDomain() *framework.Path {
 	return &framework.Path{
-		Pattern: "spiffe/trust-domain/" + framework.GenericNameRegex("name"),
+		Pattern: "trust-domain/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeString,
@@ -49,7 +53,7 @@ func (b *certAuthBackend) pathSPIFFETrustDomain() *framework.Path {
 // pathSPIFFETrustDomainList lists the configured SPIFFE trust domains.
 func (b *certAuthBackend) pathSPIFFETrustDomainList() *framework.Path {
 	return &framework.Path{
-		Pattern: "spiffe/trust-domain/?$",
+		Pattern: "trust-domain/?$",
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{Callback: b.handleTrustDomainList, Summary: "List SPIFFE trust domains"},
 		},
@@ -244,4 +248,12 @@ func (b *certAuthBackend) rebuildBundleSet(ctx context.Context) error {
 	b.spiffeBundleSet = set
 	b.spiffeMu.Unlock()
 	return nil
+}
+
+// snapshotBundleSet returns the current verification set under a read lock. It
+// may be nil if no trust domains have been loaded yet (callers fail closed).
+func (b *certAuthBackend) snapshotBundleSet() *x509bundle.Set {
+	b.spiffeMu.RLock()
+	defer b.spiffeMu.RUnlock()
+	return b.spiffeBundleSet
 }

--- a/auth/method/cert/spiffe_enforcement_test.go
+++ b/auth/method/cert/spiffe_enforcement_test.go
@@ -1,0 +1,181 @@
+package cert
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"testing"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupSpiffeMount returns a spiffe-mode backend with one trust domain registered
+// (backed by caPEM) and one spiffe role bound to it.
+func setupSpiffeMount(t *testing.T, caPEM, trustDomain, roleName string, allowedIDs []string) (*certAuthBackend, context.Context) {
+	t.Helper()
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+
+	resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+		Raw:    map[string]any{"name": trustDomain, "bundle_pem": caPEM},
+		Schema: b.pathSPIFFETrustDomain().Fields,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:             roleName,
+		TrustDomain:      trustDomain,
+		AllowedSPIFFEIDs: allowedIDs,
+		TokenPolicies:    []string{"svid-policy"},
+		TokenTTL:         "1h",
+	}))
+	return b, ctx
+}
+
+func spiffeLogin(t *testing.T, b *certAuthBackend, ctx context.Context, role string, svid *x509.Certificate) *logical.Response {
+	t.Helper()
+	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, svid)}
+	d := &framework.FieldData{Raw: map[string]any{"role": role}, Schema: b.pathLogin().Fields}
+	resp, err := b.handleLogin(ctx, req, d)
+	require.NoError(t, err)
+	return resp
+}
+
+func TestSPIFFELogin_ValidSVID(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	b, ctx := setupSpiffeMount(t, caPEM, "prod.example.org", "api", []string{"spiffe://prod.example.org/ns/+/sa/+"})
+
+	svid := testSVID(t, caCert, caKey, "spiffe://prod.example.org/ns/default/sa/api")
+	resp := spiffeLogin(t, b, ctx, "api", svid)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, resp.Auth)
+	assert.Equal(t, "spiffe://prod.example.org/ns/default/sa/api", resp.Auth.PrincipalID)
+	assert.Equal(t, "api", resp.Auth.RoleName)
+	assert.Equal(t, []string{"svid-policy"}, resp.Auth.Policies)
+	assert.Equal(t, "cert_role", resp.Auth.TokenType)
+}
+
+func TestSPIFFELogin_Rejections(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	rogueCert, rogueKey, _ := testCA(t)
+
+	b, ctx := setupSpiffeMount(t, caPEM, "prod.example.org", "api", []string{"spiffe://prod.example.org/ns/+/sa/api"})
+
+	t.Run("wrong trust domain", func(t *testing.T) {
+		svid := testSVID(t, caCert, caKey, "spiffe://other.org/ns/default/sa/api")
+		resp := spiffeLogin(t, b, ctx, "api", svid)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("path not allowed", func(t *testing.T) {
+		svid := testSVID(t, caCert, caKey, "spiffe://prod.example.org/ns/default/sa/other")
+		resp := spiffeLogin(t, b, ctx, "api", svid)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("signed by untrusted CA", func(t *testing.T) {
+		svid := testSVID(t, rogueCert, rogueKey, "spiffe://prod.example.org/ns/default/sa/api")
+		resp := spiffeLogin(t, b, ctx, "api", svid)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("CA leaf", func(t *testing.T) {
+		svid := testSVID(t, caCert, caKey, "spiffe://prod.example.org/ns/default/sa/api", func(tmpl *x509.Certificate) {
+			tmpl.IsCA = true
+			tmpl.BasicConstraintsValid = true
+		})
+		resp := spiffeLogin(t, b, ctx, "api", svid)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("unknown role", func(t *testing.T) {
+		svid := testSVID(t, caCert, caKey, "spiffe://prod.example.org/ns/default/sa/api")
+		resp := spiffeLogin(t, b, ctx, "nope", svid)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+// TestSPIFFELogin_CrossTrustDomainIsolation is the headline guarantee: with two
+// trust domains configured, a valid SVID from one cannot assume a role bound to
+// the other — the property a single shared CA pool cannot provide.
+func TestSPIFFELogin_CrossTrustDomainIsolation(t *testing.T) {
+	caA, keyA, pemA := testCA(t)
+	caB, keyB, pemB := testCA(t)
+
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+	for _, td := range []struct{ name, pem string }{{"a.example.org", pemA}, {"b.example.org", pemB}} {
+		resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
+			Raw:    map[string]any{"name": td.name, "bundle_pem": td.pem},
+			Schema: b.pathSPIFFETrustDomain().Fields,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	require.NoError(t, b.setRole(ctx, &CertRole{Name: "a-only", TrustDomain: "a.example.org", TokenTTL: "1h"}))
+
+	// A genuine, fully-valid b.example.org SVID (its bundle is configured) must
+	// still be rejected for the a.example.org-bound role.
+	svidB := testSVID(t, caB, keyB, "spiffe://b.example.org/ns/default/sa/svc")
+	assert.Equal(t, http.StatusUnauthorized, spiffeLogin(t, b, ctx, "a-only", svidB).StatusCode)
+
+	// The matching-domain SVID is accepted.
+	svidA := testSVID(t, caA, keyA, "spiffe://a.example.org/ns/default/sa/svc")
+	resp := spiffeLogin(t, b, ctx, "a-only", svidA)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "spiffe://a.example.org/ns/default/sa/svc", resp.Auth.PrincipalID)
+}
+
+func TestSPIFFEIntrospect(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	b, ctx := setupSpiffeMount(t, caPEM, "prod.example.org", "api", []string{"spiffe://prod.example.org/ns/+/sa/api"})
+
+	introspect := func(svid *x509.Certificate) []introspectedRole {
+		req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, svid)}
+		resp, err := b.handleIntrospectRoles(ctx, req, &framework.FieldData{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		return resp.Data["roles"].([]introspectedRole)
+	}
+
+	t.Run("matching SVID lists the role", func(t *testing.T) {
+		svid := testSVID(t, caCert, caKey, "spiffe://prod.example.org/ns/default/sa/api")
+		roles := introspect(svid)
+		require.Len(t, roles, 1)
+		assert.Equal(t, "api", roles[0].Name)
+	})
+
+	t.Run("non-matching SVID lists nothing", func(t *testing.T) {
+		svid := testSVID(t, caCert, caKey, "spiffe://prod.example.org/ns/default/sa/other")
+		assert.Empty(t, introspect(svid))
+	})
+}
+
+// TestX509Login_Regression confirms the classic x509 path still authenticates
+// after the spiffe branch was added.
+func TestX509Login_Regression(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{
+		"trusted_ca_pem":  caPEM,
+		"principal_claim": "cn",
+	}))
+	require.NoError(t, b.setRole(ctx, &CertRole{
+		Name:               "inventory",
+		AllowedCommonNames: []string{"inventory-*"},
+		TokenPolicies:      []string{"inv"},
+		TokenTTL:           "1h",
+	}))
+
+	clientCert := testClientCert(t, caCert, caKey, "inventory-svc")
+	resp := spiffeLogin(t, b, ctx, "inventory", clientCert)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, resp.Auth)
+	assert.Equal(t, "inventory-svc", resp.Auth.PrincipalID)
+}

--- a/auth/method/cert/spiffe_mode_test.go
+++ b/auth/method/cert/spiffe_mode_test.go
@@ -14,6 +14,16 @@ import (
 // mode config
 // =============================================================================
 
+// TestSPIFFETrustDomainRoutePatterns locks the API route so it stays
+// "auth/<mount>/trust-domain/<name>" (no redundant "spiffe/" segment that would
+// double up to "auth/spiffe/spiffe/trust-domain/..." on a spiffe-named mount),
+// keeping the documented paths correct.
+func TestSPIFFETrustDomainRoutePatterns(t *testing.T) {
+	b, _ := createTestBackend(t)
+	assert.Equal(t, "trust-domain/"+framework.GenericNameRegex("name"), b.pathSPIFFETrustDomain().Pattern)
+	assert.Equal(t, "trust-domain/?$", b.pathSPIFFETrustDomainList().Pattern)
+}
+
 func TestSetupCertConfig_ModeDefaultAndValidation(t *testing.T) {
 	b, ctx := createTestBackend(t)
 
@@ -54,6 +64,28 @@ func TestHandleConfigWrite_SpiffeModeRejectsPKIFields(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		assert.Contains(t, resp.Err.Error(), "principal_claim is not allowed in spiffe mode")
 	})
+}
+
+func TestHandleConfigWrite_SpiffeModeWithOtherFieldsInOneCall(t *testing.T) {
+	b, ctx := createTestBackend(t)
+
+	// mode set together with the mode-agnostic fields, in a single write.
+	d := &framework.FieldData{
+		Raw: map[string]any{
+			"mode":            "spiffe",
+			"token_ttl":       7200,
+			"default_role":    "api",
+			"revocation_mode": "none",
+		},
+		Schema: b.pathConfig().Fields,
+	}
+	resp, err := b.handleConfigWrite(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, modeSPIFFE, b.config.Mode)
+	assert.Equal(t, "api", b.config.DefaultRole)
+	assert.Equal(t, "2h0m0s", b.config.TokenTTL.String())
 }
 
 func TestHandleConfigWrite_ModeChangeGuard(t *testing.T) {
@@ -129,15 +161,31 @@ func TestTrustDomainCRUD(t *testing.T) {
 }
 
 func TestTrustDomain_RejectedInX509Mode(t *testing.T) {
-	b, ctx := createTestBackend(t) // config nil -> x509 mode
+	b, ctx := createTestBackend(t) // config nil -> x509 mode (default)
 
-	resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, &framework.FieldData{
-		Raw:    map[string]any{"name": "example.org", "bundle_pem": "x"},
-		Schema: b.pathSPIFFETrustDomain().Fields,
-	})
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Contains(t, resp.Err.Error(), "mode=spiffe")
+	tdSchema := b.pathSPIFFETrustDomain().Fields
+	fd := func() *framework.FieldData {
+		return &framework.FieldData{Raw: map[string]any{"name": "example.org", "bundle_pem": "x"}, Schema: tdSchema}
+	}
+
+	// Every CRUD operation on the trust-domain path is rejected with a 400 in
+	// x509 mode (the routes are registered but mode-gated in the handlers).
+	ops := map[string]func() (*logical.Response, error){
+		"write":  func() (*logical.Response, error) { return b.handleTrustDomainWrite(ctx, &logical.Request{}, fd()) },
+		"read":   func() (*logical.Response, error) { return b.handleTrustDomainRead(ctx, &logical.Request{}, fd()) },
+		"delete": func() (*logical.Response, error) { return b.handleTrustDomainDelete(ctx, &logical.Request{}, fd()) },
+		"list": func() (*logical.Response, error) {
+			return b.handleTrustDomainList(ctx, &logical.Request{}, &framework.FieldData{})
+		},
+	}
+	for name, op := range ops {
+		t.Run(name, func(t *testing.T) {
+			resp, err := op()
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Contains(t, resp.Err.Error(), "mode=spiffe")
+		})
+	}
 }
 
 func TestTrustDomainWrite_Validation(t *testing.T) {
@@ -195,40 +243,6 @@ func TestValidateRole_ModeGating(t *testing.T) {
 	err = b.validateRole(&CertRole{Name: "r", TrustDomain: "example.org", AllowedCommonNames: []string{"x"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not valid in spiffe mode")
-}
-
-// =============================================================================
-// enforcement gate (PR3: spiffe data plane not yet enabled)
-// =============================================================================
-
-func TestHandleLogin_SpiffeModeGated(t *testing.T) {
-	caCert, caKey, _ := testCA(t)
-	b, ctx := createTestBackend(t)
-	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
-
-	clientCert := testClientCert(t, caCert, caKey, "agent")
-	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, clientCert)}
-	d := &framework.FieldData{Raw: map[string]any{"role": "api"}, Schema: b.pathLogin().Fields}
-
-	resp, err := b.handleLogin(ctx, req, d)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
-	assert.Contains(t, resp.Err.Error(), "not yet enabled")
-}
-
-func TestHandleIntrospect_SpiffeModeEmpty(t *testing.T) {
-	caCert, caKey, _ := testCA(t)
-	b, ctx := createTestBackend(t)
-	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
-
-	clientCert := testClientCert(t, caCert, caKey, "agent")
-	req := &logical.Request{HTTPRequest: newCertHTTPRequest(t, clientCert)}
-
-	resp, err := b.handleIntrospectRoles(ctx, req, &framework.FieldData{})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	roles := resp.Data["roles"].([]introspectedRole)
-	assert.Empty(t, roles)
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

Turns on the spiffe data plane — replaces the gated stubs from the previous PR with real X.509-SVID verification, so a spiffe-mode mount authenticates SVIDs end to end.

## Changes

- login: `handleSPIFFELogin` verifies the presented SVID against the role's trust-domain bundle (single URI SAN, non-CA leaf, chain to the domain's authorities, trust-domain match, optional `allowed_spiffe_ids`), reuses the revocation check, and issues a token whose principal is the verified SVID ID.
- introspection: `certSatisfiesRole` verifies SVIDs the same way (revocation skipped, as before) so discovery matches login.
- `snapshotBundleSet` exposes the in-memory verification set under a read lock.
- route fix: trust-domain endpoints are `trust-domain/<name>` (gated to spiffe mode), dropping the redundant `spiffe/` segment that would otherwise double to `auth/spiffe/spiffe/trust-domain/...` on a spiffe-named mount.
- README: document the two modes, the spiffe setup flow, what is enforced, and scope URI-pattern matching to its mode.

## Tests

Accept path + every rejection (wrong trust domain, path mismatch, untrusted CA, CA leaf, unknown role), cross-trust-domain isolation, introspection match/non-match, CRUD rejection in x509 mode, the route shape, and an x509 login regression.

## Notes

#4 of the SPIFFE stack, rebased onto current `main`.
