### PR TITLE
docs(use-cases): add use-case guides and reframe README use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,57 +35,45 @@ Agents discover what they're allowed to access. Warden brokers every connection.
 
 ---
 
-## The enterprise problem
+## The problem
 
 Agents are useful only when they reach real systems: cloud accounts, code repositories, observability stacks, databases, ITSM, secrets backends. Today, pointing an agent at production means handing it over-scoped, long-lived credentials, with no per-request policy and no identity-tied audit. Each new system is another credential in the agent's environment, governed by nothing in the request path.
 
-The control gap, not the credential, is the headline. **MCP servers** make it acute — every server wraps one upstream API and holds one credential in process env, so an agent with a dozen tools has a dozen static secrets scattered across a dozen processes, none of them rotating, none of them governed.
+The control gap, not the credential, is the headline. MCP servers make it acute — every server wraps one upstream API and holds one credential in process env, so an agent with a dozen tools has a dozen static secrets scattered across a dozen processes, none of them rotating, none of them governed.
 
-Warden closes the gap by sitting in the path: the agent identifies itself, Warden decides what it can reach, and Warden brokers the connection.
+## How Warden works
 
-## How Warden works: discover then connect
+Warden sits in the request path between an agent and the systems it needs. The agent presents its own identity — a JWT, TLS client certificate, SPIFFE SVID, or Kubernetes service-account token — and points at Warden as if it were the upstream.
 
 ```
-┌──────────────┐                    ┌──────────────┐                     ┌──────────────┐
-│              │   1. Discover      │              │                     │              │
-│              │ ─────────────────▶ │              │                     │ MCP servers  │
-│   AI Agent   │   what can I do?   │              │                     │ Cloud        │
-│ MCP servers  │                    │    Warden    │   real credentials  │ LLMs         │
-│              │   2. Connect       │              │ ──────────────────▶ │ Code hosts   │
-│              │ ─────────────────▶ │              │                     │ SaaS         │
-│              │   identity only    │              │                     │ ...          │
-└──────────────┘                    └──────────────┘                     └──────────────┘
-                                    • Identity ✓
-                                    • Policy ✓
-                                    • Audit ✓
+┌──────────────┐                      ┌──────────────┐                      ┌──────────────┐
+│              │    identity only     │              │   real credentials   │ MCP servers  │
+│   AI Agent   │ ───────────────────▶ │    Warden    │ ───────────────────▶ │ Cloud · LLMs │
+│              │ ◀─────────────────── │              │ ◀─────────────────── │ Code · SaaS  │
+│              │       response       │              │       response       │ ...          │
+└──────────────┘                      └──────────────┘                      └──────────────┘
+                                      • Identity ✓
+                                      • Policy ✓
+                                      • Audit ✓
 ```
 
-**Discover.** The agent presents its identity — a JWT, TLS client certificate, SPIFFE SVID, or Kubernetes service-account token — and runs three introspection calls against Warden:
+For each request, Warden authenticates the identity, evaluates the call against policy at request time, injects the real upstream credential, and proxies it — streaming the response back unchanged. The credential belongs to Warden, never the agent, and is short-lived wherever the upstream supports it. The agent holds no secrets, gets exactly the access its policy permits — no more — and every call is tied to its identity in the audit log.
 
-1. `warden role list` — which roles is this identity permitted to assume in this namespace?
-2. `warden provider list` — which upstream systems are mounted here?
-3. `warden skill read <type>` — for the chosen system, fetch the agent-facing recipe (env vars, endpoint URL, role-selection idiom).
+Agents don't need that access wired in ahead of time. They can ask Warden which roles and systems are open to them and read a per-system recipe at runtime, then connect — so a newly mounted system is reachable without redistributing config or rebuilding an SDK. See [the agent flow](docs/agent-flow.md) for the full loop.
 
-Each response is human-readable JSON or markdown. The agent matches the task to a role and provider by reading operator-set descriptions — no config files, no role names distributed out of band, no SDK to rebuild when a new provider is mounted.
+## Use cases
 
-**Connect.** The agent picks a role and points at Warden as if it were the upstream. Warden authenticates the identity, applies the role's policy at request time, and attaches the upstream credential before forwarding — or vends a scoped grant directly, such as a database auth token or a pre-signed URL. The credential belongs to Warden, never to the agent — and is ephemeral wherever the upstream supports it.
+- **Access brokering** — Warden holds the upstream secret and injects a scoped, short-lived credential into each request; the agent presents only its own identity — a JWT, a TLS client certificate, or a SPIFFE SVID — and never holds a key. The same identity reaches every upstream the policy permits, so there's no per-system credential sprawl, nothing to rotate per integration, and nothing in the agent to leak.
+- **Breach containment** — a prompt-injected, jailbroken, or otherwise compromised agent has nothing to exfiltrate, because it never holds a credential. Every call it issues is still bounded by policy at request time and backed by short-lived access, so one bad step — or one hallucination — stays a contained, recoverable event instead of a broad compromise.
+- **Runtime authorization** — every call is authorized the moment it happens, down to the action and its arguments, evaluated against caller IP, time of day, and day of week. For MCP traffic the policy reaches inside each tool call — which tools an agent may invoke and which arguments it may pass — so the agent gets the narrowest fit for each step, not a session-wide grant.
+- **Centralized governance** — one control plane for every system an agent touches: one identity, one policy surface, and one audit log across clouds, code hosts, observability, databases, SaaS, and MCP servers. Namespaces isolate teams on shared infrastructure, and Warden rotates the upstream secrets it holds on a schedule, so they stay fresh without operator coordination.
+- **Audit & attribution** — every request tied to the real identity behind it, the role used, the policy decision, and the upstream called — including the decision recorded on each MCP tool call. A shared MCP server acting for many agents still resolves to the specific agent it acted for, and secrets are never written to the log in the clear.
 
-## The enterprise control plane
-
-What an enterprise gets from putting Warden in the path:
-
-- **Per-call least privilege** — the agent asks Warden what systems and roles are open to it, then **switches roles mid-task**, picking the narrowest fit for each operation by reading operator-set descriptions. A read-scoped role for reads, a write-scoped role only when a write is intended — the agent's posture changes step by step, not session by session.
-- **Hallucination containment** — LLMs make routine mistakes, and a single mistake under a broad credential can cause real damage. Per-call role binding constrains what the agent can do at every step; a hallucinated request that exceeds the role's scope is denied upstream — observable in the audit log, with no state change. LLM errors become recoverable instead of catastrophic.
-- **Compromise containment** — because Warden holds the upstream credentials and the agent never does, a prompt-injected, jailbroken, or otherwise compromised agent has nothing to exfiltrate. Any call it does issue is still bounded by Warden's policy at request time — regardless of what's in the agent's memory or chat history.
-- **Fine-grained access policy** — per-action capabilities and parameter filters, evaluated at request time against caller IP, time of day, and day of week. For MCP traffic the same policy reaches inside each tool call — which tools an agent may invoke, and which arguments it may pass.
-- **Identity-bound access** — a JWT, a TLS client certificate, or a first-class SPIFFE SVID (X.509 or JWT); the same identity reaches every upstream the policy permits — no per-system credential sprawl, no API keys handed to agents, nothing to rotate per integration.
-- **On-behalf-of access** — beyond reaching an upstream as a shared service account, Warden can act on behalf of a specific user: the user grants access once through a standard browser consent, and every subsequent call runs under that user's delegated grant, refreshed automatically — so a delegated action is attributed to the real person, not a shared application credential.
-- **Audit** — every request tied to the original identity, the role used, and the upstream called — plus the policy decision recorded on each MCP tool call, and non-secret metadata about the credential Warden minted, such as the identity it represents.
-- **Automatic credential rotation** — Warden rotates the upstream credentials it holds on a schedule, staging the switch for systems that need time to propagate a new key, so the broker's own secrets stay fresh without operator coordination.
+See [the use-case guides](docs/use-cases/) for the full write-ups.
 
 ## Supported systems
 
-35 systems across MCP servers, LLMs, cloud, code-hosting, observability, ITSM, Kubernetes, secrets, and databases. Follow any link below to configure your first endpoint, or see [docs/providers.md](docs/providers.md) for the full list.
+Warden fronts systems across MCP servers, LLMs, cloud, code-hosting, observability, ITSM, Kubernetes, secrets, and databases. Follow any link below to configure your first endpoint, or see [docs/providers.md](docs/providers.md) for the full list.
 
 | Category | Providers | Warden does |
 |---|---|---|
@@ -99,22 +87,6 @@ What an enterprise gets from putting Warden in the path:
 | Secrets backend | [HashiCorp Vault / OpenBao](provider/vault/README.md) | Mints short-lived tokens |
 | Databases | [AWS RDS / Aurora](provider/rds/README.md), [AWS Redshift](provider/redshift/README.md) | Issues IAM database auth token |
 
-## Use cases
-
-**MCP servers** — Warden works both sides of the protocol. Point your own MCP server at Warden instead of the upstream API, and one gateway covers every tool it exposes — replacing the per-tool-credential-in-env model with one identity and one policy surface. Or put Warden in front of a managed MCP server — GitHub, AWS, GCP — and an agent reaches it through Warden, which attaches the credential per request and enforces policy on each tool call, down to which tools run and which arguments they carry.
-
-**SRE agents** — incident-response agents reaching Prometheus, Grafana, Kubernetes, and PagerDuty under one policy layer. Warden scopes each call to the agent's identity — query dashboards but not delete them, restart a pod but not modify IAM. Every action during an incident is tied to the agent's identity in the audit log.
-
-**Agentic coding** — code agents that push to GitHub, deploy to AWS, and read from artifact stores all through one identity. Warden enforces which repos they push to, which buckets they read, and logs every action.
-
-**RAG pipelines** — retrieval agents reaching production databases and object stores under per-request grants. Warden vends a database auth token or pre-signed URL scoped to the exact query or object the agent needs.
-
-**Multi-model orchestration** — an agent reaching Anthropic for reasoning, OpenAI for embeddings, and Mistral for classification through one identity, one policy layer, and one audit log across all three.
-
-**Autonomous workflows** — long-running agents that reach systems over hours or days with time-scoped access. Warden issues credentials per request, so no token outlives the work it was minted for.
-
-Warden also secures non-agent workloads — CI/CD pipelines, microservices, developer machines — with the same identity-based model.
-
 ## Authentication methods
 
 Warden supports multiple methods for verifying caller identity.
@@ -125,8 +97,6 @@ Warden supports multiple methods for verifying caller identity.
 | **TLS Certificate** | X.509 client certificate | Identity is proven at the TLS handshake (or forwarded by a TLS-terminating proxy via `X-SSL-Client-Cert`). The SDK's credential slot is filled with any placeholder value — Warden ignores it once cert auth has proven the identity. Role selection follows the same per-provider conventions as JWT mode. |
 | **SPIFFE** | SPIFFE X.509-SVID or JWT-SVID | First-class SPIFFE identity on a single mount: a workload presents an X.509-SVID at the TLS handshake (or forwarded by a TLS-terminating proxy) or a JWT-SVID as a bearer token, and Warden verifies it against the trust domain's bundle — with federation across trust domains and periodic refresh. It relies on short-lived SVIDs and bundle rotation rather than revocation lists, so it suits workloads already issued identities by a SPIFFE provider such as SPIRE. |
 | **Kubernetes** | Kubernetes ServiceAccount token (projected SA JWT) | The pod's ServiceAccount token goes in the SDK's credential slot exactly as in JWT mode. Warden validates it by calling the issuing cluster's TokenReview API — no JWKS endpoint or public keys to distribute — and matches a role bound to the ServiceAccount's namespace and name. |
-
-This is the design property that makes Warden a *drop-in* layer rather than a rewrite tax: a pre-existing boto3, openai-python, Vault CLI, or curl-against-GitHub script becomes Warden-mediated by setting the base URL to Warden and putting the JWT where the secret used to go. It also separates Warden from dedicated auth proxies (which typically require client libraries).
 
 ## Tutorials
 

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -1,0 +1,33 @@
+# Use Cases
+
+An agent only earns its keep when it can reach real systems — clouds, code hosts,
+databases, observability stacks, MCP servers. That reach is also exactly what makes
+an agent dangerous: a program that decides what to do by reading text, holding
+credentials to production. These five pages are the problems that tension creates,
+and how Warden answers each. They are not alternatives — a single deployment relies
+on all five at once.
+
+| Use case | The problem | What Warden does |
+|----------|-------------|------------------|
+| [Access brokering](access-brokering.md) | Every integration puts another secret in the agent, where it leaks. | Holds the upstream secret and injects a scoped credential per request; the agent carries only its identity. |
+| [Breach containment](breach-containment.md) | A prompt-injected or hijacked agent can do anything its broad credential allows. | Leaves no secret to steal, bounds every call by policy, and expires the access it grants. |
+| [Runtime authorization](runtime-authorization.md) | Reaching a system means doing anything in it — every tool, every argument. | Authorizes each call at runtime, down to the tool and parameter, default-deny. |
+| [Centralized governance](centralized-governance.md) | Dozens of systems, each with its own identity, policy, secrets, and audit. | One control plane — one identity, one policy surface, one audit log, central rotation. |
+| [Audit & attribution](audit-attribution.md) | Shared identities and shared MCP servers erase who actually acted. | Ties every request to a real identity and its on-behalf-of chain, secrets hashed. |
+
+The five build on one another: [access brokering](access-brokering.md) keeps the
+credential out of the agent, which is what makes [breach
+containment](breach-containment.md) possible; [runtime
+authorization](runtime-authorization.md) decides what each call may do;
+[centralized governance](centralized-governance.md) is where all of that is
+operated from one place; and [audit & attribution](audit-attribution.md) records
+what happened.
+
+## See Also
+
+- [Concepts](../concepts/index.md) — how Warden works, end to end.
+- [Architecture](../architecture.md) — the broker in the request path, at a glance.
+- [Agent Flow](../agent-flow.md) — the path an agent takes once its identity is
+  established.
+- [Agent Identity](../agent-identity/README.md) — how an agent presents the
+  identity Warden brokers from.

--- a/docs/use-cases/access-brokering.md
+++ b/docs/use-cases/access-brokering.md
@@ -1,0 +1,85 @@
+# Access brokering
+
+_Give agents access without giving them secrets._
+
+## Every integration is one more secret in the agent
+
+An agent only earns its keep when it can reach real systems — a Git host, a cloud
+control plane, a database, an MCP server. Each of those wants a credential, so the
+usual answer is to hand the agent one: an API key in an environment variable, a
+token in a `.env` file, a service-account key baked into the image. Every new
+integration adds another long-lived secret, and every one of them now lives
+wherever the agent lives.
+
+That is exactly where secrets are hardest to protect. A key in the agent's
+environment is a key in its process memory, its logs, its crash dumps, and its
+chat context — one stray log line or one poisoned prompt away from leaking. And
+because these credentials are long-lived and broadly scoped, a single leak is not
+a momentary lapse; it is standing access that an attacker can use for as long as
+the key remains valid, from anywhere, with nothing tying it back to the agent that
+lost it.
+
+The cost compounds with scale. Ten agents reaching ten systems is a hundred places
+a secret can sit, each on its own rotation schedule, each a thing to provision when
+an agent is created and revoke when it is retired. The work of distributing and
+rotating those keys quietly becomes the dominant cost of running agents at all.
+
+## Warden holds the secret; the agent carries only an identity
+
+Warden's purpose is to keep secrets out of workloads. Instead of handing the agent
+a key, Warden **brokers access**: it holds the privileged upstream secret itself
+and, at request time, mints or retrieves a scoped, short-lived
+[credential](../concepts/credentials.md) for the upstream the agent is trying to
+reach — then injects it into the proxied request rather than handing it over. The
+agent presents **only its own identity** and never receives a credential of its
+own.
+
+The identity is something the agent already has — a JWT, an mTLS client
+certificate, or a SPIFFE SVID. The agent points an ordinary client at a Warden
+[provider](../concepts/providers.md) mount as if Warden were the upstream;
+Warden validates that identity through
+[transparent authentication](../concepts/authentication.md#transparent-authentication),
+resolves what it may draw, mints the credential, injects it, and streams the
+response back. The credential lives only inside that one hop, and the privileged
+secret that minted it never leaves Warden.
+
+Because the same identity is what reaches *every* upstream, there are no per-system
+keys to distribute and none to rotate per integration — the agent runs
+**secretless**, carrying an identity rather than a wallet of credentials. That
+identity is also what every [policy](../concepts/policies.md) decision and
+[audit](../concepts/audit.md) entry ties back to, so access is attributable to the
+agent that used it rather than to a shared key.
+
+## Benefits
+
+- **No secret in the agent** — there is nothing in the process, the environment,
+  or the chat context to leak, log, or commit, because the agent never holds an
+  upstream credential.
+- **One identity, every system** — the agent authenticates as itself everywhere,
+  so there are no per-integration keys to provision, distribute, or rotate.
+- **Short-lived by default** — Warden mints a scoped credential per request and
+  injects it for a single hop, so access does not outlive the work it was minted
+  for.
+
+## In practice
+
+A coding agent needs to push to GitHub. It runs with a SPIFFE SVID and speaks
+plain HTTPS to a `github` mount; it holds no GitHub token and no app key. When it
+makes the call, Warden validates the SVID, resolves the role, mints a short-lived
+GitHub App **installation token** from the private key it holds, injects it into
+the push, and streams GitHub's response back. No long-lived GitHub credential ever
+lands in the agent's environment or its repository secrets — the agent acted as
+itself, and Warden brokered the rest.
+
+## See Also
+
+- [Breach containment](breach-containment.md) — the containment brokering makes
+  possible: no secret in the agent means nothing to exfiltrate.
+- [Runtime authorization](runtime-authorization.md) — deciding what the brokered
+  identity may actually do, on every call.
+- [Credentials](../concepts/credentials.md) — sources, specs, drivers, lifetime,
+  and rotation.
+- [Authentication](../concepts/authentication.md) — transparent auth and the
+  credential forms an agent presents.
+- [Agent Identity](../agent-identity/README.md) — how an agent presents the
+  identity Warden brokers from.

--- a/docs/use-cases/audit-attribution.md
+++ b/docs/use-cases/audit-attribution.md
@@ -1,0 +1,88 @@
+# Audit & attribution
+
+_Know exactly who did what, on whose behalf._
+
+## Shared identities erase who actually acted
+
+When something goes wrong, the first question is always the same: who did this? For
+agents, that question is unusually hard to answer. Agents are created and destroyed
+constantly, and the easy way to give a fleet of them access is to let them share a
+service account. So when the upstream logs the call, it logs the shared account —
+the same identity for every agent, every task, every user behind them. The one
+record that survives points at all of them and therefore at none of them.
+
+It gets harder a layer up. Many agents often share a single MCP server — one
+process that authenticates with its own identity and makes calls on behalf of
+whichever agent is using it. If attribution comes only from the authenticated
+identity, every agent's actions collapse into the server's, and a request made
+*for* a specific user or agent is indistinguishable from any other. You can see
+that *something* happened; you cannot say *who* it was really for.
+
+And the record itself is often unsafe to keep. Naive logging of requests captures
+the very credentials and secrets in flight, so the audit trail becomes a second
+copy of the thing you were trying to protect — too sensitive to ship to the SIEM
+where it would actually be useful. Between shared identities, hidden delegators, and
+secrets in the log, an incident becomes something you reconstruct by guesswork
+rather than read off the record.
+
+## Every request tied to a real identity
+
+Warden sits in the path of every request, so it records every request — a
+[forensic log](../concepts/audit.md) of who asked for what, which policy decision
+was made, and which credential was issued. Each operation produces paired request
+and response entries carrying the principal and [role](../concepts/roles.md), the
+policies in force, the [namespace](../concepts/namespaces.md), the upstream called,
+and — for a brokered call — a description of the credential Warden minted. Because
+the agent authenticated [as itself](access-brokering.md), the identity on the entry
+is the real one, not a shared key.
+
+Attribution survives the extra hop. A request can carry a
+[delegation](../concepts/delegation.md) chain — the subjects it is being made *on
+behalf of* — and Warden records them alongside the authenticated principal, each
+flagged **verified** (cryptographically attested by a signed JWT `act` claim) or
+**unverified** (self-reported by a trusted caller). A shared MCP server that reuses
+one identity for many agents still produces correct per-call attribution, because
+the per-request actor takes precedence over the token-bound one. Attribution is
+kept deliberately orthogonal to authorization — naming who a call is for can never
+*widen* what the caller may do — so it is safe to trust the chain for forensics
+without it becoming an avenue for escalation.
+
+The record is built to be kept. Secrets are **never written in clear**: sensitive
+values are replaced with a keyed HMAC, deterministic enough to correlate
+occurrences of a value across the log yet impossible to reverse, so the log is safe
+to ship to a SIEM. For [MCP](../concepts/mcp.md) traffic the detail goes per tool
+call: every `mcp { }` decision is recorded on **both allow and deny**, with the tool
+or parameter that decided it — a complete account of what an agent did through a
+server, not just what it was blocked from doing.
+
+## Benefits
+
+- **A complete forensic record** — every request, its policy decision, and the
+  credential issued, tied to the identity that actually made the call.
+- **Attribution that survives the hop** — the on-behalf-of chain names the real
+  agent or user behind a shared identity or a concentrator.
+- **Safe to ship** — secrets are HMAC-hashed, never logged in clear, so the trail
+  can live in your SIEM.
+
+## In practice
+
+A shared MCP server with the principal `mcp-gateway` forwards calls for many agents,
+each request carrying an `X-Warden-On-Behalf-Of` header naming the agent it is
+acting for. An investigation into an unexpected change reads the audit log and finds
+the offending call attributed to the principal `mcp-gateway` *and* to the actor
+`agents/alpha` — so the trail leads to the specific agent, not the shared server.
+The credential Warden issued is described in the same entry, with its secret HMAC'd;
+the investigator can confirm which value was used by hashing it the same way,
+without the log ever holding a usable key.
+
+## See Also
+
+- [Audit](../concepts/audit.md) — what is recorded, and how secrets are hashed.
+- [Delegation](../concepts/delegation.md) — the on-behalf-of actor chain and how it
+  reaches the log.
+- [Model Context Protocol](../concepts/mcp.md) — per-tool-call decisions in the
+  audit trail.
+- [Access brokering](access-brokering.md) — why the identity on each entry is the
+  agent's own, not a shared key.
+- [Runtime authorization](runtime-authorization.md) — the policy decisions the log
+  records.

--- a/docs/use-cases/breach-containment.md
+++ b/docs/use-cases/breach-containment.md
@@ -1,0 +1,88 @@
+# Breach containment
+
+_When an agent is compromised, keep the damage small._
+
+## One bad step under a broad credential
+
+An agent is a program that decides what to do by reading text — and text is
+exactly what an attacker controls. A document it summarizes, a webpage it browses,
+an issue it triages can all carry instructions the model cannot reliably tell apart
+from its real task. Prompt injection, jailbreaks, and plain hallucination are not
+edge cases; they are the normal failure modes of the technology. The question is
+not whether an agent will occasionally try to do the wrong thing, but how much one
+wrong step is allowed to cost.
+
+Under the usual setup, the answer is: a great deal. If the agent holds a
+long-lived, broadly scoped credential, then whoever steers the agent for a moment
+inherits everything that credential can reach. A compromised agent with write
+access to a production database or an admin API can cause irreversible damage in
+the seconds between exploitation and notice — drop tables, delete repositories,
+exfiltrate the very keys it was given. The blast radius is not "what the agent was
+asked to do"; it is "everything the agent *could* do," and with a broad credential
+those are worlds apart.
+
+What makes this acute is that you cannot fix it by trusting the agent more. The
+model has no reliable boundary between content and command, so "be more careful"
+is not an enforcement mechanism. Containment has to come from outside the agent, or
+it does not exist.
+
+## Nothing to steal, every call bounded, access that expires
+
+Warden contains a compromised agent along three independent axes, so a breach is a
+bounded event rather than a catastrophic one:
+
+- **Nothing to steal.** Because [access is brokered](access-brokering.md), the
+  agent never holds an upstream credential. A compromised agent can leak only what
+  it has, and all it has is its own identity — useless to an attacker without
+  Warden in front of it.
+- **Every call is still bounded.** Authority rides on each request and is checked
+  at runtime against the agent's [policy](../concepts/policies.md), which is
+  **default-deny**. A request that exceeds what the agent is allowed is refused
+  before it reaches the upstream — no matter what the prompt, the memory, or the
+  chat history says. There is no ambient, pre-granted access sitting on the
+  connection to be turned against you.
+- **Access expires.** The credential Warden injects carries a short
+  [lease](../concepts/credentials.md#lifetime-and-revocation), so even an allowed
+  call buys only a brief window; where the upstream supports it, Warden also
+  revokes early. And because [roles are
+  per-request](../concepts/roles.md#roles-are-per-request), an agent that needs
+  elevated access for one step names a higher-privilege role only for that call,
+  rather than carrying the elevation through everything else it does.
+
+The same mechanics turn ordinary mistakes into **recoverable** ones. A hallucinated
+request that overruns the agent's scope is denied and recorded, with no state
+change — an observable non-event in the [audit log](../concepts/audit.md) instead
+of an incident to clean up.
+
+## Benefits
+
+- **Nothing to exfiltrate** — no upstream secret ever sits in the agent, so a
+  hijack finds no keys to steal.
+- **Every call stays in bounds** — out-of-scope requests are denied at request
+  time, whatever the agent has been talked into.
+- **Mistakes become recoverable** — a hallucinated or injected action is a denied,
+  logged non-event, not an outage.
+
+## In practice
+
+An incident-response agent reaching a `grafana` mount is prompt-injected by a
+malicious annotation in a dashboard it reads: the embedded text tells it to delete
+every dashboard and copy an API key to an external host. Neither lands. There is no
+Grafana API key in the agent's environment to copy — Warden holds it — and the
+agent's role grants only `read` on the mount, so the `DELETE` calls are refused
+before they reach Grafana, each recorded as a denied attempt with no state change.
+The injection becomes a logged non-event the on-call engineer reviews later, not an
+outage to recover from.
+
+## See Also
+
+- [Access brokering](access-brokering.md) — why there is no secret in the agent to
+  exfiltrate in the first place.
+- [Runtime authorization](runtime-authorization.md) — the per-call boundary that
+  refuses an out-of-scope request.
+- [Credentials](../concepts/credentials.md#lifetime-and-revocation) — lease,
+  expiry, and revocation that cap even an allowed call.
+- [Roles](../concepts/roles.md#roles-are-per-request) — per-request role binding
+  that narrows each step.
+- [Audit & attribution](audit-attribution.md) — where the contained attempt is
+  recorded.

--- a/docs/use-cases/centralized-governance.md
+++ b/docs/use-cases/centralized-governance.md
@@ -1,0 +1,82 @@
+# Centralized governance
+
+_One control plane for every system an agent touches._
+
+## Every system in its own silo
+
+A useful agent does not reach one system; it reaches dozens — a cloud control
+plane, a Git host, half a dozen observability tools, a database or two, an
+incident manager, a handful of MCP servers. Each of those was built with its own
+idea of identity, its own credential format, its own way of writing policy, and its
+own audit log. Wire an agent into all of them and you have not built one access
+model; you have inherited fifteen.
+
+The cost is not abstract. There is no single place to ask "what can this agent
+reach?", because the answer is scattered across fifteen consoles. There is no
+single place to *change* that answer, so tightening a policy or offboarding an
+agent means fifteen edits, and the one you forget is the one that leaks. Rotation
+is fifteen schedules. MCP makes it worse, pushing a separate credential for each
+tool into the agent's environment. And when two teams share the same infrastructure,
+nothing keeps one team's policies, secrets, and mistakes from reaching the other.
+
+What you end up governing is not the fleet of agents but the sprawl of integrations
+underneath them — and that sprawl grows with every system you add, until the
+operational weight of managing access is the thing that limits how many agents you
+can safely run.
+
+## Identity, policy, and audit in one place
+
+Warden is the single point every agent request passes through, so it is the single
+place those concerns live. One agent identity is validated once and carried to
+every upstream the policy permits. One [policy](../concepts/policies.md) surface,
+written in one language, governs access across every system — the same default-deny
+rules whether the agent is calling a cloud API, a Git host, or an MCP server. One
+[audit log](../concepts/audit.md) records every request to every upstream. The
+[providers](../concepts/providers.md) Warden ships front clouds, databases, code
+hosts, observability stacks, SaaS, and MCP servers alike, so adding a system means
+mounting a provider, not standing up another access model.
+
+The secrets stay in one place too. Warden holds the privileged upstream credentials
+and [rotates](../concepts/credentials.md#rotation) them on a schedule it manages,
+staging the change for upstreams that need time to propagate a new key — so the
+broker's own secrets stay fresh without per-integration coordination. For MCP, one
+gateway fronts every tool a server exposes, replacing the per-tool-credential-in-env
+model with a single policy surface.
+
+Where independence matters, [namespaces](../concepts/namespaces.md) give it. Each
+team, product, or environment gets a hard boundary: its mounts, identities, and
+policies are invisible to every other namespace, and a policy in one can never grant
+access in another. One Warden serves many tenants on shared infrastructure without
+their access models bleeding together.
+
+## Benefits
+
+- **One policy surface** — set, review, and answer access for every upstream in one
+  place and one language, instead of across a dozen consoles.
+- **Hard tenant isolation** — namespaces give each team or environment a sealed
+  boundary on shared infrastructure.
+- **Secrets stay fresh on their own** — Warden holds and rotates the upstream
+  credentials centrally, so rotation is not N schedules to chase.
+
+## In practice
+
+A platform team runs one Warden for the whole company. Agents across several teams
+reach AWS, GitHub, Datadog, a production database, and a set of MCP servers — all
+through Warden, all under policies the platform team writes in one place. Each team
+works inside its own namespace, so `team-a`'s mounts and secrets are invisible to
+`team-b`, and the upstream credentials Warden holds rotate on schedule without any
+team touching a key. Onboarding a new upstream is one provider mount; offboarding an
+agent is one identity removed — not a sweep across fifteen systems.
+
+## See Also
+
+- [Providers](../concepts/providers.md) — the mounts that front every upstream
+  behind one gateway.
+- [Namespaces](../concepts/namespaces.md) — the hard isolation boundary for mounts,
+  policies, and tokens.
+- [Credentials](../concepts/credentials.md#rotation) — how Warden rotates the
+  secrets it holds, centrally.
+- [Runtime authorization](runtime-authorization.md) — the per-call decisions this
+  one policy surface enforces.
+- [Audit & attribution](audit-attribution.md) — the single log every governed
+  request lands in.

--- a/docs/use-cases/runtime-authorization.md
+++ b/docs/use-cases/runtime-authorization.md
@@ -1,0 +1,84 @@
+# Runtime authorization
+
+_Control every tool call at runtime, down to the argument._
+
+## Reaching a system shouldn't mean doing anything in it
+
+Most access control is coarse and static. You grant an agent a credential — a
+token, a scope, a key — and within whatever that credential covers, the agent can
+do anything, for as long as the credential lives. The grant is made once and
+reused for the whole session, and it answers only one question: *which systems can
+you reach?* It says nothing about *what you may do* once you are there.
+
+For an agent, that gap is the whole risk. "Can reach GitHub" silently becomes "can
+delete any repository." "Can query the database" becomes "can read every table."
+The grant that lets an agent do its narrow job also lets a hijacked or hallucinating
+version of that agent do everything else the system allows. And because grants are
+made per session and rarely narrowed, they accumulate: an agent ends up holding the
+union of everything it has ever needed, long after it needs it.
+
+MCP makes the gap concrete. An MCP server exposes a bundle of tools, and a
+coarse grant hands the agent *all* of them, with *any* arguments — `delete_database`
+sitting next to `get_repository`, `env=production` as reachable as `env=staging`.
+Granting "the server" is granting every tool it will ever expose; there is no
+natural place to say *this tool but not that one*, or *this tool only with these
+arguments*.
+
+## Authorize every call, down to the argument
+
+Warden authorizes the **request**, not the session. Authority does not sit on the
+connection; it rides on each call and is evaluated the moment the call arrives,
+against the [policy](../concepts/policies.md) attached to the agent's
+[role](../concepts/roles.md). Authorization is **default-deny** — a call succeeds
+only if a rule grants exactly the capability it needs — and because [roles are
+per-request](../concepts/roles.md#roles-are-per-request), the agent can run under
+a read-only role for routine work and name a higher-privilege role only for the
+one call that genuinely needs it. Nothing accumulates; each call is judged on its
+own terms.
+
+The check reaches past the path into the content of the request. A policy can gate
+an operation on its [parameters](../concepts/policies.md#parameter-constraints) and
+on request context — source IP, time of day, day of week — before any credential is
+minted. For [MCP](../concepts/mcp.md) traffic it goes all the way inside the tool
+call: Warden parses the JSON-RPC body and decides, per call, **which tool** the
+agent may invoke, **which resource or prompt** it may name, and **which arguments**
+it may pass — refusing the call before it ever reaches the upstream. That is how you
+govern what an agent actually *does* through a server, not merely whether it can
+reach it.
+
+A denied MCP call comes back as an HTTP 403 with a short reason naming the offending
+tool or parameter, so the agent can correct course instead of guessing at an opaque
+failure — and every decision, allow or deny, is recorded.
+
+## Benefits
+
+- **Least privilege per step** — each call gets the narrowest role that fits it,
+  not a session-wide grant that fits everything.
+- **Down to the action and argument** — policy gates the specific tool, resource,
+  and parameter values, not just which system is reachable.
+- **No privilege accumulation** — authority is re-decided on every call, so nothing
+  lingers on the connection to be misused later.
+
+## In practice
+
+An agent drives a GitHub MCP server through an `mcp` mount. Its policy allows the
+`tools/call` method for `get_repository` and `list_issues`, denies any tool matching
+`delete_*`, and denies the `env` argument when it is `prod`. The agent works
+normally — listing issues, reading repositories — until a poisoned issue body
+convinces it to call `delete_repository`. Warden parses the JSON-RPC body, matches
+the denied-tools rule, and refuses the call with a 403 before it reaches GitHub. The
+repository is untouched, and the attempt is in the [audit log](../concepts/audit.md)
+with the exact tool that was blocked.
+
+## See Also
+
+- [Policies](../concepts/policies.md) — capabilities, conditions, parameter
+  constraints, and the `mcp { }` rule grammar.
+- [Roles](../concepts/roles.md#roles-are-per-request) — per-request role binding
+  and changing role mid-session.
+- [Model Context Protocol](../concepts/mcp.md) — authorizing individual tool calls
+  by name and argument.
+- [Breach containment](breach-containment.md) — the bounded blast radius this
+  per-call control produces.
+- [Audit & attribution](audit-attribution.md) — where every allow and deny is
+  recorded.


### PR DESCRIPTION
## What

Adds a problem-led **Use Cases** section to the docs and reframes the README around it.

### New docs (`docs/use-cases/`)
Five use-case guides plus a problem-framed index. Each page leads with the problem — deepening it and showing how it bites at agent scale — before turning to how Warden answers it and the benefit

- **Access brokering** — every integration is one more secret in the agent → Warden holds the secret; the agent carries only an identity.
- **Breach containment** — one bad step under a broad credential → nothing to steal, every call bounded, access that expires.
- **Runtime authorization** — reaching a system shouldn't mean doing anything in it → authorize every call, down to the argument.
- **Centralized governance** — every system in its own silo → identity, policy, and audit in one place.
- **Audit & attribution** — shared identities erase who actually acted → every request tied to a real identity.

MCP is woven in as the lead example in runtime-authorization / centralized-governance / audit-attribution rather than being a separate use case. Vocabulary is grounded in the existing concept docs, and all cross-links resolve.

### README
- Replace the "enterprise control plane" bullets with a **Use cases** section mirroring the five (all eight prior bullets fold in — none lost).
- Rename the prior "Use cases" scenarios section to **Deployment scenarios** to avoid a duplicate heading.
- Simplify **How Warden works** — describe the request path plainly instead of leading with "discover then connect"; discovery is kept as a secondary note linking the agent-flow docs.
- Drop the fixed supported-systems count so it can't drift out of date.

## Notes
Documentation only — no code changes.