### PR TITLE
feat(policy): expose request.namespace to CEL + condition cookbook

### DIFF
--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -422,7 +422,7 @@ CHECK:
 	// condition denies; the deciding result is recorded for audit on every
 	// branch.
 	if len(permissions.Conditions) > 0 {
-		allowed, condRes := evaluatePathConditions(permissions.Conditions, req, te, now)
+		allowed, condRes := evaluatePathConditions(permissions.Conditions, req, te, now, ns.Path)
 		ret.Condition = condRes
 		if !allowed {
 			return ret
@@ -441,7 +441,7 @@ CHECK:
 	// the routed backend doesn't implement the marker, or it declined
 	// the request (wrong method / Content-Type) — fail closed.
 	if len(permissions.MCP) > 0 {
-		ret.MCPDecision = decideMCP(permissions.MCP, req, te, now)
+		ret.MCPDecision = decideMCP(permissions.MCP, req, te, now, ns.Path)
 		if ret.MCPDecision != nil && ret.MCPDecision.Decision == "deny" {
 			return ret
 		}

--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -46,7 +46,8 @@ import (
 //
 //	request.path, request.operation, request.client_ip,
 //	  request.mount_point, request.mount_type, request.mount_class,
-//	  request.mount_accessor, request.transparent, request.data.<k>
+//	  request.mount_accessor, request.transparent, request.namespace,
+//	  request.data.<k>
 //	token.principal, token.role, token.type, token.namespace,
 //	  token.policies (list), token.metadata.<k>, token.actors (list of
 //	  {subject, verified}), token.ttl_seconds, token.expires_at
@@ -80,6 +81,7 @@ type celRequestInput struct {
 	MountClass    string
 	MountAccessor string
 	Transparent   bool
+	Namespace     string
 	Data          map[string]any
 }
 
@@ -338,6 +340,7 @@ func buildRequestNS(req celRequestInput) map[string]any {
 		"mount_class":    req.MountClass,
 		"mount_accessor": req.MountAccessor,
 		"transparent":    req.Transparent,
+		"namespace":      req.Namespace,
 		"data":           data,
 	}
 }
@@ -512,9 +515,13 @@ func mcpCELEnv() (*cel.Env, error) {
 
 // celRequestInputFromRequest adapts a *logical.Request into the request context
 // exposed to expressions. All fields are populated before policy evaluation.
-func celRequestInputFromRequest(req *logical.Request) celRequestInput {
+// nsPath is the request's target namespace (namespace.FromContext at eval),
+// exposed as request.namespace — distinct from token.namespace (where the token
+// was minted). It is not derivable from mount_point, which concatenates the
+// namespace prefix with the mount path.
+func celRequestInputFromRequest(req *logical.Request, nsPath string) celRequestInput {
 	if req == nil {
-		return celRequestInput{}
+		return celRequestInput{Namespace: nsPath}
 	}
 	return celRequestInput{
 		Path:          req.Path,
@@ -525,6 +532,7 @@ func celRequestInputFromRequest(req *logical.Request) celRequestInput {
 		MountClass:    req.MountClass,
 		MountAccessor: req.MountAccessor,
 		Transparent:   req.Transparent,
+		Namespace:     nsPath,
 		Data:          req.Data,
 	}
 }
@@ -574,11 +582,11 @@ func celErrorKind(err error) string {
 // semantics: the gate passes if any condition is true. An empty list is
 // unconditional. Evaluation is fail-closed — an erroring condition denies, and
 // if no condition passes the deciding result is recorded for audit (Sanitized).
-func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te *logical.TokenEntry, now time.Time) (bool, *logical.ConditionResult) {
+func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te *logical.TokenEntry, now time.Time, nsPath string) (bool, *logical.ConditionResult) {
 	if len(conds) == 0 {
 		return true, nil
 	}
-	act := newCELActivation(celRequestInputFromRequest(req), celTokenInputFromEntry(te, now), now, nil)
+	act := newCELActivation(celRequestInputFromRequest(req, nsPath), celTokenInputFromEntry(te, now), now, nil)
 
 	var deciding *logical.ConditionResult
 	for _, c := range conds {

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -247,6 +247,38 @@ func TestCBP_ConditionsBlockRemoved(t *testing.T) {
 	assert.Contains(t, err.Error(), "token.metadata")
 }
 
+// TestCBP_RequestNamespace confirms request.namespace (the request's target
+// namespace) is exposed and can be compared against token.namespace (where the
+// token was minted) — e.g. to deny a parent-namespace token acting in a child
+// namespace. Both values are captured in the audited Inputs.
+func TestCBP_RequestNamespace(t *testing.T) {
+	env, err := baseCELEnv()
+	require.NoError(t, err)
+	src := "token.namespace == request.namespace"
+	prg, refPaths, err := compileCELCondition(env, src)
+	require.NoError(t, err)
+	cond := &compiledCondition{Source: src, Program: prg, RefPaths: refPaths}
+
+	req := &logical.Request{Operation: logical.ReadOperation, Path: "x"}
+	te := &logical.TokenEntry{NamespacePath: "team-a/"}
+	now := time.Now()
+
+	// Token minted in team-a/ acting in team-a/ -> allow.
+	ok, res := evaluatePathConditions([]*compiledCondition{cond}, req, te, now, "team-a/")
+	assert.True(t, ok)
+	require.NotNil(t, res)
+	assert.Equal(t, "allow", res.Decision)
+	assert.Equal(t, "team-a/", res.Inputs["request.namespace"])
+	assert.Equal(t, "team-a/", res.Inputs["token.namespace"])
+
+	// Same token acting in child namespace team-a/team-b/ -> deny.
+	ok, res = evaluatePathConditions([]*compiledCondition{cond}, req, te, now, "team-a/team-b/")
+	assert.False(t, ok)
+	require.NotNil(t, res)
+	assert.Equal(t, "deny", res.Decision)
+	assert.Equal(t, "team-a/team-b/", res.Inputs["request.namespace"])
+}
+
 func BenchmarkAllowOperation_NoCondition(b *testing.B) {
 	ctx := testContext()
 	policy, _ := ParseCBPPolicy(namespace.RootNamespace, `

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -157,7 +157,7 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 // Every returned decision passes through sanitizeMCPDecision so
 // adversary-controlled bytes don't leak into audit or response
 // rendering.
-func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry, now time.Time) *logical.MCPDecision {
+func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry, now time.Time, nsPath string) *logical.MCPDecision {
 	if len(sets) == 0 {
 		return nil
 	}
@@ -181,7 +181,7 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry
 			RuleType: desc.ParseErr.Kind,
 		}
 	default:
-		d = evaluateMCPDescriptor(sets, desc, req, te, now)
+		d = evaluateMCPDescriptor(sets, desc, req, te, now, nsPath)
 		if d == nil {
 			// Defence in depth: evaluateMCPDescriptor returns nil
 			// only for empty sets (handled above) or for a non-nil
@@ -212,7 +212,7 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry
 // descriptor carries no calls. The caller in AllowOperation handles
 // structural failures (nil descriptor, ParseErr non-nil) before
 // invoking this function.
-func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescriptor, req *logical.Request, te *logical.TokenEntry, now time.Time) *logical.MCPDecision {
+func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescriptor, req *logical.Request, te *logical.TokenEntry, now time.Time, nsPath string) *logical.MCPDecision {
 	if len(sets) == 0 {
 		return nil
 	}
@@ -225,7 +225,7 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 	// common no-condition path allocates nothing extra.
 	var act *celActivation
 	if mcpSetsHaveCondition(sets) {
-		act = newCELActivation(celRequestInputFromRequest(req), celTokenInputFromEntry(te, now), now, nil)
+		act = newCELActivation(celRequestInputFromRequest(req, nsPath), celTokenInputFromEntry(te, now), now, nil)
 	}
 
 	batch := len(desc.Calls) > 1

--- a/core/policy_mcp_body_test.go
+++ b/core/policy_mcp_body_test.go
@@ -22,7 +22,7 @@ func TestDecideMCP_NilDescriptorDeniesMissingBody(t *testing.T) {
 		AllowedMethods: []string{"tools/list"},
 	}}
 	req := &logical.Request{} // no MCPDescriptor
-	d := decideMCP(sets, req, nil, time.Time{})
+	d := decideMCP(sets, req, nil, time.Time{}, "")
 	require.NotNil(t, d)
 	assert.Equal(t, "deny", d.Decision)
 	assert.Equal(t, mcpRuleTypeMissingBody, d.RuleType)
@@ -55,7 +55,7 @@ func TestDecideMCP_ParseErrMapsByKind(t *testing.T) {
 					},
 				},
 			}
-			d := decideMCP(sets, req, nil, time.Time{})
+			d := decideMCP(sets, req, nil, time.Time{}, "")
 			require.NotNil(t, d)
 			assert.Equal(t, "deny", d.Decision)
 			assert.Equal(t, tc.ruleType, d.RuleType)
@@ -83,7 +83,7 @@ func TestDecideMCP_DescriptorMatcherAllows(t *testing.T) {
 			}},
 		},
 	}
-	d := decideMCP(sets, req, nil, time.Time{})
+	d := decideMCP(sets, req, nil, time.Time{}, "")
 	require.NotNil(t, d)
 	assert.Equal(t, "allow", d.Decision)
 }
@@ -111,7 +111,7 @@ func TestDecideMCP_EmptyDescriptorSkipsEvaluation(t *testing.T) {
 			// Calls nil, ParseErr nil — the per-request opt-out sentinel.
 		},
 	}
-	d := decideMCP(sets, req, nil, time.Time{})
+	d := decideMCP(sets, req, nil, time.Time{}, "")
 	assert.Nil(t, d, "decideMCP must return nil for the per-request opt-out sentinel so the cap-level check decides")
 }
 
@@ -124,10 +124,10 @@ func TestDecideMCP_EmptySetsReturnNil(t *testing.T) {
 			Calls: []logical.MCPCall{{Method: "tools/list"}},
 		},
 	}
-	if d := decideMCP(nil, req, nil, time.Time{}); d != nil {
+	if d := decideMCP(nil, req, nil, time.Time{}, ""); d != nil {
 		t.Errorf("decision = %+v, want nil for empty sets", d)
 	}
-	if d := decideMCP([]*CBPMCPRules{}, req, nil, time.Time{}); d != nil {
+	if d := decideMCP([]*CBPMCPRules{}, req, nil, time.Time{}, ""); d != nil {
 		t.Errorf("decision = %+v, want nil for empty sets slice", d)
 	}
 }
@@ -146,7 +146,7 @@ func TestEvaluateMCPDescriptor_BatchDenyStampsBatchIndex(t *testing.T) {
 			{Method: "tools/call", Name: "delete_repo", BatchIndex: 2},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{}, "")
 	require.NotNil(t, d)
 	require.Equal(t, "deny", d.Decision)
 	require.NotNil(t, d.BatchIndex, "BatchIndex should be stamped for batch denies")
@@ -164,7 +164,7 @@ func TestEvaluateMCPDescriptor_SingleCallLeavesBatchIndexNil(t *testing.T) {
 			{Method: "tools/call", Name: "delete_repo"},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{}, "")
 	require.NotNil(t, d)
 	if d.BatchIndex != nil {
 		t.Errorf("BatchIndex = %v, want nil for single-call descriptor", *d.BatchIndex)
@@ -220,7 +220,7 @@ func TestDecideMCP_SanitizesDecisionBoundary(t *testing.T) {
 			}},
 		},
 	}
-	d := decideMCP(sets, req, nil, time.Time{})
+	d := decideMCP(sets, req, nil, time.Time{}, "")
 	require.NotNil(t, d)
 	assert.Equal(t, "deny", d.Decision)
 	assert.Equal(t, mcpRuleTypeDeniedTools, d.RuleType)

--- a/core/policy_mcp_descriptor_test.go
+++ b/core/policy_mcp_descriptor_test.go
@@ -23,7 +23,7 @@ func TestEvaluateMCPDescriptor_BatchOneDeniedFailsAll(t *testing.T) {
 			{Method: "tools/call", Name: "delete_repo", BatchIndex: 1},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{}, "")
 	if d == nil || d.Decision != "deny" {
 		t.Fatalf("decision = %+v, want deny", d)
 	}
@@ -45,7 +45,7 @@ func TestEvaluateMCPDescriptor_BatchAllAllowed(t *testing.T) {
 			{Method: "tools/call", Name: "search_repos", BatchIndex: 1},
 		},
 	}
-	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{})
+	d := evaluateMCPDescriptor(sets, desc, nil, nil, time.Time{}, "")
 	if d == nil || d.Decision != "allow" {
 		t.Fatalf("decision = %+v, want allow", d)
 	}
@@ -58,11 +58,10 @@ func TestEvaluateMCPDescriptor_NoCallsReturnsNil(t *testing.T) {
 	sets := []*CBPMCPRules{{
 		AllowedMethods: []string{"tools/list"},
 	}}
-	if d := evaluateMCPDescriptor(sets, nil, nil, nil, time.Time{}); d != nil {
+	if d := evaluateMCPDescriptor(sets, nil, nil, nil, time.Time{}, ""); d != nil {
 		t.Errorf("nil descriptor: decision = %+v, want nil", d)
 	}
-	if d := evaluateMCPDescriptor(sets, &logical.MCPRequestDescriptor{}, nil, nil, time.Time{}); d != nil {
+	if d := evaluateMCPDescriptor(sets, &logical.MCPRequestDescriptor{}, nil, nil, time.Time{}, ""); d != nil {
 		t.Errorf("empty Calls: decision = %+v, want nil", d)
 	}
 }
-

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -27,6 +27,8 @@ How a caller proves who it is and what that lets it do.
   resolved per request.
 - [Policies](policies.md) — capability-based authorization, path matching, and
   request-content rules.
+- [CEL Condition Cookbook](cel-conditions.md) — 20 worked examples for the
+  `condition` expression, from a numeric cap to a full payments stanza.
 
 ## Brokering access
 

--- a/docs/concepts/cel-conditions.md
+++ b/docs/concepts/cel-conditions.md
@@ -1,0 +1,364 @@
+# CEL Condition Cookbook
+
+A CBP policy grants access in two layers. The **structural** layer — `capabilities`
+and the MCP method/tool allow-lists — decides *which rule applies* and *what it
+permits* without seeing a concrete request. The **condition** layer refines that
+grant with a [Google CEL](https://cel.dev) expression evaluated against the actual
+request: values, network and time context, and the caller's verified identity.
+
+A `condition` can appear in two places:
+
+- **Path level** — inside a `path { }` block, evaluated once per request against
+  `request.*`, `token.*`, and `now`.
+- **Per call** — inside an `mcp { }` block, evaluated once per MCP tool call with
+  the additional `call.*` namespace (see [MCP](mcp.md)).
+
+The rule passes only if its structural gates pass **and** its condition evaluates
+to `true`. Evaluation is **fail-closed**: `false`, a type mismatch, or reading an
+absent key all deny.
+
+This page is a cookbook. For the full semantics — the activation contract, cost
+bounds, the two-environment rule, how inputs are recorded in the audit log — see
+[Policies → Fine-grained access](policies.md#fine-grained-access).
+
+## Quick reference
+
+The expression reads from a fixed set of namespaces:
+
+| Namespace | Fields |
+| --- | --- |
+| `request` | `path`, `operation`, `client_ip`, `mount_point`, `mount_type`, `mount_class`, `mount_accessor`, `transparent`, `namespace`, `data.<key>` |
+| `token` | `principal`, `role`, `type`, `namespace`, `policies` (list), `metadata.<key>`, `actors` (list of `{subject, verified}`), `ttl_seconds`, `expires_at` |
+| `now` | the request timestamp |
+| `call` | `method`, `tool`, `args.<key>`, `batch_index` — **`mcp { }` only** |
+
+Values you will reference often:
+
+- `request.operation` — one of `read`, `create`, `update`, `delete`, `list`,
+  `scan`, `patch`. (For an MCP gateway POST it is always `update`; gate on
+  `call.tool` instead.)
+- `token.type` — the authenticating method: `spiffe_role`, `cert_role`,
+  `jwt_role`, or `kubernetes_role`.
+- `request.mount_class` — `provider`, `auth`, `audit`, `system`, or `ns_system`.
+- `token.namespace` / `request.namespace` — a namespace path, `""` for root or
+  `"team-a/"` / `"team-a/team-b/"` (trailing slash) for children. `token.namespace`
+  is where the token was **minted**; `request.namespace` is the namespace the
+  request **targets**.
+
+Functions available: the CEL standard library (`has()`, `size()`, `in`,
+`startsWith()`/`endsWith()`/`contains()`, `all()`/`exists()`, the `? :` ternary),
+optional access `x.?field.orValue(default)`, timezone-aware
+`now.getHours(tz)` / `now.getDayOfWeek(tz)` (0 = Sunday) / `now.getMinutes(tz)`,
+and Warden's `cidrContains(cidr, ip)`.
+
+> **Three rules that bite.** *Fail-closed* — any error or `false` denies, so a
+> missing key denies unless you guard it. *Runtime typing* — `request.data.amount`
+> is compared as the type it arrived as; the string `"1000"` does **not** satisfy
+> `> 1000`, it denies. *Absent-is-OK* — when a missing field should pass, use
+> `has(...)` or `x.?field.orValue(default)` rather than a bare reference.
+
+---
+
+## Body value guards
+
+### 1. Cap a numeric field
+
+Bound a value in the request body — e.g. an LLM token budget:
+
+```hcl
+path "anthropic/role/+/gateway*" {
+  capabilities = ["create", "update"]
+  condition    = "request.data.max_tokens <= 4096"
+}
+```
+
+### 2. Pin to an allowlist
+
+Restrict a field to an approved set:
+
+```hcl
+path "anthropic/role/+/gateway*" {
+  capabilities = ["create", "update"]
+  condition    = "request.data.model in ['claude-sonnet-4-5', 'claude-opus-4-1']"
+}
+```
+
+### 3. Require a field to be present
+
+Force callers to supply a value (absent → deny):
+
+```hcl
+path "db/issue-grant" {
+  capabilities = ["create"]
+  condition    = "has(request.data.justification)"
+}
+```
+
+### 4. Optional field with a safe default
+
+Cap a field *if present*, but allow the request when it is omitted:
+
+```hcl
+path "db/issue-grant" {
+  capabilities = ["create"]
+  condition    = "request.data.?ttl_seconds.orValue(0) <= 3600"
+}
+```
+
+### 5. Closed key set
+
+Reject any request that carries a body field outside an allowed set:
+
+```hcl
+path "slack/role/+/gateway/chat.postMessage" {
+  capabilities = ["create"]
+  condition    = "request.data.all(k, k in ['channel', 'text', 'thread_ts'])"
+}
+```
+
+---
+
+## Network and time
+
+### 6. Source-IP allowlist
+
+Only accept requests originating inside a CIDR block:
+
+```hcl
+path "admin/*" {
+  capabilities = ["update"]
+  condition    = "cidrContains('10.0.0.0/8', request.client_ip)"
+}
+```
+
+> `request.client_ip` is only as trustworthy as your proxy chain — it derives from
+> `X-Real-IP` / `X-Forwarded-For`, which a client can forge if those headers are
+> not stripped at the edge.
+
+### 7. Business hours only
+
+Gate on the wall-clock hour in a named timezone:
+
+```hcl
+path "aws/role/+/*" {
+  capabilities = ["update", "delete"]
+  condition    = "now.getHours('America/New_York') >= 9 && now.getHours('America/New_York') < 17"
+}
+```
+
+### 8. Weekdays only
+
+`getDayOfWeek` returns `0` for Sunday through `6` for Saturday:
+
+```hcl
+path "aws/role/+/*" {
+  capabilities = ["update", "delete"]
+  condition    = "now.getDayOfWeek('UTC') in [1, 2, 3, 4, 5]"
+}
+```
+
+---
+
+## Operation shaping
+
+The `capabilities` list already selects the rule; a condition can narrow *which*
+operations proceed based on request context.
+
+### 9. Read-only on a wildcard path
+
+```hcl
+path "secret/data/*" {
+  capabilities = ["read", "list", "create", "update", "delete"]
+  condition    = "request.operation in ['read', 'list']"
+}
+```
+
+### 10. Reads open, writes gated by metadata
+
+```hcl
+path "kv/*" {
+  capabilities = ["read", "update", "delete"]
+  condition    = "request.operation == 'read' || token.metadata.role == 'writer'"
+}
+```
+
+---
+
+## Identity and authentication method
+
+### 11. Require a specific auth method
+
+Only accept callers that authenticated with SPIFFE (workload identity):
+
+```hcl
+path "prod/payments/*" {
+  capabilities = ["update"]
+  condition    = "token.type == 'spiffe_role'"
+}
+```
+
+> To require *any* hardware-backed method (certificate or SPIFFE, but not JWT or
+> Kubernetes): `token.type in ['cert_role', 'spiffe_role']`.
+
+### 12. Pin to a specific role
+
+Gate on *which role was assumed*, distinct from which method authenticated it:
+
+```hcl
+path "prod/payments/*" {
+  capabilities = ["update"]
+  condition    = "token.role == 'payments-writer'"
+}
+```
+
+### 13. Principal or trust-domain prefix
+
+Match the verified principal — e.g. a SPIFFE trust domain:
+
+```hcl
+path "prod/payments/*" {
+  capabilities = ["update"]
+  condition    = "token.principal.startsWith('spiffe://prod.example.org/')"
+}
+```
+
+### 14. Reject implicit (transparent) tokens
+
+`request.transparent` is `true` when the identity was established implicitly via a
+forwarded JWT rather than an explicit login. Require an explicitly authenticated
+token here:
+
+```hcl
+path "admin/*" {
+  capabilities = ["update", "delete"]
+  condition    = "!request.transparent"
+}
+```
+
+### 15. Ephemeral tokens only
+
+Refuse long-lived tokens on a sensitive path — only accept ones expiring soon:
+
+```hcl
+path "prod/break-glass/*" {
+  capabilities = ["update"]
+  condition    = "token.ttl_seconds <= 3600"
+}
+```
+
+### 16. Require an attached policy
+
+`token.policies` is the list of policies bound to the token; require a specific one:
+
+```hcl
+path "prod/break-glass/*" {
+  capabilities = ["update"]
+  condition    = "'break-glass' in token.policies"
+}
+```
+
+---
+
+## Delegation
+
+### 17. Require a verified delegate
+
+`token.actors` is the on-behalf-of chain (see [Delegation](delegation.md)). Require
+at least one actor, and that **every** actor in the chain was cryptographically
+attested:
+
+```hcl
+path "prod/payments/*" {
+  capabilities = ["update"]
+  condition    = "size(token.actors) > 0 && token.actors.all(a, a.verified)"
+}
+```
+
+The `size(...) > 0` guard matters: `all()` over an empty list is vacuously `true`,
+so without it a request with no delegation chain would pass.
+
+---
+
+## Namespace confinement
+
+`token.namespace` is where the token was minted; `request.namespace` is the
+namespace the request targets. A token minted in a parent namespace can, by
+default, act in its child namespaces — these conditions constrain that.
+
+### 18. Same-namespace only
+
+Deny a parent-namespace token acting in any child namespace:
+
+```hcl
+path "secret/data/*" {
+  capabilities = ["read", "update", "delete"]
+  condition    = "token.namespace == request.namespace"
+}
+```
+
+### 19. Parent token read-only in child namespaces
+
+Allow a parent-minted token to read across children, but write only in its own
+namespace:
+
+```hcl
+path "secret/data/*" {
+  capabilities = ["read", "list", "update", "delete"]
+  condition    = "request.operation in ['read', 'list'] || token.namespace == request.namespace"
+}
+```
+
+---
+
+## MCP per-call and composite
+
+### 20. A full payments stanza
+
+The most complex case combines every layer: structural tool gates, per-tool
+budgets over `call.args`, and request/identity/time context — all fail-closed.
+
+```hcl
+path "mcp/payments/*" {
+  capabilities = ["update"]                    # structural: which rule applies
+  mcp {
+    allowed_methods = ["tools/call"]           # structural, enumerable
+    allowed_tools   = ["create_payment", "refund"]
+    condition       = <<-CEL
+      cidrContains("10.0.0.0/8", request.client_ip)
+      && now.getDayOfWeek("America/New_York") in [1, 2, 3, 4, 5]   // Mon–Fri
+      && now.getHours("America/New_York") >= 9
+      && now.getHours("America/New_York") <  17
+      && token.metadata.env == "prod"
+      && size(token.actors) > 0 && token.actors.all(a, a.verified)
+      && (call.tool == "create_payment" ? call.args.amount <= 2500 :
+          call.tool == "refund"         ? call.args.amount <=  500 : false)
+      && call.args.currency in ["USD", "EUR", "GBP"]
+    CEL
+  }
+}
+```
+
+---
+
+## Gotchas
+
+- **An `mcp { }` condition runs for every method the block governs.** If a block
+  covers more than `tools/call`, an expression reading `call.args` will fail closed
+  on the other methods. Scope it: `call.method != 'tools/call' || call.args.amount <= 1500`.
+- **`request.operation` is `update` for MCP gateway POSTs.** Operation-conditional
+  logic there is moot; branch on `call.tool` instead.
+- **Path-level conditions cannot see `call.*`.** Referencing `call.args` in a
+  `path`-level condition is a compile-time error, not a silent deny — the two
+  layers use separate CEL environments by design.
+- **Not every reference is audited.** The values a condition reads are recorded
+  under `auth.policy_results.condition.inputs` (see [Audit](audit.md)), but
+  `now.*` and bracket/optional access (`request.data["k"]`, `call.args.?x`) are not
+  captured there — dotted field access (`request.data.model`) is.
+
+## See also
+
+- [Policies → Fine-grained access](policies.md#fine-grained-access) — the full
+  condition semantics and cost bounds.
+- [MCP → Per-call CEL conditions](mcp.md) — the `call.*` namespace and batch
+  behavior.
+- [Audit](audit.md) — how a condition's inputs are recorded and salted.

--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -92,7 +92,8 @@ mcp {
 ```
 
 The condition reads a per-call namespace on top of the request/token namespaces
-documented in [Policies → CEL conditions](policies.md#cel-conditions):
+documented in [Policies → Fine-grained access](policies.md#fine-grained-access)
+(worked examples in the [CEL Condition Cookbook](cel-conditions.md)):
 
 - `call.method` — the JSON-RPC method (`tools/call`, …)
 - `call.tool` — the name-bearing field (tool/resource/prompt name)

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -182,6 +182,10 @@ condition = "size(token.actors) > 0"
 condition = "request.operation == 'read' ? true : token.metadata.role == 'writer'"
 ```
 
+For 20 worked examples — source-IP and time gates, auth-method and delegation
+checks, namespace confinement, and a full per-tool MCP budget — see the
+[CEL Condition Cookbook](cel-conditions.md).
+
 ### Path expiration
 
 A path block can carry an `expiration` — an absolute time after which the rule

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -131,7 +131,7 @@ variables built from the request:
 
 | Namespace | Fields |
 | --- | --- |
-| `request` | `path`, `operation`, `client_ip`, `mount_point`, `mount_type`, `mount_class`, `mount_accessor`, `transparent`, `data.<key>` |
+| `request` | `path`, `operation`, `client_ip`, `mount_point`, `mount_type`, `mount_class`, `mount_accessor`, `transparent`, `namespace`, `data.<key>` |
 | `token` | `principal`, `role`, `type`, `namespace`, `policies` (list), `metadata.<key>`, `actors` (list of `{subject, verified}`), `ttl_seconds`, `expires_at` |
 | `now` | the request timestamp |
 


### PR DESCRIPTION
Tenth PR in the CEL policy-conditions stack (depends on the merged CEL PRs).

## What

Two related additions.

**1. Expose `request.namespace` to CEL** — the request's target namespace (from `namespace.FromContext` at eval time), alongside the existing `token.namespace` (where the token was minted). This makes namespace confinement expressible — e.g. deny a parent-namespace token acting in a child namespace:

```hcl
condition = "token.namespace == request.namespace"
```

`request.namespace` is not derivable from `request.mount_point` (which concatenates the namespace prefix with the mount path, and the boundary is unrecoverable in CEL); `ns.Path` is the clean primitive and shares `token.namespace`'s format (`""` root, `"team-a/"` child). Threaded through `evaluatePathConditions` / `decideMCP` / `evaluateMCPDescriptor`; captured in audit `Inputs` for free.

**2. CEL condition cookbook** — `docs/concepts/cel-conditions.md`: a compact reference (namespaces, functions, the three fail-closed rules) plus **20 worked examples** from simple → complex — body-value guards, source-IP/time gates, operation shaping, auth-method (`token.type == 'spiffe_role'`) / role / principal checks, delegation, namespace confinement, and a full per-tool MCP payments stanza. Registered in `concepts/README.md`; cross-linked from `policies.md` and `mcp.md`. Every snippet was verified to compile against the real base/MCP envs.

## Tests

`request.namespace` allows same-namespace / denies parent-in-child, and appears in `ConditionResult.Inputs`.
