### PR TITLE
feat(cert-auth): populate token metadata from certificate fields

### DIFF
--- a/auth/method/cert/path_login.go
+++ b/auth/method/cert/path_login.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/auth/helper"
@@ -162,6 +163,7 @@ func (b *certAuthBackend) handleLogin(ctx context.Context, req *logical.Request,
 			TokenTTL:       effectiveTTL,
 			ClientIP:       req.ClientIP,
 			ClientToken:    fingerprint, // Cert fingerprint for token type caching
+			Metadata:       extractCertMetadata(cert, role.MetadataMappings),
 		},
 		Data: map[string]any{
 			"principal_id": principalID,
@@ -262,6 +264,64 @@ func validateCertConstraints(cert *x509.Certificate, role *CertRole) error {
 	}
 
 	return nil
+}
+
+// validCertMetadataFields lists the certificate field selectors usable in a
+// role's metadata_mappings.
+var validCertMetadataFields = map[string]bool{
+	"cn":        true,
+	"serial":    true,
+	"ou":        true,
+	"org":       true,
+	"dns_san":   true,
+	"email_san": true,
+	"uri_san":   true,
+}
+
+// extractCertMetadata builds the token metadata map from verified certificate
+// fields using the role's mappings (cert field selector -> metadata key, source
+// -> key). Empty fields are skipped. Returns nil when nothing was mapped.
+func extractCertMetadata(cert *x509.Certificate, mappings map[string]string) map[string]string {
+	if len(mappings) == 0 {
+		return nil
+	}
+	md := make(map[string]string)
+	for source, target := range mappings {
+		if v := certFieldValue(cert, source); v != "" {
+			md[target] = v
+		}
+	}
+	if len(md) == 0 {
+		return nil
+	}
+	return md
+}
+
+// certFieldValue renders a certificate field selector to a string. Multi-valued
+// fields (OU, Org, and the SAN lists) are comma-joined so the result is a single
+// deterministic metadata value.
+func certFieldValue(cert *x509.Certificate, field string) string {
+	switch field {
+	case "cn":
+		return cert.Subject.CommonName
+	case "serial":
+		return cert.SerialNumber.String()
+	case "ou":
+		return strings.Join(cert.Subject.OrganizationalUnit, ",")
+	case "org":
+		return strings.Join(cert.Subject.Organization, ",")
+	case "dns_san":
+		return strings.Join(cert.DNSNames, ",")
+	case "email_san":
+		return strings.Join(cert.EmailAddresses, ",")
+	case "uri_san":
+		uris := make([]string, len(cert.URIs))
+		for i, u := range cert.URIs {
+			uris[i] = u.String()
+		}
+		return strings.Join(uris, ",")
+	}
+	return ""
 }
 
 // extractPrincipal extracts the principal identity from the certificate based on the claim type.

--- a/auth/method/cert/path_login_test.go
+++ b/auth/method/cert/path_login_test.go
@@ -342,6 +342,50 @@ func TestExtractPrincipal(t *testing.T) {
 	}
 }
 
+func TestExtractCertMetadata(t *testing.T) {
+	caCert, caKey, _ := testCA(t)
+
+	cert := testClientCert(t, caCert, caKey, "svc-ci", func(tmpl *x509.Certificate) {
+		tmpl.Subject.OrganizationalUnit = []string{"platform-core"}
+		tmpl.Subject.Organization = []string{"acme"}
+		tmpl.DNSNames = []string{"a.example.com", "b.example.com"}
+		tmpl.EmailAddresses = []string{"ci@example.com"}
+	})
+
+	t.Run("maps fields, comma-joins multi-valued SANs, skips empty", func(t *testing.T) {
+		// mappings are source (cert field) -> target (metadata key)
+		md := extractCertMetadata(cert, map[string]string{
+			"cn":        "cn",
+			"ou":        "team",
+			"org":       "org",
+			"dns_san":   "hosts", // multi-valued -> comma-joined in order
+			"email_san": "email",
+			"uri_san":   "uri", // no URIs on this cert -> skipped
+		})
+		assert.Equal(t, map[string]string{
+			"cn":    "svc-ci",
+			"team":  "platform-core",
+			"org":   "acme",
+			"hosts": "a.example.com,b.example.com",
+			"email": "ci@example.com",
+		}, md)
+	})
+
+	t.Run("serial", func(t *testing.T) {
+		md := extractCertMetadata(cert, map[string]string{"serial": "sn"})
+		assert.Equal(t, map[string]string{"sn": cert.SerialNumber.String()}, md)
+	})
+
+	t.Run("nil mappings", func(t *testing.T) {
+		assert.Nil(t, extractCertMetadata(cert, nil))
+	})
+
+	t.Run("all empty -> nil", func(t *testing.T) {
+		bare := testClientCert(t, caCert, caKey, "bare")
+		assert.Nil(t, extractCertMetadata(bare, map[string]string{"ou": "team"}))
+	})
+}
+
 func TestMatchesGlob(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/auth/method/cert/path_role.go
+++ b/auth/method/cert/path_role.go
@@ -75,6 +75,10 @@ func (b *certAuthBackend) pathRole() *framework.Path {
 				Description:   "Identity source from certificate (overrides global config): cn, dns_san, email_san, uri_san, serial",
 				AllowedValues: principalClaimAllowedValues(),
 			},
+			"metadata_mappings": {
+				Type:        framework.TypeMap,
+				Description: "Map of certificate field (cn, serial, ou, org, dns_san, email_san, uri_san) to token metadata key. Multi-valued fields are comma-joined.",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{
@@ -177,6 +181,7 @@ func (b *certAuthBackend) handleRoleRead(ctx context.Context, req *logical.Reque
 			"allowed_organizations":        role.AllowedOrganizations,
 			"certificate":                  role.Certificate,
 			"principal_claim":              role.PrincipalClaim,
+			"metadata_mappings":            role.MetadataMappings,
 		},
 	}, nil
 }
@@ -230,6 +235,9 @@ func (b *certAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.Req
 		}
 		if v, ok := d.GetOk("principal_claim"); ok {
 			role.PrincipalClaim = v.(string)
+		}
+		if v, ok := d.GetOk("metadata_mappings"); ok {
+			role.MetadataMappings = toStringMap(v.(map[string]any))
 		}
 	}
 
@@ -345,6 +353,14 @@ func (b *certAuthBackend) validateRole(role *CertRole) error {
 		return logical.ErrBadRequestf("invalid principal_claim %q; must be one of: %v", role.PrincipalClaim, validPrincipalClaims)
 	}
 
+	// Validate metadata_mappings certificate field selectors (the map key is
+	// the source cert field; the value is the destination metadata key).
+	for source, target := range role.MetadataMappings {
+		if !validCertMetadataFields[source] {
+			return logical.ErrBadRequestf("invalid metadata_mappings field %q for metadata key %q; must be one of: cn, serial, ou, org, dns_san, email_san, uri_san", source, target)
+		}
+	}
+
 	// Validate role-specific CA PEM if provided
 	if role.Certificate != "" {
 		if _, err := buildCAPool(role.Certificate); err != nil {
@@ -397,8 +413,24 @@ func (b *certAuthBackend) buildRoleFromFieldData(name string, d *framework.Field
 	if v, ok := d.GetOk("principal_claim"); ok {
 		role.PrincipalClaim = v.(string)
 	}
+	if v, ok := d.GetOk("metadata_mappings"); ok {
+		role.MetadataMappings = toStringMap(v.(map[string]any))
+	}
 
 	return role
+}
+
+// toStringMap coerces a TypeMap field value into map[string]string, rendering
+// each value to its string form. Nil/empty input yields nil.
+func toStringMap(m map[string]any) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	return out
 }
 
 // Storage helper methods

--- a/auth/method/cert/path_role_test.go
+++ b/auth/method/cert/path_role_test.go
@@ -66,6 +66,58 @@ func TestPathRole_TokenTypeAlwaysCertRole(t *testing.T) {
 	assert.Equal(t, "cert_role", role.TokenType)
 }
 
+func TestPathRole_MetadataMappings_RoundTrip(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	b.config = &CertAuthConfig{PrincipalClaim: "cn"}
+
+	fd := &framework.FieldData{
+		Raw: map[string]any{
+			"name":                 "meta-role",
+			"allowed_common_names": []string{"svc-*"},
+			"metadata_mappings": map[string]any{
+				"ou": "team",
+				"cn": "cn",
+			},
+		},
+		Schema: map[string]*framework.FieldSchema{
+			"name":                 {Type: framework.TypeString},
+			"allowed_common_names": {Type: framework.TypeCommaStringSlice},
+			"metadata_mappings":    {Type: framework.TypeMap},
+		},
+	}
+
+	resp, err := b.handleRoleCreate(ctx, &logical.Request{}, fd)
+	require.NoError(t, err)
+	assert.Nil(t, resp.Err)
+
+	role, err := b.getRole(ctx, "meta-role")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"ou": "team", "cn": "cn"}, role.MetadataMappings)
+}
+
+func TestPathRole_MetadataMappings_InvalidField(t *testing.T) {
+	b, ctx := createTestBackend(t)
+	b.config = &CertAuthConfig{PrincipalClaim: "cn"}
+
+	fd := &framework.FieldData{
+		Raw: map[string]any{
+			"name":                 "bad-meta-role",
+			"allowed_common_names": []string{"svc-*"},
+			"metadata_mappings":    map[string]any{"not_a_cert_field": "team"},
+		},
+		Schema: map[string]*framework.FieldSchema{
+			"name":                 {Type: framework.TypeString},
+			"allowed_common_names": {Type: framework.TypeCommaStringSlice},
+			"metadata_mappings":    {Type: framework.TypeMap},
+		},
+	}
+
+	resp, err := b.handleRoleCreate(ctx, &logical.Request{}, fd)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "invalid metadata_mappings field")
+}
+
 func TestCertRole_ParseTokenTTL(t *testing.T) {
 	t.Run("empty returns 1h", func(t *testing.T) {
 		r := &CertRole{}

--- a/auth/method/cert/role.go
+++ b/auth/method/cert/role.go
@@ -19,6 +19,12 @@ type CertRole struct {
 	TokenType                  string   `json:"token_type,omitempty"`
 	CredSpecName               string   `json:"cred_spec_name,omitempty"`
 	PrincipalClaim             string   `json:"principal_claim,omitempty"`
+
+	// MetadataMappings maps a certificate field selector to the token metadata
+	// key it populates (source -> key): cn, serial, ou, org, dns_san, email_san,
+	// uri_san. Multi-valued fields are comma-joined. Populated onto the token's
+	// Metadata and matched by token_metadata policy conditions.
+	MetadataMappings map[string]string `json:"metadata_mappings,omitempty"`
 }
 
 // ParseTokenTTL parses the TokenTTL string to a time.Duration.

--- a/docs/auth-methods/cert.md
+++ b/docs/auth-methods/cert.md
@@ -28,6 +28,7 @@ If your workload's identity is a Kubernetes ServiceAccount token, prefer the `ku
 - [URI SAN Patterns](#uri-san-patterns)
 - [How the Certificate Reaches Warden](#how-the-certificate-reaches-warden)
 - [Role-Specific CAs](#role-specific-cas)
+- [Token Metadata](#token-metadata)
 - [Discovering Assumable Roles](#discovering-assumable-roles)
 - [Configuration Reference](#configuration-reference)
 - [Troubleshooting](#troubleshooting)
@@ -219,6 +220,18 @@ When a request comes in for this role, the cert is verified against `partner-ca.
 
 If `certificate` is omitted, the role falls back to the mount's `trusted_ca_pem`. If both are unset, the role cannot accept any certificate and login fails with the generic auth-failed error.
 
+## Token Metadata
+
+A role can copy verified certificate fields onto the issued token's metadata, where `token_metadata` policy conditions can match them. `metadata_mappings` is written as `cert-field = "destination-metadata-key"`, drawing from: `cn`, `serial`, `ou`, `org`, `dns_san`, `email_san`, and `uri_san`. Multi-valued fields (the SANs, OU, Org) are comma-joined.
+
+```bash
+warden write auth/cert/role/inventory-agent \
+  allowed_common_names="inventory-agent" \
+  metadata_mappings="ou=team,cn=cn"
+```
+
+A certificate with `OU=platform-core, CN=inventory-agent` yields metadata `team="platform-core"`, `cn="inventory-agent"`. A policy can then gate a path with `conditions { token_metadata = ["team=platform*"] }`. Unknown field selectors are rejected at role write time.
+
 ## Discovering Assumable Roles
 
 Agents that don't know which role to ask for can use Warden's namespace-wide introspection endpoint. The aggregator detects the credential format (certificate vs JWT vs Kubernetes SA JWT) and fans out only to auth mounts whose registered TokenType matches — so a certificate goes to cert mounts, a generic JWT goes to JWT mounts, a K8s SA token goes to kubernetes mounts. The workload doesn't need to know which mount serves it.
@@ -264,6 +277,7 @@ At least one of the `allowed_*` constraint fields must be set — wide-open role
 | `allowed_organizations` | One of six | Exact-match list against `Subject.Organization`. |
 | `certificate` | No | Role-specific CA PEM that replaces the mount's `trusted_ca_pem` for this role only. |
 | `principal_claim` | No | Per-role override of the mount's `principal_claim`. |
+| `metadata_mappings` | No | Map of certificate field (`cn`, `serial`, `ou`, `org`, `dns_san`, `email_san`, `uri_san`) → token metadata key. Multi-valued fields are comma-joined. |
 | `token_policies` | No | Warden policies attached to the issued token. |
 | `token_ttl` | No (default `1h`) | TTL for issued tokens; overrides the mount-level `token_ttl`; further capped by the certificate's `NotAfter`. |
 | `cred_spec_name` | No | Credential spec name to bind to this role; downstream provider gateways use it to mint the upstream credential. |


### PR DESCRIPTION
## Summary

Extends the cert auth method to populate the token's `Metadata` from verified X.509
certificate fields, so `token_metadata` policy conditions can gate on them.

- New per-role `metadata_mappings` config: `cert-field` → `metadata-key`
  (`source` → `key`, consistent with the JWT method's `metadata_claims`).
- Supported fields: `cn`, `serial`, `ou`, `org`, `dns_san`, `email_san`, `uri_san`.
  Multi-valued fields (OU, Org, the SAN lists) are comma-joined into a single
  deterministic value; empty fields are skipped.
- Field selectors are validated at role creation **and** update — an unknown
  selector is rejected.

## Tests

- Field extraction: all selectors, multi-valued comma-join, skip-empty, serial, nil
  mappings.
- Role-config round-trip of `metadata_mappings`; invalid-field rejection.

## Docs

- `docs/auth-methods/cert.md`: new "Token Metadata" section + config-reference row.

## Stack

Third of six PRs. Depends only on the merged token-metadata foundation; independent
of the others.
