### PR TITLE
perf(policy): cache compiled CBP objects keyed by policy set

### DIFF
--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -5,7 +5,9 @@ package core
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logical"
@@ -1571,11 +1573,11 @@ func TestCBP_MergeConditions_DenyOverrides(t *testing.T) {
 }
 
 // =============================================================================
-// CBP() re-parse reuse (Lever A)
+// CBP() re-parse reuse
 // =============================================================================
 
 // TestCBP_ReusesCachedParse verifies that CBP() reuses the parse already
-// performed by GetPolicy instead of re-parsing Raw on every call (Lever A).
+// performed by GetPolicy instead of re-parsing Raw on every call.
 //
 // The cached *Policy is constructed so its parsed Paths intentionally diverge
 // from its Raw text: the cache grants "secret/cached" while Raw would grant
@@ -1607,9 +1609,9 @@ func TestCBP_ReusesCachedParse(t *testing.T) {
 		"Raw must not be re-parsed when Paths is already populated")
 }
 
-// TestCBP_ParsesAdditionalPolicyWithoutPaths verifies the fallback in Lever A:
-// a prefetched policy that arrives without parsed Paths is still parsed from
-// Raw so it contributes its rules.
+// TestCBP_ParsesAdditionalPolicyWithoutPaths verifies the parse fallback: a
+// prefetched policy that arrives without parsed Paths is still parsed from Raw
+// so it contributes its rules.
 func TestCBP_ParsesAdditionalPolicyWithoutPaths(t *testing.T) {
 	core := createTestCore(t)
 	ps := core.policyStore
@@ -1629,4 +1631,160 @@ func TestCBP_ParsesAdditionalPolicyWithoutPaths(t *testing.T) {
 
 	assert.Contains(t, cbp.Capabilities(ctx, "secret/extra"), ReadCapability,
 		"prefetched policy without Paths must be parsed from Raw")
+}
+
+// =============================================================================
+// Compiled-CBP cache
+// =============================================================================
+
+// TestCBP_CompiledCacheHit verifies that compiling the same policy set twice
+// returns the cached compiled CBP (identical pointer) instead of recompiling.
+func TestCBP_CompiledCacheHit(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	p := testParsePolicy(t, `path "secret/a" { capabilities = ["read"] }`)
+	p.Name = "cached-set"
+	p.Type = PolicyTypeCBP
+	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+
+	names := map[string][]string{namespace.RootNamespaceID: {"cached-set"}}
+	first, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	second, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "identical policy set should return the cached compiled CBP")
+}
+
+// TestCBP_CompiledCacheInvalidatesOnVersionBump verifies that editing a policy
+// (which bumps its DataVersion) yields a new key, so the stale compiled CBP is
+// never served.
+func TestCBP_CompiledCacheInvalidatesOnVersionBump(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	p := testParsePolicy(t, `path "secret/a" { capabilities = ["read"] }`)
+	p.Name = "versioned"
+	p.Type = PolicyTypeCBP
+	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+
+	names := map[string][]string{namespace.RootNamespaceID: {"versioned"}}
+	first, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	assert.Contains(t, first.Capabilities(ctx, "secret/a"), ReadCapability)
+
+	// Edit the policy: now grants secret/b instead. SetPolicy bumps DataVersion.
+	updated := testParsePolicy(t, `path "secret/b" { capabilities = ["read"] }`)
+	updated.Name = "versioned"
+	updated.Type = PolicyTypeCBP
+	require.NoError(t, ps.SetPolicy(ctx, updated, nil))
+
+	second, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	assert.NotSame(t, first, second, "version bump must recompile")
+	assert.Contains(t, second.Capabilities(ctx, "secret/b"), ReadCapability)
+	assert.NotContains(t, second.Capabilities(ctx, "secret/a"), ReadCapability)
+}
+
+// TestCBP_CompiledCacheExpiresWithPath verifies that a per-path expiration
+// bounds the cached compiled CBP: once it elapses the entry is recompiled and
+// the expired path is dropped.
+func TestCBP_CompiledCacheExpiresWithPath(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	exp := time.Now().Add(50 * time.Millisecond)
+	p := &Policy{
+		Name:      "expiring",
+		Type:      PolicyTypeCBP,
+		namespace: namespace.RootNamespace,
+		Paths: []*PathRules{{
+			Path:         "secret/temp",
+			Capabilities: []string{ReadCapability},
+			Permissions:  &CBPPermissions{CapabilitiesBitmap: ReadCapabilityInt},
+			Expiration:   exp,
+		}},
+	}
+	idx := ps.cacheKey(namespace.RootNamespace, "expiring")
+	ps.tokenPoliciesLRU.Add(idx, p)
+
+	names := map[string][]string{namespace.RootNamespaceID: {"expiring"}}
+	first, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	assert.Contains(t, first.Capabilities(ctx, "secret/temp"), ReadCapability)
+
+	// The cached entry must carry a time bound derived from the path expiration.
+	entry, ok := ps.compiledCBPLRU.Get(compiledCBPCacheKey([]*Policy{p}))
+	require.True(t, ok)
+	assert.False(t, entry.validUntil.IsZero(), "entry should carry a validUntil bound")
+
+	// After the path expires, the entry is recompiled and the path is gone.
+	time.Sleep(80 * time.Millisecond)
+	second, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	assert.NotSame(t, first, second, "expired entry must be recompiled")
+	assert.NotContains(t, second.Capabilities(ctx, "secret/temp"), ReadCapability,
+		"expired path must be dropped after recompile")
+}
+
+// TestCBP_CompiledCacheBypassedWithAdditionalPolicies verifies that prefetched
+// policies bypass the compiled cache entirely (no sharing, no caching).
+func TestCBP_CompiledCacheBypassedWithAdditionalPolicies(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	extra := &Policy{
+		Name:      "prefetched",
+		Type:      PolicyTypeCBP,
+		Raw:       `path "secret/extra" { capabilities = ["read"] }`,
+		namespace: namespace.RootNamespace,
+	}
+
+	first, err := ps.CBP(ctx, map[string][]string{}, extra)
+	require.NoError(t, err)
+	second, err := ps.CBP(ctx, map[string][]string{}, extra)
+	require.NoError(t, err)
+
+	assert.NotSame(t, first, second, "additional policies must bypass the compiled cache")
+	assert.Equal(t, 0, ps.compiledCBPLRU.Len(), "nothing should be cached when additional policies are present")
+}
+
+// TestCBP_CompiledCacheConcurrent exercises concurrent CBP() compilation and
+// evaluation of a shared cached CBP under the race detector.
+func TestCBP_CompiledCacheConcurrent(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	p := testParsePolicy(t, `
+		path "secret/a" { capabilities = ["read", "list"] }
+		path "secret/b/*" { capabilities = ["read"] }
+	`)
+	p.Name = "concurrent"
+	p.Type = PolicyTypeCBP
+	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+
+	names := map[string][]string{namespace.RootNamespaceID: {"concurrent"}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cbp, err := ps.CBP(ctx, names)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			req := &logical.Request{Operation: logical.ReadOperation, Path: "secret/a"}
+			cbp.AllowOperation(ctx, req, false)
+			cbp.Capabilities(ctx, "secret/b/x")
+		}()
+	}
+	wg.Wait()
 }

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -27,6 +27,15 @@ const (
 
 	// policyCacheSize is the number of policies that are kept cached
 	policyCacheSize = 1024
+
+	// compiledCBPCacheSize is the number of compiled CBP objects kept cached.
+	// Unlike the policy cache, which is keyed per individual policy (bounded by
+	// how many policies are authored), this cache is keyed per policy SET — the
+	// sorted tuple of all policies a token carries. Distinct policy-set ×
+	// version combinations are combinatorial and typically outnumber distinct
+	// policies, so it is sized larger. Correctness never depends on the size: a
+	// miss simply recompiles, so this is purely a hit-rate tuning knob.
+	compiledCBPCacheSize = 4096
 )
 
 var (
@@ -43,9 +52,26 @@ type PolicyStore struct {
 
 	tokenPoliciesLRU *lru.TwoQueueCache[string, *Policy]
 
+	// compiledCBPLRU caches compiled CBP objects keyed by the policy set they
+	// were built from (see compiledCBPCacheKey). A policy edit bumps its
+	// DataVersion, which changes the key, so stale entries are never served and
+	// age out via the LRU. Entries also carry a time-validity bound to honour
+	// per-path expirations (see compiledCBPEntry).
+	compiledCBPLRU *lru.TwoQueueCache[string, *compiledCBPEntry]
+
 	modifyLock *sync.RWMutex
 
 	logger *logger.GatedLogger
+}
+
+// compiledCBPEntry is a cached compiled CBP together with the instant after
+// which it must be recomputed. validUntil is the earliest future per-path
+// expiration across the policy set; a zero value means no path expires, so the
+// entry never times out (it can still be evicted by the LRU or superseded by a
+// version bump).
+type compiledCBPEntry struct {
+	cbp        *CBP
+	validUntil time.Time
 }
 
 // PolicyEntry is used to store a policy by name
@@ -70,6 +96,9 @@ func NewPolicyStore(ctx context.Context, core *Core, logger *logger.GatedLogger)
 
 	cache, _ := lru.New2Q[string, *Policy](policyCacheSize)
 	ps.tokenPoliciesLRU = cache
+
+	compiledCache, _ := lru.New2Q[string, *compiledCBPEntry](compiledCBPCacheSize)
+	ps.compiledCBPLRU = compiledCache
 
 	return ps, nil
 }
@@ -532,13 +561,83 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 		}
 	}
 
+	// Serve a previously compiled CBP when the exact same policy set (by name
+	// and version) was already compiled. Prefetched policies are not keyed from
+	// storage and may be ephemeral, so the cache is bypassed when any are given.
+	cacheable := len(additionalPolicies) == 0 && ps.compiledCBPLRU != nil
+	var cacheKey string
+	if cacheable {
+		cacheKey = compiledCBPCacheKey(allPolicies)
+		if entry, ok := ps.compiledCBPLRU.Get(cacheKey); ok {
+			if entry.validUntil.IsZero() || time.Now().Before(entry.validUntil) {
+				return entry.cbp, nil
+			}
+			// A per-path expiration has elapsed; drop and recompile.
+			ps.compiledCBPLRU.Remove(cacheKey)
+		}
+	}
+
 	// Construct the CBP
 	cbp, err := NewCBP(ctx, allPolicies)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct CBP: %w", err)
 	}
 
+	if cacheable {
+		ps.compiledCBPLRU.Add(cacheKey, &compiledCBPEntry{
+			cbp:        cbp,
+			validUntil: earliestPathExpiration(allPolicies),
+		})
+	}
+
 	return cbp, nil
+}
+
+// compiledCBPCacheKey builds a stable, order-independent key identifying a
+// policy set. Each policy contributes its namespace, name, data version, and
+// policy-level expiration; a version bump therefore yields a new key so edits
+// are never served from a stale compiled CBP. Per-path expirations are not part
+// of the key (they are time-driven, not version-driven) and are handled via the
+// entry's validUntil bound instead.
+func compiledCBPCacheKey(policies []*Policy) string {
+	tuples := make([]string, 0, len(policies))
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		nsUUID := ""
+		if p.namespace != nil {
+			nsUUID = p.namespace.UUID
+		}
+		tuples = append(tuples, fmt.Sprintf("%s\x1f%s\x1f%d\x1f%d",
+			nsUUID, p.Name, p.DataVersion, p.Expiration.Unix()))
+	}
+	slices.Sort(tuples)
+	return strings.Join(tuples, "\x1e")
+}
+
+// earliestPathExpiration returns the soonest future per-path expiration across
+// the policy set, which bounds how long a compiled CBP stays valid (NewCBP
+// drops already-expired paths at compile time). Already-elapsed expirations are
+// ignored. A zero return means no path expires, so the compiled CBP has no time
+// bound.
+func earliestPathExpiration(policies []*Policy) time.Time {
+	now := time.Now()
+	var earliest time.Time
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		for _, pc := range p.Paths {
+			if pc.Expiration.IsZero() || !pc.Expiration.After(now) {
+				continue
+			}
+			if earliest.IsZero() || pc.Expiration.Before(earliest) {
+				earliest = pc.Expiration
+			}
+		}
+	}
+	return earliest
 }
 
 // loadCBPPolicy is used to load default CBP policies in a specific


### PR DESCRIPTION
## What

`CBP()` rebuilt the radix trees and cloned every permission set on every request, even when the policy set was unchanged. This caches the compiled CBP in an LRU keyed by the sorted `(namespace, name, data version, expiration)` tuples of the policy set.

- A policy edit bumps its data version, changing the key, so stale entries are never served and age out via the LRU — no explicit invalidation needed.
- Per-path expirations are time-driven rather than version-driven, so each entry carries a `validUntil` bound (the earliest future path expiration); once it elapses the entry is recompiled and expired paths are dropped.
- The cache is bypassed when prefetched (`additionalPolicies`) are supplied.

## Why

Removes radix-tree construction and reflection-heavy permission cloning from the authorization hot path between policy edits.

## Safety

A compiled CBP is identity-independent: CBP policies are never templated, and request-scoped inputs (client IP, time-window conditions) are evaluated at request time, never compiled in. The shared compiled CBP is read-only during evaluation, verified under `-race`.

> Note: built on top of #352 — review/merge that first. Base will retarget to `main` once #352 lands.

## Tests

- Cache hit (pointer identity), version-bump invalidation, per-path expiry recompute, `additionalPolicies` bypass.
- 32-goroutine concurrency test passes under `-race`.
- Full `go test ./core/...` passes.