### PR TITLE
ci(deps): hold go-kms-wrapping family at v2.7.0-compatible set

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
       - "go"
     reviewers:
       - "stephnangue"
+    ignore:
+      # Hold the go-kms-wrapping family at the v2.7.0-compatible set.
+      # v2.8.0 of the core library dropped the per-provider wrapper-type
+      # constants and the aead ShamirWrapper API our KMS config relies on,
+      # and no wrapper release compatible with v2.8.0 exists yet. Remove
+      # this once upstream ships a migration path. See PR #330.
+      - dependency-name: "github.com/openbao/go-kms-wrapping/*"
     groups:
       # Group minor and patch updates together
       go-minor-patch:


### PR DESCRIPTION
## Why

Dependabot PR #330 (`go-minor-patch` group) fails to compile because it bumps `github.com/openbao/go-kms-wrapping/v2` from **v2.7.0 → v2.8.0**, which is a breaking release.

Verified against the module cache, v2.8.0 removes public API that both our code and a transitive dependency rely on:

1. **`const.go` gutted** — the per-provider wrapper-type constants (`WrapperTypeShamir`, `WrapperTypeAwsKms`, `WrapperTypeAzureKeyVault`, `WrapperTypeGcpCkms`, `WrapperTypeOciKms`, `WrapperTypeAliCloudKms`, `WrapperTypeTransit`, `WrapperTypeKmip`, `WrapperTypeStatic`) are gone. Only `WrapperTypeUnknown`, `WrapperTypeAead`, `WrapperTypeTest` remain. This breaks `internal/configutil/kms.go`.
2. **`/aead` subpackage** lost `ShamirWrapper` / `NewShamirWrapper`, which breaks `wrappers/aead/v2@v2.3.0` (its latest release) — there is no aead wrapper release compatible with core v2.8.0.

So the v2.8.0 family is not adoptable yet without a code migration that has no upstream landing path.

## What

Add a dependabot `ignore` rule holding the whole `github.com/openbao/go-kms-wrapping/*` family at the current v2.7.0-compatible set. The other 23 updates in the group can flow normally.

## Follow-up

After this merges to `main`, comment `@dependabot recreate` on #330 so it regenerates without the kms-wrapping bumps. Remove this ignore rule once upstream ships a v2.8.0-compatible aead wrapper and a migration path for the removed constants.