### PR TITLE
feat(oidc): show signing-key location in oidc-issuer read

### DIFF
--- a/cmd/oidcissuer/read.go
+++ b/cmd/oidcissuer/read.go
@@ -21,8 +21,9 @@ var (
 Usage: warden oidc-issuer read
 
   Show the current OIDC issuer configuration — enabled state, issuer URL,
-  assertion TTL, signing-key rotation timings and status, publisher (secrets
-  masked), and whether the issuer is ready to mint. Root namespace only.
+  assertion TTL, signing-key rotation timings and status, where the signing key
+  is held (in-process or an external KMS), publisher (secrets masked), and whether
+  the issuer is ready to mint. Root namespace only.
 
       $ warden oidc-issuer read
 `,
@@ -76,10 +77,14 @@ var publisherFields = []string{
 	"endpoint", "credentials_json", "rotation_period",
 }
 
+// signerFields is the field order of the signer block: where the signing key is held
+// (mode) and, for an external KMS, the backend type.
+var signerFields = []string{"mode", "backend"}
+
 // printOIDCIssuerTable renders the read response as a coherent two-column table: durations
-// as duration strings, and each nested block expanded into dot-keyed rows (publisher.type,
-// key_rotation.next_rotation, …) instead of one crammed comma-joined cell. Falls back to
-// the generic renderer for an unexpected shape.
+// as duration strings, and each nested block expanded into underscore-joined rows
+// (publisher_type, key_rotation_next_rotation, …) instead of one crammed comma-joined cell.
+// Falls back to the generic renderer for an unexpected shape.
 func printOIDCIssuerTable(data map[string]any) {
 	var rows [][]any
 	for _, k := range scalarOrder {
@@ -99,6 +104,7 @@ func printOIDCIssuerTable(data map[string]any) {
 	rows = appendBlock(rows, data, "key_rotation", rotationFields)
 	rows = appendBlock(rows, data, "publisher", publisherFields)
 	rows = appendBlock(rows, data, "publisher_rotation", rotationFields)
+	rows = appendBlock(rows, data, "signer", signerFields)
 
 	if len(rows) == 0 {
 		helpers.PrintMapAsTable(data)
@@ -107,9 +113,9 @@ func printOIDCIssuerTable(data map[string]any) {
 	helpers.PrintTable([]string{"Key", "Value"}, rows)
 }
 
-// appendBlock expands a nested map value into one dot-keyed row per field, in the given
-// order, then any unexpected keys sorted (so a field the server adds later is surfaced,
-// never silently dropped).
+// appendBlock expands a nested map value into one underscore-joined row per field, in the
+// given order, then any unexpected keys sorted (so a field the server adds later is
+// surfaced, never silently dropped).
 func appendBlock(rows [][]any, data map[string]any, name string, order []string) [][]any {
 	block, ok := data[name].(map[string]any)
 	if !ok {
@@ -119,7 +125,7 @@ func appendBlock(rows [][]any, data map[string]any, name string, order []string)
 	for _, f := range order {
 		seen[f] = true
 		if v, ok := block[f]; ok {
-			rows = append(rows, []any{name + "." + f, blockValueCell(f, v)})
+			rows = append(rows, []any{name + "_" + f, blockValueCell(f, v)})
 		}
 	}
 	extra := make([]string, 0)
@@ -130,7 +136,7 @@ func appendBlock(rows [][]any, data map[string]any, name string, order []string)
 	}
 	sort.Strings(extra)
 	for _, f := range extra {
-		rows = append(rows, []any{name + "." + f, cellString(block[f])})
+		rows = append(rows, []any{name + "_" + f, cellString(block[f])})
 	}
 	return rows
 }

--- a/cmd/oidcissuer/read_test.go
+++ b/cmd/oidcissuer/read_test.go
@@ -26,8 +26,9 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 // TestPrintOIDCIssuerTable checks the coherent read table: durations render as duration
-// strings (not bare seconds), and nested blocks expand into dot-keyed rows (not one crammed
-// comma-joined cell). Numbers arrive as json.Number, matching the API client's UseNumber decode.
+// strings (not bare seconds), and nested blocks expand into underscore-joined rows (not one
+// crammed comma-joined cell). Numbers arrive as json.Number, matching the API client's
+// UseNumber decode.
 func TestPrintOIDCIssuerTable(t *testing.T) {
 	data := map[string]any{
 		"enabled":             true,
@@ -55,6 +56,10 @@ func TestPrintOIDCIssuerTable(t *testing.T) {
 			"last_rotated_at": "2026-08-03T20:00:11Z",
 			"next_rotation":   "2026-08-03T20:01:11Z",
 		},
+		"signer": map[string]any{
+			"mode":    "external_kms",
+			"backend": "transit",
+		},
 	}
 
 	out := captureStdout(t, func() { printOIDCIssuerTable(data) })
@@ -65,20 +70,21 @@ func TestPrintOIDCIssuerTable(t *testing.T) {
 			t.Errorf("expected duration %q in output:\n%s", want, out)
 		}
 	}
-	// Nested blocks are expanded into dot-keyed rows.
+	// Nested blocks are expanded into underscore-joined rows.
 	for _, want := range []string{
-		"publisher.account_name", "wardenoidc16865",
-		"publisher.client_secret", "***********",
-		"key_rotation.running", "key_rotation.next_rotation",
-		"publisher_rotation.last_rotated_at",
+		"publisher_account_name", "wardenoidc16865",
+		"publisher_client_secret", "***********",
+		"key_rotation_running", "key_rotation_next_rotation",
+		"publisher_rotation_last_rotated_at",
+		"signer_mode", "external_kms", "signer_backend", "transit",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in output:\n%s", want, out)
 		}
 	}
 	// publisher.rotation_period is normalized to a canonical duration.
-	if !strings.Contains(out, "publisher.rotation_period") {
-		t.Errorf("expected publisher.rotation_period row:\n%s", out)
+	if !strings.Contains(out, "publisher_rotation_period") {
+		t.Errorf("expected publisher_rotation_period row:\n%s", out)
 	}
 	// The old crammed comma-joined nested cell must be gone.
 	if strings.Contains(out, "account_name=wardenoidc16865") {
@@ -102,7 +108,9 @@ func TestPrintOIDCIssuerTable_Disabled(t *testing.T) {
 	if !strings.Contains(out, "disabled") {
 		t.Errorf("expected key_rotation_period to read 'disabled':\n%s", out)
 	}
-	if strings.Contains(out, "key_rotation.") {
+	// The block is absent — assert on a block-only field (key_rotation_running), not the
+	// key_rotation_ prefix, which the top-level key_rotation_period scalar also shares.
+	if strings.Contains(out, "key_rotation_running") {
 		t.Errorf("no key_rotation block expected when disabled:\n%s", out)
 	}
 

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stephnangue/warden/core/oidcsign"
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logger"
@@ -168,7 +169,29 @@ func (b *SystemBackend) handleOIDCIssuerConfigRead(ctx context.Context, _ *logic
 		}
 		data["publisher_rotation"] = rot
 	}
+	data["signer"] = b.signerSummary()
 	return b.respondSuccess(data), nil
+}
+
+// signerSummary describes where the issuer's active signing key is held: the mode
+// (in-process vs external KMS) and, for a KMS, its backend type — both read from the
+// live active key, so they can't disagree and are correct on any node (a standby's
+// verification-only key retains the backend type). No KMS topology or token.
+func (b *SystemBackend) signerSummary() map[string]any {
+	out := map[string]any{"mode": "in_process"}
+	if iss := b.core.OIDCIssuer(); iss != nil {
+		for _, ks := range iss.Keys() {
+			if ks == nil || ks.active == nil {
+				continue
+			}
+			if rs, ok := ks.active.key.(*oidcsign.Signer); ok {
+				out["mode"] = "external_kms"
+				out["backend"] = rs.BackendType()
+				break
+			}
+		}
+	}
+	return out
 }
 
 func (b *SystemBackend) handleOIDCIssuerConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/core/sys_oidc_issuer_test.go
+++ b/core/sys_oidc_issuer_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logical"
@@ -61,6 +62,13 @@ func TestSysOIDCIssuerConfig(t *testing.T) {
 	assert.Equal(t, true, resp.Data["ready"])
 	assert.Equal(t, int64(300), resp.Data["assertion_ttl"])
 
+	// Default signing keys are generated in process, so the signer block reports
+	// in_process with no backend.
+	sgn, ok := resp.Data["signer"].(map[string]any)
+	require.True(t, ok, "signer block present")
+	assert.Equal(t, "in_process", sgn["mode"])
+	assert.NotContains(t, sgn, "backend", "no backend for in-process keys")
+
 	// Partial update: changing one field must NOT reset the others. Enabling and
 	// the issuer_url are carried forward from the stored config.
 	resp = write(ctx, map[string]any{"key_rotation_period": "24h"})
@@ -99,6 +107,41 @@ func TestSysOIDCIssuerConfig(t *testing.T) {
 	require.False(t, resp.IsError())
 	assert.Nil(t, core.OIDCIssuer())
 	assert.Equal(t, "https://warden-oidc.example", read(ctx).Data["issuer_url"], "issuer_url retained while disabled")
+}
+
+// TestSysOIDCIssuerConfig_SignerExternalKMS checks that the read signer block reports an
+// external-KMS key location, derived from the live active key (not config): after installing
+// KMS-backed keysets, the block reads external_kms with the backend's discriminator.
+func TestSysOIDCIssuerConfig_SignerExternalKMS(t *testing.T) {
+	backend, ctx, core := setupTestSystemBackend(t)
+	schema := backend.pathOIDCIssuer()[0].Fields
+
+	resp, err := backend.handleOIDCIssuerConfigWrite(ctx, createTestRequest(logical.UpdateOperation, "oidc-issuer/config", map[string]any{
+		"enabled":    true,
+		"issuer_url": "https://warden-oidc.example",
+	}), createFieldData(schema, map[string]any{"enabled": true, "issuer_url": "https://warden-oidc.example"}))
+	require.NoError(t, err)
+	require.False(t, resp.IsError(), "enable should succeed: %+v", resp.Data)
+	require.NotNil(t, core.OIDCIssuer())
+
+	// Swap the in-process keysets for KMS-backed ones (the live active key is the
+	// signer block's source of truth).
+	fake := newFakeSignBackend(t)
+	src := remoteKeySource{backend: fake, timeout: time.Second}
+	keysets := map[string]*algKeyset{}
+	for _, alg := range oidcSupportedAlgs {
+		active, next, err := src.bootstrap(ctx, alg)
+		require.NoError(t, err)
+		keysets[alg] = &algKeyset{active: active, next: next}
+	}
+	core.OIDCIssuer().RestoreKeys(keysets)
+
+	read, err := backend.handleOIDCIssuerConfigRead(ctx, createTestRequest(logical.ReadOperation, "oidc-issuer/config", nil), createFieldData(schema, nil))
+	require.NoError(t, err)
+	sgn, ok := read.Data["signer"].(map[string]any)
+	require.True(t, ok, "signer block present")
+	assert.Equal(t, "external_kms", sgn["mode"])
+	assert.Equal(t, "transit", sgn["backend"])
 }
 
 func TestSysOIDCIssuerConfig_Publisher(t *testing.T) {


### PR DESCRIPTION
## What

`warden oidc-issuer read` now reports **where the issuer's active signing key is held** via a new read-only `signer` block:

- `signer_mode` — `in_process` (key generated locally, barrier-encrypted) or `external_kms` (held in a KMS via the `signer` stanza; private key never enters Warden).
- `signer_backend` — the KMS backend discriminator (`transit`), shown only for `external_kms`.

Example (external KMS):

```
signer_mode      external_kms
signer_backend   transit
```

In-process default → just `signer_mode  in_process`.

## Why

"Where is the issuer's private signing key held?" is a first-order security-posture question. Until now it was only visible in the server startup log, which scrolls away and isn't queryable.

## How

- Both fields are derived at read time from the **live active key** (a `*oidcsign.Signer` ⇒ KMS-backed, and its `BackendType()` gives the backend), not from config. Single source of truth: the two fields can't disagree, and the block is correct whether served by the active node or a standby (a standby's reconstructed verification-only key retains the backend type). No new stored config field — the `signer` stanza stays node-local.
- Separately, the shared `read`/`configure`/`set-publisher` table renderer switches block keys from dot-joined to **underscore-joined** (`publisher_type`, `key_rotation_next_rotation`, …). This is table-only; `-o json` is keyed by the nested response shape and is unaffected by the separator (it gains the `signer` object like any block).

## Tests

- Handler: `in_process` assertion in the existing config test + a new `TestSysOIDCIssuerConfig_SignerExternalKMS` that installs KMS-backed keysets and asserts `external_kms` / `transit`.
- Renderer: underscore-keyed assertions + a `signer` block case.
- `go build ./...`, `go test ./core/ ./cmd/oidcissuer/...` green.

## Note

The underscore switch introduces a cosmetic prefix overlap in the table: the top-level scalar `key_rotation_period` shares the `key_rotation_` prefix with the `key_rotation` block. No real field collides, and `-o json` is unambiguous.
