### PR TITLE
feat(mcp_aws): filter tools/list responses in the mcp_aws gateway

### DIFF
--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -6,8 +6,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/mcpfilter"
 	"github.com/stephnangue/warden/provider/sdk/sigv4"
 )
 
@@ -29,7 +31,8 @@ var headersToStrip = []string{
 
 // handleGateway signs the incoming MCP request with AWS SigV4 using credentials
 // minted by core's implicit-auth pipeline, then forwards to the upstream MCP
-// endpoint and streams the response back.
+// endpoint and streams the response back — pruning list responses to the
+// callable items when the policy layer attached an MCP list filter.
 //
 // Pipeline:
 //  1. Read body (capped by MaxBodySize, the same value ShouldEnforceMCPPolicy
@@ -41,8 +44,10 @@ var headersToStrip = []string{
 //  5. Normalize headers (drop hop-by-hop + proxy-forwarded set).
 //  6. Sign with sigv4.ResignRequest using the URL-derived service name and the
 //     resolved region.
-//  7. Forward via sigv4.ForwardDirect, which bypasses httputil.ReverseProxy so
-//     headers and the signed body reach the upstream byte-for-byte.
+//  7. Forward via sigv4.ForwardDirect — or ForwardDirectFiltered when a list
+//     filter is set, which buffers and prunes the list response — bypassing
+//     httputil.ReverseProxy so headers and the signed body reach the upstream
+//     byte-for-byte.
 func (b *mcpAWSBackend) handleGateway(ctx context.Context, req *logical.Request) {
 	r := req.HTTPRequest
 	w := req.ResponseWriter
@@ -117,6 +122,26 @@ func (b *mcpAWSBackend) handleGateway(ctx context.Context, req *logical.Request)
 	transport := snap.transport
 	if transport == nil {
 		transport = http.DefaultTransport
+	}
+
+	// When the policy layer attached an MCP list filter, prune the response to
+	// the callable items. The outbound Accept-Encoding was already dropped by
+	// sigv4.NormalizeRequest, so the transport delivers a decompressed body the
+	// filter can parse. Nil filter → verbatim streaming, unchanged.
+	if f := req.MCPListFilter; f != nil {
+		modify := func(contentType string, respBody []byte) ([]byte, error) {
+			out, _, err := mcpfilter.FilterListResponse(f.ListMethod, contentType, respBody, f.Keep)
+			return out, err
+		}
+		// snap.maxBody is defaulted to DefaultMaxBodySize at config time; guard
+		// here too so the response buffer is always bounded (fail closed on a
+		// list response larger than the cap).
+		maxBody := snap.maxBody
+		if maxBody <= 0 {
+			maxBody = framework.DefaultMaxBodySize
+		}
+		sigv4.ForwardDirectFiltered(b.Logger, w, r, bodyBytes, transport, maxBody, modify)
+		return
 	}
 	sigv4.ForwardDirect(b.Logger, w, r, bodyBytes, transport)
 }

--- a/provider/mcp_aws/gateway_test.go
+++ b/provider/mcp_aws/gateway_test.go
@@ -340,3 +340,32 @@ func TestHandleGateway_AgentCoreServiceInference(t *testing.T) {
 	assert.Equal(t, "bedrock-agentcore", service, "AgentCore host must yield service=bedrock-agentcore via arm 1 of the structured match")
 	assert.Equal(t, "us-east-1", region)
 }
+
+// --- MCP list-response filtering ---
+
+// TestHandleGateway_FiltersToolsList drives the full mcp_aws gateway with a
+// list filter attached, proving the response is pruned to the callable items.
+func TestHandleGateway_FiltersToolsList(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"},{"name":"delete_x"}]}}`))
+	}))
+	defer srv.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+	req.MCPListFilter = &logical.MCPListFilter{
+		ListMethod: "tools/list",
+		Keep:       func(name string) bool { return !strings.HasPrefix(name, "delete_") },
+	}
+
+	b.handleGateway(context.Background(), req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	out := rec.Body.String()
+	assert.Contains(t, out, "get_x")
+	assert.NotContains(t, out, "delete_x", "denied tool must be pruned from the mcp_aws tools/list response")
+}

--- a/provider/sdk/sigv4/sigv4.go
+++ b/provider/sdk/sigv4/sigv4.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,7 +27,6 @@ import (
 // to prevent denial-of-service via a malicious chunk header. AWS SDKs use chunks
 // up to ~1MB; 10MB per chunk is generous.
 const maxChunkSize = 10 << 20 // 10MB
-
 
 var (
 	// AuthRegex parses the SigV4 Authorization header into access_key_id, date, region, service.
@@ -455,8 +455,22 @@ func RemoveAWSChunkedEncoding(r *http.Request) {
 }
 
 // ForwardDirect sends a signed request directly using the given transport,
-// bypassing httputil.ReverseProxy which modifies headers and breaks SigV4 signatures.
+// bypassing httputil.ReverseProxy which modifies headers and breaks SigV4
+// signatures. The response streams back verbatim.
 func ForwardDirect(log *logger.GatedLogger, w http.ResponseWriter, r *http.Request, body []byte, transport http.RoundTripper) {
+	ForwardDirectFiltered(log, w, r, body, transport, 0, nil)
+}
+
+// ForwardDirectFiltered is ForwardDirect with an optional response modifier.
+// When modify is nil the response streams back verbatim (identical to
+// ForwardDirect). When modify is non-nil and the upstream returns a successful
+// (2xx) response, the whole body is buffered (capped at maxBody; maxBody <= 0
+// disables the cap), passed through modify, and written with a corrected
+// Content-Length. It fails closed with 502 — rather than stream an
+// unmodified body — when the body exceeds the cap or modify errors, so a
+// response the caller couldn't transform is never leaked. Non-success
+// responses stream through untouched.
+func ForwardDirectFiltered(log *logger.GatedLogger, w http.ResponseWriter, r *http.Request, body []byte, transport http.RoundTripper, maxBody int64, modify func(contentType string, body []byte) ([]byte, error)) {
 	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), bytes.NewReader(body))
 	if err != nil {
 		log.Error("failed to create direct request", logger.Err(err))
@@ -492,6 +506,14 @@ func ForwardDirect(log *logger.GatedLogger, w http.ResponseWriter, r *http.Reque
 	}
 	defer resp.Body.Close()
 
+	// Filtered path: buffer a successful response, transform it, and write it
+	// with a corrected length. Fails closed rather than stream a body it
+	// could not transform.
+	if modify != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		writeFilteredResponse(log, w, resp, maxBody, modify)
+		return
+	}
+
 	for k, vv := range resp.Header {
 		for _, val := range vv {
 			w.Header().Add(k, val)
@@ -514,4 +536,50 @@ func ForwardDirect(log *logger.GatedLogger, w http.ResponseWriter, r *http.Reque
 	} else {
 		io.Copy(w, resp.Body)
 	}
+}
+
+// writeFilteredResponse buffers resp's body (capped at maxBody), runs it
+// through modify, and writes the result with a corrected Content-Length. It
+// fails closed with 502 on a read error, an over-cap body, or a modify error.
+// An empty body is written as-is without invoking modify.
+func writeFilteredResponse(log *logger.GatedLogger, w http.ResponseWriter, resp *http.Response, maxBody int64, modify func(contentType string, body []byte) ([]byte, error)) {
+	var reader io.Reader = resp.Body
+	if maxBody > 0 {
+		reader = io.LimitReader(resp.Body, maxBody+1)
+	}
+	buf, err := io.ReadAll(reader)
+	if err != nil {
+		log.Error("filtered forward: read upstream body", logger.Err(err))
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+	if maxBody > 0 && int64(len(buf)) > maxBody {
+		log.Error("filtered forward: response exceeds max body size")
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+
+	out := buf
+	if len(buf) > 0 {
+		out, err = modify(resp.Header.Get("Content-Type"), buf)
+		if err != nil {
+			log.Error("filtered forward: modify failed", logger.Err(err))
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+			return
+		}
+	}
+
+	// The body is fully buffered and possibly resized; drop framing/encoding
+	// headers so the client reads exactly len(out) plain bytes.
+	resp.Header.Del("Content-Length")
+	resp.Header.Del("Transfer-Encoding")
+	resp.Header.Del("Content-Encoding")
+	for k, vv := range resp.Header {
+		for _, val := range vv {
+			w.Header().Add(k, val)
+		}
+	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(out)
 }

--- a/provider/sdk/sigv4/sigv4_test.go
+++ b/provider/sdk/sigv4/sigv4_test.go
@@ -57,12 +57,12 @@ func TestIsSigV4Request(t *testing.T) {
 
 func TestExtractFromAuthHeader(t *testing.T) {
 	tests := []struct {
-		name      string
-		header    string
-		wantSvc   string
-		wantReg   string
-		wantAKID  string
-		wantErr   bool
+		name     string
+		header   string
+		wantSvc  string
+		wantReg  string
+		wantAKID string
+		wantErr  bool
 	}{
 		{
 			name:     "valid header",
@@ -487,4 +487,108 @@ func TestForwardDirect_UpstreamError(t *testing.T) {
 	ForwardDirect(log, rec, r, []byte{}, http.DefaultTransport)
 
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+// --- ForwardDirectFiltered ---
+
+func serveBody(t *testing.T, status int, contentType, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestForwardDirectFiltered_TransformsBodyAndFixesLength(t *testing.T) {
+	log := createTestLogger()
+	upstream := serveBody(t, http.StatusOK, "application/json", `{"tools":["get_x","delete_x"]}`)
+	defer upstream.Close()
+
+	r, _ := http.NewRequest("POST", upstream.URL+"/gateway", nil)
+	r.RequestURI = ""
+	rec := httptest.NewRecorder()
+
+	modify := func(ct string, body []byte) ([]byte, error) {
+		assert.Equal(t, "application/json", ct)
+		return []byte("FILTERED"), nil
+	}
+	ForwardDirectFiltered(log, rec, r, []byte{}, upstream.Client().Transport, 1<<20, modify)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "FILTERED", rec.Body.String())
+	assert.Equal(t, "8", rec.Header().Get("Content-Length"))
+}
+
+func TestForwardDirectFiltered_NilModifyVerbatim(t *testing.T) {
+	log := createTestLogger()
+	upstream := serveBody(t, http.StatusOK, "application/json", `{"tools":["delete_x"]}`)
+	defer upstream.Close()
+
+	r, _ := http.NewRequest("POST", upstream.URL+"/gateway", nil)
+	r.RequestURI = ""
+	rec := httptest.NewRecorder()
+
+	ForwardDirectFiltered(log, rec, r, []byte{}, upstream.Client().Transport, 1<<20, nil)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "delete_x")
+}
+
+func TestForwardDirectFiltered_NonSuccessSkipsModify(t *testing.T) {
+	log := createTestLogger()
+	upstream := serveBody(t, http.StatusForbidden, "application/json", `{"error":"denied"}`)
+	defer upstream.Close()
+
+	r, _ := http.NewRequest("POST", upstream.URL+"/gateway", nil)
+	r.RequestURI = ""
+	rec := httptest.NewRecorder()
+
+	modify := func(ct string, body []byte) ([]byte, error) {
+		t.Fatalf("modify must not run for a non-2xx response")
+		return nil, nil
+	}
+	ForwardDirectFiltered(log, rec, r, []byte{}, upstream.Client().Transport, 1<<20, modify)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "denied")
+}
+
+func TestForwardDirectFiltered_ModifyErrorFailsClosed(t *testing.T) {
+	log := createTestLogger()
+	upstream := serveBody(t, http.StatusOK, "application/json", `{"tools":[]}`)
+	defer upstream.Close()
+
+	r, _ := http.NewRequest("POST", upstream.URL+"/gateway", nil)
+	r.RequestURI = ""
+	rec := httptest.NewRecorder()
+
+	modify := func(ct string, body []byte) ([]byte, error) {
+		return nil, assert.AnError
+	}
+	ForwardDirectFiltered(log, rec, r, []byte{}, upstream.Client().Transport, 1<<20, modify)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestForwardDirectFiltered_OversizeFailsClosed(t *testing.T) {
+	log := createTestLogger()
+	upstream := serveBody(t, http.StatusOK, "application/json", `{"tools":["a","b","c","d","e"]}`)
+	defer upstream.Close()
+
+	r, _ := http.NewRequest("POST", upstream.URL+"/gateway", nil)
+	r.RequestURI = ""
+	rec := httptest.NewRecorder()
+
+	called := false
+	modify := func(ct string, body []byte) ([]byte, error) {
+		called = true
+		return body, nil
+	}
+	ForwardDirectFiltered(log, rec, r, []byte{}, upstream.Client().Transport, 5, modify)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.False(t, called, "modify must not run when the body exceeds the cap")
 }


### PR DESCRIPTION
## What

Brings MCP list-response filtering **live for the `mcp_aws` provider** (the AWS/SigV4-signed MCP gateway), completing the series.

PR 5 of the MCP list-filtering series (needs the mcpfilter util + the filter directive, both merged).

## Details

- Adds `sigv4.ForwardDirectFiltered` — `ForwardDirect` with an optional response modifier that buffers a successful (2xx) response, transforms it, and writes it with a corrected `Content-Length`, **failing closed** (502) on an over-cap or untransformable body *before writing anything*. `ForwardDirect` becomes a thin wrapper (nil modifier = verbatim streaming, unchanged for every other sigv4 provider — S3, etc.).
- The `mcp_aws` gateway passes a modifier that runs `mcpfilter.FilterListResponse` when the policy layer attached a list filter; otherwise it forwards verbatim as before.
- `mcp_aws` is already gzip-safe — `NormalizeRequest` drops the outbound `Accept-Encoding`, so the transport delivers a decompressed body. The response buffer is bounded by `max_body_size`.
- Covered by `ForwardDirectFiltered` unit tests (transform + length, verbatim, non-2xx-skips-modify, modify-error-fails-closed, oversize-fails-closed) and a full-gateway integration test that signs, forwards, and prunes a real `tools/list`.

## Series

Merge order: mcpfilter util (merged) → deny-by-default (merged) → filter directive (merged) → generic mcp gateway (merged) → **this** (final).
