### PR TITLE
docs(site): add a Configuration reference section

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -189,6 +189,33 @@ export default defineConfig({
         { label: 'Auth methods', autogenerate: { directory: 'auth-methods' } },
         { label: 'Agent identity', autogenerate: { directory: 'agent-identity' } },
         { label: 'CLI', autogenerate: { directory: 'cli' } },
+        {
+          // Server HCL config reference, in reading order. The seal subgroup
+          // has one page per seal type and collapses by default.
+          label: 'Configuration',
+          items: [
+            { slug: 'configuration' },
+            { slug: 'configuration/listener' },
+            { slug: 'configuration/storage' },
+            {
+              label: 'Seal',
+              collapsed: true,
+              items: [
+                { slug: 'configuration/seal' },
+                { slug: 'configuration/seal/shamir' },
+                { slug: 'configuration/seal/awskms' },
+                { slug: 'configuration/seal/azurekeyvault' },
+                { slug: 'configuration/seal/gcpkms' },
+                { slug: 'configuration/seal/transit' },
+                { slug: 'configuration/seal/pkcs11' },
+                { slug: 'configuration/seal/ocikms' },
+                { slug: 'configuration/seal/kmip' },
+                { slug: 'configuration/seal/static' },
+              ],
+            },
+            { slug: 'configuration/audit' },
+          ],
+        },
         { label: 'Quickstarts', autogenerate: { directory: 'quickstarts' } },
         { label: 'Tutorials', autogenerate: { directory: 'tutorials' } },
         { label: 'Install', autogenerate: { directory: 'install' } },

--- a/site/src/content/docs/architecture.md
+++ b/site/src/content/docs/architecture.md
@@ -41,7 +41,7 @@ listener "tcp" {
 
 ## Configuration
 
-Warden uses HCL configuration files. See `deploy/config/warden.local.hcl` for a full example covering storage backend, listener, providers, and auth methods.
+Warden uses HCL configuration files. See `deploy/config/warden.local.hcl` for a full example covering storage backend, listener, providers, and auth methods, and the [Configuration reference](/configuration/) for every stanza and parameter.
 
 The listener stanza follows the `tls_disable` convention: TLS is on by default and the listener requires both `tls_cert_file` and `tls_key_file`. Set `tls_disable = true` to run plain HTTP (intended for loopback dev work).
 

--- a/site/src/content/docs/concepts/audit.md
+++ b/site/src/content/docs/concepts/audit.md
@@ -131,4 +131,5 @@ operator-level operation, not something a tenant configures.
 - [Tokens](/concepts/tokens/) — the identity fields logged per request.
 - [Namespaces](/concepts/namespaces/) — recorded per entry; devices are root-scoped.
 - [Audit Devices](/audit-devices/) — setup guides for enabling and configuring a device.
+- [Configuration → Audit](/configuration/audit/) — declaring devices at startup in the config file.
 - [Dev Server](/concepts/dev-server/) — ships unaudited (fail-open).

--- a/site/src/content/docs/concepts/high-availability.md
+++ b/site/src/content/docs/concepts/high-availability.md
@@ -136,3 +136,4 @@ lock to time out.
 - [Seal and Unseal](/concepts/seal-unseal/) — why auto-unseal is required for unattended
   failover.
 - [Architecture](/architecture/) — where HA sits in the overall design.
+- [Configuration](/configuration/) — `api_addr`, `cluster_addr`, and the HA tuning parameters.

--- a/site/src/content/docs/concepts/seal-unseal.md
+++ b/site/src/content/docs/concepts/seal-unseal.md
@@ -152,7 +152,8 @@ seal "awskms" {
 
 Each type takes its own connection and credential keys (endpoints, key
 identifiers, TLS material). A stanza can also be marked `disabled` to designate a
-previous seal as a migration source when moving from one KMS to another.
+previous seal as a migration source when moving from one KMS to another. For every
+seal type and its keys, see [Configuration → Seal](/configuration/seal/).
 
 ## Dev Mode
 

--- a/site/src/content/docs/concepts/storage.md
+++ b/site/src/content/docs/concepts/storage.md
@@ -52,18 +52,9 @@ storage "postgres" {
 }
 ```
 
-### PostgreSQL options
-
-| Key | Purpose |
-|-----|---------|
-| `connection_url` | The Postgres DSN (required). Can be supplied out of band via the `WARDEN_PG_CONNECTION_URL` environment variable. |
-| `table` | Table holding the encrypted key/value data. |
-| `ha_table` | Table holding the [HA](/concepts/high-availability/) leader-election locks. |
-| `ha_enabled` | `"true"` to enable active/standby HA on this backend. |
-| `max_parallel` | Cap on concurrent operations against Postgres. |
-| `max_idle_connections` | Idle size of the connection pool. |
-| `max_connect_retries` | Retries while waiting for the database to come up at startup. |
-| `skip_create_table` | `"true"` to skip automatic table creation (pre-provisioned or read-only databases). |
+`connection_url` is the Postgres DSN (required); it can be supplied out of band
+via the `WARDEN_PG_CONNECTION_URL` environment variable. For every storage key and
+its default, see [Configuration → Storage](/configuration/storage/).
 
 By default Warden creates its tables on first boot and verifies the server is a
 supported PostgreSQL version. Writes are transactional (ACID), which Warden relies

--- a/site/src/content/docs/configuration/audit.md
+++ b/site/src/content/docs/configuration/audit.md
@@ -1,0 +1,64 @@
+---
+title: "Audit"
+---
+
+> Server config stanza: `audit "<type>" "<path>"`
+
+An `audit` stanza declares an audit device that is registered **at startup**,
+before the API listener accepts traffic. The stanza takes two labels — the device
+`type` and a `path` that names it — and may be repeated. See
+[Audit](/concepts/audit/) for the audit log model.
+
+```hcl
+audit "file" "default" {
+  description = "primary file audit"
+  options = {
+    file_path = "/var/log/warden/audit.log"
+  }
+}
+```
+
+The only device type is `file`.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `description` | *(none)* | Human-readable description of the device. |
+| `options` | `{}` | Device-specific settings (see below). |
+
+The `path` label must not contain slashes or spaces, and each `(type, path)` pair
+must be unique.
+
+## File device options
+
+Set inside `options = { ... }`:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `file_path` | `warden_audit.log` | Path to the audit log file. |
+| `format` | `json` | Log entry format. |
+| `prefix` | *(none)* | String prepended to every line. |
+| `file_mode` | `0600` | File permission mode. |
+| `hmac_key` | *(generated)* | Key used to HMAC sensitive fields. |
+
+Because HCL `options` values are **strings only** in this version, numeric and
+boolean knobs — rotation size, daily rotation, backup count, buffer size — cannot
+be set here. Tune those through the `sys/audit/{path}` API after startup.
+
+## Startup semantics
+
+- A device declared here is registered **before** the listener accepts traffic. A
+  misconfigured sink (unwritable path, missing parent directory, permission
+  denied) **fails startup** rather than leaving a half-initialized cluster.
+- Config-declared devices **cannot** be modified or deleted through the API — edit
+  the file and restart instead. They coexist at different paths with devices
+  enabled at runtime via `sys/audit/{path}`.
+- With **zero** audit devices the broker fail-opens, so a fresh cluster can serve
+  `sys/audit/{path}` long enough to bootstrap one. In production, declare **two or
+  more** devices so a single wedged sink cannot lock the cluster out.
+
+## See Also
+
+- [Audit](/concepts/audit/) — the audit log model and HMAC of sensitive fields.
+- [File audit device](/audit-devices/file/) — the runtime-managed counterpart.

--- a/site/src/content/docs/configuration/index.md
+++ b/site/src/content/docs/configuration/index.md
@@ -1,0 +1,127 @@
+---
+title: "Configuration"
+---
+
+A production Warden server is driven by an **HCL configuration file** — or a
+directory of them, merged in order. The file declares the server's [storage
+backend](/configuration/storage/), one or more [listeners](/configuration/listener/),
+the [seal](/configuration/seal/) that guards the barrier, any startup [audit
+devices](/configuration/audit/), and a set of top-level parameters covering
+logging, cluster addressing, and rotation bounds.
+
+This section is the key-by-key reference for that file. See
+[`warden server`](/cli/server/) for how the server is launched and
+[Concepts](/concepts/) for the ideas each stanza builds on.
+
+## Loading configuration
+
+Point the server at a single file or a directory:
+
+```bash
+# One file
+warden server --config=/etc/warden/config.hcl
+
+# Every .hcl file in a directory, merged in lexical order (later files win —
+# useful for splitting a ConfigMap and a Secret in Kubernetes)
+warden server --config-dir=/etc/warden/conf.d
+```
+
+`--config` and `--config-dir` are mutually exclusive, and one of them is required
+unless the server is started with `--dev` (see [Dev Server](/concepts/dev-server/)).
+When a directory is merged, later files override earlier ones and block stanzas
+are replaced wholesale.
+
+Unknown attributes and blocks are dropped rather than rejected, so a newer config
+stays loadable on an older binary; the server logs a warning for each one it
+ignores.
+
+## Environment variables
+
+Config files are run through a template pass before they are parsed, exposing a
+single `env` function so any value can reference an environment variable:
+
+```hcl
+api_addr = "https://{{ env "POD_NAME" }}.warden-headless.{{ env "POD_NAMESPACE" }}.svc.cluster.local:8400"
+```
+
+The `{{ env "VAR" }}` syntax is used in preference to `${VAR}` so it does not
+collide with HCL's own `${...}` interpolation, which is left untouched. A missing
+variable expands to the empty string, matching shell semantics. This is the
+recommended way to keep secrets out of the file — for example the Postgres DSN can
+be supplied out of band via the `WARDEN_PG_CONNECTION_URL` environment variable
+instead of `connection_url`.
+
+## A minimal configuration
+
+```hcl
+log_level = "info"
+
+storage "postgres" {
+  connection_url = "postgres://warden:password@db:5432/warden?sslmode=require"
+}
+
+listener "tcp" {
+  address       = ":8400"
+  tls_cert_file = "/certs/warden-cert.pem"
+  tls_key_file  = "/certs/warden-key.pem"
+}
+```
+
+With no `seal` stanza the server uses the [`shamir`](/configuration/seal/#shamir)
+seal, which requires operators to supply unseal keys at startup. Configure an
+[auto-unseal seal](/configuration/seal/) for any unattended deployment.
+
+## General parameters
+
+These are set at the top level of the file, outside any block.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `log_level` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error`. |
+| `log_format` | `standard` | `standard` or `json`. |
+| `log_file` | *(stderr)* | Path to write logs to instead of standard error. |
+| `log_rotation_period` | `0` | Rotate the log file after this many hours (`0` disables time-based rotation). |
+| `log_rotate_megabytes` | `0` | Rotate the log file once it reaches this size in MB (`0` disables size-based rotation). |
+| `log_rotate_max_files` | `0` | Number of rotated log files to retain (`0` keeps all). |
+| `api_addr` | *(none)* | Address advertised to clients for API requests. Standby nodes redirect clients here on the active node. **Required when HA is enabled.** |
+| `cluster_addr` | *(none)* | Address for inter-node cluster communication. Must be an `https://` URL with a host; a dedicated cluster listener with auto-generated mTLS is started on it. **Required when HA is enabled.** |
+| `disable_clustering` | `false` | Disable HA clustering even if the storage backend supports it. |
+| `ip_binding_policy` | `optional` | How client-IP binding is enforced for tokens: `disabled`, `optional` (check only when both creation and request IPs are present), or `required`. |
+| `min_cred_source_rotation_period` | *(none)* | Lower bound on the rotation period a credential source may request (Go duration, e.g. `24h`). |
+| `max_cred_source_rotation_period` | *(none)* | Upper bound on a credential source's rotation period. Must be ≥ the minimum. |
+| `min_cred_spec_rotation_period` | *(none)* | Lower bound on the rotation period a credential spec may request (Go duration, e.g. `1h`). |
+| `max_cred_spec_rotation_period` | *(none)* | Upper bound on a credential spec's rotation period. Must be ≥ the minimum. |
+
+## High-availability tuning
+
+These parameters tune the [HA cluster](/concepts/high-availability/) — leader
+election, step-down, and inter-node forwarding. All values are Go duration
+strings (e.g. `30s`, `1h`); omitting one uses the built-in default shown below.
+Most deployments never need to change them.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `goroutine_shutdown_timeout` | `30s` | Max time to wait for background goroutines to exit during step-down. |
+| `lock_acquisition_timeout` | `0` | Max time to wait when acquiring the HA lock. `0` waits indefinitely. |
+| `leader_cleanup_interval` | `1h` | How often the active node clears stale leader advertisements from storage. |
+| `step_down_state_lock_timeout` | `30s` | Max time to acquire the state lock during step-down before forcing teardown. |
+| `leader_lookup_timeout` | `10s` | Deadline for barrier reads when looking up the leader advertisement. |
+| `clock_skew_grace` | `1m` | Backwards offset on cluster-certificate `NotBefore` to tolerate clock drift between nodes. |
+| `cluster_listener_read_timeout` | `30s` | HTTP read timeout for the cluster listener (inter-node forwarding). |
+| `cluster_listener_write_timeout` | `1m` | HTTP write timeout for the cluster listener. |
+| `forwarding_timeout` | `1m` | Max time for a request forwarded from a standby to the active node. |
+
+## Configuration stanzas
+
+| Stanza | Purpose |
+|--------|---------|
+| [`listener`](/configuration/listener/) | Where and how the server accepts API traffic (TLS, SPIFFE). |
+| [`storage`](/configuration/storage/) | The durable backend the barrier encrypts into. |
+| [`seal`](/configuration/seal/) | The mechanism that guards the barrier's root key. |
+| [`audit`](/configuration/audit/) | Audit devices registered at startup. |
+
+## See Also
+
+- [`warden server`](/cli/server/) — the flags that pass a config file or directory.
+- [Concepts](/concepts/) — the ideas behind each stanza.
+- [High Availability](/concepts/high-availability/) — clustering and the tuning parameters above.

--- a/site/src/content/docs/configuration/listener.md
+++ b/site/src/content/docs/configuration/listener.md
@@ -1,0 +1,82 @@
+---
+title: "Listener"
+---
+
+> Server config stanza: `listener "<type>"`
+
+A `listener` stanza declares where the server accepts API traffic and how it
+secures the connection. The stanza may be repeated to serve on more than one
+address — for example a file-based TLS listener for browser clients alongside a
+[SPIFFE](#spiffe-serving-identity) listener for workloads.
+
+```hcl
+listener "tcp" {
+  address       = ":8400"
+  tls_cert_file = "/certs/warden-cert.pem"
+  tls_key_file  = "/certs/warden-key.pem"
+}
+```
+
+The type label is `tcp` or `unix`.
+
+## TLS is on by default
+
+Warden serves TLS unless you explicitly opt out. A file-based listener must
+therefore either provide both `tls_cert_file` and `tls_key_file`, or set
+`tls_disable = true` — the server refuses to start otherwise. Disabling TLS is
+only appropriate behind a trusted terminating proxy or on a loopback address.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `address` | *(required)* | Bind address, e.g. `:8400`, `127.0.0.1:8400`, or a socket path for `unix`. |
+| `tls_cert_file` | *(none)* | PEM certificate (chain) to serve. Required unless `tls_disable` or `tls_spiffe`. |
+| `tls_key_file` | *(none)* | PEM private key paired with the certificate. |
+| `tls_client_ca_file` | *(none)* | CA bundle used to verify client certificates for mTLS. |
+| `tls_disable` | `false` | Serve plaintext HTTP instead of TLS. Mutually exclusive with the TLS keys. |
+| `tls_require_client_cert` | *(true when `tls_client_ca_file` is set)* | Require and verify a client certificate. |
+| `trusted_proxies` | *(none)* | CIDR ranges of load balancers permitted to forward the client certificate (for LB cert forwarding). |
+
+## SPIFFE serving identity
+
+Instead of a certificate and key on disk, a listener can source its serving
+certificate from the **SPIFFE Workload API** (a local SPIRE agent). The X509-SVID
+is held in memory and fetched fresh on every TLS handshake, so it rotates
+transparently and no key or certificate is ever written to disk.
+
+```hcl
+listener "tcp" {
+  address    = ":8400"
+  tls_spiffe = true
+
+  # Workload API endpoint. Omit to use the SPIFFE_ENDPOINT_SOCKET env var.
+  # tls_spiffe_socket = "unix:///run/spire/agent/sockets/agent.sock"
+
+  # Max time to wait (and retry) for the first SVID at startup before failing
+  # closed. Tolerates a brief agent-not-ready window at boot.
+  # tls_spiffe_startup_timeout = "10s"
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `tls_spiffe` | `false` | Serve using a SPIFFE Workload API X509-SVID instead of file-based certs. |
+| `tls_spiffe_socket` | `$SPIFFE_ENDPOINT_SOCKET` | Workload API endpoint. |
+| `tls_spiffe_startup_timeout` | `10s` | Max wait/retry for the first SVID at boot before failing closed. |
+
+`tls_spiffe` is **mutually exclusive** with `tls_cert_file`, `tls_key_file`,
+`tls_client_ca_file`, and `tls_require_client_cert`. A SPIFFE listener always
+requests and captures the peer's certificate but never verifies it at the TLS
+layer — the [SPIFFE](/auth-methods/spiffe/) or [cert](/auth-methods/cert/) auth
+method authenticates the peer instead, so clients that authenticate by token (or
+present no certificate) still connect.
+
+The server presents a SPIFFE SVID (a `spiffe://` URI SAN with no DNS SAN), so
+clients must be SPIFFE-aware — they trust the SPIRE bundle and skip hostname
+verification. Plain or browser clients cannot use a SPIFFE listener; run a
+separate file-based listener on another port for those.
+
+## See Also
+
+- [SPIFFE auth method](/auth-methods/spiffe/) — authenticating peers by SVID.
+- [Certificate auth method](/auth-methods/cert/) — authenticating peers by client certificate.
+- [`warden server`](/cli/server/) — the dev-mode TLS flags for local work.

--- a/site/src/content/docs/configuration/seal/awskms.md
+++ b/site/src/content/docs/configuration/seal/awskms.md
@@ -1,0 +1,35 @@
+---
+title: "AWS KMS Seal"
+---
+
+> `seal "awskms"`
+
+Auto-unseal backed by **AWS KMS**. At startup Warden asks KMS to decrypt the
+stored root key, so the node opens its barrier without an operator present.
+
+```hcl
+seal "awskms" {
+  region     = "us-east-1"
+  kms_key_id = "arn:aws:kms:us-east-1:111122223333:key/<id>"
+}
+```
+
+Credentials follow the standard AWS chain (environment, shared config, instance
+role) when `access_key` / `secret_key` are omitted — the preferred setup on EC2 or
+EKS.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `kms_key_id` | *(required)* | Key ID or ARN of the KMS key. |
+| `region` | *(AWS default chain)* | AWS region of the KMS key. |
+| `access_key` | *(AWS default chain)* | AWS access key ID. |
+| `secret_key` | *(AWS default chain)* | AWS secret access key. |
+| `session_token` | *(none)* | STS session token, when using temporary credentials. |
+| `endpoint` | *(AWS default)* | Custom KMS endpoint URL. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/azurekeyvault.md
+++ b/site/src/content/docs/configuration/seal/azurekeyvault.md
@@ -1,0 +1,37 @@
+---
+title: "Azure Key Vault Seal"
+---
+
+> `seal "azurekeyvault"`
+
+Auto-unseal backed by **Azure Key Vault**. At startup Warden asks Key Vault to
+decrypt the stored root key, so the node opens its barrier without an operator
+present.
+
+```hcl
+seal "azurekeyvault" {
+  tenant_id  = "<tenant-id>"
+  vault_name = "warden-kv"
+  key_name   = "warden-unseal"
+}
+```
+
+When `client_id` / `client_secret` are omitted, Warden authenticates with the
+ambient managed identity — the preferred setup on Azure-hosted nodes.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `tenant_id` | *(required)* | Azure Active Directory tenant ID. |
+| `vault_name` | *(required)* | Name of the Key Vault. |
+| `key_name` | *(required)* | Name of the key within the vault. |
+| `client_id` | *(managed identity)* | App registration client ID. |
+| `client_secret` | *(managed identity)* | App registration client secret. |
+| `environment` | `AZUREPUBLICCLOUD` | Azure environment (e.g. `AZUREPUBLICCLOUD`, `AZUREGOVERNMENTCLOUD`). |
+| `resource` | *(none)* | Resource identifier override for the vault endpoint. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/gcpkms.md
+++ b/site/src/content/docs/configuration/seal/gcpkms.md
@@ -1,0 +1,37 @@
+---
+title: "GCP KMS Seal"
+---
+
+> `seal "gcpkms"`
+
+Auto-unseal backed by **Google Cloud KMS**. At startup Warden asks Cloud KMS to
+decrypt the stored root key, so the node opens its barrier without an operator
+present.
+
+```hcl
+seal "gcpkms" {
+  project    = "my-project"
+  region     = "global"
+  key_ring   = "warden"
+  crypto_key = "warden-unseal"
+}
+```
+
+When `credentials` is omitted, Warden uses Application Default Credentials (the
+`GOOGLE_APPLICATION_CREDENTIALS` env var or the attached service account) — the
+preferred setup on GCE or GKE.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `project` | *(required)* | GCP project ID. |
+| `region` | *(required)* | Location of the key ring (e.g. `global`, `us-east1`). |
+| `key_ring` | *(required)* | Name of the KMS key ring. |
+| `crypto_key` | *(required)* | Name of the crypto key within the ring. |
+| `credentials` | *(ADC / GOOGLE_APPLICATION_CREDENTIALS)* | Path to a service-account credentials file. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/index.md
+++ b/site/src/content/docs/configuration/seal/index.md
@@ -1,0 +1,53 @@
+---
+title: "Seal"
+---
+
+> Server config stanza: `seal "<type>"`
+
+The `seal` stanza selects the mechanism that guards the barrier's **root key** —
+the master key that unlocks everything Warden persists. With no `seal` stanza the
+server uses [`shamir`](/configuration/seal/shamir/), which requires operators to
+supply unseal keys at startup. Declaring an **auto-unseal** seal (any of the KMS
+or HSM types below) lets a node fetch and decrypt its root key from an external
+service at boot with no human in the loop — configure one for any real
+deployment. See [Seal and Unseal](/concepts/seal-unseal/) for the barrier model
+and initialization.
+
+```hcl
+seal "awskms" {
+  region     = "us-east-1"
+  kms_key_id = "arn:aws:kms:us-east-1:111122223333:key/<id>"
+}
+```
+
+## Seal types
+
+| Type | Backing service | Auto-unseal |
+|------|-----------------|-------------|
+| [`shamir`](/configuration/seal/shamir/) | Shamir secret sharing (default) | no |
+| [`awskms`](/configuration/seal/awskms/) | AWS KMS | yes |
+| [`azurekeyvault`](/configuration/seal/azurekeyvault/) | Azure Key Vault | yes |
+| [`gcpkms`](/configuration/seal/gcpkms/) | Google Cloud KMS | yes |
+| [`transit`](/configuration/seal/transit/) | Vault / OpenBao Transit | yes |
+| [`pkcs11`](/configuration/seal/pkcs11/) | PKCS#11 HSM | yes |
+| [`ocikms`](/configuration/seal/ocikms/) | Oracle Cloud KMS | yes |
+| [`kmip`](/configuration/seal/kmip/) | KMIP server | yes |
+| [`static`](/configuration/seal/static/) | A static key in the config | yes |
+
+## Common parameters
+
+These apply to any seal type:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `disabled` | `false` | `"true"` marks this as a previous seal, kept only as a migration source when moving to a new seal. |
+| `purpose` | *(none)* | Designates what the seal is used for, when more than one is specified. |
+
+A seal migration is expressed by keeping the old stanza with `disabled = "true"`
+alongside the new one.
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier, initialization, and why auto-unseal matters.
+- [High Availability](/concepts/high-availability/) — why an unattended cluster needs auto-unseal.
+- [Storage](/configuration/storage/) — the backend the barrier encrypts into.

--- a/site/src/content/docs/configuration/seal/kmip.md
+++ b/site/src/content/docs/configuration/seal/kmip.md
@@ -1,0 +1,37 @@
+---
+title: "KMIP Seal"
+---
+
+> `seal "kmip"`
+
+Auto-unseal backed by a **KMIP** server. Warden connects over mTLS and asks the
+server to unwrap the stored root key at startup.
+
+```hcl
+seal "kmip" {
+  endpoint    = "kmip.example.com:5696"
+  kms_key_id  = "<key-id>"
+  client_cert = "/certs/kmip-client-cert.pem"
+  client_key  = "/certs/kmip-client-key.pem"
+  ca_cert     = "/certs/kmip-ca.pem"
+}
+```
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `endpoint` | *(required)* | Address of the KMIP server. |
+| `kms_key_id` | *(required)* | Identifier of the key on the KMIP server. |
+| `client_cert` | *(required)* | Client certificate for the KMIP connection. |
+| `client_key` | *(required)* | Client private key paired with the certificate. |
+| `ca_cert` | *(none)* | CA certificate for verifying the KMIP server. |
+| `server_name` | *(none)* | Expected server name for TLS verification. |
+| `timeout` | *(none)* | Connection timeout in seconds. |
+| `encrypt_alg` | *(server default)* | Encryption algorithm to use. |
+| `tls12_ciphers` | *(default suite)* | Allowed TLS 1.2 cipher suites. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/ocikms.md
+++ b/site/src/content/docs/configuration/seal/ocikms.md
@@ -1,0 +1,33 @@
+---
+title: "OCI KMS Seal"
+---
+
+> `seal "ocikms"`
+
+Auto-unseal backed by **Oracle Cloud Infrastructure KMS**. Warden asks the KMS
+vault to decrypt the stored root key at startup.
+
+```hcl
+seal "ocikms" {
+  key_id              = "ocid1.key.oc1..<id>"
+  crypto_endpoint     = "https://<vault>-crypto.kms.<region>.oraclecloud.com"
+  management_endpoint = "https://<vault>-management.kms.<region>.oraclecloud.com"
+}
+```
+
+By default Warden authenticates with instance principals. Set
+`auth_type_api_key = true` to use a configured API key instead.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `key_id` | *(required)* | OCID of the KMS key. |
+| `crypto_endpoint` | *(required)* | Cryptographic endpoint of the KMS vault. |
+| `management_endpoint` | *(required)* | Management endpoint of the KMS vault. |
+| `auth_type_api_key` | `false` | `true` to authenticate with an API key instead of instance principals. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/pkcs11.md
+++ b/site/src/content/docs/configuration/seal/pkcs11.md
@@ -1,0 +1,39 @@
+---
+title: "PKCS#11 Seal"
+---
+
+> `seal "pkcs11"`
+
+Auto-unseal backed by a **PKCS#11 HSM**. The root key is wrapped by a key that
+never leaves the HSM.
+
+```hcl
+seal "pkcs11" {
+  lib        = "/usr/lib/softhsm/libsofthsm2.so"
+  slot       = "0"
+  pin        = "{{ env "HSM_PIN" }}"
+  key_label  = "warden-unseal"
+}
+```
+
+Identify the token by `slot` or `token_label`, and the wrapping key by `key_label`
+or `key_id`. Keep the PIN out of the file with
+[environment-variable interpolation](/configuration/#environment-variables).
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `lib` | *(required)* | Path to the PKCS#11 shared library. |
+| `pin` | *(required)* | PIN for the token. |
+| `slot` | *(required)* | Slot number of the token. |
+| `token_label` | *(none)* | Label of the token to use (alternative to `slot`). |
+| `key_label` | *(required)* | Label of the key used to wrap the root key. |
+| `key_id` | *(none)* | ID of the key (alternative to `key_label`). |
+| `mechanism` | *(HSM default)* | Encryption mechanism to use. |
+| `disable_software_encryption` | `false` | `true` to require the HSM to perform encryption directly. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/shamir.md
+++ b/site/src/content/docs/configuration/seal/shamir.md
@@ -1,0 +1,29 @@
+---
+title: "Shamir Seal"
+---
+
+> `seal "shamir"`
+
+`shamir` is the **default** seal — declaring no `seal` stanza is equivalent to
+`seal "shamir" {}`, and it takes no configuration of its own:
+
+```hcl
+seal "shamir" {}
+```
+
+Rather than delegate to an external service, a Shamir seal splits the root key
+into shares at [initialization](/concepts/seal-unseal/#initialization); a threshold
+of them must be supplied to unseal. The number of shares and the threshold are set
+with `warden operator init` (`-secret-shares`, `-secret-threshold`), not in the
+config file.
+
+A Shamir seal stores no wrapping key the server can fetch for itself, so a
+Shamir-sealed node does **not** unseal automatically at startup — the threshold of
+shares is held by operators, off the machine, by design. For an unattended node or
+[HA cluster](/concepts/high-availability/), configure an
+[auto-unseal seal](/configuration/seal/) instead.
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — the auto-unseal alternatives.

--- a/site/src/content/docs/configuration/seal/static.md
+++ b/site/src/content/docs/configuration/seal/static.md
@@ -1,0 +1,36 @@
+---
+title: "Static Seal"
+---
+
+> `seal "static"`
+
+A `static` seal wraps the root key with a key supplied **directly in the config**.
+It auto-unseals like the KMS types, but the wrapping key lives in the file — use it
+only where an external KMS is unavailable and the config itself is protected (for
+example an encrypted secret mounted into the process).
+
+```hcl
+seal "static" {
+  current_key_id = "v1"
+  current_key    = "{{ env "WARDEN_STATIC_SEAL_KEY" }}"
+}
+```
+
+Keep the key out of the file with
+[environment-variable interpolation](/configuration/#environment-variables), as
+above. Rotate by moving the old values to `previous_key` / `previous_key_id` and
+setting a new `current_key` / `current_key_id`.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `current_key` | *(required)* | The current wrapping key. |
+| `current_key_id` | *(required)* | Identifier for the current key. |
+| `previous_key` | *(none)* | The prior wrapping key, kept for rotation. |
+| `previous_key_id` | *(none)* | Identifier for the prior key. |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/seal/transit.md
+++ b/site/src/content/docs/configuration/seal/transit.md
@@ -1,0 +1,42 @@
+---
+title: "Transit Seal"
+---
+
+> `seal "transit"`
+
+Auto-unseal backed by an external **Vault / OpenBao Transit** mount. At startup
+Warden asks that Transit mount to decrypt the stored root key, so the node opens
+its barrier without an operator present.
+
+```hcl
+seal "transit" {
+  address    = "https://vault.example.com:8200"
+  token      = "{{ env "TRANSIT_TOKEN" }}"
+  key_name   = "warden-unseal"
+  mount_path = "transit/"
+}
+```
+
+Keep the Transit token out of the file with [environment-variable
+interpolation](/configuration/#environment-variables), as above.
+
+## Parameters
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `address` | *(required)* | Address of the Transit server. |
+| `token` | *(required)* | Token used to authenticate to the Transit server. |
+| `key_name` | *(required)* | Name of the Transit key used to encrypt the root key. |
+| `mount_path` | `transit/` | Mount path of the Transit engine. |
+| `namespace` | *(none)* | Namespace of the Transit mount. |
+| `disable_renewal` | `false` | `"true"` to disable automatic renewal of the auth token. |
+| `tls_ca_cert` | *(none)* | CA certificate for verifying the Transit server. |
+| `tls_client_cert` | *(none)* | Client certificate for mTLS to the Transit server. |
+| `tls_client_key` | *(none)* | Client private key paired with the client certificate. |
+| `tls_server_name` | *(none)* | Expected server name for TLS verification. |
+| `tls_skip_verify` | `false` | `"true"` to skip TLS verification (insecure). |
+
+## See Also
+
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier model and initialization.
+- [Seal configuration](/configuration/seal/) — common parameters and other seal types.

--- a/site/src/content/docs/configuration/storage.md
+++ b/site/src/content/docs/configuration/storage.md
@@ -1,0 +1,69 @@
+---
+title: "Storage"
+---
+
+> Server config stanza: `storage "<type>"`
+
+The `storage` stanza selects the durable backend where Warden persists its data.
+Exactly one is declared, and it is **required** — a production server will not
+start without one. Storage is fixed at startup; there is no runtime command to
+change it. Everything written here is already encrypted by the
+[barrier](/concepts/seal-unseal/), so the backend only ever holds ciphertext — see
+[Storage](/concepts/storage/) for why it is treated as untrusted.
+
+```hcl
+storage "postgres" {
+  connection_url = "postgres://warden:password@db:5432/warden?sslmode=require"
+  ha_enabled     = "true"
+}
+```
+
+## Supported backends
+
+| `type` | Use | Persistent | HA |
+|--------|-----|------------|----|
+| `postgres` | Production | yes | yes |
+| `inmem` | Dev / tests | **no** | no |
+| `inmem_ha` | HA tests | no | yes |
+
+**PostgreSQL is the production backend.** `inmem` keeps everything in memory and
+loses it on exit — it is what the [dev server](/concepts/dev-server/) uses and is
+never for production. `inmem_ha` exists only to exercise the HA code paths in
+tests.
+
+## PostgreSQL
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `connection_url` | *(required)* | The Postgres DSN. Can be supplied out of band via the `WARDEN_PG_CONNECTION_URL` environment variable. |
+| `table` | `warden_kv_store` | Table holding the encrypted key/value data. |
+| `ha_table` | `warden_ha_locks` | Table holding the [HA](/concepts/high-availability/) leader-election locks. |
+| `ha_enabled` | `false` | `"true"` to enable active/standby HA on this backend. |
+| `max_parallel` | `128` | Cap on concurrent operations against Postgres. |
+| `max_idle_connections` | *(driver default)* | Idle size of the connection pool. |
+| `max_connect_retries` | *(none)* | Retries while waiting for the database to come up at startup. |
+| `skip_create_table` | `false` | `"true"` to skip automatic table creation (pre-provisioned or read-only databases). |
+
+By default Warden creates its tables on first boot and verifies the server is a
+supported PostgreSQL version. Writes are transactional (ACID), which Warden relies
+on for atomic multi-key updates such as token persistence and credential
+rotation. Set `ha_enabled = "true"` for a clustered deployment — nodes then elect
+a leader through advisory locks in the `ha_table`, using the database's clock as
+the single source of truth.
+
+## In-memory backends
+
+`inmem` and `inmem_ha` take no configuration:
+
+```hcl
+storage "inmem" {}
+```
+
+Both keep all data in process memory and lose it on exit. Use them only for local
+development and tests, never for a real deployment.
+
+## See Also
+
+- [Storage](/concepts/storage/) — why the backend is untrusted, and the barrier that encrypts every value.
+- [Seal and Unseal](/concepts/seal-unseal/) — the barrier itself.
+- [High Availability](/concepts/high-availability/) — leader election over the storage backend.


### PR DESCRIPTION
Adds an OpenBao-style **Configuration** section to the docs site, documenting the server HCL config file. Inspired by `openbao.org/docs/configuration/`.

## What's new

**15 pages** under `site/src/content/docs/configuration/`:
- **Overview** — HCL file/directory loading and merge order, `{{ env "VAR" }}` interpolation, a minimal example, and reference tables for the general parameters (logging, `api_addr`/`cluster_addr`, `ip_binding_policy`, rotation bounds) and HA tuning durations.
- **Listener** — `tcp`/`unix`, file-based TLS, and SPIFFE serving identity.
- **Storage** — `postgres` (all keys) plus `inmem`/`inmem_ha`.
- **Seal** — an index plus one page per type: `shamir`, `awskms`, `azurekeyvault`, `gcpkms`, `transit`, `pkcs11`, `ocikms`, `kmip`, `static`.
- **Audit** — the `file` device stanza, options, and startup semantics.

**Sidebar** — a curated *Configuration* section after CLI, with a collapsible *Seal* subgroup.

**Cross-links** — the Concepts pages (storage, seal-unseal, high-availability, audit) and architecture now point to the reference. The PostgreSQL options table was removed from `concepts/storage` so keys live in exactly one place.

## Accuracy

Every documented key is grounded in `config/config.go` `hcl:` tags, with verified defaults (`warden_kv_store`, `warden_ha_locks`, `max_parallel` 128, audit `file_mode`). Deliberately **not** documented, because they are parsed but not wired up: a `file` storage backend, a `telemetry`/`service_registration` stanza, and `disable_standby_reads`.

## Verification

- `npm run build` passes — 135 pages (was 120).
- CI's `linkinator` crawl run locally: 160 links, 0 broken.
