### PR TITLE
feat(provider): add generic REST proxy provider

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -69,6 +69,7 @@ import (
 	"github.com/stephnangue/warden/provider/prometheus"
 	"github.com/stephnangue/warden/provider/rds"
 	"github.com/stephnangue/warden/provider/redshift"
+	"github.com/stephnangue/warden/provider/rest"
 	"github.com/stephnangue/warden/provider/scaleway"
 	"github.com/stephnangue/warden/provider/sentry"
 	"github.com/stephnangue/warden/provider/servicenow"
@@ -183,6 +184,7 @@ Usage: warden server [options]
 		"vault":         vault.Factory,
 		"rds":           rds.Factory,
 		"redshift":      redshift.Factory,
+		"rest":          rest.Factory,
 		"scaleway":      scaleway.Factory,
 		"sentry":        sentry.Factory,
 	}
@@ -203,6 +205,7 @@ Usage: warden server [options]
 		"mcp_aws":       mcp_aws.Skill(),
 		"openai":        openai.Skill(),
 		"rds":           rds.Skill(),
+		"rest":          rest.Skill(),
 		"scaleway":      scaleway.Skill(),
 		"slack":         slack.Skill(),
 		"vault":         vault.Skill(),

--- a/provider/rest/README.md
+++ b/provider/rest/README.md
@@ -1,0 +1,228 @@
+# REST Provider
+
+The REST provider proxies requests to **any single-token REST API** through Warden, with automatic credential injection and policy evaluation. Instead of shipping a dedicated provider per upstream, you point a `rest` mount at the API you want and describe its auth in configuration.
+
+One mount fronts one upstream. Three config fields cover the common conventions:
+
+- **`base_url`** — the upstream API base URL.
+- **`token_header`** (+ **`token_prefix`**) — which header the brokered token goes into, and the scheme prefix (`Bearer `, `token `, `SSWS `, …).
+- **`headers`** — additional static headers (tenant id, API version, app id) pinned on every request.
+
+The token *value* is always brokered per request from the credential subsystem (per-role minting, rotation, policy, audit) — it is never stored in the mount config.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Step 1: Configure JWT Auth and Create a Role](#step-1-configure-jwt-auth-and-create-a-role)
+- [Step 2: Mount and Configure the Provider](#step-2-mount-and-configure-the-provider)
+- [Step 3: Create a Credential Source and Spec](#step-3-create-a-credential-source-and-spec)
+- [Step 4: Create a Policy](#step-4-create-a-policy)
+- [Step 5: Get a JWT and Make Requests](#step-5-get-a-jwt-and-make-requests)
+- [Auth Header Recipes](#auth-header-recipes)
+- [Configuration Reference](#configuration-reference)
+- [Token Management](#token-management)
+
+## Prerequisites
+
+- A REST API reachable from Warden and a token for it (static API key, or a token mintable by one of Warden's credential sources).
+
+> **New to Warden?** Follow these steps to get a local dev environment running:
+>
+> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
+> ```bash
+> curl -fsSL -o docker-compose.quickstart.yml \
+>   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
+> docker compose -f docker-compose.quickstart.yml up -d
+> ```
+>
+> **2. Download the latest Warden binary** from the [releases page](https://github.com/stephnangue/warden/releases/latest) and add it to your `PATH`.
+>
+> **3. Start the Warden server** in dev mode:
+> ```bash
+> warden server -dev -dev-root-token=root
+> ```
+>
+> **4. In another terminal window**, export the environment variables for the CLI:
+> ```bash
+> export WARDEN_ADDR="http://127.0.0.1:8400"
+> export WARDEN_TOKEN="root"
+> ```
+
+## Step 1: Configure JWT Auth and Create a Role
+
+Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+
+> **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
+
+```bash
+# Enable JWT auth if not already enabled
+warden auth enable jwt
+
+# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
+
+# Create a role that binds the credential spec and policy
+warden write auth/jwt/role/billing-user \
+    token_policies="billing-access" \
+    user_claim=sub \
+    cred_spec_name=billing-ops
+```
+
+## Step 2: Mount and Configure the Provider
+
+Enable the provider at a path that names the upstream, and give it a **description** — this is how agents and operators discover what the mount fronts:
+
+```bash
+warden provider enable -path=billing-api -description="Internal billing REST API (api.billing.internal)" rest
+```
+
+Configure it. `base_url` and `auto_auth_path` are required; the header fields default to `Authorization: Bearer <token>`:
+
+```bash
+warden write billing-api/config <<EOF
+{
+  "base_url": "https://api.billing.internal",
+  "auto_auth_path": "auth/jwt/",
+  "token_header": "X-Auth-Token",
+  "token_prefix": "",
+  "headers": "X-Account-Id=acme,X-Api-Version=2024-01",
+  "timeout": "30s"
+}
+EOF
+```
+
+Verify the configuration (the token value is never shown — it is brokered per request):
+
+```bash
+warden read billing-api/config
+```
+
+> **Header values containing commas** (e.g. an `Accept` value like `application/vnd.heroku+json; version=3` is fine, but a comma-bearing value is not) must use the JSON-object form: `"headers": {"Accept": "a,b"}`.
+
+> **Header validation.** `token_header` and `headers` names/values are validated when you write the config — an invalid HTTP header name or value is rejected immediately rather than failing on every proxied request. Header names are treated case-insensitively, so a static header that differs from `token_header` only in case never shadows the injected token.
+
+## Step 3: Create a Credential Source and Spec
+
+The REST provider injects a `TypeAPIKey` or `TypeOAuthBearerToken` credential — any source that mints an `api_key` field works: `apikey` (static), `oauth2` (client-credentials / refresh), `grafana`, `honeycomb`, `elastic`.
+
+### Option A: Static API token
+
+```bash
+warden cred source create billing-src \
+  -type=apikey \
+  -rotation-period=0 \
+  -config=display_name=Billing
+
+warden cred spec create billing-ops \
+  -source billing-src \
+  -config api_key=your-upstream-token
+```
+
+### Option B: OAuth2 client-credentials (minted, refreshable)
+
+```bash
+warden cred source create billing-oauth-src \
+  -type=oauth2 \
+  -config=token_url=https://auth.billing.internal/oauth2/token \
+  -config=client_id=warden-agent \
+  -config=client_secret=your-client-secret \
+  -config=scope="invoices:read invoices:write"
+
+warden cred spec create billing-ops \
+  -source billing-oauth-src
+```
+
+## Step 4: Create a Policy
+
+Grant access to the provider gateway:
+
+```bash
+warden policy write billing-access - <<EOF
+path "billing-api/role/+/gateway*" {
+  capabilities = ["create", "read", "update", "delete", "patch"]
+}
+EOF
+```
+
+## Step 5: Get a JWT and Make Requests
+
+```bash
+export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+The URL pattern is `/v1/<mount>/role/{role}/gateway/{api-path}`. Everything after `/gateway/` — path, query, method, body — is forwarded verbatim:
+
+```bash
+export BILLING="${WARDEN_ADDR}/v1/billing-api/role/billing-user/gateway"
+
+# GET
+curl -s "${BILLING}/v1/invoices?status=open" \
+  -H "Authorization: Bearer ${JWT_TOKEN}"
+
+# POST
+curl -s -X POST "${BILLING}/v1/invoices" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"customer":"acme","amount":4200}'
+```
+
+Warden strips the inbound Warden JWT, injects the upstream token into your configured header (here `X-Auth-Token`), adds the pinned `X-Account-Id`/`X-Api-Version` headers, and forwards to `https://api.billing.internal`. The role may also be supplied via the `X-Warden-Role` header or the mount's `default_role` instead of the URL path.
+
+## Auth Header Recipes
+
+The same provider fronts many APIs by varying three fields. Common upstreams:
+
+| Upstream | `token_header` | `token_prefix` | `headers` |
+|---|---|---|---|
+| Stripe / HubSpot / Airtable / DigitalOcean / SendGrid | `Authorization` (default) | `Bearer ` (default) | — |
+| Notion | `Authorization` | `Bearer ` | `Notion-Version=2022-06-28` |
+| Shopify Admin | `X-Shopify-Access-Token` | `""` | — |
+| Okta | `Authorization` | `SSWS ` | — |
+| Discord (bot) | `Authorization` | `Bot ` | — |
+| Snyk | `Authorization` | `token ` | — |
+| Linear | `Authorization` | `""` | — |
+| Algolia | `X-Algolia-API-Key` | `""` | `X-Algolia-Application-Id=<app>` |
+| Postmark | `X-Postmark-Server-Token` | `""` | — |
+| Fastly | `Fastly-Key` | `""` | — |
+| Twitch (Helix) | `Authorization` | `Bearer ` | `Client-Id=<id>` |
+
+`token_prefix` distinguishes the unset default (`Bearer `) from an explicit empty string (raw token in the header) — set `token_prefix=""` for APIs that want the bare token.
+
+## Configuration Reference
+
+### Provider Config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `base_url` | string | — | **Required.** Upstream API base URL (HTTPS unless `tls_skip_verify`) |
+| `token_header` | string | `Authorization` | Header the brokered token is injected into |
+| `token_prefix` | string | `Bearer ` | Prefix prepended to the token; set `""` for a raw token |
+| `headers` | key=value | — | Additional static headers injected on every request (override client values) |
+| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
+| `timeout` | duration | `30s` | Request timeout |
+| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g. `auth/jwt/`, `auth/cert/`) |
+| `default_role` | string | — | Fallback role when not specified in the URL |
+| `tls_skip_verify` | bool | `false` | Skip upstream TLS verification (development only) |
+| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
+
+### Supported Credential Types
+
+| Source `-type` | Credential type | Notes |
+|---|---|---|
+| `apikey` | `api_key` | Static token on the spec |
+| `oauth2` | `oauth_bearer_token` | OAuth2 client-credentials / refresh; token minted and refreshed |
+| `grafana`, `honeycomb`, `elastic` | `api_key` | Dynamically minted keys |
+
+All carry the token in the `api_key` field. Git, Kubernetes, and cloud credential types are **not** supported — use their dedicated providers.
+
+## Token Management
+
+| Aspect | Details |
+|--------|---------|
+| **Storage** | The token lives on the credential spec/source, never in the `rest` mount config |
+| **Injection** | Brokered per request and placed in `token_header`; rotated tokens take effect immediately |
+| **Rotation** | Static tokens: update the spec (`warden cred spec update`). OAuth2/dynamic: minted and refreshed automatically |
+| **Exposure** | `warden read <mount>/config` shows header placement only — never the secret |

--- a/provider/rest/provider.go
+++ b/provider/rest/provider.go
@@ -1,0 +1,269 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"time"
+
+	"golang.org/x/net/http/httpguts"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+)
+
+// DefaultRESTTimeout is the default request timeout for proxied REST calls.
+const DefaultRESTTimeout = 30 * time.Second
+
+const (
+	defaultTokenHeader = "Authorization"
+	defaultTokenPrefix = "Bearer "
+)
+
+// Spec defines the generic REST provider for the httpproxy framework.
+//
+// Unlike service-specific providers (openai, slack, …) that hard-code one
+// upstream and one auth-header convention, the rest provider lets the operator
+// point a mount at any single-token REST API purely through config:
+//
+//   - base_url      the upstream API base URL
+//   - token_header  the header the brokered token is injected into (default Authorization)
+//   - token_prefix  prepended to the token (default "Bearer "; set "" for a raw token)
+//   - headers       additional static headers injected on every proxied request
+//
+// The token value itself is brokered per request from the credential subsystem
+// exactly like every other provider; only its placement is configurable.
+var Spec = &httpproxy.ProviderSpec{
+	Name:            "rest",
+	DefaultURL:      "", // operator must configure base_url
+	URLConfigKey:    "base_url",
+	DefaultTimeout:  DefaultRESTTimeout,
+	ParseStreamBody: false,
+	UserAgent:       "warden-rest-proxy",
+	HelpText:        restBackendHelp,
+
+	// Defensive default. At request time ResolveUpstream always supplies a
+	// state-derived extractor, so this is never consulted; it only guards
+	// against a nil-func call if that ever changes.
+	ExtractCredentials: tokenExtractor(defaultTokenHeader, defaultTokenPrefix, nil),
+
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"token_header": {
+			Type:        framework.TypeString,
+			Default:     defaultTokenHeader,
+			Description: "Header name the brokered token is injected into (default: Authorization)",
+		},
+		"token_prefix": {
+			Type:        framework.TypeString,
+			Default:     defaultTokenPrefix,
+			Description: `Prefix prepended to the token (e.g. "Bearer "); set to "" for a raw token in the header`,
+		},
+		"headers": {
+			Type:        framework.TypeKVPairs,
+			Description: "Additional static headers (name=value) injected on every proxied request; these override client-supplied headers of the same name",
+		},
+	},
+
+	// Single state-aware injection point: token header + static headers are
+	// returned together by the credential extractor so both are applied with
+	// override (Header.Set) semantics — operator-pinned headers cannot be
+	// suppressed by a client sending the same header name.
+	ResolveUpstream: func(_ *http.Request, _ string, state map[string]any) (httpproxy.Dispatch, bool) {
+		header := stateString(state, "token_header", defaultTokenHeader)
+		prefix := statePrefix(state)
+		static := stateHeaders(state)
+		return httpproxy.Dispatch{ExtractCredentials: tokenExtractor(header, prefix, static)}, true
+	},
+
+	OnConfigWrite: func(d *framework.FieldData, state map[string]any) (map[string]any, error) {
+		var headerName string
+		hasHeaderName := false
+		if v, ok := d.GetOk("token_header"); ok {
+			headerName = v.(string)
+			hasHeaderName = true
+		}
+		var headers map[string]string
+		if v, ok := d.GetOk("headers"); ok {
+			headers = coerceStringMap(v)
+		}
+		if err := validateRESTConfig(headerName, hasHeaderName, headers); err != nil {
+			return nil, err
+		}
+
+		if hasHeaderName {
+			state["token_header"] = headerName
+		}
+		// token_prefix is stored whenever provided (GetOk reports present even
+		// for an explicit ""), which is how a raw-token header is distinguished
+		// from the unset default.
+		if v, ok := d.GetOk("token_prefix"); ok {
+			state["token_prefix"] = v.(string)
+		}
+		if _, ok := d.GetOk("headers"); ok {
+			state["headers"] = headers
+		}
+		return state, nil
+	},
+
+	OnConfigRead: func(state map[string]any) map[string]any {
+		return map[string]any{
+			"token_header": stateString(state, "token_header", defaultTokenHeader),
+			"token_prefix": statePrefix(state),
+			"headers":      stateHeaders(state),
+		}
+	},
+
+	OnInitialize: func(config map[string]any, state map[string]any) map[string]any {
+		if v, ok := config["token_header"].(string); ok && v != "" {
+			state["token_header"] = v
+		}
+		// Preserve an explicit empty prefix (raw token); only the absence of the
+		// key falls through to the "Bearer " default at read time.
+		if v, ok := config["token_prefix"]; ok {
+			if s, ok := v.(string); ok {
+				state["token_prefix"] = s
+			}
+		}
+		if h := coerceStringMap(config["headers"]); len(h) > 0 {
+			state["headers"] = h
+		}
+		return state
+	},
+
+	ValidateExtraConfig: func(conf map[string]any) error {
+		headerName, hasHeaderName := conf["token_header"].(string)
+		return validateRESTConfig(headerName, hasHeaderName, coerceStringMap(conf["headers"]))
+	},
+}
+
+// Factory creates a new generic REST provider backend.
+var Factory = httpproxy.NewFactory(Spec)
+
+// tokenExtractor returns a credential extractor that injects the brokered token
+// into header (prefixed with prefix) alongside any static headers. The token
+// entry is written last so it wins a key collision with a static header.
+//
+// Both TypeAPIKey and TypeOAuthBearerToken are accepted: each stores its token
+// in Data["api_key"] (the oauth2 source maps its access token there), so one
+// path serves static keys, dynamically minted keys, and OAuth2 bearer tokens.
+func tokenExtractor(header, prefix string, static map[string]string) httpproxy.CredentialExtractor {
+	return func(req *logical.Request) (map[string]string, error) {
+		if req.Credential == nil {
+			return nil, fmt.Errorf("no credential available")
+		}
+		if req.Credential.Type != credential.TypeAPIKey && req.Credential.Type != credential.TypeOAuthBearerToken {
+			return nil, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+		}
+		apiKey := req.Credential.Data["api_key"]
+		if apiKey == "" {
+			return nil, fmt.Errorf("credential missing api_key field")
+		}
+		// Canonicalize header names so a static header that differs from the
+		// token header only in case collapses onto the same map key rather than
+		// surfacing as two entries that the downstream Header.Set would apply in
+		// nondeterministic (map-iteration) order. The token is written last so it
+		// always wins a collision.
+		headers := make(map[string]string, len(static)+1)
+		for k, v := range static {
+			headers[textproto.CanonicalMIMEHeaderKey(k)] = v
+		}
+		headers[textproto.CanonicalMIMEHeaderKey(header)] = prefix + apiKey
+		return headers, nil
+	}
+}
+
+// stateString returns the string value at key, defaulting when the key is
+// absent or empty.
+func stateString(state map[string]any, key, def string) string {
+	if s, _ := state[key].(string); s != "" {
+		return s
+	}
+	return def
+}
+
+// statePrefix returns the configured token prefix. An absent token_prefix key
+// yields the "Bearer " default; a key that is present — even an empty string —
+// is honored verbatim, so token_prefix="" produces a raw token in the header.
+func statePrefix(state map[string]any) string {
+	if v, ok := state["token_prefix"]; ok {
+		s, _ := v.(string)
+		return s
+	}
+	return defaultTokenPrefix
+}
+
+// stateHeaders returns the configured static headers, coercing the
+// map[string]any shape that JSON-decoded persisted config yields back into
+// map[string]string.
+func stateHeaders(state map[string]any) map[string]string {
+	return coerceStringMap(state["headers"])
+}
+
+// coerceStringMap normalizes a header map that may arrive as map[string]string
+// (fresh from FieldData) or map[string]any (after a storage JSON round-trip)
+// into map[string]string. Returns nil for any other shape.
+func coerceStringMap(v any) map[string]string {
+	switch m := v.(type) {
+	case map[string]string:
+		return m
+	case map[string]any:
+		out := make(map[string]string, len(m))
+		for k, val := range m {
+			if s, ok := val.(string); ok {
+				out[k] = s
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// validateRESTConfig rejects header names/values that the HTTP layer would
+// later refuse to write — using the same validators net/http applies at
+// request time (httpguts), so an invalid header is caught at config time
+// instead of 502-ing every proxied request. An empty token_header is allowed
+// and falls back to the Authorization default.
+func validateRESTConfig(tokenHeader string, hasTokenHeader bool, headers map[string]string) error {
+	if hasTokenHeader && tokenHeader != "" && !httpguts.ValidHeaderFieldName(tokenHeader) {
+		return fmt.Errorf("invalid token_header %q: not a valid HTTP header name", tokenHeader)
+	}
+	for k, v := range headers {
+		if !httpguts.ValidHeaderFieldName(k) {
+			return fmt.Errorf("invalid header name %q: not a valid HTTP header name", k)
+		}
+		if !httpguts.ValidHeaderFieldValue(v) {
+			return fmt.Errorf("invalid value for header %q: not a valid HTTP header value", k)
+		}
+	}
+	return nil
+}
+
+const restBackendHelp = `
+The REST provider proxies requests to any single-token REST API with automatic
+credential injection. A single provider type fronts arbitrary upstreams by
+mounting multiple instances with different configuration.
+
+Warden performs implicit authentication on every request, obtains the upstream
+token from the credential manager, and injects it into the configured header.
+The token value is never stored in the mount configuration.
+
+Configuration:
+- base_url:       Upstream API base URL (required)
+- token_header:   Header the brokered token is injected into (default: Authorization)
+- token_prefix:   Prefix prepended to the token (default: "Bearer "; set "" for a raw token)
+- headers:        Additional static headers (name=value) injected on every request
+- max_body_size:  Maximum request body size (default: 10MB, max: 100MB)
+- timeout:        Request timeout duration (default: 30s)
+- auto_auth_path: Auth mount path for implicit authentication (e.g. 'auth/jwt/')
+- default_role:   Fallback role when not specified in the URL path
+- tls_skip_verify, ca_data: TLS options for the upstream connection
+
+The gateway path format is:
+  /<mount>/gateway/{api-path}
+  /<mount>/role/{role}/gateway/{api-path}
+
+Supported credential types: api_key (apikey/grafana/honeycomb/elastic sources)
+and oauth_bearer_token (oauth2 source). Both carry the token in the api_key field.
+`

--- a/provider/rest/provider_test.go
+++ b/provider/rest/provider_test.go
@@ -1,0 +1,281 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func apiKeyReq(t string, key string) *logical.Request {
+	return &logical.Request{
+		Credential: &credential.Credential{
+			Type: t,
+			Data: map[string]string{"api_key": key},
+		},
+	}
+}
+
+func TestTokenExtractor_DefaultBearer(t *testing.T) {
+	headers, err := tokenExtractor("Authorization", "Bearer ", nil)(apiKeyReq(credential.TypeAPIKey, "sk-123"))
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer sk-123", headers["Authorization"])
+}
+
+func TestTokenExtractor_AcceptsOAuthBearerType(t *testing.T) {
+	// The oauth2 source mints TypeOAuthBearerToken but stores the token in api_key.
+	headers, err := tokenExtractor("Authorization", "Bearer ", nil)(apiKeyReq(credential.TypeOAuthBearerToken, "at-456"))
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer at-456", headers["Authorization"])
+}
+
+func TestTokenExtractor_CustomHeaderNoPrefix(t *testing.T) {
+	// Header names are canonicalized; "X-API-Key" -> "X-Api-Key" (the form the
+	// HTTP layer puts on the wire regardless).
+	headers, err := tokenExtractor("X-API-Key", "", nil)(apiKeyReq(credential.TypeAPIKey, "raw-key"))
+	require.NoError(t, err)
+	assert.Equal(t, "raw-key", headers["X-Api-Key"])
+	_, hasAuth := headers["Authorization"]
+	assert.False(t, hasAuth)
+}
+
+func TestTokenExtractor_CaseInsensitiveTokenWins(t *testing.T) {
+	// A static header that differs from the token header only in case must not
+	// shadow the token: both collapse onto the canonical key and the token wins.
+	static := map[string]string{"authorization": "attacker"}
+	headers, err := tokenExtractor("Authorization", "Bearer ", static)(apiKeyReq(credential.TypeAPIKey, "real"))
+	require.NoError(t, err)
+	assert.Len(t, headers, 1)
+	assert.Equal(t, "Bearer real", headers["Authorization"])
+}
+
+func TestTokenExtractor_PrefixScheme(t *testing.T) {
+	headers, err := tokenExtractor("Authorization", "token ", nil)(apiKeyReq(credential.TypeAPIKey, "ghp"))
+	require.NoError(t, err)
+	assert.Equal(t, "token ghp", headers["Authorization"])
+}
+
+func TestTokenExtractor_StaticHeadersMerged(t *testing.T) {
+	static := map[string]string{"X-Account-Id": "acme", "X-Api-Version": "2024-01"}
+	headers, err := tokenExtractor("X-Auth-Token", "", static)(apiKeyReq(credential.TypeAPIKey, "tok"))
+	require.NoError(t, err)
+	assert.Equal(t, "tok", headers["X-Auth-Token"])
+	assert.Equal(t, "acme", headers["X-Account-Id"])
+	assert.Equal(t, "2024-01", headers["X-Api-Version"])
+}
+
+func TestTokenExtractor_TokenWinsHeaderCollision(t *testing.T) {
+	// A static header that collides with the token header must not shadow the token.
+	static := map[string]string{"Authorization": "static-value"}
+	headers, err := tokenExtractor("Authorization", "Bearer ", static)(apiKeyReq(credential.TypeAPIKey, "real"))
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer real", headers["Authorization"])
+}
+
+func TestTokenExtractor_DoesNotMutateStatic(t *testing.T) {
+	static := map[string]string{"X-A": "1"}
+	_, err := tokenExtractor("Authorization", "Bearer ", static)(apiKeyReq(credential.TypeAPIKey, "k"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"X-A": "1"}, static, "extractor must not mutate the shared static map")
+}
+
+func TestTokenExtractor_Errors(t *testing.T) {
+	extract := tokenExtractor("Authorization", "Bearer ", nil)
+
+	_, err := extract(&logical.Request{})
+	assert.ErrorContains(t, err, "no credential available")
+
+	_, err = extract(&logical.Request{Credential: &credential.Credential{Type: credential.TypeGitHubToken}})
+	assert.ErrorContains(t, err, "unsupported credential type")
+
+	_, err = extract(&logical.Request{Credential: &credential.Credential{
+		Type: credential.TypeAPIKey,
+		Data: map[string]string{},
+	}})
+	assert.ErrorContains(t, err, "missing api_key")
+}
+
+func TestStatePrefix_AbsentVsPresentEmpty(t *testing.T) {
+	// Absent → default "Bearer "
+	assert.Equal(t, "Bearer ", statePrefix(map[string]any{}))
+	// Present empty → raw (no prefix). This is what enables a raw Authorization header.
+	assert.Equal(t, "", statePrefix(map[string]any{"token_prefix": ""}))
+	// Present non-empty → verbatim
+	assert.Equal(t, "SSWS ", statePrefix(map[string]any{"token_prefix": "SSWS "}))
+}
+
+func TestStateString_Default(t *testing.T) {
+	assert.Equal(t, "Authorization", stateString(map[string]any{}, "token_header", "Authorization"))
+	assert.Equal(t, "Authorization", stateString(map[string]any{"token_header": ""}, "token_header", "Authorization"))
+	assert.Equal(t, "X-API-Key", stateString(map[string]any{"token_header": "X-API-Key"}, "token_header", "Authorization"))
+}
+
+func TestCoerceStringMap(t *testing.T) {
+	assert.Equal(t, map[string]string{"a": "b"}, coerceStringMap(map[string]string{"a": "b"}))
+	// JSON round-trip shape
+	assert.Equal(t, map[string]string{"a": "b"}, coerceStringMap(map[string]any{"a": "b"}))
+	// non-string values in a map[string]any are dropped
+	assert.Equal(t, map[string]string{"a": "b"}, coerceStringMap(map[string]any{"a": "b", "n": 5}))
+	assert.Nil(t, coerceStringMap(nil))
+	assert.Nil(t, coerceStringMap("not-a-map"))
+}
+
+func TestResolveUpstream_BuildsExtractorFromState(t *testing.T) {
+	// Custom header, raw prefix, plus a static header — all sourced from state.
+	state := map[string]any{
+		"token_header": "X-Algolia-API-Key",
+		"token_prefix": "",
+		"headers":      map[string]string{"X-Algolia-Application-Id": "APP123"},
+	}
+	d, ok := Spec.ResolveUpstream(nil, "", state)
+	require.True(t, ok)
+	require.NotNil(t, d.ExtractCredentials)
+
+	headers, err := d.ExtractCredentials(apiKeyReq(credential.TypeAPIKey, "algkey"))
+	require.NoError(t, err)
+	assert.Equal(t, "algkey", headers["X-Algolia-Api-Key"])
+	assert.Equal(t, "APP123", headers["X-Algolia-Application-Id"])
+}
+
+// TestHeaderApplication_TokenWinsCaseCollision drives the extractor output
+// through the same Header.Set application the gateway performs (gateway.go
+// prepareHeaders), reproducing the case-collision seam: a static header that
+// differs from the token header only in case must not overwrite the token,
+// deterministically, regardless of map-iteration order.
+func TestHeaderApplication_TokenWinsCaseCollision(t *testing.T) {
+	state := map[string]any{
+		"token_header": "Authorization",
+		"token_prefix": "Bearer ",
+		"headers":      map[string]string{"authorization": "attacker", "x-tenant": "acme"},
+	}
+	// Map iteration is randomized; the applied result must be stable across runs.
+	for i := 0; i < 50; i++ {
+		d, ok := Spec.ResolveUpstream(nil, "", state)
+		require.True(t, ok)
+		extracted, err := d.ExtractCredentials(apiKeyReq(credential.TypeAPIKey, "real-token"))
+		require.NoError(t, err)
+
+		h := http.Header{}
+		for k, v := range extracted {
+			h.Set(k, v)
+		}
+		assert.Equal(t, "Bearer real-token", h.Get("Authorization"))
+		assert.Equal(t, "acme", h.Get("X-Tenant"))
+	}
+}
+
+func TestResolveUpstream_DefaultsWhenStateEmpty(t *testing.T) {
+	d, ok := Spec.ResolveUpstream(nil, "", map[string]any{})
+	require.True(t, ok)
+	headers, err := d.ExtractCredentials(apiKeyReq(credential.TypeAPIKey, "k"))
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer k", headers["Authorization"])
+}
+
+func fieldData(raw map[string]any) *framework.FieldData {
+	return &framework.FieldData{Raw: raw, Schema: Spec.ExtraConfigFields}
+}
+
+func TestOnConfigWrite_StoresFields(t *testing.T) {
+	state, err := Spec.OnConfigWrite(fieldData(map[string]any{
+		"token_header": "X-API-Key",
+		"token_prefix": "",
+		"headers":      map[string]string{"X-Env": "dev"},
+	}), map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, "X-API-Key", state["token_header"])
+	assert.Equal(t, "", state["token_prefix"])
+	assert.Equal(t, map[string]string{"X-Env": "dev"}, stateHeaders(state))
+}
+
+func TestOnConfigWrite_PartialPreservesPriorValues(t *testing.T) {
+	state := map[string]any{"token_header": "X-API-Key", "token_prefix": ""}
+	// A write that only changes headers must not clobber token_header/token_prefix.
+	state, err := Spec.OnConfigWrite(fieldData(map[string]any{
+		"headers": map[string]string{"X-A": "1"},
+	}), state)
+	require.NoError(t, err)
+	assert.Equal(t, "X-API-Key", state["token_header"])
+	assert.Equal(t, "", state["token_prefix"])
+	assert.Equal(t, map[string]string{"X-A": "1"}, stateHeaders(state))
+}
+
+func TestOnConfigWrite_RejectsInvalidConfig(t *testing.T) {
+	_, err := Spec.OnConfigWrite(fieldData(map[string]any{"token_header": "Bad Header"}), map[string]any{})
+	assert.ErrorContains(t, err, "invalid token_header")
+
+	_, err = Spec.OnConfigWrite(fieldData(map[string]any{
+		"headers": map[string]string{"X-Bad": "line1\nline2"},
+	}), map[string]any{})
+	assert.ErrorContains(t, err, "invalid value for header")
+
+	_, err = Spec.OnConfigWrite(fieldData(map[string]any{
+		"headers": map[string]string{"Bad Key": "v"},
+	}), map[string]any{})
+	assert.ErrorContains(t, err, "invalid header name")
+}
+
+func TestValidateExtraConfig_AllowsEmptyTokenHeader(t *testing.T) {
+	// An explicit empty token_header is allowed; it falls back to Authorization.
+	assert.NoError(t, Spec.ValidateExtraConfig(map[string]any{"token_header": ""}))
+	assert.Error(t, Spec.ValidateExtraConfig(map[string]any{"token_header": "X Y"}))
+}
+
+// TestConfigRoundTrip_PersistReload reproduces the SDK persist→reload cycle:
+// OnConfigWrite → OnConfigRead (persisted) → JSON storage round-trip →
+// OnInitialize. It guards F2 (headers map must survive the JSON round-trip)
+// and F3 (an explicit empty token_prefix must survive as a raw header).
+func TestConfigRoundTrip_PersistReload(t *testing.T) {
+	state, err := Spec.OnConfigWrite(fieldData(map[string]any{
+		"token_header": "X-Auth-Token",
+		"token_prefix": "",
+		"headers":      map[string]string{"X-Account-Id": "acme", "X-Api-Version": "2024-01"},
+	}), map[string]any{})
+	require.NoError(t, err)
+
+	// What the SDK persists for the extra fields.
+	persisted := Spec.OnConfigRead(state)
+
+	// Simulate storage: JSON encode then decode into the generic map shape that
+	// Initialize hands to OnInitialize (objects decode to map[string]interface{}).
+	blob, err := json.Marshal(persisted)
+	require.NoError(t, err)
+	var reloaded map[string]any
+	require.NoError(t, json.Unmarshal(blob, &reloaded))
+
+	newState := Spec.OnInitialize(reloaded, map[string]any{})
+
+	// Headers survived the round-trip (F2).
+	assert.Equal(t, map[string]string{"X-Account-Id": "acme", "X-Api-Version": "2024-01"}, stateHeaders(newState))
+	// Raw token (empty prefix) survived (F3).
+	assert.Equal(t, "", statePrefix(newState))
+	assert.Equal(t, "X-Auth-Token", stateString(newState, "token_header", defaultTokenHeader))
+
+	// And the rebuilt extractor injects the right headers.
+	d, ok := Spec.ResolveUpstream(nil, "", newState)
+	require.True(t, ok)
+	headers, err := d.ExtractCredentials(apiKeyReq(credential.TypeAPIKey, "tok"))
+	require.NoError(t, err)
+	assert.Equal(t, "tok", headers["X-Auth-Token"])
+	assert.Equal(t, "acme", headers["X-Account-Id"])
+}
+
+func TestOnInitialize_DefaultsPrefixWhenAbsent(t *testing.T) {
+	// A persisted config without token_prefix falls back to the Bearer default.
+	newState := Spec.OnInitialize(map[string]any{"token_header": "Authorization"}, map[string]any{})
+	assert.Equal(t, "Bearer ", statePrefix(newState))
+}
+
+func TestSpec(t *testing.T) {
+	assert.Equal(t, "rest", Spec.Name)
+	assert.Equal(t, "base_url", Spec.URLConfigKey)
+	assert.Equal(t, "", Spec.DefaultURL)
+	assert.NotNil(t, Spec.ResolveUpstream)
+	assert.NotNil(t, Spec.ExtractCredentials)
+	assert.NotNil(t, Factory)
+}

--- a/provider/rest/skill.go
+++ b/provider/rest/skill.go
@@ -1,0 +1,14 @@
+package rest
+
+import _ "embed"
+
+//go:embed skill.md
+var skillMD string
+
+// Skill returns the agent-facing skill markdown for the generic REST provider.
+// The content is seeded into the global skill registry the first time a rest
+// provider is mounted in the cluster; subsequent mounts are no-ops and operator
+// edits to the registered skill are preserved.
+func Skill() string {
+	return skillMD
+}

--- a/provider/rest/skill.md
+++ b/provider/rest/skill.md
@@ -1,0 +1,82 @@
+---
+name: rest
+description: "Call an arbitrary single-token REST API through Warden — the specific upstream is set by the operator per mount; identify it from the mount's description, never from the provider type."
+category: provider-guide
+provider: rest
+requires: [foundation, discovery]
+upstream: Operator-defined (see the mount description)
+---
+
+# A REST API through Warden
+
+## What it does
+
+Warden proxies requests to a single-token REST API. The agent calls a
+Warden URL; Warden authenticates the caller (JWT/cert), looks up the
+upstream token bound to the chosen role, injects it into the header the
+operator configured, and forwards the request. The agent **never holds
+the upstream token**.
+
+## Which upstream is this?
+
+The `rest` type is **generic** — one mount fronts Stripe, another fronts
+an internal billing API, another fronts Algolia. You **cannot** tell the
+upstream from the provider type, and you **must not** guess it from the
+mount path or config.
+
+Read the mount's **`description`** from discovery (`warden provider list`)
+to learn:
+- which service this mount proxies, and
+- its base path / which API routes are in scope.
+
+If the description does not make the upstream clear, stop and ask — do not
+assume. Two `rest` mounts are interchangeable only if their descriptions
+say so.
+
+## Configure the CLI/SDK
+
+`<mount-url>` and `<role>` come from the discovery flow:
+- `<mount-url>` is the chosen mount's `mount_url` from
+  `warden provider list` (e.g. `/v1/billing-api/`).
+- `<role>` is the role you picked from `warden role list` for this task —
+  it goes in the URL path.
+
+```
+URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<upstream-path>
+Auth header : Authorization: Bearer $WARDEN_TOKEN
+```
+
+Rewrite the upstream host to
+`$WARDEN_ADDR<mount-url>role/<role>/gateway` and add your Warden token as
+the bearer. Everything after `/gateway/` — path, query string, method,
+body — is forwarded verbatim to the upstream. Warden injects the upstream
+credential for you; do not send the upstream's own token.
+
+## Examples
+
+(Assume `mount_url = /v1/billing-api/` and role `finance`, fronting an
+internal REST API per its description; substitute yours.)
+
+GET a resource:
+```bash
+curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+  $WARDEN_ADDR/v1/billing-api/role/finance/gateway/v1/invoices?status=open
+```
+
+POST a resource:
+```bash
+curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"customer":"acme","amount":4200}' \
+  $WARDEN_ADDR/v1/billing-api/role/finance/gateway/v1/invoices
+```
+
+If the operator pinned extra headers (tenant id, API version, app id) on
+the mount, Warden adds them automatically — you do not send them.
+
+## Notes
+
+- All HTTP methods and status codes pass through unchanged; handle the
+  upstream's native error bodies as documented by that upstream.
+- 401 from Warden (not the upstream) means the caller/role isn't allowed
+  or no upstream credential is bound to the role — re-check discovery.


### PR DESCRIPTION
## Summary

Adds a generic `rest` provider so operators can front **any single-token REST API** (Stripe, Notion, Shopify, internal APIs, …) through Warden with configuration alone — no new Go per upstream.

Three config knobs cover the common auth conventions:
- `base_url` — upstream URL
- `token_header` (+ `token_prefix`) — which header the brokered token goes into, and its scheme prefix
- `headers` — additional static headers pinned on every request

The token *value* is brokered per request from the credential subsystem (`TypeAPIKey` / `TypeOAuthBearerToken`, both via the `api_key` field) and is never stored in mount config. Implemented as a pure `httpproxy.ProviderSpec` (no SDK/framework changes), modeled on the grafana provider.

## Details
- Token + static headers injected with **override** semantics via a state-aware `ResolveUpstream` extractor.
- Header names canonicalized so a case-variant static header cannot nondeterministically shadow the injected token; names/values validated at config time via `httpguts` (fails fast instead of 502-ing every request).
- `ParseStreamBody: false` (fronts arbitrary, possibly-binary bodies).
- Registered in `cmd/server/server.go` (factory + agent skill).
- Ships an agent skill that tells agents to identify the upstream from the operator-set mount **description**, and an operator README.

## Testing
- `go test ./provider/rest/...` — token injection (both credential types), prefix schemes, custom headers, case-collision determinism, config round-trip (persist→reload), and config validation.
- `go build ./cmd/...` — server builds with the provider registered.

## Example upstreams (config only)
Stripe, Notion, Shopify, Okta, Discord, HubSpot, Airtable, Algolia, Snyk, DigitalOcean, Vercel, Linear, Asana, Heroku, Postmark, Fastly, Twitch, SendGrid, Buildkite, Dropbox.