### PR TITLE
fix(logical): don't report HTTP 200 for an error whose Unwrap returns nil

### DIFF
--- a/logical/errors.go
+++ b/logical/errors.go
@@ -139,9 +139,14 @@ func GetErrorCode(err error) int {
 	case errors.Is(err, sdklogical.ErrInvalidRequest):
 		return http.StatusBadRequest
 	}
-	// Check if the error wraps a CodedError
+	// Check if the error wraps a CodedError. Only recurse when there is an inner
+	// error: an error that implements Unwrap() but returns nil (e.g. a token
+	// endpoint error carrying only a parsed OAuth code) is still a real failure
+	// and must not fall through to GetErrorCode(nil) == 200.
 	if unwrapped, ok := err.(interface{ Unwrap() error }); ok {
-		return GetErrorCode(unwrapped.Unwrap())
+		if inner := unwrapped.Unwrap(); inner != nil {
+			return GetErrorCode(inner)
+		}
 	}
 	return http.StatusInternalServerError
 }

--- a/logical/logical_test.go
+++ b/logical/logical_test.go
@@ -141,6 +141,13 @@ type permDeniedWrapper struct{}
 func (permDeniedWrapper) Error() string { return "boom" }
 func (permDeniedWrapper) Unwrap() error { return sdklogical.ErrPermissionDenied }
 
+// unwrapsToNil is a real error that implements Unwrap() but returns no inner
+// error — like a token-endpoint error carrying only a parsed OAuth code.
+type unwrapsToNil struct{}
+
+func (unwrapsToNil) Error() string { return "boom" }
+func (unwrapsToNil) Unwrap() error { return nil }
+
 func TestGetErrorCode(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		assert.Equal(t, 200, GetErrorCode(nil))
@@ -158,6 +165,14 @@ func TestGetErrorCode(t *testing.T) {
 		inner := ErrNotFound("not found")
 		wrapped := fmt.Errorf("wrap: %w", inner)
 		assert.Equal(t, 404, GetErrorCode(wrapped))
+	})
+
+	t.Run("error whose Unwrap returns nil is 500, not 200", func(t *testing.T) {
+		// A real failure that implements Unwrap() but has no inner error (e.g. an
+		// OAuth token-endpoint error carrying only a parsed error code) must not
+		// recurse into GetErrorCode(nil) and report success.
+		assert.Equal(t, 500, GetErrorCode(unwrapsToNil{}))
+		assert.Equal(t, 500, GetErrorCode(fmt.Errorf("wrap: %w", unwrapsToNil{})))
 	})
 
 	// SDK sentinel errors must map to their HTTP status even when wrapped or


### PR DESCRIPTION
## Problem

`GetErrorCode` resolves an error's HTTP status by recursing through `Unwrap()`:

```go
if unwrapped, ok := err.(interface{ Unwrap() error }); ok {
    return GetErrorCode(unwrapped.Unwrap())
}
```

When a **real** error implements `Unwrap()` but returns `nil` — e.g. the OAuth token-endpoint error, which carries only a parsed OAuth error code and no wrapped transport error — this recurses into `GetErrorCode(nil)`, which returns `http.StatusOK` (200). The result: a **failed** operation is reported to the client as **HTTP 200** with an error body.

This surfaced while exercising the new token-exchange driver against a real IdP: the IdP returned **400** for a rejected exchange, but the gateway surfaced **200**. It also affects the existing OAuth2 driver, which produces the same error type.

## Fix

Only recurse when there is an inner error. An error that implements `Unwrap()` but returns `nil` is still a real failure and falls through to `http.StatusInternalServerError` (500).

## Test

Added a `TestGetErrorCode` case asserting that an error whose `Unwrap()` returns `nil` maps to 500 (both bare and wrapped).
