### PR TITLE
feat(core): resolve and pass token-exchange inputs at mint time

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -864,6 +864,12 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		}
 	}
 
+	// Structurally validate any token-exchange keys. Whether a driver supports
+	// exchange is enforced at mint time (fail closed), not here.
+	if err := credential.ValidateExchangeSpecConfig(spec.Config); err != nil {
+		return logical.ErrBadRequestf("invalid token-exchange config: %s", err.Error())
+	}
+
 	// Test credential minting if driver registry is available.
 	// This catches invalid auth credentials early (e.g., wrong GitHub app_id,
 	// expired PAT, invalid private key) rather than failing at gateway time.
@@ -890,6 +896,13 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				runTestMint := true
 				if cg, ok := credType.(credential.ConnectGated); ok &&
 					cg.RequiresConnect(spec.Config) && !cg.IsConnected(spec.Config) {
+					runTestMint = false
+				}
+
+				// A token-exchange spec has no caller subject token at creation
+				// time, so it cannot be test-minted here — it mints only on a live
+				// request that carries the exchange inputs.
+				if credential.SpecRequestsExchange(spec.Config) {
 					runTestMint = false
 				}
 

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openbao/openbao/sdk/v2/helper/pathmanager"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	authhelper "github.com/stephnangue/warden/auth/helper"
+	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/helper"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/listener"
@@ -1229,6 +1230,83 @@ func (c *Core) parseFormBody(req *logical.Request) error {
 	return nil
 }
 
+// Header names carrying caller-supplied token-exchange inputs. Both are bearer
+// secrets: they are consumed here and stripped by the provider gateways before
+// any upstream forwarding, exactly like X-Warden-On-Behalf-Of.
+const (
+	headerSubjectToken = "X-Warden-Subject-Token"
+	headerActorToken   = "X-Warden-Actor-Token"
+)
+
+// resolveExchangeInputs derives the token-exchange inputs for a request from the
+// credential spec's configuration. It returns (nil, nil) when the spec does not
+// opt into exchange, so the non-exchange mint path is completely unaffected.
+//
+// The plumbing never verifies token contents — it only records provenance via
+// SubjectTokenOrigin. Every configured-but-missing input fails the request
+// closed rather than silently minting a non-exchange credential.
+func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, specName string) (*credential.ExchangeInputs, error) {
+	spec, err := c.credConfigStore.GetSpec(ctx, specName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load credential spec: %w", err)
+	}
+	if !credential.SpecRequestsExchange(spec.Config) {
+		return nil, nil
+	}
+
+	inputs := &credential.ExchangeInputs{
+		SubjectTokenType: spec.Config[credential.ConfigSubjectTokenType],
+		ActorTokenType:   spec.Config[credential.ConfigActorTokenType],
+	}
+	if inputs.SubjectTokenType == "" {
+		inputs.SubjectTokenType = credential.TokenTypeJWT
+	}
+
+	switch spec.Config[credential.ConfigSubjectTokenSource] {
+	case credential.SourceAuthToken:
+		// Reuse the JWT Warden verified during inbound authentication. It lives
+		// in ClientToken only for transparent JWT auth; an opaque session token
+		// or a cert-authenticated request has no reusable JWT and fails closed.
+		if !strings.HasPrefix(req.ClientToken, "eyJ") {
+			return nil, fmt.Errorf("spec %q requires an inbound JWT subject token but the request was not JWT-authenticated", specName)
+		}
+		inputs.SubjectToken = req.ClientToken
+		inputs.SubjectTokenOrigin = credential.ExchangeOriginVerified
+	case credential.SourceHeader:
+		tok := req.HTTPRequest.Header.Get(headerSubjectToken)
+		if tok == "" {
+			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerSubjectToken)
+		}
+		inputs.SubjectToken = tok
+		inputs.SubjectTokenOrigin = credential.ExchangeOriginUnverified
+	default:
+		// SpecRequestsExchange already excluded "none"/absent; any other value
+		// was rejected at spec-validation time.
+		return nil, fmt.Errorf("spec %q has an unsupported %s", specName, credential.ConfigSubjectTokenSource)
+	}
+
+	if spec.Config[credential.ConfigActorTokenSource] == credential.SourceHeader {
+		// The actor token is a delegation credential, distinct from the
+		// X-Warden-On-Behalf-Of attribution label.
+		tok := req.HTTPRequest.Header.Get(headerActorToken)
+		if tok == "" {
+			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerActorToken)
+		}
+		inputs.ActorToken = tok
+		if inputs.ActorTokenType == "" {
+			inputs.ActorTokenType = credential.TokenTypeJWT
+		}
+	} else {
+		// No actor requested: drop any default type so Validate's pairing holds.
+		inputs.ActorTokenType = ""
+	}
+
+	if err := inputs.Validate(); err != nil {
+		return nil, err
+	}
+	return inputs, nil
+}
+
 // mintCredentialForRequest mints credentials for requests using the credential manager
 func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Request, te *logical.TokenEntry) error {
 	if te == nil {
@@ -1267,9 +1345,16 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 		tokenTTL = 1 * time.Hour
 	}
 
+	// Resolve any caller-supplied token-exchange inputs the spec opts into.
+	// Returns nil for non-exchange specs, leaving the mint path unchanged.
+	inputs, err := c.resolveExchangeInputs(ctx, req, te.CredentialSpec)
+	if err != nil {
+		return logical.ErrBadRequestf("token exchange input resolution failed: %s", err.Error())
+	}
+
 	// Issue credential using the credential manager
 	// Credentials are cache-only (not persisted) - ExpirationEntry handles lease revocation
-	cred, err := c.credentialManager.IssueCredential(ctx, te.ID, te.CredentialSpec, tokenTTL, nil)
+	cred, err := c.credentialManager.IssueCredential(ctx, te.ID, te.CredentialSpec, tokenTTL, inputs)
 	if err != nil {
 		return fmt.Errorf("failed to issue credential: %w", err)
 	}

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logical"
@@ -2236,4 +2237,137 @@ func TestValidActorSubject(t *testing.T) {
 			assert.Equal(t, tc.want, validActorSubject(tc.input))
 		})
 	}
+}
+
+// exchangeResolveEnv wires a credential config store into a minimal Core and
+// creates a local source, so resolveExchangeInputs can read seeded specs.
+func exchangeResolveEnv(t *testing.T) (*Core, context.Context) {
+	t.Helper()
+	store, ctx := setupTestCredentialConfigStore(t)
+	c := store.core
+	c.credConfigStore = store
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "local-src", Type: "local"}))
+	return c, ctx
+}
+
+func seedSpec(t *testing.T, c *Core, ctx context.Context, name string, config map[string]string) {
+	t.Helper()
+	require.NoError(t, c.credConfigStore.CreateSpec(ctx, &credential.CredSpec{
+		Name:   name,
+		Type:   "vault_token",
+		Source: "local-src",
+		Config: config,
+	}))
+}
+
+// requestWith builds a request carrying the given inbound Warden token and headers.
+func requestWith(clientToken string, headers map[string]string) *logical.Request {
+	httpReq := httptest.NewRequest("POST", "/v1/x/gateway/foo", nil)
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	return &logical.Request{ClientToken: clientToken, HTTPRequest: httpReq}
+}
+
+func TestCreateSpec_RejectsInvalidExchangeConfig(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	// actor_token_source without a subject source is rejected by validateSpec.
+	err := c.credConfigStore.CreateSpec(ctx, &credential.CredSpec{
+		Name:   "bad-spec",
+		Type:   "vault_token",
+		Source: "local-src",
+		Config: map[string]string{credential.ConfigActorTokenSource: credential.SourceHeader},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token-exchange config")
+}
+
+func TestResolveExchangeInputs_NoExchangeConfig(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "plain", map[string]string{})
+
+	inputs, err := c.resolveExchangeInputs(ctx, requestWith("opaque-token", nil), "plain")
+	require.NoError(t, err)
+	assert.Nil(t, inputs, "non-exchange specs must yield nil inputs")
+}
+
+func TestResolveExchangeInputs_AuthToken_JWT(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "auth-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceAuthToken,
+	})
+
+	inputs, err := c.resolveExchangeInputs(ctx, requestWith("eyJhbGciOi.payload.sig", nil), "auth-spec")
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	assert.Equal(t, "eyJhbGciOi.payload.sig", inputs.SubjectToken)
+	assert.Equal(t, credential.TokenTypeJWT, inputs.SubjectTokenType)
+	assert.Equal(t, credential.ExchangeOriginVerified, inputs.SubjectTokenOrigin)
+}
+
+func TestResolveExchangeInputs_AuthToken_OpaqueFailsClosed(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "auth-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceAuthToken,
+	})
+
+	_, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque-session-token", nil), "auth-spec")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not JWT-authenticated")
+}
+
+func TestResolveExchangeInputs_HeaderSource(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "hdr-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+	})
+
+	req := requestWith("opaque-token", map[string]string{headerSubjectToken: "eyJ.caller.subject"})
+	inputs, err := c.resolveExchangeInputs(ctx, req, "hdr-spec")
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	assert.Equal(t, "eyJ.caller.subject", inputs.SubjectToken)
+	assert.Equal(t, credential.ExchangeOriginUnverified, inputs.SubjectTokenOrigin)
+	assert.Empty(t, inputs.ActorToken)
+}
+
+func TestResolveExchangeInputs_HeaderSource_MissingFailsClosed(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "hdr-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+	})
+
+	_, err := c.resolveExchangeInputs(ctx, requestWith("opaque-token", nil), "hdr-spec")
+	require.Error(t, err)
+}
+
+func TestResolveExchangeInputs_ActorHeader(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "deleg-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigActorTokenSource:   credential.SourceHeader,
+	})
+
+	req := requestWith("opaque-token", map[string]string{
+		headerSubjectToken: "eyJ.subject",
+		headerActorToken:   "eyJ.actor",
+	})
+	inputs, err := c.resolveExchangeInputs(ctx, req, "deleg-spec")
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	assert.Equal(t, "eyJ.subject", inputs.SubjectToken)
+	assert.Equal(t, "eyJ.actor", inputs.ActorToken)
+	assert.Equal(t, credential.TokenTypeJWT, inputs.ActorTokenType)
+}
+
+func TestResolveExchangeInputs_ActorHeader_MissingFailsClosed(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "deleg-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigActorTokenSource:   credential.SourceHeader,
+	})
+
+	req := requestWith("opaque-token", map[string]string{headerSubjectToken: "eyJ.subject"})
+	_, err := c.resolveExchangeInputs(ctx, req, "deleg-spec")
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Final token-exchange foundation PR. Activates the plumbing end to end: caller-derived exchange inputs are now resolved from the request and passed to issuance. Depends on #405, #406, #407 (all merged).

Since no driver implements `ExchangeMinter` yet, an exchange-enabled spec request currently ends in a **clean fail-closed error** rather than any partial or insecure mint. The `token_exchange` driver (RFC 8693/7523/ID-JAG) is the next follow-up.

## What's here

- **`resolveExchangeInputs`** (`core/request_handler.go`) derives a subject (and optional actor) token for a request from the credential spec's config:
  - `subject_token_source: auth_token` reuses the JWT Warden verified during transparent inbound auth (origin `verified`). An opaque session token or cert-authenticated request has no reusable JWT and **fails closed**.
  - `subject_token_source: header` reads `X-Warden-Subject-Token` (origin `unverified`); `actor_token_source: header` reads `X-Warden-Actor-Token`.
  - Every configured-but-missing input fails the request closed. Non-exchange specs resolve to `nil`, leaving the existing mint path untouched.
- **`mintCredentialForRequest`** passes the resolved inputs into `IssueCredential` (both the streaming and access-backend call sites get this for free).
- **`validateSpec`** structurally validates the exchange keys and skips the create-time test-mint for exchange specs (which have no caller subject token until a live request).

## Trust model

Two layers stay separate: **authorization to invoke exchange** is the existing gateway CBP policy + spec binding (no new authz here); **verifying token contents** (signature/aud/expiry) is the future driver's job. The plumbing only records provenance via the origin field.

## Testing

`core/request_handler_test.go` covers the `resolveExchangeInputs` matrix (absent config → nil; `auth_token` with a JWT vs an opaque token; `header` present/missing; actor header present/missing) and rejection of an invalid exchange config at spec creation. Full `core` package passes.
