### PR TITLE
fix(site): clear stale Astro content-layer store before build

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "rm -rf .astro node_modules/.astro",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"


### PR DESCRIPTION
## Problem

The Cloudflare deploy of #403 **failed to build** (so wardengateway.com is still serving the pre-#403 build):

```
[AstroUserError] The slug "provider-backends/local-dev-setup" specified in the
Starlight sidebar config does not exist.
```

The two new pages (`local-dev-setup.md`, `configuration.md`) **are** on `main` — the build just couldn't see them.

## Root cause

Cloudflare restores `node_modules` from its dependency cache between builds. Astro 5's content-layer store lives at `node_modules/.astro/data-store.json`, so the restored cache brings back a **stale store** from the previous deploy (which predated the two new pages).

With a stale store, the content collection goes inconsistent: every pre-existing entry logs `Duplicate id ... Later items with the same id will overwrite earlier ones`, the newly added pages never register, and the build fails when Starlight validates the sidebar's reference to the new slug.

Local and CI builds pass because they start from a clean environment and regenerate the store from source.

## Fix

Add a `prebuild` step that removes `.astro` and `node_modules/.astro` before `astro build`, so every build does a clean content sync regardless of any restored cache:

```json
"prebuild": "rm -rf .astro node_modules/.astro",
```

Verified locally: `prebuild` fires, the store is removed and regenerated, and the build completes (137 pages). Merging this triggers a fresh deploy whose `prebuild` clears the stale store, so all of #403's content goes live.
