### PR TITLE
feat(policy)!: remove request-body parameter constraints (folded into CEL)

### DIFF
--- a/core/policy.go
+++ b/core/policy.go
@@ -152,9 +152,6 @@ type MCPRulesHCL struct {
 
 type CBPPermissions struct {
 	CapabilitiesBitmap     uint32
-	AllowedParameters      map[string][]any
-	DeniedParameters       map[string][]any
-	RequiredParameters     []string
 	PaginationLimit        int
 	GrantingPoliciesMap    map[uint32][]sdklogical.PolicyInfo
 	ResponseKeysFilterPath string
@@ -233,33 +230,8 @@ func (m *CBPMCPRules) Clone() *CBPMCPRules {
 func (p *CBPPermissions) Clone() (*CBPPermissions, error) {
 	ret := &CBPPermissions{
 		CapabilitiesBitmap:     p.CapabilitiesBitmap,
-		RequiredParameters:     p.RequiredParameters[:],
 		PaginationLimit:        p.PaginationLimit,
 		ResponseKeysFilterPath: p.ResponseKeysFilterPath,
-	}
-
-	switch {
-	case p.AllowedParameters == nil:
-	case len(p.AllowedParameters) == 0:
-		ret.AllowedParameters = make(map[string][]any)
-	default:
-		clonedAllowed, err := copystructure.Copy(p.AllowedParameters)
-		if err != nil {
-			return nil, err
-		}
-		ret.AllowedParameters = clonedAllowed.(map[string][]any)
-	}
-
-	switch {
-	case p.DeniedParameters == nil:
-	case len(p.DeniedParameters) == 0:
-		ret.DeniedParameters = make(map[string][]any)
-	default:
-		clonedDenied, err := copystructure.Copy(p.DeniedParameters)
-		if err != nil {
-			return nil, err
-		}
-		ret.DeniedParameters = clonedDenied.(map[string][]any)
 	}
 
 	switch {
@@ -464,21 +436,10 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			}
 		}
 
-		if pc.AllowedParametersHCL != nil {
-			pc.Permissions.AllowedParameters = make(map[string][]interface{}, len(pc.AllowedParametersHCL))
-			for k, v := range pc.AllowedParametersHCL {
-				pc.Permissions.AllowedParameters[strings.ToLower(k)] = v
-			}
-		}
-		if pc.DeniedParametersHCL != nil {
-			pc.Permissions.DeniedParameters = make(map[string][]interface{}, len(pc.DeniedParametersHCL))
-
-			for k, v := range pc.DeniedParametersHCL {
-				pc.Permissions.DeniedParameters[strings.ToLower(k)] = v
-			}
-		}
-		if len(pc.RequiredParametersHCL) > 0 {
-			pc.Permissions.RequiredParameters = pc.RequiredParametersHCL[:]
+		if len(pc.AllowedParametersHCL) > 0 || len(pc.DeniedParametersHCL) > 0 || len(pc.RequiredParametersHCL) > 0 {
+			return fmt.Errorf("path %q: required_parameters/allowed_parameters/denied_parameters have been removed — "+
+				"express request-body constraints as a CEL `condition` over request.data, e.g. "+
+				"condition = \"has(request.data.owner) && request.data.tier in ['gold','silver']\"", key)
 		}
 		if len(pc.ResponseKeysFilterPathHCL) > 0 {
 			pc.Permissions.ResponseKeysFilterPath = pc.ResponseKeysFilterPathHCL

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,8 +12,6 @@ import (
 	"github.com/armon/go-radix"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-	"github.com/hashicorp/go-secure-stdlib/strutil"
-	"github.com/mitchellh/copystructure"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logical"
 
@@ -175,8 +171,6 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 			case pc.Permissions.CapabilitiesBitmap&DenyCapabilityInt > 0:
 				// If this new policy explicitly denies, only save the deny value
 				existingPerms.CapabilitiesBitmap = DenyCapabilityInt
-				existingPerms.AllowedParameters = nil
-				existingPerms.DeniedParameters = nil
 				goto INSERT
 
 			default:
@@ -184,62 +178,6 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 				// value
 				existingPerms.CapabilitiesBitmap = existingPerms.CapabilitiesBitmap | pc.Permissions.CapabilitiesBitmap
 				existingPerms.GrantingPoliciesMap = addGrantingPoliciesToMap(existingPerms.GrantingPoliciesMap, policy, pc.Permissions.CapabilitiesBitmap)
-			}
-
-			if len(pc.Permissions.AllowedParameters) > 0 {
-				if existingPerms.AllowedParameters == nil {
-					clonedAllowed, err := copystructure.Copy(pc.Permissions.AllowedParameters)
-					if err != nil {
-						return nil, err
-					}
-					existingPerms.AllowedParameters = clonedAllowed.(map[string][]interface{})
-				} else {
-					for key, value := range pc.Permissions.AllowedParameters {
-						pcValue, ok := existingPerms.AllowedParameters[key]
-						// If an empty array exist it should overwrite any other
-						// value.
-						if len(value) == 0 || (ok && len(pcValue) == 0) {
-							existingPerms.AllowedParameters[key] = []interface{}{}
-						} else {
-							// Merge the two maps, appending values on key conflict.
-							existingPerms.AllowedParameters[key] = append(value, existingPerms.AllowedParameters[key]...)
-						}
-					}
-				}
-			}
-
-			if len(pc.Permissions.DeniedParameters) > 0 {
-				if existingPerms.DeniedParameters == nil {
-					clonedDenied, err := copystructure.Copy(pc.Permissions.DeniedParameters)
-					if err != nil {
-						return nil, err
-					}
-					existingPerms.DeniedParameters = clonedDenied.(map[string][]interface{})
-				} else {
-					for key, value := range pc.Permissions.DeniedParameters {
-						pcValue, ok := existingPerms.DeniedParameters[key]
-						// If an empty array exist it should overwrite any other
-						// value.
-						if len(value) == 0 || (ok && len(pcValue) == 0) {
-							existingPerms.DeniedParameters[key] = []interface{}{}
-						} else {
-							// Merge the two maps, appending values on key conflict.
-							existingPerms.DeniedParameters[key] = append(value, existingPerms.DeniedParameters[key]...)
-						}
-					}
-				}
-			}
-
-			if len(pc.Permissions.RequiredParameters) > 0 {
-				if len(existingPerms.RequiredParameters) == 0 {
-					existingPerms.RequiredParameters = pc.Permissions.RequiredParameters
-				} else {
-					for _, v := range pc.Permissions.RequiredParameters {
-						if !slices.Contains(existingPerms.RequiredParameters, v) {
-							existingPerms.RequiredParameters = append(existingPerms.RequiredParameters, v)
-						}
-					}
-				}
 			}
 
 			// Lowest set pagination limit wins.
@@ -511,154 +449,47 @@ CHECK:
 
 	ret.GrantingPolicies = grantingPolicies
 
-	// Only check parameter permissions for operations that can modify
-	// parameters.
-	if op == logical.ReadOperation || op == logical.UpdateOperation || op == logical.CreateOperation || op == logical.PatchOperation {
-		for _, parameter := range permissions.RequiredParameters {
-			if _, ok := req.Data[strings.ToLower(parameter)]; !ok {
-				return ret
-			}
-		}
-
-		// If there are no data fields, allow
-		if len(req.Data) == 0 {
-			ret.Allowed = true
-			return ret
-		}
-
-		if len(permissions.DeniedParameters) == 0 {
-			goto ALLOWED_PARAMETERS
-		}
-
-		// Check if all parameters have been denied
-		if _, ok := permissions.DeniedParameters["*"]; ok {
-			return ret
-		}
-
-		for parameter, value := range req.Data {
-			// Check if parameter has been explicitly denied
-			if valueSlice, ok := permissions.DeniedParameters[strings.ToLower(parameter)]; ok {
-				// If the value exists in denied values slice, deny
-				if valueInParameterList(value, valueSlice) {
-					return ret
-				}
-			}
-		}
-
-	ALLOWED_PARAMETERS:
-		// If we don't have any allowed parameters set, allow
-		if len(permissions.AllowedParameters) == 0 {
-			ret.Allowed = true
-			return ret
-		}
-
-		_, allowedAll := permissions.AllowedParameters["*"]
-		if len(permissions.AllowedParameters) == 1 && allowedAll {
-			ret.Allowed = true
-			return ret
-		}
-
-		for parameter, value := range req.Data {
-			valueSlice, ok := permissions.AllowedParameters[strings.ToLower(parameter)]
-			// Requested parameter is not in allowed list
-			if !ok && !allowedAll {
-				return ret
-			}
-
-			// If the value doesn't exists in the allowed values slice,
-			// deny
-			if ok && !valueInParameterList(value, valueSlice) {
-				return ret
-			}
-		}
-	} else if op == logical.ListOperation || op == logical.ScanOperation {
+	// Pagination clamping and list-response key filtering for list/scan.
+	// (Request-body parameter constraints have been removed; express value
+	// rules as a CEL condition over request.data — e.g. has(request.data.x)
+	// to require a field, or request.data.tier in [...] to constrain a value.)
+	if op == logical.ListOperation || op == logical.ScanOperation {
 		if permissions.PaginationLimit > 0 {
 			valRaw, ok := req.Data[limitParameterName]
 			if !ok {
-				// For callers unaware of pagination, deny the request IF
-				// limit is a required parameter; this prevents integrations
-				// from silently continuing to work if they were not expecting
-				// to have pagination while also allowing them to continue
-				// working if the operator just wishes to enable pagination
-				// for them without breakage.
-
-				limitRequiredParameter := false
-				for _, parameter := range permissions.RequiredParameters {
-					if strings.ToLower(parameter) == limitParameterName {
-						limitRequiredParameter = true
-						break
-					}
-				}
-
-				if limitRequiredParameter {
-					return ret
-				}
-
-				// Otherwise, update our field value to the maximum allowed.
+				// No limit supplied — clamp to the maximum allowed page size.
 				if req.Data == nil {
-					// A list operation may have no parameters so we need to
-					// populate this explicitly.
 					req.Data = make(map[string]interface{}, 1)
 				}
 				req.Data[limitParameterName] = strconv.Itoa(permissions.PaginationLimit)
 			} else {
-				// Value was provided on the API request and we have a
-				// non-zero limit so we know it was intended to be a limit
-				// operation on a paginated endpoint. Parse the value and
-				// ACL accordingly.
+				// Limit supplied on a paginated endpoint — parse and clamp.
 				val, err := parseutil.SafeParseInt(valRaw)
 				if err != nil {
-					// Unable to parse provided limit as an integer; we assume
-					// the policy author is correct that this is a regular list
-					// endpoint which (optionally) takes a limit. The one
-					// exception is if the user has passed the literal value
-					// "max" to signify the maximum allowed page size, which
-					// works even if the parameter is required (versus leaving
-					// it off).
+					// Not an integer; only the literal "max" is honored, mapping
+					// to the maximum allowed page size. Anything else is denied.
 					valStr, ok := valRaw.(string)
 					if !ok || valStr != "max" {
-						// Request denied.
 						return ret
 					}
-
-					// Otherwise, update our field value to the maximum allowed.
 					req.Data[limitParameterName] = strconv.Itoa(permissions.PaginationLimit)
-				} else {
+				} else if val > permissions.PaginationLimit {
 					// Deny if we exceed our allotted page size.
-					if val > permissions.PaginationLimit {
-						return ret
-					}
+					return ret
 				}
 			}
 		} else {
-			// Check if we have the value `max` and set it to 0. This allows
-			// pagination-aware applications to read all data via the same
-			// semantics, without knowing ahead of time whether they are
-			// pagination-limited on a given endpoint: they can call with
-			// after=""&limit=max and then retry with after=<last>&limit=max
-			// and see if any results are returned, repeating until none are.
-
-			valRaw, ok := req.Data[limitParameterName]
-			if ok {
-				// Failure to parse should be ignored in this case. The
-				// operator has not indicated to us that this value of
-				// limit should be an integer limit and it may be some
-				// custom plugin with alternative behavior.
-				valStr, ok := valRaw.(string)
-				if ok && valStr == "max" {
-					// Application has indicated they're aware of the value
-					// of limit and so we should set the limit to zero
-					// (maximum).
+			// No pagination limit configured: honor the "max" sentinel so
+			// pagination-aware applications can request all data uniformly.
+			if valRaw, ok := req.Data[limitParameterName]; ok {
+				if valStr, ok := valRaw.(string); ok && valStr == "max" {
 					req.Data[limitParameterName] = "0"
 				}
 			}
 		}
-	}
 
-	// Return the ResponseKeysFilterPath value from this permission: it
-	// will allow filterListResponse to evaluate list filtering without
-	// having knowledge of concrete policies.
-	if op == logical.ListOperation || op == logical.ScanOperation {
+		// Surface the filter path so filterListResponse can evaluate list
+		// filtering without knowledge of concrete policies.
 		ret.ResponseKeysFilterPath = permissions.ResponseKeysFilterPath
 	}
 
@@ -865,37 +696,4 @@ func (c *Core) performPolicyChecks(ctx context.Context, cbp *CBP, te *logical.To
 	ret.Allowed = true
 
 	return ret
-}
-
-func valueInParameterList(v interface{}, list []interface{}) bool {
-	// Empty list is equivalent to the item always existing in the list
-	if len(list) == 0 {
-		return true
-	}
-
-	return valueInSlice(v, list)
-}
-
-func valueInSlice(v interface{}, list []interface{}) bool {
-	for _, el := range list {
-		if el == nil || v == nil {
-			// It doesn't seem possible to set up a nil entry in the list, but it is possible
-			// to pass in a null entry in the API request being checked. Just in case,
-			// nil will match nil.
-			if el == v {
-				return true
-			}
-		} else if reflect.TypeOf(el).String() == "string" && reflect.TypeOf(v).String() == "string" {
-			item := el.(string)
-			val := v.(string)
-
-			if strutil.GlobbedStringsMatch(item, val) {
-				return true
-			}
-		} else if reflect.DeepEqual(el, v) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 )
 
 // Helper function to create a context with root namespace
@@ -655,214 +657,6 @@ func TestCBP_ExistingDenyNotOverridden(t *testing.T) {
 }
 
 // =============================================================================
-// Parameter Tests - Allowed Parameters
-// =============================================================================
-
-func TestCBP_AllowedParameters(t *testing.T) {
-	ctx := testContext()
-
-	policy := testParsePolicy(t, `
-		path "secret/data/*" {
-			capabilities = ["create", "update"]
-			allowed_parameters = {
-				"key1" = []
-				"key2" = ["value1", "value2"]
-			}
-		}
-	`)
-
-	cbp, err := NewCBP(ctx, []*Policy{policy})
-	require.NoError(t, err)
-
-	// Empty allowed values means any value is allowed
-	req := &logical.Request{
-		Path:      "secret/data/test",
-		Operation: logical.CreateOperation,
-		Data: map[string]interface{}{
-			"key1": "any-value",
-		},
-	}
-	result := cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-
-	// Specific allowed value
-	req.Data = map[string]interface{}{
-		"key2": "value1",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-
-	// Value not in allowed list
-	req.Data = map[string]interface{}{
-		"key2": "value3",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-
-	// Parameter not in allowed list
-	req.Data = map[string]interface{}{
-		"key3": "value",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-}
-
-func TestCBP_AllowedParametersWildcard(t *testing.T) {
-	ctx := testContext()
-
-	policy := testParsePolicy(t, `
-		path "secret/data/*" {
-			capabilities = ["create"]
-			allowed_parameters = {
-				"*" = []
-			}
-		}
-	`)
-
-	cbp, err := NewCBP(ctx, []*Policy{policy})
-	require.NoError(t, err)
-
-	// Any parameter should be allowed
-	req := &logical.Request{
-		Path:      "secret/data/test",
-		Operation: logical.CreateOperation,
-		Data: map[string]interface{}{
-			"any_key": "any_value",
-			"another": "value",
-		},
-	}
-	result := cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-}
-
-// =============================================================================
-// Parameter Tests - Denied Parameters
-// =============================================================================
-
-func TestCBP_DeniedParameters(t *testing.T) {
-	ctx := testContext()
-
-	policy := testParsePolicy(t, `
-		path "secret/data/*" {
-			capabilities = ["create", "update"]
-			denied_parameters = {
-				"password" = []
-				"secret_key" = ["forbidden_value"]
-			}
-		}
-	`)
-
-	cbp, err := NewCBP(ctx, []*Policy{policy})
-	require.NoError(t, err)
-
-	// Denied parameter with any value
-	req := &logical.Request{
-		Path:      "secret/data/test",
-		Operation: logical.CreateOperation,
-		Data: map[string]interface{}{
-			"password": "any-password",
-		},
-	}
-	result := cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-
-	// Denied parameter with specific value
-	req.Data = map[string]interface{}{
-		"secret_key": "forbidden_value",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-
-	// Denied parameter with non-forbidden value
-	req.Data = map[string]interface{}{
-		"secret_key": "allowed_value",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-
-	// Non-denied parameter
-	req.Data = map[string]interface{}{
-		"normal_key": "value",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-}
-
-func TestCBP_DeniedParametersWildcard(t *testing.T) {
-	ctx := testContext()
-
-	policy := testParsePolicy(t, `
-		path "secret/data/*" {
-			capabilities = ["create"]
-			denied_parameters = {
-				"*" = []
-			}
-		}
-	`)
-
-	cbp, err := NewCBP(ctx, []*Policy{policy})
-	require.NoError(t, err)
-
-	// Any parameter should be denied
-	req := &logical.Request{
-		Path:      "secret/data/test",
-		Operation: logical.CreateOperation,
-		Data: map[string]interface{}{
-			"any_key": "value",
-		},
-	}
-	result := cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-
-	// No data should be allowed
-	req.Data = nil
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-}
-
-// =============================================================================
-// Parameter Tests - Required Parameters
-// =============================================================================
-
-func TestCBP_RequiredParameters(t *testing.T) {
-	ctx := testContext()
-
-	policy := testParsePolicy(t, `
-		path "secret/data/*" {
-			capabilities = ["create"]
-			required_parameters = ["name", "type"]
-		}
-	`)
-
-	cbp, err := NewCBP(ctx, []*Policy{policy})
-	require.NoError(t, err)
-
-	// All required parameters present
-	req := &logical.Request{
-		Path:      "secret/data/test",
-		Operation: logical.CreateOperation,
-		Data: map[string]interface{}{
-			"name": "test",
-			"type": "secret",
-		},
-	}
-	result := cbp.AllowOperation(ctx, req, nil, false)
-	assert.True(t, result.Allowed)
-
-	// Missing required parameter
-	req.Data = map[string]interface{}{
-		"name": "test",
-	}
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-
-	// No data at all
-	req.Data = nil
-	result = cbp.AllowOperation(ctx, req, nil, false)
-	assert.False(t, result.Allowed)
-}
-
-// =============================================================================
 // Capabilities Method Tests
 // =============================================================================
 
@@ -1271,62 +1065,26 @@ func TestPerformPolicyChecks_RootPrivsGranted(t *testing.T) {
 
 func TestCBPPermissions_Clone(t *testing.T) {
 	original := &CBPPermissions{
-		CapabilitiesBitmap: ReadCapabilityInt | CreateCapabilityInt,
-		AllowedParameters: map[string][]any{
-			"key1": {"value1", "value2"},
+		CapabilitiesBitmap:     ReadCapabilityInt | CreateCapabilityInt,
+		PaginationLimit:        100,
+		ResponseKeysFilterPath: "secret/data/{{key}}",
+		GrantingPoliciesMap: map[uint32][]sdklogical.PolicyInfo{
+			ReadCapabilityInt: {{Name: "p1"}},
 		},
-		DeniedParameters: map[string][]any{
-			"password": {},
-		},
-		RequiredParameters: []string{"name", "type"},
-		PaginationLimit:    100,
 	}
 
 	cloned, err := original.Clone()
 	require.NoError(t, err)
 
-	// Verify values are copied
 	assert.Equal(t, original.CapabilitiesBitmap, cloned.CapabilitiesBitmap)
 	assert.Equal(t, original.PaginationLimit, cloned.PaginationLimit)
-	assert.Equal(t, original.RequiredParameters, cloned.RequiredParameters)
+	assert.Equal(t, original.ResponseKeysFilterPath, cloned.ResponseKeysFilterPath)
+	assert.Equal(t, original.GrantingPoliciesMap, cloned.GrantingPoliciesMap)
 
-	// Verify deep copy of maps
-	assert.Equal(t, original.AllowedParameters, cloned.AllowedParameters)
-	assert.Equal(t, original.DeniedParameters, cloned.DeniedParameters)
-
-	// Modify original and verify clone is not affected
-	original.AllowedParameters["key1"] = []any{"modified"}
-	assert.NotEqual(t, original.AllowedParameters["key1"], cloned.AllowedParameters["key1"])
-}
-
-func TestCBPPermissions_CloneNilMaps(t *testing.T) {
-	original := &CBPPermissions{
-		CapabilitiesBitmap: ReadCapabilityInt,
-		RequiredParameters: []string{},
-	}
-
-	cloned, err := original.Clone()
-	require.NoError(t, err)
-
-	assert.Nil(t, cloned.AllowedParameters)
-	assert.Nil(t, cloned.DeniedParameters)
-}
-
-func TestCBPPermissions_CloneEmptyMaps(t *testing.T) {
-	original := &CBPPermissions{
-		CapabilitiesBitmap: ReadCapabilityInt,
-		AllowedParameters:  map[string][]any{},
-		DeniedParameters:   map[string][]any{},
-		RequiredParameters: []string{},
-	}
-
-	cloned, err := original.Clone()
-	require.NoError(t, err)
-
-	assert.NotNil(t, cloned.AllowedParameters)
-	assert.NotNil(t, cloned.DeniedParameters)
-	assert.Len(t, cloned.AllowedParameters, 0)
-	assert.Len(t, cloned.DeniedParameters, 0)
+	// Deep copy: mutating the original's granting-policies map must not
+	// affect the clone.
+	original.GrantingPoliciesMap[ReadCapabilityInt] = []sdklogical.PolicyInfo{{Name: "mutated"}}
+	assert.Equal(t, "p1", cloned.GrantingPoliciesMap[ReadCapabilityInt][0].Name)
 }
 
 // =============================================================================

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -182,6 +182,28 @@ func TestCBP_PathCondition_UnconditionalGrantWins(t *testing.T) {
 	assert.True(t, res.Allowed, "unconditional grant from B admits any request")
 }
 
+// TestCBP_RequestParamsRemoved confirms the removed request-body parameter
+// constraints are rejected at parse time with a directed "use CEL" error.
+func TestCBP_RequestParamsRemoved(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"required", `required_parameters = ["owner"]`},
+		{"allowed", `allowed_parameters = { tier = ["gold"] }`},
+		{"denied", `denied_parameters = { internal = [] }`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCBPPolicy(namespace.RootNamespace, `
+				path "secret/data/app" {
+					capabilities = ["create"]
+					`+tc.body+`
+				}
+			`)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "have been removed")
+			assert.Contains(t, err.Error(), "request.data")
+		})
+	}
+}
+
 // TestCBP_ConditionsBlockRemoved confirms the legacy conditions {} block is
 // rejected at parse time with a directed "use CEL" error.
 func TestCBP_ConditionsBlockRemoved(t *testing.T) {

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -108,31 +108,6 @@ two candidates, so the named rule is what breaks the tie.
 pattern — a different, less-specific pattern that also matches does not add its
 capabilities.)
 
-### Parameter constraints
-
-A path block can constrain the parameters of a request, not just the operation:
-
-```hcl
-path "secret/data/app" {
-  capabilities = ["create", "update"]
-
-  required_parameters = ["owner"]
-
-  allowed_parameters = {
-    "tier" = ["gold", "silver"]   # only these values
-    "name" = []                   # any value, but the key is allowed
-  }
-
-  denied_parameters = {
-    "internal" = []               # this key may never be set
-  }
-}
-```
-
-`required_parameters` must be present; `allowed_parameters` whitelists keys (and
-optionally their values); `denied_parameters` forbids keys (an empty list denies
-the key entirely).
-
 ### Fine-grained access
 
 A path block can gate access on request context and values with a
@@ -193,6 +168,9 @@ Examples:
 ```hcl
 # numeric cap on a request-body field
 condition = "request.data.ttl_seconds <= 3600"
+
+# request-body constraints: require a field, restrict a value, forbid a key
+condition = "has(request.data.owner) && request.data.tier in ['gold', 'silver'] && !has(request.data.internal)"
 
 # set membership over token metadata
 condition = "token.metadata.env in ['dev', 'staging']"

--- a/docs/provider-backends/anthropic.md
+++ b/docs/provider-backends/anthropic.md
@@ -205,11 +205,10 @@ For fine-grained cost control, restrict access based on AI request fields:
 warden policy write anthropic-restricted - <<EOF
 path "anthropic/role/+/gateway/v1/messages" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "model" = ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"]
-    "stream" = ["true"]
-    "*"      = []
-  }
+  condition = <<-CEL
+    (!has(request.data.model) || request.data.model in ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"]) &&
+    (!has(request.data.stream) || request.data.stream == true)
+  CEL
 }
 EOF
 ```
@@ -220,12 +219,9 @@ You can also combine parameter restrictions with runtime conditions to protect c
 warden policy write anthropic-prod-restricted - <<EOF
 path "anthropic/role/+/gateway/v1/messages" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "model" = ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"]
-    "stream" = ["true"]
-    "*"      = []
-  }
   condition = <<-CEL
+    (!has(request.data.model) || request.data.model in ["claude-sonnet-4-20250514", "claude-haiku-4-20250414"]) &&
+    (!has(request.data.stream) || request.data.stream == true) &&
     cidrContains("10.0.0.0/8", request.client_ip) &&
     now.getHours("UTC") >= 8 && now.getHours("UTC") < 18 &&
     now.getDayOfWeek("UTC") in [1, 2, 3, 4, 5]

--- a/docs/provider-backends/cohere.md
+++ b/docs/provider-backends/cohere.md
@@ -225,19 +225,19 @@ For request-body policies (e.g., restrict to specific models or limit token usag
 warden policy write cohere-restricted - <<EOF
 path "cohere/role/+/gateway/v2/chat" {
   capabilities = ["create"]
-  required_parameters = {
-    "model" = ["command-a-03-2025", "command-r-plus-08-2024", "command-r-08-2024"]
-  }
-  max_parameters = {
-    "max_tokens" = 4096
-  }
+  condition = <<-CEL
+    has(request.data.model) &&
+    request.data.model in ["command-a-03-2025", "command-r-plus-08-2024", "command-r-08-2024"] &&
+    (!has(request.data.max_tokens) || request.data.max_tokens <= 4096)
+  CEL
 }
 
 path "cohere/role/+/gateway/v2/embed" {
   capabilities = ["create"]
-  required_parameters = {
-    "model" = ["embed-v4.0", "embed-english-v3.0", "embed-multilingual-v3.0"]
-  }
+  condition = <<-CEL
+    has(request.data.model) &&
+    request.data.model in ["embed-v4.0", "embed-english-v3.0", "embed-multilingual-v3.0"]
+  CEL
 }
 EOF
 ```

--- a/docs/provider-backends/mistral.md
+++ b/docs/provider-backends/mistral.md
@@ -212,11 +212,10 @@ For fine-grained cost control, restrict access based on AI request fields:
 warden policy write mistral-restricted - <<EOF
 path "mistral/role/+/gateway/v1/chat/completions" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "model" = ["mistral-small-latest", "mistral-medium-latest"]
-    "stream" = ["true"]
-    "*"      = []
-  }
+  condition = <<-CEL
+    (!has(request.data.model) || request.data.model in ["mistral-small-latest", "mistral-medium-latest"]) &&
+    (!has(request.data.stream) || request.data.stream == true)
+  CEL
 }
 EOF
 ```
@@ -227,12 +226,9 @@ You can also combine parameter restrictions with runtime conditions to protect c
 warden policy write mistral-prod-restricted - <<EOF
 path "mistral/role/+/gateway/v1/chat/completions" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "model" = ["mistral-small-latest"]
-    "stream" = ["true"]
-    "*"      = []
-  }
   condition = <<-CEL
+    (!has(request.data.model) || request.data.model in ["mistral-small-latest"]) &&
+    (!has(request.data.stream) || request.data.stream == true) &&
     cidrContains("10.0.0.0/8", request.client_ip) &&
     now.getHours("UTC") >= 8 && now.getHours("UTC") < 18 &&
     now.getDayOfWeek("UTC") in [1, 2, 3, 4, 5]

--- a/docs/provider-backends/openai.md
+++ b/docs/provider-backends/openai.md
@@ -213,11 +213,10 @@ For fine-grained cost control, restrict access based on AI request fields:
 warden policy write openai-restricted - <<EOF
 path "openai/role/+/gateway/v1/chat/completions" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "model" = ["gpt-4o", "gpt-4o-mini"]
-    "stream" = ["true"]
-    "*"      = []
-  }
+  condition = <<-CEL
+    (!has(request.data.model) || request.data.model in ["gpt-4o", "gpt-4o-mini"]) &&
+    (!has(request.data.stream) || request.data.stream == true)
+  CEL
 }
 EOF
 ```
@@ -228,12 +227,9 @@ You can also combine parameter restrictions with runtime conditions to protect c
 warden policy write openai-prod-restricted - <<EOF
 path "openai/role/+/gateway/v1/chat/completions" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "model" = ["gpt-4o", "gpt-4o-mini"]
-    "stream" = ["true"]
-    "*"      = []
-  }
   condition = <<-CEL
+    (!has(request.data.model) || request.data.model in ["gpt-4o", "gpt-4o-mini"]) &&
+    (!has(request.data.stream) || request.data.stream == true) &&
     cidrContains("10.0.0.0/8", request.client_ip) &&
     now.getHours("UTC") >= 8 && now.getHours("UTC") < 18 &&
     now.getDayOfWeek("UTC") in [1, 2, 3, 4, 5]

--- a/docs/provider-backends/slack.md
+++ b/docs/provider-backends/slack.md
@@ -203,11 +203,7 @@ For fine-grained access control, restrict which Slack methods and channels a rol
 warden policy write slack-restricted - <<EOF
 path "slack/role/+/gateway/chat.postMessage" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "channel" = ["#alerts", "#ops"]
-    "text"    = []
-    "*"       = []
-  }
+  condition = "!has(request.data.channel) || request.data.channel in ['#alerts', '#ops']"
 }
 
 path "slack/role/+/gateway/conversations.list" {
@@ -216,10 +212,7 @@ path "slack/role/+/gateway/conversations.list" {
 
 path "slack/role/+/gateway/conversations.history" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "channel" = []
-    "limit"   = []
-  }
+  condition = "request.data.all(k, k in ['channel', 'limit'])"
 }
 EOF
 ```
@@ -230,15 +223,9 @@ You can combine parameter restrictions with runtime conditions. For example, res
 warden policy write slack-prod-restricted - <<EOF
 path "slack/role/+/gateway/chat.postMessage" {
   capabilities = ["create"]
-  allowed_parameters = {
-    "channel" = ["#alerts", "#incidents"]
-    "text"    = []
-    "*"       = []
-  }
-  denied_parameters = {
-    "as_user" = ["true"]
-  }
   condition = <<-CEL
+    (!has(request.data.channel) || request.data.channel in ["#alerts", "#incidents"]) &&
+    (!has(request.data.as_user) || request.data.as_user != true) &&
     cidrContains("10.0.0.0/8", request.client_ip) &&
     now.getHours("UTC") >= 8 && now.getHours("UTC") < 18 &&
     now.getDayOfWeek("UTC") in [1, 2, 3, 4, 5]
@@ -384,7 +371,7 @@ This allows operators to enforce policies such as:
 - Restrict which channels a service can post to
 - Prevent impersonation (`as_user` denied)
 - Limit read-only services to `conversations.list` and `conversations.history`
-- Require specific fields to be present (`required_parameters`)
+- Require specific fields to be present (`has(request.data.x)` in a `condition`)
 
 ## TLS Certificate Authentication
 

--- a/docs/quickstarts/workstation/01-cert-llm/README.md
+++ b/docs/quickstarts/workstation/01-cert-llm/README.md
@@ -206,8 +206,8 @@ MODEL="claude-sonnet-4-5"            # a model your Anthropic account can use
 
 warden policy write anthropic-access - <<EOF
 path "anthropic/role/+/gateway*" {
-  capabilities       = ["create", "read", "update", "delete", "patch"]
-  allowed_parameters = { "model" = ["$MODEL"], "*" = [] }
+  capabilities = ["create", "read", "update", "delete", "patch"]
+  condition    = "!has(request.data.model) || request.data.model == '$MODEL'"
 }
 EOF
 ```
@@ -272,7 +272,7 @@ MCP server so we also stop storing MCP tokens.
 - **`cred spec create` fails** — the Console key in `secrets/anthropic-key.txt` is wrong; it's
   validated via `GET /v1/models` at create time.
 - **Claude shows `403` on a model** — the `anthropic-access` policy (or a tighter
-  `allowed_parameters`) is blocking that `model`/param.
+  `condition` over `request.data.model`) is blocking that `model`.
 
 ## Cleanup
 

--- a/docs/tutorials/vault-policy-hygiene/policy-hygiene.yaml
+++ b/docs/tutorials/vault-policy-hygiene/policy-hygiene.yaml
@@ -55,8 +55,9 @@ instructions: |
          - `capabilities` list contains "sudo"
          - `path "*"` or `path "sys/*"` at top level
          - create/update/delete/patch on a glob path without
-           `allowed_parameters` narrowing
-       Remediation: narrow path, drop sudo, add allowed_parameters.
+           a `condition` narrowing it
+       Remediation: narrow path, drop sudo, add a CEL `condition`
+       over request.data.
 
   Severity is deterministic, not subjective:
     - critical: any least_privilege_smell with "sudo" OR path "*"


### PR DESCRIPTION
Seventh PR in the CEL policy-conditions stack (depends on #362/#364/#365/#366/#367/#368, all merged).

> ⚠️ **BREAKING CHANGE.** CBP path rules no longer accept `required_parameters` / `allowed_parameters` / `denied_parameters`. Express request-body value constraints as a CEL `condition` over `request.data`.

## What

The last of the three structured value-mechanisms folded into CEL. Removes the CBP request-body parameter constraints:

- `AllowOperation`: drop the param-validation branch; rewrite the list/scan block so pagination clamping (incl. the `"max"` sentinel) and `list_scan_response_keys_filter_path` no longer depend on `required_parameters`.
- Drop `AllowedParameters`/`DeniedParameters`/`RequiredParameters` from `CBPPermissions`, the merge, and clone; remove `valueInParameterList`/`valueInSlice` and now-dead imports.
- The parser rejects the three keys with a directed error naming the CEL equivalent — e.g. `has(request.data.x)` to require a field, `request.data.tier in [...]` to constrain a value.

## Docs (atomic with the removal)

`policies.md` parameter-constraints section replaced by the CEL model; provider backends, quickstart, and the policy-hygiene tutorial converted. Grep confirms no `*_parameters` remain.

## Tests

Parse-rejection test for the three keys; pagination clamping (`pagination_limit` + `"max"`) and list-response filtering retained and covered independently of the removed params.
