### PR TITLE
feat(credential): add token_exchange driver (verified-origin OBO)

### DIFF
--- a/credential/drivers/builtin.go
+++ b/credential/drivers/builtin.go
@@ -89,5 +89,10 @@ func RegisterBuiltinDrivers(registry *credential.DriverRegistry) error {
 		return err
 	}
 
+	// Register token-exchange driver factory (RFC 8693 / RFC 7523 / Entra OBO)
+	if err := registry.RegisterFactory(&TokenExchangeDriverFactory{}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -448,7 +448,7 @@ func (d *OAuth2Driver) BuildAuthorizeURL(spec *credential.CredSpec, redirectURI,
 // It delegates to the package-level postOAuthTokenForm, which is shared with the
 // token_exchange driver.
 func (d *OAuth2Driver) postTokenRequest(ctx context.Context, tokenURL string, form url.Values) (*oauth2TokenResponse, error) {
-	return postOAuthTokenForm(ctx, d.httpClient, tokenURL, form)
+	return postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, nil)
 }
 
 // tokenEndpointError is returned by postTokenRequest when the token endpoint

--- a/credential/drivers/oauth_token.go
+++ b/credential/drivers/oauth_token.go
@@ -20,7 +20,7 @@ import (
 // This is the shared token-endpoint POST used by both the OAuth2 driver and the
 // token_exchange driver, so grant assembly stays per-driver while the transport,
 // retry, and error-classification behaviour is defined once.
-func postOAuthTokenForm(ctx context.Context, httpClient *http.Client, tokenURL string, form url.Values) (*oauth2TokenResponse, error) {
+func postOAuthTokenForm(ctx context.Context, httpClient *http.Client, tokenURL string, form url.Values, extraHeaders map[string]string) (*oauth2TokenResponse, error) {
 	retryConfig := httputil.HTTPRetryConfig{
 		MaxAttempts:       oauth2MaxRetryAttempts,
 		MaxBodySize:       httputil.DefaultMaxBodySize,
@@ -28,14 +28,24 @@ func postOAuthTokenForm(ctx context.Context, httpClient *http.Client, tokenURL s
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+		"Accept":       "application/json",
+	}
+	// Extra headers carry client authentication that lives outside the form body
+	// (e.g. client_secret_basic's Authorization header). They cannot override the
+	// content negotiation above.
+	for k, v := range extraHeaders {
+		if k == "Content-Type" || k == "Accept" {
+			continue
+		}
+		headers[k] = v
+	}
 	httpReq := httputil.HTTPRequest{
-		Method: http.MethodPost,
-		URL:    tokenURL,
-		Body:   []byte(form.Encode()),
-		Headers: map[string]string{
-			"Content-Type": "application/x-www-form-urlencoded",
-			"Accept":       "application/json",
-		},
+		Method:  http.MethodPost,
+		URL:     tokenURL,
+		Body:    []byte(form.Encode()),
+		Headers: headers,
 		// RFC 6749 §5.2 returns the error body on HTTP 400 (and 401 for
 		// invalid_client). Treat those as readable so the error code can be
 		// parsed and classified, rather than discarded as a transport error.

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -1,0 +1,321 @@
+package drivers
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
+	"github.com/stephnangue/warden/logger"
+)
+
+// Exchange grants selected by the source's `grant` config.
+const (
+	tokenExchangeGrantRFC8693   = "rfc8693"
+	tokenExchangeGrantJWTBearer = "jwt_bearer"
+)
+
+// Client-authentication methods selected by the source's `client_auth` config.
+// private_key_jwt is added in a later change; the secret methods ship here.
+const (
+	clientAuthSecretBasic = "client_secret_basic"
+	clientAuthSecretPost  = "client_secret_post"
+)
+
+// grant_type URNs sent in the token request.
+const (
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	grantTypeJWTBearer     = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+)
+
+// Compile-time interface assertions.
+var _ credential.SourceDriver = (*TokenExchangeDriver)(nil)
+var _ credential.ExchangeMinter = (*TokenExchangeDriver)(nil)
+
+// TokenExchangeDriver exchanges a caller-derived identity (a subject token, and
+// optionally an actor token) for a scoped downstream bearer at an RFC 8693 / RFC
+// 7523 token endpoint. It is exchange-only: it never mints from static source
+// config, so plain MintCredential is a defensive error and all issuance flows
+// through MintCredentialWithExchange.
+type TokenExchangeDriver struct {
+	credSource *credential.CredSource
+	logger     *logger.GatedLogger
+	httpClient *http.Client
+}
+
+// TokenExchangeDriverFactory creates TokenExchangeDriver instances.
+type TokenExchangeDriverFactory struct{}
+
+// Type returns the driver type identifier.
+func (f *TokenExchangeDriverFactory) Type() string {
+	return credential.SourceTypeTokenExchange
+}
+
+// ValidateConfig validates source configuration. VerifySpec never runs for
+// exchange specs, so the factory is the place strict validation lives.
+func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) error {
+	skip := credential.GetBool(config, "tls_skip_verify", false)
+	if err := credential.ValidateSchema(config,
+		credential.StringField("token_url").
+			Required().
+			Custom(func(v string) error { return validateOAuth2SafeURL(v, "token_url", skip) }).
+			Describe("Token endpoint (HTTPS) of the STS/IdP performing the exchange").
+			Example("https://idp.example.com/oauth2/v1/token"),
+
+		credential.StringField("grant").
+			OneOf(tokenExchangeGrantRFC8693, tokenExchangeGrantJWTBearer).
+			Describe("Exchange grant: rfc8693 (token-exchange) or jwt_bearer (assertion; Entra OBO)").
+			Example("rfc8693"),
+
+		credential.StringField("client_auth").
+			OneOf(clientAuthSecretBasic, clientAuthSecretPost).
+			Describe("How Warden authenticates to the token endpoint").
+			Example("client_secret_post"),
+
+		credential.StringField("client_id").
+			Describe("OAuth2 client ID Warden presents to the token endpoint").
+			Example("warden-gateway"),
+
+		credential.StringField("client_secret").
+			Describe("OAuth2 client secret (masked on read)").
+			Example("****"),
+
+		credential.StringField("ca_data").
+			Custom(ValidateCAData).
+			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs").
+			Example("LS0tLS1CRUdJTi..."),
+
+		credential.BoolField("tls_skip_verify").
+			Describe("Skip TLS certificate verification (development only)").
+			Example("false"),
+	); err != nil {
+		return err
+	}
+
+	// The secret-based client-auth methods require client credentials.
+	switch credential.GetString(config, "client_auth", clientAuthSecretPost) {
+	case clientAuthSecretBasic, clientAuthSecretPost, "":
+		if credential.GetString(config, "client_id", "") == "" || credential.GetString(config, "client_secret", "") == "" {
+			return fmt.Errorf("client_id and client_secret are required for a secret-based client_auth")
+		}
+	}
+
+	// token_param.* must not override core token-exchange form fields.
+	protected := map[string]bool{
+		"grant_type": true, "client_id": true, "client_secret": true,
+		"client_assertion": true, "client_assertion_type": true,
+		"subject_token": true, "subject_token_type": true,
+		"actor_token": true, "actor_token_type": true, "assertion": true,
+	}
+	for key := range credential.GetPrefixed(config, "token_param.") {
+		if protected[key] {
+			return fmt.Errorf("token_param.%s cannot override a core token-exchange field", key)
+		}
+	}
+	return nil
+}
+
+// SensitiveConfigFields returns source config keys that should be masked.
+func (f *TokenExchangeDriverFactory) SensitiveConfigFields() []string {
+	return []string{"client_secret", "ca_data"}
+}
+
+// InferCredentialType returns the credential type for token_exchange sources.
+func (f *TokenExchangeDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeOAuthBearerToken, nil
+}
+
+// Create instantiates a new TokenExchangeDriver.
+func (f *TokenExchangeDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	client, err := BuildHTTPClient(config, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+	}
+	return &TokenExchangeDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeTokenExchange, Config: config},
+		logger:     log.WithSubsystem(credential.SourceTypeTokenExchange),
+		httpClient: client,
+	}, nil
+}
+
+// Type returns the driver type.
+func (d *TokenExchangeDriver) Type() string {
+	return credential.SourceTypeTokenExchange
+}
+
+// MintCredential is a defensive error: this driver is exchange-only. Reaching it
+// means a spec without a subject source slipped past validation; never forward
+// without caller identity.
+func (d *TokenExchangeDriver) MintCredential(_ context.Context, _ *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", fmt.Errorf("token_exchange requires caller exchange inputs; set %s=%s|%s on the spec",
+		credential.ConfigSubjectTokenSource, credential.SourceAuthToken, credential.SourceHeader)
+}
+
+// MintCredentialWithExchange exchanges the caller-derived subject for a scoped
+// downstream bearer token.
+func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("token_exchange: no subject token in exchange inputs")
+	}
+
+	// Origin contract. An unverified (caller-supplied header) subject must be
+	// validated before it is forwarded to the STS; that validation is added in a
+	// follow-up change, so fail closed here rather than forwarding an unvalidated
+	// caller token.
+	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
+		return nil, nil, 0, "", fmt.Errorf("token_exchange: unverified subject tokens (subject_token_source=header) are not yet supported by this source")
+	}
+	// Actor delegation is added in a follow-up change; reject rather than silently
+	// dropping the actor a caller supplied.
+	if inputs.ActorToken != "" {
+		return nil, nil, 0, "", fmt.Errorf("token_exchange: actor tokens are not yet supported by this source")
+	}
+
+	form, err := d.buildExchangeForm(spec, inputs)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	headers := map[string]string{}
+	if err := d.applyClientAuth(form, headers); err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
+	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
+	if err != nil {
+		return nil, nil, 0, "", classifyExchangeError(err)
+	}
+	if resp.AccessToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("token_exchange: token response missing access_token")
+	}
+
+	return accessTokenRawData(resp), d.subjectMetadata(resp, inputs), ttlFromExpiresIn(resp.ExpiresIn), "", nil
+}
+
+// buildExchangeForm assembles the token-endpoint form for the configured grant.
+func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, inputs *credential.ExchangeInputs) (url.Values, error) {
+	cfg := d.credSource.Config
+	form := url.Values{}
+
+	switch credential.GetString(cfg, "grant", tokenExchangeGrantRFC8693) {
+	case tokenExchangeGrantRFC8693, "":
+		form.Set("grant_type", grantTypeTokenExchange)
+		form.Set("subject_token", inputs.SubjectToken)
+		form.Set("subject_token_type", subjectTokenType(inputs))
+		if aud := d.resolve(spec, "audience"); aud != "" {
+			form.Set("audience", aud)
+		}
+		if res := d.resolve(spec, "resource"); res != "" {
+			form.Set("resource", res)
+		}
+	case tokenExchangeGrantJWTBearer:
+		form.Set("grant_type", grantTypeJWTBearer)
+		form.Set("assertion", inputs.SubjectToken)
+	default:
+		return nil, fmt.Errorf("token_exchange: unsupported grant %q", credential.GetString(cfg, "grant", ""))
+	}
+
+	if scope := d.resolve(spec, "scope"); scope != "" {
+		form.Set("scope", scope)
+	}
+	// Vendor-specific extras (e.g. Entra's requested_token_use=on_behalf_of).
+	for k, v := range credential.GetPrefixed(cfg, "token_param.") {
+		form.Set(k, v)
+	}
+	return form, nil
+}
+
+// applyClientAuth decorates the request with the configured client authentication.
+func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string) error {
+	cfg := d.credSource.Config
+	clientID := credential.GetString(cfg, "client_id", "")
+	clientSecret := credential.GetString(cfg, "client_secret", "")
+
+	switch credential.GetString(cfg, "client_auth", clientAuthSecretPost) {
+	case clientAuthSecretPost, "":
+		form.Set("client_id", clientID)
+		form.Set("client_secret", clientSecret)
+	case clientAuthSecretBasic:
+		// RFC 6749 §2.3.1: client id/secret are form-urlencoded, then Basic-encoded.
+		creds := url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)
+		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))
+	default:
+		return fmt.Errorf("token_exchange: unsupported client_auth %q", credential.GetString(cfg, "client_auth", ""))
+	}
+	return nil
+}
+
+// resolve returns spec.Config[key] when set, else the source config value.
+func (d *TokenExchangeDriver) resolve(spec *credential.CredSpec, key string) string {
+	if spec != nil {
+		if v := credential.GetString(spec.Config, key, ""); v != "" {
+			return v
+		}
+	}
+	return credential.GetString(d.credSource.Config, key, "")
+}
+
+// subjectMetadata derives the non-secret, audit-logged identity of the exchanged
+// token: the subject (from the minted token's sub claim, falling back to the
+// subject token's), and whether the subject's origin was verified.
+func (d *TokenExchangeDriver) subjectMetadata(resp *oauth2TokenResponse, inputs *credential.ExchangeInputs) map[string]interface{} {
+	meta := map[string]interface{}{
+		"subject_verified": strconv.FormatBool(inputs.SubjectTokenOrigin == credential.ExchangeOriginVerified),
+	}
+	claims := unverifiedJWTClaims(resp.AccessToken)
+	if claims == nil {
+		claims = unverifiedJWTClaims(inputs.SubjectToken)
+	}
+	if claims != nil {
+		if sub, ok := scalarClaim(claims["sub"]); ok && sub != "" {
+			meta["subject"] = sub
+		}
+	}
+	return meta
+}
+
+// Revoke is a no-op — exchanged bearer tokens expire naturally.
+func (d *TokenExchangeDriver) Revoke(_ context.Context, _ string) error {
+	return nil
+}
+
+// Cleanup releases resources.
+func (d *TokenExchangeDriver) Cleanup(_ context.Context) error {
+	d.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// subjectTokenType returns the RFC 8693 subject_token_type, defaulting to jwt.
+func subjectTokenType(inputs *credential.ExchangeInputs) string {
+	if inputs.SubjectTokenType != "" {
+		return inputs.SubjectTokenType
+	}
+	return credential.TokenTypeJWT
+}
+
+// unverifiedJWTClaims decodes a JWT's claims without verifying its signature,
+// for identity extraction only. Returns nil for opaque (non-JWT) tokens.
+func unverifiedJWTClaims(token string) map[string]interface{} {
+	claims, err := helper.ParseJWTClaimsUnverified(token)
+	if err != nil {
+		return nil
+	}
+	return claims
+}
+
+// classifyExchangeError renders a token-endpoint failure into a legible error,
+// distinguishing a rejected grant (the caller should re-authenticate) from a
+// transport/server failure.
+func classifyExchangeError(err error) error {
+	var tee *tokenEndpointError
+	if errors.As(err, &tee) && (tee.code == "invalid_grant" || tee.status == http.StatusBadRequest || tee.status == http.StatusUnauthorized) {
+		return fmt.Errorf("token_exchange rejected by the IdP (the subject token may be expired or unacceptable; re-authenticate): %w", err)
+	}
+	return fmt.Errorf("token_exchange failed: %w", err)
+}

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -1,0 +1,218 @@
+package drivers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeUnsignedJWT builds a JWT whose (unverified) payload carries the given
+// claims. Signature verification is out of scope here — the driver only decodes
+// the subject/minted token to extract audit metadata.
+func makeUnsignedJWT(claims map[string]interface{}) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + "."
+}
+
+func newExchangeDriver(config map[string]string, client *http.Client) *TokenExchangeDriver {
+	return &TokenExchangeDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeTokenExchange, Config: config},
+		httpClient: client,
+	}
+}
+
+func verifiedSubject(jwt string) *credential.ExchangeInputs {
+	return &credential.ExchangeInputs{
+		SubjectToken:       jwt,
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginVerified,
+	}
+}
+
+func TestTokenExchangeDriver_RFC8693_Verified(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user-123"})
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", r.Form.Get("grant_type"))
+		assert.Equal(t, subject, r.Form.Get("subject_token"))
+		assert.Equal(t, credential.TokenTypeJWT, r.Form.Get("subject_token_type"))
+		assert.Equal(t, "https://api.internal.example.com", r.Form.Get("audience"))
+		assert.Equal(t, "read:orders", r.Form.Get("scope"))
+		assert.Equal(t, "warden-gateway", r.Form.Get("client_id"))
+		assert.Equal(t, "s3cret", r.Form.Get("client_secret"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "downstream-token", "token_type": "Bearer", "expires_in": 1800,
+		})
+	}))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":     server.URL,
+		"grant":         tokenExchangeGrantRFC8693,
+		"client_auth":   clientAuthSecretPost,
+		"client_id":     "warden-gateway",
+		"client_secret": "s3cret",
+	}, server.Client())
+	spec := &credential.CredSpec{Name: "internal-api", Config: map[string]string{
+		"audience": "https://api.internal.example.com",
+		"scope":    "read:orders",
+	}}
+
+	rawData, meta, ttl, leaseID, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(subject))
+	require.NoError(t, err)
+	assert.Equal(t, "downstream-token", rawData["api_key"])
+	assert.Equal(t, 1800*time.Second, ttl)
+	assert.Empty(t, leaseID)
+	assert.Equal(t, "user-123", meta["subject"])
+	assert.Equal(t, "true", meta["subject_verified"])
+}
+
+func TestTokenExchangeDriver_JWTBearer_Entra(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user-9"})
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", r.Form.Get("grant_type"))
+		assert.Equal(t, subject, r.Form.Get("assertion"))
+		assert.Equal(t, "on_behalf_of", r.Form.Get("requested_token_use"))
+		assert.Equal(t, "https://graph.microsoft.com/.default", r.Form.Get("scope"))
+		assert.Empty(t, r.Form.Get("subject_token"), "jwt_bearer must not send subject_token")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "graph-token", "expires_in": 3600})
+	}))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":                       server.URL,
+		"grant":                           tokenExchangeGrantJWTBearer,
+		"client_auth":                     clientAuthSecretPost,
+		"client_id":                       "cid",
+		"client_secret":                   "cs",
+		"token_param.requested_token_use": "on_behalf_of",
+	}, server.Client())
+	spec := &credential.CredSpec{Config: map[string]string{"scope": "https://graph.microsoft.com/.default"}}
+
+	rawData, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(subject))
+	require.NoError(t, err)
+	assert.Equal(t, "graph-token", rawData["api_key"])
+}
+
+func TestTokenExchangeDriver_ClientSecretBasic(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		wantCreds := base64.StdEncoding.EncodeToString([]byte("cid:cs"))
+		assert.Equal(t, "Basic "+wantCreds, r.Header.Get("Authorization"))
+		assert.Empty(t, r.Form.Get("client_secret"), "basic auth must not put the secret in the body")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":     server.URL,
+		"client_auth":   clientAuthSecretBasic,
+		"client_id":     "cid",
+		"client_secret": "cs",
+	}, server.Client())
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, verifiedSubject(subject))
+	require.NoError(t, err)
+}
+
+func TestTokenExchangeDriver_MintCredential_DefensiveError(t *testing.T) {
+	d := newExchangeDriver(map[string]string{"token_url": "https://idp.example.com"}, http.DefaultClient)
+	_, _, _, _, err := d.MintCredential(context.Background(), &credential.CredSpec{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires caller exchange inputs")
+}
+
+func TestTokenExchangeDriver_UnverifiedRejected_NoCall(t *testing.T) {
+	called := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": server.URL, "client_id": "c", "client_secret": "s",
+	}, server.Client())
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       makeUnsignedJWT(map[string]interface{}{"sub": "u"}),
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginUnverified,
+	}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unverified subject")
+	assert.False(t, called, "the STS must not be called for an unverified subject")
+}
+
+func TestTokenExchangeDriver_ActorRejected(t *testing.T) {
+	d := newExchangeDriver(map[string]string{
+		"token_url": "https://idp.example.com", "client_id": "c", "client_secret": "s",
+	}, http.DefaultClient)
+	inputs := verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"}))
+	inputs.ActorToken = makeUnsignedJWT(map[string]interface{}{"sub": "agent"})
+	inputs.ActorTokenType = credential.TokenTypeJWT
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor tokens are not yet supported")
+}
+
+func TestTokenExchangeDriverFactory_ValidateConfig(t *testing.T) {
+	f := &TokenExchangeDriverFactory{}
+	base := func() map[string]string {
+		return map[string]string{
+			"token_url": "https://idp.example.com/token", "client_id": "c", "client_secret": "s",
+		}
+	}
+
+	require.NoError(t, f.ValidateConfig(base()))
+
+	t.Run("missing token_url", func(t *testing.T) {
+		c := base()
+		delete(c, "token_url")
+		assert.Error(t, f.ValidateConfig(c))
+	})
+	t.Run("missing client credentials", func(t *testing.T) {
+		c := base()
+		delete(c, "client_secret")
+		assert.Error(t, f.ValidateConfig(c))
+	})
+	t.Run("bad grant", func(t *testing.T) {
+		c := base()
+		c["grant"] = "nope"
+		assert.Error(t, f.ValidateConfig(c))
+	})
+	t.Run("token_param overriding a core field", func(t *testing.T) {
+		c := base()
+		c["token_param.subject_token"] = "x"
+		assert.Error(t, f.ValidateConfig(c))
+	})
+	t.Run("non-https token_url", func(t *testing.T) {
+		c := base()
+		c["token_url"] = "http://idp.example.com/token"
+		assert.Error(t, f.ValidateConfig(c))
+	})
+}
+
+func TestTokenExchangeDriverFactory_Basics(t *testing.T) {
+	f := &TokenExchangeDriverFactory{}
+	assert.Equal(t, credential.SourceTypeTokenExchange, f.Type())
+	ct, err := f.InferCredentialType(nil)
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeOAuthBearerToken, ct)
+	assert.ElementsMatch(t, []string{"client_secret", "ca_data"}, f.SensitiveConfigFields())
+}


### PR DESCRIPTION
## What

The `token_exchange` credential driver (MVP: verified-origin OBO). Exchanges a **caller identity** at an IdP token endpoint for a scoped downstream bearer token — keeping secrets out of the agent while preserving user identity across the hop (RFC 8693 / RFC 7523 jwt-bearer / Entra OBO).

- New `credential/drivers/token_exchange_driver.go` — `TokenExchangeDriver` implementing `SourceDriver` + `ExchangeMinter`.
  - `MintCredential` is a defensive error (the driver is exchange-only; a plain mint means no caller inputs were resolved).
  - `MintCredentialWithExchange` runs the OBO path for `subject_token_source=auth_token` (verified origin — the inbound JWT is forwarded as-is).
  - Grants: `rfc8693` and `jwt_bearer` (Entra OBO via `token_param.requested_token_use=on_behalf_of`).
  - Client auth: `client_secret_basic` / `client_secret_post` behind a pinned `applyClientAuth` seam.
  - Populates `subject` / `subject_verified` metadata for audit.
- `credential/drivers/builtin.go` — register the factory.
- `credential/drivers/oauth_token.go` / `oauth2_driver.go` — extend `postOAuthTokenForm` with an `extraHeaders` param so client auth can add an `Authorization` header outside the form body; OAuth2 passes `nil` (no behavior change).

Header/unverified subject specs fail closed here — they're unlocked in PR 5.

## Test

`credential/drivers/token_exchange_driver_test.go` drives `MintCredentialWithExchange` against an `httptest` IdP, asserting exact form fields for `rfc8693` and `jwt_bearer`, the Entra `requested_token_use` passthrough, and client-auth placement.

## Context

Plan PR 4 — Group B, the driver. Rebased onto `main` now that PR 2 (#415) and PR 3 (#416) have merged, so this diff is driver-only. Subsequent stack: PR 5 (unverified subject) → PR 6 (private_key_jwt) → PR 7 (actor delegation) → PR 8 (ID-JAG).
