### PR TITLE
docs(site): extract shared JWT/TLS/MCP config from provider guides

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -88,6 +88,8 @@ export default defineConfig({
           label: 'Providers',
           items: [
             { slug: 'provider-backends' },
+            { slug: 'provider-backends/local-dev-setup' },
+            { slug: 'provider-backends/configuration' },
             {
               label: 'MCP servers',
               collapsed: true,

--- a/site/src/content/docs/auth-methods/cert.md
+++ b/site/src/content/docs/auth-methods/cert.md
@@ -26,6 +26,15 @@ If your workload's identity is a Kubernetes ServiceAccount token, prefer the `ku
 - A way to get the workload's certificate to Warden — either direct mTLS termination at the Warden listener, or a trusted reverse proxy that terminates TLS and re-presents the certificate via a forwarding header. See [How the Certificate Reaches Warden](#how-the-certificate-reaches-warden).
 - A **role-mapping policy** in Warden that scopes what the resulting auth token can do (authenticating a certificate doesn't grant access on its own).
 
+## Enabling mTLS on the Listener
+
+Certificate auth requires TLS on the Warden listener so the client certificate can be presented during the handshake (mTLS). Two ways to satisfy it:
+
+- **Dev mode.** Use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. See [Serving TLS](/concepts/dev-server/#serving-tls) and [Requiring client certificates](/concepts/dev-server/#requiring-client-certificates-mtls).
+- **Behind a load balancer.** Place Warden behind a proxy that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+
+Both paths end at the same certificate extractor — see [How the Certificate Reaches Warden](#how-the-certificate-reaches-warden) for the trust-boundary details.
+
 ## Step 1: Configure Trusted CAs
 
 Enable the auth method:

--- a/site/src/content/docs/auth-methods/jwt.md
+++ b/site/src/content/docs/auth-methods/jwt.md
@@ -75,6 +75,13 @@ warden write auth/jwt/config \
 
 Multiple PEM keys can be supplied as a comma-separated list — useful during key rotation when the issuer may sign with either of two keys.
 
+**Quickstart (Ory Hydra).** The provider guides use the local [dev setup](/provider-backends/local-dev-setup/), whose bundled Hydra publishes a JWKS endpoint. Point the mount at it:
+
+```bash
+warden auth enable jwt
+warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
+```
+
 ## Step 2: Add Issuer / Audience / Claim Bindings
 
 Bindings configured on the mount apply to every login through it (a role may override most of them with per-role bindings).
@@ -147,6 +154,21 @@ The role can be set via the `X-Warden-Role` header (as above), embedded in the U
 The first request with a given (JWT, role) tuple triggers a fresh signature + claim validation and caches the result. Subsequent requests with the same tuple hit Warden's in-memory cache (TTL = `min(role.token_ttl, jwt-exp-derived)`) — no signature re-verification per call.
 
 > **Why no explicit login endpoint?** The `jwt_role` token type is part of Warden's transparent-auth family (alongside `cert_role` and `kubernetes_role`). Explicit logins returning a transparent token type are rejected by design. This keeps the workload's identity — the JWT, attested by the IdP — flowing through every call so each request is independently auditable, with no operator-distributed Warden tokens to rotate or revoke separately.
+
+## Obtaining a JWT
+
+The workload gets its JWT from your identity provider — the same IdP whose keys back the mount's [key source](#step-1-configure-the-key-source). How depends on the provider (OAuth2 client-credentials, an OIDC device flow, a CI runner's OIDC token, etc.).
+
+For the local [dev setup](/provider-backends/local-dev-setup/), the bundled Ory Hydra issues one via the OAuth2 client-credentials grant:
+
+```bash
+export JWT=$(curl -s -X POST http://localhost:4444/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
+  | jq -r '.access_token')
+```
+
+The workload then presents `$JWT` on every gateway request (as `Authorization: Bearer`, or via the provider-specific credential field documented in each provider guide).
 
 ## Group-Based Policies
 

--- a/site/src/content/docs/concepts/mcp.md
+++ b/site/src/content/docs/concepts/mcp.md
@@ -178,6 +178,26 @@ short `error_description` naming the offending method, tool, or parameter
 generic — it never reveals the shape of the policy or echoes raw body bytes — but
 it tells the agent enough to correct course rather than guess at an opaque 403.
 
+### Denial reasons
+
+Every decision records a `rule_type` in the [audit log](/concepts/audit/). Policy
+`rule_type`s name which gate fired; structural ones name a strict-parse failure,
+distinct from a policy refusal so operators can tell bad input from a governed
+denial:
+
+| `rule_type` | Trigger |
+|---|---|
+| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
+| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
+| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
+| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
+| `missing_body` | A `POST`/JSON-RPC body is absent or fails to parse on a path with MCP enforcement. Body-less verbs (`GET` SSE stream, `DELETE` session terminate) skip `mcp { }` evaluation entirely |
+| `malformed_jsonrpc` | Body is not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, …) |
+| `duplicate_key` | Duplicate object key anywhere in the body — Warden rejects the ambiguity a last-wins parser would hide |
+| `oversized_body` | Body exceeds the mount's `max_body_size` |
+| `batch_empty` | JSON-RPC batch is `[]` |
+| `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
+
 ## Auditing MCP Decisions
 
 Every consulted `mcp { }` block records its outcome to the [audit log](/concepts/audit/):

--- a/site/src/content/docs/provider-backends/alicloud.md
+++ b/site/src/content/docs/provider-backends/alicloud.md
@@ -20,15 +20,12 @@ Warden is transparent to clients: they use standard Alicloud SDKs pointed at the
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -70,6 +67,8 @@ warden write alicloud/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 If you're running Warden directly (no reverse proxy) and clients can resolve real Alicloud hostnames at Warden's address (e.g., via DNS or `/etc/hosts` overrides), omit `proxy_domains`.
 
@@ -335,7 +334,9 @@ Warden extracts the JWT from `X-Amz-Security-Token` (it starts with `eyJ`), auth
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -386,18 +387,6 @@ For cert-based transparent auth, the client signs with the **role name** as both
 # Credential=alicloud-user,... — Warden recognizes the role name and resolves
 # the cert-authenticated identity.
 ```
-
-## Configuration Reference
-
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `auto_auth_path` | string | — | Required. Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`). |
-| `default_role` | string | — | Fallback role when not provided in the URL path or resolved from the request. |
-| `proxy_domains` | []string | `[]` | Reverse-proxy DNS suffixes. Hosts of the form `<real>.aliyuncs.com.<proxy-domain>` are rewritten to `<real>.aliyuncs.com` before forwarding. Direct `*.aliyuncs.com` hosts are always accepted; anything else is rejected (SSRF guard). Entries must not themselves contain `aliyuncs.com`. |
-| `max_body_size` | int | 10MB | Maximum request body size in bytes (max 100MB). |
-| `timeout` | duration | 30s | Request timeout for verification + re-sign + forwarding. |
-| `tls_skip_verify` | bool | false | Skip TLS verification of upstream Alicloud endpoints (insecure; for testing only). |
-| `ca_data` | string | — | Base64-encoded PEM bundle to trust as the upstream CA. |
 
 ## Credential Reference
 

--- a/site/src/content/docs/provider-backends/ansible_tower.md
+++ b/site/src/content/docs/provider-backends/ansible_tower.md
@@ -10,58 +10,18 @@ The Ansible Tower provider enables proxied access to the Ansible Tower (AWX / Re
 - An **Ansible Tower** (v3.5+), **AWX** (v18.0+), or **Red Hat Ansible Automation Platform** (v2.0+) instance
 - A **Personal Access Token (PAT)** with appropriate permissions (see [Token Management](#token-management))
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -103,6 +63,8 @@ warden write ansible_tower/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Set `ansible_tower_url` to your Ansible Tower instance URL. HTTPS is required:
 
@@ -264,14 +226,7 @@ warden policy read ansible-tower-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Ansible Tower PAT automatically.
 
@@ -374,7 +329,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-3 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 1 and 5 with the following.
 
@@ -405,7 +362,7 @@ warden write auth/cert/role/ansible-tower-user \
     cred_spec_name=ansible-tower-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -429,55 +386,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/ansible_tower/role/ansible-tower-user/gateway/api/v2/ping/"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `ansible_tower_url` | string | — (required) | Ansible Tower API base URL (must use HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (for self-signed certs) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom trust |
-
-### Credential Source Config (Static PAT)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | Ansible Tower API URL for verification (default: from provider config) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/api/v2/ping/`) |
-| `auth_header_type` | string | No | How to attach token for verification: `bearer` (recommended) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static PAT)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Ansible Tower Personal Access Token (sensitive — masked in output) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key` with the PAT) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/anthropic.md
+++ b/site/src/content/docs/provider-backends/anthropic.md
@@ -9,58 +9,18 @@ The Anthropic provider enables proxied access to the Anthropic API through Warde
 - Docker and Docker Compose installed and running
 - An **Anthropic API key** from [console.anthropic.com](https://console.anthropic.com)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -101,6 +61,8 @@ warden write anthropic/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -224,7 +186,7 @@ path "anthropic/role/+/gateway/v1/models" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -234,14 +196,7 @@ warden policy read anthropic-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Anthropic API key (via `x-api-key` header) and `anthropic-version` header automatically.
 
@@ -406,7 +361,9 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -437,7 +394,7 @@ warden write auth/cert/role/anthropic-user \
     cred_spec_name=anthropic-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -467,47 +424,6 @@ curl --cert client.pem --key client-key.pem \
       "messages": [{"role": "user", "content": "Hello"}]
     }'
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `anthropic_url` | string | `https://api.anthropic.com` | Anthropic API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `120s` | Request timeout — set high for AI inference |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.anthropic.com`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/v1/models`) |
-| `auth_header_type` | string | No | Auth method: `bearer`, `token`, `custom_header` (default: `bearer`) |
-| `auth_header_name` | string | No | Header name when `auth_header_type=custom_header` (e.g., `x-api-key`) |
-| `extra_headers` | string | No | Additional static headers as `key:value` pairs (e.g., `anthropic-version:2023-06-01`) |
-| `optional_metadata` | string | No | Comma-separated spec fields to copy into credential data |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Anthropic API key (sensitive — masked in output) |
-| `organization_id` | string | No | Organization identifier |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Key Management
 

--- a/site/src/content/docs/provider-backends/atlassian.md
+++ b/site/src/content/docs/provider-backends/atlassian.md
@@ -9,58 +9,18 @@ The Atlassian provider enables proxied access to all Atlassian Cloud and Data Ce
 - Docker and Docker Compose installed and running
 - An **Atlassian API token** (from [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)) for Atlassian Cloud, or a **Personal Access Token (PAT)** for Data Center instances
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -222,14 +182,7 @@ EOF
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 The URL pattern is: `/v1/{mount}/role/{role}/gateway/{api-path}`
 
@@ -434,7 +387,9 @@ For older Data Center versions without PAT support, use Basic Auth the same way 
 
 Steps 1 and 5 use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. Steps 2-4 (provider, credential, and policy setup) are identical regardless of the auth method.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener. In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 ### Enable Cert Auth
 
@@ -480,48 +435,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/jira/role/atlassian-user/gateway/myself"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `atlassian_url` | string | — | **Required.** Atlassian product API base URL (see product URLs below) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Product Base URLs
-
-| Product | `atlassian_url` |
-|---------|----------------|
-| Jira Cloud | `https://{domain}.atlassian.net/rest/api/3` |
-| Confluence Cloud | `https://{domain}.atlassian.net/wiki/api/v2` |
-| Jira Service Management Cloud | `https://{domain}.atlassian.net/rest/servicedeskapi` |
-| Compass | `https://{domain}.atlassian.net/gateway/api/compass/v1` |
-| Atlassian Admin API | `https://api.atlassian.com` |
-| Bitbucket Cloud | `https://api.bitbucket.org/2.0` |
-| Jira Data Center | `https://{host}/rest/api/2` |
-| Confluence Data Center | `https://{host}/rest/api` |
-| Bitbucket Data Center | `https://{host}/rest/api/1.0` |
-
-### Credential Source Config (Static API Key)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-| `optional_metadata` | string | No | Set to `email` to enable Basic Auth mode for Cloud personal tokens and Bitbucket app passwords |
-| `api_url` | string | No | API base URL for token verification |
-| `verify_endpoint` | string | No | Verification path appended to `api_url` |
-
-### Credential Spec Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Atlassian API token, PAT, app password, or Admin API org key (sensitive — masked in output) |
-| `email` | string | Conditional | Account email — required for Cloud personal tokens and Bitbucket app passwords (only forwarded if source has `optional_metadata=email`) |
 
 ## Authentication Modes
 

--- a/site/src/content/docs/provider-backends/aws.md
+++ b/site/src/content/docs/provider-backends/aws.md
@@ -10,46 +10,9 @@ The AWS provider enables proxied access to AWS services through Warden. Clients 
 - AWS account with IAM access
 - AWS CLI (for initial IAM setup)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ### Create the IAM User
 
@@ -138,13 +101,10 @@ Attach the permissions policies your consumers need to this role (e.g., S3 acces
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy:
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup:
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role
@@ -192,6 +152,8 @@ EOF
 - `default_role`: the auth role to use for all requests. When set, this takes precedence over the `access_key_id` value in the SigV4 header.
 
 For production, set `proxy_domains` to your Warden server's domain (see [DNS Configuration](#dns-configuration)).
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify:
 
@@ -334,7 +296,7 @@ path "aws/gateway*" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -348,14 +310,7 @@ With Warden there is no explicit login step. The client embeds its identity dire
 
 ### JWT Auth method
 
-Get a JWT from your identity provider (Hydra in this quickstart):
-
-```bash
-export JWT=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT`.
 
 Configure the AWS SDK to use the JWT as credentials. The auth role name goes in `AWS_ACCESS_KEY_ID`, and the JWT goes in both `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`:
 
@@ -391,7 +346,9 @@ Warden detects the JWT in the `X-Amz-Security-Token` header, authenticates it ag
 
 For workloads that already have X.509 certificates (Kubernetes pods with cert-manager, VMs with machine certificates, SPIFFE X.509-SVIDs), Warden can authenticate using TLS client certificates instead of JWTs.
 
-> **Prerequisite:** TLS must be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 #### Set up cert auth and configure the provider
 
@@ -422,7 +379,7 @@ warden write aws/config <<EOF
 EOF
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 #### Configure the AWS SDK
 
@@ -450,57 +407,6 @@ docker compose -f docker-compose.quickstart.yml down -v
 ```
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
-
-## Architecture Overview
-
-```
-                          +-----------------------------+
-                          |  AWS IAM User               |
-                          |  warden-cred-source-root    |
-                          |                             |
-                          |  Policies:                  |
-                          |  - SelfManageAccessKeys     |
-                          |  - AssumeRoles (devops-*,   |
-                          |    internal-*)              |
-                          +--------+--------------------+
-                                   |
-              +--------------------+--------------------+
-              |                    |                     |
-       IAM key rotation    sts:AssumeRole         sts:AssumeRole
-       (self-management)         |                      |
-              |          +-------v--------+   +---------v-----------+
-              |          | devops-*       |   | internal-*          |
-              |          | roles          |   | roles               |
-              |          | (consumer      |   | (source driver      |
-              |          |  permissions)  |   |  permissions, e.g.  |
-              |          +-------+--------+   |  Secrets Manager)   |
-              |                  |             +---------+-----------+
-              v                  v                       v
-       Warden rotates     Warden mints           Source driver
-       base keys          STS creds for           uses elevated
-       periodically       consumers               permissions
-```
-
-### Request Flow
-
-1. Client signs request using the auth role name and JWT (or role name only for cert mode) as AWS credentials
-2. Request is sent to Warden gateway endpoint
-3. Warden authenticates the caller via the configured auth backend (JWT in `X-Amz-Security-Token` or role name as `access_key_id` for cert mode)
-4. Warden verifies the incoming SigV4 signature for request integrity
-5. Warden retrieves real AWS credentials from the credential spec
-6. Warden re-signs the request with valid AWS credentials
-7. Request is forwarded to the actual AWS endpoint
-8. Response is returned to the client
-
-### Security Model
-
-- **No credential distribution**: Clients never receive or store AWS credentials. They use their existing identity (JWT or certificate) directly.
-- **Implicit authentication**: Warden validates the embedded credential on every request — no long-lived Warden tokens to manage or revoke.
-- **Request integrity**: SigV4 signature verification ensures requests have not been tampered with in transit.
-- **Least privilege on the IAM user**: The user can only rotate its own keys and assume specific roles. If the base keys leak, the attacker still needs to know which roles to assume.
-- **Short-lived consumer credentials**: STS credentials expire automatically (controlled by TTL). No long-lived secrets are exposed to consumers.
-- **Automatic key rotation**: Warden rotates the base IAM keys on the configured schedule, limiting the window of exposure for any single key pair.
-- **Audit trail**: Each STS AssumeRole call is logged in CloudTrail with a distinct session name.
 
 ## DNS Configuration
 
@@ -573,73 +479,6 @@ warden write aws/config proxy_domains="warden.yourdomain.com"
 
 For HTTPS, you'll need a **wildcard SSL certificate** (`*.warden.yourdomain.com`), obtainable from Let's Encrypt (free, via DNS-01 challenge), commercial CAs, or internal PKI.
 
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `proxy_domains` | list(string) | `["localhost"]` | Domains that Warden listens on for proxied requests |
-| `max_body_size` | int | `10485760` (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`) |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | Yes | Path to auth mount for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Default auth role when not specified in `access_key_id` |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `access_key_id` | string | Yes | IAM user access key ID |
-| `secret_access_key` | string | Yes | IAM user secret access key |
-| `region` | string | Yes | AWS region for API calls |
-| `assume_role_arn` | string | No | Role ARN for source driver to assume (needed for Secrets Manager mint method) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config — sts_assume_role
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `sts_assume_role` |
-| `role_arn` | string | Yes | ARN of the role to assume for consumers |
-| `ttl` | duration | No | Default credential TTL (default: `1h`) |
-| `session_name` | string | No | STS session name (default: `warden-<spec_name>`) |
-| `external_id` | string | No | External ID for the AssumeRole call |
-| `policy` | string | No | Inline session policy to further restrict permissions |
-
-### Credential Spec Config — secrets_manager
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `secrets_manager` |
-| `secret_id` | string | Yes | Secret ID or ARN in Secrets Manager |
-| `version_stage` | string | No | Version stage to retrieve (default: `AWSCURRENT`) |
-
-### Credential Spec Config — static_aws (via hvault)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_aws` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to secret (must contain `access_key_id` and `secret_access_key`) |
-
-### Credential Spec Config — dynamic_aws (via hvault)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_aws` |
-| `aws_mount` | string | Yes | Vault AWS secrets engine mount path |
-| `role_name` | string | Yes | AWS role name configured in Vault |
-| `role_arn` | string | No | ARN of the role to assume (for STS) |
-| `role_session_name` | string | No | Session name for STS assumption |
-| `ttl` | duration | No | Credential TTL (clamped to spec min/max bounds) |
-
-### TTL Bounds
-
-- `-min-ttl`: Minimum credential TTL. Requests for shorter TTLs are clamped up.
-- `-max-ttl`: Maximum credential TTL. Requests for longer TTLs are clamped down.
 
 ## Supported AWS Services
 

--- a/site/src/content/docs/provider-backends/azure.md
+++ b/site/src/content/docs/provider-backends/azure.md
@@ -9,46 +9,9 @@ The Azure provider enables proxied access to Azure APIs through Warden. It manag
 - Docker and Docker Compose installed and running
 - A Microsoft Entra ID **App Registration** (service principal) with a client secret
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ### Creating a Microsoft Entra ID App Registration
 
@@ -99,15 +62,12 @@ Warden needs network access to the following Azure endpoints:
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -148,6 +108,8 @@ warden write azure/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -241,7 +203,7 @@ path "azure/role/+/gateway*" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -251,14 +213,7 @@ warden policy read azure-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Azure Bearer token automatically.
 
@@ -360,7 +315,9 @@ Warden supports automatic rotation of Azure service principal credentials via th
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -391,7 +348,7 @@ warden write auth/cert/role/azure-user \
     cred_spec_name=azure-ops 
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -420,52 +377,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     "https://warden.internal/v1/azure/gateway/management.azure.com/subscriptions?api-version=2022-12-01"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`) |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `tenant_id` | string | Yes | Microsoft Entra ID Tenant ID (UUID format) |
-| `client_id` | string | Yes | Service Principal Application (Client) ID |
-| `client_secret` | string | Yes | Service Principal client secret |
-| `subscription_id` | string | No | Azure Subscription ID |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Bearer Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | No | Must be `bearer_token` (default) |
-| `client_id` | string | Yes | Workload SP Application ID |
-| `client_secret` | string | Yes | Workload SP client secret |
-| `tenant_id` | string | No | Override tenant ID (defaults to source tenant) |
-| `resource_uri` | string | No | Token scope (default: `https://management.azure.com/`) |
-
-### Credential Spec Config (Key Vault Secret)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `key_vault_secret` |
-| `client_id` | string | Yes | SP with access to the Key Vault |
-| `client_secret` | string | Yes | SP client secret |
-| `vault_name` | string | Yes | Name of the Azure Key Vault |
-| `secret_name` | string | Yes | Name of the secret to retrieve |
-| `secret_version` | string | No | Specific version (defaults to latest) |
-| `tenant_id` | string | No | Override tenant ID |
 
 ## Troubleshooting
 

--- a/site/src/content/docs/provider-backends/cloudflare.md
+++ b/site/src/content/docs/provider-backends/cloudflare.md
@@ -14,58 +14,18 @@ The Cloudflare provider enables proxied access to Cloudflare APIs through Warden
   - An API token (from Cloudflare Dashboard > My Profile > API Tokens) for the REST API
   - R2 API credentials (access key ID + secret access key) for Object Storage — generate via Cloudflare Dashboard > R2 > Manage R2 API Tokens
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -248,14 +208,7 @@ warden policy read cloudflare-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Cloudflare token automatically.
 
@@ -400,7 +353,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -431,7 +386,7 @@ warden write auth/cert/role/cloudflare-user \
     cred_spec_name=cloudflare-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -466,51 +421,6 @@ R2 Object Storage:
 aws s3 ls s3://my-bucket/ \
   --endpoint-url "https://warden.internal/v1/cloudflare/role/cloudflare-user/gateway"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `cloudflare_url` | string | `https://api.cloudflare.com/client/v4` | Cloudflare API base URL |
-| `account_id` | string | — | Cloudflare account ID (required for R2 Object Storage) |
-| `r2_jurisdiction` | string | — | R2 jurisdiction: empty (default), `eu`, or `fedramp` |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Spec Config (static_keys)
-
-At least one mode must be configured: `api_token` for the REST API, or `access_key_id` + `secret_access_key` for R2. Both can be set for dual-mode access.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_keys` |
-| `access_key_id` | string | R2 mode | Cloudflare R2 access key ID (required with `secret_access_key`) |
-| `secret_access_key` | string | R2 mode | Cloudflare R2 secret access key (sensitive — required with `access_key_id`) |
-| `api_token` | string | API mode | API bearer token for the REST API (sensitive) |
-
-### Credential Spec Config (Vault — static_cloudflare)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_cloudflare` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/cohere.md
+++ b/site/src/content/docs/provider-backends/cohere.md
@@ -9,58 +9,18 @@ The Cohere provider enables proxied access to the Cohere API through Warden. It 
 - Docker and Docker Compose installed and running
 - A **Cohere API Key** (from [dashboard.cohere.com/api-keys](https://dashboard.cohere.com/api-keys))
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write cohere/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -240,14 +202,7 @@ warden policy read cohere-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Cohere API key automatically.
 
@@ -385,7 +340,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -416,7 +373,7 @@ warden write auth/cert/role/cohere-user \
     cred_spec_name=cohere-prod
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -441,56 +398,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/cohere/role/cohere-user/gateway/v1/models" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `cohere_url` | string | `https://api.cohere.com` | Cohere API base URL |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `120s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.cohere.com`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/v1/check-api-key`) |
-| `verify_method` | string | No | HTTP method for verification: `POST` (recommended for Cohere) |
-| `auth_header_type` | string | No | How to attach key for verification: `bearer` |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Cohere API key (sensitive — masked in output) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/configuration.md
+++ b/site/src/content/docs/provider-backends/configuration.md
@@ -1,0 +1,58 @@
+---
+title: "Provider configuration"
+---
+
+Warden's reverse-proxy providers share a common set of top-level provider-config
+fields — request handling, the auth mount to authenticate against, and TLS
+options for reaching the upstream. This page documents those shared fields once,
+so the provider guides can link here instead of repeating them. (A few
+providers — the access backends and providers that don't front an HTTP upstream —
+don't expose these fields; their guides set only the options they support.)
+
+Set these on the provider config, for example:
+
+```bash
+warden write <provider>/config <<EOF
+{
+  "proxy_domains": ["localhost"],
+  "max_body_size": 10485760,
+  "timeout": "30s",
+  "auto_auth_path": "auth/jwt/",
+  "default_role": "<role>"
+}
+EOF
+```
+
+## Common provider config fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `proxy_domains` | list(string) | `["localhost"]` | Domains Warden listens on for proxied requests. In production, set this to your Warden server's domain. |
+| `max_body_size` | int | `10485760` (10 MB) | Maximum request body size in bytes (max 100 MB). |
+| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`). |
+| `auto_auth_path` | string | Required | Path to the auth mount used for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`). See [JWT auth](/auth-methods/jwt/) and [Certificate auth](/auth-methods/cert/). |
+| `default_role` | string | — | Default auth role to use when the request doesn't specify one. When set, it takes precedence over any role encoded in the request. |
+
+## TLS options
+
+These two fields control how Warden makes its outbound TLS connection to the
+upstream. They apply both to the provider config and to any credential source
+config that talks to an upstream over TLS (e.g. a Vault credential source), and
+are documented here so the per-provider references don't repeat them.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` upstream URLs. **Development only** — never enable in production. |
+| `ca_data` | string | — | Base64-encoded PEM CA certificate for reaching an upstream that presents a custom or self-signed CA. |
+
+:::caution
+`tls_skip_verify` disables certificate verification for the upstream connection
+and permits plaintext `http://` URLs. Use it only for local development. For a
+private CA in production, supply the CA with `ca_data` instead.
+:::
+
+## See Also
+
+- [JWT auth](/auth-methods/jwt/) — configuring the `auth/jwt/` mount referenced by `auto_auth_path`.
+- [Certificate auth](/auth-methods/cert/) — configuring the `auth/cert/` mount for mTLS-based providers.
+- [Local dev setup](/provider-backends/local-dev-setup/) — the local Warden + identity-provider environment the guides assume.

--- a/site/src/content/docs/provider-backends/datadog.md
+++ b/site/src/content/docs/provider-backends/datadog.md
@@ -9,58 +9,18 @@ The Datadog provider enables proxied access to the Datadog REST API through Ward
 - Docker and Docker Compose installed and running
 - A **Datadog API Key** (from Datadog > Organization Settings > API Keys) and optionally a **Datadog Application Key** (from Datadog > Organization Settings > Application Keys)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write datadog/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Set `datadog_url` to match your Datadog site:
 
@@ -236,14 +198,7 @@ warden policy read datadog-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Datadog API key (and application key) automatically.
 
@@ -369,7 +324,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -400,7 +357,7 @@ warden write auth/cert/role/datadog-user \
     cred_spec_name=datadog-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -425,57 +382,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/datadog/role/datadog-user/gateway/api/v1/monitor" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `datadog_url` | string | `https://api.datadoghq.com` | Datadog API base URL (must match your Datadog site) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.datadoghq.com`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/api/v1/validate`) |
-| `auth_header_type` | string | No | How to attach key for verification: `custom_header` (recommended for Datadog) |
-| `auth_header_name` | string | No | Header name for verification (e.g., `DD-API-KEY`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Datadog API key (sensitive — masked in output) |
-| `application_key` | string | No | Datadog Application key (sensitive — masked in output; required for most management/read endpoints) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key`, optionally `application_key`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/dynatrace.md
+++ b/site/src/content/docs/provider-backends/dynatrace.md
@@ -11,58 +11,18 @@ The Dynatrace provider enables proxied access to the Dynatrace REST API through 
   - A **Dynatrace API Token** (from Dynatrace > Access tokens) with appropriate scopes, or
   - **OAuth2 client credentials** (from Dynatrace > Account Management > OAuth clients) for Platform API access
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -104,6 +64,8 @@ warden write dynatrace/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 > **Important:** Replace `abc12345` with your actual Dynatrace environment ID. You can find it in your Dynatrace URL (e.g., `https://abc12345.live.dynatrace.com`).
 
@@ -265,14 +227,7 @@ warden policy read dynatrace-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Dynatrace credentials automatically.
 
@@ -371,7 +326,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -402,7 +359,7 @@ warden write auth/cert/role/dynatrace-user \
     cred_spec_name=dynatrace-env
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -427,74 +384,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/dynatrace/role/dynatrace-user/gateway/api/v2/entities?pageSize=10" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `dynatrace_url` | string | — | Dynatrace API base URL (required — must include your environment ID) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL for verification |
-| `verify_endpoint` | string | No | Verification path (e.g., `/api/v2/tokens/lookup`) |
-| `verify_method` | string | No | HTTP method for verification (e.g., `POST`) |
-| `auth_header_type` | string | No | How to attach key for verification: `custom_header` |
-| `auth_header_name` | string | No | Header name for verification (e.g., `Authorization`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Dynatrace API token (sensitive — masked in output) |
-
-### Credential Source Config (OAuth2)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `client_id` | string | Yes | OAuth2 client ID (e.g., `dt0s02.XXXXXXXX`) |
-| `client_secret` | string | Yes | OAuth2 client secret (sensitive) |
-| `token_url` | string | Yes | OAuth2 token endpoint (`https://sso.dynatrace.com/sso/oauth2/token`) |
-| `default_scopes` | string | No | Default OAuth2 scopes (space-separated) |
-| `token_param.resource` | string | No | Account URN for Platform API (e.g., `urn:dtaccount:{account-uuid}`) |
-| `display_name` | string | No | Label for logs/errors (default: `OAuth2`) |
-
-### Credential Spec Config (OAuth2)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `scope` | string | No | OAuth2 scope override (space-separated; defaults to source's `default_scopes`) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/elastic.md
+++ b/site/src/content/docs/provider-backends/elastic.md
@@ -9,58 +9,18 @@ The Elastic provider enables proxied access to Elasticsearch REST APIs through W
 - Docker and Docker Compose installed and running
 - An **Elasticsearch cluster** with a reachable HTTPS endpoint and a valid **API key** (from Elasticsearch Security API or Kibana > Stack Management > API Keys)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write elastic/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 > **Note:** `elastic_url` is required and must use HTTPS. There is no default URL since Elasticsearch endpoints are deployment-specific.
 
@@ -272,14 +234,7 @@ warden policy read elastic-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Elasticsearch API key automatically.
 
@@ -370,7 +325,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -401,7 +358,7 @@ warden write auth/cert/role/elastic-user \
     cred_spec_name=elastic-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -425,74 +382,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/elastic/role/elastic-user/gateway/_cluster/health"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `elastic_url` | string | — (required) | Elasticsearch cluster URL (must use HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Keys — `apikey` type)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | Elasticsearch cluster URL for verification |
-| `verify_endpoint` | string | No | Verification path (e.g., `/`) |
-| `auth_header_type` | string | No | How to attach key for verification: `custom_header` |
-| `auth_header_name` | string | No | Header name for verification (e.g., `Authorization`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Pre-encoded Elasticsearch API key — base64 of `id:api_key` (sensitive — masked in output) |
-
-### Credential Source Config (Elasticsearch Driver — `elastic` type)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `elastic_url` | string | Yes | Elasticsearch cluster URL (HTTPS) |
-| `api_key` | string | Yes | Pre-encoded source API key with `manage_api_key` privilege (sensitive — masked in output) |
-| `api_key_id` | string | No | API key ID (extracted from `api_key` if omitted) |
-| `activation_delay` | duration | No | Wait period for key propagation during rotation (default: `10s`) |
-| `key_name_prefix` | string | No | Prefix for generated API key names (default: `warden`) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Elasticsearch Driver)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `key_name` | string | No | Override for the generated API key name |
-| `role_descriptors` | string | No | JSON string of Elasticsearch role descriptors to scope the minted key |
-| `expiration` | string | No | Key expiration (e.g., `1h`, `30d`). Default: `1h` |
-
-### Credential Source Config (Vault/OpenBao — `hvault` type)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — `static_apikey`)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key` field with the pre-encoded value) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/gcp.md
+++ b/site/src/content/docs/provider-backends/gcp.md
@@ -9,46 +9,9 @@ The GCP provider enables proxied access to Google Cloud Platform APIs through Wa
 - Docker and Docker Compose installed and running
 - A GCP **service account key** (JSON format) with appropriate IAM permissions
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ### Creating a Service Account Key
 
@@ -65,15 +28,12 @@ For impersonation, the source service account needs `iam.serviceAccounts.getAcce
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -114,6 +74,8 @@ warden write gcp/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -244,7 +206,7 @@ path "gcp/role/+/gateway*" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -254,14 +216,7 @@ warden policy read gcp-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the OAuth2 Bearer token automatically.
 
@@ -369,7 +324,9 @@ When the source key rotates, all credential specs sharing that source automatica
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -400,7 +357,7 @@ warden write auth/cert/role/gcp-user \
     cred_spec_name=gcp-cloud-platform
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -429,50 +386,3 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     "https://warden.internal/v1/gcp/gateway/storage.googleapis.com/storage/v1/b?project=my-project"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`) |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `service_account_key` | string | Yes | Full JSON service account key |
-| `activation_delay` | duration | No | Delay before activating rotated keys (default: `2m`) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Direct Access Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `access_token` |
-| `scopes` | string | No | Comma-separated OAuth2 scopes (default: `https://www.googleapis.com/auth/cloud-platform`) |
-
-### Credential Spec Config (Impersonated Access Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `impersonated_access_token` |
-| `target_service_account` | string | Yes | Email of the service account to impersonate |
-| `scopes` | string | No | Comma-separated OAuth2 scopes (default: `https://www.googleapis.com/auth/cloud-platform`) |
-| `lifetime` | string | No | Token lifetime (default: `3600s`, max: `43200s` / 12 hours) |
-
-### Credential Spec Config (Vault — dynamic_gcp)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_gcp` |
-| `gcp_mount` | string | Yes | Vault GCP secrets engine mount path |
-| `role_name` | string | Yes | GCP roleset or static account name in Vault |
-| `role_type` | string | No | `roleset` (default) or `static-account` |

--- a/site/src/content/docs/provider-backends/github.md
+++ b/site/src/content/docs/provider-backends/github.md
@@ -11,58 +11,18 @@ The GitHub provider enables proxied access to both the GitHub REST API and Git s
   - **GitHub App** with a private key and installation ID, OR
   - **Personal Access Token** (classic or fine-grained)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -104,6 +64,8 @@ warden write github/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -202,7 +164,7 @@ path "github/role/+/gateway*" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -212,14 +174,7 @@ warden policy read github-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the GitHub token automatically.
 
@@ -405,7 +360,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -436,7 +393,7 @@ warden write auth/cert/role/github-user \
     cred_spec_name=github-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -466,44 +423,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     https://warden.internal/v1/github/gateway/repos/owner/repo-name
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `github_url` | string | `https://api.github.com` | GitHub API base URL (must be HTTPS) |
-| `api_version` | string | `2022-11-28` | GitHub REST API version header (latest: `2026-03-10`) |
-| `git_max_body_size` | int | 2147483648 (2 GiB) | Maximum request body size for Git smart-HTTP requests in bytes (range: 1 MiB to 10 GiB) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size for REST requests in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`); raise for large Git pushes — see [Git over HTTPS](#git-over-https) |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `github_url` | string | `https://api.github.com` | GitHub API base URL (must be HTTPS) |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (App Mode)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `auth_method` | string | Yes | Must be `app` |
-| `app_id` | string | Yes | GitHub App ID |
-| `private_key` | string | Yes | PEM-encoded RSA private key (PKCS1 or PKCS8) |
-| `installation_id` | string | Yes | GitHub App installation ID |
-
-### Credential Spec Config (PAT Mode)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `auth_method` | string | Yes | Must be `pat` |
-| `token` | string | Yes | Personal Access Token |
 
 ## GitHub Enterprise Server
 

--- a/site/src/content/docs/provider-backends/gitlab.md
+++ b/site/src/content/docs/provider-backends/gitlab.md
@@ -11,58 +11,18 @@ The GitLab provider enables proxied access to the GitLab REST API through Warden
   - **OAuth2 application** credentials (`application_id` and `application_secret`), OR
   - **Personal Access Token** with `api` scope (and `admin` scope if rotation is needed)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -104,6 +64,8 @@ warden write gitlab/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -217,7 +179,7 @@ path "gitlab/role/+/gateway*" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -227,14 +189,7 @@ warden policy read gitlab-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the GitLab token automatically. Note that GitLab API paths start with `/api/v4/`.
 
@@ -420,7 +375,9 @@ The default activation delay is **1 minute** (configurable via `activation_delay
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -451,7 +408,7 @@ warden write auth/cert/role/gitlab-user \
     cred_spec_name=gitlab-project-token
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -481,64 +438,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     https://warden.internal/v1/gitlab/gateway/api/v4/projects
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `gitlab_address` | string | — | GitLab instance URL (required, e.g., `https://gitlab.com`) |
-| `git_max_body_size` | int | 2147483648 (2 GiB) | Maximum request body size for Git smart-HTTP requests in bytes (range: 1 MiB to 10 GiB) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size for REST requests in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`); raise for large Git pushes — see [Git over HTTPS](#git-over-https) |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (PAT Mode)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `gitlab_address` | string | Yes | GitLab instance URL |
-| `auth_method` | string | Yes | Must be `pat` |
-| `personal_access_token` | string | Yes | Personal access token with `api` scope |
-| `activation_delay` | duration | No | Delay before activating rotated credentials (default: `1m`) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Source Config (OAuth2 Mode)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `gitlab_address` | string | Yes | GitLab instance URL |
-| `auth_method` | string | Yes | Must be `oauth2` |
-| `application_id` | string | Yes | OAuth2 application ID |
-| `application_secret` | string | Yes | OAuth2 application secret |
-| `activation_delay` | duration | No | Delay before activating rotated credentials (default: `1m`) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Project Access Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `project_access_token` |
-| `project_id` | string | Yes | GitLab project ID (numeric or URL-encoded path) |
-| `token_name` | string | No | Token name (default: `warden-minted`) |
-| `scopes` | string | No | Comma-separated scopes (default: `api`) |
-| `access_level` | int | No | Access level: 10/20/30/40 (default: `30`) |
-| `ttl` | duration | No | Token TTL (default: `24h`, max: 365 days) |
-
-### Credential Spec Config (Group Access Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `group_access_token` |
-| `group_id` | string | Yes | GitLab group ID (numeric or URL-encoded path) |
-| `token_name` | string | No | Token name (default: `warden-minted`) |
-| `scopes` | string | No | Comma-separated scopes (default: `api`) |
-| `access_level` | int | No | Access level: 10/20/30/40 (default: `30`) |
-| `ttl` | duration | No | Token TTL (default: `24h`, max: 365 days) |
 
 ## Self-Hosted GitLab
 

--- a/site/src/content/docs/provider-backends/grafana.md
+++ b/site/src/content/docs/provider-backends/grafana.md
@@ -11,58 +11,18 @@ A single provider type supports all Grafana services. Mount multiple instances w
 - Docker and Docker Compose installed and running
 - A **Grafana service account token** (from Grafana > Administration > Service Accounts) or a **Grafana Cloud access policy token** (from Grafana Cloud > Access Policies)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -104,6 +64,8 @@ warden write grafana/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -218,14 +180,7 @@ EOF
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 The URL pattern is: `/v1/grafana/role/{role}/gateway/{api-path}`
 
@@ -370,7 +325,9 @@ curl -s "${TEMPO_ENDPOINT}/api/search?q={resource.service.name=\"myapp\"}" \
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -419,51 +376,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/grafana/role/grafana-user/gateway/org" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `grafana_url` | string | `https://grafana.com/api` | Grafana API base URL (must be HTTPS) |
-| `tenant_id` | string | — | Tenant/org ID injected as `X-Scope-OrgID` header (required for Loki, Mimir, Tempo, Pyroscope) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Grafana Driver)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `grafana_url` | string | Yes | Grafana API base URL (e.g., `https://mystack.grafana.net`) |
-| `admin_token` | string | Yes | Admin service account token with ServiceAccount admin permissions |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification (development only) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Grafana Driver)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `role` | string | No | Service account role: `Viewer`, `Editor`, or `Admin` (default: `Viewer`) |
-| `token_expiry` | duration | No | Token expiration duration (default: `1h`) |
-| `name_prefix` | string | No | Service account name prefix (default: `warden-`) |
-| `org_id` | string | No | Organization ID for multi-org setups |
-
-### Credential Source Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL for token verification |
-| `verify_endpoint` | string | No | Verification path (e.g., `/org`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Grafana service account token or Cloud access policy token (sensitive — masked in output) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/honeycomb.md
+++ b/site/src/content/docs/provider-backends/honeycomb.md
@@ -10,58 +10,18 @@ The Honeycomb provider enables proxied access to the Honeycomb API through Warde
 - A Honeycomb account with a management key (key ID + key secret) for dynamic key minting, **or** a static ingest/configuration key
 - Team slug from your Honeycomb organization (visible in your Honeycomb URL)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -103,6 +63,8 @@ warden write honeycomb/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 For EU region:
 
@@ -269,14 +231,7 @@ warden policy read honeycomb-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Honeycomb credential automatically.
 
@@ -370,7 +325,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-4 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -399,7 +356,7 @@ warden write auth/cert/role/honeycomb-user \
     cred_spec_name=honeycomb-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -421,72 +378,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/honeycomb/role/honeycomb-user/gateway/1/auth"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `honeycomb_url` | string | `https://api.honeycomb.io` | Honeycomb API base URL |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | -- | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | -- | Fallback role when not specified in URL |
-
-### Credential Source Config (Honeycomb Driver)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `management_key_id` | string | Yes | Management key ID (`hcxmk_` prefix) for API key operations |
-| `management_key_secret` | string | Yes | Management key secret paired with the key ID |
-| `team_slug` | string | Yes | Honeycomb team slug used in API paths |
-| `honeycomb_url` | string | No | Honeycomb API base URL (default: `https://api.honeycomb.io`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification (development only) |
-
-### Credential Spec Config (Honeycomb Driver)
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `environment_id` | string | -- | **Required.** Target Honeycomb environment ID |
-| `key_type` | string | `ingest` | Type of key to mint: `ingest` or `configuration` |
-| `key_name_prefix` | string | `warden-` | Prefix for generated key names |
-| `key_ttl` | duration | `24h` | Warden lease TTL for the minted key |
-| `permissions` | string (JSON) | -- | JSON permissions object (configuration keys only) |
-
-### Credential Source Config (Static API Key)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | Honeycomb API base URL (informational only) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Key)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Honeycomb ingest or configuration key (sensitive -- masked in output) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault -- static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/ibmcloud.md
+++ b/site/src/content/docs/provider-backends/ibmcloud.md
@@ -35,58 +35,18 @@ Only hosts matching the `allowed_host_suffixes` list (default: `.cloud.ibm.com`,
   - An API key (from IBM Cloud Console > Manage > Access (IAM) > API keys) for the REST API
   - COS HMAC credentials (access key ID + secret access key) for Object Storage — generate via IBM Cloud Console > Cloud Object Storage > Service credentials > New credential (include HMAC keys)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -128,6 +88,8 @@ warden write ibmcloud/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 To restrict which IBM hostnames the gateway will forward to (recommended for production):
 
@@ -251,14 +213,7 @@ warden policy read ibmcloud-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths with the **IBM service hostname as the first path segment**. Warden performs implicit JWT authentication and injects the real IBM Cloud IAM token server-side — clients present a Warden JWT, not an IBM API key.
 
@@ -495,7 +450,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -552,61 +509,6 @@ COS Object Storage:
 aws s3 ls s3://my-bucket/ \
   --endpoint-url "https://warden.internal/v1/ibmcloud/role/ibmcloud-user/gateway"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `ibmcloud_url` | string | `https://cloud.ibm.com` | Retained for framework compatibility; **ignored in API mode** (the target host is encoded in the request path). |
-| `allowed_host_suffixes` | list(string) | `.cloud.ibm.com,.appdomain.cloud` | Hostname suffixes permitted as API gateway targets. Each entry must start with `.`. Use `*` alone to disable (not recommended). |
-| `cos_endpoint_type` | string | `public` | IBM COS endpoint type: `public`, `private` (VPC-only), or `direct` (Classic Infrastructure) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Spec Config (iam_with_cos — IBM Source)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `iam_with_cos` |
-| `access_key_id` | string | COS mode | IBM COS HMAC access key ID (required with `secret_access_key`) |
-| `secret_access_key` | string | COS mode | IBM COS HMAC secret access key (sensitive — required with `access_key_id`) |
-
-### Credential Spec Config (dynamic_ibm — Vault IBM Secrets Engine)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_ibm` |
-| `ibm_mount` | string | Yes | Vault IBM secrets engine mount path |
-| `role_name` | string | Yes | Vault IBM secrets engine role name |
-| `iam_endpoint` | string | No | IBM Cloud IAM endpoint (default: `https://iam.cloud.ibm.com`) |
-| `ttl` | duration | No | Requested lease TTL for the dynamic API key |
-| `access_key_id` | string | COS mode | IBM COS HMAC access key ID (static, from spec config) |
-| `secret_access_key` | string | COS mode | IBM COS HMAC secret access key (static, from spec config) |
-
-### Credential Source Config (IBM)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | IBM Cloud API key |
-| `account_id` | string | No | IBM Cloud account ID (discovered from API key if omitted) |
-| `iam_endpoint` | string | No | IBM Cloud IAM endpoint (default: `https://iam.cloud.ibm.com`) |
-| `activation_delay` | duration | No | Wait period for API key propagation during rotation (default: `2m`) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/kubernetes.md
+++ b/site/src/content/docs/provider-backends/kubernetes.md
@@ -11,29 +11,16 @@ The Kubernetes provider enables proxied access to Kubernetes API servers through
 - A **ServiceAccount** with permissions to create tokens for other service accounts (see [RBAC Requirements](#rbac-requirements))
 - A **bearer token** for the source ServiceAccount
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** -- this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Start Warden in dev mode:**
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Enable JWT auth and create a role bound to a Warden policy:
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup:
 
 ```bash
-# Enable JWT auth (if not already enabled)
 warden auth enable jwt -path=auth/jwt/
-
-# Configure JWT auth with your OIDC provider
 warden write auth/jwt/config \
   jwks_url="http://localhost:4444/.well-known/jwks.json" \
   default_role="k8s-user"
@@ -56,6 +43,8 @@ warden write kubernetes/config \
   kubernetes_url="https://my-cluster.example.com:6443" \
   auto_auth_path="auth/jwt/"
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 For clusters with custom CA certificates:
 
@@ -238,14 +227,7 @@ EOF
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Kubernetes ServiceAccount token automatically.
 
@@ -318,41 +300,6 @@ roleRef:
 ```
 
 To restrict token creation to specific namespaces, use a `Role` and `RoleBinding` instead of `ClusterRole` and `ClusterRoleBinding`.
-
-## Configuration Reference
-
-### Provider Configuration
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `kubernetes_url` | string | Yes | Kubernetes API server URL (e.g., `https://my-cluster.example.com:6443`) |
-| `max_body_size` | int | No | Maximum request body size in bytes (default: 10MB, max: 100MB) |
-| `timeout` | string | No | Request timeout duration (default: `30s`) |
-| `auto_auth_path` | string | Yes | Auth mount path for implicit authentication (e.g., `auth/jwt/`) |
-| `default_role` | string | No | Default role when not specified in URL path |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom CAs |
-
-### Credential Source Configuration
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `kubernetes_url` | string | Yes | Kubernetes API server URL |
-| `token` | string | Yes | Bearer token for authenticating to the API server |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate |
-| `tls_skip_verify` | string | No | Skip TLS verification; also allows `http://` URLs (`true`/`false`, default: `false`) |
-| `source_service_account` | string | No | Name of the source SA (required for rotation) |
-| `source_namespace` | string | No | Namespace of the source SA (required for rotation) |
-| `source_token_ttl` | string | No | TTL for rotated source tokens (default: `24h`, min: `10m`, max: `48h`) |
-
-### Credential Spec Configuration
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `service_account` | string | Yes | Target service account name |
-| `namespace` | string | Yes | Namespace of the target service account |
-| `audiences` | string | No | Comma-separated list of token audiences |
-| `ttl` | string | No | Token TTL (e.g., `1h`, `30m`). Default: `1h`. Min: `10m`, Max: `48h` |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/local-dev-setup.md
+++ b/site/src/content/docs/provider-backends/local-dev-setup.md
@@ -1,0 +1,83 @@
+---
+title: "Local dev setup"
+---
+
+Every provider guide assumes you have a local Warden environment running. This
+page sets one up once — an identity provider ([Ory Hydra](https://www.ory.sh/hydra/))
+to issue the JWTs used for authentication, plus a Warden server in dev mode.
+Follow it before **Step 1** of any provider guide, then return to the provider
+you're configuring.
+
+:::note
+Dev mode uses in-memory storage — all configuration is lost when the server
+stops. It is for local evaluation only, not production.
+:::
+
+## 1. Deploy the quickstart stack
+
+This starts Ory Hydra, which issues the JWTs the provider guides authenticate in
+their Step 1 and Step 5:
+
+```bash
+curl -fsSL -o docker-compose.quickstart.yml \
+  https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
+docker compose -f docker-compose.quickstart.yml up -d
+```
+
+## 2. Download the latest Warden binary
+
+```bash
+# macOS (Apple Silicon)
+curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
+
+# macOS (Intel)
+curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
+
+# Linux (x86_64)
+curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
+
+# Linux (ARM64)
+curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
+```
+
+## 3. Add the binary to your PATH
+
+```bash
+export PATH="$PWD:$PATH"
+```
+
+## 4. Start the Warden server in dev mode
+
+```bash
+warden server -dev -dev-root-token=root
+```
+
+For TLS and mTLS dev-server options (needed for the certificate auth flow), see
+[Serving TLS](/concepts/dev-server/#serving-tls).
+
+## 5. Export the CLI environment variables
+
+In another terminal window:
+
+```bash
+export PATH="$PWD:$PATH"
+export WARDEN_ADDR="http://127.0.0.1:8400"
+export WARDEN_TOKEN="root"
+```
+
+You now have a Warden server and an identity provider running locally. Continue
+with **Step 1** of the provider guide you're following.
+
+## Cleanup
+
+To stop Warden and the identity provider:
+
+```bash
+# Stop Warden (Ctrl+C in the terminal where it's running)
+
+# Stop and remove the identity provider containers
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+Since dev mode uses in-memory storage, all configuration is lost when the server
+stops.

--- a/site/src/content/docs/provider-backends/mcp-github.md
+++ b/site/src/content/docs/provider-backends/mcp-github.md
@@ -28,62 +28,20 @@ token:
   act as a consenting user via the authorization-code flow ([Option C](#option-c-oauth2-authorization-code-flow-acting-as-a-github-user))
 - An MCP client that supports remote MCP servers over HTTP
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and
-policy. Clients authenticate directly with their JWT — no separate login step is
-needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **Set this up before configuring the provider.** Warden validates at
 > configuration time that the auth backend referenced by `auto_auth_path` is
 > already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -129,6 +87,8 @@ warden write github-mcp/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 ## Step 3: Create a Credential Source and Spec
 
@@ -263,23 +223,12 @@ If a captured field is sensitive, add its path to the audit device's `salt_field
 MCP traffic passes through two layers: the minted GitHub token (its scopes are the
 security boundary) and Warden's CBP `mcp { }` block (governance at the gateway).
 
-Enforcement is **body-authoritative**. When a policy in scope contains an
-`mcp { }` block, Warden strict-parses the JSON-RPC request body and matches
-against the parsed body. The parser fails closed on any structural problem and
-the matcher denies with a specific `rule_type`:
-
-| `rule_type` | Trigger |
-|---|---|
-| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
-| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
-| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
-| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
-| `missing_body` | Request body absent on a path the backend opted into MCP enforcement for. POST/JSON-RPC traffic that fails to parse triggers this; non-POST verbs (GET for the SSE notification stream, DELETE for session terminate) silently skip `mcp { }` evaluation |
-| `malformed_jsonrpc` | Body is not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, etc.) |
-| `duplicate_key` | Duplicate object key detected anywhere in the body |
-| `oversized_body` | Body exceeds the mount's `max_body_size` |
-| `batch_empty` | JSON-RPC batch is `[]` |
-| `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
+The `mcp { }` block is **body-authoritative** and **deny-by-default** — Warden
+strict-parses the JSON-RPC body and a block grants only what it allow-lists
+(`initialize`, `ping`, and `notifications/*` stay exempt for the handshake). See
+[Body-Authoritative Authorization](/concepts/mcp/#body-authoritative-authorization)
+for the full semantics and [Denial reasons](/concepts/mcp/#denial-reasons) for the
+`rule_type` values recorded on each decision.
 
 GitHub-flavored examples:
 
@@ -334,14 +283,7 @@ session close). The `mcp { }` block fires only on the POST half.
 
 ## Step 5: Point an MCP Client at Warden
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Then point the client at the mount. The URL pattern is:
 
@@ -388,10 +330,9 @@ client certificate — useful for workloads that already have X.509 certificates
 (Kubernetes pods with cert-manager, VMs, SPIFFE X.509-SVIDs). Steps 2–4 are
 unchanged; replace Steps 1 and 5 with the following.
 
-> **Prerequisite:** TLS must be enabled on the Warden listener so client
-> certificates are presented during the handshake (mTLS) — `-dev-tls` in dev
-> mode, or a load balancer that forwards the client cert via
-> `X-Forwarded-Client-Cert` / `X-SSL-Client-Cert`.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 ```bash
 # Enable cert auth and trust your CA
@@ -429,27 +370,6 @@ For MCP-client mTLS patterns (local terminating sidecar, or `mcp-remote` as a
 Node bridge) and role selection with a certificate, see the [generic provider
 README](/provider-backends/mcp/#tls-certificate-authentication) — the patterns are
 identical; substitute this mount's `path` (`github-mcp/`).
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mcp_url` | string | — | **Required.** `https://api.githubcopilot.com/mcp` |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size (max 100 MB) |
-| `timeout` | duration | `10m` | Session timeout; raise for long SSE sessions |
-| `tls_skip_verify` | bool | `false` | Skip TLS verification (dev only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate |
-| `auto_auth_path` | string | — | **Required.** Auth mount (`auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role |
-
-### Accepted Credentials
-
-| Credential type | Source type | Injected as | Notes |
-|-----------------|-------------|-------------|-------|
-| `github_token` | `github` | `Authorization: Bearer <token>` | App installation token or PAT; same credspec as the `github` REST provider |
-| `oauth_bearer_token` | `oauth2` | `Authorization: Bearer <token>` | Authorization-code flow — act as a consenting GitHub user |
 
 ## Token Scopes and Tool Availability
 

--- a/site/src/content/docs/provider-backends/mcp-slack.md
+++ b/site/src/content/docs/provider-backends/mcp-slack.md
@@ -37,52 +37,13 @@ consented to. This is the `mcp` provider's `oauth_bearer_token` credential shape
 - An MCP client that supports remote MCP servers over HTTP (Claude Code, Cursor,
   Continue, Cline, Goose, ...)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and
-policy. Clients authenticate directly with their JWT — no separate login step is
-needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **Set this up before configuring the provider.** The provider resolves
 > `auto_auth_path` per request — writing the config only checks that it is
@@ -91,10 +52,7 @@ needed.
 > there yet.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -148,6 +106,8 @@ warden write slack-mcp/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -356,38 +316,17 @@ support an `mcp { }` block for governance-style restrictions enforced at the
 gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs,
 prompt names, and selected tool arguments.
 
-Enforcement is **body-authoritative**. When a policy in scope contains an
-`mcp { }` block, Warden strict-parses the JSON-RPC request body and matches
-against the parsed body. The parser fails closed on any structural problem and
-the matcher denies with a specific `rule_type`:
+The `mcp { }` block is **body-authoritative** and **deny-by-default** — Warden
+strict-parses the JSON-RPC body and a block grants only what it allow-lists
+(`initialize`, `ping`, and `notifications/*` stay exempt for the handshake). See
+[Body-Authoritative Authorization](/concepts/mcp/#body-authoritative-authorization)
+for the full semantics and [Denial reasons](/concepts/mcp/#denial-reasons) for the
+`rule_type` values recorded on each decision.
 
-| `rule_type` | Trigger |
-|---|---|
-| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
-| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
-| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
-| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
-| `missing_body` | An `mcp { }` block is bound to a path served by a non-MCP-aware backend — an operator misconfiguration. The body-authoritative gate has no descriptor to evaluate and fails closed. |
-| `malformed_jsonrpc` | Body on an MCP-enforced POST is absent, unreadable, or not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, etc.) |
-| `duplicate_key` | Duplicate object key detected anywhere in the body — Warden rejects ambiguity that Go's standard JSON parser silently last-wins-resolves |
-| `oversized_body` | Body exceeds the mount's `max_body_size` |
-| `batch_empty` | JSON-RPC batch is `[]` |
-| `malformed_params` | A name-bearing method has a missing or wrong-shape selector: `params.name` for `tools/call` and `prompts/get`, or `params.uri` for `resources/read` |
-
-All examples below use `capabilities = ["create", "read", "delete"]`. MCP
-Streamable HTTP uses three HTTP verbs on the same `/gateway/` URL: POST for
-JSON-RPC requests (mapped by Warden to `create`), GET for the optional server →
-client SSE notification stream (`read`), and DELETE for session terminate
-(`delete`). All three need to be in the cap list or off-spec MCP clients fail to
-connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip
-body-authoritative evaluation automatically.
-
-`mcp { }` authorization is **deny-by-default**: an empty or absent
-`allowed_methods`/`allowed_tools` denies everything, so a block grants only what
-it allow-lists — use `["*"]` to open a family fully. The session-lifecycle
-methods `initialize`, `notifications/*`, and `ping` are **exempt**: they always
-pass without being listed, so the client handshake works no matter how narrow the
-data-plane allow-list is (an explicit `denied_methods` entry can still block them).
+All examples below use `capabilities = ["create", "read", "delete"]` — the three
+MCP Streamable HTTP verbs on the `/gateway/` URL (POST for JSON-RPC, GET for the
+SSE stream, DELETE for session terminate). The `mcp { }` block only fires on the
+POST half.
 
 The simplest policy grants the gateway and leans on the OAuth token's scopes for
 everything:
@@ -460,14 +399,7 @@ unchanged and the OAuth token's scopes alone enforce authorization.
 
 ## Step 5: Point an MCP Client at Warden
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Configure your MCP client to point at the Warden mount. The URL pattern is:
 
@@ -635,13 +567,9 @@ with a TLS client certificate. This is useful for workloads that already have
 X.509 certificates — Kubernetes pods with cert-manager, VMs with machine
 certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the
-> Warden listener so that client certificates can be presented during the TLS
-> handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated
-> certificates, or provide your own with `-dev-tls-cert-file`,
-> `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden
-> behind a load balancer that terminates TLS and forwards the client certificate
-> via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 2-4 (provider mount, credential, policy) are identical — the
 `mcp-slack-access` policy from Step 4 works for either auth method. Replace Steps
@@ -672,9 +600,7 @@ warden write auth/cert/role/mcp-user \
     cred_spec_name=slack-mcp-creds
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on
-other certificate fields: `allowed_dns_sans`, `allowed_email_sans`,
-`allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -696,34 +622,6 @@ Node bridge) and role selection with a certificate, see the equivalent section i
 the [generic provider README](/provider-backends/mcp/#tls-certificate-authentication) — the
 patterns are identical; substitute this mount's `path` (`slack-mcp/`) for the
 provider value in the header-routed configs.
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mcp_url` | string | — | **Required.** `https://mcp.slack.com/mcp` (must be HTTPS). No default |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `10m` | Session timeout. Raise for long agent sessions that keep an SSE stream open across many tool calls |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL or header |
-
-### Credential (oauth2 source)
-
-| Field | Where | Description |
-|-------|-------|-------------|
-| `auth_url` | source | `https://slack.com/oauth/v2_user/authorize` |
-| `token_url` | source | `https://slack.com/api/oauth.v2.user.access` |
-| `auth_method` | spec | `authorization_code` |
-| `client_id` / `client_secret` | spec | The Slack app's OAuth client credentials (`client_secret` via `@file`) |
-| `redirect_uri` | spec | Loopback callback registered on the Slack app (e.g. `http://127.0.0.1:8765/callback`) |
-| `scopes` | spec | Space-separated Slack **user-token** scopes |
-
-The minted credential type is `oauth_bearer_token`; Warden injects it as
-`Authorization: Bearer <token>`.
 
 ## Token Scopes and Tool Availability
 

--- a/site/src/content/docs/provider-backends/mcp.md
+++ b/site/src/content/docs/provider-backends/mcp.md
@@ -53,62 +53,20 @@ operator-set description, not by reading the URL.
 - An MCP client that supports remote MCP servers over HTTP (Claude Code, Cursor,
   Continue, Cline, Goose, ...)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and
-policy. Clients authenticate directly with their JWT — no separate login step is
-needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at
 > configuration time that the auth backend referenced by `auto_auth_path` is
 > already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -161,6 +119,8 @@ warden write cloudflare-mcp/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -251,37 +211,17 @@ that, Warden's CBP policies support an `mcp { }` block for governance-style
 restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC
 methods, tool names, resource URIs, prompt names, and selected tool arguments.
 
-Enforcement is **body-authoritative**. When a policy in scope contains an
-`mcp { }` block, Warden strict-parses the JSON-RPC request body and matches
-against the parsed body. The parser fails closed on any structural problem and
-the matcher denies with a specific `rule_type`:
+The `mcp { }` block is **body-authoritative** and **deny-by-default** — Warden
+strict-parses the JSON-RPC body and a block grants only what it allow-lists
+(`initialize`, `ping`, and `notifications/*` stay exempt for the handshake). See
+[Body-Authoritative Authorization](/concepts/mcp/#body-authoritative-authorization)
+for the full semantics and [Denial reasons](/concepts/mcp/#denial-reasons) for the
+`rule_type` values recorded on each decision.
 
-| `rule_type` | Trigger |
-|---|---|
-| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
-| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
-| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
-| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
-| `missing_body` | Request body absent on a path the backend opted into MCP enforcement for. POST/JSON-RPC traffic that fails to parse triggers this; non-POST verbs (GET for the SSE notification stream, DELETE for session terminate) silently skip `mcp { }` evaluation |
-| `malformed_jsonrpc` | Body is not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, etc.) |
-| `duplicate_key` | Duplicate object key detected anywhere in the body |
-| `oversized_body` | Body exceeds the mount's `max_body_size` |
-| `batch_empty` | JSON-RPC batch is `[]` |
-| `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
-
-MCP Streamable HTTP uses three HTTP verbs on the same `/gateway/` URL: POST for
-JSON-RPC requests (mapped by Warden to `create`), GET for the optional server →
-client SSE notification stream (`read`), and DELETE for session terminate
-(`delete`). All three need to be in the cap list or off-spec MCP clients fail to
-connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip
-body-authoritative evaluation automatically.
-
-`mcp { }` authorization is **deny-by-default**: an empty or absent
-`allowed_methods`/`allowed_tools` denies everything, so a block grants only what
-it allow-lists — use `["*"]` to open a family fully. The session-lifecycle
-methods `initialize`, `notifications/*`, and `ping` are **exempt**: they always
-pass without being listed, so the client handshake works no matter how narrow the
-data-plane allow-list is (an explicit `denied_methods` entry can still block them).
+The examples below use `capabilities = ["create", "read", "delete"]` — the three
+MCP Streamable HTTP verbs on the `/gateway/` URL (POST for JSON-RPC, GET for the
+SSE stream, DELETE for session terminate). The `mcp { }` block only fires on the
+POST half.
 
 The simplest policy grants the gateway and leans on the token's scopes for
 everything:
@@ -334,14 +274,7 @@ request through unchanged and the token's scopes alone enforce authorization.
 
 ## Step 5: Point an MCP Client at Warden
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Configure your MCP client to point at the Warden mount. The URL pattern is:
 
@@ -393,13 +326,9 @@ with a TLS client certificate — useful for workloads that already have X.509
 certificates (Kubernetes pods with cert-manager, VMs with machine certificates,
 or SPIFFE X.509-SVIDs from a service mesh).
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the
-> Warden listener so client certificates can be presented during the TLS
-> handshake (mTLS). In dev mode, use `-dev-tls`, or provide your own with
-> `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`.
-> Alternatively, place Warden behind a load balancer that terminates TLS and
-> forwards the client certificate via `X-Forwarded-Client-Cert` or
-> `X-SSL-Client-Cert`.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 2–4 (provider mount, credential, policy) are identical — the `mcp-access`
 policy from Step 4 works for either auth method. Replace Steps 1 and 5 with the
@@ -428,9 +357,7 @@ warden write auth/cert/role/mcp-user \
     cred_spec_name=mcp-creds
 ```
 
-`allowed_common_names` supports glob patterns. You can also match on
-`allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or
-`allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -539,30 +466,3 @@ With cert auth, the role resolves (in priority order):
 1. `X-Warden-Role` header — what the JSON examples set
 2. `/role/<role>/` segment in the URL path — for clients that can't send custom headers
 3. `default_role` on the cert auth method's config — useful when one cert maps 1:1 to one role
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mcp_url` | string | — | **Required.** MCP server base URL (must be HTTPS). No default — there is no canonical generic MCP endpoint |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `10m` | Session timeout. Raise for long agent sessions that keep an SSE stream open across many tool calls |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL or header |
-
-### Accepted Credential Types
-
-| Credential type | Source type | Injected as | Use for |
-|-----------------|-------------|-------------|---------|
-| `oauth_bearer_token` | `oauth2` | `Authorization: Bearer <token>` | OAuth2 MCP servers (Slack, Cloudflare, Linear, Sentry, ...) — incl. authorization-code consent flow. The shape most remote MCP servers require |
-| `api_key` | `api_key` | `Authorization: Bearer <token>` | MCP servers that authenticate a fixed bearer token (personal/service token; self-hosted & enterprise) |
-| `github_token` | `github` | `Authorization: Bearer <token>` | GitHub's hosted MCP server — App token or PAT; same credspec as the `github` REST provider. See [`mcp-github.md`](/provider-backends/mcp-github/) |
-| `gcp_access_token` | `gcp` | `Authorization: Bearer <token>` | A Google Cloud MCP server — same credspec as the `gcp` REST provider |
-
-Servers that expect a static key in a non-`Authorization` header (e.g.
-`x-api-key`), or that require request signing (AWS SigV4 — use `mcp_aws`), are
-**not** served by this provider.

--- a/site/src/content/docs/provider-backends/mcp_aws.md
+++ b/site/src/content/docs/provider-backends/mcp_aws.md
@@ -27,58 +27,18 @@ For a single developer with a laptop and personal AWS creds, `mcp-proxy-for-aws`
   - Permanent IAM credentials (access key + secret) for an identity that has `sts:AssumeRole` on the target role — these stay inside Warden's credential source and never reach the agent
 - An MCP client that supports remote MCP servers over HTTP (Claude Code, Cursor, Continue, Cline, Goose, ...)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -148,6 +108,8 @@ warden write mcp_aws/config <<EOF
 EOF
 ```
 
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
+
 Verify the configuration:
 
 ```bash
@@ -203,24 +165,9 @@ warden cred spec read aws-s3-reader
 
 MCP traffic passes through two complementary layers of authorization. The IAM role's permissions are the security boundary — they bound what the agent can actually do at AWS regardless of what Warden lets through. On top of that, Warden's CBP policies support an `mcp { }` block for governance-style restrictions enforced at the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource URIs, prompt names, and selected tool arguments.
 
-Enforcement is **body-authoritative**. When a policy in scope contains an `mcp { }` block, Warden strict-parses the JSON-RPC request body and matches against the parsed body. The parser fails closed on any structural problem and the matcher denies with a specific `rule_type`:
+The `mcp { }` block is **body-authoritative** and **deny-by-default** — Warden strict-parses the JSON-RPC body and a block grants only what it allow-lists (`initialize`, `ping`, and `notifications/*` stay exempt for the handshake). See [Body-Authoritative Authorization](/concepts/mcp/#body-authoritative-authorization) for the full semantics and [Denial reasons](/concepts/mcp/#denial-reasons) for the `rule_type` values recorded on each decision.
 
-| `rule_type` | Trigger |
-|---|---|
-| `denied_methods` / `allowed_methods` | JSON-RPC `method` matches a deny pattern, or is absent from a configured allow list |
-| `denied_tools` / `allowed_tools` | `tools/call` with a `params.name` matching a deny pattern, or not in the allow list |
-| `denied_resources` / `allowed_resources` | `resources/read` with a `params.uri` matching a deny pattern, or not in the allow list |
-| `denied_prompts` / `allowed_prompts` | `prompts/get` with a `params.name` matching a deny pattern, or not in the allow list |
-| `missing_body` | Request body absent on a path the backend opted into MCP enforcement for. POST/JSON-RPC traffic that fails to parse triggers this; non-POST verbs (GET for the SSE notification stream, DELETE for session terminate) silently skip `mcp { }` evaluation — the body-authoritative gate doesn't apply to body-less verbs. |
-| `malformed_jsonrpc` | Body is not a well-formed JSON-RPC 2.0 envelope (bad version, missing method, unknown top-level key, UTF-8 BOM, etc.) |
-| `duplicate_key` | Duplicate object key detected anywhere in the body — Warden rejects ambiguity that Go's standard JSON parser silently last-wins-resolves |
-| `oversized_body` | Body exceeds the mount's `max_body_size` |
-| `batch_empty` | JSON-RPC batch is `[]` |
-| `malformed_params` | A name-bearing method (`tools/call`, `resources/read`, `prompts/get`) has a missing or wrong-shape `params.name` / `params.uri` |
-
-All examples below use `capabilities = ["create", "read", "delete"]`. MCP Streamable HTTP uses three HTTP verbs on the same `/gateway` URL: POST for JSON-RPC requests (mapped by Warden to `create`), GET for the optional server → client SSE notification stream (`read`), and DELETE for session terminate (`delete`). All three need to be in the cap list or off-spec MCP clients fail to connect. The `mcp { }` block only fires on the POST half; GET/DELETE skip body-authoritative evaluation automatically.
-
-`mcp { }` authorization is **deny-by-default**: an empty or absent `allowed_methods`/`allowed_tools` denies everything, so a block grants only what it allow-lists — use `["*"]` to open a family fully. The session-lifecycle methods `initialize`, `notifications/*`, and `ping` are **exempt**: they always pass without being listed, so the client handshake works no matter how narrow the data-plane allow-list is (an explicit `denied_methods` entry can still block them).
+All examples below use `capabilities = ["create", "read", "delete"]` — the three MCP Streamable HTTP verbs on the `/gateway` URL (POST for JSON-RPC, GET for the SSE stream, DELETE for session terminate). The `mcp { }` block only fires on the POST half.
 
 The simplest policy grants the gateway and leans on IAM for everything:
 
@@ -313,14 +260,7 @@ Policies that omit the `mcp { }` block keep the simplest behavior: Warden passes
 
 ## Step 5: Point an MCP Client at Warden
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Configure your MCP client to point at the Warden mount. The URL pattern is:
 
@@ -435,7 +375,9 @@ The **absence** of a trailing slash on `gateway` matters — Warden composes the
 
 Steps 1 and 5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 2-4 (provider mount, credential source and spec, policy) are identical — the `mcp-aws-access` policy from Step 4 works for either auth method. Replace Steps 1 and 5 with the following.
 
@@ -466,7 +408,7 @@ warden write auth/cert/role/s3-reader \
     cred_spec_name=aws-s3-reader
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -562,22 +504,7 @@ With cert auth, the role is resolved (in priority order):
 2. `/role/<role>/` segment in the URL path — not used in header-routed mode, but available when an MCP client cannot send custom headers
 3. `default_role` set on the cert auth method's config — useful when one cert maps 1:1 to one role; the JSON config can drop `X-Warden-Role` entirely
 
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mcp_aws_url` | string | `https://aws-mcp.us-east-1.api.aws/mcp` | MCP server base URL (must be HTTPS). Drives the SigV4 service and signing-region inference. |
-| `region` | string | inferred from URL | SigV4 signing region. Required when the host doesn't yield one via DNS-label inference (e.g. GovCloud, China partition, custom test hosts). Independent of which AWS region the agent's API calls actually target. |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `10m` | Session timeout. Raise for long agent sessions that keep an SSE stream open across many tool calls. |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Region behavior
+## Region behavior
 
 The mount's `region` is the **SigV4 signing region for the upstream MCP endpoint**, not a restriction on which AWS region the agent's API calls target. AWS's MCP Server makes API calls in any region; the agent picks the target region via `region_name` inside the tool arguments. One mount fronting `aws-mcp.us-east-1.api.aws/mcp` already serves agents operating against every AWS region's APIs.
 
@@ -601,12 +528,3 @@ Common patterns:
 
 The CloudTrail entry for each AWS API call captures both the assumed-role identity and (via Warden's audit log linkage) the originating Warden session. Treat the IAM role as the security boundary and the `mcp { }` block as governance over which JSON-RPC shapes ever reach AWS.
 
-**Rotate** the source's permanent credentials by updating the source config:
-
-```bash
-warden cred source update aws-src \
-  -config=access_key_id=AKIA-new... \
-  -config=secret_access_key=...
-```
-
-Then revoke the old access key from the IAM console. STS sessions minted before the rotation continue to work until they expire (per `ttl` on the spec); new sessions use the new source credentials.

--- a/site/src/content/docs/provider-backends/mistral.md
+++ b/site/src/content/docs/provider-backends/mistral.md
@@ -9,58 +9,18 @@ The Mistral provider enables proxied access to the Mistral AI API through Warden
 - Docker and Docker Compose installed and running
 - A **Mistral AI API key** from [console.mistral.ai](https://console.mistral.ai)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write mistral/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -231,7 +193,7 @@ path "mistral/role/+/gateway/v1/models" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -241,14 +203,7 @@ warden policy read mistral-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Mistral API key automatically.
 
@@ -344,7 +299,9 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -375,7 +332,7 @@ warden write auth/cert/role/mistral-user \
     cred_spec_name=mistral-ops 
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -404,44 +361,6 @@ curl --cert client.pem --key client-key.pem \
       "messages": [{"role": "user", "content": "Hello"}]
     }'
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mistral_url` | string | `https://api.mistral.ai` | Mistral API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `120s` | Request timeout — set high for AI inference |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.mistral.ai`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/v1/models`) |
-| `optional_metadata` | string | No | Comma-separated spec fields to copy into credential data (e.g., `organization_id`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Mistral AI API key (sensitive — masked in output) |
-| `organization_id` | string | No | Organization identifier |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Key Management
 

--- a/site/src/content/docs/provider-backends/newrelic.md
+++ b/site/src/content/docs/provider-backends/newrelic.md
@@ -9,58 +9,18 @@ The New Relic provider enables proxied access to the New Relic REST API v2 and N
 - Docker and Docker Compose installed and running
 - A **New Relic User API Key** (from New Relic > API Keys, prefixed with `NRAK-`)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write newrelic/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Set `newrelic_url` to match your New Relic datacenter region:
 
@@ -227,14 +189,7 @@ warden policy read newrelic-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the New Relic User API key automatically.
 
@@ -359,7 +314,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -390,7 +347,7 @@ warden write auth/cert/role/newrelic-user \
     cred_spec_name=newrelic-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -416,56 +373,6 @@ curl --cert client.pem --key client-key.pem \
     -H "Content-Type: application/json" \
     -d '{"query": "{ actor { user { email } } }"}'
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `newrelic_url` | string | `https://api.newrelic.com` | New Relic API base URL (must match your datacenter region) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.newrelic.com`) |
-| `verify_endpoint` | string | No | Verification path (omitted — NerdGraph requires POST with body, which the verifier does not support) |
-| `auth_header_type` | string | No | How to attach key for verification: `custom_header` (recommended for New Relic) |
-| `auth_header_name` | string | No | Header name for verification (e.g., `Api-Key`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | New Relic User API key (sensitive — masked in output; prefixed with `NRAK-`) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/openai.md
+++ b/site/src/content/docs/provider-backends/openai.md
@@ -9,58 +9,18 @@ The OpenAI provider enables proxied access to the OpenAI API through Warden. It 
 - Docker and Docker Compose installed and running
 - An **OpenAI API key** from [platform.openai.com](https://platform.openai.com)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write openai/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -232,7 +194,7 @@ path "openai/role/+/gateway/v1/models" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -242,14 +204,7 @@ warden policy read openai-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the OpenAI API key automatically.
 
@@ -358,7 +313,9 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -389,7 +346,7 @@ warden write auth/cert/role/openai-user \
     cred_spec_name=openai-ops 
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -418,45 +375,6 @@ curl --cert client.pem --key client-key.pem \
       "messages": [{"role": "user", "content": "Hello"}]
     }'
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `openai_url` | string | `https://api.openai.com` | OpenAI API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `120s` | Request timeout — set high for AI inference |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.openai.com`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/v1/models`) |
-| `optional_metadata` | string | No | Comma-separated spec fields to copy into credential data (e.g., `organization_id,project_id`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | OpenAI API key (sensitive — masked in output) |
-| `organization_id` | string | No | Organization identifier (injected as `OpenAI-Organization` header) |
-| `project_id` | string | No | Project identifier (injected as `OpenAI-Project` header) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Key Management
 

--- a/site/src/content/docs/provider-backends/ovh.md
+++ b/site/src/content/docs/provider-backends/ovh.md
@@ -13,58 +13,18 @@ The OVH provider enables proxied access to OVHcloud APIs through Warden. It supp
 - An **OVHcloud account** with an OAuth2 service account (`client_id` + `client_secret`) — create one via [OVHcloud IAM](https://www.ovh.com/auth/) with `flow: "CLIENT_CREDENTIALS"`
 - For S3 Object Storage: a Public Cloud project ID and user ID
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -106,6 +66,8 @@ warden write ovh/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -226,14 +188,7 @@ warden policy read ovh-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the OVH credentials automatically.
 
@@ -391,7 +346,9 @@ S3 Object Storage regions are independent of the API region and are auto-detecte
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -422,7 +379,7 @@ warden write auth/cert/role/ovh-user \
     cred_spec_name=ovh-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -456,50 +413,6 @@ S3 Object Storage:
 aws s3 ls s3://my-bucket/ \
   --endpoint-url "https://warden.internal/v1/ovh/role/ovh-user/gateway"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `ovh_url` | string | `https://eu.api.ovh.com/1.0` | OVH API base URL |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (OVH OAuth2)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `client_id` | string | Yes | OAuth2 service account client ID |
-| `client_secret` | string | Yes | OAuth2 service account client secret (sensitive) |
-| `ovh_endpoint` | string | No | Regional endpoint: `ovh-eu` (default), `ovh-ca`, or `ovh-us` |
-| `project_id` | string | For S3 | Default Public Cloud project ID (can be overridden per-spec) |
-| `user_id` | string | For S3 | Default Public Cloud user ID (can be overridden per-spec) |
-
-### Credential Spec Config (OVH source — oauth2_token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `oauth2_token` |
-
-### Credential Spec Config (OVH source — dynamic_s3)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_s3` |
-| `project_id` | string | No | Override source default project ID |
-| `user_id` | string | No | Override source default user ID |
-
-### Credential Spec Config (OVH source — oauth2_token_and_s3)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `oauth2_token_and_s3` |
-| `project_id` | string | No | Override source default project ID |
-| `user_id` | string | No | Override source default user ID |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/pagerduty.md
+++ b/site/src/content/docs/provider-backends/pagerduty.md
@@ -9,58 +9,18 @@ The PagerDuty provider enables proxied access to the PagerDuty REST API v2 throu
 - Docker and Docker Compose installed and running
 - A **PagerDuty API Token** (from PagerDuty > Integrations > API Access Keys) **or** a **PagerDuty OAuth2 App** (client_id and client_secret from PagerDuty > Integrations > App Registration)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write pagerduty/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -233,14 +195,7 @@ warden policy read pagerduty-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the PagerDuty token automatically.
 
@@ -385,7 +340,9 @@ All gateway requests work identically — Warden transparently injects the minte
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -416,7 +373,7 @@ warden write auth/cert/role/pagerduty-user \
     cred_spec_name=pagerduty-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -441,82 +398,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/pagerduty/role/pagerduty-user/gateway/incidents" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `pagerduty_url` | string | `https://api.pagerduty.com` | PagerDuty API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://api.pagerduty.com`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/users/me`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Source Config (OAuth2 Client Credentials)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `client_id` | string | Yes | OAuth2 application client ID |
-| `client_secret` | string | Yes | OAuth2 application client secret (sensitive — masked in output) |
-| `token_url` | string | Yes | OAuth2 token endpoint (e.g., `https://identity.pagerduty.com/oauth/token`) |
-| `default_scopes` | string | No | Default OAuth2 scopes (space-separated) |
-| `verify_url` | string | No | Endpoint to verify minted tokens (e.g., `https://api.pagerduty.com/users/me`) |
-| `verify_method` | string | No | HTTP method for verify_url (default: `GET`) |
-| `auth_header_type` | string | No | How to attach token for verification: `bearer`, `token`, `custom_header` (default: `bearer`) |
-| `auth_header_name` | string | No | Header name when `auth_header_type=custom_header` |
-| `display_name` | string | No | Human-readable label for logs/errors (default: `OAuth2`) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | PagerDuty API token (sensitive — masked in output) |
-
-### Credential Spec Config (OAuth2 Client Credentials)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `scope` | string | No | OAuth2 scope to request |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Spec Config (Vault — oauth2)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `oauth2` |
-| `oauth2_mount` | string | Yes | Vault OAuth2 secrets engine mount path |
-| `credential_name` | string | Yes | Credential name configured in the OAuth2 plugin |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/prometheus.md
+++ b/site/src/content/docs/provider-backends/prometheus.md
@@ -10,58 +10,18 @@ The Prometheus provider enables proxied access to the Prometheus HTTP API throug
 - A running Prometheus instance (or a compatible service: Grafana Mimir, Amazon Managed Prometheus, Thanos, VictoriaMetrics)
 - A bearer token **or** a username/password pair for your Prometheus instance
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -103,6 +63,8 @@ warden write prometheus/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -248,14 +210,7 @@ warden policy read prometheus-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Prometheus credential automatically.
 
@@ -361,7 +316,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1–4 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1–3 (provider setup) are identical. Replace Steps 4–5 with the following.
 
@@ -390,7 +347,7 @@ warden write auth/cert/role/prometheus-user \
     cred_spec_name=prometheus-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -413,53 +370,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/prometheus/role/prometheus-user/gateway/api/v1/query" \
     --data-urlencode 'query=up'
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `prometheus_url` | string | — | **Required.** Prometheus API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | Prometheus API base URL (informational only) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-| `optional_metadata` | string | No | Comma-separated spec fields forwarded into credential data (e.g., `auth_type`) |
-
-### Credential Spec Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Bearer token, **or** base64-encoded `username:password` for basic auth (sensitive — masked in output) |
-| `auth_type` | string | No | `bearer` (default) or `basic`. Requires `optional_metadata=auth_type` on the credential source. |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/rds.md
+++ b/site/src/content/docs/provider-backends/rds.md
@@ -313,14 +313,7 @@ EOF
 
 ## Step 6: Get a Connection String
 
-Get a JWT from your identity provider:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Pass the JWT directly — no login step needed:
 
@@ -400,39 +393,3 @@ Warden injects the requesting principal's identity into the connection string fo
 | MySQL | `connectionAttributes=program_name:<principal>` | `performance_schema.session_connect_attrs` |
 
 This means database audit logs show both the shared IAM user and which Warden workload opened the connection — without requiring per-workload database users.
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`) |
-
-### Credential Spec Config (`rds_iam_token` type)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `rds_iam_token` |
-| `db_endpoint` | string | Yes | RDS endpoint hostname |
-| `db_user` | string | Yes | Database user mapped to IAM identity |
-| `db_engine` | string | No | `postgres` (default) or `mysql` |
-| `db_port` | string | No | Defaults based on engine (5432, 3306) |
-| `region` | string | No | AWS region (defaults to source region) |
-| `role_arn` | string | No | IAM role ARN for cross-account access |
-
-### Provider Grant Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `credential_spec` | string | Yes | Name of the credential spec to mint |
-| `db_name` | string | No | Database name to include in connection string |
-| `db_engine` | string | No | Overrides engine from credential spec |
-| `description` | string | No | Human-readable description |
-
-### Response Format
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `connection_string` | string | Ready-to-use DSN for `sql.Open()` or equivalent |
-| `lease_duration` | int | Token validity in seconds (900 for RDS IAM) |

--- a/site/src/content/docs/provider-backends/redshift.md
+++ b/site/src/content/docs/provider-backends/redshift.md
@@ -332,39 +332,3 @@ conn = psycopg2.connect(resp["connection_string"])
 ## Attribution
 
 Warden injects the requesting principal's identity into the connection string via PostgreSQL's `application_name` parameter. It surfaces in `STV_SESSIONS`, `STL_CONNECTION_LOG`, and Redshift audit logs — letting you trace which Warden workload opened each connection without giving every workload its own database user.
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`) |
-
-### Credential Spec Config (`redshift_iam_token` mint method)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `redshift_iam_token` |
-| `db_endpoint` | string | Yes | Redshift endpoint hostname (used in the returned connection string) |
-| `cluster_identifier` | string | One of two | Redshift provisioned cluster identifier. Mutually exclusive with `workgroup_name`. |
-| `workgroup_name` | string | One of two | Redshift Serverless workgroup name. Mutually exclusive with `cluster_identifier`. |
-| `db_name` | string | No | Database name passed to AWS for IAM scoping. If omitted, the IAM policy must allow access to all databases on the cluster/workgroup. |
-| `db_port` | string | No | Defaults to `5439` |
-| `region` | string | No | AWS region (defaults to source region) |
-| `duration_seconds` | int | No | Token TTL in seconds, 900–3600. Default `900`. |
-
-### Provider Grant Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `credential_spec` | string | Yes | Name of the credential spec to mint |
-| `db_name` | string | No | Database name to include in the connection string |
-| `description` | string | No | Human-readable description |
-
-### Response Format
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `connection_string` | string | Ready-to-use libpq DSN for `sql.Open()` or equivalent |
-| `lease_duration` | int | Token validity in seconds (900–3600 depending on `duration_seconds`) |

--- a/site/src/content/docs/provider-backends/rest.md
+++ b/site/src/content/docs/provider-backends/rest.md
@@ -16,39 +16,18 @@ The token *value* is always brokered per request from the credential subsystem (
 
 - A REST API reachable from Warden and a token for it (static API key, or a token mintable by one of Warden's credential sources).
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary** from the [releases page](https://github.com/stephnangue/warden/releases/latest) and add it to your `PATH`.
->
-> **3. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **4. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -80,6 +59,8 @@ warden write billing-api/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration (the token value is never shown — it is brokered per request):
 
@@ -136,12 +117,7 @@ EOF
 
 ## Step 5: Get a JWT and Make Requests
 
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 The URL pattern is `/v1/<mount>/role/{role}/gateway/{api-path}`. Everything after `/gateway/` — path, query, method, body — is forwarded verbatim:
 
@@ -180,33 +156,6 @@ The same provider fronts many APIs by varying three fields. Common upstreams:
 | Twitch (Helix) | `Authorization` | `Bearer ` | `Client-Id=<id>` |
 
 `token_prefix` distinguishes the unset default (`Bearer `) from an explicit empty string (raw token in the header) — set `token_prefix=""` for APIs that want the bare token.
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `base_url` | string | — | **Required.** Upstream API base URL (HTTPS unless `tls_skip_verify`) |
-| `token_header` | string | `Authorization` | Header the brokered token is injected into |
-| `token_prefix` | string | `Bearer ` | Prefix prepended to the token; set `""` for a raw token |
-| `headers` | key=value | — | Additional static headers injected on every request (override client values) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g. `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in the URL |
-| `tls_skip_verify` | bool | `false` | Skip upstream TLS verification (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Supported Credential Types
-
-| Source `-type` | Credential type | Notes |
-|---|---|---|
-| `apikey` | `api_key` | Static token on the spec |
-| `oauth2` | `oauth_bearer_token` | OAuth2 client-credentials / refresh; token minted and refreshed |
-| `grafana`, `honeycomb`, `elastic` | `api_key` | Dynamically minted keys |
-
-All carry the token in the `api_key` field. Git, Kubernetes, and cloud credential types are **not** supported — use their dedicated providers.
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/scaleway.md
+++ b/site/src/content/docs/provider-backends/scaleway.md
@@ -12,58 +12,18 @@ The Scaleway provider enables proxied access to Scaleway APIs through Warden. It
 - Docker and Docker Compose installed and running
 - A **Scaleway account** with an API key (access key + secret key) — generate one at [Scaleway Console > IAM > API Keys](https://console.scaleway.com/iam/api-keys)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -105,6 +65,8 @@ warden write scaleway/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -240,14 +202,7 @@ warden policy read scaleway-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Scaleway credentials automatically.
 
@@ -402,7 +357,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -433,7 +390,7 @@ warden write auth/cert/role/scaleway-user \
     cred_spec_name=scaleway-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -467,68 +424,6 @@ S3 Object Storage:
 aws s3 ls s3://my-bucket/ \
   --endpoint-url "https://warden.internal/v1/scaleway/role/scaleway-user/gateway"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `scaleway_url` | string | `https://api.scaleway.com` | Scaleway API base URL |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Scaleway)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `scaleway_url` | string | No | Scaleway API URL (default: `https://api.scaleway.com`) |
-| `management_secret_key` | string | Yes* | Secret key with IAM permissions to create/delete API keys (*required for `dynamic_keys` and rotation) |
-| `management_access_key` | string | Yes* | Access key matching the management secret key (*required for rotation) |
-| `activation_delay` | duration | No | Delay before activating rotated management key (default: `30s`) |
-| `iam_api_path` | string | No | IAM API path prefix (default: `/iam/v1alpha1`). Update when Scaleway promotes the API to stable. |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom CAs |
-| `tls_skip_verify` | bool | No | Skip TLS verification (development only) |
-
-### Credential Spec Config (static_keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_keys` |
-| `access_key` | string | Yes | Scaleway access key (starts with `SCW`) |
-| `secret_key` | string | Yes | Scaleway secret key (UUID format, sensitive — masked in output) |
-
-### Credential Spec Config (dynamic_keys)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_keys` |
-| `application_id` | string | Yes | IAM application ID to attach keys to |
-| `default_project_id` | string | No | Default project for Object Storage |
-| `ttl` | duration | No | Key lifetime (default: `1h`) |
-| `description` | string | No | Description for created keys (max 200 chars, default: `warden-{spec-name}`) |
-
-### Credential Spec Config (Vault — static_scaleway)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_scaleway` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/sentry.md
+++ b/site/src/content/docs/provider-backends/sentry.md
@@ -9,58 +9,18 @@ The Sentry provider enables proxied access to the Sentry REST API through Warden
 - Docker and Docker Compose installed and running
 - A **Sentry Internal Integration Token** (from Sentry > Settings > Developer Settings > Internal Integrations)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write sentry/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -213,14 +175,7 @@ warden policy read sentry-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Sentry token automatically.
 
@@ -318,7 +273,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -349,7 +306,7 @@ warden write auth/cert/role/sentry-user \
     cred_spec_name=sentry-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -374,52 +331,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/sentry/role/sentry-user/gateway/organizations/" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `sentry_url` | string | `https://sentry.io/api/0` | Sentry API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://sentry.io/api/0`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Sentry Internal Integration token (sensitive — masked in output) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/servicenow.md
+++ b/site/src/content/docs/provider-backends/servicenow.md
@@ -10,58 +10,18 @@ The ServiceNow provider enables proxied access to a ServiceNow instance REST API
 - A **ServiceNow instance** with REST API access enabled
 - A **ServiceNow user account** with REST API access (for Basic Auth via the `apikey` source type) **or** a **ServiceNow OAuth2 App** (client_id and client_secret from System OAuth > Application Registry)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -103,6 +63,8 @@ warden write servicenow/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -234,14 +196,7 @@ warden policy read servicenow-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the ServiceNow token automatically.
 
@@ -394,7 +349,9 @@ All gateway requests work identically — Warden transparently injects the minte
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -425,7 +382,7 @@ warden write auth/cert/role/servicenow-user \
     cred_spec_name=servicenow-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -450,82 +407,6 @@ curl --cert client.pem --key client-key.pem \
     -s "https://warden.internal/v1/servicenow/role/servicenow-user/gateway/api/now/table/incident" \
     -H "Content-Type: application/json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `servicenow_url` | string | — (required) | ServiceNow instance URL (must be HTTPS, e.g., `https://mycompany.service-now.com`) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `60s` | Request timeout |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (e.g., `https://mycompany.service-now.com`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/api/now/table/sys_user?sysparm_limit=1`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Source Config (OAuth2 Client Credentials)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `client_id` | string | Yes | OAuth2 application client ID |
-| `client_secret` | string | Yes | OAuth2 application client secret (sensitive — masked in output) |
-| `token_url` | string | Yes | OAuth2 token endpoint (e.g., `https://mycompany.service-now.com/oauth_token.do`) |
-| `default_scopes` | string | No | Default OAuth2 scopes (space-separated) |
-| `verify_url` | string | No | Endpoint to verify minted tokens (e.g., `https://mycompany.service-now.com/api/now/table/sys_user?sysparm_limit=1`) |
-| `verify_method` | string | No | HTTP method for verify_url (default: `GET`) |
-| `auth_header_type` | string | No | How to attach token for verification: `bearer`, `token`, `custom_header` (default: `bearer`) |
-| `auth_header_name` | string | No | Header name when `auth_header_type=custom_header` |
-| `display_name` | string | No | Human-readable label for logs/errors (default: `OAuth2`) |
-| `tls_skip_verify` | bool | No | Skip TLS certificate verification; also allows `http://` URLs (default: `false`) |
-| `ca_data` | string | No | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-
-### Credential Spec Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | ServiceNow API token (sensitive — masked in output) |
-
-### Credential Spec Config (OAuth2 Client Credentials)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `scope` | string | No | OAuth2 scope to request (e.g., `useraccount`) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Spec Config (Vault — oauth2)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `oauth2` |
-| `oauth2_mount` | string | Yes | Vault OAuth2 secrets engine mount path |
-| `credential_name` | string | Yes | Credential name configured in the OAuth2 plugin |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/slack.md
+++ b/site/src/content/docs/provider-backends/slack.md
@@ -9,58 +9,18 @@ The Slack provider enables proxied access to the Slack Web API through Warden. I
 - Docker and Docker Compose installed and running
 - A **Slack Bot Token** (`xoxb-...`) from a [Slack App](https://api.slack.com/apps) with the required OAuth scopes (e.g., `chat:write`, `channels:read`)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -102,6 +62,8 @@ warden write slack/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify the configuration:
 
@@ -228,7 +190,7 @@ path "slack/role/+/gateway/auth.test" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -238,14 +200,7 @@ warden policy read slack-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Slack bot token automatically.
 
@@ -367,7 +322,9 @@ This allows operators to enforce policies such as:
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -398,7 +355,7 @@ warden write auth/cert/role/slack-user \
     cred_spec_name=slack-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -427,43 +384,6 @@ curl --cert client.pem --key client-key.pem \
       "text": "Hello from Warden with mTLS!"
     }'
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `slack_url` | string | `https://slack.com/api` | Slack API base URL (must be HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | API base URL (default: `https://slack.com/api`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/auth.test`) |
-| `verify_method` | string | No | HTTP method for verification (default: `GET`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Slack bot token (sensitive — masked in output) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/splunk.md
+++ b/site/src/content/docs/provider-backends/splunk.md
@@ -10,58 +10,18 @@ The Splunk provider enables proxied access to the Splunk REST API through Warden
 - A **Splunk instance** (Enterprise 7.3+ or Cloud 8.0.2007+) with token authentication enabled
 - A **Splunk Bearer Token** with appropriate capabilities (see [Token Management](#token-management))
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -103,6 +63,8 @@ warden write splunk/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Set `splunk_url` to your Splunk management endpoint (port 8089). HTTPS is required:
 
@@ -251,14 +213,7 @@ warden policy read splunk-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the Splunk bearer token automatically.
 
@@ -362,7 +317,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 4-5 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -393,7 +350,7 @@ warden write auth/cert/role/splunk-user \
     cred_spec_name=splunk-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -417,55 +374,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/splunk/role/splunk-user/gateway/services/server/info?output_mode=json"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `splunk_url` | string | — (required) | Splunk management API base URL (must use HTTPS, include port 8089) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static Bearer Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | Splunk management API URL for verification (default: from provider config) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/services/server/info`) |
-| `auth_header_type` | string | No | How to attach token for verification: `bearer` (recommended) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static Bearer Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | Splunk bearer token (sensitive — masked in output) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key` with the bearer token) |
 
 ## Token Management
 

--- a/site/src/content/docs/provider-backends/tfe.md
+++ b/site/src/content/docs/provider-backends/tfe.md
@@ -10,58 +10,18 @@ The TFE provider enables proxied access to the Terraform Enterprise (TFE) and HC
 - An **HCP Terraform** account or a **Terraform Enterprise** instance (v202001-1+)
 - A **TFE API token** (User, Team, or Organization token — see [Token Types](#token-types))
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Deploy the quickstart stack** — this starts an identity provider ([Ory Hydra](https://www.ory.sh/hydra/)) needed to issue JWTs for authentication in Steps 1 and 5:
-> ```bash
-> curl -fsSL -o docker-compose.quickstart.yml \
->   https://raw.githubusercontent.com/stephnangue/warden/main/deploy/docker-compose.quickstart.yml
-> docker compose -f docker-compose.quickstart.yml up -d
-> ```
->
-> **2. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **3. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **4. Start the Warden server** in dev mode:
-> ```bash
-> warden server -dev -dev-root-token=root
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="http://127.0.0.1:8400"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Configure JWT Auth and Create a Role
 
-Set up a JWT auth method and create a role that binds the credential spec and policy. Clients authenticate directly with their JWT — no separate login step is needed.
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup.
 
 > **This step must come before configuring the provider.** Warden validates at configuration time that the auth backend referenced by `auto_auth_path` is already mounted.
 
 ```bash
-# Enable JWT auth if not already enabled
 warden auth enable jwt
-
-# Configure JWT with Hydra's JWKS endpoint (from docker-compose.quickstart.yml)
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -103,6 +63,8 @@ warden write tfe/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 For HCP Terraform, the default URL (`https://app.terraform.io`) works out of the box. For Terraform Enterprise, set `tfe_url` to your instance URL:
 
@@ -248,14 +210,7 @@ warden policy read tfe-access
 
 ## Step 5: Get a JWT and Make Requests
 
-Get a JWT from Hydra using one of the quickstart clients:
-
-```bash
-export JWT_TOKEN=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-```
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT_TOKEN`.
 
 Requests use role-based paths. Warden performs implicit JWT authentication and injects the TFE API token automatically.
 
@@ -349,7 +304,9 @@ Since Warden dev mode uses in-memory storage, all configuration is lost when the
 
 Steps 1-3 above use JWT authentication. Alternatively, you can authenticate with a TLS client certificate. This is useful for workloads that already have X.509 certificates — Kubernetes pods with cert-manager, VMs with machine certificates, or SPIFFE X.509-SVIDs from a service mesh.
 
-> **Prerequisite:** Certificate authentication requires TLS to be enabled on the Warden listener so that client certificates can be presented during the TLS handshake (mTLS). In dev mode, use `-dev-tls` to enable TLS with auto-generated certificates, or provide your own with `-dev-tls-cert-file`, `-dev-tls-key-file`, and `-dev-tls-ca-cert-file`. Alternatively, place Warden behind a load balancer that terminates TLS and forwards the client certificate via the `X-Forwarded-Client-Cert` or `X-SSL-Client-Cert` header.
+:::note[Prerequisite]
+Certificate auth requires mTLS on the Warden listener so the client certificate can be presented during the handshake. See [Enabling mTLS on the listener](/auth-methods/cert/#enabling-mtls-on-the-listener).
+:::
 
 Steps 1-3 (provider setup) are identical. Replace Steps 4-5 with the following.
 
@@ -380,7 +337,7 @@ warden write auth/cert/role/tfe-user \
     cred_spec_name=tfe-ops
 ```
 
-The `allowed_common_names` field supports glob patterns. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns; you can also match on other certificate fields. See [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ### Configure Provider for Cert Auth
 
@@ -404,56 +361,6 @@ curl --cert client.pem --key client-key.pem \
     --cacert warden-ca.pem \
     -s "https://warden.internal/v1/tfe/role/tfe-user/gateway/api/v2/organizations"
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `tfe_url` | string | `https://app.terraform.io` | TFE API base URL (must use HTTPS) |
-| `max_body_size` | int | 10485760 (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification; also allows `http://` URLs (development only) |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | Auth mount path for implicit authentication (e.g., `auth/jwt/`, `auth/cert/`) |
-| `default_role` | string | — | Fallback role when not specified in URL |
-
-### Credential Source Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_url` | string | No | TFE API URL for verification (e.g., `https://app.terraform.io/api/v2`) |
-| `verify_endpoint` | string | No | Verification path (e.g., `/account/details`) |
-| `auth_header_type` | string | No | How to attach token for verification: `bearer` (recommended) |
-| `extra_headers` | string | No | Extra headers for verification requests (e.g., `Content-Type:application/vnd.api+json`) |
-| `display_name` | string | No | Label for logs/errors (default: `API Key`) |
-
-### Credential Spec Config (Static API Token)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `api_key` | string | Yes | TFE API token (sensitive — masked in output) |
-
-### Credential Source Config (Vault/OpenBao)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address (e.g., `https://vault.example.com`) |
-| `vault_namespace` | string | No | Vault namespace (Enterprise/HCP only) |
-| `auth_method` | string | No | Authentication method (`approle`) |
-| `role_id` | string | Yes* | AppRole role ID (*required when `auth_method=approle`) |
-| `secret_id` | string | Yes* | AppRole secret ID (*required when `auth_method=approle`) |
-| `approle_mount` | string | Yes* | AppRole auth mount path (*required when `auth_method=approle`) |
-| `role_name` | string | Yes* | AppRole role name for rotation (*required when `auth_method=approle`) |
-
-### Credential Spec Config (Vault — static_apikey)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount (must contain `api_key` with the API token) |
 
 ## Token Types
 

--- a/site/src/content/docs/provider-backends/vault.md
+++ b/site/src/content/docs/provider-backends/vault.md
@@ -10,75 +10,9 @@ The Vault provider enables proxied access to HashiCorp Vault (or OpenBao) throug
 - Vault CLI (for initial AppRole setup)
 - OpenSSL (for generating certificates)
 
-> **New to Warden?** Follow these steps to get a local dev environment running:
->
-> **1. Download the latest Warden binary:**
-> ```bash
-> # macOS (Apple Silicon)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_arm64.tar.gz | tar xz
->
-> # macOS (Intel)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_darwin_amd64.tar.gz | tar xz
->
-> # Linux (x86_64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_amd64.tar.gz | tar xz
->
-> # Linux (ARM64)
-> curl -L https://github.com/stephnangue/warden/releases/latest/download/warden_$(curl -s https://api.github.com/repos/stephnangue/warden/releases/latest | grep tag_name | cut -d '"' -f4 | tr -d v)_linux_arm64.tar.gz | tar xz
-> ```
->
-> **2. Add the binary to your PATH:**
-> ```bash
-> export PATH="$PWD:$PATH"
-> ```
->
-> **3. Generate certificates** for the server and a client:
-> ```bash
-> CERT_DIR=certs
-> mkdir -p "$CERT_DIR"
->
-> # Generate a CA certificate and key
-> openssl ecparam -genkey -name prime256v1 -out "$CERT_DIR/ca.key"
-> openssl req -new -x509 -sha256 -key "$CERT_DIR/ca.key" -out "$CERT_DIR/ca.pem" -days 365 \
->     -subj "/CN=Warden Dev CA/O=Warden Dev"
->
-> # Generate a server certificate signed by the CA
-> openssl ecparam -genkey -name prime256v1 -out "$CERT_DIR/server.key"
-> openssl req -new -sha256 -key "$CERT_DIR/server.key" -out "$CERT_DIR/server.csr" \
->     -subj "/CN=localhost/O=Warden Dev"
-> openssl x509 -req -sha256 -in "$CERT_DIR/server.csr" \
->     -CA "$CERT_DIR/ca.pem" -CAkey "$CERT_DIR/ca.key" \
->     -CAcreateserial -out "$CERT_DIR/server.pem" -days 365 \
->     -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
->
-> # Generate a client certificate signed by the same CA
-> openssl ecparam -genkey -name prime256v1 -out "$CERT_DIR/client.key"
-> openssl req -new -sha256 -key "$CERT_DIR/client.key" -out "$CERT_DIR/client.csr" \
->     -subj "/CN=agent-quickstart/O=Warden Dev"
-> openssl x509 -req -sha256 -in "$CERT_DIR/client.csr" \
->     -CA "$CERT_DIR/ca.pem" -CAkey "$CERT_DIR/ca.key" \
->     -CAcreateserial -out "$CERT_DIR/client.pem" -days 365
-> ```
->
-> **4. Start the Warden server** in dev mode with TLS and mTLS:
-> ```bash
-> warden server -dev -dev-root-token=root \
->     -dev-tls-cert-file=$CERT_DIR/server.pem \
->     -dev-tls-key-file=$CERT_DIR/server.key \
->     -dev-tls-ca-cert-file=$CERT_DIR/ca.pem \
->     -dev-tls-require-client-cert
-> ```
->
-> **5. In another terminal window**, export the environment variables for the CLI:
-> ```bash
-> CERT_DIR=certs
-> export PATH="$PWD:$PATH"
-> export WARDEN_ADDR="https://127.0.0.1:8400"
-> export WARDEN_CACERT="$PWD/$CERT_DIR/ca.pem"
-> export WARDEN_CLIENT_CERT="$PWD/$CERT_DIR/client.pem"
-> export WARDEN_CLIENT_KEY="$PWD/$CERT_DIR/client.key"
-> export WARDEN_TOKEN="root"
-> ```
+:::note[New to Warden?]
+Follow [Local dev setup](/provider-backends/local-dev-setup/) to start a local dev environment (Ory Hydra + a Warden dev server) before Step 1.
+:::
 
 ## Step 1: Create an AppRole in Vault
 
@@ -201,7 +135,7 @@ warden write auth/cert/role/vault-user \
     cred_spec_name=vault-reader
 ```
 
-The `allowed_common_names` field supports glob patterns. The client certificate generated in the Prerequisites has CN `agent-quickstart`, which matches `agent-*`. You can also match on other certificate fields: `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, or `allowed_organizational_units`.
+The `allowed_common_names` field supports glob patterns. The client certificate generated in the Prerequisites has CN `agent-quickstart`, which matches `agent-*`. You can also match on other certificate fields; see [Create a role](/auth-methods/cert/#step-3-create-a-role) for the full set of constraint fields.
 
 ## Step 3: Mount and Configure the Provider
 
@@ -235,6 +169,8 @@ warden write vault/config <<EOF
 }
 EOF
 ```
+
+See [Provider configuration](/provider-backends/configuration/) for the full list of common config fields (`proxy_domains`, `timeout`, `tls_skip_verify`, `ca_data`, and more).
 
 Verify:
 
@@ -350,7 +286,7 @@ path "vault/gateway*" {
 EOF
 ```
 
-The `condition` is a [CEL](https://cel.dev) expression (see [Policies → CEL conditions](/concepts/policies/#cel-conditions)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
+The `condition` is a [CEL](https://cel.dev) expression (see [CEL conditions](/concepts/cel-conditions/)): `cidrContains` restricts by network and `now.getHours`/`now.getDayOfWeek` by time of day and weekday. It must evaluate to `true` for the rule to apply, and fails closed.
 
 Verify:
 
@@ -449,64 +385,6 @@ rm -rf $CERT_DIR/
 
 Since Warden dev mode uses in-memory storage, all configuration is lost when the server stops.
 
-## Architecture Overview
-
-```
-                +--------------------------------------+
-                |  HashiCorp Vault                     |
-                |                                      |
-                |  AppRole: warden-source              |
-                |  - Policies: warden-source           |
-                |  - secret_id auto-rotated            |
-                |                                      |
-                |  Token Roles:                        |
-                |  - reader (read-only policies)       |
-                |  - admin (elevated policies)         |
-                +--------+-----------------------------+
-                         |
-                         | AppRole auth
-                         | (rotates secret_id)
-                         |
-                +--------v-----------------------------+
-                |  Warden Vault Provider               |
-                |                                      |
-                |  Credential Source (hvault)          |
-                |    mint_method: vault_token          |
-                |    → Mints child Vault tokens        |
-                |                                      |
-                |  Gateway Proxy                       |
-                |    → Injects token into requests     |
-                +--------------------------------------+
-```
-
-### Request Flow
-
-1. Client presents its TLS certificate during the mTLS handshake with Warden
-2. Client sends request to Warden gateway
-3. Warden validates the client certificate against the trusted CA and authenticates the client
-4. Warden retrieves a Vault token from the credential spec bound to the cert auth role
-5. Warden strips client auth headers and injects the real Vault token as `X-Vault-Token`
-6. Request is forwarded to the configured Vault instance
-7. Response is returned to the client
-
-### Security Model
-
-- **Mutual TLS (mTLS)**: Both server and client authenticate via certificates, providing strong identity verification without shared secrets.
-- **Least privilege on the AppRole**: The Warden AppRole only has access to the specific secret paths it needs. Compromise of the `secret_id` is limited to those paths.
-- **Automatic secret_id rotation**: Warden rotates the AppRole credentials on the configured schedule, limiting exposure of any single `secret_id`.
-- **Short-lived consumer credentials**: Dynamic credentials (database, AWS, tokens) have bounded TTLs. Vault automatically revokes them on expiration.
-- **Lease revocation**: Warden can proactively revoke credentials before they expire. Database and AWS leases are revoked via `sys/leases/revoke`; Vault tokens are revoked via their accessor.
-
-### Rotation
-
-Warden automatically rotates the AppRole `secret_id` on the configured schedule using a three-phase protocol:
-
-1. **Prepare**: Generate a new `secret_id` (both old and new remain valid)
-2. **Commit**: Persist the new config and re-authenticate with the new `secret_id`
-3. **Cleanup**: Destroy the old `secret_id` using its accessor
-
-If cleanup fails, it is retried daily for up to 7 days. Rotation requires `auth_method=approle` with `role_name` set.
-
 ## Mint Methods
 
 | Mint Method | Credential Type | Description |
@@ -533,11 +411,10 @@ Steps 1, 3-5 (provider setup) are identical. Replace Steps 2 and 6 with the foll
 
 ### Enable JWT Auth
 
-```bash
-# Enable JWT auth
-warden auth enable jwt
+Enable the JWT auth method and point it at your identity provider's JWKS endpoint, then create a role that binds the credential spec and policy. Enabling the mount and configuring the key source is covered once in [JWT auth](/auth-methods/jwt/#step-1-configure-the-key-source) — for the local dev setup:
 
-# Configure JWT with the identity provider's JWKS endpoint
+```bash
+warden auth enable jwt
 warden write auth/jwt/config jwks_url=http://localhost:4444/.well-known/jwks.json
 
 # Create a role that binds the credential spec and policy
@@ -562,14 +439,9 @@ warden write vault/config <<EOF
 EOF
 ```
 
-Get a JWT from the identity provider and make requests:
+Get a JWT from your identity provider — see [Obtaining a JWT](/auth-methods/jwt/#obtaining-a-jwt) (the local dev setup issues one from Hydra). Export it as `$JWT`.
 
 ```bash
-export JWT=$(curl -s -X POST http://localhost:4444/oauth2/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=client_credentials&client_id=my-agent&client_secret=agent-secret&scope=api:read api:write" \
-  | jq -r '.access_token')
-
 VAULT_ENDPOINT="${WARDEN_ADDR}/v1/vault/role/vault-user/gateway"
 
 # Read a secret
@@ -598,136 +470,6 @@ To stop the identity provider containers:
 ```bash
 docker compose -f docker-compose.quickstart.yml down -v
 ```
-
-## Configuration Reference
-
-### Provider Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `vault_address` | string | — | Base URL of the Vault instance (required, e.g., `https://vault.example.com:8200`) |
-| `max_body_size` | int | `10485760` (10 MB) | Maximum request body size in bytes (max 100 MB) |
-| `timeout` | duration | `30s` | Request timeout (e.g., `30s`, `5m`) |
-| `tls_skip_verify` | bool | `false` | Skip TLS certificate verification (development only). Note: `http://` URLs are always allowed for `vault_address` |
-| `ca_data` | string | — | Base64-encoded PEM CA certificate for custom/self-signed CAs |
-| `auto_auth_path` | string | — | **Required.** Auth mount path for implicit authentication, e.g. `auth/cert/` or `auth/jwt/` |
-| `default_role` | string | — | Fallback role when not specified in the URL path |
-
-### Credential Source Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `vault_address` | string | Yes | Vault server address |
-| `auth_method` | string | No | Authentication method (`approle` or omit for pre-set token) |
-| `role_id` | string | If approle | AppRole role ID |
-| `secret_id` | string | If approle | AppRole secret ID (rotated automatically) |
-| `secret_id_accessor` | string | If approle | Secret ID accessor (used for rotation cleanup) |
-| `approle_mount` | string | If approle | AppRole auth mount path |
-| `role_name` | string | If approle | AppRole role name (required for rotation) |
-| `vault_namespace` | string | No | Vault namespace for multi-tenancy setups |
-
-### Credential Spec Config — vault_token
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `vault_token` |
-| `token_role` | string | Yes | Token role name (configured at `auth/token/roles/` in Vault) |
-| `ttl` | duration | No | Token TTL (clamped to min/max bounds) |
-| `display_name` | string | No | User-friendly name attached to the token |
-| `meta` | string | No | Metadata attached to the token |
-
-### Credential Spec Config — static_aws
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_aws` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Spec Config — static_apikey
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `static_apikey` |
-| `kv2_mount` | string | Yes | KV v2 mount path in Vault |
-| `secret_path` | string | Yes | Path to the secret within the mount |
-
-### Credential Spec Config — dynamic_aws
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_aws` |
-| `aws_mount` | string | Yes | Vault AWS engine mount path |
-| `role_name` | string | Yes | AWS role name configured in Vault |
-| `role_arn` | string | No | ARN of the role to assume (for STS) |
-| `role_session_name` | string | No | Session name for the STS assumption |
-| `ttl` | duration | No | Credential TTL (clamped to min/max bounds) |
-
-### Credential Spec Config — dynamic_gcp
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `dynamic_gcp` |
-| `gcp_mount` | string | Yes | Vault GCP secrets engine mount path |
-| `role_name` | string | Yes | GCP roleset or static account name |
-| `role_type` | string | No | `roleset` (default) or `static-account` |
-
-### Credential Spec Config — oauth2
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mint_method` | string | Yes | Must be `oauth2` |
-| `oauth2_mount` | string | Yes | Vault OAuth2 secrets engine mount path |
-| `credential_name` | string | Yes | Credential name configured in the OAuth2 plugin |
-
-### TTL Bounds
-
-- `-min-ttl`: Minimum credential TTL. Requests for shorter TTLs are clamped up.
-- `-max-ttl`: Maximum credential TTL. Requests for longer TTLs are clamped down.
-
-### Cert Auth Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `trusted_ca_pem` | string | — | PEM-encoded CA certificates that sign client certificates |
-| `principal_claim` | string | `cn` | Identity source: `cn`, `dns_san`, `email_san`, `uri_san`, `serial` |
-| `default_role` | string | — | Default role when no role is specified in the URL or request |
-| `token_ttl` | duration | `1h` | Default token TTL |
-| `revocation_mode` | string | `none` | Certificate revocation checking: `none`, `crl`, `ocsp`, `best_effort` |
-
-### Cert Auth Role Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `allowed_common_names` | list | No* | Glob patterns for allowed certificate CNs |
-| `allowed_dns_sans` | list | No* | Glob patterns for allowed DNS SANs |
-| `allowed_email_sans` | list | No* | Glob patterns for allowed email SANs |
-| `allowed_uri_sans` | list | No* | URI SAN patterns (`+` matches one segment, trailing `*` matches one or more) |
-| `allowed_organizational_units` | list | No* | Allowed organizational units |
-| `certificate` | string | No | Role-specific CA PEM (overrides global trusted CAs) |
-| `token_policies` | list | Yes | Policies to assign to tokens |
-| `token_ttl` | duration | No | Token TTL (default: 1h) |
-| `cred_spec_name` | string | No | Credential spec for gateway access |
-| `principal_claim` | string | No | Override global `principal_claim` for this role |
-
-*At least one constraint (`allowed_common_names`, `allowed_dns_sans`, etc.) should be specified.
-
-### JWT Auth Config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mode` | string | `jwt` | Auth mode: `jwt` or `oidc` |
-| `jwks_url` | string | — | URL to the JWKS endpoint for token verification |
-| `default_role` | string | — | Default role when no role is specified |
-
-### JWT Auth Role Config
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `user_claim` | string | Yes | JWT claim to use as the user identity (e.g., `sub`) |
-| `token_policies` | list | Yes | Policies to assign to tokens |
-| `token_ttl` | duration | No | Token TTL (default: 1h) |
-| `cred_spec_name` | string | No | Credential spec for gateway access |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

The provider setup guides under `site/src/content/docs/provider-backends/` each re-embedded the same boilerplate — JWT-auth setup, the mTLS prerequisite, the TLS config-reference rows, the MCP `mcp { }` authorization explanation, and a per-file "New to Warden?" dev-setup block. This extracts the shared material into canonical pages and points the provider guides at them.

## Changes

**New canonical pages**
- `provider-backends/local-dev-setup.md` — the Hydra + dev-server prerequisite (was a ~40-line blockquote in every guide)
- `provider-backends/configuration.md` — the common provider-config fields, with TLS options (`tls_skip_verify` / `ca_data`) as the headline

**Extended existing references**
- `auth-methods/jwt.md` — added a JWKS quickstart snippet and an "Obtaining a JWT" section
- `auth-methods/cert.md` — added an "Enabling mTLS on the Listener" section
- `concepts/mcp.md` — added the consolidated `rule_type` "Denial reasons" table

**Per-provider guides (38 docs)**
- Replaced the duplicated JWT/TLS/MCP boilerplate with links to the canonical pages, keeping each guide's own provider-specific commands and `mcp { }` examples
- Removed the per-provider **Configuration Reference** sections and the AWS/Vault **Architecture Overview** sections
- Repointed a pre-existing broken `/concepts/policies/#cel-conditions` link (10 files) to the dedicated `/concepts/cel-conditions/` page

Net **~3,500 fewer lines**.

## Trade-off

Removing the Configuration Reference sections wholesale also drops the provider-specific credential-source / credential-spec field tables (e.g. AWS `sts_assume_role` params, TTL bounds), which were not documented elsewhere. This was a deliberate choice to match the target shape.

## Verification

- `cd site && npm run build` → 137 pages, no errors
- Internal link-integrity check across all changed docs → all links resolve (0 broken)
- Grep confirms the duplicated blockquotes, token-fetch curls, `rule_type` tables, and removed section headings are gone
