### PR TITLE
test(policy): guard CEL cache-identity, batch-now, multi-set OR

### DIFF
--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -30,6 +30,45 @@ func testParsePolicy(t testing.TB, rules string) *Policy {
 	return policy
 }
 
+// TestCBP_ConditionIsIdentityIndependent proves a condition compiles once and is
+// evaluated against per-token activation data — never recompiled per identity.
+// One CBP, two different tokens, opposite outcomes driven purely by token data.
+func TestCBP_ConditionIsIdentityIndependent(t *testing.T) {
+	ctx := testContext()
+	p := testParsePolicy(t, `path "secret/x" { capabilities = ["read"] condition = "token.metadata.env == 'prod'" }`)
+	cbp, err := NewCBP(ctx, []*Policy{p})
+	require.NoError(t, err)
+
+	req := &logical.Request{Operation: logical.ReadOperation, Path: "secret/x"}
+	prod := &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}}
+	dev := &logical.TokenEntry{Metadata: map[string]string{"env": "dev"}}
+
+	assert.True(t, cbp.AllowOperation(ctx, req, prod, false).Allowed)
+	assert.False(t, cbp.AllowOperation(ctx, req, dev, false).Allowed)
+}
+
+// TestCBP_CompiledConditionCacheSharedAcrossCallers confirms a conditioned policy
+// set compiles once and the cached compiled CBP is reused across callers — the
+// compiled program is keyed by the policy set, not by any token identity (the
+// no-templated-policies invariant).
+func TestCBP_CompiledConditionCacheSharedAcrossCallers(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	p := testParsePolicy(t, `path "secret/x" { capabilities = ["read"] condition = "token.metadata.env == 'prod'" }`)
+	p.Name = "cond"
+	p.Type = PolicyTypeCBP
+	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+
+	names := map[string][]string{namespace.RootNamespaceID: {"cond"}}
+	first, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	second, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	assert.Same(t, first, second, "same policy set → one cached compiled CBP, shared regardless of caller")
+}
+
 // =============================================================================
 // CBP Creation Tests
 // =============================================================================

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -5,12 +5,59 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stephnangue/warden/logical"
 )
+
+// TestMCPCond_BatchSharesOneNow guards that decideMCP evaluates every call in a
+// batch against a single `now` snapshot. The condition holds only at the exact
+// instant passed in; if a refactor re-read time.Now() per call, the calls would
+// no longer match and the batch would deny.
+func TestMCPCond_BatchSharesOneNow(t *testing.T) {
+	env, err := mcpCELEnv()
+	require.NoError(t, err)
+	cond, err := compileCELCondition(env, `now == timestamp("1970-01-01T00:00:00Z")`)
+	require.NoError(t, err)
+
+	sets := []*CBPMCPRules{{
+		AllowedMethods: []string{"tools/call"},
+		AllowedTools:   []string{"pay"},
+		Condition:      cond,
+	}}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "mcp/gateway/",
+		MCPDescriptor: &logical.MCPRequestDescriptor{Calls: []logical.MCPCall{
+			{Method: "tools/call", Name: "pay", BatchIndex: 0, MatchArgs: map[string]logical.ParamValue{}},
+			{Method: "tools/call", Name: "pay", BatchIndex: 1, MatchArgs: map[string]logical.ParamValue{}},
+		}},
+	}
+
+	d := decideMCP(sets, req, nil, time.Unix(0, 0).UTC(), "")
+	require.NotNil(t, d)
+	assert.Equal(t, "allow", d.Decision, "both batch calls must see the same now snapshot")
+}
+
+// TestMCPCond_MultiSetConditionOR confirms cross-set OR at the condition level:
+// a call denied by one set's condition but allowed by another's is allowed.
+func TestMCPCond_MultiSetConditionOR(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp { allowed_methods = ["tools/call"] allowed_tools = ["pay"] condition = "call.args.amount <= 100" }
+}
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp { allowed_methods = ["tools/call"] allowed_tools = ["pay"] condition = "call.args.amount <= 5000" }
+}`)
+	req := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"pay","arguments":{"amount":1000}},"id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.True(t, res.Allowed, "set A denies (>100) but set B allows (<=5000) → cross-set OR allows")
+}
 
 // mcpReq builds a streaming MCP request from a JSON-RPC body and runs the
 // production extractor, leaving req.MCPDescriptor populated.


### PR DESCRIPTION
Regression tests for three CEL invariants that were unguarded. Tests only — no production changes.

## What

- **Identity-independence:** one CBP with a `token.metadata` condition, two different tokens → opposite outcomes driven purely by activation data (the condition compiles once, never per identity); plus a policy-store test that the same policy set yields one shared compiled CBP across callers (the no-templated-policies invariant).
- **Batch-`now`:** `decideMCP` evaluates every call in a batch against one `now` snapshot — the condition holds only at the exact instant passed in, so a per-call `time.Now()` refactor would deny.
- **Multi-set condition OR:** a call denied by one set's condition but allowed by another's is allowed (cross-set OR at the condition level).

One of a set of independent CEL-hardening PRs; based on `main`.
