### PR TITLE
feat(spiffe): serve API-listener TLS from the SPIFFE Workload API (auto-rotating SVID)

### DIFF
--- a/auth/spiffe/spiffetest/spiffetest.go
+++ b/auth/spiffe/spiffetest/spiffetest.go
@@ -1,0 +1,136 @@
+// Package spiffetest provides importable helpers for building X.509 SPIFFE
+// SVIDs, CAs, and trust bundles in tests. The leaf certificates satisfy
+// go-spiffe's SVID rules (exactly one spiffe:// URI SAN, not a CA), so they can
+// be verified by x509svid.Verify and presented/served in real TLS handshakes.
+//
+// The helpers take a testing.TB so they fail the test on error; they are only
+// ever pulled in by _test.go files.
+package spiffetest
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+)
+
+func serial(tb testing.TB) *big.Int {
+	tb.Helper()
+	n, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		tb.Fatalf("spiffetest: serial: %v", err)
+	}
+	return n
+}
+
+// CA returns a self-signed CA certificate and its key, for signing SVIDs.
+func CA(tb testing.TB) (*x509.Certificate, *ecdsa.PrivateKey) {
+	tb.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		tb.Fatalf("spiffetest: generate CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial(tb),
+		Subject:               pkix.Name{CommonName: "spiffetest CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		tb.Fatalf("spiffetest: create CA cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		tb.Fatalf("spiffetest: parse CA cert: %v", err)
+	}
+	return cert, key
+}
+
+// LeafCert mints a leaf certificate carrying exactly one spiffe:// URI SAN,
+// IsCA=false, signed by ca/caKey. opts may mutate the template (e.g. to add a
+// second URI SAN or drop the URI for negative tests). spiffeID may be any URI;
+// it is not parsed as a SPIFFE ID here, so negative cases are possible.
+func LeafCert(tb testing.TB, ca *x509.Certificate, caKey *ecdsa.PrivateKey, spiffeID string, opts ...func(*x509.Certificate)) (*x509.Certificate, *ecdsa.PrivateKey) {
+	tb.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		tb.Fatalf("spiffetest: generate leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial(tb),
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	if spiffeID != "" {
+		u, err := url.Parse(spiffeID)
+		if err != nil {
+			tb.Fatalf("spiffetest: parse URI %q: %v", spiffeID, err)
+		}
+		tmpl.URIs = []*url.URL{u}
+	}
+	for _, opt := range opts {
+		opt(tmpl)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		tb.Fatalf("spiffetest: create leaf cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		tb.Fatalf("spiffetest: parse leaf cert: %v", err)
+	}
+	return cert, key
+}
+
+// SVID builds an *x509svid.SVID (leaf + key + parsed SPIFFE ID) signed by
+// ca/caKey. The SVID carries only the leaf in Certificates; verifiers should
+// trust ca (use Bundle / CertPool). spiffeID must be a valid SPIFFE ID.
+func SVID(tb testing.TB, ca *x509.Certificate, caKey *ecdsa.PrivateKey, spiffeID string, opts ...func(*x509.Certificate)) *x509svid.SVID {
+	tb.Helper()
+	leaf, key := LeafCert(tb, ca, caKey, spiffeID, opts...)
+	id, err := spiffeid.FromString(spiffeID)
+	if err != nil {
+		tb.Fatalf("spiffetest: invalid SPIFFE ID %q: %v", spiffeID, err)
+	}
+	return &x509svid.SVID{
+		ID:           id,
+		Certificates: []*x509.Certificate{leaf},
+		PrivateKey:   crypto.Signer(key),
+	}
+}
+
+// Bundle builds an x509bundle for trust domain td trusting the given
+// authorities (typically a CA cert).
+func Bundle(tb testing.TB, td string, authorities ...*x509.Certificate) *x509bundle.Bundle {
+	tb.Helper()
+	domain, err := spiffeid.TrustDomainFromString(td)
+	if err != nil {
+		tb.Fatalf("spiffetest: invalid trust domain %q: %v", td, err)
+	}
+	return x509bundle.FromX509Authorities(domain, authorities)
+}
+
+// CertPool returns a cert pool trusting the given certs (e.g. for tls RootCAs).
+func CertPool(certs ...*x509.Certificate) *x509.CertPool {
+	pool := x509.NewCertPool()
+	for _, c := range certs {
+		pool.AddCert(c)
+	}
+	return pool
+}

--- a/cmd/server/dev.go
+++ b/cmd/server/dev.go
@@ -49,8 +49,9 @@ func devModeInit(c *core.Core, customRootToken string) (*core.InitResult, error)
 
 // printDevBanner prints the dev mode startup banner with unseal keys and root token.
 // If devTLSCertDir is non-empty, it also prints the paths to the auto-generated
-// TLS certificate and key, along with usage instructions.
-func printDevBanner(w io.Writer, result *core.InitResult, devTLSCertDir string) {
+// TLS certificate and key, along with usage instructions. If devTLSSpiffe is set,
+// it notes that the listener serves a SPIFFE SVID from the Workload API instead.
+func printDevBanner(w io.Writer, result *core.InitResult, devTLSCertDir string, devTLSSpiffe bool) {
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "==> Warden server started in dev mode! <==\n")
 	fmt.Fprintf(w, "\n")
@@ -77,6 +78,14 @@ func printDevBanner(w io.Writer, result *core.InitResult, devTLSCertDir string) 
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "  $ export WARDEN_CACERT=%s/cert.pem\n", devTLSCertDir)
 		fmt.Fprintf(w, "  $ export WARDEN_ADDR=https://127.0.0.1:8400\n")
+		fmt.Fprintf(w, "\n")
+	}
+
+	if devTLSSpiffe {
+		fmt.Fprintf(w, "Dev TLS Source: SPIFFE Workload API (auto-rotating SVID, no key on disk)\n")
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "The server presents a SPIFFE SVID; clients must be SPIFFE-aware\n")
+		fmt.Fprintf(w, "(trust the SPIRE bundle and skip hostname verification).\n")
 		fmt.Fprintf(w, "\n")
 	}
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -698,17 +698,14 @@ func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, 
 			typeLabel := lnConfig.Type
 			if lnConfig.TLSSPIFFE {
 				// SPIFFE serving identity: source the cert from the Workload API
-				// and optionally capture (not verify) the client cert.
+				// and request (capture, but never verify) the client cert so the
+				// SPIFFE/cert auth method can authenticate the peer.
 				src := spiffeSources[lnConfig.TLSSPIFFESocket]
 				if src == nil {
 					return nil, fmt.Errorf("internal error: missing SPIFFE source for listener %s", lnConfig.Address)
 				}
-				apiCfg.TLSConfig = spiffetls.BuildServerTLSConfig(src, lnConfig.TLSSPIFFERequestClientCert)
-				if lnConfig.TLSSPIFFERequestClientCert {
-					typeLabel = lnConfig.Type + " (spiffe +client-cert)"
-				} else {
-					typeLabel = lnConfig.Type + " (spiffe)"
-				}
+				apiCfg.TLSConfig = spiffetls.BuildServerTLSConfig(src, true)
+				typeLabel = lnConfig.Type + " (spiffe)"
 			} else {
 				apiCfg.TLSCertFile = lnConfig.TLSCertFile
 				apiCfg.TLSKeyFile = lnConfig.TLSKeyFile

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/listener/api"
 	clusterlistener "github.com/stephnangue/warden/listener/cluster"
+	"github.com/stephnangue/warden/listener/spiffetls"
 	log "github.com/stephnangue/warden/logger"
 	wardenlogical "github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/physical"
@@ -112,6 +113,8 @@ var (
 	flagDevTLSKeyFile           string
 	flagDevTLSCACertFile        string
 	flagDevTLSRequireClientCert bool
+	flagDevTLSSpiffe            bool
+	flagDevTLSSpiffeSocket      string
 
 	ServerCmd = &cobra.Command{
 		Use:   "server",
@@ -229,6 +232,8 @@ func init() {
 	ServerCmd.Flags().StringVar(&flagDevTLSKeyFile, "dev-tls-key-file", "", "Path to TLS private key file for dev mode")
 	ServerCmd.Flags().StringVar(&flagDevTLSCACertFile, "dev-tls-ca-cert-file", "", "Path to CA certificate for client verification in dev mode")
 	ServerCmd.Flags().BoolVar(&flagDevTLSRequireClientCert, "dev-tls-require-client-cert", false, "Require client certificates when CA cert is configured in dev mode")
+	ServerCmd.Flags().BoolVar(&flagDevTLSSpiffe, "dev-tls-spiffe", false, "Serve dev-mode TLS using a SPIFFE Workload API X509-SVID (server-auth, auto-rotating)")
+	ServerCmd.Flags().StringVar(&flagDevTLSSpiffeSocket, "dev-tls-spiffe-socket", "", "Workload API socket for -dev-tls-spiffe (default: SPIFFE_ENDPOINT_SOCKET env var)")
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -268,6 +273,14 @@ func run(cmd *cobra.Command, args []string) error {
 	if flagDevTLSRequireClientCert && flagDevTLSCACertFile == "" {
 		return fmt.Errorf("-dev-tls-require-client-cert requires -dev-tls-ca-cert-file")
 	}
+
+	// SPIFFE dev TLS: a socket implies the flag; both require -dev and are
+	// mutually exclusive with the file-based dev-TLS flags.
+	resolvedSpiffe, err := resolveDevSpiffeTLS(flagDev, flagDevTLSSpiffe, flagDevTLSSpiffeSocket, flagDevTLS, flagDevTLSCertFile, flagDevTLSKeyFile, flagDevTLSCACertFile)
+	if err != nil {
+		return err
+	}
+	flagDevTLSSpiffe = resolvedSpiffe
 
 	// Load configuration: dev mode builds defaults, otherwise requires config file or dir
 	var conf *config.Config
@@ -318,6 +331,14 @@ func run(cmd *cobra.Command, args []string) error {
 			requireClientCert := flagDevTLSRequireClientCert
 			conf.Listeners[0].TLSRequireClientCert = &requireClientCert
 		}
+	}
+
+	// Configure SPIFFE serving TLS for dev mode (server-auth). The Workload API
+	// must be reachable; source construction below fails closed if it is not.
+	if flagDevTLSSpiffe {
+		conf.Listeners[0].TLSDisable = false
+		conf.Listeners[0].TLSSPIFFE = true
+		conf.Listeners[0].TLSSPIFFESocket = flagDevTLSSpiffeSocket
 	}
 
 	// construct the logger with gate closed during initialization
@@ -447,8 +468,18 @@ func run(cmd *cobra.Command, args []string) error {
 		ForwardingTimeout:    newCore.ClusterConfig().ForwardingTimeout,
 	})
 
+	// Build SPIFFE serving sources for any listener that requests one. Sources
+	// are process-scoped (alive regardless of seal state, since the API listener
+	// serves the unseal endpoint) and shared across listeners that use the same
+	// Workload API socket. Fails closed if a configured socket is unreachable.
+	spiffeSources, closeSpiffeSources, err := buildSpiffeSources(cmd.Context(), conf)
+	if err != nil {
+		return err
+	}
+	defer closeSpiffeSources()
+
 	// init the listeners
-	lns, err := initListeners(httpHandler, newCore, conf, logger, &infoKeys, &info)
+	lns, err := initListeners(httpHandler, newCore, conf, logger, &infoKeys, &info, spiffeSources)
 	if err != nil {
 		// Error already logged in initListeners
 		return err
@@ -526,7 +557,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Print dev mode banner before opening the log gate
 	if flagDev && devInitResult != nil {
-		printDevBanner(cmd.OutOrStdout(), devInitResult, devTLSCertDir)
+		printDevBanner(cmd.OutOrStdout(), devInitResult, devTLSCertDir, flagDevTLSSpiffe)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "\n==> Warden server started! Log data will stream in below:\n")
@@ -651,30 +682,48 @@ func buildStorage(config *config.Config, logger *log.GatedLogger) (phy.Backend, 
 	return storage, nil
 }
 
-func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, logger *log.GatedLogger, infoKeys *[]string, info *map[string]string) ([]listener.Listener, error) {
+func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, logger *log.GatedLogger, infoKeys *[]string, info *map[string]string, spiffeSources map[string]*spiffetls.Source) ([]listener.Listener, error) {
 	lns := make([]listener.Listener, 0, len(conf.Listeners)+1)
 
 	for _, lnConfig := range conf.Listeners {
 		switch lnConfig.Type {
 		case listenerTypeTCP, listenerTypeUnix:
-			// construct api listener using shared HTTP handler
-			ln, err := api.NewApiListener(api.ApiListenerConfig{
-				Logger:               logger.WithSystem(subsystemListener),
-				Address:              lnConfig.Address,
-				TLSCertFile:          lnConfig.TLSCertFile,
-				TLSKeyFile:           lnConfig.TLSKeyFile,
-				TLSClientCAFile:      lnConfig.TLSClientCAFile,
-				TLSDisable:           lnConfig.TLSDisable,
-				TLSRequireClientCert: lnConfig.TLSRequireClientCert,
-				TrustedProxies:       lnConfig.TrustedProxies,
-			}, httpHandler)
+			apiCfg := api.ApiListenerConfig{
+				Logger:         logger.WithSystem(subsystemListener),
+				Address:        lnConfig.Address,
+				TLSDisable:     lnConfig.TLSDisable,
+				TrustedProxies: lnConfig.TrustedProxies,
+			}
+
+			typeLabel := lnConfig.Type
+			if lnConfig.TLSSPIFFE {
+				// SPIFFE serving identity: source the cert from the Workload API
+				// and optionally capture (not verify) the client cert.
+				src := spiffeSources[lnConfig.TLSSPIFFESocket]
+				if src == nil {
+					return nil, fmt.Errorf("internal error: missing SPIFFE source for listener %s", lnConfig.Address)
+				}
+				apiCfg.TLSConfig = spiffetls.BuildServerTLSConfig(src, lnConfig.TLSSPIFFERequestClientCert)
+				if lnConfig.TLSSPIFFERequestClientCert {
+					typeLabel = lnConfig.Type + " (spiffe +client-cert)"
+				} else {
+					typeLabel = lnConfig.Type + " (spiffe)"
+				}
+			} else {
+				apiCfg.TLSCertFile = lnConfig.TLSCertFile
+				apiCfg.TLSKeyFile = lnConfig.TLSKeyFile
+				apiCfg.TLSClientCAFile = lnConfig.TLSClientCAFile
+				apiCfg.TLSRequireClientCert = lnConfig.TLSRequireClientCert
+			}
+
+			ln, err := api.NewApiListener(apiCfg, httpHandler)
 			if err != nil {
 				return nil, fmt.Errorf("error initializing listener of type %s: %s", lnConfig.Type, err)
 			}
 			lns = append(lns, ln)
 
 			infoKey := fmt.Sprintf("listener %d", len(lns))
-			(*info)[infoKey] = fmt.Sprintf("%s (addr: %q)", lnConfig.Type, lnConfig.Address)
+			(*info)[infoKey] = fmt.Sprintf("%s (addr: %q)", typeLabel, lnConfig.Address)
 			*infoKeys = append(*infoKeys, infoKey)
 		default:
 			return nil, fmt.Errorf("unknown listener type: %s", lnConfig.Type)
@@ -711,6 +760,69 @@ func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, 
 	}
 
 	return lns, nil
+}
+
+// resolveDevSpiffeTLS validates the -dev-tls-spiffe flag combination and returns
+// whether SPIFFE serving is enabled for dev mode. Supplying a socket implies the
+// flag; either requires -dev and is mutually exclusive with the file-based
+// dev-TLS flags.
+func resolveDevSpiffeTLS(dev, spiffe bool, spiffeSocket string, devTLS bool, certFile, keyFile, caFile string) (bool, error) {
+	if spiffeSocket != "" {
+		spiffe = true
+	}
+	if !spiffe {
+		return false, nil
+	}
+	if !dev {
+		return false, fmt.Errorf("-dev-tls-spiffe can only be used with -dev")
+	}
+	if devTLS || certFile != "" || keyFile != "" || caFile != "" {
+		return false, fmt.Errorf("-dev-tls-spiffe is mutually exclusive with -dev-tls and the -dev-tls-cert-file/-key-file/-ca-cert-file flags")
+	}
+	return true, nil
+}
+
+// buildSpiffeSources constructs one SPIFFE Workload API source per distinct
+// socket used by a tls_spiffe listener, sharing a source across listeners on the
+// same socket. When several listeners share a socket, the largest configured
+// startup timeout wins. It returns the sources keyed by socket and a close func
+// that tears them all down; on any error it closes whatever was built and
+// returns the error (fail closed). The returned map is nil-safe to index.
+func buildSpiffeSources(ctx context.Context, conf *config.Config) (map[string]*spiffetls.Source, func(), error) {
+	sources := make(map[string]*spiffetls.Source)
+	closeAll := func() {
+		for _, s := range sources {
+			_ = s.Close()
+		}
+	}
+
+	// Resolve the (max) startup timeout per distinct socket.
+	timeouts := make(map[string]time.Duration)
+	for _, ln := range conf.Listeners {
+		if !ln.TLSSPIFFE {
+			continue
+		}
+		d := spiffetls.DefaultStartupTimeout
+		if ln.TLSSPIFFEStartupTimeout != "" {
+			// Already validated to parse as a positive duration in config.
+			if parsed, err := time.ParseDuration(ln.TLSSPIFFEStartupTimeout); err == nil && parsed > 0 {
+				d = parsed
+			}
+		}
+		if cur, ok := timeouts[ln.TLSSPIFFESocket]; !ok || d > cur {
+			timeouts[ln.TLSSPIFFESocket] = d
+		}
+	}
+
+	for socket, timeout := range timeouts {
+		src, err := spiffetls.NewSource(ctx, socket, timeout)
+		if err != nil {
+			closeAll()
+			return nil, nil, fmt.Errorf("error initializing SPIFFE serving identity: %w", err)
+		}
+		sources[socket] = src
+	}
+	return sources, closeAll, nil
 }
 
 // parseListenAddress extracts the host:port from a URL string.

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/config"
+)
+
+func TestResolveDevSpiffeTLS(t *testing.T) {
+	tests := []struct {
+		name        string
+		dev         bool
+		spiffe      bool
+		socket      string
+		devTLS      bool
+		certFile    string
+		keyFile     string
+		caFile      string
+		wantEnabled bool
+		wantErr     string
+	}{
+		{name: "not requested", dev: true},
+		{name: "flag with -dev — enabled", dev: true, spiffe: true, wantEnabled: true},
+		{name: "socket implies flag", dev: true, socket: "unix:///run/spire/agent.sock", wantEnabled: true},
+		{name: "flag without -dev — error", spiffe: true, wantErr: "can only be used with -dev"},
+		{name: "socket without -dev — error", socket: "unix:///x.sock", wantErr: "can only be used with -dev"},
+		{name: "spiffe + dev-tls — error", dev: true, spiffe: true, devTLS: true, wantErr: "mutually exclusive"},
+		{name: "spiffe + cert file — error", dev: true, spiffe: true, certFile: "/c.pem", wantErr: "mutually exclusive"},
+		{name: "spiffe + ca file — error", dev: true, spiffe: true, caFile: "/ca.pem", wantErr: "mutually exclusive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveDevSpiffeTLS(tt.dev, tt.spiffe, tt.socket, tt.devTLS, tt.certFile, tt.keyFile, tt.caFile)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.False(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnabled, got)
+		})
+	}
+}
+
+func TestBuildSpiffeSources_NoSpiffeListeners(t *testing.T) {
+	conf := &config.Config{
+		Listeners: []config.ListenerBlock{
+			{Type: "tcp", Address: ":8400", TLSDisable: true},
+			{Type: "tcp", Address: ":8410", TLSCertFile: "/c.pem", TLSKeyFile: "/k.pem"},
+		},
+	}
+	sources, closeFn, err := buildSpiffeSources(context.Background(), conf)
+	require.NoError(t, err)
+	assert.Empty(t, sources)
+	require.NotNil(t, closeFn)
+	closeFn() // must be safe on an empty set
+}
+
+func TestBuildSpiffeSources_FailClosed(t *testing.T) {
+	// A tls_spiffe listener pointing at an unreachable socket must fail closed
+	// (rather than start without an identity), within the short startup budget.
+	conf := &config.Config{
+		Listeners: []config.ListenerBlock{
+			{
+				Type:                    "tcp",
+				Address:                 ":8400",
+				TLSSPIFFE:               true,
+				TLSSPIFFESocket:         "unix:///nonexistent/warden-cmdtest.sock",
+				TLSSPIFFEStartupTimeout: "300ms",
+			},
+		},
+	}
+	sources, closeFn, err := buildSpiffeSources(context.Background(), conf)
+	require.Error(t, err)
+	assert.Nil(t, sources)
+	assert.Nil(t, closeFn)
+	assert.Contains(t, err.Error(), "SPIFFE serving identity")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -443,10 +443,11 @@ type ListenerBlock struct {
 	// SPIFFE serving identity. When TLSSPIFFE is set, the listener sources its
 	// serving cert from the SPIFFE Workload API (auto-rotating, never on disk)
 	// instead of tls_cert_file/tls_key_file (which are mutually exclusive with it).
-	TLSSPIFFE                  bool   `hcl:"tls_spiffe,optional"`
-	TLSSPIFFESocket            string `hcl:"tls_spiffe_socket,optional"`             // Workload API endpoint; empty => SPIFFE_ENDPOINT_SOCKET
-	TLSSPIFFERequestClientCert bool   `hcl:"tls_spiffe_request_client_cert,optional"` // request+capture (not verify) the peer cert for the auth method
-	TLSSPIFFEStartupTimeout    string `hcl:"tls_spiffe_startup_timeout,optional"`     // max wait/retry for the first SVID at boot (duration; default 10s)
+	// The listener always requests (and captures, but never verifies) the client
+	// cert so the SPIFFE/cert auth method can authenticate the peer.
+	TLSSPIFFE               bool   `hcl:"tls_spiffe,optional"`
+	TLSSPIFFESocket         string `hcl:"tls_spiffe_socket,optional"`          // Workload API endpoint; empty => SPIFFE_ENDPOINT_SOCKET
+	TLSSPIFFEStartupTimeout string `hcl:"tls_spiffe_startup_timeout,optional"` // max wait/retry for the first SVID at boot (duration; default 10s)
 }
 
 // LoadConfig reads a single HCL config file and returns a validated *Config.
@@ -631,7 +632,7 @@ func validateConfig(config *Config) error {
 	// SPIFFE serving is an alternative TLS mode, mutually exclusive with the
 	// file-based cert/key fields.
 	for i, ln := range config.Listeners {
-		spiffeSubKeySet := ln.TLSSPIFFESocket != "" || ln.TLSSPIFFERequestClientCert || ln.TLSSPIFFEStartupTimeout != ""
+		spiffeSubKeySet := ln.TLSSPIFFESocket != "" || ln.TLSSPIFFEStartupTimeout != ""
 		switch {
 		case ln.TLSDisable:
 			if ln.TLSSPIFFE || spiffeSubKeySet {
@@ -642,7 +643,7 @@ func validateConfig(config *Config) error {
 				return fmt.Errorf("listener[%d]: tls_spiffe is mutually exclusive with tls_cert_file/tls_key_file/tls_client_ca_file", i)
 			}
 			if ln.TLSRequireClientCert != nil {
-				return fmt.Errorf("listener[%d]: tls_require_client_cert is not used with tls_spiffe; use tls_spiffe_request_client_cert instead", i)
+				return fmt.Errorf("listener[%d]: tls_require_client_cert is not used with tls_spiffe; the peer cert is always captured (never verified) and the auth method authenticates it", i)
 			}
 			if ln.TLSSPIFFEStartupTimeout != "" {
 				d, err := time.ParseDuration(ln.TLSSPIFFEStartupTimeout)
@@ -656,7 +657,7 @@ func validateConfig(config *Config) error {
 		default:
 			// File-based TLS. Reject orphan SPIFFE sub-keys set without tls_spiffe.
 			if spiffeSubKeySet {
-				return fmt.Errorf("listener[%d]: tls_spiffe_socket/tls_spiffe_request_client_cert/tls_spiffe_startup_timeout require tls_spiffe = true", i)
+				return fmt.Errorf("listener[%d]: tls_spiffe_socket/tls_spiffe_startup_timeout require tls_spiffe = true", i)
 			}
 			if ln.TLSCertFile == "" || ln.TLSKeyFile == "" {
 				return fmt.Errorf("listener[%d]: TLS is on by default; set tls_disable = true or provide both tls_cert_file and tls_key_file", i)

--- a/config/config.go
+++ b/config/config.go
@@ -641,6 +641,9 @@ func validateConfig(config *Config) error {
 			if ln.TLSCertFile != "" || ln.TLSKeyFile != "" || ln.TLSClientCAFile != "" {
 				return fmt.Errorf("listener[%d]: tls_spiffe is mutually exclusive with tls_cert_file/tls_key_file/tls_client_ca_file", i)
 			}
+			if ln.TLSRequireClientCert != nil {
+				return fmt.Errorf("listener[%d]: tls_require_client_cert is not used with tls_spiffe; use tls_spiffe_request_client_cert instead", i)
+			}
 			if ln.TLSSPIFFEStartupTimeout != "" {
 				d, err := time.ParseDuration(ln.TLSSPIFFEStartupTimeout)
 				if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -439,6 +439,14 @@ type ListenerBlock struct {
 	TLSDisable           bool     `hcl:"tls_disable,optional"`             // default false => TLS on; requires tls_cert_file + tls_key_file
 	TLSRequireClientCert *bool    `hcl:"tls_require_client_cert,optional"` // nil = default (true when tls_client_ca_file set)
 	TrustedProxies       []string `hcl:"trusted_proxies,optional"`         // CIDR ranges for LB cert forwarding
+
+	// SPIFFE serving identity. When TLSSPIFFE is set, the listener sources its
+	// serving cert from the SPIFFE Workload API (auto-rotating, never on disk)
+	// instead of tls_cert_file/tls_key_file (which are mutually exclusive with it).
+	TLSSPIFFE                  bool   `hcl:"tls_spiffe,optional"`
+	TLSSPIFFESocket            string `hcl:"tls_spiffe_socket,optional"`             // Workload API endpoint; empty => SPIFFE_ENDPOINT_SOCKET
+	TLSSPIFFERequestClientCert bool   `hcl:"tls_spiffe_request_client_cert,optional"` // request+capture (not verify) the peer cert for the auth method
+	TLSSPIFFEStartupTimeout    string `hcl:"tls_spiffe_startup_timeout,optional"`     // max wait/retry for the first SVID at boot (duration; default 10s)
 }
 
 // LoadConfig reads a single HCL config file and returns a validated *Config.
@@ -620,9 +628,36 @@ func validateConfig(config *Config) error {
 	}
 
 	// Validate listener TLS config. TLS is on by default; opt out with tls_disable.
+	// SPIFFE serving is an alternative TLS mode, mutually exclusive with the
+	// file-based cert/key fields.
 	for i, ln := range config.Listeners {
-		if !ln.TLSDisable && (ln.TLSCertFile == "" || ln.TLSKeyFile == "") {
-			return fmt.Errorf("listener[%d]: TLS is on by default; set tls_disable = true or provide both tls_cert_file and tls_key_file", i)
+		spiffeSubKeySet := ln.TLSSPIFFESocket != "" || ln.TLSSPIFFERequestClientCert || ln.TLSSPIFFEStartupTimeout != ""
+		switch {
+		case ln.TLSDisable:
+			if ln.TLSSPIFFE || spiffeSubKeySet {
+				return fmt.Errorf("listener[%d]: tls_spiffe* cannot be set when tls_disable = true", i)
+			}
+		case ln.TLSSPIFFE:
+			if ln.TLSCertFile != "" || ln.TLSKeyFile != "" || ln.TLSClientCAFile != "" {
+				return fmt.Errorf("listener[%d]: tls_spiffe is mutually exclusive with tls_cert_file/tls_key_file/tls_client_ca_file", i)
+			}
+			if ln.TLSSPIFFEStartupTimeout != "" {
+				d, err := time.ParseDuration(ln.TLSSPIFFEStartupTimeout)
+				if err != nil {
+					return fmt.Errorf("listener[%d]: invalid tls_spiffe_startup_timeout %q: %w", i, ln.TLSSPIFFEStartupTimeout, err)
+				}
+				if d <= 0 {
+					return fmt.Errorf("listener[%d]: tls_spiffe_startup_timeout must be positive, got %s", i, d)
+				}
+			}
+		default:
+			// File-based TLS. Reject orphan SPIFFE sub-keys set without tls_spiffe.
+			if spiffeSubKeySet {
+				return fmt.Errorf("listener[%d]: tls_spiffe_socket/tls_spiffe_request_client_cert/tls_spiffe_startup_timeout require tls_spiffe = true", i)
+			}
+			if ln.TLSCertFile == "" || ln.TLSKeyFile == "" {
+				return fmt.Errorf("listener[%d]: TLS is on by default; set tls_disable = true or provide both tls_cert_file and tls_key_file", i)
+			}
 		}
 	}
 

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -191,6 +191,141 @@ listener "tcp" {
 	}
 }
 
+func TestLoadConfig_ListenerSPIFFE(t *testing.T) {
+	tests := []struct {
+		name    string
+		extra   string
+		wantErr string // substring; "" means expect success
+	}{
+		{
+			name: "tls_spiffe alone — ok",
+			extra: `
+listener "tcp" {
+  address    = ":8500"
+  tls_spiffe = true
+}
+`,
+		},
+		{
+			name: "tls_spiffe with socket + request_client_cert + timeout — ok",
+			extra: `
+listener "tcp" {
+  address                        = ":8501"
+  tls_spiffe                     = true
+  tls_spiffe_socket              = "unix:///run/spire/agent.sock"
+  tls_spiffe_request_client_cert = true
+  tls_spiffe_startup_timeout     = "15s"
+}
+`,
+		},
+		{
+			name: "tls_spiffe + tls_cert_file — mutually exclusive",
+			extra: `
+listener "tcp" {
+  address       = ":8502"
+  tls_spiffe    = true
+  tls_cert_file = "/c.pem"
+  tls_key_file  = "/k.pem"
+}
+`,
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "tls_spiffe + tls_client_ca_file — mutually exclusive",
+			extra: `
+listener "tcp" {
+  address             = ":8503"
+  tls_spiffe          = true
+  tls_client_ca_file  = "/ca.pem"
+}
+`,
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "tls_spiffe + tls_disable — error",
+			extra: `
+listener "tcp" {
+  address     = ":8504"
+  tls_spiffe  = true
+  tls_disable = true
+}
+`,
+			wantErr: "tls_disable",
+		},
+		{
+			name: "invalid startup timeout — error",
+			extra: `
+listener "tcp" {
+  address                    = ":8505"
+  tls_spiffe                 = true
+  tls_spiffe_startup_timeout = "soon"
+}
+`,
+			wantErr: "tls_spiffe_startup_timeout",
+		},
+		{
+			name: "non-positive startup timeout — error",
+			extra: `
+listener "tcp" {
+  address                    = ":8506"
+  tls_spiffe                 = true
+  tls_spiffe_startup_timeout = "0s"
+}
+`,
+			wantErr: "must be positive",
+		},
+		{
+			name: "orphan SPIFFE sub-key without tls_spiffe — error",
+			extra: `
+listener "tcp" {
+  address                        = ":8507"
+  tls_cert_file                  = "/c.pem"
+  tls_key_file                   = "/k.pem"
+  tls_spiffe_request_client_cert = true
+}
+`,
+			wantErr: "require tls_spiffe = true",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadFromHCL(t, minimalConfigHCL+tt.extra)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestLoadConfig_ListenerSPIFFEDecode guards the HCL tag names: all four SPIFFE
+// keys must decode into the right ListenerBlock fields.
+func TestLoadConfig_ListenerSPIFFEDecode(t *testing.T) {
+	body := `
+storage "postgres" {
+  connection_url = "postgres://u:p@db:5432/warden"
+}
+
+listener "tcp" {
+  address                        = ":8510"
+  tls_spiffe                     = true
+  tls_spiffe_socket              = "unix:///run/spire/agent.sock"
+  tls_spiffe_request_client_cert = true
+  tls_spiffe_startup_timeout     = "20s"
+}
+`
+	cfg, err := loadFromHCL(t, body)
+	require.NoError(t, err)
+	require.Len(t, cfg.Listeners, 1)
+	ln := cfg.Listeners[0]
+	assert.True(t, ln.TLSSPIFFE)
+	assert.Equal(t, "unix:///run/spire/agent.sock", ln.TLSSPIFFESocket)
+	assert.True(t, ln.TLSSPIFFERequestClientCert)
+	assert.Equal(t, "20s", ln.TLSSPIFFEStartupTimeout)
+}
+
 func TestLoadConfig_ClusterAddrValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -242,6 +242,17 @@ listener "tcp" {
 			wantErr: "mutually exclusive",
 		},
 		{
+			name: "tls_spiffe + tls_require_client_cert — error",
+			extra: `
+listener "tcp" {
+  address                 = ":8508"
+  tls_spiffe              = true
+  tls_require_client_cert = true
+}
+`,
+			wantErr: "tls_require_client_cert is not used with tls_spiffe",
+		},
+		{
 			name: "tls_spiffe + tls_disable — error",
 			extra: `
 listener "tcp" {

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -207,14 +207,13 @@ listener "tcp" {
 `,
 		},
 		{
-			name: "tls_spiffe with socket + request_client_cert + timeout — ok",
+			name: "tls_spiffe with socket + timeout — ok",
 			extra: `
 listener "tcp" {
-  address                        = ":8501"
-  tls_spiffe                     = true
-  tls_spiffe_socket              = "unix:///run/spire/agent.sock"
-  tls_spiffe_request_client_cert = true
-  tls_spiffe_startup_timeout     = "15s"
+  address                    = ":8501"
+  tls_spiffe                 = true
+  tls_spiffe_socket          = "unix:///run/spire/agent.sock"
+  tls_spiffe_startup_timeout = "15s"
 }
 `,
 		},
@@ -289,10 +288,10 @@ listener "tcp" {
 			name: "orphan SPIFFE sub-key without tls_spiffe — error",
 			extra: `
 listener "tcp" {
-  address                        = ":8507"
-  tls_cert_file                  = "/c.pem"
-  tls_key_file                   = "/k.pem"
-  tls_spiffe_request_client_cert = true
+  address                    = ":8507"
+  tls_cert_file              = "/c.pem"
+  tls_key_file               = "/k.pem"
+  tls_spiffe_startup_timeout = "5s"
 }
 `,
 			wantErr: "require tls_spiffe = true",
@@ -311,7 +310,7 @@ listener "tcp" {
 	}
 }
 
-// TestLoadConfig_ListenerSPIFFEDecode guards the HCL tag names: all four SPIFFE
+// TestLoadConfig_ListenerSPIFFEDecode guards the HCL tag names: all three SPIFFE
 // keys must decode into the right ListenerBlock fields.
 func TestLoadConfig_ListenerSPIFFEDecode(t *testing.T) {
 	body := `
@@ -320,11 +319,10 @@ storage "postgres" {
 }
 
 listener "tcp" {
-  address                        = ":8510"
-  tls_spiffe                     = true
-  tls_spiffe_socket              = "unix:///run/spire/agent.sock"
-  tls_spiffe_request_client_cert = true
-  tls_spiffe_startup_timeout     = "20s"
+  address                    = ":8510"
+  tls_spiffe                 = true
+  tls_spiffe_socket          = "unix:///run/spire/agent.sock"
+  tls_spiffe_startup_timeout = "20s"
 }
 `
 	cfg, err := loadFromHCL(t, body)
@@ -333,7 +331,6 @@ listener "tcp" {
 	ln := cfg.Listeners[0]
 	assert.True(t, ln.TLSSPIFFE)
 	assert.Equal(t, "unix:///run/spire/agent.sock", ln.TLSSPIFFESocket)
-	assert.True(t, ln.TLSSPIFFERequestClientCert)
 	assert.Equal(t, "20s", ln.TLSSPIFFEStartupTimeout)
 }
 

--- a/deploy/config/warden.hcl
+++ b/deploy/config/warden.hcl
@@ -32,6 +32,37 @@ listener "tcp" {
     tls_require_client_cert = false
 }
 
+# --- SPIFFE serving identity (alternative to file-based TLS) -----------------
+#
+# Instead of tls_cert_file/tls_key_file, a listener can source its serving
+# certificate from the SPIFFE Workload API (a local SPIRE agent). The X509-SVID
+# is kept in memory and fetched fresh on every TLS handshake, so it rotates
+# transparently and no key or cert is ever written to disk.
+#
+# tls_spiffe is mutually exclusive with tls_cert_file / tls_key_file /
+# tls_client_ca_file / tls_require_client_cert. The listener always requests and
+# captures the client's certificate but never verifies it at the TLS layer —
+# the SPIFFE/cert auth method authenticates the peer SVID against its configured
+# trust domains. RequestClientCert only *requests* a cert, so clients that
+# authenticate by token (or present no cert) connect normally.
+#
+# Note: the server presents a SPIFFE SVID (a spiffe:// URI SAN, no DNS SAN), so
+# clients must be SPIFFE-aware (trust the SPIRE bundle and skip hostname
+# verification). Plain/browser clients cannot use a SPIFFE listener — run a
+# separate file-based listener on another port for those.
+#
+# listener "tcp" {
+#   address    = ":8400"
+#   tls_spiffe = true
+#
+#   # Workload API endpoint. Omit to use the SPIFFE_ENDPOINT_SOCKET env var.
+#   # tls_spiffe_socket = "unix:///run/spire/agent/sockets/agent.sock"
+#
+#   # Max time to wait (and retry) for the first SVID at startup before failing
+#   # closed. Tolerates a brief agent-not-ready window at boot. Default "10s".
+#   # tls_spiffe_startup_timeout = "10s"
+# }
+
 # Audit devices are declared with the two-label syntax:
 #   audit "TYPE" "NAME" { description = "..." options = { ... } }
 #

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect

--- a/listener/api/listener.go
+++ b/listener/api/listener.go
@@ -33,6 +33,15 @@ type ApiListenerConfig struct {
 	TLSDisable           bool     // default false => TLS on; requires TLSCertFile + TLSKeyFile
 	TLSRequireClientCert *bool    // nil = default (true when TLSClientCAFile set)
 	TrustedProxies       []string // CIDR ranges for LB cert forwarding
+
+	// TLSConfig, when non-nil, is used verbatim as the server's TLS config and
+	// supersedes the file-based TLS fields above (TLSCertFile/TLSKeyFile and the
+	// client-CA fields are ignored). It is used to inject a dynamically-sourced
+	// config — e.g. one whose GetCertificate callback resolves the serving cert
+	// at handshake time from an in-memory, auto-rotating source — so no cert or
+	// key is ever read from disk. When set, TLSDisable must be false. File-based
+	// listeners leave this nil.
+	TLSConfig *tls.Config
 }
 
 func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListener, error) {
@@ -55,7 +64,18 @@ func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListen
 		WriteTimeout: 10 * time.Second,
 	}
 
-	if !cfg.TLSDisable {
+	switch {
+	case cfg.TLSDisable:
+		// Plaintext HTTP; nothing to configure.
+
+	case cfg.TLSConfig != nil:
+		// Injected dynamic TLS config (e.g. a SPIFFE-sourced config whose
+		// GetCertificate resolves the serving cert at handshake time). Use it
+		// verbatim and skip the file-based cert/key requirement; Start() serves
+		// with empty cert/key paths, which is valid because GetCertificate is set.
+		server.TLSConfig = cfg.TLSConfig
+
+	default:
 		if cfg.TLSCertFile == "" || cfg.TLSKeyFile == "" {
 			return nil, fmt.Errorf("TLS is on by default; set tls_disable = true or provide both tls_cert_file and tls_key_file")
 		}

--- a/listener/api/listener_test.go
+++ b/listener/api/listener_test.go
@@ -405,6 +405,104 @@ func TestApiListener_PlainHTTP_Serves(t *testing.T) {
 }
 
 // =============================================================================
+// Injected TLSConfig Tests
+// =============================================================================
+
+// loadTestServerCert loads the self-signed test cert/key into a tls.Certificate
+// and returns it alongside a CA pool that trusts it.
+func loadTestServerCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	certFile, keyFile, _ := generateTestCertFiles(t)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+	caPEM, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+	return cert, pool
+}
+
+// TestNewApiListener_InjectedTLSConfig verifies that an injected tls.Config is
+// used verbatim and that no cert/key files are required when one is supplied.
+func TestNewApiListener_InjectedTLSConfig(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	cert, _ := loadTestServerCert(t)
+
+	injected := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &cert, nil
+		},
+	}
+
+	ln, err := NewApiListener(ApiListenerConfig{
+		Logger:    log,
+		Address:   "127.0.0.1:0",
+		TLSConfig: injected,
+		// no TLSCertFile/TLSKeyFile: an injected config does not require them
+	}, http.DefaultServeMux)
+
+	require.NoError(t, err)
+	require.NotNil(t, ln)
+	assert.False(t, ln.tlsDisable)
+	assert.Same(t, injected, ln.server.TLSConfig, "injected config must be used verbatim")
+	assert.Empty(t, ln.tlsCertFile)
+	assert.Empty(t, ln.tlsKeyFile)
+}
+
+// TestApiListener_InjectedTLSConfig_Serves drives a real handshake through an
+// injected GetCertificate-only config and confirms Start() serves over TLS with
+// empty cert/key paths (ListenAndServeTLS("","") path).
+func TestApiListener_InjectedTLSConfig_Serves(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	cert, caPool := loadTestServerCert(t)
+
+	var gotCertCalls int
+	injected := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			gotCertCalls++
+			return &cert, nil
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "spiffe-ok")
+	})
+
+	port := getFreePort(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ln, err := NewApiListener(ApiListenerConfig{
+		Logger:    log,
+		Address:   addr,
+		TLSConfig: injected,
+	}, handler)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go ln.Start(ctx)
+	time.Sleep(200 * time.Millisecond)
+	defer ln.Stop()
+
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caPool}},
+		Timeout:   5 * time.Second,
+	}
+	resp, err := client.Get(fmt.Sprintf("https://%s/test", addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "spiffe-ok", string(body))
+	assert.Positive(t, gotCertCalls, "GetCertificate should be consulted during the handshake")
+}
+
+// =============================================================================
 // Helpers
 // =============================================================================
 

--- a/listener/spiffetls/spiffetls.go
+++ b/listener/spiffetls/spiffetls.go
@@ -1,0 +1,101 @@
+// Package spiffetls builds an in-memory, auto-rotating TLS serving identity from
+// the SPIFFE Workload API (go-spiffe's workloadapi.X509Source), wired into a
+// tls.Config via the GetCertificate callback so the current X509-SVID is fetched
+// on every handshake and no key or cert is ever written to disk.
+//
+// The package deliberately does NO client-SVID validation: when client-cert
+// capture is enabled it requests (but does not verify or require) the peer cert,
+// leaving authentication and authorization to the auth method. It imports only
+// go-spiffe and crypto/tls — never any auth/* package.
+package spiffetls
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+// DefaultStartupTimeout bounds how long NewSource waits (and retries) for the
+// first SVID before failing closed.
+const DefaultStartupTimeout = 10 * time.Second
+
+// Source owns a workloadapi.X509Source and exposes it as an x509svid.Source.
+// One Source can back multiple listeners that share the same Workload API
+// socket. It must be Close()d to stop the background rotation stream.
+type Source struct {
+	x *workloadapi.X509Source
+}
+
+// NewSource dials the SPIFFE Workload API and returns a Source backed by an
+// auto-rotating X509Source. It blocks until the first SVID is received or
+// startupTimeout elapses; while the socket is unreachable the underlying client
+// retries with backoff, so startupTimeout doubles as the retry budget. A
+// persistent outage fails closed with a wrapped error (there is no disk-cert
+// fallback).
+//
+// socketAddr is the Workload API endpoint (e.g. "unix:///run/spire/agent.sock").
+// When empty, go-spiffe reads the SPIFFE_ENDPOINT_SOCKET environment variable.
+//
+// parentCtx governs only startup; the ongoing rotation watch runs on an internal
+// context and is stopped by Close(), so callers may pass a request-scoped or
+// process-scoped context without affecting rotation.
+func NewSource(parentCtx context.Context, socketAddr string, startupTimeout time.Duration) (*Source, error) {
+	if startupTimeout <= 0 {
+		startupTimeout = DefaultStartupTimeout
+	}
+
+	var opts []workloadapi.X509SourceOption
+	if socketAddr != "" {
+		opts = append(opts, workloadapi.WithClientOptions(workloadapi.WithAddr(socketAddr)))
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, startupTimeout)
+	defer cancel()
+
+	x, err := workloadapi.NewX509Source(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("spiffetls: workload API X509 source unavailable (socket %s): %w", displaySocket(socketAddr), err)
+	}
+	return &Source{x: x}, nil
+}
+
+// Close stops the rotation stream and releases the underlying connection.
+func (s *Source) Close() error {
+	return s.x.Close()
+}
+
+// GetX509SVID implements x509svid.Source by delegating to the workload source,
+// returning the current in-memory SVID.
+func (s *Source) GetX509SVID() (*x509svid.SVID, error) {
+	return s.x.GetX509SVID()
+}
+
+var _ x509svid.Source = (*Source)(nil)
+
+// BuildServerTLSConfig builds a server tls.Config whose GetCertificate callback
+// resolves the serving SVID from svid on every handshake (transparent rotation).
+//
+// When requestClientCert is true the config requests and captures the peer's
+// client cert (tls.RequestClientCert) WITHOUT verifying or requiring it: the cert
+// lands in ConnectionState.PeerCertificates for the auth method to validate, and
+// clients without a cert still connect. The TLS layer performs no peer
+// validation by design.
+func BuildServerTLSConfig(svid x509svid.Source, requestClientCert bool) *tls.Config {
+	cfg := tlsconfig.TLSServerConfig(svid)
+	if requestClientCert {
+		cfg.ClientAuth = tls.RequestClientCert
+	}
+	return cfg
+}
+
+func displaySocket(addr string) string {
+	if addr == "" {
+		return "$SPIFFE_ENDPOINT_SOCKET"
+	}
+	return addr
+}

--- a/listener/spiffetls/spiffetls_test.go
+++ b/listener/spiffetls/spiffetls_test.go
@@ -1,0 +1,216 @@
+package spiffetls
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/auth/spiffe/spiffetest"
+)
+
+// --- in-memory x509svid.Source fakes ---
+
+type staticSource struct{ svid *x509svid.SVID }
+
+func (s staticSource) GetX509SVID() (*x509svid.SVID, error) { return s.svid, nil }
+
+type funcSource func() (*x509svid.SVID, error)
+
+func (f funcSource) GetX509SVID() (*x509svid.SVID, error) { return f() }
+
+func tlsCertOf(svid *x509svid.SVID) tls.Certificate {
+	chain := make([][]byte, len(svid.Certificates))
+	for i, c := range svid.Certificates {
+		chain[i] = c.Raw
+	}
+	return tls.Certificate{Certificate: chain, PrivateKey: svid.PrivateKey}
+}
+
+// startTLSServer serves handler over TLS using cfg and returns the address and a
+// stop func. The raw TCP listener is wrapped with cfg so the SPIFFE GetCertificate
+// callback drives the handshake, mirroring the API listener.
+func startTLSServer(t *testing.T, cfg *tls.Config, handler http.Handler) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(tls.NewListener(ln, cfg))
+	t.Cleanup(func() { _ = srv.Close() })
+	return ln.Addr().String(), func() { _ = srv.Close() }
+}
+
+// --- builder shape ---
+
+func TestBuildServerTLSConfig_ServerAuth(t *testing.T) {
+	ca, caKey := spiffetest.CA(t)
+	svid := spiffetest.SVID(t, ca, caKey, "spiffe://example.org/warden")
+
+	cfg := BuildServerTLSConfig(staticSource{svid}, false)
+
+	require.NotNil(t, cfg.GetCertificate, "serving cert must come from GetCertificate")
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	assert.Equal(t, tls.NoClientCert, cfg.ClientAuth, "server-auth must not request a client cert")
+	assert.Nil(t, cfg.VerifyPeerCertificate, "listener must not verify peers")
+	assert.Nil(t, cfg.ClientCAs)
+}
+
+func TestBuildServerTLSConfig_RequestClientCert(t *testing.T) {
+	ca, caKey := spiffetest.CA(t)
+	svid := spiffetest.SVID(t, ca, caKey, "spiffe://example.org/warden")
+
+	cfg := BuildServerTLSConfig(staticSource{svid}, true)
+
+	require.NotNil(t, cfg.GetCertificate)
+	assert.Equal(t, tls.RequestClientCert, cfg.ClientAuth, "must request but not require/verify the peer cert")
+	assert.Nil(t, cfg.VerifyPeerCertificate, "no TLS-layer peer validation")
+	assert.Nil(t, cfg.ClientCAs, "no peer CA; the auth method validates the SVID")
+}
+
+// --- real handshakes ---
+
+func TestServerAuth_Serves(t *testing.T) {
+	ca, caKey := spiffetest.CA(t)
+	svid := spiffetest.SVID(t, ca, caKey, "spiffe://example.org/warden")
+	bundle := spiffetest.Bundle(t, "example.org", ca)
+
+	addr, _ := startTLSServer(t, BuildServerTLSConfig(staticSource{svid}, false),
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "ok") }))
+
+	// A SPIFFE-aware client: verifies the server SVID against the bundle and
+	// skips hostname verification (the SVID has a URI SAN, no DNS SAN).
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsconfig.TLSClientConfig(bundle, tlsconfig.AuthorizeAny())},
+		Timeout:   5 * time.Second,
+	}
+	resp, err := client.Get("https://" + addr)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "ok", string(body))
+}
+
+// TestCaptureWithoutValidation is the crux of the layering decision: with
+// request-client-cert on, the listener captures whatever the peer presents
+// (a valid SVID, a foreign SVID, a non-SVID cert, or nothing) and NEVER rejects
+// it — leaving authentication to the auth method.
+func TestCaptureWithoutValidation(t *testing.T) {
+	ca, caKey := spiffetest.CA(t)
+	serverSVID := spiffetest.SVID(t, ca, caKey, "spiffe://example.org/warden")
+	serverBundle := spiffetest.Bundle(t, "example.org", ca)
+
+	// Handler echoes "<#peer-certs>|<first-uri-san>" so we can assert what was captured.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n, uri := 0, ""
+		if r.TLS != nil {
+			n = len(r.TLS.PeerCertificates)
+			if n > 0 && len(r.TLS.PeerCertificates[0].URIs) > 0 {
+				uri = r.TLS.PeerCertificates[0].URIs[0].String()
+			}
+		}
+		fmt.Fprintf(w, "%d|%s", n, uri)
+	})
+	addr, _ := startTLSServer(t, BuildServerTLSConfig(staticSource{serverSVID}, true), handler)
+
+	// Distinct CAs/domains for the client certs; the server trusts none of them.
+	otherCA, otherKey := spiffetest.CA(t)
+	validClient := spiffetest.SVID(t, otherCA, otherKey, "spiffe://example.org/client")
+	foreignClient := spiffetest.SVID(t, otherCA, otherKey, "spiffe://other.org/client")
+	classicLeaf, classicKey := spiffetest.LeafCert(t, otherCA, otherKey, "") // no URI SAN
+
+	cases := []struct {
+		name    string
+		cert    *tls.Certificate
+		wantN   string
+		wantURI string
+	}{
+		{"valid client SVID", ptr(tlsCertOf(validClient)), "1", "spiffe://example.org/client"},
+		{"foreign-domain SVID", ptr(tlsCertOf(foreignClient)), "1", "spiffe://other.org/client"},
+		{"non-SVID classic cert", &tls.Certificate{Certificate: [][]byte{classicLeaf.Raw}, PrivateKey: classicKey}, "1", ""},
+		{"no client cert", nil, "0", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientCfg := tlsconfig.TLSClientConfig(serverBundle, tlsconfig.AuthorizeAny())
+			if tc.cert != nil {
+				clientCfg.Certificates = []tls.Certificate{*tc.cert}
+			}
+			client := &http.Client{
+				Transport: &http.Transport{TLSClientConfig: clientCfg, DisableKeepAlives: true},
+				Timeout:   5 * time.Second,
+			}
+			resp, err := client.Get("https://" + addr)
+			require.NoError(t, err, "handshake must succeed regardless of the client cert")
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, tc.wantN+"|"+tc.wantURI, string(body))
+		})
+	}
+}
+
+// TestPerHandshakeFreshness proves the wiring re-reads the source on every
+// handshake (transparent rotation) without a real Workload API.
+func TestPerHandshakeFreshness(t *testing.T) {
+	ca, caKey := spiffetest.CA(t)
+	first := spiffetest.SVID(t, ca, caKey, "spiffe://example.org/warden")
+	second := spiffetest.SVID(t, ca, caKey, "spiffe://example.org/warden")
+	require.NotEqual(t, first.Certificates[0].SerialNumber, second.Certificates[0].SerialNumber)
+	bundle := spiffetest.Bundle(t, "example.org", ca)
+
+	var calls int32
+	src := funcSource(func() (*x509svid.SVID, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return first, nil
+		}
+		return second, nil
+	})
+
+	addr, _ := startTLSServer(t, BuildServerTLSConfig(src, false),
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	// DisableKeepAlives forces a fresh handshake per request.
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsconfig.TLSClientConfig(bundle, tlsconfig.AuthorizeAny()), DisableKeepAlives: true},
+		Timeout:   5 * time.Second,
+	}
+
+	serial := func() string {
+		resp, err := client.Get("https://" + addr)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NotNil(t, resp.TLS)
+		require.NotEmpty(t, resp.TLS.PeerCertificates)
+		return resp.TLS.PeerCertificates[0].SerialNumber.String()
+	}
+
+	s1, s2 := serial(), serial()
+	assert.Equal(t, first.Certificates[0].SerialNumber.String(), s1)
+	assert.Equal(t, second.Certificates[0].SerialNumber.String(), s2)
+	assert.NotEqual(t, s1, s2, "each handshake should serve the then-current SVID")
+}
+
+// TestNewSource_FailClosed confirms an unreachable socket fails closed within the
+// startup budget rather than hanging or falling back.
+func TestNewSource_FailClosed(t *testing.T) {
+	start := time.Now()
+	src, err := NewSource(context.Background(), "unix:///nonexistent/warden-spiffetest.sock", 500*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, src)
+	assert.Contains(t, err.Error(), "unavailable")
+	assert.Less(t, elapsed, 5*time.Second, "should fail within ~startupTimeout, not hang")
+}
+
+func ptr(c tls.Certificate) *tls.Certificate { return &c }


### PR DESCRIPTION
## Summary

Lets the API listener source its serving certificate from the **SPIFFE Workload API**
(go-spiffe's `workloadapi.X509Source`) instead of files on disk. The X509-SVID is held
in memory and fetched fresh on every TLS handshake via `GetCertificate`, so it rotates
transparently and **no key or cert is ever written to disk** — the way SPIFFE-aware
servers (and ghostunnel's `--use-workload-api-addr`) are meant to work.

This is the *serving* half of SPIFFE in Warden; the recently-landed `auth/spiffe` method
is the *validating* half (it authenticates client SVIDs). The serving listener
deliberately does **no** client validation — it only captures the peer cert for that
auth method.

## How it works

- New `listener/spiffetls` owns a `workloadapi.X509Source` (`NewSource`) and builds the
  server `tls.Config` (`BuildServerTLSConfig`) whose `GetCertificate` resolves the
  current SVID per handshake. It imports only go-spiffe — never `auth/*`.
- **Fail-closed** startup with a bounded retry budget: if the Workload API is
  unreachable, the server fails to start rather than serving a stale/absent identity
  (no disk fallback). `tls_spiffe_startup_timeout` tunes the budget.
- The listener always requests (`tls.RequestClientCert`) and **captures the client cert
  without verifying it**. `RequestClientCert` never *requires* one, so token-only and
  cert-less clients still connect. The existing cert-forwarding middleware hands the
  captured cert to the SPIFFE/cert auth method, which does the actual authentication —
  keeping authorization in one place (the auth roles), not two.
- Source lifetime is process-scoped (the API listener serves the unseal endpoint while
  sealed): constructed in `run()`, closed on shutdown, shared per Workload-API socket.

## Config (per listener)

```hcl
listener "tcp" {
  address    = ":8400"
  tls_spiffe = true
  # tls_spiffe_socket          = "unix:///run/spire/agent.sock"  # default: $SPIFFE_ENDPOINT_SOCKET
  # tls_spiffe_startup_timeout = "10s"
}
```

`tls_spiffe` is mutually exclusive with the file-based `tls_cert_file` / `tls_key_file` /
`tls_client_ca_file` / `tls_require_client_cert`. Dev mode adds `--dev-tls-spiffe`.

> Operational note: a `tls_spiffe` listener serves an SVID (URI SAN, no DNS SAN), so
> clients must be SPIFFE-aware. Run a separate file-based listener for classic clients.

## Tests

- `listener/spiffetls`: capture-without-validation (valid SVID, foreign SVID, non-SVID
  cert, and no cert all complete the handshake), per-handshake freshness (proves
  rotation transparency without SPIRE), fail-closed startup.
- `listener/api`: injected-`TLSConfig` serve path + empty-cert-path regression guard.
- `config`: mutual-exclusivity / orphan-key / duration validation + HCL round-trip.
- `cmd/server`: dev-flag validation + per-socket source construction.
- Shared SVID test helpers extracted to `auth/spiffe/spiffetest`.
- Verified end-to-end against a real SPIRE agent + ghostunnel (serving identity, mTLS
  round-trip, and auto-rotation).

## Not included

- Cluster-listener identity via SPIFFE and outbound client SVIDs — noted as future work.
- The SPIRE/ghostunnel dev harness used to validate this lives locally and is not part
  of this PR.
