### PR TITLE
fix(site): installer puts warden on PATH

### DIFF
--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -3,8 +3,9 @@
 #
 #   curl -sL https://wardengateway.com/install | bash
 #
-# Override the install location with WARDEN_INSTALL_DIR (default: /usr/local/bin if
-# writable, otherwise $HOME/.local/bin).
+# It installs into the first writable directory already on your PATH (so `warden`
+# works right away); otherwise it uses $HOME/.local/bin and adds that to your shell
+# profile. Override the location with WARDEN_INSTALL_DIR.
 set -euo pipefail
 
 REPO="stephnangue/warden"
@@ -36,13 +37,17 @@ VER=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
 ASSET="warden_${VER#v}_${OS}_${ARCH}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${VER}/${ASSET}"
 
-# --- choose install dir ---
+# --- choose install dir: prefer a writable directory already on PATH ---
+on_path() { case ":$PATH:" in *":$1:"*) return 0 ;; *) return 1 ;; esac; }
+
+DIR=""
 if [ -n "${WARDEN_INSTALL_DIR:-}" ]; then
   DIR="$WARDEN_INSTALL_DIR"
-elif [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
-  DIR="/usr/local/bin"
 else
-  DIR="$HOME/.local/bin"
+  for d in "$HOME/.local/bin" /opt/homebrew/bin /usr/local/bin "$HOME/bin"; do
+    if on_path "$d" && [ -d "$d" ] && [ -w "$d" ]; then DIR="$d"; break; fi
+  done
+  [ -n "$DIR" ] || DIR="$HOME/.local/bin"   # fall back (may not be on PATH yet)
 fi
 mkdir -p "$DIR"
 
@@ -56,7 +61,21 @@ chmod +x "$TMP/warden"
 mv "$TMP/warden" "$DIR/warden"
 
 info "Installed $("$DIR/warden" --version 2>/dev/null || echo warden) to $DIR/warden"
-case ":$PATH:" in
-  *":$DIR:"*) info "Verify with 'warden --version'." ;;
-  *) info "Add it to your PATH:  export PATH=\"$DIR:\$PATH\"" ;;
-esac
+
+if on_path "$DIR"; then
+  info "Verify with 'warden --version'."
+else
+  # Persist the PATH entry for future shells, then tell the user how to use it now.
+  case "$(basename "${SHELL:-}")" in
+    zsh)  profile="$HOME/.zshrc" ;;
+    bash) profile="${HOME}/.bashrc" ;;
+    *)    profile="$HOME/.profile" ;;
+  esac
+  line="export PATH=\"$DIR:\$PATH\""
+  if [ -f "$profile" ] && grep -qF "$DIR" "$profile" 2>/dev/null; then :; else
+    printf '\n# Added by the Warden installer\n%s\n' "$line" >> "$profile"
+  fi
+  info "Added $DIR to your PATH in $profile."
+  info "Open a new terminal, or run:  $line"
+  info "Then verify with 'warden --version'."
+fi


### PR DESCRIPTION
Follow-up to #425. The `/install` script placed the binary in `~/.local/bin` even when that directory wasn't on `PATH`, so `warden --version` failed immediately after install (reported on macOS).

Now the installer prefers the first **writable directory already on `PATH`** (`~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `~/bin`), so `warden` is usable right away. If none qualifies, it falls back to `~/.local/bin`, appends that dir to the user's shell profile (idempotently, based on $SHELL), and prints how to enable it in the current shell.

Verified both paths in a sandboxed $HOME: on-PATH install does no dotfile edit; the fallback writes the binary, appends to the correct profile, and prints guidance.