### PR TITLE
docs(cli): add CLI command reference

### DIFF
--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -13,9 +13,11 @@ Usage: warden audit <subcommand> [options]
   Audit devices are responsible for logging all requests and responses
   for security compliance and forensics.
 
-  IMPORTANT: Warden operates in fail-closed mode - at least one audit
-  device must always be enabled. Attempting to disable the last audit
-  device will be rejected.
+  IMPORTANT: Once any audit device is registered, Warden runs fail-closed -
+  every request must be successfully audited or it is rejected. Disabling the
+  last device is allowed and drops the server to an unaudited state until one
+  is re-enabled, so re-enable promptly. Devices declared in HCL config cannot
+  be disabled here.
 
   List all enabled audit devices:
 

--- a/core/sys_audit.go
+++ b/core/sys_audit.go
@@ -148,7 +148,7 @@ func (b *SystemBackend) pathAudit() []*framework.Path {
 					Description: "Enables an audit device of the given `type` at `path`. " +
 						"If `config.hmac_key` is omitted, Warden generates a 32-byte random salt and stores it on this device — " +
 						"used by `audit-hash/{path}` to verify whether a plaintext value appears in *this device's* audit logs. " +
-						"Warden runs fail-closed: at least one audit device must remain enabled at all times.",
+						"Once any device is registered, Warden runs fail-closed: every request must be successfully audited or it is rejected.",
 					Responses: createResponses,
 					Examples:  createExamples,
 				},
@@ -199,7 +199,8 @@ func (b *SystemBackend) pathAudit() []*framework.Path {
 					Callback: b.handleAuditDelete,
 					Summary:  "Disable an audit device",
 					Description: "Disables (unmounts) the audit device at `path`. " +
-						"Disabling the last enabled audit device returns 400 — Warden requires at least one audit device to operate (fail-closed mode).",
+						"Disabling the last device is allowed: the server drops to zero registered devices and serves unaudited (fail-open) until one is re-enabled. " +
+						"A device declared in HCL config cannot be disabled via the API and returns 400.",
 					Responses: map[int][]framework.Response{
 						http.StatusOK: {{
 							Description: "Audit device disabled successfully.",
@@ -218,7 +219,7 @@ func (b *SystemBackend) pathAudit() []*framework.Path {
 							},
 						}},
 						http.StatusBadRequest: {{
-							Description: "Cannot disable the last audit device (fail-closed mode), or the underlying disable operation failed.",
+							Description: "The device is owned by an HCL audit declaration, or the underlying disable operation failed.",
 						}},
 					},
 					Examples: []framework.RequestExample{{

--- a/docs/audit-devices/README.md
+++ b/docs/audit-devices/README.md
@@ -30,4 +30,5 @@ from. Managing devices is therefore a root-namespace, operator-level operation.
 - [Policies](../concepts/policies.md) — the authorization decisions recorded in each entry.
 - [Credentials](../concepts/credentials.md) — what "credential issued" in the log refers to.
 - [Audit Attribution](../use-cases/audit-attribution.md) — tying every request back to an identity.
+- [`warden audit`](../cli/audit.md) — the CLI for enabling, listing, and disabling devices.
 - [Concepts](../concepts/README.md) — how Warden works, end to end.

--- a/docs/auth-methods/README.md
+++ b/docs/auth-methods/README.md
@@ -29,4 +29,5 @@ over its neighbours — the [JWT](jwt.md), [Kubernetes](kubernetes.md), and
 - [Authentication](../concepts/authentication.md) — credential forms, explicit vs. transparent auth, and CLI behaviour.
 - [Roles](../concepts/roles.md) — how a validated credential maps to policies and token settings.
 - [Agent Identity](../agent-identity/README.md) — how a workload or its sidecar presents its credential to Warden.
+- [`warden auth`](../cli/auth.md) — the CLI for enabling, listing, and disabling auth methods.
 - [Concepts](../concepts/README.md) — how Warden works, end to end.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,0 +1,228 @@
+# Warden CLI
+
+The `warden` binary is both the server and the client. As a client, every
+command talks to a running Warden server over its HTTP API, authenticates the
+caller, and renders the response. This page covers the behaviour shared by every
+command — how to reach a server, the global flags, environment variables, output
+formats, and exit codes — then indexes the per-command reference pages.
+
+For what the server *does* with these calls, see [Concepts](../concepts/README.md).
+
+## Table of Contents
+
+- [Connecting to a server](#connecting-to-a-server)
+- [Global flags](#global-flags)
+- [Environment variables](#environment-variables)
+- [Output formats](#output-formats)
+- [Field projection](#field-projection)
+- [Dry run](#dry-run)
+- [Exit codes](#exit-codes)
+- [Command index](#command-index)
+- [See Also](#see-also)
+
+## Connecting to a server
+
+Two environment variables decide which server a command talks to and as whom:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WARDEN_ADDR` | `http://127.0.0.1:8400` | URL of the Warden server. May be `http://`, `https://`, or a `unix://` socket. |
+| `WARDEN_TOKEN` | *(none)* | The credential presented on each request. |
+
+```bash
+export WARDEN_ADDR=https://warden.example.com:8400
+export WARDEN_TOKEN=s.xxxxxxxxxxxxxxxxxxxx
+warden status
+```
+
+There is no `login` subcommand and no `~/.warden-token` file — the token is read
+from the environment. A first token comes from [`warden operator init`](operator.md),
+which prints a root token and an `export WARDEN_TOKEN=…` line to paste.
+
+`WARDEN_TOKEN` accepts two credential shapes. A Warden session token is sent in
+the `X-Warden-Token` header. A **JWT** (any value beginning with `eyJ`) is instead
+sent as `Authorization: Bearer …`, so the server's transparent-auth path can
+resolve it against the namespace's configured auth method. mTLS is also supported
+— set `WARDEN_CLIENT_CERT` / `WARDEN_CLIENT_KEY` and the server authenticates the
+client certificate directly. See [Authentication](../concepts/authentication.md).
+
+## Global flags
+
+These persistent flags are accepted by every command. Each has an environment
+variable equivalent; the flag wins when both are set.
+
+| Flag | Env | Description |
+|---|---|---|
+| `-n`, `--namespace` | `WARDEN_NAMESPACE` | [Namespace](../concepts/namespaces.md) to scope the command to. |
+| `-r`, `--role` | `WARDEN_ROLE` | [Role](../concepts/roles.md) to assume for the command. |
+| `-o`, `--output` | `WARDEN_OUTPUT` | Output format: `table`, `json`, `ndjson`, or `text`. |
+| `-F`, `--fields` | `WARDEN_FIELDS` | Comma-separated dot-paths to project from structured output. |
+| `-D`, `--dry-run` | `WARDEN_DRY_RUN` | Validate the payload locally against the server schema and exit without sending. |
+
+Single-dash long flags are accepted as well as double-dash (`-namespace` and
+`--namespace` are equivalent), matching the Vault/OpenBao CLI convention used
+throughout these docs.
+
+## Environment variables
+
+Beyond the global-flag variables above, the client reads the following. All are
+optional; defaults apply when unset.
+
+**Connection & identity**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WARDEN_ADDR` | `http://127.0.0.1:8400` | Server URL. |
+| `WARDEN_TOKEN` | *(none)* | Auth token (session token or JWT). |
+| `WARDEN_NAMESPACE` | *(none)* | Namespace scope (`X-Warden-Namespace` header). |
+| `WARDEN_ROLE` | *(none)* | Role to assume (`X-Warden-Role` header). |
+
+**TLS**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WARDEN_CACERT` | *(none)* | Path to a PEM CA certificate to verify the server. |
+| `WARDEN_CACERT_BYTES` | *(none)* | PEM CA certificate as an inline string. |
+| `WARDEN_CAPATH` | *(none)* | Path to a directory of PEM CA certificates. |
+| `WARDEN_CLIENT_CERT` | *(none)* | Path to a client certificate for mTLS. |
+| `WARDEN_CLIENT_KEY` | *(none)* | Path to the client private key for mTLS. |
+| `WARDEN_SKIP_VERIFY` | `false` | Disable TLS verification (insecure; testing only). |
+| `WARDEN_TLS_SERVER_NAME` | *(none)* | SNI server name for the TLS handshake. |
+
+**Networking**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WARDEN_CLIENT_TIMEOUT` | `60s` | Per-request timeout. |
+| `WARDEN_MAX_RETRIES` | `0` on the CLI | Retries on 5xx / 429 / 412. The CLI disables retries unless this is set. |
+| `WARDEN_SRV_LOOKUP` | `false` | Resolve the server address via DNS SRV records. |
+| `WARDEN_HTTP_PROXY` | *(none)* | HTTP(S) proxy URL. |
+| `WARDEN_PROXY_ADDR` | *(none)* | Proxy URL; supersedes `WARDEN_HTTP_PROXY`. |
+| `WARDEN_RATE_LIMIT` | *(none)* | Client-side rate limit, `rate[:burst]` (e.g. `10.5:20`). |
+
+## Output formats
+
+Structured commands render in one of four formats:
+
+| Format | Shape |
+|---|---|
+| `table` | Human-readable table. **Default when stdout is a terminal.** |
+| `json` | Pretty-printed JSON. **Default when stdout is not a terminal** (pipes, files). |
+| `ndjson` | One JSON record per line — stream-friendly for `jq` and agents. |
+| `text` | Logfmt-style `key=value` lines. |
+
+Resolution order: the `-o/--output` flag, then `WARDEN_OUTPUT`, then TTY
+autodetect. Because non-TTY defaults to `json`, piping any command already yields
+machine-readable output without a flag:
+
+```bash
+warden auth list                  # table on your terminal
+warden auth list | jq '.[].type'  # json when piped
+warden status -o json
+```
+
+## Field projection
+
+`-F/--fields` (or `WARDEN_FIELDS`) narrows structured output to a comma-separated
+list of dot-paths. `*` is a wildcard over every key of a map or element of a list.
+Paths that don't match are silently omitted.
+
+```bash
+warden status -o json -F sealed,is_leader,leader_address
+warden read aws/config -o json -F proxy_domains,timeout
+warden auth list -o json -F '*.type'
+```
+
+Projection applies to `json`, `ndjson`, and `text`. In `table` mode it falls back
+to a generic key/value layout and prints a hint to use `-o json` for the
+structured form.
+
+## Dry run
+
+`-D/--dry-run` (or `WARDEN_DRY_RUN`) validates a mutating command's payload
+against the server's published schema (`/v1/sys/schema`) and exits **without
+sending the request**. It catches unknown or mistyped parameters before they hit
+the wire — useful in CI and for agents composing requests. Supported by the
+write/create/enable/tune family and by `delete` (which also skips its confirmation
+prompt under dry-run).
+
+```bash
+warden provider enable aws -D
+warden write aws/config token_ttl=1h -D
+```
+
+## Exit codes
+
+Every invocation exits with a stable, category-based code. Agents and scripts can
+branch on these without parsing stderr; in `json`/`ndjson` mode failures also emit
+a `{"error":{"code":…,"message":…,"hint":…}}` envelope on stderr.
+
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | OK | Success. |
+| 1 | Unknown | Uncategorised error. |
+| 2 | Usage | CLI usage error (unknown flag, bad arg count). |
+| 3 | InvalidInput | Validation error / unprocessable 4xx. |
+| 4 | Auth | Authentication required (HTTP 401). |
+| 5 | Forbidden | Access denied (HTTP 403). |
+| 6 | NotFound | Resource not found (HTTP 404). |
+| 7 | Network | Transport error (DNS, refused, timeout, TLS). |
+| 8 | Server | Server error (HTTP 5xx). |
+| 9 | Conflict | Resource conflict (HTTP 409). |
+| 10 | Sealed | Warden is sealed or uninitialized. |
+
+## Command index
+
+### Server & operations
+
+| Command | Description |
+|---|---|
+| [`server`](server.md) | Start a Warden server. |
+| [`status`](status.md) | Show initialization, seal, and HA state. |
+| [`operator`](operator.md) | Administrative operations — initialize and generate a root token. |
+
+### Auth, audit & policy
+
+| Command | Description |
+|---|---|
+| [`auth`](auth.md) | Manage auth methods (enable, disable, list, read). |
+| [`audit`](audit.md) | Manage audit devices (enable, disable, list, read). |
+| [`policy`](policy.md) | Manage capability-based policies. |
+
+### Providers & credentials
+
+| Command | Description |
+|---|---|
+| [`provider`](provider.md) | Manage providers (enable, disable, list, read, tune). |
+| [`cred`](cred.md) | Manage credential specs and sources. |
+
+### Namespaces & roles
+
+| Command | Description |
+|---|---|
+| [`namespace`](namespace.md) | Manage namespaces. |
+| [`role`](role.md) | Discover roles the presented identity can assume. |
+
+### Skills & schema
+
+| Command | Description |
+|---|---|
+| [`skill`](skill.md) | Manage the global agent skill registry. |
+| [`schema`](schema.md) | Inspect the server's OpenAPI schema. |
+
+### Generic data access
+
+| Command | Description |
+|---|---|
+| [`read`](read.md) | Read data from a path. |
+| [`write`](write.md) | Write data to a path. |
+| [`list`](list.md) | List data at a path. |
+| [`delete`](delete.md) | Delete data at a path. |
+| [`path-help`](path-help.md) | Show backend-provided help for a path. |
+
+## See Also
+
+- [Concepts](../concepts/README.md) — how Warden works, end to end.
+- [Auth Methods](../auth-methods/README.md) — per-method setup guides.
+- [Provider Backends](../provider-backends/README.md) — per-provider setup guides.
+- [Audit Devices](../audit-devices/README.md) — audit logging configuration.

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -1,0 +1,114 @@
+# `warden audit`
+
+Manage [audit devices](../audit-devices/README.md) — the backends that log every
+request and response for compliance and forensics.
+
+> **Fail-closed at serve time:** once any audit device is registered, every
+> request must be successfully audited or it is rejected. Disabling the *last*
+> device is **not** blocked, though — it drops the server to zero registered
+> devices, which fails *open* (serves unaudited) so a fresh cluster can bootstrap
+> one. Re-enable a device promptly. Devices declared in HCL config cannot be
+> disabled via the API.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`audit enable`](#audit-enable)
+- [`audit list`](#audit-list)
+- [`audit read`](#audit-read)
+- [`audit disable`](#audit-disable)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden audit <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `enable TYPE` | Enable an audit device. |
+| `list` | List enabled audit devices. |
+| `read [PATH]` | Show one device's configuration. |
+| `disable [PATH]` | Disable an audit device. |
+
+### `audit enable`
+
+Enable an audit device of the given `TYPE` (currently only `file`). Each device
+is assigned a unique HMAC salt for hashing sensitive values in the log; the salt
+is generated on enable and lost on disable.
+
+> `--path` is the device's **mount path**; `--file-path` is the **audit log file
+> location**. They are distinct.
+
+**Usage:** `warden audit enable [options] TYPE`
+
+**Examples:**
+
+```bash
+# File device writing to a log path
+warden audit enable --file-path=/var/log/warden-audit.log file
+
+# Custom mount path
+warden audit enable --path=prod-audit --file-path=/var/log/audit.log file
+
+# Agent-friendly: full JSON payload
+warden audit enable file --json @audit-file.json
+cat audit-file.json | warden audit enable file --json -
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--description` | *(none)* | Human-friendly description of the device. |
+| `--file-path` | *(none)* | Path to the audit log file (required for the `file` type). |
+| `--format` | `json` | Log format (currently only `json` is supported). |
+| `--path` | `TYPE` | Custom mount path. |
+| `-j`, `--json` | *(none)* | Full JSON payload: `<json>`, `@file.json`, or `-` for stdin. Mutually exclusive with the typed flags. |
+
+If the JSON payload carries a `type` field it must match `TYPE`. Combine with
+`-D/--dry-run` to validate without enabling.
+
+### `audit list`
+
+List the enabled audit devices.
+
+**Usage:** `warden audit list`
+
+```bash
+warden audit list
+```
+
+### `audit read`
+
+Show the configuration of the audit device at `PATH`.
+
+**Usage:** `warden audit read [PATH]`
+
+```bash
+warden audit read file/
+```
+
+### `audit disable`
+
+Disable the audit device at `PATH`. Disabling the last device is allowed — the
+server then runs unaudited until you re-enable one. Only devices declared in HCL
+config are rejected (remove the block from the server config instead).
+
+**Usage:** `warden audit disable [PATH]`
+
+```bash
+warden audit disable file/
+```
+
+## See Also
+
+- [Audit Devices](../audit-devices/README.md) — overview and the file device guide.
+- [Audit Attribution](../use-cases/audit-attribution.md) — what the log captures and why.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -1,0 +1,110 @@
+# `warden auth`
+
+Manage [auth methods](../auth-methods/README.md) — the backends that validate a
+caller's credential and resolve it to an identity. Use these subcommands to
+enable a method, inspect it, and tear it down. The credential validation itself
+(roles, claim mapping, transparent auth) is configured by writing to the mount's
+paths; see [Authentication](../concepts/authentication.md) and the per-method
+guides.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`auth enable`](#auth-enable)
+- [`auth list`](#auth-list)
+- [`auth read`](#auth-read)
+- [`auth disable`](#auth-disable)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden auth <subcommand> [options]
+```
+
+Global flags (`-n/--namespace`, `-o/--output`, `-D/--dry-run`, …) apply to every
+subcommand — see the [CLI overview](README.md#global-flags).
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `enable TYPE` | Enable an auth method. |
+| `list` | List enabled auth methods. |
+| `read [PATH]` | Show one auth method's configuration. |
+| `disable [PATH]` | Disable an auth method. |
+
+### `auth enable`
+
+Enable an auth method of the given `TYPE` (`jwt`, `cert`, `kubernetes`,
+`spiffe`). The mount path defaults to `TYPE`; override it with `--path`.
+
+**Usage:** `warden auth enable [options] TYPE`
+
+**Examples:**
+
+```bash
+# Enable JWT auth at the default jwt/ path
+warden auth enable jwt
+
+# Mount at a custom path with a description
+warden auth enable --path=jwt-prod --description="Hydra OIDC" jwt
+
+# Agent-friendly: full JSON payload from a file or stdin
+warden auth enable jwt --json @auth-jwt.json
+cat auth-jwt.json | warden auth enable jwt --json -
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--description` | *(none)* | Human-friendly description of the mount. |
+| `--path` | `TYPE` | Custom mount path. |
+| `-j`, `--json` | *(none)* | Full JSON payload: `<json>`, `@file.json`, or `-` for stdin. Mutually exclusive with `--description`. |
+
+If the JSON payload carries a `type` field it must match `TYPE`. Combine with
+`-D/--dry-run` to validate without enabling.
+
+### `auth list`
+
+List the enabled auth methods, with path, type, accessor, and description.
+
+**Usage:** `warden auth list`
+
+```bash
+warden auth list
+warden auth list -o json
+```
+
+### `auth read`
+
+Show the configuration of the auth method at `PATH`.
+
+**Usage:** `warden auth read [PATH]`
+
+```bash
+warden auth read jwt/
+warden auth read --path=jwt/
+```
+
+The path may be given positionally or via `--path` — pick one.
+
+### `auth disable`
+
+Disable the auth method at `PATH` and remove its configuration.
+
+**Usage:** `warden auth disable [PATH]`
+
+```bash
+warden auth disable jwt/
+warden auth disable --path=jwt/
+```
+
+## See Also
+
+- [Auth Methods](../auth-methods/README.md) — setup guides for cert, JWT, Kubernetes, and SPIFFE.
+- [Authentication](../concepts/authentication.md) — credential forms and transparent auth.
+- [Roles](../concepts/roles.md) — how a validated identity maps to policies.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/cred.md
+++ b/docs/cli/cred.md
@@ -1,0 +1,137 @@
+# `warden cred`
+
+Manage [credentials](../concepts/credentials.md) — the **sources** Warden draws
+from and the **specs** that shape what gets minted and injected into a proxied
+request. A source holds the upstream connection and root credential; a spec binds
+to a source and defines type, TTLs, and rotation. The `cred` command groups two
+subcommand families: `cred source` and `cred spec`.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [`cred source`](#cred-source)
+- [`cred spec`](#cred-spec)
+- [`cred spec connect`](#cred-spec-connect)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden cred source <subcommand> [options]
+warden cred spec   <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+The `create` subcommands accept either typed flags or a full `--json` payload
+(`<json>`, `@file.json`, or `-` for stdin), mutually exclusive with the typed
+flags, and honour `-D/--dry-run`. `--config` values support `@file` references to
+read a value from disk (e.g. a PEM key).
+
+## `cred source`
+
+A credential source holds an upstream's type, configuration, and rotation policy.
+
+| Subcommand | Description |
+|---|---|
+| `create <name>` | Create a source. |
+| `list` | List sources. |
+| `read <name>` | Show a source's configuration. |
+| `update <name>` | Update a source. |
+| `delete <name>` | Delete a source. |
+
+### `cred source create`
+
+**Usage:** `warden cred source create <name> [flags]`
+
+```bash
+warden cred source create my-aws \
+    --type=aws \
+    --config=access_key_id=... \
+    --config=secret_access_key=... \
+    --config=region=us-east-1 \
+    --rotation-period=24h
+
+# Agent-friendly: full JSON payload
+warden cred source create my-aws --json @aws-source.json
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--type` | *(none)* | Source type (required unless `--json`). |
+| `--config` | *(none)* | Source configuration `KEY=VALUE`; repeatable. Values may use `@file`. |
+| `--rotation-period` | *(none)* | Rotation period for the source's root credential, e.g. `24h` (required unless `--json`). |
+| `-j`, `--json` | *(none)* | Full JSON payload. Mutually exclusive with the typed flags. |
+
+## `cred spec`
+
+A credential spec binds to a source and defines what callers receive.
+
+| Subcommand | Description |
+|---|---|
+| `create <name>` | Create a spec. |
+| `list` | List specs. |
+| `read <name>` | Show a spec's configuration. |
+| `update <name>` | Update a spec. |
+| `delete <name>` | Delete a spec. |
+| `connect <name>` | Complete interactive OAuth2 consent for a spec. |
+
+### `cred spec create`
+
+**Usage:** `warden cred spec create <name> [flags]`
+
+```bash
+warden cred spec create developer \
+    --source=my-aws \
+    --config=mint_method=sts_assume_role \
+    --config=role_arn=arn:aws:iam::1234:role/dev \
+    --min-ttl=1h --max-ttl=24h
+
+# Agent-friendly: full JSON payload
+warden cred spec create developer --json @spec.json
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--type` | *(inferred from source)* | Credential type; usually omitted. |
+| `--source` | *(none)* | Source name to bind to (required unless `--json`). |
+| `--config` | *(none)* | Type-specific configuration `KEY=VALUE`; repeatable. Values may use `@file`. |
+| `--min-ttl` | `1h` | Minimum credential TTL. |
+| `--max-ttl` | `24h` | Maximum credential TTL. |
+| `--rotation-period` | *(none)* | Rotation period for credentials stored in the spec, e.g. `24h`. Empty means no rotation. |
+| `-j`, `--json` | *(none)* | Full JSON payload. Mutually exclusive with the typed flags. |
+
+## `cred spec connect`
+
+Complete the one-time human consent for a spec that uses the OAuth2
+`authorization_code` flow. The command binds a loopback listener, opens the
+provider's consent page in a browser, captures the authorization code on the
+loopback redirect, and hands it to the server — which exchanges it (using the
+client secret it holds) and seals the resulting refresh token into the spec. The
+client secret never touches your machine.
+
+**Usage:** `warden cred spec connect <name> [flags]`
+
+```bash
+warden cred spec connect gh-oauth
+
+# Print the URL instead of launching a browser (e.g. on a headless host)
+warden cred spec connect gh-oauth --no-browser
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | `0` (ephemeral) | Loopback port to listen on. Must match the spec's pinned `redirect_uri` port when one is set. |
+| `--timeout` | `3m` | How long to wait for the browser consent callback. |
+| `--no-browser` | `false` | Print the authorize URL instead of opening a browser. |
+| `--force` | `false` | Replace an existing authorization without confirmation. |
+
+By default the listener binds an ephemeral `127.0.0.1` port; when the spec pins a
+`redirect_uri`, the command binds that fixed port instead. Re-running on an
+already-connected spec requires `--force`.
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source → spec → credential model.
+- [Delegation](../concepts/delegation.md) — how minted credentials carry the caller's identity.
+- [Provider Backends](../provider-backends/README.md) — source/spec configuration per provider.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/delete.md
+++ b/docs/cli/delete.md
@@ -1,0 +1,44 @@
+# `warden delete`
+
+Delete data at any path on the server. `delete` is the generic counterpart to the
+typed delete subcommands. It asks for confirmation by default.
+
+## Usage
+
+```text
+warden delete [PATH] [flags]
+```
+
+The `PATH` may be given positionally or via `--path` — pick one.
+
+**Path format:** `provider_mount/resource`, `auth/auth_mount/resource`, or
+`sys/path/to/resource`.
+
+## Examples
+
+```bash
+# Delete a JWT auth role (prompts for confirmation)
+warden delete auth/jwt/role/developer
+warden delete --path=auth/jwt/role/developer
+
+# Skip the confirmation prompt
+warden delete sys/providers/aws -f
+
+# Delete a namespace
+warden delete sys/namespaces/test
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `-f`, `--force` | `false` | Skip the confirmation prompt. |
+| `--path` | *(none)* | API path (alternative to the positional `PATH`). |
+
+Under `-D/--dry-run`, `delete` validates the path against the schema and exits
+before any prompt or HTTP call — a non-mutating preview needs no confirmation.
+
+## See Also
+
+- [`warden read`](read.md) · [`warden write`](write.md) · [`warden list`](list.md) — the rest of the generic data family.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -1,0 +1,43 @@
+# `warden list`
+
+List data at any path on the server. `list` enumerates the keys under a path —
+the generic counterpart to the typed `list` subcommands.
+
+## Usage
+
+```text
+warden list [PATH]
+```
+
+The `PATH` may be given positionally or via `--path` — pick one.
+
+**Path format:** `provider_mount/resource`, `auth/auth_mount/resource`, or
+`sys/path/to/resource`.
+
+## Examples
+
+```bash
+# Auth roles
+warden list auth/jwt/role
+warden list --path=auth/jwt/role
+
+# Providers
+warden list sys/providers
+
+# Namespaces
+warden list sys/namespaces
+```
+
+In `table` mode the keys print as a simple list; other formats render the full
+response and honour `-F/--fields`.
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--path` | *(none)* | API path (alternative to the positional `PATH`). |
+
+## See Also
+
+- [`warden read`](read.md) · [`warden write`](write.md) · [`warden delete`](delete.md) — the rest of the generic data family.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/namespace.md
+++ b/docs/cli/namespace.md
@@ -1,0 +1,114 @@
+# `warden namespace`
+
+Manage [namespaces](../concepts/namespaces.md) — the isolation boundary that
+separates one tenant's providers, auth methods, and policies from another's.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`namespace create`](#namespace-create)
+- [`namespace list`](#namespace-list)
+- [`namespace read`](#namespace-read)
+- [`namespace update`](#namespace-update)
+- [`namespace delete`](#namespace-delete)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden namespace <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+Namespaces nest: a `<path>` like `org/engineering` creates a child under `org`.
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `create <path>` | Create a namespace. |
+| `list` | List namespaces. |
+| `read <path>` | Show a namespace's information. |
+| `update <path>` | Update a namespace's metadata. |
+| `delete <path>` | Delete a namespace. |
+
+### `namespace create`
+
+Create a namespace at `<path>`. Optionally attach custom metadata.
+
+**Usage:** `warden namespace create <path> [options]`
+
+**Examples:**
+
+```bash
+warden namespace create my-team
+warden namespace create org/engineering
+warden namespace create my-team --metadata=environment=prod --metadata=team=platform
+
+# Agent-friendly: full JSON payload
+warden namespace create my-team --json @ns.json
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--metadata` | *(none)* | Custom `KEY=VALUE` metadata; repeatable. |
+| `-j`, `--json` | *(none)* | Full JSON payload: `<json>`, `@file.json`, or `-` for stdin. Mutually exclusive with `--metadata`. |
+
+### `namespace list`
+
+List namespaces.
+
+**Usage:** `warden namespace list`
+
+```bash
+warden namespace list
+```
+
+### `namespace read`
+
+Show information about the namespace at `<path>`.
+
+**Usage:** `warden namespace read <path>`
+
+```bash
+warden namespace read my-team
+```
+
+### `namespace update`
+
+Replace the custom metadata of an existing namespace. Mounted backends and
+configuration are unaffected. `--metadata` is required (or use `--json`);
+`--metadata=""` clears it.
+
+**Usage:** `warden namespace update <path> [options]`
+
+```bash
+warden namespace update my-team --metadata=environment=staging --metadata=team=devops
+warden namespace update my-team --metadata=""    # clear
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--metadata` | *(none)* | Custom `KEY=VALUE` metadata; repeatable. |
+| `-j`, `--json` | *(none)* | Full JSON payload. Mutually exclusive with `--metadata`. |
+
+### `namespace delete`
+
+Delete the namespace at `<path>`.
+
+**Usage:** `warden namespace delete <path>`
+
+```bash
+warden namespace delete my-team
+```
+
+## See Also
+
+- [Namespaces](../concepts/namespaces.md) — the isolation model and inheritance rules.
+- [Centralized Governance](../use-cases/centralized-governance.md) — namespaces in a multi-tenant setup.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/operator.md
+++ b/docs/cli/operator.md
@@ -1,0 +1,71 @@
+# `warden operator`
+
+Administrative operations on a Warden server. Today this groups a single
+subcommand, `init`, which initializes a fresh server and generates the first root
+token.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [`operator init`](#operator-init)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden operator <subcommand> [options]
+```
+
+Global flags apply — see the [CLI overview](README.md#global-flags).
+
+## `operator init`
+
+Initialize a new server. The root key is split into shares using Shamir's secret
+sharing; a threshold of those shares is required to unseal. `init` prints the
+unseal keys (and recovery keys, under auto-unseal) and the **root token** — once,
+and never again. Store them securely.
+
+**Usage:** `warden operator init [options]`
+
+**Examples:**
+
+```bash
+# Default: 5 shares, threshold 3
+warden operator init
+
+# Custom shares and threshold
+warden operator init --secret-shares=7 --secret-threshold=4
+
+# PGP-encrypt each unseal key
+warden operator init --pgp-keys="keybase:u1,keybase:u2,keybase:u3,keybase:u4,keybase:u5"
+
+# Machine-readable output for IaC
+warden operator init -o json
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--secret-shares` | `5` | Number of unseal key shares to generate. |
+| `--secret-threshold` | `3` | Shares required to unseal. |
+| `--pgp-keys` | *(none)* | Comma-separated PGP public keys (base64 or `keybase:user`) to encrypt the unseal keys. |
+| `--root-token-pgp-key` | *(none)* | PGP public key to encrypt the root token. |
+| `--stored-shares` | `0` | Shares to store (auto-unseal only). |
+| `--recovery-shares` | `5` | Recovery key shares (auto-unseal only). |
+| `--recovery-threshold` | `3` | Recovery shares required (auto-unseal only). |
+| `--recovery-pgp-keys` | *(none)* | PGP keys to encrypt the recovery keys (auto-unseal only). |
+
+After init, export the printed token so subsequent commands authenticate:
+
+```bash
+export WARDEN_TOKEN=<root-token>
+warden status
+```
+
+## See Also
+
+- [Seal / Unseal](../concepts/seal-unseal.md) — the seal model and unseal flow.
+- [High Availability](../concepts/high-availability.md) — auto-unseal and recovery keys.
+- [`warden status`](status.md) — check initialization and seal state.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/path-help.md
+++ b/docs/cli/path-help.md
@@ -1,0 +1,41 @@
+# `warden path-help`
+
+Display backend-provided help for a path or mount. Where [`schema`](schema.md)
+returns the machine-readable OpenAPI projection, `path-help` returns the prose
+help a backend ships for itself — gateway behaviour, request format, and
+configuration options.
+
+## Usage
+
+```text
+warden path-help PATH
+```
+
+`PATH` is required. The trailing slash is significant: `aws/` returns the
+**backend's overall help**, while `aws/config` returns help for that **specific
+path**.
+
+## Examples
+
+```bash
+# Backend-level help for the AWS provider
+warden path-help aws/
+
+# Help for a specific path
+warden path-help aws/config
+warden path-help auth/jwt/config
+
+# JSON envelope for agent consumption
+warden path-help aws/ -o json
+```
+
+## Output
+
+In TTY/table mode the help text is printed verbatim. In `json`/`ndjson`/`text`
+mode the response is returned as `{"help": "..."}` so it can be piped into `jq`.
+
+## See Also
+
+- [`warden schema`](schema.md) — the machine-readable schema for a path.
+- [Provider Backends](../provider-backends/README.md) — per-provider setup guides.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -1,0 +1,94 @@
+# `warden policy`
+
+Manage [policies](../concepts/policies.md) — the capability-based rules that
+control what an identity may do on which paths. A policy grants a set of
+`capabilities` (`create`, `read`, `update`, `delete`, `list`, …) on path globs;
+[roles](../concepts/roles.md) bind policies to authenticated identities.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`policy write`](#policy-write)
+- [`policy read`](#policy-read)
+- [`policy list`](#policy-list)
+- [`policy delete`](#policy-delete)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden policy <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `write <name> <policy_file>` | Create or update a policy. |
+| `read <name>` | Print a policy's contents. |
+| `list` | List policy names. |
+| `delete <name>` | Delete a policy. |
+
+### `policy write`
+
+Create or update the policy named `<name>` from a file, or from stdin by passing
+`-` as the filename.
+
+**Usage:** `warden policy write <name> <policy_file>`
+
+**Examples:**
+
+```bash
+# From a file
+warden policy write my-policy ./policy.hcl
+
+# From stdin
+warden policy write my-policy - <<EOF
+path "secret/data/myapp/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "secret/metadata/myapp/*" {
+  capabilities = ["list", "read", "delete"]
+}
+EOF
+```
+
+### `policy read`
+
+Print the contents of the policy named `<name>`.
+
+**Usage:** `warden policy read <name>`
+
+```bash
+warden policy read my-policy
+```
+
+### `policy list`
+
+List the names of all policies.
+
+**Usage:** `warden policy list`
+
+```bash
+warden policy list
+```
+
+### `policy delete`
+
+Delete the policy named `<name>`.
+
+**Usage:** `warden policy delete <name>`
+
+```bash
+warden policy delete my-policy
+```
+
+## See Also
+
+- [Policies](../concepts/policies.md) — the capability model and policy syntax.
+- [Roles](../concepts/roles.md) — how policies attach to an identity.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/provider.md
+++ b/docs/cli/provider.md
@@ -1,0 +1,127 @@
+# `warden provider`
+
+Manage [providers](../concepts/providers.md) — the mounted gateways that front an
+upstream system (an LLM API, a cloud control plane, a Git host, …). Use these
+subcommands to mount, inspect, retune, and unmount a provider. The upstream
+connection details and credential wiring are configured by writing to the mount's
+paths; see the [provider backend guides](../provider-backends/README.md).
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`provider enable`](#provider-enable)
+- [`provider list`](#provider-list)
+- [`provider read`](#provider-read)
+- [`provider tune`](#provider-tune)
+- [`provider disable`](#provider-disable)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden provider <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `enable TYPE` | Mount a provider. |
+| `list` | List enabled providers. |
+| `read [PATH]` | Show one provider's configuration. |
+| `tune [PATH]` | Update a provider's description. |
+| `disable [PATH]` | Unmount a provider. |
+
+### `provider enable`
+
+Mount a provider of the given `TYPE` (`aws`, `azure`, `gcp`, `anthropic`,
+`github`, …). The mount path defaults to `TYPE`; override it with `--path` to run
+several mounts of the same type.
+
+**Usage:** `warden provider enable [options] TYPE`
+
+**Examples:**
+
+```bash
+warden provider enable aws
+warden provider enable --path=azure-prod azure
+warden provider enable --description="Production AWS" aws
+
+# Agent-friendly: full JSON payload
+warden provider enable aws --json @provider-aws.json
+cat provider-aws.json | warden provider enable aws --json -
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--description` | *(none)* | Human-friendly description of the mount. |
+| `--path` | `TYPE` | Custom mount path. |
+| `-j`, `--json` | *(none)* | Full JSON payload: `<json>`, `@file.json`, or `-` for stdin. Mutually exclusive with `--description`. |
+
+> The mount **description** is significant: multi-product provider types (e.g. the
+> MCP provider) are identified by their operator-set description, so set it
+> meaningfully. See the relevant provider guide.
+
+### `provider list`
+
+List the enabled providers.
+
+**Usage:** `warden provider list`
+
+```bash
+warden provider list
+```
+
+### `provider read`
+
+Show the configuration of the provider at `PATH`, including its type, accessor,
+mount URL, and config.
+
+**Usage:** `warden provider read [PATH]`
+
+```bash
+warden provider read aws/
+```
+
+### `provider tune`
+
+Update the description of an existing provider. This is a partial update: omitting
+`--description` leaves the current value unchanged, while `--description=""`
+clears it.
+
+**Usage:** `warden provider tune [options] [PATH]`
+
+```bash
+warden provider tune aws/ --description="Production AWS"
+warden provider tune aws/ --json @tune.json
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--description` | *(unchanged)* | New description. |
+| `--path` | *(none)* | Mount path (alternative to the positional `PATH`). |
+| `-j`, `--json` | *(none)* | Full JSON payload. Mutually exclusive with `--description`. |
+
+### `provider disable`
+
+Unmount the provider at `PATH`.
+
+**Usage:** `warden provider disable [PATH]`
+
+```bash
+warden provider disable aws/
+```
+
+## See Also
+
+- [Provider Backends](../provider-backends/README.md) — per-provider setup guides.
+- [Providers](../concepts/providers.md) — the gateway model.
+- [Credentials](../concepts/credentials.md) — what a provider injects into the proxied request.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/read.md
+++ b/docs/cli/read.md
@@ -1,0 +1,46 @@
+# `warden read`
+
+Read data from any path on the server. `read` is the generic counterpart to the
+typed commands — it works against provider, auth, and `sys` paths alike, and is
+what you reach for when no dedicated subcommand exists.
+
+## Usage
+
+```text
+warden read [PATH]
+```
+
+The `PATH` may be given positionally or via `--path` — pick one; combining both is
+rejected.
+
+**Path format:** `provider_mount/resource`, `auth/auth_mount/resource`, or
+`sys/path/to/resource`. The CLI converts it to the corresponding API path.
+
+## Examples
+
+```bash
+# Provider configuration
+warden read aws/config
+warden read --path=aws/config
+
+# Auth method configuration
+warden read auth/jwt/config
+
+# System mounts
+warden read sys/mounts
+
+# Project specific fields
+warden read aws/config -F proxy_domains,timeout
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--path` | *(none)* | API path (alternative to the positional `PATH`). |
+
+## See Also
+
+- [`warden write`](write.md) · [`warden list`](list.md) · [`warden delete`](delete.md) — the rest of the generic data family.
+- [`warden path-help`](path-help.md) — discover what a path accepts.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/role.md
+++ b/docs/cli/role.md
@@ -1,0 +1,51 @@
+# `warden role`
+
+Discover the [roles](../concepts/roles.md) the presented identity can assume. A
+role selects the policies and credential a request runs with; pass one on any
+command with the global `-r/--role` flag (or `WARDEN_ROLE`).
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`role list`](#role-list)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden role <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `list` | List the roles the presented identity can assume. |
+
+### `role list`
+
+List the roles available to the caller. The server fans out to every auth mount
+matching the caller's identity type (JWT or certificate) in the current namespace
+and returns the union of roles each mount reports the identity can assume.
+
+**Usage:** `warden role list`
+
+```bash
+warden role list
+warden role list -o json
+```
+
+Introspection identifies the caller from the credential itself, so it requires a
+**JWT bearer token or a TLS client certificate** — a plain session token isn't
+enough. Present a JWT via `WARDEN_TOKEN` (any value beginning with `eyJ` is sent
+as `Authorization: Bearer`) or configure `WARDEN_CLIENT_CERT` / `WARDEN_CLIENT_KEY`
+for mTLS, and set `-n/--namespace` as needed before running.
+
+## See Also
+
+- [Roles](../concepts/roles.md) — how a role selects policies and a credential.
+- [Authentication](../concepts/authentication.md) — how the identity is established.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/schema.md
+++ b/docs/cli/schema.md
@@ -1,0 +1,50 @@
+# `warden schema`
+
+Inspect the OpenAPI schema of the running server. `schema` hits the server's
+schema endpoint and projects the OpenAPI document into a shape that's easy for
+both humans and agents to read — the parameters a path accepts, its methods, and
+its response shape. It's the machine-readable companion to
+[`path-help`](path-help.md), and the same schema backs `-D/--dry-run` validation.
+
+## Usage
+
+```text
+warden schema PATH        # describe a single path
+warden schema --list      # enumerate every path
+```
+
+`PATH` and `--list` are mutually exclusive; one of them is required.
+
+## Examples
+
+```bash
+# Describe a single path (friendly projection):
+#   { path, methods, description, parameters, response_schema, auth_required }
+warden schema sys/auth
+
+# Enumerate every available path (NDJSON-friendly)
+warden schema --list
+
+# Raw OpenAPI fragment for tooling (Stainless, openapi-typescript, oapi-codegen)
+warden schema sys/auth --raw
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--list` | `false` | List every path in the schema. Cannot be combined with `PATH`. |
+| `--raw` | `false` | Emit the raw OpenAPI fragment instead of the friendly projection. |
+
+## Notes
+
+The endpoint is namespace-scoped: `-n/--namespace` (or `WARDEN_NAMESPACE`)
+controls which mounts are visible, so a tenant cannot enumerate another tenant's
+backends. Authentication is required — set `WARDEN_TOKEN`, an mTLS client cert, or
+pass an `Authorization: Bearer` JWT.
+
+## See Also
+
+- [`warden path-help`](path-help.md) — human-readable help for a path or backend.
+- [Dry run](README.md#dry-run) — local payload validation against this schema.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -1,0 +1,83 @@
+# `warden server`
+
+Start a Warden server that responds to API requests. In production the server is
+driven by an HCL configuration file (or a directory of them); a `--dev` flag spins
+up a throwaway, pre-unsealed instance for local work.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Configuration files](#configuration-files)
+- [Dev mode](#dev-mode)
+- [Flags](#flags)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden server [options]
+```
+
+A configuration source is required unless `--dev` is set: pass `-c/--config` for a
+single file or `--config-dir` for a directory.
+
+## Configuration files
+
+```bash
+# Single configuration file
+warden server --config=/etc/warden/config.hcl
+
+# Merge every .hcl file in a directory (lexical order; later files win — useful
+# for splitting a ConfigMap and a Secret in Kubernetes)
+warden server --config-dir=/etc/warden/conf.d
+```
+
+Config files may reference environment variables via `{{ env "VAR_NAME" }}`.
+`--config` and `--config-dir` are mutually exclusive.
+
+## Dev mode
+
+`--dev` starts an in-memory server that auto-initializes and auto-unseals — no
+config file, no persistence. It prints a root token and an unseal key on startup.
+Dev mode always uses `inmem` storage, so `--config`/`--config-dir` cannot be
+combined with it. See [Dev Server](../concepts/dev-server.md).
+
+```bash
+warden server --dev
+warden server --dev --dev-root-token=root
+warden server --dev --dev-tls          # self-signed TLS listener
+```
+
+## Flags
+
+**Configuration**
+
+| Flag | Default | Description |
+|---|---|---|
+| `-c`, `--config` | *(none)* | Path to a configuration file. |
+| `--config-dir` | *(none)* | Path to a directory of `.hcl` files, merged in lexical order. |
+
+**Dev mode**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--dev` | `false` | Enable dev mode: inmem storage, auto-init, auto-unseal. |
+| `--dev-root-token` | *(none)* | Custom root token for dev mode (requires `--dev`). |
+| `--dev-tls` | `false` | Enable TLS on the dev listener (auto-generates a self-signed cert). |
+| `--dev-tls-cert-file` | *(none)* | TLS certificate file for dev mode (implies `--dev-tls`). |
+| `--dev-tls-key-file` | *(none)* | TLS private key file for dev mode (paired with the cert file). |
+| `--dev-tls-ca-cert-file` | *(none)* | CA certificate for verifying client certs in dev mode. |
+| `--dev-tls-require-client-cert` | `false` | Require client certificates (needs `--dev-tls-ca-cert-file`). |
+| `--dev-tls-spiffe` | `false` | Serve dev TLS using a SPIFFE Workload API X509-SVID (auto-rotating). |
+| `--dev-tls-spiffe-socket` | `$SPIFFE_ENDPOINT_SOCKET` | Workload API socket for `--dev-tls-spiffe`. |
+
+The dev-TLS flags require `--dev`. The SPIFFE serving mode is mutually exclusive
+with the file-based dev-TLS flags.
+
+## See Also
+
+- [Dev Server](../concepts/dev-server.md) — what dev mode sets up and its limits.
+- [Storage](../concepts/storage.md) — production storage backends.
+- [Seal / Unseal](../concepts/seal-unseal.md) — initialization and unsealing.
+- [High Availability](../concepts/high-availability.md) — clustering and HA configuration.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/skill.md
+++ b/docs/cli/skill.md
@@ -1,0 +1,115 @@
+# `warden skill`
+
+Browse and manage the global agent **skill registry** — the agent-facing recipes
+that describe how to use Warden's capabilities (a foundation flow plus one record
+per provider type). See [Discovery & Skills](../concepts/discovery-and-skills.md).
+
+> **Reads are open** to any namespace token; **writes (`create`, `update`,
+> `delete`) require a root-namespace token.** Running a mutation from a
+> sub-namespace surfaces the server's 403.
+
+## Table of Contents
+
+- [Usage](#usage)
+- [Subcommands](#subcommands)
+- [`skill list`](#skill-list)
+- [`skill read`](#skill-read)
+- [`skill create`](#skill-create)
+- [`skill update`](#skill-update)
+- [`skill delete`](#skill-delete)
+- [See Also](#see-also)
+
+## Usage
+
+```text
+warden skill <subcommand> [options]
+```
+
+Global flags apply to every subcommand — see the [CLI overview](README.md#global-flags).
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `list` | List every skill in the catalog. |
+| `read <name>` | Print one skill's markdown body. |
+| `create [NAME]` | Create a skill (root only). |
+| `update <name>` | Update a skill (root only). |
+| `delete <name>` | Delete a skill (root only). |
+
+### `skill list`
+
+List every skill in the registry.
+
+**Usage:** `warden skill list`
+
+```bash
+warden skill list
+```
+
+### `skill read`
+
+Print the full markdown body of the skill named `<name>`. Pass `--raw` to emit the
+body verbatim (no envelope), useful for piping into a file or an agent.
+
+**Usage:** `warden skill read <name> [--raw]`
+
+```bash
+warden skill read aws
+warden skill read aws --raw
+```
+
+### `skill create`
+
+Create a skill. The name comes from the positional `NAME`, the `--name` flag, or
+the payload's `name` field. Required fields (typed or via payload): `name`,
+`description`, `category`, `body`. A `provider-guide` skill also requires
+`provider`.
+
+**Usage:** `warden skill create [NAME] [options]`
+
+**Examples:**
+
+```bash
+# Typed flags
+warden skill create --name=my-runbook --category=custom \
+    --description="ops on-call" --body-file=./runbook.md
+
+# Agent-friendly: full JSON payload
+warden skill create my-runbook --json @skill.json
+cat skill.json | warden skill create my-runbook --json -
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--name` | *(from arg/payload)* | Skill name (unique slug, `[a-z0-9_-]{2,64}`). |
+| `--description` | *(none)* | One-line summary (required). |
+| `--category` | *(none)* | One of `agent-flow`, `shared`, `provider-guide`, `troubleshooting`, `custom`. |
+| `--requires` | *(none)* | Names of skills this one depends on; repeatable or comma-separated. |
+| `--upstream` | *(none)* | Reference to an upstream system, when applicable. |
+| `--provider` | *(none)* | Provider type (required when `--category=provider-guide`). |
+| `--body-file` | *(none)* | Path to the markdown body file. |
+| `-j`, `--json` | *(none)* | Full JSON payload. Mutually exclusive with all typed flags above. |
+
+### `skill update`
+
+Update an existing skill (root namespace only). Mirrors `create`'s flag set.
+
+**Usage:** `warden skill update <name> [options]`
+
+### `skill delete`
+
+Delete the skill named `<name>` (root namespace only).
+
+**Usage:** `warden skill delete <name>`
+
+```bash
+warden skill delete my-runbook
+```
+
+## See Also
+
+- [Discovery & Skills](../concepts/discovery-and-skills.md) — what skills are and how agents fetch them.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -1,0 +1,48 @@
+# `warden status`
+
+Show the server's initialization, seal, and HA/cluster state. A thin wrapper over
+the server's health endpoint.
+
+## Usage
+
+```text
+warden status
+```
+
+`status` takes no arguments. It honours the global output and field flags.
+
+## Examples
+
+```bash
+warden status
+warden status -o json
+warden status -o json -F sealed,is_leader,leader_address
+```
+
+## Output fields
+
+`initialized`, `sealed`, `standby`, `ha_enabled`, `is_leader`, `server_time`, and
+(when reported) `version`. Under HA, `leader_address` and `active_time` are
+included when set.
+
+## Exit codes
+
+`status` returns a narrowed set of [exit codes](README.md#exit-codes) so scripts
+can gate on readiness:
+
+| Code | Meaning |
+|---|---|
+| 0 | Initialized and unsealed (active or standby). |
+| 7 | Transport / connection error. |
+| 10 | Sealed or uninitialized. |
+
+```bash
+warden status >/dev/null 2>&1 && echo "ready" || echo "not ready (exit $?)"
+```
+
+## See Also
+
+- [Seal / Unseal](../concepts/seal-unseal.md) — what sealed vs. unsealed means.
+- [High Availability](../concepts/high-availability.md) — leader/standby state.
+- [`warden operator init`](operator.md) — initialize an uninitialized server.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/cli/write.md
+++ b/docs/cli/write.md
@@ -1,0 +1,64 @@
+# `warden write`
+
+Write data to any path on the server. `write` is the generic counterpart to the
+typed commands — it works against provider, auth, and `sys` paths and accepts data
+in several forms.
+
+## Usage
+
+```text
+warden write [PATH] [DATA...]
+```
+
+The `PATH` may be given positionally or via `--path` — pick one. When `--path` is
+used, all remaining positional arguments are treated as `DATA`.
+
+**Path format:** `provider_mount/resource`, `auth/auth_mount/resource`, or
+`sys/path/to/resource`.
+
+## Data forms
+
+`DATA` can be supplied three ways:
+
+**JSON via stdin**
+
+```bash
+warden write aws/config <<EOF
+{
+  "proxy_domains": ["localhost", "warden"],
+  "max_body_size": 10485760,
+  "timeout": "60s"
+}
+EOF
+```
+
+**`key=value` pairs** (types are inferred — numbers, booleans, and JSON
+arrays/objects are parsed; everything else is a string)
+
+```bash
+warden write aws/config token_ttl=1h proxy_domains='["localhost","warden"]'
+warden write --path=aws/config token_ttl=1h
+```
+
+**`@file` references** read a value from a file — handy for PEM certificates and
+large payloads
+
+```bash
+warden write auth/cert/config trusted_ca_pem=@/path/to/ca.pem default_role=my-role
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--path` | *(none)* | API path (alternative to the positional `PATH`). |
+
+Combine with `-D/--dry-run` to validate the payload against the server schema
+without writing.
+
+## See Also
+
+- [`warden read`](read.md) · [`warden list`](list.md) · [`warden delete`](delete.md) — the rest of the generic data family.
+- [`warden schema`](schema.md) — inspect what fields a path accepts.
+- [Dry run](README.md#dry-run) — catch bad parameters before they hit the wire.
+- [CLI overview](README.md) — global flags, output formats, exit codes.

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -10,6 +10,8 @@ also jump straight to a topic.
 
 - [Dev Server](dev-server.md) — spin up an in-memory Warden in one command to
   follow along.
+- [CLI Reference](../cli/README.md) — the `warden` command: connecting to a
+  server, global flags, output formats, and a page per command.
 
 ## Identity and access
 

--- a/docs/provider-backends/README.md
+++ b/docs/provider-backends/README.md
@@ -97,5 +97,6 @@ reference.
 - [Providers](../concepts/providers.md) — the gateway model: how a request is authenticated, authorized, and proxied.
 - [Credentials](../concepts/credentials.md) — what each provider injects into the proxied request.
 - [Roles](../concepts/roles.md) — how the role on a request selects access and credential.
+- [`warden provider`](../cli/provider.md) — the CLI for enabling, listing, tuning, and disabling providers.
 - [Concepts](../concepts/README.md) — how Warden works, end to end.
 </content>


### PR DESCRIPTION
## Summary

Adds `docs/cli/` — a complete reference for the `warden` CLI, modeled on the Vault/OpenBao "Commands (CLI)" docs and adapted to this repo's flat-Markdown, README-indexed convention. The `docs/cli/` directory existed but was empty.

- **Overview** (`README.md`): connecting to a server (`WARDEN_ADDR`/`WARDEN_TOKEN`, JWT-vs-session handling), global flags, full environment-variable table, output formats, field projection, dry-run, the 0–10 exit-code table, and a grouped command index.
- **One page per command/group**: `server`, `status`, `operator`, `auth`, `audit`, `provider`, `cred` (source + spec + OAuth `connect`), `namespace`, `policy`, `role`, `skill`, `schema`, and the generic `read`/`write`/`list`/`delete`/`path-help`.
- **Navigation hooks**: links to the new section from the concepts, auth-methods, provider-backends, and audit-devices READMEs.

Every flag, default, and arg-arity was pulled directly from the Cobra definitions in `cmd/**`; the docs were smoke-tested against a `warden server --dev` instance.

## Audit fail-closed correction

While verifying the audit page, the CLI help and the `sys/audit` OpenAPI descriptions were found to claim a "last audit device cannot be disabled" guard that the handler does not enforce (`handleAuditDelete` in `core/sys_audit.go`, `DisableAudit` in `core/audit.go`). This PR corrects those strings to match actual behavior:

- Disabling the last device **is allowed** — it drops to zero registered devices and serves **unaudited (fail-open)** so a fresh cluster can bootstrap.
- Fail-closed applies **at serve time** once any device is registered.
- Only **HCL-declared** devices are immutable via the API.

These are description/help-only edits — no behavior change.

## Test plan

- `go build ./core/... ./cmd/audit/...` passes.
- Ran `warden server --dev` and exercised `status` (incl. `-o json`, `-F` projection), `auth enable/list/read`, `provider list`, `provider enable -D`, `namespace create`, `policy write -`/`list`, `schema --list`, `role list` — all match the documented behavior.
- All relative links across the new pages resolve; TOC anchors match headings.
