### PR TITLE
perf(policy): reuse cached policy parse in CBP()

### DIFF
--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -1569,3 +1569,64 @@ func TestCBP_MergeConditions_DenyOverrides(t *testing.T) {
 	result := cbp.AllowOperation(ctx, req, false)
 	assert.False(t, result.Allowed)
 }
+
+// =============================================================================
+// CBP() re-parse reuse (Lever A)
+// =============================================================================
+
+// TestCBP_ReusesCachedParse verifies that CBP() reuses the parse already
+// performed by GetPolicy instead of re-parsing Raw on every call (Lever A).
+//
+// The cached *Policy is constructed so its parsed Paths intentionally diverge
+// from its Raw text: the cache grants "secret/cached" while Raw would grant
+// "secret/raw". If CBP() were to re-parse Raw, "secret/raw" would be allowed;
+// because it reuses the cached parse, only "secret/cached" is allowed.
+func TestCBP_ReusesCachedParse(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	cached := testParsePolicy(t, `path "secret/cached" { capabilities = ["read"] }`)
+	cached.Name = "diverged"
+	cached.Type = PolicyTypeCBP
+	cached.Raw = `path "secret/raw" { capabilities = ["read"] }`
+	cached.namespace = namespace.RootNamespace
+	require.NotNil(t, cached.Paths)
+
+	// Seed the LRU directly so GetPolicy returns this cached *Policy on the
+	// cache-hit path (storage is never consulted).
+	idx := ps.cacheKey(namespace.RootNamespace, "diverged")
+	ps.tokenPoliciesLRU.Add(idx, cached)
+
+	cbp, err := ps.CBP(ctx, map[string][]string{namespace.RootNamespaceID: {"diverged"}})
+	require.NoError(t, err)
+
+	assert.Contains(t, cbp.Capabilities(ctx, "secret/cached"), ReadCapability,
+		"cached parse should be reused")
+	assert.NotContains(t, cbp.Capabilities(ctx, "secret/raw"), ReadCapability,
+		"Raw must not be re-parsed when Paths is already populated")
+}
+
+// TestCBP_ParsesAdditionalPolicyWithoutPaths verifies the fallback in Lever A:
+// a prefetched policy that arrives without parsed Paths is still parsed from
+// Raw so it contributes its rules.
+func TestCBP_ParsesAdditionalPolicyWithoutPaths(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	// No Paths set; only Raw. The guard must fall back to parsing Raw.
+	extra := &Policy{
+		Name:      "prefetched",
+		Type:      PolicyTypeCBP,
+		Raw:       `path "secret/extra" { capabilities = ["read"] }`,
+		namespace: namespace.RootNamespace,
+	}
+	require.Nil(t, extra.Paths)
+
+	cbp, err := ps.CBP(ctx, map[string][]string{}, extra)
+	require.NoError(t, err)
+
+	assert.Contains(t, cbp.Capabilities(ctx, "secret/extra"), ReadCapability,
+		"prefetched policy without Paths must be parsed from Raw")
+}

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -518,7 +518,11 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 	allPolicies = append(allPolicies, additionalPolicies...)
 
 	for i, policy := range allPolicies {
-		if policy.Type == PolicyTypeCBP {
+		// Reuse the parse already performed and cached by GetPolicy. Re-parse
+		// only when a prefetched policy arrived without parsed paths. CBP
+		// policies carry no per-request templating, so a cached parse is always
+		// reusable and never identity-dependent.
+		if policy.Type == PolicyTypeCBP && policy.Paths == nil {
 			p, err := parseCBPPolicy(policy.namespace, policy.Raw)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing policy %q: %w", policy.Name, err)


### PR DESCRIPTION
## What

`GetPolicy` already parses each policy's raw HCL into `Paths` and caches the result, but `CBP()` discarded that and re-parsed every policy on every request. This skips the re-parse when `Paths` is already populated, falling back to parsing only for prefetched policies that arrive without parsed paths.

CBP policies carry no per-request templating, so a cached parse is always reusable and never identity-dependent. This aligns `CBP()` with upstream's `ACL()`, which only re-parses templated policies.

## Why

Removes a redundant HCL parse from the authorization hot path (every authenticated request).

## Tests

- `TestCBP_ReusesCachedParse` — proves the cached parse is used (cached `Paths` deliberately diverge from `Raw`).
- `TestCBP_ParsesAdditionalPolicyWithoutPaths` — the parse fallback still applies to prefetched policies lacking `Paths`.
- Full `go test ./core/...` passes.