### PR TITLE
docs(agent-identity): scope A1 to platform-fetched tokens, show their source

### DIFF
--- a/docs/agent-identity/README.md
+++ b/docs/agent-identity/README.md
@@ -32,7 +32,7 @@ the *variant* says how it lands.
 | | Variant | The agent's request carries… | Validated by |
 |---|---|---|---|
 | **A — Sidecar-Presented Identity** | | *A co-process presents identity; the agent sends a plain local request and stays identity-unaware.* | |
-| A1 | [Sidecar Token Injection](sidecar-injected-token.md) (Robin) | an `Authorization: Bearer` token the sidecar adds | `jwt` / `kubernetes` / `spiffe` |
+| A1 | [Sidecar Token Injection](sidecar-injected-token.md) (Robin) | an `Authorization: Bearer` token the sidecar adds | `kubernetes` / `spiffe` |
 | A2 | [Sidecar mTLS Tunnel](sidecar-tunneled-cert.md) (ghostunnel) | nothing — identity rides the mTLS channel the sidecar originates | `cert` / `spiffe` |
 | **B — Agent-Presented Identity** | | *The identity-aware agent attaches its own credential.* | |
 | B1 | [Self-Minted SVID](self-minted-identity.md) | an SVID the agent fetched from the Workload API | `spiffe` |

--- a/docs/agent-identity/sidecar-injected-token.md
+++ b/docs/agent-identity/sidecar-injected-token.md
@@ -9,11 +9,19 @@ identity — landing it as an **injected token**.
 ## What it is
 
 [Robin](https://github.com/stephnangue/robin) runs beside the agent, holds the
-workload's identity token — an OIDC JWT, a JWT-SVID, or a projected Kubernetes
-ServiceAccount token — and attaches it as a bearer header on every request to
-Warden. The application is wired to call
-`http://127.0.0.1:<port>` instead of Warden directly; it carries no Warden
-secret and needs no knowledge of how it is authenticated.
+workload's identity token — a projected Kubernetes ServiceAccount token or a
+SPIFFE JWT-SVID — and attaches it as a bearer header on every request to Warden.
+The application is wired to call `http://127.0.0.1:<port>` instead of Warden
+directly; it carries no Warden secret and needs no knowledge of how it is
+authenticated.
+
+Robin does not mint that token — it **reads it from where the platform already
+put it**. On Kubernetes that is the pod's projected ServiceAccount token, mounted
+into the container at a path like
+`/var/run/secrets/kubernetes.io/serviceaccount/token` and rotated by the kubelet;
+in a SPIFFE deployment it is a JWT-SVID Robin fetches from the local Workload API
+socket. Either way the token is short-lived and renewed by the platform, and
+Robin simply attaches the current value to each request.
 
 ## Request flow
 
@@ -22,16 +30,15 @@ secret and needs no knowledge of how it is authenticated.
 │  agent  │ ────────────► │  Robin   │ ────────────────────────────────► │ Warden │
 │         │   (loopback)  │ sidecar  │             (over TLS)            │        │
 └─────────┘               └──────────┘                                   └────────┘
-                          holds the JWT /
+                          reads the SA token /
                           JWT-SVID identity
 ```
 
 ## How Warden authenticates it
 
 The injected bearer token is validated by the auth method that matches its
-issuer: the `jwt` method (against an OIDC discovery URL, JWKS, or static keys);
-the `kubernetes` method, for a projected ServiceAccount token, via the cluster's
-TokenReview API; or the `spiffe` method, for a JWT-SVID, against the
+issuer: the `kubernetes` method, for a projected ServiceAccount token, via the
+cluster's TokenReview API; or the `spiffe` method, for a JWT-SVID, against the
 trust-domain bundles. Because the request arrives with no
 `X-Warden-Token`, Warden uses [transparent authentication](../concepts/authentication.md#transparent-authentication):
 it logs the caller in against the provider's configured auth mount, resolves the
@@ -78,4 +85,4 @@ nothing in the pod.
 - [Platform Token Relay](platform-issued-token.md) — the same token, presented by
   the agent itself instead of a sidecar.
 - [Authentication](../concepts/authentication.md) — transparent auth and the
-  `jwt` / `kubernetes` / `spiffe` methods.
+  `kubernetes` / `spiffe` methods.


### PR DESCRIPTION
## What

Follow-up to #345. Scopes the A1 (Sidecar Token Injection / Robin) page to the tokens a sidecar actually injects, and says where Robin gets them.

- A sidecar relays a token the **platform already issued**, so A1 is now framed around that: Robin **reads** the pod's projected ServiceAccount token (mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`, kubelet-rotated) or fetches a JWT-SVID from the local Workload API socket, and attaches the current value — it does not mint one.
- Drops the standalone `jwt`/OIDC method from A1's "validated by" list, leaving `kubernetes` and `spiffe`.

## Changes

- `README.md` — A1 "Validated by" → `kubernetes` / `spiffe`.
- `sidecar-injected-token.md` — narrowed token types in "What it is" + a new paragraph on where Robin reads the token; dropped the `jwt` clause in "How Warden authenticates it"; request-flow annotation now "reads the SA token / JWT-SVID"; See Also updated.

## Notes

Docs-only. Verified A1 has no remaining standalone `jwt`-method references, the request-flow diagram stays column-aligned, and prose wrapping is clean.
