### PR TITLE
feat(policy): add CEL evaluation foundation for policy conditions

### DIFF
--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// This file is the CEL evaluation layer for policy conditions: it builds the
+// evaluation environment(s), compiles and cost-bounds condition expressions,
+// and builds the per-request / per-call activations consumed by the policy
+// evaluator.
+//
+// Design notes:
+//   - Two envs: a base env (request/token/now) for path-level conditions and an
+//     MCP env (base + call) for mcp{} conditions. Two envs make a path-level
+//     condition that references call.* a COMPILE error, not a silent runtime
+//     deny.
+//   - request/token/call are map(string, dyn): the env is shared across every
+//     tool/path and cannot know an arbitrary argument's type. Type discipline is
+//     achieved at activation-build time (values typed from their source); a
+//     type-mismatched comparison surfaces as a runtime error → fail-closed deny.
+//   - Top-level containers are always bound as non-nil (possibly empty) maps, so
+//     has(request.data.x) is false rather than a nil-deref, and absent nested
+//     keys fail closed (deny).
+//
+// Namespaces exposed to expressions (all populated before policy evaluation in
+// handleNonLoginRequest — mount fields and request body are set before
+// CheckToken):
+//
+//	request.path, request.operation, request.client_ip,
+//	  request.mount_point, request.mount_type, request.mount_class,
+//	  request.mount_accessor, request.transparent, request.data.<k>
+//	token.principal, token.role, token.type, token.namespace,
+//	  token.policies (list), token.metadata.<k>, token.actors (list of
+//	  {subject, verified}), token.ttl_seconds, token.expires_at
+//	now (timestamp)
+//	call.method, call.tool, call.args.<k>, call.batch_index   (mcp{} only)
+//
+// Secret material (token value, accessor, client token) is never exposed.
+
+const (
+	// maxConditionCost bounds a single CEL evaluation, both statically (rejected
+	// at policy-write time) and at runtime (cel.CostLimit backstop). Units are
+	// cel-go's abstract cost units.
+	maxConditionCost uint64 = 1_000_000
+
+	// celInputSizeBound is the conservative size (entries / characters) the cost
+	// estimator assumes for our dynamic-map variables, so comprehensions/string
+	// ops over adversary-sized inputs are cost-bounded at compile time. Sized to
+	// the request/body cap; tightened when wired to the real cap.
+	celInputSizeBound uint64 = 8192
+)
+
+// celRequestInput is the request context mapped into the `request` namespace.
+// Decoupled from *logical.Request so the activation builder stays unit-testable;
+// the wiring layer adapts the request into this.
+type celRequestInput struct {
+	Path          string
+	Operation     string
+	ClientIP      string
+	MountPoint    string
+	MountType     string
+	MountClass    string
+	MountAccessor string
+	Transparent   bool
+	Data          map[string]any
+}
+
+// celTokenInput is the non-secret token context mapped into the `token`
+// namespace. Decoupled from *logical.TokenEntry so the activation builder stays
+// unit-testable; the wiring layer adapts the token entry into this.
+type celTokenInput struct {
+	Principal     string
+	Role          string
+	Type          string
+	NamespacePath string
+	Policies      []string
+	Metadata      map[string]string
+	Actors        []logical.ActorRef
+	TTLSeconds    int64
+	ExpiresAtUnix int64
+}
+
+// buildCELEnv constructs a CEL environment. When mcp is true the env also
+// declares the per-call `call` namespace, producing the MCP env; otherwise it
+// is the base (path-level) env.
+func buildCELEnv(mcp bool) (*cel.Env, error) {
+	opts := []cel.EnvOption{
+		// request-wide namespaces; dyn maps (see design note).
+		cel.Variable("request", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("token", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("now", cel.TimestampType),
+
+		// Optional types for concise optional-arg access: call.args.?x.orValue(d).
+		cel.OptionalTypes(),
+		// Allow numeric comparisons to mix int/double so `call.args.amount <= 1500`
+		// works whether the arg arrived as an integer or a decimal.
+		cel.CrossTypeNumericComparisons(true),
+
+		// source_ip replacement: cidrContains(cidr, ip) bool.
+		celCIDRContainsFunc(),
+	}
+	if mcp {
+		opts = append(opts, cel.Variable("call", cel.MapType(cel.StringType, cel.DynType)))
+	}
+	return cel.NewEnv(opts...)
+}
+
+// celCIDRContainsFunc declares cidrContains(cidr, ip) bool — reports whether ip
+// falls within the CIDR. A malformed cidr or ip yields a CEL error, which the
+// caller treats as a fail-closed deny.
+func celCIDRContainsFunc() cel.EnvOption {
+	return cel.Function("cidrContains",
+		cel.Overload("cidr_contains_string_string",
+			[]*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
+			cel.BinaryBinding(func(lhs, rhs ref.Val) ref.Val {
+				cidrStr, ok := lhs.Value().(string)
+				if !ok {
+					return types.NewErr("cidrContains: cidr argument is not a string")
+				}
+				ipStr, ok := rhs.Value().(string)
+				if !ok {
+					return types.NewErr("cidrContains: ip argument is not a string")
+				}
+				_, ipNet, err := net.ParseCIDR(cidrStr)
+				if err != nil {
+					return types.NewErr("cidrContains: invalid cidr")
+				}
+				ip := net.ParseIP(ipStr)
+				if ip == nil {
+					return types.NewErr("cidrContains: invalid ip")
+				}
+				return types.Bool(ipNet.Contains(ip))
+			}),
+		),
+	)
+}
+
+// celCostEstimator supplies input size bounds for our dynamic-map variables so
+// env.EstimateCost can bound an expression's worst-case cost at compile time.
+// cel-go owns the per-operation base costs; this only feeds the sizes cel-go
+// cannot infer.
+type celCostEstimator struct {
+	maxSize uint64
+}
+
+func (e celCostEstimator) EstimateSize(node checker.AstNode) *checker.SizeEstimate {
+	if path := node.Path(); len(path) > 0 {
+		switch path[0] {
+		case "request", "token", "call":
+			return &checker.SizeEstimate{Min: 0, Max: e.maxSize}
+		}
+	}
+	return nil
+}
+
+func (e celCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	return nil
+}
+
+// compileCELCondition compiles, type-checks, and cost-bounds a condition
+// expression against env, returning an executable program. It is the single
+// policy-write-time validation path: a syntax error, a non-bool result, an
+// undeclared reference (e.g. call.* in a path-level condition), or an
+// over-budget cost are all rejected here with a directed error.
+func compileCELCondition(env *cel.Env, src string) (cel.Program, error) {
+	ast, iss := env.Compile(src)
+	if iss != nil && iss.Err() != nil {
+		return nil, fmt.Errorf("condition does not compile: %w", iss.Err())
+	}
+	if !ast.OutputType().IsExactType(cel.BoolType) {
+		return nil, fmt.Errorf("condition must evaluate to bool, got %s", ast.OutputType())
+	}
+
+	est, err := env.EstimateCost(ast, celCostEstimator{maxSize: celInputSizeBound})
+	if err != nil {
+		return nil, fmt.Errorf("condition cost estimation failed: %w", err)
+	}
+	if est.Max > maxConditionCost {
+		return nil, fmt.Errorf("condition worst-case cost %d exceeds limit %d", est.Max, maxConditionCost)
+	}
+
+	prg, err := env.Program(ast, cel.CostLimit(maxConditionCost))
+	if err != nil {
+		return nil, fmt.Errorf("condition program construction failed: %w", err)
+	}
+	return prg, nil
+}
+
+// evalCELCondition evaluates a compiled condition against an activation.
+// It is fail-closed: any evaluation error (type mismatch, missing key,
+// runtime cost-limit) returns (false, err) so callers deny. The error is for
+// audit categorization only and must not be surfaced to clients verbatim.
+func evalCELCondition(prg cel.Program, activation map[string]any) (bool, error) {
+	out, _, err := prg.Eval(activation)
+	if err != nil {
+		return false, err
+	}
+	b, ok := out.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("condition did not evaluate to bool")
+	}
+	return b, nil
+}
+
+// buildBaseActivation assembles the request-wide activation shared by path-level
+// and mcp{} conditions. Containers are always non-nil so has() works and absent
+// nested keys fail closed. now is the once-per-request snapshot.
+func buildBaseActivation(req celRequestInput, tok celTokenInput, now time.Time) map[string]any {
+	data := req.Data
+	if data == nil {
+		data = map[string]any{}
+	}
+
+	md := make(map[string]any, len(tok.Metadata))
+	for k, v := range tok.Metadata {
+		md[k] = v
+	}
+
+	acts := make([]any, 0, len(tok.Actors))
+	for _, a := range tok.Actors {
+		acts = append(acts, map[string]any{
+			"subject":  a.Subject,
+			"verified": a.Verified,
+		})
+	}
+
+	policies := make([]any, 0, len(tok.Policies))
+	for _, p := range tok.Policies {
+		policies = append(policies, p)
+	}
+
+	return map[string]any{
+		"request": map[string]any{
+			"path":           req.Path,
+			"operation":      req.Operation,
+			"client_ip":      req.ClientIP,
+			"mount_point":    req.MountPoint,
+			"mount_type":     req.MountType,
+			"mount_class":    req.MountClass,
+			"mount_accessor": req.MountAccessor,
+			"transparent":    req.Transparent,
+			"data":           data,
+		},
+		"token": map[string]any{
+			"principal":   tok.Principal,
+			"role":        tok.Role,
+			"type":        tok.Type,
+			"namespace":   tok.NamespacePath,
+			"policies":    policies,
+			"metadata":    md,
+			"actors":      acts,
+			"ttl_seconds": tok.TTLSeconds,
+			"expires_at":  tok.ExpiresAtUnix,
+		},
+		"now": now,
+	}
+}
+
+// addCallToActivation layers the per-call `call` namespace onto a base
+// activation for an mcp{} condition. args are typed from ParamValue.Kind;
+// non-scalar / null / missing values are omitted so absent-key access fails
+// closed. Mutates and returns base.
+func addCallToActivation(base map[string]any, method, tool string, matchArgs map[string]logical.ParamValue, batchIndex int) map[string]any {
+	args := make(map[string]any, len(matchArgs))
+	for k, pv := range matchArgs {
+		if v, ok := paramValueToCEL(pv); ok {
+			args[k] = v
+		}
+	}
+	base["call"] = map[string]any{
+		"method":      method,
+		"tool":        tool,
+		"args":        args,
+		"batch_index": batchIndex,
+	}
+	return base
+}
+
+// paramValueToCEL converts a parsed MCP argument to a typed CEL value. Only
+// scalars are bound (number→float64, bool, string); null/object/array/missing
+// return ok=false so the argument is absent in the activation and any access
+// fails closed.
+func paramValueToCEL(pv logical.ParamValue) (any, bool) {
+	switch pv.Kind {
+	case logical.ParamNumber:
+		f, err := strconv.ParseFloat(pv.Str, 64)
+		if err != nil {
+			return nil, false
+		}
+		return f, true
+	case logical.ParamBool:
+		return pv.Str == "true", true
+	case logical.ParamString:
+		return pv.Str, true
+	default:
+		return nil, false
+	}
+}

--- a/core/policy_cel_test.go
+++ b/core/policy_cel_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// mustEnv builds the base or MCP env or fails the test.
+func mustEnv(t *testing.T, mcp bool) *cel.Env {
+	t.Helper()
+	env, err := buildCELEnv(mcp)
+	if err != nil {
+		t.Fatalf("buildCELEnv(mcp=%v): %v", mcp, err)
+	}
+	return env
+}
+
+// mustCompile compiles src against env or fails the test.
+func mustCompile(t *testing.T, env *cel.Env, src string) cel.Program {
+	t.Helper()
+	prg, err := compileCELCondition(env, src)
+	if err != nil {
+		t.Fatalf("compile %q: %v", src, err)
+	}
+	return prg
+}
+
+// baseAct is a minimal request/token activation for path-level tests.
+func baseAct(req celRequestInput, tok celTokenInput, now time.Time) map[string]any {
+	return buildBaseActivation(req, tok, now)
+}
+
+// mcpAct is a base activation plus a single call namespace.
+func mcpAct(now time.Time, tool string, args map[string]logical.ParamValue) map[string]any {
+	base := buildBaseActivation(celRequestInput{Path: "mcp/x", Operation: "update"}, celTokenInput{}, now)
+	return addCallToActivation(base, "tools/call", tool, args, 0)
+}
+
+func num(s string) logical.ParamValue { return logical.ParamValue{Kind: logical.ParamNumber, Str: s} }
+func str(s string) logical.ParamValue { return logical.ParamValue{Kind: logical.ParamString, Str: s} }
+
+func TestCEL_PathLevelEnvRejectsCallReference(t *testing.T) {
+	// A path-level (base) env must NOT know call.* — referencing it is a
+	// compile-time error, never a silent runtime deny.
+	if _, err := compileCELCondition(mustEnv(t, false), "call.args.amount <= 1500"); err == nil {
+		t.Fatal("expected compile error for call.* in path-level env, got nil")
+	}
+	// The MCP env accepts the same expression.
+	mustCompile(t, mustEnv(t, true), "call.args.amount <= 1500")
+}
+
+func TestCEL_NonBoolRejected(t *testing.T) {
+	if _, err := compileCELCondition(mustEnv(t, false), "1 + 1"); err == nil {
+		t.Fatal("expected rejection of non-bool condition")
+	}
+}
+
+func TestCEL_NumericComparison(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, true), "call.args.amount <= 1500")
+	now := time.Unix(0, 0).UTC()
+
+	got, err := evalCELCondition(prg, mcpAct(now, "create_payment", map[string]logical.ParamValue{"amount": num("1200")}))
+	if err != nil || !got {
+		t.Fatalf("amount=1200: got=%v err=%v, want true", got, err)
+	}
+	got, err = evalCELCondition(prg, mcpAct(now, "create_payment", map[string]logical.ParamValue{"amount": num("2000")}))
+	if err != nil || got {
+		t.Fatalf("amount=2000: got=%v err=%v, want false", got, err)
+	}
+}
+
+func TestCEL_MissingArgFailsClosed(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, true), "call.args.amount <= 1500")
+	got, err := evalCELCondition(prg, mcpAct(time.Unix(0, 0).UTC(), "create_payment", nil))
+	if err == nil {
+		t.Fatal("missing arg: expected eval error (fail-closed deny), got nil")
+	}
+	if got {
+		t.Fatal("missing arg: must not allow")
+	}
+}
+
+func TestCEL_OptionalArgPasses(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, true), "call.args.?amount.orValue(0.0) <= 1500")
+	now := time.Unix(0, 0).UTC()
+
+	got, err := evalCELCondition(prg, mcpAct(now, "create_payment", nil))
+	if err != nil || !got {
+		t.Fatalf("absent optional: got=%v err=%v, want true", got, err)
+	}
+	got, err = evalCELCondition(prg, mcpAct(now, "create_payment", map[string]logical.ParamValue{"amount": num("2000")}))
+	if err != nil || got {
+		t.Fatalf("present-and-over: got=%v err=%v, want false", got, err)
+	}
+}
+
+func TestCEL_StringVsNumericFailsClosed(t *testing.T) {
+	// A string argument against a numeric comparison must NOT silently match;
+	// it surfaces as a runtime error → deny.
+	prg := mustCompile(t, mustEnv(t, true), "call.args.amount <= 1500")
+	got, err := evalCELCondition(prg, mcpAct(time.Unix(0, 0).UTC(), "create_payment", map[string]logical.ParamValue{"amount": str("2000")}))
+	if err == nil {
+		t.Fatal("string vs numeric: expected eval error, got nil")
+	}
+	if got {
+		t.Fatal("string vs numeric: must not allow")
+	}
+}
+
+func TestCEL_TokenMetadataSet(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, false), "token.metadata.env in ['dev', 'staging']")
+	now := time.Unix(0, 0).UTC()
+
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Metadata: map[string]string{"env": "dev"}}, now))
+	if err != nil || !got {
+		t.Fatalf("env=dev: got=%v err=%v, want true", got, err)
+	}
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Metadata: map[string]string{"env": "prod"}}, now))
+	if err != nil || got {
+		t.Fatalf("env=prod: got=%v err=%v, want false", got, err)
+	}
+	// Absent key fails closed (matches the old token_metadata semantics).
+	if _, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{}, now)); err == nil {
+		t.Fatal("absent metadata key: expected eval error (fail-closed)")
+	}
+}
+
+func TestCEL_PoliciesMembership(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, false), "'admin' in token.policies")
+	now := time.Unix(0, 0).UTC()
+
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Policies: []string{"admin", "reader"}}, now))
+	if err != nil || !got {
+		t.Fatalf("admin present: got=%v err=%v, want true", got, err)
+	}
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Policies: []string{"reader"}}, now))
+	if err != nil || got {
+		t.Fatalf("admin absent: got=%v err=%v, want false", got, err)
+	}
+}
+
+func TestCEL_CIDRContains(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, false), "cidrContains('10.0.0.0/8', request.client_ip)")
+	now := time.Unix(0, 0).UTC()
+
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "10.1.2.3"}, celTokenInput{}, now))
+	if err != nil || !got {
+		t.Fatalf("in-range: got=%v err=%v, want true", got, err)
+	}
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "192.168.1.1"}, celTokenInput{}, now))
+	if err != nil || got {
+		t.Fatalf("out-of-range: got=%v err=%v, want false", got, err)
+	}
+	// A malformed client IP yields an error (fail-closed).
+	if _, err := evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "not-an-ip"}, celTokenInput{}, now)); err == nil {
+		t.Fatal("invalid ip: expected eval error")
+	}
+}
+
+func TestCEL_TimeFunctions(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, false), `now.getHours("UTC") >= 8 && now.getHours("UTC") < 18`)
+
+	inHours := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{}, inHours))
+	if err != nil || !got {
+		t.Fatalf("09:00 UTC: got=%v err=%v, want true", got, err)
+	}
+	outHours := time.Date(2026, 6, 30, 22, 0, 0, 0, time.UTC)
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{}, outHours))
+	if err != nil || got {
+		t.Fatalf("22:00 UTC: got=%v err=%v, want false", got, err)
+	}
+}
+
+func TestCEL_RequestMountFields(t *testing.T) {
+	prg := mustCompile(t, mustEnv(t, false), `request.mount_type == "aws" && request.transparent`)
+	now := time.Unix(0, 0).UTC()
+
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{MountType: "aws", Transparent: true}, celTokenInput{}, now))
+	if err != nil || !got {
+		t.Fatalf("aws+transparent: got=%v err=%v, want true", got, err)
+	}
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{MountType: "vault", Transparent: true}, celTokenInput{}, now))
+	if err != nil || got {
+		t.Fatalf("vault: got=%v err=%v, want false", got, err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/go-jose/go-jose/v3 v3.0.5
 	github.com/go-viper/mapstructure/v2 v2.5.0
+	github.com/google/cel-go v0.28.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/hcl/v2 v2.24.0
@@ -44,6 +45,7 @@ require (
 )
 
 require (
+	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.121.6 // indirect
 	cloud.google.com/go/auth v0.18.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -66,6 +68,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
@@ -130,6 +133,8 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	google.golang.org/api v0.264.0 // indirect
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=
 cloud.google.com/go v0.121.6/go.mod h1:coChdst4Ea5vUpiALcYKXEpR1S9ZgXbhEzzMcMR66vI=
@@ -56,6 +58,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.301 h1:8mgvCpqsv3mQAcqZ/baAaMGUBj5J6MKMhxLd+K8L27Q=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.301/go.mod h1:Api2AkmMgGaSUAhmk76oaFObkoeCPc/bKAqcyplPODs=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
@@ -198,6 +202,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -514,6 +520,7 @@ go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -524,6 +531,8 @@ golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
+golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=


### PR DESCRIPTION
First PR in a stack introducing **Google CEL** (`github.com/google/cel-go`) as the predicate/value layer for CBP policy conditions.

## What

A new `core/policy_cel.go` evaluation layer:

- **Two environments** — a base env (`request` / `token` / `now`) for path-level conditions and an MCP env (base + `call`) for `mcp{}` conditions. This makes a path-level reference to `call.*` a **compile-time** error rather than a silent runtime deny.
- **Custom function** `cidrContains(cidr, ip)` (source-IP predicates); `OptionalTypes()` (`x.?field.orValue(d)`) and `CrossTypeNumericComparisons` enabled.
- **Compiler** — type-check, non-bool rejection, static `EstimateCost` against input-size bounds, and a runtime `CostLimit` attached only when the worst-case cost is input-size-dependent.
- **Fail-closed eval** — any evaluation error maps to deny; request/token activation builders expose the declared namespaces.

## Scope

Foundation only — no policy surface consumes it yet (path-level and per-call `condition` land in the following PRs). **No behavior change** to existing policies.

## Tests

`core/policy_cel_test.go`: numeric / set / string ops, `cidrContains`, timezone built-ins, missing-key fail-closed, string-vs-numeric fail-closed, and the two-env rejection.

---

Part of the CEL policy-conditions stack; merges into `main` first, ahead of the path-level / per-call condition PRs.