### PR TITLE
feat(audit): record CEL condition inputs in decision audit

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -244,6 +244,33 @@ func (f *JSONFormat) saltPolicyResultsField(ctx context.Context, pr *PolicyResul
 			}
 			pr.TokenMetadata[parts[1]] = salted
 		}
+	case "condition":
+		// "...condition.inputs" salts every referenced-input value;
+		// "...condition.inputs.<dotted-key>" salts one (the input map keys are
+		// themselves dotted, e.g. token.metadata.env, so rejoin the tail).
+		if pr.Condition == nil || len(parts) < 2 || parts[1] != "inputs" {
+			return nil
+		}
+		if len(parts) == 2 {
+			for k, v := range pr.Condition.Inputs {
+				if v == "" {
+					continue
+				}
+				salted, err := f.saltFn(ctx, v)
+				if err != nil {
+					return err
+				}
+				pr.Condition.Inputs[k] = salted
+			}
+		} else if key := strings.Join(parts[2:], "."); pr.Condition.Inputs != nil {
+			if v, ok := pr.Condition.Inputs[key]; ok && v != "" {
+				salted, err := f.saltFn(ctx, v)
+				if err != nil {
+					return err
+				}
+				pr.Condition.Inputs[key] = salted
+			}
+		}
 	}
 
 	return nil

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/stephnangue/warden/logical"
 )
 
 func TestJSONFormat(t *testing.T) {
@@ -703,6 +705,74 @@ func TestFormatTokenMetadataSalting(t *testing.T) {
 		}
 		if !salted(md["team"]) {
 			t.Errorf("team should be salted, got %q", md["team"])
+		}
+	})
+}
+
+// TestFormatConditionInputsSalting exercises salt_fields for the CEL condition
+// inputs map, whose keys are themselves dotted (token.metadata.env).
+func TestFormatConditionInputsSalting(t *testing.T) {
+	mockSalt := func(ctx context.Context, data string) (string, error) {
+		return "hmac-sha256:" + data + "-salted", nil
+	}
+	newEntry := func() *LogEntry {
+		return &LogEntry{
+			Timestamp: time.Now(),
+			Auth: &Auth{
+				PolicyResults: &PolicyResults{
+					Allowed: false,
+					Condition: &logical.ConditionResult{
+						Decision:   "deny",
+						Expression: "token.metadata.env == 'prod'",
+						Inputs: map[string]string{
+							"token.metadata.env": "staging",
+							"request.data.model": "opus",
+						},
+					},
+				},
+			},
+		}
+	}
+	format := func(t *testing.T, saltFields []string) map[string]string {
+		t.Helper()
+		opts := []JSONFormatOption{WithSaltFunc(mockSalt)}
+		if saltFields != nil {
+			opts = append(opts, WithSaltFields(saltFields))
+		}
+		f := NewJSONFormat(opts...)
+		data, err := f.FormatRequest(context.Background(), newEntry())
+		if err != nil {
+			t.Fatalf("FormatRequest failed: %v", err)
+		}
+		var got LogEntry
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		return got.Auth.PolicyResults.Condition.Inputs
+	}
+	salted := func(s string) bool { return containsBytes([]byte(s), "hmac-sha256:") }
+
+	t.Run("clear by default", func(t *testing.T) {
+		in := format(t, nil)
+		if in["token.metadata.env"] != "staging" || in["request.data.model"] != "opus" {
+			t.Errorf("inputs should be clear, got %v", in)
+		}
+	})
+
+	t.Run("salt all inputs", func(t *testing.T) {
+		in := format(t, []string{"auth.policy_results.condition.inputs"})
+		if !salted(in["token.metadata.env"]) || !salted(in["request.data.model"]) {
+			t.Errorf("all inputs should be salted, got %v", in)
+		}
+	})
+
+	t.Run("salt one dotted key", func(t *testing.T) {
+		in := format(t, []string{"auth.policy_results.condition.inputs.request.data.model"})
+		if in["token.metadata.env"] != "staging" {
+			t.Errorf("other input must stay clear, got %q", in["token.metadata.env"])
+		}
+		if !salted(in["request.data.model"]) {
+			t.Errorf("request.data.model should be salted, got %q", in["request.data.model"])
 		}
 	})
 }

--- a/core/policy.go
+++ b/core/policy.go
@@ -493,11 +493,11 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			if err != nil {
 				return fmt.Errorf("path %q: cel env: %w", key, err)
 			}
-			prg, err := compileCELCondition(env, pc.ConditionHCL)
+			prg, refPaths, err := compileCELCondition(env, pc.ConditionHCL)
 			if err != nil {
 				return fmt.Errorf("path %q condition: %w", key, err)
 			}
-			pc.Permissions.Conditions = []*compiledCondition{{Source: pc.ConditionHCL, Program: prg}}
+			pc.Permissions.Conditions = []*compiledCondition{{Source: pc.ConditionHCL, Program: prg, RefPaths: refPaths}}
 		}
 
 		if pc.MCPHCL != nil {
@@ -569,11 +569,11 @@ func canonicaliseMCPRules(h *MCPRulesHCL) (*CBPMCPRules, error) {
 		if err != nil {
 			return nil, fmt.Errorf("mcp cel env: %w", err)
 		}
-		prg, err := compileCELCondition(env, h.Condition)
+		prg, refPaths, err := compileCELCondition(env, h.Condition)
 		if err != nil {
 			return nil, fmt.Errorf("mcp condition: %w", err)
 		}
-		r.Condition = &compiledCondition{Source: h.Condition, Program: prg}
+		r.Condition = &compiledCondition{Source: h.Condition, Program: prg, RefPaths: refPaths}
 	}
 	return r, nil
 }

--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -6,6 +6,7 @@ package core
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -178,21 +180,21 @@ func (e celCostEstimator) EstimateCallCost(function, overloadID string, target *
 // policy-write-time validation path: a syntax error, a non-bool result, an
 // undeclared reference (e.g. call.* in a path-level condition), or an
 // over-budget cost are all rejected here with a directed error.
-func compileCELCondition(env *cel.Env, src string) (cel.Program, error) {
+func compileCELCondition(env *cel.Env, src string) (cel.Program, []string, error) {
 	ast, iss := env.Compile(src)
 	if iss != nil && iss.Err() != nil {
-		return nil, fmt.Errorf("condition does not compile: %w", iss.Err())
+		return nil, nil, fmt.Errorf("condition does not compile: %w", iss.Err())
 	}
 	if !ast.OutputType().IsExactType(cel.BoolType) {
-		return nil, fmt.Errorf("condition must evaluate to bool, got %s", ast.OutputType())
+		return nil, nil, fmt.Errorf("condition must evaluate to bool, got %s", ast.OutputType())
 	}
 
 	est, err := env.EstimateCost(ast, celCostEstimator{maxSize: celInputSizeBound})
 	if err != nil {
-		return nil, fmt.Errorf("condition cost estimation failed: %w", err)
+		return nil, nil, fmt.Errorf("condition cost estimation failed: %w", err)
 	}
 	if est.Max > maxConditionCost {
-		return nil, fmt.Errorf("condition worst-case cost %d exceeds limit %d", est.Max, maxConditionCost)
+		return nil, nil, fmt.Errorf("condition worst-case cost %d exceeds limit %d", est.Max, maxConditionCost)
 	}
 
 	// The runtime cost tracker (cel.CostLimit) allocates per eval and wraps
@@ -204,7 +206,7 @@ func compileCELCondition(env *cel.Env, src string) (cel.Program, error) {
 	// the static bound above, so the per-eval tracker is omitted.
 	est2, err := env.EstimateCost(ast, celCostEstimator{maxSize: celInputSizeBound * 2})
 	if err != nil {
-		return nil, fmt.Errorf("condition cost estimation failed: %w", err)
+		return nil, nil, fmt.Errorf("condition cost estimation failed: %w", err)
 	}
 	var progOpts []cel.ProgramOption
 	if est2.Max != est.Max {
@@ -213,9 +215,95 @@ func compileCELCondition(env *cel.Env, src string) (cel.Program, error) {
 
 	prg, err := env.Program(ast, progOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("condition program construction failed: %w", err)
+		return nil, nil, fmt.Errorf("condition program construction failed: %w", err)
 	}
-	return prg, nil
+	return prg, celReferencedPaths(ast), nil
+}
+
+// celReferencedPaths reconstructs the dotted variable paths an expression reads
+// — e.g. token.metadata.env, call.args.amount — so the deciding condition can
+// record its inputs for audit. Only clean, Ident-rooted field-selection chains
+// under request/token/call are captured; has() test-only selects and
+// index/optional access (request.data["k"], call.args.?x) contribute no path,
+// and now.* time predicates are intentionally not captured (the expression text
+// carries the bound). The result is deduped and sorted.
+func celReferencedPaths(a *cel.Ast) []string {
+	native := a.NativeRep()
+	if native == nil {
+		return nil
+	}
+	root := native.Expr()
+	if root == nil {
+		return nil
+	}
+
+	var selects []celast.Expr
+	consumed := map[int64]bool{} // operand of some Select — an intermediate node
+	skip := map[int64]bool{}     // container of an index/optional access — not a field path
+	celast.PostOrderVisit(root, celast.NewExprVisitor(func(e celast.Expr) {
+		switch e.Kind() {
+		case celast.SelectKind:
+			selects = append(selects, e)
+			consumed[e.AsSelect().Operand().ID()] = true
+		case celast.CallKind:
+			c := e.AsCall()
+			switch c.FunctionName() {
+			case "_?._", "_[_]", "optional_index":
+				if args := c.Args(); len(args) > 0 {
+					skip[args[0].ID()] = true
+				}
+			}
+		}
+	}))
+
+	set := map[string]bool{}
+	for _, e := range selects {
+		if consumed[e.ID()] || skip[e.ID()] {
+			continue
+		}
+		if p, ok := celSelectPath(e); ok {
+			set[p] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// celSelectPath reconstructs the dotted path for a Select chain top (e.g.
+// token.metadata.env). Returns ok=false if the chain contains a test-only
+// select (has()) or does not bottom out on a request/token/call Ident.
+func celSelectPath(e celast.Expr) (string, bool) {
+	var fields []string
+	cur := e
+	for cur.Kind() == celast.SelectKind {
+		sel := cur.AsSelect()
+		if sel.IsTestOnly() {
+			return "", false
+		}
+		fields = append(fields, sel.FieldName())
+		cur = sel.Operand()
+	}
+	if cur.Kind() != celast.IdentKind {
+		return "", false
+	}
+	switch cur.AsIdent() {
+	case "request", "token", "call":
+	default:
+		return "", false
+	}
+	parts := make([]string, 0, len(fields)+1)
+	parts = append(parts, cur.AsIdent())
+	for i := len(fields) - 1; i >= 0; i-- {
+		parts = append(parts, fields[i])
+	}
+	return strings.Join(parts, "."), true
 }
 
 // evalCELCondition evaluates a compiled condition against an activation.
@@ -394,6 +482,10 @@ func paramValueToCEL(pv logical.ParamValue) (any, bool) {
 type compiledCondition struct {
 	Source  string
 	Program cel.Program
+	// RefPaths are the dotted request/token/call variable paths the expression
+	// reads (from celReferencedPaths), snapshotted into the audited
+	// ConditionResult.Inputs at eval time.
+	RefPaths []string
 }
 
 // Package-level envs, built once and reused. The base env compiles path-level
@@ -493,19 +585,77 @@ func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te
 		ok, err := evalCELCondition(c.Program, act)
 		if err != nil {
 			if deciding == nil {
-				deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source, ErrorKind: celErrorKind(err)}
+				deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source, ErrorKind: celErrorKind(err), Inputs: resolveConditionInputs(c.RefPaths, act)}
 			}
 			continue
 		}
 		if ok {
-			res := &logical.ConditionResult{Decision: "allow", Expression: c.Source}
+			res := &logical.ConditionResult{Decision: "allow", Expression: c.Source, Inputs: resolveConditionInputs(c.RefPaths, act)}
 			res.Sanitize()
 			return true, res
 		}
 		if deciding == nil {
-			deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source}
+			deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source, Inputs: resolveConditionInputs(c.RefPaths, act)}
 		}
 	}
 	deciding.Sanitize()
 	return false, deciding
+}
+
+// resolveConditionInputs snapshots the values of the expression's referenced
+// paths from the evaluation activation into a map for audit. Values are
+// formatted to strings in clear (sensitive keys are protected by optional
+// salt_fields at the audit format layer, not here). Absent keys — the
+// fail-closed case — are omitted. Returns nil when nothing resolved.
+func resolveConditionInputs(refPaths []string, act *celActivation) map[string]string {
+	if len(refPaths) == 0 || act == nil {
+		return nil
+	}
+	out := make(map[string]string, len(refPaths))
+	for _, p := range refPaths {
+		segs := strings.Split(p, ".")
+		cur, ok := act.ResolveName(segs[0])
+		if !ok {
+			continue
+		}
+		for _, s := range segs[1:] {
+			m, isMap := cur.(map[string]any)
+			if !isMap {
+				cur = nil
+				ok = false
+				break
+			}
+			if cur, ok = m[s]; !ok {
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		out[p] = formatCELValue(cur)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// formatCELValue renders a resolved activation value as an audit string.
+// Scalars format precisely; non-scalars (lists/maps such as token.policies /
+// token.actors) fall back to %v.
+func formatCELValue(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case int:
+		return strconv.Itoa(t)
+	default:
+		return fmt.Sprintf("%v", t)
+	}
 }

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -55,6 +55,19 @@ func TestMCPCond_NumericAllowDeny(t *testing.T) {
 	assert.Contains(t, res.MCPDecision.Condition.Expression, "call.args.amount")
 }
 
+// TestMCPCond_RecordsInputs confirms a per-call condition snapshots the
+// referenced call.args value into MCPDecision.Condition.Inputs.
+func TestMCPCond_RecordsInputs(t *testing.T) {
+	cbp := mcpAmountCapPolicy(t)
+
+	deny := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":2000}},"id":1}`)
+	res := cbp.AllowOperation(testContext(), deny, nil, false)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision.Condition)
+	require.NotNil(t, res.MCPDecision.Condition.Inputs)
+	assert.Equal(t, "2000", res.MCPDecision.Condition.Inputs["call.args.amount"])
+}
+
 // TestMCPCond_TokenNamespace confirms an mcp{} condition can read the token
 // namespace (threaded via the TokenEntry), not just call.*.
 func TestMCPCond_TokenNamespace(t *testing.T) {

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -59,6 +59,35 @@ func TestCBP_PathCondition_EndToEnd(t *testing.T) {
 	assert.False(t, res.Allowed)
 }
 
+// TestCBP_PathCondition_RecordsInputs confirms a deciding path-level condition
+// snapshots its referenced request/token values into ConditionResult.Inputs
+// (in clear — salting is an audit-layer opt-in).
+func TestCBP_PathCondition_RecordsInputs(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "request.data.model == 'sonnet' && token.metadata.env == 'prod'"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	prodTE := &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}}
+	res := cbp.AllowOperation(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+		Data:      map[string]any{"model": "opus"},
+	}, prodTE, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.Condition)
+	require.NotNil(t, res.Condition.Inputs)
+	assert.Equal(t, "opus", res.Condition.Inputs["request.data.model"])
+	assert.Equal(t, "prod", res.Condition.Inputs["token.metadata.env"])
+}
+
 // TestCBP_PathCondition_MissingDataFailsClosed confirms a condition over an
 // absent request.data key denies (fail-closed) and records a sanitized error
 // category rather than a raw value.

--- a/core/policy_cel_test.go
+++ b/core/policy_cel_test.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func mustEnv(t *testing.T, mcp bool) *cel.Env {
 // mustCompile compiles src against env or fails the test.
 func mustCompile(t *testing.T, env *cel.Env, src string) cel.Program {
 	t.Helper()
-	prg, err := compileCELCondition(env, src)
+	prg, _, err := compileCELCondition(env, src)
 	if err != nil {
 		t.Fatalf("compile %q: %v", src, err)
 	}
@@ -49,7 +50,7 @@ func str(s string) logical.ParamValue { return logical.ParamValue{Kind: logical.
 func TestCEL_PathLevelEnvRejectsCallReference(t *testing.T) {
 	// A path-level (base) env must NOT know call.* — referencing it is a
 	// compile-time error, never a silent runtime deny.
-	if _, err := compileCELCondition(mustEnv(t, false), "call.args.amount <= 1500"); err == nil {
+	if _, _, err := compileCELCondition(mustEnv(t, false), "call.args.amount <= 1500"); err == nil {
 		t.Fatal("expected compile error for call.* in path-level env, got nil")
 	}
 	// The MCP env accepts the same expression.
@@ -57,8 +58,44 @@ func TestCEL_PathLevelEnvRejectsCallReference(t *testing.T) {
 }
 
 func TestCEL_NonBoolRejected(t *testing.T) {
-	if _, err := compileCELCondition(mustEnv(t, false), "1 + 1"); err == nil {
+	if _, _, err := compileCELCondition(mustEnv(t, false), "1 + 1"); err == nil {
 		t.Fatal("expected rejection of non-bool condition")
+	}
+}
+
+// TestCEL_ReferencedPaths locks in the dotted request/token/call paths captured
+// for audit Inputs: clean field-selection chains are captured; has(),
+// index/optional access, and now.* are not.
+func TestCEL_ReferencedPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		mcp  bool
+		src  string
+		want []string
+	}{
+		{"token+call scalars", true,
+			"token.metadata.env == 'prod' && call.args.amount <= 1500",
+			[]string{"call.args.amount", "token.metadata.env"}},
+		{"has and index and optional contribute nothing", true,
+			`has(request.data.x) && request.data["k"] == "v" && call.args.?y.orValue(0) <= 3`,
+			nil},
+		{"nested token + list arg", false,
+			"token.principal == 'a' && size(token.policies) > 0",
+			[]string{"token.policies", "token.principal"}},
+		{"now not captured", false,
+			`now.getHours("UTC") < 18 && token.metadata.env == "prod"`,
+			[]string{"token.metadata.env"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, paths, err := compileCELCondition(mustEnv(t, tc.mcp), tc.src)
+			if err != nil {
+				t.Fatalf("compile %q: %v", tc.src, err)
+			}
+			if !reflect.DeepEqual(paths, tc.want) {
+				t.Fatalf("paths = %v, want %v", paths, tc.want)
+			}
+		})
 	}
 }
 

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -44,12 +44,12 @@ const (
 	mcpRuleTypeConditionError   = "condition_error"
 	mcpRuleTypeMissingMethod    = "missing_method_header"
 
-	mcpRuleTypeMissingBody       = "missing_body"
-	mcpRuleTypeMalformedJSONRPC  = "malformed_jsonrpc"
-	mcpRuleTypeDuplicateKey      = "duplicate_key"
-	mcpRuleTypeOversizedBody     = "oversized_body"
-	mcpRuleTypeBatchEmpty        = "batch_empty"
-	mcpRuleTypeMalformedParams   = "malformed_params"
+	mcpRuleTypeMissingBody      = "missing_body"
+	mcpRuleTypeMalformedJSONRPC = "malformed_jsonrpc"
+	mcpRuleTypeDuplicateKey     = "duplicate_key"
+	mcpRuleTypeOversizedBody    = "oversized_body"
+	mcpRuleTypeBatchEmpty       = "batch_empty"
+	mcpRuleTypeMalformedParams  = "malformed_params"
 )
 
 // MCP JSON-RPC method names that carry name-bearing semantics. For
@@ -345,13 +345,13 @@ func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.
 		if err != nil {
 			d.Decision = "deny"
 			d.RuleType = mcpRuleTypeConditionError
-			d.Condition = &logical.ConditionResult{Decision: "deny", Expression: set.Condition.Source, ErrorKind: celErrorKind(err)}
+			d.Condition = &logical.ConditionResult{Decision: "deny", Expression: set.Condition.Source, ErrorKind: celErrorKind(err), Inputs: resolveConditionInputs(set.Condition.RefPaths, act)}
 			return d
 		}
 		if !ok {
 			d.Decision = "deny"
 			d.RuleType = mcpRuleTypeCondition
-			d.Condition = &logical.ConditionResult{Decision: "deny", Expression: set.Condition.Source}
+			d.Condition = &logical.ConditionResult{Decision: "deny", Expression: set.Condition.Source, Inputs: resolveConditionInputs(set.Condition.RefPaths, act)}
 			return d
 		}
 	}
@@ -361,7 +361,7 @@ func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.
 	d.Decision = "allow"
 	d.RuleType = mcpRuleTypeAllowedMethods
 	if set.Condition != nil {
-		d.Condition = &logical.ConditionResult{Decision: "allow", Expression: set.Condition.Source}
+		d.Condition = &logical.ConditionResult{Decision: "allow", Expression: set.Condition.Source, Inputs: resolveConditionInputs(set.Condition.RefPaths, act)}
 	}
 	if len(set.AllowedMethods) > 0 {
 		d.MatchedRule = matchMCPAny(method, set.AllowedMethods)

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -47,6 +47,14 @@ be sensitive — so it is salt-able per key. You can extend or narrow this per d
   (`auth.policy_results.token_metadata` salts every value) or a single key
   (`auth.policy_results.token_metadata.clearance` salts just that one); other
   examples are `auth.token_id` and `request.data.password`.
+- **CEL condition inputs** — when a policy `condition` decides a request, the
+  values it referenced are recorded under `auth.policy_results.condition.inputs`
+  (path-level) so the decision is self-explanatory, keyed by the CEL path that
+  was read (e.g. `token.metadata.env`, `call.args.amount`, `request.data.model`).
+  These are logged in clear by default and are salt-able: `salt_fields`
+  `auth.policy_results.condition.inputs` salts every input value, and
+  `auth.policy_results.condition.inputs.request.data.model` salts just that one
+  (the trailing segments are the dotted input key).
 - `omit_fields` — dot-paths to drop entirely.
 
 To check whether a known plaintext appears in the log, hash it with the same


### PR DESCRIPTION
Eighth PR in the CEL policy-conditions stack (depends on the merged CEL PRs #362–#369).

## What

Populates `ConditionResult.Inputs` (added back in #364) so a CEL decision is self-explanatory in the audit log — it records the values the expression actually referenced, e.g. `{"token.metadata.env": "staging"}`.

- **Compile-time extraction** — `celReferencedPaths` walks the checked AST and reconstructs the dotted `request`/`token`/`call` paths an expression reads (clean field-selection chains only; `has()`, index, optional access, and `now.*` contribute nothing). Stored on the compiled condition.
- **Eval-time resolution** — `resolveConditionInputs` snapshots those paths' values into `Inputs` at both producers (path-level and per-call MCP). Values are logged CTL-stripped; sensitive keys are protected by **optional** `salt_fields`, not redaction — uniform across `request.data.*` / `token.metadata.*` / `call.args.*`.
- **Salting** — `saltPolicyResultsField` gains a `condition` case: `auth.policy_results.condition.inputs` salts every value, `…condition.inputs.<dotted-key>` salts one.
- `audit.md` documents the field and its salt paths.

## Scope

Additive — the blanket `token_metadata` audit field is untouched here (its removal is the next PR).

## Tests

`celReferencedPaths` extraction cases; path-level + MCP inputs recorded end-to-end; `condition.inputs` salt-all and per-key salting.
