### PR TITLE
feat(credential): thread token-exchange inputs through the mint path

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1269,7 +1269,7 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 
 	// Issue credential using the credential manager
 	// Credentials are cache-only (not persisted) - ExpirationEntry handles lease revocation
-	cred, err := c.credentialManager.IssueCredential(ctx, te.ID, te.CredentialSpec, tokenTTL)
+	cred, err := c.credentialManager.IssueCredential(ctx, te.ID, te.CredentialSpec, tokenTTL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to issue credential: %w", err)
 	}

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -142,9 +142,12 @@ func NewManager(
 //   - tokenID: The session token ID to bind the credential to
 //   - specName: The name of the credential spec to use
 //   - tokenTTL: The TTL of the session token (used for cache duration)
+//   - inputs: Optional caller-derived token-exchange inputs. When non-nil they
+//     are folded into the cache key so distinct exchange inputs cannot share a
+//     cached credential.
 //
 // Returns the issued credential or an error
-func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName string, tokenTTL time.Duration) (*Credential, error) {
+func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName string, tokenTTL time.Duration, inputs *ExchangeInputs) (*Credential, error) {
 	// Apply issuance timeout to prevent slow drivers from blocking indefinitely
 	ctx, cancel := context.WithTimeout(ctx, m.issuanceTimeout)
 	defer cancel()
@@ -159,6 +162,15 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 	// Including specName allows access backends to mint different specs for the same token.
 	cacheKey := fmt.Sprintf("%s:%s:%s", ns.ID, tokenID, specName)
 
+	// When the request carries token-exchange inputs, fold their fingerprint into
+	// the key so two callers sharing one session token (e.g. an opaque service
+	// token) each supplying a different subject token get distinct cached
+	// credentials instead of leaking one caller's credential to the other. The
+	// non-exchange path (inputs == nil) keeps the key byte-identical.
+	if inputs != nil {
+		cacheKey += ":x:" + inputs.Fingerprint()
+	}
+
 	// Check cache first
 	if cred, found := m.cache.Get(cacheKey); found {
 		return cred, nil
@@ -172,7 +184,7 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 		}
 
 		// Issue new credential from source
-		cred, err := m.issueCredential(ctx, specName)
+		cred, err := m.issueCredential(ctx, specName, inputs)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +236,7 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 }
 
 // issueCredential performs the actual credential issuance from the source
-func (m *Manager) issueCredential(ctx context.Context, specName string) (*Credential, error) {
+func (m *Manager) issueCredential(ctx context.Context, specName string, inputs *ExchangeInputs) (*Credential, error) {
 	// Step 1: Resolve credential spec using SpecResolver
 	spec, err := m.specResolver.ResolveSpec(ctx, specName)
 	if err != nil {
@@ -242,17 +254,17 @@ func (m *Manager) issueCredential(ctx context.Context, specName string) (*Creden
 	// token, and retry once if the provider rejects it. Other specs use the
 	// simple mint path unchanged.
 	if needsRefreshTokenWriteBack(spec) {
-		return m.issueWithWriteBack(ctx, specName, driver)
+		return m.issueWithWriteBack(ctx, specName, driver, inputs)
 	}
 
-	return m.mintAndParse(ctx, spec, driver)
+	return m.mintAndParse(ctx, spec, driver, inputs)
 }
 
 // mintAndParse mints a credential and parses it, with orphaned-lease cleanup on
 // failure. This is the simple path for specs that do not rotate a refresh token.
-func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver SourceDriver) (*Credential, error) {
+func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver SourceDriver, inputs *ExchangeInputs) (*Credential, error) {
 	var cred *Credential
-	err := m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+	err := m.mintingService.MintWithCleanup(ctx, driver, spec, inputs, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 		var parseErr error
 		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
 		return parseErr
@@ -268,7 +280,7 @@ func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver Sourc
 // rejection (the sealed token was already used — typically a rotation on
 // another node) it reloads the spec straight from storage, bypassing this
 // node's cache, and retries exactly once.
-func (m *Manager) issueWithWriteBack(ctx context.Context, specName string, driver SourceDriver) (*Credential, error) {
+func (m *Manager) issueWithWriteBack(ctx context.Context, specName string, driver SourceDriver, inputs *ExchangeInputs) (*Credential, error) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get namespace from context: %w", err)
@@ -293,7 +305,7 @@ func (m *Manager) issueWithWriteBack(ctx context.Context, specName string, drive
 			return err
 		}
 		cred = nil
-		return m.mintingService.MintWithCleanup(ctx, driver, spec, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+		return m.mintingService.MintWithCleanup(ctx, driver, spec, inputs, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 			m.consumeRotatedRefreshToken(ctx, spec, rawData)
 			var parseErr error
 			cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -343,7 +343,7 @@ func TestManager_IssueCredential_Success(t *testing.T) {
 	tokenID := "token-123"
 	tokenTTL := time.Hour
 
-	cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL)
+	cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 
@@ -377,11 +377,11 @@ func TestManager_IssueCredential_CacheHit(t *testing.T) {
 	tokenTTL := time.Hour
 
 	// First call - should mint
-	cred1, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL)
+	cred1, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 
 	// Second call - should use cache
-	cred2, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL)
+	cred2, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 
 	// Should be the same credential
@@ -398,7 +398,7 @@ func TestManager_IssueCredential_SpecNotFound(t *testing.T) {
 
 	ctx := createNamespaceContext()
 
-	_, err := manager.IssueCredential(ctx, "token-123", "nonexistent-spec", time.Hour)
+	_, err := manager.IssueCredential(ctx, "token-123", "nonexistent-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -417,7 +417,7 @@ func TestManager_IssueCredential_SourceNotFound(t *testing.T) {
 
 	ctx := createNamespaceContext()
 
-	_, err := manager.IssueCredential(ctx, "token-123", "test-spec", time.Hour)
+	_, err := manager.IssueCredential(ctx, "token-123", "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source")
 	assert.Contains(t, err.Error(), "not found")
@@ -442,7 +442,7 @@ func TestManager_IssueCredential_NoNamespace(t *testing.T) {
 	// Context without namespace
 	ctx := context.Background()
 
-	_, err := manager.IssueCredential(ctx, "token-123", "test-spec", time.Hour)
+	_, err := manager.IssueCredential(ctx, "token-123", "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "namespace")
 }
@@ -466,7 +466,7 @@ func TestManager_RevokeByExpiration_Success(t *testing.T) {
 	ctx := createNamespaceContext()
 
 	// Issue a credential first
-	cred, err := manager.IssueCredential(ctx, "token-revoke", "test-spec", time.Hour)
+	cred, err := manager.IssueCredential(ctx, "token-revoke", "test-spec", time.Hour, nil)
 	require.NoError(t, err)
 
 	// Driver is automatically created during IssueCredential, no need to manually create it
@@ -581,7 +581,7 @@ func TestManager_IssueCredential_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour)
+			cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour, nil)
 			results[idx] = cred
 			errs[idx] = err
 		}(i)
@@ -646,7 +646,7 @@ func TestManager_IssueCredential_Timeout(t *testing.T) {
 
 	ctx := createNamespaceContext()
 
-	_, err := manager.IssueCredential(ctx, "token-timeout", "test-spec", time.Hour)
+	_, err := manager.IssueCredential(ctx, "token-timeout", "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 }
@@ -684,12 +684,12 @@ func TestManager_IssueCredential_ErrorNotCached(t *testing.T) {
 	}
 
 	// First request should fail
-	_, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour)
+	_, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "transient error")
 
 	// Second request should succeed (error not cached)
-	cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour)
+	cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour, nil)
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 
@@ -784,7 +784,7 @@ func TestManager_WriteBack_StripsReservedKeyAndPersists(t *testing.T) {
 		}, nil, time.Hour, "", nil
 	}
 
-	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 
 	// The reserved rotated-token keys must be stripped before parsing.
@@ -813,7 +813,7 @@ func TestManager_WriteBack_RotatingWithoutExpiry_KeepsPriorExpiry(t *testing.T) 
 		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, nil, time.Hour, "", nil
 	}
 
-	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 
 	require.Len(t, configStore.persisted, 1)
@@ -832,7 +832,7 @@ func TestManager_WriteBack_NonRotating_NoPersist(t *testing.T) {
 		return map[string]interface{}{"api_key": "at-1"}, nil, time.Hour, "", nil
 	}
 
-	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 	assert.Empty(t, configStore.persisted, "non-rotating mint must not persist")
 }
@@ -858,7 +858,7 @@ func TestManager_InvalidGrant_RetriesOnceWithReloadedSpec(t *testing.T) {
 		return map[string]interface{}{"api_key": "at-ok"}, nil, time.Hour, "", nil
 	}
 
-	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "at-ok", cred.Data["api_key"])
 	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts), "must mint exactly twice (one retry)")
@@ -875,7 +875,7 @@ func TestManager_InvalidGrant_RetryFailsOnce_SurfacesError(t *testing.T) {
 		return nil, nil, 0, "", ErrRefreshTokenRejected // never recovers
 	}
 
-	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrRefreshTokenRejected))
 	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts), "retry is bounded to exactly one extra attempt")
@@ -892,7 +892,7 @@ func TestManager_WriteBack_PersistError_DoesNotFailIssuance(t *testing.T) {
 	}
 
 	// A persist failure must not fail issuance — the access token is still valid.
-	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour)
+	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "at-new", cred.Data["api_key"])
 }
@@ -946,4 +946,106 @@ func TestManager_LockSpec_ContextCancel(t *testing.T) {
 	_, err = manager.LockSpec(ctx, "ns-uuid", "gh")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// ============================================================================
+// Token-exchange input tests
+// ============================================================================
+
+// exchangeDriverFactory builds a single exchangeDriver instance (defined in
+// minting_service_test.go) so tests can observe its call count across issuances.
+type exchangeDriverFactory struct {
+	driver *exchangeDriver
+}
+
+func (f *exchangeDriverFactory) Type() string { return "exchange_src" }
+func (f *exchangeDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (SourceDriver, error) {
+	return f.driver, nil
+}
+func (f *exchangeDriverFactory) ValidateConfig(config map[string]string) error   { return nil }
+func (f *exchangeDriverFactory) SensitiveConfigFields() []string                 { return nil }
+func (f *exchangeDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return "", fmt.Errorf("mock exchange driver cannot infer type")
+}
+
+// createExchangeTestManager builds a manager whose source driver implements
+// ExchangeMinter, plus an exchange-enabled spec.
+func createExchangeTestManager(t *testing.T) (*Manager, *exchangeDriverFactory) {
+	t.Helper()
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	typeRegistry := NewTypeRegistry()
+	require.NoError(t, typeRegistry.Register(newMockCredentialType(TypeVaultToken, CategoryAPI)))
+
+	driverRegistry := NewDriverRegistry(nil)
+	factory := &exchangeDriverFactory{driver: &exchangeDriver{}}
+	require.NoError(t, driverRegistry.RegisterFactory(factory))
+
+	configStore := newMockConfigStore()
+	configStore.AddSource(&CredSource{Name: "ex-source", Type: "exchange_src", Config: map[string]string{}})
+	configStore.AddSpec(&CredSpec{
+		Name:   "ex-spec",
+		Type:   TypeVaultToken,
+		Source: "ex-source",
+		Config: map[string]string{ConfigSubjectTokenSource: SourceHeader},
+	})
+
+	manager, err := NewManager(typeRegistry, driverRegistry, configStore, log)
+	require.NoError(t, err)
+	return manager, factory
+}
+
+func exchangeInputsFor(subject string) *ExchangeInputs {
+	return &ExchangeInputs{
+		SubjectToken:       subject,
+		SubjectTokenType:   TokenTypeJWT,
+		SubjectTokenOrigin: ExchangeOriginUnverified,
+	}
+}
+
+// Two callers sharing one session token but supplying different subject tokens
+// must get distinct credentials (no cross-caller leak), while a repeat of the
+// same inputs is served from cache.
+func TestManager_IssueCredential_ExchangeInputs_DistinctCache(t *testing.T) {
+	manager, factory := createExchangeTestManager(t)
+	defer manager.Stop()
+
+	ctx := createNamespaceContext()
+	const sharedToken = "shared-session-token"
+	inA := exchangeInputsFor("subject-A")
+	inB := exchangeInputsFor("subject-B")
+
+	credA1, err := manager.IssueCredential(ctx, sharedToken, "ex-spec", time.Hour, inA)
+	require.NoError(t, err)
+	credA2, err := manager.IssueCredential(ctx, sharedToken, "ex-spec", time.Hour, inA)
+	require.NoError(t, err)
+	credB, err := manager.IssueCredential(ctx, sharedToken, "ex-spec", time.Hour, inB)
+	require.NoError(t, err)
+
+	// Same inputs → cached (one mint); different inputs → separate credential.
+	assert.Equal(t, credA1.CredentialID, credA2.CredentialID, "identical inputs should hit cache")
+	assert.NotEqual(t, credA1.CredentialID, credB.CredentialID, "distinct inputs must not share a credential")
+	assert.Equal(t, "subject-A", credA1.Data["username"])
+	assert.Equal(t, "subject-B", credB.Data["username"])
+	assert.Equal(t, int32(2), factory.driver.exchangeCount.Load(), "expected exactly two mints (A once, B once)")
+}
+
+// A spec that carries exchange inputs but whose driver is not an ExchangeMinter
+// must fail closed, and nothing may be cached (a retry still errors).
+func TestManager_IssueCredential_ExchangeInputs_NonExchangeDriver(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+
+	configStore.AddSource(&CredSource{Name: "test-source", Type: SourceTypeLocal, Config: map[string]string{}})
+	configStore.AddSpec(&CredSpec{Name: "test-spec", Type: TypeVaultToken, Source: "test-source", Config: map[string]string{}})
+
+	ctx := createNamespaceContext()
+	_, err := manager.IssueCredential(ctx, "tok", "test-spec", time.Hour, exchangeInputsFor("s"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not accept token-exchange inputs")
+
+	// Nothing should have been cached; a retry must error again (not serve a stale entry).
+	_, err = manager.IssueCredential(ctx, "tok", "test-spec", time.Hour, exchangeInputsFor("s"))
+	require.Error(t, err)
+	assert.Equal(t, int32(0), factory.driver.mintCalls.Load(), "plain mint must never run for exchange inputs")
 }

--- a/credential/minting_service.go
+++ b/credential/minting_service.go
@@ -53,6 +53,8 @@ func NewMintingService(logger *logger.GatedLogger) *MintingService {
 //   - ctx: Context for the minting operation
 //   - driver: The source driver to mint credentials from
 //   - spec: The credential spec defining minting parameters
+//   - inputs: Optional caller-derived token-exchange inputs. When non-nil, the
+//     driver must implement ExchangeMinter or minting fails closed.
 //   - onSuccess: Callback to process minted data (parse/validate)
 //
 // Returns an error if minting fails or if onSuccess callback fails
@@ -60,10 +62,29 @@ func (s *MintingService) MintWithCleanup(
 	ctx context.Context,
 	driver SourceDriver,
 	spec *CredSpec,
+	inputs *ExchangeInputs,
 	onSuccess func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error,
 ) error {
-	// Step 1: Mint credential from driver
-	rawData, metadata, leaseTTL, leaseID, err := driver.MintCredential(ctx, spec)
+	// Step 1: Mint credential from driver. When the caller supplied
+	// token-exchange inputs, route to the exchange-aware mint path; a driver
+	// that cannot consume them fails closed rather than dropping the bearer
+	// token or minting a generic credential under an exchange-scoped cache key.
+	var (
+		rawData  map[string]interface{}
+		metadata map[string]interface{}
+		leaseTTL time.Duration
+		leaseID  string
+		err      error
+	)
+	if inputs != nil {
+		em, ok := driver.(ExchangeMinter)
+		if !ok {
+			return fmt.Errorf("source driver %q does not accept token-exchange inputs", driver.Type())
+		}
+		rawData, metadata, leaseTTL, leaseID, err = em.MintCredentialWithExchange(ctx, spec, inputs)
+	} else {
+		rawData, metadata, leaseTTL, leaseID, err = driver.MintCredential(ctx, spec)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to fetch credential: %w", err)
 	}

--- a/credential/minting_service_test.go
+++ b/credential/minting_service_test.go
@@ -1,0 +1,132 @@
+package credential
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/logger"
+)
+
+// plainMintDriver implements SourceDriver only.
+type plainMintDriver struct {
+	mintCalled   bool
+	revokeCalled bool
+	leaseID      string
+}
+
+func (d *plainMintDriver) MintCredential(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.mintCalled = true
+	return map[string]interface{}{"k": "v"}, nil, time.Hour, d.leaseID, nil
+}
+func (d *plainMintDriver) Revoke(ctx context.Context, leaseID string) error { d.revokeCalled = true; return nil }
+func (d *plainMintDriver) Type() string                                     { return "plain" }
+func (d *plainMintDriver) Cleanup(ctx context.Context) error                { return nil }
+
+// exchangeDriver implements SourceDriver and ExchangeMinter.
+type exchangeDriver struct {
+	plainMintDriver
+	exchangeCalled bool
+	exchangeCount  atomic.Int32
+	gotInputs      *ExchangeInputs
+}
+
+func (d *exchangeDriver) MintCredentialWithExchange(ctx context.Context, spec *CredSpec, inputs *ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.exchangeCalled = true
+	d.exchangeCount.Add(1)
+	d.gotInputs = inputs
+	// Return a value derived from the subject token so distinct inputs yield
+	// distinguishable credential data.
+	return map[string]interface{}{"username": inputs.SubjectToken, "password": "x"}, nil, time.Hour, "", nil
+}
+
+var _ ExchangeMinter = (*exchangeDriver)(nil)
+
+func newTestMintingService() *MintingService {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	return NewMintingService(log)
+}
+
+func validExchangeInputs() *ExchangeInputs {
+	return &ExchangeInputs{
+		SubjectToken:       "eyJ.sub",
+		SubjectTokenType:   TokenTypeJWT,
+		SubjectTokenOrigin: ExchangeOriginUnverified,
+	}
+}
+
+func TestMintWithCleanup_NilInputs_UsesPlainMint(t *testing.T) {
+	s := newTestMintingService()
+	d := &exchangeDriver{} // implements ExchangeMinter, but nil inputs must skip it
+	spec := &CredSpec{Name: "s", Source: "src"}
+
+	err := s.MintWithCleanup(context.Background(), d, spec, nil, func(rawData, metadata map[string]interface{}, ttl time.Duration, leaseID string) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !d.mintCalled {
+		t.Error("expected MintCredential to be called")
+	}
+	if d.exchangeCalled {
+		t.Error("MintCredentialWithExchange must not be called when inputs are nil")
+	}
+}
+
+func TestMintWithCleanup_Inputs_UsesExchangeMint(t *testing.T) {
+	s := newTestMintingService()
+	d := &exchangeDriver{}
+	spec := &CredSpec{Name: "s", Source: "src"}
+	inputs := validExchangeInputs()
+
+	var gotRaw map[string]interface{}
+	err := s.MintWithCleanup(context.Background(), d, spec, inputs, func(rawData, metadata map[string]interface{}, ttl time.Duration, leaseID string) error {
+		gotRaw = rawData
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !d.exchangeCalled {
+		t.Error("expected MintCredentialWithExchange to be called")
+	}
+	if d.mintCalled {
+		t.Error("plain MintCredential must not be called when inputs are present")
+	}
+	if d.gotInputs != inputs {
+		t.Error("exchange inputs were not forwarded to the driver")
+	}
+	if gotRaw["username"] != inputs.SubjectToken {
+		t.Errorf("onSuccess did not receive the exchange mint output: %v", gotRaw)
+	}
+}
+
+func TestMintWithCleanup_Inputs_PlainDriver_FailsClosed(t *testing.T) {
+	s := newTestMintingService()
+	d := &plainMintDriver{leaseID: "lease-x"} // NOT an ExchangeMinter
+	spec := &CredSpec{Name: "s", Source: "src"}
+
+	onSuccessCalled := false
+	err := s.MintWithCleanup(context.Background(), d, spec, validExchangeInputs(), func(rawData, metadata map[string]interface{}, ttl time.Duration, leaseID string) error {
+		onSuccessCalled = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected fail-closed error for a non-ExchangeMinter driver")
+	}
+	if !strings.Contains(err.Error(), "does not accept token-exchange inputs") {
+		t.Errorf("unexpected error text: %v", err)
+	}
+	if d.mintCalled {
+		t.Error("plain mint must not run when inputs are present but unsupported")
+	}
+	if onSuccessCalled {
+		t.Error("onSuccess must not run when the dispatch fails closed")
+	}
+	if d.revokeCalled {
+		t.Error("no lease was minted, so no orphaned-lease revoke should occur")
+	}
+}


### PR DESCRIPTION
## Summary

Second of the token-exchange foundation PRs (builds on #405). Threads an optional `*ExchangeInputs` from the issuance entry point down to the driver, **without changing any existing behaviour** — every production caller passes `nil`, so the exchange branch is unreachable until the resolution layer lands.

## What's here

- **`MintWithCleanup`** dispatches to `ExchangeMinter.MintCredentialWithExchange` when inputs are present, and **fails closed** (`"source driver %q does not accept token-exchange inputs"`) if the driver cannot consume them — rather than dropping the caller's bearer token or minting a generic credential under an exchange-scoped cache key.
- **`IssueCredential`** folds the inputs' fingerprint into the cache key **only** when inputs are present, so two callers sharing one session token but supplying different subject tokens cannot share a cached credential. The nil-inputs path keeps the cache key byte-identical, and eviction uses the stored full key, so exchange entries evict correctly.
- The single production caller (`core/request_handler.go`) passes `nil` for now.

## Testing

- `minting_service_test.go` — dispatch table (nil → plain mint; inputs + `ExchangeMinter` → exchange mint; inputs + plain driver → fail closed, no orphaned-lease revoke).
- `manager_test.go` — same token+spec with two different inputs → two distinct cached credentials; non-`ExchangeMinter` driver + inputs → error, nothing cached; nil-inputs regression on the literal cache-key format.

Full `credential` and `core` packages pass.

## Review notes

Verified the cache-key change against sibling paths: the eviction path receives the stored full key (fingerprint included), and no other site reconstructs the credential cache key — so exchange entries evict correctly and there is no cross-caller leak.
