### PR TITLE
feat(policy): compute MCP list-response filter directive

### DIFF
--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -445,6 +445,16 @@ CHECK:
 		if ret.MCPDecision != nil && ret.MCPDecision.Decision == "deny" {
 			return ret
 		}
+		// The MCP call is allowed. On the real enforcement pass, wire
+		// response-side list filtering: attach a keep-filter for a single
+		// list request, or fail closed on a batched list (unfilterable).
+		if !capCheckOnly && ret.MCPDecision != nil && ret.MCPDecision.Decision == "allow" {
+			if d := attachMCPListFilter(req, permissions.MCP); d != nil {
+				sanitizeMCPDecision(d)
+				ret.MCPDecision = d
+				return ret
+			}
+		}
 	}
 
 	ret.GrantingPolicies = grantingPolicies

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -50,6 +50,13 @@ const (
 	mcpRuleTypeOversizedBody    = "oversized_body"
 	mcpRuleTypeBatchEmpty       = "batch_empty"
 	mcpRuleTypeMalformedParams  = "malformed_params"
+
+	// mcpRuleTypeBatchListUnfilterable denies an otherwise-allowed batch
+	// that contains a list method. A batched JSON-RPC list response can't
+	// be pruned per-element to the callable items, so we fail closed rather
+	// than stream an unfiltered list. (JSON-RPC batching was dropped from
+	// the MCP spec in 2025-06-18.)
+	mcpRuleTypeBatchListUnfilterable = "batch_list_unfilterable"
 )
 
 // MCP JSON-RPC method names that carry name-bearing semantics. For
@@ -121,6 +128,78 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 		return set.DeniedPrompts, set.AllowedPrompts
 	}
 	return nil, nil
+}
+
+// mcpListMethodToCall maps an MCP list method to the name-bearing call method
+// whose gate decides whether a listed item is usable: a tools/list item
+// survives iff a tools/call for it would pass, and likewise resources/list →
+// resources/read and prompts/list → prompts/get. A method absent from this map
+// is not a filterable list method.
+var mcpListMethodToCall = map[string]string{
+	"tools/list":     mcpMethodToolsCall,
+	"resources/list": mcpMethodResourcesRead,
+	"prompts/list":   mcpMethodPromptsGet,
+}
+
+// mcpListItemAllowed reports whether a name-bearing call (callMethod) for the
+// named item would pass the structural gates of at least one rule-set —
+// mirroring evaluateMCPCall's cross-set OR, but WITHOUT the CEL condition:
+// list responses carry no call arguments, so arg-level conditions are deferred
+// to call time (a condition-gated tool stays listed). This is the keep-
+// predicate behind Request.MCPListFilter. Inputs are lowercased here to match
+// the canonicalised rule-set patterns.
+func mcpListItemAllowed(sets []*CBPMCPRules, callMethod, name string) bool {
+	method := strings.ToLower(callMethod)
+	lname := strings.ToLower(name)
+	for _, set := range sets {
+		if set == nil {
+			continue
+		}
+		if evaluateMCPGates(set, method, lname) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// attachMCPListFilter wires response-side list filtering for an MCP request
+// the policy layer has already allowed. It runs only on the real enforcement
+// pass (never cap-check-only) so a probe can't leave a stale filter behind.
+//
+//   - Single list-method call → hang an MCPListFilter on the request whose
+//     Keep predicate reuses mcpListItemAllowed over the same rule-sets, so the
+//     gateway prunes the response to the callable items. Returns nil.
+//   - Batch containing any list method → return a fail-closed deny; a batched
+//     JSON-RPC list response can't be pruned per element, and streaming it
+//     unfiltered would leak denied items.
+//   - Anything else (non-list call, no descriptor) → returns nil, no filter.
+func attachMCPListFilter(req *logical.Request, sets []*CBPMCPRules) *logical.MCPDecision {
+	desc := req.MCPDescriptor
+	if desc == nil || len(desc.Calls) == 0 {
+		return nil
+	}
+
+	if len(desc.Calls) > 1 {
+		for i := range desc.Calls {
+			if _, ok := mcpListMethodToCall[strings.ToLower(desc.Calls[i].Method)]; ok {
+				return &logical.MCPDecision{Decision: "deny", RuleType: mcpRuleTypeBatchListUnfilterable}
+			}
+		}
+		return nil
+	}
+
+	method := strings.ToLower(desc.Calls[0].Method)
+	callMethod, ok := mcpListMethodToCall[method]
+	if !ok {
+		return nil
+	}
+	req.MCPListFilter = &logical.MCPListFilter{
+		ListMethod: method,
+		Keep: func(name string) bool {
+			return mcpListItemAllowed(sets, callMethod, name)
+		},
+	}
+	return nil
 }
 
 // decideMCP is the production entry point called from
@@ -483,7 +562,8 @@ func mcpDenyRank(ruleType string) int {
 		mcpRuleTypeDuplicateKey,
 		mcpRuleTypeOversizedBody,
 		mcpRuleTypeBatchEmpty,
-		mcpRuleTypeMalformedParams:
+		mcpRuleTypeMalformedParams,
+		mcpRuleTypeBatchListUnfilterable:
 		return 4
 	case mcpRuleTypeDeniedMethods,
 		mcpRuleTypeDeniedTools,
@@ -563,6 +643,8 @@ func BuildMCPDenyDescription(d *logical.MCPDecision) string {
 		return "Request batch is empty."
 	case mcpRuleTypeMalformedParams:
 		return "Request params have unexpected shape."
+	case mcpRuleTypeBatchListUnfilterable:
+		return "Batched list requests are not supported."
 	case mcpRuleTypeMissingMethod:
 		return "Request method required."
 	}

--- a/core/policy_mcp_body_test.go
+++ b/core/policy_mcp_body_test.go
@@ -244,6 +244,7 @@ func TestMCPDenyRank_StructuralFailuresOutrankExplicitDeny(t *testing.T) {
 		{mcpRuleTypeOversizedBody, 4},
 		{mcpRuleTypeBatchEmpty, 4},
 		{mcpRuleTypeMalformedParams, 4},
+		{mcpRuleTypeBatchListUnfilterable, 4},
 		{mcpRuleTypeDeniedMethods, 3},
 		{mcpRuleTypeDeniedTools, 3},
 		{mcpRuleTypeDeniedResources, 3},

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -133,9 +133,9 @@ path "mcp/gateway/*" {
 }
 `)
 	req := buildE2ERequest(t, `[
-		{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 1},
 		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 2},
-		{"jsonrpc": "2.0", "method": "tools/list", "id": 3}
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 3}
 	]`)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 
@@ -145,6 +145,31 @@ path "mcp/gateway/*" {
 	assert.Equal(t, "allow", res.MCPDecision.Decision)
 	assert.Nil(t, res.MCPDecision.BatchIndex,
 		"all-allowed batch leaves BatchIndex nil")
+}
+
+func TestMCPE2E_BatchWithListMethodDenied(t *testing.T) {
+	// End-to-end: a batch carrying a list method is denied by the
+	// response-filter guard even when every call would otherwise pass.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["search_repos"]
+  }
+}
+`)
+	req := buildE2ERequest(t, `[
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 1},
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 2}
+	]`)
+	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
+
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeBatchListUnfilterable, res.MCPDecision.RuleType)
 }
 
 // Body byte-identity: after the extractor reads and restores the
@@ -338,7 +363,6 @@ path "mcp/gateway/*" {
 	assert.False(t, res.Allowed)
 	assert.Equal(t, mcpRuleTypeMalformedParams, res.MCPDecision.RuleType)
 }
-
 
 func TestMCPE2E_EmptyBatch_DeniesBatchEmpty(t *testing.T) {
 	cbp := mustCBP(t, `

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -633,7 +633,35 @@ func TestMCPEval_Batch_AllAllowed(t *testing.T) {
 	// Three calls in a batch, all pass. Body goes through the real
 	// ParseJSONRPCStrict (producing 3 MCPCalls with BatchIndex 0/1/2)
 	// and then through the matcher; the decision is the last allow
-	// and BatchIndex stays nil because no element denied.
+	// and BatchIndex stays nil because no element denied. No list method
+	// is present, so the response-filter batch guard does not fire.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["search_repos", "get_repo"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `[
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 1},
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "get_repo"}, "id": 2},
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 3}
+	]`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed, "every batch call must allow → batch allows")
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+	assert.Nil(t, res.MCPDecision.BatchIndex,
+		"BatchIndex stamped only on denies")
+}
+
+func TestMCPEval_Batch_WithListMethod_Denied(t *testing.T) {
+	// A batch that contains a list method is denied even when every call
+	// would otherwise pass: a batched JSON-RPC list response can't be
+	// pruned per element, so the response-filter guard fails closed.
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -644,17 +672,16 @@ path "mcp/gateway/*" {
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[
-		{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
-		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 2},
-		{"jsonrpc": "2.0", "method": "tools/list", "id": 3}
+		{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "search_repos"}, "id": 1},
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 2}
 	]`)
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 
-	assert.True(t, res.Allowed, "every batch call must allow → batch allows")
+	assert.False(t, res.Allowed)
 	require.NotNil(t, res.MCPDecision)
-	assert.Equal(t, "allow", res.MCPDecision.Decision)
-	assert.Nil(t, res.MCPDecision.BatchIndex,
-		"BatchIndex stamped only on denies")
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeBatchListUnfilterable, res.MCPDecision.RuleType)
+	assert.Nil(t, req.MCPListFilter, "no filter attached for a denied batch")
 }
 
 func TestMCPEval_Batch_OneDeniedFailsBatch(t *testing.T) {
@@ -922,6 +949,9 @@ func TestBuildMCPDenyDescription_PerRuleType(t *testing.T) {
 		{mcpRuleTypeMalformedParams,
 			&logical.MCPDecision{RuleType: mcpRuleTypeMalformedParams},
 			"Request params have unexpected shape."},
+		{mcpRuleTypeBatchListUnfilterable,
+			&logical.MCPDecision{RuleType: mcpRuleTypeBatchListUnfilterable},
+			"Batched list requests are not supported."},
 	}
 	for _, c := range cases {
 		t.Run(c.ruleType, func(t *testing.T) {

--- a/core/policy_mcp_list_filter_test.go
+++ b/core/policy_mcp_list_filter_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// filterKeeps runs an allowed list request through AllowOperation and returns
+// the resulting Keep predicate. It asserts the request was allowed and a
+// filter for listMethod was attached.
+func filterKeeps(t *testing.T, cbp *CBP, path, body, listMethod string) func(string) bool {
+	t.Helper()
+	req := newMCPRequest(t, path, body)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+	require.True(t, res.Allowed, "list request must be allowed to attach a filter")
+	require.NotNil(t, req.MCPListFilter, "filter must be attached for a list method")
+	assert.Equal(t, listMethod, req.MCPListFilter.ListMethod)
+	return req.MCPListFilter.Keep
+}
+
+func TestListFilter_ToolsList_KeepsOnlyCallableTools(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["get_*"]
+    denied_tools    = ["get_secret"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.True(t, keep("get_repo"), "allowed tool kept")
+	assert.True(t, keep("GET_REPO"), "match is case-insensitive")
+	assert.False(t, keep("delete_repo"), "not in allowed_tools → dropped")
+	assert.False(t, keep("get_secret"), "denied_tools → dropped even though get_* matches")
+}
+
+func TestListFilter_NoAllowedTools_KeepsNothing(t *testing.T) {
+	// Deny-by-default: tools/list is permitted as a method, but with no
+	// allowed_tools every item is filtered out — the list comes back empty.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.False(t, keep("get_repo"))
+	assert.False(t, keep("anything"))
+}
+
+func TestListFilter_StarKeepsEverything(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["*"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.True(t, keep("delete_everything"))
+}
+
+func TestListFilter_ToolsListAllowedButNotToolsCall_EmptyList(t *testing.T) {
+	// allowed_methods permits tools/list but not tools/call, so nothing is
+	// callable → the filter keeps nothing. "Visible == callable."
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list"]
+    allowed_tools   = ["get_*"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.False(t, keep("get_repo"), "tools/call not allowed → nothing is callable")
+}
+
+func TestListFilter_ResourcesList_MatchesByUri(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods   = ["resources/list", "resources/read"]
+    allowed_resources = ["github://repo/*"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"resources/list","id":1}`, "resources/list")
+
+	assert.True(t, keep("github://repo/readme"))
+	assert.False(t, keep("github://secrets/token"))
+}
+
+func TestListFilter_PromptsList_MatchesByName(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["prompts/list", "prompts/get"]
+    allowed_prompts = ["safe_*"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"prompts/list","id":1}`, "prompts/list")
+
+	assert.True(t, keep("safe_summary"))
+	assert.False(t, keep("sudo_reset"))
+}
+
+func TestListFilter_CrossSetOR(t *testing.T) {
+	// Two stanzas: one allows get_*, the other allows list_*. A tool is kept
+	// if either set would allow the call (cross-set OR).
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["get_*"]
+  }
+}
+
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["list_*"]
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.True(t, keep("get_repo"))
+	assert.True(t, keep("list_issues"))
+	assert.False(t, keep("delete_repo"))
+}
+
+func TestListFilter_ConditionGatedToolStaysListed(t *testing.T) {
+	// A set with a per-call CEL condition still contributes its name gate to
+	// the list filter; the condition (which needs call args) is skipped at
+	// list time and enforced at call time. The condition is scoped with
+	// call.method so it doesn't deny the argument-less tools/list request
+	// itself (a set-wide call.args condition would — see docs/concepts/mcp.md).
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["create_payment"]
+    condition       = "call.method != 'tools/call' || call.args.amount <= 1500"
+  }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.True(t, keep("create_payment"), "name-allowed tool stays listed despite a CEL condition")
+}
+
+func TestListFilter_NotAttachedForToolsCall(t *testing.T) {
+	// A non-list call gets no filter — only list methods are filtered.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/call"]
+    allowed_tools   = ["get_repo"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_repo"},"id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	assert.Nil(t, req.MCPListFilter, "tools/call is not a list method")
+}
+
+func TestListFilter_NotAttachedOnCapCheckOnly(t *testing.T) {
+	// The cap-check-only pass must not leave a filter behind.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_methods = ["tools/list", "tools/call"]
+    allowed_tools   = ["*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	_ = cbp.AllowOperation(testContext(), req, nil, true) // capCheckOnly
+
+	assert.Nil(t, req.MCPListFilter, "cap-check-only must not attach a filter")
+}
+
+func TestListFilter_NotAttachedWithoutMCPBlock(t *testing.T) {
+	// A path without an mcp{} block imposes no MCP governance (opt-in), so a
+	// tools/list request streams through unfiltered.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	assert.Nil(t, req.MCPListFilter, "no mcp{} block → no filter")
+}

--- a/logical/mcp_list_filter.go
+++ b/logical/mcp_list_filter.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package logical
+
+// MCPListFilter directs a gateway to prune an MCP list-method response to the
+// items the caller is actually allowed to use, so discovery matches
+// enforcement: what an agent sees in tools/list is what it can call.
+//
+// The policy layer builds it (over the matched mcp{} rule-sets) and hangs it
+// on Request.MCPListFilter when it allows a list request whose family the
+// policy governs. A gateway that finds it non-nil buffers the upstream list
+// response and drops every item whose name Keep rejects; a nil filter means
+// "stream the response verbatim". Keep carries the policy semantics — the
+// gateway only supplies the item names — so providers need no policy
+// knowledge and the filter can't drift from the call-time gate.
+type MCPListFilter struct {
+	// ListMethod is the list method whose response this filters:
+	// "tools/list", "resources/list", or "prompts/list".
+	ListMethod string
+
+	// Keep reports whether the named item stays in the filtered response.
+	// name is the item's identity as the matching call-time gate reads it —
+	// the tool/prompt name, or the resource uri — in its original case.
+	Keep func(name string) bool
+}

--- a/logical/request.go
+++ b/logical/request.go
@@ -139,6 +139,13 @@ type Request struct {
 	// Read-only after extraction; the audit layer treats it as a
 	// deep-copy field via MCPRequestDescriptor.Clone.
 	MCPDescriptor *MCPRequestDescriptor `json:"-"`
+
+	// MCPListFilter is set by the policy layer when an allowed MCP
+	// list request (tools/list, resources/list, prompts/list) should
+	// have its response filtered to the items the caller may actually
+	// use. Nil for every other request; a gateway that sees nil streams
+	// the response through verbatim. See MCPListFilter.
+	MCPListFilter *MCPListFilter `json:"-"`
 }
 
 func (r *Request) TokenEntry() *TokenEntry {


### PR DESCRIPTION
## What

Teaches the policy layer to compute a **list-filter directive** for an allowed MCP list request, so a gateway can later prune the response to the items the caller may actually use. No gateway consumes it yet, so this PR is **inert** — no client-visible change.

PR 3 of the MCP list-filtering series (builds on deny-by-default).

## Details

- New `logical.MCPListFilter` (a `ListMethod` + a `Keep(name)` predicate) and a `Request.MCPListFilter` field.
- `mcpListItemAllowed` reuses the deny-by-default gates (`evaluateMCPGates`) with cross-set OR, **skipping CEL** — a list carries no call args, so arg-level conditions are deferred to call time (a condition-gated tool stays listed). Discovery matches enforcement.
- The filter is attached in `AllowOperation` only on the real enforcement pass (never cap-check-only) and only when an `mcp{}` block applies, preserving the opt-in.
- **Batch guard**: a batched request containing a list method fails closed with a new `batch_list_unfilterable` rule_type (a batched JSON-RPC list response can't be pruned per element), wired into the deny-description and rank tables.
- Core unit tests: keep-predicate parity with the gates, no-`allowed_tools` ⇒ keep nothing, wildcards, cross-set OR, batched-list denial, and that the filter is not attached on cap-check-only or without an `mcp{}` block.

## Series

Merge order: mcpfilter util (merged) → deny-by-default (merged) → **this** → generic mcp gateway → mcp_aws gateway.
