### PR TITLE
feat(mcp): filter tools/list responses in the generic mcp gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Warden are documented in this file.
 
 - **MCP `mcp { }` authorization is now deny-by-default.** An `mcp { }` block previously allowed anything it did not explicitly deny — an absent `allowed_methods`/`allowed_tools`/`allowed_resources`/`allowed_prompts` meant "allow all". It now **denies** anything it does not explicitly allow: an empty or absent allow-list for a family denies every method/tool/resource/prompt in it. **This silently tightens deployed policies** — e.g. `mcp { denied_tools = ["delete_*"] }` (or a block carrying only a `condition`) went from "all tools except `delete_*`" to "**deny every tool**". Before upgrading, audit every `mcp { }` block: to restore openness add `allowed_methods = ["*"]` (and `allowed_tools`/`allowed_resources`/`allowed_prompts = ["*"]` as needed), then layer `denied_*` lists and `condition`s on top. The MCP session-lifecycle methods `initialize`, `ping`, and `notifications/*` are **exempt** — they always pass without being allow-listed (a `denied_methods` entry can still block them), so the client handshake works without listing them and the previous "remember to allow-list the handshake methods" guidance no longer applies.
 
+### New Features
+
+- **MCP list responses are filtered to the callable set.** When a `tools/list`, `resources/list`, or `prompts/list` request is allowed, Warden prunes the response so it lists only the items the caller could actually use — an item survives iff a `tools/call` / `resources/read` / `prompts/get` for it would pass the policy gates (per-call CEL `condition`s are deferred to call time, so condition-gated items stay listed). Discovery now matches enforcement: an agent sees only what it can call. A batched request containing a list method is denied (`batch_list_unfilterable`), and a list response that can't be buffered within `max_body_size` fails closed rather than stream unfiltered.
+
 ## [v0.17.0] — 2026-07-04
 
 ### Breaking Changes

--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -6,7 +6,8 @@ fetch its **prompts**. Warden fronts MCP servers the same way it fronts any othe
 upstream: the agent points its MCP client at a Warden mount as if it were the
 server, and Warden authenticates the caller, **authorizes the individual
 JSON-RPC call**, injects the upstream [credential](credentials.md), and proxies
-the request — streaming the response back untouched.
+the request — streaming the response back untouched, except that a **list**
+method's response is pruned to the items the caller is allowed to use (below).
 
 What makes MCP special in Warden is the middle step. For most [providers](providers.md)
 authorization is path-and-method; for MCP, Warden parses the JSON-RPC **body** and
@@ -96,6 +97,24 @@ mcp {
 
 Argument-value constraints are expressed in the per-call `condition` (below), not
 as structured lists.
+
+### Filtering list responses
+
+The gates above decide whether a *call* is allowed. Warden also applies them to
+what an agent can *discover*: when a `tools/list`, `resources/list`, or
+`prompts/list` request is allowed, Warden prunes the response so it lists only
+the items the caller could actually use — an item survives iff a `tools/call`
+(resp. `resources/read`, `prompts/get`) for it would pass the gates. Under
+deny-by-default this means a mount with no `allowed_tools` returns an **empty**
+tools list, and one scoped to `get_*` lists only those. Discovery matches
+enforcement: what the agent sees is what it can call.
+
+Per-call CEL `condition`s are *not* evaluated during filtering — a list carries
+no arguments — so a condition-gated tool still appears in the list and its
+arguments are checked when it is actually called. A batched JSON-RPC request
+that contains a list method is denied (`batch_list_unfilterable`): a batched
+list response can't be pruned per element, so Warden fails closed rather than
+return an unfiltered list.
 
 ### Per-call CEL conditions
 

--- a/provider/sdk/httpproxy/gateway.go
+++ b/provider/sdk/httpproxy/gateway.go
@@ -100,13 +100,23 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	// Clean headers and inject credentials
 	b.prepareHeaders(r, credHeaders, dispatch)
 
+	// When the policy layer attached an MCP list filter, carry it into the
+	// proxy's ModifyResponse via the request context, and strip Accept-Encoding
+	// so the transport returns a decompressed body the filter can parse (a
+	// gzip'd list response would otherwise fail closed on every call).
+	if req.MCPListFilter != nil {
+		r = r.WithContext(withMCPListFilter(r.Context(), req.MCPListFilter))
+		r.Header.Del("Accept-Encoding")
+	}
+
 	b.Logger.Trace("Proxying request",
 		logger.String("provider", b.spec.Name),
 		logger.String("path", r.URL.Path),
 		logger.String("method", r.Method),
 	)
 
-	// Forward the request (body streams through without buffering)
+	// Forward the request (body streams through without buffering unless an
+	// MCP list filter is installed, which buffers only the list response)
 	proxy.ServeHTTP(req.ResponseWriter, r)
 }
 

--- a/provider/sdk/httpproxy/mcp_filter.go
+++ b/provider/sdk/httpproxy/mcp_filter.go
@@ -1,0 +1,100 @@
+package httpproxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/mcpfilter"
+)
+
+// mcpFilterCtxKey keys the per-request MCP list filter carried from
+// handleGateway — which stashes it on the outbound request context — to the
+// shared ReverseProxy.ModifyResponse hook that reads it back.
+type mcpFilterCtxKeyT struct{}
+
+var mcpFilterCtxKey = mcpFilterCtxKeyT{}
+
+func withMCPListFilter(ctx context.Context, f *logical.MCPListFilter) context.Context {
+	return context.WithValue(ctx, mcpFilterCtxKey, f)
+}
+
+func mcpListFilterFrom(ctx context.Context) *logical.MCPListFilter {
+	f, _ := ctx.Value(mcpFilterCtxKey).(*logical.MCPListFilter)
+	return f
+}
+
+// installMCPListFilter wires the backend's ReverseProxy so an MCP list
+// response is pruned to the items the caller may use. The hook is a no-op for
+// any response whose request context carries no filter, so every non-MCP
+// httpproxy provider — and every non-list MCP request — is unaffected.
+func (b *proxyBackend) installMCPListFilter() {
+	if b.Proxy == nil {
+		return
+	}
+	b.Proxy.ModifyResponse = func(resp *http.Response) error {
+		filter := mcpListFilterFrom(resp.Request.Context())
+		if filter == nil {
+			return nil // not an MCP list request — stream verbatim
+		}
+		return filterMCPListResponse(resp, filter, b.MaxBodySize())
+	}
+}
+
+// filterMCPListResponse buffers a successful list response, prunes it via the
+// policy-supplied keep predicate, and rewrites the body. It fails closed —
+// returning an error, which surfaces the ReverseProxy's ErrorHandler 502 —
+// rather than stream a body it cannot parse (e.g. still-compressed), because
+// that could leak denied items. A non-success (4xx/5xx) or empty response has
+// no list to leak and passes through untouched.
+//
+// maxBody caps the buffered response; on overflow it fails closed. The body is
+// consumed to buffer it, so it is always restored (filtered or original) with
+// a corrected Content-Length.
+func filterMCPListResponse(resp *http.Response, filter *logical.MCPListFilter, maxBody int64) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || resp.Body == nil {
+		return nil
+	}
+	if maxBody <= 0 {
+		maxBody = framework.DefaultMaxBodySize
+	}
+
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("mcp list filter: read upstream body: %w", err)
+	}
+	if int64(len(buf)) > maxBody {
+		return fmt.Errorf("mcp list filter: response exceeds max_body_size")
+	}
+	// An empty body carries no list to leak — restore it and pass through.
+	if len(buf) == 0 {
+		resp.Body = io.NopCloser(bytes.NewReader(buf))
+		return nil
+	}
+
+	out, _, err := mcpfilter.FilterListResponse(
+		filter.ListMethod, resp.Header.Get("Content-Type"), buf, filter.Keep)
+	if err != nil {
+		return fmt.Errorf("mcp list filter: %w", err)
+	}
+
+	// The stream was consumed to buffer it, so restore from out regardless of
+	// whether anything was dropped, and fix the framing. Accept-Encoding was
+	// stripped on the outbound request, so the body is not compressed.
+	resp.Body = io.NopCloser(bytes.NewReader(out))
+	resp.ContentLength = int64(len(out))
+	resp.TransferEncoding = nil
+	resp.Header.Set("Content-Length", strconv.Itoa(len(out)))
+	resp.Header.Del("Transfer-Encoding")
+	// The buffered body is plain bytes; drop any encoding header so the client
+	// doesn't try to decompress it. (Accept-Encoding was stripped outbound, so
+	// the transport already delivered a decoded body here.)
+	resp.Header.Del("Content-Encoding")
+	return nil
+}

--- a/provider/sdk/httpproxy/mcp_filter_test.go
+++ b/provider/sdk/httpproxy/mcp_filter_test.go
@@ -1,0 +1,253 @@
+package httpproxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+func denyDeletePrefix(name string) bool { return !strings.HasPrefix(name, "delete_") }
+
+func mkResp(status int, contentType, body string) *http.Response {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	h.Set("Content-Length", strconv.Itoa(len(body)))
+	return &http.Response{
+		StatusCode:    status,
+		Header:        h,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       httptest.NewRequest(http.MethodPost, "/gateway/", nil),
+	}
+}
+
+func toolsFilter() *logical.MCPListFilter {
+	return &logical.MCPListFilter{ListMethod: "tools/list", Keep: denyDeletePrefix}
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(b)
+}
+
+func TestFilterMCPListResponse_DropsDeniedTools(t *testing.T) {
+	resp := mkResp(200, "application/json",
+		`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_repo"},{"name":"delete_repo"}]}}`)
+
+	if err := filterMCPListResponse(resp, toolsFilter(), 1<<20); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := readBody(t, resp)
+	if strings.Contains(body, "delete_repo") {
+		t.Fatalf("denied tool leaked: %s", body)
+	}
+	if !strings.Contains(body, "get_repo") {
+		t.Fatalf("allowed tool missing: %s", body)
+	}
+	if got := resp.Header.Get("Content-Length"); got != strconv.Itoa(len(body)) {
+		t.Fatalf("Content-Length not updated: header=%s body=%d", got, len(body))
+	}
+	if resp.ContentLength != int64(len(body)) {
+		t.Fatalf("resp.ContentLength not updated: %d vs %d", resp.ContentLength, len(body))
+	}
+}
+
+func TestFilterMCPListResponse_SSE(t *testing.T) {
+	resp := mkResp(200, "text/event-stream",
+		"event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"get_x\"},{\"name\":\"delete_x\"}]}}\n\n")
+	resp.Header.Del("Content-Length")
+	resp.Header.Set("Transfer-Encoding", "chunked")
+
+	if err := filterMCPListResponse(resp, toolsFilter(), 1<<20); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := readBody(t, resp)
+	if strings.Contains(body, "delete_x") {
+		t.Fatalf("denied tool leaked in SSE: %s", body)
+	}
+	if resp.Header.Get("Transfer-Encoding") != "" {
+		t.Fatalf("Transfer-Encoding should be cleared after buffering")
+	}
+	if resp.Header.Get("Content-Length") != strconv.Itoa(len(body)) {
+		t.Fatalf("Content-Length not set for buffered SSE")
+	}
+}
+
+func TestFilterMCPListResponse_NonSuccessPassthrough(t *testing.T) {
+	resp := mkResp(403, "application/json", `{"error":"denied"}`)
+	if err := filterMCPListResponse(resp, toolsFilter(), 1<<20); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := readBody(t, resp); got != `{"error":"denied"}` {
+		t.Fatalf("4xx body altered: %s", got)
+	}
+}
+
+func TestFilterMCPListResponse_ErrorResponsePassthrough(t *testing.T) {
+	// 200 with a JSON-RPC error (no result) — nothing to filter.
+	resp := mkResp(200, "application/json",
+		`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"no"}}`)
+	if err := filterMCPListResponse(resp, toolsFilter(), 1<<20); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(readBody(t, resp), "error") {
+		t.Fatalf("error response should pass through")
+	}
+}
+
+func TestFilterMCPListResponse_OversizeFailsClosed(t *testing.T) {
+	resp := mkResp(200, "application/json",
+		`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_repo"},{"name":"delete_repo"}]}}`)
+	if err := filterMCPListResponse(resp, toolsFilter(), 10); err == nil {
+		t.Fatalf("expected fail-closed error on oversize response")
+	}
+}
+
+func TestFilterMCPListResponse_UnparseableFailsClosed(t *testing.T) {
+	// Simulates a still-compressed / garbled 200 body: must error, not stream.
+	resp := mkResp(200, "application/json", "\x1f\x8b\x08 not json")
+	if err := filterMCPListResponse(resp, toolsFilter(), 1<<20); err == nil {
+		t.Fatalf("expected fail-closed error on unparseable body")
+	}
+}
+
+func TestFilterMCPListResponse_EmptyBodyPassthrough(t *testing.T) {
+	resp := mkResp(204, "", "")
+	if err := filterMCPListResponse(resp, toolsFilter(), 1<<20); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if readBody(t, resp) != "" {
+		t.Fatalf("empty body should stay empty")
+	}
+}
+
+func TestMCPListFilterContextRoundTrip(t *testing.T) {
+	f := toolsFilter()
+	ctx := withMCPListFilter(context.Background(), f)
+	if got := mcpListFilterFrom(ctx); got != f {
+		t.Fatalf("filter not round-tripped through context")
+	}
+	if mcpListFilterFrom(context.Background()) != nil {
+		t.Fatalf("empty context must yield nil filter")
+	}
+}
+
+// newProxyToUpstream builds a proxyBackend whose ReverseProxy forwards to
+// upstreamURL, with the MCP list filter installed. Mirrors the production
+// InitProxy + installMCPListFilter wiring.
+func newProxyToUpstream(t *testing.T, upstreamURL string) *proxyBackend {
+	t.Helper()
+	b := &proxyBackend{StreamingBackend: &framework.StreamingBackend{}}
+	b.InitProxy(http.DefaultTransport)
+	// The proxy uses an empty Director, so point every request at the upstream.
+	target, err := url.Parse(upstreamURL)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	inner := b.Proxy.Director
+	b.Proxy.Director = func(r *http.Request) {
+		inner(r)
+		r.URL.Scheme = target.Scheme
+		r.URL.Host = target.Host
+		r.Host = target.Host
+	}
+	b.installMCPListFilter()
+	return b
+}
+
+// TestModifyResponse_EndToEnd drives a request through the real ReverseProxy to
+// prove the filter survives the proxy's request clone (resp.Request.Context)
+// and that the list response is pruned end-to-end.
+func TestModifyResponse_EndToEnd(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"},{"name":"delete_x"}]}}`)
+	}))
+	defer upstream.Close()
+
+	b := newProxyToUpstream(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "http://gateway/gateway/", nil)
+	req = req.WithContext(withMCPListFilter(req.Context(), toolsFilter()))
+	rw := httptest.NewRecorder()
+	b.Proxy.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d", rw.Code)
+	}
+	body := rw.Body.String()
+	if strings.Contains(body, "delete_x") {
+		t.Fatalf("denied tool leaked end-to-end: %s", body)
+	}
+	if !strings.Contains(body, "get_x") {
+		t.Fatalf("allowed tool missing: %s", body)
+	}
+}
+
+// TestModifyResponse_NoFilterPassesThrough proves a request without a filter in
+// context is streamed verbatim (the hook is a no-op for non-MCP traffic).
+func TestModifyResponse_NoFilterPassesThrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"delete_x"}]}}`)
+	}))
+	defer upstream.Close()
+
+	b := newProxyToUpstream(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "http://gateway/gateway/", nil)
+	rw := httptest.NewRecorder()
+	b.Proxy.ServeHTTP(rw, req)
+
+	if !strings.Contains(rw.Body.String(), "delete_x") {
+		t.Fatalf("no-filter response must pass through unchanged: %s", rw.Body.String())
+	}
+}
+
+// BenchmarkFilterMCPListResponse measures the per-list-call response overhead:
+// buffer + parse + prune + re-serialize a realistic 50-tool list, half denied.
+func BenchmarkFilterMCPListResponse(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString(`{"jsonrpc":"2.0","id":1,"result":{"tools":[`)
+	for i := 0; i < 50; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		name := "get_tool_" + strconv.Itoa(i)
+		if i%2 == 1 {
+			name = "delete_tool_" + strconv.Itoa(i)
+		}
+		sb.WriteString(`{"name":"` + name + `","description":"a tool that does a thing","inputSchema":{"type":"object","properties":{}}}`)
+	}
+	sb.WriteString(`]}}`)
+	body := sb.String()
+	filter := toolsFilter()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp := &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": []string{"application/json"}},
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: int64(len(body)),
+		}
+		if err := filterMCPListResponse(resp, filter, 1<<20); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -279,6 +279,11 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 		// Initialize reverse proxy with provider-type shared transport
 		b.StreamingBackend.InitProxy(sharedTransport)
 
+		// Prune MCP list responses when the policy layer attaches a filter.
+		// No-op for every request that carries none, so non-MCP providers are
+		// unaffected.
+		b.installMCPListFilter()
+
 		// Register transport shutdown hook
 		if conf.RegisterShutdownHook != nil && shutdownFn != nil {
 			conf.RegisterShutdownHook(spec.Name+"-transport", shutdownFn)


### PR DESCRIPTION
## What

Wires the generic `mcp` provider's gateway to **prune `tools/list` / `resources/list` / `prompts/list` responses** to the items the caller may use, consuming the `Request.MCPListFilter` the policy layer attaches. This is where list filtering goes **live** for the `mcp` provider.

PR 4 of the MCP list-filtering series (needs the mcpfilter util + the filter directive, both merged).

## Details

- Sets `ModifyResponse` on the reverse proxy (in `InitProxy`), reading the filter from the outbound request context. It is a **no-op** for any response that carries no filter, so non-MCP httpproxy providers and non-list requests are unaffected.
- `handleGateway` stashes the filter into the request context **and strips `Accept-Encoding`** so the transport delivers a decompressed body the filter can parse (a gzip'd list response would otherwise fail closed on every call).
- Only successful (2xx, non-empty) responses are buffered — capped at `max_body_size`, **fail-closed** (502) on overflow or an unparseable body; 4xx/5xx and empty responses stream through untouched.
- Covers `application/json` and `text/event-stream`, with an end-to-end test through a real `ReverseProxy` proving the filter survives the request clone, plus a benchmark of the filter path (~140µs for a 50-tool list).

## Series

Merge order: mcpfilter util (merged) → deny-by-default (merged) → filter directive (merged) → **this** → mcp_aws gateway.
