### PR TITLE
feat(credential): make the header token source's header name configurable

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1235,8 +1235,8 @@ func (c *Core) parseFormBody(req *logical.Request) error {
 // secrets: they are consumed here and stripped by the provider gateways before
 // any upstream forwarding, exactly like X-Warden-On-Behalf-Of.
 const (
-	headerSubjectToken = "X-Warden-Subject-Token"
-	headerActorToken   = "X-Warden-Actor-Token"
+	headerSubjectToken = credential.DefaultSubjectTokenHeader
+	headerActorToken   = credential.DefaultActorTokenHeader
 )
 
 // maxAssertionMetadataBytes bounds the JSON size of the metadata projected into a
@@ -1317,9 +1317,18 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		inputs.SubjectToken = req.ClientToken
 		inputs.SubjectTokenOrigin = credential.ExchangeOriginVerified
 	case credential.SourceHeader:
-		tok := req.HTTPRequest.Header.Get(headerSubjectToken)
+		headerName := credential.SubjectTokenHeaderName(spec.Config)
+		tok := resolveHeaderToken(req.HTTPRequest, headerName)
 		if tok == "" {
-			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerSubjectToken)
+			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerName)
+		}
+		// Fail closed if the subject header carries the caller's own auth token:
+		// the subject must be a distinct principal, not the agent itself. This is
+		// name-agnostic (equality means "same principal") and byte-exact — the
+		// Authorization Bearer strip above matches Warden's own token extractor —
+		// so it cannot be bypassed by header casing or a Bearer-scheme mismatch.
+		if tok == req.ClientToken {
+			return nil, fmt.Errorf("spec %q: the %s subject token must not equal the caller's own authentication token", specName, headerName)
 		}
 		inputs.SubjectToken = tok
 		inputs.SubjectTokenOrigin = credential.ExchangeOriginUnverified
@@ -1438,9 +1447,10 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 	case credential.SourceHeader:
 		// The actor token is a delegation credential, distinct from the
 		// X-Warden-On-Behalf-Of attribution label. Caller-supplied, so unverified.
-		tok := req.HTTPRequest.Header.Get(headerActorToken)
+		headerName := credential.ActorTokenHeaderName(spec.Config)
+		tok := resolveHeaderToken(req.HTTPRequest, headerName)
 		if tok == "" {
-			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerActorToken)
+			return nil, fmt.Errorf("spec %q requires a %s header", specName, headerName)
 		}
 		inputs.ActorToken = tok
 		inputs.ActorTokenOrigin = credential.ExchangeOriginUnverified
@@ -1535,11 +1545,30 @@ func extractToken(r *http.Request) string {
 		return token
 	}
 	// Fall back to Authorization: Bearer
-	authHeader := r.Header.Get("Authorization")
+	return stripBearer(r.Header.Get("Authorization"))
+}
+
+// stripBearer returns the token in an Authorization-style header value, matching
+// the "Bearer " scheme case-insensitively and returning the remainder verbatim
+// (no TrimSpace). It is the single source of truth for the Bearer strip so a
+// header-sourced exchange token is byte-identical to the caller's own auth token
+// when both ride Authorization — which the fail-closed guard relies on.
+func stripBearer(authHeader string) string {
 	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
 		return authHeader[7:]
 	}
 	return ""
+}
+
+// resolveHeaderToken reads a token-exchange token from the named (already
+// canonicalized) request header, stripping the Bearer scheme via stripBearer
+// when the header is Authorization, and returning any other header verbatim.
+func resolveHeaderToken(r *http.Request, headerName string) string {
+	v := r.Header.Get(headerName)
+	if headerName == "Authorization" {
+		return stripBearer(v)
+	}
+	return v
 }
 
 // actorSubjectPattern enforces the wire-format of X-Warden-On-Behalf-Of

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2351,6 +2351,74 @@ func TestResolveExchangeInputs_HeaderSource_MissingFailsClosed(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestResolveExchangeInputs_SubjectHeader_Authorization(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "authz-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigSubjectTokenHeader: "Authorization",
+	})
+
+	// A cert/SPIFFE-authenticated agent: ClientToken is not the user token, so the
+	// standard Authorization header is free to carry the subject. Bearer is stripped.
+	req := requestWith("spiffe-session", map[string]string{"Authorization": "Bearer eyJ.user"})
+	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("authz-spec"))
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	assert.Equal(t, "eyJ.user", inputs.SubjectToken, "Bearer scheme stripped from Authorization")
+	assert.Equal(t, credential.ExchangeOriginUnverified, inputs.SubjectTokenOrigin)
+}
+
+func TestResolveExchangeInputs_SubjectHeader_FailsClosedWhenEqualsCallerToken(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "authz-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigSubjectTokenHeader: "Authorization",
+	})
+
+	// A JWT-authed agent used the Authorization spec: Authorization carries its OWN
+	// auth token, so the subject would be the agent, not a distinct user. Fail closed.
+	req := requestWith("eyJ.agent", map[string]string{"Authorization": "Bearer eyJ.agent"})
+	_, err := c.resolveExchangeInputs(ctx, req, teForSpec("authz-spec"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not equal the caller's own authentication token")
+}
+
+func TestResolveExchangeInputs_SubjectHeader_GuardBypassAttempts(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	// Lowercase header name canonicalizes to Authorization.
+	seedSpec(t, c, ctx, "authz-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigSubjectTokenHeader: "authorization",
+	})
+
+	// Double space after Bearer: the shared stripBearer yields " eyJ.agent" (a
+	// leading space), byte-identical to what Warden's own token extractor sets as
+	// ClientToken at auth time — so the guard still trips and cannot be bypassed.
+	req := requestWith(" eyJ.agent", map[string]string{"Authorization": "Bearer  eyJ.agent"})
+	_, err := c.resolveExchangeInputs(ctx, req, teForSpec("authz-spec"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not equal the caller's own authentication token")
+}
+
+func TestResolveExchangeInputs_ActorHeader_CustomName(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	seedSpec(t, c, ctx, "deleg-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigActorTokenSource:   credential.SourceHeader,
+		credential.ConfigActorTokenHeader:   "X-Actor",
+	})
+
+	req := requestWith("opaque-token", map[string]string{
+		credential.DefaultSubjectTokenHeader: "eyJ.subject",
+		"X-Actor":                            "eyJ.actor",
+	})
+	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("deleg-spec"))
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	assert.Equal(t, "eyJ.actor", inputs.ActorToken)
+	assert.Equal(t, credential.ExchangeOriginUnverified, inputs.ActorTokenOrigin)
+}
+
 func TestResolveExchangeInputs_ActorHeader(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
 	seedSpec(t, c, ctx, "deleg-spec", map[string]string{

--- a/credential/exchange.go
+++ b/credential/exchange.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"net/textproto"
 	"strings"
 )
 
@@ -50,13 +51,65 @@ const (
 	// ConfigActorTokenType overrides the actor token's RFC 8693 type
 	// (default TokenTypeJWT).
 	ConfigActorTokenType = "actor_token_type"
+	// ConfigSubjectTokenHeader names the request header the "header" subject
+	// source reads. Absent/empty defaults to DefaultSubjectTokenHeader. Set it to
+	// "Authorization" (the Bearer scheme is stripped) to carry the subject token in
+	// the standard header when that header is otherwise free (e.g. a cert/SPIFFE-
+	// authenticated agent). Valid only with subject_token_source=header.
+	ConfigSubjectTokenHeader = "subject_token_header"
+	// ConfigActorTokenHeader names the request header the "header" actor source
+	// reads. Absent/empty defaults to DefaultActorTokenHeader. Valid only with
+	// actor_token_source=header.
+	ConfigActorTokenHeader = "actor_token_header"
 )
+
+// Default header names for the "header" token source. These preserve the
+// historical behaviour exactly: a spec that does not set a *_token_header reads
+// the same Warden header it always did, so this configurability adds no migration.
+const (
+	DefaultSubjectTokenHeader = "X-Warden-Subject-Token"
+	DefaultActorTokenHeader   = "X-Warden-Actor-Token"
+)
+
+// internalTokenHeaders lists request headers that carry Warden's own auth and so
+// must never be reused to carry an exchange token: pointing a *_token_header at
+// one would either leak the caller's own auth into the exchange or let a caller
+// smuggle a token past validation. Compared canonicalized.
+var internalTokenHeaders = map[string]struct{}{
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Token"): {},
+}
+
+// SubjectTokenHeaderName returns the canonicalized header name the "header"
+// subject source reads for this spec, defaulting to DefaultSubjectTokenHeader.
+func SubjectTokenHeaderName(config map[string]string) string {
+	return canonicalTokenHeader(config[ConfigSubjectTokenHeader], DefaultSubjectTokenHeader)
+}
+
+// ActorTokenHeaderName returns the canonicalized header name the "header" actor
+// source reads for this spec, defaulting to DefaultActorTokenHeader.
+func ActorTokenHeaderName(config map[string]string) string {
+	return canonicalTokenHeader(config[ConfigActorTokenHeader], DefaultActorTokenHeader)
+}
+
+// canonicalTokenHeader canonicalizes a configured header name (falling back to
+// def when unset) so name comparisons and lookups are case-insensitive and
+// consistent with net/http's own header canonicalization.
+func canonicalTokenHeader(v, def string) string {
+	if v == "" {
+		v = def
+	}
+	return textproto.CanonicalMIMEHeaderKey(v)
+}
 
 // Accepted values for the *_source config keys.
 const (
 	SourceAuthToken = "auth_token"
-	SourceHeader    = "header"
-	SourceNone      = "none"
+	// SourceHeader reads a caller-supplied token from a request header named by
+	// ConfigSubjectTokenHeader/ConfigActorTokenHeader (default the X-Warden-*-Token
+	// headers). The token is unverified — the driver validates it against the
+	// source's configured trust.
+	SourceHeader = "header"
+	SourceNone   = "none"
 	// SourceWardenIdentity mints a fresh Warden-signed identity assertion (via
 	// the OIDC issuer) as the subject token. Used for Workload Identity
 	// Federation: Warden re-issues the resolved agent identity so an upstream
@@ -347,6 +400,37 @@ func ValidateExchangeSpecConfig(config map[string]string) error {
 	if config[ConfigSubjectTokenSource] == SourceAuthToken && actorSrc == SourceAuthToken {
 		return fmt.Errorf("field '%s': cannot be '%s' when '%s' is also '%s' (one inbound token cannot be both subject and actor)",
 			ConfigActorTokenSource, SourceAuthToken, ConfigSubjectTokenSource, SourceAuthToken)
+	}
+	// A configured header name is meaningful only for the matching header source,
+	// and must not name an internal auth header.
+	if err := validateTokenHeaderKey(config, ConfigSubjectTokenHeader, ConfigSubjectTokenSource); err != nil {
+		return err
+	}
+	if err := validateTokenHeaderKey(config, ConfigActorTokenHeader, ConfigActorTokenSource); err != nil {
+		return err
+	}
+	// One header cannot carry both the subject and the actor token.
+	if config[ConfigSubjectTokenSource] == SourceHeader && actorSrc == SourceHeader &&
+		SubjectTokenHeaderName(config) == ActorTokenHeaderName(config) {
+		return fmt.Errorf("field '%s': subject and actor cannot read the same header %q",
+			ConfigActorTokenHeader, SubjectTokenHeaderName(config))
+	}
+	return nil
+}
+
+// validateTokenHeaderKey checks a *_token_header config key: it is valid only
+// when the matching *_token_source is "header", and must not name an internal
+// auth header (compared canonicalized).
+func validateTokenHeaderKey(config map[string]string, headerKey, sourceKey string) error {
+	raw := config[headerKey]
+	if raw == "" {
+		return nil
+	}
+	if config[sourceKey] != SourceHeader {
+		return fmt.Errorf("field '%s': is valid only when '%s' is '%s'", headerKey, sourceKey, SourceHeader)
+	}
+	if _, bad := internalTokenHeaders[textproto.CanonicalMIMEHeaderKey(raw)]; bad {
+		return fmt.Errorf("field '%s': %q is an internal header and cannot carry an exchange token", headerKey, raw)
 	}
 	return nil
 }

--- a/credential/exchange_test.go
+++ b/credential/exchange_test.go
@@ -246,6 +246,20 @@ func TestSpecRequestsExchange(t *testing.T) {
 	}
 }
 
+func TestTokenHeaderName_Defaults(t *testing.T) {
+	// Unset falls back to the historical Warden headers, canonicalized.
+	if got := SubjectTokenHeaderName(map[string]string{}); got != DefaultSubjectTokenHeader {
+		t.Fatalf("subject default = %q, want %q", got, DefaultSubjectTokenHeader)
+	}
+	if got := ActorTokenHeaderName(map[string]string{}); got != DefaultActorTokenHeader {
+		t.Fatalf("actor default = %q, want %q", got, DefaultActorTokenHeader)
+	}
+	// A configured name is canonicalized so comparisons are case-insensitive.
+	if got := SubjectTokenHeaderName(map[string]string{ConfigSubjectTokenHeader: "authorization"}); got != "Authorization" {
+		t.Fatalf("subject override = %q, want %q", got, "Authorization")
+	}
+}
+
 func TestValidateExchangeSpecConfig(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -362,6 +376,57 @@ func TestValidateExchangeSpecConfig(t *testing.T) {
 				ConfigAssertionResource:  "aws-secretsmanager:prod/db",
 			},
 			wantErr: true,
+		},
+		{
+			name: "subject_token_header with header source",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigSubjectTokenHeader: "Authorization",
+			},
+		},
+		{
+			name: "subject_token_header without header source",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceAuthToken,
+				ConfigSubjectTokenHeader: "Authorization",
+			},
+			wantErr: true,
+		},
+		{
+			name: "actor_token_header without header source",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigActorTokenSource:   SourceAuthToken,
+				ConfigActorTokenHeader:   "X-Actor",
+			},
+			wantErr: true,
+		},
+		{
+			name: "subject_token_header naming an internal header",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigSubjectTokenHeader: "x-warden-token",
+			},
+			wantErr: true,
+		},
+		{
+			name: "subject and actor same header rejected",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigActorTokenSource:   SourceHeader,
+				ConfigSubjectTokenHeader: "Authorization",
+				ConfigActorTokenHeader:   "authorization",
+			},
+			wantErr: true,
+		},
+		{
+			name: "subject and actor distinct headers allowed",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigActorTokenSource:   SourceHeader,
+				ConfigSubjectTokenHeader: "X-Subject",
+				ConfigActorTokenHeader:   "X-Actor",
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What

The `header` token source hard-coded `X-Warden-Subject-Token` / `X-Warden-Actor-Token`. This adds `subject_token_header` / `actor_token_header` config keys so a spec can point the source at any request header — notably the standard `Authorization: Bearer`, which is free when the agent authenticates by mTLS/SPIFFE.

The keys **default to the existing Warden headers**, so behavior is unchanged with no migration.

## Details

- When the resolved header is `Authorization`, the `Bearer ` scheme is stripped via the *same* routine as Warden's own token extractor, so a header-sourced token is byte-identical to the caller's own auth token.
- A **name-agnostic fail-closed guard** then rejects a subject token equal to the caller's own token, so the subject can never silently become the agent itself (robust to header casing and a `Bearer  token` double-space).
- Spec validation gates the new keys: valid only with the matching `*_token_source=header`, may not name an internal auth header (e.g. `X-Warden-Token`), and subject and actor may not read the same header.

## Testing

- `credential/exchange_test.go`: header-name defaults, override (incl. `Authorization`), `*_token_header` rejected without the matching source, same-header rejection, internal-header deny.
- `core/request_handler_test.go`: default reads `X-Warden-Subject-Token` verbatim; `Authorization` strips `Bearer`; fails closed when the resolved value equals the caller token — including the double-space and lowercase-header-name bypass attempts.
- `go build ./...`, `go vet`, and the `credential` / `core` suites pass.
