### PR TITLE
feat(cert): SPIFFE federation background refresh loop + lifecycle

### DIFF
--- a/auth/method/cert/README.md
+++ b/auth/method/cert/README.md
@@ -263,7 +263,47 @@ On each login Warden verifies, via the SPIFFE reference library, that the certif
 
 A certificate whose trust domain isn't configured — or differs from the role's — is rejected, even if some *other* configured bundle would have accepted it. That cross-trust-domain isolation is the property plain CA-pool matching can't provide. The transparent-auth flow behaves exactly as in x509 mode, and revocation is available too — but SVIDs are typically short-lived and carry no CRL/OCSP endpoints, so leave `revocation_mode` at `none` (a strict mode would reject an SVID that has no revocation URL).
 
-> **Chain note.** Only the leaf certificate is available on the forwarded-header path, so the registered bundle must contain the authority that directly signed the SVID (the usual SPIRE setup). **Federation note.** Bundles are configured statically or pushed by SPIRE; fetching them from SPIFFE federation endpoints with periodic refresh is not yet supported.
+> **Chain note.** Only the leaf certificate is available on the forwarded-header path, so the registered bundle must contain the authority that directly signed the SVID (the usual SPIRE setup).
+
+### Federation
+
+Instead of a static bundle, a trust domain can pull its bundle from a remote **bundle endpoint** and refresh it automatically — the SPIFFE Federation model. Setting `bundle_endpoint_profile` makes a trust domain federated:
+
+```bash
+# https_web — the endpoint's TLS cert is validated via Web PKI (system roots,
+# or web_pki_ca_pem for a private CA)
+warden write auth/spiffe/trust-domain/partner.acme.io \
+  bundle_endpoint_url="https://spire.acme.io/bundle" \
+  bundle_endpoint_profile="https_web"
+
+# https_spiffe — the endpoint is authenticated by its own SVID against a required
+# bootstrap bundle and an expected endpoint SPIFFE ID
+warden write auth/spiffe/trust-domain/partner.acme.io \
+  bundle_endpoint_url="https://spire.acme.io:8443" \
+  bundle_endpoint_profile="https_spiffe" \
+  endpoint_spiffe_id="spiffe://partner.acme.io/spire/server" \
+  bundle_pem=@bootstrap.pem
+```
+
+Fields:
+
+- `bundle_endpoint_url` — the `https://` bundle endpoint (required for a federated domain).
+- `bundle_endpoint_profile` — `https_web` or `https_spiffe`.
+- `endpoint_spiffe_id` — the SVID the endpoint presents; **required** for `https_spiffe`, rejected for `https_web`. Must be in the same trust domain.
+- `web_pki_ca_pem` — optional custom CA roots for an `https_web` endpoint's TLS cert (default: system roots).
+- For `https_spiffe` a **bootstrap bundle** (`bundle_pem` or `bundle_json`) is required — it authenticates the first fetch and is the initial set of authorities. An `https_web` domain needs no bootstrap, but has no authorities (and fails closed at login) until its first successful fetch.
+
+Refresh:
+
+- Warden refreshes each federated bundle on a background loop, honoring the bundle's `spiffe_refresh_hint` (clamped to a sane range) and de-duplicating by sequence number; a failed fetch keeps the last-good bundle and surfaces `last_error` on read. A fetched bundle with no X.509 authorities is rejected (last-good kept).
+- A config write doesn't fetch immediately; the loop primes a new federated domain on its next tick, or force a fetch now with `warden write auth/spiffe/trust-domain/<name>/refresh`.
+- `warden read auth/spiffe/trust-domain/<name>` shows the endpoint, profile, `sequence`, `last_refresh`, and `last_error`.
+
+> **HA note.** The refresh loop runs on the **active node only** (standbys forward auth requests). The fetched bundle is persisted, so on failover the new active node loads the last-good bundle and resumes refreshing.
+
+### One mount, many trust domains
+
+A single spiffe mount holds multiple trust domains — your own plus any federated peers. This is the federation-native shape, and it stays safe: a role binds exactly one `trust_domain`, an SVID validates only against its own domain's bundle, and adding a trust domain grants nothing until a role references it. Prefer **separate mounts** only for administrative isolation — distinct ACLs/audit, or different mount-level `token_ttl` / `revocation_mode` / `default_role`.
 
 ## How the Certificate Reaches Warden
 

--- a/auth/method/cert/backend.go
+++ b/auth/method/cert/backend.go
@@ -46,6 +46,14 @@ type certAuthBackend struct {
 	// SVIDs in spiffe mode. Guarded by spiffeMu, separate from configMu.
 	spiffeBundleSet *x509bundle.Set
 	spiffeMu        sync.RWMutex
+
+	// Spiffe Federation refresh loop (active-node only). fedCancel stops the goroutine;
+	// the fed*Interval fields override the defaults and exist for tests.
+	fedCancel         context.CancelFunc
+	fedMu             sync.Mutex
+	fedTickInterval   time.Duration
+	fedMinRefresh     time.Duration
+	fedDefaultRefresh time.Duration
 }
 
 // Auth mount modes. A mount operates in exactly one mode, fixed on its config.
@@ -84,6 +92,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathSPIFFETrustDomainRefresh(),
 		},
 	}
+
+	// Stop the federation refresh loop on unmount/seal (step-down is covered by
+	// the active context passed to Initialize).
+	b.Backend.Clean = func(context.Context) { b.stopFederationRefresh() }
 
 	if err := b.Backend.Setup(ctx, conf); err != nil {
 		return nil, err
@@ -228,6 +240,9 @@ func (b *certAuthBackend) Initialize(ctx context.Context) error {
 		if err := b.rebuildBundleSet(ctx); err != nil {
 			return fmt.Errorf("failed to load SPIFFE trust bundles: %w", err)
 		}
+		// Initialize runs only on the active node; ctx is the active context, so
+		// the refresh loop stops on step-down. It no-ops with no federated domains.
+		b.startFederationRefresh(ctx)
 	}
 	return nil
 }

--- a/auth/method/cert/spiffe.go
+++ b/auth/method/cert/spiffe.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
@@ -14,6 +15,16 @@ import (
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 
 	"github.com/stephnangue/warden/auth/helper"
+	lgr "github.com/stephnangue/warden/logger"
+)
+
+// Federation refresh-loop tunables. The per-backend fields (fedTickInterval,
+// fedMinRefresh, fedDefaultRefresh) override these and exist for tests.
+const (
+	federationTickInterval   = time.Minute     // how often the loop wakes to check due domains
+	federationMinRefresh     = time.Minute     // floor for a domain's refresh interval
+	federationMaxRefresh     = 24 * time.Hour  // cap for a domain's refresh interval
+	federationDefaultRefresh = 5 * time.Minute // used when a bundle carries no refresh hint
 )
 
 // SPIFFE bundle-endpoint profiles (empty = static, non-federated trust domain).
@@ -274,4 +285,118 @@ func (b *certAuthBackend) refreshFederatedTrustDomain(ctx context.Context, d *SP
 		return false, err
 	}
 	return true, nil
+}
+
+func (b *certAuthBackend) fedTick() time.Duration {
+	if b.fedTickInterval > 0 {
+		return b.fedTickInterval
+	}
+	return federationTickInterval
+}
+
+func (b *certAuthBackend) fedMin() time.Duration {
+	if b.fedMinRefresh > 0 {
+		return b.fedMinRefresh
+	}
+	return federationMinRefresh
+}
+
+func (b *certAuthBackend) fedDefault() time.Duration {
+	if b.fedDefaultRefresh > 0 {
+		return b.fedDefaultRefresh
+	}
+	return federationDefaultRefresh
+}
+
+// refreshInterval returns how long to wait before re-fetching d, honoring the
+// bundle's spiffe_refresh_hint when present and clamping to a sane range.
+func (b *certAuthBackend) refreshInterval(d *SPIFFETrustDomain) time.Duration {
+	interval := b.fedDefault()
+	if d.BundleJSON != "" {
+		if td, err := spiffeid.TrustDomainFromString(d.Name); err == nil {
+			if bundle, err := spiffebundle.Parse(td, []byte(d.BundleJSON)); err == nil {
+				if hint, ok := bundle.RefreshHint(); ok && hint > 0 {
+					interval = hint
+				}
+			}
+		}
+	}
+	if min := b.fedMin(); interval < min {
+		interval = min
+	}
+	if interval > federationMaxRefresh {
+		interval = federationMaxRefresh
+	}
+	return interval
+}
+
+// startFederationRefresh launches (or restarts) the per-mount refresh goroutine.
+// It runs only on the active node (Initialize is active-node only) and stops when
+// ctx is cancelled (step-down) or stopFederationRefresh is called (unmount/seal).
+func (b *certAuthBackend) startFederationRefresh(ctx context.Context) {
+	b.fedMu.Lock()
+	defer b.fedMu.Unlock()
+	if b.fedCancel != nil {
+		b.fedCancel() // stop any prior loop (e.g. re-init on failover)
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	b.fedCancel = cancel
+	go b.federationRefreshLoop(loopCtx)
+}
+
+// stopFederationRefresh stops the refresh goroutine if running. Idempotent.
+func (b *certAuthBackend) stopFederationRefresh() {
+	b.fedMu.Lock()
+	defer b.fedMu.Unlock()
+	if b.fedCancel != nil {
+		b.fedCancel()
+		b.fedCancel = nil
+	}
+}
+
+func (b *certAuthBackend) federationRefreshLoop(ctx context.Context) {
+	timer := time.NewTimer(jitter(b.fedTick()))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			b.refreshDueTrustDomains(ctx)
+			timer.Reset(jitter(b.fedTick()))
+		}
+	}
+}
+
+// refreshDueTrustDomains refreshes every federated trust domain whose refresh
+// interval has elapsed. A never-fetched domain is always due, which primes it.
+func (b *certAuthBackend) refreshDueTrustDomains(ctx context.Context) {
+	entries, err := b.listTrustDomainEntries(ctx)
+	if err != nil {
+		b.logger.Warn("federation: failed to list trust domains", lgr.Err(err))
+		return
+	}
+	now := time.Now()
+	for _, d := range entries {
+		if ctx.Err() != nil { // stop promptly on step-down/unmount
+			return
+		}
+		if !d.IsFederated() {
+			continue
+		}
+		if d.LastRefreshUnix != 0 && now.Before(time.Unix(d.LastRefreshUnix, 0).Add(b.refreshInterval(d))) {
+			continue
+		}
+		if _, err := b.refreshFederatedTrustDomain(ctx, d); err != nil {
+			b.logger.Warn("federation: refresh failed", lgr.String("trust_domain", d.Name), lgr.Err(err))
+		}
+	}
+}
+
+// jitter adds up to ~5% positive jitter to spread refreshes across nodes/restarts.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	return d + time.Duration(rand.Int63n(int64(d)/20+1))
 }

--- a/auth/method/cert/spiffe_federation_loop_test.go
+++ b/auth/method/cert/spiffe_federation_loop_test.go
@@ -1,0 +1,119 @@
+package cert
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fedTestTD = "partner.example.org"
+
+// countingEndpoint serves body over TLS and counts the requests it receives.
+func countingEndpoint(t *testing.T, body []byte) (*httptest.Server, *int64) {
+	t.Helper()
+	var n int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&n, 1)
+		_, _ = w.Write(body)
+	}))
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv, &n
+}
+
+// fastLoopBackend returns a spiffe-mode backend with a federated https_web trust
+// domain pointing at a counting endpoint, and loop intervals shrunk so the loop
+// refreshes every tick (the bundle carries no sequence, so each fetch re-applies).
+func fastLoopBackend(t *testing.T) (*certAuthBackend, context.Context, *int64, *x509.Certificate) {
+	caCert, caKey, _ := testCA(t)
+	srv, fetches := countingEndpoint(t, marshalBundle(t, fedTestTD, []*x509.Certificate{caCert}, 0))
+
+	b, ctx := spiffeFederationBackend(t)
+	b.fedTickInterval = 5 * time.Millisecond
+	b.fedMinRefresh = time.Millisecond
+	b.fedDefaultRefresh = time.Millisecond
+	writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    fedTestTD,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_web",
+		"web_pki_ca_pem":          certPEM(srv.Certificate()),
+	})
+	svid := testSVID(t, caCert, caKey, "spiffe://"+fedTestTD+"/ns/x/sa/y")
+	return b, ctx, fetches, svid
+}
+
+func requireEventuallyVerifies(t *testing.T, b *certAuthBackend, svid *x509.Certificate) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, _, err := verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, fedTestTD), nil)
+		return err == nil
+	}, 2*time.Second, 5*time.Millisecond)
+}
+
+// assertStopped checks that refreshing has frozen: it counted at least once, and
+// after a stop no further fetches happen.
+func assertStopped(t *testing.T, fetches *int64) {
+	t.Helper()
+	time.Sleep(20 * time.Millisecond) // let any in-flight fetch finish
+	n := atomic.LoadInt64(fetches)
+	require.Greater(t, n, int64(0), "loop never refreshed")
+	time.Sleep(40 * time.Millisecond) // several tick intervals
+	assert.Equal(t, n, atomic.LoadInt64(fetches), "refresh loop kept running after stop")
+}
+
+// TestFederationRefreshDue covers the per-tick due logic without timing.
+func TestFederationRefreshDue(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+	srv, fetches := countingEndpoint(t, marshalBundle(t, fedTestTD, []*x509.Certificate{caCert}, 1))
+
+	b, ctx := spiffeFederationBackend(t)
+	writeTrustDomain(t, b, ctx, map[string]any{
+		"name":                    fedTestTD,
+		"bundle_endpoint_url":     srv.URL,
+		"bundle_endpoint_profile": "https_web",
+		"web_pki_ca_pem":          certPEM(srv.Certificate()),
+	})
+
+	// Never fetched -> due -> primes the verification set.
+	b.refreshDueTrustDomains(ctx)
+	require.Equal(t, int64(1), atomic.LoadInt64(fetches))
+	svid := testSVID(t, caCert, caKey, "spiffe://"+fedTestTD+"/ns/x/sa/y")
+	_, _, err := verifySPIFFE(b.snapshotBundleSet(), []*x509.Certificate{svid}, mustTD(t, fedTestTD), nil)
+	require.NoError(t, err)
+
+	// Just refreshed (default interval) -> not due -> no second fetch.
+	b.refreshDueTrustDomains(ctx)
+	assert.Equal(t, int64(1), atomic.LoadInt64(fetches))
+}
+
+func TestFederationLoop_StopFederationRefresh(t *testing.T) {
+	b, ctx, fetches, svid := fastLoopBackend(t)
+	b.startFederationRefresh(ctx)
+	requireEventuallyVerifies(t, b, svid)
+	b.stopFederationRefresh()
+	assertStopped(t, fetches)
+}
+
+func TestFederationLoop_StopsOnContextCancel(t *testing.T) {
+	b, ctx, fetches, svid := fastLoopBackend(t)
+	loopCtx, cancel := context.WithCancel(ctx)
+	b.startFederationRefresh(loopCtx) // simulates the active context
+	requireEventuallyVerifies(t, b, svid)
+	cancel() // simulates step-down
+	assertStopped(t, fetches)
+}
+
+func TestFederationLoop_CleanStops(t *testing.T) {
+	b, ctx, fetches, svid := fastLoopBackend(t)
+	b.startFederationRefresh(ctx)
+	requireEventuallyVerifies(t, b, svid)
+	b.Cleanup(context.Background()) // framework Cleanup -> Clean -> stopFederationRefresh
+	assertStopped(t, fetches)
+}


### PR DESCRIPTION
## What

Second (final) SPIFFE-federation PR: federated bundles refresh automatically.

## Changes

- `federationRefreshLoop`: one active-node goroutine per mount that, each tick, refreshes every federated trust domain whose interval has elapsed (honoring the bundle's `spiffe_refresh_hint`, clamped to `[1m, 24h]`, jittered); a never-fetched domain is always due, which primes it.
- lifecycle: started in `Initialize` (active-node only, with the active context) after the bundle set loads; stops on step-down (ctx cancel), on unmount/seal (framework `Clean` hook), and bails promptly mid-iteration on ctx cancel. On failover the new active reloads last-good from storage and resumes. No-ops when no domain is federated.
- HA: refresh is active-node only; standbys forward auth and serve the persisted last-good bundle after failover.
- README: Federation subsection (both profiles, bootstrap, refresh + manual refresh, HA note) and a one-mount-many-trust-domains topology note.

## Tests (under `-race`)

Due logic, refresh-on-tick, and all three stop paths (`stopFederationRefresh`, context cancel, `Cleanup`/`Clean`).

## Notes

#6 (final) of the SPIFFE stack. Completes federation — SPIFFE support now spans strict SVID validation, mount mode, enforcement, and federation.
