### PR TITLE
feat(provider): strip token-exchange headers before upstream forwarding

### DIFF
--- a/provider/alicloud/path_gateway.go
+++ b/provider/alicloud/path_gateway.go
@@ -36,6 +36,8 @@ var headersToStrip = []string{
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
+	"X-Warden-Subject-Token",
+	"X-Warden-Actor-Token",
 	// Hop-by-hop
 	"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
 	"Te", "Trailer", "Trailers", "Transfer-Encoding", "Upgrade",

--- a/provider/azure/path_gateway.go
+++ b/provider/azure/path_gateway.go
@@ -23,6 +23,8 @@ var headersToRemove = []string{
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
+	"X-Warden-Subject-Token",
+	"X-Warden-Actor-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/gcp/path_gateway.go
+++ b/provider/gcp/path_gateway.go
@@ -23,6 +23,8 @@ var headersToRemove = []string{
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
+	"X-Warden-Subject-Token",
+	"X-Warden-Actor-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -23,6 +23,8 @@ var headersToStrip = []string{
 	"X-Warden-Provider",
 	"X-Warden-Role",
 	"X-Warden-On-Behalf-Of",
+	"X-Warden-Subject-Token",
+	"X-Warden-Actor-Token",
 	// Cookie carries client session identity that AWS will ignore but that
 	// would otherwise bleed across the trust boundary. Strip explicitly —
 	// sigv4.NormalizeRequest doesn't touch it.

--- a/provider/mcp_aws/gateway_test.go
+++ b/provider/mcp_aws/gateway_test.go
@@ -89,6 +89,8 @@ func makeMCPRequest(path, body string, cred *credential.Credential) (*logical.Re
 	r.Header.Set("X-Warden-Provider", "mcp_aws/")
 	r.Header.Set("X-Warden-Role", "s3-reader")
 	r.Header.Set("X-Warden-On-Behalf-Of", "alice@example.com")
+	r.Header.Set("X-Warden-Subject-Token", "eyJ.subject")
+	r.Header.Set("X-Warden-Actor-Token", "eyJ.actor")
 	// Hop-by-hop that NormalizeRequest must drop.
 	r.Header.Set("Connection", "keep-alive")
 
@@ -161,7 +163,7 @@ func TestHandleGateway_SignsAndForwards_STS(t *testing.T) {
 	assert.NotEmpty(t, got.headers.Get("X-Amz-Content-Sha256"))
 
 	// No Warden header leak.
-	for _, h := range []string{"X-Warden-Token", "X-Warden-Namespace", "X-Warden-Provider", "X-Warden-Role", "X-Warden-On-Behalf-Of"} {
+	for _, h := range []string{"X-Warden-Token", "X-Warden-Namespace", "X-Warden-Provider", "X-Warden-Role", "X-Warden-On-Behalf-Of", "X-Warden-Subject-Token", "X-Warden-Actor-Token"} {
 		assert.Empty(t, got.headers.Get(h), "header %q leaked to upstream", h)
 	}
 	// No Bearer leak — Authorization must be SigV4 only.

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -129,6 +129,7 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 
 	headersToRemove := []string{
 		"X-Warden-Token", "X-Warden-Role", "X-Warden-Provider", "X-Warden-On-Behalf-Of",
+		"X-Warden-Subject-Token", "X-Warden-Actor-Token",
 		"Connection", "Keep-Alive", "Transfer-Encoding", "Upgrade",
 		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
 		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",

--- a/provider/sdk/dualgateway/gateway_test.go
+++ b/provider/sdk/dualgateway/gateway_test.go
@@ -67,6 +67,9 @@ func TestHandleAPIRequest_HeaderAuth(t *testing.T) {
 		assert.Equal(t, "warden-test-proxy", r.Header.Get("User-Agent"))
 		assert.Equal(t, "test-secret-key", r.Header.Get("X-Auth-Token"))
 		assert.Empty(t, r.Header.Get("X-Warden-Token"))
+		// Token-exchange inputs are internal secrets and must never reach upstream.
+		assert.Empty(t, r.Header.Get("X-Warden-Subject-Token"))
+		assert.Empty(t, r.Header.Get("X-Warden-Actor-Token"))
 		assert.Equal(t, "/instance/v1/zones/fr-par-1/servers", r.URL.Path)
 		assert.Equal(t, "page=2", r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/json")
@@ -81,6 +84,8 @@ func TestHandleAPIRequest_HeaderAuth(t *testing.T) {
 	rec := httptest.NewRecorder()
 	httpReq := httptest.NewRequest("GET", "/instance/v1/zones/fr-par-1/servers?page=2", nil)
 	httpReq.Header.Set("X-Warden-Token", "should-be-stripped")
+	httpReq.Header.Set("X-Warden-Subject-Token", "eyJ.subject")
+	httpReq.Header.Set("X-Warden-Actor-Token", "eyJ.actor")
 
 	req := &logical.Request{
 		HTTPRequest:    httpReq,
@@ -276,7 +281,7 @@ func TestS3EndpointWithState(t *testing.T) {
 		Name: "r2", HelpText: "h", CredentialType: "c",
 		DefaultURL: "https://x.com", URLConfigKey: "r2_url",
 		DefaultTimeout: 30e9, UserAgent: "u",
-		APIAuth:    APIAuthStrategy{HeaderName: "X", HeaderValueFormat: "%s", CredentialField: "k"},
+		APIAuth: APIAuthStrategy{HeaderName: "X", HeaderValueFormat: "%s", CredentialField: "k"},
 		S3Endpoint: func(state map[string]any, region string) string {
 			acct, _ := state["account_id"].(string)
 			return acct + ".r2.cloudflarestorage.com"

--- a/provider/sdk/httpproxy/headers.go
+++ b/provider/sdk/httpproxy/headers.go
@@ -9,6 +9,8 @@ var BaseHeadersToRemove = []string{
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-On-Behalf-Of",
+	"X-Warden-Subject-Token",
+	"X-Warden-Actor-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -952,6 +952,8 @@ func TestPrepareHeaders(t *testing.T) {
 		req, _ := http.NewRequest("POST", "https://api.test.com/v1/chat", nil)
 		req.Header.Set("Authorization", "Bearer warden-token")
 		req.Header.Set("X-Warden-Token", "warden-token")
+		req.Header.Set("X-Warden-Subject-Token", "eyJ.subject")
+		req.Header.Set("X-Warden-Actor-Token", "eyJ.actor")
 		req.Header.Set("X-Custom-Remove", "should-go")
 		req.Header.Set("X-Keep", "keep-me")
 
@@ -959,6 +961,9 @@ func TestPrepareHeaders(t *testing.T) {
 
 		assert.Equal(t, "Bearer real-key", req.Header.Get("Authorization"))
 		assert.Empty(t, req.Header.Get("X-Warden-Token"))
+		// Token-exchange inputs are internal secrets and must never reach upstream.
+		assert.Empty(t, req.Header.Get("X-Warden-Subject-Token"))
+		assert.Empty(t, req.Header.Get("X-Warden-Actor-Token"))
 		assert.Empty(t, req.Header.Get("X-Custom-Remove"))
 		assert.Equal(t, "keep-me", req.Header.Get("X-Keep"))
 	})

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -16,13 +16,15 @@ import (
 // Headers to remove before proxying
 var headersToRemove = []string{
 	// Security headers (will be replaced with real values)
-	"Authorization",         // Remove Warden auth token to prevent leakage
-	"X-Vault-Token",         // Will be replaced with real Vault token
-	"X-Vault-Request",       // Internal Vault header
-	"X-Warden-Token",        // Warden-specific auth header
-	"X-Warden-Role",         // Warden role header
-	"X-Warden-Provider",     // Warden provider-mount routing header
-	"X-Warden-On-Behalf-Of", // Warden audit-propagation header — internal-only
+	"Authorization",          // Remove Warden auth token to prevent leakage
+	"X-Vault-Token",          // Will be replaced with real Vault token
+	"X-Vault-Request",        // Internal Vault header
+	"X-Warden-Token",         // Warden-specific auth header
+	"X-Warden-Role",          // Warden role header
+	"X-Warden-Provider",      // Warden provider-mount routing header
+	"X-Warden-On-Behalf-Of",  // Warden audit-propagation header — internal-only
+	"X-Warden-Subject-Token", // token-exchange subject token — internal-only, never forwarded
+	"X-Warden-Actor-Token",   // token-exchange actor token — internal-only, never forwarded
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",


### PR DESCRIPTION
## Summary

Third of the token-exchange foundation PRs. Adds `X-Warden-Subject-Token` and `X-Warden-Actor-Token` to every gateway header strip-list, alongside the existing `X-Warden-On-Behalf-Of`. These headers carry caller-supplied bearer tokens for the token-exchange flow and must never leak to an upstream service.

Independent of the other foundation PRs; landing it before the activation PR guarantees there is never a window where a header is read but not stripped.

## What's here

Both headers added to:

- the self-contained gateway strip-lists — `alicloud`, `azure`, `gcp`, `vault`, `mcp_aws`, and the `dualgateway` inline list;
- the shared `httpproxy.BaseHeadersToRemove` that SDK-based providers inherit.

Verified coverage is complete: the other ~12 `X-Warden-Token` references in `provider/` are token *extractors* (reading the inbound session token), not strip-lists.

## Testing

Extended the `httpproxy`, `mcp_aws`, and `dualgateway` header-stripping tests to assert both headers are removed before forwarding upstream. Affected provider packages pass.
