### PR TITLE
fix(credential): stop serving expired cached credentials

### DIFF
--- a/credential/manager.go
+++ b/credential/manager.go
@@ -171,15 +171,19 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 		cacheKey += ":x:" + inputs.Fingerprint()
 	}
 
-	// Check cache first
-	if cred, found := m.cache.Get(cacheKey); found {
+	// Check cache first. A cached credential that has outlived its lease is
+	// treated as a miss and re-minted: the cache carries no read-time expiry of
+	// its own, and non-revocable credentials (e.g. exchanged bearer tokens) are
+	// not tracked by the expiration manager, so IsExpired is the guard that keeps
+	// a stale token from being served past its lifetime.
+	if cred, found := m.cache.Get(cacheKey); found && !cred.IsExpired() {
 		return cred, nil
 	}
 
 	// Use singleflight to ensure only one creation per cacheKey
 	v, err, _ := m.group.Do(cacheKey, func() (interface{}, error) {
 		// Double-check cache in case another goroutine just added it
-		if cred, found := m.cache.Get(cacheKey); found {
+		if cred, found := m.cache.Get(cacheKey); found && !cred.IsExpired() {
 			return cred, nil
 		}
 
@@ -196,7 +200,19 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 		cred.TokenID = tokenID
 		cred.SpecName = specName
 
-		m.cache.Set(cacheKey, cred, 1)
+		// Cache the credential. Bound a dynamic credential's entry by its remaining
+		// lifetime (capped by the session TTL) so an expired token is actively
+		// evicted rather than lingering; the IsExpired guard on the read path is the
+		// correctness backstop, this keeps memory from accumulating stale entries.
+		if cred.LeaseTTL > 0 {
+			ttl := cred.LeaseTTL
+			if tokenTTL > 0 && tokenTTL < ttl {
+				ttl = tokenTTL
+			}
+			m.cache.SetWithTTL(cacheKey, cred, 1, ttl)
+		} else {
+			m.cache.Set(cacheKey, cred, 1)
+		}
 
 		// Wait for value to be processed (Ristretto is async)
 		m.cache.Wait()

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -392,6 +392,40 @@ func TestManager_IssueCredential_CacheHit(t *testing.T) {
 	assert.Equal(t, int32(1), factory.driver.mintCalls.Load())
 }
 
+func TestManager_IssueCredential_ExpiredNotServed(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+
+	// A short-lived, non-revocable credential (LeaseTTL>0, no leaseID) — the shape
+	// of an exchanged bearer token. It must not be served from cache once its lease
+	// has elapsed; the manager must re-mint.
+	factory.driver.mintFunc = func(ctx context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"username": "u", "password": "p"}, nil, 40 * time.Millisecond, "", nil
+	}
+
+	configStore.AddSource(&CredSource{Name: "test-source", Type: SourceTypeLocal, Config: map[string]string{}})
+	configStore.AddSpec(&CredSpec{Name: "test-spec", Type: TypeVaultToken, Source: "test-source", Config: map[string]string{}})
+
+	ctx := createNamespaceContext()
+	tokenID := "token-expiry"
+	tokenTTL := time.Hour
+
+	_, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), factory.driver.mintCalls.Load())
+
+	// Within the lease: cache hit, no re-mint.
+	_, err = manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), factory.driver.mintCalls.Load(), "should serve from cache before expiry")
+
+	// After the lease elapses: the expired entry is not served — re-mint.
+	time.Sleep(80 * time.Millisecond)
+	_, err = manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), factory.driver.mintCalls.Load(), "expired credential must be re-minted, not served stale")
+}
+
 func TestManager_IssueCredential_SpecNotFound(t *testing.T) {
 	manager, _, _ := createTestManager(t)
 	defer manager.Stop()


### PR DESCRIPTION
## Problem

The credential cache had **no read-time expiry check**, and non-revocable credentials (e.g. OAuth2 `client_credentials` bearer tokens, and the upcoming exchanged bearer tokens) are **not registered with the expiration manager**. Their cache entry was written with `cache.Set(key, cred, 1)` — no TTL — and the hit path returned it without checking `IsExpired()`. Result: a bearer token could be served past its `expires_in`, well after the upstream stopped honoring it.

## Fix

In `credential/manager.go`:

- **Guard the read path** — treat an `IsExpired()` cache entry as a miss and re-mint.
- **Bound dynamic entries with a TTL** — write them via `SetWithTTL(key, cred, 1, min(leaseTTL, tokenTTL))` so ristretto evicts them at expiry instead of holding a stale credential.

This also closes the same latent staleness for the existing OAuth2 `client_credentials` driver.

## Test

`credential/manager_test.go`: a cached credential with a short `expires_in` is not served after it elapses.

## Context

First of the token-exchange stack (plan PR 1). Independent of the driver — no dependency on the other token-exchange branches.
