### PR TITLE
ci: add a ci-gate job as the single required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,3 +252,22 @@ jobs:
       - name: Teardown E2E cluster
         if: always()
         run: bash e2e/teardown.sh
+
+  # The single status check branch protection requires. Every other job is
+  # path-filtered and skips on unrelated PRs (a docs-only change skips the Go
+  # jobs, a code-only change skips the site job), which would leave a directly
+  # required check unsatisfied and block the merge forever. This gate always
+  # runs and passes as long as nothing it depends on actually failed or was
+  # cancelled — a skipped job counts as success. Require only `ci-gate`.
+  ci-gate:
+    name: ci-gate
+    runs-on: ubuntu-latest
+    needs: [changes, unit, site, helm, helm-smoke, e2e]
+    if: always()
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "A required job did not succeed:"
+          echo '${{ toJSON(needs) }}'
+          exit 1


### PR DESCRIPTION
## Why

The paths-filter design skips the Go jobs (`unit`, `e2e`) on PRs that touch no `.go` files, and skips `site`/`helm` on PRs that don't touch them. But GitHub counts a **skipped required check as unmet** — so a PR that requires `unit`/`e2e` directly while skipping them is `BLOCKED` from merging forever. That's exactly what a docs- or site-only PR hits (e.g. #400).

## What

Adds a single `ci-gate` job that:

- `needs` every other job (`changes`, `unit`, `site`, `helm`, `helm-smoke`, `e2e`),
- runs with `if: always()`, and
- fails **only** if one of those jobs actually `failure`d or was `cancelled` — a **skipped** job counts as success.

The idea is to point branch protection at this one job instead of the individual path-filtered jobs:

- a **site/docs-only PR** → Go jobs skip → gate is green → merges;
- a **code PR with a real test failure** → `unit` fails → gate fails → stays blocked.

So gating strength on code PRs is preserved, while path-filtered skips stop wedging unrelated PRs.

## Rollout (after this merges)

1. Repo **Settings → Rules** (branch ruleset for `main`): set the required status checks to just **`ci-gate`**, and remove `unit` and `e2e` from the required list. (They still run and still fail the gate — they're just no longer required *directly*.)
2. Existing open PRs branched before this need to pick up the gate job — merge `main` into them (or rebase) so their next CI run produces the `ci-gate` check.

## Note

Requires one bootstrap step: this PR itself skips `unit`/`e2e` (it only changes a workflow file), so under the current rules it's blocked too. Merge it via the admin "merge without waiting for requirements" option — or do the ruleset swap in step 1 first (the `ci-gate` check appears on this PR once its CI runs), after which it merges normally.
