### PR TITLE
feat(credential): vend multiple credential shapes from AWS Secrets Manager

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -153,13 +153,37 @@ func (f *AWSDriverFactory) SensitiveConfigFields() []string {
 // InferCredentialType infers the credential type from the spec's mint_method.
 func (f *AWSDriverFactory) InferCredentialType(specConfig map[string]string) (string, error) {
 	mintMethod := specConfig["mint_method"]
+	// credential_type selects the stored-secret shape and is meaningful only for
+	// secrets_manager; reject it elsewhere rather than silently ignoring it.
+	if specConfig["credential_type"] != "" && mintMethod != "secrets_manager" {
+		return "", fmt.Errorf("credential_type is only valid with mint_method=secrets_manager (got mint_method=%q)", mintMethod)
+	}
 	switch mintMethod {
 	case "rds_iam_token", "redshift_iam_token":
 		return credential.TypeDBAuthToken, nil
-	case "sts_assume_role", "secrets_manager", "":
+	case "secrets_manager":
+		// A stored secret can hold different credential shapes; the spec selects one
+		// via credential_type (default: AWS access keys). This mirrors how a Vault
+		// source vends multiple shapes — the transport is one thing, the shape another.
+		return inferSecretsManagerType(specConfig["credential_type"])
+	case "sts_assume_role", "":
 		return credential.TypeAWSAccessKeys, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
+	}
+}
+
+// inferSecretsManagerType maps the operator-selected credential_type to a supported
+// stored-secret shape. Empty defaults to AWS access keys for back-compat. Extend the
+// allowlist to admit another storable type once its ValidateConfig accepts an AWS source.
+func inferSecretsManagerType(credType string) (string, error) {
+	switch credType {
+	case "", credential.TypeAWSAccessKeys:
+		return credential.TypeAWSAccessKeys, nil
+	case credential.TypeAPIKey:
+		return credential.TypeAPIKey, nil
+	default:
+		return "", fmt.Errorf("unsupported credential_type %q for mint_method=secrets_manager (supported: %s, %s)", credType, credential.TypeAWSAccessKeys, credential.TypeAPIKey)
 	}
 }
 

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/credential/types"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -410,6 +411,51 @@ func TestAWSDriverFactory_InferCredentialType_Redshift(t *testing.T) {
 	assert.Equal(t, credential.TypeDBAuthToken, credType)
 }
 
+// TestAWSDriverFactory_InferCredentialType_SecretsManager covers the shape selector:
+// a Secrets Manager secret defaults to AWS access keys, and credential_type selects a
+// different stored-secret shape.
+func TestAWSDriverFactory_InferCredentialType_SecretsManager(t *testing.T) {
+	factory := &AWSDriverFactory{}
+
+	cases := []struct {
+		name     string
+		credType string
+		want     string
+		wantErr  bool
+	}{
+		{name: "default is aws access keys", credType: "", want: credential.TypeAWSAccessKeys},
+		{name: "explicit aws access keys", credType: credential.TypeAWSAccessKeys, want: credential.TypeAWSAccessKeys},
+		{name: "api key shape", credType: credential.TypeAPIKey, want: credential.TypeAPIKey},
+		{name: "unsupported shape rejected", credType: "gitlab_access_token", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := map[string]string{"mint_method": "secrets_manager"}
+			if tc.credType != "" {
+				cfg["credential_type"] = tc.credType
+			}
+			got, err := factory.InferCredentialType(cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	// credential_type is meaningful only for secrets_manager; using it elsewhere is
+	// an explicit error, not a silent fallback to aws_access_keys.
+	t.Run("credential_type rejected for non-secrets_manager mint", func(t *testing.T) {
+		_, err := factory.InferCredentialType(map[string]string{
+			"mint_method":     "sts_assume_role",
+			"credential_type": credential.TypeAPIKey,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only valid with mint_method=secrets_manager")
+	})
+}
+
 // newRedshiftTestDriver creates a driver with verified base creds and built clients,
 // suitable for exercising mintViaRedshiftIAMToken's validation paths.
 // It does NOT make real AWS calls — tests must short-circuit before the SDK call.
@@ -735,6 +781,79 @@ func TestAWSDriver_SecretsManager_WebIdentity_HappyPath(t *testing.T) {
 	assert.Nil(t, metadata)
 	assert.Equal(t, time.Duration(0), ttl)
 	assert.Equal(t, "", leaseID)
+}
+
+// TestAWSDriver_SecretsManager_APIKey_RoundTrip proves the hvault-mirror pattern end to
+// end: the keyless secrets_manager fetch is shape-agnostic, and the same fetched blob is
+// parsed by the api_key credential type (selected via credential_type) into an API key.
+func TestAWSDriver_SecretsManager_APIKey_RoundTrip(t *testing.T) {
+	var gotToken string
+	stsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotToken = r.Form.Get("WebIdentityToken")
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>secretexample</SecretAccessKey>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
+	}))
+	defer stsSrv.Close()
+
+	// The stored secret holds an API key, not AWS access keys — the mint path does not
+	// care about the shape; the credential type does.
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"prod/app/openai","SecretString":"{\"api_key\":\"sk-test-123\"}"}`))
+	}))
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "oidc_federation", "region": "us-east-1"}},
+		logger:     log,
+		region:     "us-east-1",
+		anonSTSClient: sts.New(sts.Options{
+			Region:       "us-east-1",
+			BaseEndpoint: aws.String(stsSrv.URL),
+			Credentials:  aws.AnonymousCredentials{},
+		}),
+		smBaseEndpoint: smSrv.URL,
+	}
+	spec := &credential.CredSpec{Name: "openai", Config: map[string]string{
+		"mint_method":     "secrets_manager",
+		"credential_type": "api_key",
+		"secret_id":       "prod/app/openai",
+		"role_arn":        "arn:aws:iam::123456789012:role/WardenSecretsReader",
+	}}
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       "eyJ.warden.assertion",
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginVerified,
+	}
+
+	// Mint: the driver fetches the raw secret, shape-agnostic.
+	rawData, _, _, _, err := drv.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJ.warden.assertion", gotToken)
+
+	// The spec selected api_key, so the api_key type parses the fetched blob into a
+	// well-formed API key credential (reusing its validation and masking).
+	inferred, err := (&AWSDriverFactory{}).InferCredentialType(spec.Config)
+	require.NoError(t, err)
+	require.Equal(t, credential.TypeAPIKey, inferred)
+
+	apiKeyType := types.NewAPIKeyCredType()
+	cred, err := apiKeyType.Parse(rawData, nil, 0, "")
+	require.NoError(t, err)
+	require.NoError(t, apiKeyType.Validate(cred))
+	assert.Equal(t, credential.TypeAPIKey, cred.Type)
+	assert.Equal(t, "sk-test-123", cred.Data["api_key"])
 }
 
 // =============================================================================

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -69,10 +69,10 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 			Describe("Project ID (optional)").
 			Example("proj-xxxxxxxxxxxx"),
 
-		// Vault source - static_apikey fields
+		// Store-backed sources (vault static_apikey, aws secrets_manager)
 		credential.StringField("mint_method").
-			OneOf("static_apikey").
-			Describe("Mint method (required for vault source)").
+			OneOf("static_apikey", "secrets_manager").
+			Describe("Mint method (required for vault or aws source)").
 			Example("static_apikey"),
 
 		credential.StringField("kv2_mount").
@@ -82,6 +82,29 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("secret_path").
 			Describe("Path to secret in KV2 (required for static_apikey)").
 			Example("apikeys/my-service"),
+
+		// AWS source - Secrets Manager fields. The fetched secret must contain an
+		// api_key field (or be remapped to one via json_key_map).
+		credential.StringField("credential_type").
+			OneOf(credential.TypeAPIKey).
+			Describe("Selects the api_key shape for a Secrets Manager secret").
+			Example(credential.TypeAPIKey),
+
+		credential.StringField("secret_id").
+			Describe("AWS Secrets Manager secret ID (required for secrets_manager)").
+			Example("prod/app/openai"),
+
+		credential.StringField("role_arn").
+			Describe("IAM role ARN to assume via web identity (required for keyless secrets_manager)").
+			Example("arn:aws:iam::123456789012:role/WardenSecretsReader"),
+
+		credential.StringField("version_stage").
+			Describe("Secrets Manager version stage (optional, defaults to AWSCURRENT)").
+			Example("AWSCURRENT"),
+
+		credential.StringField("version_id").
+			Describe("Specific Secrets Manager version ID (optional)").
+			Example("uuid-version-id"),
 	}
 }
 
@@ -92,10 +115,10 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
 	// Step 1: Validate source type compatibility
 	switch sourceType {
-	case credential.SourceTypeAPIKey, credential.SourceTypeLocal, credential.SourceTypeVault:
+	case credential.SourceTypeAPIKey, credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeAWS:
 		// Supported
 	default:
-		return fmt.Errorf("api_key credentials require an apikey, local, or vault source, got: %s", sourceType)
+		return fmt.Errorf("api_key credentials require an apikey, local, vault, or aws source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema
@@ -116,6 +139,15 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 		if config["secret_path"] == "" {
 			return fmt.Errorf("'secret_path' is required when mint_method is static_apikey")
 		}
+	case credential.SourceTypeAWS:
+		// The API key is read from AWS Secrets Manager, not carried in the spec, so
+		// validate the fetch config (shared with aws_access_keys) rather than requiring
+		// an api_key field here. The secret's payload must contain api_key (or be
+		// remapped to it via json_key_map).
+		if config["mint_method"] != "secrets_manager" {
+			return fmt.Errorf("'mint_method' must be 'secrets_manager' for an aws source, got: %s", config["mint_method"])
+		}
+		return validateAWSSecretsManagerSpecConfig(config)
 	default:
 		if config["api_key"] == "" {
 			return fmt.Errorf("'api_key' is required")

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -19,6 +19,63 @@ func TestAPIKeyCredType_Metadata(t *testing.T) {
 	assert.Equal(t, time.Duration(0), metadata.DefaultTTL)
 }
 
+// TestAPIKeyCredType_ValidateConfig_AWSSource covers an API key sourced from AWS
+// Secrets Manager: the key comes from the fetched secret, so the spec validates the
+// fetch config (secret_id, role_arn for keyless) instead of requiring an api_key field.
+func TestAPIKeyCredType_ValidateConfig_AWSSource(t *testing.T) {
+	ct := NewAPIKeyCredType()
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid static secrets_manager",
+			config:  map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/app/openai"},
+			wantErr: false,
+		},
+		{
+			name:    "missing secret_id",
+			config:  map[string]string{"mint_method": "secrets_manager"},
+			wantErr: true,
+			errMsg:  "secret_id",
+		},
+		{
+			name:    "wrong mint_method for aws source",
+			config:  map[string]string{"mint_method": "sts_assume_role"},
+			wantErr: true,
+			errMsg:  "secrets_manager",
+		},
+		{
+			name:    "keyless requires role_arn",
+			config:  map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/app/openai", "subject_token_source": "warden_identity"},
+			wantErr: true,
+			errMsg:  "role_arn",
+		},
+		{
+			name:    "keyless valid with role_arn",
+			config:  map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/app/openai", "subject_token_source": "warden_identity", "role_arn": "arn:aws:iam::1:role/x"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeAWS)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 	ct := NewAPIKeyCredType()
 
@@ -100,13 +157,13 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 		},
 		// --- Unsupported source types ---
 		{
-			name: "unsupported source type - aws",
+			name: "unsupported source type - github",
 			config: map[string]string{
 				"api_key": "sk-test",
 			},
-			sourceType: "aws",
+			sourceType: "github",
 			wantErr:    true,
-			errMsg:     "require an apikey, local, or vault source",
+			errMsg:     "require an apikey, local, vault, or aws source",
 		},
 		// --- Vault source ---
 		{

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -193,19 +193,28 @@ func (t *AWSIAMAccessKeysCredType) validateAWSConfig(config map[string]string) e
 			return fmt.Errorf("'role_arn' is required when mint_method is sts_assume_role")
 		}
 	case "secrets_manager":
-		if config["secret_id"] == "" {
-			return fmt.Errorf("'secret_id' is required when mint_method is secrets_manager")
-		}
-		// The keyless (federation) variant assumes a role via web identity before
-		// reading the secret, so it also needs a role to assume. A spec requests
-		// exchange via subject_token_source; static-auth secrets specs do not and are
-		// unaffected. (The auth_method lives on the source, which this validator does
-		// not see, so the source/exchange pairing is enforced at mint time.)
-		if credential.SpecRequestsExchange(config) && config["role_arn"] == "" {
-			return fmt.Errorf("'role_arn' is required for keyless secrets_manager (a spec with subject_token_source)")
-		}
+		return validateAWSSecretsManagerSpecConfig(config)
 	}
 
+	return nil
+}
+
+// validateAWSSecretsManagerSpecConfig validates the spec config for reading a secret
+// from AWS Secrets Manager. It is shared by every credential type that can be sourced
+// from Secrets Manager (aws_access_keys, api_key, ...), so the fetch-config rules live
+// in one place independent of the shape the secret is parsed into.
+func validateAWSSecretsManagerSpecConfig(config map[string]string) error {
+	if config["secret_id"] == "" {
+		return fmt.Errorf("'secret_id' is required when mint_method is secrets_manager")
+	}
+	// The keyless (federation) variant assumes a role via web identity before
+	// reading the secret, so it also needs a role to assume. A spec requests
+	// exchange via subject_token_source; static-auth secrets specs do not and are
+	// unaffected. (The auth_method lives on the source, which this validator does
+	// not see, so the source/exchange pairing is enforced at mint time.)
+	if credential.SpecRequestsExchange(config) && config["role_arn"] == "" {
+		return fmt.Errorf("'role_arn' is required for keyless secrets_manager (a spec with subject_token_source)")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Lets one AWS Secrets Manager source vend **multiple credential shapes**, instead of forcing every secret through `aws_access_keys`. The spec selects the shape via `credential_type`, mirroring how a Vault source already vends many shapes (`static_aws` → aws keys, `static_apikey` → api key, …): the transport (`secrets_manager`) is one axis, the credential type is another.

This builds on the keyless federation work (#447) and adds `api_key` as the first extra shape.

## How it works

- `InferCredentialType` maps `mint_method=secrets_manager` + `credential_type` to a supported shape — default `aws_access_keys` (back-compat), `api_key` new; an unsupported value errors, and `credential_type` outside `secrets_manager` is rejected rather than silently ignored.
- The **driver mint path is unchanged and shape-agnostic** — `secrets_manager` fetches the raw secret JSON; only the credential *type* that parses it differs.
- The `api_key` type now accepts an AWS source and validates the shared Secrets Manager fetch config; the fetched secret must contain an `api_key` field (or be remapped to one via `json_key_map`).
- `validateAWSSecretsManagerSpecConfig` is extracted so the fetch-config rules (`secret_id`, `role_arn` for keyless) live in one place, reused by every storable credential type.

Reusing an existing type means its config schema gains the new source's fields (the AWS Secrets Manager keys are added to `api_key`'s schema) — exactly as the Vault fields already live there. That's the per-source cost, and it's small.

## Usage

Read an API key stored in Secrets Manager (keyless):

```
warden cred spec create app-openai \
  -source=aws-keyless \
  -config=mint_method=secrets_manager \
  -config=credential_type=api_key \
  -config=secret_id=prod/app/openai \
  -config=role_arn=arn:aws:iam::123456789012:role/WardenSecretsReader \
  -config=subject_token_source=warden_identity \
  -config=assertion_audience=sts.amazonaws.com
```

The same source with no `credential_type` still yields `aws_access_keys`, unchanged.

Adding the next shape is a repeatable recipe: one line in `inferSecretsManagerType`, admit the AWS source in that type's `ValidateConfig`, widen its `mint_method` schema.

## Testing

- `go build ./...`, `go vet ./credential/...`, `gofmt`, `go test ./credential/...` — all pass.
- `InferCredentialType` cases: default → aws_access_keys, `credential_type=api_key` → api_key, unsupported value → error, `credential_type` with non-secrets_manager mint → error.
- `api_key` `ValidateConfig` over an AWS source: valid static/keyless, missing `secret_id`, wrong `mint_method`, keyless missing `role_arn`.
- End-to-end round-trip: a keyless `secrets_manager` fetch returns `{"api_key":"sk-test-123"}`, and the `api_key` type parses/validates it into an API-key credential — proving the transport is shape-agnostic and the type does the shaping.
