### PR TITLE
feat(mcpfilter): add MCP list-response filter util

### DIFF
--- a/provider/sdk/mcpfilter/mcpfilter.go
+++ b/provider/sdk/mcpfilter/mcpfilter.go
@@ -1,0 +1,265 @@
+// Package mcpfilter rewrites MCP JSON-RPC list responses so that only the
+// items a policy allows remain. It handles the three name-bearing list
+// methods — tools/list, resources/list, prompts/list — for both the
+// application/json and text/event-stream (SSE) shapes that MCP Streamable
+// HTTP returns.
+//
+// The package is pure mechanics: it holds no policy state and takes a
+// keep-predicate supplied by the caller. Policy semantics (which names are
+// allowed) live in the core policy layer; this package only drops array
+// elements the predicate rejects and re-serialises the envelope.
+//
+// Fail-closed contract: a body that cannot be parsed as the expected
+// list-result shape returns an error so the gateway can refuse to stream
+// it, rather than leaking an unfiltered (e.g. still-compressed) list.
+package mcpfilter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// listFamily binds a list method to the result array key it returns and the
+// per-item field that carries the name matched by the call-time policy gate.
+// The name fields mirror the strict parser's call-side extraction:
+// tools/call → params.name, resources/read → params.uri, prompts/get →
+// params.name, so a list item is filtered by the same field the gate reads.
+type listFamily struct {
+	arrayKey  string
+	nameField string
+}
+
+var listFamilies = map[string]listFamily{
+	"tools/list":     {arrayKey: "tools", nameField: "name"},
+	"resources/list": {arrayKey: "resources", nameField: "uri"},
+	"prompts/list":   {arrayKey: "prompts", nameField: "name"},
+}
+
+// FilterListResponse rewrites a list-method response body, dropping items
+// whose name the keep predicate rejects.
+//
+//   - out is always the bytes the caller should send: the filtered body when
+//     changed is true, or the original body unchanged when changed is false.
+//     The caller must write out (it has already consumed the source stream).
+//   - changed reports whether any item was removed.
+//   - err is non-nil only when the body cannot be parsed as the expected
+//     list-result shape. The caller must fail closed (never stream the
+//     original) on an error, because an unparseable body cannot be proven
+//     free of denied items.
+//
+// listMethod must be one of tools/list, resources/list, prompts/list — the
+// only methods for which the core policy layer attaches a filter. An unknown
+// method is treated as a fail-closed error.
+func FilterListResponse(listMethod, contentType string, body []byte, keep func(name string) bool) (out []byte, changed bool, err error) {
+	fam, ok := listFamilies[strings.ToLower(listMethod)]
+	if !ok {
+		return nil, false, fmt.Errorf("mcpfilter: unsupported list method %q", listMethod)
+	}
+	if isEventStream(contentType) {
+		return filterSSE(body, fam, keep)
+	}
+	return filterJSON(body, fam, keep)
+}
+
+// isEventStream reports whether the content type is text/event-stream,
+// ignoring any parameters (charset, boundary) and case.
+func isEventStream(contentType string) bool {
+	ct := contentType
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), "text/event-stream")
+}
+
+// filterJSON handles an application/json JSON-RPC response.
+func filterJSON(body []byte, fam listFamily, keep func(string) bool) ([]byte, bool, error) {
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(body, &env); err != nil {
+		// Not a JSON object — could be a batch array, a compressed body,
+		// or garbage. We cannot prove it carries no denied items. Fail closed.
+		return nil, false, fmt.Errorf("mcpfilter: response is not a JSON object: %w", err)
+	}
+
+	resultRaw, ok := env["result"]
+	if !ok {
+		// No result (e.g. a JSON-RPC error response). Nothing to leak.
+		return body, false, nil
+	}
+
+	newResult, changed, err := filterResult(resultRaw, fam, keep)
+	if err != nil {
+		return nil, false, err
+	}
+	if !changed {
+		return body, false, nil
+	}
+
+	env["result"] = newResult
+	out, err := json.Marshal(env)
+	if err != nil {
+		return nil, false, fmt.Errorf("mcpfilter: re-marshal envelope: %w", err)
+	}
+	return out, true, nil
+}
+
+// filterResult filters the array under fam.arrayKey inside a JSON-RPC result
+// object, preserving every other field (nextCursor, unknown fields). Returns
+// the rewritten result and whether any item was dropped.
+func filterResult(resultRaw json.RawMessage, fam listFamily, keep func(string) bool) (json.RawMessage, bool, error) {
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(resultRaw, &result); err != nil {
+		// result present but not an object (null, array, scalar). We expected
+		// a list result and cannot verify its contents. Fail closed.
+		return nil, false, fmt.Errorf("mcpfilter: result is not an object: %w", err)
+	}
+
+	arrRaw, ok := result[fam.arrayKey]
+	if !ok {
+		// Result carries no array for this family — nothing to filter.
+		return nil, false, nil
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(arrRaw, &items); err != nil {
+		return nil, false, fmt.Errorf("mcpfilter: %s is not an array: %w", fam.arrayKey, err)
+	}
+
+	kept := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		name, ok := itemName(item, fam.nameField)
+		if !ok {
+			// An item whose name cannot be read cannot be proven allowed;
+			// drop it (fail closed) rather than expose an unverifiable entry.
+			continue
+		}
+		if keep(name) {
+			kept = append(kept, item)
+		}
+	}
+
+	if len(kept) == len(items) {
+		return nil, false, nil
+	}
+
+	newArr, err := json.Marshal(kept)
+	if err != nil {
+		return nil, false, fmt.Errorf("mcpfilter: re-marshal %s: %w", fam.arrayKey, err)
+	}
+	result[fam.arrayKey] = newArr
+	newResult, err := json.Marshal(result)
+	if err != nil {
+		return nil, false, fmt.Errorf("mcpfilter: re-marshal result: %w", err)
+	}
+	return newResult, true, nil
+}
+
+// itemName extracts the string value of nameField from a list item. Returns
+// ok=false when the field is absent or not a string.
+func itemName(item json.RawMessage, nameField string) (string, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(item, &obj); err != nil {
+		return "", false
+	}
+	raw, ok := obj[nameField]
+	if !ok {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// filterSSE handles a text/event-stream response. MCP Streamable HTTP returns
+// a request's response as one or more SSE events whose data payload is the
+// JSON-RPC message. Events whose data parses to a JSON-RPC result carrying the
+// family array are filtered; every other event (notifications, pings, control
+// frames) passes through untouched. When no event is filterable the original
+// body is returned unchanged.
+func filterSSE(body []byte, fam listFamily, keep func(string) bool) ([]byte, bool, error) {
+	// Normalise CRLF so event splitting is uniform; the rewritten output uses
+	// LF framing, which is spec-legal.
+	norm := strings.ReplaceAll(string(body), "\r\n", "\n")
+	blocks := strings.Split(norm, "\n\n")
+
+	anyChanged := false
+	for i, block := range blocks {
+		if strings.TrimSpace(block) == "" {
+			continue
+		}
+		newBlock, changed, err := filterSSEBlock(block, fam, keep)
+		if err != nil {
+			return nil, false, err
+		}
+		if changed {
+			blocks[i] = newBlock
+			anyChanged = true
+		}
+	}
+	if !anyChanged {
+		return body, false, nil
+	}
+	return []byte(strings.Join(blocks, "\n\n")), true, nil
+}
+
+// filterSSEBlock rewrites a single SSE event block. Non-data lines are kept in
+// order; the run of data lines is replaced by a single data line carrying the
+// filtered JSON. A block whose data does not parse as a JSON-RPC result with
+// the family array is returned unchanged (it is not this method's response).
+func filterSSEBlock(block string, fam listFamily, keep func(string) bool) (string, bool, error) {
+	lines := strings.Split(block, "\n")
+	var other []string
+	var data strings.Builder
+	hasData := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data:") {
+			hasData = true
+			payload := strings.TrimPrefix(line, "data:")
+			payload = strings.TrimPrefix(payload, " ")
+			if data.Len() > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(payload)
+			continue
+		}
+		other = append(other, line)
+	}
+	if !hasData {
+		return block, false, nil
+	}
+
+	// Only attempt to filter data that looks like a JSON object carrying a
+	// result. Anything else is a different event type and passes through.
+	raw := []byte(data.String())
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return block, false, nil
+	}
+	if _, ok := env["result"]; !ok {
+		return block, false, nil
+	}
+	newResult, changed, err := filterResult(env["result"], fam, keep)
+	if err != nil {
+		return "", false, err
+	}
+	if !changed {
+		return block, false, nil
+	}
+	env["result"] = newResult
+	newData, err := json.Marshal(env)
+	if err != nil {
+		return "", false, fmt.Errorf("mcpfilter: re-marshal sse data: %w", err)
+	}
+
+	var out bytes.Buffer
+	for _, l := range other {
+		out.WriteString(l)
+		out.WriteByte('\n')
+	}
+	out.WriteString("data: ")
+	out.Write(newData)
+	return out.String(), true, nil
+}

--- a/provider/sdk/mcpfilter/mcpfilter_test.go
+++ b/provider/sdk/mcpfilter/mcpfilter_test.go
@@ -1,0 +1,355 @@
+package mcpfilter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// denyPrefix returns a keep-predicate that drops names with the given prefix,
+// mimicking a denied_tools = ["<prefix>*"] policy gate.
+func denyPrefix(prefix string) func(string) bool {
+	return func(name string) bool { return !strings.HasPrefix(name, prefix) }
+}
+
+// allowOnly returns a keep-predicate that keeps only the listed names,
+// mimicking an allowed_* allow-list.
+func allowOnly(names ...string) func(string) bool {
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(name string) bool { return set[name] }
+}
+
+// parseTools returns the tool names in a filtered tools/list body.
+func parseTools(t *testing.T, body []byte) []string {
+	t.Helper()
+	var env struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal filtered body: %v\nbody: %s", err, body)
+	}
+	out := make([]string, len(env.Result.Tools))
+	for i, tool := range env.Result.Tools {
+		out[i] = tool.Name
+	}
+	return out
+}
+
+func TestFilterJSON_DropsDeniedTools(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+		`{"name":"get_repo","description":"a"},` +
+		`{"name":"delete_repo","description":"b"},` +
+		`{"name":"get_issue","description":"c"}` +
+		`]}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	got := parseTools(t, out)
+	want := []string{"get_repo", "get_issue"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("tools = %v, want %v", got, want)
+	}
+}
+
+func TestFilterJSON_AllowList(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+		`{"name":"get_repo"},{"name":"list_issues"},{"name":"delete_repo"}]}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, allowOnly("get_repo", "list_issues"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	got := parseTools(t, out)
+	if strings.Join(got, ",") != "get_repo,list_issues" {
+		t.Fatalf("tools = %v", got)
+	}
+}
+
+func TestFilterJSON_NoChangeReturnsOriginal(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_repo"}]}}`)
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if string(out) != string(body) {
+		t.Fatalf("expected original body returned verbatim")
+	}
+}
+
+func TestFilterJSON_PreservesNextCursorAndUnknownFields(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":7,"result":{"tools":[` +
+		`{"name":"get_repo"},{"name":"delete_repo"}],"nextCursor":"abc","_meta":{"x":1}}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	var env struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Result  struct {
+			NextCursor string          `json:"nextCursor"`
+			Meta       json.RawMessage `json:"_meta"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.JSONRPC != "2.0" || env.ID != 7 {
+		t.Fatalf("envelope fields not preserved: %+v", env)
+	}
+	if env.Result.NextCursor != "abc" {
+		t.Fatalf("nextCursor not preserved: %q", env.Result.NextCursor)
+	}
+	if string(env.Result.Meta) != `{"x":1}` {
+		t.Fatalf("_meta not preserved: %s", env.Result.Meta)
+	}
+}
+
+func TestFilterJSON_ResourcesMatchByURI(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"resources":[` +
+		`{"uri":"github://repo/readme","name":"readme"},` +
+		`{"uri":"github://secrets/token","name":"token"}]}}`)
+
+	out, changed, err := FilterListResponse("resources/list", "application/json", body, denyPrefix("github://secrets/"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	var env struct {
+		Result struct {
+			Resources []struct {
+				URI string `json:"uri"`
+			} `json:"resources"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Result.Resources) != 1 || env.Result.Resources[0].URI != "github://repo/readme" {
+		t.Fatalf("resources = %+v", env.Result.Resources)
+	}
+}
+
+func TestFilterJSON_PromptsMatchByName(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"prompts":[` +
+		`{"name":"summarize"},{"name":"sudo_reset"}]}}`)
+	out, changed, err := FilterListResponse("prompts/list", "application/json", body, denyPrefix("sudo_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if strings.Contains(string(out), "sudo_reset") {
+		t.Fatalf("denied prompt leaked: %s", out)
+	}
+}
+
+func TestFilterJSON_ErrorResponsePassesThrough(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"nope"}}`)
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("x"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false for error response")
+	}
+	if string(out) != string(body) {
+		t.Fatalf("error response not passed through verbatim")
+	}
+}
+
+func TestFilterJSON_NoArrayPassesThrough(t *testing.T) {
+	// result present but no tools array (empty capabilities result shape).
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"nextCursor":"z"}}`)
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("x"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if string(out) != string(body) {
+		t.Fatalf("expected verbatim passthrough")
+	}
+}
+
+func TestFilterJSON_DropsUnnamedItem(t *testing.T) {
+	// An item missing the name field cannot be verified → dropped (fail closed).
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+		`{"name":"get_repo"},{"description":"no name here"}]}}`)
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true (unnamed item dropped)")
+	}
+	got := parseTools(t, out)
+	if strings.Join(got, ",") != "get_repo" {
+		t.Fatalf("tools = %v, want [get_repo]", got)
+	}
+}
+
+func TestFilterJSON_UnparseableFailsClosed(t *testing.T) {
+	// Simulates a still-compressed / garbled body: must error, not passthrough.
+	body := []byte("\x1f\x8b\x08\x00 not json at all")
+	_, _, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("x"))
+	if err == nil {
+		t.Fatalf("expected fail-closed error on unparseable body")
+	}
+}
+
+func TestFilterJSON_ResultNotObjectFailsClosed(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":"unexpected"}`)
+	_, _, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("x"))
+	if err == nil {
+		t.Fatalf("expected fail-closed error when result is not an object")
+	}
+}
+
+func TestFilterListResponse_UnknownMethodFailsClosed(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`)
+	_, _, err := FilterListResponse("resources/templates/list", "application/json", body, denyPrefix("x"))
+	if err == nil {
+		t.Fatalf("expected error for unsupported list method")
+	}
+}
+
+func TestFilterJSON_DenyAllProducesEmptyArrayNotNull(t *testing.T) {
+	// Every tool denied must yield "tools":[] — a null would break clients
+	// that iterate the array, and would misrepresent the result shape.
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"delete_a"},{"name":"delete_b"}]}}`)
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if !strings.Contains(string(out), `"tools":[]`) {
+		t.Fatalf("expected empty array, got: %s", out)
+	}
+	if strings.Contains(string(out), "null") {
+		t.Fatalf("array must not be null: %s", out)
+	}
+}
+
+func TestFilterSSE_MultiEventFiltersOnlyResult(t *testing.T) {
+	// A notification event precedes the tools/list response event; only the
+	// result event is rewritten, the notification passes through.
+	body := []byte("event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"p\":1}}\n\n" +
+		"event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"get_x\"},{\"name\":\"delete_x\"}]}}\n\n")
+
+	out, changed, err := FilterListResponse("tools/list", "text/event-stream", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	s := string(out)
+	if strings.Contains(s, "delete_x") {
+		t.Fatalf("denied tool leaked: %s", s)
+	}
+	if !strings.Contains(s, "notifications/progress") {
+		t.Fatalf("notification event dropped: %s", s)
+	}
+	if !strings.Contains(s, "get_x") {
+		t.Fatalf("allowed tool missing: %s", s)
+	}
+}
+
+func TestFilterSSE_DropsDeniedTools(t *testing.T) {
+	body := []byte("event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"get_repo\"},{\"name\":\"delete_repo\"}]}}\n\n")
+
+	out, changed, err := FilterListResponse("tools/list", "text/event-stream", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if strings.Contains(string(out), "delete_repo") {
+		t.Fatalf("denied tool leaked in SSE: %s", out)
+	}
+	if !strings.Contains(string(out), "get_repo") {
+		t.Fatalf("allowed tool missing: %s", out)
+	}
+	if !strings.Contains(string(out), "event: message") {
+		t.Fatalf("event framing lost: %s", out)
+	}
+}
+
+func TestFilterSSE_CharsetParam(t *testing.T) {
+	body := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"delete_x\"}]}}\n\n")
+	out, changed, err := FilterListResponse("tools/list", "text/event-stream; charset=utf-8", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if strings.Contains(string(out), "delete_x") {
+		t.Fatalf("denied tool leaked: %s", out)
+	}
+}
+
+func TestFilterSSE_NonResultEventPassesThrough(t *testing.T) {
+	// A ping/notification event with no result must pass through untouched, and
+	// with nothing filterable the original body is returned verbatim.
+	body := []byte("event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{}}\n\n")
+	out, changed, err := FilterListResponse("tools/list", "text/event-stream", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if string(out) != string(body) {
+		t.Fatalf("expected verbatim passthrough")
+	}
+}
+
+func TestFilterSSE_CRLFFraming(t *testing.T) {
+	body := []byte("event: message\r\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"get_x\"},{\"name\":\"delete_x\"}]}}\r\n\r\n")
+	out, changed, err := FilterListResponse("tools/list", "text/event-stream", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if strings.Contains(string(out), "delete_x") {
+		t.Fatalf("denied tool leaked: %s", out)
+	}
+}


### PR DESCRIPTION
## What

Adds `provider/sdk/mcpfilter` — a small, self-contained utility that rewrites MCP JSON-RPC **list responses** (`tools/list`, `resources/list`, `prompts/list`), dropping items a caller-supplied keep-predicate rejects.

This is the **foundation** (PR 1 of the MCP list-filtering series). It has no callers yet, so merging it is inert — no behavior change.

## Details

- `FilterListResponse(listMethod, contentType, body, keep)` handles both response shapes MCP Streamable HTTP returns: `application/json` and `text/event-stream` (SSE).
- Per-family match field mirrors the call-time gates: `tools/list`→`name`, `resources/list`→`uri`, `prompts/list`→`name`.
- **Fails closed**: a body it cannot parse as the expected list result returns an error (so the gateway can refuse to stream it) rather than passing an unfiltered — e.g. still-compressed — list through. A cleanly-parsed error response or a result with no matching array passes through unchanged.
- Preserves `jsonrpc`/`id`/`nextCursor` and unknown fields; deny-all yields `[]`, not `null`; original-case item names are preserved.
- Pure mechanics — no policy state, no core/provider imports. Exhaustively unit-tested (JSON + SSE per family, wildcards, cursor/unknown-field preservation, error-response passthrough, unparseable → error).

## Series

Part of the MCP deny-by-default + list-filtering work. Merge order: **this → deny-by-default → filter directive → generic mcp gateway → mcp_aws gateway**.