### PR TITLE
feat(core): support actor_token_source=auth_token in token exchange

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1285,18 +1285,32 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		return nil, fmt.Errorf("spec %q has an unsupported %s", specName, credential.ConfigSubjectTokenSource)
 	}
 
-	if spec.Config[credential.ConfigActorTokenSource] == credential.SourceHeader {
+	switch spec.Config[credential.ConfigActorTokenSource] {
+	case credential.SourceHeader:
 		// The actor token is a delegation credential, distinct from the
-		// X-Warden-On-Behalf-Of attribution label.
+		// X-Warden-On-Behalf-Of attribution label. Caller-supplied, so unverified.
 		tok := req.HTTPRequest.Header.Get(headerActorToken)
 		if tok == "" {
 			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerActorToken)
 		}
 		inputs.ActorToken = tok
+		inputs.ActorTokenOrigin = credential.ExchangeOriginUnverified
 		if inputs.ActorTokenType == "" {
 			inputs.ActorTokenType = credential.TokenTypeJWT
 		}
-	} else {
+	case credential.SourceAuthToken:
+		// The agent's verified inbound JWT acts as the actor (agent-acting-for-user).
+		// Requires JWT auth; spec validation forbids subject_token_source=auth_token
+		// here, so ClientToken is free to serve as the actor.
+		if !strings.HasPrefix(req.ClientToken, "eyJ") {
+			return nil, fmt.Errorf("spec %q requires an inbound JWT actor token but the request was not JWT-authenticated", specName)
+		}
+		inputs.ActorToken = req.ClientToken
+		inputs.ActorTokenOrigin = credential.ExchangeOriginVerified
+		if inputs.ActorTokenType == "" {
+			inputs.ActorTokenType = credential.TokenTypeJWT
+		}
+	default:
 		// No actor requested: drop any default type so Validate's pairing holds.
 		inputs.ActorTokenType = ""
 	}

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2358,6 +2358,40 @@ func TestResolveExchangeInputs_ActorHeader(t *testing.T) {
 	assert.Equal(t, "eyJ.subject", inputs.SubjectToken)
 	assert.Equal(t, "eyJ.actor", inputs.ActorToken)
 	assert.Equal(t, credential.TokenTypeJWT, inputs.ActorTokenType)
+	assert.Equal(t, credential.ExchangeOriginUnverified, inputs.ActorTokenOrigin)
+}
+
+func TestResolveExchangeInputs_ActorAuthToken(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	// subject via header (a user token), actor via the agent's verified inbound JWT.
+	seedSpec(t, c, ctx, "deleg-auth", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigActorTokenSource:   credential.SourceAuthToken,
+	})
+
+	req := requestWith("eyJ.agent-jwt", map[string]string{headerSubjectToken: "eyJ.user"})
+	inputs, err := c.resolveExchangeInputs(ctx, req, "deleg-auth")
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	assert.Equal(t, "eyJ.user", inputs.SubjectToken)
+	assert.Equal(t, credential.ExchangeOriginUnverified, inputs.SubjectTokenOrigin)
+	assert.Equal(t, "eyJ.agent-jwt", inputs.ActorToken, "the agent's inbound JWT is reused as the actor")
+	assert.Equal(t, credential.ExchangeOriginVerified, inputs.ActorTokenOrigin)
+	assert.Equal(t, credential.TokenTypeJWT, inputs.ActorTokenType)
+}
+
+func TestResolveExchangeInputs_ActorAuthToken_OpaqueFailsClosed(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "deleg-auth", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigActorTokenSource:   credential.SourceAuthToken,
+	})
+
+	// Non-JWT (opaque) inbound token cannot serve as the actor.
+	req := requestWith("s.opaque-session", map[string]string{headerSubjectToken: "eyJ.user"})
+	_, err := c.resolveExchangeInputs(ctx, req, "deleg-auth")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not JWT-authenticated")
 }
 
 func TestResolveExchangeInputs_ActorHeader_MissingFailsClosed(t *testing.T) {

--- a/credential/exchange.go
+++ b/credential/exchange.go
@@ -82,6 +82,12 @@ type ExchangeInputs struct {
 	// SubjectTokenOrigin is one of ExchangeOriginVerified or
 	// ExchangeOriginUnverified.
 	SubjectTokenOrigin string
+	// ActorTokenOrigin records how the actor token was obtained, mirroring
+	// SubjectTokenOrigin: ExchangeOriginVerified when it is the caller's inbound
+	// JWT (actor_token_source=auth_token), ExchangeOriginUnverified when supplied
+	// on a header. Empty when no actor token is present. A driver consuming an
+	// unverified actor must validate it before forwarding, exactly as for a subject.
+	ActorTokenOrigin string
 }
 
 // Validate performs structural checks only. It does not verify token contents
@@ -111,6 +117,16 @@ func (e *ExchangeInputs) Validate() error {
 	if len(e.ActorToken) > maxExchangeTokenBytes {
 		return fmt.Errorf("actor_token exceeds %d bytes", maxExchangeTokenBytes)
 	}
+	if e.ActorToken == "" && e.ActorTokenOrigin != "" {
+		return fmt.Errorf("actor_token_origin set without actor_token")
+	}
+	if e.ActorTokenOrigin != "" {
+		switch e.ActorTokenOrigin {
+		case ExchangeOriginVerified, ExchangeOriginUnverified:
+		default:
+			return fmt.Errorf("invalid actor_token_origin %q", e.ActorTokenOrigin)
+		}
+	}
 	switch e.SubjectTokenOrigin {
 	case ExchangeOriginVerified, ExchangeOriginUnverified:
 	default:
@@ -138,6 +154,7 @@ func (e *ExchangeInputs) Fingerprint() string {
 	writeField(e.ActorTokenType)
 	writeField(e.ActorToken)
 	writeField(e.SubjectTokenOrigin)
+	writeField(e.ActorTokenOrigin)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
@@ -155,7 +172,7 @@ func SpecRequestsExchange(config map[string]string) bool {
 func ValidateExchangeSpecConfig(config map[string]string) error {
 	if err := ValidateSchema(config,
 		StringField(ConfigSubjectTokenSource).OneOf(SourceAuthToken, SourceHeader, SourceNone),
-		StringField(ConfigActorTokenSource).OneOf(SourceHeader, SourceNone),
+		StringField(ConfigActorTokenSource).OneOf(SourceAuthToken, SourceHeader, SourceNone),
 	); err != nil {
 		return err
 	}
@@ -164,6 +181,11 @@ func ValidateExchangeSpecConfig(config map[string]string) error {
 	actorSrc := config[ConfigActorTokenSource]
 	if actorSrc != "" && actorSrc != SourceNone && !SpecRequestsExchange(config) {
 		return fmt.Errorf("field '%s': requires '%s' to be set", ConfigActorTokenSource, ConfigSubjectTokenSource)
+	}
+	// A single inbound token cannot be both the subject and the actor.
+	if config[ConfigSubjectTokenSource] == SourceAuthToken && actorSrc == SourceAuthToken {
+		return fmt.Errorf("field '%s': cannot be '%s' when '%s' is also '%s' (one inbound token cannot be both subject and actor)",
+			ConfigActorTokenSource, SourceAuthToken, ConfigSubjectTokenSource, SourceAuthToken)
 	}
 	return nil
 }

--- a/credential/exchange_test.go
+++ b/credential/exchange_test.go
@@ -190,6 +190,15 @@ func TestValidateExchangeSpecConfig(t *testing.T) {
 			config:  map[string]string{ConfigActorTokenSource: SourceHeader},
 			wantErr: true,
 		},
+		{
+			name:   "subject header + actor auth_token",
+			config: map[string]string{ConfigSubjectTokenSource: SourceHeader, ConfigActorTokenSource: SourceAuthToken},
+		},
+		{
+			name:    "subject and actor both auth_token (mutually exclusive)",
+			config:  map[string]string{ConfigSubjectTokenSource: SourceAuthToken, ConfigActorTokenSource: SourceAuthToken},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Foundation extension: let the agent's **verified inbound JWT** serve as the RFC 8693 `actor_token` (the natural "agent-acting-for-user" delegation) without re-sending it as a header.

- `credential/exchange.go` — add `ActorTokenOrigin` to `ExchangeInputs` so a driver can tell a verified actor from an unverified one; add `auth_token` to the `actor_token_source` allowlist; reject `subject_token_source=auth_token` **and** `actor_token_source=auth_token` together (one inbound token can't be both subject and actor).
- `core/request_handler.go` — in `resolveExchangeInputs`, add the actor `auth_token` branch, reusing the same verified inbound JWT already read for the subject (origin = `verified`).

## Why

Without this, delegation where the agent is the actor forces the agent to send its own token twice — once to authenticate, once in `X-Warden-Actor-Token` — and re-validate it. Reusing the verified inbound identity removes the double-send and the redundant validation.

## Test

- `credential/exchange_test.go` — mutual-exclusion rule (subject+actor both `auth_token` rejected).
- `core/request_handler_test.go` — `actor_token_source=auth_token` resolves the inbound JWT as a verified actor.

## Context

Plan PR 9 of the token-exchange stack — a small change to the landed foundation. No dependency on the driver; can land any time. The actor-delegation PR (PR 7) consumes the `auth_token` actor variant.
