### PR TITLE
docs(cli): document policy condition (CEL) and write-time validation

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -13,6 +13,7 @@ control what an identity may do on which paths. A policy grants a set of
 - [`policy read`](#policy-read)
 - [`policy list`](#policy-list)
 - [`policy delete`](#policy-delete)
+- [Conditions (CEL)](#conditions-cel)
 - [See Also](#see-also)
 
 ## Usage
@@ -87,8 +88,45 @@ Delete the policy named `<name>`.
 warden policy delete my-policy
 ```
 
+## Conditions (CEL)
+
+A `path` rule may carry a **`condition`** — a [CEL](https://cel.dev) expression
+that must evaluate to `true` for the rule to apply. It refines a capability grant
+with request context, caller identity, and value logic (source IP, time of day,
+token attributes, numeric/string/set comparisons, MCP tool arguments).
+
+Conditions are **validated and cost-bounded when the policy is written**: a
+malformed, non-boolean, or too-expensive expression makes `warden policy write`
+fail with a directed error, so a broken condition never reaches the request path.
+At request time evaluation is **fail-closed** — a `false` result or any error
+(missing field, type mismatch) denies.
+
+```bash
+warden policy write pin-model - <<'EOF'
+path "anthropic/role/+/gateway*" {
+  capabilities = ["create", "update"]
+  condition    = "request.data.model == 'claude-sonnet-4-5'"
+}
+EOF
+```
+
+A bad expression is rejected at write time rather than silently denying later:
+
+```bash
+# non-boolean expression → write fails
+warden policy write bad - <<'EOF'
+path "secret/*" { capabilities = ["read"] condition = "1 + 1" }
+EOF
+# Error: ... condition must evaluate to bool
+```
+
+For the full variable namespaces, functions, and 20 worked examples, see
+[Fine-grained access](../concepts/policies.md#fine-grained-access) and the
+[CEL Condition Cookbook](../concepts/cel-conditions.md).
+
 ## See Also
 
 - [Policies](../concepts/policies.md) — the capability model and policy syntax.
+- [CEL Condition Cookbook](../concepts/cel-conditions.md) — condition recipes, simple to complex.
 - [Roles](../concepts/roles.md) — how policies attach to an identity.
 - [CLI overview](README.md) — global flags, output formats, exit codes.


### PR DESCRIPTION
The `warden policy` CLI reference never mentioned the `condition` field.

## What

Add a "Conditions (CEL)" section to `docs/cli/policy.md`:

- what a `condition` is (a CEL expression that must hold for the rule to apply);
- that it is **validated and cost-bounded at write time** — a malformed, non-boolean, or too-expensive expression fails `warden policy write` with a directed error, rather than silently denying at request time;
- that evaluation is **fail-closed**;
- an example, a rejected-expression example, and links to [Fine-grained access](../concepts/policies.md#fine-grained-access) and the [CEL Condition Cookbook](../concepts/cel-conditions.md).

Docs only. One of a set of independent CEL-hardening PRs; based on `main`.
