### PR TITLE
feat(oidc): coherent oidc-issuer CLI output + signing-key rotation status

### DIFF
--- a/cmd/oidcissuer/configure.go
+++ b/cmd/oidcissuer/configure.go
@@ -129,15 +129,19 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error configuring OIDC issuer: %w", err)
 	}
 
+	// The write response echoes only the issuer state (enabled/issuer_url/ready). Read
+	// back so the confirmation reflects the full merged config — the durations just set,
+	// the signing-key rotation status, and any publisher — in the same coherent format as
+	// 'read'. Fall back to the write response if the read fails, so success is still reported.
 	data := map[string]any{}
-	var resData map[string]any
-	if resource != nil {
-		resData = resource.Data
+	if read, rerr := c.Operator().Read(oidcIssuerConfigPath); rerr == nil && read != nil && read.Data != nil {
+		data = read.Data
+	} else if resource != nil {
+		data = resource.Data
 	}
-	helpers.MergeServerResponseInto(data, resData, map[string]any{"enabled": true})
 	return helpers.RenderMap(data, func() {
 		fmt.Println("Success! OIDC issuer configured.")
-		helpers.PrintMapAsTable(data)
+		printOIDCIssuerTable(data)
 	})
 }
 

--- a/cmd/oidcissuer/read.go
+++ b/cmd/oidcissuer/read.go
@@ -1,8 +1,11 @@
 package oidcissuer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stephnangue/warden/cmd/helpers"
@@ -18,8 +21,8 @@ var (
 Usage: warden oidc-issuer read
 
   Show the current OIDC issuer configuration — enabled state, issuer URL,
-  assertion TTL, signing-key rotation timings, publisher (secrets masked), and
-  whether the issuer is ready to mint. Root namespace only.
+  assertion TTL, signing-key rotation timings and status, publisher (secrets
+  masked), and whether the issuer is ready to mint. Root namespace only.
 
       $ warden oidc-issuer read
 `,
@@ -44,6 +47,143 @@ func runRead(cmd *cobra.Command, args []string) error {
 	}
 
 	return helpers.RenderMap(resource.Data, func() {
-		helpers.PrintMapAsTable(resource.Data)
+		printOIDCIssuerTable(resource.Data)
 	})
+}
+
+// scalarOrder is the stable, grouped order of top-level fields (not the default global
+// alphabetical sort), so related settings stay together.
+var scalarOrder = []string{
+	"enabled", "ready", "issuer_url",
+	"assertion_ttl", "jwks_cache_ttl", "retired_key_grace", "key_rotation_period",
+}
+
+// durationScalars are top-level fields the server sends as integer seconds; they render as
+// human-readable Go durations (e.g. 5m0s) rather than bare numbers.
+var durationScalars = map[string]bool{
+	"assertion_ttl": true, "jwks_cache_ttl": true, "retired_key_grace": true,
+}
+
+// rotationFields is the field order of the key_rotation and publisher_rotation status blocks.
+var rotationFields = []string{"running", "last_rotated_at", "next_rotation", "last_error", "last_error_at"}
+
+// publisherFields is the field order of the publisher block (type first, identity fields,
+// masked secrets, rotation_period last).
+var publisherFields = []string{
+	"type", "dir", "base_url", "auth_header", "auth_value",
+	"bucket", "region", "prefix", "access_key_id", "secret_access_key",
+	"account_name", "container", "tenant_id", "client_id", "client_secret", "secret_id",
+	"endpoint", "credentials_json", "rotation_period",
+}
+
+// printOIDCIssuerTable renders the read response as a coherent two-column table: durations
+// as duration strings, and each nested block expanded into dot-keyed rows (publisher.type,
+// key_rotation.next_rotation, …) instead of one crammed comma-joined cell. Falls back to
+// the generic renderer for an unexpected shape.
+func printOIDCIssuerTable(data map[string]any) {
+	var rows [][]any
+	for _, k := range scalarOrder {
+		v, ok := data[k]
+		if !ok {
+			continue
+		}
+		switch {
+		case k == "key_rotation_period":
+			rows = append(rows, []any{k, rotationPeriodCell(v)})
+		case durationScalars[k]:
+			rows = append(rows, []any{k, durationCell(v)})
+		default:
+			rows = append(rows, []any{k, cellString(v)})
+		}
+	}
+	rows = appendBlock(rows, data, "key_rotation", rotationFields)
+	rows = appendBlock(rows, data, "publisher", publisherFields)
+	rows = appendBlock(rows, data, "publisher_rotation", rotationFields)
+
+	if len(rows) == 0 {
+		helpers.PrintMapAsTable(data)
+		return
+	}
+	helpers.PrintTable([]string{"Key", "Value"}, rows)
+}
+
+// appendBlock expands a nested map value into one dot-keyed row per field, in the given
+// order, then any unexpected keys sorted (so a field the server adds later is surfaced,
+// never silently dropped).
+func appendBlock(rows [][]any, data map[string]any, name string, order []string) [][]any {
+	block, ok := data[name].(map[string]any)
+	if !ok {
+		return rows
+	}
+	seen := make(map[string]bool, len(order))
+	for _, f := range order {
+		seen[f] = true
+		if v, ok := block[f]; ok {
+			rows = append(rows, []any{name + "." + f, blockValueCell(f, v)})
+		}
+	}
+	extra := make([]string, 0)
+	for f := range block {
+		if !seen[f] {
+			extra = append(extra, f)
+		}
+	}
+	sort.Strings(extra)
+	for _, f := range extra {
+		rows = append(rows, []any{name + "." + f, cellString(block[f])})
+	}
+	return rows
+}
+
+// blockValueCell formats a nested field value, normalizing a publisher rotation_period to a
+// canonical duration string for consistency with the top-level durations.
+func blockValueCell(field string, v any) string {
+	s := cellString(v)
+	if field == "rotation_period" && s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			return d.String()
+		}
+	}
+	return s
+}
+
+// rotationPeriodCell renders key_rotation_period: 0 seconds means automatic rotation is off.
+func rotationPeriodCell(v any) string {
+	if secs, ok := toSeconds(v); ok && secs == 0 {
+		return "disabled"
+	}
+	return durationCell(v)
+}
+
+// durationCell renders a seconds value as a Go duration string; passes through otherwise.
+func durationCell(v any) string {
+	if secs, ok := toSeconds(v); ok {
+		return (time.Duration(secs) * time.Second).String()
+	}
+	return cellString(v)
+}
+
+// cellString renders any JSON-decoded scalar (json.Number, bool, string) for a table cell.
+func cellString(v any) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// toSeconds extracts an integer seconds value from a JSON-decoded number.
+func toSeconds(v any) (int64, bool) {
+	switch n := v.(type) {
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i, true
+		}
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
 }

--- a/cmd/oidcissuer/read_test.go
+++ b/cmd/oidcissuer/read_test.go
@@ -1,0 +1,113 @@
+package oidcissuer
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// TestPrintOIDCIssuerTable checks the coherent read table: durations render as duration
+// strings (not bare seconds), and nested blocks expand into dot-keyed rows (not one crammed
+// comma-joined cell). Numbers arrive as json.Number, matching the API client's UseNumber decode.
+func TestPrintOIDCIssuerTable(t *testing.T) {
+	data := map[string]any{
+		"enabled":             true,
+		"ready":               true,
+		"issuer_url":          "https://warden.example.com",
+		"assertion_ttl":       json.Number("300"),
+		"jwks_cache_ttl":      json.Number("60"),
+		"retired_key_grace":   json.Number("3600"),
+		"key_rotation_period": json.Number("86400"),
+		"key_rotation": map[string]any{
+			"running":         true,
+			"last_rotated_at": "2026-08-03T20:00:11Z",
+			"next_rotation":   "2026-08-04T20:00:11Z",
+		},
+		"publisher": map[string]any{
+			"type":            "azure_blob",
+			"account_name":    "wardenoidc16865",
+			"container":       "jwks",
+			"client_id":       "74f14cfc-860d-4c1d-87d0-48699a24f084",
+			"client_secret":   "***********",
+			"rotation_period": "1m",
+		},
+		"publisher_rotation": map[string]any{
+			"running":         true,
+			"last_rotated_at": "2026-08-03T20:00:11Z",
+			"next_rotation":   "2026-08-03T20:01:11Z",
+		},
+	}
+
+	out := captureStdout(t, func() { printOIDCIssuerTable(data) })
+
+	// Durations render human-readably, not as bare seconds.
+	for _, want := range []string{"5m0s", "1m0s", "1h0m0s", "24h0m0s"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected duration %q in output:\n%s", want, out)
+		}
+	}
+	// Nested blocks are expanded into dot-keyed rows.
+	for _, want := range []string{
+		"publisher.account_name", "wardenoidc16865",
+		"publisher.client_secret", "***********",
+		"key_rotation.running", "key_rotation.next_rotation",
+		"publisher_rotation.last_rotated_at",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+	// publisher.rotation_period is normalized to a canonical duration.
+	if !strings.Contains(out, "publisher.rotation_period") {
+		t.Errorf("expected publisher.rotation_period row:\n%s", out)
+	}
+	// The old crammed comma-joined nested cell must be gone.
+	if strings.Contains(out, "account_name=wardenoidc16865") {
+		t.Errorf("nested map should not render as a crammed key=value cell:\n%s", out)
+	}
+}
+
+// TestPrintOIDCIssuerTable_Disabled checks the disabled/minimal shapes: a 0 rotation period
+// reads as "disabled" and no key_rotation block is shown; a bare {enabled:false} still renders.
+func TestPrintOIDCIssuerTable_Disabled(t *testing.T) {
+	data := map[string]any{
+		"enabled":             true,
+		"ready":               true,
+		"issuer_url":          "https://warden.example.com",
+		"assertion_ttl":       json.Number("300"),
+		"jwks_cache_ttl":      json.Number("60"),
+		"retired_key_grace":   json.Number("3600"),
+		"key_rotation_period": json.Number("0"),
+	}
+	out := captureStdout(t, func() { printOIDCIssuerTable(data) })
+	if !strings.Contains(out, "disabled") {
+		t.Errorf("expected key_rotation_period to read 'disabled':\n%s", out)
+	}
+	if strings.Contains(out, "key_rotation.") {
+		t.Errorf("no key_rotation block expected when disabled:\n%s", out)
+	}
+
+	out = captureStdout(t, func() { printOIDCIssuerTable(map[string]any{"enabled": false}) })
+	if !strings.Contains(out, "enabled") || !strings.Contains(out, "false") {
+		t.Errorf("minimal {enabled:false} should still render:\n%s", out)
+	}
+}

--- a/cmd/oidcissuer/set_publisher.go
+++ b/cmd/oidcissuer/set_publisher.go
@@ -180,6 +180,6 @@ func runSetPublisher(cmd *cobra.Command, args []string) error {
 	}
 	return helpers.RenderMap(data, func() {
 		fmt.Println("Success! OIDC issuer publisher configured.")
-		helpers.PrintMapAsTable(data)
+		printOIDCIssuerTable(data)
 	})
 }

--- a/core/core.go
+++ b/core/core.go
@@ -1036,8 +1036,23 @@ func (c *Core) publishOIDCFor(ctx context.Context, issuer *OIDCIssuer, publisher
 // context is parented on the active context so leadership loss cancels it.
 func (c *Core) startOIDCKeyRotation(standby bool, period, firstTick time.Duration, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) {
 	c.stopOIDCKeyRotation()
-	if standby || period <= 0 || issuer == nil {
+	if standby || issuer == nil {
+		// A standby must not touch the active-node-owned status anchor.
 		return
+	}
+	storage := NewBarrierView(c.barrier, oidcIssuerStorePrefix)
+	if period <= 0 {
+		// Rotation disabled by config: drop any stale status anchor so a later re-enable
+		// reseeds from the current key age instead of reporting a stale last_rotated_at.
+		if err := clearOIDCKeyRotationState(c.activeContext, storage); err != nil {
+			c.logger.Warn("oidc issuer: key rotation: clearing status anchor failed", logger.Err(err))
+		}
+		return
+	}
+	// Seed the status anchor (display only) if absent, from the loop's real schedule anchor
+	// (earliest next-key createdAt), so next_rotation matches the loop's first tick.
+	if err := c.seedOIDCKeyRotationState(c.activeContext, storage, issuer); err != nil {
+		c.logger.Warn("oidc issuer: key rotation: seeding status anchor failed", logger.Err(err))
 	}
 	if firstTick < 0 {
 		firstTick = 0
@@ -1111,8 +1126,14 @@ func (c *Core) oidcKeyRotationLoop(ctx context.Context, done chan struct{}, peri
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			if err := c.rotateOIDCKey(ctx, issuer, publisher, cacheTTL, grace); err != nil {
-				c.logger.Warn("oidc issuer: key rotation failed", logger.Err(err))
+			rotErr := c.rotateOIDCKey(ctx, issuer, publisher, cacheTTL, grace)
+			// Record the outcome (skip if the loop is tearing down — ctx cancellation is
+			// not a rotation failure worth persisting, and the state write would fail).
+			if ctx.Err() == nil {
+				c.recordOIDCKeyRotationOutcome(ctx, rotErr)
+			}
+			if rotErr != nil {
+				c.logger.Warn("oidc issuer: key rotation failed", logger.Err(rotErr))
 			}
 			timer.Reset(period)
 		}

--- a/core/oidc_issuer.go
+++ b/core/oidc_issuer.go
@@ -247,6 +247,33 @@ func prunedRetired(retired []*signingKey, cutoff time.Time) []*signingKey {
 	return out
 }
 
+// NextKeyCreatedAt returns the earliest creation time of the pre-published next key
+// across supported algorithms (falling back to the active key for a keyset without a
+// next). This is the anchor the rotation loop schedules its next tick from, and the
+// moment of the last rotation (or of enable, before the first rotation). ok is false when
+// the issuer holds no keys.
+func (i *OIDCIssuer) NextKeyCreatedAt() (time.Time, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	var anchor time.Time
+	for _, ks := range i.keysets {
+		k := ks.next
+		if k == nil {
+			k = ks.active
+		}
+		if k == nil {
+			continue
+		}
+		if anchor.IsZero() || k.createdAt.Before(anchor) {
+			anchor = k.createdAt
+		}
+	}
+	if anchor.IsZero() {
+		return time.Time{}, false
+	}
+	return anchor, true
+}
+
 // PendingRotation returns the (active, retired) state that Rotate(alg, cutoff)
 // would produce for one algorithm, WITHOUT mutating the issuer, so the rotation
 // loop can persist it before flipping in memory (nothing signs with a key not yet

--- a/core/oidc_key_rotation.go
+++ b/core/oidc_key_rotation.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/logger"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+)
+
+// oidcKeyRotationPath is the storage key (within the issuer barrier view) of the
+// signing-key rotation status. It holds only a status/schedule anchor — the key material
+// itself lives in the keyset doc — so an operator can see signing-key rotation health via
+// the read API without tailing logs.
+const oidcKeyRotationPath = "key-rotation"
+
+// oidcKeyRotationState records signing-key rotation status for the read API. The rotation
+// loop schedules off the next key's age (see oidcRotationFirstTick); this anchor is kept
+// in lockstep with it — seeded from the same next-key createdAt and advanced on each
+// successful cycle — purely so last_rotated_at / next_rotation and the last error can be
+// surfaced without changing how scheduling works.
+type oidcKeyRotationState struct {
+	LastRotatedAt time.Time `json:"last_rotated_at"`
+	// LastError / LastErrorAt record the most recent failed cycle; cleared on success. A
+	// failure does not advance LastRotatedAt (the schedule stays anchored on last success).
+	LastError   string    `json:"last_error,omitempty"`
+	LastErrorAt time.Time `json:"last_error_at,omitempty"`
+}
+
+func loadOIDCKeyRotationState(ctx context.Context, storage sdklogical.Storage) (*oidcKeyRotationState, error) {
+	entry, err := storage.Get(ctx, oidcKeyRotationPath)
+	if err != nil {
+		return nil, fmt.Errorf("oidc key rotation: read state: %w", err)
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var s oidcKeyRotationState
+	if err := json.Unmarshal(entry.Value, &s); err != nil {
+		return nil, fmt.Errorf("oidc key rotation: unmarshal state: %w", err)
+	}
+	return &s, nil
+}
+
+func saveOIDCKeyRotationState(ctx context.Context, storage sdklogical.Storage, s *oidcKeyRotationState) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("oidc key rotation: marshal state: %w", err)
+	}
+	return storage.Put(ctx, &sdklogical.StorageEntry{Key: oidcKeyRotationPath, Value: data})
+}
+
+func clearOIDCKeyRotationState(ctx context.Context, storage sdklogical.Storage) error {
+	return storage.Delete(ctx, oidcKeyRotationPath)
+}
+
+// oidcKeyRotationActive reports whether the signing-key rotation loop is running on this
+// node (true only on the active node with a positive key_rotation_period). Used by the
+// read API to show whether rotation is actually in effect here.
+func (c *Core) oidcKeyRotationActive() bool {
+	c.oidcMu.RLock()
+	defer c.oidcMu.RUnlock()
+	return c.oidcRotationCancel != nil
+}
+
+// seedOIDCKeyRotationState seeds the status anchor when none exists yet, anchoring
+// LastRotatedAt on the issuer's earliest next-key createdAt — the same value the rotation
+// loop schedules its first tick from — so a freshly enabled (or re-enabled) rotation
+// reports a next_rotation that matches when the loop will actually fire. A no-op once
+// seeded, so the anchor stays stable across restarts and failover.
+func (c *Core) seedOIDCKeyRotationState(ctx context.Context, storage sdklogical.Storage, issuer *OIDCIssuer) error {
+	st, err := loadOIDCKeyRotationState(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if st != nil {
+		return nil
+	}
+	anchor, ok := issuer.NextKeyCreatedAt()
+	if !ok {
+		anchor = time.Now()
+	}
+	return saveOIDCKeyRotationState(ctx, storage, &oidcKeyRotationState{LastRotatedAt: anchor})
+}
+
+// recordOIDCKeyRotationOutcome persists the result of a signing-key rotation cycle. On
+// success it advances the anchor and clears any recorded error; on failure it records the
+// error (and its time) while leaving LastRotatedAt anchored on the last success, so a
+// failing cycle neither resets the schedule nor hides the reason from the read API.
+func (c *Core) recordOIDCKeyRotationOutcome(ctx context.Context, rotErr error) {
+	storage := NewBarrierView(c.barrier, oidcIssuerStorePrefix)
+	st, err := loadOIDCKeyRotationState(ctx, storage)
+	if err != nil || st == nil {
+		st = &oidcKeyRotationState{}
+	}
+	now := time.Now()
+	if rotErr == nil {
+		st.LastRotatedAt = now
+		st.LastError = ""
+		st.LastErrorAt = time.Time{}
+	} else {
+		st.LastError = rotErr.Error()
+		st.LastErrorAt = now
+	}
+	if err := saveOIDCKeyRotationState(ctx, storage, st); err != nil {
+		c.logger.Warn("oidc issuer: key rotation: persisting status failed", logger.Err(err))
+	}
+}

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -117,6 +117,36 @@ func (b *SystemBackend) handleOIDCIssuerConfigRead(ctx context.Context, _ *logic
 		"retired_key_grace":   int64(cfg.retiredKeyGrace().Seconds()),
 		"ready":               oidcIssuerReady(b.core),
 	}
+	// Signing-key rotation runtime status (distinct from the publisher-credential rotation
+	// below). Only when automatic rotation is enabled, mirroring publisher_rotation's gating.
+	if cfg.keyRotationPeriod() > 0 {
+		kr := map[string]any{"running": b.core.oidcKeyRotationActive()}
+		st, _ := loadOIDCKeyRotationState(ctx, storage)
+		anchor := time.Time{}
+		switch {
+		case st != nil && !st.LastRotatedAt.IsZero():
+			anchor = st.LastRotatedAt
+		default:
+			// State not seeded yet (e.g. upgrade of an already-enabled issuer): fall back to
+			// the issuer's schedule anchor so the block is still populated.
+			if iss := b.core.OIDCIssuer(); iss != nil {
+				if a, ok := iss.NextKeyCreatedAt(); ok {
+					anchor = a
+				}
+			}
+		}
+		if !anchor.IsZero() {
+			kr["last_rotated_at"] = anchor.UTC().Format(time.RFC3339)
+			kr["next_rotation"] = anchor.Add(cfg.keyRotationPeriod()).UTC().Format(time.RFC3339)
+		}
+		if st != nil && st.LastError != "" {
+			kr["last_error"] = st.LastError
+			if !st.LastErrorAt.IsZero() {
+				kr["last_error_at"] = st.LastErrorAt.UTC().Format(time.RFC3339)
+			}
+		}
+		data["key_rotation"] = kr
+	}
 	if cfg.Publisher.Type != "" {
 		data["publisher"] = maskedPublisher(cfg.Publisher)
 	}

--- a/core/sys_oidc_issuer_test.go
+++ b/core/sys_oidc_issuer_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -69,6 +70,28 @@ func TestSysOIDCIssuerConfig(t *testing.T) {
 	assert.Equal(t, "https://warden-oidc.example", resp.Data["issuer_url"], "issuer_url preserved")
 	assert.Equal(t, int64(300), resp.Data["assertion_ttl"], "assertion_ttl preserved")
 	assert.Equal(t, int64(24*3600), resp.Data["key_rotation_period"], "rotation period updated")
+
+	// Enabling rotation surfaces a key_rotation status block, anchored on the key age, so
+	// last_rotated_at/next_rotation are populated and running is true on this active node.
+	kr, ok := resp.Data["key_rotation"].(map[string]any)
+	require.True(t, ok, "key_rotation block present when rotation enabled")
+	assert.Equal(t, true, kr["running"], "rotation loop running on the active node")
+	assert.NotEmpty(t, kr["last_rotated_at"])
+	assert.NotEmpty(t, kr["next_rotation"])
+	assert.NotContains(t, kr, "last_error")
+
+	// A recorded rotation failure surfaces in the block without advancing the anchor.
+	prevRotatedAt := kr["last_rotated_at"]
+	core.recordOIDCKeyRotationOutcome(ctx, fmt.Errorf("generate ES256 signing key: boom"))
+	kr = read(ctx).Data["key_rotation"].(map[string]any)
+	assert.Equal(t, "generate ES256 signing key: boom", kr["last_error"])
+	assert.NotEmpty(t, kr["last_error_at"])
+	assert.Equal(t, prevRotatedAt, kr["last_rotated_at"], "a failure must not advance the anchor")
+
+	// key_rotation is gated on rotation being enabled: disabling it (period=0) hides the block.
+	resp = write(ctx, map[string]any{"key_rotation_period": 0})
+	require.False(t, resp.IsError())
+	assert.NotContains(t, read(ctx).Data, "key_rotation", "block hidden when rotation disabled")
 
 	// Disable: a partial write of just enabled=false tears the issuer down while
 	// keeping the rest of the config for a later re-enable.


### PR DESCRIPTION
## What

Two related improvements to the `warden oidc-issuer` command family.

### 1. Coherent CLI output

`warden oidc-issuer read` (and now `configure` / `set-publisher`) rendered an incoherent table: durations printed as bare integer seconds (`assertion_ttl=300`, `retired_key_grace=3600`) mixed with duration strings (`rotation_period=1m`) and RFC3339 timestamps, and the nested `publisher` / `publisher_rotation` maps were flattened into a single crammed comma-joined cell.

The three commands now share one renderer that:
- formats durations as Go duration strings (`5m0s`, `1h0m0s`); `key_rotation_period=0` reads as `disabled`
- expands nested blocks into dot-keyed rows (`publisher.account_name`, `key_rotation.next_rotation`) in a stable, grouped order
- `configure` reads the config back so its confirmation shows the full merged view

`-o json` output is unchanged (durations stay integer seconds, objects stay nested).

### 2. Signing-key rotation status

The signing key (governed by `key_rotation_period`) previously exposed no runtime status — a failed rotation was only a log line. This adds a `key_rotation` status block mirroring the existing `publisher_rotation`:

- `running` / `last_rotated_at` / `next_rotation`, plus `last_error` / `last_error_at` on a failed cycle
- backed by a new persisted status doc updated each cycle (skipped when the context is cancelled, so seal/demotion isn't recorded as a failure)
- seeded from the key age so the reported `next_rotation` matches the loop's real schedule — scheduling itself is unchanged
- gated on `key_rotation_period > 0`, like `publisher_rotation`

A post-rotation republish failure remains a warning (the rotation is already committed and the promoted key was pre-published), so it is intentionally not surfaced as a `key_rotation` error.

## Tests

- `core/sys_oidc_issuer_test.go` — block appears when enabled, a recorded failure surfaces `last_error` without advancing the anchor, block hidden when disabled
- `cmd/oidcissuer/read_test.go` — renderer formats durations, expands blocks, handles the disabled/minimal shapes

`go build ./...`, `gofmt` clean, OIDC/publisher core tests and the CLI package tests pass.
