### PR TITLE
refactor(audit)!: drop redundant token_metadata from policy results

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -223,27 +223,6 @@ func (f *JSONFormat) saltPolicyResultsField(ctx context.Context, pr *PolicyResul
 				pr.GrantingPolicies[i] = salted
 			}
 		}
-	case "token_metadata":
-		// "...token_metadata" salts every value; "...token_metadata.<key>"
-		// salts one key's value. Mirrors credential metadata salting.
-		if len(parts) == 1 {
-			for k, v := range pr.TokenMetadata {
-				if v == "" {
-					continue
-				}
-				salted, err := f.saltFn(ctx, v)
-				if err != nil {
-					return err
-				}
-				pr.TokenMetadata[k] = salted
-			}
-		} else if v, ok := pr.TokenMetadata[parts[1]]; ok && v != "" {
-			salted, err := f.saltFn(ctx, v)
-			if err != nil {
-				return err
-			}
-			pr.TokenMetadata[parts[1]] = salted
-		}
 	case "condition":
 		// "...condition.inputs" salts every referenced-input value;
 		// "...condition.inputs.<dotted-key>" salts one (the input map keys are

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -650,65 +650,6 @@ func TestFormatResponse(t *testing.T) {
 	}
 }
 
-func TestFormatTokenMetadataSalting(t *testing.T) {
-	mockSalt := func(ctx context.Context, data string) (string, error) {
-		return "hmac-sha256:" + data + "-salted", nil
-	}
-	newEntry := func() *LogEntry {
-		return &LogEntry{
-			Timestamp: time.Now(),
-			Auth: &Auth{
-				PolicyResults: &PolicyResults{
-					Allowed:       false,
-					TokenMetadata: map[string]string{"env": "dev", "team": "platform-core"},
-				},
-			},
-		}
-	}
-	format := func(t *testing.T, saltFields []string) map[string]string {
-		t.Helper()
-		opts := []JSONFormatOption{WithSaltFunc(mockSalt)}
-		if saltFields != nil {
-			opts = append(opts, WithSaltFields(saltFields))
-		}
-		f := NewJSONFormat(opts...)
-		data, err := f.FormatRequest(context.Background(), newEntry())
-		if err != nil {
-			t.Fatalf("FormatRequest failed: %v", err)
-		}
-		var got LogEntry
-		if err := json.Unmarshal(data, &got); err != nil {
-			t.Fatalf("unmarshal failed: %v", err)
-		}
-		return got.Auth.PolicyResults.TokenMetadata
-	}
-	salted := func(s string) bool { return containsBytes([]byte(s), "hmac-sha256:") }
-
-	t.Run("clear by default", func(t *testing.T) {
-		md := format(t, nil)
-		if md["env"] != "dev" || md["team"] != "platform-core" {
-			t.Errorf("metadata should be clear, got %v", md)
-		}
-	})
-
-	t.Run("salt all keys", func(t *testing.T) {
-		md := format(t, []string{"auth.policy_results.token_metadata"})
-		if !salted(md["env"]) || !salted(md["team"]) {
-			t.Errorf("all values should be salted, got %v", md)
-		}
-	})
-
-	t.Run("salt one key", func(t *testing.T) {
-		md := format(t, []string{"auth.policy_results.token_metadata.team"})
-		if md["env"] != "dev" {
-			t.Errorf("env must stay clear, got %q", md["env"])
-		}
-		if !salted(md["team"]) {
-			t.Errorf("team should be salted, got %q", md["team"])
-		}
-	})
-}
-
 // TestFormatConditionInputsSalting exercises salt_fields for the CEL condition
 // inputs map, whose keys are themselves dotted (token.metadata.env).
 func TestFormatConditionInputsSalting(t *testing.T) {

--- a/audit/types.go
+++ b/audit/types.go
@@ -134,13 +134,6 @@ type PolicyResults struct {
 	// records remain byte-identical to today's output.
 	MCPDecision *logical.MCPDecision `json:"mcp_decision,omitempty"`
 
-	// TokenMetadata is the authenticating token's verified, login-derived
-	// metadata, included so token_metadata policy decisions are explainable.
-	// omitempty so records for tokens without metadata stay byte-identical to
-	// today's output. Logged in clear by default; opt-in per-key HMAC salting
-	// via salt_fields (auth.policy_results.token_metadata[.<key>]).
-	TokenMetadata map[string]string `json:"token_metadata,omitempty"`
-
 	// Condition carries the path-level CEL condition decision when a condition
 	// was evaluated for a non-MCP request (the MCP per-call condition is
 	// recorded on MCPDecision.Condition instead). nil when none applied.
@@ -321,12 +314,6 @@ func (e *LogEntry) Clone() *LogEntry {
 			if e.Auth.PolicyResults.GrantingPolicies != nil {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))
 				copy(clone.Auth.PolicyResults.GrantingPolicies, e.Auth.PolicyResults.GrantingPolicies)
-			}
-			if e.Auth.PolicyResults.TokenMetadata != nil {
-				clone.Auth.PolicyResults.TokenMetadata = make(map[string]string, len(e.Auth.PolicyResults.TokenMetadata))
-				for k, v := range e.Auth.PolicyResults.TokenMetadata {
-					clone.Auth.PolicyResults.TokenMetadata[k] = v
-				}
 			}
 		}
 		if e.Auth.Actors != nil {

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -162,15 +162,10 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 			}
 			// Surface the path-level CEL condition decision (non-MCP paths)
 			// so denials carry their reason. Already Sanitized at evaluation.
+			// The condition's referenced inputs (incl. any token.metadata.*
+			// it read) ride ConditionResult.Inputs.
 			if auth.Condition != nil {
 				auditAuth.PolicyResults.Condition = auth.Condition
-			}
-			// Surface the token's verified metadata so token_metadata
-			// policy decisions (allow or deny) are explainable. Logged in
-			// clear by default; the format layer applies opt-in per-key
-			// HMAC salting via salt_fields.
-			if te != nil && len(te.Metadata) > 0 {
-				auditAuth.PolicyResults.TokenMetadata = te.Metadata
 			}
 		}
 	}

--- a/core/audit_test.go
+++ b/core/audit_test.go
@@ -1064,30 +1064,6 @@ func TestBuildAuditAuth_FromAuth(t *testing.T) {
 	assert.Contains(t, result.PolicyResults.GrantingPolicies, "p1")
 }
 
-func TestBuildAuditAuth_SurfacesTokenMetadata(t *testing.T) {
-	auth := &logical.Auth{
-		PolicyResults: &sdklogical.PolicyResults{Allowed: false},
-	}
-	te := &logical.TokenEntry{
-		PrincipalID: "svc-ci",
-		Metadata:    map[string]string{"env": "dev", "team": "platform-core"},
-	}
-
-	result := buildAuditAuth(auth, te)
-	require.NotNil(t, result)
-	require.NotNil(t, result.PolicyResults)
-	assert.Equal(t, map[string]string{"env": "dev", "team": "platform-core"}, result.PolicyResults.TokenMetadata)
-}
-
-func TestBuildAuditAuth_NoTokenMetadataWhenEmpty(t *testing.T) {
-	auth := &logical.Auth{PolicyResults: &sdklogical.PolicyResults{Allowed: true}}
-	te := &logical.TokenEntry{PrincipalID: "svc-ci"}
-
-	result := buildAuditAuth(auth, te)
-	require.NotNil(t, result.PolicyResults)
-	assert.Nil(t, result.PolicyResults.TokenMetadata)
-}
-
 func TestBuildAuditAuth_AuthOverridesTE(t *testing.T) {
 	te := &logical.TokenEntry{
 		PrincipalID: "old-user",

--- a/docs/audit-devices/file.md
+++ b/docs/audit-devices/file.md
@@ -173,9 +173,9 @@ for the reasoning; the operational summary:
   `hmac-sha256:<hex>` instead of plaintext. The default,
   `response.credential.data`, salts every secret Warden injects (access keys,
   tokens, passwords). Extend it to hash more, e.g. `auth.token_id`,
-  `request.data.password`, or the token's verified identity attributes — a whole map
-  (`auth.policy_results.token_metadata`) or a single key
-  (`auth.policy_results.token_metadata.clearance`).
+  `request.data.password`, or the inputs a policy `condition` referenced — a whole
+  map (`auth.policy_results.condition.inputs`) or a single key
+  (`auth.policy_results.condition.inputs.request.data.model`).
 - **`omit_fields`** — dot-paths dropped from the entry entirely. The defaults drop
   request and response bodies and headers, which are noisy and often sensitive.
 

--- a/docs/auth-methods/jwt.md
+++ b/docs/auth-methods/jwt.md
@@ -185,7 +185,7 @@ warden write auth/jwt/role/inventory-agent \
   metadata_claims="department=dept,/resource_access/warden/env=env"
 ```
 
-A JWT with `"department": "eng"` and a nested `resource_access.warden.env` of `"prod"` produces a token whose metadata carries `dept="eng"` and `env="prod"`. A policy can then gate a path with `condition = "token.metadata.env == 'prod'"`. The metadata also surfaces in audit log entries (`auth.policy_results.token_metadata`) for traceability — logged in clear by default, with opt-in per-key HMAC salting via the audit device's `salt_fields`.
+A JWT with `"department": "eng"` and a nested `resource_access.warden.env` of `"prod"` produces a token whose metadata carries `dept="eng"` and `env="prod"`. A policy can then gate a path with `condition = "token.metadata.env == 'prod'"`. When a `condition` reads a metadata value to decide a request, that value is recorded in the audit entry under `auth.policy_results.condition.inputs` (keyed by the CEL path, e.g. `token.metadata.env`) — logged in clear by default, salt-able per key via the audit device's `salt_fields`.
 
 > **Note:** metadata is matched at request time against the token's own values and is never compiled into the policy, so it stays correct for every token. Use it for authorization decisions that depend on identity attributes rather than path/capability alone.
 

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -39,14 +39,11 @@ log ever revealing it.
 By default Warden salts the **issued credential's secret data**
 (`response.credential.data`) — the access keys, tokens, and passwords Warden
 injects. Non-secret metadata is logged in clear: a forwarded token's subject, and
-the token's verified identity attributes (`auth.policy_results.token_metadata`).
-That metadata is descriptive by design, but a value like a clearance level can still
-be sensitive — so it is salt-able per key. You can extend or narrow this per device:
+the inputs a policy `condition` referenced to decide a request
+(`auth.policy_results.condition.inputs`). Those input values are descriptive by
+design, but one — a clearance level, a request-body field — can still be
+sensitive, so they are salt-able per key. You can extend or narrow this per device:
 
-- `salt_fields` — additional dot-paths to HMAC. The path can be a whole map
-  (`auth.policy_results.token_metadata` salts every value) or a single key
-  (`auth.policy_results.token_metadata.clearance` salts just that one); other
-  examples are `auth.token_id` and `request.data.password`.
 - **CEL condition inputs** — when a policy `condition` decides a request, the
   values it referenced are recorded under `auth.policy_results.condition.inputs`
   (path-level) so the decision is self-explanatory, keyed by the CEL path that
@@ -55,6 +52,8 @@ be sensitive — so it is salt-able per key. You can extend or narrow this per d
   `auth.policy_results.condition.inputs` salts every input value, and
   `auth.policy_results.condition.inputs.request.data.model` salts just that one
   (the trailing segments are the dotted input key).
+- `salt_fields` — additional dot-paths to HMAC, e.g. `auth.token_id` and
+  `request.data.password`.
 - `omit_fields` — dot-paths to drop entirely.
 
 To check whether a known plaintext appears in the log, hash it with the same


### PR DESCRIPTION
Ninth PR in the CEL policy-conditions stack (depends on #370, now merged).

> ⚠️ **BREAKING CHANGE.** Audit records no longer include `auth.policy_results.token_metadata`. The decision-relevant values are recorded under `auth.policy_results.condition.inputs` instead (#370).

## What

Removes the blanket `token_metadata` audit field. It dumped the token's entire login-derived metadata map onto **every** policy result, in clear by default — mis-categorized (identity context nested in a decision-outcome struct), redundant with `principal_id`/`role_name`/`actors`, and an over-exposure surface. The metadata that actually decides a request is now captured, targeted, by `ConditionResult.Inputs` — a CEL condition over `token.metadata.*` records exactly the value it read.

- Delete `PolicyResults.TokenMetadata` + its `LogEntry.Clone` copy; stop populating it in `buildAuditAuth`; drop the `token_metadata` `salt_fields` case (a stale salt path now no-ops harmlessly).
- Docs (`audit.md` / `file.md` / `jwt.md`) point salting guidance at `auth.policy_results.condition.inputs`.

This partially reverts `#361` (which *added* the field) — an intentional reversal after moving to CEL.

## Kept (unchanged)

Login-derived token metadata population across all auth methods (`metadata_claims`/`metadata_mappings`), `logical.TokenEntry.Metadata`, and the CEL `token.metadata.*` policy namespace. This change touches the **audit layer only**.

## Tests

Audit tests updated: `token_metadata` assertions removed; guardrail confirms no `token_metadata` remains in audit code or docs while the kept features stay present.
