### PR TITLE
feat(spiffe-auth): populate token metadata from SPIFFE ID and JWT-SVID claims

### DIFF
--- a/auth/method/spiffe/helpers.go
+++ b/auth/method/spiffe/helpers.go
@@ -4,12 +4,68 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/mitchellh/pointerstructure"
 	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logical"
 )
+
+// getClaim resolves a JWT-SVID claim value. A leading "/" is a JSON Pointer
+// (RFC 6901) for nested claims; any other string is a literal top-level key.
+// Returns nil when the claim is absent or the pointer cannot be walked (fail
+// closed). Mirrors the JWT auth method's getClaim, including the float ->
+// json.Number coercion so numeric claims stringify predictably.
+func getClaim(claims map[string]interface{}, claim string) interface{} {
+	var val interface{}
+	if !strings.HasPrefix(claim, "/") {
+		val = claims[claim]
+	} else {
+		v, err := pointerstructure.Get(claims, claim)
+		if err != nil {
+			return nil
+		}
+		val = v
+	}
+
+	switch v := val.(type) {
+	case float32:
+		return json.Number(strconv.Itoa(int(v)))
+	case float64:
+		return json.Number(strconv.Itoa(int(v)))
+	}
+	return val
+}
+
+// extractMetadata builds a token metadata map from JWT-SVID claims using the
+// role's claim mappings (source claim -> metadata key, matching OpenBao's
+// claim_mappings direction). Resolved values must be strings; a non-string
+// mapped claim is an error. Absent claims are skipped. Returns nil when nothing
+// was mapped.
+func extractMetadata(claims map[string]interface{}, claimMappings map[string]string) (map[string]string, error) {
+	if len(claimMappings) == 0 {
+		return nil, nil
+	}
+	metadata := make(map[string]string)
+	for source, target := range claimMappings {
+		value := getClaim(claims, source)
+		if value == nil {
+			continue
+		}
+		strValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("claim %q for metadata key %q is not a string", source, target)
+		}
+		metadata[target] = strValue
+	}
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	return metadata, nil
+}
 
 // maxActChainDepth bounds the nested "act" claims walked by extractActChain.
 const maxActChainDepth = 4

--- a/auth/method/spiffe/metadata_test.go
+++ b/auth/method/spiffe/metadata_test.go
@@ -1,0 +1,108 @@
+package spiffe
+
+import (
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractSPIFFEIDMetadata(t *testing.T) {
+	id, err := spiffeid.FromString("spiffe://example.org/ns/prod/sa/ci")
+	require.NoError(t, err)
+
+	t.Run("maps components", func(t *testing.T) {
+		// mappings are source (SPIFFE-ID component) -> target (metadata key)
+		md := extractSPIFFEIDMetadata(map[string]string{
+			"trust_domain": "td",
+			"spiffe_id":    "id",
+			"path":         "path",
+		}, id)
+		assert.Equal(t, map[string]string{
+			"td":   "example.org",
+			"id":   "spiffe://example.org/ns/prod/sa/ci",
+			"path": "/ns/prod/sa/ci",
+		}, md)
+	})
+
+	t.Run("nil mappings", func(t *testing.T) {
+		assert.Nil(t, extractSPIFFEIDMetadata(nil, id))
+	})
+
+	t.Run("unknown selector skipped -> nil", func(t *testing.T) {
+		assert.Nil(t, extractSPIFFEIDMetadata(map[string]string{"nope": "x"}, id))
+	})
+}
+
+func TestSpiffe_ExtractMetadata_Claims(t *testing.T) {
+	claims := map[string]interface{}{
+		"team": "platform-core",
+		"resource_access": map[string]interface{}{
+			"warden": map[string]interface{}{"env": "prod"},
+		},
+		"roles": []interface{}{"a", "b"},
+	}
+
+	t.Run("literal and nested pointer", func(t *testing.T) {
+		md, err := extractMetadata(claims, map[string]string{
+			"team":                        "team",
+			"/resource_access/warden/env": "env",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"team": "platform-core", "env": "prod"}, md)
+	})
+
+	t.Run("non-string claim errors", func(t *testing.T) {
+		_, err := extractMetadata(claims, map[string]string{"roles": "r"})
+		require.Error(t, err)
+	})
+
+	t.Run("nil mappings", func(t *testing.T) {
+		md, err := extractMetadata(claims, nil)
+		require.NoError(t, err)
+		assert.Nil(t, md)
+	})
+}
+
+func TestMergeStringMaps(t *testing.T) {
+	assert.Nil(t, mergeStringMaps(nil, nil))
+	assert.Equal(t, map[string]string{"a": "1"}, mergeStringMaps(map[string]string{"a": "1"}, nil))
+	// b wins on conflict.
+	assert.Equal(t, map[string]string{"a": "2", "b": "3"},
+		mergeStringMaps(map[string]string{"a": "1"}, map[string]string{"a": "2", "b": "3"}))
+}
+
+func TestRole_MetadataMappings_RoundTripAndValidation(t *testing.T) {
+	b, ctx := createTestBackend(t)
+
+	t.Run("round-trip", func(t *testing.T) {
+		resp := createRole(t, b, ctx, map[string]any{
+			"name":            "meta",
+			"trust_domain":    "example.org",
+			"bound_audiences": "warden",
+			"metadata_mappings": map[string]any{
+				"trust_domain": "td",
+			},
+			"metadata_claims": map[string]any{
+				"/resource_access/warden/env": "env",
+			},
+		})
+		require.Nil(t, resp.Err)
+
+		role, err := b.getRole(ctx, "meta")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"trust_domain": "td"}, role.MetadataMappings)
+		assert.Equal(t, map[string]string{"/resource_access/warden/env": "env"}, role.MetadataClaims)
+	})
+
+	t.Run("invalid metadata_mappings field rejected", func(t *testing.T) {
+		resp := createRole(t, b, ctx, map[string]any{
+			"name":              "bad-meta",
+			"trust_domain":      "example.org",
+			"metadata_mappings": map[string]any{"not_a_component": "x"},
+		})
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "invalid metadata_mappings field")
+	})
+}

--- a/auth/method/spiffe/path_login.go
+++ b/auth/method/spiffe/path_login.go
@@ -86,7 +86,8 @@ func (b *spiffeAuthBackend) handleX509SVIDLogin(ctx context.Context, req *logica
 
 	principalID := id.String()
 	fingerprint := certFingerprint(cert)
-	return b.authResponse(req, role, principalID, b.calculateTTL(cert.NotAfter, role), fingerprint, nil), nil
+	metadata := extractSPIFFEIDMetadata(role.MetadataMappings, id)
+	return b.authResponse(req, role, principalID, b.calculateTTL(cert.NotAfter, role), fingerprint, nil, metadata), nil
 }
 
 func (b *spiffeAuthBackend) handleJWTSVIDLogin(ctx context.Context, req *logical.Request, role *SPIFFERole, jwtToken string) (*logical.Response, error) {
@@ -117,14 +118,24 @@ func (b *spiffeAuthBackend) handleJWTSVIDLogin(ctx context.Context, req *logical
 
 	policies := b.resolveGroupPolicies(role, svid.Claims)
 	actors := extractActChain(svid.Claims)
-	resp := b.authResponse(req, role, svid.ID.String(), b.calculateTTL(svid.Expiry, role), jwtToken, actors)
+
+	// Metadata is drawn from both the verified SPIFFE-ID components and, for the
+	// JWT-SVID, the mapped claims. A non-string mapped claim fails the login.
+	claimMeta, err := extractMetadata(svid.Claims, role.MetadataClaims)
+	if err != nil {
+		b.logger.Warn("login failed: metadata claim extraction", lgr.Err(err), lgr.String("role", role.Name))
+		return &logical.Response{StatusCode: http.StatusUnauthorized, Err: errSPIFFEAuthFailed}, nil
+	}
+	metadata := mergeStringMaps(extractSPIFFEIDMetadata(role.MetadataMappings, svid.ID), claimMeta)
+
+	resp := b.authResponse(req, role, svid.ID.String(), b.calculateTTL(svid.Expiry, role), jwtToken, actors, metadata)
 	resp.Auth.Policies = policies
 	return resp, nil
 }
 
 // authResponse builds the common login response. policies default to the role's;
 // the JWT path overrides with group-resolved policies.
-func (b *spiffeAuthBackend) authResponse(req *logical.Request, role *SPIFFERole, principalID string, ttl time.Duration, clientToken string, actors []logical.ActorRef) *logical.Response {
+func (b *spiffeAuthBackend) authResponse(req *logical.Request, role *SPIFFERole, principalID string, ttl time.Duration, clientToken string, actors []logical.ActorRef, metadata map[string]string) *logical.Response {
 	return &logical.Response{
 		StatusCode: http.StatusOK,
 		Auth: &logical.Auth{
@@ -137,9 +148,62 @@ func (b *spiffeAuthBackend) authResponse(req *logical.Request, role *SPIFFERole,
 			ClientIP:       req.ClientIP,
 			ClientToken:    clientToken,
 			Actors:         actors,
+			Metadata:       metadata,
 		},
 		Data: map[string]any{"principal_id": principalID, "role": role.Name},
 	}
+}
+
+// validSPIFFEMetadataFields lists the SPIFFE-ID component selectors usable in a
+// role's metadata_mappings.
+var validSPIFFEMetadataFields = map[string]bool{
+	"trust_domain": true,
+	"spiffe_id":    true,
+	"path":         true,
+}
+
+// extractSPIFFEIDMetadata builds token metadata from the verified SPIFFE ID
+// using the role's mappings (SPIFFE-ID component -> metadata key, source ->
+// key). Empty values are skipped. Returns nil when nothing was mapped.
+func extractSPIFFEIDMetadata(mappings map[string]string, id spiffeid.ID) map[string]string {
+	if len(mappings) == 0 {
+		return nil
+	}
+	md := make(map[string]string)
+	for source, target := range mappings {
+		var v string
+		switch source {
+		case "trust_domain":
+			v = id.TrustDomain().String()
+		case "spiffe_id":
+			v = id.String()
+		case "path":
+			v = id.Path()
+		}
+		if v != "" {
+			md[target] = v
+		}
+	}
+	if len(md) == 0 {
+		return nil
+	}
+	return md
+}
+
+// mergeStringMaps merges b into a (b wins on key conflict). Returns nil when the
+// result is empty.
+func mergeStringMaps(a, b map[string]string) map[string]string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
 }
 
 // resolveGroupPolicies appends group-derived policies (JWT-SVID only) to the

--- a/auth/method/spiffe/path_role.go
+++ b/auth/method/spiffe/path_role.go
@@ -45,6 +45,14 @@ func (b *spiffeAuthBackend) pathRole() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Prefix prepended to each group name to form the policy name (default: group-)",
 			},
+			"metadata_mappings": {
+				Type:        framework.TypeMap,
+				Description: "Map of SPIFFE-ID component (trust_domain, spiffe_id, path) to token metadata key. Applies to both SVID flows.",
+			},
+			"metadata_claims": {
+				Type:        framework.TypeMap,
+				Description: "Map of JWT-SVID claim (literal key, or JSON Pointer /a/b for nested) to token metadata key. JWT-SVID logins only; resolved values must be strings.",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{Callback: b.handleRoleCreate, Summary: "Create a new role"},
@@ -116,6 +124,8 @@ func (b *spiffeAuthBackend) handleRoleRead(ctx context.Context, req *logical.Req
 			"cred_spec_name":      role.CredSpecName,
 			"groups_claim":        role.GroupsClaim,
 			"group_policy_prefix": role.GroupPolicyPrefix,
+			"metadata_mappings":   role.MetadataMappings,
+			"metadata_claims":     role.MetadataClaims,
 		},
 	}, nil
 }
@@ -157,6 +167,12 @@ func (b *spiffeAuthBackend) handleRoleUpdate(ctx context.Context, req *logical.R
 		}
 		if v, ok := d.GetOk("group_policy_prefix"); ok {
 			role.GroupPolicyPrefix = v.(string)
+		}
+		if v, ok := d.GetOk("metadata_mappings"); ok {
+			role.MetadataMappings = toStringMap(v.(map[string]any))
+		}
+		if v, ok := d.GetOk("metadata_claims"); ok {
+			role.MetadataClaims = toStringMap(v.(map[string]any))
 		}
 	}
 
@@ -220,6 +236,16 @@ func (b *spiffeAuthBackend) validateRole(role *SPIFFERole) error {
 	if _, err := role.ParseTokenTTL(); err != nil {
 		return logical.ErrBadRequestf("invalid token_ttl: %v", err)
 	}
+
+	// Validate metadata_mappings SPIFFE-ID component selectors (the map key is
+	// the source component; the value is the destination metadata key).
+	// metadata_claims keys are claim paths and need no validation (resolved at
+	// login).
+	for source, target := range role.MetadataMappings {
+		if !validSPIFFEMetadataFields[source] {
+			return logical.ErrBadRequestf("invalid metadata_mappings field %q for metadata key %q; must be one of: trust_domain, spiffe_id, path", source, target)
+		}
+	}
 	return nil
 }
 
@@ -260,7 +286,26 @@ func (b *spiffeAuthBackend) buildRoleFromFieldData(name string, d *framework.Fie
 	if v, ok := d.GetOk("group_policy_prefix"); ok {
 		role.GroupPolicyPrefix = v.(string)
 	}
+	if v, ok := d.GetOk("metadata_mappings"); ok {
+		role.MetadataMappings = toStringMap(v.(map[string]any))
+	}
+	if v, ok := d.GetOk("metadata_claims"); ok {
+		role.MetadataClaims = toStringMap(v.(map[string]any))
+	}
 	return role
+}
+
+// toStringMap coerces a TypeMap field value into map[string]string, rendering
+// each value to its string form. Nil/empty input yields nil.
+func toStringMap(m map[string]any) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	return out
 }
 
 // --- storage ---

--- a/auth/method/spiffe/role.go
+++ b/auth/method/spiffe/role.go
@@ -21,6 +21,18 @@ type SPIFFERole struct {
 	CredSpecName      string   `json:"cred_spec_name,omitempty"`
 	GroupsClaim       string   `json:"groups_claim,omitempty"`        // JWT-SVID group claim → policies
 	GroupPolicyPrefix string   `json:"group_policy_prefix,omitempty"` // prefix for group policies (default group-)
+
+	// MetadataMappings maps a SPIFFE-ID component to the token metadata key it
+	// populates (source -> key): trust_domain, spiffe_id, path. Applies to both
+	// SVID flows. Populated onto the token's Metadata and matched by
+	// token_metadata policy conditions.
+	MetadataMappings map[string]string `json:"metadata_mappings,omitempty"`
+
+	// MetadataClaims maps a JWT-SVID claim to the token metadata key it
+	// populates (source -> key). The source is a literal claim key, or a JSON
+	// Pointer "/a/b" for nested. JWT-SVID logins only. Resolved values must be
+	// strings.
+	MetadataClaims map[string]string `json:"metadata_claims,omitempty"`
 }
 
 // ParseTokenTTL parses the TokenTTL string to a time.Duration.

--- a/docs/auth-methods/spiffe.md
+++ b/docs/auth-methods/spiffe.md
@@ -26,6 +26,7 @@ If your workload's identity is an ordinary OIDC JWT (not a SPIFFE JWT-SVID), use
 - [Restricting Allowed SPIFFE IDs](#restricting-allowed-spiffe-ids)
 - [Federation](#federation)
 - [Group-Based Policies (JWT-SVID)](#group-based-policies-jwt-svid)
+- [Token Metadata](#token-metadata)
 - [On-Behalf-Of Chain (RFC 8693 `act` Claim)](#on-behalf-of-chain-rfc-8693-act-claim)
 - [Discovering Assumable Roles](#discovering-assumable-roles)
 - [Revocation and SVID Lifetime](#revocation-and-svid-lifetime)
@@ -214,6 +215,23 @@ warden write auth/spiffe/role/inventory-agent \
 
 A JWT-SVID carrying `"groups": ["engineering", "billing"]` gets `spiffe-engineering` and `spiffe-billing` appended to its policy list. The default prefix is `group-`. Warden accepts the claim as a JSON array, a comma-separated string, or a single string.
 
+## Token Metadata
+
+A role can copy verified attributes from the SVID onto the issued token's metadata, where `token_metadata` policy conditions can match them. Two mappings are available, both written as `source = "destination-metadata-key"`:
+
+- `metadata_mappings` — from SPIFFE-ID components (`trust_domain`, `spiffe_id`, `path`). Applies to **both** SVID flows.
+- `metadata_claims` — from JWT-SVID claims. The source is a literal claim name, or a JSON Pointer (leading `/`) for a nested claim. **JWT-SVID logins only**; resolved values must be strings.
+
+```bash
+warden write auth/spiffe/role/inventory-agent \
+  trust_domain="prod.example.org" \
+  bound_audiences="warden" \
+  metadata_mappings="trust_domain=td,path=workload" \
+  metadata_claims="/deploy/env=env"
+```
+
+An X.509-SVID `spiffe://prod.example.org/ns/prod/sa/ci` yields metadata `td="prod.example.org"`, `workload="/ns/prod/sa/ci"`. A JWT-SVID additionally maps its `deploy.env` claim to `env`. A policy can then gate a path with `conditions { token_metadata = ["env=prod"] }`. When both mappings produce the same key, the claim value wins.
+
 ## On-Behalf-Of Chain (RFC 8693 `act` Claim)
 
 RFC 8693 §4.1 defines an `act` claim that attests a delegation chain — "this token represents X, acting on behalf of Y." When a JWT-SVID carries it, Warden extracts the chain (up to a fixed depth of 4), marks each actor as verified (the trust domain signed it), and persists it on the issued token so downstream audit entries carry the full chain. No configuration needed; extraction happens automatically when the claim is present.
@@ -277,6 +295,8 @@ A trust domain is either **static** (a `bundle_pem`/`bundle_json` with no `bundl
 | `cred_spec_name` | No | Credential spec name for implicit-auth flows. |
 | `groups_claim` | No | JWT-SVID claim carrying group names for dynamic policy mapping (JWT-SVID only). |
 | `group_policy_prefix` | No (default `group-`) | Prefix prepended to each group name to form the policy name. |
+| `metadata_mappings` | No | Map of SPIFFE-ID component (`trust_domain`, `spiffe_id`, `path`) → token metadata key. Both SVID flows. |
+| `metadata_claims` | No | Map of JWT-SVID claim (literal or JSON Pointer) → token metadata key. JWT-SVID only; values must be strings. |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Extends the SPIFFE auth method to populate the token's `Metadata` from the verified
SVID, so `token_metadata` policy conditions can gate on it. Two mappings, both
`source` → `key`:

- `metadata_mappings` — from SPIFFE-ID components (`trust_domain`, `spiffe_id`,
  `path`). Applies to **both** SVID flows (X.509-SVID and JWT-SVID).
- `metadata_claims` — from JWT-SVID claims (literal claim key, or JSON Pointer for
  nested). **JWT-SVID logins only**; resolved values must be strings.

The two sources are merged onto the token's `Metadata` in the shared `authResponse`.
Component selectors are validated at role creation and update; a non-string mapped
claim fails the login closed.

## Tests

- SPIFFE-ID component extraction; claim extraction (literal + nested pointer +
  non-string error); map merge (claim value wins on key conflict).
- Role-config round-trip of both mappings; invalid-component rejection.

## Docs

- `docs/auth-methods/spiffe.md`: new "Token Metadata" section + config-reference rows.

## Stack

Fifth of six PRs. Depends only on the merged token-metadata foundation; independent
of the others.
