### PR TITLE
feat(cert): SPIFFE federation config surface + on-demand bundle fetch

### DIFF
--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -81,6 +81,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathIntrospect(),
 			b.pathSPIFFETrustDomain(),
 			b.pathSPIFFETrustDomainList(),
+			b.pathSPIFFETrustDomainRefresh(),
 		},
 	}
 

--- a/auth/method/cert/path_spiffe.go
+++ b/auth/method/cert/path_spiffe.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -38,6 +40,23 @@ func (b *certAuthBackend) pathSPIFFETrustDomain() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "SPIFFE trust-bundle (JWKS) document; only its X.509 authorities are used",
 			},
+			"bundle_endpoint_url": {
+				Type:        framework.TypeString,
+				Description: "SPIFFE Federation bundle endpoint URL (https://). Setting this makes the trust domain federated.",
+			},
+			"bundle_endpoint_profile": {
+				Type:          framework.TypeString,
+				Description:   "Bundle endpoint profile: https_web (Web PKI) or https_spiffe (endpoint authenticated by its SVID).",
+				AllowedValues: []interface{}{bundleProfileWeb, bundleProfileSPIFFE},
+			},
+			"endpoint_spiffe_id": {
+				Type:        framework.TypeString,
+				Description: "Expected SPIFFE ID of the bundle endpoint (required for https_spiffe; must be in this trust domain).",
+			},
+			"web_pki_ca_pem": {
+				Type:        framework.TypeString,
+				Description: "Optional PEM CA roots for validating the https_web endpoint's TLS cert (default: system roots).",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{Callback: b.handleTrustDomainWrite, Summary: "Register a SPIFFE trust domain bundle"},
@@ -62,6 +81,54 @@ func (b *certAuthBackend) pathSPIFFETrustDomainList() *framework.Path {
 	}
 }
 
+// pathSPIFFETrustDomainRefresh triggers an immediate bundle fetch for a federated
+// trust domain.
+func (b *certAuthBackend) pathSPIFFETrustDomainRefresh() *framework.Path {
+	return &framework.Path{
+		Pattern: "trust-domain/" + framework.GenericNameRegex("name") + "/refresh",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {Type: framework.TypeString, Description: "SPIFFE trust domain name", Required: true},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.handleTrustDomainRefresh, Summary: "Fetch and apply a federated trust domain's bundle now"},
+		},
+		HelpSynopsis:    "Refresh a federated SPIFFE trust domain's bundle",
+		HelpDescription: "Fetches the bundle from the trust domain's configured endpoint and applies it. Only valid in spiffe mode for a federated trust domain.",
+	}
+}
+
+func (b *certAuthBackend) handleTrustDomainRefresh(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if resp := b.requireSPIFFEMode(); resp != nil {
+		return resp, nil
+	}
+	name := d.Get("name").(string)
+	if td, err := spiffeid.TrustDomainFromString(name); err == nil {
+		name = td.Name()
+	}
+
+	entry, err := b.getTrustDomain(ctx, name)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if entry == nil {
+		return logical.ErrorResponse(logical.ErrNotFoundf("trust domain %q not found", name)), nil
+	}
+	if !entry.IsFederated() {
+		return &logical.Response{StatusCode: http.StatusBadRequest, Err: fmt.Errorf("trust domain %q has no bundle endpoint configured", name)}, nil
+	}
+
+	changed, err := b.refreshFederatedTrustDomain(ctx, entry)
+	if err != nil {
+		// 502: the upstream bundle endpoint fetch failed; the last-good bundle is kept.
+		return &logical.Response{StatusCode: http.StatusBadGateway, Err: fmt.Errorf("bundle refresh failed: %w", err)}, nil
+	}
+
+	return &logical.Response{
+		StatusCode: http.StatusOK,
+		Data:       map[string]any{"name": name, "changed": changed, "sequence": entry.Sequence},
+	}, nil
+}
+
 // requireSPIFFEMode returns a 400 response when the mount is not in spiffe mode.
 func (b *certAuthBackend) requireSPIFFEMode() *logical.Response {
 	if b.mountMode() != modeSPIFFE {
@@ -78,25 +145,30 @@ func (b *certAuthBackend) handleTrustDomainWrite(ctx context.Context, req *logic
 		return resp, nil
 	}
 	name := d.Get("name").(string)
-
 	td, err := spiffeid.TrustDomainFromString(name)
 	if err != nil {
 		return &logical.Response{StatusCode: http.StatusBadRequest, Err: fmt.Errorf("invalid trust domain %q: %w", name, err)}, nil
 	}
-	canonical := td.Name()
 
-	bundlePEM, _ := d.Get("bundle_pem").(string)
-	bundleJSON, _ := d.Get("bundle_json").(string)
+	// A config write replaces the entry; any fetched federation state resets so the
+	// next refresh fetches against the new config.
+	entry := &SPIFFETrustDomain{
+		Name:                  td.Name(),
+		BundlePEM:             d.Get("bundle_pem").(string),
+		BundleJSON:            d.Get("bundle_json").(string),
+		BundleEndpointURL:     d.Get("bundle_endpoint_url").(string),
+		BundleEndpointProfile: d.Get("bundle_endpoint_profile").(string),
+		EndpointSPIFFEID:      d.Get("endpoint_spiffe_id").(string),
+		WebPKICAPEM:           d.Get("web_pki_ca_pem").(string),
+	}
 
-	// Validate the bundle parses into at least one X.509 authority before storing.
-	if _, err := parseTrustDomainAuthorities(td, bundlePEM, bundleJSON); err != nil {
+	if err := validateTrustDomainConfig(entry); err != nil {
 		return &logical.Response{StatusCode: http.StatusBadRequest, Err: err}, nil
 	}
 
-	if err := b.setTrustDomain(ctx, &SPIFFETrustDomain{Name: canonical, BundlePEM: bundlePEM, BundleJSON: bundleJSON}); err != nil {
+	if err := b.setTrustDomain(ctx, entry); err != nil {
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
 	}
-
 	// Refresh the in-memory verification set so the change takes effect at once.
 	if err := b.rebuildBundleSet(ctx); err != nil {
 		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
@@ -104,8 +176,82 @@ func (b *certAuthBackend) handleTrustDomainWrite(ctx context.Context, req *logic
 
 	return &logical.Response{
 		StatusCode: http.StatusOK,
-		Data:       map[string]any{"name": canonical, "message": fmt.Sprintf("Successfully configured trust domain %s", canonical)},
+		Data:       map[string]any{"name": entry.Name, "federated": entry.IsFederated(), "message": fmt.Sprintf("Successfully configured trust domain %s", entry.Name)},
 	}, nil
+}
+
+// validateTrustDomainConfig validates a trust-domain entry: a static domain needs
+// a bundle; a federated domain needs a valid https endpoint and the profile's
+// requirements (https_spiffe: a valid in-domain endpoint_spiffe_id + a bootstrap
+// bundle; https_web: no endpoint_spiffe_id, optional custom roots).
+func validateTrustDomainConfig(d *SPIFFETrustDomain) error {
+	td, err := spiffeid.TrustDomainFromString(d.Name)
+	if err != nil {
+		return fmt.Errorf("invalid trust domain %q: %w", d.Name, err)
+	}
+	hasBundle := d.BundlePEM != "" || d.BundleJSON != ""
+
+	switch d.BundleEndpointProfile {
+	case "": // static
+		if d.BundleEndpointURL != "" || d.EndpointSPIFFEID != "" || d.WebPKICAPEM != "" {
+			return fmt.Errorf("bundle_endpoint_url/endpoint_spiffe_id/web_pki_ca_pem require bundle_endpoint_profile")
+		}
+		if _, err := parseTrustDomainAuthorities(td, d.BundlePEM, d.BundleJSON); err != nil {
+			return err
+		}
+
+	case bundleProfileWeb:
+		if err := validateHTTPSURL(d.BundleEndpointURL); err != nil {
+			return err
+		}
+		if d.EndpointSPIFFEID != "" {
+			return fmt.Errorf("endpoint_spiffe_id is not valid for the https_web profile")
+		}
+		if _, err := rootsFromPEM(d.WebPKICAPEM); err != nil {
+			return err
+		}
+		if hasBundle { // optional bootstrap; if present it must parse
+			if _, err := parseTrustDomainAuthorities(td, d.BundlePEM, d.BundleJSON); err != nil {
+				return err
+			}
+		}
+
+	case bundleProfileSPIFFE:
+		if err := validateHTTPSURL(d.BundleEndpointURL); err != nil {
+			return err
+		}
+		if d.WebPKICAPEM != "" {
+			return fmt.Errorf("web_pki_ca_pem is not valid for the https_spiffe profile")
+		}
+		endpointID, err := spiffeid.FromString(d.EndpointSPIFFEID)
+		if err != nil {
+			return fmt.Errorf("https_spiffe requires a valid endpoint_spiffe_id: %w", err)
+		}
+		if !endpointID.MemberOf(td) {
+			return fmt.Errorf("endpoint_spiffe_id %q must be in trust domain %q", d.EndpointSPIFFEID, td.Name())
+		}
+		if _, err := parseTrustDomainAuthorities(td, d.BundlePEM, d.BundleJSON); err != nil {
+			return fmt.Errorf("https_spiffe requires a bootstrap bundle (bundle_pem or bundle_json) to authenticate the endpoint: %w", err)
+		}
+
+	default:
+		return fmt.Errorf("invalid bundle_endpoint_profile %q; must be %s or %s", d.BundleEndpointProfile, bundleProfileWeb, bundleProfileSPIFFE)
+	}
+	return nil
+}
+
+func validateHTTPSURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("bundle_endpoint_url is required for a federated trust domain")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid bundle_endpoint_url: %w", err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("bundle_endpoint_url must be an https:// URL")
+	}
+	return nil
 }
 
 func (b *certAuthBackend) handleTrustDomainRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -127,9 +273,12 @@ func (b *certAuthBackend) handleTrustDomainRead(ctx context.Context, req *logica
 
 	// Trust bundles are public CA material, but the read returns a summary
 	// (count + subjects) rather than the raw bytes, matching the config-read style.
-	source := "bundle_pem"
-	if entry.BundleJSON != "" {
+	source := "none"
+	switch {
+	case entry.BundleJSON != "":
 		source = "bundle_json"
+	case entry.BundlePEM != "":
+		source = "bundle_pem"
 	}
 	subjects := []string{}
 	count := 0
@@ -142,15 +291,26 @@ func (b *certAuthBackend) handleTrustDomainRead(ctx context.Context, req *logica
 		}
 	}
 
-	return &logical.Response{
-		StatusCode: http.StatusOK,
-		Data: map[string]any{
-			"name":                    entry.Name,
-			"bundle_source":           source,
-			"x509_authority_count":    count,
-			"x509_authority_subjects": subjects,
-		},
-	}, nil
+	data := map[string]any{
+		"name":                    entry.Name,
+		"federated":               entry.IsFederated(),
+		"bundle_source":           source,
+		"x509_authority_count":    count,
+		"x509_authority_subjects": subjects,
+	}
+	if entry.IsFederated() {
+		data["bundle_endpoint_url"] = entry.BundleEndpointURL
+		data["bundle_endpoint_profile"] = entry.BundleEndpointProfile
+		data["endpoint_spiffe_id"] = entry.EndpointSPIFFEID
+		data["sequence"] = entry.Sequence
+		data["last_error"] = entry.LastError
+		data["last_refresh"] = ""
+		if entry.LastRefreshUnix != 0 {
+			data["last_refresh"] = time.Unix(entry.LastRefreshUnix, 0).UTC().Format(time.RFC3339)
+		}
+	}
+
+	return &logical.Response{StatusCode: http.StatusOK, Data: data}, nil
 }
 
 func (b *certAuthBackend) handleTrustDomainDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/auth/method/cert/spiffe.go
+++ b/auth/method/cert/spiffe.go
@@ -1,17 +1,29 @@
 package cert
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/federation"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 
 	"github.com/stephnangue/warden/auth/helper"
 )
+
+// SPIFFE bundle-endpoint profiles (empty = static, non-federated trust domain).
+const (
+	bundleProfileWeb    = "https_web"
+	bundleProfileSPIFFE = "https_spiffe"
+)
+
+// fetchTimeout bounds a single bundle-endpoint fetch.
+const fetchTimeout = 30 * time.Second
 
 // SPIFFETrustDomain is a configured SPIFFE trust domain together with the X.509
 // authorities that are authoritative for it. It is stored as JSON under the
@@ -22,12 +34,29 @@ import (
 //   - BundleJSON: a SPIFFE trust-bundle (JWKS) document. Only its X.509
 //     authorities are consumed; JWT authorities are ignored.
 //
-// The struct is intentionally minimal but kept extensible: federation (remote
-// bundle endpoints and periodic refresh) will add fields here in a later change.
+// A federated trust domain (BundleEndpointProfile set) instead pulls its bundle
+// from a remote endpoint; the fetched bundle is stored back into BundleJSON (the
+// active bundle), so verification via buildBundleSet is identical for both kinds.
 type SPIFFETrustDomain struct {
 	Name       string `json:"name"`
 	BundlePEM  string `json:"bundle_pem,omitempty"`
 	BundleJSON string `json:"bundle_json,omitempty"`
+
+	// Federation. Empty BundleEndpointProfile => static trust domain.
+	BundleEndpointURL     string `json:"bundle_endpoint_url,omitempty"`
+	BundleEndpointProfile string `json:"bundle_endpoint_profile,omitempty"` // https_web | https_spiffe
+	EndpointSPIFFEID      string `json:"endpoint_spiffe_id,omitempty"`      // https_spiffe only
+	WebPKICAPEM           string `json:"web_pki_ca_pem,omitempty"`          // https_web, optional custom roots
+
+	// Fetched federation state, managed by refresh.
+	Sequence        uint64 `json:"sequence,omitempty"`
+	LastRefreshUnix int64  `json:"last_refresh_unix,omitempty"`
+	LastError       string `json:"last_error,omitempty"`
+}
+
+// IsFederated reports whether the trust domain pulls its bundle from an endpoint.
+func (d *SPIFFETrustDomain) IsFederated() bool {
+	return d.BundleEndpointProfile != ""
 }
 
 // parseTrustDomainAuthorities parses the configured bundle into the X.509
@@ -98,6 +127,11 @@ func buildBundleSet(domains []*SPIFFETrustDomain) (*x509bundle.Set, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid trust domain %q: %w", d.Name, err)
 		}
+		// A federated trust domain may have no bundle yet (e.g. https_web before its
+		// first successful fetch); skip it — SVIDs for it fail closed until fetched.
+		if d.IsFederated() && d.BundlePEM == "" && d.BundleJSON == "" {
+			continue
+		}
 		authorities, err := parseTrustDomainAuthorities(td, d.BundlePEM, d.BundleJSON)
 		if err != nil {
 			return nil, fmt.Errorf("trust domain %q: %w", d.Name, err)
@@ -128,4 +162,116 @@ func verifySPIFFE(set *x509bundle.Set, certs []*x509.Certificate, expectedTD spi
 		return spiffeid.ID{}, nil, fmt.Errorf("SPIFFE ID %q not allowed by role", id.String())
 	}
 	return id, chains, nil
+}
+
+// rootsFromPEM builds an X.509 root pool from PEM. An empty string yields a nil
+// pool, which tells the TLS stack to use the system roots.
+func rootsFromPEM(pemData string) (*x509.CertPool, error) {
+	if pemData == "" {
+		return nil, nil
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(pemData)) {
+		return nil, fmt.Errorf("web_pki_ca_pem contains no valid certificates")
+	}
+	return pool, nil
+}
+
+// fetchFederatedBundle retrieves a federated trust domain's bundle from its
+// endpoint per the configured profile:
+//   - https_web:    endpoint TLS validated via Web PKI (custom roots or system).
+//   - https_spiffe: endpoint authenticated by its SVID against the trust domain's
+//     current authorities (bootstrap, then the last fetched bundle).
+func fetchFederatedBundle(ctx context.Context, d *SPIFFETrustDomain) (*spiffebundle.Bundle, error) {
+	td, err := spiffeid.TrustDomainFromString(d.Name)
+	if err != nil {
+		return nil, fmt.Errorf("invalid trust domain %q: %w", d.Name, err)
+	}
+
+	var opt federation.FetchOption
+	switch d.BundleEndpointProfile {
+	case bundleProfileWeb:
+		roots, err := rootsFromPEM(d.WebPKICAPEM)
+		if err != nil {
+			return nil, err
+		}
+		opt = federation.WithWebPKIRoots(roots) // nil => system roots
+
+	case bundleProfileSPIFFE:
+		authorities, err := parseTrustDomainAuthorities(td, d.BundlePEM, d.BundleJSON)
+		if err != nil {
+			return nil, fmt.Errorf("https_spiffe requires a bundle to authenticate the endpoint: %w", err)
+		}
+		endpointID, err := spiffeid.FromString(d.EndpointSPIFFEID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid endpoint_spiffe_id %q: %w", d.EndpointSPIFFEID, err)
+		}
+		opt = federation.WithSPIFFEAuth(x509bundle.FromX509Authorities(td, authorities), endpointID)
+
+	default:
+		return nil, fmt.Errorf("trust domain %q is not federated", d.Name)
+	}
+
+	bundle, err := federation.FetchBundle(ctx, td, d.BundleEndpointURL, opt)
+	if err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// refreshFederatedTrustDomain fetches d's bundle, and — when it changed — stores
+// it as the active bundle and rebuilds the verification set. It is stale-tolerant:
+// on fetch error the last-good bundle is kept and the error recorded. The bool
+// reports whether the active bundle changed. Must run on the active node (it writes
+// storage); d is mutated and persisted in place.
+func (b *certAuthBackend) refreshFederatedTrustDomain(ctx context.Context, d *SPIFFETrustDomain) (bool, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	bundle, err := fetchFederatedBundle(fetchCtx, d)
+	if err != nil {
+		// Keep the last-good bundle; record the failure (best-effort persist).
+		d.LastError = err.Error()
+		_ = b.setTrustDomain(ctx, d)
+		return false, err
+	}
+
+	// A bundle with no X.509 authorities would erase the trust domain's verification
+	// material and break the set rebuild for every domain. Reject it (a remote
+	// endpoint controls this input) and keep the last-good bundle.
+	if len(bundle.X509Authorities()) == 0 {
+		d.LastError = "fetched bundle has no X.509 authorities"
+		_ = b.setTrustDomain(ctx, d)
+		return false, fmt.Errorf("fetched bundle for %q has no X.509 authorities", d.Name)
+	}
+
+	newSeq, hasSeq := bundle.SequenceNumber()
+	fetchedBefore := d.LastRefreshUnix != 0
+	d.LastRefreshUnix = time.Now().Unix()
+	d.LastError = ""
+
+	// De-dup: a prior fetch with the same sequence means no change.
+	if fetchedBefore && hasSeq && d.Sequence == newSeq {
+		return false, b.setTrustDomain(ctx, d)
+	}
+
+	marshaled, err := bundle.Marshal()
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal fetched bundle: %w", err)
+	}
+
+	// The fetched bundle becomes the single active source.
+	d.BundleJSON = string(marshaled)
+	d.BundlePEM = ""
+	if hasSeq {
+		d.Sequence = newSeq
+	}
+
+	if err := b.setTrustDomain(ctx, d); err != nil {
+		return false, err
+	}
+	if err := b.rebuildBundleSet(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/auth/method/cert/spiffe_federation_test.go
+++ b/auth/method/cert/spiffe_federation_test.go
@@ -1,0 +1,284 @@
+package cert
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+func certPEM(cert *x509.Certificate) string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+}
+
+// marshalBundle produces a SPIFFE trust-bundle (JWKS) document for tdName carrying
+// the given authorities, with an optional sequence number.
+func marshalBundle(t *testing.T, tdName string, authorities []*x509.Certificate, seq uint64) []byte {
+	t.Helper()
+	b := spiffebundle.FromX509Authorities(mustTD(t, tdName), authorities)
+	if seq != 0 {
+		b.SetSequenceNumber(seq)
+	}
+	out, err := b.Marshal()
+	require.NoError(t, err)
+	return out
+}
+
+// startBundleEndpoint serves body over TLS at any path. A non-nil tlsCert sets the
+// server's certificate (used for the https_spiffe profile, where it is an SVID).
+func startBundleEndpoint(t *testing.T, body []byte, tlsCert *tls.Certificate) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	if tlsCert != nil {
+		srv.TLS = &tls.Config{Certificates: []tls.Certificate{*tlsCert}}
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// endpointSVIDCert mints an X.509-SVID (single spiffe:// URI SAN) usable as a TLS
+// server certificate, signed by the given CA.
+func endpointSVIDCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, spiffeID string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	u, err := url.Parse(spiffeID)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		URIs:         []*url.URL{u},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+func spiffeFederationBackend(t *testing.T) (*certAuthBackend, context.Context) {
+	b, ctx := createTestBackend(t)
+	require.NoError(t, b.setupCertConfig(ctx, map[string]any{"mode": "spiffe"}))
+	return b, ctx
+}
+
+func writeTrustDomain(t *testing.T, b *certAuthBackend, ctx context.Context, raw map[string]any) *logical.Response {
+	t.Helper()
+	d := &framework.FieldData{Raw: raw, Schema: b.pathSPIFFETrustDomain().Fields}
+	resp, err := b.handleTrustDomainWrite(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	return resp
+}
+
+func refreshTrustDomain(t *testing.T, b *certAuthBackend, ctx context.Context, name string) *logical.Response {
+	t.Helper()
+	d := &framework.FieldData{Raw: map[string]any{"name": name}, Schema: b.pathSPIFFETrustDomainRefresh().Fields}
+	resp, err := b.handleTrustDomainRefresh(ctx, &logical.Request{}, d)
+	require.NoError(t, err)
+	return resp
+}
+
+// --- tests ---
+
+func TestFederation_HTTPSWeb(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	const td = "partner.example.org"
+	srv := startBundleEndpoint(t, marshalBundle(t, td, []*x509.Certificate{caCert}, 1), nil)
+
+	b, ctx := spiffeFederationBackend(t)
+
+	resp := writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    td,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_web",
+		"web_pki_ca_pem":          certPEM(srv.Certificate()),
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://"+td+"/ns/default/sa/api")
+
+	// Before the first fetch the trust domain has no authorities -> fails closed.
+	_, _, err := verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, td), nil)
+	require.Error(t, err)
+
+	rr := refreshTrustDomain(t, b, ctx, td)
+	require.Equal(t, http.StatusOK, rr.StatusCode)
+	assert.Equal(t, true, rr.Data["changed"])
+
+	// After the fetch the bundle is active and the SVID verifies.
+	id, _, err := verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, td), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "spiffe://"+td+"/ns/default/sa/api", id.String())
+}
+
+func TestFederation_HTTPSSpiffe(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	const td = "partner.example.org"
+	endpointID := "spiffe://" + td + "/spire/server"
+	endpointCert := endpointSVIDCert(t, caCert, caKey, endpointID)
+	srv := startBundleEndpoint(t, marshalBundle(t, td, []*x509.Certificate{caCert}, 1), &endpointCert)
+
+	b, ctx := spiffeFederationBackend(t)
+
+	resp := writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    td,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_spiffe",
+		"endpoint_spiffe_id":      endpointID,
+		"bundle_pem":              caPEM, // bootstrap, authenticates the endpoint SVID
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	rr := refreshTrustDomain(t, b, ctx, td)
+	require.Equal(t, http.StatusOK, rr.StatusCode)
+	assert.Equal(t, true, rr.Data["changed"])
+
+	svid := testSVID(t, caCert, caKey, "spiffe://"+td+"/ns/default/sa/api")
+	_, _, err := verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, td), nil)
+	require.NoError(t, err)
+}
+
+func TestFederation_HTTPSSpiffe_WrongEndpointID(t *testing.T) {
+	caCert, caKey, caPEM := testCA(t)
+	const td = "partner.example.org"
+	endpointCert := endpointSVIDCert(t, caCert, caKey, "spiffe://"+td+"/spire/server")
+	srv := startBundleEndpoint(t, marshalBundle(t, td, []*x509.Certificate{caCert}, 1), &endpointCert)
+
+	b, ctx := spiffeFederationBackend(t)
+
+	// Config expects a different in-domain ID than the endpoint actually presents.
+	writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    td,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_spiffe",
+		"endpoint_spiffe_id":      "spiffe://" + td + "/spire/wrong",
+		"bundle_pem":              caPEM,
+	})
+
+	rr := refreshTrustDomain(t, b, ctx, td)
+	assert.Equal(t, http.StatusBadGateway, rr.StatusCode)
+}
+
+func TestFederation_SequenceDedup(t *testing.T) {
+	caCert, _, _ := testCA(t)
+	const td = "partner.example.org"
+	srv := startBundleEndpoint(t, marshalBundle(t, td, []*x509.Certificate{caCert}, 5), nil)
+
+	b, ctx := spiffeFederationBackend(t)
+	writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    td,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_web",
+		"web_pki_ca_pem":          certPEM(srv.Certificate()),
+	})
+
+	first := refreshTrustDomain(t, b, ctx, td)
+	assert.Equal(t, true, first.Data["changed"])
+
+	second := refreshTrustDomain(t, b, ctx, td) // same sequence -> no change
+	assert.Equal(t, false, second.Data["changed"])
+}
+
+func TestFederation_EmptyBundleKeepsLastGood(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	const td = "partner.example.org"
+	good := marshalBundle(t, td, []*x509.Certificate{caCert}, 1)
+	empty := marshalBundle(t, td, nil, 2) // valid bundle, but no X.509 authorities
+
+	var body atomic.Value
+	body.Store(good)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body.Load().([]byte))
+	}))
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	b, ctx := spiffeFederationBackend(t)
+	writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    td,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_web",
+		"web_pki_ca_pem":          certPEM(srv.Certificate()),
+	})
+	require.Equal(t, http.StatusOK, refreshTrustDomain(t, b, ctx, td).StatusCode)
+
+	svid := testSVID(t, caCert, caKey, "spiffe://"+td+"/ns/x/sa/y")
+	_, _, err := verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, td), nil)
+	require.NoError(t, err) // good bundle is active
+
+	// The endpoint now serves an authority-less bundle: refresh must reject it...
+	body.Store(empty)
+	assert.Equal(t, http.StatusBadGateway, refreshTrustDomain(t, b, ctx, td).StatusCode)
+
+	// ...and the last-good bundle must remain active.
+	_, _, err = verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, td), nil)
+	require.NoError(t, err)
+}
+
+func TestFederation_RefreshRejectsStaticTrustDomain(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	const td = "static.example.org"
+	b, ctx := spiffeFederationBackend(t)
+	writeTrustDomain(t, b, ctx, map[string]any{"name": td, "bundle_pem": caPEM})
+
+	rr := refreshTrustDomain(t, b, ctx, td)
+	assert.Equal(t, http.StatusBadRequest, rr.StatusCode)
+	assert.Contains(t, rr.Err.Error(), "no bundle endpoint")
+}
+
+func TestValidateTrustDomainConfig(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	const td = "partner.example.org"
+
+	cases := []struct {
+		name    string
+		d       *SPIFFETrustDomain
+		wantErr string
+	}{
+		{"static ok", &SPIFFETrustDomain{Name: td, BundlePEM: caPEM}, ""},
+		{"static with endpoint field", &SPIFFETrustDomain{Name: td, BundlePEM: caPEM, BundleEndpointURL: "https://x"}, "require bundle_endpoint_profile"},
+		{"bad profile", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "ftp", BundleEndpointURL: "https://x"}, "invalid bundle_endpoint_profile"},
+		{"web missing url", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_web"}, "bundle_endpoint_url is required"},
+		{"web non-https", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_web", BundleEndpointURL: "http://x"}, "must be an https"},
+		{"web ok no bootstrap", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_web", BundleEndpointURL: "https://x"}, ""},
+		{"web with endpoint id", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_web", BundleEndpointURL: "https://x", EndpointSPIFFEID: "spiffe://" + td + "/s"}, "not valid for the https_web"},
+		{"spiffe missing id", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_spiffe", BundleEndpointURL: "https://x", BundlePEM: caPEM}, "valid endpoint_spiffe_id"},
+		{"spiffe missing bootstrap", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_spiffe", BundleEndpointURL: "https://x", EndpointSPIFFEID: "spiffe://" + td + "/s"}, "requires a bootstrap bundle"},
+		{"spiffe id wrong domain", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_spiffe", BundleEndpointURL: "https://x", EndpointSPIFFEID: "spiffe://other.org/s", BundlePEM: caPEM}, "must be in trust domain"},
+		{"spiffe ok", &SPIFFETrustDomain{Name: td, BundleEndpointProfile: "https_spiffe", BundleEndpointURL: "https://x", EndpointSPIFFEID: "spiffe://" + td + "/s", BundlePEM: caPEM}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTrustDomainConfig(tc.d)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## What

First of two SPIFFE-federation PRs: a trust domain can pull its bundle from a remote endpoint, with an on-demand refresh. No background loop yet.

## Changes

- `SPIFFETrustDomain` gains endpoint fields (`bundle_endpoint_url`/`profile`, `endpoint_spiffe_id`, `web_pki_ca_pem`) and fetched state (`sequence`, `last_refresh`, `last_error`); the fetched bundle flows into the existing `BundleJSON`, so verification is unchanged.
- `fetchFederatedBundle` wraps go-spiffe `federation.FetchBundle` for both profiles (https_web via `WithWebPKIRoots`, https_spiffe via `WithSPIFFEAuth` against the trust domain's current authorities); `refreshFederatedTrustDomain` applies it, de-duped by sequence, stale-tolerant (keeps last-good + records `last_error`), and rejects a bundle with no X.509 authorities.
- trust-domain write validates the profile's requirements; read surfaces the federation state; new `trust-domain/<name>/refresh` route fetches on demand.
- `buildBundleSet` skips a federated domain with no bundle yet (https_web before first fetch) so the rebuild tolerates it (fails closed at login).

## Tests

`httptest` TLS bundle endpoint for both profiles, wrong-endpoint-ID rejection, sequence de-dup, empty-bundle keeps-last-good, and the validation matrix.

## Notes

#5 of the SPIFFE stack, rebased onto current `main`.
