### PR TITLE
feat(credential): keyless Secrets Manager reads for AWS via OIDC federation

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -57,6 +57,11 @@ type AWSDriver struct {
 	// takes no AWS credentials, only the web identity token. Built once in Create
 	// so a keyless federation (auth_method=oidc_federation) source needs no IAM keys.
 	anonSTSClient *sts.Client
+
+	// smBaseEndpoint, when non-empty, overrides the Secrets Manager endpoint for
+	// clients built from freshly federated credentials. Test-only: production leaves
+	// it empty so the SDK resolves the real regional endpoint.
+	smBaseEndpoint string
 }
 
 // awsAuthMethodStatic and awsAuthMethodOIDCFederation select how the source
@@ -66,9 +71,12 @@ type AWSDriver struct {
 const (
 	awsAuthMethodStatic         = "static"
 	awsAuthMethodOIDCFederation = "oidc_federation"
-
-	mintMethodSTSAssumeRoleWebIdentity = "sts_assume_role_web_identity"
 )
+
+// federatedFetchSessionDuration is the lifetime requested for the temporary credentials
+// backing a single federated Secrets Manager read. They are used once and discarded, so
+// this is the AWS minimum for AssumeRoleWithWebIdentity (15m) rather than the secret's TTL.
+const federatedFetchSessionDuration = 15 * time.Minute
 
 // AWSDriverFactory creates AWSDriver instances
 type AWSDriverFactory struct{}
@@ -148,7 +156,7 @@ func (f *AWSDriverFactory) InferCredentialType(specConfig map[string]string) (st
 	switch mintMethod {
 	case "rds_iam_token", "redshift_iam_token":
 		return credential.TypeDBAuthToken, nil
-	case "sts_assume_role", mintMethodSTSAssumeRoleWebIdentity, "secrets_manager", "":
+	case "sts_assume_role", "secrets_manager", "":
 		return credential.TypeAWSAccessKeys, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
@@ -293,17 +301,13 @@ func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	authMethod := credential.GetString(d.credSource.Config, "auth_method", awsAuthMethodStatic)
 
-	// The web-identity mint is exchange-only: it needs a caller identity
-	// assertion and flows through MintCredentialWithExchange. Reaching it here
-	// means the spec lacks subject_token_source=warden_identity.
-	if mintMethod == mintMethodSTSAssumeRoleWebIdentity {
-		return nil, nil, 0, "", fmt.Errorf("mint_method=%s requires token-exchange inputs; set subject_token_source=warden_identity on the spec", mintMethodSTSAssumeRoleWebIdentity)
-	}
-	// A federation source holds no static credentials, so only the web-identity
-	// mint is possible on it. Fail clearly rather than falling into authenticate()
-	// with empty keys and a misleading "invalid AWS credentials" error.
+	// A federation source holds no static credentials: it authenticates per-request
+	// by federating a caller assertion, which flows through MintCredentialWithExchange.
+	// Reaching the non-exchange path means the spec lacks subject_token_source. Fail
+	// clearly rather than falling into authenticate() with empty keys and a misleading
+	// "invalid AWS credentials" error.
 	if authMethod == awsAuthMethodOIDCFederation {
-		return nil, nil, 0, "", fmt.Errorf("auth_method=oidc_federation supports only mint_method=%s (got %q)", mintMethodSTSAssumeRoleWebIdentity, mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("auth_method=oidc_federation requires subject_token_source=warden_identity on the spec (federated minting runs through the token-exchange path)")
 	}
 
 	// Re-authenticate if needed
@@ -415,15 +419,20 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 	return rawData, metadata, leaseTTL, leaseID, nil
 }
 
-// MintCredentialWithExchange federates a caller-derived identity assertion into
-// temporary AWS credentials via sts:AssumeRoleWithWebIdentity (Workload Identity
-// Federation). It requires mint_method=sts_assume_role_web_identity and a
-// verified subject (a Warden-minted assertion, subject_token_source=warden_identity):
-// AWS validates the assertion's signature against Warden's published JWKS, so an
-// unverified caller token must never be forwarded on Warden's authority.
+// MintCredentialWithExchange federates a caller-derived identity assertion into AWS
+// via sts:AssumeRoleWithWebIdentity (Workload Identity Federation), then produces the
+// outcome the spec's mint_method asks for. It requires a keyless source
+// (auth_method=oidc_federation) and a verified subject (a Warden-minted assertion,
+// subject_token_source=warden_identity): AWS validates the assertion's signature against
+// Warden's published JWKS, so an unverified caller token must never be forwarded on
+// Warden's authority.
+//
+// Supported mint methods over federation:
+//   - sts_assume_role: the federated role credentials are themselves the issued credential.
+//   - secrets_manager: the federated credentials read one secret and are then discarded.
 func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	if credential.GetString(spec.Config, "mint_method", "") != mintMethodSTSAssumeRoleWebIdentity {
-		return nil, nil, 0, "", fmt.Errorf("aws: mint_method must be %s to accept token-exchange inputs", mintMethodSTSAssumeRoleWebIdentity)
+	if credential.GetString(d.credSource.Config, "auth_method", awsAuthMethodStatic) != awsAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("aws: web-identity federation requires auth_method=oidc_federation on the source")
 	}
 	if inputs == nil || inputs.SubjectToken == "" {
 		return nil, nil, 0, "", fmt.Errorf("aws: no subject token in exchange inputs")
@@ -431,37 +440,74 @@ func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
 		return nil, nil, 0, "", fmt.Errorf("aws: web-identity federation requires a verified subject (subject_token_source=warden_identity)")
 	}
-	return d.mintViaSTSAssumeRoleWebIdentity(ctx, spec, inputs.SubjectToken)
+
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	switch mintMethod {
+	case "sts_assume_role":
+		// The assumed-role credentials are the issued credential, so their lifetime is
+		// the spec's TTL (validated against its bounds).
+		ttl, err := federatedSessionTTL(spec)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		out, err := d.assumeRoleWithWebIdentity(ctx, spec, inputs.SubjectToken, ttl)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		return d.credsFromWebIdentity(spec, out)
+	case "secrets_manager":
+		// These credentials serve a single GetSecretValue and are then discarded, so
+		// request a short fixed session — the spec's TTL bounds govern the returned
+		// static secret, not this transient assume-role.
+		out, err := d.assumeRoleWithWebIdentity(ctx, spec, inputs.SubjectToken, federatedFetchSessionDuration)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		creds := out.Credentials
+		provider := credentials.NewStaticCredentialsProvider(
+			aws.ToString(creds.AccessKeyId),
+			aws.ToString(creds.SecretAccessKey),
+			aws.ToString(creds.SessionToken),
+		)
+		return d.fetchSecret(ctx, d.newSecretsManagerClient(provider), spec)
+	default:
+		return nil, nil, 0, "", fmt.Errorf("aws: mint_method %q is not supported over auth_method=oidc_federation (supported: sts_assume_role, secrets_manager)", mintMethod)
+	}
 }
 
-// mintViaSTSAssumeRoleWebIdentity exchanges webIdentityToken for temporary AWS
-// credentials. The call is unsigned (anonSTSClient), so an oidc_federation source
-// needs no IAM keys.
-func (d *AWSDriver) mintViaSTSAssumeRoleWebIdentity(ctx context.Context, spec *credential.CredSpec, webIdentityToken string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	roleArn, err := credential.GetStringRequired(spec.Config, "role_arn")
-	if err != nil {
-		return nil, nil, 0, "", err
-	}
-
-	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
-
+// federatedSessionTTL resolves the assume-role session duration from the spec's ttl
+// (default 1h), validated against the spec's TTL bounds.
+func federatedSessionTTL(spec *credential.CredSpec) (time.Duration, error) {
 	ttlStr := credential.GetString(spec.Config, "ttl", "1h")
 	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("invalid ttl '%s': %w", ttlStr, err)
+		return 0, fmt.Errorf("invalid ttl '%s': %w", ttlStr, err)
 	}
 	if spec.MinTTL > 0 && ttl < spec.MinTTL {
-		return nil, nil, 0, "", fmt.Errorf("requested TTL %s is below minimum %s", ttl, spec.MinTTL)
+		return 0, fmt.Errorf("requested TTL %s is below minimum %s", ttl, spec.MinTTL)
 	}
 	if spec.MaxTTL > 0 && ttl > spec.MaxTTL {
-		return nil, nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", ttl, spec.MaxTTL)
+		return 0, fmt.Errorf("requested TTL %s exceeds maximum %s", ttl, spec.MaxTTL)
 	}
+	return ttl, nil
+}
+
+// assumeRoleWithWebIdentity exchanges webIdentityToken for temporary AWS credentials via
+// the unsigned anonSTSClient, so an oidc_federation source needs no IAM keys. The session
+// duration is supplied by the caller, since a role-assumption outcome and a transient
+// secret fetch want different lifetimes.
+func (d *AWSDriver) assumeRoleWithWebIdentity(ctx context.Context, spec *credential.CredSpec, webIdentityToken string, dur time.Duration) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	roleArn, err := credential.GetStringRequired(spec.Config, "role_arn")
+	if err != nil {
+		return nil, err
+	}
+	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
 
 	input := &sts.AssumeRoleWithWebIdentityInput{
 		RoleArn:          &roleArn,
 		RoleSessionName:  &sessionName,
 		WebIdentityToken: &webIdentityToken,
-		DurationSeconds:  aws.Int32(int32(ttl.Seconds())),
+		DurationSeconds:  aws.Int32(int32(dur.Seconds())),
 	}
 	if policy := credential.GetString(spec.Config, "policy", ""); policy != "" {
 		input.Policy = &policy
@@ -469,8 +515,22 @@ func (d *AWSDriver) mintViaSTSAssumeRoleWebIdentity(ctx context.Context, spec *c
 
 	result, err := d.anonSTSClient.AssumeRoleWithWebIdentity(ctx, input)
 	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("STS AssumeRoleWithWebIdentity failed for %s: %w", roleArn, err)
+		return nil, fmt.Errorf("STS AssumeRoleWithWebIdentity failed for %s: %w", roleArn, err)
 	}
+	// A malformed 200 (e.g. an intercepting proxy) can omit the credentials block;
+	// guard here so both consumers dereference a non-nil struct.
+	if result.Credentials == nil {
+		return nil, fmt.Errorf("STS AssumeRoleWithWebIdentity for %s returned no credentials", roleArn)
+	}
+	return result, nil
+}
+
+// credsFromWebIdentity shapes the temporary credentials from a web-identity assume-role
+// into the mint tuple, for when the assumed-role credentials are themselves the issued
+// credential (mint_method=sts_assume_role over oidc_federation).
+func (d *AWSDriver) credsFromWebIdentity(spec *credential.CredSpec, result *sts.AssumeRoleWithWebIdentityOutput) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	roleArn := credential.GetString(spec.Config, "role_arn", "")
+	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
 
 	creds := result.Credentials
 	leaseTTL := time.Until(*creds.Expiration)
@@ -512,8 +572,28 @@ func (d *AWSDriver) mintViaSTSAssumeRoleWebIdentity(ctx context.Context, spec *c
 	return rawData, metadata, leaseTTL, leaseID, nil
 }
 
-// mintViaSecretsManager fetches a secret from AWS Secrets Manager
+// newSecretsManagerClient builds a Secrets Manager client bound to the given credentials
+// (e.g. freshly federated temporary credentials). smBaseEndpoint, when set, overrides the
+// endpoint for tests.
+func (d *AWSDriver) newSecretsManagerClient(creds aws.CredentialsProvider) *secretsmanager.Client {
+	cfg := aws.Config{Region: d.region, Credentials: creds}
+	if d.smBaseEndpoint != "" {
+		return secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
+			o.BaseEndpoint = aws.String(d.smBaseEndpoint)
+		})
+	}
+	return secretsmanager.NewFromConfig(cfg)
+}
+
+// mintViaSecretsManager fetches a secret using the source's authenticated client (static
+// auth). The keyless (federation) path fetches with a temp-credential client instead.
 func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return d.fetchSecret(ctx, d.secretsManagerClient, spec)
+}
+
+// fetchSecret reads and parses a Secrets Manager secret with the given client. The client
+// may be the source's own (static auth) or one bound to freshly federated credentials.
+func (d *AWSDriver) fetchSecret(ctx context.Context, sm *secretsmanager.Client, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	secretID, err := credential.GetStringRequired(spec.Config, "secret_id")
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -529,7 +609,7 @@ func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.
 		input.VersionId = &vid
 	}
 
-	result, err := d.secretsManagerClient.GetSecretValue(ctx, input)
+	result, err := sm.GetSecretValue(ctx, input)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to get secret '%s': %w", secretID, err)
 	}

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -546,26 +546,18 @@ func TestAWSDriver_Create_WIF_Keyless(t *testing.T) {
 func TestAWSDriver_MintGuards(t *testing.T) {
 	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
 
-	// A static source: the web-identity mint_method requires exchange inputs, so
-	// plain MintCredential must refuse it.
-	staticDrv := &AWSDriver{
-		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "static"}},
-		logger:     log,
-	}
-	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "sts_assume_role_web_identity", "role_arn": "arn:aws:iam::1:role/x"}}
-	_, _, _, _, err := staticDrv.MintCredential(context.TODO(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "requires token-exchange inputs")
-
-	// An oidc_federation source reached with a non-federation mint_method must fail
-	// clearly, not fall into authenticate() with empty keys.
+	// An oidc_federation source reached via the non-exchange path (the spec lacks
+	// subject_token_source) must fail clearly, not fall into authenticate() with
+	// empty keys.
 	wifDrv := &AWSDriver{
 		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "oidc_federation"}},
 		logger:     log,
 	}
-	_, _, _, _, err = wifDrv.MintCredential(context.TODO(), &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "secrets_manager"}})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "auth_method=oidc_federation supports only")
+	for _, mm := range []string{"secrets_manager", "sts_assume_role"} {
+		_, _, _, _, err := wifDrv.MintCredential(context.TODO(), &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": mm}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires subject_token_source=warden_identity")
+	}
 }
 
 // TestAWSDriver_MintCredentialWithExchange_Guards covers the exchange-path guards
@@ -576,12 +568,22 @@ func TestAWSDriver_MintCredentialWithExchange_Guards(t *testing.T) {
 		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "oidc_federation"}},
 		logger:     log,
 	}
-	roleSpec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "sts_assume_role_web_identity", "role_arn": "arn:aws:iam::1:role/x"}}
+	roleSpec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "sts_assume_role", "role_arn": "arn:aws:iam::1:role/x"}}
+	verified := &credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenOrigin: credential.ExchangeOriginVerified}
 
-	// Wrong mint_method.
-	_, _, _, _, err := drv.MintCredentialWithExchange(context.TODO(), &credential.CredSpec{Config: map[string]string{"mint_method": "sts_assume_role"}}, &credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenOrigin: credential.ExchangeOriginVerified})
+	// A static source must not reach the federation path.
+	staticDrv := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "static"}},
+		logger:     log,
+	}
+	_, _, _, _, err := staticDrv.MintCredentialWithExchange(context.TODO(), roleSpec, verified)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "sts_assume_role_web_identity")
+	assert.Contains(t, err.Error(), "auth_method=oidc_federation")
+
+	// A mint_method with no federation support is rejected before any STS call.
+	_, _, _, _, err = drv.MintCredentialWithExchange(context.TODO(), &credential.CredSpec{Config: map[string]string{"mint_method": "rds_iam_token"}}, verified)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported over auth_method=oidc_federation")
 
 	// Missing subject.
 	_, _, _, _, err = drv.MintCredentialWithExchange(context.TODO(), roleSpec, &credential.ExchangeInputs{})
@@ -591,11 +593,17 @@ func TestAWSDriver_MintCredentialWithExchange_Guards(t *testing.T) {
 	_, _, _, _, err = drv.MintCredentialWithExchange(context.TODO(), roleSpec, &credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenOrigin: credential.ExchangeOriginUnverified})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "verified subject")
+
+	// For sts_assume_role, the requested TTL is bound-checked before any STS call.
+	boundedSpec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "sts_assume_role", "role_arn": "arn:aws:iam::1:role/x", "ttl": "2h"}, MaxTTL: time.Hour}
+	_, _, _, _, err = drv.MintCredentialWithExchange(context.TODO(), boundedSpec, verified)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
-// TestAWSDriver_WebIdentity_HappyPath drives the full exchange against a mocked
-// STS endpoint, asserting the assertion is forwarded as WebIdentityToken and the
-// returned credentials are surfaced.
+// TestAWSDriver_WebIdentity_HappyPath drives mint_method=sts_assume_role over a keyless
+// (oidc_federation) source against a mocked STS endpoint, asserting the assertion is
+// forwarded as WebIdentityToken and the assumed-role credentials are surfaced.
 func TestAWSDriver_WebIdentity_HappyPath(t *testing.T) {
 	var gotToken, gotAction string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -632,7 +640,7 @@ func TestAWSDriver_WebIdentity_HappyPath(t *testing.T) {
 		}),
 	}
 	spec := &credential.CredSpec{Name: "wid", Config: map[string]string{
-		"mint_method": "sts_assume_role_web_identity",
+		"mint_method": "sts_assume_role",
 		"role_arn":    "arn:aws:iam::123456789012:role/App",
 		"ttl":         "15m",
 	}}
@@ -653,6 +661,80 @@ func TestAWSDriver_WebIdentity_HappyPath(t *testing.T) {
 	assert.Equal(t, "123456789012", metadata["account_id"])
 	assert.Equal(t, "sts:ASIAEXAMPLE", leaseID)
 	assert.Greater(t, ttl, time.Duration(0))
+}
+
+// TestAWSDriver_SecretsManager_WebIdentity_HappyPath drives the keyless two-step:
+// federate the assertion for short-lived role credentials, then read a Secrets Manager
+// secret with those credentials.
+func TestAWSDriver_SecretsManager_WebIdentity_HappyPath(t *testing.T) {
+	var gotToken, gotDuration string
+	stsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotToken = r.Form.Get("WebIdentityToken")
+		gotDuration = r.Form.Get("DurationSeconds")
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>secretexample</SecretAccessKey>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
+	}))
+	defer stsSrv.Close()
+
+	// The stored secret holds AWS IAM keys — that is the shape mint_method=secrets_manager
+	// yields (the credential type is aws_access_keys), whether static or keyless.
+	var smTarget, smAuth string
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		smTarget = r.Header.Get("X-Amz-Target")
+		smAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"prod/app/keys","SecretString":"{\"access_key_id\":\"AKIASTOREDEXAMPLE\",\"secret_access_key\":\"0123456789012345678901234567890123456789\"}"}`))
+	}))
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "oidc_federation", "region": "us-east-1"}},
+		logger:     log,
+		region:     "us-east-1",
+		anonSTSClient: sts.New(sts.Options{
+			Region:       "us-east-1",
+			BaseEndpoint: aws.String(stsSrv.URL),
+			Credentials:  aws.AnonymousCredentials{},
+		}),
+		smBaseEndpoint: smSrv.URL,
+	}
+	spec := &credential.CredSpec{Name: "app", Config: map[string]string{
+		"mint_method": "secrets_manager",
+		"secret_id":   "prod/app/keys",
+		"role_arn":    "arn:aws:iam::123456789012:role/WardenSecretsReader",
+	}}
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       "eyJ.warden.assertion",
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginVerified,
+	}
+
+	rawData, metadata, ttl, leaseID, err := drv.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJ.warden.assertion", gotToken, "the Warden assertion must be sent as WebIdentityToken")
+	// The transient fetch session is the fixed 15m minimum, not the secret's TTL.
+	assert.Equal(t, "900", gotDuration, "the federated fetch must request a fixed 15m session")
+	assert.Contains(t, smTarget, "GetSecretValue", "the second call must hit Secrets Manager")
+	// The Secrets Manager call must be signed with the freshly federated temp creds
+	// (their access key id appears in the SigV4 Credential= scope).
+	assert.Contains(t, smAuth, "ASIAEXAMPLE", "the secret read must use the federated credentials")
+	assert.Equal(t, "AKIASTOREDEXAMPLE", rawData["access_key_id"])
+	assert.Equal(t, "0123456789012345678901234567890123456789", rawData["secret_access_key"])
+	// A fetched secret is static: no metadata, no lease.
+	assert.Nil(t, metadata)
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Equal(t, "", leaseID)
 }
 
 // =============================================================================

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -37,7 +37,7 @@ func (t *AWSIAMAccessKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 		// Common field for vault and aws sources
 		credential.StringField("mint_method").
-			OneOf("static_aws", "dynamic_aws", "sts_assume_role", "sts_assume_role_web_identity", "secrets_manager", "rds_iam_token", "redshift_iam_token").
+			OneOf("static_aws", "dynamic_aws", "sts_assume_role", "secrets_manager", "rds_iam_token", "redshift_iam_token").
 			Describe("Method for minting AWS credentials").
 			Example("sts_assume_role"),
 
@@ -192,19 +192,17 @@ func (t *AWSIAMAccessKeysCredType) validateAWSConfig(config map[string]string) e
 		if config["role_arn"] == "" {
 			return fmt.Errorf("'role_arn' is required when mint_method is sts_assume_role")
 		}
-	case "sts_assume_role_web_identity":
-		if config["role_arn"] == "" {
-			return fmt.Errorf("'role_arn' is required when mint_method is sts_assume_role_web_identity")
-		}
-		// Web-identity federation is exchange-only: it needs a caller identity
-		// assertion (normally subject_token_source=warden_identity). Reject a WIF
-		// mint_method without a subject source at creation, rather than at mint.
-		if !credential.SpecRequestsExchange(config) {
-			return fmt.Errorf("mint_method=sts_assume_role_web_identity requires a subject_token_source (e.g. warden_identity)")
-		}
 	case "secrets_manager":
 		if config["secret_id"] == "" {
 			return fmt.Errorf("'secret_id' is required when mint_method is secrets_manager")
+		}
+		// The keyless (federation) variant assumes a role via web identity before
+		// reading the secret, so it also needs a role to assume. A spec requests
+		// exchange via subject_token_source; static-auth secrets specs do not and are
+		// unaffected. (The auth_method lives on the source, which this validator does
+		// not see, so the source/exchange pairing is enforced at mint time.)
+		if credential.SpecRequestsExchange(config) && config["role_arn"] == "" {
+			return fmt.Errorf("'role_arn' is required for keyless secrets_manager (a spec with subject_token_source)")
 		}
 	}
 

--- a/credential/types/aws_iam_keys_test.go
+++ b/credential/types/aws_iam_keys_test.go
@@ -89,6 +89,65 @@ func TestAWSIAMAccessKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
 	}
 }
 
+func TestAWSIAMAccessKeysCredType_ValidateConfig_AWSSource(t *testing.T) {
+	ct := &AWSIAMAccessKeysCredType{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "sts_assume_role requires role_arn",
+			config:  map[string]string{"mint_method": "sts_assume_role"},
+			wantErr: true,
+			errMsg:  "role_arn",
+		},
+		{
+			name:    "sts_assume_role valid",
+			config:  map[string]string{"mint_method": "sts_assume_role", "role_arn": "arn:aws:iam::1:role/x"},
+			wantErr: false,
+		},
+		{
+			name:    "secrets_manager requires secret_id",
+			config:  map[string]string{"mint_method": "secrets_manager"},
+			wantErr: true,
+			errMsg:  "secret_id",
+		},
+		{
+			name:    "static secrets_manager needs no role_arn",
+			config:  map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/db"},
+			wantErr: false,
+		},
+		{
+			name:    "keyless secrets_manager requires role_arn",
+			config:  map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/db", "subject_token_source": "warden_identity"},
+			wantErr: true,
+			errMsg:  "role_arn",
+		},
+		{
+			name:    "keyless secrets_manager valid with role_arn",
+			config:  map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/db", "subject_token_source": "warden_identity", "role_arn": "arn:aws:iam::1:role/x"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeAWS)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestAWSIAMAccessKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
 	ct := &AWSIAMAccessKeysCredType{}
 


### PR DESCRIPTION
## Summary

Unifies the AWS driver's minting model and adds keyless (Workload Identity Federation) access to AWS Secrets Manager.

- `mint_method` now names only the AWS **outcome** (`sts_assume_role`, `secrets_manager`, ...).
- The source's `auth_method` decides **how** Warden authenticates to AWS:
  - `static` → `sts:AssumeRole` with IAM keys
  - `oidc_federation` → `sts:AssumeRoleWithWebIdentity` with a Warden-minted assertion

| `mint_method` | `static` | `oidc_federation` |
|---|---|---|
| `sts_assume_role` | `sts:AssumeRole` | `sts:AssumeRoleWithWebIdentity` → role creds |
| `secrets_manager` | `GetSecretValue` directly | assume-role-with-web-identity → `GetSecretValue` with those creds |

The standalone `sts_assume_role_web_identity` mint method is **removed** and folded into `sts_assume_role` + `auth_method=oidc_federation`. It shipped in #436 but is not in any release (the latest tag predates it) and was referenced only in the AWS driver and its tests, so no alias or migration is needed.

## Behavior

- `MintCredentialWithExchange` requires `auth_method=oidc_federation` and a verified subject, runs the web-identity exchange once, then dispatches on `mint_method`.
- `secrets_manager` over federation uses a **fixed 15m** session — the temporary credentials serve a single `GetSecretValue` and are discarded, so the secret's TTL bounds do not apply (this also avoids requesting a sub-minimum `DurationSeconds`, which AWS rejects). `sts_assume_role` honors the spec's TTL bounds.
- Keyless `secrets_manager` specs now require `role_arn`, validated at spec-create.

A federated `secrets_manager` credential is still typed `aws_access_keys`, so the stored secret must hold AWS IAM keys (`access_key_id` + `secret_access_key`), optionally remapped via `json_key_map` — unchanged from the existing static `secrets_manager` behavior.

## Usage

Keyless source (no IAM keys):

```
warden cred source create aws-keyless \
  -type=aws \
  -config=auth_method=oidc_federation \
  -config=region=us-east-1
```

Keyless Secrets Manager read:

```
warden cred spec create app-keys-keyless \
  -source=aws-keyless \
  -config=mint_method=secrets_manager \
  -config=secret_id=prod/app/keys \
  -config=role_arn=arn:aws:iam::123456789012:role/WardenSecretsReader \
  -config=subject_token_source=warden_identity \
  -config=assertion_audience=sts.amazonaws.com
```

AWS-side prerequisites (unchanged from existing WIF): the role's trust policy allows `sts:AssumeRoleWithWebIdentity` from the Warden OIDC issuer, and for the secret read grants `secretsmanager:GetSecretValue`.

## Testing

- `go build ./...`, `go vet ./credential/...`, `go test ./credential/...` — all pass.
- Repurposed the WIF happy-path to `sts_assume_role`; added a keyless Secrets Manager happy-path that drives the full two-step against mocked STS + Secrets Manager endpoints (asserts the assertion is forwarded, the fixed 15m session is requested, and the secret read is signed with the federated credentials).
- Extended guard tests (static source rejected on the exchange path; unsupported mint methods rejected before any STS call; TTL bounds enforced) and added AWS-source spec validation coverage.
