### PR TITLE
fix(gcp): reuse access_token mint_method for OIDC federation

### DIFF
--- a/credential/drivers/assertion_claims_test.go
+++ b/credential/drivers/assertion_claims_test.go
@@ -161,7 +161,7 @@ func TestDeriveAssertionResource(t *testing.T) {
 			name:       "gcp federated names the provider from source config",
 			sourceType: credential.SourceTypeGCP,
 			sourceCfg:  map[string]string{"workload_identity_provider": testAudGCPProvider},
-			specCfg:    map[string]string{"mint_method": "federated_access_token"},
+			specCfg:    map[string]string{"mint_method": "access_token"},
 			want:       "gcp-wif:" + testAudGCPProvider,
 			wantOK:     true,
 		},

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -209,7 +209,7 @@ func (f *GCPDriverFactory) InferCredentialType(specConfig map[string]string) (st
 	switch mintMethod {
 	case "cloud_sql_iam_token":
 		return credential.TypeDBAuthToken, nil
-	case "", "access_token", "impersonated_access_token", "federated_access_token":
+	case "", "access_token", "impersonated_access_token":
 		return credential.TypeGCPAccessToken, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
@@ -469,7 +469,7 @@ const gcpFederationScope = "https://www.googleapis.com/auth/cloud-platform"
 // Supported mint methods over federation:
 //   - impersonated_access_token: STS federated token → generateAccessToken on the
 //     target SA; the impersonated token is the issued credential.
-//   - federated_access_token: the STS federated token is itself the issued credential.
+//   - access_token: the STS federated token is itself the issued credential.
 func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	if d.getAuthMethod() != gcpAuthMethodOIDCFederation {
 		return nil, nil, 0, "", fmt.Errorf("gcp: workload identity federation requires auth_method=oidc_federation on the source")
@@ -481,7 +481,7 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		return nil, nil, 0, "", fmt.Errorf("gcp: workload identity federation requires a verified subject (subject_token_source=warden_identity or auth_token); a caller-supplied, unverified subject is rejected")
 	}
 
-	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	mintMethod := credential.GetString(spec.Config, "mint_method", "access_token")
 	switch mintMethod {
 	case "impersonated_access_token":
 		targetSA := credential.GetString(spec.Config, "target_service_account", "")
@@ -526,7 +526,7 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		}
 		return rawData, metadata, ttl, "", nil
 
-	case "federated_access_token":
+	case "access_token":
 		// The federated token itself is the issued credential; honor the spec's scopes.
 		scopesStr := credential.GetString(spec.Config, "scopes", gcpFederationScope)
 		fedToken, ttl, err := d.exchangeWIFToken(ctx, inputs.SubjectToken, inputs.SubjectTokenType, scopesStr)
@@ -556,7 +556,7 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		return rawData, metadata, ttl, "", nil
 
 	default:
-		return nil, nil, 0, "", fmt.Errorf("gcp: mint_method %q is not supported over auth_method=oidc_federation (supported: impersonated_access_token, federated_access_token)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("gcp: mint_method %q is not supported over auth_method=oidc_federation (supported: impersonated_access_token, access_token)", mintMethod)
 	}
 }
 
@@ -630,12 +630,16 @@ func validateGCPLifetime(spec *credential.CredSpec, lifetime string) error {
 // config only, no network or driver state. The provider prefix is human-readable
 // sugar on an opaque value — never parse it back.
 func gcpAssertionResource(sourceCfg, specCfg map[string]string) (string, bool) {
-	switch credential.GetString(specCfg, "mint_method", "") {
+	// Default mirrors the federated mint_method dispatch in MintCredentialWithExchange
+	// (empty → access_token) so the named resource matches what the exchange reaches.
+	// A static source has no workload_identity_provider, so access_token still yields
+	// no resource there.
+	switch credential.GetString(specCfg, "mint_method", "access_token") {
 	case "impersonated_access_token":
 		if sa := credential.GetString(specCfg, "target_service_account", ""); sa != "" {
 			return "gcp-iam:" + sa, true
 		}
-	case "federated_access_token":
+	case "access_token":
 		if p := credential.GetString(sourceCfg, "workload_identity_provider", ""); p != "" {
 			return "gcp-wif:" + p, true
 		}

--- a/credential/drivers/gcp_federation_test.go
+++ b/credential/drivers/gcp_federation_test.go
@@ -89,7 +89,7 @@ func TestGCPDriverFactory_ValidateConfig_Federation(t *testing.T) {
 func TestGCPDriverFactory_InferCredentialType_Federation(t *testing.T) {
 	f := &GCPDriverFactory{}
 
-	for _, mm := range []string{"", "access_token", "impersonated_access_token", "federated_access_token"} {
+	for _, mm := range []string{"", "access_token", "impersonated_access_token"} {
 		got, err := f.InferCredentialType(map[string]string{"mint_method": mm})
 		require.NoError(t, err, "mint_method=%q", mm)
 		assert.Equal(t, credential.TypeGCPAccessToken, got, "mint_method=%q", mm)
@@ -128,7 +128,7 @@ func TestGCPDriver_MintCredentialWithExchange_RejectsStaticSource(t *testing.T) 
 		Config: map[string]string{"auth_method": "static"},
 	}}
 	inputs := &credential.ExchangeInputs{SubjectToken: "tok", SubjectTokenOrigin: credential.ExchangeOriginVerified}
-	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "federated_access_token"}}
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "access_token"}}
 	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "auth_method=oidc_federation")
@@ -137,7 +137,7 @@ func TestGCPDriver_MintCredentialWithExchange_RejectsStaticSource(t *testing.T) 
 func TestGCPDriver_MintCredentialWithExchange_RejectsUnverified(t *testing.T) {
 	d := newFederationDriver(testWIFProvider, "", "")
 	inputs := &credential.ExchangeInputs{SubjectToken: "tok", SubjectTokenOrigin: credential.ExchangeOriginUnverified}
-	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "federated_access_token"}}
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{"mint_method": "access_token"}}
 	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "verified subject")
@@ -316,13 +316,29 @@ func TestGCPDriver_MintCredentialWithExchange_Federated_TTLCap(t *testing.T) {
 	spec := &credential.CredSpec{
 		Name:   "s",
 		MaxTTL: 15 * time.Minute,
-		Config: map[string]string{"mint_method": "federated_access_token"},
+		Config: map[string]string{"mint_method": "access_token"},
 	}
 
 	raw, _, ttl, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
 	require.NoError(t, err)
 	assert.Equal(t, "FED-TOKEN", raw["access_token"])
 	assert.Equal(t, 15*time.Minute, ttl, "lease TTL capped at MaxTTL")
+}
+
+func TestGCPDriver_MintCredentialWithExchange_DefaultsToAccessToken(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"FED-TOKEN","expires_in":3600}`))
+	}))
+	defer sts.Close()
+
+	d := newFederationDriver(testWIFProvider, sts.URL, "")
+	inputs := &credential.ExchangeInputs{SubjectToken: "jwt", SubjectTokenOrigin: credential.ExchangeOriginVerified}
+	// No mint_method set: federation defaults to access_token (the federated token itself).
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{}}
+
+	raw, _, _, _, err := d.MintCredentialWithExchange(context.TODO(), spec, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "FED-TOKEN", raw["access_token"])
 }
 
 func TestGCPDriver_MintCredentialWithExchange_UnsupportedMethod(t *testing.T) {
@@ -347,7 +363,7 @@ func TestGCPAssertionResource(t *testing.T) {
 	t.Run("federated from source", func(t *testing.T) {
 		res, ok := gcpAssertionResource(
 			map[string]string{"workload_identity_provider": testWIFProvider},
-			map[string]string{"mint_method": "federated_access_token"},
+			map[string]string{"mint_method": "access_token"},
 		)
 		assert.True(t, ok)
 		assert.Equal(t, "gcp-wif:"+testWIFProvider, res)
@@ -356,7 +372,7 @@ func TestGCPAssertionResource(t *testing.T) {
 	t.Run("routed via DeriveAssertionResource", func(t *testing.T) {
 		res, ok := DeriveAssertionResource(credential.SourceTypeGCP,
 			map[string]string{"workload_identity_provider": testWIFProvider},
-			map[string]string{"mint_method": "federated_access_token"},
+			map[string]string{"mint_method": "access_token"},
 		)
 		assert.True(t, ok)
 		assert.Equal(t, "gcp-wif:"+testWIFProvider, res)


### PR DESCRIPTION
## What

Renames the GCP federation `mint_method` value `federated_access_token` → `access_token`, so GCP reuses one name across its static and federation paths (dispatched by `auth_method`) — matching how AWS reuses `sts_assume_role` and Azure reuses `bearer_token`.

## Why

The keyless OIDC federation feature (recently landed, pre-release) invented a federation-only `mint_method`, `federated_access_token`. That was a mistake: the peer drivers reuse a single name across both paths. GCP already exposes `access_token` on its static path, so the federation-native token should reuse it. The mental model becomes "`access_token` → a GCP OAuth2 access token," keyed or keyless.

## Changes

- `MintCredentialWithExchange`: rename the mint case, doc comment, and unsupported-method error; default an empty `mint_method` to `access_token` (mirrors the static path and Azure).
- `InferCredentialType`: drop the now-redundant `federated_access_token` case (`access_token` was already present).
- `gcpAssertionResource`: rename the case and default empty → `access_token` so the `warden_resource` claim stays consistent with the mint dispatch. Static sources still derive no resource (they cannot set `workload_identity_provider`).
- Tests: value swaps plus a new `DefaultsToAccessToken` case covering the empty-`mint_method` default.

Hard rename, no alias — nothing external depends on the old value yet.

## Verification

- `go build ./...` clean
- `go test ./credential/...` passes
- `grep -rIn "federated_access_token" .` → zero matches