### PR TITLE
feat(core)!: self-rotate the Azure Blob OIDC issuer publisher credential

### DIFF
--- a/cmd/oidcissuer/set_publisher.go
+++ b/cmd/oidcissuer/set_publisher.go
@@ -29,7 +29,7 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
   repeatable -config=key=value pair, so new publisher fields need no new flags.
   Config keys are the type's field names, validated server-side per type. A
   value prefixed with '@' is read from a file (handy for secrets):
-  -config=account_key=@/run/secrets/key.
+  -config=client_secret=@/run/secrets/sp.
 
   A write is a PARTIAL update over the stored publisher: unset keys keep their
   value, switching -type drops the previous type's fields, and secrets are
@@ -41,16 +41,20 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
       local_file   dir
       http_put     base_url, auth_header, auth_value
       s3           bucket, region, access_key_id, secret_access_key, prefix, endpoint
-      azure_blob   account_name, container, account_key, prefix, endpoint
+      azure_blob   account_name, container, tenant_id, client_id, client_secret,
+                   secret_id, prefix, endpoint
       gcs          bucket, credentials_json, prefix, endpoint
       none         (removes the publisher)
 
-  Automatic credential rotation (gcs and s3) is enabled with -rotation-period: on
-  that cadence Warden mints a fresh write key, verifies it, swaps it in, and deletes
-  the old one. gcs needs iam.serviceAccountKeys.create/delete on its own service
-  account; s3 needs iam:CreateAccessKey/DeleteAccessKey/ListAccessKeys on its own IAM
-  user (a permanent AKIA… key, not temporary STS credentials). Set -rotation-period=0
-  to disable.
+  Automatic credential rotation (gcs, s3, azure_blob) is enabled with
+  -rotation-period: on that cadence Warden mints a fresh write credential, verifies
+  it, swaps it in, and deletes the old one. gcs needs
+  iam.serviceAccountKeys.create/delete on its own service account; s3 needs
+  iam:CreateAccessKey/DeleteAccessKey/ListAccessKeys on its own IAM user (a permanent
+  AKIA… key, not temporary STS credentials); azure_blob authenticates with a service
+  principal (Entra ID) that has Storage Blob Data Contributor on the container and
+  Graph rights to manage its own app registration, and rotation regenerates that SP's
+  client_secret. Set -rotation-period=0 to disable.
 
   The s3 endpoint key targets an S3-compatible object store (MinIO, Cloudflare R2,
   …). Rotation always uses AWS IAM, so -rotation-period applies to real-AWS keys
@@ -63,11 +67,12 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
           -config=access_key_id=AKIA... \
           -config=secret_access_key=@/run/secrets/s3
 
-  Azure Blob:
+  Azure Blob (service-principal auth, with automatic secret rotation every 30 days):
 
-      $ warden oidc-issuer set-publisher -type=azure_blob \
+      $ warden oidc-issuer set-publisher -type=azure_blob -rotation-period=720h \
           -config=account_name=wardenoidc -config=container=jwks \
-          -config=account_key=@/run/secrets/key
+          -config=tenant_id=<tenant> -config=client_id=<app-id> \
+          -config=client_secret=@/run/secrets/sp -config=secret_id=<keyId>
 
   Google Cloud Storage (with automatic key rotation every 30 days):
 
@@ -95,8 +100,8 @@ Usage: warden oidc-issuer set-publisher -type=<type> [-config=key=value ...]
 func init() {
 	f := SetPublisherCmd.Flags()
 	f.StringVar(&pubType, "type", "", "Publisher type: none, local_file, http_put, s3, azure_blob, or gcs")
-	f.StringToStringVar(&pubConfig, "config", nil, "Type-specific config (key=value; repeatable). Use @file to read a value from a file, e.g. -config=account_key=@/run/secrets/key")
-	f.StringVar(&pubRotationPeriod, "rotation-period", "", "Automatic credential-rotation cadence for the publisher's write key (gcs and s3). A Go duration like 720h; 0 disables. Empty leaves it unchanged.")
+	f.StringToStringVar(&pubConfig, "config", nil, "Type-specific config (key=value; repeatable). Use @file to read a value from a file, e.g. -config=client_secret=@/run/secrets/sp")
+	f.StringVar(&pubRotationPeriod, "rotation-period", "", "Automatic credential-rotation cadence for the publisher's write key (gcs, s3, azure_blob). A Go duration like 720h; 0 disables. Empty leaves it unchanged.")
 	f.StringVarP(&pubJSON, "json", "j", "", "Full publisher JSON block — '<json>', '@file.json', or '-' for stdin (mutually exclusive with -type/-config)")
 }
 

--- a/core/oidc_publisher.go
+++ b/core/oidc_publisher.go
@@ -46,17 +46,25 @@ type publisherConfig struct {
 	AccessKeyID     string `json:"access_key_id,omitempty"`
 	SecretAccessKey string `json:"secret_access_key,omitempty"`
 
-	// azure_blob: Shared Key auth to an Azure Storage container. AccountKey is a
-	// stored static secret (masked); it never expires, and the storage account's
-	// two-key model keeps it rotation-ready (a rotation follow-on regenerates the
-	// inactive key and swaps AccountKey). Prefix above is reused as the blob-name
-	// prefix within the container. Endpoint overrides the service URL (for a
-	// sovereign cloud, a private endpoint, or a test/emulator); empty defaults to
-	// the public-cloud host for AccountName.
-	AccountName string `json:"account_name,omitempty"`
-	Container   string `json:"container,omitempty"`
-	AccountKey  string `json:"account_key,omitempty"`
-	Endpoint    string `json:"endpoint,omitempty"` // shared with gcs (API endpoint override)
+	// azure_blob: writes to an Azure Storage container authenticated by a service
+	// principal's OAuth token (Entra ID data-plane auth). Warden self-rotates the SP's
+	// ClientSecret via Microsoft Graph (see RotatablePublisher): on the configured
+	// cadence it adds a fresh secret to the app registration, verifies it, swaps it in,
+	// and removes the old one — which requires the SP to hold Storage Blob Data
+	// Contributor on the container and Graph rights to manage its own app registration
+	// (Application.ReadWrite.OwnedBy as an owner of its app, or Application.ReadWrite.All).
+	// ClientSecret is masked; SecretID is the Graph password-credential id (keyId) of the
+	// current secret, used to remove it on rotation. Prefix above is reused as the
+	// blob-name prefix; Endpoint overrides the blob service URL (private endpoint or a
+	// test/emulator), empty defaults to the public-cloud host. Sovereign clouds are not yet
+	// supported: the OAuth authority and Graph host are the public-cloud endpoints.
+	AccountName  string `json:"account_name,omitempty"`
+	Container    string `json:"container,omitempty"`
+	TenantID     string `json:"tenant_id,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+	SecretID     string `json:"secret_id,omitempty"`
+	Endpoint     string `json:"endpoint,omitempty"` // shared with gcs (API endpoint override)
 
 	// gcs: writes to a Google Cloud Storage bucket authenticated by a stored
 	// static service-account JSON key. CredentialsJSON is a stored static secret

--- a/core/oidc_publisher_azure.go
+++ b/core/oidc_publisher_azure.go
@@ -1,28 +1,79 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 )
 
-// azureUploadTimeout bounds a single blob upload, matching the http_put
-// publisher's per-request timeout so a slow/flaky endpoint cannot stall a
-// rotation (which runs off the request path and has no outer deadline).
+// azureUploadTimeout bounds a single blob upload, matching the http_put publisher's
+// per-request timeout so a slow/flaky endpoint cannot stall a rotation (which runs off the
+// request path and has no outer deadline). It also bounds the raw OAuth/Graph HTTP calls.
 const azureUploadTimeout = 15 * time.Second
 
-// azureBlobPublisher uploads the documents to an Azure Storage container using a
-// Shared Key (account name + account key). Like the S3 publisher this is an
-// infra-scoped write credential used only on rotation (rare), distinct from the
-// per-agent secrets WIF removes. The account key never expires; regenerating and
-// swapping it (the storage account's two-key model) is a planned rotation follow-on.
+const (
+	// azureStorageScope / azureGraphScope are the OAuth2 scopes for the blob data plane
+	// and for Microsoft Graph (app-registration secret management), respectively.
+	azureStorageScope = "https://storage.azure.com/.default"
+	azureGraphScope   = "https://graph.microsoft.com/.default"
+	// azurePublisherSecretPrefix is the base displayName Warden gives the password
+	// credentials it creates; secretDisplayName qualifies it with account/container so
+	// orphans from failed cleanups can be identified and pruned without a different Warden
+	// deployment (different bucket) pruning this one's secrets.
+	azurePublisherSecretPrefix = "warden-oidc-publisher"
+)
+
+// azureAuthorityHost / azureGraphEndpoint are the Entra ID token authority and the Graph
+// API host. They are package-level vars (not operator config) so tests can point token
+// acquisition and Graph calls at an httptest server (mirrors gcsIAMEndpoint/awsIAMEndpoint).
+var (
+	azureAuthorityHost = "https://login.microsoftonline.com"
+	azureGraphEndpoint = "https://graph.microsoft.com"
+)
+
+// azureRotationVerifyTimeout bounds how long we retry proving a brand-new client secret is
+// usable (a fresh secret is briefly rejected while Entra ID propagates it). A var so tests
+// can shorten it.
+var azureRotationVerifyTimeout = 60 * time.Second
+
+// azureInsecureAllowHTTP lets tests point the blob client at a plain-HTTP httptest server
+// (the OAuth bearer policy otherwise refuses to send a token over http). Never set in prod.
+var azureInsecureAllowHTTP = false
+
+// azureHTTPClient bounds each raw OAuth/Graph request.
+var azureHTTPClient = &http.Client{Timeout: azureUploadTimeout}
+
+// azureBlobPublisher uploads the documents to an Azure Storage container, authenticated by
+// a service principal's OAuth token (Entra ID data-plane auth). Warden self-rotates the
+// SP's client secret via Microsoft Graph (see RotatablePublisher): it adds a fresh secret
+// to the app registration, verifies it, swaps it into the live client, and removes the old
+// one. The SP needs Storage Blob Data Contributor on the container and Graph rights over
+// its own app registration (Application.ReadWrite.OwnedBy as an owner, or ...All).
 type azureBlobPublisher struct {
+	// mu guards the mutable credential (client + client secret + secret id), which
+	// CommitRotation swaps in place while Publish may be reading the client concurrently.
+	mu           sync.RWMutex
 	client       *azblob.Client
+	clientSecret string
+	secretID     string
+
+	tenantID     string
+	clientID     string
+	accountName  string
+	serviceURL   string
 	container    string
 	prefix       string
 	cacheControl string
@@ -32,29 +83,45 @@ func newAzureBlobPublisher(cfg publisherConfig, cacheControl string) (JWKSPublis
 	if cfg.AccountName == "" || cfg.Container == "" {
 		return nil, fmt.Errorf("oidc publisher: azure_blob requires 'account_name' and 'container'")
 	}
-	if cfg.AccountKey == "" {
-		return nil, fmt.Errorf("oidc publisher: azure_blob requires 'account_key'")
+	if cfg.TenantID == "" || cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return nil, fmt.Errorf("oidc publisher: azure_blob requires 'tenant_id', 'client_id', and 'client_secret' (service-principal auth)")
 	}
-	cred, err := azblob.NewSharedKeyCredential(cfg.AccountName, cfg.AccountKey)
-	if err != nil {
-		return nil, fmt.Errorf("oidc publisher: azure_blob credential: %w", err)
-	}
-	// Default to the public-cloud host; an explicit endpoint covers sovereign
-	// clouds (Government/China), a private endpoint, or a test emulator (Azurite).
+	// Default to the public-cloud blob host; an explicit endpoint covers a private endpoint
+	// or a test emulator (Azurite). Note: the OAuth authority and Graph host are the public
+	// cloud (see azureAuthorityHost/azureGraphEndpoint), so sovereign clouds (Government/
+	// China) are not yet supported for the SP-authenticated path.
 	serviceURL := cfg.Endpoint
 	if serviceURL == "" {
 		serviceURL = fmt.Sprintf("https://%s.blob.core.windows.net/", cfg.AccountName)
 	}
-	client, err := azblob.NewClientWithSharedKeyCredential(serviceURL, cred, nil)
-	if err != nil {
-		return nil, fmt.Errorf("oidc publisher: azure_blob client: %w", err)
-	}
-	return &azureBlobPublisher{
-		client:       client,
+	p := &azureBlobPublisher{
+		clientSecret: cfg.ClientSecret,
+		secretID:     cfg.SecretID,
+		tenantID:     cfg.TenantID,
+		clientID:     cfg.ClientID,
+		accountName:  cfg.AccountName,
+		serviceURL:   serviceURL,
 		container:    cfg.Container,
 		prefix:       strings.Trim(cfg.Prefix, "/"),
 		cacheControl: cacheControl,
-	}, nil
+	}
+	client, err := p.buildClient(cfg.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("oidc publisher: azure_blob client: %w", err)
+	}
+	p.client = client
+	return p, nil
+}
+
+// buildClient constructs an azblob client authenticated by the SP OAuth token for the
+// given client secret.
+func (p *azureBlobPublisher) buildClient(clientSecret string) (*azblob.Client, error) {
+	cred := &azureOAuthCredential{tenantID: p.tenantID, clientID: p.clientID, clientSecret: clientSecret}
+	var opts *azblob.ClientOptions
+	if azureInsecureAllowHTTP {
+		opts = &azblob.ClientOptions{ClientOptions: azcore.ClientOptions{InsecureAllowCredentialWithHTTP: true}}
+	}
+	return azblob.NewClient(p.serviceURL, cred, opts)
 }
 
 func (p *azureBlobPublisher) Type() string { return "azure_blob" }
@@ -77,11 +144,391 @@ func (p *azureBlobPublisher) put(ctx context.Context, name string, body []byte) 
 	}
 	ctx, cancel := context.WithTimeout(ctx, azureUploadTimeout)
 	defer cancel()
-	_, err := p.client.UploadBuffer(ctx, p.container, blobName, body, &azblob.UploadBufferOptions{
+	p.mu.RLock()
+	client := p.client
+	p.mu.RUnlock()
+	_, err := client.UploadBuffer(ctx, p.container, blobName, body, &azblob.UploadBufferOptions{
 		HTTPHeaders: headers,
 	})
 	if err != nil {
 		return fmt.Errorf("oidc publisher: azure_blob upload %s: %w", blobName, err)
 	}
 	return nil
+}
+
+// azureOAuthCredential is an azcore.TokenCredential backed by the raw OAuth2
+// client-credentials flow, so the blob client authenticates with the SP token without
+// pulling in azidentity. It honors the exact scope the SDK requests.
+type azureOAuthCredential struct {
+	tenantID, clientID, clientSecret string
+}
+
+func (c *azureOAuthCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	scope := azureStorageScope
+	if len(opts.Scopes) > 0 {
+		scope = opts.Scopes[0]
+	}
+	token, expiresOn, err := azureAcquireToken(ctx, c.tenantID, c.clientID, c.clientSecret, scope)
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+	return azcore.AccessToken{Token: token, ExpiresOn: expiresOn}, nil
+}
+
+// Azure client-secret rotation (implements RotatablePublisher).
+
+var _ RotatablePublisher = (*azureBlobPublisher)(nil)
+
+func (p *azureBlobPublisher) SupportsRotation() bool { return true }
+
+// secretDisplayName is the Graph displayName Warden stamps on the password credentials it
+// mints, qualified by account/container so pruning only ever targets THIS publisher's own
+// secrets (never an operator's, nor another Warden deployment's on a different bucket).
+func (p *azureBlobPublisher) secretDisplayName() string {
+	return fmt.Sprintf("%s/%s/%s", azurePublisherSecretPrefix, p.accountName, p.container)
+}
+
+// PrepareRotation adds and verifies a new client secret on the app registration, leaving
+// the current secret untouched.
+func (p *azureBlobPublisher) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, map[string]string, error) {
+	p.mu.RLock()
+	tenantID, clientID, oldSecret, oldSecretID := p.tenantID, p.clientID, p.clientSecret, p.secretID
+	p.mu.RUnlock()
+
+	graphToken, err := azureAcquireGraphTokenWithRetry(ctx, tenantID, clientID, oldSecret)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("oidc publisher: azure_blob rotation graph token: %w", err)
+	}
+	appObjectID, err := resolveAppObjectID(ctx, graphToken, clientID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("oidc publisher: azure_blob rotation resolve app: %w", err)
+	}
+
+	newSecret, newSecretID, err := graphAddPassword(ctx, graphToken, appObjectID, p.secretDisplayName())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("oidc publisher: azure_blob rotation add secret: %w", err)
+	}
+
+	// Verify the new secret can acquire a storage token before handing it back. If it
+	// never becomes usable, remove it (authenticating as the still-valid old secret) so a
+	// failed rotation does not leave an orphaned password on the app registration. Skip the
+	// removal on ctx cancellation (node sealing).
+	if err := p.verifySecret(ctx, tenantID, clientID, newSecret); err != nil {
+		if ctx.Err() == nil {
+			delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), azureUploadTimeout)
+			if gt, _, gerr := azureAcquireToken(delCtx, tenantID, clientID, oldSecret, azureGraphScope); gerr == nil {
+				_ = graphRemovePassword(delCtx, gt, appObjectID, newSecretID)
+			}
+			cancel()
+		}
+		return nil, nil, nil, fmt.Errorf("oidc publisher: azure_blob rotation verify new secret: %w", err)
+	}
+
+	newFields := map[string]string{"client_secret": newSecret, "secret_id": newSecretID}
+	prevFields := map[string]string{"client_secret": oldSecret}
+	cleanup := map[string]string{
+		// Remove the old secret authenticating AS the old secret (fully propagated),
+		// avoiding new-secret eventual-consistency lag. In-memory only.
+		"old_secret_id":     oldSecretID,
+		"old_client_secret": oldSecret,
+		"tenant_id":         tenantID,
+		"client_id":         clientID,
+		"app_object_id":     appObjectID,
+	}
+	return newFields, prevFields, cleanup, nil
+}
+
+// CommitRotation swaps the live blob client to the newly persisted client secret.
+func (p *azureBlobPublisher) CommitRotation(newFields map[string]string) error {
+	secret := newFields["client_secret"]
+	if secret == "" {
+		return fmt.Errorf("oidc publisher: azure_blob rotation commit: missing client_secret")
+	}
+	client, err := p.buildClient(secret)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: azure_blob rotation commit client: %w", err)
+	}
+	p.mu.Lock()
+	p.client = client
+	p.clientSecret = secret
+	p.secretID = newFields["secret_id"]
+	p.mu.Unlock()
+	return nil
+}
+
+// CleanupRotation removes the superseded secret, authenticating as the old (propagated) one.
+func (p *azureBlobPublisher) CleanupRotation(ctx context.Context, cleanup map[string]string) error {
+	oldSecretID := cleanup["old_secret_id"]
+	if oldSecretID == "" {
+		return nil
+	}
+	graphToken, err := azureAcquireGraphTokenWithRetry(ctx, cleanup["tenant_id"], cleanup["client_id"], cleanup["old_client_secret"])
+	if err != nil {
+		return fmt.Errorf("oidc publisher: azure_blob rotation cleanup graph token: %w", err)
+	}
+	if err := graphRemovePassword(ctx, graphToken, cleanup["app_object_id"], oldSecretID); err != nil {
+		return fmt.Errorf("oidc publisher: azure_blob rotation remove old secret: %w", err)
+	}
+	// Best-effort: also prune any Warden secrets leaked by *prior* failed cleanups. Runs
+	// only post-commit, keeping the just-committed live secret (p.secretID — known correct,
+	// not the possibly-stale stored config value), so it can never delete the active
+	// credential. Matches only this publisher's displayName, so it never touches another
+	// deployment's or an operator's secrets.
+	p.mu.RLock()
+	liveID, displayName := p.secretID, p.secretDisplayName()
+	p.mu.RUnlock()
+	pruneOrphanPasswords(ctx, graphToken, cleanup["app_object_id"], displayName, liveID)
+	return nil
+}
+
+// RollbackRotation removes a prepared-but-uncommitted new secret, authenticating with the
+// current (still the OLD) secret.
+func (p *azureBlobPublisher) RollbackRotation(ctx context.Context, newFields map[string]string) error {
+	newSecretID := newFields["secret_id"]
+	if newSecretID == "" {
+		return nil
+	}
+	p.mu.RLock()
+	tenantID, clientID, curSecret := p.tenantID, p.clientID, p.clientSecret
+	p.mu.RUnlock()
+	graphToken, err := azureAcquireGraphTokenWithRetry(ctx, tenantID, clientID, curSecret)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: azure_blob rotation rollback graph token: %w", err)
+	}
+	appObjectID, err := resolveAppObjectID(ctx, graphToken, clientID)
+	if err != nil {
+		return fmt.Errorf("oidc publisher: azure_blob rotation rollback resolve app: %w", err)
+	}
+	if err := graphRemovePassword(ctx, graphToken, appObjectID, newSecretID); err != nil {
+		return fmt.Errorf("oidc publisher: azure_blob rotation rollback remove new secret: %w", err)
+	}
+	return nil
+}
+
+// verifySecret proves a client secret is usable by acquiring a storage-scoped token,
+// retrying up to azureRotationVerifyTimeout to absorb Entra ID eventual consistency.
+func (p *azureBlobPublisher) verifySecret(ctx context.Context, tenantID, clientID, clientSecret string) error {
+	ctx, cancel := context.WithTimeout(ctx, azureRotationVerifyTimeout)
+	defer cancel()
+	return retryWithBackoff(ctx, func() error {
+		_, _, err := azureAcquireToken(ctx, tenantID, clientID, clientSecret, azureStorageScope)
+		return err
+	})
+}
+
+// azureAcquireGraphTokenWithRetry acquires a Graph token, retrying briefly to absorb
+// secret-propagation lag.
+func azureAcquireGraphTokenWithRetry(ctx context.Context, tenantID, clientID, clientSecret string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, azureRotationVerifyTimeout)
+	defer cancel()
+	var token string
+	if err := retryWithBackoff(ctx, func() error {
+		t, _, err := azureAcquireToken(ctx, tenantID, clientID, clientSecret, azureGraphScope)
+		token = t
+		return err
+	}); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// azureAcquireToken performs the OAuth2 client-credentials flow and returns the token and
+// its expiry. Mirrors the Azure source driver's acquireToken but takes a full scope (the
+// azblob credential shim passes the SDK's requested scope verbatim).
+func azureAcquireToken(ctx context.Context, tenantID, clientID, clientSecret, scope string) (string, time.Time, error) {
+	tokenURL := fmt.Sprintf("%s/%s/oauth2/v2.0/token", strings.TrimRight(azureAuthorityHost, "/"), url.PathEscape(tenantID))
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("scope", scope)
+	form.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := azureHTTPClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode/100 != 2 {
+		return "", time.Time{}, fmt.Errorf("token endpoint status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(respBody, &tok); err != nil {
+		return "", time.Time{}, fmt.Errorf("decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return "", time.Time{}, fmt.Errorf("token response missing access_token")
+	}
+	expiresOn := time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	return tok.AccessToken, expiresOn, nil
+}
+
+// resolveAppObjectID looks up an app registration's object id from its appId (client_id) —
+// the Graph password endpoints key on the object id, not the appId.
+func resolveAppObjectID(ctx context.Context, graphToken, appID string) (string, error) {
+	q := url.Values{}
+	// Escape single quotes in the OData string literal (doubled), so a client_id value
+	// can't break the filter.
+	q.Set("$filter", fmt.Sprintf("appId eq '%s'", strings.ReplaceAll(appID, "'", "''")))
+	q.Set("$select", "id")
+	api := fmt.Sprintf("%s/v1.0/applications?%s", strings.TrimRight(azureGraphEndpoint, "/"), q.Encode())
+	respBody, err := doGraphRequest(ctx, http.MethodGet, api, graphToken, nil)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Value []struct {
+			ID string `json:"id"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("decode applications response: %w", err)
+	}
+	if len(resp.Value) == 0 || resp.Value[0].ID == "" {
+		return "", fmt.Errorf("no app registration found for client_id")
+	}
+	return resp.Value[0].ID, nil
+}
+
+// graphAddPassword adds a new password credential to the app registration and returns its
+// secret text and keyId.
+func graphAddPassword(ctx context.Context, graphToken, appObjectID, displayName string) (secret, keyID string, err error) {
+	api := fmt.Sprintf("%s/v1.0/applications/%s/addPassword",
+		strings.TrimRight(azureGraphEndpoint, "/"), url.PathEscape(appObjectID))
+	reqBody, _ := json.Marshal(map[string]any{
+		"passwordCredential": map[string]any{"displayName": displayName},
+	})
+	respBody, err := doGraphRequest(ctx, http.MethodPost, api, graphToken, reqBody)
+	if err != nil {
+		return "", "", err
+	}
+	var resp struct {
+		SecretText string `json:"secretText"`
+		KeyID      string `json:"keyId"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", "", fmt.Errorf("decode addPassword response: %w", err)
+	}
+	if resp.SecretText == "" || resp.KeyID == "" {
+		return "", "", fmt.Errorf("addPassword response missing secretText/keyId")
+	}
+	return resp.SecretText, resp.KeyID, nil
+}
+
+// graphRemovePassword removes a password credential (by keyId) from the app registration.
+func graphRemovePassword(ctx context.Context, graphToken, appObjectID, keyID string) error {
+	api := fmt.Sprintf("%s/v1.0/applications/%s/removePassword",
+		strings.TrimRight(azureGraphEndpoint, "/"), url.PathEscape(appObjectID))
+	reqBody, _ := json.Marshal(map[string]any{"keyId": keyID})
+	_, err := doGraphRequest(ctx, http.MethodPost, api, graphToken, reqBody)
+	return err
+}
+
+// azurePasswordCredential is the subset of a Graph passwordCredential Warden needs to
+// identify and prune its own orphaned secrets.
+type azurePasswordCredential struct {
+	KeyID       string `json:"keyId"`
+	DisplayName string `json:"displayName"`
+}
+
+// listPasswordCredentials returns the app registration's password credentials.
+func listPasswordCredentials(ctx context.Context, graphToken, appObjectID string) ([]azurePasswordCredential, error) {
+	api := fmt.Sprintf("%s/v1.0/applications/%s?$select=passwordCredentials",
+		strings.TrimRight(azureGraphEndpoint, "/"), url.PathEscape(appObjectID))
+	respBody, err := doGraphRequest(ctx, http.MethodGet, api, graphToken, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		PasswordCredentials []azurePasswordCredential `json:"passwordCredentials"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode passwordCredentials response: %w", err)
+	}
+	return resp.PasswordCredentials, nil
+}
+
+// pruneOrphanPasswords removes password credentials with the given displayName that aren't
+// in keep — best-effort housekeeping for secrets leaked by prior failed cleanups. Only
+// credentials with THIS publisher's displayName are touched, so operator-managed secrets
+// (and other Warden deployments' secrets) are never removed. Callers must include the live
+// secret's keyId in keep so the active credential is never pruned.
+func pruneOrphanPasswords(ctx context.Context, graphToken, appObjectID, displayName string, keep ...string) {
+	creds, err := listPasswordCredentials(ctx, graphToken, appObjectID)
+	if err != nil {
+		return // best-effort; the rotation cycle's outcome is logged by the loop
+	}
+	keepSet := make(map[string]bool, len(keep))
+	for _, id := range keep {
+		keepSet[id] = true
+	}
+	for _, c := range creds {
+		if keepSet[c.KeyID] || c.DisplayName != displayName {
+			continue
+		}
+		_ = graphRemovePassword(ctx, graphToken, appObjectID, c.KeyID)
+	}
+}
+
+// doGraphRequest performs a bearer-authenticated Graph call, returning the body on a 2xx.
+// It retries transient failures with backoff: Azure AD serializes writes to a directory
+// object, so an add/remove pair on the same app registration (which every rotation cycle
+// does) can hit 409 Directory_ConcurrencyViolation, and Graph also throttles with 429.
+func doGraphRequest(ctx context.Context, method, api, bearer string, body []byte) ([]byte, error) {
+	backoff := time.Second
+	var lastErr error
+	for attempt := 0; attempt < 4; attempt++ {
+		respBody, status, err := doGraphOnce(ctx, method, api, bearer, body)
+		if err == nil {
+			return respBody, nil
+		}
+		lastErr = err
+		if status != http.StatusConflict && status != http.StatusTooManyRequests && status != http.StatusServiceUnavailable {
+			return nil, err // non-transient — fail fast
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+		if backoff < 8*time.Second {
+			backoff *= 2
+		}
+	}
+	return nil, lastErr
+}
+
+// doGraphOnce performs a single Graph call, returning the body, HTTP status (0 on a
+// transport error), and error.
+func doGraphOnce(ctx context.Context, method, api, bearer string, body []byte) ([]byte, int, error) {
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, api, r)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build graph request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := azureHTTPClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode/100 != 2 {
+		return nil, resp.StatusCode, fmt.Errorf("graph status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, resp.StatusCode, nil
 }

--- a/core/oidc_publisher_azure_test.go
+++ b/core/oidc_publisher_azure_test.go
@@ -2,49 +2,327 @@ package core
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAzureBlobPublisher(t *testing.T) {
-	type got struct{ method, contentType, cacheControl string }
-	seen := map[string]got{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.Copy(io.Discard, r.Body)
-		if r.Method == http.MethodPut {
-			// The blob's content type / cache control ride on x-ms-blob-* headers,
-			// not the request's own Content-Type.
-			seen[r.URL.Path] = got{r.Method, r.Header.Get("x-ms-blob-content-type"), r.Header.Get("x-ms-blob-cache-control")}
-		}
-		w.WriteHeader(http.StatusCreated)
-	}))
-	defer srv.Close()
+// --- fake Azure server (Entra ID token + Graph app-secret mgmt + blob PUT) --
 
-	// Build through the real constructor via the endpoint override, pointing at the
-	// fake server. SharedKey signing is client-side; the server ignores the
-	// signature, and the account key just needs to be valid base64.
+// fakeAzure stubs the three surfaces azure_blob rotation touches: the OAuth2 token
+// endpoint (client-credentials), Microsoft Graph (resolve app, add/remove password), and
+// the blob data plane (UploadBuffer PUT). One httptest server handles all three
+// (azureAuthorityHost/azureGraphEndpoint and the blob endpoint all point here).
+type fakeAzure struct {
+	mu                 sync.Mutex
+	appObjectID        string // returned by the /applications filter query
+	newSecret          string // returned by addPassword
+	newSecretID        string
+	failTokenForSecret string                    // token requests for this client_secret fail...
+	failTokenRemaining int                       // ...this many times (verify propagation)
+	passwords          []azurePasswordCredential // returned by the single-app GET (for prune)
+	added              []string
+	removed            []string
+	uploads            []string
+	uploadCT           map[string]string // path -> x-ms-blob-content-type
+	uploadCC           map[string]string // path -> x-ms-blob-cache-control
+}
+
+func (s *fakeAzure) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasSuffix(path, "/oauth2/v2.0/token"):
+			body, _ := io.ReadAll(r.Body)
+			form, _ := url.ParseQuery(string(body))
+			s.mu.Lock()
+			fail := form.Get("client_secret") == s.failTokenForSecret && s.failTokenRemaining > 0
+			if fail {
+				s.failTokenRemaining--
+			}
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if fail {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":"invalid_client","error_description":"secret not yet valid"}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"access_token":"faketoken","token_type":"Bearer","expires_in":3600}`)
+		case strings.HasSuffix(path, "/addPassword"):
+			s.mu.Lock()
+			s.added = append(s.added, s.newSecretID)
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"secretText":"`+s.newSecret+`","keyId":"`+s.newSecretID+`"}`)
+		case strings.HasSuffix(path, "/removePassword"):
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				KeyID string `json:"keyId"`
+			}
+			_ = json.Unmarshal(body, &req)
+			s.mu.Lock()
+			s.removed = append(s.removed, req.KeyID)
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case path == "/v1.0/applications": // filter query (resolveAppObjectID)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"value":[{"id":"`+s.appObjectID+`"}]}`)
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/v1.0/applications/"): // single app: passwordCredentials
+			s.mu.Lock()
+			body, _ := json.Marshal(struct {
+				PasswordCredentials []azurePasswordCredential `json:"passwordCredentials"`
+			}{s.passwords})
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut: // blob upload
+			_, _ = io.Copy(io.Discard, r.Body)
+			s.mu.Lock()
+			s.uploads = append(s.uploads, path)
+			if s.uploadCT != nil {
+				s.uploadCT[path] = r.Header.Get("x-ms-blob-content-type")
+			}
+			if s.uploadCC != nil {
+				s.uploadCC[path] = r.Header.Get("x-ms-blob-cache-control")
+			}
+			s.mu.Unlock()
+			w.Header().Set("ETag", `"0x8DTEST"`)
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+func withAzureFake(t *testing.T, u string) {
+	t.Helper()
+	pa, pg, pi := azureAuthorityHost, azureGraphEndpoint, azureInsecureAllowHTTP
+	azureAuthorityHost, azureGraphEndpoint, azureInsecureAllowHTTP = u, u, true
+	t.Cleanup(func() {
+		azureAuthorityHost, azureGraphEndpoint, azureInsecureAllowHTTP = pa, pg, pi
+	})
+}
+
+func withAzureVerifyTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := azureRotationVerifyTimeout
+	azureRotationVerifyTimeout = d
+	t.Cleanup(func() { azureRotationVerifyTimeout = prev })
+}
+
+func newTestAzureBlobPublisher(t *testing.T, endpoint, tenant, clientID, clientSecret, secretID string) *azureBlobPublisher {
+	t.Helper()
+	p := &azureBlobPublisher{
+		clientSecret: clientSecret,
+		secretID:     secretID,
+		tenantID:     tenant,
+		clientID:     clientID,
+		accountName:  "acct",
+		serviceURL:   endpoint,
+		container:    "jwks",
+	}
+	client, err := p.buildClient(clientSecret)
+	require.NoError(t, err)
+	p.client = client
+	return p
+}
+
+// --- publish + mechanism tests ----------------------------------------------
+
+func TestAzureBlobPublisher(t *testing.T) {
+	az := &fakeAzure{uploadCT: map[string]string{}, uploadCC: map[string]string{}}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	// Built through the real constructor with SP OAuth config + endpoint override; the
+	// blob client authenticates with the fake token, and the server records the PUTs.
 	p, err := newJWKSPublisher(publisherConfig{
 		Type: "azure_blob", AccountName: "wardenoidc", Container: "jwks", Prefix: "prod",
-		AccountKey: base64.StdEncoding.EncodeToString([]byte("dummy-account-key")),
-		Endpoint:   srv.URL,
+		TenantID: "tenant", ClientID: "client", ClientSecret: "secret", Endpoint: srv.URL,
 	}, "public, max-age=60")
 	require.NoError(t, err)
-
 	require.NoError(t, p.Publish(context.Background(), []byte(`{"issuer":"x"}`), []byte(`{"keys":[]}`)))
 
-	disc, ok := seen["/jwks/prod/.well-known/openid-configuration"]
-	require.True(t, ok, "discovery blob must be PUT")
-	assert.Equal(t, http.MethodPut, disc.method)
-	assert.Equal(t, "application/json", disc.contentType)
-	assert.Equal(t, "public, max-age=60", disc.cacheControl)
+	az.mu.Lock()
+	defer az.mu.Unlock()
+	assert.Contains(t, az.uploads, "/jwks/prod/.well-known/openid-configuration", "discovery blob must be PUT")
+	assert.Contains(t, az.uploads, "/jwks/prod/oidc/jwks", "jwks blob must be PUT")
+	// Content type / cache control ride on x-ms-blob-* headers.
+	assert.Equal(t, "application/json", az.uploadCT["/jwks/prod/.well-known/openid-configuration"])
+	assert.Equal(t, "public, max-age=60", az.uploadCC["/jwks/prod/.well-known/openid-configuration"])
+}
 
-	jwks, ok := seen["/jwks/prod/oidc/jwks"]
-	require.True(t, ok, "jwks blob must be PUT")
-	assert.Equal(t, "application/json", jwks.contentType)
+func TestAzureBlobPublisher_RotateFullCycle(t *testing.T) {
+	az := &fakeAzure{appObjectID: "appobj", newSecret: "newsecret", newSecretID: "newkid"}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "oldsecret", "oldkid")
+
+	newFields, prevFields, cleanup, err := p.PrepareRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "newsecret", newFields["client_secret"])
+	assert.Equal(t, "newkid", newFields["secret_id"])
+	assert.Equal(t, "oldsecret", prevFields["client_secret"])
+	assert.Equal(t, "oldkid", cleanup["old_secret_id"])
+	assert.Contains(t, az.added, "newkid")
+
+	require.NoError(t, p.CommitRotation(newFields))
+	p.mu.RLock()
+	assert.Equal(t, "newsecret", p.clientSecret)
+	assert.Equal(t, "newkid", p.secretID)
+	p.mu.RUnlock()
+
+	require.NoError(t, p.CleanupRotation(context.Background(), cleanup))
+	assert.Contains(t, az.removed, "oldkid")
+}
+
+func TestAzureBlobPublisher_RotateVerifyRetry(t *testing.T) {
+	az := &fakeAzure{appObjectID: "appobj", newSecret: "newsecret", newSecretID: "newkid",
+		failTokenForSecret: "newsecret", failTokenRemaining: 1}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "oldsecret", "oldkid")
+	newFields, _, _, err := p.PrepareRotation(context.Background())
+	require.NoError(t, err, "verify must retry past the initial invalid_client")
+	assert.Equal(t, "newsecret", newFields["client_secret"])
+	assert.Empty(t, az.removed, "a secret that verifies after retry must not be removed")
+}
+
+func TestAzureBlobPublisher_RotateVerifyFailureRemovesNewSecret(t *testing.T) {
+	az := &fakeAzure{appObjectID: "appobj", newSecret: "newsecret", newSecretID: "newkid",
+		failTokenForSecret: "newsecret", failTokenRemaining: 1 << 30}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+	withAzureVerifyTimeout(t, 300*time.Millisecond)
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "oldsecret", "oldkid")
+	_, _, _, err := p.PrepareRotation(context.Background())
+	require.Error(t, err, "an unusable new secret must fail rotation")
+	assert.Contains(t, az.removed, "newkid", "the unusable new secret must be removed from the app registration")
+}
+
+func TestAzureBlobPublisher_RotatePrunesOrphanSecrets(t *testing.T) {
+	az := &fakeAzure{appObjectID: "appobj", newSecret: "newsecret", newSecretID: "newkid"}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "oldsecret", "oldkid")
+	// The app already carries a leaked warden secret (from a prior failed cleanup) and an
+	// operator-managed one. Prune runs in CleanupRotation, keeping the just-committed live
+	// secret (newkid).
+	name := p.secretDisplayName()
+	az.mu.Lock()
+	az.passwords = []azurePasswordCredential{
+		{KeyID: "oldkid", DisplayName: name},                           // superseded this cycle
+		{KeyID: "orphankid", DisplayName: name},                        // leaked by a prior failed cleanup
+		{KeyID: "operatorkid", DisplayName: "operator-managed-secret"}, // NOT warden-created
+	}
+	az.mu.Unlock()
+
+	newFields, _, cleanup, err := p.PrepareRotation(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, p.CommitRotation(newFields))
+	require.NoError(t, p.CleanupRotation(context.Background(), cleanup))
+
+	assert.Contains(t, az.removed, "oldkid", "the superseded secret must be removed")
+	assert.Contains(t, az.removed, "orphankid", "a leaked warden secret must be pruned")
+	assert.NotContains(t, az.removed, "newkid", "the just-committed live secret must be kept")
+	assert.NotContains(t, az.removed, "operatorkid", "operator-managed secrets must never be pruned")
+}
+
+func TestAzureBlobPublisher_RollbackRotation(t *testing.T) {
+	az := &fakeAzure{appObjectID: "appobj", newSecret: "newsecret", newSecretID: "newkid"}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "oldsecret", "oldkid")
+	require.NoError(t, p.RollbackRotation(context.Background(), map[string]string{"secret_id": "newkid"}))
+	assert.Contains(t, az.removed, "newkid")
+}
+
+// TestAzureBlobPublisher_ConcurrentPublishAndCommit exercises the mutex under -race.
+func TestAzureBlobPublisher_ConcurrentPublishAndCommit(t *testing.T) {
+	az := &fakeAzure{appObjectID: "app", newSecret: "n", newSecretID: "nid"}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "s1", "k1")
+	var wg sync.WaitGroup
+	var commitErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 30; i++ {
+			_ = p.Publish(context.Background(), []byte(`{}`), []byte(`{}`))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 30; i++ {
+			if err := p.CommitRotation(map[string]string{"client_secret": "s2", "secret_id": "k2"}); err != nil {
+				commitErr = err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	require.NoError(t, commitErr)
+}
+
+// --- loop-level test: generic persist with azure (two-field) credentials ----
+
+func TestRotatePublisherCredential_Azure(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	az := &fakeAzure{appObjectID: "appobj", newSecret: "newsecret", newSecretID: "newkid"}
+	srv := httptest.NewServer(az.handler())
+	defer srv.Close()
+	withAzureFake(t, srv.URL)
+
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{
+		Enabled:   true,
+		IssuerURL: "https://iss.example",
+		Publisher: publisherConfig{
+			Type: "azure_blob", AccountName: "acct", Container: "jwks", Endpoint: srv.URL,
+			TenantID: "tenant", ClientID: "client", ClientSecret: "oldsecret", SecretID: "oldkid",
+			RotationPeriod: "24h",
+		},
+	}))
+
+	p := newTestAzureBlobPublisher(t, srv.URL, "tenant", "client", "oldsecret", "oldkid")
+	require.NoError(t, core.rotatePublisherCredential(ctx, p))
+
+	// The generalized persist wrote BOTH the new secret and its id.
+	cfg, err := loadIssuerConfig(ctx, storage)
+	require.NoError(t, err)
+	assert.Equal(t, "newsecret", cfg.Publisher.ClientSecret)
+	assert.Equal(t, "newkid", cfg.Publisher.SecretID)
+
+	// Live publisher swapped, old secret removed.
+	p.mu.RLock()
+	assert.Equal(t, "newsecret", p.clientSecret)
+	p.mu.RUnlock()
+	assert.Contains(t, az.removed, "oldkid")
 }

--- a/core/oidc_publisher_rotation.go
+++ b/core/oidc_publisher_rotation.go
@@ -294,6 +294,10 @@ func publisherFieldValue(pc *publisherConfig, key string) (string, bool) {
 		return pc.AccessKeyID, true
 	case "secret_access_key":
 		return pc.SecretAccessKey, true
+	case "client_secret":
+		return pc.ClientSecret, true
+	case "secret_id":
+		return pc.SecretID, true
 	default:
 		return "", false
 	}
@@ -307,6 +311,10 @@ func setPublisherField(pc *publisherConfig, key, val string) error {
 		pc.AccessKeyID = val
 	case "secret_access_key":
 		pc.SecretAccessKey = val
+	case "client_secret":
+		pc.ClientSecret = val
+	case "secret_id":
+		pc.SecretID = val
 	default:
 		return fmt.Errorf("unexpected rotated publisher field %q", key)
 	}

--- a/core/oidc_publisher_test.go
+++ b/core/oidc_publisher_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,7 @@ func TestNewJWKSPublisher_Dispatch(t *testing.T) {
 	_, err = newJWKSPublisher(publisherConfig{Type: "s3", Bucket: "b", Region: "r"}, "")
 	require.Error(t, err) // missing keys
 	_, err = newJWKSPublisher(publisherConfig{Type: "azure_blob", AccountName: "a", Container: "c"}, "")
-	require.Error(t, err) // missing account_key
+	require.Error(t, err) // missing service-principal (tenant_id/client_id/client_secret)
 	_, err = newJWKSPublisher(publisherConfig{Type: "gcs"}, "")
 	require.Error(t, err) // missing bucket
 	_, err = newJWKSPublisher(publisherConfig{Type: "gcs", Bucket: "b"}, "")
@@ -41,7 +40,7 @@ func TestNewJWKSPublisher_Dispatch(t *testing.T) {
 	assert.Equal(t, "http_put", p.Type())
 	p, err = newJWKSPublisher(publisherConfig{
 		Type: "azure_blob", AccountName: "wardenoidc", Container: "jwks",
-		AccountKey: base64.StdEncoding.EncodeToString([]byte("dummy-account-key")),
+		TenantID: "tenant", ClientID: "client", ClientSecret: "secret",
 	}, "")
 	require.NoError(t, err)
 	assert.Equal(t, "azure_blob", p.Type())

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -47,7 +47,7 @@ func (b *SystemBackend) pathOIDCIssuer() []*framework.Path {
 				},
 				"publisher": {
 					Type:        framework.TypeMap,
-					Description: "Optional publisher pushing discovery+JWKS to a bucket/CDN. Keys: type (local_file|http_put|s3|azure_blob|gcs), dir, base_url, auth_header, auth_value, bucket, region, prefix, access_key_id, secret_access_key, account_name, container, account_key, endpoint, credentials_json, rotation_period (gcs and s3). Cache-Control is derived from jwks_cache_ttl.",
+					Description: "Optional publisher pushing discovery+JWKS to a bucket/CDN. Keys: type (local_file|http_put|s3|azure_blob|gcs), dir, base_url, auth_header, auth_value, bucket, region, prefix, access_key_id, secret_access_key, account_name, container, tenant_id, client_id, client_secret, secret_id, endpoint, credentials_json, rotation_period (gcs, s3, azure_blob). Cache-Control is derived from jwks_cache_ttl.",
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -298,10 +298,13 @@ var publisherFieldOwners = map[string][]string{
 	"secret_access_key": {"s3"},
 	"account_name":      {"azure_blob"},
 	"container":         {"azure_blob"},
-	"account_key":       {"azure_blob"},
+	"tenant_id":         {"azure_blob"},
+	"client_id":         {"azure_blob"},
+	"client_secret":     {"azure_blob"},
+	"secret_id":         {"azure_blob"},
 	"endpoint":          {"azure_blob", "gcs", "s3"},
 	"credentials_json":  {"gcs"},
-	"rotation_period":   {"gcs", "s3"},
+	"rotation_period":   {"gcs", "s3", "azure_blob"},
 }
 
 // ownedBy reports whether field is valid for the given publisher type.
@@ -379,6 +382,15 @@ func mergePublisherConfig(prior publisherConfig, raw map[string]any) (publisherC
 	if v, ok := get("container"); ok {
 		pc.Container = v
 	}
+	if v, ok := get("tenant_id"); ok {
+		pc.TenantID = v
+	}
+	if v, ok := get("client_id"); ok {
+		pc.ClientID = v
+	}
+	if v, ok := get("secret_id"); ok {
+		pc.SecretID = v
+	}
 	if v, ok := get("endpoint"); ok {
 		pc.Endpoint = v
 	}
@@ -393,8 +405,8 @@ func mergePublisherConfig(prior publisherConfig, raw map[string]any) (publisherC
 	if v, ok := get("secret_access_key"); ok && v != "" && v != maskValue {
 		pc.SecretAccessKey = v
 	}
-	if v, ok := get("account_key"); ok && v != "" && v != maskValue {
-		pc.AccountKey = v
+	if v, ok := get("client_secret"); ok && v != "" && v != maskValue {
+		pc.ClientSecret = v
 	}
 	if v, ok := get("credentials_json"); ok && v != "" && v != maskValue {
 		pc.CredentialsJSON = v
@@ -439,8 +451,17 @@ func maskedPublisher(pc publisherConfig) map[string]any {
 	if pc.Container != "" {
 		m["container"] = pc.Container
 	}
-	if pc.AccountKey != "" {
-		m["account_key"] = maskValue
+	if pc.TenantID != "" {
+		m["tenant_id"] = pc.TenantID
+	}
+	if pc.ClientID != "" {
+		m["client_id"] = pc.ClientID
+	}
+	if pc.ClientSecret != "" {
+		m["client_secret"] = maskValue
+	}
+	if pc.SecretID != "" {
+		m["secret_id"] = pc.SecretID
 	}
 	if pc.Endpoint != "" {
 		m["endpoint"] = pc.Endpoint

--- a/core/sys_oidc_issuer_test.go
+++ b/core/sys_oidc_issuer_test.go
@@ -304,26 +304,32 @@ func TestMergePublisherConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "sekret", pc.AuthValue)
 
-	// A clean azure_blob config passes; prefix is shared with s3 and accepted here.
+	// A clean azure_blob (service-principal) config passes; prefix is shared with s3.
 	pc, err = mergePublisherConfig(publisherConfig{}, map[string]any{
-		"type": "azure_blob", "account_name": "wardenoidc", "container": "jwks",
-		"prefix": "prod", "account_key": "k", "endpoint": "https://wardenoidc.blob.core.usgovcloudapi.net/",
+		"type": "azure_blob", "account_name": "wardenoidc", "container": "jwks", "prefix": "prod",
+		"tenant_id": "t", "client_id": "ci", "client_secret": "cs", "secret_id": "sid",
+		"endpoint": "https://wardenoidc.blob.core.usgovcloudapi.net/",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "azure_blob", pc.Type)
 	assert.Equal(t, "wardenoidc", pc.AccountName)
 	assert.Equal(t, "jwks", pc.Container)
 	assert.Equal(t, "prod", pc.Prefix)
-	assert.Equal(t, "k", pc.AccountKey)
+	assert.Equal(t, "t", pc.TenantID)
+	assert.Equal(t, "ci", pc.ClientID)
+	assert.Equal(t, "cs", pc.ClientSecret)
+	assert.Equal(t, "sid", pc.SecretID)
 	assert.Equal(t, "https://wardenoidc.blob.core.usgovcloudapi.net/", pc.Endpoint)
 
-	// Read masks the account key but renders the non-secret fields plainly.
+	// Read masks the client secret but renders the non-secret fields plainly.
 	masked := maskedPublisher(pc)
 	assert.Equal(t, "wardenoidc", masked["account_name"])
 	assert.Equal(t, "jwks", masked["container"])
 	assert.Equal(t, "prod", masked["prefix"])
-	assert.Equal(t, "https://wardenoidc.blob.core.usgovcloudapi.net/", masked["endpoint"])
-	assert.Equal(t, maskValue, masked["account_key"])
+	assert.Equal(t, "t", masked["tenant_id"])
+	assert.Equal(t, "ci", masked["client_id"])
+	assert.Equal(t, "sid", masked["secret_id"])
+	assert.Equal(t, maskValue, masked["client_secret"])
 
 	// An s3 field under azure_blob is rejected.
 	_, err = mergePublisherConfig(publisherConfig{}, map[string]any{
@@ -331,11 +337,11 @@ func TestMergePublisherConfig(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	// A masked account_key keeps the prior one.
-	prior = publisherConfig{Type: "azure_blob", AccountName: "a", Container: "c", AccountKey: "realkey"}
-	pc, err = mergePublisherConfig(prior, map[string]any{"type": "azure_blob", "account_key": maskValue})
+	// A masked client_secret keeps the prior one.
+	prior = publisherConfig{Type: "azure_blob", AccountName: "a", Container: "c", ClientSecret: "realsecret"}
+	pc, err = mergePublisherConfig(prior, map[string]any{"type": "azure_blob", "client_secret": maskValue})
 	require.NoError(t, err)
-	assert.Equal(t, "realkey", pc.AccountKey)
+	assert.Equal(t, "realsecret", pc.ClientSecret)
 
 	// A clean gcs config passes; bucket/prefix/endpoint are shared and accepted here.
 	pc, err = mergePublisherConfig(publisherConfig{}, map[string]any{


### PR DESCRIPTION
## What

Extends OIDC issuer publisher credential rotation to **Azure Blob** — the third and last of three (GCS #443, S3 #444). The static, never-rotated credential is gone.

Because a storage account key **cannot regenerate itself** (that's a management-plane ARM op needing a *separate* credential), this switches the publisher from Shared Key to **service-principal (Entra ID) OAuth** data-plane auth and rotates the SP's `client_secret` via Microsoft Graph:

1. `addPassword` a fresh secret on the app registration,
2. **verify** it acquires a storage token (retry),
3. swap it into the live blob client,
4. `removePassword` the old one.

This makes Azure mechanically like gcs/s3 and *auto-rotates* the SP secret — turning its expiry from an operator burden into a managed one.

## ⚠️ Breaking change

`azure_blob` no longer accepts `account_key`; it now requires the SP trio (`tenant_id`, `client_id`, `client_secret`) plus `secret_id`. The publisher is recent; a stored `account_key` must migrate to a service principal.

## Design

- Single-stage verify-before-swap (credential off the hot path; built-in endpoint always serves), same as gcs/s3.
- `RotatablePublisher` via a small `azcore.TokenCredential` shim over **raw OAuth2** — no `azidentity`/`armstorage` dependency, mirroring the Azure source driver's raw Graph approach. `CleanupRotation`/`RollbackRotation` authenticate as the **old (propagated)** secret to avoid new-secret lag.
- Generic persist compare-and-swap extended with `client_secret`/`secret_id`; a concurrent operator credential change aborts+rolls back.

## Robustness (from adversarial review + a live Azure run)

- **Orphan pruning** of leaked warden-created secrets — runs **post-commit** keeping the *known-live* secret (never the possibly-stale config value), matched by an **account/container-qualified displayName** so it can never delete the live secret, an operator's, or another deployment's.
- **Retry Graph writes on transient `409 Directory_ConcurrencyViolation` / `429`** — Azure AD serializes directory writes, so the add/remove pair every cycle races otherwise. (Surfaced by a real-tenant test.)
- Escaped the OData `$filter` literal; corrected now-false sovereign-cloud comments (public-cloud authority/Graph host only — a follow-on).

## Operator requirements

The SP needs **Storage Blob Data Contributor** on the container and Graph rights to manage its own app registration (`Application.ReadWrite.OwnedBy` as an owner of its app, or `Application.ReadWrite.All`).

## Testing

- Unit tests against a fake OAuth/Graph/blob server driving the real azblob client: full cycle, verify-with-retry, verify-failure-removes-new-secret, orphan-prune (post-commit, keeps live/operator), rollback, CAS-supersede, and a `-race` swap test. Publish + dispatch + merge/mask tests updated for the SP config.
- Verified end-to-end against a real Azure tenant (secrets added/removed each period, publishing uninterrupted, `oidc-issuer read` health block) — which is what surfaced the 409-retry fix.
