### PR TITLE
feat(k8s-auth): populate token metadata from TokenReview attributes

### DIFF
--- a/auth/method/kubernetes/path_login.go
+++ b/auth/method/kubernetes/path_login.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -10,6 +11,49 @@ import (
 	lgr "github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
+
+// validK8sMetadataFields lists the verified TokenReview attributes usable in a
+// role's metadata_mappings.
+var validK8sMetadataFields = map[string]bool{
+	"service_account_namespace": true,
+	"service_account_name":      true,
+	"service_account_uid":       true,
+	"username":                  true,
+	"groups":                    true,
+}
+
+// extractK8sMetadata builds the token metadata map from verified TokenReview
+// attributes using the role's mappings (attribute -> metadata key, source ->
+// key). The multi-valued groups attribute is comma-joined. Empty values are
+// skipped. Returns nil when nothing was mapped.
+func extractK8sMetadata(mappings map[string]string, saNamespace, saName, uid, username string, groups []string) map[string]string {
+	if len(mappings) == 0 {
+		return nil
+	}
+	md := make(map[string]string)
+	for source, target := range mappings {
+		var v string
+		switch source {
+		case "service_account_namespace":
+			v = saNamespace
+		case "service_account_name":
+			v = saName
+		case "service_account_uid":
+			v = uid
+		case "username":
+			v = username
+		case "groups":
+			v = strings.Join(groups, ",")
+		}
+		if v != "" {
+			md[target] = v
+		}
+	}
+	if len(md) == 0 {
+		return nil
+	}
+	return md
+}
 
 // pathLogin returns the /login path definition.
 func (b *kubernetesAuthBackend) pathLogin() *framework.Path {
@@ -195,6 +239,7 @@ func (b *kubernetesAuthBackend) handleLogin(ctx context.Context, req *logical.Re
 			// (mountAccessor + JWT + role) into the deterministic cache ID
 			// used for transparent-mode lookups.
 			ClientToken: jwtStr,
+			Metadata:    extractK8sMetadata(role.MetadataMappings, saNamespace, saName, status.User.UID, status.User.Username, status.User.Groups),
 		},
 		Data: map[string]any{
 			"principal_id":              status.User.Username,

--- a/auth/method/kubernetes/path_role.go
+++ b/auth/method/kubernetes/path_role.go
@@ -57,6 +57,10 @@ func (b *kubernetesAuthBackend) pathRole() *framework.Path {
 				Type:        framework.TypeString,
 				Description: `Maximum elapsed time since the JWT was issued (iat). Rejects JWTs older than this. Example: "30m", "1h"`,
 			},
+			"metadata_mappings": {
+				Type:        framework.TypeMap,
+				Description: "Map of TokenReview attribute (service_account_namespace, service_account_name, service_account_uid, username, groups) to token metadata key. The groups attribute is comma-joined.",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{
@@ -149,6 +153,7 @@ func (b *kubernetesAuthBackend) handleRoleRead(ctx context.Context, _ *logical.R
 			"token_ttl":                        role.TokenTTL,
 			"cred_spec_name":                   role.CredSpecName,
 			"max_age":                          role.MaxAge,
+			"metadata_mappings":                role.MetadataMappings,
 		},
 	}, nil
 }
@@ -189,6 +194,9 @@ func (b *kubernetesAuthBackend) handleRoleUpdate(ctx context.Context, _ *logical
 		}
 		if v, ok := d.GetOk("max_age"); ok {
 			role.MaxAge = v.(string)
+		}
+		if v, ok := d.GetOk("metadata_mappings"); ok {
+			role.MetadataMappings = toStringMap(v.(map[string]any))
 		}
 	}
 
@@ -269,6 +277,14 @@ func (b *kubernetesAuthBackend) validateRole(role *KubernetesRole) error {
 		}
 	}
 
+	// Validate metadata_mappings attribute selectors (the map key is the source
+	// TokenReview attribute; the value is the destination metadata key).
+	for source, target := range role.MetadataMappings {
+		if !validK8sMetadataFields[source] {
+			return logical.ErrBadRequestf("invalid metadata_mappings field %q for metadata key %q; must be one of: service_account_namespace, service_account_name, service_account_uid, username, groups", source, target)
+		}
+	}
+
 	return nil
 }
 
@@ -315,8 +331,24 @@ func (b *kubernetesAuthBackend) buildRoleFromFieldData(name string, d *framework
 	if v, ok := d.GetOk("max_age"); ok {
 		role.MaxAge = v.(string)
 	}
+	if v, ok := d.GetOk("metadata_mappings"); ok {
+		role.MetadataMappings = toStringMap(v.(map[string]any))
+	}
 
 	return role
+}
+
+// toStringMap coerces a TypeMap field value into map[string]string, rendering
+// each value to its string form. Nil/empty input yields nil.
+func toStringMap(m map[string]any) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	return out
 }
 
 // Storage helpers — JSON-encoded under role/<name>.

--- a/auth/method/kubernetes/path_role_test.go
+++ b/auth/method/kubernetes/path_role_test.go
@@ -20,6 +20,75 @@ func roleFieldData(t *testing.T, b *kubernetesAuthBackend, raw map[string]any) *
 	return &framework.FieldData{Raw: raw, Schema: b.pathRole().Fields}
 }
 
+func TestExtractK8sMetadata(t *testing.T) {
+	t.Run("maps attributes, comma-joins groups, skips empty", func(t *testing.T) {
+		// mappings are source (TokenReview attribute) -> target (metadata key)
+		md := extractK8sMetadata(map[string]string{
+			"service_account_namespace": "ns",
+			"service_account_name":      "sa",
+			"service_account_uid":       "uid",
+			"username":                  "user",
+			"groups":                    "groups",
+		},
+			"prod", "deployer", "uid-123", "system:serviceaccount:prod:deployer",
+			[]string{"system:serviceaccounts", "system:serviceaccounts:prod"})
+		assert.Equal(t, map[string]string{
+			"ns":     "prod",
+			"sa":     "deployer",
+			"uid":    "uid-123",
+			"user":   "system:serviceaccount:prod:deployer",
+			"groups": "system:serviceaccounts,system:serviceaccounts:prod",
+		}, md)
+	})
+
+	t.Run("nil mappings", func(t *testing.T) {
+		assert.Nil(t, extractK8sMetadata(nil, "prod", "deployer", "uid", "user", nil))
+	})
+
+	t.Run("all empty -> nil", func(t *testing.T) {
+		assert.Nil(t, extractK8sMetadata(map[string]string{"groups": "g"}, "prod", "deployer", "uid", "user", nil))
+	})
+}
+
+func TestHandleRole_MetadataMappings_RoundTrip(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "meta",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"prod"},
+		"metadata_mappings": map[string]any{
+			"service_account_namespace": "ns",
+			"service_account_name":      "sa",
+		},
+	})
+	resp, err := b.handleRoleCreate(ctx, nil, d)
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "unexpected validation error: %v", resp.Err)
+
+	role, err := b.getRole(ctx, "meta")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"service_account_namespace": "ns",
+		"service_account_name":      "sa",
+	}, role.MetadataMappings)
+}
+
+func TestHandleRole_MetadataMappings_InvalidField(t *testing.T) {
+	b, ctx := newTestBackend(t)
+
+	d := roleFieldData(t, b, map[string]any{
+		"name":                             "bad-meta",
+		"bound_service_account_names":      []string{"app"},
+		"bound_service_account_namespaces": []string{"prod"},
+		"metadata_mappings":                map[string]any{"not_an_attr": "x"},
+	})
+	resp, err := b.handleRoleCreate(ctx, nil, d)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err)
+	assert.Contains(t, resp.Err.Error(), "invalid metadata_mappings field")
+}
+
 func TestHandleRoleCreate_Basic(t *testing.T) {
 	b, ctx := newTestBackend(t)
 

--- a/auth/method/kubernetes/role.go
+++ b/auth/method/kubernetes/role.go
@@ -33,6 +33,13 @@ type KubernetesRole struct {
 	// MaxAge optionally caps the elapsed time since the JWT's iat claim.
 	// Empty = no freshness check. Same shape as JWTRole.MaxAge.
 	MaxAge string `json:"max_age,omitempty"`
+
+	// MetadataMappings maps a verified TokenReview attribute to the token
+	// metadata key it populates (source -> key): service_account_namespace,
+	// service_account_name, service_account_uid, username, groups. The
+	// multi-valued groups attribute is comma-joined. Populated onto the token's
+	// Metadata and matched by token_metadata policy conditions.
+	MetadataMappings map[string]string `json:"metadata_mappings,omitempty"`
 }
 
 // ParseTokenTTL parses the TokenTTL string to a time.Duration.

--- a/docs/auth-methods/kubernetes.md
+++ b/docs/auth-methods/kubernetes.md
@@ -22,6 +22,7 @@ Operators who have used Vault's or OpenBao's `auth/kubernetes` will find the sha
 - [Self-Reviewing Mode (No `token_reviewer_jwt`)](#self-reviewing-mode-no-token_reviewer_jwt)
 - [Multi-Spoke Topologies](#multi-spoke-topologies)
 - [Audience Binding](#audience-binding)
+- [Token Metadata](#token-metadata)
 - [Discovering Assumable Roles](#discovering-assumable-roles)
 - [Configuration Reference](#configuration-reference)
 - [Troubleshooting](#troubleshooting)
@@ -190,6 +191,19 @@ The practical use:
 
 Without `audience`, the kube-apiserver returns whatever audiences the token naturally carries, and Warden accepts any of them. Add `audience` when you want enforcement; leave it empty when binding by SA name + namespace is enough.
 
+## Token Metadata
+
+A role can copy verified TokenReview attributes onto the issued token's metadata, where `token_metadata` policy conditions can match them. `metadata_mappings` is written as `attribute = "destination-metadata-key"`, drawing from: `service_account_namespace`, `service_account_name`, `service_account_uid`, `username`, and `groups` (multi-valued, comma-joined).
+
+```bash
+warden write auth/kubernetes/role/inventory-agent \
+  bound_service_account_names="inventory-agent" \
+  bound_service_account_namespaces="prod" \
+  metadata_mappings="service_account_namespace=ns,service_account_name=sa"
+```
+
+A workload whose SA is `system:serviceaccount:prod:inventory-agent` yields metadata `ns="prod"`, `sa="inventory-agent"`. A policy can then gate a path with `conditions { token_metadata = ["ns=prod"] }`. Unknown attribute selectors are rejected at role write time.
+
 ## Discovering Assumable Roles
 
 Agents that don't know which role to ask for can use Warden's namespace-wide introspection endpoint to discover the roles their token could assume. The workload doesn't need to know which auth mount serves it — the aggregator detects the token's shape, fans out to every auth mount in the namespace whose registered TokenType matches that shape, and merges the responses.
@@ -233,6 +247,7 @@ A Kubernetes SA token (recognized by its `sub: system:serviceaccount:*` claim) o
 | `token_ttl` | No (default `1h`) | TTL for issued tokens; overrides the mount-level `token_ttl`. |
 | `cred_spec_name` | No | Credential spec name for implicit-auth flows. |
 | `max_age` | No | Maximum elapsed time since the JWT's `iat` claim. Example: `30m`. Empty disables the check. |
+| `metadata_mappings` | No | Map of TokenReview attribute (`service_account_namespace`, `service_account_name`, `service_account_uid`, `username`, `groups`) → token metadata key. `groups` is comma-joined. |
 
 A `*`/`*` binding (both names and namespaces only contain `"*"`) is refused at role-create time — at least one of the two must contain a concrete value.
 


### PR DESCRIPTION
## Summary

Extends the Kubernetes auth method to populate the token's `Metadata` from verified
TokenReview attributes, so `token_metadata` policy conditions can gate on them.

- New per-role `metadata_mappings` config: `attribute` → `metadata-key`
  (`source` → `key`, consistent with the other auth methods).
- Supported attributes: `service_account_namespace`, `service_account_name`,
  `service_account_uid`, `username`, `groups`. The multi-valued `groups` is
  comma-joined; empty values are skipped.
- Attribute selectors are validated at role creation **and** update.

## Tests

- Attribute extraction: all selectors, groups comma-join, skip-empty, nil mappings.
- Role-config round-trip of `metadata_mappings`; invalid-field rejection.

## Docs

- `docs/auth-methods/kubernetes.md`: new "Token Metadata" section + config-reference
  row.

## Stack

Fourth of six PRs. Depends only on the merged token-metadata foundation; independent
of the others.
