### PR TITLE
feat(oidc): hold the issuer signing key in an external KMS (remote signing)

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -450,6 +450,18 @@ func run(cmd *cobra.Command, args []string) error {
 	info["storage"] = conf.Storage.Type
 	infoKeys = append(infoKeys, "storage")
 
+	// Surface the OIDC issuer external signer (never the token) so an operator can
+	// confirm the signer stanza was loaded and the issuer key will live in the KMS.
+	if conf.Signer != nil {
+		prefix := conf.Signer.KeyNamePrefix
+		if prefix == "" {
+			prefix = "warden-oidc"
+		}
+		info["oidc signer"] = fmt.Sprintf("%s (mount: %s, key_prefix: %s)",
+			conf.Signer.Type, conf.Signer.MountPath, prefix)
+		infoKeys = append(infoKeys, "oidc signer")
+	}
+
 	if conf.APIAddr != "" {
 		info["api address"] = conf.APIAddr
 		infoKeys = append(infoKeys, "api address")

--- a/core/core.go
+++ b/core/core.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stephnangue/warden/api"
 	"github.com/stephnangue/warden/audit"
 	"github.com/stephnangue/warden/config"
+	"github.com/stephnangue/warden/core/oidcsign"
 	"github.com/stephnangue/warden/core/seal"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/credential/drivers"
@@ -229,6 +230,14 @@ type Core struct {
 	oidcMu        sync.RWMutex
 	oidcIssuer    *OIDCIssuer
 	oidcPublisher JWKSPublisher
+
+	// oidcSignBackend is the external KMS signer for the issuer key when the
+	// signer HCL stanza is configured (nil = default in-process keys). It is built
+	// lazily on the active serving path in setupOIDCIssuer and closed in
+	// stopOIDCIssuer, so a standby holds no idle KMS token. Guarded by oidcSetupMu.
+	// oidcSignTimeout is its per-call timeout.
+	oidcSignBackend oidcsign.Backend
+	oidcSignTimeout time.Duration
 
 	// oidcRotationCancel stops the active node's signing-key rotation loop, and
 	// oidcRotationDone is closed when the loop goroutine has exited (so stop can
@@ -858,7 +867,83 @@ func (c *Core) GetRotationManager() *RotationManager {
 // active node generates and persists one; a standby leaves the issuer not-ready
 // (it cannot write) and will activate on promotion, when unseal runs again as
 // active. Key generation and persistence therefore happen only on the active node.
-func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
+const (
+	defaultOIDCKeyNamePrefix      = "warden-oidc"
+	defaultOIDCSignRequestTimeout = 10 * time.Second
+)
+
+// parseConfigBool parses a string config value as a bool, treating empty/invalid
+// as false — matching how the seal stanza reads its bool-ish string fields.
+func parseConfigBool(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}
+
+// ensureOIDCSignBackend builds the external issuer signer from the HCL `signer`
+// stanza once (active serving path only), returning a nil backend when no stanza
+// is configured (the default: in-process keys). A construction failure is a
+// config error (bad TLS/address); transit being unreachable is not detected here.
+// Called under oidcSetupMu.
+func (c *Core) ensureOIDCSignBackend() (oidcsign.Backend, time.Duration, error) {
+	if c.oidcSignBackend != nil {
+		return c.oidcSignBackend, c.oidcSignTimeout, nil
+	}
+	conf, _ := c.rawConfig.Load().(*config.Config)
+	if conf == nil || conf.Signer == nil {
+		return nil, 0, nil
+	}
+	s := conf.Signer
+	timeout := defaultOIDCSignRequestTimeout
+	if s.RequestTimeout != "" {
+		d, err := time.ParseDuration(s.RequestTimeout)
+		if err != nil {
+			return nil, 0, fmt.Errorf("invalid signer request_timeout %q: %w", s.RequestTimeout, err)
+		}
+		timeout = d
+	}
+	prefix := s.KeyNamePrefix
+	if prefix == "" {
+		prefix = defaultOIDCKeyNamePrefix
+	}
+	backend, err := oidcsign.NewTransitBackend(oidcsign.TransitConfig{
+		Address:        s.Address,
+		Token:          s.Token,
+		MountPath:      s.MountPath,
+		KeyNamePrefix:  prefix,
+		Namespace:      s.Namespace,
+		RequestTimeout: timeout,
+		DisableRenewal: parseConfigBool(s.DisableRenewal),
+		TLSCACert:      s.TlsCaCert,
+		TLSCAPath:      s.TlsCaPath,
+		TLSClientCert:  s.TlsClientCert,
+		TLSClientKey:   s.TlsClientKey,
+		TLSServerName:  s.TlsServerName,
+		TLSSkipVerify:  parseConfigBool(s.TlsSkipVerify),
+	}, c.logger.WithSystem("oidc.signer"))
+	if err != nil {
+		return nil, 0, err
+	}
+	c.oidcSignBackend = backend
+	c.oidcSignTimeout = timeout
+	c.logger.Info("oidc issuer: external signer configured", logger.String("type", backend.Type()), logger.String("mount_path", s.MountPath))
+	return backend, timeout, nil
+}
+
+// closeOIDCSignBackend stops the external signer's token renewal and drops it, so
+// a stepped-down/sealed node holds no KMS token. Called under oidcSetupMu.
+func (c *Core) closeOIDCSignBackend() {
+	if c.oidcSignBackend != nil {
+		c.oidcSignBackend.Close()
+		c.oidcSignBackend = nil
+		c.oidcSignTimeout = 0
+	}
+}
+
+// setupOIDCIssuer (re)builds the issuer from the persisted config. configWrite is
+// true when called from the operator config-write path (which surfaces a remote
+// bootstrap failure synchronously) and false from unseal/promotion (which degrades
+// to not-ready rather than bricking startup).
+func (c *Core) setupOIDCIssuer(ctx context.Context, standby, configWrite bool) error {
 	// Serialize issuer setup/teardown so concurrent config writes (or a write racing
 	// seal/promotion) cannot interleave rotation-loop start/stop and leak a goroutine.
 	c.oidcSetupMu.Lock()
@@ -872,13 +957,19 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
 	// snapshot (which would leave the publisher holding a deleted key). It is restarted
 	// at the end from the fresh config.
 	c.stopPublisherCredRotation()
+	// Likewise join the signing-key rotation loop up front: a rotation tick in flight
+	// (its propagation-floor wait can span the JWKS cache TTL) would otherwise persist
+	// the pre-reload keyset over a cutover/regeneration performed below, diverging
+	// storage from the live issuer. Restarted at the end from the fresh keyset.
+	c.stopOIDCKeyRotation()
 
 	cfg, err := loadIssuerConfig(ctx, storage)
 	if err != nil {
 		return err
 	}
 	if cfg == nil || !cfg.Enabled {
-		c.stopOIDCKeyRotation() // never leak the loop when disabling
+		c.stopOIDCKeyRotation()  // never leak the loop when disabling
+		c.closeOIDCSignBackend() // release the KMS token when the issuer is off
 		// Drop any publisher-rotation schedule anchor so re-enabling the issuer later
 		// starts a fresh period rather than firing off a stale timestamp (active only —
 		// the active node owns this shared state).
@@ -913,13 +1004,41 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
 	issuer.SetAssertionTTL(cfg.assertionTTL())
 	issuer.SetCacheControl(cfg.jwksCacheTTL())
 
-	keysets, err := loadKeySet(ctx, storage)
+	// Choose where signing keys come from. On the active/serving path build the
+	// external signer when the `signer` stanza is configured; a standby uses no
+	// backend (it holds no KMS token) and reconstructs any remote keys as
+	// verification-only.
+	var backend oidcsign.Backend
+	var signTimeout time.Duration
+	if !standby {
+		b, to, berr := c.ensureOIDCSignBackend()
+		if berr != nil {
+			return fmt.Errorf("oidc issuer: configure external signer: %w", berr)
+		}
+		backend, signTimeout = b, to
+	}
+	keySource := oidcKeySource(localKeySource{})
+	if backend != nil {
+		keySource = remoteKeySource{backend: backend, timeout: signTimeout}
+	}
+
+	keysets, err := loadKeySet(ctx, storage, backend, signTimeout, c.logger)
 	if err != nil {
 		return err
 	}
 	if keysets == nil {
 		keysets = make(map[string]*algKeyset)
 	}
+
+	// Cutover: the stored keys live under a different source than is now configured
+	// (the signer stanza was just added or removed). Retire the old keys — they keep
+	// verifying in-flight assertions through the grace window — leaving each keyset
+	// incomplete so fresh keys are provisioned from the new source below. Active only.
+	if !standby && oidcKeySetSourceMismatch(keysets, keySource.remote()) {
+		c.logger.Warn("oidc issuer: signing-key location changed; cutting over to the newly configured source (old keys retired for the grace window)")
+		retireOIDCKeysetsForCutover(keysets)
+	}
+
 	// A keyset is complete only with both an active and a pre-published next key.
 	incomplete := func(alg string) bool {
 		ks := keysets[alg]
@@ -947,25 +1066,42 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
 			c.oidcMu.Unlock()
 			return nil
 		}
-		// Active node: generate the active key AND its pre-published successor for
+		// Active node: provision the active key AND its pre-published successor for
 		// every supported algorithm still missing one, so each next key is in the
 		// JWKS from the first publish, a full rotation period before it ever signs.
-		// (Also self-heals a keyset added after an algorithm becomes supported.)
+		// (Also self-heals a keyset added after an algorithm becomes supported, and
+		// completes a cutover.)
 		for _, alg := range oidcSupportedAlgs {
 			if !incomplete(alg) {
 				continue
 			}
-			active, err := generateSigningKey(alg)
-			if err != nil {
-				return err
+			active, next, gerr := keySource.bootstrap(ctx, alg)
+			if gerr != nil {
+				// A remote signer unreachable at first enable must not brick unseal:
+				// install the issuer not-ready and recover on a later config write or
+				// restart. The config-write path surfaces the error to the operator.
+				if configWrite {
+					return gerr
+				}
+				c.logger.Error("oidc issuer: could not provision signing keys from the external signer; issuer stays not-ready until recovery",
+					logger.String("alg", alg), logger.Err(gerr))
+				c.stopOIDCKeyRotation()
+				issuer.RestoreKeys(keysets)
+				c.oidcMu.Lock()
+				c.oidcIssuer = issuer
+				c.oidcPublisher = publisher
+				c.oidcMu.Unlock()
+				return nil
 			}
-			next, err := generateSigningKey(alg)
-			if err != nil {
-				return err
+			// Preserve any retired keys (e.g. demoted by a cutover) beside the new pair.
+			var retired []*signingKey
+			if ks := keysets[alg]; ks != nil {
+				retired = ks.retired
 			}
-			keysets[alg] = &algKeyset{active: active, next: next}
-			c.logger.Info("oidc issuer generated signing keys",
-				logger.String("alg", alg), logger.String("active_kid", active.kid), logger.String("next_kid", next.kid))
+			keysets[alg] = &algKeyset{active: active, next: next, retired: retired}
+			c.logger.Info("oidc issuer provisioned signing keys",
+				logger.String("alg", alg), logger.Bool("remote", keySource.remote()),
+				logger.String("active_kid", active.kid), logger.String("next_kid", next.kid))
 		}
 		if err := persistKeySet(ctx, storage, keysets); err != nil {
 			return err
@@ -994,7 +1130,7 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby bool) error {
 	// (re)setup so a config change or promotion picks up the current settings.
 	period := cfg.keyRotationPeriod()
 	firstTick := oidcRotationFirstTick(keysets, period)
-	c.startOIDCKeyRotation(standby, period, firstTick, issuer, publisher, cfg.jwksCacheTTL(), cfg.retiredKeyGrace())
+	c.startOIDCKeyRotation(standby, keySource, period, firstTick, issuer, publisher, cfg.jwksCacheTTL(), cfg.retiredKeyGrace())
 
 	// Publisher-credential rotation (active node, credential-bearing publishers only).
 	c.startPublisherCredRotation(standby, cfg.Publisher.rotationPeriod(), publisher)
@@ -1034,7 +1170,7 @@ func (c *Core) publishOIDCFor(ctx context.Context, issuer *OIDCIssuer, publisher
 // loop is stopped (and joined) first. The loop operates on the issuer/publisher
 // it is handed, so a later config swap never affects an in-flight rotation. The
 // context is parented on the active context so leadership loss cancels it.
-func (c *Core) startOIDCKeyRotation(standby bool, period, firstTick time.Duration, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) {
+func (c *Core) startOIDCKeyRotation(standby bool, keySource oidcKeySource, period, firstTick time.Duration, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) {
 	c.stopOIDCKeyRotation()
 	if standby || issuer == nil {
 		// A standby must not touch the active-node-owned status anchor.
@@ -1063,7 +1199,7 @@ func (c *Core) startOIDCKeyRotation(standby bool, period, firstTick time.Duratio
 	c.oidcRotationCancel = cancel
 	c.oidcRotationDone = done
 	c.oidcMu.Unlock()
-	go c.oidcKeyRotationLoop(ctx, done, period, firstTick, issuer, publisher, cacheTTL, grace)
+	go c.oidcKeyRotationLoop(ctx, done, keySource, period, firstTick, issuer, publisher, cacheTTL, grace)
 	c.logger.Info("oidc issuer: signing-key rotation enabled", logger.String("period", period.String()))
 }
 
@@ -1117,7 +1253,7 @@ func (c *Core) stopOIDCKeyRotation() {
 	}
 }
 
-func (c *Core) oidcKeyRotationLoop(ctx context.Context, done chan struct{}, period, firstTick time.Duration, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) {
+func (c *Core) oidcKeyRotationLoop(ctx context.Context, done chan struct{}, keySource oidcKeySource, period, firstTick time.Duration, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) {
 	defer close(done)
 	timer := time.NewTimer(firstTick)
 	defer timer.Stop()
@@ -1126,7 +1262,7 @@ func (c *Core) oidcKeyRotationLoop(ctx context.Context, done chan struct{}, peri
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			rotErr := c.rotateOIDCKey(ctx, issuer, publisher, cacheTTL, grace)
+			rotErr := c.rotateOIDCKey(ctx, keySource, issuer, publisher, cacheTTL, grace)
 			// Record the outcome (skip if the loop is tearing down — ctx cancellation is
 			// not a rotation failure worth persisting, and the state write would fail).
 			if ctx.Err() == nil {
@@ -1149,8 +1285,13 @@ func (c *Core) oidcKeyRotationLoop(ctx context.Context, done chan struct{}, peri
 // promoted key was persisted as `next` by the previous rotation and the fresh next
 // is persisted here before it can ever be promoted, so Warden never signs with a
 // key absent from storage.
-func (c *Core) rotateOIDCKey(ctx context.Context, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) error {
+func (c *Core) rotateOIDCKey(ctx context.Context, keySource oidcKeySource, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) error {
 	if issuer == nil || !issuer.Ready() {
+		return nil
+	}
+	// Defensive: key provisioning/rotation is single-writer (active node only). The
+	// loop is parented to the active context, but guard against a stepped-down node.
+	if c.standby.Load() {
 		return nil
 	}
 
@@ -1210,7 +1351,7 @@ func (c *Core) rotateOIDCKey(ctx context.Context, issuer *OIDCIssuer, publisher 
 			// Ready() guarantees every supported alg is present; defensive.
 			return fmt.Errorf("oidc issuer: missing %s keyset", alg)
 		}
-		newNext, err := generateSigningKey(alg)
+		newNext, err := keySource.nextKey(ctx, alg)
 		if err != nil {
 			return err
 		}
@@ -1245,6 +1386,9 @@ func (c *Core) stopOIDCIssuer() error {
 	defer c.oidcSetupMu.Unlock()
 	c.stopOIDCKeyRotation()
 	c.stopPublisherCredRotation()
+	// Close the external signer AFTER joining the rotation loop, so no in-flight
+	// rotation uses a closed KMS client. A standby holds no signer to close.
+	c.closeOIDCSignBackend()
 	c.oidcMu.Lock()
 	c.oidcIssuer = nil
 	c.oidcPublisher = nil
@@ -1885,8 +2029,10 @@ func (readonlyUnsealStrategy) unsealShared(ctx context.Context, log *logger.Gate
 	c.credConfigStore.SetRotationManager(c.rotationManager)
 
 	// Setup the OIDC issuer (Workload Identity Federation). Disabled by default;
-	// generates/persists a signing key only on the active node.
-	if err := c.setupOIDCIssuer(ctx, standby); err != nil {
+	// generates/persists a signing key only on the active node. Unseal path
+	// (configWrite=false): an unreachable external signer degrades to not-ready
+	// rather than bricking startup.
+	if err := c.setupOIDCIssuer(ctx, standby, false); err != nil {
 		return err
 	}
 

--- a/core/oidc_issuer_storage.go
+++ b/core/oidc_issuer_storage.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/core/oidcsign"
+	"github.com/stephnangue/warden/logger"
 )
 
 // oidcIssuerStorePrefix is the barrier-view prefix under which the issuer's
@@ -24,12 +26,25 @@ const oidcIssuerStorePrefix = "core/oidc-issuer/"
 const oidcKeySetPath = "keyset"
 
 // storedSigningKey is the barrier-encrypted storage format of one signing key.
+// Exactly one of KeyPKCS8 (a local in-process key) or Remote (an external-KMS
+// handle) is set.
 type storedSigningKey struct {
-	Kid       string    `json:"kid"`
-	Alg       string    `json:"alg"`
-	KeyPKCS8  string    `json:"key_pkcs8"` // base64(std) PKCS#8 DER (RSA or ECDSA)
-	CreatedAt time.Time `json:"created_at"`
-	RetiredAt time.Time `json:"retired_at,omitempty"`
+	Kid       string           `json:"kid"`
+	Alg       string           `json:"alg"`
+	KeyPKCS8  string           `json:"key_pkcs8,omitempty"` // local key: base64(std) PKCS#8 DER (RSA or ECDSA)
+	Remote    *storedRemoteKey `json:"remote,omitempty"`    // external KMS handle; no private material
+	CreatedAt time.Time        `json:"created_at"`
+	RetiredAt time.Time        `json:"retired_at,omitempty"`
+}
+
+// storedRemoteKey is the storage format of a KMS-backed key: a handle plus the
+// cached PKIX PEM public key, so unseal and JWKS never need a KMS round-trip. No
+// private key material is stored.
+type storedRemoteKey struct {
+	Backend      string `json:"backend"` // e.g. "transit"
+	KeyName      string `json:"key_name"`
+	KeyVersion   int    `json:"key_version"`
+	PublicKeyPEM string `json:"public_key_pem"`
 }
 
 // storedAlgKeyset is one algorithm's stored active + pre-published next + retired
@@ -48,20 +63,62 @@ type storedKeySet struct {
 }
 
 func toStored(sk *signingKey) (storedSigningKey, error) {
+	out := storedSigningKey{Kid: sk.kid, Alg: sk.alg, CreatedAt: sk.createdAt, RetiredAt: sk.retiredAt}
+	// A KMS-backed key has no exportable private material — persist only its handle
+	// and cached public key.
+	if rs, ok := sk.key.(*oidcsign.Signer); ok {
+		pemStr, err := oidcsign.MarshalPublicKeyPEM(rs.Public())
+		if err != nil {
+			return storedSigningKey{}, fmt.Errorf("oidc issuer: %w", err)
+		}
+		ref := rs.Ref()
+		out.Remote = &storedRemoteKey{
+			Backend:      rs.BackendType(),
+			KeyName:      ref.KeyName,
+			KeyVersion:   ref.Version,
+			PublicKeyPEM: pemStr,
+		}
+		return out, nil
+	}
 	der, err := x509.MarshalPKCS8PrivateKey(sk.key)
 	if err != nil {
 		return storedSigningKey{}, fmt.Errorf("oidc issuer: marshal signing key: %w", err)
 	}
-	return storedSigningKey{
-		Kid:       sk.kid,
-		Alg:       sk.alg,
-		KeyPKCS8:  base64.StdEncoding.EncodeToString(der),
-		CreatedAt: sk.createdAt,
-		RetiredAt: sk.retiredAt,
-	}, nil
+	out.KeyPKCS8 = base64.StdEncoding.EncodeToString(der)
+	return out, nil
 }
 
-func fromStored(s storedSigningKey) (*signingKey, error) {
+// fromStored reconstructs a signing key. For a remote key it builds a
+// signing-capable signer when backend matches the stored backend type, otherwise
+// a verification-only signer so the key still verifies its in-flight assertions in
+// the JWKS. The verification-only case arises on the active node after a
+// remote->local cutover (the signer stanza was removed, so backend is nil) or for
+// retired keys left behind by a previously-configured backend. backend may be nil.
+func fromStored(s storedSigningKey, backend oidcsign.Backend, timeout time.Duration) (*signingKey, error) {
+	if s.Remote != nil {
+		pub, err := oidcsign.ParsePublicKeyPEM(s.Remote.PublicKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("oidc issuer: %w", err)
+		}
+		// The kid is a pure function of the public key; a mismatch means the stored
+		// handle and public key disagree (corruption or tampering).
+		kid, err := signingKeyID(pub)
+		if err != nil {
+			return nil, err
+		}
+		if kid != s.Kid {
+			return nil, fmt.Errorf("oidc issuer: stored remote key kid mismatch (stored %q, computed %q)", s.Kid, kid)
+		}
+		ref := oidcsign.KeyRef{KeyName: s.Remote.KeyName, Version: s.Remote.KeyVersion, Alg: s.Alg}
+		var signer crypto.Signer
+		if backend != nil && backend.Type() == s.Remote.Backend {
+			signer = oidcsign.NewSigner(backend, ref, pub, timeout)
+		} else {
+			signer = oidcsign.NewVerifyingSigner(s.Remote.Backend, ref, pub)
+		}
+		return &signingKey{key: signer, alg: s.Alg, kid: s.Kid, createdAt: s.CreatedAt, retiredAt: s.RetiredAt}, nil
+	}
+
 	der, err := base64.StdEncoding.DecodeString(s.KeyPKCS8)
 	if err != nil {
 		return nil, fmt.Errorf("oidc issuer: decode stored key: %w", err)
@@ -90,7 +147,7 @@ func persistKeySet(ctx context.Context, storage sdklogical.Storage, keysets map[
 	if len(keysets) == 0 {
 		return fmt.Errorf("oidc issuer: cannot persist an empty keyset")
 	}
-	set := storedKeySet{Version: 3, Keysets: make(map[string]storedAlgKeyset, len(keysets))}
+	set := storedKeySet{Version: 4, Keysets: make(map[string]storedAlgKeyset, len(keysets))}
 	for alg, ks := range keysets {
 		if ks == nil || ks.active == nil {
 			return fmt.Errorf("oidc issuer: cannot persist %s keyset with no active key", alg)
@@ -125,7 +182,9 @@ func persistKeySet(ctx context.Context, storage sdklogical.Storage, keysets map[
 
 // loadKeySet reads the per-algorithm keyset map from storage. It returns (nil, nil)
 // when none has been persisted yet, so the caller can decide to generate the keys.
-func loadKeySet(ctx context.Context, storage sdklogical.Storage) (map[string]*algKeyset, error) {
+// backend (and its per-call timeout) reconstructs signing-capable remote keys; pass
+// nil to reconstruct any remote keys as verification-only.
+func loadKeySet(ctx context.Context, storage sdklogical.Storage, backend oidcsign.Backend, timeout time.Duration, log *logger.GatedLogger) (map[string]*algKeyset, error) {
 	entry, err := storage.Get(ctx, oidcKeySetPath)
 	if err != nil {
 		return nil, fmt.Errorf("oidc issuer: read keyset: %w", err)
@@ -138,27 +197,33 @@ func loadKeySet(ctx context.Context, storage sdklogical.Storage) (map[string]*al
 		return nil, fmt.Errorf("oidc issuer: unmarshal keyset: %w", err)
 	}
 	// Fail loudly on an unrecognized version rather than silently regenerating over
-	// (and destroying) an existing keyset. No pre-v3 migration is written: the
+	// (and destroying) an existing keyset. No pre-v4 migration is written: the
 	// feature is not yet released, so a stale keyset is cleared and re-created by
 	// hand, not migrated.
-	if set.Version != 3 {
-		return nil, fmt.Errorf("oidc issuer: unsupported keyset version %d (expected 3)", set.Version)
+	if set.Version != 4 {
+		return nil, fmt.Errorf("oidc issuer: unsupported keyset version %d (expected 4)", set.Version)
 	}
 	keysets := make(map[string]*algKeyset, len(set.Keysets))
 	for alg, sk := range set.Keysets {
-		active, err := fromStored(sk.Active)
+		active, err := fromStored(sk.Active, backend, timeout)
 		if err != nil {
 			return nil, err
 		}
-		next, err := fromStored(sk.Next)
+		next, err := fromStored(sk.Next, backend, timeout)
 		if err != nil {
 			return nil, err
 		}
 		ks := &algKeyset{active: active, next: next}
 		for _, sr := range sk.Retired {
-			r, err := fromStored(sr)
+			r, err := fromStored(sr, backend, timeout)
 			if err != nil {
-				return nil, err
+				// A retired key only verifies soon-to-expire assertions; a corrupt one
+				// must not brick unseal (unlike active/next, which fail loud above).
+				// Drop it — a mismatched key could not verify anything anyway.
+				if log != nil {
+					log.Warn("oidc issuer: dropping unreadable retired signing key", logger.String("alg", alg), logger.String("kid", sr.Kid), logger.Err(err))
+				}
+				continue
 			}
 			ks.retired = append(ks.retired, r)
 		}

--- a/core/oidc_issuer_test.go
+++ b/core/oidc_issuer_test.go
@@ -40,7 +40,7 @@ func rs256Keys(iss *OIDCIssuer) (active, next *signingKey, retired []*signingKey
 // loadRS256 loads the persisted keyset and returns the RS256 keyset's active,
 // next, and retired keys (all nil when none is persisted).
 func loadRS256(ctx context.Context, storage sdklogical.Storage) (active, next *signingKey, retired []*signingKey, err error) {
-	keysets, err := loadKeySet(ctx, storage)
+	keysets, err := loadKeySet(ctx, storage, nil, 0, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -307,7 +307,7 @@ func TestOIDCIssuer_ES256_StorageRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ES256", stored.Alg)
 
-	loaded, err := fromStored(stored)
+	loaded, err := fromStored(stored, nil, 0)
 	require.NoError(t, err)
 	assert.Equal(t, orig.kid, loaded.kid)
 	assert.Equal(t, "ES256", loaded.alg)
@@ -326,7 +326,7 @@ func TestOIDCIssuer_KeyStorage_RejectsOldVersion(t *testing.T) {
 	require.NoError(t, storage.Put(ctx, &sdklogical.StorageEntry{
 		Key: oidcKeySetPath, Value: []byte(`{"version":2,"active":{}}`),
 	}))
-	_, err := loadKeySet(ctx, storage)
+	_, err := loadKeySet(ctx, storage, nil, 0, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported keyset version 2")
 }
@@ -522,7 +522,7 @@ func TestCore_setupOIDCIssuer(t *testing.T) {
 	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
 
 	// Disabled by default: no config -> nil issuer.
-	if err := core.setupOIDCIssuer(ctx, false); err != nil {
+	if err := core.setupOIDCIssuer(ctx, false, false); err != nil {
 		t.Fatalf("setup (no config): %v", err)
 	}
 	if core.OIDCIssuer() != nil {
@@ -533,7 +533,7 @@ func TestCore_setupOIDCIssuer(t *testing.T) {
 	if err := saveIssuerConfig(ctx, storage, &issuerConfig{Enabled: false, IssuerURL: "https://iss.example"}); err != nil {
 		t.Fatalf("save disabled config: %v", err)
 	}
-	if err := core.setupOIDCIssuer(ctx, false); err != nil {
+	if err := core.setupOIDCIssuer(ctx, false, false); err != nil {
 		t.Fatalf("setup (disabled): %v", err)
 	}
 	if core.OIDCIssuer() != nil {
@@ -544,7 +544,7 @@ func TestCore_setupOIDCIssuer(t *testing.T) {
 	if err := saveIssuerConfig(ctx, storage, &issuerConfig{Enabled: true, IssuerURL: "https://iss.example"}); err != nil {
 		t.Fatalf("save enabled config: %v", err)
 	}
-	if err := core.setupOIDCIssuer(ctx, true /* standby */); err != nil {
+	if err := core.setupOIDCIssuer(ctx, true /* standby */, false); err != nil {
 		t.Fatalf("setup (standby): %v", err)
 	}
 	if iss := core.OIDCIssuer(); iss == nil || iss.Ready() {
@@ -555,7 +555,7 @@ func TestCore_setupOIDCIssuer(t *testing.T) {
 	}
 
 	// Enabled, active -> generates + persists a key, issuer ready and can mint.
-	if err := core.setupOIDCIssuer(ctx, false /* active */); err != nil {
+	if err := core.setupOIDCIssuer(ctx, false /* active */, false); err != nil {
 		t.Fatalf("setup (active): %v", err)
 	}
 	iss := core.OIDCIssuer()
@@ -580,7 +580,7 @@ func TestCore_setupOIDCIssuer(t *testing.T) {
 	firstKid, firstNextKid := persisted.kid, persistedNext.kid
 
 	// Re-setup (active) must reuse the persisted keys, not generate new ones.
-	if err := core.setupOIDCIssuer(ctx, false); err != nil {
+	if err := core.setupOIDCIssuer(ctx, false, false); err != nil {
 		t.Fatalf("setup (reuse): %v", err)
 	}
 	reloaded, reloadedNext, _, _ := loadRS256(ctx, storage)
@@ -636,7 +636,7 @@ func enableIssuer(t *testing.T, core *Core) *OIDCIssuer {
 	ctx := context.Background()
 	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
 	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{Enabled: true, IssuerURL: "https://iss.example"}))
-	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
 	iss := core.OIDCIssuer()
 	require.NotNil(t, iss)
 	require.True(t, iss.Ready())
@@ -684,7 +684,7 @@ func TestRotateOIDCKey(t *testing.T) {
 
 	oldActive, oldNext, _ := rs256Keys(iss)
 
-	require.NoError(t, core.rotateOIDCKey(ctx, iss, nil, 0, defaultRetiredKeyGrace))
+	require.NoError(t, core.rotateOIDCKey(ctx, localKeySource{}, iss, nil, 0, defaultRetiredKeyGrace))
 
 	newActive, newNext, retired := rs256Keys(iss)
 	assert.Equal(t, oldNext.kid, newActive.kid, "rotation must promote the next key to active")
@@ -726,7 +726,7 @@ func TestOIDCIssuer_DerivedCacheControl(t *testing.T) {
 	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{
 		Enabled: true, IssuerURL: "https://iss.example", JWKSCacheTTL: "150s",
 	}))
-	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
 	assert.Equal(t, "public, max-age=150", core.OIDCIssuer().CacheControl())
 }
 
@@ -765,7 +765,7 @@ func TestRotateOIDCKey_NextPrePublished(t *testing.T) {
 	// The next key is in the JWKS before it ever signs.
 	assert.True(t, jwksKIDs(t, iss)[oldNext.kid], "the next key must be published before activation")
 
-	require.NoError(t, core.rotateOIDCKey(ctx, iss, nil, 0, defaultRetiredKeyGrace))
+	require.NoError(t, core.rotateOIDCKey(ctx, localKeySource{}, iss, nil, 0, defaultRetiredKeyGrace))
 
 	newActive, _, _ := rs256Keys(iss)
 	assert.Equal(t, oldNext.kid, newActive.kid, "the pre-published next key must become active")
@@ -787,7 +787,7 @@ func TestRotateOIDCKey_CancelDuringFloorWait(t *testing.T) {
 	// A large cache TTL forces the floor to be active: the next key was just created
 	// at enable, so it is younger than the TTL and the rotation must wait — and here
 	// the cancelled context aborts that wait.
-	err := core.rotateOIDCKey(ctx, iss, &spyPublisher{}, time.Minute, defaultRetiredKeyGrace)
+	err := core.rotateOIDCKey(ctx, localKeySource{}, iss, &spyPublisher{}, time.Minute, defaultRetiredKeyGrace)
 	require.Error(t, err)
 
 	after, afterNext, retired := rs256Keys(iss)
@@ -814,7 +814,7 @@ func TestRotateOIDCKey_PublishesOnceWithFullKeyset(t *testing.T) {
 	oldActive, oldNext, _ := rs256Keys(iss)
 
 	// cacheTTL=0 -> no floor wait; one publish after the flip.
-	require.NoError(t, core.rotateOIDCKey(context.Background(), iss, spy, 0, defaultRetiredKeyGrace))
+	require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, spy, 0, defaultRetiredKeyGrace))
 	newActive, newNext, _ := rs256Keys(iss)
 
 	require.Len(t, spy.jwks, 1, "rotation must publish exactly once")
@@ -842,16 +842,16 @@ func TestOIDCKeyRotation_Lifecycle(t *testing.T) {
 	iss := enableIssuer(t, core)
 
 	// Standby -> no loop.
-	core.startOIDCKeyRotation(true, time.Hour, time.Hour, iss, nil, time.Minute, time.Hour)
+	core.startOIDCKeyRotation(true, localKeySource{}, time.Hour, time.Hour, iss, nil, time.Minute, time.Hour)
 	assert.Nil(t, core.oidcRotationCancel, "standby must not start a rotation loop")
 
 	// period 0 -> no loop.
-	core.startOIDCKeyRotation(false, 0, 0, iss, nil, time.Minute, time.Hour)
+	core.startOIDCKeyRotation(false, localKeySource{}, 0, 0, iss, nil, time.Minute, time.Hour)
 	assert.Nil(t, core.oidcRotationCancel)
 
 	// Active + positive period -> loop started, with a far-future first tick so it
 	// never fires during the test.
-	core.startOIDCKeyRotation(false, time.Hour, time.Hour, iss, nil, time.Minute, time.Hour)
+	core.startOIDCKeyRotation(false, localKeySource{}, time.Hour, time.Hour, iss, nil, time.Minute, time.Hour)
 	require.NotNil(t, core.oidcRotationCancel, "active node must start the loop")
 	require.NotNil(t, core.oidcRotationDone)
 	done := core.oidcRotationDone
@@ -975,7 +975,7 @@ func TestRotateOIDCKey_PropagationFloor(t *testing.T) {
 		defer core.tokenStore.Close()
 		iss := enableIssuer(t, core) // next created ~now
 		start := time.Now()
-		require.NoError(t, core.rotateOIDCKey(context.Background(), iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
+		require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
 		assert.GreaterOrEqual(t, time.Since(start), 450*time.Millisecond, "a young next key must wait out most of the floor")
 	})
 
@@ -988,7 +988,7 @@ func TestRotateOIDCKey_PropagationFloor(t *testing.T) {
 		next.createdAt = time.Now().Add(-time.Hour)
 		iss.RestoreKeys(rs256Keyset(active, next, retired))
 		start := time.Now()
-		require.NoError(t, core.rotateOIDCKey(context.Background(), iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
+		require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
 		assert.Less(t, time.Since(start), 300*time.Millisecond, "an old-enough next key must not wait")
 	})
 }
@@ -1002,6 +1002,6 @@ func TestRotateOIDCKey_NoFloorWithoutPublisher(t *testing.T) {
 	start := time.Now()
 	// Large cache TTL, but publisher == nil -> no wait. The bound sits well below
 	// the TTL yet above a rotation's RSA-keygen cost so the check is not flaky.
-	require.NoError(t, core.rotateOIDCKey(context.Background(), iss, nil, time.Minute, defaultRetiredKeyGrace))
+	require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, nil, time.Minute, defaultRetiredKeyGrace))
 	assert.Less(t, time.Since(start), 300*time.Millisecond, "no publisher means no propagation floor")
 }

--- a/core/oidc_publisher_rotation_test.go
+++ b/core/oidc_publisher_rotation_test.go
@@ -192,7 +192,7 @@ func TestSetupOIDCIssuer_PublisherRotationLifecycle(t *testing.T) {
 		IssuerURL: "https://iss.example",
 		Publisher: publisherConfig{Type: "gcs", Bucket: "b", CredentialsJSON: saKey, Endpoint: stg.URL, RotationPeriod: "720h"},
 	}))
-	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
 
 	core.oidcMu.RLock()
 	running := core.oidcPubRotationCancel != nil
@@ -210,7 +210,7 @@ func TestSetupOIDCIssuer_PublisherRotationLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	cfg.Publisher.RotationPeriod = ""
 	require.NoError(t, saveIssuerConfig(ctx, storage, cfg))
-	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
 
 	core.oidcMu.RLock()
 	running2 := core.oidcPubRotationCancel != nil

--- a/core/oidc_signing_backend.go
+++ b/core/oidc_signing_backend.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/core/oidcsign"
+)
+
+// oidcKeySource abstracts where the issuer's signing keys come from: local
+// in-process generation (the default) or an external KMS that holds the private
+// key and signs remotely. Only the active node calls these — key generation and
+// rotation are single-writer.
+type oidcKeySource interface {
+	// bootstrap returns a fresh active key and its pre-published next key for alg.
+	bootstrap(ctx context.Context, alg string) (active, next *signingKey, err error)
+	// nextKey returns a fresh pre-published next key for alg (rotation).
+	nextKey(ctx context.Context, alg string) (*signingKey, error)
+	// remote reports whether this source produces KMS-backed keys, so setup can
+	// detect a change of key location against what is stored.
+	remote() bool
+}
+
+// localKeySource generates RSA/ECDSA keys in process (the default). The private
+// key lives in Warden's memory and is stored barrier-encrypted.
+type localKeySource struct{}
+
+func (localKeySource) bootstrap(_ context.Context, alg string) (*signingKey, *signingKey, error) {
+	active, err := generateSigningKey(alg)
+	if err != nil {
+		return nil, nil, err
+	}
+	next, err := generateSigningKey(alg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return active, next, nil
+}
+
+func (localKeySource) nextKey(_ context.Context, alg string) (*signingKey, error) {
+	return generateSigningKey(alg)
+}
+
+func (localKeySource) remote() bool { return false }
+
+// remoteKeySource provisions and signs with keys held in an external KMS: the
+// active/next/retired model maps onto KMS key versions, and the private key never
+// enters Warden. active/next are two distinct versions of the alg's key.
+type remoteKeySource struct {
+	backend oidcsign.Backend
+	timeout time.Duration
+}
+
+func (r remoteKeySource) bootstrap(ctx context.Context, alg string) (*signingKey, *signingKey, error) {
+	// EnsureKey adopts (or creates) the key and returns its latest version as the
+	// active key; NewVersion pre-publishes the successor.
+	activeInfo, err := r.backend.EnsureKey(ctx, alg)
+	if err != nil {
+		return nil, nil, err
+	}
+	active, err := r.newRemoteSigningKey(activeInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	nextInfo, err := r.backend.NewVersion(ctx, alg)
+	if err != nil {
+		return nil, nil, err
+	}
+	next, err := r.newRemoteSigningKey(nextInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return active, next, nil
+}
+
+func (r remoteKeySource) nextKey(ctx context.Context, alg string) (*signingKey, error) {
+	info, err := r.backend.NewVersion(ctx, alg)
+	if err != nil {
+		return nil, err
+	}
+	return r.newRemoteSigningKey(info)
+}
+
+func (r remoteKeySource) remote() bool { return true }
+
+// newRemoteSigningKey wraps a provisioned KMS key version as a signingKey. The kid
+// is the RFC 7638 thumbprint of the public key — identical to a local key's kid
+// and stable across restarts — and createdAt is the KMS-side creation time, so the
+// rotation scheduler's anchor survives restarts.
+func (r remoteKeySource) newRemoteSigningKey(info oidcsign.KeyInfo) (*signingKey, error) {
+	kid, err := signingKeyID(info.Public)
+	if err != nil {
+		return nil, err
+	}
+	signer := oidcsign.NewSigner(r.backend, info.Ref, info.Public, r.timeout)
+	return &signingKey{key: signer, alg: info.Ref.Alg, kid: kid, createdAt: info.CreatedAt}, nil
+}
+
+// isRemoteSigningKey reports whether a signing key is KMS-backed.
+func isRemoteSigningKey(sk *signingKey) bool {
+	if sk == nil {
+		return false
+	}
+	_, ok := sk.key.(*oidcsign.Signer)
+	return ok
+}
+
+// oidcKeySetSourceMismatch reports whether any supported algorithm's active key
+// cannot sign under the configured source, meaning the key location changed and a
+// cutover is needed.
+func oidcKeySetSourceMismatch(keysets map[string]*algKeyset, wantRemote bool) bool {
+	for _, alg := range oidcSupportedAlgs {
+		ks := keysets[alg]
+		if ks == nil || ks.active == nil {
+			continue
+		}
+		if oidcActiveKeyNeedsCutover(ks.active, wantRemote) {
+			return true
+		}
+	}
+	return false
+}
+
+// oidcActiveKeyNeedsCutover reports whether an active key must be replaced because
+// it cannot sign under the configured source. For a local config, any remote key
+// must go. For a remote config, a local key must go — AND a remote key that cannot
+// sign (a different or removed backend left it verification-only) must go too, so
+// adding a second backend type later cannot silently install an unusable key.
+func oidcActiveKeyNeedsCutover(active *signingKey, wantRemote bool) bool {
+	rs, isRemote := active.key.(*oidcsign.Signer)
+	if !wantRemote {
+		return isRemote
+	}
+	if !isRemote {
+		return true
+	}
+	return !rs.CanSign()
+}
+
+// retireOIDCKeysetsForCutover moves every supported algorithm's active and next
+// keys into retired (stamped now) so they keep verifying in-flight assertions
+// through the grace window, leaving each keyset incomplete so fresh keys are
+// provisioned from the newly configured source. Unsupported (stray) algorithms are
+// left untouched, matching the rest of the issuer's key management.
+func retireOIDCKeysetsForCutover(keysets map[string]*algKeyset) {
+	now := time.Now()
+	for _, alg := range oidcSupportedAlgs {
+		ks := keysets[alg]
+		if ks == nil {
+			continue
+		}
+		retired := append([]*signingKey(nil), ks.retired...)
+		for _, k := range []*signingKey{ks.active, ks.next} {
+			if k == nil {
+				continue
+			}
+			kk := *k
+			kk.retiredAt = now
+			retired = append(retired, &kk)
+		}
+		keysets[alg] = &algKeyset{retired: retired}
+	}
+}
+
+// signingKeyID computes the stable RFC 7638 JWK thumbprint kid for a public key,
+// matching the kid generateSigningKey assigns to a local key of the same public
+// half, so a key keeps its kid whether held locally or remotely.
+func signingKeyID(pub crypto.PublicKey) (string, error) {
+	switch k := pub.(type) {
+	case *rsa.PublicKey:
+		return rsaThumbprint(k), nil
+	case *ecdsa.PublicKey:
+		return ecThumbprint(k)
+	default:
+		return "", fmt.Errorf("oidc issuer: unsupported public key type %T", pub)
+	}
+}

--- a/core/oidc_signing_backend_test.go
+++ b/core/oidc_signing_backend_test.go
@@ -1,0 +1,468 @@
+package core
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/cap/jwt"
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/core/oidcsign"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSignBackend is an in-memory oidcsign.Backend for tests: it holds a real
+// RSA/ECDSA key per alg version and signs by delegating to the underlying
+// crypto.Signer, so its output matches the crypto.Signer contract exactly (RSA
+// PKCS#1 v1.5, ECDSA ASN.1 DER) and minted assertions verify against the JWKS.
+type fakeSignBackend struct {
+	t        *testing.T
+	mu       sync.Mutex
+	closed   bool
+	opErr    error                      // when set, EnsureKey/NewVersion fail (simulate KMS down)
+	versions map[string][]crypto.Signer // alg -> keys, index 0 == version 1
+}
+
+func newFakeSignBackend(t *testing.T) *fakeSignBackend {
+	return &fakeSignBackend{t: t, versions: map[string][]crypto.Signer{}}
+}
+
+func genForAlg(t *testing.T, alg string) crypto.Signer {
+	t.Helper()
+	switch alg {
+	case oidcAlgRS256:
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		return k
+	case oidcAlgES256:
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		return k
+	}
+	t.Fatalf("fake backend: unhandled alg %q", alg)
+	return nil
+}
+
+func (f *fakeSignBackend) Type() string { return "transit" }
+
+func (f *fakeSignBackend) infoLocked(alg string) oidcsign.KeyInfo {
+	vers := f.versions[alg]
+	ver := len(vers)
+	return oidcsign.KeyInfo{
+		Ref:       oidcsign.KeyRef{KeyName: "fake-" + alg, Version: ver, Alg: alg},
+		Public:    vers[ver-1].Public(),
+		CreatedAt: time.Now().Add(time.Duration(ver) * time.Second),
+	}
+}
+
+func (f *fakeSignBackend) EnsureKey(_ context.Context, alg string) (oidcsign.KeyInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.opErr != nil {
+		return oidcsign.KeyInfo{}, f.opErr
+	}
+	if len(f.versions[alg]) == 0 {
+		f.versions[alg] = []crypto.Signer{genForAlg(f.t, alg)}
+	}
+	return f.infoLocked(alg), nil
+}
+
+func (f *fakeSignBackend) NewVersion(_ context.Context, alg string) (oidcsign.KeyInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.opErr != nil {
+		return oidcsign.KeyInfo{}, f.opErr
+	}
+	f.versions[alg] = append(f.versions[alg], genForAlg(f.t, alg))
+	return f.infoLocked(alg), nil
+}
+
+func (f *fakeSignBackend) PublicKey(_ context.Context, ref oidcsign.KeyRef) (crypto.PublicKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.versions[ref.Alg][ref.Version-1].Public(), nil
+}
+
+func (f *fakeSignBackend) Sign(_ context.Context, ref oidcsign.KeyRef, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	f.mu.Lock()
+	signer := f.versions[ref.Alg][ref.Version-1]
+	f.mu.Unlock()
+	return signer.Sign(rand.Reader, digest, opts)
+}
+
+func (f *fakeSignBackend) Close() { f.closed = true }
+
+func TestRemoteKeySource_BootstrapAndNext(t *testing.T) {
+	fake := newFakeSignBackend(t)
+	src := remoteKeySource{backend: fake, timeout: time.Second}
+	ctx := context.Background()
+
+	active, next, err := src.bootstrap(ctx, oidcAlgRS256)
+	require.NoError(t, err)
+	// active is v1, next is v2, distinct kids.
+	assert.NotEqual(t, active.kid, next.kid)
+	// kid must equal the thumbprint of the (remote) public key — identical to a
+	// local key's kid, so it is stable regardless of where the key lives.
+	wantKid := rsaThumbprint(active.key.Public().(*rsa.PublicKey))
+	assert.Equal(t, wantKid, active.kid)
+	// createdAt comes from the backend (KMS creation time), not time.Now here.
+	assert.False(t, active.createdAt.IsZero())
+	// The signingKey is remote (KMS-backed).
+	assert.True(t, isRemoteSigningKey(active))
+
+	nk, err := src.nextKey(ctx, oidcAlgRS256)
+	require.NoError(t, err)
+	assert.NotEqual(t, next.kid, nk.kid, "rotation must yield a new version/kid")
+}
+
+func TestStorageV4_RemoteRoundTrip(t *testing.T) {
+	fake := newFakeSignBackend(t)
+	info, err := fake.EnsureKey(context.Background(), oidcAlgRS256)
+	require.NoError(t, err)
+	kid, err := signingKeyID(info.Public)
+	require.NoError(t, err)
+	sk := &signingKey{key: oidcsign.NewSigner(fake, info.Ref, info.Public, time.Second), alg: oidcAlgRS256, kid: kid, createdAt: info.CreatedAt}
+
+	stored, err := toStored(sk)
+	require.NoError(t, err)
+	require.NotNil(t, stored.Remote, "a remote key must serialize as a handle")
+	assert.Empty(t, stored.KeyPKCS8, "no private material may be stored for a remote key")
+	assert.Equal(t, "transit", stored.Remote.Backend)
+	assert.Equal(t, info.Ref.KeyName, stored.Remote.KeyName)
+
+	// With a matching backend -> signing-capable.
+	back, err := fromStored(stored, fake, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, kid, back.kid)
+	rs := back.key.(*oidcsign.Signer)
+	assert.True(t, rs.CanSign())
+
+	// With no backend -> verification-only (fails closed on Sign) but same public key/kid.
+	vonly, err := fromStored(stored, nil, 0)
+	require.NoError(t, err)
+	assert.False(t, vonly.key.(*oidcsign.Signer).CanSign())
+	assert.Equal(t, kid, vonly.kid)
+
+	// A tampered kid is rejected (the kid is a pure function of the public key).
+	bad := stored
+	bad.Kid = "tampered"
+	_, err = fromStored(bad, fake, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kid mismatch")
+}
+
+func TestOIDCKeySetSourceMismatch_and_Cutover(t *testing.T) {
+	fake := newFakeSignBackend(t)
+	src := remoteKeySource{backend: fake, timeout: time.Second}
+	ctx := context.Background()
+
+	// A remote keyset vs a local config = mismatch; vs a remote config = match.
+	rActive, rNext, err := src.bootstrap(ctx, oidcAlgRS256)
+	require.NoError(t, err)
+	remoteKeysets := map[string]*algKeyset{oidcAlgRS256: {active: rActive, next: rNext}}
+	assert.True(t, oidcKeySetSourceMismatch(remoteKeysets, false), "remote keys vs local config is a mismatch")
+	assert.False(t, oidcKeySetSourceMismatch(remoteKeysets, true), "remote keys vs remote config matches")
+
+	// A local keyset vs remote config = mismatch.
+	localKeysets := map[string]*algKeyset{oidcAlgRS256: {active: mustGen(t, oidcAlgRS256), next: mustGen(t, oidcAlgRS256)}}
+	assert.True(t, oidcKeySetSourceMismatch(localKeysets, true))
+
+	// Cutover retires active+next into retired, leaving the keyset incomplete.
+	retireOIDCKeysetsForCutover(remoteKeysets)
+	ks := remoteKeysets[oidcAlgRS256]
+	assert.Nil(t, ks.active)
+	assert.Nil(t, ks.next)
+	assert.Len(t, ks.retired, 2)
+	for _, r := range ks.retired {
+		assert.False(t, r.retiredAt.IsZero(), "retired keys must be stamped")
+	}
+}
+
+func TestOIDCActiveKeyNeedsCutover(t *testing.T) {
+	fake := newFakeSignBackend(t)
+	info, err := fake.EnsureKey(context.Background(), oidcAlgRS256)
+	require.NoError(t, err)
+
+	local := mustGen(t, oidcAlgRS256)
+	remoteSigning := &signingKey{key: oidcsign.NewSigner(fake, info.Ref, info.Public, time.Second)}
+	// A remote key whose backend is absent/different — reconstructed verify-only.
+	remoteVerifyOnly := &signingKey{key: oidcsign.NewVerifyingSigner("transit", info.Ref, info.Public)}
+
+	// Local config: only remote keys need to go.
+	assert.False(t, oidcActiveKeyNeedsCutover(local, false))
+	assert.True(t, oidcActiveKeyNeedsCutover(remoteSigning, false))
+	assert.True(t, oidcActiveKeyNeedsCutover(remoteVerifyOnly, false))
+
+	// Remote config: a local key goes, a signing remote key stays, and a
+	// verify-only remote key (wrong/removed backend) must ALSO go — otherwise a
+	// future second backend type would silently install an unusable active key.
+	assert.True(t, oidcActiveKeyNeedsCutover(local, true))
+	assert.False(t, oidcActiveKeyNeedsCutover(remoteSigning, true))
+	assert.True(t, oidcActiveKeyNeedsCutover(remoteVerifyOnly, true))
+}
+
+// setupRemoteIssuer enables the issuer and installs the fake backend on core, then
+// runs an active setup. Returns the storage view for assertions.
+func setupRemoteIssuer(t *testing.T, core *Core, fake oidcsign.Backend) {
+	t.Helper()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{Enabled: true, IssuerURL: "https://iss.example"}))
+	// Pre-install the backend so ensureOIDCSignBackend adopts it instead of building
+	// a real transit client from HCL.
+	core.oidcSignBackend = fake
+	core.oidcSignTimeout = time.Second
+	require.NoError(t, core.setupOIDCIssuer(ctx, false /* active */, false))
+}
+
+func TestCore_setupOIDCIssuer_Remote(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	fake := newFakeSignBackend(t)
+	setupRemoteIssuer(t, core, fake)
+
+	iss := core.OIDCIssuer()
+	require.NotNil(t, iss)
+	require.True(t, iss.Ready(), "remote-backed issuer must be ready")
+
+	// The persisted keyset holds remote handles, not private material.
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+	entry, err := storage.Get(context.Background(), oidcKeySetPath)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Contains(t, string(entry.Value), "\"remote\":", "keyset must store remote handles")
+	assert.NotContains(t, string(entry.Value), "key_pkcs8", "no private key material may be persisted")
+
+	// A minted assertion verifies against the served JWKS (public keys from the KMS).
+	jwks := serveJWKS(t, iss)
+	tok, err := iss.MintIdentityAssertion(context.Background(),
+		&logical.TokenEntry{PrincipalID: "p", NamespaceID: "n", MountAccessor: "m"},
+		AssertionClaims{Audience: "aud", TTL: time.Minute, Alg: oidcAlgRS256})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	keySet, err := jwt.NewJSONWebKeySet(ctx, jwks.URL, "")
+	require.NoError(t, err)
+	validator, err := jwt.NewValidator(keySet)
+	require.NoError(t, err)
+	_, err = validator.Validate(ctx, tok, jwt.Expected{
+		Issuer: "https://iss.example", Audiences: []string{"aud"}, SigningAlgorithms: []jwt.Alg{jwt.RS256},
+	})
+	require.NoError(t, err, "remotely-signed assertion must verify against the JWKS")
+
+	// ES256 through the remote path too: transit returns ASN.1, signJWT converts to
+	// R‖S, and the assertion must verify — the combination no other test exercises.
+	tokES, err := iss.MintIdentityAssertion(ctx,
+		&logical.TokenEntry{PrincipalID: "p", NamespaceID: "n", MountAccessor: "m"},
+		AssertionClaims{Audience: "aud", TTL: time.Minute, Alg: oidcAlgES256})
+	require.NoError(t, err)
+	_, err = validator.Validate(ctx, tokES, jwt.Expected{
+		Issuer: "https://iss.example", Audiences: []string{"aud"}, SigningAlgorithms: []jwt.Alg{jwt.ES256},
+	})
+	require.NoError(t, err, "remotely-signed ES256 assertion must verify against the JWKS")
+}
+
+// TestCore_setupOIDCIssuer_RemoteDegrade covers the degrade-not-brick behavior: an
+// unreachable KMS at first enable must not fail unseal, but must fail the operator
+// config-write path, and the issuer recovers once the KMS is reachable again.
+func TestCore_setupOIDCIssuer_RemoteDegrade(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{Enabled: true, IssuerURL: "https://iss.example"}))
+
+	fake := newFakeSignBackend(t)
+	fake.opErr = errors.New("transit unreachable")
+	core.oidcSignBackend = fake
+	core.oidcSignTimeout = time.Second
+
+	// Unseal path: must NOT brick — install a not-ready issuer and return nil.
+	require.NoError(t, core.setupOIDCIssuer(ctx, false /* active */, false /* unseal */))
+	iss := core.OIDCIssuer()
+	require.NotNil(t, iss)
+	require.False(t, iss.Ready(), "issuer must be not-ready when the KMS is unreachable at enable")
+	_, err := iss.MintIdentityAssertion(ctx,
+		&logical.TokenEntry{PrincipalID: "p", NamespaceID: "n", MountAccessor: "m"},
+		AssertionClaims{Audience: "aud", TTL: time.Minute, Alg: oidcAlgRS256})
+	require.Error(t, err, "mint must fail closed while not ready")
+
+	// Config-write path: must surface the error to the operator.
+	require.Error(t, core.setupOIDCIssuer(ctx, false, true /* configWrite */),
+		"config-write must surface an unreachable-KMS error")
+
+	// Recovery: the KMS comes back; the next setup provisions and becomes ready.
+	fake.opErr = nil
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
+	require.True(t, core.OIDCIssuer().Ready(), "issuer must recover once the KMS is reachable")
+}
+
+// TestCore_rotateOIDCKey_Remote drives a full rotation cycle with a KMS-backed key
+// source: the pre-published next is promoted, a fresh next is provisioned from the
+// KMS, the old active is retired, and the result is persisted — all remote.
+func TestCore_rotateOIDCKey_Remote(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	fake := newFakeSignBackend(t)
+	setupRemoteIssuer(t, core, fake)
+	iss := core.OIDCIssuer()
+
+	before := iss.Keys()[oidcAlgRS256]
+	oldActive, oldNext := before.active.kid, before.next.kid
+
+	src := remoteKeySource{backend: fake, timeout: time.Second}
+	require.NoError(t, core.rotateOIDCKey(ctx, src, iss, nil, 0, defaultRetiredKeyGrace))
+
+	after := iss.Keys()[oidcAlgRS256]
+	assert.Equal(t, oldNext, after.active.kid, "the pre-published next must be promoted to active")
+	assert.NotEqual(t, oldNext, after.next.kid, "a fresh next must be provisioned from the KMS")
+	assert.True(t, isRemoteSigningKey(after.active) && isRemoteSigningKey(after.next), "rotated keys stay remote")
+	foundRetired := false
+	for _, r := range after.retired {
+		if r.kid == oldActive {
+			foundRetired = true
+		}
+	}
+	assert.True(t, foundRetired, "the old active key must be retired")
+
+	// The rotation must be persisted before the in-memory flip.
+	reloaded, err := loadKeySet(ctx, NewBarrierView(core.barrier, oidcIssuerStorePrefix), fake, time.Second, core.logger)
+	require.NoError(t, err)
+	assert.Equal(t, oldNext, reloaded[oidcAlgRS256].active.kid, "the promoted active must be in storage")
+}
+
+// TestCore_OIDCSignBackend_ClosedOnDisableAndStop asserts the KMS backend is closed
+// (its token released) when the issuer is disabled and on teardown, so a standby
+// holds no idle token.
+func TestCore_OIDCSignBackend_ClosedOnDisableAndStop(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+
+	fake := newFakeSignBackend(t)
+	setupRemoteIssuer(t, core, fake)
+	require.NotNil(t, core.oidcSignBackend)
+
+	// Disabling the issuer closes and drops the backend.
+	require.NoError(t, saveIssuerConfig(ctx, storage, &issuerConfig{Enabled: false, IssuerURL: "https://iss.example"}))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
+	assert.True(t, fake.closed, "backend must be closed when the issuer is disabled")
+	assert.Nil(t, core.oidcSignBackend, "backend reference must be dropped on disable")
+
+	// Re-enable, then stopOIDCIssuer (seal/step-down) closes it too.
+	fake2 := newFakeSignBackend(t)
+	setupRemoteIssuer(t, core, fake2)
+	require.NotNil(t, core.oidcSignBackend)
+	require.NoError(t, core.stopOIDCIssuer())
+	assert.True(t, fake2.closed, "backend must be closed on stopOIDCIssuer")
+	assert.Nil(t, core.oidcSignBackend)
+}
+
+// TestLoadKeySet_CorruptRetiredVsActive verifies the availability trade-off: a
+// corrupt retired key is dropped with a warning (not fatal), but a corrupt
+// active/next key fails the load loudly.
+func TestLoadKeySet_CorruptRetiredVsActive(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)
+	fake := newFakeSignBackend(t)
+	src := remoteKeySource{backend: fake, timeout: time.Second}
+
+	active, next, err := src.bootstrap(ctx, oidcAlgRS256)
+	require.NoError(t, err)
+	ret, err := src.nextKey(ctx, oidcAlgRS256)
+	require.NoError(t, err)
+	ret.retiredAt = time.Now()
+
+	persist := func() {
+		require.NoError(t, persistKeySet(ctx, storage,
+			map[string]*algKeyset{oidcAlgRS256: {active: active, next: next, retired: []*signingKey{ret}}}))
+	}
+	// tamperKid corrupts the kid of one stored key so its recomputed thumbprint no
+	// longer matches, then writes the keyset back.
+	tamperKid := func(slot string, idx int) {
+		entry, err := storage.Get(ctx, oidcKeySetPath)
+		require.NoError(t, err)
+		var set map[string]interface{}
+		require.NoError(t, json.Unmarshal(entry.Value, &set))
+		rs := set["keysets"].(map[string]interface{})[oidcAlgRS256].(map[string]interface{})
+		switch v := rs[slot].(type) {
+		case map[string]interface{}:
+			v["kid"] = "tampered"
+		case []interface{}:
+			v[idx].(map[string]interface{})["kid"] = "tampered"
+		}
+		val, err := json.Marshal(set)
+		require.NoError(t, err)
+		require.NoError(t, storage.Put(ctx, &sdklogical.StorageEntry{Key: oidcKeySetPath, Value: val}))
+	}
+
+	// A corrupt RETIRED key is dropped, not fatal.
+	persist()
+	tamperKid("retired", 0)
+	loaded, err := loadKeySet(ctx, storage, fake, time.Second, core.logger)
+	require.NoError(t, err, "a corrupt retired key must not fail the load")
+	require.NotNil(t, loaded[oidcAlgRS256].active)
+	assert.Empty(t, loaded[oidcAlgRS256].retired, "the corrupt retired key must be dropped")
+
+	// A corrupt ACTIVE key fails the load loudly.
+	persist()
+	tamperKid("active", 0)
+	_, err = loadKeySet(ctx, storage, fake, time.Second, core.logger)
+	require.Error(t, err, "a corrupt active key must fail the load")
+}
+
+func TestCore_setupOIDCIssuer_RemoteToLocalCutover(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+	ctx := context.Background()
+
+	fake := newFakeSignBackend(t)
+	setupRemoteIssuer(t, core, fake)
+	remoteActive, _, _, _ := loadRS256(ctx, NewBarrierView(core.barrier, oidcIssuerStorePrefix))
+	require.NotNil(t, remoteActive)
+	require.True(t, isRemoteSigningKey(remoteActive))
+	remoteKid := remoteActive.kid
+
+	// Simulate removing the signer stanza: drop the backend so setup selects the
+	// local source, triggering a remote->local cutover.
+	core.closeOIDCSignBackend()
+	require.NoError(t, core.setupOIDCIssuer(ctx, false /* active */, false))
+
+	iss := core.OIDCIssuer()
+	require.True(t, iss.Ready(), "issuer must be ready after cutover")
+
+	active, _, retired, _ := loadRS256(ctx, NewBarrierView(core.barrier, oidcIssuerStorePrefix))
+	require.NotNil(t, active)
+	assert.False(t, isRemoteSigningKey(active), "new active key must be local after remote->local cutover")
+
+	// The old remote key was retired (kept for the grace window), still verifying.
+	foundOld := false
+	for _, r := range retired {
+		if r.kid == remoteKid {
+			foundOld = true
+			assert.True(t, isRemoteSigningKey(r), "retired old key stays remote (verification-only)")
+		}
+	}
+	assert.True(t, foundOld, "the old remote active key must be retained as retired")
+
+	// The new local key mints and verifies.
+	tok, err := iss.MintIdentityAssertion(ctx,
+		&logical.TokenEntry{PrincipalID: "p", NamespaceID: "n", MountAccessor: "m"},
+		AssertionClaims{Audience: "aud", TTL: time.Minute, Alg: oidcAlgRS256})
+	require.NoError(t, err)
+	assert.NotEmpty(t, tok)
+}

--- a/core/oidcsign/backend.go
+++ b/core/oidcsign/backend.go
@@ -85,16 +85,30 @@ var algParamsByAlg = map[string]algParams{
 // closed), used for retired remote keys after a cutover or once the stanza is
 // removed.
 type Signer struct {
-	backend Backend
-	ref     KeyRef
-	pub     crypto.PublicKey
-	timeout time.Duration
-	ctx     context.Context // optional request-scoped context bound via WithContext
+	backend     Backend
+	backendType string // persisted discriminator, retained even when backend is nil
+	ref         KeyRef
+	pub         crypto.PublicKey
+	timeout     time.Duration
+	ctx         context.Context // optional request-scoped context bound via WithContext
 }
 
-// NewSigner builds a Signer. backend may be nil for a verification-only signer.
+// NewSigner builds a signing-capable Signer bound to a live backend.
 func NewSigner(backend Backend, ref KeyRef, pub crypto.PublicKey, timeout time.Duration) *Signer {
-	return &Signer{backend: backend, ref: ref, pub: pub, timeout: timeout}
+	bt := ""
+	if backend != nil {
+		bt = backend.Type()
+	}
+	return &Signer{backend: backend, backendType: bt, ref: ref, pub: pub, timeout: timeout}
+}
+
+// NewVerifyingSigner builds a verification-only Signer (no live backend): Public
+// works, Sign fails closed. Used to reconstruct a retired remote key after a
+// cutover, or when the signer stanza has been removed — it keeps the key in the
+// JWKS so its in-flight assertions still verify. backendType is retained so the
+// key re-serializes as remote.
+func NewVerifyingSigner(backendType string, ref KeyRef, pub crypto.PublicKey) *Signer {
+	return &Signer{backendType: backendType, ref: ref, pub: pub}
 }
 
 // Public returns the cached public key (never a KMS round-trip).
@@ -102,6 +116,10 @@ func (s *Signer) Public() crypto.PublicKey { return s.pub }
 
 // Ref returns the backend key reference this signer is bound to.
 func (s *Signer) Ref() KeyRef { return s.ref }
+
+// BackendType returns the backend discriminator ("transit"), retained even for a
+// verification-only signer so it round-trips through storage as a remote key.
+func (s *Signer) BackendType() string { return s.backendType }
 
 // CanSign reports whether this signer has a live backend (vs verification-only).
 func (s *Signer) CanSign() bool { return s.backend != nil }

--- a/core/oidcsign/transit.go
+++ b/core/oidcsign/transit.go
@@ -381,7 +381,7 @@ func (kd *transitKeyData) publicKeyForVersion(version int) (crypto.PublicKey, er
 	if err != nil {
 		return nil, err
 	}
-	return parsePublicKeyPEM(v.PublicKey)
+	return ParsePublicKeyPEM(v.PublicKey)
 }
 
 func (kd *transitKeyData) creationTimeForVersion(version int) (time.Time, error) {
@@ -396,8 +396,8 @@ func (kd *transitKeyData) creationTimeForVersion(version int) (time.Time, error)
 	return t, nil
 }
 
-// parsePublicKeyPEM decodes a PKIX PEM public key and ensures it is RSA or ECDSA.
-func parsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
+// ParsePublicKeyPEM decodes a PKIX PEM public key and ensures it is RSA or ECDSA.
+func ParsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
 	if pemStr == "" {
 		return nil, fmt.Errorf("oidcsign: empty public key")
 	}
@@ -415,6 +415,16 @@ func parsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
 	default:
 		return nil, fmt.Errorf("oidcsign: unsupported public key type %T", pub)
 	}
+}
+
+// MarshalPublicKeyPEM encodes an RSA/ECDSA public key as a PKIX PEM block, the
+// form persisted alongside a remote key handle (so JWKS/unseal need no KMS call).
+func MarshalPublicKeyPEM(pub crypto.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("oidcsign: marshal public key: %w", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})), nil
 }
 
 // decodeTransitSignature extracts the raw signature bytes from transit's

--- a/core/oidcsign/transit_test.go
+++ b/core/oidcsign/transit_test.go
@@ -303,7 +303,7 @@ func TestDecodeTransitSignature(t *testing.T) {
 func TestSigner_NilBackend_And_Context(t *testing.T) {
 	// Verification-only signer (nil backend) fails closed on Sign but exposes Public.
 	pub := genKey(t, "rsa-2048").Public()
-	s := NewSigner(nil, KeyRef{KeyName: "k", Version: 1, Alg: "RS256"}, pub, time.Second)
+	s := NewVerifyingSigner("transit", KeyRef{KeyName: "k", Version: 1, Alg: "RS256"}, pub)
 	assert.False(t, s.CanSign())
 	assert.Equal(t, pub, s.Public())
 	_, err := s.Sign(rand.Reader, []byte("d"), crypto.SHA256)
@@ -379,11 +379,11 @@ func TestTransit_Sign_Rejects(t *testing.T) {
 }
 
 func TestParsePublicKeyPEM_Rejects(t *testing.T) {
-	_, err := parsePublicKeyPEM("")
+	_, err := ParsePublicKeyPEM("")
 	require.Error(t, err)
-	_, err = parsePublicKeyPEM("not pem at all")
+	_, err = ParsePublicKeyPEM("not pem at all")
 	require.Error(t, err)
-	_, err = parsePublicKeyPEM("-----BEGIN PUBLIC KEY-----\nZm9v\n-----END PUBLIC KEY-----\n")
+	_, err = ParsePublicKeyPEM("-----BEGIN PUBLIC KEY-----\nZm9v\n-----END PUBLIC KEY-----\n")
 	require.Error(t, err, "valid PEM framing but garbage DER must fail")
 }
 

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -293,7 +293,7 @@ func (b *SystemBackend) handleOIDCIssuerConfigWrite(ctx context.Context, _ *logi
 	// Activate the change: reload the issuer from the just-written config. On the
 	// active node this generates and persists a signing key on first enable, and
 	// builds the publisher (a misconfigured publisher fails here).
-	if err := b.core.setupOIDCIssuer(ctx, b.core.Standby()); err != nil {
+	if err := b.core.setupOIDCIssuer(ctx, b.core.Standby(), true); err != nil {
 		return logical.ErrorResponse(err), nil
 	}
 	// Surface a publish failure at config time (unseal only warns).

--- a/core/sys_oidc_issuer_test.go
+++ b/core/sys_oidc_issuer_test.go
@@ -231,7 +231,7 @@ func TestSetupOIDCIssuer_BadPublisherDoesNotFailUnseal(t *testing.T) {
 	}))
 
 	// Setup (as unseal would) must NOT fail; the issuer comes up, publisher is nil.
-	require.NoError(t, core.setupOIDCIssuer(ctx, false))
+	require.NoError(t, core.setupOIDCIssuer(ctx, false, false))
 	require.NotNil(t, core.OIDCIssuer())
 	assert.True(t, core.OIDCIssuer().Ready())
 	assert.Nil(t, core.oidcPublisher, "an invalid publisher degrades to endpoint-only")


### PR DESCRIPTION
Wires the `oidcsign` backend into the OIDC issuer so an operator can opt in, via the `signer` HCL stanza, to holding the issuer signing key in an external KMS (transit) where the private key never leaves the KMS. Warden keeps only a handle plus the cached public key and asks the KMS to sign each assertion. In-process keys remain the default. This is the PR that makes the feature live.

Builds on #452, #453, #454.

## Changes
- **Storage v4:** a signing key serializes as either local PKCS#8 or a remote handle (backend, key name, version, cached PKIX public key). `fromStored` rebuilds a signing-capable signer when the backend matches, else a verification-only signer so retired keys still verify in the JWKS; it cross-checks the kid against the public key. A corrupt retired key is dropped with a warning rather than bricking unseal.
- **Key source:** local vs remote provisioning behind one interface. Remote keys map active/next/retired onto KMS key versions, keep the same thumbprint kid, and anchor rotation on the KMS creation time.
- **Lifecycle:** `setupOIDCIssuer` builds the signer once on the active serving path and closes it on disable/step-down, so a standby holds no KMS token. It cuts over when the stored key location no longer matches config (old keys retired for the grace window) and, on unseal, degrades to not-ready rather than bricking startup when the KMS is unreachable; the config-write path surfaces the error.
- **Rotation** threads the key source through so the next key is provisioned from the configured source; the rotation loop is joined up front in setup so an in-flight tick cannot persist a stale keyset over a cutover.
- **Startup banner** now shows the configured signer (type + mount + key prefix, never the token).

## Notes
- Cutover detection keys off whether the active key can *sign* under the configured source, not merely whether it is remote, so a future second backend type cannot silently install an unusable key.
- Tests cover the remote setup end-to-end (assertion verifies against the JWKS), remote→local cutover, degrade-not-brick, a full remote rotation cycle, backend-close lifecycle, corrupt-retired leniency, and ES256 through the full remote path.
