### PR TITLE
feat(policy): evaluate per-call CEL conditions in the mcp{} block

### DIFF
--- a/core/policy.go
+++ b/core/policy.go
@@ -147,6 +147,7 @@ type MCPRulesHCL struct {
 	DeniedPrompts    []string            `hcl:"denied_prompts"`
 	AllowedParams    map[string][]string `hcl:"allowed_params"`
 	DeniedParams     map[string][]string `hcl:"denied_params"`
+	Condition        string              `hcl:"condition"`
 }
 
 type CBPPermissions struct {
@@ -193,6 +194,10 @@ type CBPMCPRules struct {
 	DeniedPrompts    []string
 	AllowedParams    map[string][]string
 	DeniedParams     map[string][]string
+	// Condition is the optional per-call CEL condition for this rule-set,
+	// compiled against the MCP env (call.* available). The set allows a call
+	// only if its structural gates pass AND this condition evaluates true.
+	Condition *compiledCondition
 }
 
 // Clone returns a deep copy of the CBPMCPRules. Safe to call on a nil
@@ -239,6 +244,8 @@ func (m *CBPMCPRules) Clone() *CBPMCPRules {
 			clone.DeniedParams[k] = append([]string(nil), v...)
 		}
 	}
+	// Program is immutable; share the pointer.
+	clone.Condition = m.Condition
 	return clone
 }
 
@@ -641,6 +648,17 @@ func canonicaliseMCPRules(h *MCPRulesHCL) (*CBPMCPRules, error) {
 	}
 	if r.DeniedParams, err = canonMap("denied_params", h.DeniedParams); err != nil {
 		return nil, err
+	}
+	if h.Condition != "" {
+		env, err := mcpCELEnv()
+		if err != nil {
+			return nil, fmt.Errorf("mcp cel env: %w", err)
+		}
+		prg, err := compileCELCondition(env, h.Condition)
+		if err != nil {
+			return nil, fmt.Errorf("mcp condition: %w", err)
+		}
+		r.Condition = &compiledCondition{Source: h.Condition, Program: prg}
 	}
 	return r, nil
 }

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -539,7 +539,7 @@ CHECK:
 	// the routed backend doesn't implement the marker, or it declined
 	// the request (wrong method / Content-Type) — fail closed.
 	if len(permissions.MCP) > 0 {
-		ret.MCPDecision = decideMCP(permissions.MCP, req)
+		ret.MCPDecision = decideMCP(permissions.MCP, req, te, now)
 		if ret.MCPDecision != nil && ret.MCPDecision.Decision == "deny" {
 			return ret
 		}

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -21,7 +21,7 @@ func testContext() context.Context {
 }
 
 // Helper function to parse a policy for testing
-func testParsePolicy(t *testing.T, rules string) *Policy {
+func testParsePolicy(t testing.TB, rules string) *Policy {
 	t.Helper()
 	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
 	require.NoError(t, err)

--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -345,19 +345,26 @@ func (a *celActivation) ResolveName(name string) (any, bool) {
 // non-scalar / null / missing values are omitted so absent-key access fails
 // closed. Mutates and returns base.
 func addCallToActivation(base map[string]any, method, tool string, matchArgs map[string]logical.ParamValue, batchIndex int) map[string]any {
+	base["call"] = buildCallNS(method, tool, matchArgs, batchIndex)
+	return base
+}
+
+// buildCallNS builds the per-call `call` namespace. args are typed from
+// ParamValue.Kind; non-scalar / null / missing values are omitted so absent-key
+// access fails closed.
+func buildCallNS(method, tool string, matchArgs map[string]logical.ParamValue, batchIndex int) map[string]any {
 	args := make(map[string]any, len(matchArgs))
 	for k, pv := range matchArgs {
 		if v, ok := paramValueToCEL(pv); ok {
 			args[k] = v
 		}
 	}
-	base["call"] = map[string]any{
+	return map[string]any{
 		"method":      method,
 		"tool":        tool,
 		"args":        args,
 		"batch_index": batchIndex,
 	}
-	return base
 }
 
 // paramValueToCEL converts a parsed MCP argument to a typed CEL value. Only

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// mcpReq builds a streaming MCP request from a JSON-RPC body and runs the
+// production extractor, leaving req.MCPDescriptor populated.
+func mcpReq(t *testing.T, body string) *logical.Request {
+	t.Helper()
+	req := buildE2ERequest(t, body)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+	return req
+}
+
+func mcpAmountCapPolicy(t *testing.T) *CBP {
+	t.Helper()
+	return mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["create_payment"]
+    condition       = "call.args.amount <= 1500"
+  }
+}`)
+}
+
+func TestMCPCond_NumericAllowDeny(t *testing.T) {
+	cbp := mcpAmountCapPolicy(t)
+
+	allow := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":1200}},"id":1}`)
+	res := cbp.AllowOperation(testContext(), allow, nil, false)
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	require.NotNil(t, res.MCPDecision.Condition)
+	assert.Equal(t, "allow", res.MCPDecision.Condition.Decision)
+
+	deny := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":2000}},"id":1}`)
+	res = cbp.AllowOperation(testContext(), deny, nil, false)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeCondition, res.MCPDecision.RuleType)
+	require.NotNil(t, res.MCPDecision.Condition)
+	assert.Equal(t, "deny", res.MCPDecision.Condition.Decision)
+	assert.Contains(t, res.MCPDecision.Condition.Expression, "call.args.amount")
+}
+
+// TestMCPCond_TokenNamespace confirms an mcp{} condition can read the token
+// namespace (threaded via the TokenEntry), not just call.*.
+func TestMCPCond_TokenNamespace(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["create_payment"]
+    condition       = "token.metadata.env == 'prod'"
+  }
+}`)
+	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":1}},"id":1}`
+
+	prod := cbp.AllowOperation(testContext(), mcpReq(t, body), &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}}, false)
+	assert.True(t, prod.Allowed)
+
+	dev := cbp.AllowOperation(testContext(), mcpReq(t, body), &logical.TokenEntry{Metadata: map[string]string{"env": "dev"}}, false)
+	assert.False(t, dev.Allowed)
+	assert.Equal(t, mcpRuleTypeCondition, dev.MCPDecision.RuleType)
+}
+
+// TestMCPCond_BatchSingleFailAllFail confirms a batch is denied when any one
+// call fails the condition, with BatchIndex stamping the offending call.
+func TestMCPCond_BatchSingleFailAllFail(t *testing.T) {
+	cbp := mcpAmountCapPolicy(t)
+	req := mcpReq(t, `[
+		{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":100}},"id":1},
+		{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":9000}},"id":2}
+	]`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeCondition, res.MCPDecision.RuleType)
+	require.NotNil(t, res.MCPDecision.BatchIndex)
+	assert.Equal(t, 1, *res.MCPDecision.BatchIndex, "second call (index 1) is the one over cap")
+}
+
+// TestMCPCond_TypeMismatchFailsClosed confirms a non-numeric argument against a
+// numeric comparison denies (fail-closed) with a sanitized error category.
+func TestMCPCond_TypeMismatchFailsClosed(t *testing.T) {
+	cbp := mcpAmountCapPolicy(t)
+	req := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":"2000"}},"id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeConditionError, res.MCPDecision.RuleType)
+	require.NotNil(t, res.MCPDecision.Condition)
+	assert.Equal(t, "deny", res.MCPDecision.Condition.Decision)
+	assert.NotEmpty(t, res.MCPDecision.Condition.ErrorKind)
+}
+
+// TestMCPCond_MissingArgFailsClosed confirms an absent argument denies.
+func TestMCPCond_MissingArgFailsClosed(t *testing.T) {
+	cbp := mcpAmountCapPolicy(t)
+	req := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{}},"id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, mcpRuleTypeConditionError, res.MCPDecision.RuleType)
+}
+
+// TestMCPCond_AppliesToEveryMethodInSet locks an important semantic: a set's
+// condition applies to EVERY method the set governs, not just tools/call. A
+// condition that reads call.args therefore fail-closed-denies an argument-less
+// method (e.g. tools/list) the same set allows. Authors must scope with
+// call.method (e.g. `call.method != "tools/call" || call.args.amount <= 1500`).
+func TestMCPCond_AppliesToEveryMethodInSet(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["create_payment"]
+    condition       = "call.args.amount <= 1500"
+  }
+}`)
+	// tools/list carries no args -> the args-referencing condition errors ->
+	// fail-closed deny (NOT a silent allow).
+	list := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	res := cbp.AllowOperation(testContext(), list, nil, false)
+	assert.False(t, res.Allowed, "set-wide condition denies the argument-less method")
+	assert.Equal(t, mcpRuleTypeConditionError, res.MCPDecision.RuleType)
+
+	// A properly scoped condition lets tools/list through.
+	scoped := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["create_payment"]
+    condition       = "call.method != 'tools/call' || call.args.amount <= 1500"
+  }
+}`)
+	list2 := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	assert.True(t, scoped.AllowOperation(testContext(), list2, nil, false).Allowed, "scoped condition admits tools/list")
+}
+
+// Benchmarks reuse one extracted request across iterations (the descriptor is
+// read-only during evaluation), isolating the per-call decide cost.
+
+func benchMCP(b *testing.B, policy, body string, te *logical.TokenEntry) {
+	b.Helper()
+	cbp := mustCBP(b, policy)
+	req := buildE2ERequest(b, body)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, te, false)
+	}
+}
+
+const benchMCPNoCond = `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp { 
+    allowed_methods = ["tools/call"] 
+	allowed_tools   = ["create_payment"] 
+  }
+}`
+
+const benchMCPWithCond = `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["create_payment"]
+    condition       = "call.args.amount <= 1500"
+  }
+}`
+
+const benchMCPCall = `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":1200}},"id":1}`
+
+const benchMCPBatch = `[
+	{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":100}},"id":1},
+	{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":200}},"id":2},
+	{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":300}},"id":3}
+]`
+
+func BenchmarkMCPDecide_NoCondition(b *testing.B)   { benchMCP(b, benchMCPNoCond, benchMCPCall, nil) }
+func BenchmarkMCPDecide_WithCondition(b *testing.B) { benchMCP(b, benchMCPWithCond, benchMCPCall, nil) }
+func BenchmarkMCPDecide_Batch3_NoCondition(b *testing.B) {
+	benchMCP(b, benchMCPNoCond, benchMCPBatch, nil)
+}
+func BenchmarkMCPDecide_Batch3_WithCondition(b *testing.B) {
+	benchMCP(b, benchMCPWithCond, benchMCPBatch, nil)
+}

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -6,6 +6,7 @@ package core
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/logical"
@@ -39,6 +40,8 @@ const (
 	mcpRuleTypeDeniedPrompts    = "denied_prompts"
 	mcpRuleTypeAllowedParams    = "allowed_params"
 	mcpRuleTypeDeniedParams     = "denied_params"
+	mcpRuleTypeCondition        = "condition"
+	mcpRuleTypeConditionError   = "condition_error"
 	mcpRuleTypeMissingMethod    = "missing_method_header"
 
 	mcpRuleTypeMissingBody       = "missing_body"
@@ -154,7 +157,7 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 // Every returned decision passes through sanitizeMCPDecision so
 // adversary-controlled bytes don't leak into audit or response
 // rendering.
-func decideMCP(sets []*CBPMCPRules, req *logical.Request) *logical.MCPDecision {
+func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry, now time.Time) *logical.MCPDecision {
 	if len(sets) == 0 {
 		return nil
 	}
@@ -178,7 +181,7 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request) *logical.MCPDecision {
 			RuleType: desc.ParseErr.Kind,
 		}
 	default:
-		d = evaluateMCPDescriptor(sets, desc)
+		d = evaluateMCPDescriptor(sets, desc, req, te, now)
 		if d == nil {
 			// Defence in depth: evaluateMCPDescriptor returns nil
 			// only for empty sets (handled above) or for a non-nil
@@ -209,7 +212,7 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request) *logical.MCPDecision {
 // descriptor carries no calls. The caller in AllowOperation handles
 // structural failures (nil descriptor, ParseErr non-nil) before
 // invoking this function.
-func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescriptor) *logical.MCPDecision {
+func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescriptor, req *logical.Request, te *logical.TokenEntry, now time.Time) *logical.MCPDecision {
 	if len(sets) == 0 {
 		return nil
 	}
@@ -217,13 +220,25 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 		return nil
 	}
 
+	// Build the request-wide activation once (reused across the batch) only
+	// when at least one set carries a CEL condition; nil otherwise so the
+	// common no-condition path allocates nothing extra.
+	var act *celActivation
+	if mcpSetsHaveCondition(sets) {
+		act = newCELActivation(celRequestInputFromRequest(req), celTokenInputFromEntry(te, now), now, nil)
+	}
+
 	batch := len(desc.Calls) > 1
 	var lastAllow *logical.MCPDecision
 	for i := range desc.Calls {
-		d := evaluateMCPCall(sets, &desc.Calls[i])
+		call := &desc.Calls[i]
+		if act != nil {
+			act.call = buildCallNS(call.Method, call.Name, call.MatchArgs, call.BatchIndex)
+		}
+		d := evaluateMCPCall(sets, call, act)
 		if d.Decision == "deny" {
 			if batch {
-				idx := desc.Calls[i].BatchIndex
+				idx := call.BatchIndex
 				d.BatchIndex = &idx
 			}
 			return d
@@ -233,10 +248,20 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 	return lastAllow
 }
 
+func mcpSetsHaveCondition(sets []*CBPMCPRules) bool {
+	for _, s := range sets {
+		if s != nil && s.Condition != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // evaluateMCPCall runs all rule-sets against one MCPCall and applies
 // the cross-set OR / strongest-reason-deny semantics. Lowercases
 // method/name once at the boundary so per-set comparisons stay cheap.
-func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall) *logical.MCPDecision {
+// act carries the per-call CEL activation (nil when no set has a condition).
+func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall, act *celActivation) *logical.MCPDecision {
 	method := strings.ToLower(call.Method)
 	name := strings.ToLower(call.Name)
 
@@ -244,7 +269,7 @@ func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall) *logical.MCPDec
 	var denyRank int
 
 	for _, set := range sets {
-		setDecision := evaluateMCPSetForCall(set, method, name, call)
+		setDecision := evaluateMCPSetForCall(set, method, name, call, act)
 		if setDecision.Decision == "allow" {
 			return setDecision
 		}
@@ -262,7 +287,7 @@ func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall) *logical.MCPDec
 // nil) — either an allow with the matching pattern stamped, or a
 // deny with the failing gate and pattern stamped. Reads param values
 // from call.MatchArgs.
-func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.MCPCall) *logical.MCPDecision {
+func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.MCPCall, act *celActivation) *logical.MCPDecision {
 	d := &logical.MCPDecision{Method: method, Name: name}
 
 	// (a) Missing method → deny. The body-authoritative parser
@@ -354,10 +379,32 @@ func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.
 		}
 	}
 
-	// (f) Nothing denied — this set allows. Record the gate that
+	// (f) CEL condition gate (last, after the structured gates). Fail-closed:
+	// an erroring or false condition denies. Evaluated against the request /
+	// token namespaces plus this call.
+	if set.Condition != nil {
+		ok, err := evalCELCondition(set.Condition.Program, act)
+		if err != nil {
+			d.Decision = "deny"
+			d.RuleType = mcpRuleTypeConditionError
+			d.Condition = &logical.ConditionResult{Decision: "deny", Expression: set.Condition.Source, ErrorKind: celErrorKind(err)}
+			return d
+		}
+		if !ok {
+			d.Decision = "deny"
+			d.RuleType = mcpRuleTypeCondition
+			d.Condition = &logical.ConditionResult{Decision: "deny", Expression: set.Condition.Source}
+			return d
+		}
+	}
+
+	// (g) Nothing denied — this set allows. Record the gate that
 	// authorised the request so audit can show which rule fired.
 	d.Decision = "allow"
 	d.RuleType = mcpRuleTypeAllowedMethods
+	if set.Condition != nil {
+		d.Condition = &logical.ConditionResult{Decision: "allow", Expression: set.Condition.Source}
+	}
 	if len(set.AllowedMethods) > 0 {
 		d.MatchedRule = matchMCPAny(method, set.AllowedMethods)
 	} else {
@@ -448,7 +495,9 @@ func mcpDenyRank(ruleType string) int {
 		mcpRuleTypeDeniedTools,
 		mcpRuleTypeDeniedResources,
 		mcpRuleTypeDeniedPrompts,
-		mcpRuleTypeDeniedParams:
+		mcpRuleTypeDeniedParams,
+		mcpRuleTypeCondition,
+		mcpRuleTypeConditionError:
 		return 3
 	case mcpRuleTypeAllowedMethods,
 		mcpRuleTypeAllowedTools,
@@ -542,6 +591,7 @@ func sanitizeMCPDecision(d *logical.MCPDecision) {
 	d.MatchedRule = stripCTL(d.MatchedRule)
 	d.ParamName = stripCTL(d.ParamName)
 	d.ParamValue = stripCTL(d.ParamValue)
+	d.Condition.Sanitize()
 }
 
 // stripCTL removes ASCII control characters (\x00-\x1F, \x7F) from s.

--- a/core/policy_mcp_body_test.go
+++ b/core/policy_mcp_body_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestDecideMCP_NilDescriptorDeniesMissingBody(t *testing.T) {
 		AllowedMethods: []string{"tools/list"},
 	}}
 	req := &logical.Request{} // no MCPDescriptor
-	d := decideMCP(sets, req)
+	d := decideMCP(sets, req, nil, time.Time{})
 	require.NotNil(t, d)
 	assert.Equal(t, "deny", d.Decision)
 	assert.Equal(t, mcpRuleTypeMissingBody, d.RuleType)
@@ -54,7 +55,7 @@ func TestDecideMCP_ParseErrMapsByKind(t *testing.T) {
 					},
 				},
 			}
-			d := decideMCP(sets, req)
+			d := decideMCP(sets, req, nil, time.Time{})
 			require.NotNil(t, d)
 			assert.Equal(t, "deny", d.Decision)
 			assert.Equal(t, tc.ruleType, d.RuleType)
@@ -82,7 +83,7 @@ func TestDecideMCP_DescriptorMatcherAllows(t *testing.T) {
 			}},
 		},
 	}
-	d := decideMCP(sets, req)
+	d := decideMCP(sets, req, nil, time.Time{})
 	require.NotNil(t, d)
 	assert.Equal(t, "allow", d.Decision)
 }
@@ -110,7 +111,7 @@ func TestDecideMCP_EmptyDescriptorSkipsEvaluation(t *testing.T) {
 			// Calls nil, ParseErr nil — the per-request opt-out sentinel.
 		},
 	}
-	d := decideMCP(sets, req)
+	d := decideMCP(sets, req, nil, time.Time{})
 	assert.Nil(t, d, "decideMCP must return nil for the per-request opt-out sentinel so the cap-level check decides")
 }
 
@@ -123,10 +124,10 @@ func TestDecideMCP_EmptySetsReturnNil(t *testing.T) {
 			Calls: []logical.MCPCall{{Method: "tools/list"}},
 		},
 	}
-	if d := decideMCP(nil, req); d != nil {
+	if d := decideMCP(nil, req, nil, time.Time{}); d != nil {
 		t.Errorf("decision = %+v, want nil for empty sets", d)
 	}
-	if d := decideMCP([]*CBPMCPRules{}, req); d != nil {
+	if d := decideMCP([]*CBPMCPRules{}, req, nil, time.Time{}); d != nil {
 		t.Errorf("decision = %+v, want nil for empty sets slice", d)
 	}
 }
@@ -145,7 +146,7 @@ func TestEvaluateMCPDescriptor_BatchDenyStampsBatchIndex(t *testing.T) {
 			{Method: "tools/call", Name: "delete_repo", BatchIndex: 2},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc)
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 	require.NotNil(t, d)
 	require.Equal(t, "deny", d.Decision)
 	require.NotNil(t, d.BatchIndex, "BatchIndex should be stamped for batch denies")
@@ -163,7 +164,7 @@ func TestEvaluateMCPDescriptor_SingleCallLeavesBatchIndexNil(t *testing.T) {
 			{Method: "tools/call", Name: "delete_repo"},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc)
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 	require.NotNil(t, d)
 	if d.BatchIndex != nil {
 		t.Errorf("BatchIndex = %v, want nil for single-call descriptor", *d.BatchIndex)
@@ -219,7 +220,7 @@ func TestDecideMCP_SanitizesDecisionBoundary(t *testing.T) {
 			}},
 		},
 	}
-	d := decideMCP(sets, req)
+	d := decideMCP(sets, req, nil, time.Time{})
 	require.NotNil(t, d)
 	assert.Equal(t, "deny", d.Decision)
 	assert.Equal(t, mcpRuleTypeDeniedTools, d.RuleType)

--- a/core/policy_mcp_descriptor_test.go
+++ b/core/policy_mcp_descriptor_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/logical"
 )
@@ -29,7 +30,7 @@ func TestEvaluateMCPDescriptor_SingleCallParamString(t *testing.T) {
 			},
 		}},
 	}
-	d := evaluateMCPDescriptor(sets, desc)
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 	if d == nil || d.Decision != "allow" {
 		t.Fatalf("decision = %+v, want allow", d)
 	}
@@ -55,7 +56,7 @@ func TestEvaluateMCPDescriptor_NumericParamMatches(t *testing.T) {
 			},
 		}},
 	}
-	d := evaluateMCPDescriptor(sets, desc)
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 	if d == nil || d.Decision != "deny" {
 		t.Fatalf("decision = %+v, want deny", d)
 	}
@@ -85,7 +86,7 @@ func TestEvaluateMCPDescriptor_NonScalarParamTreatedAsMissing(t *testing.T) {
 				},
 			}},
 		}
-		d := evaluateMCPDescriptor(sets, desc)
+		d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 		if d == nil || d.Decision != "allow" {
 			t.Fatalf("decision = %+v, want allow (object value skipped by deny gate)", d)
 		}
@@ -110,7 +111,7 @@ func TestEvaluateMCPDescriptor_NonScalarParamTreatedAsMissing(t *testing.T) {
 				},
 			}},
 		}
-		d := evaluateMCPDescriptor(sets, desc)
+		d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 		if d == nil || d.Decision != "allow" {
 			t.Fatalf("decision = %+v, want allow (object value treated as missing; conditional skip)", d)
 		}
@@ -130,7 +131,7 @@ func TestEvaluateMCPDescriptor_BatchOneDeniedFailsAll(t *testing.T) {
 			{Method: "tools/call", Name: "delete_repo", BatchIndex: 1},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc)
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 	if d == nil || d.Decision != "deny" {
 		t.Fatalf("decision = %+v, want deny", d)
 	}
@@ -152,7 +153,7 @@ func TestEvaluateMCPDescriptor_BatchAllAllowed(t *testing.T) {
 			{Method: "tools/call", Name: "search_repos", BatchIndex: 1},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc)
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
 	if d == nil || d.Decision != "allow" {
 		t.Fatalf("decision = %+v, want allow", d)
 	}
@@ -165,10 +166,10 @@ func TestEvaluateMCPDescriptor_NoCallsReturnsNil(t *testing.T) {
 	sets := []*CBPMCPRules{{
 		AllowedMethods: []string{"tools/list"},
 	}}
-	if d := evaluateMCPDescriptor(sets, nil); d != nil {
+	if d := evaluateMCPDescriptor(sets, nil, nil, nil, time.Time{}); d != nil {
 		t.Errorf("nil descriptor: decision = %+v, want nil", d)
 	}
-	if d := evaluateMCPDescriptor(sets, &logical.MCPRequestDescriptor{}); d != nil {
+	if d := evaluateMCPDescriptor(sets, &logical.MCPRequestDescriptor{}, nil, nil, time.Time{}); d != nil {
 		t.Errorf("empty Calls: decision = %+v, want nil", d)
 	}
 }

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -69,7 +69,7 @@ func synthesizeMCPDescriptorFromBody(body []byte) *logical.MCPRequestDescriptor 
 
 // mustCBP builds a CBP from raw policy HCL, failing the test on any
 // parse or build error. Keeps every test case to a four-line setup.
-func mustCBP(t *testing.T, rules string) *CBP {
+func mustCBP(t testing.TB, rules string) *CBP {
 	t.Helper()
 	policy := testParsePolicy(t, rules)
 	cbp, err := NewCBP(testContext(), []*Policy{policy})


### PR DESCRIPTION
Fourth PR in the CEL policy-conditions stack (depends on #362/#364/#365, all merged).

## What

Adds a **per-call `condition`** inside the `mcp { }` block, evaluated once per MCP tool call.

- Compiled against the MCP env (base namespaces + `call`), so it can read `call.method` / `call.tool` / `call.args.<k>` / `call.batch_index` alongside `request.*` / `token.*` / `now`.
- Evaluated in `evaluateMCPSetForCall` **after** the structured method/name gates (fail-fast: the cheap deny/allow lists run first). A call passes only if its structural gates and its condition hold; fail-closed on `false` or error.
- Composes with batch semantics (single-fail-all-fail, `BatchIndex` stamping) and the cross-set OR / strongest-reason deny ranking (a condition deny ranks below structural failures). Records `rule_type = "condition"` / `"condition_error"`, and populates `MCPDecision.Condition`.
- `now` is shared with the path-level snapshot (one instant per request).

## Scope

Additive — the MCP `allowed_params`/`denied_params` mechanism still works alongside this; its removal is a later PR. Non-MCP paths and condition-less MCP blocks are unaffected.

## Tests

`core/policy_cel_mcp_test.go`: numeric allow/deny, token-namespace access, batch single-fail-all-fail, type-mismatch and missing-arg fail-closed, applies-to-every-method-in-set, plus benchmarks.
