### PR TITLE
feat(policy)!: flip mcp{} authorization to deny-by-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Warden are documented in this file.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **MCP `mcp { }` authorization is now deny-by-default.** An `mcp { }` block previously allowed anything it did not explicitly deny — an absent `allowed_methods`/`allowed_tools`/`allowed_resources`/`allowed_prompts` meant "allow all". It now **denies** anything it does not explicitly allow: an empty or absent allow-list for a family denies every method/tool/resource/prompt in it. **This silently tightens deployed policies** — e.g. `mcp { denied_tools = ["delete_*"] }` (or a block carrying only a `condition`) went from "all tools except `delete_*`" to "**deny every tool**". Before upgrading, audit every `mcp { }` block: to restore openness add `allowed_methods = ["*"]` (and `allowed_tools`/`allowed_resources`/`allowed_prompts = ["*"]` as needed), then layer `denied_*` lists and `condition`s on top. The MCP session-lifecycle methods `initialize`, `ping`, and `notifications/*` are **exempt** — they always pass without being allow-listed (a `denied_methods` entry can still block them), so the client handshake works without listing them and the previous "remember to allow-list the handshake methods" guidance no longer applies.
+
 ## [v0.17.0] — 2026-07-04
 
 ### Breaking Changes

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -295,60 +295,99 @@ func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall, act *celActivat
 	return deny
 }
 
+// isLifecycleMethod reports whether method is an MCP session-lifecycle
+// method that is exempt from the deny-by-default method gate. These carry
+// no tool/resource/data access — they only establish and maintain the
+// session (handshake, keepalive, notifications) — so requiring operators
+// to allow-list them in every policy would break the MCP handshake without
+// improving the security posture. An explicit denied_methods entry still
+// blocks them, because the deny gate runs first. method is expected
+// lowercased.
+func isLifecycleMethod(method string) bool {
+	return method == "initialize" ||
+		method == "ping" ||
+		strings.HasPrefix(method, "notifications/")
+}
+
+// isNameBearingMethod reports whether method carries a name gated by an
+// allowed_/denied_ family list (tools/call → tool name, resources/read →
+// uri, prompts/get → name). Under deny-by-default the name gate runs for
+// these methods whether or not the operator configured a family list, so
+// this predicate — not "is a list present" — drives the gate.
+func isNameBearingMethod(method string) bool {
+	switch method {
+	case mcpMethodToolsCall, mcpMethodResourcesRead, mcpMethodPromptsGet:
+		return true
+	}
+	return false
+}
+
+// evaluateMCPGates runs the structural method + name gates of one rule-set
+// under DENY-BY-DEFAULT semantics, without the CEL condition. Returns a
+// deny decision (method/name stamped) when a gate fails, or nil when every
+// gate passes. Shared by evaluateMCPSetForCall — which then applies the CEL
+// gate and the allow-stamp — and by mcpListItemAllowed, which filters list
+// responses and deliberately skips CEL (no call args exist at list time).
+//
+// Deny-by-default: an empty allowed_methods denies every non-lifecycle
+// method, and an empty allowed_<family> denies every tool/resource/prompt.
+// Operators open a mount with allowed_* = ["*"]. Session-lifecycle methods
+// (initialize, ping, notifications/*) are exempt from the method gate.
+func evaluateMCPGates(set *CBPMCPRules, method, name string) *logical.MCPDecision {
+	// (a) Missing method → deny. The body-authoritative parser rejects an
+	// empty method as malformed_jsonrpc before we get here, so this branch
+	// is reachable only via test-synthesised descriptors. Fail closed.
+	if method == "" {
+		return &logical.MCPDecision{Decision: "deny", RuleType: mcpRuleTypeMissingMethod}
+	}
+
+	// (b) Explicit denied_methods match → deny. Runs before the lifecycle
+	// exemption so an operator can still block a lifecycle method by name.
+	if m := matchMCPAny(method, set.DeniedMethods); m != "" {
+		return &logical.MCPDecision{Method: method, Name: name, Decision: "deny", RuleType: mcpRuleTypeDeniedMethods, MatchedRule: m}
+	}
+
+	// (c) Session-lifecycle methods are exempt from the method allow-list
+	// and carry no name — pass straight through.
+	if isLifecycleMethod(method) {
+		return nil
+	}
+
+	// (d) allowed_methods gate, deny-by-default: the method must match a
+	// configured pattern. An empty list matches nothing and so denies.
+	if m := matchMCPAny(method, set.AllowedMethods); m == "" {
+		return &logical.MCPDecision{Method: method, Name: name, Decision: "deny", RuleType: mcpRuleTypeAllowedMethods}
+	}
+
+	// (e) Name gate for name-bearing methods, deny-by-default: a denied_*
+	// match denies; otherwise the name must match allowed_* (empty ⇒ deny).
+	if isNameBearingMethod(method) {
+		denyList, allowList := nameListForMethod(set, method)
+		if m := matchMCPAny(name, denyList); m != "" {
+			return &logical.MCPDecision{Method: method, Name: name, Decision: "deny", RuleType: mcpDenyRuleTypeForName(method), MatchedRule: m}
+		}
+		if m := matchMCPAny(name, allowList); m == "" {
+			return &logical.MCPDecision{Method: method, Name: name, Decision: "deny", RuleType: mcpAllowRuleTypeForName(method)}
+		}
+	}
+
+	return nil
+}
+
 // evaluateMCPSetForCall runs one rule-set against the canonicalised
 // method, name, and call. Returns the set's MCPDecision (always non-
 // nil) — either an allow with the matching pattern stamped, or a
 // deny with the failing gate and pattern stamped. Reads param values
 // from call.MatchArgs.
 func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.MCPCall, act *celActivation) *logical.MCPDecision {
+	// Structural method + name gates (deny-by-default). A non-nil result is
+	// a binding deny; nil means the structured gates passed and the CEL
+	// gate + allow-stamp below decide.
+	if d := evaluateMCPGates(set, method, name); d != nil {
+		return d
+	}
+
 	d := &logical.MCPDecision{Method: method, Name: name}
-
-	// (a) Missing method → deny. The body-authoritative parser
-	// rejects an empty method as malformed_jsonrpc before we get
-	// here, so this branch is now reachable only via test-synthesised
-	// descriptors that intentionally drop method. Fail closed.
-	if method == "" {
-		d.Decision = "deny"
-		d.RuleType = mcpRuleTypeMissingMethod
-		d.Name = "" // no meaningful name without method
-		return d
-	}
-
-	// (b) Explicit denied_methods match → deny.
-	if m := matchMCPAny(method, set.DeniedMethods); m != "" {
-		d.Decision = "deny"
-		d.RuleType = mcpRuleTypeDeniedMethods
-		d.MatchedRule = m
-		return d
-	}
-
-	// (c) allowed_methods configured but method not in it → deny.
-	if len(set.AllowedMethods) > 0 {
-		if m := matchMCPAny(method, set.AllowedMethods); m == "" {
-			d.Decision = "deny"
-			d.RuleType = mcpRuleTypeAllowedMethods
-			return d
-		}
-	}
-
-	// (d) Name gate for name-bearing methods. Skipped entirely when
-	// neither the relevant deny-list nor allow-list is configured
-	// for this method — the rule isn't making a name claim.
-	if denyList, allowList := nameListForMethod(set, method); len(denyList) > 0 || len(allowList) > 0 {
-		if m := matchMCPAny(name, denyList); m != "" {
-			d.Decision = "deny"
-			d.RuleType = mcpDenyRuleTypeForName(method)
-			d.MatchedRule = m
-			return d
-		}
-		if len(allowList) > 0 {
-			if m := matchMCPAny(name, allowList); m == "" {
-				d.Decision = "deny"
-				d.RuleType = mcpAllowRuleTypeForName(method)
-				return d
-			}
-		}
-	}
 
 	// (e) CEL condition gate (last, after the structured gates). Fail-closed:
 	// an erroring or false condition denies. Evaluated against the request /
@@ -376,12 +415,17 @@ func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.
 	if set.Condition != nil {
 		d.Condition = &logical.ConditionResult{Decision: "allow", Expression: set.Condition.Source, Inputs: resolveConditionInputs(set.Condition.RefPaths, set.Condition.RefSegs, act)}
 	}
-	if len(set.AllowedMethods) > 0 {
-		d.MatchedRule = matchMCPAny(method, set.AllowedMethods)
+	// Lifecycle methods pass the exemption without matching allowed_methods;
+	// stamp a sentinel so audit distinguishes them from an allow-list match.
+	if isLifecycleMethod(method) {
+		d.MatchedRule = "(lifecycle)"
 	} else {
-		d.MatchedRule = method
+		d.MatchedRule = matchMCPAny(method, set.AllowedMethods)
 	}
-	if _, allowList := nameListForMethod(set, method); len(allowList) > 0 {
+	// A name-bearing method that reached here matched allowed_<family>
+	// (deny-by-default requires it); surface that as the deciding rule.
+	if isNameBearingMethod(method) {
+		_, allowList := nameListForMethod(set, method)
 		d.RuleType = mcpAllowRuleTypeForName(method)
 		d.MatchedRule = matchMCPAny(name, allowList)
 	}

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -130,6 +130,103 @@ path "mcp/gateway/*" {
 	assert.Equal(t, mcpRuleTypeAllowedMethods, res.MCPDecision.RuleType)
 }
 
+// =============================================================================
+// Deny-by-default + lifecycle exemption
+// =============================================================================
+
+func TestMCPEval_LifecycleMethods_ExemptFromMethodGate(t *testing.T) {
+	// initialize / ping / notifications/* must pass even though the block
+	// allow-lists only data-plane methods — otherwise the MCP handshake
+	// breaks. The exemption skips the allowed_methods gate for them.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+    allowed_tools   = ["*"]
+  }
+}
+`)
+	for _, method := range []string{"initialize", "ping", "notifications/initialized"} {
+		body := `{"jsonrpc":"2.0","method":"` + method + `","id":1}`
+		if strings.HasPrefix(method, "notifications/") {
+			body = `{"jsonrpc":"2.0","method":"` + method + `"}` // notification, no id
+		}
+		req := newMCPRequest(t, "mcp/gateway/", body)
+		res := cbp.AllowOperation(testContext(), req, nil, false)
+		assert.True(t, res.Allowed, "lifecycle method %q must be allowed", method)
+		require.NotNil(t, res.MCPDecision)
+		assert.Equal(t, "allow", res.MCPDecision.Decision, "method %q", method)
+		assert.Equal(t, "(lifecycle)", res.MCPDecision.MatchedRule, "method %q", method)
+	}
+}
+
+func TestMCPEval_LifecycleMethod_ExplicitDenyStillBlocks(t *testing.T) {
+	// The deny gate runs before the exemption: an operator can still block
+	// a lifecycle method by naming it in denied_methods.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+    denied_methods  = ["ping"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":"ping","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeDeniedMethods, res.MCPDecision.RuleType)
+	assert.Equal(t, "ping", res.MCPDecision.MatchedRule)
+}
+
+func TestMCPEval_ToolsCall_NeedsBothMethodAndToolAllow(t *testing.T) {
+	// Deny-by-default: allowing tools/call as a method is not enough — the
+	// tool name must also match allowed_tools. Empty allowed_tools ⇒ deny.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "get_repository"},
+		"id":      1
+	}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeAllowedTools, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_StarOpensEverything(t *testing.T) {
+	// allowed_* = ["*"] restores fully-open behavior for a data-plane call.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["*"]
+    allowed_tools   = ["*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "delete_repository"},
+		"id":      1
+	}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+}
+
 func TestMCPEval_DeniedMethods_Match(t *testing.T) {
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
@@ -228,11 +325,15 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_DeniedTools_Match(t *testing.T) {
+	// allowed_methods admits tools/call so the request reaches the name
+	// gate; denied_tools then fires. (Under deny-by-default a set without
+	// allowed_methods would deny at the method gate before the name gate.)
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
   mcp {
-    denied_tools = ["delete_*"]
+    allowed_methods = ["tools/call"]
+    denied_tools    = ["delete_*"]
   }
 }
 `)
@@ -310,7 +411,10 @@ path "mcp/gateway/*" {
 // NOT match the deny pattern passes through the name gate.
 // Pre-Phase-5 the matcher returned (nil, allowList) for resources/read
 // so this code path didn't exist; pinning it here.
-func TestMCPEval_DeniedResources_Only_NonMatchingAllowed(t *testing.T) {
+func TestMCPEval_DeniedResources_NoAllowList_Denies(t *testing.T) {
+	// Deny-by-default: allowed_methods admits resources/read, but with no
+	// allowed_resources every uri is denied — even one matching no
+	// denied_resources pattern. (Was allowed under allow-by-default.)
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -328,7 +432,10 @@ path "mcp/gateway/*" {
 	}`)
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 
-	assert.True(t, res.Allowed)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeAllowedResources, res.MCPDecision.RuleType)
 }
 
 // Deny-list precedence on resources/read: when the same name matches
@@ -383,9 +490,10 @@ path "mcp/gateway/*" {
 		"name gate didn't fire for name-less method")
 }
 
-func TestMCPEval_EmptyBlock_AllowsAnyMethod(t *testing.T) {
-	// Empty mcp { } block doesn't impose any restriction beyond
-	// "body must parse." A tools/call with arguments still passes.
+func TestMCPEval_EmptyBlock_DeniesByDefault(t *testing.T) {
+	// Deny-by-default: an empty mcp { } block allow-lists nothing, so a
+	// data-plane method is denied at the method gate (empty allowed_methods
+	// matches nothing). (Was allow-any before the flip.)
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -400,8 +508,10 @@ path "mcp/gateway/*" {
 	}`)
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 
-	assert.True(t, res.Allowed)
-	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeAllowedMethods, res.MCPDecision.RuleType)
 }
 
 // =============================================================================
@@ -496,7 +606,8 @@ path "mcp/gateway/*" {
 path "mcp/gateway/*" {
   capabilities = ["update"]
   mcp {
-    denied_tools = ["delete_*"]
+    allowed_methods = ["tools/call"]
+    denied_tools    = ["delete_*"]
   }
 }
 `)

--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -57,19 +57,45 @@ only:
 
 ### Evaluation order
 
-Each call passes through gates in order; the first failure denies it:
+Authorization is **deny-by-default**: an `mcp { }` block grants nothing until you
+allow-list it. Each call passes through gates in order; the first failure denies it:
 
-1. **Method** — `denied_methods` then `allowed_methods`.
+1. **Method** — `denied_methods` rejects first; then the method must appear in
+   `allowed_methods`. An empty or absent `allowed_methods` matches nothing and so
+   **denies every method**. *Exception:* the session-lifecycle methods
+   `initialize`, `ping`, and `notifications/*` are exempt from the allow-list —
+   they carry no tool/resource/data access and must work for the handshake — but
+   `denied_methods` can still block them explicitly.
 2. **Name** (for the three name-bearing methods) — `denied_tools`/`resources`/`prompts`
-   then the matching `allowed_*` list.
+   rejects first; then the name must appear in the matching `allowed_*` list. An
+   empty or absent list **denies every name**.
 3. **Condition** (CEL) — the block's per-call `condition`, if present, runs last
    and gates on argument values (`call.args`).
 
-Within a name/method gate, a `denied_*` match always rejects; an `allowed_*`
-list, if present, means the value must match it. Patterns are matched with a
-**trailing `*`** wildcard (`delete_*`, or a bare `*` for "anything"),
-case-insensitively. Argument-value constraints are expressed in the per-call
-`condition` (below), not as structured lists.
+Within a name/method gate a `denied_*` match always rejects, and the value must
+then match the corresponding `allowed_*` list — which is **mandatory** under
+deny-by-default. Patterns are matched with a **trailing `*`** wildcard
+(`delete_*`, or a bare `*` for "anything"), case-insensitively. To open a mount
+fully, allow-list `["*"]`:
+
+```hcl
+# fully open (the explicit form of "no restriction")
+mcp {
+  allowed_methods   = ["*"]
+  allowed_tools     = ["*"]
+  allowed_resources = ["*"]
+  allowed_prompts   = ["*"]
+}
+
+# read-only: list and call get_*/list_* only; delete_* is never callable
+mcp {
+  allowed_methods = ["tools/list", "tools/call"]
+  allowed_tools   = ["get_*", "list_*"]
+}
+```
+
+Argument-value constraints are expressed in the per-call `condition` (below), not
+as structured lists.
 
 ### Per-call CEL conditions
 

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -290,13 +290,19 @@ path "mcp/gateway/*" {
 
 Semantics:
 
-- **Deny is checked before allow.** A call matching a `denied_*` list is
-  rejected; otherwise, if an `allowed_*` list is present, the call must match it.
+- **Deny-by-default.** An `mcp { }` block grants nothing until it allow-lists it:
+  an empty or absent `allowed_methods`/`allowed_tools`/`allowed_resources`/`allowed_prompts`
+  denies every method/tool/resource/prompt. Use `["*"]` to open a family fully.
+- **Deny is checked before allow.** A call matching a `denied_*` list is rejected;
+  otherwise it must match the corresponding (mandatory) `allowed_*` list.
+- **Lifecycle methods are exempt.** `initialize`, `ping`, and `notifications/*`
+  bypass the method allow-list so the client handshake always works (a
+  `denied_methods` entry can still block them).
 - **Patterns use trailing `*` only.** `delete_*` and a bare `*` are valid; a `*`
   in any other position is rejected at parse time.
 - **Argument values are gated by the CEL `condition`** over `call.args`,
   evaluated per call after the name/method lists.
-- **Multiple `mcp` blocks OR together** — adding policies can only widen what is
+- **Multiple `mcp` blocks OR together** — adding blocks can only widen what is
   allowed. In a batched JSON-RPC request, a single denied call denies the batch.
 
 This is the authorization step a provider performs after authentication and

--- a/docs/provider-backends/mcp-github.md
+++ b/docs/provider-backends/mcp-github.md
@@ -273,7 +273,7 @@ warden policy write mcp-github-readonly - <<EOF
 path "github-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = ["initialize","notifications/initialized","tools/list","tools/call","resources/list","resources/read","ping"]
+    allowed_methods = ["tools/list","tools/call","resources/list","resources/read"]
     allowed_tools   = ["get_repository","get_pull_request","list_issues","search_code"]
   }
 }
@@ -288,7 +288,8 @@ warden policy write mcp-github-no-protected-branches - <<EOF
 path "github-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = ["initialize","notifications/initialized","tools/call","ping"]
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["create_or_update_file"]
     condition = <<-CEL
       !has(call.args.branch) || !(
         call.args.branch in ["main", "master", "production"] ||

--- a/docs/provider-backends/mcp-slack.md
+++ b/docs/provider-backends/mcp-slack.md
@@ -356,11 +356,12 @@ client SSE notification stream (`read`), and DELETE for session terminate
 connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip
 body-authoritative evaluation automatically.
 
-The `allowed_methods` examples list the MCP **protocol** methods every
-spec-compliant client uses in its handshake — `initialize`,
-`notifications/initialized`, `ping` — alongside the data-plane methods
-(`tools/list`, `tools/call`, …). Omitting the lifecycle methods makes
-`claude mcp list` (and similar client health checks) hang on connect.
+`mcp { }` authorization is **deny-by-default**: an empty or absent
+`allowed_methods`/`allowed_tools` denies everything, so a block grants only what
+it allow-lists — use `["*"]` to open a family fully. The session-lifecycle
+methods `initialize`, `notifications/*`, and `ping` are **exempt**: they always
+pass without being listed, so the client handshake works no matter how narrow the
+data-plane allow-list is (an explicit `denied_methods` entry can still block them).
 
 The simplest policy grants the gateway and leans on the OAuth token's scopes for
 everything:
@@ -380,29 +381,25 @@ warden policy write mcp-slack-readonly - <<EOF
 path "slack-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = [
-      "initialize",
-      "notifications/initialized",
-      "tools/list",
-      "tools/call",
-      "resources/list",
-      "resources/read",
-      "ping"
-    ]
+    allowed_methods = ["tools/list", "tools/call", "resources/list", "resources/read"]
     allowed_tools   = ["list_channels", "get_messages", "get_thread", "search_messages"]
   }
 }
 EOF
 ```
 
-A complementary deny-list shape — permissive by default, blocks dangerous tools:
+An open-then-subtract shape — allow every method and tool, then blocklist the
+dangerous ones. Under deny-by-default the `["*"]` allow-lists are required; the
+`denied_*` lists carve exceptions out of them:
 
 ```bash
 warden policy write mcp-slack-safe - <<EOF
 path "slack-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    denied_tools = ["delete_*", "remove_*", "archive_channel"]
+    allowed_methods = ["*"]
+    allowed_tools   = ["*"]
+    denied_tools    = ["delete_*", "remove_*", "archive_channel"]
   }
 }
 EOF
@@ -419,13 +416,8 @@ warden policy write mcp-slack-approved-channels - <<EOF
 path "slack-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = [
-      "initialize",
-      "notifications/initialized",
-      "tools/call",
-      "ping"
-    ]
-    allowed_tools  = ["post_message"]
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["post_message"]
     condition = "!has(call.args.channel_id) || call.args.channel_id in ['C0123456789', 'C0987654321']"
   }
 }

--- a/docs/provider-backends/mcp.md
+++ b/docs/provider-backends/mcp.md
@@ -249,11 +249,12 @@ client SSE notification stream (`read`), and DELETE for session terminate
 connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip
 body-authoritative evaluation automatically.
 
-The `allowed_methods` examples below list the MCP **protocol** methods every
-spec-compliant client uses in its handshake — `initialize`,
-`notifications/initialized`, `ping` — alongside the data-plane methods. Omitting
-the lifecycle methods makes `claude mcp list` (and similar client health checks)
-hang on connect.
+`mcp { }` authorization is **deny-by-default**: an empty or absent
+`allowed_methods`/`allowed_tools` denies everything, so a block grants only what
+it allow-lists — use `["*"]` to open a family fully. The session-lifecycle
+methods `initialize`, `notifications/*`, and `ping` are **exempt**: they always
+pass without being listed, so the client handshake works no matter how narrow the
+data-plane allow-list is (an explicit `denied_methods` entry can still block them).
 
 The simplest policy grants the gateway and leans on the token's scopes for
 everything:
@@ -273,29 +274,25 @@ warden policy write mcp-readonly - <<EOF
 path "cloudflare-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = [
-      "initialize",
-      "notifications/initialized",
-      "tools/list",
-      "tools/call",
-      "resources/list",
-      "resources/read",
-      "ping"
-    ]
+    allowed_methods = ["tools/list", "tools/call", "resources/list", "resources/read"]
     allowed_tools   = ["search_docs", "list_*", "get_*"]
   }
 }
 EOF
 ```
 
-A complementary deny-list shape — permissive by default, blocks dangerous tools:
+An open-then-subtract shape — allow every method and tool, then blocklist the
+dangerous ones. Under deny-by-default the `["*"]` allow-lists are required; the
+`denied_*` lists carve exceptions out of them:
 
 ```bash
 warden policy write mcp-safe - <<EOF
 path "cloudflare-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    denied_tools = ["delete_*", "purge_*", "update_*"]
+    allowed_methods = ["*"]
+    allowed_tools   = ["*"]
+    denied_tools    = ["delete_*", "purge_*", "update_*"]
   }
 }
 EOF

--- a/docs/provider-backends/mcp_aws.md
+++ b/docs/provider-backends/mcp_aws.md
@@ -191,7 +191,7 @@ Enforcement is **body-authoritative**. When a policy in scope contains an `mcp {
 
 All examples below use `capabilities = ["create", "read", "delete"]`. MCP Streamable HTTP uses three HTTP verbs on the same `/gateway` URL: POST for JSON-RPC requests (mapped by Warden to `create`), GET for the optional server → client SSE notification stream (`read`), and DELETE for session terminate (`delete`). All three need to be in the cap list or off-spec MCP clients fail to connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip body-authoritative evaluation automatically.
 
-The `allowed_methods` examples below list the MCP **protocol** methods every spec-compliant client uses in its handshake — `initialize`, `notifications/initialized`, `ping` — alongside the data-plane methods (`tools/list`, `tools/call`). Omitting the lifecycle methods makes `claude mcp list` (and similar client health checks) hang on connect.
+`mcp { }` authorization is **deny-by-default**: an empty or absent `allowed_methods`/`allowed_tools` denies everything, so a block grants only what it allow-lists — use `["*"]` to open a family fully. The session-lifecycle methods `initialize`, `notifications/*`, and `ping` are **exempt**: they always pass without being listed, so the client handshake works no matter how narrow the data-plane allow-list is (an explicit `denied_methods` entry can still block them).
 
 The simplest policy grants the gateway and leans on IAM for everything:
 
@@ -210,13 +210,7 @@ warden policy write mcp-aws-s3-readonly - <<EOF
 path "mcp_aws/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = [
-      "initialize",
-      "notifications/initialized",
-      "tools/list",
-      "tools/call",
-      "ping"
-    ]
+    allowed_methods = ["tools/list", "tools/call"]
     allowed_tools   = ["aws___call_aws"]
     condition = "!has(call.args.service_name) || call.args.service_name in ['s3', 'dynamodb']"
   }
@@ -224,13 +218,15 @@ path "mcp_aws/role/+/gateway*" {
 EOF
 ```
 
-A complementary deny shape — permissive by default, blocks dangerous operations regardless of which service they target. The `condition` reads `call.args.operation_name` and denies the dangerous prefixes/names:
+An open-then-subtract shape — allow every method and tool, then block dangerous operations regardless of which service they target. Under deny-by-default the `["*"]` allow-lists are required; the `condition` reads `call.args.operation_name` and denies the dangerous prefixes/names on top:
 
 ```bash
 warden policy write mcp-aws-safe - <<EOF
 path "mcp_aws/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
+    allowed_methods = ["*"]
+    allowed_tools   = ["*"]
     condition = <<-CEL
       !has(call.args.operation_name) || !(
         call.args.operation_name.startsWith("delete_") ||
@@ -250,13 +246,7 @@ warden policy write mcp-aws-us-only - <<EOF
 path "mcp_aws/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    allowed_methods = [
-      "initialize",
-      "notifications/initialized",
-      "tools/list",
-      "tools/call",
-      "ping"
-    ]
+    allowed_methods = ["tools/list", "tools/call"]
     allowed_tools   = ["aws___call_aws"]
     condition = <<-CEL
       (!has(call.args.service_name) || call.args.service_name in ["s3", "dynamodb", "lambda"]) &&
@@ -279,13 +269,7 @@ path "mcp_aws/role/+/gateway*" {
     now.getDayOfWeek("UTC") in [1, 2, 3, 4, 5]
   CEL
   mcp {
-    allowed_methods = [
-      "initialize",
-      "notifications/initialized",
-      "tools/list",
-      "tools/call",
-      "ping"
-    ]
+    allowed_methods = ["tools/list", "tools/call"]
     allowed_tools   = ["aws___call_aws"]
   }
 }

--- a/docs/quickstarts/workstation/02-cert-llm-mcp/README.md
+++ b/docs/quickstarts/workstation/02-cert-llm-mcp/README.md
@@ -109,11 +109,14 @@ warden cred spec create github-ops -source github-src \
 # Policy + cert-auth role — same client cert (allowed_common_names="mcp-agent").
 # The mcp{} block reaches inside each tool call: read/list/search tools pass,
 # state-changing tools are denied at Warden (demonstrated in Step 6).
+# Deny-by-default: allow every method+tool, then block the state-changing ones.
 warden policy write mcp-github-access - <<'EOF'
 path "github-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
   mcp {
-    denied_tools = ["delete_*", "create_*", "update_*", "push_*", "merge_*", "fork_*"]
+    allowed_methods = ["*"]
+    allowed_tools   = ["*"]
+    denied_tools    = ["delete_*", "create_*", "update_*", "push_*", "merge_*", "fork_*"]
   }
 }
 EOF

--- a/docs/quickstarts/workstation/03-spiffe-llm-mcp/README.md
+++ b/docs/quickstarts/workstation/03-spiffe-llm-mcp/README.md
@@ -187,7 +187,12 @@ warden cred spec create github-ops -source github-src -config auth_method=pat -c
 warden policy write mcp-github-access - <<'EOF'
 path "github-mcp/role/+/gateway*" {
   capabilities = ["create", "read", "delete"]
-  mcp { denied_tools = ["delete_*", "create_*", "update_*", "push_*", "merge_*", "fork_*"] }
+  # Deny-by-default: open every method+tool, then block the state-changing ones.
+  mcp {
+    allowed_methods = ["*"]
+    allowed_tools   = ["*"]
+    denied_tools    = ["delete_*", "create_*", "update_*", "push_*", "merge_*", "fork_*"]
+  }
 }
 EOF
 


### PR DESCRIPTION
## What (⚠️ breaking change)

An `mcp { }` policy block previously **allowed** anything it did not explicitly deny — an absent `allowed_methods`/`allowed_tools`/`allowed_resources`/`allowed_prompts` meant "allow all". It now **denies** anything it does not explicitly allow. Operators open a family with `allowed_* = ["*"]`.

This is PR 2 of the MCP list-filtering series and the semantic foundation the later filtering builds on (discovery matches enforcement: what you see is what you can call).

## ⚠️ Migration

This **silently tightens deployed policies**. For example `mcp { denied_tools = ["delete_*"] }` (or a block carrying only a `condition`) goes from "all tools except `delete_*`" to **deny every tool**. Before upgrading, audit every `mcp { }` block: add `allowed_methods = ["*"]` (and `allowed_tools`/`allowed_resources`/`allowed_prompts = ["*"]` as needed), then layer `denied_*` lists and `condition`s on top. See the CHANGELOG entry.

## Details

- Refactor the structural gates out of `evaluateMCPSetForCall` into a shared `evaluateMCPGates` (reused by the upcoming list filter); drop the allow-by-default length guards.
- **Lifecycle exemption**: `initialize`, `ping`, and `notifications/*` always pass the method gate so the MCP handshake works without allow-listing plumbing (an explicit `denied_methods` entry can still block them). This lets us delete the old "remember to add lifecycle methods" doc warnings.
- Update the tests that relied on empty-allow-means-allow; add deny-by-default + lifecycle + `["*"]`-opens coverage.
- Rewrite the affected docs (concepts, provider-backends, quickstarts) and add a CHANGELOG breaking-change entry with the migration recipe.

## Series

Merge order: mcpfilter util (merged) → **this** → filter directive → generic mcp gateway → mcp_aws gateway.