### PR TITLE
docs(audit-devices): add audit-device section and file-device guide

### DIFF
--- a/docs/audit-devices/README.md
+++ b/docs/audit-devices/README.md
@@ -1,0 +1,33 @@
+# Audit Devices
+
+An **audit device** is a pluggable sink that receives the formatted request and
+response entries Warden produces for every operation, and writes them to a
+destination you control. Enabling at least one device is what turns the
+[audit log](../concepts/audit.md) from a concept into a forensic record — and what
+flips Warden from fail-open to fail-closed, so a request is served only if it can
+be audited.
+
+This section is the operational counterpart to the [Audit](../concepts/audit.md)
+concept page. The concept page explains *what* gets recorded, how secrets are
+HMAC-salted, and the fail-open→fail-closed guarantee; the pages here are setup
+guides — how to enable, configure, tune, and troubleshoot each device.
+
+Warden ships one device. The page below is a setup guide — enabling it three ways
+(CLI, declarative HCL, HTTP API), a full configuration reference, rotation and
+retention, and troubleshooting.
+
+| Device | Writes | Reach for it when |
+|--------|--------|-------------------|
+| [File](file.md) | JSON-lines to a local file, with size- and time-based rotation | you want a durable on-disk audit trail you can tail, rotate, and ship to a SIEM or log collector. |
+
+Audit devices live in the **root namespace** and are **global**: every namespace's
+traffic is logged to the same devices, and each entry records the namespace it came
+from. Managing devices is therefore a root-namespace, operator-level operation.
+
+## See Also
+
+- [Audit](../concepts/audit.md) — the recording model: what's logged, HMAC salting, and fail-open/closed.
+- [Policies](../concepts/policies.md) — the authorization decisions recorded in each entry.
+- [Credentials](../concepts/credentials.md) — what "credential issued" in the log refers to.
+- [Audit Attribution](../use-cases/audit-attribution.md) — tying every request back to an identity.
+- [Concepts](../concepts/README.md) — how Warden works, end to end.

--- a/docs/audit-devices/file.md
+++ b/docs/audit-devices/file.md
@@ -1,0 +1,208 @@
+# File Audit Device
+
+The **file** device writes the audit log to a local file, one JSON object per line.
+Writes are buffered for throughput and flushed on an interval, and the file rotates
+by size, by day, or both, with old files pruned automatically. It is the device you
+reach for when you want a durable on-disk trail you can tail during an incident,
+rotate with your usual tooling, and ship to a SIEM or log collector.
+
+This page is the operational guide: how to enable the device, every configuration
+key it accepts, how rotation and retention behave, and how to troubleshoot it. For
+*what* ends up in each entry — the request/response fields, HMAC salting of
+secrets, and the fail-open→fail-closed guarantee — see the
+[Audit](../concepts/audit.md) concept page.
+
+Audit devices are a **root-namespace, operator-level** concern: they are global,
+and every namespace's traffic is logged to the same set of devices.
+
+## Contents
+
+- [Enable it](#enable-it)
+  - [CLI](#cli)
+  - [Declarative (HCL)](#declarative-hcl)
+  - [HTTP API](#http-api)
+- [Configuration reference](#configuration-reference)
+- [Rotation and retention](#rotation-and-retention)
+- [Salting and omission](#salting-and-omission)
+- [Troubleshooting](#troubleshooting)
+- [See Also](#see-also)
+
+## Enable it
+
+A device is identified by its **mount path** (where it lives in `sys/audit/`) and
+configured with the keys in the [reference](#configuration-reference) below. The
+only required key for the file device is `file_path` — the location of the log file
+on disk. Note that the *mount path* and the *file path* are two different things:
+the mount path names the device, the file path is where it writes.
+
+There are three ways to enable a device. The CLI and HTTP API create devices at
+runtime; HCL declares them in server config and registers them at startup.
+
+### CLI
+
+Enable a file device with the typed flags:
+
+```bash
+# Mount path defaults to the type ("file"); -file-path is the log location.
+warden audit enable -file-path=/var/log/warden/audit.log file
+
+# A custom mount path, so you can run more than one file device.
+warden audit enable -path=prod-audit -file-path=/var/log/warden/audit.log file
+```
+
+The `enable` flags are `-file-path`, `-description`, `-format`, `-path`, and
+`-json`. For richer configuration (rotation, buffering, salting), pass a full JSON
+payload instead of the typed flags — `-json` is mutually exclusive with
+`-description` / `-file-path` / `-format`:
+
+```bash
+warden audit enable file -json @audit-file.json
+cat audit-file.json | warden audit enable file -json -
+```
+
+Add `-dry-run` to validate a payload locally without enabling anything. Inspect and
+remove devices with:
+
+```bash
+warden audit list            # all enabled devices
+warden audit read   file/    # one device's config (hmac_key is masked)
+warden audit disable file/   # remove a device by mount path
+```
+
+### Declarative (HCL)
+
+Declare devices in the server config with the two-label `audit "TYPE" "NAME"`
+syntax. The labels are the device type and the mount name:
+
+```hcl
+audit "file" "default" {
+  description = "primary file audit"
+  options = {
+    file_path = "/var/log/warden/audit.log"
+  }
+}
+```
+
+A few things specific to declared devices:
+
+- **They register at startup, before the API listener accepts traffic.** A
+  misconfigured sink — unwritable path, missing parent directory, permission
+  denied — **fails startup** rather than leaving a half-initialized server.
+- **They are immutable from the API.** A device declared in HCL cannot be modified
+  or deleted via `sys/audit/`; edit the file and restart instead. Declared and
+  API-enabled devices coexist at their own mount paths.
+- **All `options` values are strings.** Non-string knobs such as `rotate_size` and
+  `rotate_daily` are best tuned through the HTTP API (below) for now.
+- **Declare at least two devices in production.** With zero devices the server
+  fail-opens (so a fresh server can serve `sys/audit/` long enough to bootstrap
+  one); a single device that wedges can otherwise block traffic.
+
+### HTTP API
+
+The CLI is a thin wrapper over the `sys/audit/` endpoints, which you can call
+directly:
+
+```bash
+# Enable (returns the device accessor); config carries the keys below.
+curl -X POST "$WARDEN_ADDR/v1/sys/audit/file" \
+  -H "X-Warden-Token: $WARDEN_TOKEN" \
+  -d '{"type":"file","config":{"file_path":"/var/log/warden/audit.log"}}'
+
+curl "$WARDEN_ADDR/v1/sys/audit/"        # list devices
+curl -X DELETE "$WARDEN_ADDR/v1/sys/audit/file"   # disable a device
+```
+
+To check whether a known plaintext appears in the log, hash it with a device's salt
+via `sys/audit-hash/<path>` and compare against the `hmac-sha256:…` values in the
+log:
+
+```bash
+warden write sys/audit-hash/file input="AKIA...EXAMPLE"
+```
+
+## Configuration reference
+
+These keys go in the CLI `-json` payload, the HTTP `config` object, or — as strings
+— an HCL `options` block. Defaults are what the device applies when you omit a key.
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `file_path` | `warden_audit.log` | File to write to. Required; the parent directory must exist and be writable. |
+| `file_mode` | `0600` | Octal permissions on the log file. |
+| `format` | `json` | Serialization format. Only `json` is supported. |
+| `rotate_size` | `104857600` (100 MB) | Rotate when the file reaches this many bytes. `0` disables size-based rotation. |
+| `rotate_daily` | `true` | Also rotate at UTC midnight. |
+| `max_backups` | `5` | Number of rotated files to keep; older ones are pruned. |
+| `buffer_size` | `100` | Entries buffered before a flush. |
+| `flush_period` | `5s` | Maximum time between flushes. |
+| `hmac_key` | _(auto-generated)_ | The salt key for hashing sensitive fields. Generated if you don't supply one; masked on read. |
+| `salt_fields` | `["response.credential.data"]` | Dot-paths to HMAC instead of logging in clear. |
+| `omit_fields` | `["request.data","request.headers","response.data","response.headers"]` | Dot-paths to drop entirely. |
+| `prefix` | _(none)_ | Optional string prefixed to each log line. |
+| `enabled` | `true` | Whether the device is active. |
+| `skip_test` | `false` | Skip the write-test performed when the device is created. |
+
+Validation bounds (a value outside these is rejected at enable time):
+
+- `buffer_size`: 1 – 100000
+- `flush_period`: 100ms – 1h
+- `rotate_size`: 0 – 100 GB (`0` means no size-based rotation)
+- `max_backups`: 1 – 1000
+
+## Rotation and retention
+
+The file device rotates on two independent triggers:
+
+- **Size** — when the active file reaches `rotate_size` bytes (default 100 MB). Set
+  `rotate_size` to `0` to turn this off.
+- **Daily** — when `rotate_daily` is `true` (the default), the file also rotates at
+  UTC midnight regardless of size.
+
+On each rotation the active file is rolled to a timestamped backup and a fresh file
+is opened. Warden keeps the most recent `max_backups` files (default 5) and prunes
+the rest. If you ship logs off-box with an external collector, size the buffer and
+backups so a collector hiccup doesn't lose entries before they're forwarded.
+
+## Salting and omission
+
+Two knobs control which fields are protected. See
+[Audit → Secrets Are Never Logged in Clear](../concepts/audit.md#secrets-are-never-logged-in-clear)
+for the reasoning; the operational summary:
+
+- **`salt_fields`** — dot-paths whose values are replaced with
+  `hmac-sha256:<hex>` instead of plaintext. The default,
+  `response.credential.data`, salts every secret Warden injects (access keys,
+  tokens, passwords). Extend it to hash more, e.g. `auth.token_id` or
+  `request.data.password`.
+- **`omit_fields`** — dot-paths dropped from the entry entirely. The defaults drop
+  request and response bodies and headers, which are noisy and often sensitive.
+
+The hash is deterministic under a given device's key, so the same value always
+produces the same hash and you can correlate occurrences without the log revealing
+the plaintext. A device's salt is **not preserved across disable→enable** — a
+re-enabled device gets a fresh key, so hashes from before no longer correlate.
+
+## Troubleshooting
+
+- **Server won't start after adding an HCL `audit` block.** A declared device that
+  can't write fails startup by design. Check that `file_path`'s parent directory
+  exists and is writable by the Warden process, and that `file_mode` is a valid
+  octal string.
+- **`enable` returns an error instead of failing startup.** API- and CLI-created
+  devices surface the same write/permission problems as an error response rather
+  than a crash — fix the path or permissions and retry.
+- **Can't disable a device** (`cannot disable the last audit device`). Once any
+  device is enabled, Warden runs fail-closed and refuses to remove the last one,
+  which would silently stop auditing. Enable a replacement first, then disable.
+- **`hmac_key` reads back masked.** Expected — the salt is never returned. Use
+  `sys/audit-hash/<path>` to hash a known value under the device's key.
+- **`only 'json' format is supported`.** `format` must be `json`; no other format
+  exists yet.
+
+## See Also
+
+- [Audit](../concepts/audit.md) — the recording model, HMAC salting, and fail-open/closed.
+- [Audit Devices](README.md) — the section overview.
+- [Policies](../concepts/policies.md) — the authorization decisions recorded in each entry.
+- [Credentials](../concepts/credentials.md) — what "credential issued" in the log refers to.
+- [High Availability](../concepts/high-availability.md) — audit continuity across leader failover.

--- a/docs/auth-methods/README.md
+++ b/docs/auth-methods/README.md
@@ -29,4 +29,4 @@ over its neighbours — the [JWT](jwt.md), [Kubernetes](kubernetes.md), and
 - [Authentication](../concepts/authentication.md) — credential forms, explicit vs. transparent auth, and CLI behaviour.
 - [Roles](../concepts/roles.md) — how a validated credential maps to policies and token settings.
 - [Agent Identity](../agent-identity/README.md) — how a workload or its sidecar presents its credential to Warden.
-- [Concepts](../concepts/index.md) — how Warden works, end to end.
+- [Concepts](../concepts/README.md) — how Warden works, end to end.

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -54,6 +54,8 @@ a credential of its own.
 - [Namespaces](namespaces.md) — the hard isolation boundary for every mount,
   policy, and token.
 - [Audit](audit.md) — the forensic record of every request, with secrets hashed.
+- [Audit Devices](../audit-devices/README.md) — setup guides for enabling and
+  configuring the sinks that receive the audit log.
 
 ## Running in production
 

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -54,32 +54,15 @@ warden write sys/audit-hash/file input="AKIA...EXAMPLE"
 
 An **audit device** is a pluggable sink that receives the formatted entries.
 Warden ships the **`file`** device, which writes JSON lines to a file and rotates
-them. Its main config keys:
+them. You enable devices from the CLI, in declarative server config, or over the
+`sys/audit/<path>` API, and a device's salt is **not preserved** across
+disable/enable — a re-enabled device gets a fresh key, so old hashes no longer
+correlate.
 
-| Key | Default | Purpose |
-|-----|---------|---------|
-| `file_path` | `warden_audit.log` | File to write to. |
-| `file_mode` | `0600` | Permissions on the file. |
-| `format` | `json` | Serialization format. |
-| `rotate_size` | 100 MB | Rotate when the file reaches this size. |
-| `rotate_daily` | `true` | Also rotate at UTC midnight. |
-| `max_backups` | `5` | Rotated files to keep. |
-| `buffer_size` / `flush_period` | `100` / `5s` | Batching, for throughput. |
-| `hmac_key` | _(auto)_ | The salt key; generated if you don't supply one. |
-
-Enable, inspect, and disable devices from the CLI (or the `sys/audit/<path>`
-endpoints):
-
-```bash
-warden audit enable file -file-path=/var/log/warden/audit.log
-warden audit list
-warden audit read   file/
-warden audit disable file/
-```
-
-The `hmac_key` is masked on read. Note that a device's salt is **not preserved**
-across disable/enable — a re-enabled device gets a fresh key, so old hashes no
-longer correlate.
+For the full configuration reference, the three ways to enable a device, rotation
+and retention, and troubleshooting, see the
+[Audit Devices](../audit-devices/README.md) section and the
+[file device guide](../audit-devices/file.md).
 
 ## Fail-Open Until Configured, Then Fail-Closed
 
@@ -131,4 +114,5 @@ operator-level operation, not something a tenant configures.
 - [Credentials](credentials.md) — what "credential issued" in the log refers to.
 - [Tokens](tokens.md) — the identity fields logged per request.
 - [Namespaces](namespaces.md) — recorded per entry; devices are root-scoped.
+- [Audit Devices](../audit-devices/README.md) — setup guides for enabling and configuring a device.
 - [Dev Server](dev-server.md) — ships unaudited (fail-open).

--- a/docs/provider-backends/README.md
+++ b/docs/provider-backends/README.md
@@ -97,5 +97,5 @@ reference.
 - [Providers](../concepts/providers.md) — the gateway model: how a request is authenticated, authorized, and proxied.
 - [Credentials](../concepts/credentials.md) — what each provider injects into the proxied request.
 - [Roles](../concepts/roles.md) — how the role on a request selects access and credential.
-- [Concepts](../concepts/index.md) — how Warden works, end to end.
+- [Concepts](../concepts/README.md) — how Warden works, end to end.
 </content>

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -25,7 +25,7 @@ what happened.
 
 ## See Also
 
-- [Concepts](../concepts/index.md) — how Warden works, end to end.
+- [Concepts](../concepts/README.md) — how Warden works, end to end.
 - [Architecture](../architecture.md) — the broker in the request path, at a glance.
 - [Agent Flow](../agent-flow.md) — the path an agent takes once its identity is
   established.


### PR DESCRIPTION
## What

Fills in the stubbed `docs/audit-devices/` section, the last empty section after the recent docs reorganization.

- **New** [docs/audit-devices/README.md](docs/audit-devices/README.md) — section hub: what an audit device is, the shipped device, root-namespace/global scope, and cross-links.
- **New** [docs/audit-devices/file.md](docs/audit-devices/file.md) — operational guide for the file device: enabling via CLI, declarative HCL, and the `sys/audit` API; a full configuration reference with runtime defaults and validation bounds; rotation & retention; salting & omission; troubleshooting.
- **Trim** [docs/concepts/audit.md](docs/concepts/audit.md) — replaced the duplicated config table + CLI block with a short forward link, so the concept page stays conceptual and operational detail lives in one place.
- **Rename** `docs/concepts/index.md` → `docs/concepts/README.md` to match the section-hub convention every other section uses, updating the inbound `../concepts/index.md` links in the auth-methods, use-cases, provider-backends, and audit-devices READMEs.

## Scope notes

- Documents the **`file`** device only — it is the only type registered to a factory. The `syslog`/`socket` sinks exist in the `audit/` package but are not wired to any factory, so they are intentionally left out.
- Config keys, defaults, validation bounds, CLI flags, and the HCL block shape were verified against the source (`audit/config.go`, `cmd/audit/enable.go`, `config/config.go`). Runtime defaults are used (e.g. the real 100 MB `rotate_size`, not the stale struct-tag value).

## Verification

- All relative links and the section anchor resolve; no dangling `concepts/index.md` references remain.
- No code changes.
