### PR TITLE
refactor(seal): use core aead subpackage instead of the aead wrapper shim

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
+	aead "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/sdk/v2/logical"
 	phy "github.com/openbao/openbao/sdk/v2/physical"
 	physInmem "github.com/openbao/openbao/sdk/v2/physical/inmem"
@@ -875,7 +875,7 @@ func setSeal(conf *config.Config, logger *log.GatedLogger, infoKeys *[]string, i
 
 		var seal core.Seal
 		sealLogger := logger.WithSystem(fmt.Sprintf("seal.%s", sealType))
-		defaultSeal := core.NewDefaultSeal(wardenseal.NewAccess(aeadwrapper.NewShamirWrapper()))
+		defaultSeal := core.NewDefaultSeal(wardenseal.NewAccess(aead.NewWrapper()))
 		var sealInfoKeys []string
 		sealInfoMap := map[string]string{}
 		wrapper, sealConfigError = configutil.ConfigureWrapper(&configSeal, &sealInfoKeys, &sealInfoMap, sealLogger)

--- a/core/core.go
+++ b/core/core.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
+	aead "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/stephnangue/warden/api"
@@ -548,7 +548,7 @@ func CreateCore(conf *CoreConfig) (*Core, error) {
 
 	// Load seal information.
 	if c.seal == nil {
-		wrapper := aeadwrapper.NewShamirWrapper()
+		wrapper := aead.NewWrapper()
 		wrapper.SetConfig(context.Background())
 
 		c.seal = NewDefaultSeal(seal.NewAccess(wrapper))
@@ -1027,7 +1027,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 		case existBarrierSealConfig.Type == wrapping.WrapperTypeShamir.String():
 			// The configured seal is not Shamir, the stored seal config is Shamir.
 			// This is a migration away from Shamir.
-			unwrapSeal = NewDefaultSeal(seal.NewAccess(aeadwrapper.NewShamirWrapper()))
+			unwrapSeal = NewDefaultSeal(seal.NewAccess(aead.NewWrapper()))
 		default:
 			// We know at this point that there is a configured non-Shamir seal,
 			// that it does not match the stored non-Shamir seal config, and that

--- a/core/seal.go
+++ b/core/seal.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
+	aead "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/stephnangue/warden/core/seal"
@@ -65,7 +65,7 @@ type Seal interface {
 	SetRecoveryKey(context.Context, []byte) error
 	VerifyRecoveryKey(context.Context, []byte) error // SealAccess
 	GetAccess() seal.Access                          // SealAccess
-	GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error)
+	GetShamirWrapper() (*aead.Wrapper, error)
 }
 
 type defaultSeal struct {
@@ -257,12 +257,12 @@ func (d *defaultSeal) SetRecoveryKey(ctx context.Context, key []byte) error {
 	return errors.New("recovery not supported")
 }
 
-func (d *defaultSeal) GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error) {
-	// defaultSeal is meant to be for Shamir seals, so it should always have a ShamirWrapper.
+func (d *defaultSeal) GetShamirWrapper() (*aead.Wrapper, error) {
+	// defaultSeal is meant to be for Shamir seals, so it should always have a Shamir wrapper.
 	// Nonetheless, NewDefaultSeal does not check, so let's play it safe.
-	w, ok := d.GetAccess().GetWrapper().(*aeadwrapper.ShamirWrapper)
+	w, ok := d.GetAccess().GetWrapper().(*aead.Wrapper)
 	if !ok {
-		return nil, fmt.Errorf("expected defaultSeal to have a ShamirWrapper, but found a %T instead", d.GetAccess().GetWrapper())
+		return nil, fmt.Errorf("expected defaultSeal to have a Shamir wrapper, but found a %T instead", d.GetAccess().GetWrapper())
 	}
 	return w, nil
 }

--- a/core/seal_autoseal.go
+++ b/core/seal_autoseal.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
-	aeadwrapper "github.com/openbao/go-kms-wrapping/wrappers/aead/v2"
+	aead "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/sdk/v2/physical"
 	"github.com/stephnangue/warden/core/seal"
 	log "github.com/stephnangue/warden/logger"
@@ -100,8 +100,8 @@ func (d *autoSeal) BarrierType() wrapping.WrapperType {
 	return d.barrierType
 }
 
-func (d *autoSeal) GetShamirWrapper() (*aeadwrapper.ShamirWrapper, error) {
-	return nil, errors.New("autoSeal does not use a ShamirWrapper")
+func (d *autoSeal) GetShamirWrapper() (*aead.Wrapper, error) {
+	return nil, errors.New("autoSeal does not use a Shamir wrapper")
 }
 
 func (d *autoSeal) StoredKeysSupported() seal.StoredKeysSupport {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/oklog/ulid v1.3.1
 	github.com/openbao/go-kms-wrapping/v2 v2.7.0
-	github.com/openbao/go-kms-wrapping/wrappers/aead/v2 v2.3.0
 	github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.2.0
 	github.com/openbao/go-kms-wrapping/wrappers/awskms/v2 v2.3.0
 	github.com/openbao/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,6 @@ github.com/olekukonko/tablewriter v1.1.4 h1:ORUMI3dXbMnRlRggJX3+q7OzQFDdvgbN9nVW
 github.com/olekukonko/tablewriter v1.1.4/go.mod h1:+kedxuyTtgoZLwif3P1Em4hARJs+mVnzKxmsCL/C5RY=
 github.com/openbao/go-kms-wrapping/v2 v2.7.0 h1:/Vm3UF0bMLdeU2U1fXI0hLVuJbqBlqpAwXlmn88IJ2Q=
 github.com/openbao/go-kms-wrapping/v2 v2.7.0/go.mod h1:xoUdq1btm4MNgwBpMkVLvXxuvnH4gGzODozWGFpft8w=
-github.com/openbao/go-kms-wrapping/wrappers/aead/v2 v2.3.0 h1:4nrE306wqZAKP/EUkrwA8LcnqpJbPDir+EZBxeOQBSM=
-github.com/openbao/go-kms-wrapping/wrappers/aead/v2 v2.3.0/go.mod h1:vapnd+guYhTvRnwHtxNxlKrTdIFkznVp7r1LYzD4aeI=
 github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.2.0 h1:evwGV3ojzXhno2AnCYzyj10HxGHujq6R93zSlaGRRNk=
 github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.2.0/go.mod h1:wiZapI8HCPoK5UMKITxBzdboKGvZAJiZUW7ZVsgtEgc=
 github.com/openbao/go-kms-wrapping/wrappers/awskms/v2 v2.3.0 h1:Zccqnf/5zjtptBU8OliC3iCbBfwrXvBlcP/Pw9UDAh4=


### PR DESCRIPTION
## What

Stop depending on the `github.com/openbao/go-kms-wrapping/wrappers/aead/v2` module. That module is a thin re-export shim over the core library's `go-kms-wrapping/v2/aead` subpackage. Warden now constructs the Shamir barrier wrapper directly from the core subpackage:

- `aeadwrapper.NewShamirWrapper()` → `aead.NewWrapper()`
- `*aeadwrapper.ShamirWrapper` → `*aead.Wrapper`
- import `wrappers/aead/v2` → `go-kms-wrapping/v2/aead`

`go mod tidy` drops the now-unused `wrappers/aead/v2` require line.

## Why

This is step 1 of 3 in migrating off go-kms-wrapping v2.7.0. The v2.8.0 release removed `ShamirWrapper`/`NewShamirWrapper` from the aead subpackage, and the `wrappers/aead` shim has no v2.8.0-compatible release — so it is the hard blocker for the bump. The plain `Wrapper` carries the same AES-GCM key methods the seal path uses (`SetAesGcmKeyBytes`, `Encrypt`, `Decrypt`), so there is no behavior or on-disk-format change. This change compiles and tests green on the current core v2.7.0, de-risking the eventual bump.

## Test

- `go build ./...`
- `go test ./core/...` (passes; exercises seal construction and envelope encryption)
- No remaining references to `aeadwrapper` / `wrappers/aead`.

## Follow-ups

- PR 2: introduce a warden-owned `WrapperTypeShamir` constant.
- PR 3: bump the go-kms-wrapping family to v2.8.0, cut the KMS factory over to each wrapper's own `Type` constant, and remove the dependabot hold added in #335.
