### PR TITLE
feat(audit): add ConditionResult for CEL condition decisions

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -140,6 +140,11 @@ type PolicyResults struct {
 	// today's output. Logged in clear by default; opt-in per-key HMAC salting
 	// via salt_fields (auth.policy_results.token_metadata[.<key>]).
 	TokenMetadata map[string]string `json:"token_metadata,omitempty"`
+
+	// Condition carries the path-level CEL condition decision when a condition
+	// was evaluated for a non-MCP request (the MCP per-call condition is
+	// recorded on MCPDecision.Condition instead). nil when none applied.
+	Condition *logical.ConditionResult `json:"condition,omitempty"`
 }
 
 // AuthResult contains authentication result from login operations
@@ -311,6 +316,7 @@ func (e *LogEntry) Clone() *LogEntry {
 			clone.Auth.PolicyResults = &PolicyResults{
 				Allowed:     e.Auth.PolicyResults.Allowed,
 				MCPDecision: e.Auth.PolicyResults.MCPDecision.Clone(),
+				Condition:   e.Auth.PolicyResults.Condition.Clone(),
 			}
 			if e.Auth.PolicyResults.GrantingPolicies != nil {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -1,6 +1,7 @@
 package logical
 
 import (
+	"strings"
 	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -136,6 +137,11 @@ type MCPDecision struct {
 	// NOT participate in the strongest-reason ranking that selects
 	// which set's deny surfaces on a multi-set deny.
 	BatchIndex *int `json:"batch_index,omitempty"`
+
+	// Condition carries the CEL condition decision when an mcp{} condition
+	// was evaluated for this call. Populated when RuleType is "condition" or
+	// "condition_error"; nil when no condition applied.
+	Condition *ConditionResult `json:"condition,omitempty"`
 }
 
 // Clone returns a deep copy of the MCPDecision. Safe to call on a nil
@@ -149,7 +155,82 @@ func (d *MCPDecision) Clone() *MCPDecision {
 		idx := *d.BatchIndex
 		clone.BatchIndex = &idx
 	}
+	clone.Condition = d.Condition.Clone()
 	return &clone
+}
+
+// ConditionResult is the audited outcome of evaluating a CEL condition. It is
+// recorded at both audit sites — PolicyResults.Condition (path-level) and
+// MCPDecision.Condition (per-call) — and carries enough to explain a decision
+// without sub-expression tracing: the operator-authored expression, the
+// referenced input values, and (on a fail-closed error) a sanitized category.
+//
+// Hygiene: Expression is operator-authored and safe to log. Inputs values may
+// be adversary-influenced and are CTL-stripped here; secret-bearing keys are
+// redacted/salted by the audit format layer. ErrorKind is a category, never a
+// raw eval-error string or adversary value.
+type ConditionResult struct {
+	// Decision is "allow" or "deny".
+	Decision string `json:"decision"`
+
+	// Expression is the CEL text that decided (the deciding condition on an
+	// OR-merge across policies).
+	Expression string `json:"expression,omitempty"`
+
+	// ErrorKind is a sanitized category for a fail-closed eval error
+	// (e.g. "no_such_key", "type_mismatch", "cost_exceeded"); empty for a
+	// clean allow/deny.
+	ErrorKind string `json:"error_kind,omitempty"`
+
+	// Inputs maps the expression's referenced variables to their CTL-stripped
+	// values so a denial is self-explanatory. Sensitive keys are
+	// redacted/salted by the audit format layer.
+	Inputs map[string]string `json:"inputs,omitempty"`
+}
+
+// Clone returns a deep copy of the ConditionResult. Safe to call on a nil
+// receiver (returns nil).
+func (c *ConditionResult) Clone() *ConditionResult {
+	if c == nil {
+		return nil
+	}
+	clone := *c
+	if c.Inputs != nil {
+		clone.Inputs = make(map[string]string, len(c.Inputs))
+		for k, v := range c.Inputs {
+			clone.Inputs[k] = v
+		}
+	}
+	return &clone
+}
+
+// Sanitize CTL-strips string fields so adversary-influenced input values
+// cannot inject control characters into audit records. Redaction/salting of
+// sensitive Inputs keys is applied separately by the audit format layer.
+func (c *ConditionResult) Sanitize() {
+	if c == nil {
+		return
+	}
+	c.Decision = stripControlChars(c.Decision)
+	c.Expression = stripControlChars(c.Expression)
+	c.ErrorKind = stripControlChars(c.ErrorKind)
+	if c.Inputs != nil {
+		cleaned := make(map[string]string, len(c.Inputs))
+		for k, v := range c.Inputs {
+			cleaned[stripControlChars(k)] = stripControlChars(v)
+		}
+		c.Inputs = cleaned
+	}
+}
+
+// stripControlChars removes C0 control characters and DEL.
+func stripControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7F {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // ActorRef identifies a subject in the on-behalf-of chain. Verified

--- a/logical/auth_test.go
+++ b/logical/auth_test.go
@@ -94,3 +94,37 @@ func TestMCPDecision_Clone_DeepCopy(t *testing.T) {
 	assert.Equal(t, "delete_repository", original.Name)
 	assert.Equal(t, "delete_*", original.MatchedRule)
 }
+
+func TestConditionResult_Clone(t *testing.T) {
+	assert.Nil(t, (*ConditionResult)(nil).Clone())
+
+	original := &ConditionResult{
+		Decision:   "deny",
+		Expression: "call.args.amount <= 1500",
+		Inputs:     map[string]string{"call.args.amount": "2000"},
+	}
+	clone := original.Clone()
+	require.NotNil(t, clone)
+	assert.Equal(t, *original, *clone)
+
+	// Mutating the clone's map must not affect the original.
+	clone.Inputs["call.args.amount"] = "0"
+	clone.Decision = "allow"
+	assert.Equal(t, "2000", original.Inputs["call.args.amount"])
+	assert.Equal(t, "deny", original.Decision)
+}
+
+func TestConditionResult_Sanitize(t *testing.T) {
+	(*ConditionResult)(nil).Sanitize() // nil-safe
+
+	c := &ConditionResult{
+		Decision:   "deny",
+		Expression: "call.args.x <= 1\x00",
+		ErrorKind:  "type_mismatch\n",
+		Inputs:     map[string]string{"call.args.x\x07": "ab\x1bcd"},
+	}
+	c.Sanitize()
+	assert.Equal(t, "call.args.x <= 1", c.Expression)
+	assert.Equal(t, "type_mismatch", c.ErrorKind)
+	assert.Equal(t, map[string]string{"call.args.x": "abcd"}, c.Inputs)
+}


### PR DESCRIPTION
Second PR in the CEL policy-conditions stack (depends on #362, now merged).

## What

Introduces the `logical.ConditionResult` audit type — the structured, explainable record of a CEL condition decision:

- `Decision` (`allow`/`deny`), `Expression` (the deciding CEL text), `ErrorKind` (a sanitized category on a fail-closed error), and `Inputs` (the referenced variable values — populated by a later PR).
- `Clone` (deep copy) and `Sanitize` (CTL-strips adversary-influenced fields) for safe audit handling.
- Referenced from both audit sites: `MCPDecision.Condition` (per-call) and `audit.PolicyResults.Condition` (path-level).

## Scope

Type + wiring only — **no producer yet** (path-level and per-call evaluators set it in later PRs). No behavior change.

## Tests

`logical/auth_test.go`: `ConditionResult` sanitize/clone (nil-safe, CTL-stripping of expression/error/input values).
