### PR TITLE
feat(credential): token-exchange input carrier and ExchangeMinter interface

### DIFF
--- a/credential/exchange.go
+++ b/credential/exchange.go
@@ -1,0 +1,169 @@
+package credential
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+// RFC 8693 §3 token-type identifiers. These label the format of a subject or
+// actor token in a token-exchange request so the downstream STS knows how to
+// interpret it. Operators set them per credential spec; callers never choose
+// them, so an arbitrary blob cannot be relabelled as, say, an access token.
+const (
+	TokenTypeAccessToken  = "urn:ietf:params:oauth:token-type:access_token"
+	TokenTypeRefreshToken = "urn:ietf:params:oauth:token-type:refresh_token"
+	TokenTypeIDToken      = "urn:ietf:params:oauth:token-type:id_token"
+	TokenTypeJWT          = "urn:ietf:params:oauth:token-type:jwt"
+	TokenTypeSAML2        = "urn:ietf:params:oauth:token-type:saml2"
+)
+
+// Subject/actor token origins record how Warden obtained a token, which is the
+// only trust signal the plumbing carries. A driver that consumes exchange
+// inputs uses this to decide whether it may forward the token as-is or must
+// validate it first.
+const (
+	// ExchangeOriginVerified marks a token Warden already verified during
+	// inbound authentication (a transparent-auth JWT reused as the subject).
+	ExchangeOriginVerified = "verified"
+	// ExchangeOriginUnverified marks a token the caller supplied on the
+	// request that Warden has NOT verified.
+	ExchangeOriginUnverified = "unverified"
+)
+
+// Spec-config keys that opt a credential spec into token exchange and describe
+// where the subject and actor tokens come from.
+const (
+	// ConfigSubjectTokenSource selects the subject-token source:
+	// "auth_token" reuses the verified inbound JWT, "header" reads a
+	// caller-supplied header, "none" (or absent) disables exchange.
+	ConfigSubjectTokenSource = "subject_token_source"
+	// ConfigSubjectTokenType overrides the subject token's RFC 8693 type
+	// (default TokenTypeJWT).
+	ConfigSubjectTokenType = "subject_token_type"
+	// ConfigActorTokenSource selects the actor-token source: "header" or
+	// "none" (or absent).
+	ConfigActorTokenSource = "actor_token_source"
+	// ConfigActorTokenType overrides the actor token's RFC 8693 type
+	// (default TokenTypeJWT).
+	ConfigActorTokenType = "actor_token_type"
+)
+
+// Accepted values for the *_source config keys.
+const (
+	SourceAuthToken = "auth_token"
+	SourceHeader    = "header"
+	SourceNone      = "none"
+)
+
+// maxExchangeTokenBytes bounds a single subject or actor token. Real JWTs and
+// access tokens are far smaller; the cap guards against a caller pushing an
+// oversized blob through the exchange plumbing.
+const maxExchangeTokenBytes = 256 * 1024
+
+// ExchangeInputs carries caller-derived RFC 8693 token-exchange inputs from an
+// inbound request down to a credential driver at mint time. The values are
+// bearer secrets: the plumbing never logs them, never persists them, and never
+// places them in a credential's data map. Only a driver that implements
+// ExchangeMinter receives them.
+type ExchangeInputs struct {
+	// SubjectToken is the RFC 8693 §2.1 subject_token — the identity being
+	// exchanged.
+	SubjectToken string
+	// SubjectTokenType is the RFC 8693 §2.1 subject_token_type.
+	SubjectTokenType string
+	// ActorToken is the optional RFC 8693 §2.1 actor_token — the party acting
+	// on behalf of the subject (delegation).
+	ActorToken string
+	// ActorTokenType is the RFC 8693 §2.1 actor_token_type. Required when
+	// ActorToken is set, empty otherwise.
+	ActorTokenType string
+	// SubjectTokenOrigin is one of ExchangeOriginVerified or
+	// ExchangeOriginUnverified.
+	SubjectTokenOrigin string
+}
+
+// Validate performs structural checks only. It does not verify token contents
+// (signature, audience, expiry) — that is a driver's responsibility, since the
+// meaning of a token depends on the exchange being performed.
+func (e *ExchangeInputs) Validate() error {
+	if e == nil {
+		return fmt.Errorf("exchange inputs are nil")
+	}
+	if e.SubjectToken == "" {
+		return fmt.Errorf("subject_token is required")
+	}
+	if e.SubjectTokenType == "" {
+		return fmt.Errorf("subject_token_type is required")
+	}
+	if len(e.SubjectToken) > maxExchangeTokenBytes {
+		return fmt.Errorf("subject_token exceeds %d bytes", maxExchangeTokenBytes)
+	}
+	// RFC 8693 §2.1: actor_token_type is required when actor_token is present,
+	// and meaningless without it.
+	if e.ActorToken != "" && e.ActorTokenType == "" {
+		return fmt.Errorf("actor_token_type is required when actor_token is set")
+	}
+	if e.ActorToken == "" && e.ActorTokenType != "" {
+		return fmt.Errorf("actor_token_type set without actor_token")
+	}
+	if len(e.ActorToken) > maxExchangeTokenBytes {
+		return fmt.Errorf("actor_token exceeds %d bytes", maxExchangeTokenBytes)
+	}
+	switch e.SubjectTokenOrigin {
+	case ExchangeOriginVerified, ExchangeOriginUnverified:
+	default:
+		return fmt.Errorf("invalid subject_token_origin %q", e.SubjectTokenOrigin)
+	}
+	return nil
+}
+
+// Fingerprint returns a hex-encoded SHA-256 over the inputs, used solely to
+// key cached credentials per distinct exchange input. It is never logged.
+//
+// Each field is length-prefixed before hashing so that no two distinct field
+// combinations can collide by concatenation (e.g. subject "ab"/actor "c" must
+// not hash the same as subject "a"/actor "bc").
+func (e *ExchangeInputs) Fingerprint() string {
+	h := sha256.New()
+	writeField := func(s string) {
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s)))
+		h.Write(lenBuf[:])
+		h.Write([]byte(s))
+	}
+	writeField(e.SubjectTokenType)
+	writeField(e.SubjectToken)
+	writeField(e.ActorTokenType)
+	writeField(e.ActorToken)
+	writeField(e.SubjectTokenOrigin)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// SpecRequestsExchange reports whether a spec's config opts into token
+// exchange, i.e. subject_token_source is set to something other than "none".
+func SpecRequestsExchange(config map[string]string) bool {
+	src := config[ConfigSubjectTokenSource]
+	return src != "" && src != SourceNone
+}
+
+// ValidateExchangeSpecConfig performs structural validation of the
+// exchange-related keys in a spec config. It does not check that any driver
+// supports exchange — an exchange spec bound to a non-exchange source fails
+// closed at mint time instead.
+func ValidateExchangeSpecConfig(config map[string]string) error {
+	if err := ValidateSchema(config,
+		StringField(ConfigSubjectTokenSource).OneOf(SourceAuthToken, SourceHeader, SourceNone),
+		StringField(ConfigActorTokenSource).OneOf(SourceHeader, SourceNone),
+	); err != nil {
+		return err
+	}
+	// An actor token only has meaning alongside a subject token (RFC 8693 §2.1),
+	// so reject an actor source without a subject source.
+	actorSrc := config[ConfigActorTokenSource]
+	if actorSrc != "" && actorSrc != SourceNone && !SpecRequestsExchange(config) {
+		return fmt.Errorf("field '%s': requires '%s' to be set", ConfigActorTokenSource, ConfigSubjectTokenSource)
+	}
+	return nil
+}

--- a/credential/exchange_test.go
+++ b/credential/exchange_test.go
@@ -1,0 +1,205 @@
+package credential
+
+import "testing"
+
+func TestExchangeInputs_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		inputs  *ExchangeInputs
+		wantErr bool
+	}{
+		{
+			name: "valid subject only",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.sub",
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+		},
+		{
+			name: "valid subject and actor",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.sub",
+				SubjectTokenType:   TokenTypeJWT,
+				ActorToken:         "eyJ.act",
+				ActorTokenType:     TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginUnverified,
+			},
+		},
+		{
+			name: "missing subject token",
+			inputs: &ExchangeInputs{
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing subject token type",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.sub",
+				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+			wantErr: true,
+		},
+		{
+			name: "actor token without type",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.sub",
+				SubjectTokenType:   TokenTypeJWT,
+				ActorToken:         "eyJ.act",
+				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+			wantErr: true,
+		},
+		{
+			name: "actor type without token",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.sub",
+				SubjectTokenType:   TokenTypeJWT,
+				ActorTokenType:     TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown origin",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.sub",
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: "made-up",
+			},
+			wantErr: true,
+		},
+		{
+			name: "oversized subject token",
+			inputs: &ExchangeInputs{
+				SubjectToken:       string(make([]byte, maxExchangeTokenBytes+1)),
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.inputs.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestExchangeInputs_Validate_Nil(t *testing.T) {
+	var e *ExchangeInputs
+	if err := e.Validate(); err == nil {
+		t.Fatal("expected error validating nil inputs")
+	}
+}
+
+func TestExchangeInputs_Fingerprint_Deterministic(t *testing.T) {
+	a := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified}
+	b := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified}
+	if a.Fingerprint() != b.Fingerprint() {
+		t.Fatal("identical inputs must fingerprint identically")
+	}
+}
+
+func TestExchangeInputs_Fingerprint_Distinct(t *testing.T) {
+	base := ExchangeInputs{
+		SubjectToken:       "sub",
+		SubjectTokenType:   TokenTypeJWT,
+		ActorToken:         "act",
+		ActorTokenType:     TokenTypeJWT,
+		SubjectTokenOrigin: ExchangeOriginVerified,
+	}
+	variants := map[string]ExchangeInputs{
+		"different subject":       {SubjectToken: "sub2", SubjectTokenType: TokenTypeJWT, ActorToken: "act", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified},
+		"different actor":         {SubjectToken: "sub", SubjectTokenType: TokenTypeJWT, ActorToken: "act2", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified},
+		"different subject type":  {SubjectToken: "sub", SubjectTokenType: TokenTypeAccessToken, ActorToken: "act", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified},
+		"different origin":        {SubjectToken: "sub", SubjectTokenType: TokenTypeJWT, ActorToken: "act", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginUnverified},
+		"swapped subject / actor": {SubjectToken: "act", SubjectTokenType: TokenTypeJWT, ActorToken: "sub", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified},
+	}
+	baseFP := base.Fingerprint()
+	for name, v := range variants {
+		if v.Fingerprint() == baseFP {
+			t.Errorf("%s: fingerprint collided with base", name)
+		}
+	}
+}
+
+// TestExchangeInputs_Fingerprint_NoConcatAmbiguity guards the length-prefixing:
+// moving a byte across a field boundary must change the fingerprint.
+func TestExchangeInputs_Fingerprint_NoConcatAmbiguity(t *testing.T) {
+	x := &ExchangeInputs{SubjectToken: "ab", SubjectTokenType: TokenTypeJWT, ActorToken: "c", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified}
+	y := &ExchangeInputs{SubjectToken: "a", SubjectTokenType: TokenTypeJWT, ActorToken: "bc", ActorTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified}
+	if x.Fingerprint() == y.Fingerprint() {
+		t.Fatal("length-prefixing must prevent concatenation ambiguity")
+	}
+}
+
+func TestSpecRequestsExchange(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+		want   bool
+	}{
+		{"absent", map[string]string{}, false},
+		{"none", map[string]string{ConfigSubjectTokenSource: SourceNone}, false},
+		{"auth_token", map[string]string{ConfigSubjectTokenSource: SourceAuthToken}, true},
+		{"header", map[string]string{ConfigSubjectTokenSource: SourceHeader}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SpecRequestsExchange(tt.config); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateExchangeSpecConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+	}{
+		{"empty is valid", map[string]string{}, false},
+		{"subject auth_token", map[string]string{ConfigSubjectTokenSource: SourceAuthToken}, false},
+		{"subject header", map[string]string{ConfigSubjectTokenSource: SourceHeader}, false},
+		{
+			name:   "subject + actor header",
+			config: map[string]string{ConfigSubjectTokenSource: SourceHeader, ConfigActorTokenSource: SourceHeader},
+		},
+		{
+			name:    "invalid subject source",
+			config:  map[string]string{ConfigSubjectTokenSource: "bogus"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid actor source",
+			config:  map[string]string{ConfigSubjectTokenSource: SourceHeader, ConfigActorTokenSource: "bogus"},
+			wantErr: true,
+		},
+		{
+			name:    "actor without subject",
+			config:  map[string]string{ConfigActorTokenSource: SourceHeader},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExchangeSpecConfig(tt.config)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -61,8 +61,9 @@ type SourceDriverFactory interface {
 // and returns raw credential data that the credential type's Parse method structures
 // into a Credential object.
 //
-// Drivers may optionally implement Rotatable (to rotate their own source credentials)
-// and/or SpecRotatable (to rotate credentials embedded in specs).
+// Drivers may optionally implement Rotatable (to rotate their own source credentials),
+// SpecRotatable (to rotate credentials embedded in specs), and/or ExchangeMinter (to
+// consume caller-derived RFC 8693 token-exchange inputs at mint time).
 type SourceDriver interface {
 	// MintCredential retrieves or mint raw credential data from the source
 	// Takes a CredSpec as input
@@ -234,4 +235,25 @@ type OAuth2Authorizer interface {
 	// returns the spec-config keys to seal (notably "refresh_token", or a static
 	// "access_token" for providers that do not issue refresh tokens).
 	ExchangeAuthorizationCode(ctx context.Context, spec *CredSpec, code, redirectURI, codeVerifier string) (map[string]string, error)
+}
+
+// ExchangeMinter is an optional interface for drivers that consume caller-derived
+// RFC 8693 token-exchange inputs (a subject token and optional actor token). The
+// minting layer type-asserts for it and calls MintCredentialWithExchange only when
+// inputs are non-nil; otherwise MintCredential is used. When inputs are present and
+// the driver does not implement this interface, minting fails closed rather than
+// dropping the caller's bearer token.
+//
+// Drivers MUST treat unverified subject tokens
+// (inputs.SubjectTokenOrigin == ExchangeOriginUnverified) as untrusted and validate
+// them (signature, audience, expiry) before forwarding to any STS — the plumbing
+// performs structural checks only.
+//
+// A driver implementing this interface asserts it at compile time:
+//
+//	var _ credential.ExchangeMinter = (*TokenExchangeDriver)(nil)
+type ExchangeMinter interface {
+	// MintCredentialWithExchange mints a credential using the given exchange
+	// inputs. The return contract matches SourceDriver.MintCredential.
+	MintCredentialWithExchange(ctx context.Context, spec *CredSpec, inputs *ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
 }


### PR DESCRIPTION
## Summary

First of four foundation PRs adding a native way to carry caller-derived RFC 8693 token-exchange inputs (a `subject_token` and optional `actor_token`) from an inbound request down to a credential driver at mint time. A `token_exchange` driver (RFC 8693/7523/ID-JAG) is a later follow-up.

This PR adds only the plumbing **types** — it is additive and merges as unused code; nothing references the new symbols yet.

## What's here

- **`ExchangeInputs`** carrier (`credential/exchange.go`): subject/actor tokens, their RFC 8693 token-type URNs, and a provenance origin (`verified` vs `unverified`).
  - `Validate()` — structural checks only (RFC 8693 §2.1 actor pairing, a 256 KiB per-token cap). It deliberately does not inspect token contents; that is a driver's job.
  - `Fingerprint()` — length-prefixed SHA-256, used only to key cached credentials per distinct exchange input. Never logged.
  - Spec-config keys (`subject_token_source`, `actor_token_source`, ...) plus `SpecRequestsExchange` / `ValidateExchangeSpecConfig`.
- **`ExchangeMinter`** optional driver interface (`credential/source_driver.go`), mirroring the `Rotatable`/`SpecVerifier` precedent. Drivers that do not implement it will (in a later PR) fail closed rather than drop a caller's bearer token.

## Testing

`credential/exchange_test.go` covers the validation matrix, fingerprint determinism/distinctness (including field-swap and concatenation-ambiguity cases), and config validation. `go build`, `go vet`, and the full `credential` package pass.

## Follow-ups (separate PRs, stacked)

1. Thread `ExchangeInputs` through the mint path (fail-closed dispatch + cache-key fingerprint).
2. Strip the new headers in all provider gateways.
3. Resolve inputs in core and wire them into issuance + spec validation.
