### PR TITLE
docs(mcp): document the discovery interface; add e2e discovery test

### DIFF
--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -188,6 +188,33 @@ on **both** allow and deny, so the audit trail shows not just what was blocked
 but every tool call that was permitted — a complete record of an agent's activity
 through the server.
 
+## Warden as an MCP Server (Discovery Interface)
+
+Everything above is about Warden **fronting** an upstream MCP server. Warden also
+answers MCP for **its own** capabilities, so an agent can discover what it is
+allowed to do *before* it picks a role and touches a gateway. This discovery
+interface lives at a dedicated, always-on endpoint — `/v1/sys/mcp` — and needs no
+role: it authorizes on the identity the agent presents (a bearer JWT or an mTLS
+client certificate), exactly like the rest of Warden's introspection. A caller in
+a sub-namespace selects it with the usual `X-Warden-Namespace` header.
+
+It exposes two tools:
+
+- **`list_roles`** — the roles the caller's identity can assume, each with its
+  operator-written **description**. This is the agent's menu (see
+  [Roles → Discovery](roles.md#discovery-what-roles-can-i-assume)). By convention
+  the operator embeds the **skill name** in the description — e.g.
+  *"search & read any repo (skill: github)"* — and the agent reads it verbatim.
+- **`get_skill`** — given a **skill name** (the one just read out of a role
+  description), returns that **skill**: the markdown recipe that teaches the agent
+  how to drive the provider through the gateway.
+
+The loop, then, is: connect to `/v1/sys/mcp` → `list_roles` to see the menu → read
+a role's skill name from its description → `get_skill` to learn how to drive it →
+switch to the role-scoped gateway to do the work. The discovery interface is the
+MCP-native form of `warden role list` + `warden skill read`; it only *tells* the
+agent what it can do — the work still flows through the gateways described above.
+
 ## Using an MCP Mount
 
 An agent points its MCP client at the mount's gateway URL and presents its
@@ -222,3 +249,4 @@ skill that documents its quirks.
 - [Credentials](credentials.md) — the bearer token or AWS credential injected.
 - [Audit](audit.md) — where each MCP decision is recorded.
 - [Discovery and Skills](discovery-and-skills.md) — how an agent finds an MCP mount.
+- [Roles](roles.md) — the discovery loop `list_roles`/`get_skill` mirrors, one role per step.

--- a/docs/concepts/roles.md
+++ b/docs/concepts/roles.md
@@ -54,6 +54,13 @@ The agent doesn't need to know the role names in advance. It asks Warden which
 roles its identity can assume and reads each role's **description** to choose the
 right one for a step — the same introspection you get from `warden role list`.
 
+An agent speaking MCP gets this natively: Warden runs its own MCP discovery
+interface whose `list_roles` and `get_skill` tools are the MCP form of
+`warden role list` + `warden skill read` — the agent lists its roles, reads a
+skill name out of a description, and fetches that skill, all over MCP before it
+drives a gateway. See
+[MCP → Warden as an MCP Server](mcp.md#warden-as-an-mcp-server-discovery-interface).
+
 <p align="center"><img alt="The agent lists its available roles and Warden returns each with its description" src="../images/warden-role-role-list.png" width="520"></p>
 
 ### Planning: one role per step

--- a/e2e/discovery/discovery_test.go
+++ b/e2e/discovery/discovery_test.go
@@ -1,0 +1,213 @@
+//go:build e2e
+
+// Package discovery exercises Warden's own MCP server — the discovery
+// interface at /v1/sys/mcp (list_roles + get_skill) — end to end against the
+// live cluster, following the roles.md scenario: an agent connects, lists the
+// roles its identity can assume, reads a skill name out of a role description,
+// and fetches that skill — the recipe that teaches it how to drive the
+// provider through the gateway.
+package discovery
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// jwtRoundTripper presents the agent's JWT on every request and trusts the
+// self-signed e2e cert.
+type jwtRoundTripper struct {
+	base http.RoundTripper
+	jwt  string
+}
+
+func (rt jwtRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", "Bearer "+rt.jwt)
+	return rt.base.RoundTrip(r)
+}
+
+// connectDiscovery dials the leader's /v1/sys/mcp with the default JWT and
+// returns a connected MCP client session.
+func connectDiscovery(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	port := h.GetLeaderPort(t)
+	jwt := h.GetDefaultJWT(t)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "e2e-agent", Version: "1.0.0"}, nil)
+	transport := &mcp.StreamableClientTransport{
+		Endpoint: h.NodeURL(port) + "/v1/sys/mcp",
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: jwtRoundTripper{
+				base: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed e2e cert
+				},
+				jwt: jwt,
+			},
+		},
+		DisableStandaloneSSE: true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect to /v1/sys/mcp: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// decodeStructured re-decodes a tool result's structured content into dst.
+func decodeStructured(t *testing.T, res *mcp.CallToolResult, dst any) {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("tool returned an error: %v", res.Content)
+	}
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	if err := json.Unmarshal(raw, dst); err != nil {
+		t.Fatalf("unmarshal structured content: %v\n%s", err, raw)
+	}
+}
+
+type rolesResult struct {
+	Roles []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"roles"`
+	Warnings []string `json:"warnings"`
+}
+
+// TestMCPDiscovery_ToolsAndListRoles connects to the discovery endpoint,
+// verifies both tools are advertised, and that list_roles returns the roles
+// the default JWT identity can assume.
+func TestMCPDiscovery_ToolsAndListRoles(t *testing.T) {
+	session := connectDiscovery(t)
+	ctx := context.Background()
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	got := map[string]bool{}
+	for _, tl := range tools.Tools {
+		got[tl.Name] = true
+	}
+	for _, want := range []string{"list_roles", "get_skill"} {
+		if !got[want] {
+			t.Errorf("tools/list missing %q; got %v", want, got)
+		}
+	}
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_roles"})
+	if err != nil {
+		t.Fatalf("call list_roles: %v", err)
+	}
+	var roles rolesResult
+	decodeStructured(t, res, &roles)
+	if len(roles.Roles) == 0 {
+		t.Fatalf("expected at least one role for the default JWT; got none")
+	}
+	// The projection drops auth_path — each entry is {name, description}.
+	for _, r := range roles.Roles {
+		if r.Name == "" {
+			t.Errorf("role with empty name: %#v", r)
+		}
+	}
+}
+
+// TestMCPDiscovery_GetSkillByName fetches a skill by name. The e2e cluster
+// mounts the vault provider, which seeds the "vault" skill.
+func TestMCPDiscovery_GetSkillByName(t *testing.T) {
+	session := connectDiscovery(t)
+	ctx := context.Background()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "get_skill",
+		Arguments: map[string]any{"skill": "vault"},
+	})
+	if err != nil {
+		t.Fatalf("get_skill by name: %v", err)
+	}
+	var skill map[string]any
+	decodeStructured(t, res, &skill)
+	if skill["name"] != "vault" {
+		t.Fatalf("skill vault resolved to %v, want vault", skill["name"])
+	}
+	if bodyStr, _ := skill["body"].(string); bodyStr == "" {
+		t.Errorf("resolved skill has an empty body")
+	}
+}
+
+// skillNameRe extracts the skill name an operator embeds in a role
+// description, e.g. "read secrets (skill: vault)".
+var skillNameRe = regexp.MustCompile(`skill:\s*([A-Za-z0-9._-]+)`)
+
+// TestMCPDiscovery_FullLoop walks the roles.md discovery loop: create a role
+// whose description embeds a skill name, list roles, parse the name out of the
+// description, then fetch that skill.
+func TestMCPDiscovery_FullLoop(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	const roleName = "e2e-mcp-discovery"
+	body := `{"token_policies":["vault-gateway-access"],"cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":300,"description":"read app secrets through Vault (skill: vault)"}`
+	status, respBody := h.APIRequest(t, "POST", "auth/jwt/role/"+roleName, port, body)
+	if status != 200 && status != 201 && status != 204 {
+		t.Fatalf("create role failed: status %d, body %s", status, string(respBody))
+	}
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+roleName, port, "")
+	})
+
+	session := connectDiscovery(t)
+	ctx := context.Background()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_roles"})
+	if err != nil {
+		t.Fatalf("call list_roles: %v", err)
+	}
+	var roles rolesResult
+	decodeStructured(t, res, &roles)
+
+	var skillName string
+	for _, r := range roles.Roles {
+		if r.Name != roleName {
+			continue
+		}
+		m := skillNameRe.FindStringSubmatch(r.Description)
+		if m == nil {
+			t.Fatalf("role %q description %q had no parseable skill name", roleName, r.Description)
+		}
+		skillName = m[1]
+	}
+	if skillName == "" {
+		t.Fatalf("role %q not found in list_roles output", roleName)
+	}
+
+	skillRes, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "get_skill",
+		Arguments: map[string]any{"skill": skillName},
+	})
+	if err != nil {
+		t.Fatalf("get_skill{skill: %q}: %v", skillName, err)
+	}
+	var skill map[string]any
+	decodeStructured(t, skillRes, &skill)
+	if skill["name"] != "vault" {
+		t.Fatalf("parsed skill name %q resolved to skill %v, want vault", skillName, skill["name"])
+	}
+	if bodyStr, _ := skill["body"].(string); bodyStr == "" {
+		t.Errorf("resolved skill has an empty body")
+	}
+}


### PR DESCRIPTION
## What

Documents the MCP discovery interface and adds an end-to-end test for it (stacked on #388, #389).

- `docs/concepts/mcp.md` — a "Warden as an MCP Server (Discovery Interface)" section: the `/v1/sys/mcp` endpoint and the `list_roles` / `get_skill` tools.
- `docs/concepts/roles.md` — cross-link from the Discovery section (the MCP-native form of `warden role list` + `warden skill read`).
- `e2e/discovery/discovery_test.go` — drives the real `/v1/sys/mcp` over the SDK MCP client against the live cluster: `tools/list`, `list_roles`, `get_skill` by name, and the full roles.md loop (create a role whose description embeds a skill name → list → parse → fetch).

## Test plan

- `go vet -tags e2e ./e2e/discovery/` (compiles under the e2e build tag).
- `make test-e2e` runs it against the 3-node cluster (verified locally earlier in development: all three discovery tests pass).

## Stack

#3 of 7. Stacked on #389 (merged). #4 (`feat/retire-cli-discovery-skills`) targets `main` once this merges.
