### PR TITLE
feat(site): rebuild the landing "why" section as five pillars

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,32 +8,6 @@ const nav = [
   { label: 'Download', href: `${github}/releases/latest` },
   { label: 'GitHub', href: github },
 ];
-const benefits = [
-  {
-    h: 'A compromised agent has nothing to steal',
-    p: 'Prompt-injected, jailbroken, or simply wrong — it never held a credential, so there is nothing to exfiltrate. One bad step stays a contained, recoverable event instead of a broad compromise.',
-  },
-  {
-    h: 'No credential sprawl to chase',
-    p: 'One identity reaches every system its policy permits. Nothing to distribute per integration, nothing to rotate per integration, and no static secrets left sitting in a dozen process environments.',
-  },
-  {
-    h: 'Least privilege on every single call',
-    p: 'The agent gets exactly the access its policy allows for that step — down to the tool it may call and the arguments it may pass — never a session-wide grant it can wander around inside.',
-  },
-  {
-    h: 'One place to govern every system',
-    p: 'One identity, one policy surface, and one audit log across clouds, code hosts, observability, databases, SaaS, and MCP servers. Namespaces keep teams isolated on shared infrastructure.',
-  },
-  {
-    h: 'An answer when someone asks who did what',
-    p: 'Every request tied to the real identity behind it, the role it used, the decision that was made, and the upstream it called — with secrets never written to the log in the clear.',
-  },
-  {
-    h: 'Adoption costs you one line',
-    p: 'The identity goes in the credential slot your SDK already expects, so existing code keeps working — only the base URL changes.',
-  },
-];
 ---
 
 <!doctype html>
@@ -133,79 +107,209 @@ const benefits = [
         </div>
       </section>
 
-      <!-- Features -->
-      <section class="band">
-        <div class="wrap">
-          <div class="feat-head">
-            <h2 class="h">Broker, authorize, and audit every agent request</h2>
-            <p class="lead">
-              The control gap, not the credential, is the headline: pointing an agent at
-              production means over-scoped, long-lived credentials, no per-request policy, and
-              no identity-tied audit. Warden mints a short-lived credential per request,
-              decides each call as it happens, and ties every request back to the identity that
-              made it.
-            </p>
-          </div>
-          <div class="feat-cols">
-            <div class="feat">
-              <div class="ico">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <circle cx="7.5" cy="15.5" r="4.5" />
-                  <path d="M10.7 12.3 21 2m-3 3 2.5 2.5M15 5l2.5 2.5" />
-                </svg>
-              </div>
-              <h3>Access brokering</h3>
-              <p>
-                Warden mints a scoped, short-lived credential for every request and injects it
-                on the way through. The agent presents only its own identity and never holds a
-                key — so there is nothing in it to leak.
-              </p>
-            </div>
-            <div class="feat">
-              <div class="ico">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-                  <path d="M9 12l2 2 4-4" />
-                </svg>
-              </div>
-              <h3>Runtime authorization</h3>
-              <p>
-                Every call is authorized the moment it happens — down to the action and its
-                arguments, and for MCP, which tools an agent may invoke and which arguments it
-                may pass. Never a session-wide grant.
-              </p>
-            </div>
-            <div class="feat">
-              <div class="ico">
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                  <circle cx="12" cy="12" r="3" />
-                </svg>
-              </div>
-              <h3>Audit &amp; attribution</h3>
-              <p>
-                Every request tied to the real identity behind it, the role used, the policy
-                decision, and the upstream called — with secrets never written to the log in
-                the clear.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Benefits -->
-      <section class="band">
+      <!-- Pillars -->
+      <section class="band pillars">
         <div class="wrap">
           <div class="section-head">
             <h2 class="h">Everything your agents need. Nothing they can leak.</h2>
           </div>
-          <div class="grid grid-3">
-            {benefits.map((b) => (
-              <div class="card">
-                <h3>{b.h}</h3>
-                <p>{b.p}</p>
+
+          <div class="pillar-list">
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">Beyond short-lived credentials</p>
+                <h3>Remove every secret from the agent environment</h3>
+                <p>
+                  A short-lived token is still a secret sitting in the agent's environment —
+                  just one that expires. Warden removes it entirely. The agent presents only its
+                  own identity; Warden authenticates it, mints the credential, and injects it on
+                  the way through, so the agent never sees a key. Prompt-injected or jailbroken,
+                  it has nothing to exfiltrate — because there was never anything there to take.
+                </p>
+                <a class="pillar-link" href="/concepts/credentials/">How credentials work <span class="arw" aria-hidden="true">→</span></a>
               </div>
-            ))}
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="An agent holds only its identity; the credential it would otherwise carry is struck out.">
+                  <rect x="24" y="34" width="150" height="122" rx="12" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.5" />
+                  <text x="99" y="70" text-anchor="middle" fill="#1a2233" font="600 15px sans-serif" font-family="sans-serif" font-weight="600" font-size="15">Agent</text>
+                  <rect x="46" y="86" width="106" height="26" rx="13" fill="#fff" stroke="#e01e1e" stroke-width="1.5" />
+                  <text x="99" y="103" text-anchor="middle" fill="#e01e1e" font-family="sans-serif" font-weight="700" font-size="10.5" letter-spacing="0.4">IDENTITY ONLY</text>
+                  <g stroke="#8791ab" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="210" cy="90" r="13" />
+                    <circle cx="210" cy="90" r="4.5" />
+                    <line x1="223" y1="90" x2="286" y2="90" />
+                    <line x1="272" y1="90" x2="272" y2="101" />
+                    <line x1="283" y1="90" x2="283" y2="98" />
+                  </g>
+                  <g stroke="#e01e1e" stroke-width="2.8" stroke-linecap="round">
+                    <line x1="216" y1="58" x2="276" y2="122" />
+                    <line x1="276" y1="58" x2="216" y2="122" />
+                  </g>
+                  <text x="246" y="140" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="11">no key held</text>
+                </svg>
+              </div>
+            </article>
+
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">Beyond static API specs</p>
+                <h3>Let agents discover exactly what they can call</h3>
+                <p>
+                  An MCP server advertises its tools; a plain REST API just hands over a
+                  sprawling spec and leaves the agent to guess. Warden gives every non-MCP
+                  system the same treatment — the agent asks what it can do and gets back only
+                  the endpoints its policy allows, each with a schema scoped to the arguments it
+                  may pass. Fewer failed calls, and no ten-thousand-line spec stuffed into the
+                  context window.
+                </p>
+                <a class="pillar-link" href="/concepts/discovery-and-skills/">How discovery works <span class="arw" aria-hidden="true">→</span></a>
+              </div>
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="A discovery response lists only the endpoints the agent may call, each with a schema scoped to the arguments it may pass; disallowed endpoints stay hidden.">
+                  <rect x="24" y="16" width="272" height="158" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.5" />
+                  <text x="44" y="42" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10.5" letter-spacing="0.6">DISCOVER · what can I use?</text>
+                  <line x1="44" y1="52" x2="276" y2="52" stroke="#e6e8ee" stroke-width="1.3" />
+                  <g font-family="sans-serif" font-size="12">
+                    <rect x="44" y="64" width="232" height="28" rx="7" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="56" y="82" fill="#1a2233">POST /deploy</text>
+                    <text x="264" y="82" text-anchor="end" fill="#e01e1e" font-size="10.5">{"{ env, region }"}</text>
+                    <rect x="44" y="100" width="232" height="28" rx="7" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="56" y="118" fill="#1a2233">GET /logs</text>
+                    <text x="264" y="118" text-anchor="end" fill="#e01e1e" font-size="10.5">{"{ service }"}</text>
+                    <rect x="44" y="136" width="232" height="28" rx="7" fill="#fff" stroke="#e6e8ee" stroke-width="1.2" stroke-dasharray="4 4" />
+                    <text x="56" y="154" fill="#b6bccb">DELETE /records</text>
+                    <text x="264" y="154" text-anchor="end" fill="#b6bccb" font-size="10.5">not exposed</text>
+                  </g>
+                </svg>
+              </div>
+            </article>
+
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">Beyond a single access level</p>
+                <h3>Let one agent assume the right role for each task</h3>
+                <p>
+                  Hand an agent one access level and it carries the same broad permissions
+                  everywhere. Warden breaks access into roles — named, least-privilege slices,
+                  each scoped to a single task, that the agent assumes one at a time. It reads a
+                  repo under one role, pushes under another, posts to Slack under a third, and
+                  each role exposes only the tools its policy allows — the rest aren't just blocked,
+                  they're also invisible. No other gateway models agent access this way.
+                </p>
+                <a class="pillar-link" href="/concepts/roles/">How roles work <span class="arw" aria-hidden="true">→</span></a>
+              </div>
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="The read-repo role allows search_repos and read_file but not push; the push-repo role allows push but not search_repos or read_file — each role scopes a different set of tools.">
+                  <text x="160" y="18" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10" letter-spacing="0.5">TOOLS ARE SCOPED TO ROLES</text>
+                  <g font-family="sans-serif">
+                    <!-- read-repo: reads allowed, push not -->
+                    <rect x="14" y="38" width="142" height="140" rx="11" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="85" y="60" text-anchor="middle" fill="#1a2233" font-size="12" font-weight="600">read-repo</text>
+                    <line x1="26" y1="70" x2="144" y2="70" stroke="#e6e8ee" stroke-width="1.2" />
+                    <circle cx="34" cy="92" r="7" fill="#0b1020" />
+                    <path d="M31 92 l2 2 l4 -5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                    <text x="48" y="96" fill="#1a2233" font-size="10.5">search_repos</text>
+                    <circle cx="34" cy="120" r="7" fill="#0b1020" />
+                    <path d="M31 120 l2 2 l4 -5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                    <text x="48" y="124" fill="#1a2233" font-size="10.5">read_file</text>
+                    <circle cx="34" cy="148" r="7" fill="#e01e1e" />
+                    <path d="M31 145 l6 6 M37 145 l-6 6" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" />
+                    <text x="48" y="152" fill="#b6bccb" font-size="10.5">push</text>
+
+                    <!-- push-repo: push allowed, reads not -->
+                    <rect x="164" y="38" width="142" height="140" rx="11" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="235" y="60" text-anchor="middle" fill="#1a2233" font-size="12" font-weight="600">push-repo</text>
+                    <line x1="176" y1="70" x2="294" y2="70" stroke="#e6e8ee" stroke-width="1.2" />
+                    <circle cx="184" cy="92" r="7" fill="#e01e1e" />
+                    <path d="M181 89 l6 6 M187 89 l-6 6" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" />
+                    <text x="198" y="96" fill="#b6bccb" font-size="10.5">search_repos</text>
+                    <circle cx="184" cy="120" r="7" fill="#e01e1e" />
+                    <path d="M181 117 l6 6 M187 117 l-6 6" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" />
+                    <text x="198" y="124" fill="#b6bccb" font-size="10.5">read_file</text>
+                    <circle cx="184" cy="148" r="7" fill="#0b1020" />
+                    <path d="M181 148 l2 2 l4 -5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                    <text x="198" y="152" fill="#1a2233" font-size="10.5">push</text>
+                  </g>
+                </svg>
+              </div>
+            </article>
+
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">Beyond scope-based access</p>
+                <h3>Control what the agent can do, down to the argument</h3>
+                <p>
+                  OAuth scopes and IAM roles hand out broad, session-wide access, then trust the
+                  agent to stay inside it. Warden decides each call as it happens — which action,
+                  which tool, and which arguments are allowed for that step. Least privilege on
+                  every request, never a coarse grant the agent can wander around inside.
+                </p>
+                <a class="pillar-link" href="/concepts/policies/">How policies work <span class="arw" aria-hidden="true">→</span></a>
+              </div>
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="A call is evaluated argument by argument: one argument is allowed, another is blocked.">
+                  <rect x="24" y="20" width="272" height="150" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.5" />
+                  <text x="44" y="46" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10.5" letter-spacing="0.6">CALL · deploy(service, env)</text>
+                  <line x1="44" y1="58" x2="276" y2="58" stroke="#e6e8ee" stroke-width="1.3" />
+                  <g font-family="sans-serif" font-size="12.5">
+                    <rect x="44" y="72" width="232" height="34" rx="8" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
+                    <circle cx="64" cy="89" r="9" fill="#0b1020" />
+                    <path d="M60 89 l3 3 l5 -6" stroke="#fff" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                    <text x="84" y="93" fill="#1a2233">env = "staging"</text>
+                    <text x="266" y="93" text-anchor="end" fill="#5b6478" font-size="10.5">allowed</text>
+                  </g>
+                  <g font-family="sans-serif" font-size="12.5">
+                    <rect x="44" y="116" width="232" height="34" rx="8" fill="#fff" stroke="#e01e1e" stroke-width="1.4" />
+                    <circle cx="64" cy="133" r="9" fill="#e01e1e" />
+                    <path d="M60 129 l8 8 M68 129 l-8 8" stroke="#fff" stroke-width="1.8" fill="none" stroke-linecap="round" />
+                    <text x="84" y="137" fill="#1a2233">env = "production"</text>
+                    <text x="266" y="137" text-anchor="end" fill="#e01e1e" font-size="10.5">blocked</text>
+                  </g>
+                </svg>
+              </div>
+            </article>
+
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">Beyond MCP servers</p>
+                <h3>Reach every system with one identity</h3>
+                <p>
+                  MCP standardizes one kind of connection, but your agents also need LLMs,
+                  clouds, code hosts, SaaS, and any other REST API — each with its own way in.
+                  Warden puts a single identity in front of all of them, so one policy reaches
+                  every system it permits. Nothing to distribute per integration, nothing to
+                  rotate in a dozen places, no static keys left in process environments.
+                </p>
+                <a class="pillar-link" href="/provider-backends/">Browse supported providers <span class="arw" aria-hidden="true">→</span></a>
+              </div>
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="One identity fans out to MCP, LLMs, cloud, code hosts, SaaS, and REST APIs.">
+                  <line x1="66" y1="95" x2="196" y2="20" stroke="#cbd2e0" stroke-width="1.6" />
+                  <line x1="66" y1="95" x2="196" y2="49" stroke="#cbd2e0" stroke-width="1.6" />
+                  <line x1="66" y1="95" x2="196" y2="78" stroke="#cbd2e0" stroke-width="1.6" />
+                  <line x1="66" y1="95" x2="196" y2="107" stroke="#cbd2e0" stroke-width="1.6" />
+                  <line x1="66" y1="95" x2="196" y2="136" stroke="#cbd2e0" stroke-width="1.6" />
+                  <line x1="66" y1="95" x2="196" y2="165" stroke="#cbd2e0" stroke-width="1.6" />
+                  <circle cx="52" cy="95" r="30" fill="#0b1020" />
+                  <text x="52" y="92" text-anchor="middle" fill="#fff" font-family="sans-serif" font-weight="700" font-size="17">1</text>
+                  <text x="52" y="108" text-anchor="middle" fill="#aab2c5" font-family="sans-serif" font-size="8.5" letter-spacing="0.5">IDENTITY</text>
+                  <g font-family="sans-serif" font-size="11.5" fill="#1a2233">
+                    <rect x="196" y="8" width="98" height="24" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="245" y="24" text-anchor="middle">MCP</text>
+                    <rect x="196" y="37" width="98" height="24" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="245" y="53" text-anchor="middle">LLMs</text>
+                    <rect x="196" y="66" width="98" height="24" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="245" y="82" text-anchor="middle">Cloud</text>
+                    <rect x="196" y="95" width="98" height="24" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="245" y="111" text-anchor="middle">Code hosts</text>
+                    <rect x="196" y="124" width="98" height="24" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="245" y="140" text-anchor="middle">SaaS</text>
+                    <rect x="196" y="153" width="98" height="24" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
+                    <text x="245" y="169" text-anchor="middle">REST APIs</text>
+                  </g>
+                </svg>
+              </div>
+            </article>
           </div>
         </div>
       </section>

--- a/site/src/styles/marketing.css
+++ b/site/src/styles/marketing.css
@@ -363,6 +363,70 @@ h2.h {
   line-height: 1.6;
 }
 
+/* ---- Pillars (alternating rows) ---- */
+.pillar-list {
+  display: grid;
+  gap: clamp(2.5rem, 6vw, 4.5rem);
+  margin-top: 3rem;
+}
+.pillar {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: clamp(1.5rem, 4vw, 3.5rem);
+  align-items: center;
+}
+.pillar:nth-child(even) .pillar-visual {
+  order: -1;
+}
+.pillar-tag {
+  color: var(--red);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  margin: 0 0 0.6rem;
+}
+.pillar h3 {
+  font-size: clamp(1.5rem, 2.8vw, 2rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.75rem;
+  font-weight: 700;
+}
+.pillar-copy p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+.pillar-visual {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+.pillar-visual svg {
+  width: 100%;
+  height: auto;
+}
+.pillar-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 1.1rem;
+  color: var(--red);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+.pillar-link:hover {
+  color: var(--red-dark);
+}
+.pillar-link .arw {
+  transition: transform 0.15s ease;
+}
+.pillar-link:hover .arw {
+  transform: translateX(3px);
+}
+
 /* ---- Steps (how it works) ---- */
 .steps {
   display: grid;
@@ -530,6 +594,12 @@ h2.h {
   .steps,
   .grid-3 {
     grid-template-columns: 1fr;
+  }
+  .pillar {
+    grid-template-columns: 1fr;
+  }
+  .pillar:nth-child(even) .pillar-visual {
+    order: 0;
   }
   .footer-inner {
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Why

The landing page's "why" section was two middle bands — a feature row and a six-card benefits grid. They said true things but buried the point: each of Warden's differentiators goes a step further than the obvious approach a reader already assumes. Nothing tied the claims back to the docs, either.

## What

Replaces both bands with one section of **five alternating-row pillars**. Each pillar has a red "beyond X" tag that names what it surpasses, a capability headline, a supporting paragraph, an inline-SVG illustration in the existing visual language, and a link into the docs.

In reading order:

1. **Remove every secret from the agent environment** — *beyond short-lived credentials* → `/concepts/credentials/`
2. **Let agents discover exactly what they can call** — *beyond static API specs* → `/concepts/discovery-and-skills/`
3. **Let one agent assume the right role for each task** — *beyond a single access level* → `/concepts/roles/`
4. **Control what the agent can do, down to the argument** — *beyond scope-based access* → `/concepts/policies/`
5. **Reach every system with one identity** — *beyond MCP* → `/provider-backends/`

The roles illustration shows the same tools (`search_repos`, `read_file`, `push`) allowed/denied differently under `read-repo` vs `push-repo`, making "tools are scoped to roles" concrete. A `.pillar*` block is added to `marketing.css` for the two-column alternating layout (visual side swaps per row, stacks to one column below 900px) plus the inline arrow link. No existing CSS rules change.

## Verification

- `npm run build` succeeds — 121 pages.
- The link check passes clean — 146 links scanned, 0 broken — so all five pillar targets resolve.
- Walked the built preview at desktop width (rows alternate correctly) and below 900px (rows stack, visual above copy, no horizontal scroll).
- The section now bookends nothing awkwardly: it sits between the hero and the existing "Remove every secret from the agent" CTA.
