### PR TITLE
feat(credential): validate header-sourced subject tokens in token_exchange

### DIFF
--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -8,12 +8,18 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
+	"github.com/hashicorp/cap/jwt"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/helper"
 	"github.com/stephnangue/warden/logger"
 )
+
+// subjectSigningAlgs are the JWT signing algorithms accepted when validating an
+// unverified (header-sourced) subject or actor token.
+var subjectSigningAlgs = []jwt.Alg{jwt.RS256, jwt.RS384, jwt.RS512, jwt.ES256, jwt.ES384, jwt.ES512}
 
 // Exchange grants selected by the source's `grant` config.
 const (
@@ -47,6 +53,13 @@ type TokenExchangeDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
 	httpClient *http.Client
+
+	// subjectValidator validates unverified (header-sourced) subject/actor tokens
+	// against the source's configured JWKS/OIDC keys. It is built lazily on first
+	// use (it performs network I/O) and reused; cap/jwt validators are safe for
+	// concurrent use.
+	validatorMu      sync.Mutex
+	subjectValidator *jwt.Validator
 }
 
 // TokenExchangeDriverFactory creates TokenExchangeDriver instances.
@@ -90,6 +103,34 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Custom(ValidateCAData).
 			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs").
 			Example("LS0tLS1CRUdJTi..."),
+
+		// Subject-validation keys: required at mint time to accept an unverified
+		// (subject_token_source=header) subject/actor token. Validated here for
+		// well-formedness; enforced as fail-closed in the driver.
+		credential.StringField("subject_oidc_discovery_url").
+			Custom(func(v string) error {
+				if v == "" {
+					return nil
+				}
+				return validateOAuth2SafeURL(v, "subject_oidc_discovery_url", skip)
+			}).
+			Describe("OIDC discovery URL of the issuer that signs header-sourced subject/actor tokens").
+			Example("https://login.example.com/.well-known/openid-configuration"),
+		credential.StringField("subject_jwks_url").
+			Custom(func(v string) error {
+				if v == "" {
+					return nil
+				}
+				return validateOAuth2SafeURL(v, "subject_jwks_url", skip)
+			}).
+			Describe("JWKS URL for header-sourced subject/actor token signature validation").
+			Example("https://login.example.com/keys"),
+		credential.StringField("subject_issuer").
+			Describe("Expected issuer (iss) of a header-sourced subject/actor token").
+			Example("https://login.example.com/"),
+		credential.StringField("subject_audience").
+			Describe("Expected audience (aud) of a header-sourced subject/actor token").
+			Example("api://warden"),
 
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
@@ -164,12 +205,14 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 		return nil, nil, 0, "", fmt.Errorf("token_exchange: no subject token in exchange inputs")
 	}
 
-	// Origin contract. An unverified (caller-supplied header) subject must be
-	// validated before it is forwarded to the STS; that validation is added in a
-	// follow-up change, so fail closed here rather than forwarding an unvalidated
-	// caller token.
+	// Origin contract. A verified subject (Warden authenticated it inbound) is
+	// forwarded as-is. An unverified (caller-supplied header) subject MUST be
+	// validated — signature, issuer, audience, expiry — before it is forwarded to
+	// the STS, and the mint fails closed if the source lacks validation config.
 	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
-		return nil, nil, 0, "", fmt.Errorf("token_exchange: unverified subject tokens (subject_token_source=header) are not yet supported by this source")
+		if err := d.validateUntrustedToken(ctx, inputs.SubjectToken, "subject"); err != nil {
+			return nil, nil, 0, "", err
+		}
 	}
 	// Actor delegation is added in a follow-up change; reject rather than silently
 	// dropping the actor a caller supplied.
@@ -289,6 +332,71 @@ func (d *TokenExchangeDriver) Revoke(_ context.Context, _ string) error {
 func (d *TokenExchangeDriver) Cleanup(_ context.Context) error {
 	d.httpClient.CloseIdleConnections()
 	return nil
+}
+
+// validateUntrustedToken verifies a caller-supplied (header-sourced) token
+// against the source's configured issuer, audience and signing keys before it is
+// forwarded to the STS. It fails closed when the source lacks validation config:
+// an unvalidated caller token must never reach the token endpoint on Warden's
+// authority. `role` is "subject" or "actor" for error messages.
+func (d *TokenExchangeDriver) validateUntrustedToken(ctx context.Context, token, role string) error {
+	cfg := d.credSource.Config
+	issuer := credential.GetString(cfg, "subject_issuer", "")
+	audience := credential.GetString(cfg, "subject_audience", "")
+	if issuer == "" || audience == "" {
+		return fmt.Errorf("token_exchange: refusing an unverified %s token — subject_issuer and subject_audience must be configured on the source to validate it", role)
+	}
+
+	validator, err := d.getSubjectValidator(ctx)
+	if err != nil {
+		return fmt.Errorf("token_exchange: cannot validate the %s token (fail closed): %w", role, err)
+	}
+
+	expected := jwt.Expected{
+		SigningAlgorithms: subjectSigningAlgs,
+		Issuer:            issuer,
+		Audiences:         []string{audience},
+	}
+	if _, err := validator.Validate(ctx, token, expected); err != nil {
+		return fmt.Errorf("token_exchange: %s token failed validation: %w", role, err)
+	}
+	return nil
+}
+
+// getSubjectValidator lazily builds and caches the cap/jwt validator from the
+// source's subject_oidc_discovery_url or subject_jwks_url. A build failure is not
+// cached, so a transient network error is retried on the next request.
+func (d *TokenExchangeDriver) getSubjectValidator(ctx context.Context) (*jwt.Validator, error) {
+	d.validatorMu.Lock()
+	defer d.validatorMu.Unlock()
+	if d.subjectValidator != nil {
+		return d.subjectValidator, nil
+	}
+
+	cfg := d.credSource.Config
+	discoveryURL := credential.GetString(cfg, "subject_oidc_discovery_url", "")
+	jwksURL := credential.GetString(cfg, "subject_jwks_url", "")
+
+	var keySet jwt.KeySet
+	var err error
+	switch {
+	case discoveryURL != "":
+		keySet, err = jwt.NewOIDCDiscoveryKeySet(ctx, discoveryURL, "")
+	case jwksURL != "":
+		keySet, err = jwt.NewJSONWebKeySet(ctx, jwksURL, "")
+	default:
+		return nil, fmt.Errorf("no subject_oidc_discovery_url or subject_jwks_url configured")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	validator, err := jwt.NewValidator(keySet)
+	if err != nil {
+		return nil, err
+	}
+	d.subjectValidator = validator
+	return validator, nil
 }
 
 // subjectTokenType returns the RFC 8693 subject_token_type, defaulting to jwt.

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -2,6 +2,8 @@ package drivers
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -9,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	jose "github.com/go-jose/go-jose/v3"
+	josejwt "github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -206,6 +210,117 @@ func TestTokenExchangeDriverFactory_ValidateConfig(t *testing.T) {
 		c["token_url"] = "http://idp.example.com/token"
 		assert.Error(t, f.ValidateConfig(c))
 	})
+}
+
+// signRS256JWT signs claims with priv and serves the matching JWKS from a test
+// server, returning the token and the JWKS URL.
+func signRS256JWT(t *testing.T, priv *rsa.PrivateKey, claims josejwt.Claims) string {
+	t.Helper()
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: priv}, (&jose.SignerOptions{}).WithType("JWT"))
+	require.NoError(t, err)
+	tok, err := josejwt.Signed(signer).Claims(claims).CompactSerialize()
+	require.NoError(t, err)
+	return tok
+}
+
+func jwksServer(t *testing.T, pub *rsa.PublicKey) *httptest.Server {
+	t.Helper()
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{Key: pub, KeyID: "k1", Algorithm: "RS256", Use: "sig"}}}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(set)
+	}))
+}
+
+func TestTokenExchangeDriver_HeaderSubject_ValidatedAndExchanged(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	jwks := jwksServer(t, &priv.PublicKey)
+	defer jwks.Close()
+
+	now := time.Now()
+	subject := signRS256JWT(t, priv, josejwt.Claims{
+		Issuer:   "https://issuer.example.com/",
+		Subject:  "user-abc",
+		Audience: josejwt.Audience{"api://warden"},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(time.Hour)),
+	})
+
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, subject, r.Form.Get("subject_token"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "down", "expires_in": 300})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":        sts.URL,
+		"client_id":        "c",
+		"client_secret":    "s",
+		"subject_jwks_url": jwks.URL,
+		"subject_issuer":   "https://issuer.example.com/",
+		"subject_audience": "api://warden",
+	}, sts.Client())
+
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       subject,
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginUnverified,
+	}
+	rawData, meta, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "down", rawData["api_key"])
+	assert.Equal(t, "user-abc", meta["subject"])
+	assert.Equal(t, "false", meta["subject_verified"], "a header-sourced subject is validated but not inbound-verified")
+}
+
+func TestTokenExchangeDriver_HeaderSubject_BadSignature_FailClosed(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	other, _ := rsa.GenerateKey(rand.Reader, 2048) // signs the token; not in the JWKS
+	jwks := jwksServer(t, &priv.PublicKey)
+	defer jwks.Close()
+
+	now := time.Now()
+	subject := signRS256JWT(t, other, josejwt.Claims{
+		Issuer: "https://issuer.example.com/", Subject: "attacker",
+		Audience: josejwt.Audience{"api://warden"}, Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+	})
+
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+		"subject_jwks_url": jwks.URL, "subject_issuer": "https://issuer.example.com/", "subject_audience": "api://warden",
+	}, sts.Client())
+	inputs := &credential.ExchangeInputs{SubjectToken: subject, SubjectTokenType: credential.TokenTypeJWT, SubjectTokenOrigin: credential.ExchangeOriginUnverified}
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed validation")
+	assert.False(t, called, "an invalid subject must never reach the STS")
+}
+
+func TestTokenExchangeDriver_HeaderSubject_NoKeyset_FailClosed(t *testing.T) {
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+	// issuer+audience set, but no jwks/discovery URL → cannot validate → fail closed.
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+		"subject_issuer": "https://issuer.example.com/", "subject_audience": "api://warden",
+	}, sts.Client())
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       makeUnsignedJWT(map[string]interface{}{"sub": "u"}),
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginUnverified,
+	}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.False(t, called)
 }
 
 func TestTokenExchangeDriverFactory_Basics(t *testing.T) {


### PR DESCRIPTION
## What

Unlock `subject_token_source=header` for the `token_exchange` driver by validating the caller-supplied (unverified-origin) subject token before exchanging it.

- New source keys: `subject_oidc_discovery_url` **or** `subject_jwks_url`, plus `subject_issuer` and `subject_audience`.
- On an `unverified`-origin subject, the driver validates signature, issuer, audience, and expiry with `hashicorp/cap/jwt` before forwarding to the IdP.
- **Fails closed**: if the source lacks the validation keys, the mint errors — an unvalidated caller blob is never forwarded to the STS. `verified`-origin subjects (the inbound JWT Warden already authenticated) skip local validation and forward as-is.

## Why

The origin contract is the trust model: `verified` = Warden authenticated it inbound; `unverified` = caller-supplied, so the driver must validate or fail closed. This is a hard requirement of the `ExchangeMinter` contract, not a nicety.

## Test

`credential/drivers/token_exchange_driver_test.go`: unverified subject with (a) no validation config → error, IdP never called; (b) bad signature / wrong audience / expired → rejected; (c) valid → exchanged.

## Context

Plan PR 5 of the token-exchange stack. Rebased onto `main` after PR 4 (#418) merged — diff is this capability only. Depends on PR 4.
