### PR TITLE
docs: per-driver credential-driver reference pages

### DIFF
--- a/core/sys_mcp.go
+++ b/core/sys_mcp.go
@@ -196,9 +196,8 @@ func (c *Core) registerGetSkillTool(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_skill",
 		Description: "Fetch an agent skill as markdown by name. The name is the one " +
-			"embedded in a role description (list_roles); it names the provider-type " +
-			"recipe teaching the agent how to drive that provider through Warden's " +
-			"gateway.",
+			"embedded in a role description (list_roles); it identifies the recipe " +
+			"teaching the agent how to drive that role through Warden's gateway.",
 	}, c.handleMCPGetSkill)
 }
 

--- a/docs/agent-flow.md
+++ b/docs/agent-flow.md
@@ -193,6 +193,12 @@ providers, the gateway URL in each role's description), writes policies, and
 attaches the agent runtime's MCP client to `/v1/sys/mcp` and the MCP-provider
 gateways. After this, the operator is not in the per-call loop.
 
+Each provider seeds a default skill on first mount, but the catalog is the
+operator's to shape: they can override a seeded skill or author their own and
+point a role at it. This is how a skill is kept small — a skill scoped to one
+role need only document the handful of endpoints that role exposes, not the
+provider's whole API. See [Discovery and Skills](concepts/discovery-and-skills.md#skills-are-yours-to-write).
+
 ### Per-call — every time an agent makes an upstream call
 
 ```

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -38,6 +38,8 @@ a credential of its own.
 
 - [Credentials](credentials.md) — sources, specs, drivers, lifetime, and
   rotation.
+- [Credential drivers](../credential-drivers/README.md) — a reference page per
+  driver: config keys, mint methods, credential types, and rotation behaviour.
 - [Providers](providers.md) — the gateway mounts that authenticate, authorize,
   inject a credential, and proxy to an upstream.
 - [Model Context Protocol](mcp.md) — fronting MCP servers and authorizing

--- a/docs/concepts/credentials.md
+++ b/docs/concepts/credentials.md
@@ -152,7 +152,7 @@ source's `type` selects the driver. Warden ships drivers for:
 
 | Driver `type` | Upstream |
 |---------------|----------|
-| `vault` | HashiCorp Vault / OpenBao |
+| `hvault` | HashiCorp Vault / OpenBao |
 | `aws` | AWS IAM / STS |
 | `azure` | Azure AD / Microsoft Graph |
 | `gcp` | Google Cloud IAM |
@@ -163,6 +163,9 @@ source's `type` selects the driver. Warden ships drivers for:
 | `local` | Static secrets stored in the spec itself |
 | `apikey` | Generic static API keys |
 | `ibm`, `elastic`, `grafana`, `honeycomb`, `alicloud`, `scaleway`, `ovh` | The respective SaaS / cloud APIs |
+
+Each driver has a reference page under [Credential drivers](../credential-drivers/README.md)
+covering its config keys, mint methods, credential types, and rotation behaviour.
 
 Every driver implements a small core contract — mint a credential from a spec,
 revoke a lease, and clean up — and may opt into additional capabilities:
@@ -268,6 +271,7 @@ its own credential configuration, with no inheritance across boundaries.
 
 ## See Also
 
+- [Credential drivers](../credential-drivers/README.md) — a reference page per driver.
 - [Roles](roles.md) — how `cred_spec_name` binds a spec to an identity.
 - [Providers](providers.md) — the mounts that inject or return credentials.
 - [Tokens](tokens.md) — the token a credential is bound to and expires with.

--- a/docs/concepts/discovery-and-skills.md
+++ b/docs/concepts/discovery-and-skills.md
@@ -122,12 +122,13 @@ in the MCP client config, wired at `claude mcp add` time.
 ## Skills
 
 A **skill** is an agent-facing markdown document, stored in a single global
-registry, that teaches an agent how to use a capability. `get_skill` returns one
-by name. Each skill is markdown with structured frontmatter:
+registry, that teaches an agent how to drive a role once it has been discovered.
+`get_skill` returns one by name. Each skill is markdown with structured
+frontmatter:
 
 | Field | Meaning |
 |-------|---------|
-| `name` | Unique slug (for a provider guide, the provider type, e.g. `aws`). This is the name embedded in a role description. |
+| `name` | Unique slug — the name embedded in a role description and passed to `get_skill`. Warden's default provider guides use the provider type (e.g. `aws`), but a name you author can be anything. |
 | `description` | One-line summary an agent reads to decide relevance. |
 | `category` | `agent-flow`, `shared`, `provider-guide`, `troubleshooting`, or `custom`. |
 | `requires` | Names of other skills this one depends on (often empty). |
@@ -141,24 +142,47 @@ headers to send, and the provider's quirks (an AWS skill notes that an expired
 JWT surfaces as a SigV4 `SignatureDoesNotMatch`; a Slack skill notes that HTTP
 200 does not mean success — check the `ok` field).
 
+### Skills are yours to write
+
+Skills are not a fixed, built-in catalogue — they are **plain markdown you author
+and own**. Warden seeds a sensible default guide for each provider type so an
+agent has something to read out of the box, but nothing about a skill is frozen:
+you can edit a seeded one, override it wholesale, or add entirely new skills of
+your own — an internal runbook, a house convention, a guide narrowed to a single
+workflow. The defaults are a starting point, not a ceiling, and a role's
+description can point at whichever skill name you choose.
+
+This authoring freedom is what lets you **scope a skill to a role** rather than to
+a whole provider. For a non-MCP provider that is what keeps a skill small:
+instead of embedding the provider's entire OpenAPI surface, a role-scoped skill
+documents only the handful of endpoints that role actually exposes — often just
+three or four operations. The role narrows the API down to its task; you write a
+skill that covers exactly that slice. One provider can then be fronted by several
+roles, each paired with its own tight, purpose-built skill. This is a large part
+of why roles matter for REST/OpenAPI providers: they let skills stay small,
+focused, and cheap for an agent to read.
+
 ### Where skills come from
 
+- **Default provider skills** ship alongside each provider's code and are seeded
+  into the registry the **first time a provider of that type is mounted**. Seeding
+  is idempotent: mounting a second instance does not overwrite your edits, and a
+  skill that fails to seed never blocks the mount.
 - **The `troubleshooting` skill** is seeded into every server on first unseal —
   a shared guide to Warden's error model.
-- **Provider skills** ship alongside each provider's code and are seeded into the
-  registry the **first time a provider of that type is mounted**. Seeding is
-  idempotent: mounting a second instance does not overwrite an operator's edits,
-  and a skill that fails to seed never blocks the mount.
+- **Your own skills** — anything you author through the system API (below),
+  including overrides of the seeded defaults.
 
 So if `get_skill` reports *skill "aws" not found*, no AWS provider has been
-enabled on the server — the honest signal to an agent that the capability does
-not exist, rather than an endpoint to fabricate.
+enabled on the server (and no one has authored a skill by that name) — the honest
+signal to an agent that the capability does not exist, rather than an endpoint to
+fabricate.
 
-### Managing skills
+### Authoring skills
 
-Skills are read over MCP with `get_skill`, but they are *authored* by operators.
-An operator can add custom skills — internal runbooks, house conventions — or
-override a seeded one, through the system API:
+Skills are read over MCP with `get_skill`, but they are *authored* by operators
+through the system API. Create a new custom skill, override a seeded one, or
+remove one you added:
 
 ```bash
 warden skill create -name=oncall-runbook -category=custom \
@@ -167,8 +191,10 @@ warden skill update aws -description="our AWS override"
 warden skill delete oncall-runbook
 ```
 
-Reads are open in any namespace; **mutations (`create`/`update`/`delete`) are
-restricted to the root namespace** — a sub-namespace request is rejected with
+Point a role's description at a skill by embedding its `name` (e.g.
+`skill: oncall-runbook`), and any agent that discovers the role reads your recipe
+verbatim. Reads are open in any namespace; **mutations (`create`/`update`/`delete`)
+are restricted to the root namespace** — a sub-namespace request is rejected with
 *"skill mutations are restricted to the root namespace."*
 
 ## Everything Is Identity-Scoped

--- a/docs/credential-drivers/README.md
+++ b/docs/credential-drivers/README.md
@@ -1,0 +1,68 @@
+# Credential Drivers
+
+A **driver** is the pluggable component that knows how to talk to one kind of
+upstream. A [credential source](../concepts/credentials.md) names a driver through
+its `type`, holds the privileged secret, and the driver mints or retrieves the
+scoped credential a workload needs — an STS session, a Vault token, a GitHub
+installation token — which Warden injects into the proxied request.
+
+Every driver implements the same core contract — **mint** a credential from a spec,
+**revoke** a lease, and **clean up** — and may opt into extra capabilities:
+
+- **Spec verification** — validate a spec's credentials with a light upstream call
+  at create/update time, so a bad key fails early rather than at the gateway.
+- **Source rotation** — rotate the source's *own* privileged secret on a schedule.
+  A driver is **fast** (prepare and activate in one step) when its upstream is
+  immediately consistent, or **slow** (stage the new secret and wait for it to
+  propagate before destroying the old one) when it is eventually consistent. The
+  wait is tunable per source via `activation_delay`.
+- **Spec rotation** — use the source's elevated permissions to rotate a credential
+  embedded in a spec.
+- **OAuth2 authorization-code consent** — drive a one-time interactive consent flow.
+
+See [Credentials](../concepts/credentials.md) for the source / spec / credential
+model these pages build on.
+
+## Generic and static
+
+| Driver | `type` | Serves | Capabilities |
+|--------|--------|--------|--------------|
+| [Local](local.md) | `local` | static secrets stored directly in the spec | mint only |
+| [Static API Key](apikey.md) | `apikey` | a static API key (in the spec) for any HTTP API | spec verification |
+
+## Platform
+
+| Driver | `type` | Upstream | Capabilities |
+|--------|--------|----------|--------------|
+| [HashiCorp Vault](vault.md) | `hvault` | Vault / OpenBao — KV, AWS/GCP/IBM engines, tokens, OAuth2 | source rotation (fast) |
+| [Kubernetes](kubernetes.md) | `kubernetes` | ServiceAccount tokens via the TokenRequest API | spec verification · source rotation (fast) |
+| [OAuth2](oauth2.md) | `oauth2` | generic OAuth2 providers | spec verification · OAuth2 consent |
+
+## Cloud
+
+| Driver | `type` | Upstream | Capabilities |
+|--------|--------|----------|--------------|
+| [AWS](aws.md) | `aws` | STS, Secrets Manager, RDS / Redshift IAM tokens | source rotation (slow, ~5m) |
+| [Azure](azure.md) | `azure` | Azure AD bearer tokens, Key Vault secrets | source rotation (slow, ~5m) · **spec rotation** |
+| [GCP](gcp.md) | `gcp` | IAM access tokens, service-account impersonation | source rotation (slow, ~2m) |
+| [IBM Cloud](ibm.md) | `ibm` | IAM bearer tokens, COS keys | spec verification · source rotation (slow, ~2m) |
+| [Alibaba Cloud](alicloud.md) | `alicloud` | STS AssumeRole | spec verification · source rotation (slow, ~5m) |
+| [Scaleway](scaleway.md) | `scaleway` | IAM static or dynamic API keys | spec verification · source rotation (slow, ~30s) |
+| [OVHcloud](ovh.md) | `ovh` | OAuth2 bearer tokens, dynamic S3 credentials | spec verification |
+
+## SaaS
+
+| Driver | `type` | Upstream | Capabilities |
+|--------|--------|----------|--------------|
+| [GitHub](github.md) | `github` | App installation tokens and PATs (auth in the spec) | spec verification |
+| [GitLab](gitlab.md) | `gitlab` | project and group access tokens | source rotation (fast) |
+| [Elasticsearch](elastic.md) | `elastic` | `/_security` API keys | spec verification · source rotation (slow, ~10s) |
+| [Grafana](grafana.md) | `grafana` | service-account tokens | spec verification |
+| [Honeycomb](honeycomb.md) | `honeycomb` | V2 API keys | spec verification |
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model, plus lifetime, revocation, and rotation.
+- [Provider backends](../provider-backends/README.md) — end-to-end operator setup guides per upstream.
+- [Roles](../concepts/roles.md) — how a spec binds to an identity.
+- [`warden cred`](../cli/cred.md) — the CLI for sources and specs.

--- a/docs/credential-drivers/alicloud.md
+++ b/docs/credential-drivers/alicloud.md
@@ -1,0 +1,70 @@
+# Alibaba Cloud Driver
+
+> Source `type`: `alicloud`
+
+The Alibaba Cloud driver mints temporary credentials from **Alibaba Cloud STS** (Security Token Service). It exposes a single mint method — **`assume_role`** — which calls STS `AssumeRole` and returns a session-based access key trio (ID, secret, and security token) scoped to a RAM role. RAM dynamic access keys are intentionally not offered: freshly created RAM keys take seconds to minutes to propagate across regions, so first requests routinely fail; STS session tokens sidestep that window.
+
+The privileged **management access key** lives in the **source** config, and it is what STS signs mint requests with. Each **spec** names the `role_arn` to assume and optional session parameters. An operator reaches for this driver to hand short-lived, role-scoped Alibaba Cloud credentials to a workload without ever exposing the long-lived management key.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=alicloud -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `access_key_id` | No | — | Management access key ID (usually starts with `LTAI`). |
+| `access_key_secret` | No | — | Management access key secret (secret, masked on read). |
+| `sts_endpoint` | No | `https://sts.aliyuncs.com` | STS API endpoint. |
+| `ram_endpoint` | No | `https://ram.aliyuncs.com` | RAM API endpoint (used for rotation). |
+| `management_user_name` | No | — | RAM user that owns the management access key (required for rotation). |
+| `activation_delay` | No | `5m` | Wait between creating a new management key and using it, for RAM eventual consistency. |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+Although the schema marks no key required, `assume_role` needs `access_key_id` and `access_key_secret`, and rotation additionally needs `management_user_name`.
+
+## Specs and mint methods
+
+Only `assume_role` is supported. Set these with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `mint_method` | Yes | — | Must be `assume_role`. |
+| `role_arn` | Yes | — | ARN of the RAM role to assume. |
+| `role_session_name` | No | `warden-session` | Session name recorded on the assumed-role session. |
+| `duration_seconds` | No | `1h` | Session lifetime, clamped to 900s–3600s. |
+| `policy` | No | — | Inline session policy to further restrict the returned credentials. |
+
+## Credential issued
+
+`InferCredentialType` always returns `alicloud_keys`. The credential is **dynamic** — it carries the STS session TTL (900s–3600s) as its lease — but it is **not revocable**: STS tokens are self-expiring and have no server-side revocation handle, so revoke is a no-op. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time with a live pre-flight STS `AssumeRole` (minimum 900s duration, result discarded), catching broken management keys, a bad `role_arn`, or trust-policy misconfig before first mint.
+- **Source rotation** — **slow** — rotates the management RAM access key: it creates a new key for `management_user_name` while the old one stays valid, then waits ~5 minutes (default `DefaultAlicloudActivationDelay`, tunable via the source's `activation_delay`) for RAM eventual consistency before marking the old key Inactive and deleting it. Requires `access_key_id`, `access_key_secret`, and `management_user_name`.
+
+## Example
+
+```bash
+warden cred source create alicloud-prod \
+  -type=alicloud \
+  -config=access_key_id=LTAIxxxxxxxxxxxxxxxx \
+  -config=access_key_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=management_user_name=warden-management \
+  -config=activation_delay=5m \
+  -rotation-period=720h
+
+warden cred spec create alicloud-app \
+  -source=alicloud-prod \
+  -config=mint_method=assume_role \
+  -config=role_arn=acs:ram::123456789012:role/app-reader \
+  -config=role_session_name=warden-session \
+  -config=duration_seconds=3600
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Alibaba Cloud provider](../provider-backends/alicloud.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/apikey.md
+++ b/docs/credential-drivers/apikey.md
@@ -1,0 +1,68 @@
+# Static API Key Driver
+
+> Source `type`: `apikey`
+
+The **static API key** driver serves a long-lived **API key** to any HTTP API — OpenAI, Anthropic, or any service that authenticates with a header token. Unlike most drivers, the privileged secret does not live on the **source**: the `api_key` is supplied per **credential spec**, so one source can describe the shape of an API (its base URL, how to attach the key, how to verify it) while many specs each carry a different key. This lets a single source back several teams or projects that hit the same API with distinct keys.
+
+An operator reaches for this driver when the upstream has no dynamic-credential API — the key is minted out-of-band and Warden simply stores it, verifies it, and injects it. At mint time the key is returned as-is with **no TTL and no lease**. The source config also controls an optional verification call so a bad key is caught the moment a spec is created.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=apikey -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `api_url` | Yes* | — | API base URL. Must be `https://` (or `http://` when `tls_skip_verify` is set). *Not enforced by config validation, but a source cannot mint or verify without it. |
+| `verify_endpoint` | No | — | Path appended to `api_url` for spec verification. If empty, verification is skipped. |
+| `verify_method` | No | `GET` | HTTP method for the verification call — `GET` or `POST`. |
+| `auth_header_type` | No | `bearer` | How the key is attached when verifying: `bearer`, `token`, or `custom_header`. |
+| `auth_header_name` | No* | — | Header name to carry the key. *Required when `auth_header_type=custom_header`. |
+| `extra_headers` | No | — | Additional static headers as comma-separated `key:value` pairs. |
+| `optional_metadata` | No | — | Comma-separated spec-config field names to copy into the minted credential data. |
+| `display_name` | No | `API Key` | Human-readable label used in logs and errors. |
+| `ca_data` | No | — | Base64-encoded PEM CA bundle for custom/self-signed CAs. (secret, masked on read) |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+There is a single mint path. The spec carries the actual key plus whatever fields the source named in `optional_metadata`.
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `api_key` | Yes | — | The API key to serve. Returned verbatim as the credential. |
+| *fields from `optional_metadata`* | No | — | Any field named in the source's `optional_metadata` (e.g. `organization_id`, `project_id`) is copied into the credential data when present. |
+
+## Credential issued
+
+Issues a credential of type `api_key`. It is **static** — no lease, no TTL — and **not revocable**: revocation is a no-op because the key is owned and rotated outside Warden. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — if `verify_endpoint` is set, creating or updating a spec triggers a light call to `api_url` + `verify_endpoint` using the configured method and auth header, retried on HTTP 429 or 500. A key that fails the call is rejected. With no `verify_endpoint`, verification is skipped.
+
+No rotation of any kind — the key is static and managed upstream.
+
+## Example
+
+```bash
+warden cred source create openai \
+  -type=apikey \
+  -config=api_url=https://api.openai.com \
+  -config=verify_endpoint=/v1/models \
+  -config=verify_method=GET \
+  -config=auth_header_type=bearer \
+  -config=optional_metadata=organization_id \
+  -config=display_name=OpenAI \
+  -rotation-period=0
+
+warden cred spec create openai-team-a \
+  -source=openai \
+  -config=api_key=sk-proj-abc123... \
+  -config=organization_id=org-XXXX
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [`local`](local.md) — static secrets with no upstream verification.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/aws.md
+++ b/docs/credential-drivers/aws.md
@@ -1,0 +1,91 @@
+# AWS Driver
+
+> Source `type`: `aws`
+
+The AWS driver brokers credentials from **Amazon Web Services**. The **source** holds a long-lived IAM **access key** (`access_key_id` / `secret_access_key`) and a region; it can optionally chain into an elevated session by assuming a role. From that authenticated base, each **spec** picks a `mint_method` to produce one of several credential shapes — temporary STS session credentials, a secret pulled from Secrets Manager, or a short-lived database IAM auth token for RDS or Redshift.
+
+Reach for this driver when workloads need scoped, time-bounded access to AWS APIs or to IAM-authenticated databases without ever handling the operator's standing IAM key. The privileged key lives only in the source config; specs carry the per-request details (which role, which secret, which database).
+
+## Source config
+
+Keys for `warden cred source create <name> -type=aws -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `access_key_id` | Yes | — | AWS IAM access key ID for the source. |
+| `secret_access_key` | Yes | — | AWS IAM secret access key (secret, masked on read). |
+| `region` | Yes | — | AWS region for API calls (e.g. `us-east-1`). |
+| `assume_role_arn` | No | — | Optional IAM role ARN to assume for elevated permissions. |
+| `session_name` | No | `warden-source-session` | Session name for AssumeRole operations. |
+| `session_duration` | No | `1h` | Duration for AssumeRole sessions. |
+| `external_id` | No | — | Optional external ID for AssumeRole operations. |
+
+## Specs and mint methods
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `sts_assume_role` | `aws_access_keys` | `role_arn` (required), `ttl` (default `1h`), `session_name`, `external_id`, `policy` |
+| `secrets_manager` | `aws_access_keys` | `secret_id` (required), `version_stage`, `version_id`, `json_key_map` |
+| `rds_iam_token` | `db_auth_token` | `db_endpoint` (required), `db_user` (required), `db_engine` (default `postgres`), `db_port`, `region` |
+| `redshift_iam_token` | `db_auth_token` | `db_endpoint` (required), plus exactly one of `cluster_identifier` or `workgroup_name`, `db_name`, `db_port` (default `5439`), `duration_seconds` (900–3600, default `900`), `region` |
+
+Spec-config keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Meaning |
+|-----|----------|---------|---------|
+| `mint_method` | Yes | — | Which minting path to use — one of the four values above. Must be set explicitly; there is no default. |
+| `role_arn` | Yes (`sts_assume_role`) | — | Role the session assumes. |
+| `ttl` | No | `1h` | STS session lifetime; bounded by the spec's MinTTL/MaxTTL. |
+| `session_name` | No | `warden-<spec>` | STS role session name. |
+| `external_id` | No | — | External ID passed to AssumeRole. |
+| `policy` | No | — | Inline session policy scoping the STS credentials. |
+| `secret_id` | Yes (`secrets_manager`) | — | Secret name or ARN to fetch. |
+| `version_stage` | No | — | Secrets Manager version stage. |
+| `version_id` | No | — | Secrets Manager version ID. |
+| `json_key_map` | No | — | Comma-separated `srcKey=destKey` remap of the secret's JSON keys. |
+| `db_endpoint` | Yes (DB methods) | — | Database host endpoint. |
+| `db_user` | Yes (`rds_iam_token`) | — | Database user the token authenticates as. |
+| `db_engine` | No | `postgres` | RDS engine (drives the default port). |
+| `db_port` | No | engine default / `5439` | Database port. |
+| `cluster_identifier` | One of two (`redshift_iam_token`) | — | Provisioned Redshift cluster. |
+| `workgroup_name` | One of two (`redshift_iam_token`) | — | Redshift Serverless workgroup. |
+| `db_name` | No | — | Target database name for Redshift. |
+| `duration_seconds` | No | `900` | Redshift token lifetime, 900–3600 seconds. |
+| `region` | No | source `region` | Overrides the source region for the DB token. |
+
+## Credential issued
+
+- `sts_assume_role` and `secrets_manager` issue **`aws_access_keys`**.
+- `rds_iam_token` and `redshift_iam_token` issue **`db_auth_token`**.
+
+STS credentials are **dynamic** — they carry a lease and TTL — but are **not revocable**: AWS provides no way to invalidate temporary STS credentials, so they are tracked under a synthetic lease ID and simply expire. RDS and Redshift IAM tokens are also short-lived and expiry-bound (RDS tokens last ~15 minutes; Redshift honors `duration_seconds`). Secrets Manager values are **static** — no lease, no revocation. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **slow**: stages a newly created IAM access key alongside the old one and waits ~5 minutes (`DefaultAWSActivationDelay`, tunable via the source's `activation_delay`) so the new key propagates through AWS IAM's eventual consistency before the old key is destroyed. Only permanent IAM keys (those with an `AKIA` prefix) are rotatable. What gets rotated is the source's own IAM access key pair.
+
+No spec verification.
+
+## Example
+
+```bash
+warden cred source create prod-aws \
+  -type=aws \
+  -config=access_key_id=AKIAIOSFODNN7EXAMPLE \
+  -config=secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+  -config=region=us-east-1 \
+  -rotation-period=720h
+
+warden cred spec create deploy-role \
+  -source=prod-aws \
+  -config=mint_method=sts_assume_role \
+  -config=role_arn=arn:aws:iam::123456789012:role/DeployRole \
+  -config=ttl=1h
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [AWS provider](../provider-backends/aws.md) — full operator setup guide.
+- [RDS](../provider-backends/rds.md) and [Redshift](../provider-backends/redshift.md) — database IAM auth tokens.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/azure.md
+++ b/docs/credential-drivers/azure.md
@@ -1,0 +1,101 @@
+# Azure Driver
+
+> Source `type`: `azure`
+
+The Azure driver brokers credentials against **Azure AD** and **Azure Key Vault**. Its
+**source** holds a privileged service-principal login (tenant, client id, and client
+secret) that Warden uses to authenticate to Azure AD and to call the **Microsoft Graph**
+API. From that source, a **spec** mints short-lived **Azure AD bearer tokens** for a
+workload service principal, or fetches a **Key Vault secret**. An operator reaches for
+this driver to hand workloads scoped Azure access tokens without distributing a
+long-lived client secret, or to read secrets out of Key Vault on demand.
+
+This driver is unusual in two ways. First, the credentials it mints are supplied
+**per spec** — each spec carries its own workload service-principal `client_id` and
+`client_secret`, and the source login is used only to authenticate and to rotate. Second,
+it is the only driver that rotates **both** its own source secret **and** the secret
+embedded in a spec, both through Microsoft Graph.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=azure -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `tenant_id` | Yes | — | Azure AD tenant ID (UUID). |
+| `client_id` | Yes | — | Azure AD application (client) ID for the source service principal. |
+| `client_secret` | Yes | — | Client secret for the source service principal (secret, masked on read). |
+| `secret_id` | Yes | — | Key ID of the current client secret, tracked so rotation can retire the old one. |
+| `ca_data` | No | — | Base64-encoded PEM CA bundle for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+Source rotation also reads an optional `activation_delay` (duration) that tunes the
+propagation wait described under Capabilities.
+
+## Specs and mint methods
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `bearer_token` (default) | An Azure AD bearer token for a resource | `client_id`, `client_secret`, `resource_uri` |
+| `key_vault_secret` | The value of a Key Vault secret | `client_id`, `client_secret`, `vault_name`, `secret_name` |
+
+Keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Meaning |
+|-----|----------|---------|---------|
+| `mint_method` | No | `bearer_token` | Which credential to mint. |
+| `tenant_id` | No | source `tenant_id` | Tenant of the workload service principal. |
+| `client_id` | Yes | — | Workload service-principal application (client) ID. |
+| `client_secret` | Yes | — | Workload service-principal client secret (secret). |
+| `secret_id` | No | — | Key ID of the spec's client secret, tracked for spec rotation. |
+| `resource_uri` | No | `https://management.azure.com/` | Resource the bearer token targets (`bearer_token` only). |
+| `vault_name` | Yes* | — | Key Vault name (`key_vault_secret` only). |
+| `secret_name` | Yes* | — | Secret name in the vault (`key_vault_secret` only). |
+| `secret_version` | No | latest | Specific secret version (`key_vault_secret` only). |
+
+\* Required when `mint_method=key_vault_secret`.
+
+## Credential issued
+
+The default `bearer_token` method issues an `azure_bearer_token` — a **dynamic**
+credential that carries the token's Azure AD TTL, and is **not revocable**: Azure bearer
+tokens expire naturally, so revocation is a no-op. The `key_vault_secret` method returns
+the secret value as a **static** credential with no lease or TTL. See
+[the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **slow**: stages a new source `client_secret` (a fresh Azure AD
+  password credential added via Microsoft Graph) and waits ~5m (default, tunable via the
+  source's `activation_delay`) so it propagates across Azure AD before the old secret is
+  destroyed. Requires the source service principal to hold `Application.ReadWrite.All`.
+- **Spec rotation** — **slow**: rotates the workload service principal's `client_secret`
+  stored in the spec, again through Microsoft Graph and with the same propagation wait.
+  This is the only driver that rotates a spec's own embedded secret.
+
+No spec verification.
+
+## Example
+
+```bash
+warden cred source create azure-prod \
+  -type=azure \
+  -config=tenant_id=00000000-0000-0000-0000-000000000000 \
+  -config=client_id=11111111-1111-1111-1111-111111111111 \
+  -config=client_secret=s3cr3t-value \
+  -config=secret_id=22222222-2222-2222-2222-222222222222 \
+  -rotation-period=720h
+
+warden cred spec create arm-token \
+  -source=azure-prod \
+  -config=mint_method=bearer_token \
+  -config=client_id=33333333-3333-3333-3333-333333333333 \
+  -config=client_secret=workload-s3cr3t \
+  -config=resource_uri=https://management.azure.com/
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Azure provider](../provider-backends/azure.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/elastic.md
+++ b/docs/credential-drivers/elastic.md
@@ -1,0 +1,61 @@
+# Elasticsearch Driver
+
+> Source `type`: `elastic`
+
+The Elasticsearch driver mints short-lived **API keys** from an Elasticsearch cluster's Security API. The privileged secret is a pre-encoded API key held in the **source** config; Warden authenticates to the cluster with it and, for each **credential**, creates a scoped, expiring API key via the cluster's Security API.
+
+Operators reach for this driver when a workload needs to talk to Elasticsearch and should carry its own narrowly-scoped key rather than a shared cluster credential. Per-spec parameters control the key's name, lifetime, and role descriptors, so one source can back many specs with different privilege sets.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=elastic -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `elastic_url` | Yes | — | Cluster URL; must use `https` (plain `http` allowed only with `tls_skip_verify`). |
+| `api_key` | Yes | — | Pre-encoded API key, base64 of `id:api_key` (secret, masked on read). |
+| `api_key_id` | No | derived | API key ID; extracted from `api_key` if omitted. |
+| `activation_delay` | No | `10s` | Wait for key propagation during source rotation. |
+| `key_name_prefix` | No | `warden` | Prefix for generated API key names. |
+| `ca_data` | No | — | Base64-encoded PEM CA bundle for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+A single mint method: each spec creates one Elasticsearch API key. Keys operators set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `key_name` | No | `<prefix>-<spec>-<unix>` | Name for the generated API key. |
+| `expiration` | No | `1h` | Key expiration, e.g. `30d`; sets the credential's TTL. |
+| `role_descriptors` | No | — | JSON string of role descriptors scoping the key's privileges. |
+
+## Credential issued
+
+`InferCredentialType` always returns `api_key`. The minted key is **dynamic** — it carries a TTL derived from the cluster's returned expiration timestamp — and **revocable**: Warden invalidates the key through the Security API when the lease ends. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates the source credentials with a light authenticate call at create/update time.
+- **Source rotation** — **slow** — stages a newly minted API key and waits ~10s (default, tunable via the source's `activation_delay`) for in-cluster propagation before invalidating the old key. Rotates the driver's own source API key via the Security API; requires the `manage_api_key` or `manage_own_api_key` cluster privilege.
+
+## Example
+
+```bash
+warden cred source create es-prod \
+  -type=elastic \
+  -config=elastic_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
+  -config=api_key=dXNlcjpwYXNzd29yZA== \
+  -rotation-period=720h
+
+warden cred spec create es-search-ro \
+  -source=es-prod \
+  -config=expiration=24h \
+  -config=role_descriptors={"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Elasticsearch provider](../provider-backends/elastic.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/gcp.md
+++ b/docs/credential-drivers/gcp.md
@@ -1,0 +1,79 @@
+# GCP Driver
+
+> Source `type`: `gcp`
+
+The GCP driver brokers **Google Cloud** access. It holds a **service-account JSON key**
+in the **source** config and exchanges that key for short-lived **OAuth2 access tokens**,
+either for the source service account itself or, by **impersonation**, for another service
+account it is authorized to act as. The minted token is what Warden injects into the
+workload's Google Cloud API request.
+
+The privileged secret — the SA key — lives only in the source config and is masked on
+read. Each **spec** selects a `mint_method` and the scopes, target account, and lifetime
+of the token to issue. An operator reaches for this driver to hand workloads scoped,
+expiring Google Cloud tokens without ever exposing the underlying key.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=gcp -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `service_account_key` | Yes | — | GCP service-account key in JSON format; must contain `client_email` and `private_key` (secret, masked on read) |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read) |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only) |
+
+## Specs and mint methods
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `access_token` (default) | OAuth2 access token for the source SA | `scopes` |
+| `impersonated_access_token` | OAuth2 access token for a target SA via IAM | `target_service_account`, `scopes`, `lifetime` |
+
+Spec-config keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `mint_method` | No | `access_token` | Which token to mint (see table above) |
+| `scopes` | No | `https://www.googleapis.com/auth/cloud-platform` | Comma-separated OAuth2 scopes |
+| `target_service_account` | Yes (impersonation only) | — | Email of the service account to impersonate |
+| `lifetime` | No | `3600s` | Requested token lifetime (impersonation only) |
+
+## Credential issued
+
+Both mint methods issue a credential of type `gcp_access_token`. It is **dynamic** — it
+carries the token's natural expiry as its TTL — but it is **not revocable**: a GCP access
+token cannot be invalidated early and simply expires. See
+[the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **slow**: stages a freshly created service-account key (minted
+  via the IAM API against the source SA) and waits ~2 minutes (default, tunable via the
+  source's `activation_delay`) for GCP IAM propagation before destroying the old key.
+  Rotation requires the SA to hold `iam.serviceAccountKeys.create` and
+  `iam.serviceAccountKeys.delete` on itself.
+
+No spec verification.
+
+## Example
+
+```bash
+warden cred source create prod-gcp \
+  -type=gcp \
+  -config=service_account_key=@sa-key.json \
+  -rotation-period=720h
+
+warden cred spec create bigquery-reader \
+  -source=prod-gcp \
+  -config=mint_method=impersonated_access_token \
+  -config=target_service_account=bq-reader@my-project.iam.gserviceaccount.com \
+  -config=scopes=https://www.googleapis.com/auth/bigquery.readonly \
+  -config=lifetime=1800s
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [GCP provider](../provider-backends/gcp.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/github.md
+++ b/docs/credential-drivers/github.md
@@ -1,0 +1,67 @@
+# GitHub Driver
+
+> Source `type`: `github`
+
+The GitHub driver mints **GitHub tokens** for workloads that call the GitHub REST API — github.com or a GitHub Enterprise instance. Unusually, the privileged auth material does **not** live on the **source**. The source config holds only connection details (`github_url` plus TLS options); the actual credentials — a GitHub App private key or a Personal Access Token — are supplied per **spec** and read at mint time. This means many specs, each carrying a different PAT or App installation, can share a single source.
+
+Each spec picks an **`auth_method`**: `app` (the default) uses a GitHub App private key to mint short-lived installation access tokens (~1h TTL), while `pat` passes through a static Personal Access Token. An operator reaches for this driver whenever a workload needs to authenticate to GitHub without holding the long-lived App key or PAT itself.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=github -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `github_url` | No | `https://api.github.com` | GitHub API URL — the default for github.com, or a GitHub Enterprise URL. |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom or self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+The `auth_method` spec key selects how the token is obtained:
+
+| `auth_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `app` (default) | Short-lived GitHub App installation access token (~1h TTL) | `private_key`, `app_id`, `installation_id` |
+| `pat` | Static Personal Access Token, passed through unchanged | `token` |
+
+Spec-config keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `auth_method` | No | `app` | Auth mode: `app` or `pat`. |
+| `private_key` | For `app` | — | PEM-encoded RSA private key for the GitHub App (PKCS1 or PKCS8). |
+| `app_id` | For `app` | — | GitHub App ID (JWT issuer). |
+| `installation_id` | For `app` | — | Installation ID the token is minted for. |
+| `token` | For `pat` | — | The Personal Access Token to pass through. |
+
+## Credential issued
+
+The driver always issues the `github_token` type. In `app` mode the token is **dynamic** — it carries a TTL (~1h) tied to the installation token's expiry. In `pat` mode the token is **static** — no lease, no TTL. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation). GitHub App installation tokens are revocable and expire naturally; the driver relies on their short lifetime rather than tracking leases for explicit revocation.
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time. In `pat` mode it confirms the token with a lightweight identity call; in `app` mode the spec is exercised by a trial mint against the GitHub API.
+- **Not rotatable — by design.** GitHub App installation tokens are ephemeral (~1h) and are simply re-minted on demand, and GitHub exposes no API to rotate a PAT. There is nothing long-lived on the source to rotate, so the driver does not implement source rotation.
+
+## Example
+
+```bash
+warden cred source create github-prod \
+  -type=github \
+  -config=github_url=https://api.github.com \
+  -rotation-period=0
+
+warden cred spec create ci-deploy \
+  -source=github-prod \
+  -config=auth_method=app \
+  -config=app_id=123456 \
+  -config=installation_id=7891011 \
+  -config=private_key="$(cat app-private-key.pem)"
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [GitHub provider](../provider-backends/github.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/gitlab.md
+++ b/docs/credential-drivers/gitlab.md
@@ -1,0 +1,72 @@
+# GitLab Driver
+
+> Source `type`: `gitlab`
+
+The GitLab driver mints **project access tokens** and **group access tokens** from a GitLab server. Warden calls the GitLab API to create short-lived, scoped tokens on demand and revokes them when their lease ends, so workloads never hold a long-lived credential.
+
+The privileged secret lives in the **source** config. The driver authenticates to GitLab one of two ways, set by `auth_method`: **PAT mode** (default) uses a **personal access token**, and **OAuth2 mode** uses an application ID and secret via the client-credentials flow. Each **spec** then names a project or group and the scopes the minted token should carry. An operator reaches for this driver to broker CI and automation access to specific GitLab projects or groups without distributing standing tokens.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=gitlab -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `gitlab_address` | Yes | — | GitLab server address (`http://` or `https://`), e.g. `https://gitlab.example.com`. |
+| `auth_method` | No | `pat` | Authentication method: `pat` or `oauth2`. |
+| `personal_access_token` | Yes (pat) | — | GitLab personal access token (secret, masked on read). Required in PAT mode. |
+| `application_id` | Yes (oauth2) | — | GitLab OAuth2 application ID. Required in OAuth2 mode. |
+| `application_secret` | Yes (oauth2) | — | GitLab OAuth2 application secret (secret, masked on read). Required in OAuth2 mode. |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `project_access_token` | A project access token | `project_id` |
+| `group_access_token` | A group access token | `group_id` |
+
+Spec-config keys for `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `mint_method` | Yes | — | `project_access_token` or `group_access_token`. |
+| `project_id` | Yes (project) | — | Project ID or URL-encoded path. Used by `project_access_token`. |
+| `group_id` | Yes (group) | — | Group ID or URL-encoded path. Used by `group_access_token`. |
+| `token_name` | No | `warden-minted` | Display name for the created token. |
+| `scopes` | No | `api` | Comma-separated token scopes. |
+| `access_level` | No | `30` | Access level for the token (30 = developer). |
+| `ttl` | No | `24h` | Token lifetime; sets the expiry date and the lease TTL. |
+
+## Credential issued
+
+Both mint methods issue a `gitlab_access_token`. It is **dynamic** — it carries a lease and TTL derived from `ttl` — and **revocable**: Warden deletes the token via the GitLab API when the lease ends. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **fast**, prepares and activates in one step (immediately-consistent upstream). The driver rotates its own source credential: in PAT mode it calls GitLab's atomic PAT rotate endpoint; in OAuth2 mode it renews the application secret. In both cases GitLab invalidates the old credential as part of the rotate, so the new one is committed inline with no propagation delay.
+
+## Example
+
+```bash
+warden cred source create gitlab-ci \
+  -type=gitlab \
+  -config=gitlab_address=https://gitlab.example.com \
+  -config=auth_method=pat \
+  -config=personal_access_token=glpat-xxxxxxxxxxxx \
+  -rotation-period=720h
+
+warden cred spec create gitlab-app-deploy \
+  -source=gitlab-ci \
+  -config=mint_method=project_access_token \
+  -config=project_id=42 \
+  -config=scopes=api,read_repository \
+  -config=ttl=24h
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [GitLab provider](../provider-backends/gitlab.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/grafana.md
+++ b/docs/credential-drivers/grafana.md
@@ -1,0 +1,61 @@
+# Grafana Driver
+
+> Source `type`: `grafana`
+
+The Grafana driver mints **Grafana service-account tokens** by talking to the Grafana HTTP API. For every mint it creates a **temporary service account**, generates a bounded-TTL token on it, and hands the token to the workload; on **revoke** it deletes that service account (and with it every token), so minted credentials are fully revocable.
+
+The privileged secret lives in the **source**: an `admin_token` (an admin service-account token with permission to create and delete service accounts) plus the `grafana_url` to reach. Each **spec** decides the shape of what gets minted — the role granted, the naming prefix, an optional org, and the token TTL. An operator reaches for this driver to grant workloads short-lived, least-privilege Grafana access without ever sharing the standing admin token.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=grafana -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `grafana_url` | Yes | — | Grafana API base URL, e.g. `https://mystack.grafana.net`. Must be `https://` (or `http://` only with `tls_skip_verify`). |
+| `admin_token` | Yes | — | Admin service-account token with ServiceAccount admin permissions (secret, masked on read). |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+A single mint method: each mint creates a service account and issues one token on it. Keys operators set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `role` | No | `Viewer` | Role granted to the service account: `Viewer`, `Editor`, or `Admin`. |
+| `name_prefix` | No | `warden-` | Prefix for the generated service-account name. |
+| `org_id` | No | — | Grafana organization ID to scope the service account to; omit for the default org. |
+| `token_expiry` | No | `1h` | TTL of the minted token. |
+
+## Credential issued
+
+Issues a credential of type `api_key`. It is **dynamic** — it carries a lease and a TTL equal to `token_expiry` — and it is **revocable**: revoking deletes the backing service account and invalidates the token. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates the source's admin token at spec create/update time with a lightweight service-account listing call.
+
+Mint and revoke otherwise; no source or spec rotation. Create the source with `-rotation-period=0`.
+
+## Example
+
+```bash
+warden cred source create grafana-cloud \
+  -type=grafana \
+  -config=grafana_url=https://mystack.grafana.net \
+  -config=admin_token=glsa_xxxxxxxxxxxxxxxxxxxx \
+  -rotation-period=0
+
+warden cred spec create grafana-dashboards \
+  -source=grafana-cloud \
+  -config=role=Viewer \
+  -config=name_prefix=warden- \
+  -config=token_expiry=1h
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Grafana provider](../provider-backends/grafana.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/honeycomb.md
+++ b/docs/credential-drivers/honeycomb.md
@@ -1,0 +1,65 @@
+# Honeycomb Driver
+
+> Source `type`: `honeycomb`
+
+The **Honeycomb** driver mints **Honeycomb V2 API keys** from the key-management API. The privileged secret is a **management key** (an ID and secret pair) that lives in the **source** config and can create and delete API keys for a team. Each **spec** then decides the environment, key type, naming, and permissions of the keys minted from that management key.
+
+Reach for this driver when a workload needs a short-lived Honeycomb **ingest** or **configuration** key rather than a long-lived hand-issued one. Minted key secrets are **capture-once** — Honeycomb returns the secret only at creation time, so Warden captures it then and injects it on demand. Keys do not expire natively, so the spec's `key_ttl` governs the Warden lease.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=honeycomb -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `honeycomb_url` | No | `https://api.honeycomb.io` | Honeycomb API base URL (must be `https://`). |
+| `management_key_id` | Yes | — | Management key ID (`hcxmk_` prefix). (secret, masked on read) |
+| `management_key_secret` | Yes | — | Management key secret paired with the key ID. (secret, masked on read) |
+| `team_slug` | Yes | — | Honeycomb team slug used in API paths (e.g. `my-team`). |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom or self-signed CAs. (secret, masked on read) |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+A single mint method issues Honeycomb API keys. Keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `environment_id` | Yes | — | Honeycomb environment the key is scoped to. |
+| `key_type` | No | `ingest` | Key type: `ingest` or `configuration`. |
+| `key_name_prefix` | No | `warden-` | Prefix for the generated key name (name is `<prefix><spec>-<timestamp>`). |
+| `permissions` | No | — | JSON permission object; allowed only for `configuration` keys. |
+| `key_ttl` | No | `24h` | Warden lease duration for the minted key. |
+
+## Credential issued
+
+Issues a credential of type `api_key`. It is **dynamic** — it carries a lease whose TTL comes from the spec's `key_ttl` — and it is **revocable**: expiry or explicit revoke deletes the underlying Honeycomb key. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates the spec's `environment_id` and `key_type`, then lists API keys with a page size of 1 to confirm the management key and team slug work at spec create/update time.
+
+Mint and revoke otherwise; no source or spec rotation.
+
+## Example
+
+```bash
+warden cred source create honeycomb-prod \
+  -type=honeycomb \
+  -config=team_slug=my-team \
+  -config=management_key_id=hcxmk_abc123 \
+  -config=management_key_secret=s3cr3t \
+  -rotation-period=0
+
+warden cred spec create honeycomb-ingest \
+  -source=honeycomb-prod \
+  -config=environment_id=env_prod01 \
+  -config=key_type=ingest \
+  -config=key_ttl=12h
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Honeycomb provider](../provider-backends/honeycomb.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/ibm.md
+++ b/docs/credential-drivers/ibm.md
@@ -1,0 +1,67 @@
+# IBM Cloud Driver
+
+> Source `type`: `ibm`
+
+The IBM Cloud driver brokers access to **IBM Cloud** by exchanging a long-lived **IBM Cloud API key** for short-lived **IAM bearer tokens**. The privileged API key lives in the **source** config; each **spec** decides whether a workload receives a bare bearer token or that token paired with static **Cloud Object Storage (COS)** HMAC keys. IAM tokens expire on their own, so nothing is left behind after use.
+
+An operator reaches for this driver when workloads need to call IBM Cloud APIs (or COS S3-compatible endpoints) without holding the account API key themselves. Warden can also rotate the source API key on a schedule, minting a fresh key for the same IAM identity and retiring the old one.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=ibm -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `api_key` | Yes | — | IBM Cloud API key (secret, masked on read). |
+| `account_id` | No | discovered from the API key | IBM Cloud account ID; auto-filled from the key's details when omitted. |
+| `iam_endpoint` | No | `https://iam.cloud.ibm.com` | IAM endpoint; must use `https` unless `tls_skip_verify` is set. |
+| `ca_data` | No | — | Base64-encoded PEM CA bundle for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+The `mint_method` spec key selects what is issued:
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `iam_token` (default) | IAM bearer token | none |
+| `iam_with_cos` | IAM bearer token plus optional static COS HMAC keys | `access_key_id`, `secret_access_key` |
+
+Spec-config keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `mint_method` | No | `iam_token` | Selects the mint method (`iam_token` or `iam_with_cos`). |
+| `access_key_id` | No | — | COS HMAC access key ID; only used by `iam_with_cos`. Both keys must be present to be included. |
+| `secret_access_key` | No | — | COS HMAC secret access key; only used by `iam_with_cos`. |
+
+## Credential issued
+
+`iam_token` issues an `oauth_bearer_token`; `iam_with_cos` issues `ibmcloud_keys`. Both are **dynamic** — the credential carries the IAM token's remaining TTL as its lease. They are **not revocable**: IAM tokens expire naturally and revoke is a no-op. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time with a lightweight IAM token exchange.
+- **Source rotation** — **slow**: stages a newly created API key for the same IAM identity and waits ~2 minutes (default, tunable via the source's `activation_delay`) so it propagates before the old key is deleted. What rotates is the source `api_key`. Rotation is available only when the key's IAM identity was discovered and can create/delete API keys.
+
+## Example
+
+```bash
+warden cred source create ibm-prod \
+  -type=ibm \
+  -config=api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=account_id=abcdef1234567890abcdef1234567890 \
+  -rotation-period=720h
+
+warden cred spec create ibm-cos \
+  -source=ibm-prod \
+  -config=mint_method=iam_with_cos \
+  -config=access_key_id=AKIAEXAMPLE \
+  -config=secret_access_key=wJalrEXAMPLEKEY
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [IBM Cloud provider](../provider-backends/ibmcloud.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/kubernetes.md
+++ b/docs/credential-drivers/kubernetes.md
@@ -1,0 +1,67 @@
+# Kubernetes Driver
+
+> Source `type`: `kubernetes`
+
+The Kubernetes driver mints short-lived **ServiceAccount tokens** through the cluster's **TokenRequest API**. Each token is an audience-scoped bearer credential that a workload presents to the Kubernetes API server (or to any service that trusts the cluster's token issuer) as a specific service account.
+
+The privileged secret — a bearer **token** with permission to create tokens for the target service accounts — lives in the **source** config alongside the API server URL and TLS settings. Each **spec** names the service account and namespace to mint for, plus optional audiences and TTL. An operator reaches for this driver to hand workloads narrowly-scoped, expiring identities without distributing long-lived service-account secrets.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=kubernetes -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `kubernetes_url` | Yes | — | Kubernetes API server URL. Must use `https` unless `tls_skip_verify` is set. |
+| `token` | Yes | — | Bearer token for authenticating to the API server (secret, masked on read). |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for the cluster (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (dev/test clusters only). |
+| `source_service_account` | No | — | Name of the source service account. Required for rotation. |
+| `source_namespace` | No | — | Namespace of the source service account. Required for rotation. |
+| `source_token_ttl` | No | `24h` | TTL for rotated source tokens. Min `10m`, max `48h`. |
+
+## Specs and mint methods
+
+The driver has a single mint path: it calls the TokenRequest API for the named service account. Keys operators set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `service_account` | Yes | — | Target service account name. |
+| `namespace` | Yes | — | Namespace of the target service account. |
+| `audiences` | No | — | Comma-separated token audiences. |
+| `ttl` | No | `1h` | Requested token TTL, e.g. `1h`. The cluster may clamp this. |
+
+## Credential issued
+
+The credential `type` is `kubernetes_token`. It is **dynamic** — the token carries a TTL derived from the API server's returned expiration timestamp — but it is **not revocable**: ServiceAccount tokens expire naturally and cannot be invalidated through the API. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates that the target service account exists in its namespace with a light API call at create/update time.
+- **Source rotation** — available only when `source_service_account` and `source_namespace` are set. **Fast** — prepares and activates in one step (immediately-consistent upstream): the driver mints a fresh token for its own service account and swaps it in. Old tokens are left to expire naturally.
+
+## Example
+
+```bash
+warden cred source create prod-k8s \
+  -type=kubernetes \
+  -config=kubernetes_url=https://my-cluster.example.com:6443 \
+  -config=token=eyJhbGciOiJSUzI1NiIs... \
+  -config=ca_data=LS0tLS1CRUdJTi... \
+  -config=source_service_account=warden-token-creator \
+  -config=source_namespace=warden \
+  -rotation-period=24h
+
+warden cred spec create app-token \
+  -source=prod-k8s \
+  -config=service_account=my-app \
+  -config=namespace=default \
+  -config=audiences=https://kubernetes.default.svc \
+  -config=ttl=1h
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Kubernetes provider](../provider-backends/kubernetes.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/local.md
+++ b/docs/credential-drivers/local.md
@@ -1,0 +1,54 @@
+# Local Driver
+
+> Source `type`: `local`
+
+The **local** driver serves **static credentials** that live directly in the **spec** config. There is no upstream to talk to and no privileged secret held by the **source** — the source is an empty shell whose only job is to name the driver. Whatever key/value pairs an operator puts on the spec become the credential data, verbatim.
+
+Reach for `local` when you already hold a fixed secret — a pre-issued token, a shared password, a static connection string — and simply want Warden to broker it to a workload. Because a local source can serve many different credential shapes, the credential `type` cannot be inferred and must be stated explicitly on the spec with `-type=`.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=local -config=key=value ...`:
+
+The local driver takes **no configuration**. The source needs only a name and the `-type=local` flag; any config passed is accepted but ignored, and there are no required keys and no secret fields.
+
+## Specs and mint methods
+
+A local spec has a single, implicit mint method: it copies every field of the spec config into the minted credential. There are no reserved keys — the config is just arbitrary key/value pairs that become the credential data (for example `token`, `username`, `password`, `url`).
+
+Because the source cannot infer a type, `-type=` must be set explicitly when creating the spec.
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `<any>` | No | — | Arbitrary field copied verbatim into the credential data. |
+
+## Credential issued
+
+The credential `type` is whatever you pass to `-type=` on the spec (the driver serves many types). Local credentials are **static**: they carry no lease and no TTL, and they are **not revocable** — revocation is a no-op. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+Mint only — no verification, no rotation, and revocation and cleanup are no-ops.
+
+## Example
+
+```bash
+warden cred source create my-static \
+  -type=local \
+  -rotation-period=0
+
+warden cred spec create slack-bot-token \
+  -source=my-static \
+  -type=api_key \
+  -config=api_key=xoxb-EXAMPLE-STATIC-TOKEN
+```
+
+The spec config becomes the credential data verbatim, so the fields you set must
+match what the chosen `-type` expects — here the `api_key` type reads an `api_key`
+field.
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [`apikey`](apikey.md) — a static API key with an upstream verify check, when the key targets an HTTP API.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/oauth2.md
+++ b/docs/credential-drivers/oauth2.md
@@ -1,0 +1,87 @@
+# OAuth2 Driver
+
+> Source `type`: `oauth2`
+
+The **OAuth2 driver** exchanges OAuth2 credentials for short-lived **bearer tokens** against any standards-compliant provider. It supports two flows: the **client_credentials** flow (machine-to-machine, no user present) and the **authorization_code** flow with refresh-token rotation (acting on behalf of a user who granted consent once). Reach for it when a workload needs an OAuth2 access token and no purpose-built driver exists for the provider.
+
+The token endpoint and connection options live in the **source** config (`token_url` required). The `client_id` and `client_secret` may live on the source — natural for `client_credentials` — or be supplied per **spec**, resolved spec-over-source. For the `authorization_code` flow, per-user tokens are sealed onto the spec by a one-time interactive consent step, and the driver refreshes them at mint time.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=oauth2 -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `token_url` | Yes | — | OAuth2 token endpoint (HTTPS). |
+| `client_id` | No | — | OAuth2 client ID (source-level for client_credentials; may be set per-spec). |
+| `client_secret` | No | — | OAuth2 client secret (secret, masked on read). |
+| `auth_url` | No | — | Authorization endpoint (HTTPS); required for authorization_code specs. |
+| `introspection_url` | No | — | Userinfo/introspection endpoint called at mint to fetch identity fields for opaque tokens. |
+| `metadata_fields` | No | `sub` | Comma-separated identity fields copied into the credential's non-secret, audit-logged metadata (empty disables). |
+| `default_scopes` | No | — | Default OAuth2 scopes (space-separated). |
+| `verify_url` | No | — | Endpoint to verify minted tokens (skipped if empty). |
+| `verify_method` | No | `GET` | HTTP method for `verify_url` (GET or POST). |
+| `auth_header_type` | No | `bearer` | How to attach the token for verification: `bearer`, `token`, or `custom_header`. |
+| `auth_header_name` | No | — | Header name when `auth_header_type=custom_header` (required in that case). |
+| `display_name` | No | `OAuth2` | Human-readable label for logs and errors. |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+The spec's `auth_method` selects the flow:
+
+| `auth_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `client_credentials` (default) | Bearer token from client credentials | `scope`, `client_id`, `client_secret` |
+| `authorization_code` | Bearer token refreshed from a sealed grant | `refresh_token`, `access_token`, expiry keys (set by consent) |
+
+Keys operators set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `auth_method` | No | `client_credentials` | Flow to use: `client_credentials` or `authorization_code`. |
+| `scope` | No | source `default_scopes` | Scopes requested for `client_credentials`. |
+| `client_id` | No | source `client_id` | Client ID, resolved spec-over-source. |
+| `client_secret` | No | source `client_secret` | Client secret, resolved spec-over-source. |
+| `refresh_token` | No | — | Sealed refresh token for `authorization_code` (set by consent). |
+| `access_token` | No | — | Sealed static access token for providers that issue no refresh token (set by consent). |
+| `access_token_expires_at` | No | — | RFC3339 expiry of a sealed static access token. |
+| `refresh_token_expires_at` | No | — | RFC3339 expiry of a sealed refresh token. |
+
+For `authorization_code`, do not set the token keys by hand — they are populated by the one-time consent flow (see Capabilities). When the provider rotates the refresh token during a refresh, the driver surfaces the new value to the minting layer automatically, so the sealed grant stays current.
+
+## Credential issued
+
+Always `oauth_bearer_token`. It is **dynamic** when the provider returns an expiry (the credential carries a lease TTL and is re-minted on expiry) and **static** (non-expiring) when it does not. Bearer tokens are not revocable — they expire naturally, so revocation is a no-op. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — mints a token and, when `verify_url` is set, calls it to confirm the token works before the spec is accepted.
+- **OAuth2 authorization-code consent** — this is the only OAuth2 authorizer. For an `authorization_code` spec, run the one-time interactive `warden cred spec connect <name>`: it opens the provider's authorize URL, captures the returned code on a loopback redirect, exchanges it for tokens, and seals the resulting refresh token (or static access token) onto the spec. Later mints refresh from the sealed grant with no user present.
+
+No source rotation — the source secret is not rotated by the driver.
+
+## Example
+
+```bash
+warden cred source create pagerduty \
+  -type=oauth2 \
+  -config=token_url=https://identity.pagerduty.com/oauth/token \
+  -config=client_id=your-client-id \
+  -config=client_secret=your-client-secret \
+  -config=default_scopes="read write" \
+  -config=verify_url=https://api.pagerduty.com/users/me \
+  -rotation-period=0
+
+warden cred spec create pagerduty-readonly \
+  -source=pagerduty \
+  -config=auth_method=client_credentials \
+  -config=scope="read"
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [OAuth2 consent](../concepts/credentials.md#oauth2-consent) — the authorization-code flow.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/ovh.md
+++ b/docs/credential-drivers/ovh.md
@@ -1,0 +1,72 @@
+# OVHcloud Driver
+
+> Source `type`: `ovh`
+
+The OVHcloud driver mints credentials for **OVHcloud** APIs and Public Cloud services. It talks to OVHcloud's OAuth2 token endpoint and cloud API to issue either short-lived **bearer tokens**, **S3 credentials** for object storage, or both together. The choice is made per **spec** through the `mint_method` parameter.
+
+The privileged, long-lived secret is an OAuth2 service account — its `client_id` and `client_secret` — held in the **source** config. The source also carries optional default `project_id` and `user_id` for S3 credential management; a **spec** may override these. One source can back many specs that mint different credential shapes from the same service account.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=ovh -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `client_id` | Yes | — | OAuth2 service account client ID. |
+| `client_secret` | Yes | — | OAuth2 service account client secret (secret, masked on read). |
+| `ovh_endpoint` | No | `ovh-eu` | Regional endpoint: `ovh-eu`, `ovh-ca`, or `ovh-us`. |
+| `project_id` | No | — | Default Public Cloud project ID for S3 credential management. |
+| `user_id` | No | — | Default Public Cloud user ID for S3 credential management. |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+Set `mint_method` on the spec to choose what to mint:
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `oauth2_token` | Bearer token (~1h TTL) via OAuth2 client_credentials grant | none |
+| `dynamic_s3` | S3 access/secret key pair (revocable) | `project_id`, `user_id` |
+| `oauth2_token_and_s3` | Both a bearer token and an S3 key pair | `project_id`, `user_id` |
+
+Spec-config keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `mint_method` | Yes | — | One of `oauth2_token`, `dynamic_s3`, `oauth2_token_and_s3`. |
+| `project_id` | For S3 methods | source value | Public Cloud project ID; overrides the source default. Required (on source or spec) for `dynamic_s3` and `oauth2_token_and_s3`. |
+| `user_id` | For S3 methods | source value | Public Cloud user ID; overrides the source default. Required (on source or spec) for `dynamic_s3` and `oauth2_token_and_s3`. |
+
+## Credential issued
+
+All methods issue the credential type `ovh_keys`. Credentials are **dynamic**: they carry a lease and TTL derived from the OAuth2 token (~1h). The bearer token expires naturally, while S3 key pairs are **revocable** — Warden deletes them via the cloud API when the lease expires or is revoked. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time: confirms the `mint_method` is supported and, for the S3 methods, that `project_id` and `user_id` resolve from the source or spec.
+
+Mint and revoke otherwise — no source or spec rotation.
+
+## Example
+
+```bash
+warden cred source create ovh-prod \
+  -type=ovh \
+  -config=client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -config=client_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=ovh_endpoint=ovh-eu \
+  -config=project_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=user_id=12345 \
+  -rotation-period=0
+
+warden cred spec create ovh-s3 \
+  -source=ovh-prod \
+  -config=mint_method=dynamic_s3
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [OVHcloud provider](../provider-backends/ovh.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/scaleway.md
+++ b/docs/credential-drivers/scaleway.md
@@ -1,0 +1,77 @@
+# Scaleway Driver
+
+> Source `type`: `scaleway`
+
+The Scaleway driver brokers credentials from **Scaleway IAM**. A **source** holds the connection details for the Scaleway API and, when dynamic minting or rotation is used, a privileged **management key** (an access-key/secret-key pair with IAM permission to create and delete API keys). Each **spec** decides how a credential is produced: either by handing back a pre-existing key pair stored on the spec, or by asking the IAM API to mint a fresh, expiring API key on demand.
+
+Operators reach for this driver to give workloads Scaleway API keys without embedding long-lived secrets in the workload. Static keys are convenient when a key pair already exists; dynamic keys let Warden create short-lived keys per lease and revoke them automatically when the lease ends.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=scaleway -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `scaleway_url` | No | `https://api.scaleway.com` | Base URL for the Scaleway API. |
+| `management_access_key` | No | — | Access key of the management key (starts with `SCW`). Required for rotation. |
+| `management_secret_key` | No | — | Secret key with IAM permission to create/delete API keys (UUID format). Required for dynamic minting and rotation. (secret, masked on read) |
+| `iam_api_path` | No | `/iam/v1alpha1` | IAM API path prefix. Update when Scaleway promotes the API to stable. |
+| `ca_data` | No | — | Base64-encoded PEM CA bundle for custom/self-signed CAs. (secret, masked on read) |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+## Specs and mint methods
+
+The spec's `mint_method` selects how the credential is produced:
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `static_keys` (default) | A pre-existing key pair read straight from the spec | `access_key`, `secret_key` |
+| `dynamic_keys` | A fresh API key created via the IAM API, revoked on expiry | `application_id`, `ttl`, `description`, `default_project_id` |
+
+Spec-config keys (`warden cred spec create ... -config=key=value`):
+
+| Key | Required | Default | Meaning |
+|-----|----------|---------|---------|
+| `mint_method` | No | `static_keys` | `static_keys` or `dynamic_keys`. |
+| `access_key` | Yes (static) | — | Access key returned as the credential. |
+| `secret_key` | Yes (static) | — | Secret key returned as the credential. |
+| `application_id` | Yes (dynamic) | — | IAM application the new key is bound to. |
+| `ttl` | No (dynamic) | `1h` | Lifetime of the minted key; sets its `expires_at`. |
+| `description` | No (dynamic) | `warden-<spec>` | Description recorded on the created key. |
+| `default_project_id` | No (dynamic) | — | Default project scoped to the created key. |
+
+## Credential issued
+
+Both mint methods issue credentials of type `scaleway_keys` (an `access_key` / `secret_key` pair).
+
+- `static_keys` credentials are **static** — no lease, no TTL, not revocable by Warden.
+- `dynamic_keys` credentials are **dynamic** — they carry a lease/TTL and are **revocable**: Warden deletes the API key via the IAM API when the lease expires or is revoked.
+
+See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time. For `static_keys` it confirms the key pair resolves against the IAM API; for `dynamic_keys` it checks that the source has a management key and the spec sets `application_id`.
+- **Source rotation** — **slow**: stages a newly minted management key alongside the old one and waits ~30 seconds (default, tunable via the source's `activation_delay`) so it propagates before the old key is destroyed. Rotates the source's `management_access_key` / `management_secret_key`; requires both to be present.
+
+## Example
+
+```bash
+warden cred source create scw-prod \
+  -type=scaleway \
+  -config=management_access_key=SCWXXXXXXXXXXXXXXXXX \
+  -config=management_secret_key=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -rotation-period=720h
+
+warden cred spec create scw-app-keys \
+  -source=scw-prod \
+  -config=mint_method=dynamic_keys \
+  -config=application_id=11111111-2222-3333-4444-555555555555 \
+  -config=ttl=1h
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Scaleway provider](../provider-backends/scaleway.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.

--- a/docs/credential-drivers/vault.md
+++ b/docs/credential-drivers/vault.md
@@ -1,0 +1,100 @@
+# HashiCorp Vault Driver
+
+> Source `type`: `hvault`
+
+The `hvault` driver brokers credentials out of **HashiCorp Vault** (or **OpenBao**). The **source** holds how Warden authenticates to the Vault server — typically an **AppRole** identity (`role_id` + `secret_id`) — plus the server address and optional namespace. That one source can back many **specs**, each of which selects a **mint method** naming which Vault engine to draw from and what shape of credential to hand back to the workload.
+
+Reach for it when your secrets already live in Vault: static KV entries, dynamic cloud credentials from the AWS/GCP/IBM engines, OAuth2 bearer tokens from the oauthapp engine, or freshly minted Vault tokens. Warden authenticates once with the source's privileged AppRole, then mints per request against whatever engine the spec points at.
+
+## Source config
+
+Keys for `warden cred source create <name> -type=hvault -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `vault_address` | Yes | — | Vault/OpenBao server URL (`http://` or `https://`), e.g. `https://vault.example.com`. |
+| `vault_namespace` | No | — | Namespace to scope all requests to. |
+| `auth_method` | No | — | Authentication method; only `approle` is supported. Omit to use a pre-set token. |
+| `role_id` | If approle | — | AppRole role ID. |
+| `secret_id` | If approle | — | AppRole secret ID (secret, masked on read). |
+| `approle_mount` | If approle | — | Mount path of the AppRole auth backend, e.g. `approle`. |
+| `role_name` | If approle | — | AppRole role name; required so the source can rotate its own secret ID. |
+| `ca_data` | No | — | Base64-encoded PEM CA bundle for outbound upstream calls (e.g. the IBM IAM token exchange used by `dynamic_ibm`). Does not affect the connection to the Vault/OpenBao server itself. |
+| `tls_skip_verify` | No | `false` | Disable TLS verification on those outbound upstream calls (test only). Does not affect the Vault/OpenBao connection. |
+
+The `token` and `secret_id_accessor` fields are also treated as sensitive and masked on read.
+
+## Specs and mint methods
+
+Each spec sets a `mint_method` that picks the Vault engine and the credential shape:
+
+| `mint_method` | Issues | Notable spec config |
+|---------------|--------|---------------------|
+| `static_aws` | AWS access keys | `kv2_mount`, `secret_path` |
+| `static_apikey` | API key | `kv2_mount`, `secret_path` |
+| `dynamic_aws` | AWS access keys | `aws_mount`, `role_name`, `role_arn`, `role_session_name`, `ttl` |
+| `dynamic_gcp` | GCP access token | `gcp_mount`, `role_name`, `role_type` |
+| `dynamic_ibm` | IBM Cloud keys | `ibm_mount`, `role_name`, `ttl`, `iam_endpoint`, `access_key_id`, `secret_access_key` |
+| `vault_token` (or unset) | Vault token | `token_role`, `ttl`, `display_name`, `meta` |
+| `oauth2` | OAuth bearer token | `oauth2_mount`, `credential_name` |
+
+Spec-config keys set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Meaning |
+|-----|----------|---------|---------|
+| `kv2_mount` | For static | — | KV v2 mount holding the secret. |
+| `secret_path` | For static | — | Path of the secret within the KV mount. |
+| `aws_mount` | For `dynamic_aws` | — | Mount of the AWS secrets engine. |
+| `gcp_mount` | For `dynamic_gcp` | — | Mount of the GCP secrets engine. |
+| `ibm_mount` | For `dynamic_ibm` | — | Mount of the IBM secrets engine. |
+| `oauth2_mount` | For `oauth2` | — | Mount of the OAuth2 (oauthapp) engine. |
+| `role_name` | For dynamic aws/gcp/ibm | — | Engine role to generate credentials from. |
+| `role_type` | No | `roleset` | GCP role kind: `roleset` or `static-account`. |
+| `credential_name` | For `oauth2` | — | Named credential on the OAuth2 mount. |
+| `token_role` | For `vault_token` | — | Token role for `auth/token/create/<role>`. |
+| `ttl` | No | — | Requested lease TTL; validated against the spec's min/max bounds. |
+| `iam_endpoint` | No | IBM IAM default | Endpoint used to exchange the IBM API key for a bearer token. |
+| `role_arn` | No | — | AWS role ARN to assume (`dynamic_aws`). |
+| `role_session_name` | No | — | AWS session name (`dynamic_aws`). |
+| `access_key_id` / `secret_access_key` | No | — | Optional COS HMAC keys added to IBM credentials. |
+| `display_name` | No | — | Display name for a minted Vault token. |
+| `meta` | No | — | Metadata for a minted Vault token. |
+
+## Credential issued
+
+The credential `type` depends on the mint method: `static_aws`/`dynamic_aws` issue `aws_access_keys`, `static_apikey` issues `api_key`, `dynamic_gcp` issues `gcp_access_token`, `dynamic_ibm` issues `ibmcloud_keys`, `oauth2` issues `oauth_bearer_token`, and `vault_token` issues `vault_token`.
+
+Static KV secrets are **static** — no lease, no TTL, not revocable. Every dynamic method (`dynamic_aws`, `dynamic_gcp`, `dynamic_ibm`, `oauth2`, `vault_token`) is **dynamic** — it carries a lease/TTL and is **revocable**: Vault leases are revoked by lease ID and Vault tokens by accessor. See [the lifetime model](../concepts/credentials.md#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **fast**: prepares and activates in one step (immediately-consistent upstream). Rotates the source's own AppRole `secret_id` by generating a new one, re-authenticating, then destroying the old secret ID by accessor. Requires `auth_method=approle` and `role_name`.
+
+No spec verification. Static KV mints only fetch and revoke.
+
+## Example
+
+```bash
+warden cred source create prod-vault \
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=role-id-uuid \
+  -config=secret_id=secret-id-uuid \
+  -config=approle_mount=approle \
+  -config=role_name=warden-source-role \
+  -rotation-period=720h
+
+warden cred spec create prod-aws \
+  -source=prod-vault \
+  -config=mint_method=dynamic_aws \
+  -config=aws_mount=aws \
+  -config=role_name=deploy \
+  -config=ttl=30m
+```
+
+## See Also
+
+- [Credentials](../concepts/credentials.md) — the source, spec, and credential model.
+- [Vault provider](../provider-backends/vault.md) — full operator setup guide.
+- [Credential drivers](README.md) — every driver.


### PR DESCRIPTION
## Summary

Adds `docs/credential-drivers/` — a reference page for each of the 17 built-in credential drivers, plus a README index — and aligns the surrounding concept docs.

Each driver page documents, straight from the driver's schema builder and mint code:

- source `type` string, source-config key table (required / default / description)
- mint methods and their spec-config keys
- the credential type issued (dynamic vs. static, revocable or not)
- capabilities: spec verification, source rotation (fast vs. slow path + default `activation_delay`), spec rotation, OAuth2 consent
- a worked `warden cred source/spec create` example

## Also in this PR

- **Registration:** links the new folder from `concepts/README.md` and `concepts/credentials.md`, and fixes the Vault driver `type` (`vault` → `hvault`) in `credentials.md`.
- **discovery-and-skills.md:** overhauls the Skills section around skills being author-owned markdown you can scope to a role — so a non-MCP skill need only cover the handful of endpoints that role exposes rather than the provider's whole OpenAPI surface.
- **agent-flow.md:** one sentence in the operator-setup section pointing at the above.
- **core/sys_mcp.go:** clarifies the `get_skill` tool description — the skill name identifies the recipe for driving a *role*, not a provider type.

## Verification

Every page was generated from its driver source and then independently re-verified against that source. All 17 `type` strings match the `SourceType*` constants and the registered factories; all relative links resolve; CLI examples use single-dash flags. Three pages (aws, apikey, vault) had inaccuracies caught in review and corrected (e.g. AWS `mint_method` is required, not defaulted; Vault's `ca_data`/`tls_skip_verify` apply to outbound upstream calls, not the Vault connection).

Docs-only apart from the one `get_skill` description string.
