### PR TITLE
feat(oidc): add oidcsign remote-signer package with transit backend

### DIFF
--- a/core/oidcsign/backend.go
+++ b/core/oidcsign/backend.go
@@ -1,0 +1,134 @@
+// Package oidcsign provides remote signing backends for the OIDC issuer's
+// signing keys, so an operator can hold the private key in an external KMS (e.g.
+// an OpenBao/Vault transit engine) where it never leaves the KMS. Warden keeps
+// only a handle plus the public key and asks the KMS to sign each assertion.
+//
+// The package has no dependency on the core package: a Backend produces a
+// crypto.Signer (Signer) that drops into the issuer's signingKey.key seam, and
+// signing/verification flow through the standard crypto.Signer / crypto.PublicKey
+// interfaces. Cloud KMS and PKCS#11/HSM backends can be added by implementing
+// Backend without touching the issuer.
+package oidcsign
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"io"
+	"time"
+)
+
+// ErrRotationUnsupported is returned by a Backend whose keys are provisioned and
+// rotated out-of-band (e.g. an HSM referenced by label): NewVersion is not a
+// programmatic operation there, and the caller degrades to operator-managed
+// rotation. The transit backend supports rotation and never returns this.
+var ErrRotationUnsupported = errors.New("oidcsign: backend does not support programmatic key rotation")
+
+// KeyRef names one immutable key version in the backend. Alg is carried so a
+// stateless Sign call can select the signing parameters (hash, and PKCS#1 v1.5
+// vs the KMS default) without inspecting key material.
+type KeyRef struct {
+	KeyName string
+	Version int
+	Alg     string // JWS alg, e.g. "RS256" / "ES256"
+}
+
+// KeyInfo is a provisioned key version and its public half.
+type KeyInfo struct {
+	Ref       KeyRef
+	Public    crypto.PublicKey // *rsa.PublicKey or *ecdsa.PublicKey
+	CreatedAt time.Time        // KMS-side creation time; anchors rotation scheduling
+}
+
+// Backend provisions and signs with keys whose private half never leaves the KMS.
+//
+// Create/rotate are optional capabilities: a backend whose keys are provisioned
+// out-of-band (HSM/KMIP) implements EnsureKey as "adopt an existing key by
+// reference" and may return ErrRotationUnsupported from NewVersion.
+type Backend interface {
+	// Type is the persisted discriminator, e.g. "transit".
+	Type() string
+	// EnsureKey ensures alg's key exists (idempotent) and returns its latest version.
+	EnsureKey(ctx context.Context, alg string) (KeyInfo, error)
+	// NewVersion rotates alg's key and returns the new latest version, or
+	// ErrRotationUnsupported for out-of-band-managed backends.
+	NewVersion(ctx context.Context, alg string) (KeyInfo, error)
+	// PublicKey fetches one specific version's public key.
+	PublicKey(ctx context.Context, ref KeyRef) (crypto.PublicKey, error)
+	// Sign signs an already-hashed digest with the exact version in ref, honoring
+	// the crypto.Signer contract: RSA -> PKCS#1 v1.5 raw bytes; ECDSA -> ASN.1 DER.
+	Sign(ctx context.Context, ref KeyRef, digest []byte, opts crypto.SignerOpts) ([]byte, error)
+	// Close releases resources (e.g. stops token renewal).
+	Close()
+}
+
+// algParams maps a JWS alg to the backend-neutral signing parameters. Duplicated
+// from the core alg table by value (these are standard wire constants) to keep
+// this package free of a core import.
+type algParams struct {
+	transitKeyType string      // transit key type, e.g. "rsa-2048"
+	hashName       string      // transit hash_algorithm, e.g. "sha2-256"
+	hash           crypto.Hash // the digest the caller must have used
+	isRSA          bool
+}
+
+var algParamsByAlg = map[string]algParams{
+	"RS256": {transitKeyType: "rsa-2048", hashName: "sha2-256", hash: crypto.SHA256, isRSA: true},
+	"RS384": {transitKeyType: "rsa-3072", hashName: "sha2-384", hash: crypto.SHA384, isRSA: true},
+	"ES256": {transitKeyType: "ecdsa-p256", hashName: "sha2-256", hash: crypto.SHA256, isRSA: false},
+	"ES384": {transitKeyType: "ecdsa-p384", hashName: "sha2-384", hash: crypto.SHA384, isRSA: false},
+}
+
+// Signer adapts one (Backend, KeyRef) pair to crypto.Signer, so it drops into the
+// issuer's signingKey.key. It holds no private key material — Sign reaches the
+// backend. A nil backend makes it verification-only (Public works; Sign fails
+// closed), used for retired remote keys after a cutover or once the stanza is
+// removed.
+type Signer struct {
+	backend Backend
+	ref     KeyRef
+	pub     crypto.PublicKey
+	timeout time.Duration
+	ctx     context.Context // optional request-scoped context bound via WithContext
+}
+
+// NewSigner builds a Signer. backend may be nil for a verification-only signer.
+func NewSigner(backend Backend, ref KeyRef, pub crypto.PublicKey, timeout time.Duration) *Signer {
+	return &Signer{backend: backend, ref: ref, pub: pub, timeout: timeout}
+}
+
+// Public returns the cached public key (never a KMS round-trip).
+func (s *Signer) Public() crypto.PublicKey { return s.pub }
+
+// Ref returns the backend key reference this signer is bound to.
+func (s *Signer) Ref() KeyRef { return s.ref }
+
+// CanSign reports whether this signer has a live backend (vs verification-only).
+func (s *Signer) CanSign() bool { return s.backend != nil }
+
+// Sign signs an already-hashed digest by asking the backend, under a per-call
+// timeout bounded further by any context bound via WithContext.
+func (s *Signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	if s.backend == nil {
+		return nil, errors.New("oidcsign: no signing backend for this key (verification-only)")
+	}
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.timeout)
+		defer cancel()
+	}
+	return s.backend.Sign(ctx, s.ref, digest, opts)
+}
+
+// WithContext returns a shallow copy bound to ctx, so the mint request's
+// deadline/cancellation reaches the backend round-trip. Implements the optional
+// interface signJWT type-asserts.
+func (s *Signer) WithContext(ctx context.Context) crypto.Signer {
+	cp := *s
+	cp.ctx = ctx
+	return &cp
+}

--- a/core/oidcsign/transit.go
+++ b/core/oidcsign/transit.go
@@ -1,0 +1,460 @@
+package oidcsign
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stephnangue/warden/logger"
+)
+
+// backendTypeTransit is the persisted discriminator for the transit backend.
+const backendTypeTransit = "transit"
+
+// TransitConfig configures a transit-backed remote signer. It mirrors the fields
+// of the `signer "transit"` HCL stanza.
+type TransitConfig struct {
+	Address        string
+	Token          string // optional; falls back to VAULT_TOKEN via api.NewClient
+	MountPath      string // transit mount, e.g. "transit"
+	KeyNamePrefix  string // e.g. "warden-oidc" -> keys warden-oidc-rs256, warden-oidc-es256
+	Namespace      string
+	RequestTimeout time.Duration
+	DisableRenewal bool
+
+	TLSCACert     string
+	TLSCAPath     string
+	TLSClientCert string
+	TLSClientKey  string
+	TLSServerName string
+	TLSSkipVerify bool
+}
+
+// TransitBackend signs OIDC assertions via an OpenBao/Vault transit engine, where
+// the private key is created non-exportable and never leaves the KMS.
+type TransitBackend struct {
+	client        *api.Client
+	mountPath     string
+	keyNamePrefix string
+	timeout       time.Duration
+	watcher       *api.LifetimeWatcher
+	log           *logger.GatedLogger
+}
+
+var _ Backend = (*TransitBackend)(nil)
+
+// NewTransitBackend builds a transit-backed signer client. A construction failure
+// (bad TLS material, malformed address) is a config error and is returned here;
+// transit being unreachable is not detected until a key operation. log may be nil.
+func NewTransitBackend(cfg TransitConfig, log *logger.GatedLogger) (*TransitBackend, error) {
+	if strings.TrimSpace(cfg.MountPath) == "" {
+		return nil, fmt.Errorf("oidcsign: transit mount_path is required")
+	}
+	if strings.TrimSpace(cfg.KeyNamePrefix) == "" {
+		return nil, fmt.Errorf("oidcsign: transit key_name_prefix is required")
+	}
+
+	apiCfg := api.DefaultConfig()
+	if cfg.Address != "" {
+		apiCfg.Address = cfg.Address
+	}
+	if cfg.TLSCACert != "" || cfg.TLSCAPath != "" || cfg.TLSClientCert != "" ||
+		cfg.TLSClientKey != "" || cfg.TLSServerName != "" || cfg.TLSSkipVerify {
+		tls := &api.TLSConfig{
+			CACert:        cfg.TLSCACert,
+			CAPath:        cfg.TLSCAPath,
+			ClientCert:    cfg.TLSClientCert,
+			ClientKey:     cfg.TLSClientKey,
+			TLSServerName: cfg.TLSServerName,
+			Insecure:      cfg.TLSSkipVerify,
+		}
+		if err := apiCfg.ConfigureTLS(tls); err != nil {
+			return nil, fmt.Errorf("oidcsign: configure transit TLS: %w", err)
+		}
+	}
+
+	client, err := api.NewClient(apiCfg)
+	if err != nil {
+		return nil, fmt.Errorf("oidcsign: create transit client: %w", err)
+	}
+	if cfg.Token != "" {
+		client.SetToken(cfg.Token)
+	}
+	if cfg.Namespace != "" {
+		client.SetNamespace(cfg.Namespace)
+	}
+
+	b := &TransitBackend{
+		client:        client,
+		mountPath:     strings.Trim(cfg.MountPath, "/"),
+		keyNamePrefix: cfg.KeyNamePrefix,
+		timeout:       cfg.RequestTimeout,
+		log:           log,
+	}
+	b.startRenewal(cfg.DisableRenewal)
+	return b, nil
+}
+
+// startRenewal keeps a renewable token alive for the life of the backend, mirroring
+// the transit auto-seal wrapper. A non-renewable or short-lived static token simply
+// runs without a watcher; signing fails closed once it expires.
+func (b *TransitBackend) startRenewal(disable bool) {
+	if disable || b.client.Token() == "" {
+		return
+	}
+	// Bound the initial renew so a down KMS cannot hang construction (the HTTP
+	// client's 60s default would otherwise apply). A non-renewable token simply
+	// runs without a watcher and fails closed when it expires.
+	renewTimeout := b.timeout
+	if renewTimeout <= 0 {
+		renewTimeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), renewTimeout)
+	defer cancel()
+	secret, err := b.client.Auth().Token().RenewTokenAsSelfWithContext(ctx, b.client.Token(), 0)
+	if err != nil {
+		b.logInfo("oidcsign: transit token not renewable, disabling renewal", logger.Err(err))
+		return
+	}
+	watcher, err := b.client.NewLifetimeWatcher(&api.LifetimeWatcherInput{Secret: secret})
+	if err != nil {
+		b.logInfo("oidcsign: failed to start transit token renewal", logger.Err(err))
+		return
+	}
+	b.watcher = watcher
+	go func() {
+		for {
+			select {
+			case err := <-watcher.DoneCh():
+				if err != nil {
+					b.logError("oidcsign: transit token renewal stopped", logger.Err(err))
+				}
+				return
+			case <-watcher.RenewCh():
+			}
+		}
+	}()
+	go watcher.Start()
+}
+
+func (b *TransitBackend) Type() string { return backendTypeTransit }
+
+// Close stops token renewal.
+func (b *TransitBackend) Close() {
+	if b.watcher != nil {
+		b.watcher.Stop()
+	}
+}
+
+// keyNameFor derives the transit key name for a JWS alg, e.g. "warden-oidc-rs256".
+func (b *TransitBackend) keyNameFor(alg string) string {
+	return b.keyNamePrefix + "-" + strings.ToLower(alg)
+}
+
+// EnsureKey creates alg's key if absent (idempotent) and returns its latest version.
+func (b *TransitBackend) EnsureKey(ctx context.Context, alg string) (KeyInfo, error) {
+	p, ok := algParamsByAlg[alg]
+	if !ok {
+		return KeyInfo{}, fmt.Errorf("oidcsign: unsupported signing algorithm %q", alg)
+	}
+	name := b.keyNameFor(alg)
+	ctx, cancel := b.withTimeout(ctx)
+	defer cancel()
+	if _, err := b.client.Logical().WriteWithContext(ctx, b.keysPath(name), map[string]interface{}{
+		"type": p.transitKeyType,
+	}); err != nil {
+		return KeyInfo{}, fmt.Errorf("oidcsign: ensure transit key %q: %w", name, err)
+	}
+	return b.latestKeyInfo(ctx, alg)
+}
+
+// NewVersion rotates alg's key and returns the new latest version.
+func (b *TransitBackend) NewVersion(ctx context.Context, alg string) (KeyInfo, error) {
+	if _, ok := algParamsByAlg[alg]; !ok {
+		return KeyInfo{}, fmt.Errorf("oidcsign: unsupported signing algorithm %q", alg)
+	}
+	name := b.keyNameFor(alg)
+	ctx, cancel := b.withTimeout(ctx)
+	defer cancel()
+	if _, err := b.client.Logical().WriteWithContext(ctx, b.keysPath(name)+"/rotate", nil); err != nil {
+		return KeyInfo{}, fmt.Errorf("oidcsign: rotate transit key %q: %w", name, err)
+	}
+	return b.latestKeyInfo(ctx, alg)
+}
+
+// PublicKey fetches one specific version's public key, re-asserting the key type
+// and non-exportability (transit allows flipping a key to exportable after
+// creation, so this rarer path cheaply re-checks the invariant).
+func (b *TransitBackend) PublicKey(ctx context.Context, ref KeyRef) (crypto.PublicKey, error) {
+	ctx, cancel := b.withTimeout(ctx)
+	defer cancel()
+	kd, err := b.readKey(ctx, ref.KeyName)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateTransitKey(kd, ref.KeyName, ref.Alg); err != nil {
+		return nil, err
+	}
+	return kd.publicKeyForVersion(ref.Version)
+}
+
+// validateTransitKey enforces the two invariants a signing key must hold: it is
+// the type the alg expects, and it is non-exportable (the whole point of remote
+// signing).
+func validateTransitKey(kd *transitKeyData, name, alg string) error {
+	p, ok := algParamsByAlg[alg]
+	if !ok {
+		return fmt.Errorf("oidcsign: unsupported signing algorithm %q", alg)
+	}
+	if kd.Type != p.transitKeyType {
+		return fmt.Errorf("oidcsign: transit key %q has type %q, expected %q for %s", name, kd.Type, p.transitKeyType, alg)
+	}
+	if kd.Exportable {
+		return fmt.Errorf("oidcsign: transit key %q is exportable; the OIDC issuer key must be non-exportable (recreate with exportable=false)", name)
+	}
+	return nil
+}
+
+// Sign signs an already-hashed digest with the exact version in ref via
+// transit/sign. RSA is forced to PKCS#1 v1.5 (transit defaults to PSS); ECDSA is
+// requested in ASN.1 form, matching the crypto.Signer contract.
+func (b *TransitBackend) Sign(ctx context.Context, ref KeyRef, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	if _, ok := opts.(*rsa.PSSOptions); ok {
+		return nil, fmt.Errorf("oidcsign: RSA-PSS is not supported by the transit signer")
+	}
+	p, ok := algParamsByAlg[ref.Alg]
+	if !ok {
+		return nil, fmt.Errorf("oidcsign: unsupported signing algorithm %q", ref.Alg)
+	}
+	if ref.Version < 1 {
+		// A zero version resolves to "latest" server-side, so refuse it up front
+		// rather than sign with the wrong (pre-published next) key.
+		return nil, fmt.Errorf("oidcsign: key version must be >= 1, got %d", ref.Version)
+	}
+	// Guard the digest against an alg/hash mismatch. For ECDSA transit signs
+	// whatever prehashed bytes arrive, so a wrong-hash digest would produce a
+	// well-formed but permanently unverifiable signature — fail fast instead.
+	if opts.HashFunc() != p.hash {
+		return nil, fmt.Errorf("oidcsign: %s requires a %v digest, got %v", ref.Alg, p.hash, opts.HashFunc())
+	}
+	if len(digest) != p.hash.Size() {
+		return nil, fmt.Errorf("oidcsign: %s digest must be %d bytes, got %d", ref.Alg, p.hash.Size(), len(digest))
+	}
+
+	data := map[string]interface{}{
+		"input":                base64.StdEncoding.EncodeToString(digest),
+		"prehashed":            true,
+		"hash_algorithm":       p.hashName,
+		"key_version":          ref.Version,
+		"marshaling_algorithm": "asn1",
+	}
+	if p.isRSA {
+		data["signature_algorithm"] = "pkcs1v15"
+	}
+	ctx, cancel := b.withTimeout(ctx)
+	defer cancel()
+	secret, err := b.client.Logical().WriteWithContext(ctx, b.signPath(ref.KeyName), data)
+	if err != nil {
+		return nil, fmt.Errorf("oidcsign: transit sign %q: %w", ref.KeyName, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, fmt.Errorf("oidcsign: transit sign %q returned no data", ref.KeyName)
+	}
+	// The response's key_version is the authoritative, template-independent proof
+	// of which version signed; verify it pinned to the version we asked for.
+	if signedVer, err := asInt(secret.Data["key_version"]); err == nil && signedVer != ref.Version {
+		return nil, fmt.Errorf("oidcsign: transit signed with key version %d, expected %d", signedVer, ref.Version)
+	}
+	raw, _ := secret.Data["signature"].(string)
+	return decodeTransitSignature(raw)
+}
+
+// latestKeyInfo reads alg's key, validates it, and returns its latest version.
+func (b *TransitBackend) latestKeyInfo(ctx context.Context, alg string) (KeyInfo, error) {
+	name := b.keyNameFor(alg)
+	kd, err := b.readKey(ctx, name)
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	if err := validateTransitKey(kd, name, alg); err != nil {
+		return KeyInfo{}, err
+	}
+	pub, err := kd.publicKeyForVersion(kd.LatestVersion)
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	created, err := kd.creationTimeForVersion(kd.LatestVersion)
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	return KeyInfo{
+		Ref:       KeyRef{KeyName: name, Version: kd.LatestVersion, Alg: alg},
+		Public:    pub,
+		CreatedAt: created,
+	}, nil
+}
+
+func (b *TransitBackend) keysPath(name string) string { return b.mountPath + "/keys/" + name }
+func (b *TransitBackend) signPath(name string) string { return b.mountPath + "/sign/" + name }
+
+func (b *TransitBackend) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if b.timeout > 0 {
+		return context.WithTimeout(ctx, b.timeout)
+	}
+	return context.WithCancel(ctx)
+}
+
+func (b *TransitBackend) logInfo(msg string, f ...logger.TypedField) {
+	if b.log != nil {
+		b.log.Info(msg, f...)
+	}
+}
+
+func (b *TransitBackend) logError(msg string, f ...logger.TypedField) {
+	if b.log != nil {
+		b.log.Error(msg, f...)
+	}
+}
+
+// transitKeyData is the parsed subset of a transit/keys/<name> read response.
+type transitKeyData struct {
+	Type          string
+	Exportable    bool
+	LatestVersion int
+	Keys          map[string]transitKeyVersion
+}
+
+type transitKeyVersion struct {
+	PublicKey    string `json:"public_key"`
+	CreationTime string `json:"creation_time"`
+}
+
+// readKey reads and parses a transit key's metadata (type, exportable, versions).
+func (b *TransitBackend) readKey(ctx context.Context, name string) (*transitKeyData, error) {
+	secret, err := b.client.Logical().ReadWithContext(ctx, b.keysPath(name))
+	if err != nil {
+		return nil, fmt.Errorf("oidcsign: read transit key %q: %w", name, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, fmt.Errorf("oidcsign: transit key %q not found", name)
+	}
+	kd := &transitKeyData{}
+	kd.Type, _ = secret.Data["type"].(string)
+	kd.Exportable, _ = secret.Data["exportable"].(bool)
+	lv, err := asInt(secret.Data["latest_version"])
+	if err != nil {
+		return nil, fmt.Errorf("oidcsign: transit key %q: bad latest_version: %w", name, err)
+	}
+	kd.LatestVersion = lv
+	// Re-marshal the versions map through JSON to decode into typed structs. This
+	// is best-effort: a symmetric key (AES/ChaCha) returns "keys" as a map of
+	// creation timestamps (numbers), which fails to decode here — leaving Keys nil
+	// so the caller's type check reports the clean "wrong key type" error instead.
+	if rawKeys, ok := secret.Data["keys"]; ok {
+		if buf, err := json.Marshal(rawKeys); err == nil {
+			_ = json.Unmarshal(buf, &kd.Keys)
+		}
+	}
+	return kd, nil
+}
+
+func (kd *transitKeyData) versionEntry(version int) (transitKeyVersion, error) {
+	v, ok := kd.Keys[strconv.Itoa(version)]
+	if !ok {
+		return transitKeyVersion{}, fmt.Errorf("oidcsign: transit key has no version %d", version)
+	}
+	return v, nil
+}
+
+func (kd *transitKeyData) publicKeyForVersion(version int) (crypto.PublicKey, error) {
+	v, err := kd.versionEntry(version)
+	if err != nil {
+		return nil, err
+	}
+	return parsePublicKeyPEM(v.PublicKey)
+}
+
+func (kd *transitKeyData) creationTimeForVersion(version int) (time.Time, error) {
+	v, err := kd.versionEntry(version)
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := time.Parse(time.RFC3339Nano, v.CreationTime)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("oidcsign: parse transit key creation_time %q: %w", v.CreationTime, err)
+	}
+	return t, nil
+}
+
+// parsePublicKeyPEM decodes a PKIX PEM public key and ensures it is RSA or ECDSA.
+func parsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
+	if pemStr == "" {
+		return nil, fmt.Errorf("oidcsign: empty public key")
+	}
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("oidcsign: public key is not valid PEM")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("oidcsign: parse public key: %w", err)
+	}
+	switch pub.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey:
+		return pub, nil
+	default:
+		return nil, fmt.Errorf("oidcsign: unsupported public key type %T", pub)
+	}
+}
+
+// decodeTransitSignature extracts the raw signature bytes from transit's
+// "<prefix>:v<N>:<base64>" envelope. The base64 payload is the final
+// colon-delimited segment (standard base64 contains no colon), so this tolerates a
+// custom version_template in the prefix; the key version itself is validated by the
+// caller against the response's authoritative key_version field. asn1 marshaling
+// uses standard base64.
+func decodeTransitSignature(sig string) ([]byte, error) {
+	if sig == "" {
+		return nil, fmt.Errorf("oidcsign: transit returned an empty signature")
+	}
+	i := strings.LastIndex(sig, ":")
+	if i < 0 || i == len(sig)-1 {
+		return nil, fmt.Errorf("oidcsign: malformed transit signature")
+	}
+	raw, err := base64.StdEncoding.DecodeString(sig[i+1:])
+	if err != nil {
+		return nil, fmt.Errorf("oidcsign: decode transit signature: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("oidcsign: transit returned an empty signature payload")
+	}
+	return raw, nil
+}
+
+// asInt coerces a JSON-decoded number (json.Number, float64, int, or string) to int.
+func asInt(v interface{}) (int, error) {
+	switch n := v.(type) {
+	case json.Number:
+		i, err := n.Int64()
+		return int(i), err
+	case float64:
+		return int(n), nil
+	case int:
+		return n, nil
+	case string:
+		i, err := strconv.Atoi(n)
+		return i, err
+	default:
+		return 0, fmt.Errorf("not a number: %T", v)
+	}
+}

--- a/core/oidcsign/transit_test.go
+++ b/core/oidcsign/transit_test.go
@@ -1,0 +1,402 @@
+package oidcsign
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKey is one transit key: a type plus a private key per version. The fake KMS
+// holds the private key so signatures actually verify against the served public key.
+type fakeKey struct {
+	keyType    string
+	exportable bool
+	versions   []crypto.Signer // index 0 == version 1
+}
+
+// fakeTransit is a minimal transit engine over httptest: create/rotate/read/sign.
+type fakeTransit struct {
+	t        *testing.T
+	keys     map[string]*fakeKey
+	lastSign map[string]interface{} // captured params of the most recent sign call
+}
+
+func newFakeTransit(t *testing.T) *fakeTransit {
+	return &fakeTransit{t: t, keys: map[string]*fakeKey{}}
+}
+
+func genKey(t *testing.T, keyType string) crypto.Signer {
+	t.Helper()
+	switch keyType {
+	case "rsa-2048":
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		return k
+	case "rsa-3072":
+		k, err := rsa.GenerateKey(rand.Reader, 3072)
+		require.NoError(t, err)
+		return k
+	case "ecdsa-p256":
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		return k
+	case "ecdsa-p384":
+		k, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		require.NoError(t, err)
+		return k
+	}
+	t.Fatalf("unknown key type %q", keyType)
+	return nil
+}
+
+func pubPEM(t *testing.T, s crypto.Signer) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(s.Public())
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func (f *fakeTransit) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/v1/")
+		writeJSON := func(v interface{}) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(v)
+		}
+		switch {
+		case strings.HasSuffix(path, "/rotate"):
+			name := strings.TrimSuffix(strings.TrimPrefix(path, "transit/keys/"), "/rotate")
+			k := f.keys[name]
+			require.NotNil(f.t, k, "rotate on missing key %q", name)
+			k.versions = append(k.versions, genKey(f.t, k.keyType))
+			writeJSON(map[string]interface{}{"data": map[string]interface{}{}})
+		case strings.HasPrefix(path, "transit/keys/"):
+			name := strings.TrimPrefix(path, "transit/keys/")
+			if r.Method == http.MethodGet {
+				k := f.keys[name]
+				if k == nil {
+					w.WriteHeader(http.StatusNotFound)
+					writeJSON(map[string]interface{}{"errors": []string{"not found"}})
+					return
+				}
+				keys := map[string]interface{}{}
+				for i, v := range k.versions {
+					keys[strconv.Itoa(i+1)] = map[string]interface{}{
+						"public_key":    pubPEM(f.t, v),
+						"creation_time": time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano),
+					}
+				}
+				writeJSON(map[string]interface{}{"data": map[string]interface{}{
+					"type":           k.keyType,
+					"exportable":     k.exportable,
+					"latest_version": len(k.versions),
+					"keys":           keys,
+				}})
+				return
+			}
+			// create (idempotent upsert)
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if f.keys[name] == nil {
+				kt, _ := body["type"].(string)
+				f.keys[name] = &fakeKey{keyType: kt, versions: []crypto.Signer{genKey(f.t, kt)}}
+			}
+			writeJSON(map[string]interface{}{"data": map[string]interface{}{}})
+		case strings.HasPrefix(path, "transit/sign/"):
+			name := strings.TrimPrefix(path, "transit/sign/")
+			var body map[string]interface{}
+			require.NoError(f.t, json.NewDecoder(r.Body).Decode(&body))
+			f.lastSign = body
+			k := f.keys[name]
+			require.NotNil(f.t, k, "sign on missing key %q", name)
+			ver, _ := asInt(body["key_version"])
+			require.True(f.t, ver >= 1 && ver <= len(k.versions), "bad key_version %d", ver)
+			signer := k.versions[ver-1]
+			input, _ := body["input"].(string)
+			digest, err := base64.StdEncoding.DecodeString(input)
+			require.NoError(f.t, err)
+			var sig []byte
+			switch key := signer.(type) {
+			case *rsa.PrivateKey:
+				h := crypto.SHA256
+				if body["hash_algorithm"] == "sha2-384" {
+					h = crypto.SHA384
+				}
+				sig, err = rsa.SignPKCS1v15(rand.Reader, key, h, digest)
+			case *ecdsa.PrivateKey:
+				sig, err = ecdsa.SignASN1(rand.Reader, key, digest)
+			}
+			require.NoError(f.t, err)
+			writeJSON(map[string]interface{}{"data": map[string]interface{}{
+				"signature":   "vault:v" + strconv.Itoa(ver) + ":" + base64.StdEncoding.EncodeToString(sig),
+				"key_version": ver,
+			}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(map[string]interface{}{"errors": []string{"unhandled: " + path}})
+		}
+	})
+}
+
+func newTestBackend(t *testing.T, f *fakeTransit) *TransitBackend {
+	t.Helper()
+	srv := httptest.NewServer(f.handler())
+	t.Cleanup(srv.Close)
+	b, err := NewTransitBackend(TransitConfig{
+		Address:        srv.URL,
+		Token:          "test-token",
+		MountPath:      "transit",
+		KeyNamePrefix:  "warden-oidc",
+		RequestTimeout: 5 * time.Second,
+		DisableRenewal: true,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(b.Close)
+	return b
+}
+
+func TestTransit_EnsureKey_and_Sign_RSA(t *testing.T) {
+	f := newFakeTransit(t)
+	b := newTestBackend(t, f)
+	ctx := context.Background()
+
+	info, err := b.EnsureKey(ctx, "RS256")
+	require.NoError(t, err)
+	assert.Equal(t, "warden-oidc-rs256", info.Ref.KeyName)
+	assert.Equal(t, 1, info.Ref.Version)
+	assert.Equal(t, "RS256", info.Ref.Alg)
+	rsaPub, ok := info.Public.(*rsa.PublicKey)
+	require.True(t, ok)
+
+	digest := sha256.Sum256([]byte("signing.input"))
+	sig, err := b.Sign(ctx, info.Ref, digest[:], crypto.SHA256)
+	require.NoError(t, err)
+	require.NoError(t, rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, digest[:], sig),
+		"transit RSA signature must verify against the served public key")
+
+	// Sign request must force pkcs1v15, prehashed, asn1 marshaling, and pin the version.
+	assert.Equal(t, true, f.lastSign["prehashed"])
+	assert.Equal(t, "pkcs1v15", f.lastSign["signature_algorithm"])
+	assert.Equal(t, "asn1", f.lastSign["marshaling_algorithm"])
+	assert.Equal(t, "sha2-256", f.lastSign["hash_algorithm"])
+	v, _ := asInt(f.lastSign["key_version"])
+	assert.Equal(t, 1, v)
+}
+
+func TestTransit_Sign_EC_ASN1(t *testing.T) {
+	f := newFakeTransit(t)
+	b := newTestBackend(t, f)
+	ctx := context.Background()
+
+	info, err := b.EnsureKey(ctx, "ES256")
+	require.NoError(t, err)
+	ecPub, ok := info.Public.(*ecdsa.PublicKey)
+	require.True(t, ok)
+
+	digest := sha256.Sum256([]byte("ec.signing.input"))
+	sig, err := b.Sign(ctx, info.Ref, digest[:], crypto.SHA256)
+	require.NoError(t, err)
+
+	// The signer returns ASN.1 DER (crypto.Signer contract); it must verify.
+	var parsed struct{ R, S *big.Int }
+	_, err = asn1.Unmarshal(sig, &parsed)
+	require.NoError(t, err)
+	assert.True(t, ecdsa.Verify(ecPub, digest[:], parsed.R, parsed.S))
+
+	// EC must NOT carry signature_algorithm (that is RSA-only).
+	_, hasSigAlg := f.lastSign["signature_algorithm"]
+	assert.False(t, hasSigAlg)
+	assert.Equal(t, "asn1", f.lastSign["marshaling_algorithm"])
+}
+
+func TestTransit_NewVersion_PinsActiveVersion(t *testing.T) {
+	f := newFakeTransit(t)
+	b := newTestBackend(t, f)
+	ctx := context.Background()
+
+	active, err := b.EnsureKey(ctx, "RS256") // v1
+	require.NoError(t, err)
+	require.Equal(t, 1, active.Ref.Version)
+	activePub := active.Public.(*rsa.PublicKey)
+
+	next, err := b.NewVersion(ctx, "RS256") // v2 (latest)
+	require.NoError(t, err)
+	require.Equal(t, 2, next.Ref.Version)
+
+	// Signing with the ACTIVE ref (v1) must pin v1 and verify against v1's key,
+	// even though v2 is now latest — proving we never default to latest.
+	digest := sha256.Sum256([]byte("pin"))
+	sig, err := b.Sign(ctx, active.Ref, digest[:], crypto.SHA256)
+	require.NoError(t, err)
+	v, _ := asInt(f.lastSign["key_version"])
+	assert.Equal(t, 1, v)
+	require.NoError(t, rsa.VerifyPKCS1v15(activePub, crypto.SHA256, digest[:], sig))
+	assert.NotEqual(t, activePub.N, next.Public.(*rsa.PublicKey).N, "v1 and v2 must be distinct keys")
+}
+
+func TestTransit_Exportable_HardError(t *testing.T) {
+	f := newFakeTransit(t)
+	f.keys["warden-oidc-rs256"] = &fakeKey{keyType: "rsa-2048", exportable: true, versions: []crypto.Signer{genKey(t, "rsa-2048")}}
+	b := newTestBackend(t, f)
+
+	_, err := b.EnsureKey(context.Background(), "RS256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exportable")
+}
+
+func TestTransit_WrongType_HardError(t *testing.T) {
+	f := newFakeTransit(t)
+	// An RS256 key name backed by an EC key type — a misconfiguration that would
+	// otherwise yield unverifiable JWTs.
+	f.keys["warden-oidc-rs256"] = &fakeKey{keyType: "ecdsa-p256", versions: []crypto.Signer{genKey(t, "ecdsa-p256")}}
+	b := newTestBackend(t, f)
+
+	_, err := b.EnsureKey(context.Background(), "RS256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected")
+}
+
+func TestDecodeTransitSignature(t *testing.T) {
+	raw := []byte{0x01, 0x02, 0x03}
+	enc := base64.StdEncoding.EncodeToString(raw)
+
+	got, err := decodeTransitSignature("vault:v3:" + enc)
+	require.NoError(t, err)
+	assert.Equal(t, raw, got)
+
+	// A custom version_template prefix (extra segments) still yields the payload,
+	// since it is the final colon-delimited segment.
+	got, err = decodeTransitSignature("my:org:v3:" + enc)
+	require.NoError(t, err)
+	assert.Equal(t, raw, got)
+
+	// Empty payload must be rejected, not returned as a zero-length signature.
+	_, err = decodeTransitSignature("vault:v1:")
+	require.Error(t, err)
+
+	_, err = decodeTransitSignature("garbage")
+	require.Error(t, err)
+
+	_, err = decodeTransitSignature("")
+	require.Error(t, err)
+}
+
+func TestSigner_NilBackend_And_Context(t *testing.T) {
+	// Verification-only signer (nil backend) fails closed on Sign but exposes Public.
+	pub := genKey(t, "rsa-2048").Public()
+	s := NewSigner(nil, KeyRef{KeyName: "k", Version: 1, Alg: "RS256"}, pub, time.Second)
+	assert.False(t, s.CanSign())
+	assert.Equal(t, pub, s.Public())
+	_, err := s.Sign(rand.Reader, []byte("d"), crypto.SHA256)
+	require.Error(t, err)
+
+	// WithContext returns a distinct signer bound to ctx and does not mutate the original.
+	ctx := context.Background()
+	s2 := s.WithContext(ctx).(*Signer)
+	assert.Nil(t, s.ctx)
+	assert.NotNil(t, s2.ctx)
+}
+
+func TestTransit_Sign_AllAlgs(t *testing.T) {
+	for _, alg := range []string{"RS256", "RS384", "ES256", "ES384"} {
+		t.Run(alg, func(t *testing.T) {
+			f := newFakeTransit(t)
+			b := newTestBackend(t, f)
+			ctx := context.Background()
+
+			info, err := b.EnsureKey(ctx, alg)
+			require.NoError(t, err)
+
+			h := algParamsByAlg[alg].hash
+			hh := h.New()
+			hh.Write([]byte("payload for " + alg))
+			digest := hh.Sum(nil)
+
+			sig, err := b.Sign(ctx, info.Ref, digest, h)
+			require.NoError(t, err)
+			assert.Equal(t, true, f.lastSign["prehashed"], "prehashed must be set for all algs")
+
+			switch pub := info.Public.(type) {
+			case *rsa.PublicKey:
+				require.NoError(t, rsa.VerifyPKCS1v15(pub, h, digest, sig))
+			case *ecdsa.PublicKey:
+				var parsed struct{ R, S *big.Int }
+				_, err := asn1.Unmarshal(sig, &parsed)
+				require.NoError(t, err)
+				assert.True(t, ecdsa.Verify(pub, digest, parsed.R, parsed.S))
+			default:
+				t.Fatalf("unexpected public key type %T", pub)
+			}
+		})
+	}
+}
+
+func TestTransit_Sign_Rejects(t *testing.T) {
+	f := newFakeTransit(t)
+	b := newTestBackend(t, f)
+	ctx := context.Background()
+	info, err := b.EnsureKey(ctx, "RS256")
+	require.NoError(t, err)
+	d := sha256.Sum256([]byte("x"))
+
+	// RSA-PSS is not supported.
+	_, err = b.Sign(ctx, info.Ref, d[:], &rsa.PSSOptions{Hash: crypto.SHA256})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PSS")
+
+	// Wrong hash for the alg (SHA-384 digest for an RS256 key) must fail fast,
+	// before any KMS round-trip, so it cannot yield an unverifiable signature.
+	d384 := make([]byte, crypto.SHA384.Size())
+	_, err = b.Sign(ctx, info.Ref, d384, crypto.SHA384)
+	require.Error(t, err)
+
+	// A zero/negative version resolves to "latest" server-side; reject it up front.
+	_, err = b.Sign(ctx, KeyRef{KeyName: info.Ref.KeyName, Version: 0, Alg: "RS256"}, d[:], crypto.SHA256)
+	require.Error(t, err)
+
+	// Unknown alg.
+	_, err = b.Sign(ctx, KeyRef{KeyName: "k", Version: 1, Alg: "HS256"}, d[:], crypto.SHA256)
+	require.Error(t, err)
+}
+
+func TestParsePublicKeyPEM_Rejects(t *testing.T) {
+	_, err := parsePublicKeyPEM("")
+	require.Error(t, err)
+	_, err = parsePublicKeyPEM("not pem at all")
+	require.Error(t, err)
+	_, err = parsePublicKeyPEM("-----BEGIN PUBLIC KEY-----\nZm9v\n-----END PUBLIC KEY-----\n")
+	require.Error(t, err, "valid PEM framing but garbage DER must fail")
+}
+
+func TestSigner_RoutesToBackend(t *testing.T) {
+	f := newFakeTransit(t)
+	b := newTestBackend(t, f)
+	info, err := b.EnsureKey(context.Background(), "RS256")
+	require.NoError(t, err)
+
+	s := NewSigner(b, info.Ref, info.Public, 5*time.Second)
+	require.True(t, s.CanSign())
+	digest := sha256.Sum256([]byte("via signer"))
+	sig, err := s.Sign(rand.Reader, digest[:], crypto.SHA256)
+	require.NoError(t, err)
+	require.NoError(t, rsa.VerifyPKCS1v15(info.Public.(*rsa.PublicKey), crypto.SHA256, digest[:], sig))
+}


### PR DESCRIPTION
Introduces `core/oidcsign`, a KMS-backed signing abstraction for the OIDC issuer key so the private key can live in an external KMS and never enter Warden. Nothing consumes it yet — later PRs wire it into the issuer.

## Changes
- `Backend` interface (`Type`/`EnsureKey`/`NewVersion`/`PublicKey`/`Sign`/`Close`) producing a `crypto.Signer` (`Signer`) that drops into the issuer's signing seam. A nil backend yields a verification-only signer (Public works, Sign fails closed) for retired keys.
- Transit backend over `hashicorp/vault/api`: provisions a non-exportable key per algorithm, pins the requested key version, forces PKCS#1 v1.5 (transit defaults to PSS) and ASN.1 marshaling to honor the `crypto.Signer` contract, caches public keys, and hard-errors on exportable or wrong-typed keys.
- Guards the digest against an alg/hash mismatch, validates the signed version against the response, and bounds token-renewal at construction so a down KMS can't hang startup.
- `ErrRotationUnsupported` sentinel so a future out-of-band HSM/KMIP backend can decline programmatic rotation without reshaping the interface.

## Notes
- Independent PR; the package is unused until the integration PR.
- Unit tests use an httptest fake transit holding real keys, so signatures actually verify — covering RS256/RS384/ES256/ES384, active-not-latest version pinning, PSS rejection, and the exportable/wrong-type hard-errors.