### PR TITLE
feat(token-metadata): add login-derived token metadata, populated from JWT claims

### DIFF
--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -33,14 +33,13 @@ type JWTAuthConfig struct {
 	JWTValidationPubKeys []string `json:"jwt_validation_pubkeys,omitempty"`
 
 	// Validation
-	BoundIssuer       string            `json:"bound_issuer,omitempty"`
-	BoundAudiences    []string          `json:"bound_audiences,omitempty"`
-	BoundSubject      string            `json:"bound_subject,omitempty"`
-	BoundClaims       map[string]any    `json:"bound_claims,omitempty"`
-	ClaimMappings     map[string]string `json:"claim_mappings,omitempty"`
-	UserClaim         string            `json:"user_claim,omitempty" default:"sub"`
-	GroupsClaim       string            `json:"groups_claim,omitempty"`
-	GroupPolicyPrefix string            `json:"group_policy_prefix,omitempty"`
+	BoundIssuer       string         `json:"bound_issuer,omitempty"`
+	BoundAudiences    []string       `json:"bound_audiences,omitempty"`
+	BoundSubject      string         `json:"bound_subject,omitempty"`
+	BoundClaims       map[string]any `json:"bound_claims,omitempty"`
+	UserClaim         string         `json:"user_claim,omitempty" default:"sub"`
+	GroupsClaim       string         `json:"groups_claim,omitempty"`
+	GroupPolicyPrefix string         `json:"group_policy_prefix,omitempty"`
 
 	// Token settings
 	TokenTTL time.Duration `json:"token_ttl" default:"1h"`

--- a/auth/method/jwt/backend_test.go
+++ b/auth/method/jwt/backend_test.go
@@ -166,17 +166,6 @@ func TestJWTAuthConfig_BoundAudiences(t *testing.T) {
 	assert.Equal(t, []string{"aud1", "aud2"}, config.BoundAudiences)
 }
 
-func TestJWTAuthConfig_ClaimMappings(t *testing.T) {
-	config := &JWTAuthConfig{
-		ClaimMappings: map[string]string{
-			"email": "user_email",
-			"name":  "display_name",
-		},
-	}
-	assert.Equal(t, "user_email", config.ClaimMappings["email"])
-	assert.Equal(t, "display_name", config.ClaimMappings["name"])
-}
-
 // =============================================================================
 // setupJWTConfig Tests
 // =============================================================================

--- a/auth/method/jwt/helper.go
+++ b/auth/method/jwt/helper.go
@@ -1,9 +1,12 @@
 package jwt
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/mitchellh/pointerstructure"
 	"github.com/stephnangue/warden/logical"
 )
 
@@ -106,6 +109,61 @@ func extractClaim(claims map[string]interface{}, claimName string) string {
 		}
 	}
 	return ""
+}
+
+// getClaim resolves a claim value. A leading "/" is interpreted as a JSON
+// Pointer (RFC 6901) so nested claims can be addressed (e.g.
+// "/resource_access/warden/env"); any other string is a literal top-level key,
+// which also makes namespaced OIDC keys like "https://warden.io/env" resolve
+// as-is. Returns nil when the claim is absent or the pointer cannot be walked
+// (fail closed). Mirrors OpenBao's builtin/credential/jwt getClaim, including
+// the float -> json.Number coercion so numeric claims stringify predictably.
+func getClaim(claims map[string]interface{}, claim string) interface{} {
+	var val interface{}
+	if !strings.HasPrefix(claim, "/") {
+		val = claims[claim]
+	} else {
+		v, err := pointerstructure.Get(claims, claim)
+		if err != nil {
+			return nil
+		}
+		val = v
+	}
+
+	switch v := val.(type) {
+	case float32:
+		return json.Number(strconv.Itoa(int(v)))
+	case float64:
+		return json.Number(strconv.Itoa(int(v)))
+	}
+	return val
+}
+
+// extractMetadata builds a token metadata map from verified claims using the
+// role's claim mappings (source claim -> metadata key, matching OpenBao's
+// claim_mappings direction). Resolved values must be strings; a non-string
+// mapped claim is an error rather than being flattened. Absent claims are
+// skipped. Returns nil when nothing was mapped.
+func extractMetadata(claims map[string]interface{}, claimMappings map[string]string) (map[string]string, error) {
+	if len(claimMappings) == 0 {
+		return nil, nil
+	}
+	metadata := make(map[string]string)
+	for source, target := range claimMappings {
+		value := getClaim(claims, source)
+		if value == nil {
+			continue
+		}
+		strValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("claim %q for metadata key %q is not a string", source, target)
+		}
+		metadata[target] = strValue
+	}
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	return metadata, nil
 }
 
 // extractActChain walks the RFC 8693 §4.1 "act" claim chain into a

--- a/auth/method/jwt/metadata_test.go
+++ b/auth/method/jwt/metadata_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package jwt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClaim_LiteralTopLevelKey(t *testing.T) {
+	claims := map[string]interface{}{"team": "platform-core"}
+	assert.Equal(t, "platform-core", getClaim(claims, "team"))
+}
+
+func TestGetClaim_NestedJSONPointer(t *testing.T) {
+	claims := map[string]interface{}{
+		"resource_access": map[string]interface{}{
+			"warden": map[string]interface{}{"env": "prod"},
+		},
+	}
+	assert.Equal(t, "prod", getClaim(claims, "/resource_access/warden/env"))
+}
+
+func TestGetClaim_NamespacedLiteralKey(t *testing.T) {
+	// A namespaced OIDC key contains slashes but has no leading "/", so it is
+	// resolved as a literal top-level key, not a JSON Pointer.
+	claims := map[string]interface{}{"https://warden.io/env": "prod"}
+	assert.Equal(t, "prod", getClaim(claims, "https://warden.io/env"))
+}
+
+func TestGetClaim_UnresolvedPointerFailsClosed(t *testing.T) {
+	claims := map[string]interface{}{"resource_access": map[string]interface{}{}}
+	assert.Nil(t, getClaim(claims, "/resource_access/warden/env"))
+	assert.Nil(t, getClaim(claims, "/missing"))
+}
+
+func TestGetClaim_EarlyLeafFailsClosed(t *testing.T) {
+	// "env" is a string, so walking further into it must not panic and must
+	// return nil rather than a partial value.
+	claims := map[string]interface{}{"env": "prod"}
+	assert.Nil(t, getClaim(claims, "/env/deeper"))
+}
+
+func TestGetClaim_FloatCoercedToJSONNumber(t *testing.T) {
+	claims := map[string]interface{}{"level": float64(42)}
+	assert.Equal(t, json.Number("42"), getClaim(claims, "level"))
+}
+
+func TestExtractMetadata_MapsConfiguredClaims(t *testing.T) {
+	claims := map[string]interface{}{
+		"team": "platform-core",
+		"resource_access": map[string]interface{}{
+			"warden": map[string]interface{}{"env": "prod"},
+		},
+	}
+	md, err := extractMetadata(claims, map[string]string{
+		"team":                        "team",
+		"/resource_access/warden/env": "env",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"team": "platform-core", "env": "prod"}, md)
+}
+
+func TestExtractMetadata_NoMappingsReturnsNil(t *testing.T) {
+	md, err := extractMetadata(map[string]interface{}{"team": "x"}, nil)
+	require.NoError(t, err)
+	assert.Nil(t, md)
+}
+
+func TestExtractMetadata_AbsentClaimSkipped(t *testing.T) {
+	md, err := extractMetadata(map[string]interface{}{"team": "platform"}, map[string]string{
+		"team": "team",
+		"env":  "env", // not present in claims
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"team": "platform"}, md)
+}
+
+func TestExtractMetadata_AllClaimsAbsentReturnsNil(t *testing.T) {
+	md, err := extractMetadata(map[string]interface{}{}, map[string]string{"env": "env"})
+	require.NoError(t, err)
+	assert.Nil(t, md)
+}
+
+func TestExtractMetadata_NonStringClaimErrors(t *testing.T) {
+	claims := map[string]interface{}{"roles": []interface{}{"a", "b"}}
+	md, err := extractMetadata(claims, map[string]string{"roles": "roles"})
+	require.Error(t, err)
+	assert.Nil(t, md)
+}

--- a/auth/method/jwt/parser_test.go
+++ b/auth/method/jwt/parser_test.go
@@ -127,23 +127,6 @@ func TestMapToJWTAuthConfig_BoundClaims(t *testing.T) {
 	assert.Equal(t, "admin", config.BoundClaims["role"])
 }
 
-func TestMapToJWTAuthConfig_ClaimMappings(t *testing.T) {
-	data := map[string]any{
-		"jwks_url": "https://example.com/.well-known/jwks.json",
-		"claim_mappings": map[string]string{
-			"preferred_username": "username",
-			"email":              "user_email",
-		},
-	}
-
-	config, err := mapToJWTAuthConfig(data)
-	require.NoError(t, err)
-
-	require.NotNil(t, config.ClaimMappings)
-	assert.Equal(t, "username", config.ClaimMappings["preferred_username"])
-	assert.Equal(t, "user_email", config.ClaimMappings["email"])
-}
-
 func TestMapToJWTAuthConfig_GroupsClaim(t *testing.T) {
 	data := map[string]any{
 		"jwks_url":     "https://example.com/.well-known/jwks.json",
@@ -199,7 +182,6 @@ func TestMapToJWTAuthConfig_AllFields(t *testing.T) {
 		"bound_audiences": []string{"aud1"},
 		"bound_subject":   "expected-sub",
 		"bound_claims":    map[string]any{"claim1": "value1"},
-		"claim_mappings":  map[string]string{"c1": "m1"},
 		"user_claim":      "email",
 		"groups_claim":    "roles",
 		"token_ttl":       "4h",
@@ -214,7 +196,6 @@ func TestMapToJWTAuthConfig_AllFields(t *testing.T) {
 	assert.Equal(t, []string{"aud1"}, config.BoundAudiences)
 	assert.Equal(t, "expected-sub", config.BoundSubject)
 	assert.Equal(t, "value1", config.BoundClaims["claim1"])
-	assert.Equal(t, "m1", config.ClaimMappings["c1"])
 	assert.Equal(t, "email", config.UserClaim)
 	assert.Equal(t, "roles", config.GroupsClaim)
 	assert.Equal(t, 4*time.Hour, config.TokenTTL)

--- a/auth/method/jwt/path_config.go
+++ b/auth/method/jwt/path_config.go
@@ -47,10 +47,6 @@ func (b *jwtAuthBackend) pathConfig() *framework.Path {
 				Type:        framework.TypeMap,
 				Description: "Map of claims to required values for JWT validation",
 			},
-			"claim_mappings": {
-				Type:        framework.TypeKVPairs,
-				Description: "Map of claims to copy to token metadata",
-			},
 			"jwt_validation_pubkeys": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "PEM-encoded RSA or ECDSA public keys for static JWT validation. Set exactly one of oidc_discovery_url, jwks_url, or jwt_validation_pubkeys.",
@@ -96,8 +92,8 @@ endpoint), or 'jwt_validation_pubkeys' (static PEM-encoded RSA/ECDSA keys)
 to configure how token signatures are verified.
 
 Use 'bound_issuer', 'bound_audiences', 'bound_subject', and 'bound_claims'
-to constrain which tokens are accepted. Use 'claim_mappings' to copy JWT
-claims into token metadata for use in policies.`,
+to constrain which tokens are accepted. Per-role 'metadata_claims' copies
+JWT claims into token metadata for use in token_metadata policy conditions.`,
 	}
 }
 
@@ -125,7 +121,6 @@ func (b *jwtAuthBackend) handleConfigRead(ctx context.Context, req *logical.Requ
 			"bound_audiences":        b.config.BoundAudiences,
 			"bound_subject":          b.config.BoundSubject,
 			"bound_claims":           b.config.BoundClaims,
-			"claim_mappings":         b.config.ClaimMappings,
 			"user_claim":             b.config.UserClaim,
 			"groups_claim":           b.config.GroupsClaim,
 			"group_policy_prefix":    b.config.GroupPolicyPrefix,
@@ -152,7 +147,6 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 		conf["bound_audiences"] = b.config.BoundAudiences
 		conf["bound_subject"] = b.config.BoundSubject
 		conf["bound_claims"] = b.config.BoundClaims
-		conf["claim_mappings"] = b.config.ClaimMappings
 		conf["user_claim"] = b.config.UserClaim
 		conf["groups_claim"] = b.config.GroupsClaim
 		conf["group_policy_prefix"] = b.config.GroupPolicyPrefix
@@ -191,7 +185,6 @@ func (b *jwtAuthBackend) handleConfigWrite(ctx context.Context, req *logical.Req
 			"bound_audiences":        b.config.BoundAudiences,
 			"bound_subject":          b.config.BoundSubject,
 			"bound_claims":           b.config.BoundClaims,
-			"claim_mappings":         b.config.ClaimMappings,
 			"user_claim":             b.config.UserClaim,
 			"groups_claim":           b.config.GroupsClaim,
 			"group_policy_prefix":    b.config.GroupPolicyPrefix,

--- a/auth/method/jwt/path_login.go
+++ b/auth/method/jwt/path_login.go
@@ -253,6 +253,15 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 	// claim. Recorded with verified=true; flows through to audit.
 	actors := extractActChain(claims)
 
+	// Verified, login-derived metadata mapped from claims per the role's
+	// metadata_claims config. Persisted onto the token and matched by
+	// token_metadata policy conditions.
+	metadata, err := extractMetadata(claims, role.MetadataClaims)
+	if err != nil {
+		b.logger.Warn("login failed: metadata claim extraction", lgr.Err(err), lgr.String("role", roleName))
+		return logical.ErrorResponse(logical.ErrBadRequest(errAuthFailed.Error())), nil
+	}
+
 	// Return auth response using role configuration.
 	// ClientToken carries the raw JWT so that LoginCreateToken can pass it to
 	// JWTRoleTokenType.Generate(), which hashes jwt+role to compute the
@@ -269,6 +278,7 @@ func (b *jwtAuthBackend) handleLogin(ctx context.Context, req *logical.Request, 
 			ClientIP:       req.ClientIP,
 			ClientToken:    jwtToken,
 			Actors:         actors,
+			Metadata:       metadata,
 		},
 		Data: map[string]any{
 			"principal_id": principalID,

--- a/auth/method/jwt/path_role.go
+++ b/auth/method/jwt/path_role.go
@@ -69,6 +69,10 @@ func (b *jwtAuthBackend) pathRole() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Maximum elapsed time since JWT was issued (iat). Rejects JWTs older than this. Example: 30m, 1h",
 			},
+			"metadata_claims": {
+				Type:        framework.TypeMap,
+				Description: "Map of source claim to token metadata key. The source is a literal top-level claim name, or a JSON Pointer (leading /) for a nested claim. Resolved claim values must be strings.",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{
@@ -170,6 +174,7 @@ func (b *jwtAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reques
 			"groups_claim":        role.GroupsClaim,
 			"group_policy_prefix": role.GroupPolicyPrefix,
 			"max_age":             role.MaxAge,
+			"metadata_claims":     role.MetadataClaims,
 		},
 	}, nil
 }
@@ -220,6 +225,9 @@ func (b *jwtAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Requ
 		}
 		if v, ok := d.GetOk("max_age"); ok {
 			role.MaxAge = v.(string)
+		}
+		if v, ok := d.GetOk("metadata_claims"); ok {
+			role.MetadataClaims = toStringMap(v.(map[string]any))
 		}
 	}
 
@@ -351,8 +359,24 @@ func (b *jwtAuthBackend) buildRoleFromFieldData(name string, d *framework.FieldD
 	if v, ok := d.GetOk("max_age"); ok {
 		role.MaxAge = v.(string)
 	}
+	if v, ok := d.GetOk("metadata_claims"); ok {
+		role.MetadataClaims = toStringMap(v.(map[string]any))
+	}
 
 	return role
+}
+
+// toStringMap coerces a TypeMap field value into map[string]string, rendering
+// each value to its string form. Nil/empty input yields nil.
+func toStringMap(m map[string]any) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	return out
 }
 
 // Storage helper methods

--- a/auth/method/jwt/path_role_test.go
+++ b/auth/method/jwt/path_role_test.go
@@ -62,6 +62,36 @@ func TestPathRole_Create(t *testing.T) {
 	assert.Equal(t, "aws-dev", role.CredSpecName)
 }
 
+func TestPathRole_Create_MetadataClaims(t *testing.T) {
+	b, ctx := createTestBackendWithStorage(t)
+
+	fieldData := &framework.FieldData{
+		Raw: map[string]any{
+			"name": "meta-role",
+			"metadata_claims": map[string]any{
+				"team":                        "team",
+				"/resource_access/warden/env": "env",
+			},
+		},
+		Schema: map[string]*framework.FieldSchema{
+			"name":            {Type: framework.TypeString},
+			"metadata_claims": {Type: framework.TypeMap},
+		},
+	}
+
+	resp, err := b.handleRoleCreate(ctx, &logical.Request{}, fieldData)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	role, err := b.getRole(ctx, "meta-role")
+	require.NoError(t, err)
+	require.NotNil(t, role)
+	assert.Equal(t, map[string]string{
+		"team":                        "team",
+		"/resource_access/warden/env": "env",
+	}, role.MetadataClaims)
+}
+
 func TestPathRole_CreateDuplicate(t *testing.T) {
 	b, ctx := createTestBackendWithStorage(t)
 

--- a/auth/method/jwt/role.go
+++ b/auth/method/jwt/role.go
@@ -20,6 +20,14 @@ type JWTRole struct {
 	GroupsClaim       string         `json:"groups_claim,omitempty"`        // Override global groups_claim for this role
 	GroupPolicyPrefix string         `json:"group_policy_prefix,omitempty"` // Override global group_policy_prefix for this role
 	MaxAge            string         `json:"max_age,omitempty"`             // Max time since iat (e.g. "30m", "1h"). Empty = no check.
+
+	// MetadataClaims maps a source claim to the token metadata key it
+	// populates (source -> key, matching OpenBao's claim_mappings). The
+	// source is resolved by getClaim: a leading "/" is a JSON Pointer
+	// (RFC 6901) for nested claims, otherwise a literal top-level key.
+	// Resolved values must be strings; populated onto the token's Metadata
+	// and matched by token_metadata policy conditions.
+	MetadataClaims map[string]string `json:"metadata_claims,omitempty"`
 }
 
 // ParseTokenTTL parses the TokenTTL string to a time.Duration.

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -708,6 +708,7 @@ func (c *Core) LoginCreateToken(ctx context.Context, req *logical.Request, resp 
 		TokenValue:     auth.ClientToken,
 		MountAccessor:  mountAccessor,
 		Actors:         auth.Actors,
+		Metadata:       auth.Metadata,
 	}
 
 	tokenValue, err := c.tokenStore.GenerateToken(ctx, auth.TokenType, &authData)

--- a/core/token_store.go
+++ b/core/token_store.go
@@ -406,6 +406,7 @@ func (s *TokenStore) generateWithCollisionDetection(
 			CredentialSpec: authData.CredentialSpec,
 			CreatedByIP:    authData.ClientIP,
 			Actors:         authData.Actors,
+			Metadata:       authData.Metadata,
 		}
 
 		// Generate accessor (Tier 2)
@@ -998,6 +999,7 @@ func (s *TokenStore) ReplaceRootTokenValue(customToken string) error {
 		CreatedByIP:    oldEntry.CreatedByIP,
 		Data:           map[string]string{"token": customToken},
 		Actors:         oldEntry.Actors,
+		Metadata:       oldEntry.Metadata,
 	}
 
 	// Compute new ID from custom token value

--- a/core/token_store_test.go
+++ b/core/token_store_test.go
@@ -210,6 +210,35 @@ func TestTokenStore_LookupToken(t *testing.T) {
 	assert.Equal(t, entry.Policies, lookedUpEntry.Policies)
 }
 
+// TestTokenStore_Metadata_RoundTrip verifies login-derived Metadata is
+// persisted onto the token and survives a lookup.
+func TestTokenStore_Metadata_RoundTrip(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	authData := &AuthData{
+		PrincipalID: "test-user",
+		RoleName:    "test-role",
+		ExpireAt:    time.Now().Add(24 * time.Hour),
+		Policies:    []string{"default"},
+		Metadata:    map[string]string{"env": "prod", "team": "platform-core"},
+	}
+
+	entry, err := core.tokenStore.GenerateToken(ctx, TypeWardenToken, authData)
+	require.NoError(t, err)
+	assert.Equal(t, authData.Metadata, entry.Metadata)
+
+	tokenValue := entry.Data["token"]
+	require.NotEmpty(t, tokenValue)
+
+	lookedUpEntry, err := core.LookupToken(ctx, tokenValue)
+	require.NoError(t, err)
+	require.NotNil(t, lookedUpEntry)
+	assert.Equal(t, map[string]string{"env": "prod", "team": "platform-core"}, lookedUpEntry.Metadata)
+}
+
 // TestTokenStore_LookupToken_NotFound tests looking up a non-existent token
 func TestTokenStore_LookupToken_NotFound(t *testing.T) {
 	core := createTestCore(t)

--- a/docs/auth-methods/jwt.md
+++ b/docs/auth-methods/jwt.md
@@ -20,7 +20,7 @@ If your workloads present **SPIFFE identities** — an X.509-SVID or a JWT-SVID 
 - [Step 3: Create a Role](#step-3-create-a-role)
 - [Step 4: Wire Up Transparent Auth](#step-4-wire-up-transparent-auth)
 - [Group-Based Policies](#group-based-policies)
-- [Claim Mappings](#claim-mappings)
+- [Token Metadata](#token-metadata)
 - [On-Behalf-Of Chain (RFC 8693 `act` Claim)](#on-behalf-of-chain-rfc-8693-act-claim)
 - [Discovering Assumable Roles](#discovering-assumable-roles)
 - [Configuration Reference](#configuration-reference)
@@ -176,18 +176,18 @@ The prefix is required to keep group-derived policies in a namespace operators c
 
 Per-role overrides for `groups_claim` and `group_policy_prefix` let one mount serve multiple IdP claim conventions.
 
-## Claim Mappings
+## Token Metadata
 
-`claim_mappings` copies arbitrary JWT claims into the issued Warden token's metadata. The mapping is `source-claim=destination-metadata-key`.
+A role's `metadata_claims` copies verified JWT claims onto the issued token's metadata, where `token_metadata` policy conditions can match them. The mapping is `source-claim=destination-metadata-key`. The source is a literal claim name, or a JSON Pointer (leading `/`) for a nested claim; resolved values must be strings.
 
 ```bash
-warden write auth/jwt/config \
-  claim_mappings="tenant=tenant_id,department=dept"
+warden write auth/jwt/role/inventory-agent \
+  metadata_claims="department=dept,/resource_access/warden/env=env"
 ```
 
-A JWT with `"tenant": "acme"` and `"department": "eng"` produces a Warden token whose metadata carries `tenant_id="acme"` and `dept="eng"`. The metadata surfaces in audit log entries for traceability and downstream correlation.
+A JWT with `"department": "eng"` and a nested `resource_access.warden.env` of `"prod"` produces a token whose metadata carries `dept="eng"` and `env="prod"`. A policy can then gate a path with `conditions { token_metadata = ["env=prod"] }`. The metadata also surfaces in audit log entries (`auth.policy_results.token_metadata`) for traceability — logged in clear by default, with opt-in per-key HMAC salting via the audit device's `salt_fields`.
 
-> **Heads-up:** Warden's policy engine does not currently support templated permissions that reference token metadata (e.g. `{{identity.metadata.tenant_id}}` in a policy path). `claim_mappings` is useful today for audit-log enrichment; policy-templating support would consume this metadata when it lands.
+> **Note:** metadata is matched at request time against the token's own values and is never compiled into the policy, so it stays correct for every token. Use it for authorization decisions that depend on identity attributes rather than path/capability alone.
 
 ## On-Behalf-Of Chain (RFC 8693 `act` Claim)
 
@@ -227,7 +227,6 @@ Exactly one of `oidc_discovery_url`, `jwks_url`, or `jwt_validation_pubkeys` mus
 | `bound_audiences` | No | Accepted values of the JWT's `aud` claim. Roles may override with their own list. |
 | `bound_subject` | No | Pinned `sub` claim. Roles may override. |
 | `bound_claims` | No | Map of arbitrary claim → required value. Roles may add their own claims. |
-| `claim_mappings` | No | Map of source-claim → destination-metadata-key. Copies JWT claims into the issued token's metadata. |
 | `user_claim` | No (default `sub`) | Which claim Warden uses as the principal identity. |
 | `groups_claim` | No | JWT claim carrying a list of group names. When set, group-derived policies are appended to the issued token. |
 | `group_policy_prefix` | No (default `group-`) | Prefix prepended to each group name to form the policy name. |
@@ -246,6 +245,7 @@ Exactly one of `oidc_discovery_url`, `jwks_url`, or `jwt_validation_pubkeys` mus
 | `token_ttl` | No (default `1h`) | TTL for issued tokens; overrides the mount-level `token_ttl`. |
 | `groups_claim` | No | Per-role override of the mount's `groups_claim`. |
 | `group_policy_prefix` | No | Per-role override of the mount's `group_policy_prefix`. |
+| `metadata_claims` | No | Map of source claim (literal or JSON Pointer) → token metadata key. Copies verified claims into the token's metadata for `token_metadata` policy conditions. Values must be strings. |
 | `cred_spec_name` | No | Credential spec name for implicit-auth flows. |
 | `max_age` | No | Maximum elapsed time since the JWT's `iat` claim. Example: `30m`. Empty disables the check. |
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/copystructure v1.2.0
+	github.com/mitchellh/pointerstructure v1.2.1
 	github.com/oklog/ulid v1.3.1
 	github.com/openbao/go-kms-wrapping/v2 v2.8.0
 	github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,11 @@ github.com/mitchellh/go-testing-interface v1.14.2-0.20210821155943-2d9075ca8770 
 github.com/mitchellh/go-testing-interface v1.14.2-0.20210821155943-2d9075ca8770/go.mod h1:SO/iHr6q2EzbqRApt+8/E9wqebTwQn5y+UlB04bxzo0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/pointerstructure v1.2.1 h1:ZhBBeX8tSlRpu/FFhXH4RC4OJzFlqsQhoHZAz4x7TIw=
+github.com/mitchellh/pointerstructure v1.2.1/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -60,6 +60,13 @@ type Auth struct {
 	// through buildAuditAuth into the audit log; not used for policy
 	// decisions.
 	Actors []ActorRef
+
+	// Metadata is a set of verified, login-derived attributes the auth
+	// method extracted from the authenticated identity (e.g. JWT claims,
+	// certificate fields, service-account attributes). It is persisted onto
+	// the issued token and consulted by token_metadata policy conditions.
+	// Never caller-supplied — only an auth method writes it.
+	Metadata map[string]string
 }
 
 // MCPDecision records the outcome of evaluating an mcp { } policy block
@@ -174,4 +181,9 @@ type AuthData struct {
 	// (e.g. JWT "act" claim) so it can be persisted onto the issued
 	// TokenEntry for transparent-mode cache reuse.
 	Actors []ActorRef
+
+	// Metadata carries verified, login-derived identity attributes the auth
+	// method extracted (e.g. mapped JWT claims). Persisted onto the issued
+	// TokenEntry and consulted by token_metadata policy conditions.
+	Metadata map[string]string
 }

--- a/logical/token.go
+++ b/logical/token.go
@@ -33,6 +33,12 @@ type TokenEntry struct {
 	// Token Data
 	Data map[string]string // Type-specific credential data
 
+	// Metadata holds verified, login-derived identity attributes (mapped
+	// from JWT claims, certificate fields, service-account attributes, etc.)
+	// that token_metadata policy conditions match against. Distinct from
+	// Data, which is type-specific credential material. Never caller-supplied.
+	Metadata map[string]string
+
 	// Usage Tracking
 	mu   sync.RWMutex
 	used bool // One-time use flag


### PR DESCRIPTION
## Summary

Introduces a per-token `Metadata` map carrying verified, login-derived identity
attributes — the foundation for `token_metadata` policy conditions and the other
auth methods (cert / Kubernetes / SPIFFE) and audit surfacing that build on it.

- Adds `Metadata map[string]string` to `TokenEntry`, `AuthData`, and `logical.Auth`;
  persisted on the issued token and threaded through token creation. Distinct from
  `Data`, which is type-specific credential material.
- The JWT auth method populates it from a new per-role `metadata_claims` mapping
  (`source-claim` → `metadata-key`). Claim resolution mirrors OpenBao's `getClaim`:
  a leading `/` is a JSON Pointer (RFC 6901) for nested claims, otherwise a literal
  top-level key. Resolved values must be strings; a non-string mapped claim fails
  the login closed.
- Removes the dead mount-level `claim_mappings` config — it was declared and stored
  but never consumed at login. Its intent is now served by role-level
  `metadata_claims`.
- Adds `github.com/mitchellh/pointerstructure` (already in the module graph via
  OpenBao) as a direct dependency.

## Tests

- Claim resolver: literal key, nested JSON Pointer, namespaced literal key,
  unresolved-pointer fail-closed, non-string error, and `float64` → `json.Number`
  coercion.
- Token-store round-trip of `Metadata`; role-config round-trip of `metadata_claims`.

## Docs

- `docs/auth-methods/jwt.md`: rewrote the "Claim Mappings" section as "Token
  Metadata" (role-level `metadata_claims`, JSON Pointer, audit note).

## Stack

First of six PRs adding token metadata and `token_metadata` policy conditions across
all auth methods plus audit surfacing. The remaining PRs depend on this one.
