### PR TITLE
feat(skills): retune provider skills for MCP-only discovery

### DIFF
--- a/provider/ansible_tower/skill.md
+++ b/provider/ansible_tower/skill.md
@@ -3,7 +3,7 @@ name: ansible_tower
 description: "Call the Ansible Tower / AWX / AAP REST API through Warden — launch job templates, read inventories, check job status — without holding a PAT."
 category: provider-guide
 provider: ansible_tower
-requires: [foundation, discovery]
+requires: []
 upstream: Ansible Tower / AWX / AAP REST API (api/v2)
 ---
 
@@ -19,17 +19,23 @@ it as `Authorization: Bearer <pat>`, and forwards to Tower. The agent
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/ansible_tower/`,
-  `/v1/team-ops/tower-prod/`). Warden has already baked the namespace
-  + mount path in.
-- `<role>` is the role you picked from `warden role list` to perform
-  this task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/api/v2/<endpoint>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url>api/v2/<endpoint>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 Tower's API path (`/api/v2/…`) is part of the upstream URL — Warden
@@ -38,30 +44,31 @@ does not strip or prepend it. Write the upstream path verbatim after
 
 ## Examples
 
-(All examples assume `mount_url = /v1/ansible_tower/` and role
-`ansible-ops`; substitute yours.)
+(Examples use a concrete `<gateway-url>` of
+`/v1/ansible_tower/role/ansible-ops/gateway/`; substitute the one from your
+role's `list_roles` description.)
 
 Ping (health check):
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/ping/
 ```
 
 Current user (verifies the injected PAT is valid):
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/me/
 ```
 
 List job templates:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/job_templates/
 ```
 
 Launch a job template with extra_vars (replace `42` with the template id):
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"extra_vars":{"target_host":"web01","deploy_version":"1.2.3"}}' \
   $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/job_templates/42/launch/
@@ -69,13 +76,13 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 Check job status (`<id>` comes from the launch response's `job` field):
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/jobs/<id>/
 ```
 
 List inventories:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/ansible_tower/role/ansible-ops/gateway/api/v2/inventories/
 ```
 

--- a/provider/atlassian/skill.md
+++ b/provider/atlassian/skill.md
@@ -3,7 +3,7 @@ name: atlassian
 description: "Call Jira, Confluence, or Bitbucket REST APIs through Warden — search and create issues, read and write pages, list repos — without holding an API token, PAT, or app password."
 category: provider-guide
 provider: atlassian
-requires: [foundation, discovery]
+requires: []
 upstream: Atlassian Jira / Confluence / Bitbucket REST APIs
 ---
 
@@ -20,24 +20,30 @@ The agent **never holds an API token, PAT, or app password**.
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/jira/`, `/v1/confluence/`,
-  `/v1/bitbucket/`). Warden has already baked the namespace +
-  mount path in.
-- `<role>` is the role you picked from `warden role list` to perform
-  this task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<api-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><api-path>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 **One `atlassian` mount = one product.** A single Atlassian provider
 type fronts every Atlassian REST API; the operator picks which —
 Jira, Confluence, or Bitbucket — at mount time and signals the
-choice via the mount's **description**. Read the description you
-already pulled in discovery Step 4 (e.g. "Engineering Jira Cloud",
+choice via the mount's **description**. Read the role's `list_roles`
+description (e.g. "Engineering Jira Cloud",
 "Docs Confluence space", "Platform Bitbucket"), match it to the
 product, then use the path shapes for that product below:
 
@@ -57,19 +63,21 @@ strip or prepend it. Write the path verbatim after `/gateway/`.
 
 ## Examples
 
-(All examples assume `mount-url = /v1/jira/` and role `atlassian-ops`
-for Jira, `/v1/confluence/` for Confluence, `/v1/bitbucket/` for
-Bitbucket; substitute yours.)
+(Examples use a concrete `<gateway-url>` of
+`/v1/jira/role/atlassian-ops/gateway/` for Jira,
+`/v1/confluence/role/atlassian-ops/gateway/` for Confluence,
+`/v1/bitbucket/role/atlassian-ops/gateway/` for Bitbucket; substitute the one
+from your role's `list_roles` description.)
 
 Current user (verifies the injected credential is valid):
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/jira/role/atlassian-ops/gateway/myself
 ```
 
 Search issues with JQL (use POST to skip URL-encoding):
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"jql":"project = ENG AND status = Open","fields":["summary","status"]}' \
   $WARDEN_ADDR/v1/jira/role/atlassian-ops/gateway/search/jql
@@ -77,7 +85,7 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 Create a Jira issue (note the ADF `description` — see Quirks):
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{
     "fields": {
@@ -95,13 +103,13 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 List Confluence spaces:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/confluence/role/atlassian-ops/gateway/spaces
 ```
 
 Create a Confluence page (requires numeric `spaceId` — see Quirks):
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{
     "spaceId": "123456",
@@ -114,7 +122,7 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 List Bitbucket repositories in a workspace:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/bitbucket/role/atlassian-ops/gateway/repositories/my-workspace
 ```
 

--- a/provider/aws/skill.md
+++ b/provider/aws/skill.md
@@ -3,7 +3,7 @@ name: aws
 description: "Call AWS services (S3, EC2, Lambda, DynamoDB, STS, …) through Warden's SigV4 gateway."
 category: provider-guide
 provider: aws
-requires: [foundation, discovery]
+requires: []
 upstream: AWS
 ---
 
@@ -18,27 +18,34 @@ AWS service. **No SDK code changes** — only env vars.
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role-name>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/aws/`, `/v1/team-data/aws-prod/`).
-  Warden has already baked the namespace + mount path in — just append
-  the per-provider suffix (`gateway` for AWS).
-- `<role-name>` is the role you picked from `warden role list` to perform
-  this task.
+Two values are per-task:
+- `<role>` is the role you chose for this task. AWS is unusual: the
+  role travels in `AWS_ACCESS_KEY_ID` (Warden reads it out of the SigV4
+  Authorization header to pick the credential spec), **not** in the URL.
+- `<gateway-url>` is the gateway URL for that role, embedded in the
+  role's `description` returned by the `list_roles` MCP tool. It is a
+  **relative** path — for AWS, mount-level: `/v1/<namespace>/<mount>/gateway`
+  (e.g. `/v1/aws/gateway`, `/v1/team-data/aws-prod/gateway`). Prepend
+  `$WARDEN_ADDR`.
 
-The JWT comes in via `$WARDEN_TOKEN` — see `foundation`. Just use it:
+Present your identity as the JWT placed in the SigV4 secret slots
+(below); Warden verifies the signature against it. A stale JWT surfaces
+as `SignatureDoesNotMatch` (typical JWT TTL 5–60 min) — refresh the JWT
+and retry.
 
 ```bash
-export AWS_ACCESS_KEY_ID="<role-name>"          # role from `warden role list`
-export AWS_SECRET_ACCESS_KEY="$WARDEN_TOKEN"
-export AWS_SESSION_TOKEN="$WARDEN_TOKEN"        # Warden detects "eyJ" prefix
-export AWS_ENDPOINT_URL="$WARDEN_ADDR<mount-url>gateway"
+export AWS_ACCESS_KEY_ID="<role>"               # Warden role name, not an AWS key
+export AWS_SECRET_ACCESS_KEY="<jwt>"
+export AWS_SESSION_TOKEN="<jwt>"                # Warden detects "eyJ" prefix
+export AWS_ENDPOINT_URL="$WARDEN_ADDR<gateway-url>"
 ```
 
 The role-selection idiom is non-obvious: **`AWS_ACCESS_KEY_ID` carries
 the Warden role name** (not an AWS access key). Warden reads it from
 the SigV4 Authorization header to decide which credential spec to
-use.
+use. To act as a different role, set `AWS_ACCESS_KEY_ID` to that role's
+name. If Warden can't resolve a role from the key, it falls back to the
+mount's `default_role`, when the operator has configured one.
 
 ## Examples
 

--- a/provider/github/skill.md
+++ b/provider/github/skill.md
@@ -3,7 +3,7 @@ name: github
 description: "Call the GitHub REST API or clone/push Git repos through Warden — without holding a GitHub PAT. Covers REST (read repos, manage issues, push releases) and Git smart-HTTP (clone, fetch, push)."
 category: provider-guide
 provider: github
-requires: [foundation, discovery]
+requires: []
 upstream: GitHub REST API (api.github.com or GHE) and Git smart-HTTP (github.com or GHE)
 ---
 
@@ -19,48 +19,55 @@ The agent **never holds a PAT**.
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/github/`, `/v1/team-data/github-enterprise/`).
-  Warden has already baked the namespace + mount path in.
-- `<role>` is the role you picked from `warden role list` to perform this
-  task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<github-api-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><github-api-path>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 For `curl` or any HTTP client: rewrite the GitHub host to
-`$WARDEN_ADDR<mount-url>role/<role>/gateway` and add the bearer token.
+`$WARDEN_ADDR<gateway-url>` and add the bearer token.
 
 ## Examples
 
-(All examples assume `mount_url = /v1/github/` and role `repo-reader`;
-substitute yours.)
+(Examples use a concrete `<gateway-url>` of `/v1/github/role/repo-reader/gateway/`;
+substitute the one from your role's `list_roles` description.)
 
 List your authenticated user's repos:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/github/role/repo-reader/gateway/user/repos
 ```
 
 Read a specific repo's issues:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/github/role/repo-reader/gateway/repos/myorg/myrepo/issues
 ```
 
 Open an issue (operator must grant a write-capable role):
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Accept: application/vnd.github+json" \
   -d '{"title":"Bug","body":"..."}' \
   $WARDEN_ADDR/v1/github/role/issue-writer/gateway/repos/myorg/myrepo/issues
 ```
 
 For the Octokit JS / PyGithub clients: configure the `baseUrl` /
-`base_url` to `$WARDEN_ADDR<mount-url>role/<role>/gateway`
+`base_url` to `$WARDEN_ADDR<gateway-url>`
 and supply your JWT as the auth token.
 
 ## Quirks
@@ -72,8 +79,8 @@ and supply your JWT as the auth token.
   request supplies its own. Override by setting the header in your
   call.
 - **GHE (GitHub Enterprise Server) deployments** point Warden at the
-  GHE host instead of `api.github.com`; check
-  `warden read github/config` to confirm which.
+  GHE host instead of `api.github.com`; ask the operator which host the
+  mount fronts.
 - **Rate limits propagate from GitHub**. Warden does not retry; back
   off when you see `403 rate limit exceeded` headers.
 
@@ -86,21 +93,20 @@ dispatches per-request based on path shape — `.git/info/refs`,
 `.git/git-upload-pack`, and `.git/git-receive-pack` route to the Git
 host with HTTP Basic Auth instead of the REST `Authorization: token`.
 
-(All examples below assume `mount_url = /v1/github/`; substitute yours
-from `warden provider list`.)
+(Examples use a concrete `<gateway-url>` of `/v1/github/role/repo-reader/gateway/`;
+substitute the one from your role's `list_roles` description.)
 
 ### Clone
 
 The clone URL carries the Warden role as the Basic Auth username and
-the Warden JWT as the password. Substitute `<role>` and the mount URL:
+the Warden JWT as the password. Substitute `<role>` and the mount path:
 
 Git embeds Basic Auth between scheme and host in the clone URL, so
-split `$WARDEN_ADDR` (the canonical env var from the `foundation`
-skill) — `${WARDEN_ADDR%%://*}` is the scheme, `${WARDEN_ADDR#*://}`
-is the host (and port if present):
+split `$WARDEN_ADDR` — `${WARDEN_ADDR%%://*}` is the scheme,
+`${WARDEN_ADDR#*://}` is the host (and port if present):
 
 ```bash
-git clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/v1/github/gateway/<owner>/<repo>.git"
+git clone "${WARDEN_ADDR%%://*}://<role>:<jwt>@${WARDEN_ADDR#*://}/v1/github/gateway/<owner>/<repo>.git"
 ```
 
 Git's credential helpers cache on URL+username, so each role gets a
@@ -116,21 +122,16 @@ git config --global credential.helper "cache --timeout=900"
 ### Header-routed alternative
 
 If you prefer a clone URL that looks like a real Git URL, pass the
-mount path as `X-Warden-Provider` and the namespace as
-`X-Warden-Namespace` via `http.extraheader` instead. `path` comes
-from `warden provider list`; `$WARDEN_NAMESPACE` is in your
-environment:
+mount and namespace as headers via `http.extraheader` instead. Both come
+straight out of `<gateway-url>` (`/v1/<namespace>/<mount>/role/<role>/gateway/`):
+`X-Warden-Provider` is the `<mount>` segment and `X-Warden-Namespace` is
+the `<namespace>` segment.
 
 ```bash
-path=$(warden provider list -o json | jq -r '.[] | select(.type=="github") | .path' | head -1)
-git -c http.extraheader="X-Warden-Provider: $path" \
-    -c http.extraheader="X-Warden-Namespace: $WARDEN_NAMESPACE" \
-    clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/<owner>/<repo>.git"
+git -c http.extraheader="X-Warden-Provider: <mount>" \
+    -c http.extraheader="X-Warden-Namespace: <namespace>" \
+    clone "${WARDEN_ADDR%%://*}://<role>:<jwt>@${WARDEN_ADDR#*://}/<owner>/<repo>.git"
 ```
-
-When more than one `github` mount exists, replace `head -1` with a
-`select(.description=="...")` matching the upstream you want — `path`
-alone doesn't tell you which GitHub host or org the mount fronts.
 
 `http.extraheader` persists into `.git/config` at clone time, so both
 headers carry through to follow-up operations automatically.

--- a/provider/gitlab/skill.md
+++ b/provider/gitlab/skill.md
@@ -3,7 +3,7 @@ name: gitlab
 description: "Call the GitLab REST API or clone/push Git repos through Warden — without holding a GitLab access token. Covers REST (read projects, manage issues, trigger pipelines) and Git smart-HTTP (clone, fetch, push)."
 category: provider-guide
 provider: gitlab
-requires: [foundation, discovery]
+requires: []
 upstream: GitLab REST API (gitlab.com/api/v4 or self-hosted /api/v4) and Git smart-HTTP (same host)
 ---
 
@@ -19,16 +19,23 @@ access token bound to the chosen role, injects it as
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/gitlab/`, `/v1/team-data/gitlab-self-hosted/`).
-  Warden has already baked the namespace + mount path in.
-- `<role>` is the role you picked from `warden role list` to perform this
-  task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/api/v4/<gitlab-api-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url>api/v4/<gitlab-api-path>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 Unlike GitHub (which proxies REST off the host root), GitLab's REST
@@ -36,42 +43,42 @@ API lives under `/api/v4/`, so the gateway path includes `api/v4/`
 **after** the `gateway/` segment.
 
 For `curl` or any HTTP client: rewrite the GitLab host (including
-`/api/v4`) to `$WARDEN_ADDR<mount-url>role/<role>/gateway/api/v4` and
+`/api/v4`) to `$WARDEN_ADDR<gateway-url>api/v4` and
 add the bearer token.
 
 ## Examples
 
-(All examples assume `mount_url = /v1/gitlab/` and role `repo-reader`;
-substitute yours.)
+(Examples use a concrete `<gateway-url>` of `/v1/gitlab/role/repo-reader/gateway/`;
+substitute the one from your role's `list_roles` description.)
 
 List projects you're a member of:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/gitlab/role/repo-reader/gateway/api/v4/projects?membership=true
 ```
 
 Read a specific project's issues:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   "$WARDEN_ADDR/v1/gitlab/role/repo-reader/gateway/api/v4/projects/<id>/issues"
 ```
 
 Open an issue (operator must grant a write-capable role):
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"title":"Bug","description":"..."}' \
   "$WARDEN_ADDR/v1/gitlab/role/issue-writer/gateway/api/v4/projects/<id>/issues"
 ```
 
 For the python-gitlab client: configure `gitlab.Gitlab(url=...)` with
-`$WARDEN_ADDR<mount-url>role/<role>/gateway` (no `/api/v4` suffix — the
-client appends it) and use `oauth_token=$WARDEN_TOKEN` for auth.
+`$WARDEN_ADDR<gateway-url>` (no `/api/v4` suffix — the
+client appends it) and use `oauth_token=<jwt>` for auth.
 
 ## Quirks
 
 - **The injected header is `Authorization: Bearer <token>`** —
-  Warden swaps your `Authorization: Bearer $WARDEN_TOKEN` (incoming)
+  Warden swaps your `Authorization: Bearer <jwt>` (incoming)
   for the credential token (outgoing). GitLab accepts the same Bearer
   shape for OAuth2 tokens, personal access tokens, and project/group
   access tokens.
@@ -79,8 +86,8 @@ client appends it) and use `oauth_token=$WARDEN_TOKEN` for auth.
   client prefers GitLab's native auth header, send the JWT there
   instead of `Authorization`. Warden strips it before proxying.
 - **Self-hosted instances** point Warden at the instance URL (e.g.
-  `https://gitlab.example.com`); check `warden read gitlab/config` to
-  confirm which. The same `gitlab_address` covers both REST and Git.
+  `https://gitlab.example.com`); ask the operator which host the mount
+  fronts. The same `gitlab_address` covers both REST and Git.
 - **Rate limits propagate from GitLab**. Warden does not retry; back
   off when you see `429 Too Many Requests`.
 
@@ -92,21 +99,20 @@ provider dispatches per-request based on path shape — `.git/info/refs`,
 `.git/git-upload-pack`, and `.git/git-receive-pack` route to GitLab
 with HTTP Basic Auth instead of the REST `Authorization: Bearer`.
 
-(All examples below assume `mount_url = /v1/gitlab/`; substitute yours
-from `warden provider list`.)
+(Examples use a concrete `<gateway-url>` of `/v1/gitlab/role/repo-reader/gateway/`;
+substitute the one from your role's `list_roles` description.)
 
 ### Clone
 
 The clone URL carries the Warden role as the Basic Auth username and
-the Warden JWT as the password. Substitute `<role>` and the mount URL:
+the Warden JWT as the password. Substitute `<role>` and the mount path:
 
 Git embeds Basic Auth between scheme and host in the clone URL, so
-split `$WARDEN_ADDR` (the canonical env var from the `foundation`
-skill) — `${WARDEN_ADDR%%://*}` is the scheme, `${WARDEN_ADDR#*://}`
-is the host (and port if present):
+split `$WARDEN_ADDR` — `${WARDEN_ADDR%%://*}` is the scheme,
+`${WARDEN_ADDR#*://}` is the host (and port if present):
 
 ```bash
-git clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/v1/gitlab/gateway/<group>/<repo>.git"
+git clone "${WARDEN_ADDR%%://*}://<role>:<jwt>@${WARDEN_ADDR#*://}/v1/gitlab/gateway/<group>/<repo>.git"
 ```
 
 Note: Git smart-HTTP paths use `<group>/<repo>.git` directly off the
@@ -126,21 +132,16 @@ git config --global credential.helper "cache --timeout=900"
 ### Header-routed alternative
 
 If you prefer a clone URL that looks like a real Git URL, pass the
-mount path as `X-Warden-Provider` and the namespace as
-`X-Warden-Namespace` via `http.extraheader` instead. `path` comes
-from `warden provider list`; `$WARDEN_NAMESPACE` is in your
-environment:
+mount and namespace as headers via `http.extraheader` instead. Both come
+straight out of `<gateway-url>` (`/v1/<namespace>/<mount>/role/<role>/gateway/`):
+`X-Warden-Provider` is the `<mount>` segment and `X-Warden-Namespace` is
+the `<namespace>` segment.
 
 ```bash
-path=$(warden provider list -o json | jq -r '.[] | select(.type=="gitlab") | .path' | head -1)
-git -c http.extraheader="X-Warden-Provider: $path" \
-    -c http.extraheader="X-Warden-Namespace: $WARDEN_NAMESPACE" \
-    clone "${WARDEN_ADDR%%://*}://<role>:${WARDEN_TOKEN}@${WARDEN_ADDR#*://}/<group>/<repo>.git"
+git -c http.extraheader="X-Warden-Provider: <mount>" \
+    -c http.extraheader="X-Warden-Namespace: <namespace>" \
+    clone "${WARDEN_ADDR%%://*}://<role>:<jwt>@${WARDEN_ADDR#*://}/<group>/<repo>.git"
 ```
-
-When more than one `gitlab` mount exists, replace `head -1` with a
-`select(.description=="...")` matching the upstream you want — `path`
-alone doesn't tell you which GitLab instance the mount fronts.
 
 `http.extraheader` persists into `.git/config` at clone time, so both
 headers carry through to follow-up operations automatically.

--- a/provider/mcp/skill.md
+++ b/provider/mcp/skill.md
@@ -1,9 +1,9 @@
 ---
 name: mcp
-description: "Talk to any bearer-authenticated MCP server through Warden — without holding the OAuth token or API key. Point any MCP client (Claude Code, Cursor, ...) at Warden; tools and JSON/SSE responses pass through unchanged."
+description: "Talk to any bearer-authenticated MCP server through Warden — without holding the OAuth token or API key. Your MCP client points at Warden under a role fixed at attach time (one attached server per role). Tools and JSON/SSE pass through unchanged."
 category: provider-guide
 provider: mcp
-requires: [foundation, discovery]
+requires: []
 upstream: Any bearer-authenticated MCP server (operator-configured; e.g. Cloudflare, Slack, Linear, Sentry, Notion)
 ---
 
@@ -11,158 +11,79 @@ upstream: Any bearer-authenticated MCP server (operator-configured; e.g. Cloudfl
 
 ## What it does
 
-Warden proxies traffic to a bearer-authenticated MCP server. The MCP client
-calls a Warden URL; Warden authenticates the caller (JWT/cert), mints a bearer
-token bound to the chosen role, injects it as `Authorization: Bearer <token>`,
-and streams the response (JSON or SSE) back unchanged. The agent **never holds
-the OAuth token or API key**.
+Warden proxies traffic to a bearer-authenticated MCP server. Your MCP client
+calls Warden **under a role**; Warden authenticates the caller (JWT/cert), mints
+a bearer token bound to that role, injects it as `Authorization: Bearer <token>`,
+and streams the response (JSON or SSE) back unchanged. You **never hold the OAuth
+token or API key**.
 
-## Pick the right mount
+## Your role — one attached server per role
 
-The `mcp` type is generic, so a single mount fronts exactly **one** MCP server —
-Cloudflare, Slack, Linear, or whatever an operator stood up — each at its own
-`mcp_url`. **Identify the mount you want by its operator-set description from
-`warden provider list`, never by reading `mcp_url` or guessing from the provider
-type.** The URL tells you nothing about which product the mount fronts; the
-description does. When several `mcp` mounts exist, the type alone can't tell
-them apart.
+Everything depends on **which role** the call runs under — the role's policy
+decides which tools you can list and call, and which upstream credential Warden
+mints.
 
-## Configure the MCP client
+Your role is the `role/<role>/gateway/` segment of the URL this MCP server was
+attached at. It is **fixed for this server** and you cannot change it at
+runtime: an MCP client sends a fixed set of headers, and the role cannot be
+passed in a tool call. This attached server *is* that role.
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/mcp/`, `/v1/team-tools/cloudflare-mcp/`).
-  Warden has already baked the namespace and mount path in.
-- `<role>` is the role you picked from `warden role list` to perform this
-  task — it goes in the URL path.
+To act under a **different** role, call the MCP server the operator attached for
+*that* role. The operator attaches **one server per role** — each at its own
+`…/role/<role>/gateway/` URL, named or described so you can match it to a role
+from the `list_roles` discovery tool. Pick the attached server whose role fits
+the task.
 
-```
-MCP server URL : $WARDEN_ADDR<mount-url>role/<role>/gateway/
-Auth header    : Authorization: Bearer $WARDEN_TOKEN
-```
+## Attaching the client
 
-For MCP client configuration files, the entry looks like (Claude Code / Cursor
-/ Continue / Cline / Goose all accept this shape):
+The MCP server is attached to your client by the operator or your runtime (for
+Claude Code, `claude mcp add`; Cursor/Continue/Cline/Goose take the same
+HTTP-server shape), with your identity as a header — one attachment per role:
 
 ```json
 {
   "type": "http",
-  "url": "$WARDEN_ADDR<mount-url>role/<role>/gateway/",
-  "headers": {
-    "Authorization": "Bearer $WARDEN_TOKEN"
-  }
+  "url": "$WARDEN_ADDR/v1/<namespace>/<mount>/role/<role>/gateway/",
+  "headers": { "Authorization": "Bearer <jwt>" }
 }
-```
-
-Substitute `$WARDEN_ADDR`, `<mount-url>`, `<role>`, and `$WARDEN_TOKEN` before
-saving — most MCP clients do not expand environment variables inside config
-files.
-
-## Examples
-
-(All examples below assume `mount_url = /v1/mcp/` and role `mcp-user`;
-substitute yours from `warden provider list`.)
-
-List the tools the server exposes:
-```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  $WARDEN_ADDR/v1/mcp/role/mcp-user/gateway/
-```
-
-Call a tool (the bound token's scopes bound what actually succeeds — see
-Quirks):
-```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"<tool>","arguments":{}}}' \
-  $WARDEN_ADDR/v1/mcp/role/mcp-user/gateway/
 ```
 
 The trailing slash on `gateway/` matters — Warden composes the upstream URL as
-the mount's configured upstream URL plus the gateway suffix.
+the mount's configured upstream URL plus the gateway suffix. A `401` means the
+JWT expired (typical TTL 5–60 min) — refresh it in the client config.
 
-## Header-routed alternative
+## Using it
 
-If you prefer an MCP server URL that is just `$WARDEN_ADDR/` (some MCP clients
-dislike long paths, or you want to mux several MCP providers under one base
-URL), pass the mount path as `X-Warden-Provider` and the namespace as
-`X-Warden-Namespace`:
-
-```bash
-path=$(warden provider list -o json | jq -r '.[] | select(.description=="<your-mount-description>") | .path' | head -1)
-
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
-  -H "X-Warden-Provider: $path" \
-  -H "X-Warden-Namespace: $WARDEN_NAMESPACE" \
-  -H "X-Warden-Role: mcp-user" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  $WARDEN_ADDR/
-```
-
-For an MCP client config:
-
-```json
-{
-  "type": "http",
-  "url": "$WARDEN_ADDR/",
-  "headers": {
-    "Authorization": "Bearer $WARDEN_TOKEN",
-    "X-Warden-Provider": "<path-from-warden-provider-list>",
-    "X-Warden-Namespace": "<namespace>",
-    "X-Warden-Role": "<role>"
-  }
-}
-```
-
-Select the mount by `description` rather than `type` — when more than one `mcp`
-mount exists, the type and `path` alone don't tell you which upstream product
-the mount fronts.
+- **`tools/list` is policy-filtered.** It returns only the tools this server's
+  role allows — fewer tools than the raw upstream offers is the policy, not a
+  bug. If the tool you need isn't listed, this role cannot call it; call the
+  attached server for a role whose `list_roles` description fits the task.
+- **Call tools normally.** Warden injects the upstream credential per request.
 
 ## Quirks
 
-- **The injected header is `Authorization: Bearer <token>`.** Warden mints the
-  token per request from the bound credspec. It accepts both an
-  `oauth_bearer_token` (OAuth2) and a static `api_key`. Servers that expect a
-  static key in a non-`Authorization` header (e.g. `x-api-key`) are **not**
-  supported by this provider — they need a dedicated provider.
 - **The bound token's scopes determine which tools resolve.** The upstream
-  enforces its own authorization on the minted token. A `403` or
+  enforces its own authorization on the minted token. A `403` /
   `permission denied` from a `tools/call` usually means the bound credential
-  lacks the required scope/grant. Ask the operator to widen it rather than
-  switching Warden roles unless one with broader reach exists.
-- **OAuth vs static key is an operator choice you don't see.** Whether the mount
-  is backed by a browser-consented OAuth grant (refreshed automatically) or a
-  static API key is configured by the operator; from the client side both look
-  like `Authorization: Bearer $WARDEN_TOKEN` to Warden. The per-upstream notes
-  under the provider's `docs/` folder (e.g. `slack.md`) call out which shape a
-  given upstream uses.
-- **Warden policy can gate tools too — body-authoritative.** Operators may bind
-  a policy with an `mcp { }` block that restricts JSON-RPC methods, tool names,
-  resource URIs, prompt names, and `tools/call` arguments. Warden strict-parses
-  the JSON-RPC request body and matches against the parsed body — no client-side
-  opt-in or header mirroring is required. A deny shows up as HTTP 403 with an
-  RFC 6750 `WWW-Authenticate: Bearer error="insufficient_permissions",
-  error_description="..."` header and a small JSON body of the same shape; the
-  description names the offending method/tool/parameter. This is independent of
-  upstream scope errors — read the `error_description` to tell the two apart.
-  The parser also fails closed on structural problems (malformed JSON-RPC,
-  duplicate keys, oversized body, etc.) with a specific `rule_type` in the audit
-  log. See the README's "Create a Policy" section for the full rule_type table.
-- **Streamable HTTP / SSE flows through transparently.** Send
-  `Accept: application/json, text/event-stream` and the server's choice of
-  framing comes back unchanged. The `Mcp-Session-Id` response header round-trips
-  automatically; subsequent client requests carrying it reach the same upstream
-  session.
+  lacks the scope/grant — ask the operator to widen it rather than switching
+  roles, unless one with broader reach exists.
+- **Warden policy can gate tools too — body-authoritative.** An operator may bind
+  a policy with an `mcp { }` block restricting JSON-RPC methods, tool names,
+  resource URIs, prompt names, and `tools/call` arguments; Warden strict-parses
+  the request body and matches against it. A deny is HTTP 403 with an RFC 6750
+  `WWW-Authenticate: Bearer error="insufficient_permissions",
+  error_description="..."` header naming the offending method/tool/parameter.
+  Read the `error_description` to tell a Warden policy deny from an upstream
+  scope error. Structural problems (malformed JSON-RPC, duplicate keys, oversized
+  body) also fail closed.
+- **Streamable HTTP / SSE flows through transparently.** The server's framing
+  comes back unchanged, and the `Mcp-Session-Id` response header round-trips
+  automatically so follow-up requests reach the same upstream session.
 - **Session timeout is mount-wide.** The mount's `timeout` config caps an entire
-  SSE session (default 10 minutes). For longer agent sessions, ask the operator
-  to raise it.
-- **Not in scope**: OAuth flows initiated by the *client* (Dynamic Client
-  Registration, PRM discovery, `.well-known/oauth-protected-resource`), stdio
-  transport, and legacy split-endpoint HTTP+SSE. Warden brokers the bearer token
-  for you; use the bearer-token path above.
+  SSE session (default 10 minutes). For longer sessions, ask the operator to
+  raise it.
+- **Static-key upstreams that expect a non-`Authorization` header** (e.g.
+  `x-api-key`) are not served by this provider — they need a dedicated one.
+- **Not in scope:** client-initiated OAuth (Dynamic Client Registration, PRM
+  discovery), stdio transport, and legacy split-endpoint HTTP+SSE. Warden brokers
+  the bearer token for you.

--- a/provider/mcp_aws/skill.md
+++ b/provider/mcp_aws/skill.md
@@ -1,9 +1,9 @@
 ---
 name: mcp_aws
-description: "Talk to AWS-hosted MCP through Warden — without holding IAM keys. Use any MCP client (Claude Code, Cursor, ...) by pointing it at Warden; tools and JSON/SSE responses pass through unchanged. Fronts both AWS's hosted MCP Server (aws-mcp.{region}.api.aws) and customer-owned MCP servers on Bedrock AgentCore."
+description: "Talk to AWS-hosted MCP through Warden — without holding IAM keys. Your MCP client points at Warden under a role fixed at attach time (one attached server per role). Fronts both AWS's hosted MCP Server (aws-mcp.{region}.api.aws) and customer-owned MCP servers on Bedrock AgentCore."
 category: provider-guide
 provider: mcp_aws
-requires: [foundation, discovery]
+requires: []
 upstream: AWS-hosted MCP servers — the GA AWS MCP Server (aws-mcp.{region}.api.aws/mcp) and Bedrock AgentCore Runtime/Gateway endpoints
 ---
 
@@ -11,219 +11,90 @@ upstream: AWS-hosted MCP servers — the GA AWS MCP Server (aws-mcp.{region}.api
 
 ## What it does
 
-Warden proxies MCP traffic to an AWS-hosted MCP endpoint, signing each
-outgoing request with AWS SigV4 using IAM credentials minted by the
-`aws` source driver. The MCP client calls a Warden URL; Warden
-authenticates the caller (JWT/cert), looks up the IAM role bound to the
-chosen Warden role, mints short-lived STS credentials, signs the
-upstream request with SigV4, and streams the response (JSON or SSE)
-back unchanged. The agent **never holds IAM credentials** — no
-`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` on the agent host, no
-`~/.aws/credentials`, no profile to leak.
+Warden proxies MCP traffic to an AWS-hosted MCP endpoint, signing each outgoing
+request with AWS SigV4 using IAM credentials minted by the `aws` source driver.
+Your MCP client calls Warden **under a role**; Warden authenticates the caller
+(JWT/cert), looks up the IAM role bound to that Warden role, mints short-lived
+STS credentials, signs the upstream request with SigV4, and streams the response
+(JSON or SSE) back unchanged. You **never hold IAM credentials** — no
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` on the host, no
+`~/.aws/credentials` to leak.
 
-## Pick the right mount
+## Your role — one attached server per role
 
-A single `mcp_aws` mount fronts exactly one upstream — either AWS's
-hosted MCP Server product, or a customer-owned MCP server on Bedrock
-AgentCore Runtime / Gateway. When more than one `mcp_aws` mount exists,
-**match by the operator-set mount description**, not by inspecting the
-upstream URL. The description reflects what the operator intends the
-mount to be used for (which IAM role, which region, which AgentCore
-server); the URL is a backend detail that may change without semantic
-meaning.
+Which **role** the call runs under decides which IAM role is assumed (and which
+Warden policy applies). Your role is the `role/<role>/gateway` segment of the URL
+this server was attached at — **fixed for this server**, and not changeable at
+runtime (an MCP client sends fixed headers, and the role can't be passed in a
+tool call). To act under a *different* role, call the MCP server the operator
+attached for that role: the operator attaches **one server per role**, named or
+described to match a `list_roles` entry.
 
-```bash
-warden provider list -o json | jq -r '.[] | select(.type=="mcp_aws") | "\(.path)\t\(.description)"'
-```
+## Attaching the client
 
-Pick the mount whose description matches your task. If none of the
-descriptions cover what you need, ask the operator to mount one — do
-not pick the first mcp_aws mount by URL pattern alone.
-
-## Configure the MCP client
-
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/mcp_aws/`,
-  `/v1/team-data/mcp_aws/`). Warden has already baked the namespace
-  and mount path in.
-- `<role>` is the role you picked from `warden role list` to perform
-  this task — it goes in the URL path.
-
-```
-MCP server URL : $WARDEN_ADDR<mount-url>role/<role>/gateway
-Auth header    : Authorization: Bearer $WARDEN_TOKEN
-```
-
-Note **no trailing slash** on `gateway` — this is the opposite of
-GitHub's hosted MCP server. AWS's hosted MCP Server lives at exactly `/mcp` and
-rejects requests to `/mcp/` with a JSON-RPC `-32600 Invalid request
-path` error. Bedrock AgentCore endpoints follow the same convention.
-
-For MCP client configuration files, the entry looks like (Claude Code
-/ Cursor / Continue / Cline / Goose all accept this shape):
+The server is attached by the operator or your runtime (Claude Code
+`claude mcp add`; Cursor/Continue/Cline/Goose take the same HTTP-server shape),
+with your identity as a header — one attachment per role:
 
 ```json
 {
   "type": "http",
-  "url": "$WARDEN_ADDR<mount-url>role/<role>/gateway",
-  "headers": {
-    "Authorization": "Bearer $WARDEN_TOKEN"
-  }
+  "url": "$WARDEN_ADDR/v1/<namespace>/<mount>/role/<role>/gateway",
+  "headers": { "Authorization": "Bearer <jwt>" }
 }
 ```
 
-Substitute `$WARDEN_ADDR`, `<mount-url>`, `<role>`, and `$WARDEN_TOKEN`
-before saving — most MCP clients do not expand environment variables
-inside config files.
+**No trailing slash** on `gateway` — the opposite of GitHub's hosted MCP server.
+AWS's hosted MCP Server lives at exactly `/mcp` and rejects `/mcp/` with a
+JSON-RPC `-32600 Invalid request path`; Bedrock AgentCore follows the same
+convention. A `401` means the JWT expired (typical TTL 5–60 min) — refresh it.
 
-## Examples
+## Using it
 
-(All examples below assume `mount_url = /v1/mcp_aws/` and role
-`s3-reader`; substitute yours from `warden provider list`.)
+- **`tools/list` is policy-filtered** to the active role's grant. For AWS's
+  hosted MCP Server, every AWS API call goes through a single `call_aws` tool
+  whose arguments select service, operation, and region:
 
-List the tools the server exposes:
-```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  $WARDEN_ADDR/v1/mcp_aws/role/s3-reader/gateway
-```
+  ```json
+  {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call_aws",
+   "arguments":{"service_name":"s3","operation_name":"list_buckets",
+   "region_name":"us-east-1","parameters":{}}}}
+  ```
 
-Call a tool (the operator must grant a role whose IAM permissions cover
-the requested AWS operation — see Quirks below). For AWS's hosted MCP
-Server, every AWS API call goes through a single `call_aws` tool whose
-arguments select the service, operation, and target region:
-
-```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call_aws","arguments":{"service_name":"s3","operation_name":"list_buckets","region_name":"us-east-1","parameters":{}}}}' \
-  $WARDEN_ADDR/v1/mcp_aws/role/s3-reader/gateway
-```
-
-The `region_name` inside the tool arguments selects which AWS region's
-API to call — this is **independent** of the mount's signing region.
-A mount fronting `aws-mcp.us-east-1.api.aws/mcp` can still reach
-`eu-west-1` S3, `ap-southeast-2` DynamoDB, etc., as long as the bound
-IAM role's permissions cover those operations.
-
-For a Bedrock AgentCore-hosted MCP server, the available tools depend
-on what the customer's server exposes — discover them via `tools/list`
-and call them with their published argument shapes.
-
-The **absence** of a trailing slash on `gateway` matters — Warden
-composes the upstream URL as the mount's configured base + whatever
-follows `gateway` in the request. AWS's hosted MCP Server requires
-`/mcp` exactly; `/mcp/` returns JSON-RPC `-32600 Invalid request path`.
-(This is the opposite convention from GitHub's hosted MCP server, which
-requires the trailing slash on `/mcp/`.)
-
-## Header-routed alternative
-
-If you prefer an MCP server URL that is just `$WARDEN_ADDR/` (some MCP
-clients dislike long paths, or you want to mux several MCP providers
-under one base URL), pass the mount path as `X-Warden-Provider` and the
-namespace as `X-Warden-Namespace`:
-
-```bash
-path=$(warden provider list -o json | jq -r '.[] | select(.type=="mcp_aws" and .description=="<the description you want>") | .path' | head -1)
-
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
-  -H "X-Warden-Provider: $path" \
-  -H "X-Warden-Namespace: $WARDEN_NAMESPACE" \
-  -H "X-Warden-Role: s3-reader" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  $WARDEN_ADDR/
-```
-
-For an MCP client config:
-
-```json
-{
-  "type": "http",
-  "url": "$WARDEN_ADDR/",
-  "headers": {
-    "Authorization": "Bearer $WARDEN_TOKEN",
-    "X-Warden-Provider": "<path-from-warden-provider-list>",
-    "X-Warden-Namespace": "<namespace>",
-    "X-Warden-Role": "<role>"
-  }
-}
-```
-
-When more than one `mcp_aws` mount exists, the `jq` filter above keys
-on `.description` — the same rule as "Pick the right mount" above.
+  `region_name` selects the target AWS region and is **independent** of the
+  mount's signing region — a mount fronting `aws-mcp.us-east-1.api.aws/mcp` can
+  still reach `eu-west-1` S3, as long as the bound IAM role's permissions cover
+  it. For a Bedrock AgentCore server, the tools are whatever the customer's
+  server exposes — discover them via `tools/list`.
 
 ## Quirks
 
-- **The injected auth is AWS SigV4, not Bearer.** Unlike the generic `mcp`
-  provider, which injects `Authorization: Bearer <token>`, mcp_aws builds an
-  `Authorization: AWS4-HMAC-SHA256 Credential=…/{date}/{region}/{service}/aws4_request,SignedHeaders=…,Signature=…`
-  header per request along with `X-Amz-Date`, `X-Amz-Content-Sha256`,
-  and (for STS-minted credentials) `X-Amz-Security-Token`. The signing
-  service and region are derived from the upstream URL host — agents
-  don't need to know either.
-- **IAM permissions determine which calls succeed.** The bound IAM
-  role's policy is the security boundary. A `403` or
-  `AccessDeniedException` from the upstream means the role lacks the
-  required permission for the target service / action / resource.
-  Operators provision IAM roles whose permissions cover the intended
-  toolset; agents hitting `AccessDenied` should ask the operator to
-  widen the role's policy, not try a different Warden role unless one
+- **The injected auth is AWS SigV4, not Bearer.** mcp_aws builds an
+  `Authorization: AWS4-HMAC-SHA256 …` header per request (plus `X-Amz-Date`,
+  `X-Amz-Content-Sha256`, and `X-Amz-Security-Token` for STS creds). Signing
+  service/region derive from the upstream host — you don't need either.
+- **IAM permissions determine which calls succeed.** The bound IAM role's policy
+  is the security boundary. A `403` / `AccessDeniedException` from the upstream
+  means the role lacks the permission for the target service/action/resource —
+  ask the operator to widen it, don't switch Warden roles unless a broader one
   exists.
-- **Warden policy can gate tools too — body-authoritative.** Operators
-  may bind a policy with an `mcp { }` block that restricts JSON-RPC
-  methods, tool names, resource URIs, prompt names, and `tools/call`
-  arguments (including the `service_name` / `operation_name` /
-  `region_name` keys the AWS MCP Server's `call_aws` tool reads).
-  Warden strict-parses the JSON-RPC request body and matches against
-  the parsed body — no client-side opt-in or header mirroring required.
-  A deny shows up as HTTP 403 with an RFC 6750
-  `WWW-Authenticate: Bearer error="insufficient_permissions", error_description="..."`
-  header and a small JSON body of the same shape; the description
-  names the offending method/tool/parameter. This is **independent**
-  of IAM `AccessDenied` errors, which surface as native AWS error
-  responses streamed back from the upstream — read the
-  `error_description` to tell the two apart. The strict parser also
-  fails closed on structural problems (malformed JSON-RPC, duplicate
-  keys, oversized body, etc.) with a specific `rule_type` in the audit
-  log. See the README's "Create a Policy" section for the full
-  rule_type table.
-- **Streamable HTTP / SSE flows through transparently.** Send
-  `Accept: application/json, text/event-stream` and the server's
-  choice of framing comes back unchanged. The `Mcp-Session-Id`
-  response header round-trips automatically; subsequent client
-  requests carrying it reach the same upstream session.
-- **Session timeout is mount-wide.** The mount's `timeout` config
-  caps an entire SSE session (default 10 minutes). For longer agent
-  sessions, ask the operator to raise it.
-- **The mount's region is the *signing* region, not a restriction on
-  AWS region of API calls.** AWS's MCP Server can call any region's
-  APIs; the agent picks the target region via `region_name` inside
-  the tool arguments. A second mount is only needed when the operator
-  specifically wants the MCP server itself in another region — for
-  latency, data sovereignty, or failover.
-- **AgentCore-hosted MCP servers expose different tool shapes.** When
-  the upstream is `*.bedrock-agentcore.{region}.amazonaws.com`, the
-  available tools and their argument schemas come from whatever the
-  customer-owned server exposes — discover via `tools/list`. The
-  `call_aws` example above is specific to AWS's hosted MCP Server
-  product.
-- **STS credentials are short-lived.** The bound IAM role's STS
-  session duration caps how long any individual MCP request can take
-  end-to-end on the signing side. The signed request is valid for 15
-  minutes from `X-Amz-Date`; long-running tool calls beyond that
-  window will fail with a SigV4 expiration error rather than a token
-  refresh. Restart the MCP session for very long operations.
-- **Rate limits propagate from AWS.** Warden does not retry; back off
-  when you see `ThrottlingException` / `RequestLimitExceeded` from
-  AWS. CloudTrail captures every call for audit.
-- **Not in scope**: OAuth flows (Dynamic Client Registration, PRM
-  discovery), stdio transport, and any path that requires running
-  AWS's `mcp-proxy-for-aws` on the client side. Warden replaces that
-  proxy; the client just speaks plain Streamable HTTP MCP to Warden.
+- **Warden policy can gate tools too — body-authoritative.** An operator may bind
+  an `mcp { }` block restricting JSON-RPC methods, tool names, and `tools/call`
+  arguments (including `service_name` / `operation_name` / `region_name`). A deny
+  is HTTP 403 with an RFC 6750 `WWW-Authenticate: Bearer
+  error="insufficient_permissions", error_description="..."` header naming the
+  offender — **independent** of IAM `AccessDenied` (a native AWS error streamed
+  back). Read the `error_description` to tell them apart. Structural problems
+  (malformed JSON-RPC, duplicate keys, oversized body) also fail closed.
+- **Streamable HTTP / SSE flows through transparently.** The `Mcp-Session-Id`
+  response header round-trips so follow-up requests reach the same session.
+- **Session timeout is mount-wide** (default 10 minutes); ask the operator to
+  raise it for longer sessions.
+- **STS credentials are short-lived.** A signed request is valid 15 minutes from
+  `X-Amz-Date`; tool calls beyond that fail with a SigV4 expiration error rather
+  than refreshing — restart the session for very long operations.
+- **Rate limits propagate from AWS.** Warden does not retry; back off on
+  `ThrottlingException` / `RequestLimitExceeded`. CloudTrail captures every call.
+- **Not in scope:** client-initiated OAuth (DCR, PRM discovery), stdio transport,
+  and anything requiring AWS's `mcp-proxy-for-aws` on the client — Warden
+  replaces that proxy; the client speaks plain Streamable HTTP MCP to Warden.

--- a/provider/openai/skill.md
+++ b/provider/openai/skill.md
@@ -3,7 +3,7 @@ name: openai
 description: "Call the OpenAI API through Warden — chat, embeddings, moderation — without holding an OpenAI API key."
 category: provider-guide
 provider: openai
-requires: [foundation, discovery]
+requires: []
 upstream: OpenAI REST API (api.openai.com)
 ---
 
@@ -19,17 +19,23 @@ and forwards. The agent **never holds an API key**.
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/openai/`, `/v1/team-data/openai-prod/`).
-  Warden has already baked the namespace + mount path in — append
-  `role/<role>/gateway/<openai-api-path>` for transparent mode.
-- `<role>` is the role you picked from `warden role list` to perform this
-  task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<openai-api-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><openai-api-path>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 The same shape as upstream OpenAI requests, just with the host swapped
@@ -40,8 +46,8 @@ out and a JWT instead of an API key.
 ```python
 from openai import OpenAI
 client = OpenAI(
-    base_url=f"{WARDEN_ADDR}{MOUNT_URL}role/llm-app/gateway",
-    api_key=WARDEN_TOKEN,                  # JWT, not an OpenAI key
+    base_url=f"{WARDEN_ADDR}<gateway-url>",  # e.g. .../v1/openai/role/llm-app/gateway/
+    api_key="<jwt>",                         # JWT, not an OpenAI key
 )
 ```
 
@@ -50,18 +56,19 @@ client = OpenAI(
 ```js
 import OpenAI from "openai";
 const client = new OpenAI({
-  baseURL: `${process.env.WARDEN_ADDR}${MOUNT_URL}role/llm-app/gateway`,
-  apiKey: process.env.WARDEN_TOKEN,
+  baseURL: `${process.env.WARDEN_ADDR}<gateway-url>`,  // e.g. .../v1/openai/role/llm-app/gateway/
+  apiKey: "<jwt>",
 });
 ```
 
 ## Examples
 
-(All examples assume `mount_url = /v1/openai/`; substitute yours.)
+(Examples use a concrete `<gateway-url>` of `/v1/openai/role/llm-app/gateway/`;
+substitute the one from your role's `list_roles` description.)
 
 Chat completion via `curl`:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}]}' \
   $WARDEN_ADDR/v1/openai/role/llm-app/gateway/chat/completions
@@ -69,7 +76,7 @@ curl -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 Embeddings:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"model":"text-embedding-3-small","input":"some text"}' \
   $WARDEN_ADDR/v1/openai/role/embeddings/gateway/embeddings
@@ -77,7 +84,7 @@ curl -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 List models:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/openai/role/llm-app/gateway/models
 ```
 

--- a/provider/rds/skill.md
+++ b/provider/rds/skill.md
@@ -3,7 +3,7 @@ name: rds
 description: "Get a short-lived database connection string for AWS RDS through Warden — agent connects to the DB directly with a 15-min IAM auth token."
 category: provider-guide
 provider: rds
-requires: [foundation, discovery]
+requires: []
 upstream: AWS RDS (PostgreSQL, MySQL)
 ---
 
@@ -26,33 +26,40 @@ The Warden call returns a *connection string* you feed to your
 PostgreSQL or MySQL client unchanged. There's no SDK setup; this is
 a single HTTP call followed by a regular DB connection.
 
-`<mount-url>`, `<grant-name>`, and `<role>` below come from the discovery
-flow plus one extra step:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/rds/`, `/v1/team-data/rds-prod/`).
-  Warden has already baked the namespace + mount path in.
+You need three values:
+- `<access-url>` is the access URL for the role you chose, embedded in
+  the role's `description` returned by the `list_roles` MCP tool. RDS is
+  not a gateway provider, so this is a **relative** access path
+  `/v1/<namespace>/<mount>/access/` (e.g. `/v1/rds/access/`,
+  `/v1/team-data/rds-prod/access/`) — prepend `$WARDEN_ADDR`.
 - `<grant-name>` is a pre-configured grant (operator decides which
-  RDS instance + DB user + capabilities each grant exposes). List them
-  with `warden list <mount-url>access` and pick by description.
-- `<role>` is the role you picked from `warden role list`. Access
-  backends take the role as a **query parameter** on the access URL
-  (gateway providers take it as a path segment — different shape).
+  RDS instance + DB user + capabilities each grant exposes). Grants are
+  operator-managed and can't be listed by the agent — the grant to use
+  is the one the operator points you at (typically named in the role's
+  description).
+- `<role>` is the role you chose. Access backends take the role as a
+  **query parameter** on the access URL (gateway providers take it as a
+  path segment — different shape).
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>access/<grant-name>?role=<role>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<access-url><grant-name>?role=<role>
+Auth header : Authorization: Bearer <jwt>
 ```
+
+Present identity as `Authorization: Bearer <jwt>` (or an mTLS client
+cert). A `401` means the JWT expired (typical TTL 5–60 min) — refresh
+and retry.
 
 If the operator has set a `default_role` on the auth method, omitting
 `?role=` falls back to that default.
 
 ## Examples
 
-(All examples assume `mount_url = /v1/rds-prod/`; substitute yours.)
+(Examples use `<access-url>` = `/v1/rds-prod/access/`.)
 
 ```bash
 # Mint a connection string (role passed as query param)
-RESP=$(curl -sH "Authorization: Bearer $WARDEN_TOKEN" \
+RESP=$(curl -sH "Authorization: Bearer <jwt>" \
   "$WARDEN_ADDR/v1/rds-prod/access/analytics-reader?role=analytics-ro")
 
 # {"connection_string":"host=db.example.com port=5432 dbname=analytics user=ro_user password=eyJ...IAM-TOKEN... sslmode=require","lease_duration":900}
@@ -97,8 +104,8 @@ to get a fresh token-bearing connection string.
   the data path. The DB endpoint must be reachable from the agent's
   network; Warden doesn't tunnel it.
 - **Grants are pre-configured by the operator.** Agents can't create
-  grants via this provider — only consume existing ones. Use
-  `warden list <mount>/access` to see what's available.
+  or enumerate grants via this provider — only consume existing ones.
+  The grant to use is the one the operator provisions for your role.
 - **`rds_iam_token` is the underlying mint method.** RDS instances
   must have IAM database authentication enabled and the DB user
   pre-created with `rds_iam` group membership.

--- a/provider/rest/skill.md
+++ b/provider/rest/skill.md
@@ -3,7 +3,7 @@ name: rest
 description: "Call an arbitrary single-token REST API through Warden — the specific upstream is set by the operator per mount; identify it from the mount's description, never from the provider type."
 category: provider-guide
 provider: rest
-requires: [foundation, discovery]
+requires: []
 upstream: Operator-defined (see the mount description)
 ---
 
@@ -24,7 +24,7 @@ an internal billing API, another fronts Algolia. You **cannot** tell the
 upstream from the provider type, and you **must not** guess it from the
 mount path or config.
 
-Read the mount's **`description`** from discovery (`warden provider list`)
+Read the role's **`description`** from the `list_roles` discovery tool
 to learn:
 - which service this mount proxies, and
 - its base path / which API routes are in scope.
@@ -35,37 +35,46 @@ say so.
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` come from the discovery flow:
-- `<mount-url>` is the chosen mount's `mount_url` from
-  `warden provider list` (e.g. `/v1/billing-api/`).
-- `<role>` is the role you picked from `warden role list` for this task —
-  it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<upstream-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><upstream-path>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 Rewrite the upstream host to
-`$WARDEN_ADDR<mount-url>role/<role>/gateway` and add your Warden token as
+`$WARDEN_ADDR<gateway-url>` and add your Warden token as
 the bearer. Everything after `/gateway/` — path, query string, method,
 body — is forwarded verbatim to the upstream. Warden injects the upstream
 credential for you; do not send the upstream's own token.
 
 ## Examples
 
-(Assume `mount_url = /v1/billing-api/` and role `finance`, fronting an
-internal REST API per its description; substitute yours.)
+(Examples use a concrete `<gateway-url>` of `/v1/billing-api/role/finance/gateway/`,
+fronting an internal REST API per its description; substitute the one from your
+role's `list_roles` description.)
 
 GET a resource:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/billing-api/role/finance/gateway/v1/invoices?status=open
 ```
 
 POST a resource:
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"customer":"acme","amount":4200}' \
   $WARDEN_ADDR/v1/billing-api/role/finance/gateway/v1/invoices

--- a/provider/scaleway/skill.md
+++ b/provider/scaleway/skill.md
@@ -3,7 +3,7 @@ name: scaleway
 description: "Call the Scaleway REST API and Scaleway Object Storage (S3-compatible) through Warden — one provider, two patterns auto-detected."
 category: provider-guide
 provider: scaleway
-requires: [foundation, discovery]
+requires: []
 upstream: Scaleway REST API + Object Storage
 ---
 
@@ -24,20 +24,33 @@ cares about *one* of the two modes per task.
 
 ## Configure the CLI/SDK
 
-`<mount-url>`, `<role>`, and (for S3 mode) `<role-name>` below come from
-the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/scaleway/`, `/v1/team-data/scaleway-prod/`).
-  Warden has already baked the namespace + mount path in.
-- `<role>` / `<role-name>` is the role you picked from `warden role list`
-  for this task — REST mode puts it in the URL path; S3 mode puts the
-  same value in `AWS_ACCESS_KEY_ID`.
+You need two values:
+- `<gateway-url>` is the gateway URL for the role you chose, embedded in
+  the role's `description` returned by the `list_roles` MCP tool. It is a
+  **relative** path `/v1/<namespace>/<mount>/role/<role>/gateway/`
+  (e.g. `/v1/scaleway/role/cloud-reader/gateway/`,
+  `/v1/team-data/scaleway-prod/role/cloud-reader/gateway/`) — prepend
+  `$WARDEN_ADDR`. REST mode appends the Scaleway API path after it; S3
+  mode uses it as the endpoint.
+- `<role>` is the same role name. S3 mode also puts it in
+  `AWS_ACCESS_KEY_ID` (Warden reads it from the SigV4 header).
+
+**Choosing a role.** The role rides in the URL path (the `role/<role>` segment
+of `<gateway-url>`, or `AWS_ACCESS_KEY_ID` for S3). To act as a different role,
+use that role's `<gateway-url>` from `list_roles` — each role provides its own
+role-bearing URL in its description. If the operator has set a mount
+`default_role`, a request with no role at all falls back to it.
+
+Present identity as `Authorization: Bearer <jwt>` for REST, or as the JWT
+in the SigV4 secret slots for S3 (below); an mTLS client cert also works.
+A `401` on REST — or a stale-JWT `SignatureDoesNotMatch` on S3 — means the
+JWT expired (typical TTL 5–60 min); refresh and retry.
 
 ### REST API (HTTP, Bearer-style)
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<scaleway-api-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><scaleway-api-path>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 The official Scaleway CLI (`scw`) authenticates via `X-Auth-Token`
@@ -50,17 +63,18 @@ header.
 
 `curl`:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/scaleway/role/cloud-reader/gateway/instance/v1/zones/fr-par-1/servers
 ```
 
 Python (using `requests`):
 ```python
 import os, requests
+jwt = "<jwt>"   # the Warden JWT for the role you chose
 base = f"{os.environ['WARDEN_ADDR']}/v1/scaleway/role/cloud-reader/gateway"
 r = requests.get(
     f"{base}/instance/v1/zones/fr-par-1/servers",
-    headers={"Authorization": f"Bearer {os.environ['WARDEN_TOKEN']}"},
+    headers={"Authorization": f"Bearer {jwt}"},
 )
 r.raise_for_status()
 servers = r.json()["servers"]
@@ -73,9 +87,9 @@ provider but pointing at this mount:
 
 ```bash
 export AWS_ACCESS_KEY_ID="<role-name>"
-export AWS_SECRET_ACCESS_KEY="$WARDEN_TOKEN"
-export AWS_SESSION_TOKEN="$WARDEN_TOKEN"
-export AWS_ENDPOINT_URL="$WARDEN_ADDR<mount-url>role/<role>/gateway"
+export AWS_SECRET_ACCESS_KEY="<jwt>"
+export AWS_SESSION_TOKEN="<jwt>"
+export AWS_ENDPOINT_URL="$WARDEN_ADDR<gateway-url>"
 ```
 
 Then any AWS S3-compatible CLI/SDK works:
@@ -90,17 +104,17 @@ keys.
 
 ## Examples
 
-(All examples assume `mount_url = /v1/scaleway/`; substitute yours.)
+(Examples use `<gateway-url>` = `/v1/scaleway/role/<role>/gateway/`.)
 
 Read your IAM users (REST):
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/scaleway/role/iam-reader/gateway/iam/v1alpha1/users
 ```
 
 List instances in a zone (REST):
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/scaleway/role/compute/gateway/instance/v1/zones/fr-par-1/servers
 ```
 
@@ -120,5 +134,6 @@ aws s3 cp ./report.csv s3://analytics-bucket/2026/05/report.csv \
   `fr-par`, `nl-ams`, `pl-waw`, `it-mil`. Other values get rejected.
 - **REST and S3 use different credentials internally.** The cred
   spec maps `static_keys` (long-lived API key) or `dynamic_keys`
-  (short-lived) — operator decision; check `warden read scaleway/config`.
+  (short-lived) — an operator/config detail on the mount, not something
+  the agent sets.
 

--- a/provider/slack/skill.md
+++ b/provider/slack/skill.md
@@ -3,7 +3,7 @@ name: slack
 description: "Call the Slack Web API through Warden — post messages, read channels, manage reactions — without holding a bot token."
 category: provider-guide
 provider: slack
-requires: [foundation, discovery]
+requires: []
 upstream: Slack Web API (slack.com/api)
 ---
 
@@ -19,29 +19,37 @@ token bound to the chosen role, injects it as
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/slack/`, `/v1/team-ops/slack-prod/`).
-  Warden has already baked the namespace + mount path in.
-- `<role>` is the role you picked from `warden role list` to perform this
-  task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
+
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>`, or an mTLS
+client certificate. A `401` means the JWT expired (typical TTL 5–60 min) —
+refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<slack-method>
-Auth header : Authorization: Bearer $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><slack-method>
+Auth header : Authorization: Bearer <jwt>
 ```
 
 For `curl` or any HTTP client: rewrite the Slack host to
-`$WARDEN_ADDR<mount-url>role/<role>/gateway` and add the bearer token.
+`$WARDEN_ADDR<gateway-url>` and add the bearer token.
 
 ## Examples
 
-(All examples assume `mount_url = /v1/slack/` and role `slack-user`;
-substitute yours. All Slack Web API calls are **POST**, even reads.)
+(Examples use a concrete `<gateway-url>` of
+`/v1/slack/role/slack-user/gateway/`; substitute the one from your role's
+`list_roles` description. All Slack Web API calls are **POST**, even reads.)
 
 Post a message to a channel:
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"channel":"#general","text":"Hello from Warden!"}' \
   $WARDEN_ADDR/v1/slack/role/slack-user/gateway/chat.postMessage
@@ -49,7 +57,7 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 List conversations the bot can see:
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"limit":100}' \
   $WARDEN_ADDR/v1/slack/role/slack-user/gateway/conversations.list
@@ -57,7 +65,7 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 Read recent messages from a channel:
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{"channel":"C01ABC123","limit":50}' \
   $WARDEN_ADDR/v1/slack/role/slack-user/gateway/conversations.history
@@ -65,7 +73,7 @@ curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
 
 Test that the injected bot token is valid:
 ```bash
-curl -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -X POST -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/slack/role/slack-user/gateway/auth.test
 ```
 
@@ -79,7 +87,7 @@ at most one canvas, so replace any prior one. Four calls in order:
 1. **Check for an existing canvas** — `conversations.info` reads
    `.channel.properties.canvas.file_id`:
    ```bash
-   EXISTING=$(curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+   EXISTING=$(curl -sSf -X POST -H "Authorization: Bearer <jwt>" \
         -H "Content-Type: application/json" \
         -d '{"channel":"C01ABC123"}' \
         $WARDEN_ADDR/v1/slack/role/slack-user/gateway/conversations.info \
@@ -90,7 +98,7 @@ at most one canvas, so replace any prior one. Four calls in order:
    ```bash
    if [ -n "$EXISTING" ]; then
      jq -n --arg id "$EXISTING" '{canvas_id:$id}' \
-       | curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+       | curl -sSf -X POST -H "Authorization: Bearer <jwt>" \
               -H "Content-Type: application/json" --data @- \
               $WARDEN_ADDR/v1/slack/role/slack-user/gateway/canvases.delete
    fi
@@ -105,7 +113,7 @@ at most one canvas, so replace any prior one. Four calls in order:
          --rawfile md report.md \
          '{channel_id:$ch, title:$title,
            document_content:{type:"markdown", markdown:$md}}' \
-     | curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+     | curl -sSf -X POST -H "Authorization: Bearer <jwt>" \
             -H "Content-Type: application/json" --data @- \
             $WARDEN_ADDR/v1/slack/role/slack-user/gateway/conversations.canvases.create
    ```
@@ -114,7 +122,7 @@ at most one canvas, so replace any prior one. Four calls in order:
    in the channel header but a short message draws attention:
    ```bash
    jq -n --arg ch "C01ABC123" '{channel:$ch, text:"Report updated."}' \
-     | curl -sSf -X POST -H "Authorization: Bearer $WARDEN_TOKEN" \
+     | curl -sSf -X POST -H "Authorization: Bearer <jwt>" \
             -H "Content-Type: application/json" --data @- \
             $WARDEN_ADDR/v1/slack/role/slack-user/gateway/chat.postMessage
    ```
@@ -128,7 +136,7 @@ Slack Web API. The four above are the real ones.
 
 For the `@slack/web-api` (Node) or `slack_sdk` (Python) clients:
 point the `slackApiUrl` / `base_url` at
-`$WARDEN_ADDR<mount-url>role/<role>/gateway` and supply your JWT as the
+`$WARDEN_ADDR<gateway-url>` and supply your JWT as the
 auth token instead of an `xoxb-` token.
 
 ## Quirks

--- a/provider/vault/skill.md
+++ b/provider/vault/skill.md
@@ -3,7 +3,7 @@ name: vault
 description: "Call HashiCorp Vault / OpenBao through Warden — read secrets, sign, encrypt, manage PKI — without ever holding a Vault token."
 category: provider-guide
 provider: vault
-requires: [foundation, discovery]
+requires: []
 upstream: HashiCorp Vault / OpenBao
 ---
 
@@ -19,18 +19,23 @@ The agent **never holds a Vault token**.
 
 ## Configure the CLI/SDK
 
-`<mount-url>` and `<role>` below come from the discovery flow:
-- `<mount-url>` is the chosen provider's `mount_url` from
-  `warden provider list` (e.g. `/v1/vault/`, `/v1/team-data/secrets-prod/`).
-  Warden has already baked the namespace + mount path in.
-- `<role>` is the role you picked from `warden role list` to perform this
-  task — it goes in the URL path.
+`<gateway-url>` comes from the role you chose: the `list_roles` discovery tool
+returns each role with a `description`, and for a non-MCP provider the operator
+embeds the role's **gateway URL** in it — a relative path
+`/v1/<namespace>/<mount>/role/<role>/gateway/`, with the namespace, mount, and role already baked in. Prepend `$WARDEN_ADDR` (the address you already
+used to discover your roles).
 
-Auth is your JWT:
+The `role/<role>/` segment in `<gateway-url>` is the role this call runs under.
+To act under a *different* role, use the `<gateway-url>` of that role from
+`list_roles` — each role provides its own role-bearing URL in its description.
+
+Present your identity on every call: `Authorization: Bearer <jwt>` (Vault also
+accepts the JWT in `X-Vault-Token`), or an mTLS client certificate. A `401`
+means the JWT expired (typical TTL 5–60 min) — refresh and retry.
 
 ```bash
-URL pattern : $WARDEN_ADDR<mount-url>role/<role>/gateway/<vault-api-path>
-Auth header : Authorization: Bearer $WARDEN_TOKEN  # OR X-Vault-Token: $WARDEN_TOKEN
+URL pattern : $WARDEN_ADDR<gateway-url><vault-api-path>
+Auth header : Authorization: Bearer <jwt>  # OR X-Vault-Token: <jwt>
 ```
 
 ### Vault / OpenBao CLI
@@ -55,8 +60,8 @@ Both honour `VAULT_ADDR` + `VAULT_TOKEN` (yes, `bao` reads
 `VAULT_*` env vars too):
 
 ```bash
-export VAULT_ADDR="$WARDEN_ADDR<mount-url>role/<role>/gateway"
-export VAULT_TOKEN="$WARDEN_TOKEN"
+export VAULT_ADDR="$WARDEN_ADDR<gateway-url>"
+export VAULT_TOKEN="<jwt>"
 
 $CLI kv get secret/myapp/config
 $CLI kv put secret/myapp/config foo=bar
@@ -69,21 +74,21 @@ The agent never holds a real Vault token; the JWT is the identity.
 ### Vault SDK
 
 For the official Go / Python / Node Vault SDKs, the same shape: set
-the client's `Address` to `$WARDEN_ADDR<mount-url>role/<role>/gateway`
+the client's `Address` to `$WARDEN_ADDR<gateway-url>`
 and its `Token` to the JWT.
 
 ### Raw HTTP (curl)
 
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
-  "$WARDEN_ADDR<mount-url>role/<role>/gateway/v1/secret/data/myapp/config"
+curl -H "Authorization: Bearer <jwt>" \
+  "$WARDEN_ADDR<gateway-url>v1/secret/data/myapp/config"
 ```
 
 ## Examples
 
-(All examples assume `mount_url = /v1/vault/` and role `secrets-reader`;
-substitute yours. `VAULT_ADDR` and `VAULT_TOKEN` are exported as
-shown above.)
+(Examples use a concrete `<gateway-url>` of `/v1/vault/role/secrets-reader/gateway/`;
+substitute the one from your role's `list_roles` description. `VAULT_ADDR` and
+`VAULT_TOKEN` are exported as shown above.)
 
 KV v2 read:
 ```bash
@@ -109,7 +114,7 @@ vault write pki/sign/server-tpl csr=@./req.csr
 
 Same operations via raw HTTP for scripting:
 ```bash
-curl -H "Authorization: Bearer $WARDEN_TOKEN" \
+curl -H "Authorization: Bearer <jwt>" \
   $WARDEN_ADDR/v1/vault/role/secrets-reader/gateway/v1/secret/data/app/db
 ```
 


### PR DESCRIPTION
## What

Retune all 13 `provider/*/skill.md` for MCP-only discovery (stacked on #391).

- Drop the retired `[foundation, discovery]` from `requires`, and remove the CLI discovery loop (`warden provider list` / `role list` / `skill read`, `mount_url`) from every skill. The gateway URL now comes from the role's `list_roles` description; the identity-attachment guidance (Bearer JWT / client cert, JWT expiry) that lived in the `foundation` skill is inlined.

Two interaction models:
- **MCP** (`mcp`, `mcp_aws`): the server is attached to the agent's MCP client, **one attachment per role** (the role is the `role/<role>/` in the attach URL and is fixed — an MCP tool call can't set a header). To use another role, call the attached server for it.
- **Non-MCP** (vault, github, gitlab, openai, rest, ansible_tower, atlassian, aws, rds, scaleway, slack): the agent calls the gateway URL from the role's description; the `role/<role>/` path segment **is** the role, so another role = another URL (aws carries the role in `AWS_ACCESS_KEY_ID`; rds via `?role=`). The github/gitlab git-clone sections (`http.extraheader`, Basic-Auth username) are kept — a real git client sets those.

## Test plan

- `go build ./...`; provider skills still seed (frontmatter `name` == provider type for all 13).
- `get_skill` returns the retuned bodies (spot-checked on a dev server during development).

## Stack

#5 of 7. Stacked on #391 (merged). #6 (`docs/mcp-only-discovery-concepts`) targets `main` once this merges.
