### PR TITLE
feat(core): self-rotate the GCS OIDC issuer publisher credential

### DIFF
--- a/cmd/oidcissuer/set_publisher.go
+++ b/cmd/oidcissuer/set_publisher.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	pubType   string
-	pubConfig map[string]string
-	pubJSON   string
+	pubType           string
+	pubConfig         map[string]string
+	pubRotationPeriod string
+	pubJSON           string
 
 	SetPublisherCmd = &cobra.Command{
 		Use:           "set-publisher",
@@ -44,6 +45,12 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
       gcs          bucket, credentials_json, prefix, endpoint
       none         (removes the publisher)
 
+  Automatic credential rotation (gcs only) is enabled with -rotation-period: on
+  that cadence Warden mints a fresh service-account key, verifies it, swaps it in,
+  and deletes the old one (the service account must hold
+  iam.serviceAccountKeys.create/delete on itself). Set -rotation-period=0 to
+  disable.
+
   S3:
 
       $ warden oidc-issuer set-publisher -type=s3 \
@@ -57,9 +64,9 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
           -config=account_name=wardenoidc -config=container=jwks \
           -config=account_key=@/run/secrets/key
 
-  Google Cloud Storage:
+  Google Cloud Storage (with automatic key rotation every 30 days):
 
-      $ warden oidc-issuer set-publisher -type=gcs \
+      $ warden oidc-issuer set-publisher -type=gcs -rotation-period=720h \
           -config=bucket=my-jwks \
           -config=credentials_json=@/run/secrets/sa.json
 
@@ -84,6 +91,7 @@ func init() {
 	f := SetPublisherCmd.Flags()
 	f.StringVar(&pubType, "type", "", "Publisher type: none, local_file, http_put, s3, azure_blob, or gcs")
 	f.StringToStringVar(&pubConfig, "config", nil, "Type-specific config (key=value; repeatable). Use @file to read a value from a file, e.g. -config=account_key=@/run/secrets/key")
+	f.StringVar(&pubRotationPeriod, "rotation-period", "", "Automatic credential-rotation cadence for the publisher's write key (gcs only). A Go duration like 720h; 0 disables. Empty leaves it unchanged.")
 	f.StringVarP(&pubJSON, "json", "j", "", "Full publisher JSON block — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -type/-config)")
 }
 
@@ -101,8 +109,9 @@ func runSetPublisher(cmd *cobra.Command, args []string) error {
 	var publisher map[string]any
 	if jsonPayload != nil {
 		if err := helpers.RejectFlagsWithJSON(true, map[string]bool{
-			"-type":   pubType != "",
-			"-config": len(pubConfig) > 0,
+			"-type":            pubType != "",
+			"-config":          len(pubConfig) > 0,
+			"-rotation-period": pubRotationPeriod != "",
 		}); err != nil {
 			return err
 		}
@@ -127,6 +136,11 @@ func runSetPublisher(cmd *cobra.Command, args []string) error {
 		publisher = map[string]any{"type": pubType}
 		for k, v := range resolved {
 			publisher[k] = v
+		}
+		// rotation_period is a publisher field surfaced as a typed flag; fold it into
+		// the same payload so the server validates and merges it per type.
+		if pubRotationPeriod != "" {
+			publisher["rotation_period"] = pubRotationPeriod
 		}
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -235,6 +235,19 @@ type Core struct {
 	// join it). nil when rotation is disabled or the node is a standby.
 	oidcRotationCancel context.CancelFunc
 	oidcRotationDone   chan struct{}
+	// oidcPubRotationCancel/oidcPubRotationDone are the same pair for the active
+	// node's publisher-credential rotation loop (see oidc_publisher_rotation.go).
+	oidcPubRotationCancel context.CancelFunc
+	oidcPubRotationDone   chan struct{}
+	// oidcConfigMu serializes the load-modify-save of the issuer config doc so a
+	// rotation persist and an operator config write cannot lost-update each other.
+	oidcConfigMu sync.Mutex
+	// oidcSetupMu serializes setupOIDCIssuer/stopOIDCIssuer so two concurrent config
+	// writes (or a write racing seal/promotion) cannot interleave loop start/stop and
+	// leak a rotation goroutine that outlives its cancel func. Distinct from oidcConfigMu
+	// (which the config-write handler releases before calling setupOIDCIssuer) to avoid a
+	// deadlock against the rotation loop's own oidcConfigMu acquisition.
+	oidcSetupMu sync.Mutex
 	// oidcJWKSCacheTTL / oidcRetiredKeyGrace are the rotation timings from config.
 	// oidcJWKSCacheTTL is the published JWKS Cache-Control max-age, which also
 	// floors how long a fresh next key is pre-published before it may sign.
@@ -846,7 +859,19 @@ func (c *Core) GetRotationManager() *RotationManager {
 // (it cannot write) and will activate on promotion, when unseal runs again as
 // active. Key generation and persistence therefore happen only on the active node.
 func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
+	// Serialize issuer setup/teardown so concurrent config writes (or a write racing
+	// seal/promotion) cannot interleave rotation-loop start/stop and leak a goroutine.
+	c.oidcSetupMu.Lock()
+	defer c.oidcSetupMu.Unlock()
+
 	storage := NewBarrierView(c.barrier, oidcIssuerStorePrefix)
+
+	// Stop the publisher-credential rotation loop BEFORE reading config and rebuilding
+	// the publisher: joining it here guarantees no in-flight rotation can commit+delete
+	// a key after we have already rebuilt the live publisher from a pre-rotation config
+	// snapshot (which would leave the publisher holding a deleted key). It is restarted
+	// at the end from the fresh config.
+	c.stopPublisherCredRotation()
 
 	cfg, err := loadIssuerConfig(ctx, storage)
 	if err != nil {
@@ -854,6 +879,14 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
 	}
 	if cfg == nil || !cfg.Enabled {
 		c.stopOIDCKeyRotation() // never leak the loop when disabling
+		// Drop any publisher-rotation schedule anchor so re-enabling the issuer later
+		// starts a fresh period rather than firing off a stale timestamp (active only —
+		// the active node owns this shared state).
+		if !standby {
+			if derr := clearPublisherRotationState(ctx, storage); derr != nil {
+				c.logger.Warn("oidc issuer: publisher-credential rotation: clearing schedule anchor failed", logger.Err(derr))
+			}
+		}
 		c.oidcMu.Lock()
 		c.oidcIssuer = nil
 		c.oidcPublisher = nil
@@ -962,6 +995,9 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
 	period := cfg.keyRotationPeriod()
 	firstTick := oidcRotationFirstTick(keysets, period)
 	c.startOIDCKeyRotation(standby, period, firstTick, issuer, publisher, cfg.jwksCacheTTL(), cfg.retiredKeyGrace())
+
+	// Publisher-credential rotation (active node, credential-bearing publishers only).
+	c.startPublisherCredRotation(standby, cfg.Publisher.rotationPeriod(), publisher)
 	return nil
 }
 
@@ -1184,7 +1220,10 @@ func (c *Core) rotateOIDCKey(ctx context.Context, issuer *OIDCIssuer, publisher 
 
 // stopOIDCIssuer tears down the issuer during seal.
 func (c *Core) stopOIDCIssuer() error {
+	c.oidcSetupMu.Lock()
+	defer c.oidcSetupMu.Unlock()
 	c.stopOIDCKeyRotation()
+	c.stopPublisherCredRotation()
 	c.oidcMu.Lock()
 	c.oidcIssuer = nil
 	c.oidcPublisher = nil

--- a/core/oidc_publisher.go
+++ b/core/oidc_publisher.go
@@ -3,11 +3,16 @@ package core
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -70,11 +75,33 @@ type publisherConfig struct {
 
 	// gcs: writes to a Google Cloud Storage bucket authenticated by a stored
 	// static service-account JSON key. CredentialsJSON is a stored static secret
-	// (masked); like the s3/azure_blob keys it is an infra-scoped write credential
-	// used only on rotation, and key rotation is a planned follow-on. Bucket above
-	// is reused; Prefix is reused as the object-name prefix; Endpoint overrides the
-	// storage API endpoint (for a private endpoint or a test/emulator).
+	// (masked); like the s3/azure_blob keys it is an infra-scoped write credential.
+	// Warden can self-rotate it (see RotatablePublisher): on the configured cadence
+	// it mints a fresh key via the IAM API, verifies it, swaps it in, and deletes the
+	// old one — which requires the service account to hold
+	// iam.serviceAccountKeys.create/delete on itself. Bucket above is reused; Prefix
+	// is reused as the object-name prefix; Endpoint overrides the storage API endpoint
+	// (for a private endpoint or a test/emulator).
 	CredentialsJSON string `json:"credentials_json,omitempty"`
+
+	// RotationPeriod, when > 0, enables automatic rotation of the credential-bearing
+	// publisher's write key on that cadence (currently gcs only). Empty/0 disables it.
+	// A duration string ("720h"); validated and floored server-side.
+	RotationPeriod string `json:"rotation_period,omitempty"`
+}
+
+// rotationPeriod parses the configured publisher-credential rotation cadence; 0
+// (empty or unparseable) disables automatic rotation. The write path parses and
+// bounds the value strictly before it is stored, so a stored value is well-formed.
+func (c *publisherConfig) rotationPeriod() time.Duration {
+	if c.RotationPeriod == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.RotationPeriod)
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
 }
 
 // JWKSPublisher pushes the issuer's public discovery + JWKS documents to an
@@ -83,6 +110,40 @@ type publisherConfig struct {
 type JWKSPublisher interface {
 	Publish(ctx context.Context, discovery, jwks []byte) error
 	Type() string
+}
+
+// RotatablePublisher is an optional interface a publisher implements when Warden can
+// self-rotate its stored write credential. The rotation loop discovers it by type
+// assertion, so a publisher that cannot rotate simply does not implement it.
+//
+// Rotation is single-stage with verify-before-swap (the credential is off the request
+// hot path, and the built-in endpoint always serves, so no timed propagation overlap is
+// needed):
+//  1. PrepareRotation mints a NEW credential and verifies it works, leaving the old one
+//     untouched. It returns the config fields to persist and an opaque handle for
+//     deleting the old credential.
+//  2. [the loop persists newFields into the publisher config]
+//  3. CommitRotation swaps the live in-memory credential to the just-persisted new one.
+//  4. CleanupRotation destroys the old credential (best-effort).
+type RotatablePublisher interface {
+	// SupportsRotation reports whether this publisher instance can rotate its credential.
+	SupportsRotation() bool
+
+	// PrepareRotation mints and verifies a new credential without touching the old one.
+	// newFields are the publisher-config keys to persist (e.g. {"credentials_json": …});
+	// cleanup is the handle CleanupRotation needs to destroy the superseded credential.
+	PrepareRotation(ctx context.Context) (newFields, cleanup map[string]string, err error)
+
+	// CommitRotation swaps the live in-memory credential to newFields (already persisted).
+	CommitRotation(newFields map[string]string) error
+
+	// CleanupRotation destroys the superseded credential (best-effort).
+	CleanupRotation(ctx context.Context, cleanup map[string]string) error
+
+	// RollbackRotation destroys a credential that PrepareRotation minted but that was
+	// never persisted or committed (e.g. persistence failed), so a failed rotation does
+	// not leak a live-but-unreferenced credential. Best-effort.
+	RollbackRotation(ctx context.Context, newFields map[string]string) error
 }
 
 // newJWKSPublisher builds the configured publisher, or (nil, nil) when none is
@@ -349,7 +410,12 @@ const gcsScope = "https://www.googleapis.com/auth/devstorage.read_write"
 // SDK keeps the credential path identical to the source drivers and avoids a large
 // dependency for two small PUTs.
 type gcsPublisher struct {
-	tokenSource  oauth2.TokenSource
+	// mu guards the mutable credential (tokenSource + credentialsJSON), which
+	// CommitRotation swaps in place while Publish may be reading it concurrently.
+	mu              sync.RWMutex
+	tokenSource     oauth2.TokenSource
+	credentialsJSON string // raw SA key JSON, retained for rotation
+
 	endpoint     string
 	bucket       string
 	prefix       string
@@ -368,7 +434,7 @@ func newGCSPublisher(cfg publisherConfig, cacheControl string) (JWKSPublisher, e
 	// config here is a security risk: an external_account/workload-identity JSON
 	// could point token minting at an attacker-controlled URL, so anything but a
 	// service account is rejected.
-	creds, err := google.CredentialsFromJSONWithType(context.Background(), []byte(cfg.CredentialsJSON), google.ServiceAccount, gcsScope)
+	creds, err := google.CredentialsFromJSONWithType(gcsOAuthCtx(context.Background()), []byte(cfg.CredentialsJSON), google.ServiceAccount, gcsScope)
 	if err != nil {
 		return nil, fmt.Errorf("oidc publisher: gcs credentials: %w", err)
 	}
@@ -377,12 +443,13 @@ func newGCSPublisher(cfg publisherConfig, cacheControl string) (JWKSPublisher, e
 		endpoint = gcsDefaultEndpoint
 	}
 	return &gcsPublisher{
-		tokenSource:  creds.TokenSource,
-		endpoint:     strings.TrimRight(endpoint, "/"),
-		bucket:       cfg.Bucket,
-		prefix:       strings.Trim(cfg.Prefix, "/"),
-		cacheControl: cacheControl,
-		client:       &http.Client{},
+		tokenSource:     creds.TokenSource,
+		credentialsJSON: cfg.CredentialsJSON,
+		endpoint:        strings.TrimRight(endpoint, "/"),
+		bucket:          cfg.Bucket,
+		prefix:          strings.Trim(cfg.Prefix, "/"),
+		cacheControl:    cacheControl,
+		client:          &http.Client{},
 	}, nil
 }
 
@@ -400,7 +467,10 @@ func (p *gcsPublisher) put(ctx context.Context, name string, body []byte) error 
 	if p.prefix != "" {
 		object = p.prefix + "/" + name
 	}
-	token, err := p.tokenSource.Token()
+	p.mu.RLock()
+	ts := p.tokenSource
+	p.mu.RUnlock()
+	token, err := ts.Token()
 	if err != nil {
 		return fmt.Errorf("oidc publisher: gcs token: %w", err)
 	}
@@ -427,4 +497,331 @@ func (p *gcsPublisher) put(ctx context.Context, name string, body []byte) error 
 		return fmt.Errorf("oidc publisher: gcs upload %s returned status %d", object, resp.StatusCode)
 	}
 	return nil
+}
+
+// GCS credential rotation (implements RotatablePublisher).
+//
+// Warden self-rotates the stored service-account key: it mints a fresh key via the IAM
+// API using the current key, verifies the new key can mint a token, swaps it in, and
+// deletes the old key. This requires the service account to hold
+// iam.serviceAccountKeys.create/delete on itself (roles/iam.serviceAccountKeyAdmin).
+
+var _ RotatablePublisher = (*gcsPublisher)(nil)
+
+const (
+	// gcsIAMScope is the OAuth2 scope needed to manage the service account's own keys.
+	gcsIAMScope = "https://www.googleapis.com/auth/iam"
+	// gcsRotationMaxResponseBody caps IAM API response reads.
+	gcsRotationMaxResponseBody = 1 << 20 // 1MB
+)
+
+// gcsRotationVerifyTimeout bounds how long we retry proving a brand-new key is usable
+// (a freshly created key can be briefly invalid_grant while it propagates). It is a var
+// so tests can shorten it.
+var gcsRotationVerifyTimeout = 60 * time.Second
+
+// gcsTokenHTTPTimeout bounds a single OAuth2 token exchange. The x/oauth2 JWT flow neither
+// honors context cancellation nor sets a client timeout on the token POST, so a
+// black-holed token endpoint would otherwise wedge a token fetch forever — hanging the
+// rotation goroutine and, through it, seal and config writes that join the loop. We bound
+// it by injecting a timeout-bearing HTTP client into the context the credential is built
+// with (the token source reuses that client for every fetch).
+const gcsTokenHTTPTimeout = 15 * time.Second
+
+// gcsOAuthCtx returns ctx carrying an HTTP client whose per-request timeout bounds OAuth2
+// token exchanges built from it.
+func gcsOAuthCtx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: gcsTokenHTTPTimeout})
+}
+
+// minPublisherRotationPeriod is the floor for the publisher-credential rotation cadence,
+// enforced on the config-write path so automatic rotation cannot hammer the provider API.
+const minPublisherRotationPeriod = 24 * time.Hour
+
+// gcsIAMEndpoint is the IAM API host. It is a package-level var (not operator config)
+// so tests can point key create/delete at an httptest server; the operator-facing
+// storage endpoint override targets object storage, which does not serve the IAM APIs.
+var gcsIAMEndpoint = "https://iam.googleapis.com"
+
+// gcsServiceAccountKey is the subset of a GCP service-account JSON key Warden needs to
+// address the key for rotation.
+type gcsServiceAccountKey struct {
+	ProjectID    string `json:"project_id"`
+	PrivateKeyID string `json:"private_key_id"`
+	ClientEmail  string `json:"client_email"`
+}
+
+func parseGCSServiceAccountKey(s string) (*gcsServiceAccountKey, error) {
+	var k gcsServiceAccountKey
+	if err := json.Unmarshal([]byte(s), &k); err != nil {
+		return nil, fmt.Errorf("invalid service-account key JSON: %w", err)
+	}
+	if k.ProjectID == "" || k.ClientEmail == "" || k.PrivateKeyID == "" {
+		return nil, fmt.Errorf("service-account key JSON missing project_id/client_email/private_key_id")
+	}
+	return &k, nil
+}
+
+func (p *gcsPublisher) SupportsRotation() bool { return true }
+
+// PrepareRotation mints and verifies a new SA key, leaving the current key untouched.
+func (p *gcsPublisher) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, error) {
+	p.mu.RLock()
+	curJSON := p.credentialsJSON
+	p.mu.RUnlock()
+
+	saKey, err := parseGCSServiceAccountKey(curJSON)
+	if err != nil {
+		return nil, nil, fmt.Errorf("oidc publisher: gcs rotation parse current key: %w", err)
+	}
+
+	iamToken, err := gcsMintToken(ctx, curJSON, gcsIAMScope)
+	if err != nil {
+		return nil, nil, fmt.Errorf("oidc publisher: gcs rotation iam token: %w", err)
+	}
+
+	newJSON, err := p.createSAKey(ctx, iamToken, saKey.ProjectID, saKey.ClientEmail)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Verify the new key can mint a storage token before we hand it back to be
+	// persisted and swapped. If it never becomes usable, delete it so a failed
+	// rotation does not leak toward the 10-key-per-SA quota. But when verification
+	// failed only because the caller's context was cancelled (node sealing/demoting),
+	// skip the delete: the loop is being torn down and a synchronous best-effort call
+	// here would block seal for up to the delete timeout — a leftover key is a
+	// tolerated orphan. The delete runs on a detached context (its own timeout) so a
+	// genuine verify failure still cleans up even though verifyKey exhausted ctx.
+	if err := p.verifyKey(ctx, newJSON); err != nil {
+		if ctx.Err() == nil {
+			if newKey, perr := parseGCSServiceAccountKey(newJSON); perr == nil {
+				delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gcsUploadTimeout)
+				_ = p.deleteSAKey(delCtx, iamToken, newKey.ProjectID, newKey.ClientEmail, newKey.PrivateKeyID)
+				cancel()
+			}
+		}
+		return nil, nil, fmt.Errorf("oidc publisher: gcs rotation verify new key: %w", err)
+	}
+
+	newFields := map[string]string{"credentials_json": newJSON}
+	cleanup := map[string]string{
+		"old_key_id":            saKey.PrivateKeyID,
+		"service_account_email": saKey.ClientEmail,
+		"project_id":            saKey.ProjectID,
+		// Delete the old key authenticating AS the old key: it has been live all period
+		// and is fully propagated, so it mints reliably — unlike the brand-new key, whose
+		// public half may not yet be recognized across Google's replicas (a transient
+		// "Invalid JWT Signature"). The token stays valid even after the key is deleted.
+		"old_credentials_json": curJSON,
+	}
+	return newFields, cleanup, nil
+}
+
+// CommitRotation swaps the live token source to the newly persisted key.
+func (p *gcsPublisher) CommitRotation(newFields map[string]string) error {
+	newJSON := newFields["credentials_json"]
+	if newJSON == "" {
+		return fmt.Errorf("oidc publisher: gcs rotation commit: missing credentials_json")
+	}
+	creds, err := google.CredentialsFromJSONWithType(gcsOAuthCtx(context.Background()), []byte(newJSON), google.ServiceAccount, gcsScope)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs rotation commit credentials: %w", err)
+	}
+	p.mu.Lock()
+	p.tokenSource = creds.TokenSource
+	p.credentialsJSON = newJSON
+	p.mu.Unlock()
+	return nil
+}
+
+// CleanupRotation deletes the superseded key. It authenticates AS the old key (which is
+// fully propagated) rather than the just-committed new key (whose public half may not have
+// propagated yet), falling back to the live credential if the old key JSON is absent.
+func (p *gcsPublisher) CleanupRotation(ctx context.Context, cleanup map[string]string) error {
+	oldKeyID := cleanup["old_key_id"]
+	if oldKeyID == "" {
+		return nil
+	}
+	authJSON := cleanup["old_credentials_json"]
+	if authJSON == "" {
+		p.mu.RLock()
+		authJSON = p.credentialsJSON
+		p.mu.RUnlock()
+	}
+	iamToken, err := gcsMintIAMTokenWithRetry(ctx, authJSON)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs rotation cleanup iam token: %w", err)
+	}
+	if err := p.deleteSAKey(ctx, iamToken, cleanup["project_id"], cleanup["service_account_email"], oldKeyID); err != nil {
+		return fmt.Errorf("oidc publisher: gcs rotation delete old key: %w", err)
+	}
+	return nil
+}
+
+// RollbackRotation deletes a prepared-but-uncommitted new key. It authenticates with the
+// current (still the OLD) key, since the new key was never committed to the live state.
+func (p *gcsPublisher) RollbackRotation(ctx context.Context, newFields map[string]string) error {
+	newJSON := newFields["credentials_json"]
+	if newJSON == "" {
+		return nil
+	}
+	nk, err := parseGCSServiceAccountKey(newJSON)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs rotation rollback parse new key: %w", err)
+	}
+	p.mu.RLock()
+	curJSON := p.credentialsJSON
+	p.mu.RUnlock()
+	iamToken, err := gcsMintIAMTokenWithRetry(ctx, curJSON)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: gcs rotation rollback iam token: %w", err)
+	}
+	if err := p.deleteSAKey(ctx, iamToken, nk.ProjectID, nk.ClientEmail, nk.PrivateKeyID); err != nil {
+		return fmt.Errorf("oidc publisher: gcs rotation rollback delete new key: %w", err)
+	}
+	return nil
+}
+
+// gcsMintIAMTokenWithRetry mints an IAM-scoped token, retrying briefly to absorb
+// eventual-consistency lag in GCP's key propagation: a recently created key can
+// transiently return "Invalid JWT Signature" from the token endpoint before its public
+// half is recognized across all replicas. Abortable via ctx.
+func gcsMintIAMTokenWithRetry(ctx context.Context, credJSON string) (string, error) {
+	var err error
+	backoff := time.Second
+	for attempt := 0; ; attempt++ {
+		var tok string
+		if tok, err = gcsMintToken(ctx, credJSON, gcsIAMScope); err == nil {
+			return tok, nil
+		}
+		if attempt >= 4 {
+			return "", err
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(backoff):
+		}
+		if backoff < 8*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// verifyKey proves a key can mint a storage-scoped token, retrying (with backoff, and
+// abortable via ctx) up to gcsRotationVerifyTimeout to absorb brand-new-key propagation.
+func (p *gcsPublisher) verifyKey(ctx context.Context, credJSON string) error {
+	ctx, cancel := context.WithTimeout(ctx, gcsRotationVerifyTimeout)
+	defer cancel()
+	// Build the credential from the bounded, timeout-scoped context so each token
+	// attempt is both time-bounded (the HTTP client timeout) and unable to outlive the
+	// verify window.
+	creds, err := google.CredentialsFromJSONWithType(gcsOAuthCtx(ctx), []byte(credJSON), google.ServiceAccount, gcsScope)
+	if err != nil {
+		return err
+	}
+	backoff := time.Second
+	for {
+		if _, terr := creds.TokenSource.Token(); terr == nil {
+			return nil
+		} else {
+			err = terr
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("new key not usable within %s: %w", gcsRotationVerifyTimeout, err)
+		case <-time.After(backoff):
+		}
+		if backoff < 8*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// gcsMintToken mints an OAuth2 access token for the given scope from an SA key JSON,
+// pinned to a service-account credential (never external_account/workload-identity).
+func gcsMintToken(ctx context.Context, credJSON, scope string) (string, error) {
+	creds, err := google.CredentialsFromJSONWithType(gcsOAuthCtx(ctx), []byte(credJSON), google.ServiceAccount, scope)
+	if err != nil {
+		return "", fmt.Errorf("credentials: %w", err)
+	}
+	tok, err := creds.TokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("token: %w", err)
+	}
+	return tok.AccessToken, nil
+}
+
+// createSAKey creates a new key for the service account via the IAM API and returns the
+// decoded JSON key file. Mirrors the GCP source driver's single-request key creation.
+func (p *gcsPublisher) createSAKey(ctx context.Context, iamToken, projectID, saEmail string) (string, error) {
+	api := fmt.Sprintf("%s/v1/projects/%s/serviceAccounts/%s/keys",
+		gcsIAMEndpoint, url.PathEscape(projectID), url.PathEscape(saEmail))
+	reqBody, _ := json.Marshal(map[string]string{
+		"privateKeyType": "TYPE_GOOGLE_CREDENTIALS_FILE",
+		"keyAlgorithm":   "KEY_ALG_RSA_2048",
+	})
+	respBody, err := p.doIAMRequest(ctx, http.MethodPost, api, iamToken, reqBody)
+	if err != nil {
+		return "", fmt.Errorf("oidc publisher: gcs create key: %w", err)
+	}
+	var keyResp struct {
+		PrivateKeyData string `json:"privateKeyData"` // base64(std) JSON key file
+	}
+	if err := json.Unmarshal(respBody, &keyResp); err != nil {
+		return "", fmt.Errorf("oidc publisher: gcs create key: decode response: %w", err)
+	}
+	if keyResp.PrivateKeyData == "" {
+		return "", fmt.Errorf("oidc publisher: gcs create key: response missing privateKeyData")
+	}
+	keyJSON, err := base64.StdEncoding.DecodeString(keyResp.PrivateKeyData)
+	if err != nil {
+		return "", fmt.Errorf("oidc publisher: gcs create key: decode privateKeyData: %w", err)
+	}
+	if _, err := parseGCSServiceAccountKey(string(keyJSON)); err != nil {
+		return "", fmt.Errorf("oidc publisher: gcs create key: %w", err)
+	}
+	return string(keyJSON), nil
+}
+
+// deleteSAKey deletes a specific key from the service account via the IAM API.
+func (p *gcsPublisher) deleteSAKey(ctx context.Context, iamToken, projectID, saEmail, keyID string) error {
+	api := fmt.Sprintf("%s/v1/projects/%s/serviceAccounts/%s/keys/%s",
+		gcsIAMEndpoint, url.PathEscape(projectID), url.PathEscape(saEmail), url.PathEscape(keyID))
+	if _, err := p.doIAMRequest(ctx, http.MethodDelete, api, iamToken, nil); err != nil {
+		return fmt.Errorf("oidc publisher: gcs delete key: %w", err)
+	}
+	return nil
+}
+
+// doIAMRequest performs a bearer-authenticated IAM API call and returns the response
+// body on a 2xx, or an error carrying the status. It bounds each call with its own
+// timeout so a black-holed IAM endpoint cannot stall a rotation cycle indefinitely
+// (which runs off the request path and has no outer deadline).
+func (p *gcsPublisher) doIAMRequest(ctx context.Context, method, api, bearer string, body []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, gcsUploadTimeout)
+	defer cancel()
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, api, r)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, gcsRotationMaxResponseBody))
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, nil
 }

--- a/core/oidc_publisher_rotation.go
+++ b/core/oidc_publisher_rotation.go
@@ -1,0 +1,290 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/logger"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+)
+
+// oidcPublisherRotationPath is the storage key (within the issuer barrier view) of the
+// publisher-credential rotation state. It holds only a schedule anchor — no secret and
+// no staged credential — because rotation is single-stage (see RotatablePublisher).
+const oidcPublisherRotationPath = "publisher-rotation"
+
+// publisherRotationState anchors the rotation schedule so restarts and failovers do not
+// re-mint a credential on every unseal (which would burn the provider's per-account key
+// quota). The next rotation is due at LastRotatedAt + period. It also records the last
+// rotation's outcome so operators can see rotation health via the read API without
+// tailing logs.
+type publisherRotationState struct {
+	LastRotatedAt time.Time `json:"last_rotated_at"`
+	// LastError / LastErrorAt record the most recent failed cycle; cleared on success. A
+	// failure does not advance LastRotatedAt (the schedule stays anchored on last success).
+	LastError   string    `json:"last_error,omitempty"`
+	LastErrorAt time.Time `json:"last_error_at,omitempty"`
+}
+
+func loadPublisherRotationState(ctx context.Context, storage sdklogical.Storage) (*publisherRotationState, error) {
+	entry, err := storage.Get(ctx, oidcPublisherRotationPath)
+	if err != nil {
+		return nil, fmt.Errorf("oidc publisher rotation: read state: %w", err)
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var s publisherRotationState
+	if err := json.Unmarshal(entry.Value, &s); err != nil {
+		return nil, fmt.Errorf("oidc publisher rotation: unmarshal state: %w", err)
+	}
+	return &s, nil
+}
+
+func savePublisherRotationState(ctx context.Context, storage sdklogical.Storage, s *publisherRotationState) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("oidc publisher rotation: marshal state: %w", err)
+	}
+	return storage.Put(ctx, &sdklogical.StorageEntry{Key: oidcPublisherRotationPath, Value: data})
+}
+
+func clearPublisherRotationState(ctx context.Context, storage sdklogical.Storage) error {
+	return storage.Delete(ctx, oidcPublisherRotationPath)
+}
+
+// publisherRotationActive reports whether the publisher-credential rotation loop is
+// running on this node (true only on the active node with a rotatable, configured
+// publisher). Used by the read API to show whether rotation is actually in effect here.
+func (c *Core) publisherRotationActive() bool {
+	c.oidcMu.RLock()
+	defer c.oidcMu.RUnlock()
+	return c.oidcPubRotationCancel != nil
+}
+
+// startPublisherCredRotation launches the active node's publisher-credential rotation
+// loop. It is a no-op on a standby, when the period is unset, or when the configured
+// publisher cannot rotate. Always stops any prior loop first, so it is safe to call on
+// every (re)setup.
+func (c *Core) startPublisherCredRotation(standby bool, period time.Duration, publisher JWKSPublisher) {
+	c.stopPublisherCredRotation()
+	if standby {
+		// The active node owns the shared schedule state; a standby must not touch it.
+		return
+	}
+	storage := NewBarrierView(c.barrier, oidcIssuerStorePrefix)
+	if period <= 0 {
+		// Rotation is disabled by config (period unset, or a type switch cleared the
+		// gcs-only rotation_period). Drop any stale schedule anchor so a later re-enable
+		// starts a fresh period instead of firing immediately off an old timestamp.
+		if err := clearPublisherRotationState(c.activeContext, storage); err != nil {
+			c.logger.Warn("oidc issuer: publisher-credential rotation: clearing schedule anchor failed", logger.Err(err))
+		}
+		return
+	}
+	rp, ok := publisher.(RotatablePublisher)
+	if publisher == nil || !ok || !rp.SupportsRotation() {
+		// period > 0 but the publisher is not rotatable — since rotation_period is gcs-only,
+		// this means the gcs publisher failed to build (e.g. a corrupted stored key degraded
+		// setup to endpoint-only). Do NOT clear the anchor: preserve the schedule so a
+		// repaired config resumes on its original cadence rather than waiting a fresh period.
+		c.logger.Warn("oidc issuer: publisher-credential rotation configured but the publisher is not rotatable; not rotating (publisher build may have failed)")
+		return
+	}
+
+	firstTick, err := c.publisherRotationFirstTick(c.activeContext, storage, period)
+	if err != nil {
+		// A state read/seed failure must not brick unseal; schedule a full period out
+		// and let a later cycle re-seed the anchor.
+		c.logger.Warn("oidc issuer: publisher-credential rotation: state read failed; scheduling a full period out", logger.Err(err))
+		firstTick = period
+	}
+
+	ctx, cancel := context.WithCancel(c.activeContext)
+	done := make(chan struct{})
+	c.oidcMu.Lock()
+	c.oidcPubRotationCancel = cancel
+	c.oidcPubRotationDone = done
+	c.oidcMu.Unlock()
+	go c.publisherCredRotationLoop(ctx, done, period, firstTick, rp)
+	c.logger.Info("oidc issuer: publisher-credential rotation enabled", logger.String("period", period.String()))
+}
+
+// publisherRotationFirstTick returns the delay until the first rotation. On a first-ever
+// start (no persisted state) it seeds LastRotatedAt=now and schedules a full period out,
+// so a restart within a period never re-mints. Otherwise it anchors on the persisted
+// LastRotatedAt (stable across restarts and failover).
+func (c *Core) publisherRotationFirstTick(ctx context.Context, storage sdklogical.Storage, period time.Duration) (time.Duration, error) {
+	st, err := loadPublisherRotationState(ctx, storage)
+	if err != nil {
+		return 0, err
+	}
+	if st == nil {
+		if err := savePublisherRotationState(ctx, storage, &publisherRotationState{LastRotatedAt: time.Now()}); err != nil {
+			return 0, err
+		}
+		return period, nil
+	}
+	return time.Until(st.LastRotatedAt.Add(period)), nil
+}
+
+// stopPublisherCredRotation cancels the loop and joins it, so a demoted/sealing node
+// never keeps rotating (or racing a rebuild in setupOIDCIssuer).
+func (c *Core) stopPublisherCredRotation() {
+	c.oidcMu.Lock()
+	cancel := c.oidcPubRotationCancel
+	done := c.oidcPubRotationDone
+	c.oidcPubRotationCancel = nil
+	c.oidcPubRotationDone = nil
+	c.oidcMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (c *Core) publisherCredRotationLoop(ctx context.Context, done chan struct{}, period, firstTick time.Duration, rp RotatablePublisher) {
+	defer close(done)
+	if firstTick < 0 {
+		firstTick = 0
+	}
+	timer := time.NewTimer(firstTick)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			rotErr := c.rotatePublisherCredential(ctx, rp)
+			// Record the outcome (skip if the loop is tearing down — ctx cancellation is
+			// not a rotation failure worth persisting, and the state write would fail).
+			if ctx.Err() == nil {
+				c.recordPublisherRotationOutcome(ctx, rotErr)
+			}
+			if rotErr != nil {
+				c.logger.Warn("oidc issuer: publisher-credential rotation failed", logger.Err(rotErr))
+			}
+			timer.Reset(jitterDuration(period, 0.05))
+		}
+	}
+}
+
+// rotatePublisherCredential runs one single-stage verify-before-swap cycle: mint+verify a
+// new credential (old untouched), persist it, swap the live publisher in place, then
+// delete the old credential best-effort. A failure before the swap leaves the old
+// credential live, so publishing never breaks; the cycle retries next tick.
+func (c *Core) rotatePublisherCredential(ctx context.Context, rp RotatablePublisher) error {
+	// 1. Create + verify the new credential (abortable via ctx so stop() joins fast).
+	newFields, cleanup, err := rp.PrepareRotation(ctx)
+	if err != nil {
+		return fmt.Errorf("prepare: %w", err)
+	}
+
+	// 2. Persist the new credential into the publisher config (durable before swap).
+	// Aborts (and rolls back) if the stored config no longer holds the key this cycle
+	// chained from — e.g. an operator swapped credentials_json or changed the publisher
+	// type concurrently. Overwriting there would silently discard the operator's change
+	// (a compromise remediation!) and re-instate a key minted from the old chain.
+	if err := c.persistRotatedPublisherFields(ctx, newFields, cleanup); err != nil {
+		// The new credential was created + verified but never persisted or committed;
+		// delete it (best-effort) so a persist failure does not leak a live key toward
+		// the provider quota. Skip when ctx was cancelled (node sealing) — the loop is
+		// tearing down and a leftover key is a tolerated orphan.
+		if ctx.Err() == nil {
+			if rbErr := rp.RollbackRotation(ctx, newFields); rbErr != nil {
+				c.logger.Warn("oidc issuer: publisher-credential rotation: rollback of unpersisted key failed (orphan left)", logger.Err(rbErr))
+			}
+		}
+		return fmt.Errorf("persist: %w", err)
+	}
+
+	// 3. Swap the live in-memory credential to the just-persisted one.
+	if err := rp.CommitRotation(newFields); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	// 4. Delete the superseded credential (best-effort; a leftover is a harmless orphan).
+	if err := rp.CleanupRotation(ctx, cleanup); err != nil {
+		c.logger.Warn("oidc issuer: publisher-credential rotation: deleting old credential failed (orphan left)", logger.Err(err))
+	}
+
+	c.logger.Info("oidc issuer: rotated publisher credential")
+	return nil
+}
+
+// recordPublisherRotationOutcome persists the result of a rotation cycle. On success it
+// advances the schedule anchor and clears any recorded error; on failure it records the
+// error (and its time) while leaving LastRotatedAt anchored on the last success, so a
+// failing cycle neither resets the schedule nor hides the reason from the read API.
+func (c *Core) recordPublisherRotationOutcome(ctx context.Context, rotErr error) {
+	storage := NewBarrierView(c.barrier, oidcIssuerStorePrefix)
+	st, err := loadPublisherRotationState(ctx, storage)
+	if err != nil || st == nil {
+		st = &publisherRotationState{}
+	}
+	now := time.Now()
+	if rotErr == nil {
+		st.LastRotatedAt = now
+		st.LastError = ""
+		st.LastErrorAt = time.Time{}
+	} else {
+		st.LastError = rotErr.Error()
+		st.LastErrorAt = now
+	}
+	if err := savePublisherRotationState(ctx, storage, st); err != nil {
+		c.logger.Warn("oidc issuer: publisher-credential rotation: persisting rotation state failed", logger.Err(err))
+	}
+}
+
+// errRotationSuperseded means the stored config changed under a rotation cycle (the
+// operator swapped the credential or the publisher type), so the persist was abandoned.
+var errRotationSuperseded = errors.New("rotation superseded by a concurrent config change")
+
+// persistRotatedPublisherFields overlays the rotated credential fields onto the stored
+// issuer config and saves it, under oidcConfigMu so a concurrent operator config write
+// cannot lost-update the credential. It first compare-and-swaps: the stored publisher
+// must still be gcs and still hold the exact key this cycle started from (identified by
+// cleanup["old_key_id"]); otherwise it returns errRotationSuperseded and persists nothing.
+func (c *Core) persistRotatedPublisherFields(ctx context.Context, newFields, cleanup map[string]string) error {
+	c.oidcConfigMu.Lock()
+	defer c.oidcConfigMu.Unlock()
+
+	storage := NewBarrierView(c.barrier, oidcIssuerStorePrefix)
+	cfg, err := loadIssuerConfig(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return fmt.Errorf("issuer config missing")
+	}
+
+	// Compare-and-swap guard: only overwrite if the stored key is still the one we
+	// chained from. If the operator changed the publisher (new key, or a type switch
+	// that clears credentials_json) while this cycle ran, abandon the persist so their
+	// change stands and our now-stale new key is rolled back by the caller.
+	if oldKeyID := cleanup["old_key_id"]; oldKeyID != "" {
+		if cfg.Publisher.Type != "gcs" {
+			return errRotationSuperseded
+		}
+		curKey, err := parseGCSServiceAccountKey(cfg.Publisher.CredentialsJSON)
+		if err != nil || curKey.PrivateKeyID != oldKeyID {
+			return errRotationSuperseded
+		}
+	}
+
+	for k, v := range newFields {
+		switch k {
+		case "credentials_json":
+			cfg.Publisher.CredentialsJSON = v
+		default:
+			return fmt.Errorf("unexpected rotated publisher field %q", k)
+		}
+	}
+	return saveIssuerConfig(ctx, storage, cfg)
+}

--- a/core/oidc_publisher_rotation_test.go
+++ b/core/oidc_publisher_rotation_test.go
@@ -1,0 +1,471 @@
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2/google"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers -----------------------------------------------------------
+
+// genTestSAKeyJSON builds a service-account key JSON with a real RSA private key so the
+// OAuth2 JWT-bearer flow can sign an assertion, and points token_uri at a fake server so
+// no real Google token exchange happens.
+func genTestSAKeyJSON(t *testing.T, tokenURI, projectID, email, keyID string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	b, err := json.Marshal(map[string]string{
+		"type":           "service_account",
+		"project_id":     projectID,
+		"private_key_id": keyID,
+		"private_key":    string(pemBytes),
+		"client_email":   email,
+		"token_uri":      tokenURI,
+	})
+	require.NoError(t, err)
+	return string(b)
+}
+
+// fakeTokenServer returns access tokens, failing the first failFirst calls with
+// invalid_grant (to exercise verify-with-retry / propagation absorption).
+func fakeTokenServer(t *testing.T, failFirst int) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	calls := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if n <= failFirst {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+	}))
+}
+
+// fakeIAMServer serves the SA-key create/delete endpoints. POST returns newKeyJSON as the
+// created key; DELETE records the request path so tests can assert the deleted key id.
+func fakeIAMServer(t *testing.T, newKeyJSON string, deletes *[]string) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			enc := base64.StdEncoding.EncodeToString([]byte(newKeyJSON))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"privateKeyData":"` + enc + `"}`))
+		case http.MethodDelete:
+			mu.Lock()
+			*deletes = append(*deletes, r.URL.Path)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+func withIAMEndpoint(t *testing.T, url string) {
+	t.Helper()
+	prev := gcsIAMEndpoint
+	gcsIAMEndpoint = url
+	t.Cleanup(func() { gcsIAMEndpoint = prev })
+}
+
+func withVerifyTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := gcsRotationVerifyTimeout
+	gcsRotationVerifyTimeout = d
+	t.Cleanup(func() { gcsRotationVerifyTimeout = prev })
+}
+
+func newTestGCSPublisher(t *testing.T, credJSON, endpoint string, client *http.Client) *gcsPublisher {
+	t.Helper()
+	creds, err := google.CredentialsFromJSONWithType(context.Background(), []byte(credJSON), google.ServiceAccount, gcsScope)
+	require.NoError(t, err)
+	return &gcsPublisher{
+		tokenSource:     creds.TokenSource,
+		credentialsJSON: credJSON,
+		endpoint:        endpoint,
+		bucket:          "b",
+		client:          client,
+	}
+}
+
+// --- mechanism tests --------------------------------------------------------
+
+func TestGCSPublisher_RotateFullCycle(t *testing.T) {
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	oldKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj.iam.gserviceaccount.com", "OLDKEY")
+	newKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj.iam.gserviceaccount.com", "NEWKEY")
+
+	var deletes []string
+	iamSrv := fakeIAMServer(t, newKey, &deletes)
+	defer iamSrv.Close()
+	withIAMEndpoint(t, iamSrv.URL)
+
+	p := newTestGCSPublisher(t, oldKey, "https://storage.invalid", &http.Client{})
+
+	newFields, cleanup, err := p.PrepareRotation(context.Background())
+	require.NoError(t, err)
+	nk, err := parseGCSServiceAccountKey(newFields["credentials_json"])
+	require.NoError(t, err)
+	assert.Equal(t, "NEWKEY", nk.PrivateKeyID)
+	assert.Equal(t, "OLDKEY", cleanup["old_key_id"])
+	assert.Equal(t, "sa@proj.iam.gserviceaccount.com", cleanup["service_account_email"])
+
+	require.NoError(t, p.CommitRotation(newFields))
+	p.mu.RLock()
+	assert.Equal(t, newFields["credentials_json"], p.credentialsJSON)
+	p.mu.RUnlock()
+
+	require.NoError(t, p.CleanupRotation(context.Background(), cleanup))
+	require.Len(t, deletes, 1)
+	assert.Contains(t, deletes[0], "OLDKEY")
+}
+
+func TestGCSPublisher_RotateVerifyRetry(t *testing.T) {
+	oldTokenSrv := fakeTokenServer(t, 0) // old key mints IAM token fine
+	defer oldTokenSrv.Close()
+	newTokenSrv := fakeTokenServer(t, 1) // new key: first verify attempt fails, then succeeds
+	defer newTokenSrv.Close()
+
+	oldKey := genTestSAKeyJSON(t, oldTokenSrv.URL, "proj", "sa@proj", "OLDKEY")
+	newKey := genTestSAKeyJSON(t, newTokenSrv.URL, "proj", "sa@proj", "NEWKEY")
+
+	var deletes []string
+	iamSrv := fakeIAMServer(t, newKey, &deletes)
+	defer iamSrv.Close()
+	withIAMEndpoint(t, iamSrv.URL)
+
+	p := newTestGCSPublisher(t, oldKey, "https://storage.invalid", &http.Client{})
+
+	newFields, _, err := p.PrepareRotation(context.Background())
+	require.NoError(t, err, "prepare must retry verification until the new key is usable")
+	nk, err := parseGCSServiceAccountKey(newFields["credentials_json"])
+	require.NoError(t, err)
+	assert.Equal(t, "NEWKEY", nk.PrivateKeyID)
+	assert.Empty(t, deletes, "a key that verifies after retry must not be deleted")
+}
+
+func TestGCSPublisher_RotateVerifyFailureDeletesNewKey(t *testing.T) {
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	oldKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "OLDKEY")
+	// A structurally invalid new key: creation succeeds (id fields present) but building a
+	// credential from it fails, so verification fails without any network round-trip.
+	badNewKey := `{"type":"service_account","project_id":"proj","private_key_id":"NEWKEY","client_email":"sa@proj","private_key":"-----BEGIN PRIVATE KEY-----\nnot-a-key\n-----END PRIVATE KEY-----\n","token_uri":"` + tokenSrv.URL + `"}`
+
+	var deletes []string
+	iamSrv := fakeIAMServer(t, badNewKey, &deletes)
+	defer iamSrv.Close()
+	withIAMEndpoint(t, iamSrv.URL)
+
+	p := newTestGCSPublisher(t, oldKey, "https://storage.invalid", &http.Client{})
+
+	// Shorten the internal verify timeout so the retry loop gives up quickly. The parent
+	// context stays alive (Background), so this is a genuine verify failure — not a
+	// cancellation — and the unusable new key is deleted to protect the quota.
+	withVerifyTimeout(t, 300*time.Millisecond)
+	_, _, err := p.PrepareRotation(context.Background())
+	require.Error(t, err, "an unusable new key must fail rotation")
+	require.Len(t, deletes, 1, "a new key that fails verification must be deleted to protect the quota")
+	assert.Contains(t, deletes[0], "NEWKEY")
+}
+
+func TestGCSPublisher_RollbackRotation(t *testing.T) {
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	oldKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "OLDKEY")
+	newKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "NEWKEY")
+	var deletes []string
+	iamSrv := fakeIAMServer(t, newKey, &deletes)
+	defer iamSrv.Close()
+	withIAMEndpoint(t, iamSrv.URL)
+
+	p := newTestGCSPublisher(t, oldKey, "https://storage.invalid", &http.Client{})
+
+	// Rollback deletes the uncommitted new key, authenticating with the still-live old key.
+	require.NoError(t, p.RollbackRotation(context.Background(), map[string]string{"credentials_json": newKey}))
+	require.Len(t, deletes, 1)
+	assert.Contains(t, deletes[0], "NEWKEY")
+
+	// Empty newFields is a no-op.
+	deletes = nil
+	require.NoError(t, p.RollbackRotation(context.Background(), map[string]string{}))
+	assert.Empty(t, deletes)
+}
+
+// TestGCSPublisher_ConcurrentPublishAndCommit exercises the gcsPublisher mutex: a Publish
+// reading the live token source must not race a CommitRotation swapping it. Run with -race.
+func TestGCSPublisher_ConcurrentPublishAndCommit(t *testing.T) {
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	stg := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer stg.Close()
+
+	k1 := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "K1")
+	k2 := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "K2")
+	p := newTestGCSPublisher(t, k1, stg.URL, stg.Client())
+
+	var wg sync.WaitGroup
+	var commitErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = p.Publish(context.Background(), []byte(`{}`), []byte(`{}`))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			// Don't call require.* off the test goroutine (its FailNow is undefined
+			// there); record and assert after the join.
+			if err := p.CommitRotation(map[string]string{"credentials_json": k2}); err != nil {
+				commitErr = err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	require.NoError(t, commitErr)
+}
+
+// --- loop / state tests -----------------------------------------------------
+
+func TestPublisherRotationFirstTick(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	// No state: seed LastRotatedAt=now and schedule a full period out.
+	ft, err := core.publisherRotationFirstTick(ctx, storage, time.Hour)
+	require.NoError(t, err)
+	assert.InDelta(t, time.Hour.Seconds(), ft.Seconds(), 5)
+
+	// State now persisted: anchored on it, still ~a period out (restart within a period
+	// must not re-rotate).
+	ft2, err := core.publisherRotationFirstTick(ctx, storage, time.Hour)
+	require.NoError(t, err)
+	assert.InDelta(t, time.Hour.Seconds(), ft2.Seconds(), 5)
+
+	// A due-in-the-past anchor yields a non-positive delay (rotate promptly).
+	require.NoError(t, savePublisherRotationState(ctx, storage, &publisherRotationState{LastRotatedAt: time.Now().Add(-2 * time.Hour)}))
+	ft3, err := core.publisherRotationFirstTick(ctx, storage, time.Hour)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, ft3, time.Duration(0))
+}
+
+func TestRotatePublisherCredential_PersistsSwapsAndCleans(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	oldKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "OLDKEY")
+	newKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "NEWKEY")
+	var deletes []string
+	iamSrv := fakeIAMServer(t, newKey, &deletes)
+	defer iamSrv.Close()
+	withIAMEndpoint(t, iamSrv.URL)
+
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{
+		Enabled:   true,
+		IssuerURL: "https://iss.example",
+		Publisher: publisherConfig{Type: "gcs", Bucket: "b", CredentialsJSON: oldKey, RotationPeriod: "24h"},
+	}))
+
+	p := newTestGCSPublisher(t, oldKey, "https://storage.invalid", &http.Client{})
+	rotErr := core.rotatePublisherCredential(ctx, p)
+	require.NoError(t, rotErr)
+	core.recordPublisherRotationOutcome(ctx, rotErr) // the loop records the outcome after each cycle
+
+	// Config persisted with the new key.
+	cfg, err := loadIssuerConfig(ctx, storage)
+	require.NoError(t, err)
+	pk, err := parseGCSServiceAccountKey(cfg.Publisher.CredentialsJSON)
+	require.NoError(t, err)
+	assert.Equal(t, "NEWKEY", pk.PrivateKeyID)
+
+	// Live publisher swapped in place.
+	p.mu.RLock()
+	livePK, err := parseGCSServiceAccountKey(p.credentialsJSON)
+	p.mu.RUnlock()
+	require.NoError(t, err)
+	assert.Equal(t, "NEWKEY", livePK.PrivateKeyID)
+
+	// Old key deleted, and the schedule anchor advanced.
+	require.Len(t, deletes, 1)
+	assert.Contains(t, deletes[0], "OLDKEY")
+	st, err := loadPublisherRotationState(ctx, storage)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.WithinDuration(t, time.Now(), st.LastRotatedAt, 5*time.Second)
+	assert.Empty(t, st.LastError)
+}
+
+// TestRecordPublisherRotationOutcome verifies the state doc tracks rotation health: a
+// success advances the anchor and clears the error; a subsequent failure records the error
+// while preserving the last-success anchor (so a failing cycle neither resets the schedule
+// nor hides the reason).
+func TestRecordPublisherRotationOutcome(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	// Success.
+	core.recordPublisherRotationOutcome(ctx, nil)
+	st, err := loadPublisherRotationState(ctx, storage)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.WithinDuration(t, time.Now(), st.LastRotatedAt, 5*time.Second)
+	assert.Empty(t, st.LastError)
+	lastSuccess := st.LastRotatedAt
+
+	// Failure: error recorded, anchor preserved (schedule stays on last success).
+	core.recordPublisherRotationOutcome(ctx, assertAnError())
+	st, err = loadPublisherRotationState(ctx, storage)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, lastSuccess, st.LastRotatedAt, "a failure must not advance the schedule anchor")
+	assert.NotEmpty(t, st.LastError)
+	assert.False(t, st.LastErrorAt.IsZero())
+
+	// Recovery clears the error.
+	core.recordPublisherRotationOutcome(ctx, nil)
+	st, err = loadPublisherRotationState(ctx, storage)
+	require.NoError(t, err)
+	assert.Empty(t, st.LastError)
+	assert.True(t, st.LastErrorAt.IsZero())
+}
+
+func assertAnError() error { return fmt.Errorf("prepare: boom") }
+
+// TestRotatePublisherCredential_SupersededByConfigChange verifies the compare-and-swap
+// guard: if the stored credential changed while a rotation was in flight (e.g. an operator
+// swapped credentials_json), the persist aborts, the operator's key stands, and the newly
+// minted key is rolled back rather than silently discarding the operator's change.
+func TestRotatePublisherCredential_SupersededByConfigChange(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	oldKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "OLDKEY")     // what the cycle chained from
+	otherKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "OTHERKEY") // operator's concurrent replacement
+	newKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "NEWKEY")     // minted by this cycle
+	var deletes []string
+	iamSrv := fakeIAMServer(t, newKey, &deletes)
+	defer iamSrv.Close()
+	withIAMEndpoint(t, iamSrv.URL)
+
+	// Stored config already holds the operator's replacement key, not the one the cycle
+	// started from — simulating a config write that landed during PrepareRotation.
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{
+		Enabled:   true,
+		IssuerURL: "https://iss.example",
+		Publisher: publisherConfig{Type: "gcs", Bucket: "b", CredentialsJSON: otherKey, RotationPeriod: "24h"},
+	}))
+
+	p := newTestGCSPublisher(t, oldKey, "https://storage.invalid", &http.Client{})
+	err := core.rotatePublisherCredential(ctx, p)
+	require.Error(t, err, "rotation must abort when the stored credential changed underneath it")
+
+	// The operator's key stands.
+	cfg, err := loadIssuerConfig(ctx, storage)
+	require.NoError(t, err)
+	pk, err := parseGCSServiceAccountKey(cfg.Publisher.CredentialsJSON)
+	require.NoError(t, err)
+	assert.Equal(t, "OTHERKEY", pk.PrivateKeyID, "operator's replacement key must not be overwritten")
+
+	// The just-minted key was rolled back (deleted), not left as a live orphan.
+	require.Len(t, deletes, 1)
+	assert.Contains(t, deletes[0], "NEWKEY")
+}
+
+func TestSetupOIDCIssuer_PublisherRotationLifecycle(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	tokenSrv := fakeTokenServer(t, 0)
+	defer tokenSrv.Close()
+	stg := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer stg.Close()
+	saKey := genTestSAKeyJSON(t, tokenSrv.URL, "proj", "sa@proj", "K1")
+
+	// Enabled gcs publisher with rotation on; a long period keeps the loop from firing
+	// during the test (we only assert it starts/stops). Endpoint points at a fake so the
+	// initial publish does not reach the real Google.
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{
+		Enabled:   true,
+		IssuerURL: "https://iss.example",
+		Publisher: publisherConfig{Type: "gcs", Bucket: "b", CredentialsJSON: saKey, Endpoint: stg.URL, RotationPeriod: "720h"},
+	}))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+
+	core.oidcMu.RLock()
+	running := core.oidcPubRotationCancel != nil
+	core.oidcMu.RUnlock()
+	assert.True(t, running, "rotation loop must be running when rotation_period is set")
+
+	// Enabling seeds the schedule anchor.
+	st, err := loadPublisherRotationState(ctx, storage)
+	require.NoError(t, err)
+	require.NotNil(t, st, "enabling rotation must seed the schedule anchor")
+
+	// Disable rotation and re-setup: the loop must stop and the anchor must be cleared so
+	// a later re-enable starts a fresh period instead of firing off a stale timestamp.
+	cfg, err := loadIssuerConfig(ctx, storage)
+	require.NoError(t, err)
+	cfg.Publisher.RotationPeriod = ""
+	require.NoError(t, saveIssuerConfig(ctx, storage, cfg))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+
+	core.oidcMu.RLock()
+	running2 := core.oidcPubRotationCancel != nil
+	core.oidcMu.RUnlock()
+	assert.False(t, running2, "rotation loop must stop when rotation_period is cleared")
+
+	st2, err := loadPublisherRotationState(ctx, storage)
+	require.NoError(t, err)
+	assert.Nil(t, st2, "disabling rotation must clear the schedule anchor")
+
+	require.NoError(t, core.stopOIDCIssuer())
+}

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -47,7 +47,7 @@ func (b *SystemBackend) pathOIDCIssuer() []*framework.Path {
 				},
 				"publisher": {
 					Type:        framework.TypeMap,
-					Description: "Optional publisher pushing discovery+JWKS to a bucket/CDN. Keys: type (local_file|http_put|s3|azure_blob|gcs), dir, base_url, auth_header, auth_value, bucket, region, prefix, access_key_id, secret_access_key, account_name, container, account_key, endpoint, credentials_json. Cache-Control is derived from jwks_cache_ttl.",
+					Description: "Optional publisher pushing discovery+JWKS to a bucket/CDN. Keys: type (local_file|http_put|s3|azure_blob|gcs), dir, base_url, auth_header, auth_value, bucket, region, prefix, access_key_id, secret_access_key, account_name, container, account_key, endpoint, credentials_json, rotation_period (gcs only). Cache-Control is derived from jwks_cache_ttl.",
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -120,6 +120,24 @@ func (b *SystemBackend) handleOIDCIssuerConfigRead(ctx context.Context, _ *logic
 	if cfg.Publisher.Type != "" {
 		data["publisher"] = maskedPublisher(cfg.Publisher)
 	}
+	// Publisher-credential rotation runtime status (separate from the config above), so an
+	// operator can see rotation health without tailing logs. Only when rotation is enabled.
+	if cfg.Publisher.rotationPeriod() > 0 {
+		rot := map[string]any{"running": b.core.publisherRotationActive()}
+		if st, serr := loadPublisherRotationState(ctx, storage); serr == nil && st != nil {
+			if !st.LastRotatedAt.IsZero() {
+				rot["last_rotated_at"] = st.LastRotatedAt.UTC().Format(time.RFC3339)
+				rot["next_rotation"] = st.LastRotatedAt.Add(cfg.Publisher.rotationPeriod()).UTC().Format(time.RFC3339)
+			}
+			if st.LastError != "" {
+				rot["last_error"] = st.LastError
+				if !st.LastErrorAt.IsZero() {
+					rot["last_error_at"] = st.LastErrorAt.UTC().Format(time.RFC3339)
+				}
+			}
+		}
+		data["publisher_rotation"] = rot
+	}
 	return b.respondSuccess(data), nil
 }
 
@@ -128,75 +146,111 @@ func (b *SystemBackend) handleOIDCIssuerConfigWrite(ctx context.Context, _ *logi
 		return resp, nil
 	}
 
-	storage := NewBarrierView(b.core.barrier, oidcIssuerStorePrefix)
-	prior, _ := loadIssuerConfig(ctx, storage)
-
-	// Partial update: start from the current config (or an empty one on first
-	// write) and overlay ONLY the fields the request actually set, so changing one
-	// setting never silently reverts the others to their defaults. A field is
-	// cleared/disabled by setting it explicitly (e.g. key_rotation_period=0).
+	// Load-modify-save under oidcConfigMu so a concurrent rotation persist (which also
+	// writes the config doc) cannot lost-update this write, and vice versa. The lock is
+	// scoped to this closure and released before setupOIDCIssuer below — setup joins the
+	// rotation loop, which itself takes oidcConfigMu, so holding it across setup would
+	// deadlock. On a validation failure the closure returns (resp, true) to short-circuit.
 	cfg := &issuerConfig{}
-	if prior != nil {
-		*cfg = *prior
-	}
-	if v, ok := d.GetOk("enabled"); ok {
-		cfg.Enabled = v.(bool)
-	}
-	if v, ok := d.GetOk("issuer_url"); ok {
-		cfg.IssuerURL = strings.TrimSpace(v.(string))
-	}
-	if v, ok := d.GetOk("assertion_ttl"); ok {
-		cfg.TTL = (time.Duration(v.(int)) * time.Second).String()
-	}
-	if v, ok := d.GetOk("key_rotation_period"); ok {
-		cfg.KeyRotationPeriod = (time.Duration(v.(int)) * time.Second).String()
-	}
-	if v, ok := d.GetOk("jwks_cache_ttl"); ok {
-		cfg.JWKSCacheTTL = (time.Duration(v.(int)) * time.Second).String()
-	}
-	if v, ok := d.GetOk("retired_key_grace"); ok {
-		cfg.RetiredKeyGrace = (time.Duration(v.(int)) * time.Second).String()
-	}
-	if v, ok := d.GetOk("publisher"); ok {
-		// Field-level merge over the current publisher: unset fields keep their
-		// value, a type switch clears the old type's fields, and a field set for
-		// the wrong type is rejected rather than silently ignored.
-		merged, err := mergePublisherConfig(cfg.Publisher, v.(map[string]any))
-		if err != nil {
-			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+	if resp, done := func() (*logical.Response, bool) {
+		b.core.oidcConfigMu.Lock()
+		defer b.core.oidcConfigMu.Unlock()
+
+		storage := NewBarrierView(b.core.barrier, oidcIssuerStorePrefix)
+		prior, lerr := loadIssuerConfig(ctx, storage)
+		if lerr != nil {
+			// Do NOT fall through on a read error: a nil prior would turn this partial
+			// update into a destructive overwrite that wipes issuer_url and the whole
+			// publisher block (including the stored write credential).
+			return logical.ErrorResponse(lerr), true
 		}
-		cfg.Publisher = merged
-	}
 
-	// Validate the MERGED result (not just the request), so enabling without
-	// re-supplying an already-stored issuer_url still passes.
-	if cfg.Enabled {
-		if cfg.IssuerURL == "" {
-			return logical.ErrorResponse(logical.ErrBadRequest("issuer_url is required when the issuer is enabled")), nil
+		// Partial update: start from the current config (or an empty one on first
+		// write) and overlay ONLY the fields the request actually set, so changing one
+		// setting never silently reverts the others to their defaults. A field is
+		// cleared/disabled by setting it explicitly (e.g. key_rotation_period=0).
+		if prior != nil {
+			*cfg = *prior
 		}
-		if !strings.HasPrefix(cfg.IssuerURL, "https://") {
-			return logical.ErrorResponse(logical.ErrBadRequest("issuer_url must be https:// (AWS/GCP/Azure require HTTPS OIDC providers)")), nil
+		if v, ok := d.GetOk("enabled"); ok {
+			cfg.Enabled = v.(bool)
 		}
-	}
+		if v, ok := d.GetOk("issuer_url"); ok {
+			cfg.IssuerURL = strings.TrimSpace(v.(string))
+		}
+		if v, ok := d.GetOk("assertion_ttl"); ok {
+			cfg.TTL = (time.Duration(v.(int)) * time.Second).String()
+		}
+		if v, ok := d.GetOk("key_rotation_period"); ok {
+			cfg.KeyRotationPeriod = (time.Duration(v.(int)) * time.Second).String()
+		}
+		if v, ok := d.GetOk("jwks_cache_ttl"); ok {
+			cfg.JWKSCacheTTL = (time.Duration(v.(int)) * time.Second).String()
+		}
+		if v, ok := d.GetOk("retired_key_grace"); ok {
+			cfg.RetiredKeyGrace = (time.Duration(v.(int)) * time.Second).String()
+		}
+		if v, ok := d.GetOk("publisher"); ok {
+			// Field-level merge over the current publisher: unset fields keep their
+			// value, a type switch clears the old type's fields, and a field set for
+			// the wrong type is rejected rather than silently ignored.
+			merged, err := mergePublisherConfig(cfg.Publisher, v.(map[string]any))
+			if err != nil {
+				return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), true
+			}
+			cfg.Publisher = merged
+		}
 
-	// A rotation cadence must comfortably outlast the JWKS cache TTL, otherwise the
-	// pre-published next key would not have been cacheable for a full period before
-	// it signs — this guarantees the rotation-time propagation floor is a no-op in
-	// the steady state. (The published JWKS Cache-Control max-age is derived from
-	// the same value, so a cached JWKS is always refreshed before a new key signs.)
-	if p := cfg.keyRotationPeriod(); p > 0 && p <= cfg.jwksCacheTTL() {
-		return logical.ErrorResponse(logical.ErrBadRequestf("key_rotation_period (%s) must exceed jwks_cache_ttl (%s)", p, cfg.jwksCacheTTL())), nil
-	}
+		// Validate the MERGED result (not just the request), so enabling without
+		// re-supplying an already-stored issuer_url still passes.
+		if cfg.Enabled {
+			if cfg.IssuerURL == "" {
+				return logical.ErrorResponse(logical.ErrBadRequest("issuer_url is required when the issuer is enabled")), true
+			}
+			if !strings.HasPrefix(cfg.IssuerURL, "https://") {
+				return logical.ErrorResponse(logical.ErrBadRequest("issuer_url must be https:// (AWS/GCP/Azure require HTTPS OIDC providers)")), true
+			}
+		}
 
-	// Validate the publisher builds BEFORE persisting, so an invalid config can
-	// never be stored (a persisted-but-invalid publisher would otherwise degrade
-	// every subsequent unseal to endpoint-only with a warning).
-	if _, err := newJWKSPublisher(cfg.Publisher, ""); err != nil {
-		return logical.ErrorResponse(logical.ErrBadRequestf("invalid publisher config: %v", err)), nil
-	}
+		// A rotation cadence must comfortably outlast the JWKS cache TTL, otherwise the
+		// pre-published next key would not have been cacheable for a full period before
+		// it signs — this guarantees the rotation-time propagation floor is a no-op in
+		// the steady state. (The published JWKS Cache-Control max-age is derived from
+		// the same value, so a cached JWKS is always refreshed before a new key signs.)
+		if p := cfg.keyRotationPeriod(); p > 0 && p <= cfg.jwksCacheTTL() {
+			return logical.ErrorResponse(logical.ErrBadRequestf("key_rotation_period (%s) must exceed jwks_cache_ttl (%s)", p, cfg.jwksCacheTTL())), true
+		}
 
-	if err := saveIssuerConfig(ctx, storage, cfg); err != nil {
-		return logical.ErrorResponse(err), nil
+		// Validate the publisher builds BEFORE persisting, so an invalid config can
+		// never be stored (a persisted-but-invalid publisher would otherwise degrade
+		// every subsequent unseal to endpoint-only with a warning).
+		if _, err := newJWKSPublisher(cfg.Publisher, ""); err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequestf("invalid publisher config: %v", err)), true
+		}
+
+		// Validate rotation_period strictly (the stored value is trusted by the lenient
+		// rotationPeriod() reader, so a typo must be caught here, not silently disable
+		// rotation). An empty value or "0" disables it; anything else must parse as a Go
+		// duration and clear a floor that keeps rotation from hammering the provider API.
+		if rp := strings.TrimSpace(cfg.Publisher.RotationPeriod); rp != "" {
+			dur, err := time.ParseDuration(rp)
+			if err != nil {
+				return logical.ErrorResponse(logical.ErrBadRequestf("invalid rotation_period %q: use a Go duration like 720h, or 0 to disable", rp)), true
+			}
+			switch {
+			case dur == 0:
+				cfg.Publisher.RotationPeriod = "" // normalize "0" to unset so reads stay clean
+			case dur < minPublisherRotationPeriod:
+				return logical.ErrorResponse(logical.ErrBadRequestf("rotation_period (%s) must be at least %s", dur, minPublisherRotationPeriod)), true
+			}
+		}
+
+		if err := saveIssuerConfig(ctx, storage, cfg); err != nil {
+			return logical.ErrorResponse(err), true
+		}
+		return nil, false
+	}(); done {
+		return resp, nil
 	}
 
 	// Activate the change: reload the issuer from the just-written config. On the
@@ -240,6 +294,7 @@ var publisherFieldOwners = map[string][]string{
 	"account_key":       {"azure_blob"},
 	"endpoint":          {"azure_blob", "gcs"},
 	"credentials_json":  {"gcs"},
+	"rotation_period":   {"gcs"},
 }
 
 // ownedBy reports whether field is valid for the given publisher type.
@@ -320,6 +375,9 @@ func mergePublisherConfig(prior publisherConfig, raw map[string]any) (publisherC
 	if v, ok := get("endpoint"); ok {
 		pc.Endpoint = v
 	}
+	if v, ok := get("rotation_period"); ok {
+		pc.RotationPeriod = v
+	}
 	// Secrets: overlay only a real value; an omitted/empty/masked secret keeps the
 	// prior one (carried via pc=prior when the type is unchanged).
 	if v, ok := get("auth_value"); ok && v != "" && v != maskValue {
@@ -382,6 +440,9 @@ func maskedPublisher(pc publisherConfig) map[string]any {
 	}
 	if pc.CredentialsJSON != "" {
 		m["credentials_json"] = maskValue
+	}
+	if pc.RotationPeriod != "" {
+		m["rotation_period"] = pc.RotationPeriod
 	}
 	return m
 }


### PR DESCRIPTION
## What

Adds automatic rotation of the **GCS OIDC issuer publisher**'s service-account key. Until now the GCS publisher held a static service-account JSON key that never expired — a leaked key stayed valid indefinitely. On a configured cadence, the active node now:

1. mints a fresh SA key via the GCP IAM API,
2. **verifies** it can mint a token,
3. swaps it into the live publisher,
4. deletes the old key.

## Design

Single-stage **verify-before-swap** (not the source-driver two-stage staged/propagation-wait). The publisher credential is off the request hot path and the built-in HTTP endpoint always serves, so a rare transient publish failure self-heals — no timed propagation overlap is needed. The logic is a self-contained loop in the OIDC issuer subsystem (mirroring the signing-key rotation loop); the shared `RotationManager` is untouched since the publisher is not a `SourceDriver`/`CredSpec`.

- **`RotatablePublisher` interface** with a GCS implementation — generic, so `s3`/`azure_blob` can follow by adding their own rotation methods.
- **`rotation_period`** as a gcs-only publisher config key (type-owned validation, strict parse, 24h floor), surfaced as `set-publisher -rotation-period`.
- **Restart safety** via a persisted `last_rotated_at` anchor so unseal/failover never re-mints (protecting the 10-key-per-SA quota).

## Correctness / concurrency

- `gcsPublisher` `RWMutex` for the in-place credential swap vs. concurrent `Publish`.
- `oidcConfigMu` serializes the config load-modify-save (rotation persist vs. operator write); `oidcSetupMu` serializes issuer setup/teardown so concurrent config writes can't leak a rotation goroutine.
- **Compare-and-swap on persist**: a concurrent operator credential change (e.g. a compromise remediation) is never silently clobbered — the cycle aborts and rolls back its new key.
- **Bounded OAuth/IAM HTTP timeouts** so a black-holed endpoint can't wedge the loop and hang seal; the loop stops-and-joins at the top of setup to avoid rebuilding onto a key a rotation is about to delete.
- **Cleanup authenticates as the old (propagated) key** with retry, to absorb new-key eventual consistency (`Invalid JWT Signature` on a seconds-old key) — surfaced by a live GCP run.
- Graceful failure: a missing permission logs + retries and never touches the live key.

## Observability

`oidc-issuer read` now returns a `publisher_rotation` block: `running`, `last_rotated_at`, `next_rotation`, and `last_error` / `last_error_at` when the last cycle failed.

## Testing

- Unit tests against fake IAM/token/storage servers: full cycle, verify-with-retry, verify-failure-deletes-new-key, rollback, compare-and-swap supersede, restart quota-guard, setup lifecycle + anchor clearing, outcome recording, and a `-race` concurrency test.
- Verified end-to-end against a real GCP project (rotation firing each period, keys created/deleted, publishing uninterrupted) — which is what surfaced the cleanup-auth eventual-consistency fix.

Operator note: the service account must hold `iam.serviceAccountKeys.create`/`delete` on itself (`roles/iam.serviceAccountKeyAdmin`).
