### PR TITLE
docs(site): group credential drivers and providers in the sidebar

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -91,7 +91,7 @@ export default defineConfig({
             { slug: 'provider-backends/local-dev-setup' },
             { slug: 'provider-backends/configuration' },
             {
-              label: 'MCP servers',
+              label: 'MCP',
               collapsed: true,
               items: [
                 { slug: 'provider-backends/mcp' },
@@ -101,7 +101,7 @@ export default defineConfig({
               ],
             },
             {
-              label: 'LLM APIs',
+              label: 'LLM',
               collapsed: true,
               items: [
                 { slug: 'provider-backends/anthropic' },
@@ -111,7 +111,7 @@ export default defineConfig({
               ],
             },
             {
-              label: 'Cloud infrastructure',
+              label: 'Cloud',
               collapsed: true,
               items: [
                 { slug: 'provider-backends/aws' },
@@ -125,7 +125,7 @@ export default defineConfig({
               ],
             },
             {
-              label: 'Code hosting & CI/CD',
+              label: 'CI/CD',
               collapsed: true,
               items: [
                 { slug: 'provider-backends/github' },
@@ -151,7 +151,7 @@ export default defineConfig({
               ],
             },
             {
-              label: 'Incident & ITSM',
+              label: 'ITSM',
               collapsed: true,
               items: [
                 { slug: 'provider-backends/pagerduty' },
@@ -160,33 +160,73 @@ export default defineConfig({
               ],
             },
             {
-              label: 'Databases',
+              // Kubernetes, the Vault secrets backend, and databases.
+              label: 'Infrastructure',
               collapsed: true,
               items: [
+                { slug: 'provider-backends/kubernetes' },
+                { slug: 'provider-backends/vault' },
                 { slug: 'provider-backends/rds' },
                 { slug: 'provider-backends/redshift' },
               ],
             },
             {
-              label: 'Kubernetes',
-              collapsed: true,
-              items: [{ slug: 'provider-backends/kubernetes' }],
-            },
-            {
-              label: 'Secrets backend',
-              collapsed: true,
-              items: [{ slug: 'provider-backends/vault' }],
-            },
-            {
-              label: 'Generic REST',
+              label: 'Generic',
               collapsed: true,
               items: [{ slug: 'provider-backends/rest' }],
             },
           ],
         },
         {
+          // Grouped by the categories in credential-drivers/index.md, not
+          // alphabetical. Subgroups collapse by default; the active page's
+          // group opens.
           label: 'Credential drivers',
-          autogenerate: { directory: 'credential-drivers' },
+          items: [
+            { slug: 'credential-drivers' },
+            {
+              label: 'Generic',
+              collapsed: true,
+              items: [
+                { slug: 'credential-drivers/local' },
+                { slug: 'credential-drivers/apikey' },
+              ],
+            },
+            {
+              label: 'Platform',
+              collapsed: true,
+              items: [
+                { slug: 'credential-drivers/vault' },
+                { slug: 'credential-drivers/kubernetes' },
+                { slug: 'credential-drivers/oauth2' },
+                { slug: 'credential-drivers/token-exchange' },
+              ],
+            },
+            {
+              label: 'Cloud',
+              collapsed: true,
+              items: [
+                { slug: 'credential-drivers/aws' },
+                { slug: 'credential-drivers/azure' },
+                { slug: 'credential-drivers/gcp' },
+                { slug: 'credential-drivers/ibm' },
+                { slug: 'credential-drivers/alicloud' },
+                { slug: 'credential-drivers/scaleway' },
+                { slug: 'credential-drivers/ovh' },
+              ],
+            },
+            {
+              label: 'SaaS',
+              collapsed: true,
+              items: [
+                { slug: 'credential-drivers/github' },
+                { slug: 'credential-drivers/gitlab' },
+                { slug: 'credential-drivers/elastic' },
+                { slug: 'credential-drivers/grafana' },
+                { slug: 'credential-drivers/honeycomb' },
+              ],
+            },
+          ],
         },
         { label: 'Auth methods', autogenerate: { directory: 'auth-methods' } },
         { label: 'Agent identity', autogenerate: { directory: 'agent-identity' } },

--- a/site/src/content/docs/provider-backends/index.md
+++ b/site/src/content/docs/provider-backends/index.md
@@ -14,14 +14,14 @@ Each page below is a setup guide for one provider — prerequisites, mount
 configuration, credential sources and specs, policy, and a configuration
 reference.
 
-## MCP servers
+## MCP
 
 | Provider | Description |
 |---|---|
 | [Generic](/provider-backends/mcp/) | Any bearer-authenticated Model Context Protocol server. Per-upstream recipes: [GitHub](/provider-backends/mcp-github/), [Slack](/provider-backends/mcp-slack/), Cloudflare, … |
 | [AWS](/provider-backends/mcp_aws/) | AWS's hosted Model Context Protocol server |
 
-## LLM APIs
+## LLM
 
 | Provider | Description |
 |---|---|
@@ -30,20 +30,20 @@ reference.
 | [Mistral](/provider-backends/mistral/) | Mistral chat and embeddings models |
 | [Cohere](/provider-backends/cohere/) | Cohere generation, embeddings, and rerank models |
 
-## Cloud infrastructure
+## Cloud
 
 | Provider | Description |
 |---|---|
 | [AWS](/provider-backends/aws/) | Amazon Web Services control plane and service APIs |
-| [Alicloud](/provider-backends/alicloud/) | Alibaba Cloud OpenAPI (ACS3) and OSS object storage |
 | [Azure](/provider-backends/azure/) | Microsoft Azure resource management and services |
 | [GCP](/provider-backends/gcp/) | Google Cloud Platform APIs |
+| [Alicloud](/provider-backends/alicloud/) | Alibaba Cloud OpenAPI (ACS3) and OSS object storage |
 | [IBM Cloud](/provider-backends/ibmcloud/) | IBM Cloud platform services |
 | [OVH](/provider-backends/ovh/) | OVHcloud public cloud and hosting APIs |
 | [Scaleway](/provider-backends/scaleway/) | Scaleway cloud platform APIs |
 | [Cloudflare](/provider-backends/cloudflare/) | Cloudflare edge platform — API and Logpush |
 
-## Code hosting & CI/CD
+## CI/CD
 
 | Provider | Description |
 |---|---|
@@ -67,7 +67,7 @@ reference.
 | [Sentry](/provider-backends/sentry/) | Sentry error and performance monitoring |
 | [Splunk](/provider-backends/splunk/) | Splunk logging and search platform |
 
-## Incident & ITSM
+## ITSM
 
 | Provider | Description |
 |---|---|
@@ -75,18 +75,14 @@ reference.
 | [ServiceNow](/provider-backends/servicenow/) | ServiceNow ITSM platform |
 | [Slack](/provider-backends/slack/) | Slack messaging and Web API |
 
-## Infrastructure automation
+## Infrastructure
 
 | Provider | Description |
 |---|---|
 | [Kubernetes](/provider-backends/kubernetes/) | Kubernetes API server |
-
-## Secrets
-
-| Provider | Description |
-|---|---|
 | [HashiCorp Vault / OpenBao](/provider-backends/vault/) | HashiCorp Vault / OpenBao secrets platform |
-
+| [RDS](/provider-backends/rds/) | Short-lived IAM auth tokens for PostgreSQL and MySQL on Amazon RDS and Aurora |
+| [Redshift](/provider-backends/redshift/) | Short-lived IAM auth tokens for Amazon Redshift provisioned clusters and Serverless |
 
 ## Generic
 


### PR DESCRIPTION
## Summary

Restructure the docs sidebar so the **Credential drivers** and **Providers** sections are grouped by category instead of a flat list.

- **Credential drivers** — replaces the autogenerated flat listing with the four categories used on the index page: Generic, Platform, Cloud, SaaS.
- **Providers** — regrouped into MCP, LLM, Cloud, CI/CD, Observability, ITSM, Infrastructure (Kubernetes, Vault, databases), and Generic.

Each category's index page stays as the top entry; subgroups collapse by default and open on the active page.

## Testing

Verified locally with `npm run dev` — sidebar renders the new groups; all driver and provider pages remain reachable.
