### PR TITLE
test(policy): cover CEL cost bounds and error categorization

### DIFF
--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -57,15 +57,28 @@ import (
 // Secret material (token value, accessor, client token) is never exposed.
 
 const (
-	// maxConditionCost bounds a single CEL evaluation, both statically (rejected
-	// at policy-write time) and at runtime (cel.CostLimit backstop). Units are
-	// cel-go's abstract cost units.
+	// maxConditionCost bounds a single CEL evaluation in cel-go's abstract cost
+	// units. It serves two distinct roles:
+	//   - Runtime backstop (the real DoS guard): attached as cel.CostLimit to
+	//     every input-size-dependent expression, it caps the work of one Eval
+	//     regardless of the actual input size — a comprehension over an
+	//     adversary-sized request.data/call.args aborts (→ fail-closed deny) once
+	//     it exceeds this budget. This is what bounds per-request cost; it does
+	//     not depend on celInputSizeBound.
+	//   - Write-time rejection: an expression whose worst-case estimate at
+	//     celInputSizeBound already exceeds this is rejected when the policy is
+	//     written (operator gets a directed error instead of a runtime deny).
 	maxConditionCost uint64 = 1_000_000
 
-	// celInputSizeBound is the conservative size (entries / characters) the cost
-	// estimator assumes for our dynamic-map variables, so comprehensions/string
-	// ops over adversary-sized inputs are cost-bounded at compile time. Sized to
-	// the request/body cap; tightened when wired to the real cap.
+	// celInputSizeBound is the size (map entries / string length) the cost
+	// estimator assumes for the dynamic-map variables (request/token/call) that
+	// cel-go cannot size itself. It is a heuristic for the *write-time* check —
+	// large enough to admit reasonable expressions, small enough to reject
+	// pathological ones (e.g. nested comprehensions, ~size² cost). It is
+	// deliberately NOT the real body cap (framework.DefaultMaxBodySize, 10MB →
+	// far more entries): the runtime cel.CostLimit above is the actual per-eval
+	// guard, so this only tunes which expressions fail fast at write time rather
+	// than fail closed at request time.
 	celInputSizeBound uint64 = 8192
 )
 
@@ -183,6 +196,14 @@ func (e celCostEstimator) EstimateCallCost(function, overloadID string, target *
 // undeclared reference (e.g. call.* in a path-level condition), or an
 // over-budget cost are all rejected here with a directed error.
 func compileCELCondition(env *cel.Env, src string) (*compiledCondition, error) {
+	return compileCELConditionWithLimits(env, src, maxConditionCost, celInputSizeBound)
+}
+
+// compileCELConditionWithLimits is compileCELCondition parameterized by the cost
+// budget and estimator size bound. Production always uses the package constants;
+// tests inject small limits to exercise the compile-time rejection and the
+// runtime CostLimit deterministically without building giant activations.
+func compileCELConditionWithLimits(env *cel.Env, src string, maxCost, sizeBound uint64) (*compiledCondition, error) {
 	ast, iss := env.Compile(src)
 	if iss != nil && iss.Err() != nil {
 		return nil, fmt.Errorf("condition does not compile: %w", iss.Err())
@@ -191,28 +212,25 @@ func compileCELCondition(env *cel.Env, src string) (*compiledCondition, error) {
 		return nil, fmt.Errorf("condition must evaluate to bool, got %s", ast.OutputType())
 	}
 
-	est, err := env.EstimateCost(ast, celCostEstimator{maxSize: celInputSizeBound})
+	est, err := env.EstimateCost(ast, celCostEstimator{maxSize: sizeBound})
 	if err != nil {
 		return nil, fmt.Errorf("condition cost estimation failed: %w", err)
 	}
-	if est.Max > maxConditionCost {
-		return nil, fmt.Errorf("condition worst-case cost %d exceeds limit %d", est.Max, maxConditionCost)
+	if est.Max > maxCost {
+		return nil, fmt.Errorf("condition worst-case cost %d exceeds limit %d", est.Max, maxCost)
 	}
 
-	// The runtime cost tracker (cel.CostLimit) allocates per eval and wraps
-	// the program in an observable interpretable — a real hot-path cost. It is
-	// only a backstop for inputs larger than the static estimate assumed, so
-	// it is only needed when the expression's cost is input-size-dependent.
-	// Detect that by re-estimating with a larger size bound: if the worst-case
-	// cost is unchanged, the cost is input-independent and already capped by
-	// the static bound above, so the per-eval tracker is omitted.
-	est2, err := env.EstimateCost(ast, celCostEstimator{maxSize: celInputSizeBound * 2})
-	if err != nil {
-		return nil, fmt.Errorf("condition cost estimation failed: %w", err)
-	}
+	// The runtime cost tracker (cel.CostLimit) allocates per eval and wraps the
+	// program in an observable interpretable — a real hot-path cost. It is only
+	// a backstop for inputs larger than the static estimate assumed, so attach
+	// it only when the expression's cost is input-size-dependent.
 	var progOpts []cel.ProgramOption
-	if est2.Max != est.Max {
-		progOpts = append(progOpts, cel.CostLimit(maxConditionCost))
+	sizeDependent, err := celCostIsSizeDependent(env, ast, sizeBound)
+	if err != nil {
+		return nil, err
+	}
+	if sizeDependent {
+		progOpts = append(progOpts, cel.CostLimit(maxCost))
 	}
 
 	prg, err := env.Program(ast, progOpts...)
@@ -229,6 +247,23 @@ func compileCELCondition(env *cel.Env, src string) (*compiledCondition, error) {
 		TokFields:  tokF,
 		CallFields: callF,
 	}, nil
+}
+
+// celCostIsSizeDependent reports whether an expression's worst-case cost grows
+// with input size — detected by re-estimating at a doubled size bound and
+// checking whether the worst-case changes. A size-independent (constant-cost)
+// expression is already capped by the compile-time estimate and needs no
+// per-eval CostLimit; a size-dependent one does.
+func celCostIsSizeDependent(env *cel.Env, ast *cel.Ast, sizeBound uint64) (bool, error) {
+	est, err := env.EstimateCost(ast, celCostEstimator{maxSize: sizeBound})
+	if err != nil {
+		return false, fmt.Errorf("condition cost estimation failed: %w", err)
+	}
+	est2, err := env.EstimateCost(ast, celCostEstimator{maxSize: sizeBound * 2})
+	if err != nil {
+		return false, fmt.Errorf("condition cost estimation failed: %w", err)
+	}
+	return est2.Max != est.Max, nil
 }
 
 // fieldSet is the set of top-level namespace fields (e.g. "data", "metadata")

--- a/core/policy_cel_test.go
+++ b/core/policy_cel_test.go
@@ -4,7 +4,10 @@
 package core
 
 import (
+	"errors"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +15,26 @@ import (
 
 	"github.com/stephnangue/warden/logical"
 )
+
+// mustAst compiles src to a checked AST or fails the test.
+func mustAst(t *testing.T, env *cel.Env, src string) *cel.Ast {
+	t.Helper()
+	ast, iss := env.Compile(src)
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("compile %q: %v", src, iss.Err())
+	}
+	return ast
+}
+
+// bigStringKeyMap builds a request.data map with n distinct keys, used to drive
+// a size-dependent condition past a (test-injected) runtime cost limit.
+func bigStringKeyMap(n int) map[string]any {
+	m := make(map[string]any, n)
+	for i := 0; i < n; i++ {
+		m["k"+strconv.Itoa(i)] = i
+	}
+	return m
+}
 
 // mustEnv builds the base or MCP env or fails the test.
 func mustEnv(t *testing.T, mcp bool) *cel.Env {
@@ -60,6 +83,104 @@ func TestCEL_PathLevelEnvRejectsCallReference(t *testing.T) {
 func TestCEL_NonBoolRejected(t *testing.T) {
 	if _, err := compileCELCondition(mustEnv(t, false), "1 + 1"); err == nil {
 		t.Fatal("expected rejection of non-bool condition")
+	}
+}
+
+// TestCEL_CostRejectedAtCompile confirms an expression whose worst-case cost
+// exceeds the budget at the estimator size bound is rejected at policy-write
+// time (a nested comprehension is ~size², well over the limit at 8192).
+func TestCEL_CostRejectedAtCompile(t *testing.T) {
+	_, err := compileCELCondition(mustEnv(t, true),
+		"call.args.all(k, call.args.all(j, k == j))")
+	if err == nil {
+		t.Fatal("expected compile-time cost rejection for a nested comprehension")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Fatalf("expected a cost-limit error, got: %v", err)
+	}
+}
+
+// TestCEL_CostIsSizeDependent locks the decision that gates the runtime
+// CostLimit: comprehensions/size-scaling ops are size-dependent, scalar
+// comparisons are not.
+func TestCEL_CostIsSizeDependent(t *testing.T) {
+	mcp := mustEnv(t, true)
+	dep, err := celCostIsSizeDependent(mcp, mustAst(t, mcp, "call.args.all(k, k != '')"), 8192)
+	if err != nil || !dep {
+		t.Fatalf("comprehension should be size-dependent: dep=%v err=%v", dep, err)
+	}
+	base := mustEnv(t, false)
+	dep, err = celCostIsSizeDependent(base, mustAst(t, base, "request.mount_type == 'vault'"), 8192)
+	if err != nil || dep {
+		t.Fatalf("scalar comparison should be size-independent: dep=%v err=%v", dep, err)
+	}
+}
+
+// TestCEL_RuntimeCostLimitDenies exercises the runtime cel.CostLimit backstop:
+// a size-dependent expression compiles under a small injected budget (its
+// estimate at the small size bound fits), then a larger activation drives eval
+// past the budget → fail-closed error. Uses the compile-with-limits seam so the
+// test is deterministic without a million-entry activation.
+func TestCEL_RuntimeCostLimitDenies(t *testing.T) {
+	env := mustEnv(t, false)
+	c, err := compileCELConditionWithLimits(env, "request.data.all(k, k != '')", 100, 5)
+	if err != nil {
+		t.Fatalf("expected the expression to compile under the injected bound: %v", err)
+	}
+	now := time.Unix(0, 0).UTC()
+	act := buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celTokenInput{}, now)
+	ok, err := evalCELCondition(c.Program, act)
+	if ok {
+		t.Fatal("cost-exceeded eval must not allow")
+	}
+	if err == nil {
+		t.Fatal("expected a runtime cost-limit error")
+	}
+	if got := celErrorKind(err); got != "cost_exceeded" {
+		t.Fatalf("error kind = %q, want cost_exceeded (err: %v)", got, err)
+	}
+}
+
+// TestCEL_ErrorKind pins celErrorKind's categorization (it substring-matches
+// cel-go v0.28.1 error text — a table test guards against silent reclassification
+// on upgrade).
+func TestCEL_ErrorKind(t *testing.T) {
+	now := time.Unix(0, 0).UTC()
+	mcp := mustEnv(t, true)
+	base := mustEnv(t, false)
+
+	mustErrKind := func(label string, err error, want string) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected an eval error, got none", label)
+		}
+		if got := celErrorKind(err); got != want {
+			t.Fatalf("%s: kind=%q want %q (err: %v)", label, got, want, err)
+		}
+	}
+
+	// no_such_key — missing argument.
+	_, err := evalCELCondition(mustCompile(t, mcp, "call.args.amount <= 1500"),
+		mcpAct(now, "pay", nil))
+	mustErrKind("missing arg", err, "no_such_key")
+
+	// type_mismatch — string argument against a numeric comparison.
+	_, err = evalCELCondition(mustCompile(t, mcp, "call.args.amount <= 1500"),
+		mcpAct(now, "pay", map[string]logical.ParamValue{"amount": str("x")}))
+	mustErrKind("string vs numeric", err, "type_mismatch")
+
+	// cost_exceeded — runtime cost-limit trip (via the seam).
+	c, err := compileCELConditionWithLimits(base, "request.data.all(k, k != '')", 100, 5)
+	if err != nil {
+		t.Fatalf("seam compile: %v", err)
+	}
+	_, err = evalCELCondition(c.Program,
+		buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celTokenInput{}, now))
+	mustErrKind("cost limit", err, "cost_exceeded")
+
+	// eval_error — any error outside the known categories maps to the catch-all.
+	if got := celErrorKind(errors.New("unexpected internal failure")); got != "eval_error" {
+		t.Fatalf("generic error: kind=%q want eval_error", got)
 	}
 }
 


### PR DESCRIPTION
Closes a coverage gap: the CEL cost guard (compile-time reject + runtime CostLimit) and `celErrorKind` categorization were untested.

## What

- Extract `compileCELConditionWithLimits(env, src, maxCost, sizeBound)`; the public `compileCELCondition` calls it with the package constants (**production behavior unchanged**). Tests inject small limits to exercise both bounds deterministically without giant activations.
- Extract `celCostIsSizeDependent` (the est2-doubling decision that gates the runtime `CostLimit`) so it is unit-testable directly.
- Rewrite the `maxConditionCost` / `celInputSizeBound` doc comments: the runtime `CostLimit` is the real per-eval DoS backstop (independent of the size bound); the size bound is a write-time reject-pathological heuristic. Removes the stale "wire to real cap" TODO.

## Tests

Compile-time rejection of a nested comprehension; `celCostIsSizeDependent` true/false; runtime `CostLimit` deny via the seam; and a `celErrorKind` table (`no_such_key` / `type_mismatch` / `cost_exceeded` / `eval_error`) that guards the brittle cel-go error-string matching.

One of a set of independent CEL-hardening PRs; based on `main`.
