### PR TITLE
feat(core): add gcs OIDC issuer publisher

### DIFF
--- a/cmd/oidcissuer/set_publisher.go
+++ b/cmd/oidcissuer/set_publisher.go
@@ -41,6 +41,7 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
       http_put     base_url, auth_header, auth_value
       s3           bucket, region, access_key_id, secret_access_key, prefix
       azure_blob   account_name, container, account_key, prefix, endpoint
+      gcs          bucket, credentials_json, prefix, endpoint
       none         (removes the publisher)
 
   S3:
@@ -55,6 +56,12 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
       $ warden oidc-issuer set-publisher -type=azure_blob \
           -config=account_name=wardenoidc -config=container=jwks \
           -config=account_key=@/run/secrets/key
+
+  Google Cloud Storage:
+
+      $ warden oidc-issuer set-publisher -type=gcs \
+          -config=bucket=my-jwks \
+          -config=credentials_json=@/run/secrets/sa.json
 
   Remove the publisher:
 
@@ -75,7 +82,7 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
 
 func init() {
 	f := SetPublisherCmd.Flags()
-	f.StringVar(&pubType, "type", "", "Publisher type: none, local_file, http_put, s3, or azure_blob")
+	f.StringVar(&pubType, "type", "", "Publisher type: none, local_file, http_put, s3, azure_blob, or gcs")
 	f.StringToStringVar(&pubConfig, "config", nil, "Type-specific config (key=value; repeatable). Use @file to read a value from a file, e.g. -config=account_key=@/run/secrets/key")
 	f.StringVarP(&pubJSON, "json", "j", "", "Full publisher JSON block — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -type/-config)")
 }

--- a/core/oidc_publisher.go
+++ b/core/oidc_publisher.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 // The OIDC issuer's public documents are published under these object paths, so
@@ -32,7 +34,7 @@ const (
 // signing key never leaves Warden.
 type publisherConfig struct {
 	// Type is "", "none" (serve only from Warden's own endpoint), "local_file",
-	// "http_put", "s3", or "azure_blob".
+	// "http_put", "s3", "azure_blob", or "gcs".
 	Type string `json:"type,omitempty"`
 
 	// local_file: an external process (with its own credentials) syncs the
@@ -64,7 +66,15 @@ type publisherConfig struct {
 	AccountName string `json:"account_name,omitempty"`
 	Container   string `json:"container,omitempty"`
 	AccountKey  string `json:"account_key,omitempty"`
-	Endpoint    string `json:"endpoint,omitempty"`
+	Endpoint    string `json:"endpoint,omitempty"` // shared with gcs (API endpoint override)
+
+	// gcs: writes to a Google Cloud Storage bucket authenticated by a stored
+	// static service-account JSON key. CredentialsJSON is a stored static secret
+	// (masked); like the s3/azure_blob keys it is an infra-scoped write credential
+	// used only on rotation, and key rotation is a planned follow-on. Bucket above
+	// is reused; Prefix is reused as the object-name prefix; Endpoint overrides the
+	// storage API endpoint (for a private endpoint or a test/emulator).
+	CredentialsJSON string `json:"credentials_json,omitempty"`
 }
 
 // JWKSPublisher pushes the issuer's public discovery + JWKS documents to an
@@ -94,6 +104,8 @@ func newJWKSPublisher(cfg publisherConfig, cacheControl string) (JWKSPublisher, 
 		return newS3Publisher(cfg, cacheControl)
 	case "azure_blob":
 		return newAzureBlobPublisher(cfg, cacheControl)
+	case "gcs":
+		return newGCSPublisher(cfg, cacheControl)
 	default:
 		return nil, fmt.Errorf("oidc publisher: unsupported type %q", cfg.Type)
 	}
@@ -312,6 +324,107 @@ func (p *azureBlobPublisher) put(ctx context.Context, name string, body []byte) 
 	})
 	if err != nil {
 		return fmt.Errorf("oidc publisher: azure_blob upload %s: %w", blobName, err)
+	}
+	return nil
+}
+
+// gcsUploadTimeout bounds a single object upload, matching the other cloud
+// publishers' per-upload timeout so a slow/flaky endpoint cannot stall a rotation
+// (which runs off the request path and has no outer deadline).
+const gcsUploadTimeout = 15 * time.Second
+
+// gcsDefaultEndpoint is the public Cloud Storage host; Endpoint overrides it for a
+// private endpoint or a test server.
+const gcsDefaultEndpoint = "https://storage.googleapis.com"
+
+// gcsScope is the OAuth2 scope needed to write objects.
+const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
+
+// gcsPublisher uploads the documents to a Google Cloud Storage bucket over the
+// single-request upload API, authenticated by an OAuth2 token minted from a stored
+// static service-account JSON key. Like the S3/Azure publishers this is an
+// infra-scoped write credential used only on rotation (rare), distinct from the
+// per-agent secrets WIF removes. The key does not expire; regenerating and swapping
+// it is a planned rotation follow-on. Uploading directly rather than via the cloud
+// SDK keeps the credential path identical to the source drivers and avoids a large
+// dependency for two small PUTs.
+type gcsPublisher struct {
+	tokenSource  oauth2.TokenSource
+	endpoint     string
+	bucket       string
+	prefix       string
+	cacheControl string
+	client       *http.Client
+}
+
+func newGCSPublisher(cfg publisherConfig, cacheControl string) (JWKSPublisher, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("oidc publisher: gcs requires 'bucket'")
+	}
+	if cfg.CredentialsJSON == "" {
+		return nil, fmt.Errorf("oidc publisher: gcs requires 'credentials_json'")
+	}
+	// Pin the credential type to a service-account key. Accepting an unvalidated
+	// config here is a security risk: an external_account/workload-identity JSON
+	// could point token minting at an attacker-controlled URL, so anything but a
+	// service account is rejected.
+	creds, err := google.CredentialsFromJSONWithType(context.Background(), []byte(cfg.CredentialsJSON), google.ServiceAccount, gcsScope)
+	if err != nil {
+		return nil, fmt.Errorf("oidc publisher: gcs credentials: %w", err)
+	}
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = gcsDefaultEndpoint
+	}
+	return &gcsPublisher{
+		tokenSource:  creds.TokenSource,
+		endpoint:     strings.TrimRight(endpoint, "/"),
+		bucket:       cfg.Bucket,
+		prefix:       strings.Trim(cfg.Prefix, "/"),
+		cacheControl: cacheControl,
+		client:       &http.Client{},
+	}, nil
+}
+
+func (p *gcsPublisher) Type() string { return "gcs" }
+
+func (p *gcsPublisher) Publish(ctx context.Context, discovery, jwks []byte) error {
+	if err := p.put(ctx, oidcDiscoveryObjectPath, discovery); err != nil {
+		return err
+	}
+	return p.put(ctx, oidcJWKSObjectPath, jwks)
+}
+
+func (p *gcsPublisher) put(ctx context.Context, name string, body []byte) error {
+	object := name
+	if p.prefix != "" {
+		object = p.prefix + "/" + name
+	}
+	token, err := p.tokenSource.Token()
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs token: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, gcsUploadTimeout)
+	defer cancel()
+	// Single-request upload: PUT {endpoint}/{bucket}/{object}. Object names may
+	// contain '/', which stays a path separator in the URL.
+	url := p.endpoint + "/" + p.bucket + "/" + object
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs build PUT %s: %w", object, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p.cacheControl != "" {
+		req.Header.Set("Cache-Control", p.cacheControl)
+	}
+	token.SetAuthHeader(req)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs upload %s: %w", object, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("oidc publisher: gcs upload %s returned status %d", object, resp.StatusCode)
 	}
 	return nil
 }

--- a/core/oidc_publisher_test.go
+++ b/core/oidc_publisher_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestNewJWKSPublisher_Dispatch(t *testing.T) {
@@ -32,6 +33,10 @@ func TestNewJWKSPublisher_Dispatch(t *testing.T) {
 	require.Error(t, err) // missing keys
 	_, err = newJWKSPublisher(publisherConfig{Type: "azure_blob", AccountName: "a", Container: "c"}, "")
 	require.Error(t, err) // missing account_key
+	_, err = newJWKSPublisher(publisherConfig{Type: "gcs"}, "")
+	require.Error(t, err) // missing bucket
+	_, err = newJWKSPublisher(publisherConfig{Type: "gcs", Bucket: "b"}, "")
+	require.Error(t, err) // missing credentials_json
 
 	// unsupported type.
 	_, err = newJWKSPublisher(publisherConfig{Type: "ftp"}, "")
@@ -161,5 +166,42 @@ func TestAzureBlobPublisher(t *testing.T) {
 
 	jwks, ok := seen["/jwks/prod/oidc/jwks"]
 	require.True(t, ok, "jwks blob must be PUT")
+	assert.Equal(t, "application/json", jwks.contentType)
+}
+
+func TestGCSPublisher(t *testing.T) {
+	type got struct{ method, auth, contentType, cacheControl string }
+	seen := map[string]got{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		if r.Method == http.MethodPut {
+			seen[r.URL.Path] = got{r.Method, r.Header.Get("Authorization"), r.Header.Get("Content-Type"), r.Header.Get("Cache-Control")}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Inject a static token source and point the endpoint at the fake server, so the
+	// upload path is exercised without a real Google token exchange.
+	p := &gcsPublisher{
+		tokenSource:  oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+		endpoint:     srv.URL,
+		bucket:       "warden-oidc",
+		prefix:       "prod",
+		cacheControl: "public, max-age=60",
+		client:       srv.Client(),
+	}
+
+	require.NoError(t, p.Publish(context.Background(), []byte(`{"issuer":"x"}`), []byte(`{"keys":[]}`)))
+
+	disc, ok := seen["/warden-oidc/prod/.well-known/openid-configuration"]
+	require.True(t, ok, "discovery object must be PUT")
+	assert.Equal(t, http.MethodPut, disc.method)
+	assert.Equal(t, "Bearer test-token", disc.auth)
+	assert.Equal(t, "application/json", disc.contentType)
+	assert.Equal(t, "public, max-age=60", disc.cacheControl)
+
+	jwks, ok := seen["/warden-oidc/prod/oidc/jwks"]
+	require.True(t, ok, "jwks object must be PUT")
 	assert.Equal(t, "application/json", jwks.contentType)
 }

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -47,7 +47,7 @@ func (b *SystemBackend) pathOIDCIssuer() []*framework.Path {
 				},
 				"publisher": {
 					Type:        framework.TypeMap,
-					Description: "Optional publisher pushing discovery+JWKS to a bucket/CDN. Keys: type (local_file|http_put|s3|azure_blob), dir, base_url, auth_header, auth_value, bucket, region, prefix, access_key_id, secret_access_key, account_name, container, account_key, endpoint. Cache-Control is derived from jwks_cache_ttl.",
+					Description: "Optional publisher pushing discovery+JWKS to a bucket/CDN. Keys: type (local_file|http_put|s3|azure_blob|gcs), dir, base_url, auth_header, auth_value, bucket, region, prefix, access_key_id, secret_access_key, account_name, container, account_key, endpoint, credentials_json. Cache-Control is derived from jwks_cache_ttl.",
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -230,15 +230,16 @@ var publisherFieldOwners = map[string][]string{
 	"base_url":          {"http_put"},
 	"auth_header":       {"http_put"},
 	"auth_value":        {"http_put"},
-	"bucket":            {"s3"},
+	"bucket":            {"s3", "gcs"},
 	"region":            {"s3"},
-	"prefix":            {"s3", "azure_blob"},
+	"prefix":            {"s3", "azure_blob", "gcs"},
 	"access_key_id":     {"s3"},
 	"secret_access_key": {"s3"},
 	"account_name":      {"azure_blob"},
 	"container":         {"azure_blob"},
 	"account_key":       {"azure_blob"},
-	"endpoint":          {"azure_blob"},
+	"endpoint":          {"azure_blob", "gcs"},
+	"credentials_json":  {"gcs"},
 }
 
 // ownedBy reports whether field is valid for the given publisher type.
@@ -330,6 +331,9 @@ func mergePublisherConfig(prior publisherConfig, raw map[string]any) (publisherC
 	if v, ok := get("account_key"); ok && v != "" && v != maskValue {
 		pc.AccountKey = v
 	}
+	if v, ok := get("credentials_json"); ok && v != "" && v != maskValue {
+		pc.CredentialsJSON = v
+	}
 
 	return pc, nil
 }
@@ -375,6 +379,9 @@ func maskedPublisher(pc publisherConfig) map[string]any {
 	}
 	if pc.Endpoint != "" {
 		m["endpoint"] = pc.Endpoint
+	}
+	if pc.CredentialsJSON != "" {
+		m["credentials_json"] = maskValue
 	}
 	return m
 }

--- a/core/sys_oidc_issuer_test.go
+++ b/core/sys_oidc_issuer_test.go
@@ -336,6 +336,37 @@ func TestMergePublisherConfig(t *testing.T) {
 	pc, err = mergePublisherConfig(prior, map[string]any{"type": "azure_blob", "account_key": maskValue})
 	require.NoError(t, err)
 	assert.Equal(t, "realkey", pc.AccountKey)
+
+	// A clean gcs config passes; bucket/prefix/endpoint are shared and accepted here.
+	pc, err = mergePublisherConfig(publisherConfig{}, map[string]any{
+		"type": "gcs", "bucket": "my-jwks", "prefix": "prod",
+		"credentials_json": `{"type":"service_account"}`, "endpoint": "https://storage.example",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "gcs", pc.Type)
+	assert.Equal(t, "my-jwks", pc.Bucket)
+	assert.Equal(t, "prod", pc.Prefix)
+	assert.Equal(t, `{"type":"service_account"}`, pc.CredentialsJSON)
+	assert.Equal(t, "https://storage.example", pc.Endpoint)
+
+	// Read masks the credentials but renders the non-secret fields plainly.
+	masked = maskedPublisher(pc)
+	assert.Equal(t, "my-jwks", masked["bucket"])
+	assert.Equal(t, "prod", masked["prefix"])
+	assert.Equal(t, "https://storage.example", masked["endpoint"])
+	assert.Equal(t, maskValue, masked["credentials_json"])
+
+	// An azure_blob field under gcs is rejected.
+	_, err = mergePublisherConfig(publisherConfig{}, map[string]any{
+		"type": "gcs", "bucket": "b", "credentials_json": "c", "account_name": "a",
+	})
+	require.Error(t, err)
+
+	// Masked credentials_json keeps the prior one.
+	prior = publisherConfig{Type: "gcs", Bucket: "b", CredentialsJSON: "realkey"}
+	pc, err = mergePublisherConfig(prior, map[string]any{"type": "gcs", "credentials_json": maskValue})
+	require.NoError(t, err)
+	assert.Equal(t, "realkey", pc.CredentialsJSON)
 }
 
 // TestSysOIDCIssuerConfig_PublisherCrossTypeRejected verifies a cross-type


### PR DESCRIPTION
## Summary

Adds a fifth OIDC issuer publisher type, `gcs`, that pushes the discovery and JWKS documents to a Google Cloud Storage bucket — closing the gap left after the `s3` and `azure_blob` publishers.

- Uploads over the single-request object upload API (`PUT {endpoint}/{bucket}/{object}`), authenticated by an OAuth2 token minted from a stored static **service-account JSON key** (`credentials_json`, masked) via `golang.org/x/oauth2/google` — the same credential path the GCP source driver already uses.
- The credential type is **pinned to a service account** (`CredentialsFromJSONWithType`, not the deprecated `CredentialsFromJSON`), so an unvalidated `external_account`/workload-identity config cannot redirect token minting.
- Publishing two small documents does not justify the Cloud Storage SDK's dependency weight (it added ~21 MB to the binary), so the REST path is used and **`go.mod` is unchanged**.
- `bucket`, `prefix`, and `endpoint` are reused from the shared publisher config; `credentials_json` is the one new `gcs`-owned secret. Each upload is bounded by a 15s timeout, matching the other cloud publishers on the deadline-less rotation path.

## Config keys

| key | ownership | notes |
|-----|-----------|-------|
| `bucket` | `s3`, `gcs` | GCS bucket name |
| `prefix` | `s3`, `azure_blob`, `gcs` | object-name prefix |
| `endpoint` | `azure_blob`, `gcs` | optional API endpoint override |
| `credentials_json` | `gcs` | service-account JSON key — **masked secret** |

No new CLI flags: `set-publisher` is type-agnostic, so only its help text and the server-side field-owner map, merge, mask, and schema description are extended.

Example:

```
warden oidc-issuer set-publisher -type=gcs \
  -config=bucket=my-jwks \
  -config=credentials_json=@/run/secrets/sa.json
```

## Testing

- `TestGCSPublisher` — drives the publisher at an in-process fake server (static token source), asserting both documents `PUT` at the prefixed object paths with `Bearer` auth, `application/json`, and the derived `Cache-Control`.
- `TestNewJWKSPublisher_Dispatch` — missing-`bucket` and missing-`credentials_json` error cases.
- `TestMergePublisherConfig` — `gcs` merge, mask-on-read of `credentials_json`, cross-type field rejection, and masked-secret preservation on partial update.
- Verified end-to-end against a local `fake-gcs-server`: both objects landed at `prod/oidc/jwks` and `prod/.well-known/openid-configuration` with the right content-type and cache-control.
