### PR TITLE
feat(audit): surface token metadata in policy results

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -223,6 +223,27 @@ func (f *JSONFormat) saltPolicyResultsField(ctx context.Context, pr *PolicyResul
 				pr.GrantingPolicies[i] = salted
 			}
 		}
+	case "token_metadata":
+		// "...token_metadata" salts every value; "...token_metadata.<key>"
+		// salts one key's value. Mirrors credential metadata salting.
+		if len(parts) == 1 {
+			for k, v := range pr.TokenMetadata {
+				if v == "" {
+					continue
+				}
+				salted, err := f.saltFn(ctx, v)
+				if err != nil {
+					return err
+				}
+				pr.TokenMetadata[k] = salted
+			}
+		} else if v, ok := pr.TokenMetadata[parts[1]]; ok && v != "" {
+			salted, err := f.saltFn(ctx, v)
+			if err != nil {
+				return err
+			}
+			pr.TokenMetadata[parts[1]] = salted
+		}
 	}
 
 	return nil

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -648,6 +648,65 @@ func TestFormatResponse(t *testing.T) {
 	}
 }
 
+func TestFormatTokenMetadataSalting(t *testing.T) {
+	mockSalt := func(ctx context.Context, data string) (string, error) {
+		return "hmac-sha256:" + data + "-salted", nil
+	}
+	newEntry := func() *LogEntry {
+		return &LogEntry{
+			Timestamp: time.Now(),
+			Auth: &Auth{
+				PolicyResults: &PolicyResults{
+					Allowed:       false,
+					TokenMetadata: map[string]string{"env": "dev", "team": "platform-core"},
+				},
+			},
+		}
+	}
+	format := func(t *testing.T, saltFields []string) map[string]string {
+		t.Helper()
+		opts := []JSONFormatOption{WithSaltFunc(mockSalt)}
+		if saltFields != nil {
+			opts = append(opts, WithSaltFields(saltFields))
+		}
+		f := NewJSONFormat(opts...)
+		data, err := f.FormatRequest(context.Background(), newEntry())
+		if err != nil {
+			t.Fatalf("FormatRequest failed: %v", err)
+		}
+		var got LogEntry
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		return got.Auth.PolicyResults.TokenMetadata
+	}
+	salted := func(s string) bool { return containsBytes([]byte(s), "hmac-sha256:") }
+
+	t.Run("clear by default", func(t *testing.T) {
+		md := format(t, nil)
+		if md["env"] != "dev" || md["team"] != "platform-core" {
+			t.Errorf("metadata should be clear, got %v", md)
+		}
+	})
+
+	t.Run("salt all keys", func(t *testing.T) {
+		md := format(t, []string{"auth.policy_results.token_metadata"})
+		if !salted(md["env"]) || !salted(md["team"]) {
+			t.Errorf("all values should be salted, got %v", md)
+		}
+	})
+
+	t.Run("salt one key", func(t *testing.T) {
+		md := format(t, []string{"auth.policy_results.token_metadata.team"})
+		if md["env"] != "dev" {
+			t.Errorf("env must stay clear, got %q", md["env"])
+		}
+		if !salted(md["team"]) {
+			t.Errorf("team should be salted, got %q", md["team"])
+		}
+	})
+}
+
 func TestFormatResponseWithSalting(t *testing.T) {
 	mockSalt := func(ctx context.Context, data string) (string, error) {
 		return "hmac-sha256:" + data + "-salted", nil

--- a/audit/types.go
+++ b/audit/types.go
@@ -133,6 +133,13 @@ type PolicyResults struct {
 	// such block applied. The field is omitempty so non-MCP audit
 	// records remain byte-identical to today's output.
 	MCPDecision *logical.MCPDecision `json:"mcp_decision,omitempty"`
+
+	// TokenMetadata is the authenticating token's verified, login-derived
+	// metadata, included so token_metadata policy decisions are explainable.
+	// omitempty so records for tokens without metadata stay byte-identical to
+	// today's output. Logged in clear by default; opt-in per-key HMAC salting
+	// via salt_fields (auth.policy_results.token_metadata[.<key>]).
+	TokenMetadata map[string]string `json:"token_metadata,omitempty"`
 }
 
 // AuthResult contains authentication result from login operations
@@ -308,6 +315,12 @@ func (e *LogEntry) Clone() *LogEntry {
 			if e.Auth.PolicyResults.GrantingPolicies != nil {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))
 				copy(clone.Auth.PolicyResults.GrantingPolicies, e.Auth.PolicyResults.GrantingPolicies)
+			}
+			if e.Auth.PolicyResults.TokenMetadata != nil {
+				clone.Auth.PolicyResults.TokenMetadata = make(map[string]string, len(e.Auth.PolicyResults.TokenMetadata))
+				for k, v := range e.Auth.PolicyResults.TokenMetadata {
+					clone.Auth.PolicyResults.TokenMetadata[k] = v
+				}
 			}
 		}
 		if e.Auth.Actors != nil {

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -160,6 +160,13 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 			if auth.MCPDecision != nil {
 				auditAuth.PolicyResults.MCPDecision = auth.MCPDecision
 			}
+			// Surface the token's verified metadata so token_metadata
+			// policy decisions (allow or deny) are explainable. Logged in
+			// clear by default; the format layer applies opt-in per-key
+			// HMAC salting via salt_fields.
+			if te != nil && len(te.Metadata) > 0 {
+				auditAuth.PolicyResults.TokenMetadata = te.Metadata
+			}
 		}
 	}
 

--- a/core/audit_test.go
+++ b/core/audit_test.go
@@ -574,7 +574,7 @@ func TestLoadAuditsReconcile(t *testing.T) {
 			Path:        "default",
 			Description: "primary",
 			Config:      map[string]any{"file_path": auditPath},
-			Declarative:  true,
+			Declarative: true,
 		}}
 
 		require.NoError(t, core.loadAudits(ctx))
@@ -690,7 +690,7 @@ func TestLoadAuditsReconcile(t *testing.T) {
 			Path:        "default/",
 			Accessor:    "audit_file_seed",
 			Config:      map[string]any{"file_path": filepath.Join(tmp, "audit.log"), "hmac_key": "x"},
-			Declarative:  true,
+			Declarative: true,
 			NamespaceID: namespace.RootNamespaceID,
 		}}
 		require.NoError(t, core.persistAudits(ctx))
@@ -721,7 +721,7 @@ func TestLoadAuditsReconcile(t *testing.T) {
 			Path:        "api-mount/",
 			Accessor:    "audit_file_apiseed",
 			Config:      map[string]any{"file_path": apiPath, "hmac_key": "x"},
-			Declarative:  false,
+			Declarative: false,
 			NamespaceID: namespace.RootNamespaceID,
 		}}
 		require.NoError(t, core.persistAudits(ctx))
@@ -756,7 +756,7 @@ func TestLoadAuditsReconcile(t *testing.T) {
 			Path:        "shared/",
 			Accessor:    "audit_file_apipre",
 			Config:      map[string]any{"file_path": filepath.Join(tmp, "api.log"), "hmac_key": "x"},
-			Declarative:  false,
+			Declarative: false,
 			NamespaceID: namespace.RootNamespaceID,
 		}}
 		require.NoError(t, core.persistAudits(ctx))
@@ -780,9 +780,9 @@ func TestEnableAudit_ConfigOriginProtection(t *testing.T) {
 
 	// Pre-seat a config-origin entry as if loadAudits had registered it.
 	core.audit.Entries = []*MountEntry{{
-		Class:      mountClassAudit,
-		Type:       "mock",
-		Path:       "owned/",
+		Class:       mountClassAudit,
+		Type:        "mock",
+		Path:        "owned/",
 		Declarative: true,
 	}}
 
@@ -801,9 +801,9 @@ func TestDisableAudit_ConfigOriginProtection(t *testing.T) {
 	core := createMockCoreForAudit()
 
 	core.audit.Entries = []*MountEntry{{
-		Class:      mountClassAudit,
-		Type:       "mock",
-		Path:       "owned/",
+		Class:       mountClassAudit,
+		Type:        "mock",
+		Path:        "owned/",
 		Declarative: true,
 	}}
 
@@ -1062,6 +1062,30 @@ func TestBuildAuditAuth_FromAuth(t *testing.T) {
 	assert.Equal(t, "agent-1", result.PrincipalID)
 	assert.True(t, result.PolicyResults.Allowed)
 	assert.Contains(t, result.PolicyResults.GrantingPolicies, "p1")
+}
+
+func TestBuildAuditAuth_SurfacesTokenMetadata(t *testing.T) {
+	auth := &logical.Auth{
+		PolicyResults: &sdklogical.PolicyResults{Allowed: false},
+	}
+	te := &logical.TokenEntry{
+		PrincipalID: "svc-ci",
+		Metadata:    map[string]string{"env": "dev", "team": "platform-core"},
+	}
+
+	result := buildAuditAuth(auth, te)
+	require.NotNil(t, result)
+	require.NotNil(t, result.PolicyResults)
+	assert.Equal(t, map[string]string{"env": "dev", "team": "platform-core"}, result.PolicyResults.TokenMetadata)
+}
+
+func TestBuildAuditAuth_NoTokenMetadataWhenEmpty(t *testing.T) {
+	auth := &logical.Auth{PolicyResults: &sdklogical.PolicyResults{Allowed: true}}
+	te := &logical.TokenEntry{PrincipalID: "svc-ci"}
+
+	result := buildAuditAuth(auth, te)
+	require.NotNil(t, result.PolicyResults)
+	assert.Nil(t, result.PolicyResults.TokenMetadata)
 }
 
 func TestBuildAuditAuth_AuthOverridesTE(t *testing.T) {

--- a/docs/audit-devices/file.md
+++ b/docs/audit-devices/file.md
@@ -172,8 +172,10 @@ for the reasoning; the operational summary:
 - **`salt_fields`** — dot-paths whose values are replaced with
   `hmac-sha256:<hex>` instead of plaintext. The default,
   `response.credential.data`, salts every secret Warden injects (access keys,
-  tokens, passwords). Extend it to hash more, e.g. `auth.token_id` or
-  `request.data.password`.
+  tokens, passwords). Extend it to hash more, e.g. `auth.token_id`,
+  `request.data.password`, or the token's verified identity attributes — a whole map
+  (`auth.policy_results.token_metadata`) or a single key
+  (`auth.policy_results.token_metadata.clearance`).
 - **`omit_fields`** — dot-paths dropped from the entry entirely. The defaults drop
   request and response bodies and headers, which are noisy and often sensitive.
 

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -16,7 +16,10 @@ Each operation produces two entries — a **request** entry when it arrives and 
 Between them they capture:
 
 - **Identity** — the [token](tokens.md) ID and accessor, token type, principal
-  and [role](roles.md), the granted policies, and the [namespace](namespaces.md).
+  and [role](roles.md), the granted policies, the [namespace](namespaces.md), and —
+  when the token carries them — its verified, login-derived **metadata** attributes
+  (clearance, team, on-behalf-of user), so a decision that turned on a
+  [`token_metadata`](policies.md#token_metadata) condition is explainable.
 - **Request** — operation, path, HTTP method, client IP, mount point and type,
   and whether it was transparent/unauthenticated/streamed.
 - **Response** — status, any warnings, the upstream URL for a proxied request,
@@ -35,11 +38,15 @@ log ever revealing it.
 
 By default Warden salts the **issued credential's secret data**
 (`response.credential.data`) — the access keys, tokens, and passwords Warden
-injects. Non-secret `metadata` (such as a forwarded token's subject) is logged in
-clear. You can extend or narrow this per device:
+injects. Non-secret metadata is logged in clear: a forwarded token's subject, and
+the token's verified identity attributes (`auth.policy_results.token_metadata`).
+That metadata is descriptive by design, but a value like a clearance level can still
+be sensitive — so it is salt-able per key. You can extend or narrow this per device:
 
-- `salt_fields` — additional dot-paths to HMAC (e.g. `auth.token_id`,
-  `request.data.password`).
+- `salt_fields` — additional dot-paths to HMAC. The path can be a whole map
+  (`auth.policy_results.token_metadata` salts every value) or a single key
+  (`auth.policy_results.token_metadata.clearance` salts just that one); other
+  examples are `auth.token_id` and `request.data.password`.
 - `omit_fields` — dot-paths to drop entirely.
 
 To check whether a known plaintext appears in the log, hash it with the same


### PR DESCRIPTION
## Summary

Surfaces the token's verified `Metadata` in the audit log, so an authorization
decision that turned on a `token_metadata` condition is explainable.

- Adds `TokenMetadata` to the audit `PolicyResults`, populated in `buildAuditAuth`
  from the token entry. It is `omitempty`, so records for tokens without metadata are
  byte-identical to today's output.
- Logged **in clear by default** (it is descriptive identity data), with **opt-in
  per-key HMAC salting** via `salt_fields` — the whole map
  (`auth.policy_results.token_metadata`) or a single key
  (`auth.policy_results.token_metadata.clearance`), mirroring the existing
  credential-metadata salting precedent.
- Extends the `LogEntry` deep-copy so the salted clone carries the new map.

## Tests

- `buildAuditAuth` surfaces / omits `TokenMetadata` correctly.
- Salting: clear by default, salt-all-keys, salt-one-key.

## Docs

- `docs/concepts/audit.md`: "What Gets Recorded" notes the metadata makes a
  `token_metadata` decision explainable; salting section documents the clear-by-default
  and per-key salt behavior.
- `docs/audit-devices/file.md`: `salt_fields` reference lists the new path.

## Stack

Sixth and final PR. Depends only on the merged token-metadata foundation; independent
of the others.
