### PR TITLE
docs: add agent-identity section with four identity-presentation patterns

### DIFF
--- a/docs/agent-identity/README.md
+++ b/docs/agent-identity/README.md
@@ -1,0 +1,76 @@
+# Agent Identity
+
+Before Warden can broker access for an agent, it has to know *who the agent is*.
+The agent presents an **identity vehicle** — a JWT, a SPIFFE SVID, a client
+certificate, a platform-issued token — and Warden validates it, attaches the
+resulting principal to the policy decision and the audit trail, and mints the
+upstream credential on the agent's behalf. Warden never issues or mints the
+agent's own identity; it only consumes one the agent (or its platform) already
+holds.
+
+This section is about the **shape of that presentation**: who attaches the
+credential, and how it reaches Warden. The validation mechanics — the auth
+methods, transparent vs. explicit authentication, roles — live in
+[Authentication](../concepts/authentication.md); this section sits on top of
+them and helps you choose an approach.
+
+## Two questions
+
+Every approach answers two questions, and the names below are built from the
+answers:
+
+1. **Who presents the identity?** A **sidecar** running beside the agent
+   (Pattern A), or the **agent itself** (Pattern B).
+2. **How does the identity land?** As an injected **token**, an **mTLS tunnel**,
+   a **self-minted SVID**, or a **relayed platform token**.
+
+Read a name and you already know what it does: the *pattern* says who presents,
+the *variant* says how it lands.
+
+## The approaches
+
+| | Variant | The agent's request carries… | Validated by |
+|---|---|---|---|
+| **A — Sidecar-Presented Identity** | | *A co-process presents identity; the agent sends a plain local request and stays identity-unaware.* | |
+| A1 | [Sidecar Token Injection](sidecar-injected-token.md) (Robin) | an `Authorization: Bearer` token the sidecar adds | `jwt` / `kubernetes` / `spiffe` |
+| A2 | [Sidecar mTLS Tunnel](sidecar-tunneled-cert.md) (ghostunnel) | nothing — identity rides the mTLS channel the sidecar originates | `cert` / `spiffe` |
+| **B — Agent-Presented Identity** | | *The identity-aware agent attaches its own credential.* | |
+| B1 | [Self-Minted SVID](self-minted-identity.md) | an SVID the agent fetched from the Workload API | `spiffe` |
+| B2 | [Platform Token Relay](platform-issued-token.md) | a token the platform issued (projected SA token, CI OIDC) | `kubernetes` / `jwt` |
+
+All four are **transparent authentication** — the agent points an ordinary
+client at Warden, sends no Warden session token, and re-presents its credential
+on each request. Warden validates it in line and caches the result. See
+[transparent authentication](../concepts/authentication.md#transparent-authentication).
+
+## Choosing
+
+```
+Is the agent identity-aware?
+├── no → Pattern A (a sidecar presents identity)
+│        Is the credential a bearer token or a certificate?
+│        ├── token → A1  Sidecar Token Injection   (Robin)
+│        └── cert  → A2  Sidecar mTLS Tunnel        (ghostunnel)
+│
+└── yes → Pattern B (the agent presents its own credential)
+         Does the agent mint its own SVID, or relay one the platform issued?
+         ├── mints  → B1  Self-Minted SVID
+         └── relays → B2  Platform Token Relay
+```
+
+- **Reach for Pattern A** when you do not want to change the application: it
+  speaks plain HTTP on loopback to the sidecar and carries no secret. This is the
+  common shape for agents and off-the-shelf workloads.
+- **Reach for Pattern B** when the agent is already identity-aware — it links a
+  SPIFFE library (B1) or runs on a platform that hands it a token (B2) — and you
+  would rather not run a co-process.
+
+## See Also
+
+- [Authentication](../concepts/authentication.md) — the credential forms, auth
+  methods, and transparent auth these approaches build on.
+- [Tokens](../concepts/tokens.md) — what authentication produces.
+- [Agent Flow](../agent-flow.md) — the end-to-end path once identity is
+  established.
+- [Workstation quickstart 03 — SPIFFE](../quickstarts/workstation/03-spiffe-llm-mcp/)
+  — a keyless, auto-rotating SVID in practice.

--- a/docs/agent-identity/platform-issued-token.md
+++ b/docs/agent-identity/platform-issued-token.md
@@ -1,0 +1,75 @@
+# Platform Token Relay — B2
+
+The identity-aware agent **forwards a token its platform already issued** —
+a projected Kubernetes ServiceAccount token, a CI system's OIDC token — to
+Warden directly. No sidecar sits in the request path, and the agent does not
+mint identity of its own; it relays the platform's. This is Pattern B — the
+agent presents its own credential — landing it as a **relayed platform token**.
+
+## What it is
+
+The runtime hands the agent a token that already attests who it is: Kubernetes
+projects a ServiceAccount token into the pod, a CI runner exposes an OIDC token
+for the job. The agent reads that token and attaches it as
+`Authorization: Bearer <token>` on its requests to Warden. It did not create the
+identity — the platform did — it simply relays it.
+
+## Request flow
+
+```
+┌────────────────┐  issues token   ┌─────────┐   Authorization: Bearer <token>   ┌────────┐
+│   platform     │ ──────────────► │  agent  │ ────────────────────────────────► │ Warden │
+│ (K8s SA / CI)  │  projected SA   │         │                                   │        │
+└────────────────┘  token, OIDC    └─────────┘                                   └────────┘
+```
+
+## How Warden authenticates it
+
+The relayed token is validated by the auth method that matches its issuer: the
+`kubernetes` method verifies a ServiceAccount token via the cluster's
+TokenReview API; the `jwt` method verifies a CI OIDC token against the
+provider's discovery URL or JWKS. With no `X-Warden-Token` on the request,
+Warden uses [transparent authentication](../concepts/authentication.md#transparent-authentication)
+to resolve the token to a role per request and caches the result. See
+[Authentication](../concepts/authentication.md#auth-methods).
+
+## In practice
+
+A headless AI agent runs as a job in a GitHub Actions workflow — an autonomous
+release agent that promotes builds and needs short-lived AWS access to do it. The
+runner exposes a per-job OIDC token; the agent fetches it (via
+`ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) and attaches
+it to its requests to Warden as `Authorization: Bearer`. Warden validates the
+token through the `jwt` method against GitHub's OIDC issuer, checks the repository
+and branch claims via the role, mints short-lived AWS credentials, and proxies the
+calls. No long-lived AWS keys ever live in the repository's secrets, and the
+identity is scoped to the exact workflow run.
+
+## When to choose it
+
+- The agent **already runs on a platform that issues an identity token** —
+  Kubernetes, a CI/CD system — and you would rather use that than introduce
+  SPIFFE or a sidecar.
+- The agent is **identity-aware** enough to read the projected token and set a
+  header, but you want **no co-process** in the request path.
+- You want identity that the platform **rotates and scopes** for you (projected
+  SA tokens are short-lived and audience-bound).
+
+## Trade-offs
+
+- **Application change** — the agent must locate and attach the platform token
+  (read the projected file, call the CI token endpoint).
+- **Tied to the platform** — the identity is only as good as the issuer; moving
+  off Kubernetes/CI means changing how identity is obtained.
+- **Bearer-token blast radius** — like any bearer token it is replayable until it
+  expires, so prefer short-lived, audience-restricted tokens.
+
+## See Also
+
+- [Sidecar Token Injection](sidecar-injected-token.md) — the same kind of token,
+  attached by a sidecar so the agent stays identity-unaware.
+- [Self-Minted SVID](self-minted-identity.md) — the agent presents its own
+  credential here too, but mints a SPIFFE SVID instead of relaying a platform
+  token.
+- [Authentication](../concepts/authentication.md) — transparent auth and the
+  `kubernetes` / `jwt` methods.

--- a/docs/agent-identity/self-minted-identity.md
+++ b/docs/agent-identity/self-minted-identity.md
@@ -1,0 +1,75 @@
+# Self-Minted SVID — B1
+
+The identity-aware agent **fetches its own SVID from the SPIFFE Workload API and
+presents it** to Warden directly. No sidecar sits in the request path. This is
+Pattern B — the agent presents its own credential — landing it as a
+**self-minted SVID**.
+
+## What it is
+
+The agent links a SPIFFE library and dials the local Workload API
+(`$SPIFFE_ENDPOINT_SOCKET`, typically the SPIRE agent's Unix socket). The
+Workload API attests the process and hands back its identity — an X.509-SVID or
+a JWT-SVID — which the agent presents to Warden: the X.509-SVID by originating
+its own mTLS connection, or the JWT-SVID as a bearer header. The SVID is
+short-lived and rotates automatically; no key or certificate is written to disk.
+
+> The Workload API issues the SVID; **Warden validates it, never mints it.**
+> Warden can source *its own serving certificate* from the Workload API the same
+> way, but that is the server side — this page is about the agent presenting its
+> identity.
+
+## Request flow
+
+```
+   ┌──────────────┐  attest + issue SVID   ┌─────────┐   SVID (mTLS or JWT-SVID)   ┌────────┐
+   │ Workload API │ ─────────────────────► │  agent  │ ──────────────────────────► │ Warden │
+   │ (SPIRE agent)│   auto-rotating        │         │                             │        │
+   └──────────────┘                        └─────────┘                             └────────┘
+```
+
+## How Warden authenticates it
+
+The presented SVID — X.509-SVID via the TLS handshake, or JWT-SVID on
+`Authorization: Bearer` — is validated by the `spiffe` auth method against the
+trust-domain bundles (static or federated). With no `X-Warden-Token`, Warden
+uses [transparent authentication](../concepts/authentication.md#transparent-authentication)
+and resolves the SPIFFE ID to a role per request. SPIFFE relies on short-lived
+SVIDs and bundle rotation rather than revocation lists. See
+[Authentication](../concepts/authentication.md#auth-methods).
+
+## In practice
+
+An autonomous remediation agent written in Go runs in a SPIRE-enabled cluster. At
+startup it uses the `go-spiffe` Workload API client to obtain its X.509-SVID, then
+opens a mutually-authenticated connection straight to Warden — no sidecar in the
+path. The SVID rotates in memory on its own and the agent writes no key to disk.
+Warden validates the SVID's SPIFFE ID through the `spiffe` method and maps it to a
+role scoped to exactly what the agent may do — for instance, restart a single
+named Kubernetes deployment and nothing else.
+
+## When to choose it
+
+- The agent is **identity-aware** and can link a SPIFFE library.
+- You run a **SPIFFE/SPIRE** deployment and want keyless, auto-rotating identity
+  with **no sidecar** in the request path.
+- You want the agent to be able to **reason about its own identity** (e.g. to
+  fetch SVIDs for several destinations, not just Warden).
+
+## Trade-offs
+
+- **Application change** — the agent must integrate the Workload API rather than
+  speaking plain HTTP to a co-process.
+- **Requires a SPIFFE provider** — a SPIRE agent (or equivalent) must run on the
+  node and expose the Workload API socket.
+- **Strong upside** — no long-lived credential anywhere, automatic rotation, and
+  cryptographic, attested per-workload identity.
+
+## See Also
+
+- [Sidecar mTLS Tunnel](sidecar-tunneled-cert.md) — same SPIFFE identity, but a
+  sidecar originates the mTLS leg so the agent stays identity-unaware.
+- [Platform Token Relay](platform-issued-token.md) — the agent presents identity
+  itself here too, but relays a platform token instead of minting an SVID.
+- [Authentication](../concepts/authentication.md) — transparent auth and the
+  `spiffe` method.

--- a/docs/agent-identity/sidecar-injected-token.md
+++ b/docs/agent-identity/sidecar-injected-token.md
@@ -1,0 +1,81 @@
+# Sidecar Token Injection (Robin) — A1
+
+A sidecar holds the workload's identity token and **adds it to each request**.
+The agent sends a plain HTTP request to the sidecar on loopback and stays
+identity-unaware; the sidecar attaches `Authorization: Bearer <token>` and
+forwards the call to Warden. This is Pattern A — a co-process presents the
+identity — landing it as an **injected token**.
+
+## What it is
+
+[Robin](https://github.com/stephnangue/robin) runs beside the agent, holds the
+workload's identity token — an OIDC JWT, a JWT-SVID, or a projected Kubernetes
+ServiceAccount token — and attaches it as a bearer header on every request to
+Warden. The application is wired to call
+`http://127.0.0.1:<port>` instead of Warden directly; it carries no Warden
+secret and needs no knowledge of how it is authenticated.
+
+## Request flow
+
+```
+┌─────────┐  plain HTTP   ┌──────────┐  + Authorization: Bearer <jwt>    ┌────────┐
+│  agent  │ ────────────► │  Robin   │ ────────────────────────────────► │ Warden │
+│         │   (loopback)  │ sidecar  │             (over TLS)            │        │
+└─────────┘               └──────────┘                                   └────────┘
+                          holds the JWT /
+                          JWT-SVID identity
+```
+
+## How Warden authenticates it
+
+The injected bearer token is validated by the auth method that matches its
+issuer: the `jwt` method (against an OIDC discovery URL, JWKS, or static keys);
+the `kubernetes` method, for a projected ServiceAccount token, via the cluster's
+TokenReview API; or the `spiffe` method, for a JWT-SVID, against the
+trust-domain bundles. Because the request arrives with no
+`X-Warden-Token`, Warden uses [transparent authentication](../concepts/authentication.md#transparent-authentication):
+it logs the caller in against the provider's configured auth mount, resolves the
+role, and caches the result — no Warden session token is ever returned to the
+agent. The auth-method and role mechanics are in
+[Authentication](../concepts/authentication.md#auth-methods).
+
+## In practice
+
+A LangChain agent runs as a pod in a Kubernetes cluster and needs the Anthropic
+API. Kubernetes projects a ServiceAccount token into the pod; a **Robin** sidecar
+in the same pod reads it and attaches it as `Authorization: Bearer` on every
+call. The agent is configured with `ANTHROPIC_BASE_URL=http://127.0.0.1:8080` —
+as far as it knows, it is talking to the Anthropic API directly. Robin forwards
+to Warden, which validates the ServiceAccount token through the `kubernetes`
+method, injects the real Anthropic key, and proxies the request. The agent image
+holds no API key and no Warden token, and rotating the upstream key changes
+nothing in the pod.
+
+## When to choose it
+
+- The credential is a **bearer token**, not a certificate.
+- You want the application **unchanged** — it speaks plain HTTP and knows nothing
+  about identity.
+- Especially strong on **Kubernetes**: each pod already has a ServiceAccount
+  identity, so Robin can present a per-pod JWT to Warden without baking a
+  long-lived secret into the image or manifest.
+
+## Trade-offs
+
+- **Runs a co-process** — one more container/process to deploy and watch.
+- **The agent stays identity-unaware** — nothing to change in application code,
+  but also nothing the application can reason about regarding its own identity.
+- **Bearer-token blast radius** — a leaked bearer token is replayable until it
+  expires; favour short-lived, frequently-rotated tokens.
+- **Loopback trust** — anything that can reach the sidecar's loopback port speaks
+  as the workload, so the sidecar and app must share a trust boundary (e.g. the
+  same pod).
+
+## See Also
+
+- [Sidecar mTLS Tunnel](sidecar-tunneled-cert.md) — the certificate sibling, when
+  identity is an X.509/SVID rather than a bearer token.
+- [Platform Token Relay](platform-issued-token.md) — the same token, presented by
+  the agent itself instead of a sidecar.
+- [Authentication](../concepts/authentication.md) — transparent auth and the
+  `jwt` / `kubernetes` / `spiffe` methods.

--- a/docs/agent-identity/sidecar-tunneled-cert.md
+++ b/docs/agent-identity/sidecar-tunneled-cert.md
@@ -1,0 +1,84 @@
+# Sidecar mTLS Tunnel (ghostunnel) — A2
+
+A sidecar **terminates the agent's plaintext locally and carries identity in an
+mTLS channel** to Warden. The agent sends a plain HTTP request on loopback; the
+sidecar holds the client certificate, originates the mutually-authenticated TLS
+leg, and forwards the request. This is Pattern A — a co-process presents the
+identity — landing it as an **mTLS tunnel**.
+
+## What it is
+
+[ghostunnel](https://github.com/ghostunnel/ghostunnel) runs beside the agent,
+holds the workload's client certificate and key (or an X.509-SVID), and
+originates the client-authenticated TLS connection to Warden, forwarding
+plaintext from the local application. The identity rides the TLS handshake
+itself — the request body carries no credential header at all.
+
+> **mTLS is a property of the connection, not of any one client.** A certificate
+> authenticates because it is presented during the TLS handshake — *any* client
+> that completes a client-authenticated handshake works. ghostunnel is simply the
+> process that completes it on the workload's behalf.
+
+## Request flow
+
+```
+┌─────────┐  plain HTTP   ┌────────────┐   mTLS (client cert / X.509-SVID)   ┌────────┐
+│  agent  │ ────────────► │ ghostunnel │ ──────────────────────────────────► │ Warden │
+│         │   (loopback)  │  sidecar   │       identity in the TLS leg       │        │
+└─────────┘               └────────────┘                                     └────────┘
+                          holds the cert/key
+```
+
+## How Warden authenticates it
+
+The client certificate from the handshake is validated by the `cert` auth
+method (chain-of-trust against the configured CA bundle) or, for an X.509-SVID,
+the `spiffe` method against the trust-domain bundles. With no `X-Warden-Token`
+on the request, Warden uses [transparent authentication](../concepts/authentication.md#transparent-authentication)
+and resolves the identity from the certificate per request. The identity can
+equally arrive on a forwarded header (`X-Forwarded-Client-Cert`) when Warden
+sits behind a TLS-terminating proxy. mTLS requires a Warden listener configured
+to request client certificates — see [Authentication](../concepts/authentication.md#auth-methods).
+
+## In practice
+
+**Claude Code** runs on a developer's workstation, where you cannot mint a bearer
+token without holding a static credential to mint it from — so identity is a
+keyless SPIFFE X.509-SVID instead, attested and delivered by SPIRE. Claude Code
+routes its model calls to whatever endpoint `ANTHROPIC_BASE_URL` names, but it
+cannot originate a TLS client handshake itself. A local **ghostunnel** process
+holds the workstation's SPIRE-issued X.509-SVID, listens on loopback, and
+originates the mTLS leg to Warden; `ANTHROPIC_BASE_URL` points at that local
+ghostunnel listener and Claude Code is otherwise untouched. Its model calls go
+through Warden, which validates the SVID through the `spiffe` method, injects the
+real Anthropic Console key
+server-side, and proxies the request. No certificate handling — issuance,
+rotation, or the handshake — ever enters the agent. This is exactly the
+[SPIFFE workstation quickstart](../quickstarts/workstation/03-spiffe-llm-mcp/).
+
+## When to choose it
+
+- Identity is a **certificate or X.509-SVID** rather than a bearer token.
+- You want the application **unchanged** — it speaks plain HTTP on loopback.
+- You want **channel-bound** identity: the credential is never a replayable
+  header, it is tied to the live TLS connection.
+
+## Trade-offs
+
+- **Runs a co-process** — one more container/process to deploy and watch.
+- **Needs an mTLS-capable listener** — does nothing against a plain-HTTP dev
+  listener; the deployment must terminate client-authenticated TLS at Warden or a
+  trusted proxy.
+- **Certificate lifecycle** — cert/key issuance and rotation must be handled
+  (SPIRE-issued X.509-SVIDs rotate automatically; static certs do not).
+- **Loopback trust** — anything that can reach the sidecar's loopback port is
+  tunnelled as the workload, so sidecar and app must share a trust boundary.
+
+## See Also
+
+- [Sidecar Token Injection](sidecar-injected-token.md) — the bearer-token sibling,
+  when identity is a JWT rather than a certificate.
+- [Self-Minted SVID](self-minted-identity.md) — the agent fetches and presents the
+  SVID itself instead of letting a sidecar originate the tunnel.
+- [Authentication](../concepts/authentication.md) — transparent auth, mTLS, and the
+  `cert` / `spiffe` methods.

--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -103,6 +103,10 @@ than a bearer token.
 Either way the workload holds no Warden-specific secret; Warden authenticates the
 presented JWT or certificate through [transparent authentication](#transparent-authentication).
 
+For the full set of identity-presentation approaches — sidecar-presented and
+agent-presented, and how to choose between them — see
+[Agent Identity](../agent-identity/README.md).
+
 ## Warden Tokens
 
 A Warden session token is an opaque string with the prefix `cws.` followed by 64

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -39,6 +39,9 @@ a credential of its own.
 
 ## For AI agents
 
+- [Agent Identity](../agent-identity/README.md) — how an agent presents its
+  identity to Warden: sidecar-presented or agent-presented, and the four
+  approaches under each.
 - [Discovery and Skills](discovery-and-skills.md) — how an agent learns, at
   runtime, what it may do and how.
 - [Delegation](delegation.md) — carrying the on-behalf-of chain into the audit


### PR DESCRIPTION
## What

Adds `docs/agent-identity/` — a decision-oriented section on how an agent presents its identity to Warden. It sits on top of `concepts/authentication.md` (which covers the auth-method mechanics) and helps a reader choose an approach.

The section is organized as a small taxonomy: the **pattern** says *who presents*, the **variant** says *how identity lands*.

| | Variant | Identity lands as | Validated by |
|---|---|---|---|
| **A — Sidecar-Presented** | A1 Sidecar Token Injection (Robin) | bearer token the sidecar adds | `jwt` / `kubernetes` / `spiffe` |
| | A2 Sidecar mTLS Tunnel (ghostunnel) | X.509 cert/SVID in the mTLS channel | `cert` / `spiffe` |
| **B — Agent-Presented** | B1 Self-Minted SVID | SVID fetched from the Workload API | `spiffe` |
| | B2 Platform Token Relay | a relayed platform token (SA, CI OIDC) | `kubernetes` / `jwt` |

## Contents

- `README.md` — overview + decision guide (two questions, the 2x2, a decision tree).
- One page per variant: what it is, an ASCII request-flow diagram, how Warden authenticates it (linking back for mechanics), a real-world example (LangChain pod, Claude Code workstation, Go remediation agent, CI release agent), when to choose it, and trade-offs.
- Wires the section into `concepts/index.md` ("For AI agents") and the sidecar section of `concepts/authentication.md`.

## Notes

- Docs-only change. All four are framed as **transparent authentication**; the docs are explicit that Warden validates, never mints, an agent's identity.
- Verified: all relative links and `authentication.md` anchors resolve; the four flow diagrams are column-aligned; taxonomy names are consistent across the table, page titles, and decision tree.
