### PR TITLE
docs(examples): demonstrate central policy + audit in the workstation series

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ one rung at a time, without changing how the agent works:
   auto-rotating SPIFFE SVID, so even the private key leaves the
   disk. Zero long-lived credentials remain on the machine.
 
-Every rung makes the same three wins concrete: the secret leaves
-the workstation, every request is policy-checked, and every call is
-audited under the caller's identity. See
-[the series](docs/examples/workstation/README.md).
+Every rung makes the same three wins concrete — and demonstrates
+them, not just asserts them: the secret leaves the workstation, and
+each rung turns on the audit log and watches a request get denied by
+policy. See [the series](docs/examples/workstation/README.md).
 
 ## Architecture
 

--- a/docs/examples/workstation/01-cert-llm/README.md
+++ b/docs/examples/workstation/01-cert-llm/README.md
@@ -168,8 +168,72 @@ claude
 ```
 
 Every prompt is now routed through Warden: the Console key lives only in Warden, and you can cap
-`model`/`max_tokens` centrally in the `anthropic-access` policy. (To persist it, put
-`ANTHROPIC_BASE_URL` under `env` in `~/.claude/settings.json`.)
+`model`/`max_tokens` centrally in the `anthropic-access` policy (proven in Step 7). (To persist
+it, put `ANTHROPIC_BASE_URL` under `env` in `~/.claude/settings.json`.)
+
+### Step 6 — turn on the audit log
+
+So far "every call is audited" has been a claim. Make it concrete: enable a **file audit
+device**, which writes one JSON entry per request and per response into the mounted `./audit/`:
+
+```bash
+warden audit enable file -file-path=/audit/audit.log
+warden audit list                    # one device — Warden is fail-closed once it has one
+```
+
+Watch it in a second terminal:
+
+```bash
+tail -f audit/audit.log | jq '{type, id: .auth.principal_id, role: .auth.role_name,
+  allowed: .auth.policy_results.allowed, upstream: .response.upstream_url, cred: .response.credential.type}'
+```
+
+Re-run Step 4's curl and an entry appears: `id` is the cert CN `mcp-agent`, `role` is
+`anthropic-user`, `allowed` is `true`, `upstream` is the Anthropic URL, and `cred` is `api_key`.
+The injected key is never in the clear — credential values are salted to `hmac-sha256:…`.
+
+> Only the `file` device type exists. If a bind-mounted log is awkward on your host, enable it to
+> `-file-path=/dev/stdout` instead and read entries with `docker compose logs warden`.
+
+### Step 7 — watch the policy enforce a limit
+
+The role may call the model — but *which* model is a policy decision. Pin it: rewrite the policy
+so only one model is permitted (missing params stay allowed; `"*" = []` permits every other
+field):
+
+```bash
+MODEL="claude-sonnet-4-5"            # a model your Anthropic account can use
+
+warden policy write anthropic-access - <<EOF
+path "anthropic/role/+/gateway*" {
+  capabilities       = ["create", "read", "update", "delete", "patch"]
+  allowed_parameters = { "model" = ["$MODEL"], "*" = [] }
+}
+EOF
+```
+
+A request naming the pinned model is forwarded; one naming any other model is **denied by Warden
+before it reaches Anthropic** (no upstream call, no spend):
+
+```bash
+# Allowed — passes policy, forwarded upstream
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  http://127.0.0.1:9000/v1/anthropic/role/anthropic-user/gateway/v1/messages \
+  -H 'content-type: application/json' \
+  -d "{\"model\":\"$MODEL\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"
+# 200
+
+# Denied — different model, blocked at Warden
+curl -sS http://127.0.0.1:9000/v1/anthropic/role/anthropic-user/gateway/v1/messages \
+  -H 'content-type: application/json' \
+  -d '{"model":"some-other-model","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+# {"errors":["permission denied"]}   (HTTP 403)
+```
+
+In the audit tail the two calls sit side by side — same `id` and `role`, but `allowed: true` on
+the first and `allowed: false` on the second. That's the whole point made real: the limit lives
+in Warden (change it once, for everyone), and every decision — allowed or denied — is recorded
+against the caller's identity.
 
 ---
 
@@ -181,9 +245,13 @@ Every prompt is now routed through Warden: the Console key lives only in Warden,
    warden` shows a cert login + `anthropic-ops` credential issue, and the upstream call carries
    the injected `x-api-key` (your placeholder is stripped).
 4. Your key never left Warden: `printf '%s' "$ANTHROPIC_API_KEY"` on the workstation is just
-   `placeholder`, and `grep -r sk-ant ~/.claude/` finds nothing. The real key lives only in
-   Warden, every request was policy-checked, and each is in Warden's audit log under the cert
-   identity.
+   `placeholder`, and `grep -r sk-ant ~/.claude/` finds nothing.
+5. **Audit is real:** `audit/audit.log` has a `response` entry for your call with
+   `auth.role_name = "anthropic-user"` and `response.credential.type = "api_key"` (the key value
+   salted to `hmac-sha256:…`).
+6. **Policy bites:** the pinned-model curl returns `200`, the other-model curl returns `403`
+   `permission denied`, and both show in the audit log — `allowed:true` and `allowed:false`
+   under the same identity.
 
 ## Scorecard
 
@@ -211,7 +279,7 @@ MCP server so we also stop storing MCP tokens.
 ```bash
 unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY WARDEN_ADDR WARDEN_TOKEN
 docker compose down -v
-rm -rf certs secrets        # certs/ is a bind mount; down -v won't remove it
+rm -rf certs secrets audit  # certs/ and audit/ are bind mounts; down -v won't remove them
 ```
 
 > Dev mode uses in-memory storage — everything resets on `down`. No Warden source is modified;

--- a/docs/examples/workstation/01-cert-llm/docker-compose.yml
+++ b/docs/examples/workstation/01-cert-llm/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - --dev-tls-ca-cert-file=/certs/ca.crt
     volumes:
       - ./certs:/certs:ro
+      - ./audit:/audit                 # the file audit device writes JSON entries here
     ports:
       - "127.0.0.1:9000:9000"          # ghostunnel (shares this netns) is published here
     depends_on:

--- a/docs/examples/workstation/02-cert-llm-mcp/README.md
+++ b/docs/examples/workstation/02-cert-llm-mcp/README.md
@@ -106,9 +106,16 @@ warden cred source create github-src -type=github -rotation-period=0 \
 warden cred spec create github-ops -source github-src \
   -config auth_method=pat -config token=$GH_PAT
 
-# Policy + cert-auth role — same client cert (allowed_common_names="mcp-agent")
+# Policy + cert-auth role — same client cert (allowed_common_names="mcp-agent").
+# The mcp{} block reaches inside each tool call: read/list/search tools pass,
+# state-changing tools are denied at Warden (demonstrated in Step 6).
 warden policy write mcp-github-access - <<'EOF'
-path "github-mcp/role/+/gateway*" { capabilities = ["create", "read", "delete"] }
+path "github-mcp/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+  mcp {
+    denied_tools = ["delete_*", "create_*", "update_*", "push_*", "merge_*", "fork_*"]
+  }
+}
 EOF
 
 warden write auth/cert/role/github-user \
@@ -156,6 +163,41 @@ This rung is "LLM **+** MCP". If you want inference routed through Warden as wel
 Anthropic provider/role here (it's the same cert stack) and set `ANTHROPIC_BASE_URL` — see
 [01, Steps 3 & 5](../01-cert-llm/#step-3--route-the-anthropic-api-through-warden).
 
+### Step 5 — turn on the audit log
+
+Enable a file audit device so every gateway call is recorded (skip if you already did this in 01):
+
+```bash
+warden audit enable file -file-path=/audit/audit.log
+
+# second terminal
+tail -f audit/audit.log | jq '{type, id: .auth.principal_id, role: .auth.role_name,
+  allowed: .auth.policy_results.allowed, tool: .auth.policy_results.mcp_decision.name}'
+```
+
+Re-run Step 3's `tools/list` and an entry appears with `role: "github-user"` and `allowed: true`
+(the injected GitHub token is salted to `hmac-sha256:…`, never in the clear).
+
+### Step 6 — watch the policy block a tool
+
+The `denied_tools` rule from Step 2 is evaluated *inside* each `tools/call`, **before** Warden
+forwards anything. A read tool passes; a state-changing tool is refused at Warden — so the repo
+is never touched:
+
+```bash
+# Denied — a write tool, blocked at Warden (nothing reaches GitHub)
+curl -sS http://127.0.0.1:9000/v1/github-mcp/role/github-user/gateway/ \
+  -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+       "params":{"name":"delete_repository","arguments":{"owner":"me","repo":"demo"}}}'
+# {"error":"insufficient_permissions","error_description":"Tool 'delete_repository' not allowed."}  (403)
+```
+
+The audit entry for that call shows `allowed: false` with the offending `tool`. Ask Claude to do
+the same ("delete the demo repo") and it gets the identical refusal — the model can *propose* a
+dangerous tool, but Warden won't run it. **A hallucinated or injected write is contained at the
+gateway, recorded, and never executed.**
+
 ---
 
 ## Verify it worked
@@ -166,8 +208,11 @@ Anthropic provider/role here (it's the same cert stack) and set `ANTHROPIC_BASE_
 3. A read-only GitHub tool call from Claude returns data; `docker compose logs warden` shows a
    cert login + `github-ops` credential issue.
 4. **Nothing on disk:** `grep -ri 'ghp_\|Bearer ' ~/.claude.json` finds no token — the config
-   holds only the gateway URL, and the call was authorized by the cert and recorded in Warden's
-   audit log.
+   holds only the gateway URL.
+5. **Audit is real:** the `tools/list` call has an entry with `auth.role_name = "github-user"`,
+   `allowed:true`; the injected token is salted to `hmac-sha256:…`.
+6. **Policy bites:** the `delete_*` `tools/call` returns `403 insufficient_permissions`, shows
+   `allowed:false` with the tool name in the audit log, and no repository was changed.
 
 ## Scorecard
 
@@ -193,7 +238,7 @@ MCP token** remain. What's *still* on disk is the mTLS **client private key**
 claude mcp remove github
 unset GH_PAT WARDEN_ADDR WARDEN_TOKEN
 docker compose down -v
-rm -rf certs
+rm -rf certs audit
 ```
 
 > To add Slack and AWS MCP servers behind the same cert, see the *Add more upstreams* appendix

--- a/docs/examples/workstation/02-cert-llm-mcp/docker-compose.yml
+++ b/docs/examples/workstation/02-cert-llm-mcp/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - --dev-tls-ca-cert-file=/certs/ca.crt
     volumes:
       - ./certs:/certs:ro
+      - ./audit:/audit                 # the file audit device writes JSON entries here
     ports:
       - "127.0.0.1:9000:9000"
     depends_on:

--- a/docs/examples/workstation/03-spiffe-llm-mcp/README.md
+++ b/docs/examples/workstation/03-spiffe-llm-mcp/README.md
@@ -185,7 +185,10 @@ warden cred source create github-src -type=github -rotation-period=0 \
 warden cred spec create github-ops -source github-src -config auth_method=pat -config token=$GH_PAT
 
 warden policy write mcp-github-access - <<'EOF'
-path "github-mcp/role/+/gateway*" { capabilities = ["create", "read", "delete"] }
+path "github-mcp/role/+/gateway*" {
+  capabilities = ["create", "read", "delete"]
+  mcp { denied_tools = ["delete_*", "create_*", "update_*", "push_*", "merge_*", "fork_*"] }
+}
 EOF
 
 warden write auth/spiffe/role/github \
@@ -223,6 +226,35 @@ claude -p "Using the github MCP server, list 3 of my repositories." \
 
 That prompt's **inference and tool call are both routed** over the same SVID.
 
+### Step 9 — policy and audit, under the keyless identity
+
+Everything 01 and 02 enforced still applies — but now the *subject* of every decision is the
+SVID, not a cert CN. Turn on the audit log and watch:
+
+```bash
+warden audit enable file -file-path=/audit/audit.log
+
+# second terminal
+tail -f audit/audit.log | jq '{id: .auth.principal_id, role: .auth.role_name,
+  allowed: .auth.policy_results.allowed, tool: .auth.policy_results.mcp_decision.name}'
+```
+
+Re-run Step 8's `tools/list`: the entry's `id` is `spiffe://example.org/ghostunnel` with
+`allowed: true`. Then try a state-changing tool — the `denied_tools` rule from Step 7 blocks it
+at Warden, before anything reaches GitHub:
+
+```bash
+curl -sS http://127.0.0.1:8200/v1/github-mcp/role/github/gateway/ \
+  -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+       "params":{"name":"delete_repository","arguments":{"owner":"me","repo":"demo"}}}'
+# {"error":"insufficient_permissions","error_description":"Tool 'delete_repository' not allowed."}  (403)
+```
+
+The audit log now holds two decisions under the same keyless SVID — `allowed: true` for the read,
+`allowed: false` for the blocked write. Zero credentials on disk, **and** every call
+policy-checked and attributed to a rotating identity that never touched the workstation.
+
 ---
 
 ## Verify it worked — the zero-credential check
@@ -240,6 +272,11 @@ ls *.key 2>/dev/null || echo "no private key on disk"
 All three come back clean — there's nothing sensitive on the laptop to leak, scope, or
 mis-audit. Every call Claude makes now carries the keyless SVID identity, is checked against
 Warden's policy, and lands in one audit trail.
+
+4. **Policy + audit (Step 9):** the read tool's audit entry shows
+   `auth.principal_id = "spiffe://example.org/ghostunnel"` with `allowed:true`; the `delete_*`
+   call returns `403 insufficient_permissions` and logs `allowed:false` — same keyless identity,
+   no repository changed.
 
 The workstation holds **zero long-lived credentials** — so even a fully cooperative (or fully
 compromised) agent has nothing to hand over.
@@ -271,6 +308,7 @@ removed to all of them. Same Claude Code, same workflow; the laptop just stopped
 claude mcp remove github
 unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY JOIN_TOKEN GH_PAT WARDEN_ADDR WARDEN_TOKEN
 docker compose down -v
+rm -rf audit
 rm -f anthropic-key.txt example.org-ca.pem
 ```
 

--- a/docs/examples/workstation/03-spiffe-llm-mcp/docker-compose.yml
+++ b/docs/examples/workstation/03-spiffe-llm-mcp/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       org.example.spiffe: "warden"
     volumes:
       - spire-sockets:/run/spire/sockets:ro
+      - ./audit:/audit                            # the file audit device writes JSON entries here
     ports:
       - "8200:8200"                               # ghostunnel (shares this netns) is published here
     networks: [spiffe]

--- a/docs/examples/workstation/README.md
+++ b/docs/examples/workstation/README.md
@@ -11,6 +11,8 @@ machine** in plaintext (readable by any dependency, script, or tool that runs as
 and it leaves **no central audit** (calls hit the provider directly, with no record of who did
 what). Each rung moves a credential into Warden, which fixes all three: the secret leaves the
 laptop, every request is policy-checked, and every call is audited under the caller's identity.
+And each rung *shows* the last two — it turns on the audit log and watches a request get denied
+by policy, rather than just asserting it.
 
 ## Warden in a nutshell
 
@@ -90,4 +92,3 @@ where agents really run:
 - **Agents in CI/CD** — pipeline identity (OIDC from the CI platform), no long-lived tokens in
   repo or runner secrets.
 
-Both reuse the discover-then-connect model you'll learn here.


### PR DESCRIPTION
## What

The workstation rungs claimed every call is "policy-checked and audited," but nothing in the steps made either visible. This adds a concrete demonstration of both to all three rungs, grounded in Warden's real mechanisms.

Follows #333 (the workstation series, now merged).

## Audit (all rungs)

- Each `warden` service mounts `./audit`.
- A step enables a `file` audit device (`warden audit enable file -file-path=/audit/audit.log`) and watches it with `tail … | jq`, surfacing `auth.principal_id`, `auth.role_name`, `auth.policy_results.allowed`, `response.upstream_url`, and `response.credential.type` (secret values appear salted as `hmac-sha256:…`).
- `/dev/stdout` + `docker compose logs` documented as a fallback.

## Policy denial (per rung)

- **01** — pins the model via `allowed_parameters`; the pinned model returns `200`, any other returns `403 {"errors":["permission denied"]}`, blocked before any upstream call. Audit shows both as `allowed:true` / `allowed:false`.
- **02** — adds `mcp { denied_tools = [...] }`; a `delete_*` `tools/call` returns `403 insufficient_permissions ("Tool 'delete_repository' not allowed.")`, evaluated inside the call so nothing reaches GitHub.
- **03** — reuses the tool-gate under the SVID; audit entries are attributed to `spiffe://example.org/ghostunnel`. The LLM policy is left permissive so the `claude` session isn't constrained.

## Framing

Series index and top-level README now say the examples *demonstrate* (not just assert) policy + audit. Verify sections and cleanups (`rm -rf … audit`) updated.

## Notes / to confirm on a real run

- Docs only — no Warden source changes; all three compose files pass `docker compose config -q`.
- Confirm live GitHub MCP write-tool names match the `delete_*`/`create_*` patterns.
- Confirm the audit file is writable on the bind mount under Docker Desktop (else use the documented `/dev/stdout` fallback).
