### PR TITLE
fix(audit): correct HTTP status for permission denials and quiet the logs

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -506,6 +506,31 @@ func synthesizeGatewayPath(provider, role, apiPath string) (string, error) {
 	return b.String(), nil
 }
 
+// statusClientClosedRequest is nginx's non-standard 499 "Client Closed
+// Request": the client disconnected before any response was written. It has no
+// net/http constant.
+const statusClientClosedRequest = 499
+
+// streamedStatusCode resolves the status code to record for a streamed
+// response. It returns the code the writer actually captured; when nothing was
+// ever written to the client (captured == 0), it derives a code from why the
+// stream ended so the audit distinguishes an aborted stream from an unknown
+// outcome: a canceled context (client hung up) → 499, a deadline (upstream
+// timeout) → 504. If nothing was written and there is no context error, the
+// outcome is genuinely unknown and 0 is preserved.
+func streamedStatusCode(captured int, ctxErr error) int {
+	if captured != 0 {
+		return captured
+	}
+	switch {
+	case errors.Is(ctxErr, context.Canceled):
+		return statusClientClosedRequest
+	case errors.Is(ctxErr, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout
+	}
+	return captured
+}
+
 func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request) (resp *logical.Response, err error) {
 	// MountPoint will not always be set at this point, so we ensure the req contains it
 	req.MountPoint = c.router.MatchingMount(ctx, req.Path)
@@ -528,7 +553,11 @@ func (c *Core) handleCancelableRequest(ctx context.Context, req *logical.Request
 
 	if resp != nil && resp.Streamed {
 		if srw, ok := req.ResponseWriter.(*logical.StatusRecordingWriter); ok {
-			resp.StatusCode = srw.StatusCode()
+			var ctxErr error
+			if req.HTTPRequest != nil {
+				ctxErr = req.HTTPRequest.Context().Err()
+			}
+			resp.StatusCode = streamedStatusCode(srw.StatusCode(), ctxErr)
 		}
 	}
 
@@ -882,7 +911,17 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		var ctErr error
 		auth, _, te, ctErr = c.CheckToken(ctx, req, false)
 		if ctErr != nil {
-			c.logger.Warn("error when checking token", logger.Err(ctErr))
+			// A permission denial is an expected authorization outcome, not an
+			// operational fault, and is already recorded in full in the audit
+			// log — so it is kept out of the operational log entirely (even at
+			// debug), or an MCP client probing capabilities (e.g. prompts/list
+			// under a policy that doesn't allow it) would spam it. Genuine
+			// failures (internal errors, malformed requests) still warn.
+			permDenied := errwrap.Contains(ctErr, sdklogical.ErrPermissionDenied.Error()) &&
+				!errwrap.Contains(ctErr, ErrInternalError.Error())
+			if !permDenied {
+				c.logger.Warn("error when checking token", logger.Err(ctErr))
+			}
 			switch {
 			case ctErr == ErrInternalError,
 				errwrap.Contains(ctErr, ErrInternalError.Error()),

--- a/core/stream_status_test.go
+++ b/core/stream_status_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamedStatusCode(t *testing.T) {
+	// A captured status always wins, even if the context later errored.
+	assert.Equal(t, http.StatusOK, streamedStatusCode(http.StatusOK, nil))
+	assert.Equal(t, http.StatusOK, streamedStatusCode(http.StatusOK, context.Canceled))
+	assert.Equal(t, http.StatusForbidden, streamedStatusCode(http.StatusForbidden, context.DeadlineExceeded))
+
+	// Nothing written + client hung up → 499.
+	assert.Equal(t, statusClientClosedRequest, streamedStatusCode(0, context.Canceled))
+	// Wrapped cancellation still resolves (errors.Is traversal).
+	assert.Equal(t, statusClientClosedRequest, streamedStatusCode(0, fmt.Errorf("ctx: %w", context.Canceled)))
+
+	// Nothing written + upstream deadline → 504.
+	assert.Equal(t, http.StatusGatewayTimeout, streamedStatusCode(0, context.DeadlineExceeded))
+
+	// Nothing written and no context error → outcome unknown, preserve 0.
+	assert.Equal(t, 0, streamedStatusCode(0, nil))
+}

--- a/logical/errors.go
+++ b/logical/errors.go
@@ -4,8 +4,11 @@
 package logical
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 )
 
 // CodedError is an error that carries an HTTP status code.
@@ -119,6 +122,22 @@ func GetErrorCode(err error) int {
 	}
 	if coded, ok := err.(*CodedError); ok {
 		return coded.Status
+	}
+	// Recognise the SDK sentinel errors so their HTTP status survives being
+	// wrapped in an ErrorResponse — otherwise a permission denial (or any
+	// sentinel) recorded in the audit log falls through to 500 even though the
+	// wire response is correct. Mirrors http.errorToStatusCode so the audit
+	// status and the wire status can't drift. errors.Is traverses wrapping,
+	// including multierror, so a wrapped or appended sentinel still matches.
+	switch {
+	case errors.Is(err, sdklogical.ErrPermissionDenied):
+		return http.StatusForbidden
+	case errors.Is(err, sdklogical.ErrUnsupportedOperation):
+		return http.StatusMethodNotAllowed
+	case errors.Is(err, sdklogical.ErrUnsupportedPath):
+		return http.StatusNotFound
+	case errors.Is(err, sdklogical.ErrInvalidRequest):
+		return http.StatusBadRequest
 	}
 	// Check if the error wraps a CodedError
 	if unwrapped, ok := err.(interface{ Unwrap() error }); ok {

--- a/logical/logical_test.go
+++ b/logical/logical_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"testing"
 
+	multierror "github.com/hashicorp/go-multierror"
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,6 +133,14 @@ func TestWrapWithCode(t *testing.T) {
 	assert.Equal(t, inner, wrapped.Unwrap())
 }
 
+// permDeniedWrapper mirrors core.ErrMCPPolicyDenied: a typed error that
+// Unwraps to the permission-denied sentinel. Used to prove GetErrorCode
+// traverses wrapping the same way the HTTP status mapping does.
+type permDeniedWrapper struct{}
+
+func (permDeniedWrapper) Error() string { return "boom" }
+func (permDeniedWrapper) Unwrap() error { return sdklogical.ErrPermissionDenied }
+
 func TestGetErrorCode(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		assert.Equal(t, 200, GetErrorCode(nil))
@@ -149,6 +159,42 @@ func TestGetErrorCode(t *testing.T) {
 		wrapped := fmt.Errorf("wrap: %w", inner)
 		assert.Equal(t, 404, GetErrorCode(wrapped))
 	})
+
+	// SDK sentinel errors must map to their HTTP status even when wrapped or
+	// appended into a multierror — otherwise the audit log records 500 for a
+	// denial the client received as 403.
+	t.Run("permission denied sentinel", func(t *testing.T) {
+		assert.Equal(t, 403, GetErrorCode(sdklogical.ErrPermissionDenied))
+	})
+
+	t.Run("permission denied in multierror", func(t *testing.T) {
+		assert.Equal(t, 403, GetErrorCode(multierror.Append(nil, sdklogical.ErrPermissionDenied)))
+	})
+
+	t.Run("permission denied via Unwrap in multierror", func(t *testing.T) {
+		assert.Equal(t, 403, GetErrorCode(multierror.Append(nil, permDeniedWrapper{})))
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+		assert.Equal(t, 405, GetErrorCode(sdklogical.ErrUnsupportedOperation))
+	})
+
+	t.Run("unsupported path", func(t *testing.T) {
+		assert.Equal(t, 404, GetErrorCode(sdklogical.ErrUnsupportedPath))
+	})
+
+	t.Run("invalid request wrapped", func(t *testing.T) {
+		assert.Equal(t, 400, GetErrorCode(fmt.Errorf("ctx: %w", sdklogical.ErrInvalidRequest)))
+	})
+}
+
+// TestErrorResponse_PermissionDeniedStatus is the end-to-end assertion for the
+// reported bug: an ErrorResponse built from a permission denial (as the request
+// handler does on a failed token check) must carry 403 so the audit log records
+// the same status the client received on the wire.
+func TestErrorResponse_PermissionDeniedStatus(t *testing.T) {
+	resp := ErrorResponse(multierror.Append(nil, sdklogical.ErrPermissionDenied))
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 func TestIsNotFound(t *testing.T) {


### PR DESCRIPTION
## What

Three related audit/log fixes, all surfaced while testing MCP: an MCP client probes `prompts/list`, the policy denies it (expected), but the observability around that denial was wrong.

Independent bugfix — no dependency on the MCP list-filtering series.

## Fixes

1. **Audit status was 500 for a 403 denial.** `logical.ErrorResponse` derives its status from `GetErrorCode`, which only understood `*CodedError` and fell through to 500 for the `ErrPermissionDenied` sentinel (and the `ErrMCPPolicyDenied` wrapper). `GetErrorCode` now recognises the SDK sentinels via `errors.Is` — permission-denied → 403, unsupported-operation → 405, unsupported-path → 404, invalid-request → 400 — so it traverses wrapping/`multierror` and can't drift from the HTTP layer's `errorToStatusCode`. The wire was already 403; this makes the audit agree.

2. **Permission denials spammed the operational log at WARN.** An agent probing MCP capabilities generated a WARN per expected denial. Denials are now kept out of the operational log entirely (they're fully recorded in the audit log); genuine internal errors and malformed requests still WARN.

3. **Streamed responses recorded an ambiguous `status_code: 0`.** When a stream ends with nothing written to the client, the audit now records **499 (Client Closed Request)** if the client hung up, or **504** on an upstream deadline — instead of `0`. Common for MCP `GET` SSE notification streams the client opens and drops before the upstream responds. (Audit-only; the wire is unchanged.)

## Tests

`GetErrorCode` extended with the sentinel + `multierror` + `Unwrap`-wrapper cases (the regression) and an end-to-end `ErrorResponse` assertion; new `streamedStatusCode` unit test (captured-wins, 499, 504, wrapped-cancel, unknown→0).
