### PR TITLE
feat(config): add signer stanza for the OIDC issuer external signer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Storage   *StorageBlock   `hcl:"storage,block"`
 	Seals     []KMS           `hcl:"seal,block"`
 	Audits    []AuditBlock    `hcl:"audit,block"`
+	Signer    *SignerBlock    `hcl:"signer,block"`
 
 	// APIAddr is the address advertised to clients for API requests.
 	// In HA mode, standby nodes redirect clients to this address on the active node.
@@ -68,6 +69,32 @@ type Config struct {
 	ClusterListenerReadTimeout  string `hcl:"cluster_listener_read_timeout,optional"`
 	ClusterListenerWriteTimeout string `hcl:"cluster_listener_write_timeout,optional"`
 	ForwardingTimeout           string `hcl:"forwarding_timeout,optional"`
+}
+
+// SignerBlock configures an external signer for the OIDC issuer's signing keys,
+// so the private key is held in a KMS and never enters Warden (remote signing).
+// The type label selects the backend; only "transit" is supported today. Omit the
+// block entirely for the default in-process keys. This is node-local
+// infrastructure (like the seal stanza); the issuer's runtime config
+// (issuer_url, TTLs, rotation period) is managed separately via the API.
+type SignerBlock struct {
+	Type string `hcl:"type,label"`
+
+	// config for the transit signer
+	Address        string `hcl:"address,optional"`
+	Token          string `hcl:"token,optional"` // optional; falls back to VAULT_TOKEN
+	MountPath      string `hcl:"mount_path,optional"`
+	KeyNamePrefix  string `hcl:"key_name_prefix,optional"` // default "warden-oidc" (applied by core)
+	Namespace      string `hcl:"namespace,optional"`
+	RequestTimeout string `hcl:"request_timeout,optional"` // Go duration; per-KMS-call timeout
+	DisableRenewal string `hcl:"disable_renewal,optional"`
+
+	TlsCaCert     string `hcl:"tls_ca_cert,optional"`
+	TlsCaPath     string `hcl:"tls_ca_path,optional"`
+	TlsClientCert string `hcl:"tls_client_cert,optional"`
+	TlsClientKey  string `hcl:"tls_client_key,optional"`
+	TlsServerName string `hcl:"tls_server_name,optional"`
+	TlsSkipVerify string `hcl:"tls_skip_verify,optional"`
 }
 
 type KMS struct {
@@ -710,6 +737,33 @@ func validateConfig(config *Config) error {
 			return fmt.Errorf("audit[%d]: duplicate (type=%q, path=%q) already declared at audit[%d]", i, a.Type, a.Path, prev)
 		}
 		auditSeen[key] = i
+	}
+
+	// Validate the OIDC issuer external signer stanza if present. Only transit is
+	// supported today; the rest are shape checks so a misconfiguration fails at
+	// load time rather than at first mint.
+	if s := config.Signer; s != nil {
+		if s.Type != "transit" {
+			return fmt.Errorf("signer: unsupported type %q; only \"transit\" is supported", s.Type)
+		}
+		if s.MountPath == "" {
+			return fmt.Errorf("signer %q: mount_path is required", s.Type)
+		}
+		if s.Address == "" && os.Getenv("VAULT_ADDR") == "" {
+			return fmt.Errorf("signer %q: address is required (or set VAULT_ADDR)", s.Type)
+		}
+		if strings.Contains(s.KeyNamePrefix, "/") {
+			return fmt.Errorf("signer %q: key_name_prefix %q must not contain '/'", s.Type, s.KeyNamePrefix)
+		}
+		if s.RequestTimeout != "" {
+			d, err := time.ParseDuration(s.RequestTimeout)
+			if err != nil {
+				return fmt.Errorf("signer %q: invalid request_timeout %q: %w", s.Type, s.RequestTimeout, err)
+			}
+			if d <= 0 {
+				return fmt.Errorf("signer %q: request_timeout must be positive, got %s", s.Type, d)
+			}
+		}
 	}
 
 	// Validate cluster_addr format if set

--- a/config/decode.go
+++ b/config/decode.go
@@ -115,10 +115,12 @@ func init() {
 	storageSchema, _ := gohcl.ImpliedBodySchema(StorageBlock{})
 	sealSchema, _ := gohcl.ImpliedBodySchema(KMS{})
 	auditSchema, _ := gohcl.ImpliedBodySchema(AuditBlock{})
+	signerSchema, _ := gohcl.ImpliedBodySchema(SignerBlock{})
 	nestedSchemas = map[string]*hcl.BodySchema{
 		"listener": listenerSchema,
 		"storage":  storageSchema,
 		"seal":     sealSchema,
 		"audit":    auditSchema,
+		"signer":   signerSchema,
 	}
 }

--- a/config/helpers.go
+++ b/config/helpers.go
@@ -6,7 +6,7 @@ func (c *Config) GetStorage() *StorageBlock {
 
 // mergeConfig copies non-zero fields from src into dst, so a sequence of
 // loaded configs collapses to a single merged *Config with "later wins"
-// semantics. Slice and pointer block fields (Listeners, Storage, Seals)
+// semantics. Slice and pointer block fields (Listeners, Storage, Seals, Signer)
 // are replaced wholesale when src defines them — there is no per-field
 // merge inside a block, which matches how operators typically split
 // secret vs non-secret HCL (one file owns each block entirely).
@@ -40,6 +40,9 @@ func mergeConfig(dst, src *Config) {
 	}
 	if len(src.Audits) > 0 {
 		dst.Audits = src.Audits
+	}
+	if src.Signer != nil {
+		dst.Signer = src.Signer
 	}
 	if src.APIAddr != "" {
 		dst.APIAddr = src.APIAddr

--- a/config/signer_test.go
+++ b/config/signer_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig_SignerBlock(t *testing.T) {
+	t.Setenv("VAULT_ADDR", "")
+	dir := t.TempDir()
+	p := writeFile(t, dir, "signer.hcl", `
+signer "transit" {
+  address         = "https://bao.example.com:8200"
+  token           = "s.abc123"
+  mount_path      = "transit"
+  key_name_prefix = "warden-oidc"
+  namespace       = "ns1"
+  request_timeout = "10s"
+  tls_ca_cert     = "/etc/warden/ca.pem"
+  disable_renewal = "false"
+}
+`)
+	cfg, err := LoadConfig(p)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Signer)
+	s := cfg.Signer
+	assert.Equal(t, "transit", s.Type)
+	assert.Equal(t, "https://bao.example.com:8200", s.Address)
+	assert.Equal(t, "s.abc123", s.Token)
+	assert.Equal(t, "transit", s.MountPath)
+	assert.Equal(t, "warden-oidc", s.KeyNamePrefix)
+	assert.Equal(t, "ns1", s.Namespace)
+	assert.Equal(t, "10s", s.RequestTimeout)
+	assert.Equal(t, "/etc/warden/ca.pem", s.TlsCaCert)
+}
+
+func TestLoadConfig_SignerBlock_EnvInterpolation(t *testing.T) {
+	t.Setenv("WARDEN_TEST_SIGNER_TOKEN", "s.from-env")
+	t.Setenv("VAULT_ADDR", "")
+	dir := t.TempDir()
+	p := writeFile(t, dir, "signer.hcl", `
+signer "transit" {
+  address    = "https://bao:8200"
+  mount_path = "transit"
+  token      = "{{ env "WARDEN_TEST_SIGNER_TOKEN" }}"
+}
+`)
+	cfg, err := LoadConfig(p)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Signer)
+	assert.Equal(t, "s.from-env", cfg.Signer.Token)
+}
+
+func TestLoadConfig_SignerBlock_PrunesUnknownKeys(t *testing.T) {
+	t.Setenv("VAULT_ADDR", "")
+	dir := t.TempDir()
+	p := writeFile(t, dir, "signer.hcl", `
+signer "transit" {
+  address        = "https://bao:8200"
+  mount_path     = "transit"
+  not_a_real_key = "ignored"
+}
+`)
+	cfg, err := LoadConfig(p)
+	require.NoError(t, err, "an unknown attribute must be pruned with a warning, not fail the load")
+	require.NotNil(t, cfg.Signer)
+	assert.Equal(t, "transit", cfg.Signer.Type)
+}
+
+func TestValidateConfig_SignerBlock(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     map[string]string
+		signer  *SignerBlock
+		wantErr string
+	}{
+		{
+			name:   "valid",
+			signer: &SignerBlock{Type: "transit", Address: "https://bao:8200", MountPath: "transit"},
+		},
+		{
+			name:    "unsupported type",
+			signer:  &SignerBlock{Type: "awskms", Address: "https://bao:8200", MountPath: "transit"},
+			wantErr: "only \"transit\" is supported",
+		},
+		{
+			name:    "missing mount_path",
+			signer:  &SignerBlock{Type: "transit", Address: "https://bao:8200"},
+			wantErr: "mount_path is required",
+		},
+		{
+			name:    "missing address without VAULT_ADDR",
+			signer:  &SignerBlock{Type: "transit", MountPath: "transit"},
+			wantErr: "address is required",
+		},
+		{
+			name:   "missing address but VAULT_ADDR set",
+			env:    map[string]string{"VAULT_ADDR": "https://bao:8200"},
+			signer: &SignerBlock{Type: "transit", MountPath: "transit"},
+		},
+		{
+			name:    "key_name_prefix with slash",
+			signer:  &SignerBlock{Type: "transit", Address: "https://bao:8200", MountPath: "transit", KeyNamePrefix: "a/b"},
+			wantErr: "must not contain '/'",
+		},
+		{
+			name:    "bad request_timeout",
+			signer:  &SignerBlock{Type: "transit", Address: "https://bao:8200", MountPath: "transit", RequestTimeout: "soon"},
+			wantErr: "invalid request_timeout",
+		},
+		{
+			name:    "non-positive request_timeout",
+			signer:  &SignerBlock{Type: "transit", Address: "https://bao:8200", MountPath: "transit", RequestTimeout: "0s"},
+			wantErr: "must be positive",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Default VAULT_ADDR empty unless the case sets it, so the address check is deterministic.
+			if _, ok := tc.env["VAULT_ADDR"]; !ok {
+				t.Setenv("VAULT_ADDR", "")
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			err := validateConfig(&Config{Signer: tc.signer})
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Adds an opt-in `signer "transit"` HCL stanza that selects an external signer for the OIDC issuer signing keys, so the private key can be held in a KMS rather than in-process. This PR is the config surface only — nothing consumes it yet.

## Changes
- `SignerBlock` (type label + transit fields) wired as `Config.Signer`, registered in the decode schema (so unknown keys inside the block are pruned with a warning rather than failing the load), merged wholesale across multi-file configs, and validated at load time: type must be `transit`, `mount_path` required, `address` required unless `VAULT_ADDR` is set, `key_name_prefix` no slash, `request_timeout` a positive duration.

## Notes
- Independent PR; nothing reads `Config.Signer` until the integration PR.
- Shape parallels the seal stanza's transit fields, with `key_name_prefix` (the signer provisions a key per algorithm) and a `request_timeout` for the per-sign call path.
