### PR TITLE
feat(mcp): add /v1/sys/mcp discovery server with list_roles tool

### DIFF
--- a/core/sys_mcp.go
+++ b/core/sys_mcp.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+)
+
+// Warden as an MCP server (discovery interface).
+//
+// This file makes Warden answer MCP for its own capabilities so an agent can
+// discover what it may do before it selects a role and drives a gateway.
+//
+// The endpoint is always-on at /v1/sys/mcp (wired in http/handler.go). It is
+// meta-introspection that runs *before* role selection, so it needs no role
+// token; it authorizes on the presented identity alone, exactly like
+// sys/introspect/roles and sys/skills reads.
+//
+// Two tools are exposed:
+//   - list_roles: the roles the caller's identity can assume, each with its
+//     operator-written description (the agent's "menu").
+//   - get_skill:  (added in a later change) the provider-type recipe teaching
+//     the agent how to drive a provider through the gateway.
+
+// mcpServerVersion is the implementation version advertised in the MCP
+// initialize handshake. It is informational only; the wire protocol revision
+// is negotiated by the SDK independently of this string.
+const mcpServerVersion = "1.0.0"
+
+// mcpRequestKey is the private context key under which the middleware stashes
+// the inbound *http.Request so tool handlers can recover the caller's
+// credentials (Authorization header and forwarded client certificate). The
+// SDK does not hand the raw request to tool handlers — it surfaces only
+// headers via req.Extra.Header and, notably, not the TLS client certificate —
+// so credential detection (detectIntrospectCredentialFormat) needs the
+// request threaded through the context.
+type mcpRequestKey struct{}
+
+func withMCPRequest(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, mcpRequestKey{}, r)
+}
+
+// mcpRequestFromContext recovers the inbound *http.Request stashed by the
+// middleware. Returns nil if absent (should not happen for a request routed
+// through mcpServerHandler).
+func mcpRequestFromContext(ctx context.Context) *http.Request {
+	r, _ := ctx.Value(mcpRequestKey{}).(*http.Request)
+	return r
+}
+
+// mcpServerHandler builds the always-on MCP discovery endpoint served at
+// /v1/sys/mcp. It runs the official SDK's Streamable HTTP transport in
+// stateless JSON mode: each POST is a self-contained request/response with no
+// Mcp-Session-Id affinity, so a standby node can forward it to the active node
+// without session-stickiness concerns. The SDK still performs the full
+// initialize + protocol-version negotiation on every call.
+func (c *Core) MCPServerHandler() http.Handler {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "warden",
+		Version: mcpServerVersion,
+	}, nil)
+
+	c.registerListRolesTool(server)
+
+	streamable := mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return server },
+		&mcp.StreamableHTTPOptions{Stateless: true, JSONResponse: true},
+	)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject on a sealed node. This route bypasses HandleRequest (which
+		// guards seal state before any namespace access), so without this
+		// check a POST to a sealed node would dereference c.namespaceStore
+		// after seal has niled it (teardownNamespaceStore). Standby is already
+		// handled upstream: the route is not in standbyAllowedPaths, so
+		// wrapGenericHandler forwards it to the active node.
+		if c.Sealed() {
+			http.Error(w, "Warden is sealed", http.StatusServiceUnavailable)
+			return
+		}
+
+		// Resolve the caller's namespace the same way transparent callers
+		// select one: the X-Warden-Namespace header. One fixed route serves
+		// every namespace; a root caller omits the header, a caller in
+		// team-data sends "team-data". The tool handlers' fan-out and
+		// mount lookups then resolve in this namespace.
+		nsHeader := r.Header.Get("X-Warden-Namespace")
+		ns, _ := c.namespaceStore.ResolveNamespaceFromRequest(nsHeader, "sys/mcp")
+		if ns == nil {
+			http.Error(w, "namespace not found", http.StatusNotFound)
+			return
+		}
+
+		// Thread the namespace into the context (used by the tool handlers'
+		// reused core logic) and stash the raw request (used for credential
+		// detection). The request's own context already carries the
+		// Authorization header and the forwarded client cert — the listener's
+		// certForwardingMiddleware injected the latter before routing — so
+		// stashing r preserves both for detectIntrospectCredentialFormat.
+		ctx := namespace.ContextWithNamespace(r.Context(), ns)
+		ctx = withMCPRequest(ctx, r)
+		streamable.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// mcpRole is a single role projected for the list_roles tool. The aggregator's
+// auth_path is deliberately dropped — the agent reads the provider path out of
+// the description verbatim and never needs the auth mount path.
+type mcpRole struct {
+	Name        string `json:"name" jsonschema:"the role name the identity can assume"`
+	Description string `json:"description,omitempty" jsonschema:"operator-written description; the provider mount path is embedded here for the agent to parse"`
+}
+
+// listRolesInput is the (empty) input for the list_roles tool.
+type listRolesInput struct{}
+
+// listRolesOutput is the structured output for the list_roles tool.
+type listRolesOutput struct {
+	Roles    []mcpRole `json:"roles" jsonschema:"roles the presented identity can assume across the namespace's auth mounts"`
+	Warnings []string  `json:"warnings" jsonschema:"per-mount failure messages; may be empty"`
+}
+
+// registerListRolesTool wires the list_roles tool onto the MCP server. It
+// reuses the sys/introspect/roles aggregator in full — no discovery logic is
+// duplicated — and projects each role down to {name, description}.
+func (c *Core) registerListRolesTool(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "list_roles",
+		Description: "List the roles the presented identity can assume, each with its " +
+			"operator-written description. This is the agent's discovery menu: the " +
+			"provider mount path is embedded in each role's description for the agent " +
+			"to read and feed to get_skill. Authorizes on the presented identity " +
+			"(JWT bearer token or TLS client certificate); no role is required.",
+	}, c.handleMCPListRoles)
+}
+
+func (c *Core) handleMCPListRoles(ctx context.Context, _ *mcp.CallToolRequest, _ listRolesInput) (*mcp.CallToolResult, listRolesOutput, error) {
+	if c.systemBackend == nil {
+		return nil, listRolesOutput{}, fmt.Errorf("system backend not initialized")
+	}
+	httpReq := mcpRequestFromContext(ctx)
+	if httpReq == nil {
+		return nil, listRolesOutput{}, fmt.Errorf("internal: request context missing")
+	}
+
+	lreq := &logical.Request{
+		HTTPRequest: httpReq,
+		ClientIP:    httpReq.RemoteAddr,
+	}
+
+	// FieldData is ignored by the aggregator, so pass nil.
+	resp, err := c.systemBackend.handleIntrospectRoles(ctx, lreq, nil)
+	if err != nil {
+		return nil, listRolesOutput{}, err
+	}
+	// A no-credential call comes back as a 401 with Err set (mirrors the
+	// endpoint). Surface it as an MCP tool error so the model can see it.
+	if resp != nil && resp.Err != nil {
+		return nil, listRolesOutput{}, resp.Err
+	}
+
+	out := listRolesOutput{Roles: []mcpRole{}, Warnings: []string{}}
+	if resp != nil && resp.Data != nil {
+		if raw, ok := resp.Data["roles"].([]aggregatedRole); ok {
+			out.Roles = make([]mcpRole, len(raw))
+			for i, r := range raw {
+				out.Roles[i] = mcpRole{Name: r.Name, Description: r.Description}
+			}
+		}
+		if w, ok := resp.Data["warnings"].([]string); ok {
+			out.Warnings = w
+		}
+	}
+
+	return nil, out, nil
+}

--- a/core/sys_mcp_test.go
+++ b/core/sys_mcp_test.go
@@ -1,0 +1,236 @@
+package core
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// mcpBearerRoundTripper injects an Authorization: Bearer header on every
+// outbound request, letting the SDK client present a JWT identity to the
+// discovery endpoint.
+type mcpBearerRoundTripper struct {
+	base   http.RoundTripper
+	bearer string
+}
+
+func (rt mcpBearerRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if rt.bearer != "" {
+		r.Header.Set("Authorization", "Bearer "+rt.bearer)
+	}
+	return rt.base.RoundTrip(r)
+}
+
+// startMCPTestServer serves the MCP discovery handler over HTTP. When cert is
+// non-nil, each request is wrapped with a forwarded client certificate in its
+// context, simulating the listener's certForwardingMiddleware so the X.509
+// credential path can be exercised end-to-end (the SDK does not surface the
+// client cert to tool handlers, so the handler must recover it from the
+// threaded request context).
+func startMCPTestServer(t *testing.T, c *Core, cert *x509.Certificate) *httptest.Server {
+	t.Helper()
+	handler := c.MCPServerHandler()
+	if cert != nil {
+		inner := handler
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := listener.WithForwardedClientCert(r.Context(), cert)
+			inner.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// connectMCP dials the discovery endpoint with an optional bearer token and
+// returns a connected client session.
+func connectMCP(t *testing.T, srv *httptest.Server, bearer string) *mcp.ClientSession {
+	t.Helper()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-agent", Version: "1.0.0"}, nil)
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:             srv.URL + "/v1/sys/mcp",
+		HTTPClient:           &http.Client{Transport: mcpBearerRoundTripper{base: http.DefaultTransport, bearer: bearer}},
+		DisableStandaloneSSE: true,
+	}
+	session, err := client.Connect(context.Background(), transport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// decodeListRoles asserts a successful list_roles result and returns the
+// structured output.
+func decodeListRoles(t *testing.T, res *mcp.CallToolResult) listRolesOutput {
+	t.Helper()
+	require.False(t, res.IsError, "unexpected tool error: %v", res.Content)
+	raw, err := json.Marshal(res.StructuredContent)
+	require.NoError(t, err)
+	var out listRolesOutput
+	require.NoError(t, json.Unmarshal(raw, &out))
+	return out
+}
+
+// TestMCPServer_ListRoles_JWTFanOut drives the full transport with a Bearer
+// JWT: the handshake negotiates the latest protocol revision, tools/list
+// advertises list_roles, and the tool result matches what the introspection
+// aggregator returns for a JWT identity.
+func TestMCPServer_ListRoles_JWTFanOut(t *testing.T) {
+	_, ctx, c := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	c.authMethods["jwt"] = ctrl.factory()
+	require.NoError(t, c.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "jwt-a/"}))
+	require.NoError(t, c.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "jwt", Path: "jwt-b/"}))
+	ctrl.rolesByMount["auth/jwt-a/"] = []map[string]any{
+		{"name": "reader", "description": "search & read any repo (provider: mcp-github/)"},
+	}
+	ctrl.rolesByMount["auth/jwt-b/"] = []map[string]any{
+		{"name": "writer", "description": "write staging"},
+	}
+
+	srv := startMCPTestServer(t, c, nil)
+	session := connectMCP(t, srv, "eyJ.any.token")
+
+	// The SDK client requests the latest revision and uses the SEP-2575
+	// server/discover RPC; the negotiated version is the end-of-July RC.
+	require.NotNil(t, session.InitializeResult())
+	assert.Equal(t, "2026-07-28", session.InitializeResult().ProtocolVersion)
+
+	// tools/list advertises list_roles.
+	tools, err := session.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	var names []string
+	for _, tl := range tools.Tools {
+		names = append(names, tl.Name)
+	}
+	assert.Contains(t, names, "list_roles")
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_roles"})
+	require.NoError(t, err)
+	out := decodeListRoles(t, res)
+
+	// Sorted by auth_path then name: jwt-a/reader, jwt-b/writer. auth_path is
+	// dropped from the projection — only {name, description} survive.
+	require.Len(t, out.Roles, 2)
+	assert.Equal(t, "reader", out.Roles[0].Name)
+	assert.Equal(t, "search & read any repo (provider: mcp-github/)", out.Roles[0].Description)
+	assert.Equal(t, "writer", out.Roles[1].Name)
+	assert.Empty(t, out.Warnings)
+}
+
+// TestMCPServer_ListRoles_CertPath exercises the X.509 credential path: no
+// Authorization header is sent, only a forwarded client certificate. This
+// proves the capturing middleware threads the cert (which the SDK does not
+// surface to tool handlers) through to detectIntrospectCredentialFormat.
+func TestMCPServer_ListRoles_CertPath(t *testing.T) {
+	_, ctx, c := setupTestSystemBackend(t)
+	ctrl := newIntrospectMock()
+
+	c.authMethods["cert"] = ctrl.factory()
+	require.NoError(t, c.mount(ctx, &MountEntry{Class: mountClassAuth, Type: "cert", Path: "cert-mount/"}))
+	ctrl.rolesByMount["auth/cert-mount/"] = []map[string]any{
+		{"name": "cert-role", "description": "clone via Git (provider: github/)"},
+	}
+
+	cert := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "agent"}}
+	srv := startMCPTestServer(t, c, cert)
+	session := connectMCP(t, srv, "") // identity is the cert, not a bearer token
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_roles"})
+	require.NoError(t, err)
+	out := decodeListRoles(t, res)
+
+	require.Len(t, out.Roles, 1)
+	assert.Equal(t, "cert-role", out.Roles[0].Name)
+}
+
+// TestMCPServer_ListRoles_NoCredential asserts that a call with neither a
+// bearer token nor a client cert returns an MCP tool error (mirroring the
+// endpoint's 401) rather than a protocol-level failure, so the model can see
+// the error and self-correct.
+func TestMCPServer_ListRoles_NoCredential(t *testing.T) {
+	_, _, c := setupTestSystemBackend(t)
+	srv := startMCPTestServer(t, c, nil)
+	session := connectMCP(t, srv, "")
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_roles"})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "no-credential call must be a tool error")
+	require.NotEmpty(t, res.Content)
+	txt, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, txt.Text, "JWT bearer token or TLS client certificate")
+}
+
+// TestMCPServer_SealedNode_Returns503 pins that the discovery route rejects
+// cleanly on a sealed node instead of nil-panicking. This route bypasses
+// HandleRequest's seal guard, and seal nils c.namespaceStore, so the handler
+// must short-circuit on c.Sealed() before touching it.
+func TestMCPServer_SealedNode_Returns503(t *testing.T) {
+	_, _, c := setupTestSystemBackend(t)
+
+	// Simulate seal: flip the sealed flag and drop the namespace store, exactly
+	// as teardownNamespaceStore does. The handler must not dereference it.
+	atomic.StoreUint32(c.sealed, 1)
+	c.namespaceStore = nil
+
+	srv := startMCPTestServer(t, c, nil)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/sys/mcp", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestMCPServer_ProtocolNegotiation_FallsBackForOlderClients drives the legacy
+// initialize handshake directly with older protocol revisions and asserts the
+// server negotiates each requested (supported) version rather than forcing the
+// latest. The SEP-2575 discover path for the latest revision is covered by
+// TestMCPServer_ListRoles_JWTFanOut's InitializeResult assertion.
+func TestMCPServer_ProtocolNegotiation_FallsBackForOlderClients(t *testing.T) {
+	_, _, c := setupTestSystemBackend(t)
+	srv := startMCPTestServer(t, c, nil)
+
+	negotiate := func(t *testing.T, requested string) string {
+		t.Helper()
+		body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":%q,"capabilities":{},"clientInfo":{"name":"c","version":"1"}}}`, requested)
+		req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/sys/mcp", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		raw, _ := io.ReadAll(resp.Body)
+		var parsed struct {
+			Result struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			} `json:"result"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &parsed), "body: %s", raw)
+		return parsed.Result.ProtocolVersion
+	}
+
+	assert.Equal(t, "2025-11-25", negotiate(t, "2025-11-25"))
+	assert.Equal(t, "2025-06-18", negotiate(t, "2025-06-18"))
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/pointerstructure v1.2.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.2 // TODO: bump to stable v1.7.0 once cut (~end of July 2026); transport is identical, one-line change.
 	github.com/oklog/ulid v1.3.1
 	github.com/openbao/go-kms-wrapping/v2 v2.8.0
 	github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.3.0
@@ -91,6 +92,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
@@ -126,7 +128,10 @@ require (
 	github.com/ovh/kmip-go v0.3.3 // indirect
 	github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -363,6 +365,8 @@ github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
 github.com/moby/sys/user v0.4.0/go.mod h1:bG+tYYYJgaMtRKgEmuueC0hJEAZWwtIbZTB+85uoHjs=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
+github.com/modelcontextprotocol/go-sdk v1.7.0-pre.2 h1:3JwUps1pdSpXYndBMGO9SMca6CSkP9AKnOaKAkSSGHc=
+github.com/modelcontextprotocol/go-sdk v1.7.0-pre.2/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -459,6 +463,10 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
 github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -497,6 +505,8 @@ github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaO
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
 github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=

--- a/http/handler.go
+++ b/http/handler.go
@@ -72,6 +72,12 @@ func Handler(props *HandlerProperties) http.Handler {
 	// System init endpoint - handles initialization before system is ready
 	mux.Handle("/v1/sys/init", handleSysInit(core, log))
 
+	// MCP discovery interface — Warden answering MCP for its own
+	// capabilities (list_roles, get_skill). Registered before the /v1/sys/
+	// catch-all. Not in standbyAllowedPaths: it reads live mount/skill/
+	// introspection state, so standby nodes forward it to the active node.
+	mux.Handle("/v1/sys/mcp", handleSysMCP(core, log))
+
 	// System backend endpoints - catch-all for /v1/sys/
 	// Handles providers, auth, namespaces, credentials, etc.
 	mux.Handle("/v1/sys/", handleLogical(core, log, forwarder))

--- a/http/sys_mcp.go
+++ b/http/sys_mcp.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/stephnangue/warden/core"
+	"github.com/stephnangue/warden/logger"
+)
+
+// handleSysMCP returns the HTTP handler for the /v1/sys/mcp discovery
+// interface — Warden answering MCP for its own capabilities (list_roles,
+// get_skill).
+//
+// The MCP server, its tools, and the identity/namespace middleware are built
+// in the core package because they reuse core-internal machinery (the
+// introspection aggregator, the skill store, the namespace store) that is not
+// exported. This wrapper keeps registration consistent with the other
+// handleXXX(core, log, …) endpoints and builds the handler once, at
+// registration time.
+func handleSysMCP(c *core.Core, log *logger.GatedLogger) http.Handler {
+	log.Debug("registering MCP discovery interface at /v1/sys/mcp")
+	return c.MCPServerHandler()
+}

--- a/http/sys_mcp_test.go
+++ b/http/sys_mcp_test.go
@@ -1,0 +1,13 @@
+package http
+
+import "testing"
+
+// TestSysMCP_NotStandbyAllowed pins that the MCP discovery route is NOT served
+// directly on standby nodes. It reads live mount/skill/introspection state, so
+// standby nodes must forward it to the active node. If someone adds it to
+// standbyAllowedPaths, standby callers would get stale or empty results.
+func TestSysMCP_NotStandbyAllowed(t *testing.T) {
+	if standbyAllowedPaths["/v1/sys/mcp"] {
+		t.Fatal("/v1/sys/mcp must not be in standbyAllowedPaths: it reads live state and must forward to the active node")
+	}
+}


### PR DESCRIPTION
## What

Adds an always-on MCP discovery endpoint at `/v1/sys/mcp` — Warden answering MCP for its *own* capabilities so an agent can discover what it may do before selecting a role and driving a gateway. This PR delivers the transport plus the first tool, `list_roles`.

- Wires the official MCP Go SDK (`v1.7.0-pre.2`) as a **stateless Streamable-HTTP** server (each POST self-contained — no `Mcp-Session-Id` affinity, so standby nodes forward cleanly). First external MCP lib in the repo; a TODO marks the bump to stable v1.7.0.
- Authorizes on the **presented identity** (JWT bearer or forwarded TLS client cert) — no role token, exactly like `sys/introspect/roles`.
- A thin middleware rejects sealed nodes (`c.Sealed()` → 503, since the route bypasses `HandleRequest`'s seal guard), resolves the namespace from `X-Warden-Namespace`, and threads the raw request into the tool-handler context (the SDK doesn't surface the client cert to handlers).
- `list_roles` reuses the `sys/introspect/roles` aggregator in full and projects each role to `{name, description}`.
- Registered before the `/v1/sys/` catch-all; **not** in `standbyAllowedPaths` (reads live state → standby forwards to active).

## Test plan

- `go build ./...`
- `go test ./core/ ./http/` — new `core/sys_mcp_test.go` (protocol negotiation to `2026-07-28` via SEP-2575 discover + older-client fallback; Bearer-JWT and TLS-cert paths; no-credential tool error; sealed-node 503) and `http/sys_mcp_test.go` (standby-forwarding regression guard).

## Stack

First of 7 stacked PRs (discovery interface, then MCP-only migration). Merge bottom-up; #2 (`feat/mcp-sys-get-skill`) targets this once merged.