### PR TITLE
feat(credential): add private_key_jwt client auth to token_exchange

### DIFF
--- a/credential/drivers/jwt_sign.go
+++ b/credential/drivers/jwt_sign.go
@@ -1,0 +1,53 @@
+package drivers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// signRS256JWT signs the given header and claims as a compact RS256 JWS. It is
+// the general-purpose counterpart to the GitHub App JWT signer, used to build
+// RFC 7523 client-assertion JWTs for private_key_jwt client authentication.
+func signRS256JWT(key *rsa.PrivateKey, header map[string]string, claims map[string]interface{}) (string, error) {
+	if key == nil {
+		return "", fmt.Errorf("private key not configured")
+	}
+	if header == nil {
+		header = map[string]string{}
+	}
+	header["alg"] = "RS256"
+	if header["typ"] == "" {
+		header["typ"] = "JWT"
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JWT header: %w", err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JWT claims: %w", err)
+	}
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	h := rsaSHA256Hash()
+	h.Write([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(nil, key, rsaSHA256HashType(), h.Sum(nil))
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+// newJTI returns a random token identifier for a client assertion.
+func newJTI() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -30,9 +30,16 @@ const (
 // Client-authentication methods selected by the source's `client_auth` config.
 // private_key_jwt is added in a later change; the secret methods ship here.
 const (
-	clientAuthSecretBasic = "client_secret_basic"
-	clientAuthSecretPost  = "client_secret_post"
+	clientAuthSecretBasic   = "client_secret_basic"
+	clientAuthSecretPost    = "client_secret_post"
+	clientAuthPrivateKeyJWT = "private_key_jwt"
 )
+
+// clientAssertionType is the RFC 7523 client-assertion type for private_key_jwt.
+const clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+// clientAssertionTTL bounds the lifetime of a signed client assertion.
+const clientAssertionTTL = 5 * time.Minute
 
 // grant_type URNs sent in the token request.
 const (
@@ -87,7 +94,7 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("rfc8693"),
 
 		credential.StringField("client_auth").
-			OneOf(clientAuthSecretBasic, clientAuthSecretPost).
+			OneOf(clientAuthSecretBasic, clientAuthSecretPost, clientAuthPrivateKeyJWT).
 			Describe("How Warden authenticates to the token endpoint").
 			Example("client_secret_post"),
 
@@ -96,8 +103,28 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("warden-gateway"),
 
 		credential.StringField("client_secret").
-			Describe("OAuth2 client secret (masked on read)").
+			Describe("OAuth2 client secret (masked on read; for client_secret_* auth)").
 			Example("****"),
+
+		credential.StringField("private_key").
+			Custom(func(v string) error {
+				if v == "" {
+					return nil
+				}
+				_, err := parseRSAPrivateKey(v)
+				return err
+			}).
+			Describe("PEM RSA private key for private_key_jwt client authentication (masked on read)").
+			Example("-----BEGIN PRIVATE KEY----- ..."),
+
+		credential.StringField("client_assertion_alg").
+			OneOf("RS256").
+			Describe("Signing algorithm for the private_key_jwt client assertion (RS256)").
+			Example("RS256"),
+
+		credential.StringField("client_assertion_kid").
+			Describe("Optional key id (kid) header for the client assertion").
+			Example("key-1"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -139,11 +166,15 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 		return err
 	}
 
-	// The secret-based client-auth methods require client credentials.
+	// Client-auth method determines which credentials are required.
 	switch credential.GetString(config, "client_auth", clientAuthSecretPost) {
 	case clientAuthSecretBasic, clientAuthSecretPost, "":
 		if credential.GetString(config, "client_id", "") == "" || credential.GetString(config, "client_secret", "") == "" {
 			return fmt.Errorf("client_id and client_secret are required for a secret-based client_auth")
+		}
+	case clientAuthPrivateKeyJWT:
+		if credential.GetString(config, "client_id", "") == "" || credential.GetString(config, "private_key", "") == "" {
+			return fmt.Errorf("client_id and private_key are required for client_auth=private_key_jwt")
 		}
 	}
 
@@ -164,7 +195,7 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 
 // SensitiveConfigFields returns source config keys that should be masked.
 func (f *TokenExchangeDriverFactory) SensitiveConfigFields() []string {
-	return []string{"client_secret", "ca_data"}
+	return []string{"client_secret", "private_key", "ca_data"}
 }
 
 // InferCredentialType returns the credential type for token_exchange sources.
@@ -224,12 +255,12 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
+	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
 	headers := map[string]string{}
-	if err := d.applyClientAuth(form, headers); err != nil {
+	if err := d.applyClientAuth(form, headers, tokenURL); err != nil {
 		return nil, nil, 0, "", err
 	}
 
-	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
 	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
 	if err != nil {
 		return nil, nil, 0, "", classifyExchangeError(err)
@@ -274,8 +305,10 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 	return form, nil
 }
 
-// applyClientAuth decorates the request with the configured client authentication.
-func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string) error {
+// applyClientAuth decorates the request with the configured client
+// authentication. tokenEndpoint is the audience for a private_key_jwt assertion
+// (each ID-JAG leg authenticates against its own endpoint).
+func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string, tokenEndpoint string) error {
 	cfg := d.credSource.Config
 	clientID := credential.GetString(cfg, "client_id", "")
 	clientSecret := credential.GetString(cfg, "client_secret", "")
@@ -288,10 +321,50 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 		// RFC 6749 §2.3.1: client id/secret are form-urlencoded, then Basic-encoded.
 		creds := url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)
 		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))
+	case clientAuthPrivateKeyJWT:
+		assertion, err := d.buildClientAssertion(clientID, tokenEndpoint)
+		if err != nil {
+			return err
+		}
+		form.Set("client_id", clientID)
+		form.Set("client_assertion_type", clientAssertionType)
+		form.Set("client_assertion", assertion)
 	default:
 		return fmt.Errorf("token_exchange: unsupported client_auth %q", credential.GetString(cfg, "client_auth", ""))
 	}
 	return nil
+}
+
+// buildClientAssertion builds and signs an RFC 7523 client-assertion JWT: a
+// short-lived JWT with iss=sub=client_id and aud=tokenEndpoint, signed with the
+// source's configured RSA private key.
+func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint string) (string, error) {
+	key, err := parseRSAPrivateKey(credential.GetString(d.credSource.Config, "private_key", ""))
+	if err != nil {
+		return "", fmt.Errorf("token_exchange: invalid private_key: %w", err)
+	}
+	jti, err := newJTI()
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	header := map[string]string{}
+	if kid := credential.GetString(d.credSource.Config, "client_assertion_kid", ""); kid != "" {
+		header["kid"] = kid
+	}
+	claims := map[string]interface{}{
+		"iss": clientID,
+		"sub": clientID,
+		"aud": tokenEndpoint,
+		"jti": jti,
+		"iat": now.Unix(),
+		"exp": now.Add(clientAssertionTTL).Unix(),
+	}
+	assertion, err := signRS256JWT(key, header, claims)
+	if err != nil {
+		return "", fmt.Errorf("token_exchange: failed to sign client assertion: %w", err)
+	}
+	return assertion, nil
 }
 
 // resolve returns spec.Config[key] when set, else the source config value.

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -212,9 +214,9 @@ func TestTokenExchangeDriverFactory_ValidateConfig(t *testing.T) {
 	})
 }
 
-// signRS256JWT signs claims with priv and serves the matching JWKS from a test
+// signTestJWT signs claims with priv and serves the matching JWKS from a test
 // server, returning the token and the JWKS URL.
-func signRS256JWT(t *testing.T, priv *rsa.PrivateKey, claims josejwt.Claims) string {
+func signTestJWT(t *testing.T, priv *rsa.PrivateKey, claims josejwt.Claims) string {
 	t.Helper()
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: priv}, (&jose.SignerOptions{}).WithType("JWT"))
 	require.NoError(t, err)
@@ -239,7 +241,7 @@ func TestTokenExchangeDriver_HeaderSubject_ValidatedAndExchanged(t *testing.T) {
 	defer jwks.Close()
 
 	now := time.Now()
-	subject := signRS256JWT(t, priv, josejwt.Claims{
+	subject := signTestJWT(t, priv, josejwt.Claims{
 		Issuer:   "https://issuer.example.com/",
 		Subject:  "user-abc",
 		Audience: josejwt.Audience{"api://warden"},
@@ -283,7 +285,7 @@ func TestTokenExchangeDriver_HeaderSubject_BadSignature_FailClosed(t *testing.T)
 	defer jwks.Close()
 
 	now := time.Now()
-	subject := signRS256JWT(t, other, josejwt.Claims{
+	subject := signTestJWT(t, other, josejwt.Claims{
 		Issuer: "https://issuer.example.com/", Subject: "attacker",
 		Audience: josejwt.Audience{"api://warden"}, Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
 	})
@@ -323,11 +325,51 @@ func TestTokenExchangeDriver_HeaderSubject_NoKeyset_FailClosed(t *testing.T) {
 	assert.False(t, called)
 }
 
+func TestTokenExchangeDriver_PrivateKeyJWT(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+	var gotAssertion string
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, clientAssertionType, r.Form.Get("client_assertion_type"))
+		assert.Empty(t, r.Form.Get("client_secret"))
+		gotAssertion = r.Form.Get("client_assertion")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":   sts.URL,
+		"client_auth": clientAuthPrivateKeyJWT,
+		"client_id":   "warden-gateway",
+		"private_key": privPEM,
+	}, sts.Client())
+
+	_, _, _, _, err = d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"})))
+	require.NoError(t, err)
+
+	// The client assertion must verify against the public key with the expected claims.
+	require.NotEmpty(t, gotAssertion)
+	parsed, err := josejwt.ParseSigned(gotAssertion)
+	require.NoError(t, err)
+	var claims josejwt.Claims
+	require.NoError(t, parsed.Claims(&priv.PublicKey, &claims))
+	assert.Equal(t, "warden-gateway", claims.Issuer)
+	assert.Equal(t, "warden-gateway", claims.Subject)
+	assert.Contains(t, claims.Audience, sts.URL)
+	assert.NotEmpty(t, claims.ID, "assertion should carry a jti")
+}
+
 func TestTokenExchangeDriverFactory_Basics(t *testing.T) {
 	f := &TokenExchangeDriverFactory{}
 	assert.Equal(t, credential.SourceTypeTokenExchange, f.Type())
 	ct, err := f.InferCredentialType(nil)
 	require.NoError(t, err)
 	assert.Equal(t, credential.TypeOAuthBearerToken, ct)
-	assert.ElementsMatch(t, []string{"client_secret", "ca_data"}, f.SensitiveConfigFields())
+	assert.ElementsMatch(t, []string{"client_secret", "private_key", "ca_data"}, f.SensitiveConfigFields())
 }


### PR DESCRIPTION
## What

Add `client_auth=private_key_jwt` to the `token_exchange` driver — RFC 7523 client authentication via a signed JWT assertion instead of a shared client secret.

- New `credential/drivers/jwt_sign.go` — `signRS256JWT` / `newJTI`, a small reusable RS256 signer.
- `credential/drivers/token_exchange_driver.go` — when `client_auth=private_key_jwt`, build a client assertion (`iss=sub=client_id`, `aud=token_url`, `exp`, `jti`, RS256 over the source's `private_key`) and send `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` + `client_assertion` in place of `client_secret`.
- New source keys: `private_key` (PEM, masked) and `client_assertion_alg` (RS256 in v1).

## Test

`credential/drivers/token_exchange_driver_test.go`: `private_key_jwt` mint sends a valid `client_assertion` whose signature verifies against the configured public key, with the expected claims.

## Context

Plan PR 6 of the token-exchange stack. Rebased onto `main` after PR 5 (#419) merged — diff is this capability only. Depends on PR 4. (When CIMD lands, its shared authenticator becomes the single impl behind the `applyClientAuth` seam.)
