### PR TITLE
feat(credential): keyless Azure bearer tokens via OIDC federation

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -849,8 +849,17 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				return logical.ErrBadRequestf("invalid config for type '%s': %s", spec.Type, err.Error())
 			}
 
-			// Enforce rotation_period for types that embed rotatable credentials
-			if credType.RequiresSpecRotation() && spec.RotationPeriod <= 0 {
+			// A token-exchange spec (subject_token_source set) is minted fresh per
+			// request from a caller-derived assertion; it embeds no secret, so
+			// scheduled rotation is meaningless. Reject rotation_period outright —
+			// otherwise the spec is enrolled for a rotation that can never persist,
+			// and a spec-rotating type would mutate the upstream every failed cycle.
+			if credential.SpecRequestsExchange(spec.Config) {
+				if spec.RotationPeriod > 0 {
+					return logical.ErrBadRequestf("rotation_period is not supported for credential type '%s' (token-exchange spec; credentials are minted per request, not rotated)", spec.Type)
+				}
+			} else if credType.RequiresSpecRotation() && spec.RotationPeriod <= 0 {
+				// Types that embed rotatable credentials must schedule rotation.
 				return logical.ErrBadRequestf("rotation_period is required for credential type '%s' which embeds rotatable credentials", spec.Type)
 			}
 

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -840,9 +840,85 @@ func TestCredentialConfigStore_ValidateSpec_TypeValidation(t *testing.T) {
 	}
 }
 
+// TestCredentialConfigStore_ValidateSpec_ExchangeRotation covers the rotation_period
+// rules around token-exchange (keyless federation) specs: a rotating type still
+// requires rotation_period normally, an exchange spec is exempt from that requirement,
+// and an exchange spec must NOT carry a rotation_period (it mints fresh per request and
+// enrolling it would schedule a rotation that can never persist).
+func TestCredentialConfigStore_ValidateSpec_ExchangeRotation(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+
+	rotType := &testCredentialType{typeName: "rotating_type", requiresRotation: true}
+	if err := store.core.credentialTypeRegistry.Register(rotType); err != nil {
+		t.Fatalf("failed to register type: %v", err)
+	}
+
+	// Local source: the test-mint block is skipped, so no driver is needed.
+	store.core.credentialDriverRegistry = nil
+	if err := store.CreateSource(ctx, &credential.CredSource{Name: "local-src", Type: "local"}); err != nil {
+		t.Fatalf("failed to create source: %v", err)
+	}
+
+	exchangeCfg := map[string]string{
+		"subject_token_source": "warden_identity",
+		"assertion_audience":   "api://AzureADTokenExchange",
+	}
+
+	tests := []struct {
+		name        string
+		spec        *credential.CredSpec
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "rotating type without rotation_period is rejected",
+			spec: &credential.CredSpec{
+				Name: "needs-rotation", Type: "rotating_type", Source: "local-src",
+				MinTTL: time.Minute, MaxTTL: time.Hour,
+			},
+			expectError: true,
+			errorMsg:    "rotation_period is required",
+		},
+		{
+			name: "exchange spec is exempt from the rotation_period requirement",
+			spec: &credential.CredSpec{
+				Name: "exchange-no-rotation", Type: "rotating_type", Source: "local-src",
+				Config: exchangeCfg, MinTTL: time.Minute, MaxTTL: time.Hour,
+			},
+			expectError: false,
+		},
+		{
+			name: "exchange spec must not set rotation_period",
+			spec: &credential.CredSpec{
+				Name: "exchange-with-rotation", Type: "rotating_type", Source: "local-src",
+				Config: exchangeCfg, RotationPeriod: 24 * time.Hour, MinTTL: time.Minute, MaxTTL: time.Hour,
+			},
+			expectError: true,
+			errorMsg:    "not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.CreateSpec(ctx, tt.spec)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errorMsg)
+				} else if tt.errorMsg != "" && !contains(err.Error(), tt.errorMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errorMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 // testCredentialType is a minimal credential type for testing
 type testCredentialType struct {
-	typeName string
+	typeName         string
+	requiresRotation bool
 }
 
 func (t *testCredentialType) Metadata() credential.TypeMetadata {
@@ -890,7 +966,7 @@ func (t *testCredentialType) Revoke(ctx context.Context, cred *credential.Creden
 }
 
 func (t *testCredentialType) RequiresSpecRotation() bool {
-	return false
+	return t.requiresRotation
 }
 
 func (t *testCredentialType) SensitiveConfigFields() []string { return nil }

--- a/credential/drivers/azure_driver.go
+++ b/credential/drivers/azure_driver.go
@@ -36,8 +36,21 @@ const addPasswordMaxAttempts = 5
 // mechanism (3 immediate retries + daily retry for 7 days).
 const removePasswordMaxAttempts = 3
 
+// Source authentication methods. static uses a stored client_secret; oidc_federation
+// is keyless — a caller-scoped Warden assertion is presented as a client_assertion
+// (Azure AD Workload Identity Federation), so no secret is stored in Warden.
+const (
+	azureAuthMethodStatic         = "static"
+	azureAuthMethodOIDCFederation = "oidc_federation"
+)
+
 // tenantIDPattern matches Azure AD tenant IDs (UUID format)
 var tenantIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// defaultAzureLoginHost is the public-cloud Entra ID authority host. The driver's
+// loginHost field defaults to this; tests override the field to point token
+// acquisition at a local server.
+const defaultAzureLoginHost = "https://login.microsoftonline.com"
 
 // validateTenantID checks that the tenant ID is a valid UUID
 func validateTenantID(tenantID string) error {
@@ -156,6 +169,7 @@ func (d *AzureDriver) doAzureRequest(ctx context.Context, apiReq azureAPIRequest
 var _ credential.SourceDriver = (*AzureDriver)(nil)
 var _ credential.Rotatable = (*AzureDriver)(nil)
 var _ credential.SpecRotatable = (*AzureDriver)(nil)
+var _ credential.ExchangeMinter = (*AzureDriver)(nil)
 
 // AzureDriver mints credentials from Azure services.
 // It exchanges pre-provisioned service principal credentials (stored in specs)
@@ -190,6 +204,10 @@ type AzureDriver struct {
 
 	// HTTP client for Azure API calls
 	httpClient *http.Client
+
+	// Entra ID authority host; empty means the public-cloud default. Tests set it
+	// to a local server so token acquisition can be exercised without Azure.
+	loginHost string
 
 	// Flag to track if source credentials have been verified
 	sourceVerified bool
@@ -227,26 +245,27 @@ func (f *AzureDriverFactory) Type() string {
 
 // ValidateConfig validates Azure driver configuration using declarative schema
 func (f *AzureDriverFactory) ValidateConfig(config map[string]string) error {
-	return credential.ValidateSchema(config,
+	if err := credential.ValidateSchema(config,
+		credential.StringField("auth_method").
+			OneOf(azureAuthMethodStatic, azureAuthMethodOIDCFederation).
+			Describe("How the source authenticates: static (client secret) or oidc_federation (Workload Identity Federation, keyless)").
+			Example("static"),
+
 		credential.StringField("tenant_id").
-			Required().
 			Custom(validateTenantID).
-			Describe("Azure AD tenant ID (UUID)").
+			Describe("Azure AD tenant ID (UUID; required for auth_method=static)").
 			Example("00000000-0000-0000-0000-000000000000"),
 
 		credential.StringField("client_id").
-			Required().
-			Describe("Azure AD application (client) ID").
+			Describe("Azure AD application (client) ID (required for auth_method=static)").
 			Example("11111111-1111-1111-1111-111111111111"),
 
 		credential.StringField("client_secret").
-			Required().
-			Describe("Azure AD application client secret").
+			Describe("Azure AD application client secret (required for auth_method=static)").
 			Example("secret-value"),
 
 		credential.StringField("secret_id").
-			Required().
-			Describe("Secret ID for the client secret (for rotation tracking)").
+			Describe("Secret ID for the client secret (for rotation tracking; required for auth_method=static)").
 			Example("secret-id-uuid"),
 
 		credential.StringField("ca_data").
@@ -257,7 +276,27 @@ func (f *AzureDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
-	)
+	); err != nil {
+		return err
+	}
+
+	// Cross-field rules per auth_method.
+	switch credential.GetString(config, "auth_method", azureAuthMethodStatic) {
+	case azureAuthMethodStatic:
+		if credential.GetString(config, "tenant_id", "") == "" ||
+			credential.GetString(config, "client_id", "") == "" ||
+			credential.GetString(config, "client_secret", "") == "" ||
+			credential.GetString(config, "secret_id", "") == "" {
+			return fmt.Errorf("tenant_id, client_id, client_secret, and secret_id are required for auth_method=static")
+		}
+	case azureAuthMethodOIDCFederation:
+		// A federation source holds no static secret. Reject leftover static config
+		// so a misconfiguration cannot silently mix modes.
+		if credential.GetString(config, "client_secret", "") != "" || credential.GetString(config, "secret_id", "") != "" {
+			return fmt.Errorf("client_secret/secret_id must not be set for auth_method=oidc_federation")
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -271,7 +310,7 @@ func (f *AzureDriverFactory) InferCredentialType(specConfig map[string]string) (
 	switch mintMethod {
 	case "azure_db_iam_token":
 		return credential.TypeDBAuthToken, nil
-	case "":
+	case "", "bearer_token":
 		return credential.TypeAzureBearerToken, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
@@ -296,6 +335,12 @@ func (f *AzureDriverFactory) Create(config map[string]string, log *logger.GatedL
 	}
 	driver.httpClient = httpClient
 
+	// A keyless federation source holds no client_secret to verify — the caller-scoped
+	// assertion arrives only at mint time. Skip the eager source-token probe.
+	if credential.GetString(config, "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
+		return driver, nil
+	}
+
 	// Validate source credentials by acquiring a token
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -311,11 +356,18 @@ func (f *AzureDriverFactory) Create(config map[string]string, log *logger.GatedL
 // MintCredential mints credentials based on the spec's mint_method.
 // Credentials are minted using the SP credentials stored in the spec (not the source).
 func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A keyless source mints only through the exchange path, which carries the
+	// caller-scoped assertion. Fail closed here to avoid silently minting with
+	// no credential material.
+	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("azure: source uses auth_method=oidc_federation; the spec must set subject_token_source=warden_identity")
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "bearer_token")
 
 	switch mintMethod {
 	case "bearer_token":
-		return d.mintBearerToken(ctx, spec)
+		return d.mintBearerToken(ctx, spec, "")
 	case "key_vault_secret":
 		return d.fetchKeyVaultSecret(ctx, spec)
 	default:
@@ -323,20 +375,56 @@ func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	}
 }
 
-// mintBearerToken exchanges spec's SP credentials for an Azure AD bearer token
-func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	// Get SP credentials from spec config (pre-provisioned)
-	tenantID := credential.GetString(spec.Config, "tenant_id", d.getTenantID())
-	clientID := credential.GetString(spec.Config, "client_id", "")
-	clientSecret := credential.GetString(spec.Config, "client_secret", "")
-	resourceURI := credential.GetString(spec.Config, "resource_uri", "https://management.azure.com/")
-
-	if clientID == "" || clientSecret == "" {
-		return nil, nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'client_secret' for bearer_token mint method")
+// MintCredentialWithExchange mints a bearer token via Azure AD Workload Identity
+// Federation: the caller-scoped Warden assertion in inputs is presented to Entra as a
+// client_assertion, so a keyless source needs no stored secret. Gated on a federation
+// source and a verified subject (Warden minted it — an unverified caller token is never
+// forwarded on Warden's authority).
+func (d *AzureDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) != azureAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("azure: workload identity federation requires auth_method=oidc_federation on the source")
+	}
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("azure: no subject token in exchange inputs")
+	}
+	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
+		return nil, nil, 0, "", fmt.Errorf("azure: workload identity federation requires a verified subject (subject_token_source=warden_identity)")
 	}
 
-	// Exchange for bearer token
-	token, expiresIn, err := d.acquireToken(ctx, tenantID, clientID, clientSecret, resourceURI)
+	mintMethod := credential.GetString(spec.Config, "mint_method", "bearer_token")
+	switch mintMethod {
+	case "bearer_token":
+		return d.mintBearerToken(ctx, spec, inputs.SubjectToken)
+	default:
+		return nil, nil, 0, "", fmt.Errorf("azure: mint_method %q is not supported over auth_method=oidc_federation (supported: bearer_token)", mintMethod)
+	}
+}
+
+// mintBearerToken exchanges the spec's SP identity for an Azure AD bearer token.
+// When assertion is non-empty the token is acquired via Workload Identity Federation
+// (the assertion is presented as a client_assertion, no client_secret needed);
+// otherwise the pre-provisioned client_secret from the spec is used.
+func (d *AzureDriver) mintBearerToken(ctx context.Context, spec *credential.CredSpec, assertion string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// Get SP identity from spec config (pre-provisioned)
+	tenantID := credential.GetString(spec.Config, "tenant_id", d.getTenantID())
+	clientID := credential.GetString(spec.Config, "client_id", "")
+	resourceURI := credential.GetString(spec.Config, "resource_uri", "https://management.azure.com/")
+
+	var token string
+	var expiresIn int
+	var err error
+	if assertion != "" {
+		if clientID == "" || tenantID == "" {
+			return nil, nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'tenant_id' for federated bearer_token mint method")
+		}
+		token, expiresIn, err = d.acquireTokenWithAssertion(ctx, tenantID, clientID, assertion, resourceURI)
+	} else {
+		clientSecret := credential.GetString(spec.Config, "client_secret", "")
+		if clientID == "" || clientSecret == "" {
+			return nil, nil, 0, "", fmt.Errorf("spec config must contain 'client_id' and 'client_secret' for bearer_token mint method")
+		}
+		token, expiresIn, err = d.acquireToken(ctx, tenantID, clientID, clientSecret, resourceURI)
+	}
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to acquire Azure AD token: %w", err)
 	}
@@ -695,17 +783,42 @@ func (d *AzureDriver) CleanupSpecRotation(ctx context.Context, cleanupConfig map
 
 // acquireToken exchanges client credentials for an Azure AD token
 func (d *AzureDriver) acquireToken(ctx context.Context, tenantID, clientID, clientSecret, resourceURI string) (string, int, error) {
-	if err := validateTenantID(tenantID); err != nil {
-		return "", 0, err
-	}
-
-	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
-
 	data := url.Values{}
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
 	data.Set("scope", resourceURI+".default")
 	data.Set("grant_type", "client_credentials")
+	return d.postTokenRequest(ctx, tenantID, data, "acquireToken")
+}
+
+// acquireTokenWithAssertion exchanges a Warden-minted assertion for an Azure AD token
+// via the JWT-bearer client-credentials grant (Workload Identity Federation). The
+// assertion is presented as a client_assertion instead of a client_secret; the target
+// app registration must trust Warden's OIDC issuer via a federated identity credential.
+func (d *AzureDriver) acquireTokenWithAssertion(ctx context.Context, tenantID, clientID, assertion, resourceURI string) (string, int, error) {
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("client_assertion_type", clientAssertionType)
+	data.Set("client_assertion", assertion)
+	data.Set("scope", resourceURI+".default")
+	data.Set("grant_type", "client_credentials")
+	return d.postTokenRequest(ctx, tenantID, data, "acquireTokenWithAssertion")
+}
+
+// postTokenRequest POSTs an OAuth2 token request to the Entra ID token endpoint for
+// tenantID and returns the access token and its lifetime in seconds. Callers supply the
+// grant-specific form fields (client_secret vs client_assertion); the URL construction,
+// tenant validation, HTTP call, and response decoding are shared.
+func (d *AzureDriver) postTokenRequest(ctx context.Context, tenantID string, data url.Values, operation string) (string, int, error) {
+	if err := validateTenantID(tenantID); err != nil {
+		return "", 0, err
+	}
+
+	host := d.loginHost
+	if host == "" {
+		host = defaultAzureLoginHost
+	}
+	tokenURL := fmt.Sprintf("%s/%s/oauth2/v2.0/token", host, tenantID)
 
 	respBody, err := d.doAzureRequest(ctx, azureAPIRequest{
 		method:      "POST",
@@ -713,7 +826,7 @@ func (d *AzureDriver) acquireToken(ctx context.Context, tenantID, clientID, clie
 		body:        []byte(data.Encode()),
 		contentType: "application/x-www-form-urlencoded",
 		okStatuses:  []int{http.StatusOK},
-		operation:   "acquireToken",
+		operation:   operation,
 	}, nil, 1)
 	if err != nil {
 		return "", 0, err
@@ -809,6 +922,12 @@ func (d *AzureDriver) getGraphTokenLocked(ctx context.Context) (string, error) {
 // hasGraphPermissions checks if the source has Graph API access (result is cached).
 // Uses graphPermsMu (not tokenMu) to avoid blocking token operations during the probe.
 func (d *AzureDriver) hasGraphPermissions() bool {
+	// A keyless federation source has no client_secret, so the source-token probe
+	// below would be a doomed round-trip. It also has nothing to rotate.
+	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
+		return false
+	}
+
 	d.graphPermsMu.Lock()
 	defer d.graphPermsMu.Unlock()
 

--- a/credential/drivers/azure_driver_test.go
+++ b/credential/drivers/azure_driver_test.go
@@ -3,10 +3,12 @@ package drivers
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -501,4 +503,204 @@ func TestAzureBearerTokenMetadata(t *testing.T) {
 		_, ok := v.(string)
 		assert.Truef(t, ok, "metadata[%q] is %T, expected string", k, v)
 	}
+}
+
+// TestAzureDriverFactory_ValidateConfig_Federation covers the per-auth_method
+// cross-field rules for a keyless (oidc_federation) source.
+func TestAzureDriverFactory_ValidateConfig_Federation(t *testing.T) {
+	factory := &AzureDriverFactory{}
+
+	// A keyless source needs no client_secret/secret_id.
+	require.NoError(t, factory.ValidateConfig(map[string]string{
+		"auth_method": "oidc_federation",
+		"tenant_id":   "00000000-0000-0000-0000-000000000001",
+		"client_id":   "00000000-0000-0000-0000-000000000002",
+	}))
+
+	// A keyless source with no identity at all is still valid (tenant/client_id
+	// come from the spec at mint time).
+	require.NoError(t, factory.ValidateConfig(map[string]string{
+		"auth_method": "oidc_federation",
+	}))
+
+	// A stray static secret must be rejected so modes cannot silently mix.
+	err := factory.ValidateConfig(map[string]string{
+		"auth_method":   "oidc_federation",
+		"client_secret": "leftover",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be set for auth_method=oidc_federation")
+
+	err = factory.ValidateConfig(map[string]string{
+		"auth_method": "oidc_federation",
+		"secret_id":   "leftover",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be set for auth_method=oidc_federation")
+
+	// An unknown auth_method is rejected by the schema.
+	err = factory.ValidateConfig(map[string]string{"auth_method": "bogus"})
+	require.Error(t, err)
+}
+
+// TestAzureDriver_Create_Federation_Keyless verifies an oidc_federation source is
+// constructed with no client_secret and without an eager token probe (no network).
+func TestAzureDriver_Create_Federation_Keyless(t *testing.T) {
+	factory := &AzureDriverFactory{}
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := factory.Create(map[string]string{
+		"auth_method": "oidc_federation",
+		"tenant_id":   "00000000-0000-0000-0000-000000000001",
+		"client_id":   "00000000-0000-0000-0000-000000000002",
+	}, log)
+	require.NoError(t, err)
+	require.NotNil(t, drv)
+
+	azureDrv := drv.(*AzureDriver)
+	assert.False(t, azureDrv.sourceVerified, "a keyless source performs no eager probe")
+	// A keyless source has nothing to rotate and never probes Graph.
+	assert.False(t, azureDrv.SupportsRotation())
+	assert.False(t, azureDrv.SupportsSpecRotation())
+}
+
+// TestAzureDriver_MintCredential_Federation_FailsClosed verifies the non-exchange
+// path refuses to mint for a keyless source (which carries no credential material).
+func TestAzureDriver_MintCredential_Federation_FailsClosed(t *testing.T) {
+	drv := &AzureDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAzure, Config: map[string]string{"auth_method": "oidc_federation"}},
+	}
+	_, _, _, _, err := drv.MintCredential(context.TODO(), &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "bearer_token"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject_token_source=warden_identity")
+}
+
+// TestAzureDriver_MintCredentialWithExchange_Guards covers the exchange-path guards
+// before any network call.
+func TestAzureDriver_MintCredentialWithExchange_Guards(t *testing.T) {
+	fedDrv := &AzureDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAzure, Config: map[string]string{"auth_method": "oidc_federation"}},
+	}
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "bearer_token", "tenant_id": "00000000-0000-0000-0000-000000000001", "client_id": "app"}}
+	verified := &credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+
+	// A static source must not reach the federation path.
+	staticDrv := &AzureDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAzure, Config: map[string]string{"auth_method": "static"}},
+	}
+	_, _, _, _, err := staticDrv.MintCredentialWithExchange(context.TODO(), spec, verified)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth_method=oidc_federation")
+
+	// Missing subject token.
+	_, _, _, _, err = fedDrv.MintCredentialWithExchange(context.TODO(), spec, &credential.ExchangeInputs{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no subject token")
+
+	// Unverified origin must be rejected (only Warden-minted assertions allowed).
+	_, _, _, _, err = fedDrv.MintCredentialWithExchange(context.TODO(), spec, &credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenOrigin: credential.ExchangeOriginUnverified})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verified subject")
+
+	// An unsupported mint_method is rejected before any network call.
+	kvSpec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "key_vault_secret", "tenant_id": "00000000-0000-0000-0000-000000000001", "client_id": "app"}}
+	_, _, _, _, err = fedDrv.MintCredentialWithExchange(context.TODO(), kvSpec, verified)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported over auth_method=oidc_federation")
+
+	// A federated bearer_token spec missing tenant_id fails with a clear message
+	// (defense in depth — spec validation also requires it at create time).
+	noTenant := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "bearer_token", "client_id": "app"}}
+	_, _, _, _, err = fedDrv.MintCredentialWithExchange(context.TODO(), noTenant, verified)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'client_id' and 'tenant_id'")
+}
+
+// TestAzureDriver_MintCredentialWithExchange_HappyPath drives mint_method=bearer_token
+// over a keyless source against a mocked Entra token endpoint, asserting the Warden
+// assertion is forwarded as a client_assertion (and no client_secret is sent).
+func TestAzureDriver_MintCredentialWithExchange_HappyPath(t *testing.T) {
+	var gotAssertion, gotAssertionType, gotClientID, gotScope, gotGrant, gotSecret string
+	var sawSecretKey bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotAssertion = r.PostForm.Get("client_assertion")
+		gotAssertionType = r.PostForm.Get("client_assertion_type")
+		gotClientID = r.PostForm.Get("client_id")
+		gotScope = r.PostForm.Get("scope")
+		gotGrant = r.PostForm.Get("grant_type")
+		gotSecret, sawSecretKey = r.PostForm.Get("client_secret"), r.PostForm.Has("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"eyJ.azure.token","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	drv := &AzureDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAzure, Config: map[string]string{"auth_method": "oidc_federation"}},
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		loginHost:  srv.URL,
+	}
+	spec := &credential.CredSpec{Name: "azure-mgmt", Config: map[string]string{
+		"mint_method":  "bearer_token",
+		"tenant_id":    "00000000-0000-0000-0000-000000000001",
+		"client_id":    "11111111-1111-1111-1111-111111111111",
+		"resource_uri": "https://management.azure.com/",
+	}}
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       "eyJ.warden.assertion",
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginVerified,
+	}
+
+	rawData, metadata, ttl, leaseID, err := drv.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+
+	// The Warden assertion is presented as a client_assertion (JWT-bearer), never a secret.
+	assert.Equal(t, "eyJ.warden.assertion", gotAssertion)
+	assert.Equal(t, clientAssertionType, gotAssertionType)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", gotClientID)
+	assert.Equal(t, "https://management.azure.com/.default", gotScope)
+	assert.Equal(t, "client_credentials", gotGrant)
+	assert.False(t, sawSecretKey, "a federated exchange must not send a client_secret")
+	assert.Empty(t, gotSecret)
+
+	// The minted bearer token surfaces as the credential.
+	assert.Equal(t, "eyJ.azure.token", rawData["access_token"])
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", metadata["subject"])
+	assert.Equal(t, time.Hour, ttl)
+	assert.Empty(t, leaseID, "bearer tokens expire naturally; no lease")
+}
+
+// TestAzureDriver_MintBearerToken_Static_HappyPath exercises the static client_secret
+// path through the refactored postTokenRequest helper: the secret is sent (never a
+// client_assertion) and the minted token surfaces.
+func TestAzureDriver_MintBearerToken_Static_HappyPath(t *testing.T) {
+	var gotSecret, gotAssertion, gotGrant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotSecret = r.PostForm.Get("client_secret")
+		gotAssertion = r.PostForm.Get("client_assertion")
+		gotGrant = r.PostForm.Get("grant_type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"eyJ.static.token","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	drv := &AzureDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAzure, Config: map[string]string{"auth_method": "static"}},
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		loginHost:  srv.URL,
+	}
+	spec := &credential.CredSpec{Name: "azure-static", Config: map[string]string{
+		"mint_method":   "bearer_token",
+		"tenant_id":     "00000000-0000-0000-0000-000000000001",
+		"client_id":     "11111111-1111-1111-1111-111111111111",
+		"client_secret": "the-secret",
+	}}
+
+	rawData, _, _, _, err := drv.MintCredential(context.TODO(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "the-secret", gotSecret)
+	assert.Empty(t, gotAssertion, "static path must not send a client_assertion")
+	assert.Equal(t, "client_credentials", gotGrant)
+	assert.Equal(t, "eyJ.static.token", rawData["access_token"])
 }

--- a/credential/types/azure_bearer_token.go
+++ b/credential/types/azure_bearer_token.go
@@ -72,13 +72,11 @@ func (t *AzureBearerTokenCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("12345678-1234-1234-1234-123456789012"),
 
 		credential.StringField("client_secret").
-			Required().
-			Describe("Azure AD service principal client secret").
+			Describe("Azure AD service principal client secret (required for static specs; omit for keyless federation)").
 			Example("my-client-secret"),
 
 		credential.StringField("secret_id").
-			Required().
-			Describe("Azure AD password credential ID for rotation tracking").
+			Describe("Azure AD password credential ID for rotation tracking (required for static specs; omit for keyless federation)").
 			Example("uuid-secret-id"),
 
 		credential.StringField("resource_uri").
@@ -117,6 +115,27 @@ func (t *AzureBearerTokenCredType) ValidateConfig(config map[string]string, sour
 	schema := t.ConfigSchema()
 	if err := credential.ValidateSchema(config, schema...); err != nil {
 		return err
+	}
+
+	// Step 3: Cross-field rules for keyless federation vs static specs.
+	// A federated spec (subject_token_source set) presents a Warden assertion as a
+	// client_assertion, so it holds no client_secret. The audience/algorithm rules
+	// for warden_identity are enforced generically by ValidateExchangeSpecConfig.
+	mintMethod := config["mint_method"]
+	if credential.SpecRequestsExchange(config) {
+		if config["tenant_id"] == "" {
+			return fmt.Errorf("'tenant_id' is required for a keyless federated spec (a spec with subject_token_source)")
+		}
+		if config["client_secret"] != "" || config["secret_id"] != "" {
+			return fmt.Errorf("'client_secret'/'secret_id' must not be set for a keyless federated spec")
+		}
+		if mintMethod != "" && mintMethod != "bearer_token" {
+			return fmt.Errorf("mint_method %q is not supported over federation (supported: bearer_token)", mintMethod)
+		}
+	} else {
+		if config["client_secret"] == "" || config["secret_id"] == "" {
+			return fmt.Errorf("'client_secret' and 'secret_id' are required for a static azure spec")
+		}
 	}
 
 	return nil

--- a/credential/types/azure_bearer_token_test.go
+++ b/credential/types/azure_bearer_token_test.go
@@ -121,6 +121,95 @@ func TestAzureBearerTokenCredType_ValidateConfig(t *testing.T) {
 	}
 }
 
+func TestAzureBearerTokenCredType_ValidateConfig_Federation(t *testing.T) {
+	credType := NewAzureBearerTokenCredType()
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid federated spec",
+			config: map[string]string{
+				"mint_method":          "bearer_token",
+				"subject_token_source": "warden_identity",
+				"assertion_audience":   "api://AzureADTokenExchange",
+				"tenant_id":            "00000000-0000-0000-0000-000000000001",
+				"client_id":            "11111111-1111-1111-1111-111111111111",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid federated spec with default mint_method",
+			config: map[string]string{
+				"subject_token_source": "warden_identity",
+				"assertion_audience":   "api://AzureADTokenExchange",
+				"tenant_id":            "00000000-0000-0000-0000-000000000001",
+				"client_id":            "11111111-1111-1111-1111-111111111111",
+			},
+			wantErr: false,
+		},
+		{
+			name: "federated spec missing tenant_id",
+			config: map[string]string{
+				"subject_token_source": "warden_identity",
+				"assertion_audience":   "api://AzureADTokenExchange",
+				"client_id":            "11111111-1111-1111-1111-111111111111",
+			},
+			wantErr: true,
+			errMsg:  "tenant_id",
+		},
+		{
+			name: "federated spec must not carry client_secret",
+			config: map[string]string{
+				"subject_token_source": "warden_identity",
+				"assertion_audience":   "api://AzureADTokenExchange",
+				"tenant_id":            "00000000-0000-0000-0000-000000000001",
+				"client_id":            "11111111-1111-1111-1111-111111111111",
+				"client_secret":        "leftover",
+			},
+			wantErr: true,
+			errMsg:  "must not be set",
+		},
+		{
+			name: "federated spec rejects key_vault_secret",
+			config: map[string]string{
+				"mint_method":          "key_vault_secret",
+				"subject_token_source": "warden_identity",
+				"assertion_audience":   "api://AzureADTokenExchange",
+				"tenant_id":            "00000000-0000-0000-0000-000000000001",
+				"client_id":            "11111111-1111-1111-1111-111111111111",
+			},
+			wantErr: true,
+			errMsg:  "not supported over federation",
+		},
+		{
+			name: "federated spec still requires client_id",
+			config: map[string]string{
+				"subject_token_source": "warden_identity",
+				"assertion_audience":   "api://AzureADTokenExchange",
+				"tenant_id":            "00000000-0000-0000-0000-000000000001",
+			},
+			wantErr: true,
+			errMsg:  "client_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := credType.ValidateConfig(tt.config, credential.SourceTypeAzure)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestAzureBearerTokenCredType_Parse(t *testing.T) {
 	credType := NewAzureBearerTokenCredType()
 


### PR DESCRIPTION
## Summary

Adds **Azure AD Workload Identity Federation** (keyless) to the Azure credential driver, mirroring the existing AWS keyless path. Instead of a stored `client_secret`, the driver presents a short-lived Warden-minted assertion to Entra as a `client_assertion` (JWT-bearer grant), and Entra validates it against Warden's published JWKS via a federated identity credential.

Two-sided opt-in, identical in shape to AWS:
- **Source** (`azure`): `auth_method=oidc_federation` — no `client_secret`/`secret_id`.
- **Spec** (`azure_bearer_token`): `subject_token_source=warden_identity` + `assertion_audience` + `mint_method=bearer_token` + `client_id`/`tenant_id`.

Scope: only `bearer_token` is federated; `key_vault_secret` fails closed at spec-create and at mint. No changes to the OIDC issuer, publisher, or exchange plumbing — the `warden_identity` minting and `ExchangeMinter` dispatch are shared with AWS.

## Changes

- **`credential/drivers/azure_driver.go`**
  - `MintCredentialWithExchange` (implements `ExchangeMinter`), gated on a federation source **and** a verified subject origin.
  - `acquireTokenWithAssertion` presents the assertion as `client_assertion`; extracted a shared `postTokenRequest` helper (also used by the static path).
  - `Create` skips the eager token probe for keyless sources; `hasGraphPermissions` short-circuits so a keyless source reports no rotation support.
  - `auth_method` field + per-mode cross-field validation; `InferCredentialType` accepts `bearer_token`.
- **`credential/types/azure_bearer_token.go`** — `client_secret`/`secret_id` relaxed from required; exchange specs require `client_id`/`tenant_id`, reject secrets, and reject `key_vault_secret`.
- **`core/credential_config_store.go`** — reject `rotation_period` on any token-exchange spec (minted per request, nothing to rotate) rather than merely exempting the requirement.

## Testing

- `go build ./...`, `gofmt`, `go vet` clean.
- New unit tests: federated mint happy-path (asserts `client_assertion` sent, **no** `client_secret`), exchange guards (static source / missing subject / unverified origin / `key_vault_secret`), static path through the refactored helper, spec-validation branches, and the rotation-on-exchange-spec rule.
- Verified end-to-end against real Entra ID using an S3-published JWKS: Warden mints the assertion → federates at Entra → injects the bearer token → proxies to Azure Resource Manager.
