### PR TITLE
feat(credential): id_jag grant, RFC 8707 resources, and token-exchange docs

### DIFF
--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -331,19 +331,26 @@ func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential
 func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (*oauth2TokenResponse, error) {
 	cfg := d.credSource.Config
 
-	// Leg 1: exchange the subject for an ID-JAG at the home IdP.
+	// Leg 1: exchange the subject for an ID-JAG at the home IdP. The ID-JAG must be
+	// bound to the resource authorization server via audience.
 	idpURL := credential.GetString(cfg, "token_url", "")
+	audience := d.resolve(spec, "audience")
+	if audience == "" {
+		return nil, fmt.Errorf("id_jag: audience (the resource authorization server) is required")
+	}
 	leg1 := url.Values{}
 	leg1.Set("grant_type", grantTypeTokenExchange)
 	leg1.Set("subject_token", inputs.SubjectToken)
 	leg1.Set("subject_token_type", subjectTokenType(inputs))
 	leg1.Set("requested_token_type", tokenTypeIDJAG)
-	if aud := d.resolve(spec, "audience"); aud != "" {
-		leg1.Set("audience", aud)
-	}
+	leg1.Set("audience", audience)
 	if inputs.ActorToken != "" {
 		leg1.Set("actor_token", inputs.ActorToken)
 		leg1.Set("actor_token_type", actorTokenType(inputs))
+	}
+	// Vendor-specific extras apply to the exchange (leg 1) at the home IdP.
+	for k, v := range credential.GetPrefixed(cfg, "token_param.") {
+		leg1.Set(k, v)
 	}
 	h1 := map[string]string{}
 	if err := d.applyClientAuth(leg1, h1, idpURL); err != nil {
@@ -355,6 +362,10 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 	}
 	if jag.AccessToken == "" {
 		return nil, fmt.Errorf("id_jag: leg 1 returned no ID-JAG assertion")
+	}
+	// If the IdP labels the issued token, confirm it is an ID-JAG before redeeming it.
+	if jag.IssuedTokenType != "" && jag.IssuedTokenType != tokenTypeIDJAG {
+		return nil, fmt.Errorf("id_jag: leg 1 returned issued_token_type %q, expected %q", jag.IssuedTokenType, tokenTypeIDJAG)
 	}
 
 	// Leg 2: redeem the ID-JAG at the resource authorization server.
@@ -558,13 +569,24 @@ func (d *TokenExchangeDriver) getSubjectValidator(ctx context.Context) (*jwt.Val
 	discoveryURL := credential.GetString(cfg, "subject_oidc_discovery_url", "")
 	jwksURL := credential.GetString(cfg, "subject_jwks_url", "")
 
+	// Reuse the source CA (if any) for the JWKS/discovery fetch, so a header-subject
+	// issuer behind a private CA validates instead of silently failing closed.
+	caPEM := ""
+	if caData := credential.GetString(cfg, "ca_data", ""); caData != "" {
+		decoded, err := base64.StdEncoding.DecodeString(caData)
+		if err != nil {
+			return nil, fmt.Errorf("ca_data is not valid base64: %w", err)
+		}
+		caPEM = string(decoded)
+	}
+
 	var keySet jwt.KeySet
 	var err error
 	switch {
 	case discoveryURL != "":
-		keySet, err = jwt.NewOIDCDiscoveryKeySet(ctx, discoveryURL, "")
+		keySet, err = jwt.NewOIDCDiscoveryKeySet(ctx, discoveryURL, caPEM)
 	case jwksURL != "":
-		keySet, err = jwt.NewJSONWebKeySet(ctx, jwksURL, "")
+		keySet, err = jwt.NewJSONWebKeySet(ctx, jwksURL, caPEM)
 	default:
 		return nil, fmt.Errorf("no subject_oidc_discovery_url or subject_jwks_url configured")
 	}

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -376,6 +377,9 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 	if scope := d.resolve(spec, "scope"); scope != "" {
 		leg2.Set("scope", scope)
 	}
+	// RFC 8707 resource indicators scope the final access token, so they belong on
+	// leg 2 (the resource-AS redemption), not leg 1 (which mints the ID-JAG).
+	d.addResources(leg2, spec)
 	h2 := map[string]string{}
 	if err := d.applyClientAuth(leg2, h2, resURL); err != nil {
 		return nil, err
@@ -400,23 +404,17 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 		if aud := d.resolve(spec, "audience"); aud != "" {
 			form.Set("audience", aud)
 		}
-		if res := d.resolve(spec, "resource"); res != "" {
-			form.Set("resource", res)
-		}
 		if inputs.ActorToken != "" {
 			form.Set("actor_token", inputs.ActorToken)
 			form.Set("actor_token_type", actorTokenType(inputs))
 		}
 	case tokenExchangeGrantJWTBearer:
-		// audience/resource are RFC 8693 token-exchange parameters; jwt-bearer has
-		// no slot for them (it targets via scope). Reject rather than silently drop
-		// an operator-set value — if a specific IdP genuinely needs one, it can be
-		// sent explicitly via token_param.audience / token_param.resource.
+		// audience is an RFC 8693 token-exchange parameter; jwt-bearer has no slot
+		// for it (it targets via scope). Reject rather than silently drop an
+		// operator-set value — if a specific IdP needs it, send token_param.audience.
+		// (RFC 8707 resources are grant-agnostic and handled below.)
 		if aud := d.resolve(spec, "audience"); aud != "" {
-			return nil, fmt.Errorf("token_exchange: 'audience' is not sent with grant=jwt_bearer; target via 'scope', or set 'token_param.audience' if your IdP requires it")
-		}
-		if res := d.resolve(spec, "resource"); res != "" {
-			return nil, fmt.Errorf("token_exchange: 'resource' is not sent with grant=jwt_bearer; target via 'scope', or set 'token_param.resource' if your IdP requires it")
+			return nil, fmt.Errorf("token_exchange: 'audience' is not sent with grant=jwt_bearer; target via 'scope'/'resources', or set 'token_param.audience' if your IdP requires it")
 		}
 		form.Set("grant_type", grantTypeJWTBearer)
 		form.Set("assertion", inputs.SubjectToken)
@@ -427,6 +425,8 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 	if scope := d.resolve(spec, "scope"); scope != "" {
 		form.Set("scope", scope)
 	}
+	// RFC 8707 resource indicators (grant-agnostic).
+	d.addResources(form, spec)
 	// Vendor-specific extras (e.g. Entra's requested_token_use=on_behalf_of).
 	for k, v := range credential.GetPrefixed(cfg, "token_param.") {
 		form.Set(k, v)
@@ -494,6 +494,16 @@ func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint strin
 		return "", fmt.Errorf("token_exchange: failed to sign client assertion: %w", err)
 	}
 	return assertion, nil
+}
+
+// addResources appends the source/spec's RFC 8707 resource indicators as repeated
+// `resource` form parameters. `resources` is a space-separated list of absolute
+// URIs; RFC 8707 §2 allows the parameter to appear multiple times. It is
+// grant-agnostic, so it applies to rfc8693, jwt_bearer, and the id_jag legs alike.
+func (d *TokenExchangeDriver) addResources(form url.Values, spec *credential.CredSpec) {
+	for _, r := range strings.Fields(d.resolve(spec, "resources")) {
+		form.Add("resource", r)
+	}
 }
 
 // resolve returns spec.Config[key] when set, else the source config value.

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -408,6 +408,16 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 			form.Set("actor_token_type", actorTokenType(inputs))
 		}
 	case tokenExchangeGrantJWTBearer:
+		// audience/resource are RFC 8693 token-exchange parameters; jwt-bearer has
+		// no slot for them (it targets via scope). Reject rather than silently drop
+		// an operator-set value — if a specific IdP genuinely needs one, it can be
+		// sent explicitly via token_param.audience / token_param.resource.
+		if aud := d.resolve(spec, "audience"); aud != "" {
+			return nil, fmt.Errorf("token_exchange: 'audience' is not sent with grant=jwt_bearer; target via 'scope', or set 'token_param.audience' if your IdP requires it")
+		}
+		if res := d.resolve(spec, "resource"); res != "" {
+			return nil, fmt.Errorf("token_exchange: 'resource' is not sent with grant=jwt_bearer; target via 'scope', or set 'token_param.resource' if your IdP requires it")
+		}
 		form.Set("grant_type", grantTypeJWTBearer)
 		form.Set("assertion", inputs.SubjectToken)
 	default:

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -25,7 +25,12 @@ var subjectSigningAlgs = []jwt.Alg{jwt.RS256, jwt.RS384, jwt.RS512, jwt.ES256, j
 const (
 	tokenExchangeGrantRFC8693   = "rfc8693"
 	tokenExchangeGrantJWTBearer = "jwt_bearer"
+	tokenExchangeGrantIDJAG     = "id_jag"
 )
+
+// tokenTypeIDJAG is the requested_token_type for an ID-JAG assertion (leg 1 of
+// the cross-app-access flow).
+const tokenTypeIDJAG = "urn:ietf:params:oauth:token-type:id-jag"
 
 // Client-authentication methods selected by the source's `client_auth` config.
 // private_key_jwt is added in a later change; the secret methods ship here.
@@ -89,9 +94,19 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("https://idp.example.com/oauth2/v1/token"),
 
 		credential.StringField("grant").
-			OneOf(tokenExchangeGrantRFC8693, tokenExchangeGrantJWTBearer).
-			Describe("Exchange grant: rfc8693 (token-exchange) or jwt_bearer (assertion; Entra OBO)").
+			OneOf(tokenExchangeGrantRFC8693, tokenExchangeGrantJWTBearer, tokenExchangeGrantIDJAG).
+			Describe("Exchange grant: rfc8693 (token-exchange), jwt_bearer (assertion; Entra OBO), or id_jag (cross-app access)").
 			Example("rfc8693"),
+
+		credential.StringField("resource_token_url").
+			Custom(func(v string) error {
+				if v == "" {
+					return nil
+				}
+				return validateOAuth2SafeURL(v, "resource_token_url", skip)
+			}).
+			Describe("Resource authorization-server token endpoint (HTTPS) for id_jag leg 2").
+			Example("https://auth.resourceapp.example.com/oauth2/token"),
 
 		credential.StringField("client_auth").
 			OneOf(clientAuthSecretBasic, clientAuthSecretPost, clientAuthPrivateKeyJWT).
@@ -164,6 +179,13 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("false"),
 	); err != nil {
 		return err
+	}
+
+	// id_jag needs a second (resource authorization-server) endpoint for leg 2.
+	if credential.GetString(config, "grant", tokenExchangeGrantRFC8693) == tokenExchangeGrantIDJAG {
+		if credential.GetString(config, "resource_token_url", "") == "" {
+			return fmt.Errorf("resource_token_url is required for grant=id_jag")
+		}
 	}
 
 	// Client-auth method determines which credentials are required.
@@ -260,25 +282,98 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 		}
 	}
 
-	form, err := d.buildExchangeForm(spec, inputs)
+	var (
+		resp *oauth2TokenResponse
+		err  error
+	)
+	if credential.GetString(d.credSource.Config, "grant", tokenExchangeGrantRFC8693) == tokenExchangeGrantIDJAG {
+		resp, err = d.mintIDJAG(ctx, spec, inputs)
+	} else {
+		resp, err = d.exchangeOnce(ctx, spec, inputs)
+	}
 	if err != nil {
 		return nil, nil, 0, "", err
-	}
-	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
-	headers := map[string]string{}
-	if err := d.applyClientAuth(form, headers, tokenURL); err != nil {
-		return nil, nil, 0, "", err
-	}
-
-	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
-	if err != nil {
-		return nil, nil, 0, "", classifyExchangeError(err)
 	}
 	if resp.AccessToken == "" {
 		return nil, nil, 0, "", fmt.Errorf("token_exchange: token response missing access_token")
 	}
 
 	return accessTokenRawData(resp), d.subjectMetadata(resp, inputs), ttlFromExpiresIn(resp.ExpiresIn), "", nil
+}
+
+// exchangeOnce performs a single-hop exchange (rfc8693 or jwt_bearer).
+func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (*oauth2TokenResponse, error) {
+	form, err := d.buildExchangeForm(spec, inputs)
+	if err != nil {
+		return nil, err
+	}
+	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
+	headers := map[string]string{}
+	if err := d.applyClientAuth(form, headers, tokenURL); err != nil {
+		return nil, err
+	}
+	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
+	if err != nil {
+		return nil, classifyExchangeError(err)
+	}
+	return resp, nil
+}
+
+// mintIDJAG runs the two-leg ID-JAG cross-app-access flow inside one mint:
+//
+//	leg 1 → token_url (home IdP): RFC 8693 token-exchange with
+//	        requested_token_type=id-jag → an ID-JAG assertion bound to the resource AS
+//	leg 2 → resource_token_url (resource AS): RFC 7523 jwt-bearer with the ID-JAG
+//	        as the assertion → the downstream access token
+//
+// Client auth runs on both legs (each with its own endpoint as the assertion
+// audience). Only the final access token is returned; the ID-JAG is single-use.
+func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (*oauth2TokenResponse, error) {
+	cfg := d.credSource.Config
+
+	// Leg 1: exchange the subject for an ID-JAG at the home IdP.
+	idpURL := credential.GetString(cfg, "token_url", "")
+	leg1 := url.Values{}
+	leg1.Set("grant_type", grantTypeTokenExchange)
+	leg1.Set("subject_token", inputs.SubjectToken)
+	leg1.Set("subject_token_type", subjectTokenType(inputs))
+	leg1.Set("requested_token_type", tokenTypeIDJAG)
+	if aud := d.resolve(spec, "audience"); aud != "" {
+		leg1.Set("audience", aud)
+	}
+	if inputs.ActorToken != "" {
+		leg1.Set("actor_token", inputs.ActorToken)
+		leg1.Set("actor_token_type", actorTokenType(inputs))
+	}
+	h1 := map[string]string{}
+	if err := d.applyClientAuth(leg1, h1, idpURL); err != nil {
+		return nil, err
+	}
+	jag, err := postOAuthTokenForm(ctx, d.httpClient, idpURL, leg1, h1)
+	if err != nil {
+		return nil, classifyExchangeError(err)
+	}
+	if jag.AccessToken == "" {
+		return nil, fmt.Errorf("id_jag: leg 1 returned no ID-JAG assertion")
+	}
+
+	// Leg 2: redeem the ID-JAG at the resource authorization server.
+	resURL := credential.GetString(cfg, "resource_token_url", "")
+	leg2 := url.Values{}
+	leg2.Set("grant_type", grantTypeJWTBearer)
+	leg2.Set("assertion", jag.AccessToken)
+	if scope := d.resolve(spec, "scope"); scope != "" {
+		leg2.Set("scope", scope)
+	}
+	h2 := map[string]string{}
+	if err := d.applyClientAuth(leg2, h2, resURL); err != nil {
+		return nil, err
+	}
+	final, err := postOAuthTokenForm(ctx, d.httpClient, resURL, leg2, h2)
+	if err != nil {
+		return nil, classifyExchangeError(err)
+	}
+	return final, nil
 }
 
 // buildExchangeForm assembles the token-endpoint form for the configured grant.

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -298,6 +298,17 @@ func TestTokenExchangeDriverFactory_ValidateConfig(t *testing.T) {
 		c["token_param.subject_token"] = "x"
 		assert.Error(t, f.ValidateConfig(c))
 	})
+	t.Run("id_jag without resource_token_url", func(t *testing.T) {
+		c := base()
+		c["grant"] = tokenExchangeGrantIDJAG
+		assert.Error(t, f.ValidateConfig(c))
+	})
+	t.Run("id_jag with resource_token_url", func(t *testing.T) {
+		c := base()
+		c["grant"] = tokenExchangeGrantIDJAG
+		c["resource_token_url"] = "https://auth.resourceapp.example.com/token"
+		assert.NoError(t, f.ValidateConfig(c))
+	})
 	t.Run("non-https token_url", func(t *testing.T) {
 		c := base()
 		c["token_url"] = "http://idp.example.com/token"
@@ -454,6 +465,50 @@ func TestTokenExchangeDriver_PrivateKeyJWT(t *testing.T) {
 	assert.Equal(t, "warden-gateway", claims.Subject)
 	assert.Contains(t, claims.Audience, sts.URL)
 	assert.NotEmpty(t, claims.ID, "assertion should carry a jti")
+}
+
+func TestTokenExchangeDriver_IDJAG(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user"})
+
+	// Leg 2: resource authorization server redeems the ID-JAG for an access token.
+	resSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", r.Form.Get("grant_type"))
+		assert.Equal(t, "the-id-jag", r.Form.Get("assertion"))
+		assert.Equal(t, "files:read", r.Form.Get("scope"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "final-access", "expires_in": 600})
+	}))
+	defer resSrv.Close()
+
+	// Leg 1: home IdP exchanges the subject for an ID-JAG bound to the resource AS.
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", r.Form.Get("grant_type"))
+		assert.Equal(t, tokenTypeIDJAG, r.Form.Get("requested_token_type"))
+		assert.Equal(t, subject, r.Form.Get("subject_token"))
+		assert.Equal(t, "https://resource-as.example.com", r.Form.Get("audience"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "the-id-jag", "issued_token_type": tokenTypeIDJAG, "expires_in": 300})
+	}))
+	defer idpSrv.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":          idpSrv.URL,
+		"resource_token_url": resSrv.URL,
+		"grant":              tokenExchangeGrantIDJAG,
+		"client_id":          "c",
+		"client_secret":      "s",
+	}, &http.Client{})
+	spec := &credential.CredSpec{Config: map[string]string{
+		"audience": "https://resource-as.example.com",
+		"scope":    "files:read",
+	}}
+
+	rawData, _, ttl, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(subject))
+	require.NoError(t, err)
+	assert.Equal(t, "final-access", rawData["api_key"], "the final resource-AS access token is returned, not the ID-JAG")
+	assert.Equal(t, 600*time.Second, ttl)
 }
 
 func TestTokenExchangeDriverFactory_Basics(t *testing.T) {

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -408,6 +408,63 @@ func TestTokenExchangeDriver_HeaderSubject_BadSignature_FailClosed(t *testing.T)
 	assert.False(t, called, "an invalid subject must never reach the STS")
 }
 
+func TestTokenExchangeDriver_HeaderSubject_Expired_FailClosed(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	jwks := jwksServer(t, &priv.PublicKey)
+	defer jwks.Close()
+	now := time.Now()
+	// Validly signed, correct issuer/audience, but expired (well past the 150s leeway).
+	subject := signTestJWT(t, priv, josejwt.Claims{
+		Issuer: "https://issuer.example.com/", Subject: "u",
+		Audience: josejwt.Audience{"api://warden"},
+		IssuedAt: josejwt.NewNumericDate(now.Add(-2 * time.Hour)),
+		Expiry:   josejwt.NewNumericDate(now.Add(-1 * time.Hour)),
+	})
+
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+		"subject_jwks_url": jwks.URL, "subject_issuer": "https://issuer.example.com/", "subject_audience": "api://warden",
+	}, sts.Client())
+	inputs := &credential.ExchangeInputs{SubjectToken: subject, SubjectTokenType: credential.TokenTypeJWT, SubjectTokenOrigin: credential.ExchangeOriginUnverified}
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed validation")
+	assert.False(t, called, "an expired subject must never reach the STS")
+}
+
+func TestTokenExchangeDriver_HeaderSubject_WrongAudience_FailClosed(t *testing.T) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	jwks := jwksServer(t, &priv.PublicKey)
+	defer jwks.Close()
+	now := time.Now()
+	// Valid signature and issuer, but the token is audienced for a different service.
+	subject := signTestJWT(t, priv, josejwt.Claims{
+		Issuer: "https://issuer.example.com/", Subject: "u",
+		Audience: josejwt.Audience{"api://someone-else"},
+		IssuedAt: josejwt.NewNumericDate(now), Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+	})
+
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+		"subject_jwks_url": jwks.URL, "subject_issuer": "https://issuer.example.com/", "subject_audience": "api://warden",
+	}, sts.Client())
+	inputs := &credential.ExchangeInputs{SubjectToken: subject, SubjectTokenType: credential.TokenTypeJWT, SubjectTokenOrigin: credential.ExchangeOriginUnverified}
+
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed validation")
+	assert.False(t, called, "a wrong-audience subject must never reach the STS")
+}
+
 func TestTokenExchangeDriver_HeaderSubject_NoKeyset_FailClosed(t *testing.T) {
 	called := false
 	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -114,22 +115,52 @@ func TestTokenExchangeDriver_JWTBearer_Entra(t *testing.T) {
 	assert.Equal(t, "graph-token", rawData["api_key"])
 }
 
-func TestTokenExchangeDriver_JWTBearer_RejectsAudienceResource(t *testing.T) {
-	// audience/resource are rfc8693 params; with jwt_bearer they must be rejected,
-	// not silently dropped — and the STS must not be called.
+func TestTokenExchangeDriver_JWTBearer_RejectsAudience(t *testing.T) {
+	// audience is an rfc8693 param with no jwt-bearer slot: reject, don't silently
+	// drop — and the STS must not be called. (resources are RFC 8707 and allowed.)
 	called := false
 	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
 	defer sts.Close()
-	for _, key := range []string{"audience", "resource"} {
-		d := newExchangeDriver(map[string]string{
-			"token_url": sts.URL, "grant": tokenExchangeGrantJWTBearer, "client_id": "c", "client_secret": "s",
-		}, sts.Client())
-		spec := &credential.CredSpec{Config: map[string]string{key: "https://target.example.com"}}
-		_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"})))
-		require.Error(t, err, "jwt_bearer + %s must error", key)
-		assert.Contains(t, err.Error(), key)
-	}
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "grant": tokenExchangeGrantJWTBearer, "client_id": "c", "client_secret": "s",
+	}, sts.Client())
+	spec := &credential.CredSpec{Config: map[string]string{"audience": "https://target.example.com"}}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"})))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience")
 	assert.False(t, called, "the STS must not be called when the config is rejected")
+}
+
+// resourceValues returns all repeated `resource` form values the STS received.
+func assertResources(t *testing.T, form url.Values, want ...string) {
+	t.Helper()
+	assert.ElementsMatch(t, want, form["resource"], "repeated RFC 8707 resource indicators")
+}
+
+func TestTokenExchangeDriver_Resources_MultiValue(t *testing.T) {
+	// RFC 8707: `resources` (space-separated) is sent as repeated `resource` params,
+	// on both rfc8693 and jwt_bearer.
+	for _, grant := range []string{tokenExchangeGrantRFC8693, tokenExchangeGrantJWTBearer} {
+		t.Run(grant, func(t *testing.T) {
+			var got url.Values
+			sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				got = r.Form
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+			}))
+			defer sts.Close()
+			d := newExchangeDriver(map[string]string{
+				"token_url": sts.URL, "grant": grant, "client_id": "c", "client_secret": "s",
+			}, sts.Client())
+			spec := &credential.CredSpec{Config: map[string]string{
+				"resources": "https://api.example.com https://api2.example.com",
+			}}
+			_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"})))
+			require.NoError(t, err)
+			assertResources(t, got, "https://api.example.com", "https://api2.example.com")
+		})
+	}
 }
 
 func TestTokenExchangeDriver_ClientSecretBasic(t *testing.T) {
@@ -551,6 +582,7 @@ func TestTokenExchangeDriver_IDJAG(t *testing.T) {
 		assert.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", r.Form.Get("grant_type"))
 		assert.Equal(t, "the-id-jag", r.Form.Get("assertion"))
 		assert.Equal(t, "files:read", r.Form.Get("scope"))
+		assertResources(t, r.Form, "https://api.example.com") // RFC 8707 on the final token (leg 2)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "final-access", "expires_in": 600})
 	}))
@@ -563,6 +595,7 @@ func TestTokenExchangeDriver_IDJAG(t *testing.T) {
 		assert.Equal(t, tokenTypeIDJAG, r.Form.Get("requested_token_type"))
 		assert.Equal(t, subject, r.Form.Get("subject_token"))
 		assert.Equal(t, "https://resource-as.example.com", r.Form.Get("audience"))
+		assert.Empty(t, r.Form["resource"], "resources belong on leg 2, not leg 1")
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "the-id-jag", "issued_token_type": tokenTypeIDJAG, "expires_in": 300})
 	}))
@@ -576,8 +609,9 @@ func TestTokenExchangeDriver_IDJAG(t *testing.T) {
 		"client_secret":      "s",
 	}, &http.Client{})
 	spec := &credential.CredSpec{Config: map[string]string{
-		"audience": "https://resource-as.example.com",
-		"scope":    "files:read",
+		"audience":  "https://resource-as.example.com",
+		"scope":     "files:read",
+		"resources": "https://api.example.com",
 	}}
 
 	rawData, _, ttl, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(subject))

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -114,6 +114,24 @@ func TestTokenExchangeDriver_JWTBearer_Entra(t *testing.T) {
 	assert.Equal(t, "graph-token", rawData["api_key"])
 }
 
+func TestTokenExchangeDriver_JWTBearer_RejectsAudienceResource(t *testing.T) {
+	// audience/resource are rfc8693 params; with jwt_bearer they must be rejected,
+	// not silently dropped — and the STS must not be called.
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+	for _, key := range []string{"audience", "resource"} {
+		d := newExchangeDriver(map[string]string{
+			"token_url": sts.URL, "grant": tokenExchangeGrantJWTBearer, "client_id": "c", "client_secret": "s",
+		}, sts.Client())
+		spec := &credential.CredSpec{Config: map[string]string{key: "https://target.example.com"}}
+		_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, verifiedSubject(makeUnsignedJWT(map[string]interface{}{"sub": "u"})))
+		require.Error(t, err, "jwt_bearer + %s must error", key)
+		assert.Contains(t, err.Error(), key)
+	}
+	assert.False(t, called, "the STS must not be called when the config is rejected")
+}
+
 func TestTokenExchangeDriver_ClientSecretBasic(t *testing.T) {
 	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
 

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -109,9 +109,9 @@ func (t *OAuthBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("audience").
 			Describe("Target audience for the exchanged token (token_exchange source)").
 			Example("https://api.internal.example.com"),
-		credential.StringField("resource").
-			Describe("RFC 8707 resource indicator for the exchanged token (token_exchange source)").
-			Example("https://api.internal.example.com"),
+		credential.StringField("resources").
+			Describe("RFC 8707 resource indicator(s) for the exchanged token — space-separated absolute URIs (token_exchange source)").
+			Example("https://api.internal.example.com https://api2.internal.example.com"),
 	}
 }
 

--- a/site/src/content/docs/concepts/credentials.md
+++ b/site/src/content/docs/concepts/credentials.md
@@ -48,7 +48,8 @@ naming a different role on each request.
 ### Sources
 
 A source is created with a name, a `type` (the driver), a `config` map holding
-the upstream connection and privileged secret, and a required `rotation_period`
+the upstream connection and the credentials the driver uses — a privileged secret,
+or the client credentials for an identity exchange — and a required `rotation_period`
 (pass `0` to disable rotation):
 
 ```bash

--- a/site/src/content/docs/concepts/delegation.md
+++ b/site/src/content/docs/concepts/delegation.md
@@ -1,39 +1,82 @@
 ---
-title: "Delegation (On-Behalf-Of)"
+title: "Delegation and Impersonation"
 ---
 
-A request is made *by* an authenticated principal, but it is often made *on behalf
-of* someone else — an AI agent acting for a user, or a **concentrator** that holds
-one identity and serves many agents through it. Warden lets a request carry that
-chain of subjects, the **actors**, and records them in the [audit log](/concepts/audit/)
-so attribution survives the hop.
+A request is made *by* an authenticated principal, but it is often made *on behalf of*
+someone else — an AI agent acting for a user. Warden supports this at the **credential
+boundary**: when the [token-exchange driver](/credential-drivers/token-exchange/) mints a
+downstream credential, it exchanges the caller's identity for a token that either *is* the
+subject (impersonation) or names the acting party in a signed **`act` claim** (delegation),
+which the upstream API and its authorization server enforce.
 
-The chain is for **attribution, not authorization** — see
-[Attribution, Not Authorization](#attribution-not-authorization) below. It answers
-"who was this *really* for?", not "is this allowed?".
+Separately, Warden records an **actor chain** in its [audit log](/concepts/audit/) so attribution
+survives the hop — covered [at the end](#the-audit-actor-chain).
 
-## The Actor Chain
+## Supported Standards
 
-Each actor is a subject plus a trust flag:
+Warden does not invent a delegation protocol — it speaks the established ones, selected per
+[credential source](/concepts/credentials/) by the `grant` setting so it interoperates with whatever
+the upstream's authorization server expects:
+
+| Standard | Role | Selected by |
+|----------|------|-------------|
+| **RFC 8693** — OAuth 2.0 Token Exchange | exchange a subject (and optional actor) for a scoped token | `grant=rfc8693` |
+| **RFC 7523** — JWT Bearer assertion | present the subject as a signed `assertion` | `grant=jwt_bearer` |
+| **Microsoft Entra ID On-Behalf-Of** | Entra's OBO (a jwt-bearer variant) | `grant=jwt_bearer` + `token_param.requested_token_use=on_behalf_of` |
+| **ID-JAG** — Identity Assertion Authorization Grant | cross-app access: chain an ID-JAG from the home IdP to a resource authorization server | `grant=id_jag` |
+
+Warden authenticates itself to the token endpoint with a client secret
+(`client_secret_basic`/`client_secret_post`) or a signed **private_key_jwt** client assertion
+(RFC 7523 §2.2) — configured independently of the grant.
+
+## Impersonation vs Delegation
+
+RFC 8693 §1.1 distinguishes the two by whether the **minted token carries an `act` claim**:
+
+- **Impersonation** — the minted token represents *only the subject*; no acting party is recorded.
+  Warden exchanges the caller's identity (or a user token the agent carries) for a downstream token
+  that *is* that principal, with no trace of the agent.
+- **Delegation** — the minted token carries an `act` chain ("agent A acting for user B"), so the
+  downstream sees, and can enforce policy on, both the subject and the actor.
+
+An `act` claim arises when Warden sends an `actor_token` during the exchange, **or** when the
+subject token already carries an embedded `act` (a subject that is itself a delegated token yields
+a delegated result even with no actor).
+
+## The Subject and the Actor
+
+Both the subject (who the action is *for*) and the optional actor (who is *acting*) are
+caller-derived tokens, each with a trust **origin**:
+
+| Origin | Source | Handling |
+|--------|--------|----------|
+| **Verified** | the caller's inbound JWT Warden authenticated at the auth mount (`…_token_source=auth_token`) | forwarded as-is |
+| **Unverified** | a request header (`X-Warden-Subject-Token` / `X-Warden-Actor-Token`, `…_token_source=header`) | the driver validates signature, issuer, audience and expiry, or **fails closed** |
+
+The canonical delegation shape is **agent-acting-for-user**: the agent carries the user's token as
+the subject and its own verified inbound JWT as the actor, so the minted token reads "agent for
+user" — with the agent's token sent once, not re-validated. Because the actor is a real, signed
+token, it can serve as a cryptographic RFC 8693 actor; the audit label described below cannot.
+
+See [Impersonation vs delegation](/credential-drivers/token-exchange/#impersonation-vs-delegation)
+on the driver page for the full configuration and worked examples.
+
+## The Audit Actor Chain
+
+Independently of what is minted, Warden records who a request was *for* in the audit trail. This
+chain is an **attribution** record; each actor is a subject plus a trust flag:
 
 | Field | Meaning |
 |-------|---------|
 | `subject` | The identity being acted for (e.g. `agents/alpha`, `user@example.com`). |
 | `verified` | Whether the actor is cryptographically attested (`true`) or self-reported (`false`). |
 
-A request can carry several actors, ordered from the nearest delegator outward,
-and they appear as the `actors` array on the request's audit entry.
-
-## Two Sources
-
-An actor chain reaches Warden two ways, distinguished by whether it can be
-cryptographically trusted.
+It reaches Warden two ways, and appears as the `actors` array on the request's audit entry.
 
 ### JWT `act` claim — verified
 
-A JWT can carry an RFC 8693 §4.1 **`act`** ("actor") claim, and because the JWT is
-signed by the identity provider, the chain it asserts is **attested** — recorded
-as `verified: true`. The claim nests to express a chain:
+A signed JWT can carry an RFC 8693 §4.1 **`act`** claim; because the IdP signed it, the chain is
+**attested** (`verified: true`) and nests to express a chain:
 
 ```json
 { "sub": "gateway-service",
@@ -41,99 +84,40 @@ as `verified: true`. The claim nests to express a chain:
            "act": { "sub": "agents/alpha" } } }
 ```
 
-→ actors `[broker-beta (verified), agents/alpha (verified)]`. Warden walks the
-nesting up to a depth of **4**, stopping gracefully at any malformed layer. These
-actors are extracted at login and **persisted on the [token](/concepts/tokens/)**, so the
-chain survives transparent-token caching.
+→ actors `[broker-beta (verified), agents/alpha (verified)]`. Warden walks the nesting up to a depth
+of **4**, and these actors are extracted at login and **persisted on the [token](/concepts/tokens/)**
+so the chain survives transparent-token caching.
 
 ### `X-Warden-On-Behalf-Of` header — unverified
 
-When the delegator cannot embed the chain in a JWT — typically a concentrator
-that authenticates with its own identity — it names the subject it is acting for
-in the `X-Warden-On-Behalf-Of` header. Warden has no proof of this, so it is
-recorded as `verified: false`:
+When the delegator cannot embed the chain in a JWT — typically a **concentrator** that
+authenticates with its own identity and serves many agents — it names the subject it acts for in
+the `X-Warden-On-Behalf-Of` header. Warden has no proof of this, so it is recorded as
+`verified: false`:
 
 ```
 X-Warden-On-Behalf-Of: agents/alpha
 ```
 
-The header carries a **single** subject (1–256 chars, `[A-Za-z0-9._:@/+-]`, no
-commas), is validated and dropped if malformed (never failing the request), is
-**per-request**, and is **stripped before the request is proxied upstream** so it
-never leaks past Warden.
+The header carries a **single** subject (1–256 chars, `[A-Za-z0-9._:@/+-]`, no commas), is validated
+and dropped if malformed (never failing the request), is **per-request**, and is **stripped before
+the request is proxied upstream** so it never leaks past Warden.
 
-## Verified vs. Unverified
-
-The `verified` flag tells an audit reader how much to trust an actor:
-
-- **`verified: true`** — the identity provider attested it by signing the JWT; the
-  caller cannot forge it. Suitable for strong non-repudiation.
-- **`verified: false`** — the authenticated principal simply asserted it via the
-  header. Record it as context, but the *principal* is accountable for its
-  accuracy.
-
-In both cases the **authenticated principal** is still recorded separately; the
-actors sit alongside it, they do not replace it.
-
-## Per-Request Beats Token-Bound
-
-This is the point of having both sources. A **concentrator** holds one transparent
-JWT and reuses it — and so one cached token — for many downstream agents. If
-attribution came only from the token, every agent's calls would collapse into the
-concentrator's identity. So the per-request **header wins** over the token-bound
-`act` chain:
+Being per-request, the header **wins** over the token-bound `act` chain — so a concentrator reusing
+one cached token still attributes each call to the right agent; the token's verified `act` chain is
+used only when no header is present:
 
 ```
 agent alpha  ─▶ concentrator ─▶ Warden   X-Warden-On-Behalf-Of: agents/alpha
 agent beta   ─▶ concentrator ─▶ Warden   X-Warden-On-Behalf-Of: agents/beta
 ```
 
-Both calls reuse the concentrator's one token, but each audit entry shows the
-right agent. When no header is present, the token's verified `act` chain is used
-instead.
-
-## Attribution, Not Authorization
-
-Actors **never affect access decisions**. No [policy](/concepts/policies/) capability,
-condition, or `mcp { }` rule consults them; a policy cannot allow or deny based on
-who a request is on behalf of. The chain exists purely to enrich the
-[audit](/concepts/audit/) trail and support non-repudiation. Keeping it orthogonal to
-authorization is deliberate: a self-reported header must never be able to widen
-what a caller may do.
-
-## Example
-
-A concentrator (principal `mcp-broker`) forwards an agent's call:
-
-```
-POST /v1/openai/gateway/v1/chat/completions
-Authorization: Bearer <concentrator session token>
-X-Warden-On-Behalf-Of: agents/alpha
-```
-
-The resulting audit entry attributes the call to both:
-
-```json
-{
-  "auth": {
-    "principal_id": "mcp-broker",
-    "actors": [{ "subject": "agents/alpha", "verified": false }]
-  }
-}
-```
-
-Had the chain instead come from a signed JWT `act` claim, the same entry would
-show `"verified": true`.
-
-## Surface
-
-Delegation is **header- and token-driven** — there is no CLI flag or environment
-variable. The verified chain comes from the JWT your identity provider issues; the
-unverified actor is a header an SDK or concentrator sets per request. Either way,
-it lands in the audit log and nowhere else.
+This audit chain is a string-only attribution label; unlike the signed subject/actor tokens above,
+it cannot serve as a cryptographic RFC 8693 actor token.
 
 ## See Also
 
+- [Token Exchange](/credential-drivers/token-exchange/) — minting delegated/impersonated downstream tokens.
 - [Audit](/concepts/audit/) — where the actor chain is recorded.
 - [Authentication](/concepts/authentication/) — the principal the actors act alongside.
 - [Tokens](/concepts/tokens/) — where a verified `act` chain is persisted.

--- a/site/src/content/docs/credential-drivers/index.md
+++ b/site/src/content/docs/credential-drivers/index.md
@@ -4,9 +4,13 @@ title: "Credential Drivers"
 
 A **driver** is the pluggable component that knows how to talk to one kind of
 upstream. A [credential source](/concepts/credentials/) names a driver through
-its `type`, holds the privileged secret, and the driver mints or retrieves the
-scoped credential a workload needs — an STS session, a Vault token, a GitHub
-installation token — which Warden injects into the proxied request.
+its `type` and holds whatever that driver needs to obtain credentials — usually a
+privileged secret, though some drivers instead **exchange the caller's own
+identity** for a downstream credential and hold only the client credentials to
+authenticate to an STS. The driver then mints or retrieves the scoped credential a
+workload needs — an STS session, a Vault token, a GitHub installation token, a
+token exchanged from the caller's identity — which Warden injects into the proxied
+request.
 
 Every driver implements the same core contract — **mint** a credential from a spec,
 **revoke** a lease, and **clean up** — and may opt into extra capabilities:
@@ -21,6 +25,9 @@ Every driver implements the same core contract — **mint** a credential from a 
 - **Spec rotation** — use the source's elevated permissions to rotate a credential
   embedded in a spec.
 - **OAuth2 authorization-code consent** — drive a one-time interactive consent flow.
+- **Token exchange** — mint from caller-derived RFC 8693 inputs (a subject token,
+  and optionally an actor token) rather than the source's own secret, exchanging
+  the caller's identity for a scoped downstream credential.
 
 See [Credentials](/concepts/credentials/) for the source / spec / credential
 model these pages build on.
@@ -39,6 +46,7 @@ model these pages build on.
 | [HashiCorp Vault](/credential-drivers/vault/) | `hvault` | Vault / OpenBao — KV, AWS/GCP/IBM engines, tokens, OAuth2 | source rotation (fast) |
 | [Kubernetes](/credential-drivers/kubernetes/) | `kubernetes` | ServiceAccount tokens via the TokenRequest API | spec verification · source rotation (fast) |
 | [OAuth2](/credential-drivers/oauth2/) | `oauth2` | generic OAuth2 providers | spec verification · OAuth2 consent |
+| [Token Exchange](/credential-drivers/token-exchange/) | `token_exchange` | RFC 8693 / RFC 7523 exchange at any OAuth2 STS (Entra OBO, ID-JAG) | token exchange |
 
 ## Cloud
 

--- a/site/src/content/docs/credential-drivers/token-exchange.md
+++ b/site/src/content/docs/credential-drivers/token-exchange.md
@@ -10,25 +10,55 @@ It is **exchange-only**: it never mints from static source config. Every spec mu
 
 ## Grant modes
 
-- **`rfc8693`** — `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` with `subject_token`, `subject_token_type`, `audience`/`scope`/`resource`, and (for delegation) `actor_token`.
+- **`rfc8693`** — `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` with `subject_token`, `subject_token_type`, `audience`/`scope`/`resources`, and (for delegation) `actor_token`.
 - **`jwt_bearer`** — `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` with the subject as `assertion`. Entra OBO adds `token_param.requested_token_use=on_behalf_of`.
 - **`id_jag`** — two legs inside one mint: leg 1 exchanges the subject at `token_url` for an ID-JAG assertion (`requested_token_type=…:id-jag`, `audience`=the resource AS); leg 2 redeems the ID-JAG at `resource_token_url` via `jwt_bearer`. Only the final access token is returned.
 
 ## Impersonation vs delegation
 
-RFC 8693 §1.1 distinguishes two outcomes by whether the **minted token carries an `act` claim** (delegation — an acting party is recorded) or not (impersonation — only the subject). An `act` claim arises two ways: Warden sends an `actor_token`, **or** the subject token already carries an embedded `act`.
+Every exchange has a **subject** — the identity the new downstream token will *represent* (who
+the request is *for*). It may also name an **actor** — a second identity recorded as *acting on
+behalf of* the subject. Whether the minted token names an actor decides the outcome (RFC 8693 §1.1):
 
-**Warden sends no actor token** (`actor_token_source=none`) — forwards only a subject; works with `rfc8693` and `jwt_bearer`.
-- Normally **impersonation** — the minted token represents only the subject:
-  - `subject_token_source=auth_token` — act as the caller's own verified identity.
-  - `subject_token_source=header` — act as a distinct identity the agent carries (e.g. a user token).
-- **Pre-delegated subject:** if the subject token *already carries an embedded `act`* (it is itself a delegated token), the minted token inherits that chain, so the **result is delegation** even though Warden sent no actor token. This holds for either subject source, including `subject_token_source=auth_token`.
+- **Impersonation** — the token represents **only the subject**. The upstream can't tell an agent
+  was involved; Warden hands it a token that simply *is* the principal.
+- **Delegation** — the token also carries an **`act` claim** naming the actor, so the upstream sees
+  "**agent A acting for user B**" and can audit or authorize on both.
 
-**Warden sends an actor token** (`actor_token_source=auth_token` or `header`) — adds an acting party, so the minted token carries an `act` chain ("agent acting for user"). **`rfc8693` only** (jwt-bearer has no actor slot).
-- Preferred: `subject_token_source=header` (user token) + `actor_token_source=auth_token` (the agent's verified inbound JWT — sent once, not re-validated).
-- `actor_token_source=header` when the actor is a distinct token the agent supplies.
+### Where the subject and actor come from
 
-`subject_token_source=auth_token` requires JWT-based inbound auth. `actor_token_source=auth_token` requires `subject_token_source=header` (one inbound token cannot be both subject and actor).
+Each is a caller-derived token, drawn from one of two sources (both validated per the
+[origin trust model](#origin-trust-model) below):
+
+- **`auth_token`** — the caller's **own inbound JWT**, the identity it authenticated to Warden with.
+- **`header`** — a **separate token the caller carries**, supplied in `X-Warden-Subject-Token` /
+  `X-Warden-Actor-Token` (e.g. an end user's token the agent is holding).
+
+### The patterns
+
+| What you want | `subject_token_source` | `actor_token_source` | Minted token |
+|---|---|---|---|
+| Act **as yourself** | `auth_token` | `none` | represents the caller — *impersonation* |
+| Act **as a user you carry** | `header` (user token) | `none` | represents the user; agent invisible — *impersonation* |
+| **Agent acting for a user** | `header` (user token) | `auth_token` (agent's JWT) | `sub`=user, `act`=agent — *delegation* |
+| Delegation with a **distinct** actor | `header` | `header` | `act`=the supplied actor — *delegation* |
+
+The third row is the canonical delegation: the agent presents the **user's** token as the subject
+(`X-Warden-Subject-Token`), and its **own** inbound JWT — the one it already sent in `Authorization`
+to authenticate — is reused as the actor. It needs no separate `X-Warden-Actor-Token`, unlike
+`actor_token_source=header`, where the agent would send its token a second time.
+
+### Two things that trip people up
+
+- **A pre-delegated subject yields delegation on its own.** If the subject token is *itself* already
+  a delegated token (it carries an embedded `act`), the minted token inherits that chain — so you get
+  a *delegation* result even with `actor_token_source=none`. Adding an actor on top just nests another
+  layer.
+- **Delegation is `rfc8693`-only.** The `jwt_bearer`/Entra grant has no slot for an actor token, so
+  an actor is rejected there. (Impersonation works with both grants.)
+
+**Constraints:** `auth_token` requires JWT-based inbound auth; and since one inbound token can't be
+both subject and actor, `actor_token_source=auth_token` requires `subject_token_source=header`.
 
 ## Origin trust model
 
@@ -67,8 +97,13 @@ warden cred spec create internal-api \
   -source=idp-exchange \
   -config=subject_token_source=auth_token \
   -config=audience=https://api.internal.example.com \
-  -config=scope=read:orders
+  -config=scope=read:orders \
+  -config=resources="https://api.internal.example.com https://reports.internal.example.com"
 ```
+
+`resources` is a space-separated list of RFC 8707 resource indicators, sent as
+repeated `resource` parameters so the exchanged token can be bound to one or more
+downstream APIs.
 
 **Microsoft Entra OBO (`jwt_bearer`)** — the subject is sent as `assertion` with Entra's on-behalf-of flag.
 
@@ -144,8 +179,13 @@ warden cred spec create resource-api \
   -source=crossapp \
   -config=subject_token_source=auth_token \
   -config=audience=https://auth.resourceapp.example.com \
-  -config=scope=files:read
+  -config=scope=files:read \
+  -config=resources=https://files.resourceapp.example.com
 ```
+
+For `id_jag`, `resources` is sent on **leg 2** (the resource-AS redemption), so it
+scopes the final access token — `audience` still binds the ID-JAG to the resource
+authorization server on leg 1.
 
 ## Source config
 
@@ -183,4 +223,4 @@ Every `token_exchange` spec **must** set `subject_token_source`. Keys operators 
 | `actor_token_type` | No | `…:token-type:jwt` | RFC 8693 actor token type. |
 | `audience` | No | — | Target audience for the exchanged token (the resource AS for `id_jag`). |
 | `scope` | No | — | Scope requested for the exchanged token. |
-| `resource` | No | — | RFC 8707 resource indicator. |
+| `resources` | No | — | RFC 8707 resource indicator(s) — space-separated absolute URIs, sent as repeated `resource` parameters. Grant-agnostic (rfc8693 and jwt_bearer; for `id_jag`, on leg 2 — the final access token). |

--- a/site/src/content/docs/credential-drivers/token-exchange.md
+++ b/site/src/content/docs/credential-drivers/token-exchange.md
@@ -178,7 +178,7 @@ Every `token_exchange` spec **must** set `subject_token_source`. Keys operators 
 | Key | Required | Default | Description |
 |-----|----------|---------|-------------|
 | `subject_token_source` | Yes | — | Subject origin: `auth_token` (the caller's verified inbound JWT) or `header` (`X-Warden-Subject-Token`, validated by the driver). |
-| `subject_token_type` | No | `…:token-type:jwt` | RFC 8693 subject token type. |
+| `subject_token_type` | No | `…:token-type:jwt` | RFC 8693 subject token type. Some STSs are strict — e.g. Keycloak's Standard Token Exchange accepts only `urn:ietf:params:oauth:token-type:access_token`, so set this explicitly for them. |
 | `actor_token_source` | No | `none` | Delegation actor: `none`, `auth_token` (the agent's inbound JWT), or `header` (`X-Warden-Actor-Token`). |
 | `actor_token_type` | No | `…:token-type:jwt` | RFC 8693 actor token type. |
 | `audience` | No | — | Target audience for the exchanged token (the resource AS for `id_jag`). |

--- a/site/src/content/docs/credential-drivers/token-exchange.md
+++ b/site/src/content/docs/credential-drivers/token-exchange.md
@@ -51,6 +51,102 @@ Always `oauth_bearer_token`. It is **dynamic** when the token endpoint returns a
 - `client_secret` and `private_key` are masked; subject/actor/minted tokens are never logged.
 - `tls_skip_verify` is for development only (a cleartext IdP would expose caller tokens).
 
+## Examples
+
+**RFC 8693 OBO of the caller's own identity** — the agent's verified inbound JWT is exchanged for a token scoped to an internal API.
+
+```bash
+warden cred source create idp-exchange \
+  -type=token_exchange \
+  -config=token_url=https://idp.example.com/oauth2/v1/token \
+  -config=client_auth=client_secret_post \
+  -config=client_id=warden-gateway \
+  -config=client_secret="$OAUTH_CLIENT_SECRET"
+
+warden cred spec create internal-api \
+  -source=idp-exchange \
+  -config=subject_token_source=auth_token \
+  -config=audience=https://api.internal.example.com \
+  -config=scope=read:orders
+```
+
+**Microsoft Entra OBO (`jwt_bearer`)** — the subject is sent as `assertion` with Entra's on-behalf-of flag.
+
+```bash
+warden cred source create entra-obo \
+  -type=token_exchange \
+  -config=token_url=https://login.microsoftonline.com/$TENANT/oauth2/v2.0/token \
+  -config=grant=jwt_bearer \
+  -config=client_auth=client_secret_post \
+  -config=client_id=$CLIENT_ID \
+  -config=client_secret="$CLIENT_SECRET" \
+  -config=token_param.requested_token_use=on_behalf_of
+
+warden cred spec create graph \
+  -source=entra-obo \
+  -config=subject_token_source=auth_token \
+  -config=scope=https://graph.microsoft.com/.default
+```
+
+**Header-sourced subject (a carried user token)** — the agent supplies a user's token in `X-Warden-Subject-Token`; the source's `subject_*` keys let the driver validate it before exchanging.
+
+```bash
+warden cred source create partner-idp \
+  -type=token_exchange \
+  -config=token_url=https://idp.example.com/oauth2/v1/token \
+  -config=client_auth=client_secret_post \
+  -config=client_id=warden-gateway \
+  -config=client_secret="$OAUTH_CLIENT_SECRET" \
+  -config=subject_jwks_url=https://login.example.com/keys \
+  -config=subject_issuer=https://login.example.com/ \
+  -config=subject_audience=api://warden
+
+warden cred spec create internal-api \
+  -source=partner-idp \
+  -config=subject_token_source=header \
+  -config=audience=https://api.internal.example.com
+```
+
+**`private_key_jwt` client authentication** — Warden signs a client assertion instead of sending a secret.
+
+```bash
+warden cred source create idp-pkjwt \
+  -type=token_exchange \
+  -config=token_url=https://idp.example.com/oauth2/v1/token \
+  -config=client_auth=private_key_jwt \
+  -config=client_id=warden-gateway \
+  -config=private_key="$(cat client-key.pem)"
+```
+
+**Delegation — agent acting for a user** — the user's token is the subject (header); the agent's own verified inbound JWT is the actor. The minted token carries an `act` chain.
+
+```bash
+warden cred spec create internal-api-deleg \
+  -source=idp-exchange \
+  -config=subject_token_source=header \
+  -config=actor_token_source=auth_token \
+  -config=audience=https://api.internal.example.com
+```
+
+**ID-JAG cross-app access** — two legs in one mint: an ID-JAG from the home IdP, redeemed at the resource authorization server.
+
+```bash
+warden cred source create crossapp \
+  -type=token_exchange \
+  -config=grant=id_jag \
+  -config=token_url=https://idp.example.com/oauth2/v1/token \
+  -config=resource_token_url=https://auth.resourceapp.example.com/oauth2/token \
+  -config=client_auth=private_key_jwt \
+  -config=client_id=warden-gateway \
+  -config=private_key="$(cat client-key.pem)"
+
+warden cred spec create resource-api \
+  -source=crossapp \
+  -config=subject_token_source=auth_token \
+  -config=audience=https://auth.resourceapp.example.com \
+  -config=scope=files:read
+```
+
 ## Source config
 
 Keys for `warden cred source create <name> -type=token_exchange -config=key=value ...`:

--- a/site/src/content/docs/credential-drivers/token-exchange.md
+++ b/site/src/content/docs/credential-drivers/token-exchange.md
@@ -1,0 +1,90 @@
+---
+title: "Token Exchange"
+---
+
+> Source `type`: `token_exchange`
+
+The **token-exchange driver** brokers a downstream bearer token by **exchanging a caller's identity** at an identity provider's token endpoint — RFC 8693 token-exchange, RFC 7523 `jwt-bearer` (Microsoft Entra OBO), or the ID-JAG cross-app-access flow. The workload presents only its own identity to Warden; Warden exchanges that identity for a scoped token for the upstream and injects it, so a downstream token never passes through the agent.
+
+It is **exchange-only**: it never mints from static source config. Every spec must declare where the subject comes from, and the driver mints solely from that caller-derived subject (and an optional actor). The token endpoint, client identity, and grant live on the **source**; the target audience, scope, and token-exchange wiring live on the **spec**.
+
+## Grant modes
+
+- **`rfc8693`** — `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` with `subject_token`, `subject_token_type`, `audience`/`scope`/`resource`, and (for delegation) `actor_token`.
+- **`jwt_bearer`** — `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` with the subject as `assertion`. Entra OBO adds `token_param.requested_token_use=on_behalf_of`.
+- **`id_jag`** — two legs inside one mint: leg 1 exchanges the subject at `token_url` for an ID-JAG assertion (`requested_token_type=…:id-jag`, `audience`=the resource AS); leg 2 redeems the ID-JAG at `resource_token_url` via `jwt_bearer`. Only the final access token is returned.
+
+## Impersonation vs delegation
+
+RFC 8693 §1.1 distinguishes two outcomes by whether the **minted token carries an `act` claim** (delegation — an acting party is recorded) or not (impersonation — only the subject). An `act` claim arises two ways: Warden sends an `actor_token`, **or** the subject token already carries an embedded `act`.
+
+**Warden sends no actor token** (`actor_token_source=none`) — forwards only a subject; works with `rfc8693` and `jwt_bearer`.
+- Normally **impersonation** — the minted token represents only the subject:
+  - `subject_token_source=auth_token` — act as the caller's own verified identity.
+  - `subject_token_source=header` — act as a distinct identity the agent carries (e.g. a user token).
+- **Pre-delegated subject:** if the subject token *already carries an embedded `act`* (it is itself a delegated token), the minted token inherits that chain, so the **result is delegation** even though Warden sent no actor token. This holds for either subject source, including `subject_token_source=auth_token`.
+
+**Warden sends an actor token** (`actor_token_source=auth_token` or `header`) — adds an acting party, so the minted token carries an `act` chain ("agent acting for user"). **`rfc8693` only** (jwt-bearer has no actor slot).
+- Preferred: `subject_token_source=header` (user token) + `actor_token_source=auth_token` (the agent's verified inbound JWT — sent once, not re-validated).
+- `actor_token_source=header` when the actor is a distinct token the agent supplies.
+
+`subject_token_source=auth_token` requires JWT-based inbound auth. `actor_token_source=auth_token` requires `subject_token_source=header` (one inbound token cannot be both subject and actor).
+
+## Origin trust model
+
+The driver receives one trust signal per token: its **origin**.
+
+- **Verified** — the token is the caller's inbound JWT that Warden already authenticated at the auth mount (`…_token_source=auth_token`). Forwarded as-is.
+- **Unverified** — the token was supplied on a request header (`…_token_source=header`). The driver **must** validate it — signature (via `subject_jwks_url`/`subject_oidc_discovery_url`), `subject_issuer`, `subject_audience`, and expiry — before forwarding, and **fails closed** if that validation config is absent. An unvalidated caller token never reaches the token endpoint.
+
+Warden authenticates the caller on the verified token, not on a self-asserted `act` claim. The `act` chain a token carries is surfaced to [policy conditions](/concepts/policies/) and the audit trail — see the [on-behalf-of chain](/concepts/delegation/).
+
+## Credential issued
+
+Always `oauth_bearer_token`. It is **dynamic** when the token endpoint returns an expiry (re-minted on expiry) and non-revocable — bearer tokens expire naturally, so revocation is a no-op. See [the lifetime model](/concepts/credentials/#lifetime-and-revocation). The credential's audit metadata records the exchanged `subject` and `subject_verified`.
+
+## Security
+
+- Caller tokens are forwarded to the configured IdP — the IdP must be trusted to receive them.
+- Unverified (header-sourced) subject and actor tokens are validated or the mint fails closed.
+- `X-Warden-Subject-Token` / `X-Warden-Actor-Token` are stripped before any upstream forwarding.
+- `client_secret` and `private_key` are masked; subject/actor/minted tokens are never logged.
+- `tls_skip_verify` is for development only (a cleartext IdP would expose caller tokens).
+
+## Source config
+
+Keys for `warden cred source create <name> -type=token_exchange -config=key=value ...`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `token_url` | Yes | — | Token endpoint (HTTPS) of the STS/IdP performing the exchange. |
+| `grant` | No | `rfc8693` | Exchange grant: `rfc8693`, `jwt_bearer`, or `id_jag`. |
+| `client_auth` | No | `client_secret_post` | How Warden authenticates to the token endpoint: `client_secret_basic`, `client_secret_post`, or `private_key_jwt`. |
+| `client_id` | Yes | — | OAuth2 client ID Warden presents to the token endpoint. |
+| `client_secret` | For secret auth | — | Client secret (secret, masked on read). |
+| `private_key` | For `private_key_jwt` | — | PEM RSA private key that signs the client assertion (secret, masked on read). |
+| `client_assertion_alg` | No | `RS256` | Signing algorithm for the client assertion (RS256). |
+| `client_assertion_kid` | No | — | Optional `kid` header for the client assertion. |
+| `resource_token_url` | For `id_jag` | — | Resource authorization-server token endpoint (HTTPS) for ID-JAG leg 2. |
+| `subject_oidc_discovery_url` | For `header` subjects | — | OIDC discovery URL of the issuer that signs caller-supplied tokens. |
+| `subject_jwks_url` | For `header` subjects | — | JWKS URL for caller-supplied token signature validation. |
+| `subject_issuer` | For `header` subjects | — | Expected `iss` of a caller-supplied token. |
+| `subject_audience` | For `header` subjects | — | Expected `aud` of a caller-supplied token. |
+| `ca_data` | No | — | Base64-encoded PEM CA certificate for custom/self-signed CAs (secret, masked on read). |
+| `tls_skip_verify` | No | `false` | Skip TLS certificate verification (development only). |
+
+Vendor-specific token-endpoint parameters go through `token_param.*` (e.g. `token_param.requested_token_use=on_behalf_of`); they may not override a core exchange field.
+
+## Spec config
+
+Every `token_exchange` spec **must** set `subject_token_source`. Keys operators set with `warden cred spec create ... -config=key=value`:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `subject_token_source` | Yes | — | Subject origin: `auth_token` (the caller's verified inbound JWT) or `header` (`X-Warden-Subject-Token`, validated by the driver). |
+| `subject_token_type` | No | `…:token-type:jwt` | RFC 8693 subject token type. |
+| `actor_token_source` | No | `none` | Delegation actor: `none`, `auth_token` (the agent's inbound JWT), or `header` (`X-Warden-Actor-Token`). |
+| `actor_token_type` | No | `…:token-type:jwt` | RFC 8693 actor token type. |
+| `audience` | No | — | Target audience for the exchanged token (the resource AS for `id_jag`). |
+| `scope` | No | — | Scope requested for the exchanged token. |
+| `resource` | No | — | RFC 8707 resource indicator. |


### PR DESCRIPTION
## What

Final PR of the token-exchange stack: the **ID-JAG cross-app-access grant**, the multi-valued **RFC 8707 `resources`** refactor across all grants, and the full **documentation** for the driver.

### ID-JAG (`grant=id_jag`)
Two legs inside one `MintCredentialWithExchange`, composing the modes already built:
- **Leg 1** → source `token_url` (home IdP): RFC 8693 with `requested_token_type=…:id-jag`, `subject_token=<caller>`, audience = the resource AS → an ID-JAG assertion.
- **Leg 2** → new source key `resource_token_url` (resource AS, SSRF-guarded): jwt_bearer with `assertion=<ID-JAG>` → the access token.
- Client auth runs on both legs; only the final access token is returned/cached.

### RFC 8707 `resources` (multi-valued)
Replace the single-valued `resource` with space-separated `resources`, emitted as repeated `resource` form params, across `rfc8693`, `jwt_bearer`, and `id_jag` (on leg 2). `jwt_bearer` rejects `audience` only. Also folds in the review fixes and the `reject audience/resource with grant=jwt_bearer` correctness fix.

### Docs
- New `credential-drivers/token-exchange.md` — driver reference: grants, config tables, worked examples, impersonation-vs-delegation guidance, origin-trust security callouts.
- `concepts/delegation.md` — overhauled to lead with token-exchange delegation/impersonation and a Supported Standards table.
- `credential-drivers/index.md` + `concepts/credentials.md` — add the `token_exchange` driver row and the `ExchangeMinter` capability.
- Note that strict STSs (Keycloak) require `subject_token_type=access_token`.

## Test

`credential/drivers/token_exchange_driver_test.go`: the two-leg ID-JAG exchange (leg 1 requested_token_type + audience, leg 2 assertion + resources), multi-valued `resources` emitted as repeated params on each grant, and jwt_bearer rejecting `audience`.

## Context

Plan PR 8 (+ the token-exchange docs and the `resources` refactor). Rebased onto `main` after PR 7 (#421) merged — diff is ID-JAG, resources, and docs only. Depends on PR 4 / PR 6 / PR 3, all upstream. Completes the token-exchange feature.
