### PR TITLE
refactor(cli): split OIDC issuer publisher config into `set-publisher`

### DIFF
--- a/cmd/oidcissuer/configure.go
+++ b/cmd/oidcissuer/configure.go
@@ -17,21 +17,6 @@ var (
 	cfgJWKSCacheTTL      string
 	cfgRetiredKeyGrace   string
 
-	cfgPublisherType        string
-	cfgPublisherDir         string
-	cfgPublisherBaseURL     string
-	cfgPublisherAuthHdr     string
-	cfgPublisherAuthValue   string
-	cfgPublisherBucket      string
-	cfgPublisherRegion      string
-	cfgPublisherPrefix      string
-	cfgPublisherAccessKey   string
-	cfgPublisherSecretKey   string
-	cfgPublisherAccountName string
-	cfgPublisherContainer   string
-	cfgPublisherAccountKey  string
-	cfgPublisherEndpoint    string
-
 	cfgJSON string
 
 	ConfigureCmd = &cobra.Command{
@@ -42,9 +27,9 @@ var (
 		Long: `
 Usage: warden oidc-issuer configure [options]
 
-  Enable the OIDC issuer and set its issuer URL, assertion TTL, signing-key
-  rotation timings, and (optionally) a publisher that pushes the discovery +
-  JWKS documents to a bucket/CDN. Root namespace only.
+  Enable the OIDC issuer and set its issuer URL, assertion TTL, and signing-key
+  rotation timings. Root namespace only. Use 'warden oidc-issuer set-publisher'
+  to push the discovery + JWKS documents to a bucket/CDN.
 
   A write is a PARTIAL update: only the fields you pass change; everything else
   keeps its current value. So you can tweak one setting without re-supplying the
@@ -59,18 +44,6 @@ Usage: warden oidc-issuer configure [options]
   Change just the rotation cadence later (issuer_url and the rest are kept):
 
       $ warden oidc-issuer configure -key-rotation-period=24h
-
-  Configure with an S3 publisher:
-
-      $ warden oidc-issuer configure -issuer-url=https://cdn.example.com/oidc \
-          -publisher-type=s3 -publisher-bucket=my-jwks -publisher-region=us-east-1 \
-          -publisher-access-key-id=AKIA... -publisher-secret-access-key=...
-
-  Configure with an Azure Blob publisher:
-
-      $ warden oidc-issuer configure -issuer-url=https://cdn.example.com/oidc \
-          -publisher-type=azure_blob -publisher-account-name=wardenoidc \
-          -publisher-container=jwks -publisher-account-key=...
 
   Full JSON payload (agent-friendly):
 
@@ -92,21 +65,6 @@ func init() {
 	f.StringVar(&cfgJWKSCacheTTL, "jwks-cache-ttl", "", "Cache-Control max-age of the published JWKS; also the min pre-publication age of a new key (default 1m)")
 	f.StringVar(&cfgRetiredKeyGrace, "retired-key-grace", "", "Margin beyond the assertion TTL before a retired key is pruned from the JWKS (default 1h)")
 
-	f.StringVar(&cfgPublisherType, "publisher-type", "", "Publisher type: none, local_file, http_put, s3, or azure_blob")
-	f.StringVar(&cfgPublisherDir, "publisher-dir", "", "local_file: directory the documents are written to")
-	f.StringVar(&cfgPublisherBaseURL, "publisher-base-url", "", "http_put: origin the documents are PUT under")
-	f.StringVar(&cfgPublisherAuthHdr, "publisher-auth-header", "", "http_put: auth header name (default Authorization)")
-	f.StringVar(&cfgPublisherAuthValue, "publisher-auth-value", "", "http_put: auth header value, e.g. 'Bearer <token>' (masked on read)")
-	f.StringVar(&cfgPublisherBucket, "publisher-bucket", "", "s3: bucket name")
-	f.StringVar(&cfgPublisherRegion, "publisher-region", "", "s3: region")
-	f.StringVar(&cfgPublisherPrefix, "publisher-prefix", "", "s3/azure_blob: blob-name/key prefix")
-	f.StringVar(&cfgPublisherAccessKey, "publisher-access-key-id", "", "s3: access key id")
-	f.StringVar(&cfgPublisherSecretKey, "publisher-secret-access-key", "", "s3: secret access key (masked on read)")
-	f.StringVar(&cfgPublisherAccountName, "publisher-account-name", "", "azure_blob: storage account name")
-	f.StringVar(&cfgPublisherContainer, "publisher-container", "", "azure_blob: container name")
-	f.StringVar(&cfgPublisherAccountKey, "publisher-account-key", "", "azure_blob: storage account key (masked on read)")
-	f.StringVar(&cfgPublisherEndpoint, "publisher-endpoint", "", "azure_blob: override service URL (sovereign cloud, private endpoint, or emulator; default is public cloud)")
-
 	f.StringVarP(&cfgJSON, "json", "j", "", "Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with the typed flags)")
 }
 
@@ -124,25 +82,11 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	var payload map[string]any
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"-issuer-url":                  cfgIssuerURL != "",
-			"-assertion-ttl":               cfgAssertionTTL != "",
-			"-key-rotation-period":         cfgKeyRotationPeriod != "",
-			"-jwks-cache-ttl":              cfgJWKSCacheTTL != "",
-			"-retired-key-grace":           cfgRetiredKeyGrace != "",
-			"-publisher-type":              cfgPublisherType != "",
-			"-publisher-dir":               cfgPublisherDir != "",
-			"-publisher-base-url":          cfgPublisherBaseURL != "",
-			"-publisher-auth-header":       cfgPublisherAuthHdr != "",
-			"-publisher-auth-value":        cfgPublisherAuthValue != "",
-			"-publisher-bucket":            cfgPublisherBucket != "",
-			"-publisher-region":            cfgPublisherRegion != "",
-			"-publisher-prefix":            cfgPublisherPrefix != "",
-			"-publisher-access-key-id":     cfgPublisherAccessKey != "",
-			"-publisher-secret-access-key": cfgPublisherSecretKey != "",
-			"-publisher-account-name":      cfgPublisherAccountName != "",
-			"-publisher-container":         cfgPublisherContainer != "",
-			"-publisher-account-key":       cfgPublisherAccountKey != "",
-			"-publisher-endpoint":          cfgPublisherEndpoint != "",
+			"-issuer-url":          cfgIssuerURL != "",
+			"-assertion-ttl":       cfgAssertionTTL != "",
+			"-key-rotation-period": cfgKeyRotationPeriod != "",
+			"-jwks-cache-ttl":      cfgJWKSCacheTTL != "",
+			"-retired-key-grace":   cfgRetiredKeyGrace != "",
 		}); err != nil {
 			return err
 		}
@@ -173,25 +117,6 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("-%s: %w", strings.ReplaceAll(d.key, "_", "-"), err)
 			}
 			payload[d.key] = secs
-		}
-
-		publisher := map[string]any{}
-		setIfNonEmpty(publisher, "type", cfgPublisherType)
-		setIfNonEmpty(publisher, "dir", cfgPublisherDir)
-		setIfNonEmpty(publisher, "base_url", cfgPublisherBaseURL)
-		setIfNonEmpty(publisher, "auth_header", cfgPublisherAuthHdr)
-		setIfNonEmpty(publisher, "auth_value", cfgPublisherAuthValue)
-		setIfNonEmpty(publisher, "bucket", cfgPublisherBucket)
-		setIfNonEmpty(publisher, "region", cfgPublisherRegion)
-		setIfNonEmpty(publisher, "prefix", cfgPublisherPrefix)
-		setIfNonEmpty(publisher, "access_key_id", cfgPublisherAccessKey)
-		setIfNonEmpty(publisher, "secret_access_key", cfgPublisherSecretKey)
-		setIfNonEmpty(publisher, "account_name", cfgPublisherAccountName)
-		setIfNonEmpty(publisher, "container", cfgPublisherContainer)
-		setIfNonEmpty(publisher, "account_key", cfgPublisherAccountKey)
-		setIfNonEmpty(publisher, "endpoint", cfgPublisherEndpoint)
-		if len(publisher) > 0 {
-			payload["publisher"] = publisher
 		}
 	}
 

--- a/cmd/oidcissuer/oidcissuer.go
+++ b/cmd/oidcissuer/oidcissuer.go
@@ -26,6 +26,11 @@ Usage: warden oidc-issuer <subcommand> [options]
 
       $ warden oidc-issuer configure -issuer-url=https://warden.example.com
 
+  Publish the discovery + JWKS documents to a bucket/CDN:
+
+      $ warden oidc-issuer set-publisher -type=s3 \
+          -config=bucket=my-jwks -config=region=us-east-1
+
   Show the current configuration and readiness:
 
       $ warden oidc-issuer read
@@ -41,6 +46,7 @@ Usage: warden oidc-issuer <subcommand> [options]
 
 func init() {
 	OIDCIssuerCmd.AddCommand(ConfigureCmd)
+	OIDCIssuerCmd.AddCommand(SetPublisherCmd)
 	OIDCIssuerCmd.AddCommand(ReadCmd)
 	OIDCIssuerCmd.AddCommand(DisableCmd)
 }

--- a/cmd/oidcissuer/set_publisher.go
+++ b/cmd/oidcissuer/set_publisher.go
@@ -1,0 +1,154 @@
+package oidcissuer
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	pubType   string
+	pubConfig map[string]string
+	pubJSON   string
+
+	SetPublisherCmd = &cobra.Command{
+		Use:           "set-publisher",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Configure the OIDC issuer's discovery/JWKS publisher",
+		Long: `
+Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
+
+  Configure the publisher that pushes the discovery + JWKS documents to a
+  bucket/CDN. This never changes whether the issuer is enabled; it only sets the
+  publisher. Root namespace only.
+
+  The publisher type is selected with -type; every other field is passed as a
+  repeatable -config=key=value pair, so new publisher fields need no new flags.
+  Config keys are the type's field names, validated server-side per type. A
+  value prefixed with '@' is read from a file (handy for secrets):
+  -config=account_key=@/run/secrets/key.
+
+  A write is a PARTIAL update over the stored publisher: unset keys keep their
+  value, switching -type drops the previous type's fields, and secrets are
+  preserved when omitted (or sent masked). Set -type=none to remove the
+  publisher and serve the documents only from Warden's own endpoint.
+
+  Publisher types and their config keys:
+
+      local_file   dir
+      http_put     base_url, auth_header, auth_value
+      s3           bucket, region, access_key_id, secret_access_key, prefix
+      azure_blob   account_name, container, account_key, prefix, endpoint
+      none         (removes the publisher)
+
+  S3:
+
+      $ warden oidc-issuer set-publisher -type=s3 \
+          -config=bucket=my-jwks -config=region=us-east-1 \
+          -config=access_key_id=AKIA... \
+          -config=secret_access_key=@/run/secrets/s3
+
+  Azure Blob:
+
+      $ warden oidc-issuer set-publisher -type=azure_blob \
+          -config=account_name=wardenoidc -config=container=jwks \
+          -config=account_key=@/run/secrets/key
+
+  Remove the publisher:
+
+      $ warden oidc-issuer set-publisher -type=none
+
+  Full JSON payload (agent-friendly):
+
+      $ warden oidc-issuer set-publisher -json @publisher.json
+      $ cat publisher.json | warden oidc-issuer set-publisher -json -
+
+  -json is mutually exclusive with -type/-config. Combine any mode with
+  -dry-run to validate the payload against the server schema without writing.
+`,
+		Args: cobra.NoArgs,
+		RunE: runSetPublisher,
+	}
+)
+
+func init() {
+	f := SetPublisherCmd.Flags()
+	f.StringVar(&pubType, "type", "", "Publisher type: none, local_file, http_put, s3, or azure_blob")
+	f.StringToStringVar(&pubConfig, "config", nil, "Type-specific config (key=value; repeatable). Use @file to read a value from a file, e.g. -config=account_key=@/run/secrets/key")
+	f.StringVarP(&pubJSON, "json", "j", "", "Full publisher JSON block — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -type/-config)")
+}
+
+func runSetPublisher(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	jsonPayload, err := helpers.ResolveJSONInput(pubJSON)
+	if err != nil {
+		return err
+	}
+
+	var publisher map[string]any
+	if jsonPayload != nil {
+		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
+			"-type":   pubType != "",
+			"-config": len(pubConfig) > 0,
+		}); err != nil {
+			return err
+		}
+		// -json here is the publisher block only (e.g. {"type":"s3",...}), not
+		// the full issuer config that 'configure -json' takes. Catch a mistakenly
+		// reused config document up front — otherwise it would be silently nested
+		// under "publisher" and rejected server-side with a cryptic per-field error.
+		for _, k := range []string{"enabled", "issuer_url", "assertion_ttl", "key_rotation_period", "jwks_cache_ttl", "retired_key_grace", "publisher"} {
+			if _, ok := jsonPayload[k]; ok {
+				return fmt.Errorf("-json expects the publisher block only (e.g. {\"type\":\"s3\",...}), but got issuer-level field %q; use 'warden oidc-issuer configure -json' for the full config: %w", k, helpers.ErrUsage)
+			}
+		}
+		publisher = jsonPayload
+	} else {
+		if pubType == "" {
+			return fmt.Errorf("-type is required (or use -json): %w", helpers.ErrUsage)
+		}
+		resolved, err := helpers.ResolveFileRefs(pubConfig)
+		if err != nil {
+			return err
+		}
+		publisher = map[string]any{"type": pubType}
+		for k, v := range resolved {
+			publisher[k] = v
+		}
+	}
+
+	// No "enabled" key: this only merges the publisher, leaving the issuer's
+	// on/off state untouched. The server field-merges the publisher over the
+	// stored config and validates it per type before persisting.
+	payload := map[string]any{"publisher": publisher}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "POST", oidcIssuerConfigPath, payload)
+	}
+
+	resource, err := c.Operator().Write(oidcIssuerConfigPath, payload)
+	if err != nil {
+		return fmt.Errorf("error configuring OIDC issuer publisher: %w", err)
+	}
+
+	// The write response echoes only the issuer state (enabled/issuer_url/ready),
+	// not the publisher. Read back so the confirmation reflects the merged,
+	// server-masked publisher — the point of this command. Fall back to the write
+	// response if the read fails, so success is still reported.
+	data := map[string]any{}
+	if read, rerr := c.Operator().Read(oidcIssuerConfigPath); rerr == nil && read != nil && read.Data != nil {
+		data = read.Data
+	} else if resource != nil {
+		data = resource.Data
+	}
+	return helpers.RenderMap(data, func() {
+		fmt.Println("Success! OIDC issuer publisher configured.")
+		helpers.PrintMapAsTable(data)
+	})
+}


### PR DESCRIPTION
## Why

`warden oidc-issuer configure` bundled **14 `-publisher-*` flags** — one per field across five publisher types (`local_file`, `http_put`, `s3`, `azure_blob`, `none`). Every new publisher field meant a new top-level flag, `--help` was a wall of mostly-irrelevant options, and the same 14 names had to be repeated in the JSON mutual-exclusion map and the payload assembly. It didn't scale.

## What

- **`configure` is trimmed to the issuer itself** — it enables the issuer and sets its URL/timings. The 14 `-publisher-*` flags are gone.
- **New `oidc-issuer set-publisher`** mirrors the credential-spec CLI: a `-type` discriminator plus a single repeatable `-config=key=value` flag, with `@file` support for secrets (`-config=account_key=@/run/secrets/key`). `-type=none` removes the publisher. Adding a future publisher field now needs **zero** CLI changes.

```
warden oidc-issuer configure -issuer-url=https://cdn.example.com/oidc
warden oidc-issuer set-publisher -type=azure_blob \
  -config=account_name=wardenoidc -config=container=jwks \
  -config=account_key=@/run/secrets/key
warden oidc-issuer set-publisher -type=none      # remove the publisher
```

## Notes

- **No server changes.** `set-publisher` writes only the `publisher` block (no `enabled` key), so it never flips the issuer's on/off state; the server already field-merges and validates the publisher per type before persisting.
- `-json` on `set-publisher` is the *publisher block only*; a guard rejects a mistakenly-reused full-config document with a clear message pointing to `configure -json`.
- The success output reads back the merged, **server-masked** publisher so the confirmation reflects what was actually set.

## Verification

Exercised end-to-end against a dev server: configure → set-publisher (Azure/S3/http_put/local_file) → read (secrets masked, `enabled` preserved) → partial update → `-type=none`. `local_file` wrote both `.well-known/openid-configuration` and `oidc/jwks`. Usage errors (missing `-type`, `-json`/`-config` exclusion, wrong-type field, config-shaped `-json`) all fire correctly. Dry-run validates against the live schema. `go build ./...` and `go vet` clean.