### PR TITLE
feat(gcp): add keyless OIDC federation (Workload Identity Federation) mode

### DIFF
--- a/credential/drivers/assertion_resource.go
+++ b/credential/drivers/assertion_resource.go
@@ -25,6 +25,8 @@ func DeriveAssertionResource(sourceType string, sourceCfg, specCfg map[string]st
 		return azureAssertionResource(specCfg)
 	case credential.SourceTypeTokenExchange:
 		return tokenExchangeAssertionResource(sourceCfg, specCfg)
+	case credential.SourceTypeGCP:
+		return gcpAssertionResource(sourceCfg, specCfg)
 	default:
 		return "", false
 	}

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -25,9 +25,31 @@ const DefaultGCPActivationDelay = 2 * time.Minute
 // gcpMaxResponseBodySize limits response body reads to prevent OOM
 const gcpMaxResponseBodySize = 1 << 20 // 1MB
 
+// gcpAuthMethodStatic and gcpAuthMethodOIDCFederation select how the source
+// authenticates. static (default) exchanges a stored service-account JSON key for
+// OAuth2 tokens; oidc_federation holds no key and mints only by exchanging a
+// caller-presented identity assertion through Workload Identity Federation.
+const (
+	gcpAuthMethodStatic         = "static"
+	gcpAuthMethodOIDCFederation = "oidc_federation"
+)
+
+// Default GCP API hosts. The driver's stsHost/iamCredentialsHost fields default to
+// these; tests override the fields to point token exchange and impersonation at a
+// local server.
+const (
+	defaultGCPSTSHost            = "https://sts.googleapis.com"
+	defaultGCPIAMCredentialsHost = "https://iamcredentials.googleapis.com"
+)
+
+// gcpFederatedTokenFallbackTTL is used when the STS token-exchange response omits
+// the optional expires_in, so the lease is never zero/negative.
+const gcpFederatedTokenFallbackTTL = 1 * time.Hour
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GCPDriver)(nil)
 var _ credential.Rotatable = (*GCPDriver)(nil)
+var _ credential.ExchangeMinter = (*GCPDriver)(nil)
 
 // serviceAccountKey represents the parsed structure of a GCP service account JSON key file
 type serviceAccountKey struct {
@@ -64,12 +86,25 @@ type GCPDriver struct {
 
 	// Flag to track if source credentials have been verified
 	sourceVerified bool
+
+	// API hosts, defaulting to the public GCP endpoints. Overridden in tests to
+	// point STS token exchange and SA impersonation at a local server.
+	stsHost            string
+	iamCredentialsHost string
 }
 
 // Config accessors — single source of truth is credSource.Config.
 
 func (d *GCPDriver) getServiceAccountKey() string {
 	return credential.GetString(d.credSource.Config, "service_account_key", "")
+}
+
+func (d *GCPDriver) getAuthMethod() string {
+	return credential.GetString(d.credSource.Config, "auth_method", gcpAuthMethodStatic)
+}
+
+func (d *GCPDriver) getWorkloadIdentityProvider() string {
+	return credential.GetString(d.credSource.Config, "workload_identity_provider", "")
 }
 
 func (d *GCPDriver) parseServiceAccountKey() (*serviceAccountKey, error) {
@@ -94,9 +129,13 @@ func (f *GCPDriverFactory) Type() string {
 
 // ValidateConfig validates GCP driver configuration using declarative schema
 func (f *GCPDriverFactory) ValidateConfig(config map[string]string) error {
-	return credential.ValidateSchema(config,
+	if err := credential.ValidateSchema(config,
+		credential.StringField("auth_method").
+			OneOf(gcpAuthMethodStatic, gcpAuthMethodOIDCFederation).
+			Describe("How the source authenticates: static (service account key) or oidc_federation (Workload Identity Federation, keyless)").
+			Example("static"),
+
 		credential.StringField("service_account_key").
-			Required().
 			Custom(func(value string) error {
 				// Validate that service_account_key is valid JSON with required fields
 				var saKey serviceAccountKey
@@ -111,8 +150,12 @@ func (f *GCPDriverFactory) ValidateConfig(config map[string]string) error {
 				}
 				return nil
 			}).
-			Describe("GCP service account key in JSON format").
+			Describe("GCP service account key in JSON format (required for auth_method=static)").
 			Example("{\"type\":\"service_account\",\"project_id\":\"...\",\"private_key\":\"...\"}"),
+
+		credential.StringField("workload_identity_provider").
+			Describe("Full WIF provider resource name (required for auth_method=oidc_federation)").
+			Example("//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/warden-oidc"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -122,7 +165,37 @@ func (f *GCPDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
-	)
+	); err != nil {
+		return err
+	}
+
+	// Cross-field rules per auth_method.
+	switch credential.GetString(config, "auth_method", gcpAuthMethodStatic) {
+	case gcpAuthMethodStatic:
+		if credential.GetString(config, "service_account_key", "") == "" {
+			return fmt.Errorf("service_account_key is required for auth_method=static")
+		}
+		// workload_identity_provider drives only federation (and later seeds the
+		// warden_identity assertion audience); on a static source it would be
+		// silently ignored, so reject it rather than mislead.
+		if credential.GetString(config, "workload_identity_provider", "") != "" {
+			return fmt.Errorf("workload_identity_provider is only valid for auth_method=oidc_federation")
+		}
+	case gcpAuthMethodOIDCFederation:
+		// A federation source holds no static key. Reject leftover static config so a
+		// misconfiguration cannot silently mix modes.
+		if credential.GetString(config, "service_account_key", "") != "" {
+			return fmt.Errorf("service_account_key must not be set for auth_method=oidc_federation")
+		}
+		provider := credential.GetString(config, "workload_identity_provider", "")
+		if provider == "" {
+			return fmt.Errorf("workload_identity_provider is required for auth_method=oidc_federation")
+		}
+		if !strings.HasPrefix(provider, "//iam.googleapis.com/") {
+			return fmt.Errorf("workload_identity_provider must start with //iam.googleapis.com/")
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -136,7 +209,7 @@ func (f *GCPDriverFactory) InferCredentialType(specConfig map[string]string) (st
 	switch mintMethod {
 	case "cloud_sql_iam_token":
 		return credential.TypeDBAuthToken, nil
-	case "":
+	case "", "access_token", "impersonated_access_token", "federated_access_token":
 		return credential.TypeGCPAccessToken, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
@@ -150,8 +223,10 @@ func (f *GCPDriverFactory) Create(config map[string]string, log *logger.GatedLog
 			Type:   credential.SourceTypeGCP,
 			Config: config,
 		},
-		logger:     log.WithSubsystem(credential.SourceTypeGCP),
-		tokenCache: NewTokenCache(),
+		logger:             log.WithSubsystem(credential.SourceTypeGCP),
+		tokenCache:         NewTokenCache(),
+		stsHost:            defaultGCPSTSHost,
+		iamCredentialsHost: defaultGCPIAMCredentialsHost,
 	}
 
 	httpClient, err := BuildHTTPClient(config, 30*time.Second)
@@ -159,6 +234,13 @@ func (f *GCPDriverFactory) Create(config map[string]string, log *logger.GatedLog
 		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 	}
 	driver.httpClient = httpClient
+
+	// A federation source holds no service-account key: skip the eager credential
+	// probe. All authentication happens per-request from the caller's identity
+	// assertion via the exchange path.
+	if credential.GetString(config, "auth_method", gcpAuthMethodStatic) == gcpAuthMethodOIDCFederation {
+		return driver, nil
+	}
 
 	// Validate source credentials by acquiring a token
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -174,6 +256,13 @@ func (f *GCPDriverFactory) Create(config map[string]string, log *logger.GatedLog
 
 // MintCredential mints credentials based on the spec's mint_method.
 func (d *GCPDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A keyless source mints only through the exchange path, which carries the
+	// caller-scoped assertion. Fail closed here to avoid the misleading
+	// "service_account_key is empty" error a federation source would otherwise hit.
+	if d.getAuthMethod() == gcpAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("gcp: source uses auth_method=oidc_federation; the spec must set subject_token_source (warden_identity or auth_token)")
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "access_token")
 
 	switch mintMethod {
@@ -259,7 +348,8 @@ func (d *GCPDriver) mintAccessToken(ctx context.Context, spec *credential.CredSp
 	return rawData, metadata, ttl, "", nil
 }
 
-// mintImpersonatedAccessToken impersonates another service account via IAM Credentials API
+// mintImpersonatedAccessToken impersonates another service account via IAM Credentials API,
+// using the source SA's own token as the impersonation authority.
 func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	targetSA := credential.GetString(spec.Config, "target_service_account", "")
 	if targetSA == "" {
@@ -276,59 +366,17 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		return nil, nil, 0, "", fmt.Errorf("failed to get source token for impersonation: %w", err)
 	}
 
-	// Call IAM Credentials API to generate an access token for the target SA
-	apiURL := fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
-		url.PathEscape(targetSA))
-
-	reqBody := map[string]interface{}{
-		"scope":    scopes,
-		"lifetime": lifetime,
-	}
-	bodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to marshal impersonation request: %w", err)
-	}
-
-	respBody, err := d.doGCPRequest(ctx, gcpAPIRequest{
-		method:      "POST",
-		url:         apiURL,
-		body:        bodyBytes,
-		contentType: "application/json",
-		bearerToken: sourceToken,
-		okStatuses:  []int{http.StatusOK},
-		operation:   "generateAccessToken",
-	}, 1)
+	accessToken, expireTime, err := d.generateAccessToken(ctx, sourceToken, targetSA, scopes, lifetime)
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
 
-	var tokenResp struct {
-		AccessToken string `json:"accessToken"`
-		ExpireTime  string `json:"expireTime"` // RFC3339
-	}
-	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to decode impersonation response: %w", err)
-	}
-
-	if tokenResp.AccessToken == "" {
-		return nil, nil, 0, "", fmt.Errorf("impersonation response missing accessToken")
-	}
-
-	// Parse expiry time
-	var ttl time.Duration
-	if tokenResp.ExpireTime != "" {
-		if expiry, err := time.Parse(time.RFC3339, tokenResp.ExpireTime); err == nil {
-			ttl = time.Until(expiry)
-		}
-	}
-	if ttl <= 0 {
-		ttl = 1 * time.Hour // fallback
-	}
+	ttl := ttlFromExpireTime(expireTime, gcpFederatedTokenFallbackTTL)
 
 	saKey, _ := d.parseServiceAccountKey()
 
 	rawData := map[string]interface{}{
-		"access_token": tokenResp.AccessToken,
+		"access_token": accessToken,
 	}
 
 	if d.logger != nil {
@@ -339,9 +387,260 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		)
 	}
 
-	metadata := gcpImpersonatedMetadata(saKey, targetSA, scopesStr, lifetime, tokenResp.ExpireTime)
+	metadata := gcpImpersonatedMetadata(saKey, targetSA, scopesStr, lifetime, expireTime)
 
 	return rawData, metadata, ttl, "", nil
+}
+
+// generateAccessToken calls the IAM Credentials API to mint an access token for
+// targetSA, using bearerToken as the impersonation authority. bearerToken is the
+// source SA's token in the static path and a WIF-federated token in the federation
+// path — the call is identical either way. Returns the token and its RFC3339
+// expireTime (may be empty).
+func (d *GCPDriver) generateAccessToken(ctx context.Context, bearerToken, targetSA string, scopes []string, lifetime string) (string, string, error) {
+	apiURL := fmt.Sprintf("%s/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+		d.iamCredentialsHost, url.PathEscape(targetSA))
+
+	reqBody := map[string]interface{}{
+		"scope":    scopes,
+		"lifetime": lifetime,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal impersonation request: %w", err)
+	}
+
+	respBody, err := d.doGCPRequest(ctx, gcpAPIRequest{
+		method:      "POST",
+		url:         apiURL,
+		body:        bodyBytes,
+		contentType: "application/json",
+		bearerToken: bearerToken,
+		okStatuses:  []int{http.StatusOK},
+		operation:   "generateAccessToken",
+	}, 1)
+	if err != nil {
+		return "", "", err
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"accessToken"`
+		ExpireTime  string `json:"expireTime"` // RFC3339
+	}
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", "", fmt.Errorf("failed to decode impersonation response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", "", fmt.Errorf("impersonation response missing accessToken")
+	}
+	return tokenResp.AccessToken, tokenResp.ExpireTime, nil
+}
+
+// ttlFromExpireTime parses an RFC3339 expireTime into a remaining duration,
+// returning fallback when the timestamp is empty, unparseable, or already elapsed.
+func ttlFromExpireTime(expireTime string, fallback time.Duration) time.Duration {
+	if expireTime != "" {
+		if expiry, err := time.Parse(time.RFC3339, expireTime); err == nil {
+			if ttl := time.Until(expiry); ttl > 0 {
+				return ttl
+			}
+		}
+	}
+	return fallback
+}
+
+// ============================================================================
+// ExchangeMinter Interface Implementation (Workload Identity Federation)
+// ============================================================================
+
+// gcpTokenExchangeGrantType is the RFC 8693 token-exchange grant used against
+// GCP STS. GCP STS does not define a package-level constant, so it lives here.
+const gcpTokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+// gcpFederationScope is the scope requested from STS for the federated token on the
+// impersonation path: the token only needs to call generateAccessToken, and the
+// real per-credential scopes are applied there. Matches x/oauth2 externalaccount.
+const gcpFederationScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// MintCredentialWithExchange mints a GCP credential over Workload Identity
+// Federation by exchanging the caller's verified identity assertion at GCP STS for
+// a federated access token, then optionally impersonating a target service account.
+//
+// Supported mint methods over federation:
+//   - impersonated_access_token: STS federated token → generateAccessToken on the
+//     target SA; the impersonated token is the issued credential.
+//   - federated_access_token: the STS federated token is itself the issued credential.
+func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() != gcpAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("gcp: workload identity federation requires auth_method=oidc_federation on the source")
+	}
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("gcp: no subject token in exchange inputs")
+	}
+	if inputs.SubjectTokenOrigin != credential.ExchangeOriginVerified {
+		return nil, nil, 0, "", fmt.Errorf("gcp: workload identity federation requires a verified subject (subject_token_source=warden_identity or auth_token); a caller-supplied, unverified subject is rejected")
+	}
+
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	switch mintMethod {
+	case "impersonated_access_token":
+		targetSA := credential.GetString(spec.Config, "target_service_account", "")
+		if targetSA == "" {
+			return nil, nil, 0, "", fmt.Errorf("gcp: target_service_account is required for impersonated_access_token")
+		}
+		lifetime := credential.GetString(spec.Config, "lifetime", "3600s")
+		if err := validateGCPLifetime(spec, lifetime); err != nil {
+			return nil, nil, 0, "", err
+		}
+		scopesStr := credential.GetString(spec.Config, "scopes", gcpFederationScope)
+		scopes := splitScopes(scopesStr)
+
+		// Exchange the assertion for a federated token scoped to call the IAM
+		// Credentials API, then impersonate the target SA with it.
+		fedToken, _, err := d.exchangeWIFToken(ctx, inputs.SubjectToken, inputs.SubjectTokenType, gcpFederationScope)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		accessToken, expireTime, err := d.generateAccessToken(ctx, fedToken, targetSA, scopes, lifetime)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		ttl := ttlFromExpireTime(expireTime, gcpFederatedTokenFallbackTTL)
+
+		rawData := map[string]interface{}{"access_token": accessToken}
+		metadata := map[string]interface{}{
+			"subject":  targetSA,
+			"scopes":   scopesStr,
+			"lifetime": lifetime,
+			"provider": d.getWorkloadIdentityProvider(),
+		}
+		if expireTime != "" {
+			metadata["expiration"] = expireTime
+		}
+		if d.logger != nil {
+			d.logger.Debug("minted federated impersonated GCP access token",
+				logger.String("spec", spec.Name),
+				logger.String("target_sa", targetSA),
+				logger.String("ttl", ttl.String()),
+			)
+		}
+		return rawData, metadata, ttl, "", nil
+
+	case "federated_access_token":
+		// The federated token itself is the issued credential; honor the spec's scopes.
+		scopesStr := credential.GetString(spec.Config, "scopes", gcpFederationScope)
+		fedToken, ttl, err := d.exchangeWIFToken(ctx, inputs.SubjectToken, inputs.SubjectTokenType, scopesStr)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		// The token's real validity cannot be shortened, but the lease/cache lifetime
+		// must not exceed the spec's MaxTTL. MinTTL is deliberately NOT enforced here:
+		// unlike the AWS assume-role path (where a duration is requested), the STS
+		// token's lifetime is fixed by GCP, so a value below MinTTL cannot be raised —
+		// capping to MaxTTL is the only bound we can apply.
+		if spec.MaxTTL > 0 && ttl > spec.MaxTTL {
+			ttl = spec.MaxTTL
+		}
+		rawData := map[string]interface{}{"access_token": fedToken}
+		metadata := map[string]interface{}{
+			"subject":  d.getWorkloadIdentityProvider(),
+			"scopes":   scopesStr,
+			"provider": d.getWorkloadIdentityProvider(),
+		}
+		if d.logger != nil {
+			d.logger.Debug("minted federated GCP access token",
+				logger.String("spec", spec.Name),
+				logger.String("ttl", ttl.String()),
+			)
+		}
+		return rawData, metadata, ttl, "", nil
+
+	default:
+		return nil, nil, 0, "", fmt.Errorf("gcp: mint_method %q is not supported over auth_method=oidc_federation (supported: impersonated_access_token, federated_access_token)", mintMethod)
+	}
+}
+
+// exchangeWIFToken exchanges a subject assertion for a federated GCP access token at
+// STS. subjectTokenType defaults to a JWT when empty. scope is the space/comma-list
+// of scopes requested for the federated token. Returns the token and its lifetime.
+func (d *GCPDriver) exchangeWIFToken(ctx context.Context, subjectToken, subjectTokenType, scope string) (string, time.Duration, error) {
+	if subjectTokenType == "" {
+		subjectTokenType = credential.TokenTypeJWT
+	}
+	// STS wants a space-delimited scope list; accept a comma-separated spec value.
+	scope = strings.Join(splitScopes(scope), " ")
+
+	form := url.Values{}
+	form.Set("grant_type", gcpTokenExchangeGrantType)
+	form.Set("audience", d.getWorkloadIdentityProvider())
+	form.Set("scope", scope)
+	form.Set("requested_token_type", credential.TokenTypeAccessToken)
+	form.Set("subject_token_type", subjectTokenType)
+	form.Set("subject_token", subjectToken)
+
+	respBody, err := d.doGCPRequest(ctx, gcpAPIRequest{
+		method:      "POST",
+		url:         d.stsHost + "/v1/token",
+		body:        []byte(form.Encode()),
+		contentType: "application/x-www-form-urlencoded",
+		okStatuses:  []int{http.StatusOK},
+		operation:   "stsTokenExchange",
+	}, 1)
+	if err != nil {
+		return "", 0, err
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", 0, fmt.Errorf("failed to decode STS token-exchange response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", 0, fmt.Errorf("STS token-exchange response missing access_token")
+	}
+
+	ttl := time.Duration(tokenResp.ExpiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = gcpFederatedTokenFallbackTTL
+	}
+	return tokenResp.AccessToken, ttl, nil
+}
+
+// validateGCPLifetime parses a GCP lifetime string (e.g. "1800s") and checks it
+// against the spec's TTL bounds, mirroring the AWS federated session-TTL guard.
+func validateGCPLifetime(spec *credential.CredSpec, lifetime string) error {
+	dur, err := time.ParseDuration(lifetime)
+	if err != nil {
+		return fmt.Errorf("gcp: invalid lifetime %q: %w", lifetime, err)
+	}
+	if spec.MinTTL > 0 && dur < spec.MinTTL {
+		return fmt.Errorf("gcp: lifetime %s is below the spec minimum %s", dur, spec.MinTTL)
+	}
+	if spec.MaxTTL > 0 && dur > spec.MaxTTL {
+		return fmt.Errorf("gcp: lifetime %s exceeds the spec maximum %s", dur, spec.MaxTTL)
+	}
+	return nil
+}
+
+// gcpAssertionResource reports the canonical downstream resource a GCP federation
+// spec targets, for the warden_resource assertion claim. Pure: reads source/spec
+// config only, no network or driver state. The provider prefix is human-readable
+// sugar on an opaque value — never parse it back.
+func gcpAssertionResource(sourceCfg, specCfg map[string]string) (string, bool) {
+	switch credential.GetString(specCfg, "mint_method", "") {
+	case "impersonated_access_token":
+		if sa := credential.GetString(specCfg, "target_service_account", ""); sa != "" {
+			return "gcp-iam:" + sa, true
+		}
+	case "federated_access_token":
+		if p := credential.GetString(sourceCfg, "workload_identity_provider", ""); p != "" {
+			return "gcp-wif:" + p, true
+		}
+	}
+	return "", false
 }
 
 // Revoke is a no-op for GCP credentials (they expire naturally)
@@ -369,10 +668,11 @@ func (d *GCPDriver) Cleanup(ctx context.Context) error {
 // ============================================================================
 
 // SupportsRotation returns true if this driver can rotate its source SA key.
-// Rotation requires the SA to have iam.serviceAccountKeys.create and
-// iam.serviceAccountKeys.delete permissions on itself.
+// Only a static-key source has a key to rotate; a keyless federation source has
+// nothing to rotate. Rotation requires the SA to have iam.serviceAccountKeys.create
+// and iam.serviceAccountKeys.delete permissions on itself.
 func (d *GCPDriver) SupportsRotation() bool {
-	return true
+	return d.getAuthMethod() == gcpAuthMethodStatic
 }
 
 // PrepareRotation creates a new SA key for the source service account.

--- a/credential/drivers/gcp_federation_test.go
+++ b/credential/drivers/gcp_federation_test.go
@@ -1,0 +1,369 @@
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testWIFProvider = "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/warden/providers/warden-oidc"
+
+// newFederationDriver builds a keyless GCP driver whose STS and IAM Credentials
+// hosts point at the given test servers.
+func newFederationDriver(provider, stsHost, iamHost string) *GCPDriver {
+	return &GCPDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGCP,
+			Config: map[string]string{
+				"auth_method":                gcpAuthMethodOIDCFederation,
+				"workload_identity_provider": provider,
+			},
+		},
+		httpClient:         &http.Client{},
+		tokenCache:         NewTokenCache(),
+		stsHost:            stsHost,
+		iamCredentialsHost: iamHost,
+	}
+}
+
+func TestGCPDriverFactory_ValidateConfig_Federation(t *testing.T) {
+	f := &GCPDriverFactory{}
+
+	t.Run("missing workload_identity_provider", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{"auth_method": "oidc_federation"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workload_identity_provider is required")
+	})
+
+	t.Run("service_account_key rejected in federation", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"auth_method":                "oidc_federation",
+			"workload_identity_provider": testWIFProvider,
+			"service_account_key":        `{"client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not be set")
+	})
+
+	t.Run("bad provider prefix", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"auth_method":                "oidc_federation",
+			"workload_identity_provider": "https://iam.googleapis.com/projects/123/x",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with //iam.googleapis.com/")
+	})
+
+	t.Run("valid federation config", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"auth_method":                "oidc_federation",
+			"workload_identity_provider": testWIFProvider,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("static still requires key", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{"auth_method": "static"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service_account_key is required")
+	})
+
+	t.Run("workload_identity_provider rejected on static", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"auth_method":                "static",
+			"service_account_key":        `{"client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+			"workload_identity_provider": testWIFProvider,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only valid for auth_method=oidc_federation")
+	})
+}
+
+func TestGCPDriverFactory_InferCredentialType_Federation(t *testing.T) {
+	f := &GCPDriverFactory{}
+
+	for _, mm := range []string{"", "access_token", "impersonated_access_token", "federated_access_token"} {
+		got, err := f.InferCredentialType(map[string]string{"mint_method": mm})
+		require.NoError(t, err, "mint_method=%q", mm)
+		assert.Equal(t, credential.TypeGCPAccessToken, got, "mint_method=%q", mm)
+	}
+
+	got, err := f.InferCredentialType(map[string]string{"mint_method": "cloud_sql_iam_token"})
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeDBAuthToken, got)
+
+	_, err = f.InferCredentialType(map[string]string{"mint_method": "bogus"})
+	require.Error(t, err)
+}
+
+func TestGCPDriver_SupportsRotation_ByAuthMethod(t *testing.T) {
+	fed := newFederationDriver(testWIFProvider, "", "")
+	assert.False(t, fed.SupportsRotation(), "federation source has no key to rotate")
+
+	static := &GCPDriver{credSource: &credential.CredSource{
+		Type:   credential.SourceTypeGCP,
+		Config: map[string]string{"auth_method": "static"},
+	}}
+	assert.True(t, static.SupportsRotation())
+}
+
+func TestGCPDriver_MintCredential_FederationFailsClosed(t *testing.T) {
+	d := newFederationDriver(testWIFProvider, "", "")
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "access_token"}}
+	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject_token_source")
+}
+
+func TestGCPDriver_MintCredentialWithExchange_RejectsStaticSource(t *testing.T) {
+	d := &GCPDriver{credSource: &credential.CredSource{
+		Type:   credential.SourceTypeGCP,
+		Config: map[string]string{"auth_method": "static"},
+	}}
+	inputs := &credential.ExchangeInputs{SubjectToken: "tok", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "federated_access_token"}}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth_method=oidc_federation")
+}
+
+func TestGCPDriver_MintCredentialWithExchange_RejectsUnverified(t *testing.T) {
+	d := newFederationDriver(testWIFProvider, "", "")
+	inputs := &credential.ExchangeInputs{SubjectToken: "tok", SubjectTokenOrigin: credential.ExchangeOriginUnverified}
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "federated_access_token"}}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verified subject")
+}
+
+func TestGCPDriver_ExchangeWIFToken(t *testing.T) {
+	t.Run("form params and ttl", func(t *testing.T) {
+		var gotForm map[string]string
+		sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			gotForm = map[string]string{
+				"grant_type":           r.PostForm.Get("grant_type"),
+				"audience":             r.PostForm.Get("audience"),
+				"scope":                r.PostForm.Get("scope"),
+				"requested_token_type": r.PostForm.Get("requested_token_type"),
+				"subject_token_type":   r.PostForm.Get("subject_token_type"),
+				"subject_token":        r.PostForm.Get("subject_token"),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"FED-TOKEN","expires_in":1800,"token_type":"Bearer"}`))
+		}))
+		defer sts.Close()
+
+		d := newFederationDriver(testWIFProvider, sts.URL, "")
+		tok, ttl, err := d.exchangeWIFToken(context.TODO(), "SUBJECT-JWT", "", "https://www.googleapis.com/auth/cloud-platform")
+		require.NoError(t, err)
+		assert.Equal(t, "FED-TOKEN", tok)
+		assert.Equal(t, 1800*time.Second, ttl)
+
+		assert.Equal(t, gcpTokenExchangeGrantType, gotForm["grant_type"])
+		assert.Equal(t, testWIFProvider, gotForm["audience"])
+		assert.Equal(t, credential.TokenTypeAccessToken, gotForm["requested_token_type"])
+		assert.Equal(t, credential.TokenTypeJWT, gotForm["subject_token_type"], "empty type defaults to jwt")
+		assert.Equal(t, "SUBJECT-JWT", gotForm["subject_token"])
+	})
+
+	t.Run("subject_token_type forwarded", func(t *testing.T) {
+		var gotType string
+		sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			gotType = r.PostForm.Get("subject_token_type")
+			_, _ = w.Write([]byte(`{"access_token":"t","expires_in":10}`))
+		}))
+		defer sts.Close()
+		d := newFederationDriver(testWIFProvider, sts.URL, "")
+		_, _, err := d.exchangeWIFToken(context.TODO(), "jwt", credential.TokenTypeIDToken, "scope")
+		require.NoError(t, err)
+		assert.Equal(t, credential.TokenTypeIDToken, gotType)
+	})
+
+	t.Run("missing expires_in falls back", func(t *testing.T) {
+		sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"access_token":"t"}`))
+		}))
+		defer sts.Close()
+		d := newFederationDriver(testWIFProvider, sts.URL, "")
+		_, ttl, err := d.exchangeWIFToken(context.TODO(), "jwt", "", "scope")
+		require.NoError(t, err)
+		assert.Equal(t, gcpFederatedTokenFallbackTTL, ttl)
+	})
+
+	t.Run("comma-separated scope normalized to space list", func(t *testing.T) {
+		var gotScope string
+		sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			gotScope = r.PostForm.Get("scope")
+			_, _ = w.Write([]byte(`{"access_token":"t","expires_in":10}`))
+		}))
+		defer sts.Close()
+		d := newFederationDriver(testWIFProvider, sts.URL, "")
+		_, _, err := d.exchangeWIFToken(context.TODO(), "jwt", "",
+			"https://www.googleapis.com/auth/bigquery, https://www.googleapis.com/auth/devstorage.read_only")
+		require.NoError(t, err)
+		assert.Equal(t, "https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/devstorage.read_only", gotScope)
+	})
+
+	t.Run("STS error status propagates", func(t *testing.T) {
+		sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"audience mismatch"}`))
+		}))
+		defer sts.Close()
+		d := newFederationDriver(testWIFProvider, sts.URL, "")
+		_, _, err := d.exchangeWIFToken(context.TODO(), "jwt", "", "scope")
+		require.Error(t, err)
+	})
+}
+
+func TestGCPDriver_MintCredentialWithExchange_Impersonation(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"FED-TOKEN","expires_in":3600}`))
+	}))
+	defer sts.Close()
+
+	var gotAuth, gotPath string
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accessToken":"IMPERSONATED-TOKEN","expireTime":"2099-01-01T00:00:00Z"}`))
+	}))
+	defer iam.Close()
+
+	d := newFederationDriver(testWIFProvider, sts.URL, iam.URL)
+	inputs := &credential.ExchangeInputs{SubjectToken: "SUBJECT-JWT", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	spec := &credential.CredSpec{
+		Name:   "s",
+		MaxTTL: 24 * time.Hour,
+		Config: map[string]string{
+			"mint_method":            "impersonated_access_token",
+			"target_service_account": "bq@proj.iam.gserviceaccount.com",
+			"lifetime":               "1800s",
+		},
+	}
+
+	raw, meta, ttl, lease, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "IMPERSONATED-TOKEN", raw["access_token"])
+	assert.Empty(t, lease, "GCP tokens are irrevocable, no lease")
+	assert.Greater(t, ttl, time.Duration(0))
+	assert.Equal(t, "bq@proj.iam.gserviceaccount.com", meta["subject"])
+
+	// The bearer on the impersonation call must be the WIF-federated token, not any
+	// source-SA token.
+	assert.Equal(t, "Bearer FED-TOKEN", gotAuth)
+	assert.True(t, strings.HasSuffix(gotPath, ":generateAccessToken"), "path was %q", gotPath)
+}
+
+func TestGCPDriver_MintCredentialWithExchange_ImpersonationIAMError(t *testing.T) {
+	// STS leg succeeds, but the generateAccessToken leg denies the impersonation.
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"FED-TOKEN","expires_in":3600}`))
+	}))
+	defer sts.Close()
+	iam := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"permission denied on workloadIdentityUser"}}`))
+	}))
+	defer iam.Close()
+
+	d := newFederationDriver(testWIFProvider, sts.URL, iam.URL)
+	inputs := &credential.ExchangeInputs{SubjectToken: "jwt", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	spec := &credential.CredSpec{Name: "s", MaxTTL: time.Hour, Config: map[string]string{
+		"mint_method":            "impersonated_access_token",
+		"target_service_account": "bq@proj.iam.gserviceaccount.com",
+	}}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.Error(t, err)
+}
+
+func TestGCPDriver_MintCredentialWithExchange_ImpersonationLifetimeBounds(t *testing.T) {
+	d := newFederationDriver(testWIFProvider, "", "")
+	inputs := &credential.ExchangeInputs{SubjectToken: "jwt", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	spec := &credential.CredSpec{
+		Name:   "s",
+		MaxTTL: 15 * time.Minute,
+		Config: map[string]string{
+			"mint_method":            "impersonated_access_token",
+			"target_service_account": "bq@proj.iam.gserviceaccount.com",
+			"lifetime":               "3600s", // exceeds MaxTTL
+		},
+	}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the spec maximum")
+}
+
+func TestGCPDriver_MintCredentialWithExchange_Federated_TTLCap(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"FED-TOKEN","expires_in":3600}`)) // 1h
+	}))
+	defer sts.Close()
+
+	d := newFederationDriver(testWIFProvider, sts.URL, "")
+	inputs := &credential.ExchangeInputs{SubjectToken: "jwt", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	spec := &credential.CredSpec{
+		Name:   "s",
+		MaxTTL: 15 * time.Minute,
+		Config: map[string]string{"mint_method": "federated_access_token"},
+	}
+
+	raw, _, ttl, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "FED-TOKEN", raw["access_token"])
+	assert.Equal(t, 15*time.Minute, ttl, "lease TTL capped at MaxTTL")
+}
+
+func TestGCPDriver_MintCredentialWithExchange_UnsupportedMethod(t *testing.T) {
+	d := newFederationDriver(testWIFProvider, "", "")
+	inputs := &credential.ExchangeInputs{SubjectToken: "jwt", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "impersonated_service_account"}}
+	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported over auth_method=oidc_federation")
+}
+
+func TestGCPAssertionResource(t *testing.T) {
+	t.Run("impersonation from spec", func(t *testing.T) {
+		res, ok := gcpAssertionResource(
+			map[string]string{"workload_identity_provider": testWIFProvider},
+			map[string]string{"mint_method": "impersonated_access_token", "target_service_account": "bq@proj.iam.gserviceaccount.com"},
+		)
+		assert.True(t, ok)
+		assert.Equal(t, "gcp-iam:bq@proj.iam.gserviceaccount.com", res)
+	})
+
+	t.Run("federated from source", func(t *testing.T) {
+		res, ok := gcpAssertionResource(
+			map[string]string{"workload_identity_provider": testWIFProvider},
+			map[string]string{"mint_method": "federated_access_token"},
+		)
+		assert.True(t, ok)
+		assert.Equal(t, "gcp-wif:"+testWIFProvider, res)
+	})
+
+	t.Run("routed via DeriveAssertionResource", func(t *testing.T) {
+		res, ok := DeriveAssertionResource(credential.SourceTypeGCP,
+			map[string]string{"workload_identity_provider": testWIFProvider},
+			map[string]string{"mint_method": "federated_access_token"},
+		)
+		assert.True(t, ok)
+		assert.Equal(t, "gcp-wif:"+testWIFProvider, res)
+	})
+
+	t.Run("no resource when unset", func(t *testing.T) {
+		_, ok := gcpAssertionResource(map[string]string{}, map[string]string{"mint_method": "access_token"})
+		assert.False(t, ok)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `auth_method=oidc_federation` to the GCP credential driver, giving GCP the same **keyless** federation path that the AWS and Azure drivers already have. A federation source holds **no service-account key**; it mints Google Cloud tokens by exchanging a caller's verified Warden identity assertion at GCP STS (Workload Identity Federation), then optionally impersonating a target service account.

This mirrors the AWS reference implementation (`aws_driver.go`) throughout.

## What changed

- **`ValidateConfig`** — add `auth_method` + `workload_identity_provider`; require the provider and reject a stored key under federation; `static` still requires a service-account key.
- **`ExchangeMinter`** — `MintCredentialWithExchange` with two federated mint methods:
  - `impersonated_access_token` — STS federated token → `generateAccessToken` on the target SA (the standard, recommended GCP pattern).
  - `federated_access_token` — the STS token is itself the issued credential.
  Rejects unverified subjects and non-federation sources; applies the spec's TTL bounds (and caps the federated-token lease at `max_ttl`).
- **`exchangeWIFToken`** — RFC 8693 token exchange at `sts.googleapis.com`; forwards the spec's `subject_token_type`; falls back when `expires_in` is absent.
- **Shared `generateAccessToken`** — the IAM Credentials impersonation call is extracted into one helper used by both the static and federated paths (behaviour preserved exactly for the static path).
- **Fail-closed guards** — `MintCredential` errors on a federation source (spec must set `subject_token_source`); `SupportsRotation` gated on `static`; `Create` skips the eager credential probe for federation.
- **Assertion resource claim** — `gcpAssertionResource` + `SourceTypeGCP` routed through `DeriveAssertionResource`.

## Notes

- No new `go.mod` dependencies; STS is called via raw HTTP through the existing helper.
- A federation spec at this stage still sets `assertion_audience` explicitly — a follow-up PR derives it from the source so specs don't repeat it.

## Testing

- `go build ./...`, `go vet ./credential/...`
- `go test ./credential/drivers/` — unit tests cover the STS exchange request shape, `subject_token_type` forwarding and `expires_in` fallback, the impersonation bearer (asserts the WIF-federated token, not a source-SA token), TTL bounds/cap, STS and IAM error propagation, and config validation.
- Verified end-to-end against live GCP Workload Identity Federation (Warden issuer bundle published to a GCS bucket → WIF pool/provider → impersonated token calling the GCS API).