### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Warden are documented in this file.
 
 ## [Unreleased]
 
+## [v0.17.0] — 2026-07-04
+
+### Breaking Changes
+
+- **CBP policy: the structured `conditions {}` block is removed in favour of a CEL `condition`.** The block's four predicates (`source_ip`, `time_window`, `day_of_week`, `token_metadata`) are all expressible as a single [CEL](https://cel.dev) expression, so the bespoke evaluator is gone and the parser rejects the block with a directed error naming the CEL equivalent: `source_ip` → `cidrContains("10.0.0.0/8", request.client_ip)`, `time_window` → `now.getHours(tz)` / `now.getMinutes(tz)`, `day_of_week` → `now.getDayOfWeek("UTC")` (0 = Sunday), `token_metadata` → `token.metadata.<key>`. Rewrite affected `path` rules to carry a `condition` string.
+
+- **MCP `allowed_params` / `denied_params` are removed in favour of a per-call CEL `condition` over `call.args`.** Argument-value matching now lives in the `mcp { }` block's `condition` — e.g. `condition = "call.args.amount <= 1500 && call.args.currency in ['USD','EUR']"`. Note the deliberate semantics change: the old convention was *absent argument → passes*, whereas a `condition` is fail-closed (*absent → deny*); use the optional form `call.args.?x.orValue(d)` where "absent is OK". The parser rejects the removed keys with a directed error.
+
+- **CBP request-body `required_parameters` / `allowed_parameters` / `denied_parameters` are removed in favour of a CEL `condition` over `request.data`.** Express body constraints directly — `has(request.data.owner)` to require a field, `request.data.tier in ['gold','silver']` to constrain a value, `!has(request.data.internal)` to forbid one. Pagination clamping (`pagination_limit`) and list-response key filtering are unchanged. The parser rejects the removed keys with a directed error.
+
+### New Features
+
+- **CEL policy conditions: one expressive predicate layer for CBP.** A `path` rule can carry a `condition` (evaluated once per request) and an `mcp { }` block can carry a per-call `condition` (evaluated once per tool call) — a [CEL](https://cel.dev) expression that must evaluate to `true` for the rule to apply. Expressions read a fixed namespace: `request.*` (`path`, `operation`, `client_ip`, `mount_point`/`mount_type`/`mount_class`/`mount_accessor`, `transparent`, `namespace`, `data.<key>`), `token.*` (`principal`, `role`, `type`, `namespace`, `policies`, `metadata.<key>`, `actors`, `ttl_seconds`, `expires_at`), `now`, and — inside `mcp { }` — `call.*` (`method`, `tool`, `args.<key>`, `batch_index`). Helpers: `cidrContains(cidr, ip)`, optional access (`x.?field.orValue(d)`), and timezone-aware `now.getHours(tz)` / `getDayOfWeek(tz)` / `getMinutes(tz)`. Evaluation is **fail-closed** (a `false` result or any error — missing key, type mismatch — denies) and **cost-bounded** (expressions are type-checked and cost-limited at policy-write time, and a runtime cost limit backstops size-dependent expressions). Conditions are compiled once and are identity-independent, so they ride the compiled-policy cache unchanged. A path-level condition referencing `call.*` is a compile-time error. See the new [CEL condition cookbook](docs/concepts/cel-conditions.md).
+
+- **Login-derived token metadata across every auth method.** The `jwt`, `cert`, `kubernetes`, and `spiffe` methods can map verified identity attributes onto the issued token via a per-role `metadata_claims` (JWT / JWT-SVID claims, with JSON-Pointer support for nested claims) or `metadata_mappings` (certificate fields, TokenReview attributes, SPIFFE-ID components). The resulting `token.metadata.<key>` is consulted by CEL conditions and attributed in the audit log.
+
+- **CEL decisions are explainable in the audit log.** When a condition decides a request, the audit record carries `auth.policy_results.condition` — the expression, the decision, a sanitized error category on a fail-closed error, and the referenced input values (`inputs`). Input values are logged in clear by default and are HMAC-salt-able per key via `salt_fields` (`auth.policy_results.condition.inputs[.<dotted-key>]`).
+
+- **New generic `rest` provider: a REST/HTTP reverse-proxy backend.** Proxies a workload's HTTP request to a configured upstream with a Warden-injected credential, for JSON/REST APIs that don't have a dedicated provider. (#342)
+
+### Performance
+
+- **CBP evaluation is faster on the policy hot path.** Compiled CBP objects are cached keyed by the policy set (#353) and the policy parse is reused within `CBP()` (#352). For conditioned rules, the CEL activation is pruned to only the namespace fields the expression references, roughly halving per-request allocations on the conditioned path; condition-less rules are unchanged.
+
+### Documentation
+
+- **Docs tree restructure and expansion.** A new `docs/` layout with dedicated sections for concepts, use-cases, auth-methods, provider-backends, agent-identity, and audit-devices; a per-command CLI reference; the CEL condition cookbook (20 worked examples, simple → complex); documentation of path expiration; and a "Securing agents on the workstation" quickstart/tutorial series.
+
+### Dependencies
+
+- Bump the `go-kms-wrapping` family to v2.8.0 and refactor the seal layer onto Warden-owned Shamir/AEAD constants; grouped `go-minor-patch` and `golang.org/x/net` updates.
+
+### Chart
+
+- Chart version bumped `0.3.2` → `0.3.3`. `appVersion` tracks the v0.17.0 binary; no template or values changes.
+
 ## [v0.16.0] — 2026-06-15
 
 ### Breaking Changes
@@ -670,6 +706,7 @@ Initial release. See the [v0.1.0 release notes](https://github.com/stephnangue/w
 - Docker image published to `ghcr.io/stephnangue/warden`
 - Pre-built binaries for Linux, macOS, and Windows
 
+[v0.17.0]: https://github.com/stephnangue/warden/compare/v0.16.0...v0.17.0
 [v0.16.0]: https://github.com/stephnangue/warden/compare/v0.15.0...v0.16.0
 [v0.15.0]: https://github.com/stephnangue/warden/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/stephnangue/warden/compare/v0.13.2...v0.14.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,53 +1,32 @@
-## Warden v0.16.0
+## Warden v0.17.0
 
-v0.16.0 is the SPIFFE release. A new first-class **`spiffe` auth method** accepts a SPIFFE X.509-SVID (over mTLS or a trusted forwarding header) and a SPIFFE JWT-SVID (bearer) on the **same mount**, verifying each against the trust domain's bundle — which carries both the X.509 and JWT key sets — and issuing one token type. Roles bind on `trust_domain`, `allowed_spiffe_ids`, and `bound_audiences`; bundles are managed on the mount and can be **federated** from upstream endpoints with periodic refresh. The method leans on short-lived SVIDs and bundle rotation rather than CRL/OCSP. The control plane itself can now run on SPIFFE: the **API listener can serve its TLS certificate straight from the SPIFFE Workload API**, rotating automatically as the SVID renews. This release also **consolidates the MCP providers** — a single generic `mcp` provider replaces the typed `mcp_github` and `mcp_gcp` — and threads **non-secret subject metadata into the audit log** across the AWS, GCP, Azure, Kubernetes, and Vault sources, so a brokered call records *which* upstream identity acted. Two breaking changes — read the **Upgrading** section before bumping.
+v0.17.0 is the CEL release. Capability-Based Policy gains one expressive predicate layer: a path rule can carry a **`condition`** (evaluated once per request) and an `mcp { }` block a **per-call `condition`** (evaluated once per tool call) — a [CEL](https://cel.dev) expression over a fixed `request.*` / `token.*` / `now` / `call.*` namespace, with helpers for CIDR matching (`cidrContains`), optional arguments (`call.args.?x.orValue(d)`), and timezone-aware time (`now.getHours(tz)`, `now.getDayOfWeek(tz)`). Evaluation is **fail-closed** and **cost-bounded**, conditions are compiled once and identity-independent, and every decision is **explainable in the audit log** (the expression and the exact input values it read). CEL replaces — and this release **removes** — the three structured mechanisms it subsumes: the `conditions {}` block, MCP `allowed_params`/`denied_params`, and CBP request-body `*_parameters`. Alongside it, **login-derived token metadata** lands across all four auth methods (feeding `token.metadata.*` in conditions), a new generic **`rest` provider** proxies arbitrary JSON/REST upstreams, and the documentation is substantially restructured and expanded (including a 20-example CEL cookbook). Three breaking changes — read **Upgrading** before bumping.
 
 ### Breaking Changes
 
-- **The `mcp_github` and `mcp_gcp` provider types are removed in favour of a single generic `mcp` provider.** The new `mcp` provider fronts any bearer-authenticated MCP server (GitHub, Google Cloud, Slack, Cloudflare, …) and injects `Authorization: Bearer` for `oauth_bearer_token`, `api_key`, `github_token`, `gcp_access_token`, and `azure_bearer_token` — a superset of the typed providers it replaces. Re-mount as type `mcp` and set `mcp_url` (`https://api.githubcopilot.com/mcp` for GitHub; the operator's URL for Google Cloud). `mcp_aws` is unaffected — it SigV4-signs requests rather than injecting a bearer token.
+- **The structured `conditions {}` block is removed — express it as a CEL `condition`.** Its four predicates map directly: `source_ip` → `cidrContains("10.0.0.0/8", request.client_ip)`, `time_window` → `now.getHours(tz)` / `now.getMinutes(tz)`, `day_of_week` → `now.getDayOfWeek("UTC")` (0 = Sunday), `token_metadata` → `token.metadata.<key>`. The parser rejects the block with a directed error.
 
-- **`jwt` auth method: the `bound_uri_patterns` and `uri_claim` role fields are removed.** They provided segment-aware string matching against a JWT claim as a stand-in for real SPIFFE JWT-SVID validation. SPIFFE identities now belong to the new `spiffe` auth method, which verifies a JWT-SVID against a trust-domain bundle and enforces its audience. Stored roles carrying these keys decode cleanly and ignore them — a role that relied on URI-pattern matching becomes more permissive, so migrate it to the `spiffe` method.
+- **MCP `allowed_params` / `denied_params` are removed — express them as a per-call `condition` over `call.args`.** e.g. `condition = "call.args.amount <= 1500 && call.args.currency in ['USD','EUR']"`. Semantics change deliberately: a condition is fail-closed (absent argument → deny), whereas the old lists let an absent argument pass — use `call.args.?x.orValue(d)` where "absent is OK".
+
+- **CBP request-body `required_parameters` / `allowed_parameters` / `denied_parameters` are removed — express them as a `condition` over `request.data`.** `has(request.data.owner)` requires a field, `request.data.tier in ['gold','silver']` constrains a value, `!has(request.data.internal)` forbids one. Pagination (`pagination_limit`) and list-response filtering are unchanged. The parser rejects the removed keys.
 
 ### New Features
 
-- **New `spiffe` auth method: first-class SPIFFE support for both SVID types on one mount.** Accepts a SPIFFE X.509-SVID (presented over mTLS or a trusted forwarding header) and a SPIFFE JWT-SVID (bearer) on the same mount, verifying each against the trust domain's bundle and issuing a single `spiffe_role` token type. When a request presents both, the explicitly-presented JWT-SVID wins over an ambient forwarded certificate. Roles bind on `trust_domain`, `allowed_spiffe_ids`, and `bound_audiences`; an audience is required for JWT-SVID logins, as SPIFFE mandates. Trust-domain bundles are managed on the mount and can be federated from upstream endpoints with periodic refresh. There is no X.509-SVID revocation surface — the method relies on short-lived SVIDs and bundle rotation, and an issued token's TTL is capped by the SVID's expiry.
+- **CEL policy conditions.** Path-level and per-call `mcp { }` conditions over `request.*` (incl. the new `request.namespace`), `token.*`, `now`, and `call.*`; helpers `cidrContains`, optional types, and the timezone-aware `now.get*` built-ins. Fail-closed and cost-bounded (type-checked and cost-limited at write time; a runtime cost limit backstops size-dependent expressions). A path-level condition that references `call.*` is a compile-time error. See the [CEL condition cookbook](https://github.com/stephnangue/warden/blob/main/docs/concepts/cel-conditions.md).
 
-- **The API listener can serve its TLS certificate from the SPIFFE Workload API.** Instead of a static certificate and key on disk, the listener can obtain an X.509-SVID from a SPIFFE Workload API endpoint and rotate it automatically as the SVID is renewed, keeping the control-plane TLS identity short-lived and self-renewing.
+- **Login-derived token metadata across `jwt`, `cert`, `kubernetes`, and `spiffe`.** Per-role `metadata_claims` (claims, incl. nested via JSON Pointer) or `metadata_mappings` (certificate fields, TokenReview attributes, SPIFFE-ID components) map verified identity attributes onto the token; `token.metadata.<key>` is then usable in conditions and attributed in audit.
 
-- **`cert` auth method consolidated to pure PKI.** The never-shipped experimental SPIFFE mode (`mode=spiffe`, trust-domain config, bundle federation, and the `spiffe_id` principal claim) is removed in favour of the dedicated `spiffe` method. The `cert` method keeps its X.509 chain-of-trust validation and URI-SAN matching (`uri_san` principal claim plus `allowed_uri_sans`), so a SPIFFE X.509-SVID can still be accepted as an ordinary client certificate bound on its URI SAN.
+- **Explainable audit for CEL decisions.** `auth.policy_results.condition` records the expression, decision, a sanitized error category, and the referenced `inputs` — logged in clear by default and HMAC-salt-able per key via `salt_fields`.
 
-- **Audit-log subject metadata across the cloud and secrets sources.** The AWS, GCP, Azure, Kubernetes, and Vault drivers now populate the non-secret `Credential.Metadata` introduced in v0.15.0 when they mint — the assume-role identity on an AWS STS mint, and the token/access-token subject on the others — so an audit record shows which upstream identity a brokered call acted as, not merely that a call occurred.
-
-### Bug Fixes
-
-- **`httpproxy`: the gateway suffix is forwarded verbatim.** Gateway-suffix path extraction now preserves the upstream path exactly — including trailing slashes — so the SigV4-signed `mcp_aws` gateway's canonical request stays valid.
-
-### Documentation
-
-- Operator README for the new `spiffe` auth method, with SPIFFE content retargeted across the `cert`, `jwt`, and Vault-provider docs to point SPIFFE workloads at the dedicated method.
-- `mcp_aws` README: a Claude Code CLI registration step (`claude mcp add`) for pointing Claude Code at an `mcp_aws` mount.
-- Root README: a dedicated `spiffe` row in the authentication-methods table.
+- **Generic `rest` provider.** A REST/HTTP reverse-proxy backend for JSON/REST APIs without a dedicated provider, with a Warden-injected credential.
 
 ### Upgrading
 
-```bash
-helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.3.2 \
-  -n warden --reset-then-reuse-values
-```
+Rewrite any policy that used the removed structured mechanisms as a CEL `condition`:
 
-Chart `0.3.1` → `0.3.2` is an `appVersion` bump to track the v0.16.0 binary — there are no chart template or values changes, so existing values files apply as-is.
+- `conditions { source_ip = ["10.0.0.0/8"] }` → `condition = "cidrContains('10.0.0.0/8', request.client_ip)"`
+- `conditions { token_metadata = { env = ["prod"] } }` → `condition = "token.metadata.env == 'prod'"`
+- MCP `allowed_params { amount = ["<=1500"] }` → `mcp { condition = "call.args.amount <= 1500" }` (add `call.args.?amount.orValue(0) <= 1500` if an absent argument should still pass)
+- CBP `required_parameters = ["owner"]` → `condition = "has(request.data.owner)"`
 
-Two operator-facing migrations before bumping:
-
-- **Re-mount any `mcp_github` or `mcp_gcp` provider as type `mcp`** and set `mcp_url` (`https://api.githubcopilot.com/mcp` for GitHub; the operator's URL for Google Cloud). The generic provider reuses the same credential types, so existing credential specs apply unchanged. `mcp_aws` is unaffected.
-- **Migrate any `jwt` role that used `bound_uri_patterns` or `uri_claim` to the `spiffe` method.** Those fields are gone; a role that relied on them now ignores them and becomes more permissive until migrated.
-
-### Resources
-
-- New installs and detailed upgrade procedures: [docs/deployment/kubernetes.md](https://github.com/stephnangue/warden/blob/main/docs/deployment/kubernetes.md).
-- SPIFFE, MCP, and auth-method setup: [README](https://github.com/stephnangue/warden#readme) and the per-provider and per-method READMEs.
-
-### License
-
-[MPL-2.0](https://github.com/stephnangue/warden/blob/main/LICENSE)
+The parser rejects each removed construct at policy-write time with an error naming its CEL equivalent, so a stale policy fails fast on `warden policy write` rather than changing behaviour silently.

--- a/deploy/helm/warden/Chart.yaml
+++ b/deploy/helm/warden/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: warden
 description: Identity-aware egress proxy for AI agents — Helm chart for Kubernetes deployments.
 type: application
-version: 0.3.2
-appVersion: "0.16.0"
+version: 0.3.3
+appVersion: "0.17.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/stephnangue/warden
 sources:

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -78,7 +78,7 @@ Helm 3.8+ pulls OCI charts natively — no `helm repo add` needed:
 
 ```bash
 helm install warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
+  --version 0.3.3 \
   -n warden --create-namespace \
   -f your-values.yaml
 ```
@@ -91,8 +91,8 @@ To pin to a specific Warden binary version against the same chart:
 
 ```bash
 helm install warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
-  --set image.tag=v0.12.0 \
+  --version 0.3.3 \
+  --set image.tag=v0.17.0 \
   -n warden --create-namespace \
   -f your-values.yaml
 ```
@@ -105,7 +105,7 @@ tarball to the GitHub Release page:
 
 ```bash
 curl -L -o warden-chart.tgz \
-  https://github.com/stephnangue/warden/releases/download/v0.12.0/warden-0.1.0.tgz
+  https://github.com/stephnangue/warden/releases/download/v0.17.0/warden-0.3.3.tgz
 
 helm install warden ./warden-chart.tgz \
   -n warden --create-namespace \
@@ -222,12 +222,12 @@ The dev values file lives inside the chart, so for the OCI install path
 download it first with `helm show values`:
 
 ```bash
-helm show values oci://ghcr.io/stephnangue/charts/warden --version 0.1.0 \
+helm show values oci://ghcr.io/stephnangue/charts/warden --version 0.3.3 \
   > /tmp/warden-values.yaml
 # Edit /tmp/warden-values.yaml — or skip this step and use --set flags only.
 
 helm install warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
+  --version 0.3.3 \
   -n warden \
   --set replicaCount=1 \
   --set seal.type=static \
@@ -312,7 +312,7 @@ reference your synced Secret names via `--set` instead.
 
 ```bash
 helm install warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
+  --version 0.3.3 \
   -n warden --create-namespace \
   --set tls.existingSecret=warden-tls \
   --set storage.existingSecret=warden-db \
@@ -422,7 +422,7 @@ different namespace.
 
 ```bash
 helm install warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.2.0 \
+  --version 0.3.3 \
   -n warden --create-namespace \
   --set tls.certManager.enabled=true \
   --set tls.certManager.issuerRef.name=warden-pki \
@@ -568,7 +568,7 @@ done
 
 ```bash
 helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.1 \
+  --version 0.3.3 \
   -n warden -f your-values.yaml
 ```
 
@@ -585,9 +585,9 @@ Bump `image.tag` (or upgrade the chart whose `appVersion` advances):
 
 ```bash
 helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
+  --version 0.3.3 \
   -n warden --reuse-values \
-  --set image.tag=v0.13.0
+  --set image.tag=v0.17.0
 ```
 
 Same rolling-restart mechanics. Check release notes for any
@@ -638,7 +638,7 @@ A standby is promoted within ~10s.
 
 ```bash
 helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
+  --version 0.3.3 \
   -n warden --reuse-values \
   --set replicaCount=5
 ```
@@ -802,14 +802,14 @@ no other values to adjust:
 
 ```bash
 helm upgrade warden oci://ghcr.io/stephnangue/charts/warden \
-  --version 0.1.0 \
+  --version 0.3.3 \
   -n warden --reuse-values \
-  --set image.tag=v0.13.0-debug
+  --set image.tag=v0.17.0-debug
 
 kubectl -n warden exec warden-0 -- sh -c 'ls /config && id'
 ```
 
-Roll back to the production tag (`--set image.tag=v0.13.0`, or
+Roll back to the production tag (`--set image.tag=v0.17.0`, or
 `--set image.tag=""` to fall back to the chart's `appVersion`)
 once the investigation is done. The debug variant is meant for short-lived
 diagnostic windows, not steady-state operation — it carries a

--- a/docs/quickstarts/workstation/01-cert-llm/README.md
+++ b/docs/quickstarts/workstation/01-cert-llm/README.md
@@ -56,7 +56,7 @@ Download the **Warden CLI** onto your `PATH` (Apple Silicon shown — swap `darw
 `darwin_amd64` or `linux_*`):
 
 ```bash
-VER=0.16.0
+VER=0.17.0
 curl -fsSL "https://github.com/stephnangue/warden/releases/download/v${VER}/warden_${VER}_darwin_arm64.tar.gz" \
   | tar -xz warden && chmod +x warden
 export PATH="$PWD:$PATH"
@@ -198,8 +198,7 @@ The injected key is never in the clear — credential values are salted to `hmac
 ### Step 7 — watch the policy enforce a limit
 
 The role may call the model — but *which* model is a policy decision. Pin it: rewrite the policy
-so only one model is permitted (missing params stay allowed; `"*" = []` permits every other
-field):
+so only one model is permitted (missing params stay allowed):
 
 ```bash
 MODEL="claude-sonnet-4-5"            # a model your Anthropic account can use

--- a/docs/quickstarts/workstation/01-cert-llm/docker-compose.yml
+++ b/docs/quickstarts/workstation/01-cert-llm/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   # Client certs are optional: the admin CLI reaches it through ghostunnel; ghostunnel's
   # client cert is still verified when presented and captured for cert auth.
   warden:
-    image: ghcr.io/stephnangue/warden:v0.16.0
+    image: ghcr.io/stephnangue/warden:v0.17.0
     command:
       - --dev
       - --dev-root-token=root

--- a/docs/quickstarts/workstation/02-cert-llm-mcp/README.md
+++ b/docs/quickstarts/workstation/02-cert-llm-mcp/README.md
@@ -58,7 +58,7 @@ inject. Download the **Warden CLI** onto your `PATH` (swap `darwin_arm64` for `d
 `linux_*`):
 
 ```bash
-VER=0.16.0
+VER=0.17.0
 curl -fsSL "https://github.com/stephnangue/warden/releases/download/v${VER}/warden_${VER}_darwin_arm64.tar.gz" \
   | tar -xz warden && chmod +x warden
 export PATH="$PWD:$PATH"

--- a/docs/quickstarts/workstation/02-cert-llm-mcp/docker-compose.yml
+++ b/docs/quickstarts/workstation/02-cert-llm-mcp/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./certs:/certs
 
   warden:
-    image: ghcr.io/stephnangue/warden:v0.16.0
+    image: ghcr.io/stephnangue/warden:v0.17.0
     command:
       - --dev
       - --dev-root-token=root

--- a/docs/quickstarts/workstation/03-spiffe-llm-mcp/README.md
+++ b/docs/quickstarts/workstation/03-spiffe-llm-mcp/README.md
@@ -58,7 +58,7 @@ claude --version
 Download the **Warden CLI** onto your `PATH` (swap `darwin_arm64` for `darwin_amd64` or `linux_*`):
 
 ```bash
-VER=0.16.0
+VER=0.17.0
 curl -fsSL "https://github.com/stephnangue/warden/releases/download/v${VER}/warden_${VER}_darwin_arm64.tar.gz" \
   | tar -xz warden && chmod +x warden
 export PATH="$PWD:$PATH"

--- a/docs/quickstarts/workstation/03-spiffe-llm-mcp/docker-compose.yml
+++ b/docs/quickstarts/workstation/03-spiffe-llm-mcp/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     networks: [spiffe]
 
   warden:
-    image: ghcr.io/stephnangue/warden:v0.16.0      # published multi-arch image
+    image: ghcr.io/stephnangue/warden:v0.17.0      # published multi-arch image
     command: ["--dev", "--dev-root-token=root", "--dev-tls-spiffe"]  # fixed dev root token = "root"
     environment:
       SPIFFE_ENDPOINT_SOCKET: "unix:///run/spire/sockets/agent.sock"


### PR DESCRIPTION
Release preparation for **v0.17.0** — the CEL release. **No tag is pushed by this PR**; tagging `v0.17.0` after merge triggers the publish workflow.

## What's in this release (since v0.16.0)

- **CEL policy conditions** become the single predicate/value layer for CBP (path-level `condition` + per-call `mcp{}` condition), **removing** the three structured mechanisms they replace: `conditions{}`, MCP `allowed_params`/`denied_params`, and CBP request-body `*_parameters` (all breaking; each rejected at write time with a directed error naming the CEL equivalent).
- **Login-derived token metadata** across `jwt`/`cert`/`kubernetes`/`spiffe`, consulted by `token.metadata.*` and attributed in audit; CEL decisions are explainable via `auth.policy_results.condition`.
- **Generic `rest` provider**; CBP hot-path perf; large docs restructure + CEL cookbook.

## Changes in this PR

- `CHANGELOG.md` — v0.17.0 entry (2026-07-04) + fresh `[Unreleased]` + compare link.
- `RELEASE_NOTES.md` — goreleaser release body (`--release-notes` source): lead + breaking + features + **Upgrading** migration mappings.
- `deploy/helm/warden/Chart.yaml` — `version` `0.3.2` → `0.3.3`, `appVersion` → `0.17.0` (chart otherwise unchanged; the version must bump — the release workflow refuses to re-publish an existing chart version).
- Docs version pins → the v0.17.0 pair: workstation quickstart `VER` and `docker-compose.yml` image tags (×3); `docs/install/kubernetes.md` normalized (chart `0.3.3`, image `v0.17.0`/`-debug`, tarball `warden-0.3.3.tgz`).

## Verification

`go build ./...` ✓, `helm lint deploy/helm/warden` ✓ (0 failed), CHANGELOG has an empty `[Unreleased]` above the new entry, and grep confirms no residual `v0.16.0`/`v0.12`/`v0.13`/`0.1.x`/`0.2.0` latest-tracking pins remain.

## To cut the release (after merge)

```
git tag -a v0.17.0 -m "Release v0.17.0" && git push origin v0.17.0
```

Triggers `.github/workflows/release.yml`: CI → goreleaser (binaries, archives, checksums, Docker images `ghcr.io/stephnangue/warden:v0.17.0` + `-debug`) → Helm push to `oci://ghcr.io/stephnangue/charts` → GitHub Release from `RELEASE_NOTES.md`.
