### PR TITLE
feat(credential): allow keyless vault_token specs without token_role

### DIFF
--- a/credential/types/vault_token.go
+++ b/credential/types/vault_token.go
@@ -48,8 +48,7 @@ func (t *VaultTokenCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("vault_token"),
 
 		credential.StringField("token_role").
-			Required().
-			Describe("Vault token role to use for minting").
+			Describe("Vault token role for the static path (auth/token/create/{token_role}); required unless subject_token_source is set, where the exchanged/login token is vended directly and token_role must be omitted").
 			Example("app-backend"),
 
 		credential.DurationField("ttl").
@@ -79,6 +78,21 @@ func (t *VaultTokenCredType) ValidateConfig(config map[string]string, sourceType
 	schema := t.ConfigSchema()
 	if err := credential.ValidateSchema(config, schema...); err != nil {
 		return err
+	}
+
+	// Step 3: token_role governs only the static path, where the token is minted via
+	// auth/token/create/{token_role}. Any exchange spec (subject_token_source set —
+	// warden_identity, auth_token, header) vends the exchanged/login token directly
+	// and never consults token_role, so require it off the exchange path and reject a
+	// set-but-ignored token_role on it rather than silently dropping the operator's
+	// intent (which would vend a token with the wrong policy set). The credential type
+	// sees the spec config, so it distinguishes the two without the source config.
+	if credential.SpecRequestsExchange(config) {
+		if config["token_role"] != "" {
+			return fmt.Errorf("field 'token_role' is not used when '%s' is set: an exchange-minted vault_token vends the exchanged token directly", credential.ConfigSubjectTokenSource)
+		}
+	} else if config["token_role"] == "" {
+		return fmt.Errorf("field 'token_role' is required for mint_method=vault_token")
 	}
 
 	return nil

--- a/credential/types/vault_token_test.go
+++ b/credential/types/vault_token_test.go
@@ -54,6 +54,35 @@ func TestVaultTokenCredType_ValidateConfig_VaultSource(t *testing.T) {
 			errMsg:     "token_role",
 		},
 		{
+			name: "warden_identity exchange spec valid without token_role",
+			config: map[string]string{
+				"mint_method":          "vault_token",
+				"subject_token_source": credential.SourceWardenIdentity,
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
+		},
+		{
+			name: "auth_token exchange spec valid without token_role",
+			config: map[string]string{
+				"mint_method":          "vault_token",
+				"subject_token_source": credential.SourceAuthToken,
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
+		},
+		{
+			name: "exchange spec rejects an ignored token_role",
+			config: map[string]string{
+				"mint_method":          "vault_token",
+				"subject_token_source": credential.SourceWardenIdentity,
+				"token_role":           "my-role",
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "not used when",
+		},
+		{
 			name: "unsupported mint_method",
 			config: map[string]string{
 				"mint_method": "invalid",


### PR DESCRIPTION
A `vault_token` spec minted over the token-exchange path (`subject_token_source` set: `warden_identity`, `auth_token`, or `header`) vends the exchanged/login token directly and has no `token_role` — but the credential type marked `token_role` unconditionally required, which would reject such a spec at creation. Make it conditional on the mint path:

- **static path** (no `subject_token_source`): `token_role` required, as before (token minted via `auth/token/create/{token_role}`).
- **exchange path** (`subject_token_source` set): `token_role` must be **omitted** — it would be silently ignored, vending a token with the wrong policy set, so it is rejected rather than dropped.

The credential type sees the spec config, so it distinguishes the two without the source config (mirrors the mint-method branching in `aws_iam_keys.go`). No new `mint_method`; no effect on existing static specs. Covered in `vault_token_test.go`.