### PR TITLE
docs(credential-drivers): put config last, add worked examples

### DIFF
--- a/site/src/content/docs/credential-drivers/alicloud.md
+++ b/site/src/content/docs/credential-drivers/alicloud.md
@@ -8,6 +8,52 @@ The Alibaba Cloud driver mints temporary credentials from **Alibaba Cloud STS** 
 
 The privileged **management access key** lives in the **source** config, and it is what STS signs mint requests with. Each **spec** names the `role_arn` to assume and optional session parameters. An operator reaches for this driver to hand short-lived, role-scoped Alibaba Cloud credentials to a workload without ever exposing the long-lived management key.
 
+## Credential issued
+
+`InferCredentialType` always returns `alicloud_keys`. The credential is **dynamic** — it carries the STS session TTL (900s–3600s) as its lease — but it is **not revocable**: STS tokens are self-expiring and have no server-side revocation handle, so revoke is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time with a live pre-flight STS `AssumeRole` (minimum 900s duration, result discarded), catching broken management keys, a bad `role_arn`, or trust-policy misconfig before first mint.
+- **Source rotation** — **slow** — rotates the management RAM access key: it creates a new key for `management_user_name` while the old one stays valid, then waits ~5 minutes (default `DefaultAlicloudActivationDelay`, tunable via the source's `activation_delay`) for RAM eventual consistency before marking the old key Inactive and deleting it. Requires `access_key_id`, `access_key_secret`, and `management_user_name`.
+
+## Examples
+
+One source holds the management access key; each spec below assumes a RAM role via STS.
+
+```bash
+warden cred source create alicloud-prod \
+  -type=alicloud \
+  -config=access_key_id=LTAIxxxxxxxxxxxxxxxx \
+  -config=access_key_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=management_user_name=warden-management \
+  -config=activation_delay=5m \
+  -rotation-period=720h
+```
+
+**STS AssumeRole** — session credentials scoped to a RAM role:
+
+```bash
+warden cred spec create alicloud-app \
+  -source=alicloud-prod \
+  -config=mint_method=assume_role \
+  -config=role_arn=acs:ram::123456789012:role/app-reader \
+  -config=role_session_name=warden-session \
+  -config=duration_seconds=3600
+```
+
+**STS AssumeRole with an inline session policy** — further restrict the returned credentials:
+
+```bash
+warden cred spec create alicloud-scoped \
+  -source=alicloud-prod \
+  -config=mint_method=assume_role \
+  -config=role_arn=acs:ram::123456789012:role/data-role \
+  -config=role_session_name=warden-analytics \
+  -config=duration_seconds=900 \
+  -config=policy='{"Version":"1","Statement":[{"Effect":"Allow","Action":["oss:GetObject"],"Resource":["acs:oss:*:*:reports/*"]}]}'
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=alicloud -config=key=value ...`:
@@ -36,34 +82,6 @@ Only `assume_role` is supported. Set these with `warden cred spec create ... -co
 | `role_session_name` | No | `warden-session` | Session name recorded on the assumed-role session. |
 | `duration_seconds` | No | `1h` | Session lifetime, clamped to 900s–3600s. |
 | `policy` | No | — | Inline session policy to further restrict the returned credentials. |
-
-## Credential issued
-
-`InferCredentialType` always returns `alicloud_keys`. The credential is **dynamic** — it carries the STS session TTL (900s–3600s) as its lease — but it is **not revocable**: STS tokens are self-expiring and have no server-side revocation handle, so revoke is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates a spec at create/update time with a live pre-flight STS `AssumeRole` (minimum 900s duration, result discarded), catching broken management keys, a bad `role_arn`, or trust-policy misconfig before first mint.
-- **Source rotation** — **slow** — rotates the management RAM access key: it creates a new key for `management_user_name` while the old one stays valid, then waits ~5 minutes (default `DefaultAlicloudActivationDelay`, tunable via the source's `activation_delay`) for RAM eventual consistency before marking the old key Inactive and deleting it. Requires `access_key_id`, `access_key_secret`, and `management_user_name`.
-
-## Example
-
-```bash
-warden cred source create alicloud-prod \
-  -type=alicloud \
-  -config=access_key_id=LTAIxxxxxxxxxxxxxxxx \
-  -config=access_key_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-  -config=management_user_name=warden-management \
-  -config=activation_delay=5m \
-  -rotation-period=720h
-
-warden cred spec create alicloud-app \
-  -source=alicloud-prod \
-  -config=mint_method=assume_role \
-  -config=role_arn=acs:ram::123456789012:role/app-reader \
-  -config=role_session_name=warden-session \
-  -config=duration_seconds=3600
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/apikey.md
+++ b/site/src/content/docs/credential-drivers/apikey.md
@@ -8,6 +8,42 @@ The **static API key** driver serves a long-lived **API key** to any HTTP API �
 
 An operator reaches for this driver when the upstream has no dynamic-credential API — the key is minted out-of-band and Warden simply stores it, verifies it, and injects it. At mint time the key is returned as-is with **no TTL and no lease**. The source config also controls an optional verification call so a bad key is caught the moment a spec is created.
 
+## Credential issued
+
+Issues a credential of type `api_key`. It is **static** — no lease, no TTL — and **not revocable**: revocation is a no-op because the key is owned and rotated outside Warden. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — if `verify_endpoint` is set, creating or updating a spec triggers a light call to `api_url` + `verify_endpoint` using the configured method and auth header, retried on HTTP 429 or 500. A key that fails the call is rejected. With no `verify_endpoint`, verification is skipped.
+
+No rotation of any kind — the key is static and managed upstream.
+
+## Examples
+
+One source describes the API; each spec carries a different key. Here two teams share the same OpenAI source with distinct keys:
+
+```bash
+warden cred source create openai \
+  -type=apikey \
+  -config=api_url=https://api.openai.com \
+  -config=verify_endpoint=/v1/models \
+  -config=verify_method=GET \
+  -config=auth_header_type=bearer \
+  -config=optional_metadata=organization_id \
+  -config=display_name=OpenAI \
+  -rotation-period=0
+
+warden cred spec create openai-team-a \
+  -source=openai \
+  -config=api_key=sk-proj-abc123... \
+  -config=organization_id=org-XXXX
+
+warden cred spec create openai-team-b \
+  -source=openai \
+  -config=api_key=sk-proj-def456... \
+  -config=organization_id=org-YYYY
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=apikey -config=key=value ...`:
@@ -33,35 +69,6 @@ There is a single mint path. The spec carries the actual key plus whatever field
 |-----|----------|---------|-------------|
 | `api_key` | Yes | — | The API key to serve. Returned verbatim as the credential. |
 | *fields from `optional_metadata`* | No | — | Any field named in the source's `optional_metadata` (e.g. `organization_id`, `project_id`) is copied into the credential data when present. |
-
-## Credential issued
-
-Issues a credential of type `api_key`. It is **static** — no lease, no TTL — and **not revocable**: revocation is a no-op because the key is owned and rotated outside Warden. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — if `verify_endpoint` is set, creating or updating a spec triggers a light call to `api_url` + `verify_endpoint` using the configured method and auth header, retried on HTTP 429 or 500. A key that fails the call is rejected. With no `verify_endpoint`, verification is skipped.
-
-No rotation of any kind — the key is static and managed upstream.
-
-## Example
-
-```bash
-warden cred source create openai \
-  -type=apikey \
-  -config=api_url=https://api.openai.com \
-  -config=verify_endpoint=/v1/models \
-  -config=verify_method=GET \
-  -config=auth_header_type=bearer \
-  -config=optional_metadata=organization_id \
-  -config=display_name=OpenAI \
-  -rotation-period=0
-
-warden cred spec create openai-team-a \
-  -source=openai \
-  -config=api_key=sk-proj-abc123... \
-  -config=organization_id=org-XXXX
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/aws.md
+++ b/site/src/content/docs/credential-drivers/aws.md
@@ -8,6 +8,73 @@ The AWS driver brokers credentials from **Amazon Web Services**. The **source** 
 
 Reach for this driver when workloads need scoped, time-bounded access to AWS APIs or to IAM-authenticated databases without ever handling the operator's standing IAM key. The privileged key lives only in the source config; specs carry the per-request details (which role, which secret, which database).
 
+## Credential issued
+
+- `sts_assume_role` and `secrets_manager` issue **`aws_access_keys`**.
+- `rds_iam_token` and `redshift_iam_token` issue **`db_auth_token`**.
+
+STS credentials are **dynamic** — they carry a lease and TTL — but are **not revocable**: AWS provides no way to invalidate temporary STS credentials, so they are tracked under a synthetic lease ID and simply expire. RDS and Redshift IAM tokens are also short-lived and expiry-bound (RDS tokens last ~15 minutes; Redshift honors `duration_seconds`). Secrets Manager values are **static** — no lease, no revocation. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **slow**: stages a newly created IAM access key alongside the old one and waits ~5 minutes (`DefaultAWSActivationDelay`, tunable via the source's `activation_delay`) so the new key propagates through AWS IAM's eventual consistency before the old key is destroyed. Only permanent IAM keys (those with an `AKIA` prefix) are rotatable. What gets rotated is the source's own IAM access key pair.
+
+No spec verification.
+
+## Examples
+
+One source holds the standing IAM key; each spec below picks a `mint_method`.
+
+```bash
+warden cred source create prod-aws \
+  -type=aws \
+  -config=access_key_id=AKIAIOSFODNN7EXAMPLE \
+  -config=secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+  -config=region=us-east-1 \
+  -rotation-period=720h
+```
+
+**STS AssumeRole** — temporary session credentials for a role:
+
+```bash
+warden cred spec create deploy-role \
+  -source=prod-aws \
+  -config=mint_method=sts_assume_role \
+  -config=role_arn=arn:aws:iam::123456789012:role/DeployRole \
+  -config=ttl=1h
+```
+
+**Secrets Manager** — fetch a stored secret:
+
+```bash
+warden cred spec create db-password \
+  -source=prod-aws \
+  -config=mint_method=secrets_manager \
+  -config=secret_id=prod/db/credentials
+```
+
+**RDS IAM auth token** — a short-lived database password:
+
+```bash
+warden cred spec create rds-token \
+  -source=prod-aws \
+  -config=mint_method=rds_iam_token \
+  -config=db_endpoint=mydb.abc123.us-east-1.rds.amazonaws.com \
+  -config=db_user=app_user \
+  -config=db_engine=postgres
+```
+
+**Redshift IAM auth token** — for a provisioned cluster:
+
+```bash
+warden cred spec create redshift-token \
+  -source=prod-aws \
+  -config=mint_method=redshift_iam_token \
+  -config=db_endpoint=mycluster.abc123.us-east-1.redshift.amazonaws.com \
+  -config=cluster_identifier=mycluster \
+  -config=db_name=analytics
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=aws -config=key=value ...`:
@@ -54,36 +121,6 @@ Spec-config keys set with `warden cred spec create ... -config=key=value`:
 | `db_name` | No | — | Target database name for Redshift. |
 | `duration_seconds` | No | `900` | Redshift token lifetime, 900–3600 seconds. |
 | `region` | No | source `region` | Overrides the source region for the DB token. |
-
-## Credential issued
-
-- `sts_assume_role` and `secrets_manager` issue **`aws_access_keys`**.
-- `rds_iam_token` and `redshift_iam_token` issue **`db_auth_token`**.
-
-STS credentials are **dynamic** — they carry a lease and TTL — but are **not revocable**: AWS provides no way to invalidate temporary STS credentials, so they are tracked under a synthetic lease ID and simply expire. RDS and Redshift IAM tokens are also short-lived and expiry-bound (RDS tokens last ~15 minutes; Redshift honors `duration_seconds`). Secrets Manager values are **static** — no lease, no revocation. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Source rotation** — **slow**: stages a newly created IAM access key alongside the old one and waits ~5 minutes (`DefaultAWSActivationDelay`, tunable via the source's `activation_delay`) so the new key propagates through AWS IAM's eventual consistency before the old key is destroyed. Only permanent IAM keys (those with an `AKIA` prefix) are rotatable. What gets rotated is the source's own IAM access key pair.
-
-No spec verification.
-
-## Example
-
-```bash
-warden cred source create prod-aws \
-  -type=aws \
-  -config=access_key_id=AKIAIOSFODNN7EXAMPLE \
-  -config=secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
-  -config=region=us-east-1 \
-  -rotation-period=720h
-
-warden cred spec create deploy-role \
-  -source=prod-aws \
-  -config=mint_method=sts_assume_role \
-  -config=role_arn=arn:aws:iam::123456789012:role/DeployRole \
-  -config=ttl=1h
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/azure.md
+++ b/site/src/content/docs/credential-drivers/azure.md
@@ -18,6 +18,78 @@ This driver is unusual in two ways. First, the credentials it mints are supplied
 it is the only driver that rotates **both** its own source secret **and** the secret
 embedded in a spec, both through Microsoft Graph.
 
+## Credential issued
+
+The default `bearer_token` method issues an `azure_bearer_token` — a **dynamic**
+credential that carries the token's Azure AD TTL, and is **not revocable**: Azure bearer
+tokens expire naturally, so revocation is a no-op. The `key_vault_secret` method returns
+the secret value as a **static** credential with no lease or TTL. See
+[the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **slow**: stages a new source `client_secret` (a fresh Azure AD
+  password credential added via Microsoft Graph) and waits ~5m (default, tunable via the
+  source's `activation_delay`) so it propagates across Azure AD before the old secret is
+  destroyed. Requires the source service principal to hold `Application.ReadWrite.All`.
+- **Spec rotation** — **slow**: rotates the workload service principal's `client_secret`
+  stored in the spec, again through Microsoft Graph and with the same propagation wait.
+  This is the only driver that rotates a spec's own embedded secret.
+
+No spec verification.
+
+## Examples
+
+One source holds the privileged service-principal login; each spec below picks a
+`mint_method` and carries its own workload service-principal credentials.
+
+```bash
+warden cred source create azure-prod \
+  -type=azure \
+  -config=tenant_id=00000000-0000-0000-0000-000000000000 \
+  -config=client_id=11111111-1111-1111-1111-111111111111 \
+  -config=client_secret=s3cr3t-value \
+  -config=secret_id=22222222-2222-2222-2222-222222222222 \
+  -rotation-period=720h
+```
+
+**Bearer token** — a short-lived Azure AD token for the Azure Resource Manager API:
+
+```bash
+warden cred spec create arm-token \
+  -source=azure-prod \
+  -config=mint_method=bearer_token \
+  -config=client_id=33333333-3333-3333-3333-333333333333 \
+  -config=client_secret=workload-s3cr3t \
+  -config=resource_uri=https://management.azure.com/
+```
+
+**Key Vault secret** — fetch a stored secret by vault and name:
+
+```bash
+warden cred spec create db-password \
+  -source=azure-prod \
+  -config=mint_method=key_vault_secret \
+  -config=client_id=44444444-4444-4444-4444-444444444444 \
+  -config=client_secret=workload-s3cr3t \
+  -config=vault_name=prod-kv \
+  -config=secret_name=db-connection-string
+```
+
+**Rotating workload secret** — a bearer-token spec whose embedded `client_secret` Warden
+rotates on a schedule through Microsoft Graph:
+
+```bash
+warden cred spec create graph-token \
+  -source=azure-prod \
+  -config=mint_method=bearer_token \
+  -config=client_id=55555555-5555-5555-5555-555555555555 \
+  -config=client_secret=workload-s3cr3t \
+  -config=secret_id=66666666-6666-6666-6666-666666666666 \
+  -config=resource_uri=https://graph.microsoft.com/ \
+  -rotation-period=720h
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=azure -config=key=value ...`:
@@ -56,45 +128,6 @@ Keys set with `warden cred spec create ... -config=key=value`:
 | `secret_version` | No | latest | Specific secret version (`key_vault_secret` only). |
 
 \* Required when `mint_method=key_vault_secret`.
-
-## Credential issued
-
-The default `bearer_token` method issues an `azure_bearer_token` — a **dynamic**
-credential that carries the token's Azure AD TTL, and is **not revocable**: Azure bearer
-tokens expire naturally, so revocation is a no-op. The `key_vault_secret` method returns
-the secret value as a **static** credential with no lease or TTL. See
-[the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Source rotation** — **slow**: stages a new source `client_secret` (a fresh Azure AD
-  password credential added via Microsoft Graph) and waits ~5m (default, tunable via the
-  source's `activation_delay`) so it propagates across Azure AD before the old secret is
-  destroyed. Requires the source service principal to hold `Application.ReadWrite.All`.
-- **Spec rotation** — **slow**: rotates the workload service principal's `client_secret`
-  stored in the spec, again through Microsoft Graph and with the same propagation wait.
-  This is the only driver that rotates a spec's own embedded secret.
-
-No spec verification.
-
-## Example
-
-```bash
-warden cred source create azure-prod \
-  -type=azure \
-  -config=tenant_id=00000000-0000-0000-0000-000000000000 \
-  -config=client_id=11111111-1111-1111-1111-111111111111 \
-  -config=client_secret=s3cr3t-value \
-  -config=secret_id=22222222-2222-2222-2222-222222222222 \
-  -rotation-period=720h
-
-warden cred spec create arm-token \
-  -source=azure-prod \
-  -config=mint_method=bearer_token \
-  -config=client_id=33333333-3333-3333-3333-333333333333 \
-  -config=client_secret=workload-s3cr3t \
-  -config=resource_uri=https://management.azure.com/
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/elastic.md
+++ b/site/src/content/docs/credential-drivers/elastic.md
@@ -8,6 +8,45 @@ The Elasticsearch driver mints short-lived **API keys** from an Elasticsearch cl
 
 Operators reach for this driver when a workload needs to talk to Elasticsearch and should carry its own narrowly-scoped key rather than a shared cluster credential. Per-spec parameters control the key's name, lifetime, and role descriptors, so one source can back many specs with different privilege sets.
 
+## Credential issued
+
+`InferCredentialType` always returns `api_key`. The minted key is **dynamic** — it carries a TTL derived from the cluster's returned expiration timestamp — and **revocable**: Warden invalidates the key through the Security API when the lease ends. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates the source credentials with a light authenticate call at create/update time.
+- **Source rotation** — **slow** — stages a newly minted API key and waits ~10s (default, tunable via the source's `activation_delay`) for in-cluster propagation before invalidating the old key. Rotates the driver's own source API key via the Security API; requires the `manage_api_key` or `manage_own_api_key` cluster privilege.
+
+## Examples
+
+One source holds the pre-encoded cluster API key; each spec creates a scoped, expiring key from it.
+
+```bash
+warden cred source create es-prod \
+  -type=elastic \
+  -config=elastic_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
+  -config=api_key=dXNlcjpwYXNzd29yZA== \
+  -rotation-period=720h
+```
+
+**Scoped read-only key** — role descriptors restrict the key to reading `logs-*` indices, with a 24h lifetime:
+
+```bash
+warden cred spec create es-search-ro \
+  -source=es-prod \
+  -config=expiration=24h \
+  -config=role_descriptors={"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}
+```
+
+**Named unscoped key** — no role descriptors (inherits the source key's privileges), a custom key name, and a short 1h lifetime:
+
+```bash
+warden cred spec create es-ingest \
+  -source=es-prod \
+  -config=key_name=ingest-writer \
+  -config=expiration=1h
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=elastic -config=key=value ...`:
@@ -31,30 +70,6 @@ A single mint method: each spec creates one Elasticsearch API key. Keys operator
 | `key_name` | No | `<prefix>-<spec>-<unix>` | Name for the generated API key. |
 | `expiration` | No | `1h` | Key expiration, e.g. `30d`; sets the credential's TTL. |
 | `role_descriptors` | No | — | JSON string of role descriptors scoping the key's privileges. |
-
-## Credential issued
-
-`InferCredentialType` always returns `api_key`. The minted key is **dynamic** — it carries a TTL derived from the cluster's returned expiration timestamp — and **revocable**: Warden invalidates the key through the Security API when the lease ends. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates the source credentials with a light authenticate call at create/update time.
-- **Source rotation** — **slow** — stages a newly minted API key and waits ~10s (default, tunable via the source's `activation_delay`) for in-cluster propagation before invalidating the old key. Rotates the driver's own source API key via the Security API; requires the `manage_api_key` or `manage_own_api_key` cluster privilege.
-
-## Example
-
-```bash
-warden cred source create es-prod \
-  -type=elastic \
-  -config=elastic_url=https://my-cluster.es.us-east-1.aws.cloud.es.io \
-  -config=api_key=dXNlcjpwYXNzd29yZA== \
-  -rotation-period=720h
-
-warden cred spec create es-search-ro \
-  -source=es-prod \
-  -config=expiration=24h \
-  -config=role_descriptors={"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/gcp.md
+++ b/site/src/content/docs/credential-drivers/gcp.md
@@ -15,6 +15,54 @@ read. Each **spec** selects a `mint_method` and the scopes, target account, and 
 of the token to issue. An operator reaches for this driver to hand workloads scoped,
 expiring Google Cloud tokens without ever exposing the underlying key.
 
+## Credential issued
+
+Both mint methods issue a credential of type `gcp_access_token`. It is **dynamic** — it
+carries the token's natural expiry as its TTL — but it is **not revocable**: a GCP access
+token cannot be invalidated early and simply expires. See
+[the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **slow**: stages a freshly created service-account key (minted
+  via the IAM API against the source SA) and waits ~2 minutes (default, tunable via the
+  source's `activation_delay`) for GCP IAM propagation before destroying the old key.
+  Rotation requires the SA to hold `iam.serviceAccountKeys.create` and
+  `iam.serviceAccountKeys.delete` on itself.
+
+No spec verification.
+
+## Examples
+
+One source holds the service-account JSON key; each spec below picks a `mint_method`.
+
+```bash
+warden cred source create prod-gcp \
+  -type=gcp \
+  -config=service_account_key=@sa-key.json \
+  -rotation-period=720h
+```
+
+**Access token** — an OAuth2 token for the source service account itself:
+
+```bash
+warden cred spec create platform-token \
+  -source=prod-gcp \
+  -config=mint_method=access_token \
+  -config=scopes=https://www.googleapis.com/auth/cloud-platform
+```
+
+**Impersonated access token** — a token for another service account via IAM:
+
+```bash
+warden cred spec create bigquery-reader \
+  -source=prod-gcp \
+  -config=mint_method=impersonated_access_token \
+  -config=target_service_account=bq-reader@my-project.iam.gserviceaccount.com \
+  -config=scopes=https://www.googleapis.com/auth/bigquery.readonly \
+  -config=lifetime=1800s
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=gcp -config=key=value ...`:
@@ -40,39 +88,6 @@ Spec-config keys set with `warden cred spec create ... -config=key=value`:
 | `scopes` | No | `https://www.googleapis.com/auth/cloud-platform` | Comma-separated OAuth2 scopes |
 | `target_service_account` | Yes (impersonation only) | — | Email of the service account to impersonate |
 | `lifetime` | No | `3600s` | Requested token lifetime (impersonation only) |
-
-## Credential issued
-
-Both mint methods issue a credential of type `gcp_access_token`. It is **dynamic** — it
-carries the token's natural expiry as its TTL — but it is **not revocable**: a GCP access
-token cannot be invalidated early and simply expires. See
-[the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Source rotation** — **slow**: stages a freshly created service-account key (minted
-  via the IAM API against the source SA) and waits ~2 minutes (default, tunable via the
-  source's `activation_delay`) for GCP IAM propagation before destroying the old key.
-  Rotation requires the SA to hold `iam.serviceAccountKeys.create` and
-  `iam.serviceAccountKeys.delete` on itself.
-
-No spec verification.
-
-## Example
-
-```bash
-warden cred source create prod-gcp \
-  -type=gcp \
-  -config=service_account_key=@sa-key.json \
-  -rotation-period=720h
-
-warden cred spec create bigquery-reader \
-  -source=prod-gcp \
-  -config=mint_method=impersonated_access_token \
-  -config=target_service_account=bq-reader@my-project.iam.gserviceaccount.com \
-  -config=scopes=https://www.googleapis.com/auth/bigquery.readonly \
-  -config=lifetime=1800s
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/github.md
+++ b/site/src/content/docs/credential-drivers/github.md
@@ -8,6 +8,46 @@ The GitHub driver mints **GitHub tokens** for workloads that call the GitHub RES
 
 Each spec picks an **`auth_method`**: `app` (the default) uses a GitHub App private key to mint short-lived installation access tokens (~1h TTL), while `pat` passes through a static Personal Access Token. An operator reaches for this driver whenever a workload needs to authenticate to GitHub without holding the long-lived App key or PAT itself.
 
+## Credential issued
+
+The driver always issues the `github_token` type. In `app` mode the token is **dynamic** — it carries a TTL (~1h) tied to the installation token's expiry. In `pat` mode the token is **static** — no lease, no TTL. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation). GitHub App installation tokens are revocable and expire naturally; the driver relies on their short lifetime rather than tracking leases for explicit revocation.
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time. In `pat` mode it confirms the token with a lightweight identity call; in `app` mode the spec is exercised by a trial mint against the GitHub API.
+- **Not rotatable — by design.** GitHub App installation tokens are ephemeral (~1h) and are simply re-minted on demand, and GitHub exposes no API to rotate a PAT. There is nothing long-lived on the source to rotate, so the driver does not implement source rotation.
+
+## Examples
+
+One source holds only connection details; each spec below picks an `auth_method`.
+
+```bash
+warden cred source create github-prod \
+  -type=github \
+  -config=github_url=https://api.github.com \
+  -rotation-period=0
+```
+
+**GitHub App** — mint short-lived installation access tokens from an App private key:
+
+```bash
+warden cred spec create ci-deploy \
+  -source=github-prod \
+  -config=auth_method=app \
+  -config=app_id=123456 \
+  -config=installation_id=7891011 \
+  -config=private_key="$(cat app-private-key.pem)"
+```
+
+**Personal Access Token** — pass a static PAT through unchanged:
+
+```bash
+warden cred spec create readonly-pat \
+  -source=github-prod \
+  -config=auth_method=pat \
+  -config=token=ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=github -config=key=value ...`:
@@ -36,31 +76,6 @@ Spec-config keys set with `warden cred spec create ... -config=key=value`:
 | `app_id` | For `app` | — | GitHub App ID (JWT issuer). |
 | `installation_id` | For `app` | — | Installation ID the token is minted for. |
 | `token` | For `pat` | — | The Personal Access Token to pass through. |
-
-## Credential issued
-
-The driver always issues the `github_token` type. In `app` mode the token is **dynamic** — it carries a TTL (~1h) tied to the installation token's expiry. In `pat` mode the token is **static** — no lease, no TTL. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation). GitHub App installation tokens are revocable and expire naturally; the driver relies on their short lifetime rather than tracking leases for explicit revocation.
-
-## Capabilities
-
-- **Spec verification** — validates a spec at create/update time. In `pat` mode it confirms the token with a lightweight identity call; in `app` mode the spec is exercised by a trial mint against the GitHub API.
-- **Not rotatable — by design.** GitHub App installation tokens are ephemeral (~1h) and are simply re-minted on demand, and GitHub exposes no API to rotate a PAT. There is nothing long-lived on the source to rotate, so the driver does not implement source rotation.
-
-## Example
-
-```bash
-warden cred source create github-prod \
-  -type=github \
-  -config=github_url=https://api.github.com \
-  -rotation-period=0
-
-warden cred spec create ci-deploy \
-  -source=github-prod \
-  -config=auth_method=app \
-  -config=app_id=123456 \
-  -config=installation_id=7891011 \
-  -config=private_key="$(cat app-private-key.pem)"
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/gitlab.md
+++ b/site/src/content/docs/credential-drivers/gitlab.md
@@ -8,6 +8,54 @@ The GitLab driver mints **project access tokens** and **group access tokens** fr
 
 The privileged secret lives in the **source** config. The driver authenticates to GitLab one of two ways, set by `auth_method`: **PAT mode** (default) uses a **personal access token**, and **OAuth2 mode** uses an application ID and secret via the client-credentials flow. Each **spec** then names a project or group and the scopes the minted token should carry. An operator reaches for this driver to broker CI and automation access to specific GitLab projects or groups without distributing standing tokens.
 
+## Credential issued
+
+Both mint methods issue a `gitlab_access_token`. It is **dynamic** — it carries a lease and TTL derived from `ttl` — and **revocable**: Warden deletes the token via the GitLab API when the lease ends. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **fast**, prepares and activates in one step (immediately-consistent upstream). The driver rotates its own source credential: in PAT mode it calls GitLab's atomic PAT rotate endpoint; in OAuth2 mode it renews the application secret. In both cases GitLab invalidates the old credential as part of the rotate, so the new one is committed inline with no propagation delay.
+
+## Examples
+
+**PAT source, project access token** — authenticate with a personal access token and mint a project-scoped token:
+
+```bash
+warden cred source create gitlab-ci \
+  -type=gitlab \
+  -config=gitlab_address=https://gitlab.example.com \
+  -config=auth_method=pat \
+  -config=personal_access_token=glpat-xxxxxxxxxxxx \
+  -rotation-period=720h
+
+warden cred spec create gitlab-app-deploy \
+  -source=gitlab-ci \
+  -config=mint_method=project_access_token \
+  -config=project_id=42 \
+  -config=scopes=api,read_repository \
+  -config=ttl=24h
+```
+
+**OAuth2 source, group access token** — authenticate with an application ID and secret and mint a group-scoped token:
+
+```bash
+warden cred source create gitlab-oauth \
+  -type=gitlab \
+  -config=gitlab_address=https://gitlab.example.com \
+  -config=auth_method=oauth2 \
+  -config=application_id=your-application-id \
+  -config=application_secret=your-application-secret \
+  -rotation-period=720h
+
+warden cred spec create gitlab-group-ci \
+  -source=gitlab-oauth \
+  -config=mint_method=group_access_token \
+  -config=group_id=100 \
+  -config=scopes=read_repository \
+  -config=access_level=30 \
+  -config=ttl=24h
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=gitlab -config=key=value ...`:
@@ -40,32 +88,6 @@ Spec-config keys for `warden cred spec create ... -config=key=value`:
 | `scopes` | No | `api` | Comma-separated token scopes. |
 | `access_level` | No | `30` | Access level for the token (30 = developer). |
 | `ttl` | No | `24h` | Token lifetime; sets the expiry date and the lease TTL. |
-
-## Credential issued
-
-Both mint methods issue a `gitlab_access_token`. It is **dynamic** — it carries a lease and TTL derived from `ttl` — and **revocable**: Warden deletes the token via the GitLab API when the lease ends. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Source rotation** — **fast**, prepares and activates in one step (immediately-consistent upstream). The driver rotates its own source credential: in PAT mode it calls GitLab's atomic PAT rotate endpoint; in OAuth2 mode it renews the application secret. In both cases GitLab invalidates the old credential as part of the rotate, so the new one is committed inline with no propagation delay.
-
-## Example
-
-```bash
-warden cred source create gitlab-ci \
-  -type=gitlab \
-  -config=gitlab_address=https://gitlab.example.com \
-  -config=auth_method=pat \
-  -config=personal_access_token=glpat-xxxxxxxxxxxx \
-  -rotation-period=720h
-
-warden cred spec create gitlab-app-deploy \
-  -source=gitlab-ci \
-  -config=mint_method=project_access_token \
-  -config=project_id=42 \
-  -config=scopes=api,read_repository \
-  -config=ttl=24h
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/grafana.md
+++ b/site/src/content/docs/credential-drivers/grafana.md
@@ -8,6 +8,48 @@ The Grafana driver mints **Grafana service-account tokens** by talking to the Gr
 
 The privileged secret lives in the **source**: an `admin_token` (an admin service-account token with permission to create and delete service accounts) plus the `grafana_url` to reach. Each **spec** decides the shape of what gets minted — the role granted, the naming prefix, an optional org, and the token TTL. An operator reaches for this driver to grant workloads short-lived, least-privilege Grafana access without ever sharing the standing admin token.
 
+## Credential issued
+
+Issues a credential of type `api_key`. It is **dynamic** — it carries a lease and a TTL equal to `token_expiry` — and it is **revocable**: revoking deletes the backing service account and invalidates the token. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates the source's admin token at spec create/update time with a lightweight service-account listing call.
+
+Mint and revoke otherwise; no source or spec rotation. Create the source with `-rotation-period=0`.
+
+## Examples
+
+One source holds the standing admin token; each spec below decides the role, org, and token TTL.
+
+```bash
+warden cred source create grafana-cloud \
+  -type=grafana \
+  -config=grafana_url=https://mystack.grafana.net \
+  -config=admin_token=glsa_xxxxxxxxxxxxxxxxxxxx \
+  -rotation-period=0
+```
+
+**Viewer token** — read-only dashboard access with a 1h lifetime:
+
+```bash
+warden cred spec create grafana-dashboards \
+  -source=grafana-cloud \
+  -config=role=Viewer \
+  -config=name_prefix=warden- \
+  -config=token_expiry=1h
+```
+
+**Editor token scoped to an org** — write access within a specific Grafana organization:
+
+```bash
+warden cred spec create grafana-editor \
+  -source=grafana-cloud \
+  -config=role=Editor \
+  -config=org_id=2 \
+  -config=token_expiry=4h
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=grafana -config=key=value ...`:
@@ -29,32 +71,6 @@ A single mint method: each mint creates a service account and issues one token o
 | `name_prefix` | No | `warden-` | Prefix for the generated service-account name. |
 | `org_id` | No | — | Grafana organization ID to scope the service account to; omit for the default org. |
 | `token_expiry` | No | `1h` | TTL of the minted token. |
-
-## Credential issued
-
-Issues a credential of type `api_key`. It is **dynamic** — it carries a lease and a TTL equal to `token_expiry` — and it is **revocable**: revoking deletes the backing service account and invalidates the token. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates the source's admin token at spec create/update time with a lightweight service-account listing call.
-
-Mint and revoke otherwise; no source or spec rotation. Create the source with `-rotation-period=0`.
-
-## Example
-
-```bash
-warden cred source create grafana-cloud \
-  -type=grafana \
-  -config=grafana_url=https://mystack.grafana.net \
-  -config=admin_token=glsa_xxxxxxxxxxxxxxxxxxxx \
-  -rotation-period=0
-
-warden cred spec create grafana-dashboards \
-  -source=grafana-cloud \
-  -config=role=Viewer \
-  -config=name_prefix=warden- \
-  -config=token_expiry=1h
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/honeycomb.md
+++ b/site/src/content/docs/credential-drivers/honeycomb.md
@@ -8,6 +8,50 @@ The **Honeycomb** driver mints **Honeycomb V2 API keys** from the key-management
 
 Reach for this driver when a workload needs a short-lived Honeycomb **ingest** or **configuration** key rather than a long-lived hand-issued one. Minted key secrets are **capture-once** — Honeycomb returns the secret only at creation time, so Warden captures it then and injects it on demand. Keys do not expire natively, so the spec's `key_ttl` governs the Warden lease.
 
+## Credential issued
+
+Issues a credential of type `api_key`. It is **dynamic** — it carries a lease whose TTL comes from the spec's `key_ttl` — and it is **revocable**: expiry or explicit revoke deletes the underlying Honeycomb key. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates the spec's `environment_id` and `key_type`, then lists API keys with a page size of 1 to confirm the management key and team slug work at spec create/update time.
+
+Mint and revoke otherwise; no source or spec rotation.
+
+## Examples
+
+One source holds the team management key; each spec picks an environment and key type.
+
+```bash
+warden cred source create honeycomb-prod \
+  -type=honeycomb \
+  -config=team_slug=my-team \
+  -config=management_key_id=hcxmk_abc123 \
+  -config=management_key_secret=s3cr3t \
+  -rotation-period=0
+```
+
+**Ingest key** — for shipping telemetry into an environment, on a 12h lease:
+
+```bash
+warden cred spec create honeycomb-ingest \
+  -source=honeycomb-prod \
+  -config=environment_id=env_prod01 \
+  -config=key_type=ingest \
+  -config=key_ttl=12h
+```
+
+**Configuration key** — a scoped management key carrying an explicit permission object:
+
+```bash
+warden cred spec create honeycomb-config \
+  -source=honeycomb-prod \
+  -config=environment_id=env_prod01 \
+  -config=key_type=configuration \
+  -config=permissions={"boards":{"read":true},"datasets":{"read":true}} \
+  -config=key_ttl=24h
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=honeycomb -config=key=value ...`:
@@ -32,33 +76,6 @@ A single mint method issues Honeycomb API keys. Keys set with `warden cred spec 
 | `key_name_prefix` | No | `warden-` | Prefix for the generated key name (name is `<prefix><spec>-<timestamp>`). |
 | `permissions` | No | — | JSON permission object; allowed only for `configuration` keys. |
 | `key_ttl` | No | `24h` | Warden lease duration for the minted key. |
-
-## Credential issued
-
-Issues a credential of type `api_key`. It is **dynamic** — it carries a lease whose TTL comes from the spec's `key_ttl` — and it is **revocable**: expiry or explicit revoke deletes the underlying Honeycomb key. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates the spec's `environment_id` and `key_type`, then lists API keys with a page size of 1 to confirm the management key and team slug work at spec create/update time.
-
-Mint and revoke otherwise; no source or spec rotation.
-
-## Example
-
-```bash
-warden cred source create honeycomb-prod \
-  -type=honeycomb \
-  -config=team_slug=my-team \
-  -config=management_key_id=hcxmk_abc123 \
-  -config=management_key_secret=s3cr3t \
-  -rotation-period=0
-
-warden cred spec create honeycomb-ingest \
-  -source=honeycomb-prod \
-  -config=environment_id=env_prod01 \
-  -config=key_type=ingest \
-  -config=key_ttl=12h
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/ibm.md
+++ b/site/src/content/docs/credential-drivers/ibm.md
@@ -8,6 +8,45 @@ The IBM Cloud driver brokers access to **IBM Cloud** by exchanging a long-lived 
 
 An operator reaches for this driver when workloads need to call IBM Cloud APIs (or COS S3-compatible endpoints) without holding the account API key themselves. Warden can also rotate the source API key on a schedule, minting a fresh key for the same IAM identity and retiring the old one.
 
+## Credential issued
+
+`iam_token` issues an `oauth_bearer_token`; `iam_with_cos` issues `ibmcloud_keys`. Both are **dynamic** — the credential carries the IAM token's remaining TTL as its lease. They are **not revocable**: IAM tokens expire naturally and revoke is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time with a lightweight IAM token exchange.
+- **Source rotation** — **slow**: stages a newly created API key for the same IAM identity and waits ~2 minutes (default, tunable via the source's `activation_delay`) so it propagates before the old key is deleted. What rotates is the source `api_key`. Rotation is available only when the key's IAM identity was discovered and can create/delete API keys.
+
+## Examples
+
+One source holds the IBM Cloud API key; each spec below picks a `mint_method`.
+
+```bash
+warden cred source create ibm-prod \
+  -type=ibm \
+  -config=api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=account_id=abcdef1234567890abcdef1234567890 \
+  -rotation-period=720h
+```
+
+**IAM token** — a bare IAM bearer token for IBM Cloud APIs:
+
+```bash
+warden cred spec create ibm-api \
+  -source=ibm-prod \
+  -config=mint_method=iam_token
+```
+
+**IAM token with COS keys** — the bearer token paired with static COS HMAC keys for S3-compatible access:
+
+```bash
+warden cred spec create ibm-cos \
+  -source=ibm-prod \
+  -config=mint_method=iam_with_cos \
+  -config=access_key_id=AKIAEXAMPLE \
+  -config=secret_access_key=wJalrEXAMPLEKEY
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=ibm -config=key=value ...`:
@@ -36,31 +75,6 @@ Spec-config keys set with `warden cred spec create ... -config=key=value`:
 | `mint_method` | No | `iam_token` | Selects the mint method (`iam_token` or `iam_with_cos`). |
 | `access_key_id` | No | — | COS HMAC access key ID; only used by `iam_with_cos`. Both keys must be present to be included. |
 | `secret_access_key` | No | — | COS HMAC secret access key; only used by `iam_with_cos`. |
-
-## Credential issued
-
-`iam_token` issues an `oauth_bearer_token`; `iam_with_cos` issues `ibmcloud_keys`. Both are **dynamic** — the credential carries the IAM token's remaining TTL as its lease. They are **not revocable**: IAM tokens expire naturally and revoke is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates a spec at create/update time with a lightweight IAM token exchange.
-- **Source rotation** — **slow**: stages a newly created API key for the same IAM identity and waits ~2 minutes (default, tunable via the source's `activation_delay`) so it propagates before the old key is deleted. What rotates is the source `api_key`. Rotation is available only when the key's IAM identity was discovered and can create/delete API keys.
-
-## Example
-
-```bash
-warden cred source create ibm-prod \
-  -type=ibm \
-  -config=api_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-  -config=account_id=abcdef1234567890abcdef1234567890 \
-  -rotation-period=720h
-
-warden cred spec create ibm-cos \
-  -source=ibm-prod \
-  -config=mint_method=iam_with_cos \
-  -config=access_key_id=AKIAEXAMPLE \
-  -config=secret_access_key=wJalrEXAMPLEKEY
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/kubernetes.md
+++ b/site/src/content/docs/credential-drivers/kubernetes.md
@@ -8,6 +8,52 @@ The Kubernetes driver mints short-lived **ServiceAccount tokens** through the cl
 
 The privileged secret — a bearer **token** with permission to create tokens for the target service accounts — lives in the **source** config alongside the API server URL and TLS settings. Each **spec** names the service account and namespace to mint for, plus optional audiences and TTL. An operator reaches for this driver to hand workloads narrowly-scoped, expiring identities without distributing long-lived service-account secrets.
 
+## Credential issued
+
+The credential `type` is `kubernetes_token`. It is **dynamic** — the token carries a TTL derived from the API server's returned expiration timestamp — but it is **not revocable**: ServiceAccount tokens expire naturally and cannot be invalidated through the API. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates that the target service account exists in its namespace with a light API call at create/update time.
+- **Source rotation** — available only when `source_service_account` and `source_namespace` are set. **Fast** — prepares and activates in one step (immediately-consistent upstream): the driver mints a fresh token for its own service account and swaps it in. Old tokens are left to expire naturally.
+
+## Examples
+
+One source holds the token-creating bearer token; each spec mints for a specific service account.
+
+```bash
+warden cred source create prod-k8s \
+  -type=kubernetes \
+  -config=kubernetes_url=https://my-cluster.example.com:6443 \
+  -config=token=eyJhbGciOiJSUzI1NiIs... \
+  -config=ca_data=LS0tLS1CRUdJTi... \
+  -config=source_service_account=warden-token-creator \
+  -config=source_namespace=warden \
+  -rotation-period=24h
+```
+
+**API-server audience** — a token the workload presents to the Kubernetes API as `my-app`:
+
+```bash
+warden cred spec create app-token \
+  -source=prod-k8s \
+  -config=service_account=my-app \
+  -config=namespace=default \
+  -config=audiences=https://kubernetes.default.svc \
+  -config=ttl=1h
+```
+
+**Custom audience and longer TTL** — a token scoped for a service that trusts the cluster's issuer:
+
+```bash
+warden cred spec create vault-auth-token \
+  -source=prod-k8s \
+  -config=service_account=vault-auth \
+  -config=namespace=platform \
+  -config=audiences=https://vault.example.com \
+  -config=ttl=4h
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=kubernetes -config=key=value ...`:
@@ -32,35 +78,6 @@ The driver has a single mint path: it calls the TokenRequest API for the named s
 | `namespace` | Yes | — | Namespace of the target service account. |
 | `audiences` | No | — | Comma-separated token audiences. |
 | `ttl` | No | `1h` | Requested token TTL, e.g. `1h`. The cluster may clamp this. |
-
-## Credential issued
-
-The credential `type` is `kubernetes_token`. It is **dynamic** — the token carries a TTL derived from the API server's returned expiration timestamp — but it is **not revocable**: ServiceAccount tokens expire naturally and cannot be invalidated through the API. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates that the target service account exists in its namespace with a light API call at create/update time.
-- **Source rotation** — available only when `source_service_account` and `source_namespace` are set. **Fast** — prepares and activates in one step (immediately-consistent upstream): the driver mints a fresh token for its own service account and swaps it in. Old tokens are left to expire naturally.
-
-## Example
-
-```bash
-warden cred source create prod-k8s \
-  -type=kubernetes \
-  -config=kubernetes_url=https://my-cluster.example.com:6443 \
-  -config=token=eyJhbGciOiJSUzI1NiIs... \
-  -config=ca_data=LS0tLS1CRUdJTi... \
-  -config=source_service_account=warden-token-creator \
-  -config=source_namespace=warden \
-  -rotation-period=24h
-
-warden cred spec create app-token \
-  -source=prod-k8s \
-  -config=service_account=my-app \
-  -config=namespace=default \
-  -config=audiences=https://kubernetes.default.svc \
-  -config=ttl=1h
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/local.md
+++ b/site/src/content/docs/credential-drivers/local.md
@@ -8,6 +8,48 @@ The **local** driver serves **static credentials** that live directly in the **s
 
 Reach for `local` when you already hold a fixed secret — a pre-issued token, a shared password, a static connection string — and simply want Warden to broker it to a workload. Because a local source can serve many different credential shapes, the credential `type` cannot be inferred and must be stated explicitly on the spec with `-type=`.
 
+## Credential issued
+
+The credential `type` is whatever you pass to `-type=` on the spec (the driver serves many types). Local credentials are **static**: they carry no lease and no TTL, and they are **not revocable** — revocation is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+Mint only — no verification, no rotation, and revocation and cleanup are no-ops.
+
+## Examples
+
+One empty source can back specs of many different credential shapes; each spec states its own `-type=`.
+
+```bash
+warden cred source create my-static \
+  -type=local \
+  -rotation-period=0
+```
+
+**Static API key** — a pre-issued Slack bot token served as the `api_key` type:
+
+```bash
+warden cred spec create slack-bot-token \
+  -source=my-static \
+  -type=api_key \
+  -config=api_key=xoxb-EXAMPLE-STATIC-TOKEN
+```
+
+The spec config becomes the credential data verbatim, so the fields you set must
+match what the chosen `-type` expects — here the `api_key` type reads an `api_key`
+field.
+
+**Multi-field secret** — a fixed username/password/URL bundle served under a chosen type:
+
+```bash
+warden cred spec create legacy-db \
+  -source=my-static \
+  -type=database \
+  -config=username=app \
+  -config=password=s3cr3t \
+  -config=url=postgres://db.example.com:5432/app
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=local -config=key=value ...`:
@@ -23,31 +65,6 @@ Because the source cannot infer a type, `-type=` must be set explicitly when cre
 | Key | Required | Default | Description |
 |-----|----------|---------|-------------|
 | `<any>` | No | — | Arbitrary field copied verbatim into the credential data. |
-
-## Credential issued
-
-The credential `type` is whatever you pass to `-type=` on the spec (the driver serves many types). Local credentials are **static**: they carry no lease and no TTL, and they are **not revocable** — revocation is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-Mint only — no verification, no rotation, and revocation and cleanup are no-ops.
-
-## Example
-
-```bash
-warden cred source create my-static \
-  -type=local \
-  -rotation-period=0
-
-warden cred spec create slack-bot-token \
-  -source=my-static \
-  -type=api_key \
-  -config=api_key=xoxb-EXAMPLE-STATIC-TOKEN
-```
-
-The spec config becomes the credential data verbatim, so the fields you set must
-match what the chosen `-type` expects — here the `api_key` type reads an `api_key`
-field.
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/oauth2.md
+++ b/site/src/content/docs/credential-drivers/oauth2.md
@@ -8,6 +8,59 @@ The **OAuth2 driver** exchanges OAuth2 credentials for short-lived **bearer toke
 
 The token endpoint and connection options live in the **source** config (`token_url` required). The `client_id` and `client_secret` may live on the source — natural for `client_credentials` — or be supplied per **spec**, resolved spec-over-source. For the `authorization_code` flow, per-user tokens are sealed onto the spec by a one-time interactive consent step, and the driver refreshes them at mint time.
 
+## Credential issued
+
+Always `oauth_bearer_token`. It is **dynamic** when the provider returns an expiry (the credential carries a lease TTL and is re-minted on expiry) and **static** (non-expiring) when it does not. Bearer tokens are not revocable — they expire naturally, so revocation is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — mints a token and, when `verify_url` is set, calls it to confirm the token works before the spec is accepted.
+- **OAuth2 authorization-code consent** — this is the only OAuth2 authorizer. For an `authorization_code` spec, run the one-time interactive `warden cred spec connect <name>`: it opens the provider's authorize URL, captures the returned code on a loopback redirect, exchanges it for tokens, and seals the resulting refresh token (or static access token) onto the spec. Later mints refresh from the sealed grant with no user present.
+
+No source rotation — the source secret is not rotated by the driver.
+
+## Examples
+
+**client_credentials** — machine-to-machine, client credentials on the source:
+
+```bash
+warden cred source create pagerduty \
+  -type=oauth2 \
+  -config=token_url=https://identity.pagerduty.com/oauth/token \
+  -config=client_id=your-client-id \
+  -config=client_secret=your-client-secret \
+  -config=default_scopes="read write" \
+  -config=verify_url=https://api.pagerduty.com/users/me \
+  -rotation-period=0
+
+warden cred spec create pagerduty-readonly \
+  -source=pagerduty \
+  -config=auth_method=client_credentials \
+  -config=scope="read"
+```
+
+**authorization_code** — acting on behalf of a user who consents once. Set `auth_url` on the source and leave the token keys unset; they are sealed onto the spec by the consent step:
+
+```bash
+warden cred source create google-user \
+  -type=oauth2 \
+  -config=token_url=https://oauth2.googleapis.com/token \
+  -config=auth_url=https://accounts.google.com/o/oauth2/v2/auth \
+  -config=client_id=your-client-id \
+  -config=client_secret=your-client-secret \
+  -config=introspection_url=https://openidconnect.googleapis.com/v1/userinfo \
+  -config=metadata_fields=sub,email \
+  -rotation-period=0
+
+warden cred spec create google-calendar \
+  -source=google-user \
+  -config=auth_method=authorization_code \
+  -config=scope="https://www.googleapis.com/auth/calendar.readonly"
+
+# one-time interactive consent seals the refresh token onto the spec
+warden cred spec connect google-calendar
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=oauth2 -config=key=value ...`:
@@ -52,35 +105,6 @@ Keys operators set with `warden cred spec create ... -config=key=value`:
 | `refresh_token_expires_at` | No | — | RFC3339 expiry of a sealed refresh token. |
 
 For `authorization_code`, do not set the token keys by hand — they are populated by the one-time consent flow (see Capabilities). When the provider rotates the refresh token during a refresh, the driver surfaces the new value to the minting layer automatically, so the sealed grant stays current.
-
-## Credential issued
-
-Always `oauth_bearer_token`. It is **dynamic** when the provider returns an expiry (the credential carries a lease TTL and is re-minted on expiry) and **static** (non-expiring) when it does not. Bearer tokens are not revocable — they expire naturally, so revocation is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — mints a token and, when `verify_url` is set, calls it to confirm the token works before the spec is accepted.
-- **OAuth2 authorization-code consent** — this is the only OAuth2 authorizer. For an `authorization_code` spec, run the one-time interactive `warden cred spec connect <name>`: it opens the provider's authorize URL, captures the returned code on a loopback redirect, exchanges it for tokens, and seals the resulting refresh token (or static access token) onto the spec. Later mints refresh from the sealed grant with no user present.
-
-No source rotation — the source secret is not rotated by the driver.
-
-## Example
-
-```bash
-warden cred source create pagerduty \
-  -type=oauth2 \
-  -config=token_url=https://identity.pagerduty.com/oauth/token \
-  -config=client_id=your-client-id \
-  -config=client_secret=your-client-secret \
-  -config=default_scopes="read write" \
-  -config=verify_url=https://api.pagerduty.com/users/me \
-  -rotation-period=0
-
-warden cred spec create pagerduty-readonly \
-  -source=pagerduty \
-  -config=auth_method=client_credentials \
-  -config=scope="read"
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/ovh.md
+++ b/site/src/content/docs/credential-drivers/ovh.md
@@ -8,6 +8,57 @@ The OVHcloud driver mints credentials for **OVHcloud** APIs and Public Cloud ser
 
 The privileged, long-lived secret is an OAuth2 service account — its `client_id` and `client_secret` — held in the **source** config. The source also carries optional default `project_id` and `user_id` for S3 credential management; a **spec** may override these. One source can back many specs that mint different credential shapes from the same service account.
 
+## Credential issued
+
+All methods issue the credential type `ovh_keys`. Credentials are **dynamic**: they carry a lease and TTL derived from the OAuth2 token (~1h). The bearer token expires naturally, while S3 key pairs are **revocable** — Warden deletes them via the cloud API when the lease expires or is revoked. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time: confirms the `mint_method` is supported and, for the S3 methods, that `project_id` and `user_id` resolve from the source or spec.
+
+Mint and revoke otherwise — no source or spec rotation.
+
+## Examples
+
+One source holds the OAuth2 service account; each spec picks a `mint_method`.
+
+```bash
+warden cred source create ovh-prod \
+  -type=ovh \
+  -config=client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -config=client_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=ovh_endpoint=ovh-eu \
+  -config=project_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  -config=user_id=12345 \
+  -rotation-period=0
+```
+
+**OAuth2 bearer token** — a short-lived token for the OVHcloud API:
+
+```bash
+warden cred spec create ovh-api \
+  -source=ovh-prod \
+  -config=mint_method=oauth2_token
+```
+
+**Dynamic S3 credentials** — a revocable access/secret key pair for object storage:
+
+```bash
+warden cred spec create ovh-s3 \
+  -source=ovh-prod \
+  -config=mint_method=dynamic_s3
+```
+
+**Both** — a bearer token and an S3 key pair, overriding the source's project and user:
+
+```bash
+warden cred spec create ovh-combined \
+  -source=ovh-prod \
+  -config=mint_method=oauth2_token_and_s3 \
+  -config=project_id=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy \
+  -config=user_id=67890
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=ovh -config=key=value ...`:
@@ -39,33 +90,6 @@ Spec-config keys set with `warden cred spec create ... -config=key=value`:
 | `mint_method` | Yes | — | One of `oauth2_token`, `dynamic_s3`, `oauth2_token_and_s3`. |
 | `project_id` | For S3 methods | source value | Public Cloud project ID; overrides the source default. Required (on source or spec) for `dynamic_s3` and `oauth2_token_and_s3`. |
 | `user_id` | For S3 methods | source value | Public Cloud user ID; overrides the source default. Required (on source or spec) for `dynamic_s3` and `oauth2_token_and_s3`. |
-
-## Credential issued
-
-All methods issue the credential type `ovh_keys`. Credentials are **dynamic**: they carry a lease and TTL derived from the OAuth2 token (~1h). The bearer token expires naturally, while S3 key pairs are **revocable** — Warden deletes them via the cloud API when the lease expires or is revoked. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates a spec at create/update time: confirms the `mint_method` is supported and, for the S3 methods, that `project_id` and `user_id` resolve from the source or spec.
-
-Mint and revoke otherwise — no source or spec rotation.
-
-## Example
-
-```bash
-warden cred source create ovh-prod \
-  -type=ovh \
-  -config=client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-  -config=client_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-  -config=ovh_endpoint=ovh-eu \
-  -config=project_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-  -config=user_id=12345 \
-  -rotation-period=0
-
-warden cred spec create ovh-s3 \
-  -source=ovh-prod \
-  -config=mint_method=dynamic_s3
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/scaleway.md
+++ b/site/src/content/docs/credential-drivers/scaleway.md
@@ -8,6 +8,52 @@ The Scaleway driver brokers credentials from **Scaleway IAM**. A **source** hold
 
 Operators reach for this driver to give workloads Scaleway API keys without embedding long-lived secrets in the workload. Static keys are convenient when a key pair already exists; dynamic keys let Warden create short-lived keys per lease and revoke them automatically when the lease ends.
 
+## Credential issued
+
+Both mint methods issue credentials of type `scaleway_keys` (an `access_key` / `secret_key` pair).
+
+- `static_keys` credentials are **static** — no lease, no TTL, not revocable by Warden.
+- `dynamic_keys` credentials are **dynamic** — they carry a lease/TTL and are **revocable**: Warden deletes the API key via the IAM API when the lease expires or is revoked.
+
+See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Spec verification** — validates a spec at create/update time. For `static_keys` it confirms the key pair resolves against the IAM API; for `dynamic_keys` it checks that the source has a management key and the spec sets `application_id`.
+- **Source rotation** — **slow**: stages a newly minted management key alongside the old one and waits ~30 seconds (default, tunable via the source's `activation_delay`) so it propagates before the old key is destroyed. Rotates the source's `management_access_key` / `management_secret_key`; requires both to be present.
+
+## Examples
+
+The source carries a management key when dynamic minting or rotation is in play. Each spec then picks a `mint_method`.
+
+```bash
+warden cred source create scw-prod \
+  -type=scaleway \
+  -config=management_access_key=SCWXXXXXXXXXXXXXXXXX \
+  -config=management_secret_key=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+  -rotation-period=720h
+```
+
+**Dynamic keys** — Warden mints a fresh, expiring API key per lease bound to an IAM application, and revokes it on expiry:
+
+```bash
+warden cred spec create scw-app-keys \
+  -source=scw-prod \
+  -config=mint_method=dynamic_keys \
+  -config=application_id=11111111-2222-3333-4444-555555555555 \
+  -config=ttl=1h
+```
+
+**Static keys** — hand back a pre-existing key pair stored on the spec, with no lease or revocation:
+
+```bash
+warden cred spec create scw-legacy \
+  -source=scw-prod \
+  -config=mint_method=static_keys \
+  -config=access_key=SCWYYYYYYYYYYYYYYYYY \
+  -config=secret_key=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=scaleway -config=key=value ...`:
@@ -41,36 +87,6 @@ Spec-config keys (`warden cred spec create ... -config=key=value`):
 | `ttl` | No (dynamic) | `1h` | Lifetime of the minted key; sets its `expires_at`. |
 | `description` | No (dynamic) | `warden-<spec>` | Description recorded on the created key. |
 | `default_project_id` | No (dynamic) | — | Default project scoped to the created key. |
-
-## Credential issued
-
-Both mint methods issue credentials of type `scaleway_keys` (an `access_key` / `secret_key` pair).
-
-- `static_keys` credentials are **static** — no lease, no TTL, not revocable by Warden.
-- `dynamic_keys` credentials are **dynamic** — they carry a lease/TTL and are **revocable**: Warden deletes the API key via the IAM API when the lease expires or is revoked.
-
-See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Spec verification** — validates a spec at create/update time. For `static_keys` it confirms the key pair resolves against the IAM API; for `dynamic_keys` it checks that the source has a management key and the spec sets `application_id`.
-- **Source rotation** — **slow**: stages a newly minted management key alongside the old one and waits ~30 seconds (default, tunable via the source's `activation_delay`) so it propagates before the old key is destroyed. Rotates the source's `management_access_key` / `management_secret_key`; requires both to be present.
-
-## Example
-
-```bash
-warden cred source create scw-prod \
-  -type=scaleway \
-  -config=management_access_key=SCWXXXXXXXXXXXXXXXXX \
-  -config=management_secret_key=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-  -rotation-period=720h
-
-warden cred spec create scw-app-keys \
-  -source=scw-prod \
-  -config=mint_method=dynamic_keys \
-  -config=application_id=11111111-2222-3333-4444-555555555555 \
-  -config=ttl=1h
-```
 
 ## See Also
 

--- a/site/src/content/docs/credential-drivers/vault.md
+++ b/site/src/content/docs/credential-drivers/vault.md
@@ -8,6 +8,98 @@ The `hvault` driver brokers credentials out of **HashiCorp Vault** (or **OpenBao
 
 Reach for it when your secrets already live in Vault: static KV entries, dynamic cloud credentials from the AWS/GCP/IBM engines, OAuth2 bearer tokens from the oauthapp engine, or freshly minted Vault tokens. Warden authenticates once with the source's privileged AppRole, then mints per request against whatever engine the spec points at.
 
+## Credential issued
+
+The credential `type` depends on the mint method: `static_aws`/`dynamic_aws` issue `aws_access_keys`, `static_apikey` issues `api_key`, `dynamic_gcp` issues `gcp_access_token`, `dynamic_ibm` issues `ibmcloud_keys`, `oauth2` issues `oauth_bearer_token`, and `vault_token` issues `vault_token`.
+
+Static KV secrets are **static** — no lease, no TTL, not revocable. Every dynamic method (`dynamic_aws`, `dynamic_gcp`, `dynamic_ibm`, `oauth2`, `vault_token`) is **dynamic** — it carries a lease/TTL and is **revocable**: Vault leases are revoked by lease ID and Vault tokens by accessor. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
+
+## Capabilities
+
+- **Source rotation** — **fast**: prepares and activates in one step (immediately-consistent upstream). Rotates the source's own AppRole `secret_id` by generating a new one, re-authenticating, then destroying the old secret ID by accessor. Requires `auth_method=approle` and `role_name`.
+
+No spec verification. Static KV mints only fetch and revoke.
+
+## Examples
+
+One source holds the standing AppRole identity; each spec below picks a `mint_method`.
+
+```bash
+warden cred source create prod-vault \
+  -type=hvault \
+  -config=vault_address=https://vault.example.com \
+  -config=auth_method=approle \
+  -config=role_id=role-id-uuid \
+  -config=secret_id=secret-id-uuid \
+  -config=approle_mount=approle \
+  -config=role_name=warden-source-role \
+  -rotation-period=720h
+```
+
+**Static KV secret** — fetch a stored value from a KV v2 mount:
+
+```bash
+warden cred spec create static-apikey \
+  -source=prod-vault \
+  -config=mint_method=static_apikey \
+  -config=kv2_mount=secret \
+  -config=secret_path=services/billing/api-key
+```
+
+**Dynamic AWS** — generate temporary AWS access keys from the AWS engine:
+
+```bash
+warden cred spec create prod-aws \
+  -source=prod-vault \
+  -config=mint_method=dynamic_aws \
+  -config=aws_mount=aws \
+  -config=role_name=deploy \
+  -config=ttl=30m
+```
+
+**Dynamic GCP** — mint a GCP access token from a roleset:
+
+```bash
+warden cred spec create prod-gcp \
+  -source=prod-vault \
+  -config=mint_method=dynamic_gcp \
+  -config=gcp_mount=gcp \
+  -config=role_name=viewer \
+  -config=role_type=roleset
+```
+
+**Dynamic IBM** — mint IBM Cloud credentials from the IBM engine:
+
+```bash
+warden cred spec create prod-ibm \
+  -source=prod-vault \
+  -config=mint_method=dynamic_ibm \
+  -config=ibm_mount=ibmcloud \
+  -config=role_name=reader \
+  -config=ttl=1h
+```
+
+**Vault token** — mint a fresh Vault token from a token role:
+
+```bash
+warden cred spec create app-token \
+  -source=prod-vault \
+  -config=mint_method=vault_token \
+  -config=token_role=app \
+  -config=ttl=1h \
+  -config=display_name=app-worker
+```
+
+**OAuth2 bearer** — draw a bearer token from the OAuth2 (oauthapp) engine:
+
+```bash
+warden cred spec create oauth-bearer \
+  -source=prod-vault \
+  -config=mint_method=oauth2 \
+  -config=oauth2_mount=oauth2 \
+  -config=credential_name=github-app
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=hvault -config=key=value ...`:
@@ -61,39 +153,6 @@ Spec-config keys set with `warden cred spec create ... -config=key=value`:
 | `access_key_id` / `secret_access_key` | No | — | Optional COS HMAC keys added to IBM credentials. |
 | `display_name` | No | — | Display name for a minted Vault token. |
 | `meta` | No | — | Metadata for a minted Vault token. |
-
-## Credential issued
-
-The credential `type` depends on the mint method: `static_aws`/`dynamic_aws` issue `aws_access_keys`, `static_apikey` issues `api_key`, `dynamic_gcp` issues `gcp_access_token`, `dynamic_ibm` issues `ibmcloud_keys`, `oauth2` issues `oauth_bearer_token`, and `vault_token` issues `vault_token`.
-
-Static KV secrets are **static** — no lease, no TTL, not revocable. Every dynamic method (`dynamic_aws`, `dynamic_gcp`, `dynamic_ibm`, `oauth2`, `vault_token`) is **dynamic** — it carries a lease/TTL and is **revocable**: Vault leases are revoked by lease ID and Vault tokens by accessor. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation).
-
-## Capabilities
-
-- **Source rotation** — **fast**: prepares and activates in one step (immediately-consistent upstream). Rotates the source's own AppRole `secret_id` by generating a new one, re-authenticating, then destroying the old secret ID by accessor. Requires `auth_method=approle` and `role_name`.
-
-No spec verification. Static KV mints only fetch and revoke.
-
-## Example
-
-```bash
-warden cred source create prod-vault \
-  -type=hvault \
-  -config=vault_address=https://vault.example.com \
-  -config=auth_method=approle \
-  -config=role_id=role-id-uuid \
-  -config=secret_id=secret-id-uuid \
-  -config=approle_mount=approle \
-  -config=role_name=warden-source-role \
-  -rotation-period=720h
-
-warden cred spec create prod-aws \
-  -source=prod-vault \
-  -config=mint_method=dynamic_aws \
-  -config=aws_mount=aws \
-  -config=role_name=deploy \
-  -config=ttl=30m
-```
 
 ## See Also
 


### PR DESCRIPTION
## What

Restructure all 17 credential-driver reference pages to a consistent shape:

```
intro → Credential issued → Capabilities → Examples → Source config → Specs and mint methods → See Also
```

Each page now leads with several runnable examples (one `source create` plus one `spec create` per mint method) and defers the full config tables to the end, so a reader sees *how to use the driver* before the exhaustive key reference.

## Why

The pages previously opened with large config tables, making the common "show me how to set this up" path hard to find. Putting worked examples first — config last — matches how operators actually reach for these docs.

## Coverage

All 17 driver docs: alicloud, apikey, aws, azure, elastic, gcp, github, gitlab, grafana, honeycomb, ibm, kubernetes, local, oauth2, ovh, scaleway, vault.

Examples per page range from 2 (single-mint drivers) to 6 (vault: KV, dynamic AWS/GCP/IBM, vault_token, oauth2).

## Verification

- Heading order identical across all 17 files.
- Every source-config and mint-method table row preserved (`comm` diff against `main`).
- All code fences balanced.
