### PR TITLE
feat(credential): support auth_token subject for web-identity federation

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -331,7 +331,7 @@ func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	// clearly rather than falling into authenticate() with empty keys and a misleading
 	// "invalid AWS credentials" error.
 	if authMethod == awsAuthMethodOIDCFederation {
-		return nil, nil, 0, "", fmt.Errorf("auth_method=oidc_federation requires subject_token_source=warden_identity on the spec (federated minting runs through the token-exchange path)")
+		return nil, nil, 0, "", fmt.Errorf("auth_method=oidc_federation requires subject_token_source on the spec (warden_identity or auth_token); federated minting runs through the token-exchange path")
 	}
 
 	// Re-authenticate if needed
@@ -443,13 +443,19 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 	return rawData, metadata, leaseTTL, leaseID, nil
 }
 
-// MintCredentialWithExchange federates a caller-derived identity assertion into AWS
-// via sts:AssumeRoleWithWebIdentity (Workload Identity Federation), then produces the
+// MintCredentialWithExchange federates a caller-derived identity into AWS via
+// sts:AssumeRoleWithWebIdentity (Workload Identity Federation), then produces the
 // outcome the spec's mint_method asks for. It requires a keyless source
-// (auth_method=oidc_federation) and a verified subject (a Warden-minted assertion,
-// subject_token_source=warden_identity): AWS validates the assertion's signature against
-// Warden's published JWKS, so an unverified caller token must never be forwarded on
-// Warden's authority.
+// (auth_method=oidc_federation) and a verified subject, of which there are two shapes:
+//   - subject_token_source=warden_identity: Warden mints a fresh assertion and AWS
+//     validates its signature against Warden's published JWKS (federate Warden once).
+//   - subject_token_source=auth_token: Warden forwards the caller's origin-verified
+//     inbound JWT untouched, and AWS validates it against the origin IdP's JWKS
+//     (the role must federate that IdP directly, and its trust policy must accept the
+//     token's audience — Warden pins nothing here since it did not mint the token).
+//
+// Either way the subject is one Warden verified inbound; an unverified caller token
+// (subject_token_source=header) is never forwarded on Warden's authority.
 //
 // Supported mint methods over federation:
 //   - sts_assume_role: the federated role credentials are themselves the issued credential.
@@ -462,7 +468,7 @@ func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		return nil, nil, 0, "", fmt.Errorf("aws: no subject token in exchange inputs")
 	}
 	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
-		return nil, nil, 0, "", fmt.Errorf("aws: web-identity federation requires a verified subject (subject_token_source=warden_identity)")
+		return nil, nil, 0, "", fmt.Errorf("aws: web-identity federation requires a verified subject (subject_token_source=warden_identity or auth_token); a caller-supplied, unverified subject is rejected")
 	}
 
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -602,7 +602,7 @@ func TestAWSDriver_MintGuards(t *testing.T) {
 	for _, mm := range []string{"secrets_manager", "sts_assume_role"} {
 		_, _, _, _, err := wifDrv.MintCredential(context.TODO(), &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": mm}})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "requires subject_token_source=warden_identity")
+		assert.Contains(t, err.Error(), "requires subject_token_source on the spec (warden_identity or auth_token)")
 	}
 }
 
@@ -707,6 +707,65 @@ func TestAWSDriver_WebIdentity_HappyPath(t *testing.T) {
 	assert.Equal(t, "123456789012", metadata["account_id"])
 	assert.Equal(t, "sts:ASIAEXAMPLE", leaseID)
 	assert.Greater(t, ttl, time.Duration(0))
+}
+
+// TestAWSDriver_WebIdentity_ForwardedSubject_HappyPath drives the auth_token federation
+// topology: the subject is the caller's origin-verified inbound JWT that Warden forwards
+// untouched (not a Warden-minted assertion), so ResolveSubjectToken and CacheIdentity are
+// unset. The driver treats any verified subject the same, so this must reach STS and
+// forward the token verbatim. It guards the supported contract against a future change
+// that re-gates federation to Warden-minted subjects only.
+func TestAWSDriver_WebIdentity_ForwardedSubject_HappyPath(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotToken = r.Form.Get("WebIdentityToken")
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>secretexample</SecretAccessKey>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/App/warden-wid</Arn>
+      <AssumedRoleId>AROAEXAMPLE:warden-wid</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
+	}))
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{"auth_method": "oidc_federation", "region": "us-east-1"}},
+		logger:     log,
+		region:     "us-east-1",
+		anonSTSClient: sts.New(sts.Options{
+			Region:       "us-east-1",
+			BaseEndpoint: aws.String(srv.URL),
+			Credentials:  aws.AnonymousCredentials{},
+		}),
+	}
+	spec := &credential.CredSpec{Name: "wid", Config: map[string]string{
+		"mint_method": "sts_assume_role",
+		"role_arn":    "arn:aws:iam::123456789012:role/App",
+		"ttl":         "15m",
+	}}
+	// A forwarded inbound JWT: verified origin, but no ResolveSubjectToken and no
+	// CacheIdentity (the token is eager and stable, so it keys the cache itself).
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       "eyJ.inbound.idp.jwt",
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginVerified,
+	}
+
+	rawData, _, _, _, err := drv.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJ.inbound.idp.jwt", gotToken, "the forwarded inbound JWT must be sent as WebIdentityToken verbatim")
+	assert.Equal(t, "ASIAEXAMPLE", rawData["access_key_id"])
 }
 
 // TestAWSDriver_SecretsManager_WebIdentity_HappyPath drives the keyless two-step:

--- a/credential/drivers/azure_driver.go
+++ b/credential/drivers/azure_driver.go
@@ -360,7 +360,7 @@ func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	// caller-scoped assertion. Fail closed here to avoid silently minting with
 	// no credential material.
 	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
-		return nil, nil, 0, "", fmt.Errorf("azure: source uses auth_method=oidc_federation; the spec must set subject_token_source=warden_identity")
+		return nil, nil, 0, "", fmt.Errorf("azure: source uses auth_method=oidc_federation; the spec must set subject_token_source (warden_identity or auth_token)")
 	}
 
 	mintMethod := credential.GetString(spec.Config, "mint_method", "bearer_token")
@@ -376,10 +376,13 @@ func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredS
 }
 
 // MintCredentialWithExchange mints a bearer token via Azure AD Workload Identity
-// Federation: the caller-scoped Warden assertion in inputs is presented to Entra as a
-// client_assertion, so a keyless source needs no stored secret. Gated on a federation
-// source and a verified subject (Warden minted it — an unverified caller token is never
-// forwarded on Warden's authority).
+// Federation: the subject in inputs is presented to Entra as a client_assertion, so a
+// keyless source needs no stored secret. Gated on a federation source and a verified
+// subject, of which there are two shapes: a Warden-minted assertion
+// (subject_token_source=warden_identity, the app federates Warden's issuer) or the
+// caller's origin-verified inbound JWT forwarded untouched (subject_token_source=auth_token,
+// the app's federated credential must trust the origin IdP directly). An unverified caller
+// token (subject_token_source=header) is never forwarded on Warden's authority.
 func (d *AzureDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) != azureAuthMethodOIDCFederation {
 		return nil, nil, 0, "", fmt.Errorf("azure: workload identity federation requires auth_method=oidc_federation on the source")
@@ -388,7 +391,7 @@ func (d *AzureDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 		return nil, nil, 0, "", fmt.Errorf("azure: no subject token in exchange inputs")
 	}
 	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
-		return nil, nil, 0, "", fmt.Errorf("azure: workload identity federation requires a verified subject (subject_token_source=warden_identity)")
+		return nil, nil, 0, "", fmt.Errorf("azure: workload identity federation requires a verified subject (subject_token_source=warden_identity or auth_token); a caller-supplied, unverified subject is rejected")
 	}
 
 	mintMethod := credential.GetString(spec.Config, "mint_method", "bearer_token")

--- a/credential/drivers/azure_driver_test.go
+++ b/credential/drivers/azure_driver_test.go
@@ -571,7 +571,7 @@ func TestAzureDriver_MintCredential_Federation_FailsClosed(t *testing.T) {
 	}
 	_, _, _, _, err := drv.MintCredential(context.TODO(), &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "bearer_token"}})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "subject_token_source=warden_identity")
+	assert.Contains(t, err.Error(), "subject_token_source (warden_identity or auth_token)")
 }
 
 // TestAzureDriver_MintCredentialWithExchange_Guards covers the exchange-path guards
@@ -668,6 +668,51 @@ func TestAzureDriver_MintCredentialWithExchange_HappyPath(t *testing.T) {
 	assert.Equal(t, "11111111-1111-1111-1111-111111111111", metadata["subject"])
 	assert.Equal(t, time.Hour, ttl)
 	assert.Empty(t, leaseID, "bearer tokens expire naturally; no lease")
+}
+
+// TestAzureDriver_MintCredentialWithExchange_ForwardedSubject_HappyPath drives the
+// auth_token federation topology: the subject is the caller's origin-verified inbound JWT
+// that Warden forwards untouched (not a Warden-minted assertion), so ResolveSubjectToken
+// and CacheIdentity are unset. The driver treats any verified subject the same, so this
+// must reach Entra and be presented as the client_assertion verbatim. It guards the
+// supported contract against a future change that re-gates federation to Warden-minted
+// subjects only.
+func TestAzureDriver_MintCredentialWithExchange_ForwardedSubject_HappyPath(t *testing.T) {
+	var gotAssertion, gotAssertionType string
+	var sawSecretKey bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotAssertion = r.PostForm.Get("client_assertion")
+		gotAssertionType = r.PostForm.Get("client_assertion_type")
+		_, sawSecretKey = r.PostForm.Get("client_secret"), r.PostForm.Has("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"eyJ.azure.token","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	drv := &AzureDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAzure, Config: map[string]string{"auth_method": "oidc_federation"}},
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		loginHost:  srv.URL,
+	}
+	spec := &credential.CredSpec{Name: "azure-mgmt", Config: map[string]string{
+		"mint_method": "bearer_token",
+		"tenant_id":   "00000000-0000-0000-0000-000000000001",
+		"client_id":   "11111111-1111-1111-1111-111111111111",
+	}}
+	// A forwarded inbound JWT: verified origin, no ResolveSubjectToken, no CacheIdentity.
+	inputs := &credential.ExchangeInputs{
+		SubjectToken:       "eyJ.inbound.idp.jwt",
+		SubjectTokenType:   credential.TokenTypeJWT,
+		SubjectTokenOrigin: credential.ExchangeOriginVerified,
+	}
+
+	rawData, _, _, _, err := drv.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJ.inbound.idp.jwt", gotAssertion, "the forwarded inbound JWT must be presented as the client_assertion verbatim")
+	assert.Equal(t, clientAssertionType, gotAssertionType)
+	assert.False(t, sawSecretKey, "a federated exchange must not send a client_secret")
+	assert.Equal(t, "eyJ.azure.token", rawData["access_token"])
 }
 
 // TestAzureDriver_MintBearerToken_Static_HappyPath exercises the static client_secret


### PR DESCRIPTION
## What

Make `subject_token_source=auth_token` a first-class, tested subject for AWS/Azure web-identity federation, alongside the existing `warden_identity`.

Two legitimate federation topologies exist:

- **`warden_identity`** — Warden mints a fresh assertion against its own JWKS; the provider federates Warden's issuer once, and the agent's inbound auth method is fungible.
- **`auth_token`** — the agent's identity already comes from an IdP the provider federates **directly**, so Warden forwards the caller's origin-verified inbound JWT untouched instead of re-minting.

## Why

The second topology already worked mechanically: both drivers gate only on `origin == verified`, and `auth_token` produces a verified subject. But every fail-closed hint, origin-gate error, and the AWS doc comment hard-named `subject_token_source=warden_identity` as the *only* valid subject — so operators reading the errors believed `auth_token` was unsupported, and the path had no test coverage. The contract lied.

## What changed

Contract only — **no gate-logic, field, or config-key change** (the origin gate already admitted `auth_token`):

- Generalized the five `warden_identity`-only strings across `aws_driver.go` and `azure_driver.go` to name both valid subjects and state the real invariant: a *verified* subject is required; an unverified `header` subject is still rejected.
- Rewrote the AWS/Azure exchange doc comments to describe both topologies, including that with `auth_token` the provider must federate the origin IdP directly and its trust policy must accept the token's audience — Warden pins nothing there since it did not mint the token.

Tests:

- Updated the two assertions that pinned the old wording.
- Added a forwarded-subject happy-path per driver (`..._ForwardedSubject_HappyPath`): a verified subject with no lazy resolver reaches STS/Entra and is forwarded verbatim. These guard the supported contract against a future re-gate to Warden-minted subjects only.
- Confirmed the core wiring (`auth_token` → verified origin, nil resolver) is already covered.

## Out of scope

- **Docs** — the whole `oidc_federation` federation feature is currently undocumented in `aws.md`/`azure.md`; documenting both modes is a separate follow-up.
- **Audience validation** — reconciling the forwarded token's `aud` with the provider trust policy is the operator's job by design.

## Verification

`go build ./...`, `gofmt`, `go vet`, and the full `credential/...` + `core/...` suites pass.
