### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to Warden are documented in this file.
 
 ## [Unreleased]
 
+## [v0.16.0] — 2026-06-15
+
 ### Breaking Changes
+
+- **The `mcp_github` and `mcp_gcp` provider types are removed in favour of a single generic `mcp` provider.** The new `mcp` provider fronts any bearer-authenticated MCP server (GitHub, Google Cloud, Slack, Cloudflare, …); its credential extractor injects `Authorization: Bearer` for `oauth_bearer_token`, `api_key`, `github_token`, `gcp_access_token`, and `azure_bearer_token`, making it a superset of the typed bearer-token providers it replaces. The only provider-specific logic those providers carried was credential extraction, now folded into the generic switch; their curated setup guidance moves to per-upstream docs (`github.md`, `slack.md`, …) under the provider. Migration: re-mount as type `mcp` and set `mcp_url` — `https://api.githubcopilot.com/mcp` for GitHub, the operator's URL for Google Cloud. `mcp_aws` is unaffected — it signs requests with SigV4 rather than injecting a bearer token.
 
 - **`jwt` auth method: the `bound_uri_patterns` and `uri_claim` role fields are removed.** They provided segment-aware string matching against a JWT claim as a stand-in for real SPIFFE JWT-SVID validation (shipped in v0.4.0). SPIFFE identities now belong to the new `spiffe` auth method, which verifies a JWT-SVID against a trust-domain bundle and enforces its audience rather than pattern-matching a claim. Stored roles carrying these JSON keys decode cleanly and ignore them; a role that relied on URI-pattern matching becomes more permissive — migrate it to the `spiffe` method.
 
@@ -14,9 +18,23 @@ All notable changes to Warden are documented in this file.
 
 - **`cert` auth method consolidated to pure PKI.** The experimental SPIFFE mode (`mode=spiffe`, trust-domain configuration, bundle federation, and the `spiffe_id` value for `principal_claim`) — added on `main` after the v0.15.0 release and never shipped in a tagged version — is removed in favour of the dedicated `spiffe` auth method. The `cert` method keeps its X.509 chain-of-trust validation and URI-SAN matching (`uri_san` principal claim plus `allowed_uri_sans`), so a SPIFFE X.509-SVID can still be accepted as an ordinary client certificate bound on its URI SAN.
 
+- **The API listener can serve its TLS certificate from the SPIFFE Workload API.** Instead of a static certificate and key on disk, the listener can fetch an X.509-SVID from a SPIFFE Workload API endpoint and rotate it automatically as the SVID is renewed, keeping the control-plane TLS identity short-lived and self-renewing. (#331)
+
+- **Credential drivers attach non-secret subject metadata to the audit log across the AWS, GCP, Azure, Kubernetes, and Vault sources.** Each driver now populates the non-secret `Credential.Metadata` introduced in v0.15.0 when it mints — the assume-role identity on an AWS STS mint, and the token/access-token subject on the GCP, Azure, Kubernetes, and Vault mints — so an audit record shows *which* upstream identity a brokered call acted as, not merely that a call occurred. As part of this, purely descriptive (non-secret) fields are trimmed from the raw credential payload now that they travel as metadata.
+
+### Bug Fixes
+
+- **`httpproxy`: the gateway suffix is forwarded verbatim.** Gateway-suffix path extraction now preserves the upstream path exactly — including trailing slashes — so providers built on the shared HTTP proxy keep a byte-exact path; in particular the SigV4-signed `mcp_aws` gateway's canonical request stays valid.
+
 ### Documentation
 
 - **Operator README for the new `spiffe` auth method**, and SPIFFE content retargeted across the `cert`, `jwt`, and Vault-provider docs to point SPIFFE workloads at the dedicated method.
+
+- **`mcp_aws` README: a Claude Code CLI registration step** (`claude mcp add`) for pointing Claude Code at an `mcp_aws` mount.
+
+### Chart
+
+- Chart version bumped `0.3.1` → `0.3.2`. `appVersion` tracks the v0.16.0 binary; no template or values changes.
 
 ## [v0.15.0] — 2026-06-06
 
@@ -652,6 +670,8 @@ Initial release. See the [v0.1.0 release notes](https://github.com/stephnangue/w
 - Docker image published to `ghcr.io/stephnangue/warden`
 - Pre-built binaries for Linux, macOS, and Windows
 
+[v0.16.0]: https://github.com/stephnangue/warden/compare/v0.15.0...v0.16.0
+[v0.15.0]: https://github.com/stephnangue/warden/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/stephnangue/warden/compare/v0.13.2...v0.14.0
 [v0.13.2]: https://github.com/stephnangue/warden/compare/v0.13.1...v0.13.2
 [v0.13.1]: https://github.com/stephnangue/warden/compare/v0.13.0...v0.13.1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 **The secure gateway connecting AI agents to the enterprise systems they need to do real work.**
 
-Agents discover what they're allowed to access. Warden brokers every connection. Operators get one control plane for identity, policy, and audit — across every cloud, code-host, observability stack, database, and SaaS the agent reaches.
+Agents discover what they're allowed to access. Warden brokers every connection. Operators get one control plane for identity, policy, and audit — across every MCP server, cloud, code-host, observability stack, database, and SaaS the agent reaches.
 
 ---
 
@@ -60,7 +60,7 @@ Warden closes the gap by sitting in the path: the agent identifies itself, Warde
                                     • Audit ✓
 ```
 
-**Discover.** The agent presents its identity — a JWT or TLS client certificate — and runs three introspection calls against Warden:
+**Discover.** The agent presents its identity — a JWT, TLS client certificate, SPIFFE SVID, or Kubernetes service-account token — and runs three introspection calls against Warden:
 
 1. `warden role list` — which roles is this identity permitted to assume in this namespace?
 2. `warden provider list` — which upstream systems are mounted here?
@@ -78,7 +78,7 @@ What an enterprise gets from putting Warden in the path:
 - **Hallucination containment** — LLMs make routine mistakes, and a single mistake under a broad credential can cause real damage. Per-call role binding constrains what the agent can do at every step; a hallucinated request that exceeds the role's scope is denied upstream — observable in the audit log, with no state change. LLM errors become recoverable instead of catastrophic.
 - **Compromise containment** — because Warden holds the upstream credentials and the agent never does, a prompt-injected, jailbroken, or otherwise compromised agent has nothing to exfiltrate. Any call it does issue is still bounded by Warden's policy at request time — regardless of what's in the agent's memory or chat history.
 - **Fine-grained access policy** — per-action capabilities and parameter filters, evaluated at request time against caller IP, time of day, and day of week. For MCP traffic the same policy reaches inside each tool call — which tools an agent may invoke, and which arguments it may pass.
-- **Identity-bound access** — JWT (including SPIFFE JWT-SVID) or TLS client certificate (including SPIFFE X.509-SVID); the same identity reaches every upstream the policy permits — no per-system credential sprawl, no API keys handed to agents, nothing to rotate per integration.
+- **Identity-bound access** — a JWT, a TLS client certificate, or a first-class SPIFFE SVID (X.509 or JWT); the same identity reaches every upstream the policy permits — no per-system credential sprawl, no API keys handed to agents, nothing to rotate per integration.
 - **On-behalf-of access** — beyond reaching an upstream as a shared service account, Warden can act on behalf of a specific user: the user grants access once through a standard browser consent, and every subsequent call runs under that user's delegated grant, refreshed automatically — so a delegated action is attributed to the real person, not a shared application credential.
 - **Audit** — every request tied to the original identity, the role used, and the upstream called — plus the policy decision recorded on each MCP tool call, and non-secret metadata about the credential Warden minted, such as the identity it represents.
 - **Automatic credential rotation** — Warden rotates the upstream credentials it holds on a schedule, staging the switch for systems that need time to propagate a new key, so the broker's own secrets stay fresh without operator coordination.
@@ -121,8 +121,9 @@ Warden supports multiple methods for verifying caller identity.
 
 | Method | Identity Source | How the agent presents the credential to its SDK |
 |--------|----------------|----|
-| **JWT** | Signed JWT token or SPIFFE JWT-SVID | The **same JWT** goes in whichever credential slot the upstream SDK natively expects (`AWS_SECRET_ACCESS_KEY`, `OPENAI_API_KEY`, `X-Vault-Token`, `Authorization: Bearer`, …). Warden detects it, validates the identity, and swaps in the real upstream credential. Existing SDK code keeps working — only the base URL changes. |
-| **TLS Certificate** | X.509 client certificate or SPIFFE X.509-SVID | Identity is proven at the TLS handshake (or forwarded by a TLS-terminating proxy via `X-SSL-Client-Cert`). The SDK's credential slot is filled with any placeholder value — Warden ignores it once cert auth has proven the identity. Role selection follows the same per-provider conventions as JWT mode. |
+| **JWT** | Signed JWT token | The **same JWT** goes in whichever credential slot the upstream SDK natively expects (`AWS_SECRET_ACCESS_KEY`, `OPENAI_API_KEY`, `X-Vault-Token`, `Authorization: Bearer`, …). Warden detects it, validates the identity, and swaps in the real upstream credential. Existing SDK code keeps working — only the base URL changes. |
+| **TLS Certificate** | X.509 client certificate | Identity is proven at the TLS handshake (or forwarded by a TLS-terminating proxy via `X-SSL-Client-Cert`). The SDK's credential slot is filled with any placeholder value — Warden ignores it once cert auth has proven the identity. Role selection follows the same per-provider conventions as JWT mode. |
+| **SPIFFE** | SPIFFE X.509-SVID or JWT-SVID | First-class SPIFFE identity on a single mount: a workload presents an X.509-SVID at the TLS handshake (or forwarded by a TLS-terminating proxy) or a JWT-SVID as a bearer token, and Warden verifies it against the trust domain's bundle — with federation across trust domains and periodic refresh. It relies on short-lived SVIDs and bundle rotation rather than revocation lists, so it suits workloads already issued identities by a SPIFFE provider such as SPIRE. |
 | **Kubernetes** | Kubernetes ServiceAccount token (projected SA JWT) | The pod's ServiceAccount token goes in the SDK's credential slot exactly as in JWT mode. Warden validates it by calling the issuing cluster's TokenReview API — no JWKS endpoint or public keys to distribute — and matches a role bound to the ServiceAccount's namespace and name. |
 
 This is the design property that makes Warden a *drop-in* layer rather than a rewrite tax: a pre-existing boto3, openai-python, Vault CLI, or curl-against-GitHub script becomes Warden-mediated by setting the base URL to Warden and putting the JWT where the secret used to go. It also separates Warden from dedicated auth proxies (which typically require client libraries).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,61 +1,52 @@
-## Warden v0.15.0
+## Warden v0.16.0
 
-v0.15.0 is the MCP release. A new `mcp { }` policy block brings **body-authoritative governance** to MCP (JSON-RPC) traffic — gate by method, tool, resource, prompt, and tool-argument values, with the gateway strict-parsing the request body rather than trusting client-supplied headers — and three new providers carry it: `mcp_github` (transparent proxy to GitHub's hosted MCP server), `mcp_aws` (SigV4-signed gateway to AWS's hosted MCP servers and Bedrock AgentCore), and `mcp_gcp` (bearer-token gateway to a Google Cloud MCP server). The OAuth2 credential source gains an **authorization-code flow**, so a Warden role can broker calls as a *consenting user* — consent captured once through `warden cred spec connect`, refresh tokens rotated and written back automatically. `github` and `gitlab` now proxy **Git smart-HTTP** (`clone` / `fetch` / `push`) on the same mount as their REST API, and a new `kubernetes` auth method validates workload identities via **TokenReview**. Three breaking changes — read the **Upgrading** section before bumping.
+v0.16.0 is the SPIFFE release. A new first-class **`spiffe` auth method** accepts a SPIFFE X.509-SVID (over mTLS or a trusted forwarding header) and a SPIFFE JWT-SVID (bearer) on the **same mount**, verifying each against the trust domain's bundle — which carries both the X.509 and JWT key sets — and issuing one token type. Roles bind on `trust_domain`, `allowed_spiffe_ids`, and `bound_audiences`; bundles are managed on the mount and can be **federated** from upstream endpoints with periodic refresh. The method leans on short-lived SVIDs and bundle rotation rather than CRL/OCSP. The control plane itself can now run on SPIFFE: the **API listener can serve its TLS certificate straight from the SPIFFE Workload API**, rotating automatically as the SVID renews. This release also **consolidates the MCP providers** — a single generic `mcp` provider replaces the typed `mcp_github` and `mcp_gcp` — and threads **non-secret subject metadata into the audit log** across the AWS, GCP, Azure, Kubernetes, and Vault sources, so a brokered call records *which* upstream identity acted. Two breaking changes — read the **Upgrading** section before bumping.
 
 ### Breaking Changes
 
-- **Transparent-auth role resolution: the provider role-extractor now outranks `default_role`.** The chain is `X-Warden-Role` header > role embedded in the path > the provider's role-extractor hook > the mount's `default_role`. Mounts that combine an extractor with `default_role` change behaviour — `github` Git smart-HTTP, AWS-with-SigV4, and Alicloud-with-ACS3/SigV4 now resolve to the extractor-derived role instead of `default_role`. Mounts without an extractor (or AWS/Alicloud requests that aren't SigV4-signed) are unchanged.
+- **The `mcp_github` and `mcp_gcp` provider types are removed in favour of a single generic `mcp` provider.** The new `mcp` provider fronts any bearer-authenticated MCP server (GitHub, Google Cloud, Slack, Cloudflare, …) and injects `Authorization: Bearer` for `oauth_bearer_token`, `api_key`, `github_token`, `gcp_access_token`, and `azure_bearer_token` — a superset of the typed providers it replaces. Re-mount as type `mcp` and set `mcp_url` (`https://api.githubcopilot.com/mcp` for GitHub; the operator's URL for Google Cloud). `mcp_aws` is unaffected — it SigV4-signs requests rather than injecting a bearer token.
 
-- **`github` provider: the `git_url` config field is removed.** It was declared but never read at runtime. Operators who had it set now get a clear "unknown field" error on config write instead of a silent no-op — drop it; the Git host is derived from `github_url` as before.
-
-- **SDK signature changes for out-of-tree backends.** `StreamBodyParser.ShouldParseStreamBody` and `TransparentModeProvider.IsUnauthenticatedPath` now take the `*http.Request`, and `TransparentAuthRoleExtractor` returns `string` (was `(string, bool)`). In-tree backends are unaffected; only code implementing these interfaces out of tree needs updating.
+- **`jwt` auth method: the `bound_uri_patterns` and `uri_claim` role fields are removed.** They provided segment-aware string matching against a JWT claim as a stand-in for real SPIFFE JWT-SVID validation. SPIFFE identities now belong to the new `spiffe` auth method, which verifies a JWT-SVID against a trust-domain bundle and enforces its audience. Stored roles carrying these keys decode cleanly and ignore them — a role that relied on URI-pattern matching becomes more permissive, so migrate it to the `spiffe` method.
 
 ### New Features
 
-- **OAuth2 authorization-code flow — a Warden role can broker calls as a consenting user.** The `oauth2` source gains an `authorization_code` auth method alongside `client_credentials`, so a credential spec can hold a user's consent rather than a service identity. `warden cred spec connect <name>` runs the one-time browser consent over a loopback callback with PKCE and `state`, and the token exchange happens server-side — the client secret never reaches the operator's machine. Refresh tokens (and their expiry) are rotated and written back automatically under a per-spec lock that serializes concurrent mints. The audit log records which upstream identity acted, per call. `mcp_github` accepts these credentials, so one role can act as a GitHub App, a PAT, or a consenting GitHub user.
+- **New `spiffe` auth method: first-class SPIFFE support for both SVID types on one mount.** Accepts a SPIFFE X.509-SVID (presented over mTLS or a trusted forwarding header) and a SPIFFE JWT-SVID (bearer) on the same mount, verifying each against the trust domain's bundle and issuing a single `spiffe_role` token type. When a request presents both, the explicitly-presented JWT-SVID wins over an ambient forwarded certificate. Roles bind on `trust_domain`, `allowed_spiffe_ids`, and `bound_audiences`; an audience is required for JWT-SVID logins, as SPIFFE mandates. Trust-domain bundles are managed on the mount and can be federated from upstream endpoints with periodic refresh. There is no X.509-SVID revocation surface — the method relies on short-lived SVIDs and bundle rotation, and an issued token's TTL is capped by the SVID's expiry.
 
-- **`mcp { }` policy block: body-authoritative governance of MCP (JSON-RPC) traffic.** A new `mcp { }` block inside a control-by-policy `path` rule gates requests by JSON-RPC `method`, by the `name` in `tools/call` / `resources/read` / `prompts/get`, and by tool-call argument values — each with allow/deny symmetry and case-insensitive trailing-`*` globs. The gateway strict-parses the JSON-RPC body and fails closed on any malformed 2.0 envelope, then evaluates against the parsed body rather than client headers. Opt-in per provider and method-aware (only JSON-RPC POSTs are evaluated, so Streamable HTTP's GET/DELETE pass through). Denials return an OAuth-shaped HTTP 403, and the audit log carries a structured `mcp_decision`.
+- **The API listener can serve its TLS certificate from the SPIFFE Workload API.** Instead of a static certificate and key on disk, the listener can obtain an X.509-SVID from a SPIFFE Workload API endpoint and rotate it automatically as the SVID is renewed, keeping the control-plane TLS identity short-lived and self-renewing.
 
-- **Three new MCP providers.** `mcp_github` transparently proxies GitHub's hosted MCP server (reusing the GitHub credential, so one spec grants both REST and MCP reach). `mcp_aws` SigV4-signs traffic to AWS's hosted MCP servers and Bedrock AgentCore, inferring service and region from the endpoint. `mcp_gcp` mints a short-lived GCP access token per request for a Google Cloud MCP server. All three opt into `mcp { }` enforcement.
+- **`cert` auth method consolidated to pure PKI.** The never-shipped experimental SPIFFE mode (`mode=spiffe`, trust-domain config, bundle federation, and the `spiffe_id` principal claim) is removed in favour of the dedicated `spiffe` method. The `cert` method keeps its X.509 chain-of-trust validation and URI-SAN matching (`uri_san` principal claim plus `allowed_uri_sans`), so a SPIFFE X.509-SVID can still be accepted as an ordinary client certificate bound on its URI SAN.
 
-- **`github` and `gitlab` Git smart-HTTP.** Both providers now proxy `git clone` / `fetch` / `push` on the same mount that proxies their REST API. Clone URLs carry the Warden role as the Basic Auth username and the Warden JWT as the password, so Git's credential helpers cache cleanly per role. A new `git_max_body_size` config field caps Git request bodies separately from the REST `max_body_size`.
-
-- **`kubernetes` auth method: validate workload tokens via TokenReview.** The first cloud-native member of the transparent-auth family validates a workload service-account token by calling `TokenReview` on the issuing kube-apiserver — no JWKS endpoint required on the spoke, awkward on hardened distros — matching the `auth/kubernetes` shape Vault and OpenBao operators know. The SA UID, namespace, and name land in the audit log for attribution.
-
-- **Provider `tune` endpoint.** `warden provider tune <path> -description=...` updates a mount's description in place; previously this required an unmount and remount.
-
-- **`X-Warden-Provider` requests may omit the `/v1/` prefix.** Header-routed calls (the documented `git clone` form via `http.extraheader`) no longer require the `/v1/` prefix on the path; the middleware prepends it when the header is present. The canonical `/v1/`-prefixed form is unchanged, and `sys/`-targeted requests with the header are rejected with 400.
+- **Audit-log subject metadata across the cloud and secrets sources.** The AWS, GCP, Azure, Kubernetes, and Vault drivers now populate the non-secret `Credential.Metadata` introduced in v0.15.0 when they mint — the assume-role identity on an AWS STS mint, and the token/access-token subject on the others — so an audit record shows which upstream identity a brokered call acted as, not merely that a call occurred.
 
 ### Bug Fixes
 
-- **SigV4: client cancellation logs at debug, not error.** A client that disconnects mid-request on a SigV4 provider no longer produces an error-level log line.
+- **`httpproxy`: the gateway suffix is forwarded verbatim.** Gateway-suffix path extraction now preserves the upstream path exactly — including trailing slashes — so the SigV4-signed `mcp_aws` gateway's canonical request stays valid.
 
 ### Documentation
 
-- Operator READMEs for the `cert`, `jwt`, and `kubernetes` auth methods.
-- `mcp_github` provider docs: authorization-code flow setup around a GitHub App (with a Claude Code `claude mcp add` worked example) and a body-authoritative `mcp { }` policy section.
-- `mcp_aws` skill and operator README; `httpproxy` SDK hook reference; root README coverage of the MCP-server providers, on-behalf-of attribution, Kubernetes auth, and credential rotation.
+- Operator README for the new `spiffe` auth method, with SPIFFE content retargeted across the `cert`, `jwt`, and Vault-provider docs to point SPIFFE workloads at the dedicated method.
+- `mcp_aws` README: a Claude Code CLI registration step (`claude mcp add`) for pointing Claude Code at an `mcp_aws` mount.
+- Root README: a dedicated `spiffe` row in the authentication-methods table.
 
 ### Upgrading
 
 ```bash
 helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.3.1 \
+  --version 0.3.2 \
   -n warden --reset-then-reuse-values
 ```
 
-Chart `0.3.0` → `0.3.1` is an `appVersion` bump to track the v0.15.0 binary — there are no chart template or values changes, so existing values files apply as-is.
+Chart `0.3.1` → `0.3.2` is an `appVersion` bump to track the v0.16.0 binary — there are no chart template or values changes, so existing values files apply as-is.
 
-The binary breaking changes are mostly transparent to a Helm install, but be aware of three things before bumping:
+Two operator-facing migrations before bumping:
 
-- **Mounts that set `default_role` together with a role-extractor** (`github` Git smart-HTTP, AWS/Alicloud with SigV4) now resolve to the extractor-derived role instead of `default_role`. Review those mounts if you relied on `default_role` winning.
-- **The `github` `git_url` config field is gone** — drop it from any provider config (the Git host is derived from `github_url`).
-- **Out-of-tree providers** that implement `StreamBodyParser.ShouldParseStreamBody`, `TransparentModeProvider.IsUnauthenticatedPath`, or `TransparentAuthRoleExtractor` must update those signatures. In-tree providers and a stock Helm install need no changes.
+- **Re-mount any `mcp_github` or `mcp_gcp` provider as type `mcp`** and set `mcp_url` (`https://api.githubcopilot.com/mcp` for GitHub; the operator's URL for Google Cloud). The generic provider reuses the same credential types, so existing credential specs apply unchanged. `mcp_aws` is unaffected.
+- **Migrate any `jwt` role that used `bound_uri_patterns` or `uri_claim` to the `spiffe` method.** Those fields are gone; a role that relied on them now ignores them and becomes more permissive until migrated.
 
 ### Resources
 
 - New installs and detailed upgrade procedures: [docs/deployment/kubernetes.md](https://github.com/stephnangue/warden/blob/main/docs/deployment/kubernetes.md).
-- MCP, OAuth2, and auth-method setup: [README](https://github.com/stephnangue/warden#readme) and the per-provider READMEs under [provider/](https://github.com/stephnangue/warden/tree/main/provider).
+- SPIFFE, MCP, and auth-method setup: [README](https://github.com/stephnangue/warden#readme) and the per-provider and per-method READMEs.
 
 ### License
 

--- a/deploy/helm/warden/Chart.yaml
+++ b/deploy/helm/warden/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: warden
 description: Identity-aware egress proxy for AI agents — Helm chart for Kubernetes deployments.
 type: application
-version: 0.3.1
-appVersion: "0.15.0"
+version: 0.3.2
+appVersion: "0.16.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/stephnangue/warden
 sources:


### PR DESCRIPTION
Prepares the **v0.16.0** release. Docs/version artifacts only — no code changes. Tagging is left to the maintainer.

## What's in v0.16.0

The SPIFFE release, plus an MCP provider consolidation and audit-log metadata work.

### Breaking
- **`mcp_github` / `mcp_gcp` provider types removed** in favour of a single generic `mcp` provider — re-mount as type `mcp` with `mcp_url`. `mcp_aws` is unaffected (SigV4).
- **`jwt`: `bound_uri_patterns` / `uri_claim` removed** — migrate those roles to the new `spiffe` method.

### Highlights
- New first-class **`spiffe` auth method** (X.509-SVID + JWT-SVID on one mount, trust-domain bundle verification, federation).
- **API listener can serve TLS from the SPIFFE Workload API** (auto-rotating SVID).
- **Audit-log subject metadata** across AWS, GCP, Azure, Kubernetes, and Vault mints.
- `httpproxy` gateway-suffix-verbatim fix.

## Files
- `CHANGELOG.md` — stamped `[v0.16.0] — 2026-06-15`, filled the missing entries, added `v0.15.0`/`v0.16.0` compare-links.
- `RELEASE_NOTES.md` — rewritten for v0.16.0 (GoReleaser sources the GitHub Release body from this).
- `deploy/helm/warden/Chart.yaml` — `version 0.3.1 → 0.3.2`, `appVersion → 0.16.0`.
- `README.md` — dedicated `spiffe` row in the auth-methods table, plus capability bullet and discovery intro updated.

## Verification
- `helm lint deploy/helm/warden` passes (0 failed).
- All 21 commits since v0.15.0 map to a changelog entry.
- No stale `0.15.0` / `0.3.1` release metadata.
- Zero `.go` files touched — build/test status unchanged from `main`.

## After merge
Tag `main` with `v0.16.0` and push to trigger the release (GoReleaser binaries + Docker images, Helm chart publish).
