### PR TITLE
feat(policy): evaluate path-level CEL conditions in CBP

### DIFF
--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -160,6 +160,11 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 			if auth.MCPDecision != nil {
 				auditAuth.PolicyResults.MCPDecision = auth.MCPDecision
 			}
+			// Surface the path-level CEL condition decision (non-MCP paths)
+			// so denials carry their reason. Already Sanitized at evaluation.
+			if auth.Condition != nil {
+				auditAuth.PolicyResults.Condition = auth.Condition
+			}
 			// Surface the token's verified metadata so token_metadata
 			// policy decisions (allow or deny) are explainable. Logged in
 			// clear by default; the format layer applies opt-in per-key

--- a/core/policy.go
+++ b/core/policy.go
@@ -120,6 +120,11 @@ type PathRules struct {
 	ResponseKeysFilterPathHCL string              `hcl:"list_scan_response_keys_filter_path"`
 	ConditionsHCL             map[string][]string `hcl:"conditions"`
 
+	// ConditionHCL is the optional path-level CEL condition expression. The
+	// rule applies only if it evaluates true (in addition to the structured
+	// gates). Compiled at parse time into pc.Permissions.Conditions.
+	ConditionHCL string `hcl:"condition"`
+
 	// MCPHCL is the parsed `mcp { }` block. Nil when no such block is
 	// present on this path stanza. Stored on PathRules as the HCL
 	// decode target; the parser then validates it and appends a
@@ -157,6 +162,12 @@ type CBPPermissions struct {
 	// Non-nil: each entry is one policy's conditions; request must satisfy at
 	// least one set (OR between sets, AND within each set's types).
 	ConditionSets []*PolicyConditions
+	// Conditions holds compiled path-level CEL conditions from all merged
+	// policies for this path. nil means no CEL condition (unconditional at this
+	// layer). Non-nil: the gate passes if at least one program evaluates true
+	// (OR across policies), ANDed with the ConditionSets gate. Programs are
+	// immutable and shared (not deep-copied) across merged CBPs.
+	Conditions []*compiledCondition
 	// MCP holds mcp { } rule-sets from all merged policies for this path.
 	// nil/empty means no MCP enforcement applies. Non-nil: each entry is one
 	// source stanza's mcp block; a request is allowed if at least one set
@@ -287,6 +298,15 @@ func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
 	}
 
 	switch {
+	case p.Conditions == nil:
+	case len(p.Conditions) == 0:
+		ret.Conditions = make([]*compiledCondition, 0)
+	default:
+		// Programs are immutable; copy the slice of pointers, not the programs.
+		ret.Conditions = append([]*compiledCondition(nil), p.Conditions...)
+	}
+
+	switch {
 	case p.MCP == nil:
 	case len(p.MCP) == 0:
 		ret.MCP = make([]*CBPMCPRules, 0)
@@ -390,6 +410,7 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			"expiration",
 			"list_scan_response_keys_filter_path",
 			"conditions",
+			"condition",
 			"mcp",
 		}
 		if err := hclutil.CheckHCLKeys(item.Val, valid); err != nil {
@@ -527,6 +548,18 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 				return fmt.Errorf("path %q: %w", key, err)
 			}
 			pc.Permissions.ConditionSets = []*PolicyConditions{conditions}
+		}
+
+		if pc.ConditionHCL != "" {
+			env, err := baseCELEnv()
+			if err != nil {
+				return fmt.Errorf("path %q: cel env: %w", key, err)
+			}
+			prg, err := compileCELCondition(env, pc.ConditionHCL)
+			if err != nil {
+				return fmt.Errorf("path %q condition: %w", key, err)
+			}
+			pc.Permissions.Conditions = []*compiledCondition{{Source: pc.ConditionHCL, Program: prg}}
 		}
 
 		if pc.MCPHCL != nil {

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -69,6 +69,11 @@ type CBPResults struct {
 	// possible — the MCP gate runs between conditions and the
 	// parameter check, so a later check can deny after MCP allows.
 	MCPDecision *logical.MCPDecision
+
+	// Condition is populated when a path-level CEL condition was evaluated,
+	// carrying the audited decision (expression + sanitized error). nil when
+	// the matched permission had no path-level condition.
+	Condition *logical.ConditionResult
 }
 
 const limitParameterName = "limit"
@@ -256,14 +261,33 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 			// If existing is already unconditional (nil), it stays nil.
 			// If the new policy has no conditions, clear to nil (unconditional wins).
 			// If both have conditions, append new conditions (OR across sets).
-			if existingPerms.ConditionSets != nil {
-				if pc.Permissions.ConditionSets == nil {
+			// Conditions merge (structured condition sets AND CEL conditions)
+			// with OR-across-policies semantics. A policy counts as
+			// unconditional only when it has NEITHER kind of condition; an
+			// unconditional grant from any policy makes the path unconditional
+			// (it already permits every request). The unconditional decision
+			// must consider both mechanisms together — clearing them
+			// independently would fail OPEN when one policy carries only a CEL
+			// condition and another only a structured block.
+			//
+			// When two conditional policies merge, both mechanisms are
+			// appended and the eval gate ANDs them, so mixing CEL and
+			// structured conditions across policies on one path is
+			// conservatively ANDed rather than ORed — a temporary
+			// additive-phase limitation, removed once the structured block is
+			// retired.
+			{
+				existingUncond := existingPerms.ConditionSets == nil && existingPerms.Conditions == nil
+				mergingUncond := pc.Permissions.ConditionSets == nil && pc.Permissions.Conditions == nil
+				switch {
+				case existingUncond:
+					// Path already unconditional; stays unconditional.
+				case mergingUncond:
 					existingPerms.ConditionSets = nil
-				} else {
-					existingPerms.ConditionSets = append(
-						existingPerms.ConditionSets,
-						pc.Permissions.ConditionSets...,
-					)
+					existingPerms.Conditions = nil
+				default:
+					existingPerms.ConditionSets = append(existingPerms.ConditionSets, pc.Permissions.ConditionSets...)
+					existingPerms.Conditions = append(existingPerms.Conditions, pc.Permissions.Conditions...)
 				}
 			}
 
@@ -301,7 +325,7 @@ func (a *CBP) Capabilities(ctx context.Context, path string) (pathCapabilities [
 		Operation: logical.ListOperation,
 	}
 
-	res := a.AllowOperation(ctx, req, true)
+	res := a.AllowOperation(ctx, req, nil, true)
 	if res.IsRoot {
 		return []string{RootCapability}
 	}
@@ -342,7 +366,7 @@ func (a *CBP) Capabilities(ctx context.Context, path string) (pathCapabilities [
 }
 
 // AllowOperation is used to check if the given operation is permitted.
-func (a *CBP) AllowOperation(ctx context.Context, req *logical.Request, capCheckOnly bool) (ret *CBPResults) {
+func (a *CBP) AllowOperation(ctx context.Context, req *logical.Request, te *logical.TokenEntry, capCheckOnly bool) (ret *CBPResults) {
 	ret = new(CBPResults)
 
 	// Fast-path root
@@ -472,17 +496,33 @@ CHECK:
 		return ret
 	}
 
+	// now is snapshotted once so the structured conditions and the path-level
+	// CEL condition evaluate against a single, consistent instant.
+	now := time.Now()
+
 	// Check conditions before parameter validation. Conditions restrict
 	// access at the path+operation level, independent of parameters.
 	if permissions.ConditionSets != nil {
 		conditionsMet := false
 		for _, conds := range permissions.ConditionSets {
-			if conds.Evaluate(req.ClientIP, time.Now(), req.TokenMetadata) {
+			if conds.Evaluate(req.ClientIP, now, req.TokenMetadata) {
 				conditionsMet = true
 				break
 			}
 		}
 		if !conditionsMet {
+			return ret
+		}
+	}
+
+	// Path-level CEL condition gate. Peer to ConditionSets: both gates must
+	// pass (AND). Empty/nil Conditions is unconditional. Fail-closed: an
+	// erroring or false condition denies; the deciding result is recorded for
+	// audit on every branch.
+	if len(permissions.Conditions) > 0 {
+		allowed, condRes := evaluatePathConditions(permissions.Conditions, req, te, now)
+		ret.Condition = condRes
+		if !allowed {
 			return ret
 		}
 	}
@@ -841,7 +881,7 @@ func (c *Core) performPolicyChecks(ctx context.Context, cbp *CBP, te *logical.To
 
 	// First, perform normal CBP checks if requested.
 	if cbp != nil && !opts.Unauth {
-		ret.CBPResults = cbp.AllowOperation(ctx, req, false)
+		ret.CBPResults = cbp.AllowOperation(ctx, req, te, false)
 		ret.RootPrivs = ret.CBPResults.RootPrivs
 		// Root is always allowed; skip other checks
 		if ret.CBPResults.IsRoot {

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -166,7 +166,7 @@ func TestCBP_RootAllowsEverything(t *testing.T) {
 				Operation: tc.operation,
 			}
 
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.True(t, result.Allowed)
 			assert.True(t, result.IsRoot)
 			assert.True(t, result.RootPrivs)
@@ -195,12 +195,12 @@ func TestCBP_ExactPathMatch(t *testing.T) {
 		Path:      "secret/data/mykey",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Different path should not be allowed
 	req.Path = "secret/data/otherkey"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -221,12 +221,12 @@ func TestCBP_ExactPathNoMatch(t *testing.T) {
 		Path:      "secret/data",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// Longer path should not match
 	req.Path = "secret/data/specific/extra"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -263,7 +263,7 @@ func TestCBP_PrefixPathMatch(t *testing.T) {
 				Path:      tc.path,
 				Operation: logical.ReadOperation,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.Equal(t, tc.allowed, result.Allowed, "path: %s", tc.path)
 		})
 	}
@@ -289,17 +289,17 @@ func TestCBP_MultiplePrefixPaths(t *testing.T) {
 		Path:      "secret/data",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	req.Operation = logical.CreateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// kv/* should have read and create
 	req.Path = "kv/data"
 	req.Operation = logical.CreateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -337,7 +337,7 @@ func TestCBP_SegmentWildcard(t *testing.T) {
 				Path:      tc.path,
 				Operation: logical.ReadOperation,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.Equal(t, tc.allowed, result.Allowed, "path: %s", tc.path)
 		})
 	}
@@ -372,7 +372,7 @@ func TestCBP_MultipleSegmentWildcards(t *testing.T) {
 				Path:      tc.path,
 				Operation: logical.ReadOperation,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.Equal(t, tc.allowed, result.Allowed, "path: %s", tc.path)
 		})
 	}
@@ -406,7 +406,7 @@ func TestCBP_SegmentWildcardWithGlob(t *testing.T) {
 				Path:      tc.path,
 				Operation: logical.ReadOperation,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.Equal(t, tc.allowed, result.Allowed, "path: %s", tc.path)
 		})
 	}
@@ -444,7 +444,7 @@ func TestCBP_AllCapabilities(t *testing.T) {
 				Path:      "test/key",
 				Operation: op,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.True(t, result.Allowed, "operation: %s", op)
 		})
 	}
@@ -454,7 +454,7 @@ func TestCBP_AllCapabilities(t *testing.T) {
 		Path:      "test/key",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.RootPrivs)
 }
 
@@ -478,21 +478,21 @@ func TestCBP_SpecificCapabilities(t *testing.T) {
 		Path:      "readonly/key",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	req.Operation = logical.CreateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// writeonly path
 	req.Path = "writeonly/key"
 	req.Operation = logical.CreateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	req.Operation = logical.ReadOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -522,7 +522,7 @@ func TestCBP_DenyCapability(t *testing.T) {
 				Path:      "secret/sensitive/key",
 				Operation: op,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.False(t, result.Allowed, "operation %s should be denied", op)
 		})
 	}
@@ -544,7 +544,7 @@ func TestCBP_HelpOperationAlwaysAllowed(t *testing.T) {
 		Path:      "secret/data",
 		Operation: logical.HelpOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -575,20 +575,20 @@ func TestCBP_MergePoliciesAddCapabilities(t *testing.T) {
 		Path:      "secret/key",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	req.Operation = logical.CreateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	req.Operation = logical.UpdateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// But not delete
 	req.Operation = logical.DeleteOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -617,11 +617,11 @@ func TestCBP_DenyOverridesAll(t *testing.T) {
 		Path:      "secret/key",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	req.Operation = logical.CreateOperation
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -650,7 +650,7 @@ func TestCBP_ExistingDenyNotOverridden(t *testing.T) {
 		Path:      "secret/key",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -682,28 +682,28 @@ func TestCBP_AllowedParameters(t *testing.T) {
 			"key1": "any-value",
 		},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Specific allowed value
 	req.Data = map[string]interface{}{
 		"key2": "value1",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Value not in allowed list
 	req.Data = map[string]interface{}{
 		"key2": "value3",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// Parameter not in allowed list
 	req.Data = map[string]interface{}{
 		"key3": "value",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -731,7 +731,7 @@ func TestCBP_AllowedParametersWildcard(t *testing.T) {
 			"another": "value",
 		},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -763,28 +763,28 @@ func TestCBP_DeniedParameters(t *testing.T) {
 			"password": "any-password",
 		},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// Denied parameter with specific value
 	req.Data = map[string]interface{}{
 		"secret_key": "forbidden_value",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// Denied parameter with non-forbidden value
 	req.Data = map[string]interface{}{
 		"secret_key": "allowed_value",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Non-denied parameter
 	req.Data = map[string]interface{}{
 		"normal_key": "value",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -811,12 +811,12 @@ func TestCBP_DeniedParametersWildcard(t *testing.T) {
 			"any_key": "value",
 		},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// No data should be allowed
 	req.Data = nil
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -846,19 +846,19 @@ func TestCBP_RequiredParameters(t *testing.T) {
 			"type": "secret",
 		},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Missing required parameter
 	req.Data = map[string]interface{}{
 		"name": "test",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// No data at all
 	req.Data = nil
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -941,12 +941,12 @@ func TestCBP_ListOperation(t *testing.T) {
 		Path:      "secret/data/",
 		Operation: logical.ListOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// List operation without trailing slash
 	req.Path = "secret/data"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -971,21 +971,21 @@ func TestCBP_ListWithPaginationLimit(t *testing.T) {
 			"limit": 50,
 		},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Exceeds limit
 	req.Data = map[string]interface{}{
 		"limit": 200,
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 
 	// Using "max" keyword
 	req.Data = map[string]interface{}{
 		"limit": "max",
 	}
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 	assert.Equal(t, "100", req.Data["limit"])
 }
@@ -1018,7 +1018,7 @@ func TestCBP_RevokeRenewRollbackOperations(t *testing.T) {
 				Path:      "auth/token/renew",
 				Operation: op,
 			}
-			result := cbp.AllowOperation(ctx, req, false)
+			result := cbp.AllowOperation(ctx, req, nil, false)
 			assert.True(t, result.Allowed, "operation %s should use update capability", op)
 		})
 	}
@@ -1046,7 +1046,7 @@ func TestCBP_CapCheckOnly(t *testing.T) {
 	}
 
 	// With capCheckOnly = true
-	result := cbp.AllowOperation(ctx, req, true)
+	result := cbp.AllowOperation(ctx, req, nil, true)
 	assert.True(t, result.RootPrivs)
 	assert.Equal(t, ReadCapabilityInt|SudoCapabilityInt, result.CapabilitiesBitmap)
 	assert.False(t, result.Allowed) // Allowed is not set with capCheckOnly
@@ -1073,12 +1073,12 @@ func TestCBP_LeadingSlashHandling(t *testing.T) {
 		Path:      "/secret/data",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Path without leading slash
 	req.Path = "secret/data"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -1158,7 +1158,7 @@ func TestCBP_GrantingPolicies(t *testing.T) {
 		Path:      "secret/data",
 		Operation: logical.ReadOperation,
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 	assert.Len(t, result.GrantingPolicies, 1)
 	assert.Equal(t, "test-policy", result.GrantingPolicies[0].Name)
@@ -1354,7 +1354,7 @@ func TestCBP_ConditionsSourceIP_Allowed(t *testing.T) {
 		ClientIP:  "10.1.2.3",
 	}
 
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -1379,7 +1379,7 @@ func TestCBP_ConditionsSourceIP_Denied(t *testing.T) {
 		ClientIP:  "192.168.1.1",
 	}
 
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -1403,21 +1403,21 @@ func TestCBP_ConditionsTokenMetadata_AllowDeny(t *testing.T) {
 		Path:          "secret/data/foo",
 		TokenMetadata: map[string]string{"env": "prod", "team": "platform-core"},
 	}
-	assert.True(t, cbp.AllowOperation(ctx, allowed, false).Allowed)
+	assert.True(t, cbp.AllowOperation(ctx, allowed, nil, false).Allowed)
 
 	wrongTeam := &logical.Request{
 		Operation:     logical.ReadOperation,
 		Path:          "secret/data/foo",
 		TokenMetadata: map[string]string{"env": "prod", "team": "billing"},
 	}
-	assert.False(t, cbp.AllowOperation(ctx, wrongTeam, false).Allowed)
+	assert.False(t, cbp.AllowOperation(ctx, wrongTeam, nil, false).Allowed)
 
 	missingKey := &logical.Request{
 		Operation:     logical.ReadOperation,
 		Path:          "secret/data/foo",
 		TokenMetadata: map[string]string{"env": "prod"},
 	}
-	assert.False(t, cbp.AllowOperation(ctx, missingKey, false).Allowed)
+	assert.False(t, cbp.AllowOperation(ctx, missingKey, nil, false).Allowed)
 }
 
 // TestCBP_ConditionsTokenMetadata_SharedCompiledCBP_CrossToken proves the
@@ -1452,10 +1452,10 @@ func TestCBP_ConditionsTokenMetadata_SharedCompiledCBP_CrossToken(t *testing.T) 
 		TokenMetadata: map[string]string{"env": "dev"},
 	}
 
-	assert.True(t, cbp.AllowOperation(ctx, prodReq, false).Allowed, "prod token should be allowed")
-	assert.False(t, cbp.AllowOperation(ctx, devReq, false).Allowed, "dev token must not inherit prod's decision")
+	assert.True(t, cbp.AllowOperation(ctx, prodReq, nil, false).Allowed, "prod token should be allowed")
+	assert.False(t, cbp.AllowOperation(ctx, devReq, nil, false).Allowed, "dev token must not inherit prod's decision")
 	// Re-run prod after dev to confirm no state leaked between evaluations.
-	assert.True(t, cbp.AllowOperation(ctx, prodReq, false).Allowed)
+	assert.True(t, cbp.AllowOperation(ctx, prodReq, nil, false).Allowed)
 }
 
 func TestCBP_ConditionsCapCheckOnly_SkipsConditions(t *testing.T) {
@@ -1479,7 +1479,7 @@ func TestCBP_ConditionsCapCheckOnly_SkipsConditions(t *testing.T) {
 		ClientIP:  "192.168.1.1", // Does NOT match, but capCheckOnly should skip
 	}
 
-	result := cbp.AllowOperation(ctx, req, true)
+	result := cbp.AllowOperation(ctx, req, nil, true)
 	assert.True(t, result.CapabilitiesBitmap&ReadCapabilityInt > 0)
 }
 
@@ -1508,12 +1508,12 @@ func TestCBP_ConditionsWithParameters(t *testing.T) {
 		ClientIP:  "10.1.2.3",
 		Data:      map[string]any{"key": "value"},
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Bad IP, valid parameter → denied by conditions
 	req.ClientIP = "192.168.1.1"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -1535,7 +1535,7 @@ func TestCBP_ConditionsEmpty_NoEffect(t *testing.T) {
 		ClientIP:  "anything",
 	}
 
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -1568,7 +1568,7 @@ func TestCBP_MergeConditions_OneUnconditional(t *testing.T) {
 		ClientIP:  "192.168.1.1",
 	}
 
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 }
 
@@ -1602,17 +1602,17 @@ func TestCBP_MergeConditions_BothConditional_OR(t *testing.T) {
 		Path:      "secret/data/foo",
 		ClientIP:  "10.1.2.3",
 	}
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Matches policyB's conditions
 	req.ClientIP = "192.168.1.1"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.True(t, result.Allowed)
 
 	// Matches neither
 	req.ClientIP = "172.16.0.1"
-	result = cbp.AllowOperation(ctx, req, false)
+	result = cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -1643,7 +1643,7 @@ func TestCBP_MergeConditions_DenyOverrides(t *testing.T) {
 		ClientIP:  "10.1.2.3",
 	}
 
-	result := cbp.AllowOperation(ctx, req, false)
+	result := cbp.AllowOperation(ctx, req, nil, false)
 	assert.False(t, result.Allowed)
 }
 
@@ -1773,8 +1773,8 @@ func TestCBP_CompiledCacheHit_TokenMetadataNotLeaked(t *testing.T) {
 		TokenMetadata: map[string]string{"env": "dev"},
 	}
 
-	assert.True(t, second.AllowOperation(ctx, prodReq, false).Allowed)
-	assert.False(t, second.AllowOperation(ctx, devReq, false).Allowed)
+	assert.True(t, second.AllowOperation(ctx, prodReq, nil, false).Allowed)
+	assert.False(t, second.AllowOperation(ctx, devReq, nil, false).Allowed)
 }
 
 // TestCBP_CompiledCacheInvalidatesOnVersionBump verifies that editing a policy
@@ -1901,7 +1901,7 @@ func TestCBP_CompiledCacheConcurrent(t *testing.T) {
 				return
 			}
 			req := &logical.Request{Operation: logical.ReadOperation, Path: "secret/a"}
-			cbp.AllowOperation(ctx, req, false)
+			cbp.AllowOperation(ctx, req, nil, false)
 			cbp.Capabilities(ctx, "secret/b/x")
 		}()
 	}

--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter"
 
 	"github.com/stephnangue/warden/logical"
 )
@@ -192,7 +195,23 @@ func compileCELCondition(env *cel.Env, src string) (cel.Program, error) {
 		return nil, fmt.Errorf("condition worst-case cost %d exceeds limit %d", est.Max, maxConditionCost)
 	}
 
-	prg, err := env.Program(ast, cel.CostLimit(maxConditionCost))
+	// The runtime cost tracker (cel.CostLimit) allocates per eval and wraps
+	// the program in an observable interpretable — a real hot-path cost. It is
+	// only a backstop for inputs larger than the static estimate assumed, so
+	// it is only needed when the expression's cost is input-size-dependent.
+	// Detect that by re-estimating with a larger size bound: if the worst-case
+	// cost is unchanged, the cost is input-independent and already capped by
+	// the static bound above, so the per-eval tracker is omitted.
+	est2, err := env.EstimateCost(ast, celCostEstimator{maxSize: celInputSizeBound * 2})
+	if err != nil {
+		return nil, fmt.Errorf("condition cost estimation failed: %w", err)
+	}
+	var progOpts []cel.ProgramOption
+	if est2.Max != est.Max {
+		progOpts = append(progOpts, cel.CostLimit(maxConditionCost))
+	}
+
+	prg, err := env.Program(ast, progOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("condition program construction failed: %w", err)
 	}
@@ -203,7 +222,7 @@ func compileCELCondition(env *cel.Env, src string) (cel.Program, error) {
 // It is fail-closed: any evaluation error (type mismatch, missing key,
 // runtime cost-limit) returns (false, err) so callers deny. The error is for
 // audit categorization only and must not be surfaced to clients verbatim.
-func evalCELCondition(prg cel.Program, activation map[string]any) (bool, error) {
+func evalCELCondition(prg cel.Program, activation any) (bool, error) {
 	out, _, err := prg.Eval(activation)
 	if err != nil {
 		return false, err
@@ -215,20 +234,32 @@ func evalCELCondition(prg cel.Program, activation map[string]any) (bool, error) 
 	return b, nil
 }
 
-// buildBaseActivation assembles the request-wide activation shared by path-level
-// and mcp{} conditions. Containers are always non-nil so has() works and absent
-// nested keys fail closed. now is the once-per-request snapshot.
-func buildBaseActivation(req celRequestInput, tok celTokenInput, now time.Time) map[string]any {
+// buildRequestNS builds the `request` namespace. data is always non-nil so
+// has(request.data.x) is false rather than a nil-deref.
+func buildRequestNS(req celRequestInput) map[string]any {
 	data := req.Data
 	if data == nil {
 		data = map[string]any{}
 	}
+	return map[string]any{
+		"path":           req.Path,
+		"operation":      req.Operation,
+		"client_ip":      req.ClientIP,
+		"mount_point":    req.MountPoint,
+		"mount_type":     req.MountType,
+		"mount_class":    req.MountClass,
+		"mount_accessor": req.MountAccessor,
+		"transparent":    req.Transparent,
+		"data":           data,
+	}
+}
 
+// buildTokenNS builds the `token` namespace. metadata is always non-nil.
+func buildTokenNS(tok celTokenInput) map[string]any {
 	md := make(map[string]any, len(tok.Metadata))
 	for k, v := range tok.Metadata {
 		md[k] = v
 	}
-
 	acts := make([]any, 0, len(tok.Actors))
 	for _, a := range tok.Actors {
 		acts = append(acts, map[string]any{
@@ -236,36 +267,76 @@ func buildBaseActivation(req celRequestInput, tok celTokenInput, now time.Time) 
 			"verified": a.Verified,
 		})
 	}
-
 	policies := make([]any, 0, len(tok.Policies))
 	for _, p := range tok.Policies {
 		policies = append(policies, p)
 	}
-
 	return map[string]any{
-		"request": map[string]any{
-			"path":           req.Path,
-			"operation":      req.Operation,
-			"client_ip":      req.ClientIP,
-			"mount_point":    req.MountPoint,
-			"mount_type":     req.MountType,
-			"mount_class":    req.MountClass,
-			"mount_accessor": req.MountAccessor,
-			"transparent":    req.Transparent,
-			"data":           data,
-		},
-		"token": map[string]any{
-			"principal":   tok.Principal,
-			"role":        tok.Role,
-			"type":        tok.Type,
-			"namespace":   tok.NamespacePath,
-			"policies":    policies,
-			"metadata":    md,
-			"actors":      acts,
-			"ttl_seconds": tok.TTLSeconds,
-			"expires_at":  tok.ExpiresAtUnix,
-		},
-		"now": now,
+		"principal":   tok.Principal,
+		"role":        tok.Role,
+		"type":        tok.Type,
+		"namespace":   tok.NamespacePath,
+		"policies":    policies,
+		"metadata":    md,
+		"actors":      acts,
+		"ttl_seconds": tok.TTLSeconds,
+		"expires_at":  tok.ExpiresAtUnix,
+	}
+}
+
+// buildBaseActivation eagerly builds the full activation map. Retained for unit
+// tests; the request path uses celActivation (lazy) to avoid building
+// namespaces an expression never references.
+func buildBaseActivation(req celRequestInput, tok celTokenInput, now time.Time) map[string]any {
+	return map[string]any{
+		"request": buildRequestNS(req),
+		"token":   buildTokenNS(tok),
+		"now":     now,
+	}
+}
+
+// celActivation is a lazy interpreter.Activation: it builds each top-level
+// namespace (request/token/call) only when the expression resolves it, so an
+// expression touching only one namespace doesn't allocate the others. One
+// activation is built per evaluation (never shared), so the memoization is not
+// a concurrency concern.
+type celActivation struct {
+	req  celRequestInput
+	tok  celTokenInput
+	now  time.Time
+	call map[string]any // nil for path-level conditions
+
+	reqNS map[string]any
+	tokNS map[string]any
+}
+
+func newCELActivation(req celRequestInput, tok celTokenInput, now time.Time, call map[string]any) *celActivation {
+	return &celActivation{req: req, tok: tok, now: now, call: call}
+}
+
+func (a *celActivation) Parent() interpreter.Activation { return nil }
+
+func (a *celActivation) ResolveName(name string) (any, bool) {
+	switch name {
+	case "request":
+		if a.reqNS == nil {
+			a.reqNS = buildRequestNS(a.req)
+		}
+		return a.reqNS, true
+	case "token":
+		if a.tokNS == nil {
+			a.tokNS = buildTokenNS(a.tok)
+		}
+		return a.tokNS, true
+	case "now":
+		return a.now, true
+	case "call":
+		if a.call != nil {
+			return a.call, true
+		}
+		return nil, false
+	default:
+		return nil, false
 	}
 }
 
@@ -308,4 +379,126 @@ func paramValueToCEL(pv logical.ParamValue) (any, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// compiledCondition is a CEL condition compiled at policy-parse time, ready to
+// evaluate. Program is immutable and safe for concurrent Eval, so it is shared
+// (not deep-copied) when merged into a CBP.
+type compiledCondition struct {
+	Source  string
+	Program cel.Program
+}
+
+// Package-level envs, built once and reused. The base env compiles path-level
+// conditions; the MCP env (base + call.*) compiles mcp{} conditions.
+var (
+	baseEnvOnce sync.Once
+	baseEnv     *cel.Env
+	baseEnvErr  error
+
+	mcpEnvOnce sync.Once
+	mcpEnv     *cel.Env
+	mcpEnvErr  error
+)
+
+func baseCELEnv() (*cel.Env, error) {
+	baseEnvOnce.Do(func() { baseEnv, baseEnvErr = buildCELEnv(false) })
+	return baseEnv, baseEnvErr
+}
+
+func mcpCELEnv() (*cel.Env, error) {
+	mcpEnvOnce.Do(func() { mcpEnv, mcpEnvErr = buildCELEnv(true) })
+	return mcpEnv, mcpEnvErr
+}
+
+// celRequestInputFromRequest adapts a *logical.Request into the request context
+// exposed to expressions. All fields are populated before policy evaluation.
+func celRequestInputFromRequest(req *logical.Request) celRequestInput {
+	if req == nil {
+		return celRequestInput{}
+	}
+	return celRequestInput{
+		Path:          req.Path,
+		Operation:     string(req.Operation),
+		ClientIP:      req.ClientIP,
+		MountPoint:    req.MountPoint,
+		MountType:     req.MountType,
+		MountClass:    req.MountClass,
+		MountAccessor: req.MountAccessor,
+		Transparent:   req.Transparent,
+		Data:          req.Data,
+	}
+}
+
+// celTokenInputFromEntry adapts a *logical.TokenEntry into the non-secret token
+// context exposed to expressions. now is the once-per-request snapshot used to
+// derive the remaining TTL.
+func celTokenInputFromEntry(te *logical.TokenEntry, now time.Time) celTokenInput {
+	if te == nil {
+		return celTokenInput{}
+	}
+	var ttl, expires int64
+	if !te.ExpireAt.IsZero() {
+		ttl = int64(te.ExpireAt.Sub(now).Seconds())
+		expires = te.ExpireAt.Unix()
+	}
+	return celTokenInput{
+		Principal:     te.PrincipalID,
+		Role:          te.RoleName,
+		Type:          te.Type,
+		NamespacePath: te.NamespacePath,
+		Policies:      te.Policies,
+		Metadata:      te.Metadata,
+		Actors:        te.Actors,
+		TTLSeconds:    ttl,
+		ExpiresAtUnix: expires,
+	}
+}
+
+// celErrorKind maps a CEL evaluation error to a coarse, sanitized category for
+// audit. It never embeds the raw error string or any adversary-controlled value.
+func celErrorKind(err error) string {
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "no such key"), strings.Contains(s, "no such attribute"):
+		return "no_such_key"
+	case strings.Contains(s, "operation cancelled: actual cost limit exceeded"), strings.Contains(s, "cost limit"):
+		return "cost_exceeded"
+	case strings.Contains(s, "no such overload"):
+		return "type_mismatch"
+	default:
+		return "eval_error"
+	}
+}
+
+// evaluatePathConditions evaluates the merged path-level conditions with OR
+// semantics: the gate passes if any condition is true. An empty list is
+// unconditional. Evaluation is fail-closed — an erroring condition denies, and
+// if no condition passes the deciding result is recorded for audit (Sanitized).
+func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te *logical.TokenEntry, now time.Time) (bool, *logical.ConditionResult) {
+	if len(conds) == 0 {
+		return true, nil
+	}
+	act := newCELActivation(celRequestInputFromRequest(req), celTokenInputFromEntry(te, now), now, nil)
+
+	var deciding *logical.ConditionResult
+	for _, c := range conds {
+		ok, err := evalCELCondition(c.Program, act)
+		if err != nil {
+			if deciding == nil {
+				deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source, ErrorKind: celErrorKind(err)}
+			}
+			continue
+		}
+		if ok {
+			res := &logical.ConditionResult{Decision: "allow", Expression: c.Source}
+			res.Sanitize()
+			return true, res
+		}
+		if deciding == nil {
+			deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source}
+		}
+	}
+	deciding.Sanitize()
+	return false, deciding
 }

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+)
+
+// TestCBP_PathCondition_EndToEnd parses a policy with a path-level CEL
+// condition, compiles it into a CBP, and exercises allow/deny through
+// AllowOperation. The condition reads request.data (body) and token.metadata
+// (from the TokenEntry threaded into AllowOperation).
+func TestCBP_PathCondition_EndToEnd(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.ttl_seconds <= 3600 && token.metadata.env == 'prod'"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	prodTE := &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}}
+
+	req := func(ttl int) *logical.Request {
+		return &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "db/issue-grant",
+			Data:      map[string]any{"ttl_seconds": ttl},
+		}
+	}
+
+	// Within cap and prod -> allow, with the condition decision recorded.
+	res := cbp.AllowOperation(ctx, req(3600), prodTE, false)
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.Condition)
+	assert.Equal(t, "allow", res.Condition.Decision)
+	assert.Contains(t, res.Condition.Expression, "request.data.ttl_seconds")
+
+	// Over cap -> deny, recorded.
+	res = cbp.AllowOperation(ctx, req(7200), prodTE, false)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.Condition)
+	assert.Equal(t, "deny", res.Condition.Decision)
+
+	// Wrong env -> deny (token metadata gate).
+	devTE := &logical.TokenEntry{Metadata: map[string]string{"env": "dev"}}
+	res = cbp.AllowOperation(ctx, req(100), devTE, false)
+	assert.False(t, res.Allowed)
+}
+
+// TestCBP_PathCondition_MissingDataFailsClosed confirms a condition over an
+// absent request.data key denies (fail-closed) and records a sanitized error
+// category rather than a raw value.
+func TestCBP_PathCondition_MissingDataFailsClosed(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.ttl_seconds <= 3600"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	// No Data at all -> request.data.ttl_seconds is a no-such-key error -> deny.
+	res := cbp.AllowOperation(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+	}, nil, false)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.Condition)
+	assert.Equal(t, "deny", res.Condition.Decision)
+	assert.Equal(t, "no_such_key", res.Condition.ErrorKind)
+}
+
+// TestCBP_PathCondition_OptionalArgAllowsAbsent confirms the optional-syntax
+// escape hatch: an absent key passes when the author opts in.
+func TestCBP_PathCondition_OptionalArgAllowsAbsent(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.?ttl_seconds.orValue(0) <= 3600"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	res := cbp.AllowOperation(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+	}, nil, false)
+	assert.True(t, res.Allowed)
+}
+
+// TestCBP_PathCondition_RejectedAtParse confirms invalid conditions fail at
+// policy-write time with a directed error: a non-bool result and a path-level
+// reference to the mcp-only call.* namespace.
+func TestCBP_PathCondition_RejectedAtParse(t *testing.T) {
+	for _, tc := range []struct{ name, cond string }{
+		{"non-bool", `1 + 1`},
+		{"call-in-path-level", `call.args.amount <= 1`},
+		{"syntax", `request.data.x <=`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCBPPolicy(namespace.RootNamespace, `
+				path "p" {
+					capabilities = ["read"]
+					condition = "`+tc.cond+`"
+				}
+			`)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestCBP_PathCondition_CapCheckOnlySkips confirms capability-listing does not
+// evaluate the condition (returns early), so introspection stays request-free.
+func TestCBP_PathCondition_CapCheckOnlySkips(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.ttl_seconds <= 3600"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	res := cbp.AllowOperation(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+	}, nil, true)
+	// capCheckOnly returns the capability bitmap before the condition step;
+	// the condition is not evaluated, so no decision is recorded.
+	assert.Nil(t, res.Condition)
+}
+
+// TestCBP_PathCondition_MultiPolicyOR confirms two policies' CEL conditions on
+// the same path OR across policies (more policies admit more requests).
+func TestCBP_PathCondition_MultiPolicyOR(t *testing.T) {
+	ctx := testContext()
+	a := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.team == 'red'" }`)
+	b := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.team == 'blue'" }`)
+	cbp, err := NewCBP(ctx, []*Policy{a, b})
+	require.NoError(t, err)
+
+	read := &logical.Request{Operation: logical.ReadOperation, Path: "x"}
+	team := func(v string) *logical.TokenEntry { return &logical.TokenEntry{Metadata: map[string]string{"team": v}} }
+
+	assert.True(t, cbp.AllowOperation(ctx, read, team("red"), false).Allowed, "red satisfies policy A")
+	assert.True(t, cbp.AllowOperation(ctx, read, team("blue"), false).Allowed, "blue satisfies policy B")
+	assert.False(t, cbp.AllowOperation(ctx, read, team("green"), false).Allowed, "green satisfies neither")
+}
+
+// TestCBP_PathCondition_UnconditionalGrantWins confirms a policy that grants the
+// path with no condition makes it unconditional (OR: an unconditional grant
+// admits everything), overriding another policy's condition.
+func TestCBP_PathCondition_UnconditionalGrantWins(t *testing.T) {
+	ctx := testContext()
+	a := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.team == 'red'" }`)
+	b := testParsePolicy(t, `path "x" { capabilities = ["read"] }`) // unconditional
+	cbp, err := NewCBP(ctx, []*Policy{a, b})
+	require.NoError(t, err)
+
+	read := &logical.Request{Operation: logical.ReadOperation, Path: "x"}
+	res := cbp.AllowOperation(ctx, read, &logical.TokenEntry{Metadata: map[string]string{"team": "green"}}, false)
+	assert.True(t, res.Allowed, "unconditional grant from B admits any request")
+}
+
+// TestCBP_PathCondition_MixedMechanismsNotFailOpen is the regression guard for
+// the merge fail-open: a CEL-only policy and a conditions{}-only policy on one
+// path must NOT collapse to unconditional. A request satisfying neither is
+// denied.
+func TestCBP_PathCondition_MixedMechanismsNotFailOpen(t *testing.T) {
+	ctx := testContext()
+	celOnly := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.env == 'prod'" }`)
+	structuredOnly := testParsePolicy(t, `path "x" { capabilities = ["read"] conditions { token_metadata = ["team=red"] } }`)
+	cbp, err := NewCBP(ctx, []*Policy{celOnly, structuredOnly})
+	require.NoError(t, err)
+
+	// Satisfies neither gate -> must be denied (the fail-open this guards).
+	neither := &logical.Request{
+		Operation:     logical.ReadOperation,
+		Path:          "x",
+		TokenMetadata: map[string]string{"env": "dev", "team": "blue"},
+	}
+	assert.False(t, cbp.AllowOperation(ctx, neither, &logical.TokenEntry{Metadata: map[string]string{"env": "dev", "team": "blue"}}, false).Allowed,
+		"mixed mechanisms must not fail open")
+
+	// Satisfies both gates -> allowed (mixed is conservatively ANDed).
+	both := &logical.Request{
+		Operation:     logical.ReadOperation,
+		Path:          "x",
+		TokenMetadata: map[string]string{"env": "prod", "team": "red"},
+	}
+	assert.True(t, cbp.AllowOperation(ctx, both, &logical.TokenEntry{Metadata: map[string]string{"env": "prod", "team": "red"}}, false).Allowed)
+}
+
+func BenchmarkAllowOperation_NoCondition(b *testing.B) {
+	ctx := testContext()
+	policy, _ := ParseCBPPolicy(namespace.RootNamespace, `
+		path "db/issue-grant" { capabilities = ["create"] }
+	`)
+	cbp, _ := NewCBP(ctx, []*Policy{policy})
+	req := &logical.Request{Operation: logical.CreateOperation, Path: "db/issue-grant"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, nil, false)
+	}
+}
+
+func BenchmarkAllowOperation_WithConditionRequestOnly(b *testing.B) {
+	// Touches only the request namespace; the lazy activation never builds the
+	// token namespace (metadata copy, policies/actors slices).
+	ctx := testContext()
+	policy, _ := ParseCBPPolicy(namespace.RootNamespace, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.ttl_seconds <= 3600"
+		}
+	`)
+	cbp, _ := NewCBP(ctx, []*Policy{policy})
+	te := &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}, Policies: []string{"p1", "p2"}}
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+		Data:      map[string]any{"ttl_seconds": 3600},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, te, false)
+	}
+}
+
+func BenchmarkAllowOperation_WithCondition(b *testing.B) {
+	ctx := testContext()
+	policy, _ := ParseCBPPolicy(namespace.RootNamespace, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.ttl_seconds <= 3600 && token.metadata.env == 'prod'"
+		}
+	`)
+	cbp, _ := NewCBP(ctx, []*Policy{policy})
+	te := &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}, ExpireAt: time.Now().Add(time.Hour)}
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+		Data:      map[string]any{"ttl_seconds": 3600},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, te, false)
+	}
+}

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -113,7 +113,7 @@ path "mcp/gateway/*" {
 	}`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -139,7 +139,7 @@ path "mcp/gateway/*" {
 	]`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Equal(t, "allow", res.MCPDecision.Decision)
@@ -196,7 +196,7 @@ path "mcp/gateway/*" {
 	}`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -232,7 +232,7 @@ path "mcp/gateway/*" {
 	}`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -270,7 +270,7 @@ path "mcp/gateway/*" {
 	}`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed,
 		"non-scalar argument is treated as missing; missing is a conditional skip under the allow-list, not a deny")
@@ -293,7 +293,7 @@ path "mcp/gateway/*" {
 	]`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision.BatchIndex)
@@ -317,7 +317,7 @@ path "mcp/gateway/*" {
 	req := buildE2ERequest(t, `{ not json`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeMalformedJSONRPC, res.MCPDecision.RuleType)
@@ -340,7 +340,7 @@ path "mcp/gateway/*" {
 	}`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeDuplicateKey, res.MCPDecision.RuleType)
@@ -366,7 +366,7 @@ path "mcp/gateway/*" {
 	req := buildE2ERequest(t, body)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: cap})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeOversizedBody, res.MCPDecision.RuleType)
@@ -404,7 +404,7 @@ path "mcp/gateway/*" {
 	}`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeMalformedParams, res.MCPDecision.RuleType)
@@ -423,7 +423,7 @@ path "mcp/gateway/*" {
 	req := buildE2ERequest(t, `[]`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeBatchEmpty, res.MCPDecision.RuleType)
@@ -462,7 +462,7 @@ path "mcp/gateway/*" {
 	require.Nil(t, req.MCPDescriptor.ParseErr,
 		"sentinel descriptor must have ParseErr nil")
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Nil(t, res.MCPDecision,
@@ -487,7 +487,7 @@ path "mcp/gateway/*" {
 	require.Nil(t, req.MCPDescriptor.Calls)
 	require.Nil(t, req.MCPDescriptor.ParseErr)
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Nil(t, res.MCPDecision)
@@ -511,7 +511,7 @@ path "mcp/gateway/*" {
 	require.Nil(t, req.MCPDescriptor,
 		"non-MCP backend (no marker interface) leaves descriptor nil")
 
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeMissingBody, res.MCPDecision.RuleType)
@@ -547,12 +547,12 @@ path "mcp/gateway/*" {
 	// Backend type A.
 	reqA := buildE2ERequest(t, body)
 	runExtract(reqA, &mcpMockBackend{enforce: true, cap: 1 << 20})
-	resA := cbp.AllowOperation(testContext(), reqA, false)
+	resA := cbp.AllowOperation(testContext(), reqA, nil, false)
 
 	// Backend type B (different struct, same interface).
 	reqB := buildE2ERequest(t, body)
 	runExtract(reqB, &mcpMockBackendAlt{enforce: true, cap: 1 << 20})
-	resB := cbp.AllowOperation(testContext(), reqB, false)
+	resB := cbp.AllowOperation(testContext(), reqB, nil, false)
 
 	require.NotNil(t, resA.MCPDecision)
 	require.NotNil(t, resB.MCPDecision)

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -95,7 +95,7 @@ path "mcp/gateway/*" {
 		"method":  "tools/list",
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -120,7 +120,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "x"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -145,7 +145,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "x"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -167,7 +167,7 @@ path "mcp/gateway/*" {
 		"method":  "tools/list",
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Nil(t, res.MCPDecision, "no mcp block → no decision recorded")
@@ -193,7 +193,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "get_repository"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -219,7 +219,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "code-review"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -242,7 +242,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "delete_repository"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -270,7 +270,7 @@ path "mcp/gateway/*" {
 		"params":  {"uri": "github://secrets/api-key"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -297,7 +297,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "sudo_admin"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -326,7 +326,7 @@ path "mcp/gateway/*" {
 		"params":  {"uri": "github://repo/readme.md"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 }
@@ -351,7 +351,7 @@ path "mcp/gateway/*" {
 		"params":  {"uri": "github://secrets/api-key"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeDeniedResources, res.MCPDecision.RuleType)
@@ -375,7 +375,7 @@ path "mcp/gateway/*" {
 		"method":  "tools/list",
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed, "tools/list passes — name gate doesn't fire for name-less method")
 	assert.Equal(t, "tools/list", res.MCPDecision.Method)
@@ -398,7 +398,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "x"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Equal(t, "allow", res.MCPDecision.Decision)
@@ -430,7 +430,7 @@ path "mcp/gateway/*" {
 		},
 		"id": 1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Equal(t, "allow", res.MCPDecision.Decision)
@@ -458,7 +458,7 @@ path "mcp/gateway/*" {
 		},
 		"id": 1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, "deny", res.MCPDecision.Decision)
@@ -498,7 +498,7 @@ path "mcp/gateway/*" {
 		},
 		"id": 1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed,
 		"missing argument is not a constraint violation under conditional semantics")
@@ -527,7 +527,7 @@ path "mcp/gateway/*" {
 		},
 		"id": 1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 }
@@ -558,7 +558,7 @@ path "mcp/gateway/*" {
 		},
 		"id": 1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 	assert.True(t, res.Allowed, "both keys satisfied → allow")
 }
 
@@ -589,7 +589,7 @@ path "mcp/gateway/*" {
 		},
 		"id": 1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed, "AND across keys: any failing key denies")
 	assert.Equal(t, "mode", res.MCPDecision.ParamName)
@@ -626,7 +626,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "get_repository"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed, "set 1 allows, OR wins")
 	assert.Equal(t, "allow", res.MCPDecision.Decision)
@@ -667,7 +667,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "delete_repository"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 	assert.False(t, res.Allowed, "additive merge: MCP restriction from one policy still applies even with un-mcp'd policy alongside")
 	assert.Equal(t, mcpRuleTypeAllowedTools, res.MCPDecision.RuleType)
 }
@@ -698,7 +698,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "delete_repository"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeDeniedTools, res.MCPDecision.RuleType,
@@ -729,7 +729,7 @@ path "mcp/gateway/*" {
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 2},
 		{"jsonrpc": "2.0", "method": "tools/list", "id": 3}
 	]`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed, "every batch call must allow → batch allows")
 	require.NotNil(t, res.MCPDecision)
@@ -757,7 +757,7 @@ path "mcp/gateway/*" {
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 2},
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "delete_repo"}, "id": 3}
 	]`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -789,7 +789,7 @@ path "mcp/gateway/*" {
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "delete_repo"}, "id": 2},
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "drop_database"}, "id": 3}
 	]`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -817,7 +817,7 @@ path "mcp/gateway/*" {
 	req := newMCPRequest(t, "mcp/gateway/", `[
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "delete_repo"}, "id": 1}
 	]`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, "deny", res.MCPDecision.Decision)
@@ -839,7 +839,7 @@ path "mcp/gateway/*" {
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[]`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
@@ -862,7 +862,7 @@ path "mcp/gateway/*" {
 		{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
 		{"jsonrpc": "2.0", "method": "tools/call", "method": "tools/list", "params": {"name": "x"}, "id": 2}
 	]`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeDuplicateKey, res.MCPDecision.RuleType)
@@ -892,7 +892,7 @@ path "mcp/gateway/*" {
 		"params":  {"name": "GET_Repository"},
 		"id":      1
 	}`)
-	res := cbp.AllowOperation(testContext(), req, false)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
 	assert.Equal(t, "tools/call", res.MCPDecision.Method)
@@ -1059,7 +1059,7 @@ path "secret/*" {
 	ctx := testContext()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = cbp.AllowOperation(ctx, req, false)
+		_ = cbp.AllowOperation(ctx, req, nil, false)
 	}
 }
 
@@ -1098,7 +1098,7 @@ path "mcp/gateway/*" {
 	ctx := testContext()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = cbp.AllowOperation(ctx, req, false)
+		_ = cbp.AllowOperation(ctx, req, nil, false)
 	}
 }
 
@@ -1117,7 +1117,7 @@ func BenchmarkAllowOperation_StressMCP(b *testing.B) {
 	ctx := testContext()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = cbp.AllowOperation(ctx, req, false)
+		_ = cbp.AllowOperation(ctx, req, nil, false)
 	}
 }
 

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -176,6 +176,10 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 	if accessControlResults.CBPResults != nil && accessControlResults.CBPResults.MCPDecision != nil {
 		auth.MCPDecision = accessControlResults.CBPResults.MCPDecision
 	}
+	// Carry the path-level CEL condition decision through to buildAuditAuth.
+	if accessControlResults.CBPResults != nil && accessControlResults.CBPResults.Condition != nil {
+		auth.Condition = accessControlResults.CBPResults.Condition
+	}
 
 	if !accessControlResults.Allowed {
 		retErr := accessControlResults.Error

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -44,6 +44,12 @@ type Auth struct {
 	// OAuth-shaped 403 body.
 	MCPDecision *MCPDecision
 
+	// Condition carries the path-level CEL condition decision when a
+	// path-level condition was evaluated during CBP evaluation. nil when the
+	// matched permission had no path-level condition. Flows through
+	// buildAuditAuth into audit.PolicyResults.Condition.
+	Condition *ConditionResult
+
 	PrincipalID string
 
 	RoleName string


### PR DESCRIPTION
Third PR in the CEL policy-conditions stack (depends on #362 and #364, both merged).

## What

Wires the **path-level `condition`** into CBP — the first surface that consumes CEL.

- Parse a `condition` expression on a `path { }` rule (compiled at policy-write time; rides the existing compiled-CBP cache, identity-independent).
- Evaluate it in `AllowOperation` as a gate after the capability check: the rule passes only if its capability is granted **and** the condition holds. Fail-closed — a `false` result or any eval error (missing key, type mismatch) denies.
- `now` is snapshotted once per request so a batch evaluates against one instant.
- Cross-policy merge: conditions OR across policies granting the same path; a policy is unconditional only when it has neither a structured block nor a CEL condition (combined check — avoids a fail-open when a conditional and an unconditional policy cover one path).
- The decision flows to audit via `logical.Auth.Condition` → `audit.PolicyResults.Condition`.

## Scope

Path-level only; the per-call `mcp { }` condition and the removal of the old structured mechanisms land in later PRs. Rules without a `condition` keep their existing sub-µs path unchanged.

## Tests

`core/policy_cel_path_test.go`: allow/deny end-to-end, missing-key fail-closed, optional-arg passes, parse rejection of malformed expressions, cap-check-only skips evaluation, multi-policy OR, and unconditional-grant-wins.
