### PR TITLE
docs: concepts index, explicit-auth rename, access-brokering wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See [docs/architecture.md](docs/architecture.md) for Warden's design decisions, 
 
 A first-party Helm chart deploys Warden as a 3-replica HA cluster on any Kubernetes 1.27+ cluster — bring your own Postgres, your own TLS certificate, and either a Vault Transit endpoint for auto-unseal or a static seal key for development. The chart ships production-leaning defaults; a quickstart values file shrinks the install to a single replica for kind or minikube.
 
-See [docs/deployment/kubernetes.md](docs/deployment/kubernetes.md) for the full guide.
+See [docs/install/kubernetes.md](docs/install/kubernetes.md) for the full guide.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Warden is a Go service that sits between workloads and providers. A [provider](c
 
 **Key design decisions:**
 - **Seal/unseal model** — Warden protects secrets at rest with envelope encryption behind a barrier. A running server unseals itself at startup from an auto-unseal seal (Transit, AWS/GCP/Azure/OCI KMS, PKCS#11, KMIP, or a static key); `shamir` is the default seal type and splits the key into shares. Dev mode uses an in-memory seal. See [Seal and Unseal](concepts/seal-unseal.md).
-- **Credential brokering** — Warden holds the privileged upstream secret and injects a scoped, often short-lived [credential](concepts/credentials.md) into each proxied request, so workloads never hold long-lived keys.
+- **Access brokering** — Warden holds the privileged upstream secret and injects a scoped, often short-lived [credential](concepts/credentials.md) into each proxied request, so workloads reach upstreams without ever holding long-lived keys.
 - **Active/standby HA** — See [High Availability](#high-availability) below.
 - **Namespace isolation** — Every credential source, policy, and mount point is scoped to a [namespace](concepts/namespaces.md) with hard boundaries. Policies cannot leak across namespaces.
 

--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -40,14 +40,14 @@ next.
 
 ## Two Styles of Authentication
 
-### Session-token authentication
+### Explicit authentication
 
-A **Warden token** is a session credential that Warden issues and tracks. You
-obtain one by logging in against an auth method (or, for a fresh dev/production
-server, you start with the root token), then send it on the `X-Warden-Token`
-header with every subsequent request. Warden looks the token up, checks that it
-has not expired and belongs to the request's namespace, and uses the policies
-attached to it.
+You authenticate **explicitly** by logging in. A caller presents a credential to
+an auth method, Warden issues a **session token** (a Warden token), and the caller
+sends it on the `X-Warden-Token` header with every subsequent request. Warden
+looks the token up, checks that it has not expired and belongs to the request's
+namespace, and uses the policies attached to it. (A fresh dev or production server
+starts with the root token.)
 
 This is the familiar Vault-style flow: authenticate once, carry a token.
 

--- a/docs/concepts/credentials.md
+++ b/docs/concepts/credentials.md
@@ -1,11 +1,11 @@
 # Credentials
 
 Warden's purpose is to keep secrets out of workloads. Instead of
-handing an agent a static API key, Warden **brokers** credentials: it holds the
-privileged secret itself, and at request time mints or retrieves a scoped,
-often short-lived credential for the upstream system the caller is trying to
-reach. The workload presents only its [identity](authentication.md); Warden
-turns that into a usable credential.
+handing an agent a static API key, Warden **brokers access**: it holds the
+privileged secret itself and, at request time, mints or retrieves a scoped,
+often short-lived credential for the upstream the caller is trying to reach — then
+injects it into the request rather than handing it over. The workload presents only
+its [identity](authentication.md); it never holds a credential of its own.
 
 This document describes the credential model end to end — the three configuration
 objects that define where credentials come from, the drivers that talk to

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,64 @@
+# Warden Concepts
+
+A guided tour of how Warden works. The pages are ordered for a first read — top to
+bottom takes you from running a server, through the identity and authorization
+model, into how it brokers access and the agent-facing features, and out to
+multi-tenancy and production operations. Every page is cross-linked, so you can
+also jump straight to a topic.
+
+## Getting started
+
+- [Dev Server](dev-server.md) — spin up an in-memory Warden in one command to
+  follow along.
+
+## Identity and access
+
+How a caller proves who it is and what that lets it do.
+
+- [Authentication](authentication.md) — the three credential forms, transparent
+  authentication, and identity-channelling sidecars.
+- [Tokens](tokens.md) — what authentication produces: session and transparent
+  tokens, and the root token.
+- [Roles](roles.md) — how a validated credential maps to policies and access,
+  resolved per request.
+- [Policies](policies.md) — capability-based authorization, path matching, and
+  request-content rules.
+
+## Brokering access
+
+What Warden actually does: hold the privileged secret and inject a scoped credential
+into each proxied request, so the workload reaches the upstream without ever holding
+a credential of its own.
+
+- [Credentials](credentials.md) — sources, specs, drivers, lifetime, and
+  rotation.
+- [Providers](providers.md) — the gateway mounts that authenticate, authorize,
+  inject a credential, and proxy to an upstream.
+- [Model Context Protocol](mcp.md) — fronting MCP servers and authorizing
+  individual tool calls.
+
+## For AI agents
+
+- [Discovery and Skills](discovery-and-skills.md) — how an agent learns, at
+  runtime, what it may do and how.
+- [Delegation](delegation.md) — carrying the on-behalf-of chain into the audit
+  trail.
+
+## Multi-tenancy and audit
+
+- [Namespaces](namespaces.md) — the hard isolation boundary for every mount,
+  policy, and token.
+- [Audit](audit.md) — the forensic record of every request, with secrets hashed.
+
+## Running in production
+
+- [Seal and Unseal](seal-unseal.md) — the barrier, auto-unseal, and the seal
+  types.
+- [Storage](storage.md) — the encrypted-at-rest backend.
+- [High Availability](high-availability.md) — active/standby clustering over the
+  shared storage backend.
+
+---
+
+For how these pieces fit together at a glance, see the
+[Architecture](../architecture.md) overview.


### PR DESCRIPTION
Follow-up to #343 (now merged).

### Changes
- **Concepts index** — add `docs/concepts/index.md`, a reading-order table of contents for the concept guide: getting started, identity and access, brokering access, agent features, multi-tenancy and audit, production ops.
- **Explicit authentication** — rename the "Session-token authentication" style to **Explicit authentication**, so it parallels **Transparent authentication**.
- **Access brokering wording** — frame the workload-facing value as brokering *access*, not handing over credentials (`index.md`, `architecture.md`, `credentials.md`): Warden holds the privileged secret and **injects** a scoped credential into the proxied request, so the workload never holds one. Incidental "brokered credential" references, which name the credential Warden injects internally, are left intact.
- **README link** — point the Kubernetes link at `docs/install/kubernetes.md`; it still referenced the old `docs/deployment/` path after the restructure in #343.

All internal cross-links and heading anchors verified to resolve.
