### PR TITLE
test(e2e): assert CEL condition decisions in audit + request.namespace

### DIFF
--- a/e2e/auth/auth_test.go
+++ b/e2e/auth/auth_test.go
@@ -8,7 +8,24 @@ import (
 	"time"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
+	"github.com/stephnangue/warden/logical"
 )
+
+// findAuditedCondition polls the leader node's audit log for up to ~6s for an
+// entry (whose raw line contains marker) that carries a path-level CEL condition
+// decision, and returns it. Audit writes are asynchronous, hence the poll.
+func findAuditedCondition(t *testing.T, nodeNum int, marker string) *logical.ConditionResult {
+	t.Helper()
+	for i := 0; i < 30; i++ {
+		for _, e := range h.ReadAuditEntries(t, nodeNum, marker) {
+			if e.Auth != nil && e.Auth.PolicyResults != nil && e.Auth.PolicyResults.Condition != nil {
+				return e.Auth.PolicyResults.Condition
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil
+}
 
 // TestJWTLoginExpiredJWT verifies expired JWT is rejected (T-058).
 func TestJWTLoginExpiredJWT(t *testing.T) {
@@ -187,5 +204,71 @@ func TestConditionRejectsInvalidCEL(t *testing.T) {
 		`{"policy":"path \"secret/*\" {\n  capabilities = [\"read\"]\n  condition = \"1 + 1\"\n}"}`)
 	if status != 400 {
 		t.Fatalf("expected 400 for a non-bool CEL condition, got %d", status)
+	}
+}
+
+// TestConditionRecordedInAudit verifies that a path-level CEL condition's
+// decision and referenced inputs are recorded in the audit log. The policy path
+// matches the role used for the request so the condition is actually reached
+// (T-073).
+func TestConditionRecordedInAudit(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	node := h.NodeNumberForPort(port)
+
+	// Condition always holds (request.path is non-empty) → allow, and records
+	// request.path in the audited inputs.
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-audit", port,
+		`{"policy":"path \"vault/role/e2e-cond-audit-role/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n  condition = \"request.path != ''\"\n}"}`)
+	h.APIRequest(t, "POST", "auth/jwt/role/e2e-cond-audit-role", port,
+		`{"token_policies":["e2e-cond-audit"],"cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":300}`)
+	defer func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/e2e-cond-audit-role", port, "")
+		h.APIRequest(t, "DELETE", "sys/policies/cbp/e2e-cond-audit", port, "")
+	}()
+
+	jwt := h.GetDefaultJWT(t)
+	status, _ := h.VaultTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-cond-audit-role", port, jwt)
+	if status != 200 {
+		t.Fatalf("expected 200 (condition allows), got %d", status)
+	}
+
+	cond := findAuditedCondition(t, node, "e2e-cond-audit-role")
+	if cond == nil {
+		t.Fatal("expected an audit entry carrying auth.policy_results.condition")
+	}
+	if cond.Decision != "allow" {
+		t.Fatalf("condition decision = %q, want allow", cond.Decision)
+	}
+	if cond.Inputs["request.path"] == "" {
+		t.Fatalf("expected request.path recorded in condition inputs, got %v", cond.Inputs)
+	}
+}
+
+// TestConditionRequestNamespaceEnforced verifies the request.namespace variable:
+// a condition matching the request's (root) namespace allows; one requiring a
+// different namespace denies (T-074).
+func TestConditionRequestNamespaceEnforced(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	h.APIRequest(t, "POST", "auth/jwt/role/e2e-cond-ns-role", port,
+		`{"token_policies":["e2e-cond-ns"],"cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":300}`)
+	defer func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/e2e-cond-ns-role", port, "")
+		h.APIRequest(t, "DELETE", "sys/policies/cbp/e2e-cond-ns", port, "")
+	}()
+	jwt := h.GetDefaultJWT(t)
+
+	// Root request → request.namespace == "" → condition matches → allow.
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-ns", port,
+		`{"policy":"path \"vault/role/e2e-cond-ns-role/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n  condition = \"request.namespace == ''\"\n}"}`)
+	if status, _ := h.VaultTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-cond-ns-role", port, jwt); status != 200 {
+		t.Fatalf("root-namespace match: expected 200, got %d", status)
+	}
+
+	// Same request, condition now requires a different namespace → deny.
+	h.APIRequest(t, "POST", "sys/policies/cbp/e2e-cond-ns", port,
+		`{"policy":"path \"vault/role/e2e-cond-ns-role/gateway/*\" {\n  capabilities = [\"read\",\"list\"]\n  condition = \"request.namespace == 'other/'\"\n}"}`)
+	if status, _ := h.VaultTransparentRequest(t, "GET", "secret/data/e2e/app-config", "e2e-cond-ns-role", port, jwt); status != 403 {
+		t.Fatalf("cross-namespace mismatch: expected 403, got %d", status)
 	}
 }

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -17,6 +17,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stephnangue/warden/audit"
 )
 
 // Node ports for the 3-node cluster.
@@ -545,6 +547,30 @@ func GrepNodeLog(t *testing.T, nodeNum int, pattern string) bool {
 	t.Helper()
 	log := ReadNodeLog(t, nodeNum)
 	return strings.Contains(log, pattern)
+}
+
+// ReadAuditEntries parses the JSON file-audit-device log for a node
+// (.logs/node{N}-audit.log — one LogEntry per line) and returns the entries
+// whose raw line contains substr (all entries when substr is ""). Non-audit or
+// partial lines are skipped, so it is safe to poll while the node is writing.
+func ReadAuditEntries(t *testing.T, nodeNum int, substr string) []audit.LogEntry {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(E2EDir(), ".logs", fmt.Sprintf("node%d-audit.log", nodeNum)))
+	if err != nil {
+		return nil
+	}
+	var out []audit.LogEntry
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || (substr != "" && !strings.Contains(line, substr)) {
+			continue
+		}
+		var e audit.LogEntry
+		if json.Unmarshal([]byte(line), &e) == nil && e.Type != "" {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // LoginJWT logs in with a JWT and role, returns (statusCode, wardenToken).


### PR DESCRIPTION
Adds e2e coverage for CEL conditions beyond the existing write-time rejection tests.

## What

- **`ReadAuditEntries` helper** (`e2e/helpers`): parse the per-node JSON file-audit log (`.logs/node{N}-audit.log`, one `LogEntry` per line), filtered by a marker — reusable scaffolding, safe to poll while the node writes.
- **`TestConditionRecordedInAudit`**: a path-level condition allows a gateway request, then asserts the audit entry carries `auth.policy_results.condition` with `decision=allow` and the referenced `request.path` in its `inputs`. Policy path and role name are kept aligned so the condition is actually reached (unlike the pre-existing source-IP test, which can 403 on a path/role mismatch — worth a follow-up fix).
- **`TestConditionRequestNamespaceEnforced`**: `request.namespace` matches the request's root namespace → allow (200); requiring a different namespace → deny (403).

## Verification

Ran against a live 3-node e2e cluster (`make test-e2e-setup` → `go test -tags e2e -run TestCondition` → teardown): all 5 condition tests pass, including the two new ones (audit log parsed; namespace allow/deny).

One of a set of independent CEL-hardening PRs; based on `main`.
