### PR TITLE
refactor(seal): define a warden-owned WrapperTypeShamir constant

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -857,12 +857,12 @@ func setSeal(conf *config.Config, logger *log.GatedLogger, infoKeys *[]string, i
 	// Handle the case where no seal is provided
 	switch len(conf.Seals) {
 	case 0:
-		conf.Seals = append(conf.Seals, config.KMS{Type: wrapping.WrapperTypeShamir.String()})
+		conf.Seals = append(conf.Seals, config.KMS{Type: wardenseal.WrapperTypeShamir.String()})
 	case 1:
 		// If there's only one seal and it's disabled assume they want to
 		// migrate to a shamir seal and simply didn't provide it
 		if conf.Seals[0].IsDisabled() {
-			conf.Seals = append(conf.Seals, config.KMS{Type: wrapping.WrapperTypeShamir.String()})
+			conf.Seals = append(conf.Seals, config.KMS{Type: wardenseal.WrapperTypeShamir.String()})
 		}
 	}
 	createdSeals := make([]core.Seal, len(conf.Seals))

--- a/core/core.go
+++ b/core/core.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	aead "github.com/openbao/go-kms-wrapping/v2/aead"
 	"github.com/openbao/openbao/sdk/v2/helper/jsonutil"
 	"github.com/openbao/openbao/sdk/v2/physical"
@@ -951,7 +950,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 	// In older versions of warden the default seal would not store a type. This
 	// is here to offer backwards compatibility for older seal configs.
 	if barrierConf.Type == "" {
-		barrierConf.Type = wrapping.WrapperTypeShamir.String()
+		barrierConf.Type = seal.WrapperTypeShamir.String()
 	}
 
 	var recoveryConf *SealConfig
@@ -971,7 +970,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 		// In older versions of warden the default seal would not store a type. This
 		// is here to offer backwards compatibility for older seal configs.
 		if recoveryConf.Type == "" {
-			recoveryConf.Type = wrapping.WrapperTypeShamir.String()
+			recoveryConf.Type = seal.WrapperTypeShamir.String()
 		}
 	}
 
@@ -1018,13 +1017,13 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 			// We have the same barrier type and the unwrap seal is nil so we're not
 			// migrating from same to same, IOW we assume it's not a migration.
 			return nil
-		case c.seal.BarrierType() == wrapping.WrapperTypeShamir:
+		case c.seal.BarrierType() == seal.WrapperTypeShamir:
 			// The stored barrier config is not shamir, there is no disabled seal
 			// in config, and either no configured seal (which equates to Shamir)
 			// or an explicitly configured Shamir seal.
 			return fmt.Errorf("cannot seal migrate from %q to Shamir, no disabled seal in configuration",
 				existBarrierSealConfig.Type)
-		case existBarrierSealConfig.Type == wrapping.WrapperTypeShamir.String():
+		case existBarrierSealConfig.Type == seal.WrapperTypeShamir.String():
 			// The configured seal is not Shamir, the stored seal config is Shamir.
 			// This is a migration away from Shamir.
 			unwrapSeal = NewDefaultSeal(seal.NewAccess(aead.NewWrapper()))
@@ -1039,7 +1038,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 		// If we're not coming from Shamir we expect the previous seal to be
 		// in the config and disabled.
 
-		if unwrapSeal.BarrierType() == wrapping.WrapperTypeShamir {
+		if unwrapSeal.BarrierType() == seal.WrapperTypeShamir {
 			//nolint:staticcheck // Shamir is a proper noun
 			return errors.New("Shamir seals cannot be set disabled (they should simply not be set)")
 		}
@@ -1049,7 +1048,7 @@ func (c *Core) adjustForSealMigration(unwrapSeal Seal) error {
 	// c.migrationInfo.seal (old seal) and c.seal (new seal) populated.
 	unwrapSeal.SetCore(c)
 
-	if existBarrierSealConfig.Type != wrapping.WrapperTypeShamir.String() && existRecoverySealConfig == nil {
+	if existBarrierSealConfig.Type != seal.WrapperTypeShamir.String() && existRecoverySealConfig == nil {
 		return errors.New("recovery seal configuration not found for existing seal")
 	}
 

--- a/core/init.go
+++ b/core/init.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
-	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/openbao/openbao/sdk/v2/helper/shamir"
 	"github.com/stephnangue/warden/core/seal"
 	"github.com/stephnangue/warden/internal/namespace"
@@ -245,7 +244,7 @@ func (c *Core) initializeInternal(ctx context.Context, initParams *InitParams) (
 	var sealKey []byte
 	var sealKeyShares [][]byte
 
-	if barrierConfig.StoredShares == 1 && c.seal.BarrierType() == wrapping.WrapperTypeShamir {
+	if barrierConfig.StoredShares == 1 && c.seal.BarrierType() == seal.WrapperTypeShamir {
 		sealKey, sealKeyShares, err = c.generateShares(barrierConfig)
 		if err != nil {
 			c.logger.Error("error generating shares",
@@ -458,7 +457,7 @@ func (c *Core) UnsealWithStoredKeys(ctx context.Context) error {
 	c.unsealWithStoredKeysLock.Lock()
 	defer c.unsealWithStoredKeysLock.Unlock()
 
-	if c.seal.BarrierType() == wrapping.WrapperTypeShamir {
+	if c.seal.BarrierType() == seal.WrapperTypeShamir {
 		return nil
 	}
 

--- a/core/seal.go
+++ b/core/seal.go
@@ -116,7 +116,7 @@ func (d *defaultSeal) Finalize(ctx context.Context) error {
 }
 
 func (d *defaultSeal) BarrierType() wrapping.WrapperType {
-	return wrapping.WrapperTypeShamir
+	return seal.WrapperTypeShamir
 }
 
 func (d *defaultSeal) StoredKeysSupported() seal.StoredKeysSupport {

--- a/core/seal/seal.go
+++ b/core/seal/seal.go
@@ -8,6 +8,12 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+// WrapperTypeShamir identifies a Shamir barrier seal. The upstream
+// go-kms-wrapping library no longer defines per-type constants, so this is the
+// canonical value for warden. It must stay the literal "shamir" to remain
+// compatible with seal configuration already persisted on disk.
+const WrapperTypeShamir wrapping.WrapperType = "shamir"
+
 type StoredKeysSupport int
 
 const (


### PR DESCRIPTION
## What

Introduce a warden-owned constant `seal.WrapperTypeShamir = "shamir"` in the `core/seal` package and re-point every barrier-type reference in `core` and the server command from `wrapping.WrapperTypeShamir` to it (as `seal.WrapperTypeShamir` / `wardenseal.WrapperTypeShamir`). Drops the now-unused `go-kms-wrapping/v2` import from `core/core.go` and `core/init.go`.

## Why

Step 2 of 3 in migrating off go-kms-wrapping v2.7.0. The v2.8.0 release removes the per-provider `WrapperType` constants from the core library; `WrapperTypeShamir` is the only one warden references outside the KMS factory. Establishing a warden-owned source of truth now decouples the seal code from that upstream removal. The literal value stays `"shamir"`, so `defaultSeal.BarrierType()` and all stored seal-config comparisons are unchanged — no behavior or on-disk-format change. Compiles and tests green on the current core v2.7.0.

`core/seal` is already imported by both `core` and `cmd/server`; no new dependency and no import cycle (`core/seal` imports only `wrapping`).

## Test

- `go build ./...`
- `go test ./core/...` (passes)
- No remaining `wrapping.WrapperTypeShamir` references in `core/` or `cmd/`.

## Follow-ups

- PR 3: bump the go-kms-wrapping family to v2.8.0, cut the KMS factory (`internal/configutil/kms.go`) over to each wrapper's own `Type` constant plus this `seal.WrapperTypeShamir`, and remove the dependabot hold from #335.
