### PR TITLE
feat(credential): emit and validate actor tokens in token_exchange

### DIFF
--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -245,10 +245,19 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 			return nil, nil, 0, "", err
 		}
 	}
-	// Actor delegation is added in a follow-up change; reject rather than silently
-	// dropping the actor a caller supplied.
+
+	// Actor delegation (RFC 8693). jwt-bearer has no actor slot, so reject an actor
+	// there. An unverified (header-sourced) actor is validated like a subject; a
+	// verified (auth_token) actor — the agent's inbound JWT — is forwarded as-is.
 	if inputs.ActorToken != "" {
-		return nil, nil, 0, "", fmt.Errorf("token_exchange: actor tokens are not yet supported by this source")
+		if credential.GetString(d.credSource.Config, "grant", tokenExchangeGrantRFC8693) == tokenExchangeGrantJWTBearer {
+			return nil, nil, 0, "", fmt.Errorf("token_exchange: actor tokens are not supported with grant=jwt_bearer (no actor slot)")
+		}
+		if inputs.ActorTokenOrigin != credential.ExchangeOriginVerified {
+			if err := d.validateUntrustedToken(ctx, inputs.ActorToken, "actor"); err != nil {
+				return nil, nil, 0, "", err
+			}
+		}
 	}
 
 	form, err := d.buildExchangeForm(spec, inputs)
@@ -287,6 +296,10 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 		}
 		if res := d.resolve(spec, "resource"); res != "" {
 			form.Set("resource", res)
+		}
+		if inputs.ActorToken != "" {
+			form.Set("actor_token", inputs.ActorToken)
+			form.Set("actor_token_type", actorTokenType(inputs))
 		}
 	case tokenExchangeGrantJWTBearer:
 		form.Set("grant_type", grantTypeJWTBearer)
@@ -476,6 +489,14 @@ func (d *TokenExchangeDriver) getSubjectValidator(ctx context.Context) (*jwt.Val
 func subjectTokenType(inputs *credential.ExchangeInputs) string {
 	if inputs.SubjectTokenType != "" {
 		return inputs.SubjectTokenType
+	}
+	return credential.TokenTypeJWT
+}
+
+// actorTokenType returns the RFC 8693 actor_token_type, defaulting to jwt.
+func actorTokenType(inputs *credential.ExchangeInputs) string {
+	if inputs.ActorTokenType != "" {
+		return inputs.ActorTokenType
 	}
 	return credential.TokenTypeJWT
 }

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -164,17 +164,108 @@ func TestTokenExchangeDriver_UnverifiedRejected_NoCall(t *testing.T) {
 	assert.False(t, called, "the STS must not be called for an unverified subject")
 }
 
-func TestTokenExchangeDriver_ActorRejected(t *testing.T) {
+func TestTokenExchangeDriver_ActorVerified_Forwarded(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user"})
+	actor := makeUnsignedJWT(map[string]interface{}{"sub": "agent"})
+
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, subject, r.Form.Get("subject_token"))
+		assert.Equal(t, actor, r.Form.Get("actor_token"))
+		assert.Equal(t, credential.TokenTypeJWT, r.Form.Get("actor_token_type"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer sts.Close()
+
+	// A verified (auth_token) actor is forwarded as-is — no subject-validation config needed.
 	d := newExchangeDriver(map[string]string{
-		"token_url": "https://idp.example.com", "client_id": "c", "client_secret": "s",
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+	}, sts.Client())
+	inputs := verifiedSubject(subject)
+	inputs.ActorToken = actor
+	inputs.ActorTokenType = credential.TokenTypeJWT
+	inputs.ActorTokenOrigin = credential.ExchangeOriginVerified
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.NoError(t, err)
+}
+
+func TestTokenExchangeDriver_ActorHeader_Validated(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	jwks := jwksServer(t, &priv.PublicKey)
+	defer jwks.Close()
+	now := time.Now()
+	actor := signTestJWT(t, priv, josejwt.Claims{
+		Issuer: "https://issuer.example.com/", Subject: "agent",
+		Audience: josejwt.Audience{"api://warden"},
+		IssuedAt: josejwt.NewNumericDate(now), NotBefore: josejwt.NewNumericDate(now),
+		Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+	})
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user"})
+
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, actor, r.Form.Get("actor_token"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+		"subject_jwks_url": jwks.URL, "subject_issuer": "https://issuer.example.com/", "subject_audience": "api://warden",
+	}, sts.Client())
+	inputs := verifiedSubject(subject) // subject verified (forwarded as-is)
+	inputs.ActorToken = actor
+	inputs.ActorTokenType = credential.TokenTypeJWT
+	inputs.ActorTokenOrigin = credential.ExchangeOriginUnverified // header-sourced → validated
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.NoError(t, err)
+}
+
+func TestTokenExchangeDriver_ActorHeader_BadSignature_FailClosed(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	other, _ := rsa.GenerateKey(rand.Reader, 2048)
+	jwks := jwksServer(t, &priv.PublicKey)
+	defer jwks.Close()
+	actor := signTestJWT(t, other, josejwt.Claims{
+		Issuer: "https://issuer.example.com/", Subject: "attacker",
+		Audience: josejwt.Audience{"api://warden"}, Expiry: josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+		"subject_jwks_url": jwks.URL, "subject_issuer": "https://issuer.example.com/", "subject_audience": "api://warden",
+	}, sts.Client())
+	inputs := verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "user"}))
+	inputs.ActorToken = actor
+	inputs.ActorTokenType = credential.TokenTypeJWT
+	inputs.ActorTokenOrigin = credential.ExchangeOriginUnverified
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor token failed validation")
+	assert.False(t, called)
+}
+
+func TestTokenExchangeDriver_Actor_JWTBearerRejected(t *testing.T) {
+	d := newExchangeDriver(map[string]string{
+		"token_url": "https://idp.example.com", "grant": tokenExchangeGrantJWTBearer, "client_id": "c", "client_secret": "s",
 	}, http.DefaultClient)
 	inputs := verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"}))
 	inputs.ActorToken = makeUnsignedJWT(map[string]interface{}{"sub": "agent"})
 	inputs.ActorTokenType = credential.TokenTypeJWT
+	inputs.ActorTokenOrigin = credential.ExchangeOriginVerified
 
 	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "actor tokens are not yet supported")
+	assert.Contains(t, err.Error(), "no actor slot")
 }
 
 func TestTokenExchangeDriverFactory_ValidateConfig(t *testing.T) {


### PR DESCRIPTION
## What

Actor delegation for the `token_exchange` driver — forward an `actor_token` so the STS records an `act` chain ("agent-acting-for-user") on the minted token.

- On `grant=rfc8693`, when the exchange inputs carry an actor, emit `actor_token` + `actor_token_type` on the token-endpoint form.
- Reject an actor token under `grant=jwt_bearer` — jwt-bearer has no actor slot.
- Actor validation follows the subject's origin contract: a `header`-sourced (unverified) actor is validated with the same `cap/jwt` path as the subject; an `auth_token`-sourced (verified) actor — the agent's own inbound JWT — is forwarded as-is.

This unlocks `actor_token_source=header` and `actor_token_source=auth_token`.

## Test

`credential/drivers/token_exchange_driver_test.go`: actor fields present on the rfc8693 form iff inputs carry an actor; jwt_bearer + actor rejected; unverified actor validated (bad → rejected, valid → forwarded); verified actor forwarded without local validation.

## Context

Plan PR 7 of the token-exchange stack. Rebased onto `main` after PR 6 (#420) merged — diff is this capability only. Depends on PR 4, PR 5 (actor validation reuses the subject validator), and PR 9 (#417, the `auth_token` actor source), all now upstream.
