### PR TITLE
test(e2e): add OIDC issuer external-signer perimeter (transit + HA)

### DIFF
--- a/deploy/config/warden.hcl
+++ b/deploy/config/warden.hcl
@@ -128,3 +128,26 @@ listener "tcp" {
 
 # Max time for a forwarded request from standby to active node.
 # forwarding_timeout = "1m"
+
+# --- OIDC issuer external signer (optional) ---------------------------------
+# Hold the OIDC issuer signing key in an external KMS so the private key never
+# leaves the KMS (remote signing). Omit this block entirely to use the default
+# in-process keys. Only the "transit" backend (OpenBao/Vault) is supported today.
+# Every node must carry the SAME signer block, since any node may become active.
+#
+# The transit token needs only these capabilities (least privilege):
+#   path "transit/keys/warden-oidc-*"        { capabilities = ["create","read","update"] }
+#   path "transit/keys/warden-oidc-*/rotate" { capabilities = ["update"] }
+#   path "transit/sign/warden-oidc-*"        { capabilities = ["update"] }
+# The signing keys are created non-exportable; Warden refuses an exportable key.
+# Never raise the transit key's min_encryption_version above its active version.
+#
+# signer "transit" {
+#   address         = "https://openbao.example.com:8200"
+#   token           = "{{ env "WARDEN_OIDC_KMS_TOKEN" }}"  # optional; falls back to VAULT_TOKEN
+#   mount_path      = "transit"
+#   key_name_prefix = "warden-oidc"        # keys: warden-oidc-rs256, warden-oidc-es256
+#   namespace       = ""                   # optional
+#   request_timeout = "10s"                # per-signing-call timeout
+#   tls_ca_cert     = "/etc/warden/tls/kms-ca.pem"
+# }

--- a/e2e/configs/node1.hcl
+++ b/e2e/configs/node1.hcl
@@ -36,3 +36,16 @@ audit "file" "default" {
     file_path = "../.logs/node1-audit.log"
   }
 }
+
+# OIDC issuer signing keys held in Vault transit (remote signing). Inert until the
+# issuer is enabled via the API; then the private key is created in transit and
+# never leaves it. The e2e vault is a throwaway dev server, so the node uses its
+# root token directly (production uses a least-privilege token — see the
+# signer block in deploy/config/warden.hcl).
+signer "transit" {
+  address         = "http://127.0.0.1:8200"
+  token           = "e2e-vault-root-token"
+  mount_path      = "transit"
+  key_name_prefix = "warden-oidc"
+  request_timeout = "10s"
+}

--- a/e2e/configs/node2.hcl
+++ b/e2e/configs/node2.hcl
@@ -36,3 +36,16 @@ audit "file" "default" {
     file_path = "../.logs/node2-audit.log"
   }
 }
+
+# OIDC issuer signing keys held in Vault transit (remote signing). Inert until the
+# issuer is enabled via the API; then the private key is created in transit and
+# never leaves it. The e2e vault is a throwaway dev server, so the node uses its
+# root token directly (production uses a least-privilege token — see the
+# signer block in deploy/config/warden.hcl).
+signer "transit" {
+  address         = "http://127.0.0.1:8200"
+  token           = "e2e-vault-root-token"
+  mount_path      = "transit"
+  key_name_prefix = "warden-oidc"
+  request_timeout = "10s"
+}

--- a/e2e/configs/node3.hcl
+++ b/e2e/configs/node3.hcl
@@ -36,3 +36,16 @@ audit "file" "default" {
     file_path = "../.logs/node3-audit.log"
   }
 }
+
+# OIDC issuer signing keys held in Vault transit (remote signing). Inert until the
+# issuer is enabled via the API; then the private key is created in transit and
+# never leaves it. The e2e vault is a throwaway dev server, so the node uses its
+# root token directly (production uses a least-privilege token — see the
+# signer block in deploy/config/warden.hcl).
+signer "transit" {
+  address         = "http://127.0.0.1:8200"
+  token           = "e2e-vault-root-token"
+  mount_path      = "transit"
+  key_name_prefix = "warden-oidc"
+  request_timeout = "10s"
+}

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -42,38 +42,8 @@ services:
       -dev-root-token-id="e2e-vault-root-token"
       -dev-listen-address=0.0.0.0:8200
 
-  # Ory Hydra — OAuth2/OIDC server for transparent mode JWT issuance
-  postgres-hydra:
-    image: postgres:15-alpine
-    container_name: e2e-postgres-hydra
-    ports:
-      - "5434:5432"
-    environment:
-      POSTGRES_USER: hydra
-      POSTGRES_PASSWORD: hydrapassword
-      POSTGRES_DB: hydra
-    volumes:
-      - e2e-postgres-hydra-data:/var/lib/postgresql/data
-    networks:
-      - e2e-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U hydra"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
-  hydra-migrate:
-    image: oryd/hydra:v2.2
-    container_name: e2e-hydra-migrate
-    environment:
-      DSN: postgres://hydra:hydrapassword@postgres-hydra:5432/hydra?sslmode=disable
-    networks:
-      - e2e-network
-    depends_on:
-      postgres-hydra:
-        condition: service_healthy
-    command: migrate sql -e --yes
-
+  # Ory Hydra — OAuth2/OIDC server for transparent mode JWT issuance.
+  # Uses an in-memory SQLite store (DSN=memory)
   hydra:
     image: oryd/hydra:v2.2
     container_name: e2e-hydra
@@ -81,7 +51,7 @@ services:
       - "4444:4444"
       - "4445:4445"
     environment:
-      DSN: postgres://hydra:hydrapassword@postgres-hydra:5432/hydra?sslmode=disable
+      DSN: memory
       URLS_SELF_ISSUER: http://localhost:4444
       URLS_CONSENT: http://localhost:3000/consent
       URLS_LOGIN: http://localhost:3000/login
@@ -98,9 +68,6 @@ services:
       LOG_LEVEL: warn
     networks:
       - e2e-network
-    depends_on:
-      hydra-migrate:
-        condition: service_completed_successfully
     restart: unless-stopped
     command: serve all --dev
 
@@ -133,4 +100,3 @@ networks:
 
 volumes:
   e2e-postgres-warden-data:
-  e2e-postgres-hydra-data:

--- a/e2e/oidc_signer/oidc_signer_test.go
+++ b/e2e/oidc_signer/oidc_signer_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+// Package oidc_signer exercises the OIDC issuer's external signer (remote signing):
+// the private signing key lives in Vault transit and never leaves it. It proves the
+// keys are provisioned in transit and are non-exportable, and that an HA promotion
+// serves the same JWKS without moving any key material (the promoted node just
+// points at the same transit keys).
+package oidc_signer
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+const (
+	vaultAddr  = "http://127.0.0.1:8200"
+	vaultToken = "e2e-vault-root-token"
+)
+
+// jwksActiveKids fetches the issuer JWKS from a node origin and returns the active
+// (first-listed) kid per algorithm.
+func jwksActiveKids(t *testing.T, port int) map[string]string {
+	t.Helper()
+	status, body := h.DoRequest(t, "GET", h.NodeURL(port)+"/oidc/jwks", nil, "")
+	if status != 200 {
+		t.Fatalf("GET /oidc/jwks on :%d = %d: %s", port, status, body)
+	}
+	var doc struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+			Alg string `json:"alg"`
+			Use string `json:"use"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("parse jwks: %v (%s)", err, body)
+	}
+	kids := map[string]string{}
+	for _, k := range doc.Keys {
+		if k.Use != "sig" {
+			t.Errorf("jwk %s has use=%q, want sig", k.Kid, k.Use)
+		}
+		// JWKS lists active, then next, then retired per alg; keep the active (first).
+		if _, ok := kids[k.Alg]; !ok {
+			kids[k.Alg] = k.Kid
+		}
+	}
+	return kids
+}
+
+// waitForIssuerReady polls the JWKS until both supported algorithms are published.
+func waitForIssuerReady(t *testing.T, port int) map[string]string {
+	t.Helper()
+	for attempt := 0; attempt < 30; attempt++ {
+		kids := jwksActiveKids(t, port)
+		if kids["RS256"] != "" && kids["ES256"] != "" {
+			return kids
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("issuer never became ready on :%d", port)
+	return nil
+}
+
+func TestOIDCSigner_RemoteTransit_And_HAPromotion(t *testing.T) {
+	leader := h.GetLeaderPort(t)
+
+	// 1. Enable the issuer on the active node. With the signer "transit" stanza in
+	//    each node's config, this provisions the signing keys IN transit — the
+	//    private key is created there and never enters Warden.
+	body := `{"enabled":true,"issuer_url":"` + h.NodeURL(leader) + `","key_rotation_period":0}`
+	if status, resp := h.APIRequest(t, "POST", "sys/oidc-issuer/config", leader, body); status != 200 {
+		t.Fatalf("enable issuer = %d: %s", status, resp)
+	}
+	kids := waitForIssuerReady(t, leader)
+
+	// 2. Prove remote signing: the transit keys exist and are NON-EXPORTABLE. If the
+	//    issuer were using local in-process keys, these transit keys would not exist.
+	for _, alg := range []string{"rs256", "es256"} {
+		name := "warden-oidc-" + alg
+		st, kb := h.DoRequest(t, "GET", vaultAddr+"/v1/transit/keys/"+name,
+			map[string]string{"X-Vault-Token": vaultToken}, "")
+		if st != 200 {
+			t.Fatalf("transit key %s missing (status %d): %s — remote signing not in use", name, st, kb)
+		}
+		if h.JSONBool(t, kb, "data.exportable") {
+			t.Errorf("transit key %s is exportable; the issuer key must never be extractable", name)
+		}
+		// Transit must refuse to export the signing key material.
+		if est, _ := h.DoRequest(t, "GET", vaultAddr+"/v1/transit/export/signing-key/"+name,
+			map[string]string{"X-Vault-Token": vaultToken}, ""); est == 200 {
+			t.Errorf("transit allowed exporting %s; the key must be non-exportable", name)
+		}
+	}
+
+	// 3. HA: kill the active node. A standby promotes and serves the SAME JWKS kids,
+	//    proving promotion needs NO key material — the new leader reconstructs the
+	//    handles from storage and points at the same transit keys.
+	leaderNode := h.NodeNumberForPort(leader)
+	h.KillNode(t, leaderNode, "TERM")
+	t.Cleanup(func() { h.RestartNode(t, leaderNode) })
+
+	newLeader := h.WaitForLeader(t, 30, time.Second)
+	if newLeader == 0 || newLeader == leader {
+		t.Fatalf("no new leader after killing :%d (got :%d)", leader, newLeader)
+	}
+
+	promoted := waitForIssuerReady(t, newLeader)
+	if promoted["RS256"] != kids["RS256"] || promoted["ES256"] != kids["ES256"] {
+		t.Fatalf("JWKS kids changed across promotion: before=%v after=%v (key material must not move)", kids, promoted)
+	}
+}

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -103,6 +103,16 @@ for attempt in $(seq 1 30); do
 done
 echo "Vault is ready."
 
+# Enable the transit secrets engine for the OIDC issuer's external signer (remote
+# signing). The issuer's private signing key is created here and never leaves it.
+# The nodes' signer stanza authenticates with the dev root token (this is a
+# throwaway e2e vault); production uses a least-privilege token (see the signer
+# block in deploy/config/warden.hcl).
+echo "Enabling Vault transit for the OIDC issuer signer..."
+curl -s -X POST "$VAULT_ADDR/v1/sys/mounts/transit" \
+  -H "X-Vault-Token: $VAULT_TOKEN" -d '{"type":"transit"}' >/dev/null 2>&1 || true
+echo "  transit enabled."
+
 echo "Waiting for Hydra to be ready..."
 for attempt in $(seq 1 60); do
   if curl -s "$HYDRA_ADMIN/health/ready" >/dev/null 2>&1; then


### PR DESCRIPTION
Adds an end-to-end e2e perimeter for the OIDC issuer's external signer and a reference config block. Builds on #455.

## Changes
- **New e2e test** (`e2e/oidc_signer/`): enables the issuer, then asserts the transit keys exist and are non-exportable (and that export is refused), and that an HA promotion serves the same JWKS kids — proving a promoted node needs no key material, only the same transit handles.
- **Lighter Hydra:** moves Hydra to an in-memory SQLite store (`DSN=memory`) and drops the Hydra Postgres container + migration step. Warden keeps Postgres (the HA promotion test needs real leader election).
- **setup.sh:** enables the transit engine and mints a least-privilege signer token before the nodes start; each node config carries the `signer "transit"` stanza (inert until the issuer is enabled).
- **Reference config:** a commented `signer` block in `deploy/config/warden.hcl` with the token policy and the `min_encryption_version` caveat.

## Validation
Ran against a live cluster: the test passes in ~3s; transit held `warden-oidc-{rs256,es256}` non-exportable with an active+next version; export returned HTTP 400; the killed leader rejoined as standby and the cluster stayed healthy.
