### PR TITLE
feat(credential): allow actor_token_source=warden_identity for delegation

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -880,16 +880,37 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		return logical.ErrBadRequestf("invalid token-exchange config: %s", err.Error())
 	}
 
-	// A warden_identity assertion must declare its audience. The spec may omit it
-	// only when the source can derive one (e.g. a GCP federation source derives it
-	// from its workload_identity_provider); otherwise it is required. This check is
-	// source-aware, so it lives here rather than in the source-agnostic structural
-	// validator above. Re-checked at mint time (defence in depth).
-	if spec.Config[credential.ConfigSubjectTokenSource] == credential.SourceWardenIdentity &&
-		spec.Config[credential.ConfigAssertionAudience] == "" {
+	// Any actor token source (header, auth_token, warden_identity) is consumed only
+	// by the token_exchange driver, which forwards the actor to an RFC 8693 STS;
+	// every other driver ignores ActorToken entirely. Pin any actor source to a
+	// token_exchange source so a delegation spec can't be bound to a source that
+	// would silently drop the actor (losing the delegation and its audit
+	// attribution), and reject a grant with no actor slot — otherwise the spec is
+	// accepted but every request fails at mint time. These are source-aware, so
+	// they live here, not in the structural validator above.
+	if actorSrc := spec.Config[credential.ConfigActorTokenSource]; actorSrc != "" && actorSrc != credential.SourceNone {
+		if source.Type != credential.SourceTypeTokenExchange {
+			return logical.ErrBadRequestf("field '%s': an actor token requires a '%s' source (only token exchange consumes an actor token)",
+				credential.ConfigActorTokenSource, credential.SourceTypeTokenExchange)
+		}
+		if !drivers.TokenExchangeSupportsActor(source.Config) {
+			return logical.ErrBadRequestf("field '%s': an actor token is not supported with grant=jwt_bearer (no actor slot)",
+				credential.ConfigActorTokenSource)
+		}
+	}
+
+	// A warden_identity assertion — whether the subject or the actor — must declare
+	// its audience. The spec may omit it only when the source can derive one (e.g. a
+	// GCP federation source derives it from its workload_identity_provider);
+	// otherwise it is required. This check is source-aware, so it lives here rather
+	// than in the source-agnostic structural validator above. Re-checked at mint
+	// time (defence in depth).
+	mintsAssertion := spec.Config[credential.ConfigSubjectTokenSource] == credential.SourceWardenIdentity ||
+		spec.Config[credential.ConfigActorTokenSource] == credential.SourceWardenIdentity
+	if mintsAssertion && spec.Config[credential.ConfigAssertionAudience] == "" {
 		if _, ok := drivers.DeriveAssertionAudience(source.Type, source.Config, spec.Config); !ok {
-			return logical.ErrBadRequestf("field '%s': is required when '%s' is '%s'",
-				credential.ConfigAssertionAudience, credential.ConfigSubjectTokenSource, credential.SourceWardenIdentity)
+			return logical.ErrBadRequestf("field '%s': is required when the subject or actor is '%s'",
+				credential.ConfigAssertionAudience, credential.SourceWardenIdentity)
 		}
 	}
 

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -915,6 +915,127 @@ func TestCredentialConfigStore_ValidateSpec_ExchangeRotation(t *testing.T) {
 	}
 }
 
+// TestCredentialConfigStore_ValidateSpec_ActorWardenIdentity covers the two
+// source-aware gates for actor_token_source=warden_identity: it must bind to a
+// token_exchange source (only that driver consumes an actor token) and it must
+// have a resolvable assertion audience.
+func TestCredentialConfigStore_ValidateSpec_ActorWardenIdentity(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	store.core.credentialDriverRegistry = nil // skip the test-mint block
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "sts-src", Type: credential.SourceTypeTokenExchange,
+		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "rfc8693"},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "jwtbearer-src", Type: credential.SourceTypeTokenExchange,
+		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "jwt_bearer"},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "local-src", Type: "local"}))
+
+	spec := func(name, source string, cfg map[string]string) *credential.CredSpec {
+		full := map[string]string{
+			credential.ConfigSubjectTokenSource: credential.SourceHeader,
+			credential.ConfigActorTokenSource:   credential.SourceWardenIdentity,
+		}
+		for k, v := range cfg {
+			full[k] = v
+		}
+		return &credential.CredSpec{Name: name, Type: "vault_token", Source: source, Config: full}
+	}
+
+	tests := []struct {
+		name     string
+		spec     *credential.CredSpec
+		errorMsg string // empty => expect success
+	}{
+		{
+			name: "accepted on token_exchange with explicit audience",
+			spec: spec("obo-ok", "sts-src", map[string]string{
+				credential.ConfigAssertionAudience: "https://sts.example/aud",
+			}),
+		},
+		{
+			name: "rejected on a non-token_exchange source",
+			spec: spec("obo-bad-source", "local-src", map[string]string{
+				credential.ConfigAssertionAudience: "https://sts.example/aud",
+			}),
+			errorMsg: "requires a 'token_exchange' source",
+		},
+		{
+			name:     "rejected when audience missing and not derivable",
+			spec:     spec("obo-no-aud", "sts-src", map[string]string{}),
+			errorMsg: "is required when the subject or actor is",
+		},
+		{
+			name: "rejected on a jwt_bearer grant (no actor slot)",
+			spec: spec("obo-jwtbearer", "jwtbearer-src", map[string]string{
+				credential.ConfigAssertionAudience: "https://sts.example/aud",
+			}),
+			errorMsg: "grant=jwt_bearer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.CreateSpec(ctx, tt.spec)
+			if tt.errorMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			if !contains(err.Error(), tt.errorMsg) {
+				t.Errorf("expected error containing %q, got %q", tt.errorMsg, err.Error())
+			}
+		})
+	}
+}
+
+// TestCredentialConfigStore_ValidateSpec_ActorSourceRequiresTokenExchange locks
+// in that ANY actor token source — not just warden_identity — is pinned to a
+// token_exchange source, since only that driver consumes an actor token; every
+// other driver would silently drop it.
+func TestCredentialConfigStore_ValidateSpec_ActorSourceRequiresTokenExchange(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	store.core.credentialDriverRegistry = nil // skip the test-mint block
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "sts-src", Type: credential.SourceTypeTokenExchange,
+		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "rfc8693"},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "local-src", Type: "local"}))
+
+	tests := []struct {
+		name     string
+		source   string
+		actorSrc string
+		errorMsg string // empty => expect success
+	}{
+		{"header actor on local source rejected", "local-src", credential.SourceHeader, "requires a 'token_exchange' source"},
+		{"auth_token actor on local source rejected", "local-src", credential.SourceAuthToken, "requires a 'token_exchange' source"},
+		{"header actor on token_exchange accepted", "sts-src", credential.SourceHeader, ""},
+		{"auth_token actor on token_exchange accepted", "sts-src", credential.SourceAuthToken, ""},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// subject=header so the actor pairing is valid regardless of actor source.
+			err := store.CreateSpec(ctx, &credential.CredSpec{
+				Name: fmt.Sprintf("actor-spec-%d", i), Type: "vault_token", Source: tt.source,
+				Config: map[string]string{
+					credential.ConfigSubjectTokenSource: credential.SourceHeader,
+					credential.ConfigActorTokenSource:   tt.actorSrc,
+				},
+			})
+			if tt.errorMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			if !contains(err.Error(), tt.errorMsg) {
+				t.Errorf("expected error containing %q, got %q", tt.errorMsg, err.Error())
+			}
+		})
+	}
+}
+
 // testCredentialType is a minimal credential type for testing
 type testCredentialType struct {
 	typeName         string

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1282,12 +1282,14 @@ func projectAssertionMetadata(md map[string]string, keys []string) (map[string]s
 // opt into exchange, so the non-exchange mint path is completely unaffected.
 //
 // The plumbing never verifies token contents — it only records provenance via
-// SubjectTokenOrigin. Every configured-but-missing input fails the request
-// closed rather than silently minting a non-exchange credential.
+// SubjectTokenOrigin/ActorTokenOrigin. Every configured-but-missing input fails
+// the request closed rather than silently minting a non-exchange credential.
 //
-// For subject_token_source=warden_identity the assertion mint is deferred to a
-// credential-cache miss (via inputs.ResolveSubjectToken) so a cache hit pays no
-// signing cost; the issuer-ready and audience checks stay eager and fail closed.
+// A warden_identity subject or actor defers its assertion mint to a
+// credential-cache miss (via inputs.ResolveSubjectToken / ResolveActorToken) so a
+// cache hit pays no signing cost; the issuer-ready and audience checks stay eager
+// and fail closed. The subject and actor resolve independently — an eager header
+// subject can pair with a lazily-minted warden_identity actor.
 func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, te *logical.TokenEntry) (*credential.ExchangeInputs, error) {
 	specName := te.CredentialSpec
 	spec, err := c.credConfigStore.GetSpec(ctx, specName)
@@ -1304,6 +1306,22 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 	}
 	if inputs.SubjectTokenType == "" {
 		inputs.SubjectTokenType = credential.TokenTypeJWT
+	}
+
+	// loadSource fetches the spec's source at most once per request, only when a
+	// warden_identity subject or actor derivation actually needs it (an unset
+	// audience or unset assertion_resource). Shared across both switches so a spec
+	// that derives from the source loads it once, not twice.
+	var srcCached *credential.CredSource
+	loadSource := func() (*credential.CredSource, error) {
+		if srcCached == nil {
+			s, err := c.credConfigStore.GetSource(ctx, spec.Source)
+			if err != nil {
+				return nil, fmt.Errorf("spec %q: failed to load source %q: %w", specName, spec.Source, err)
+			}
+			srcCached = s
+		}
+		return srcCached, nil
 	}
 
 	switch spec.Config[credential.ConfigSubjectTokenSource] {
@@ -1334,109 +1352,17 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		inputs.SubjectTokenOrigin = credential.ExchangeOriginUnverified
 	case credential.SourceWardenIdentity:
 		// Warden mints a fresh, short-lived assertion of the caller's resolved
-		// identity (origin verified — Warden signed it). Fails closed if the
-		// issuer is disabled/not-ready or the audience is missing.
-		issuer := c.OIDCIssuer()
-		if issuer == nil || !issuer.Ready() {
-			return nil, fmt.Errorf("spec %q requires subject_token_source=warden_identity but the OIDC issuer is not enabled/ready", specName)
-		}
-
-		// Load the source at most once, and only when a derivation actually needs it
-		// (an unset audience or an unset assertion_resource). A spec that sets the
-		// audience explicitly and opts out of / pins the resource never loads the
-		// source, preserving the prior behaviour and error surface for those specs.
-		var srcCached *credential.CredSource
-		loadSource := func() (*credential.CredSource, error) {
-			if srcCached == nil {
-				s, err := c.credConfigStore.GetSource(ctx, spec.Source)
-				if err != nil {
-					return nil, fmt.Errorf("spec %q: failed to load source %q: %w", specName, spec.Source, err)
-				}
-				srcCached = s
-			}
-			return srcCached, nil
-		}
-
-		// The assertion audience: an explicit spec value wins; otherwise derive it
-		// from the source (e.g. a GCP federation source derives it from its
-		// workload_identity_provider). Fails closed if neither yields one.
-		audience := spec.Config[credential.ConfigAssertionAudience]
-		if audience == "" {
-			src, srcErr := loadSource()
-			if srcErr != nil {
-				return nil, srcErr
-			}
-			audience, _ = drivers.DeriveAssertionAudience(src.Type, src.Config, spec.Config)
-		}
-		if audience == "" {
-			return nil, fmt.Errorf("spec %q with subject_token_source=warden_identity requires %s", specName, credential.ConfigAssertionAudience)
-		}
-		// Resolve the single downstream resource to name in the assertion so a
-		// verifier can pin it to one resource. Unset derives it from the source/spec
-		// config (pure, network-free — no live driver is built here); "none" opts
-		// out; any other value is emitted verbatim. Best-effort: a spec with no
-		// single static resource simply carries no warden_resource claim.
-		var resource string
-		switch r := spec.Config[credential.ConfigAssertionResource]; r {
-		case credential.AssertionResourceNone:
-			// opt-out: emit no warden_resource claim
-		case "":
-			src, srcErr := loadSource()
-			if srcErr != nil {
-				return nil, srcErr
-			}
-			resource, _ = drivers.DeriveAssertionResource(src.Type, src.Config, spec.Config)
-		default:
-			resource = r
-		}
-		// Project only the operator-allowlisted metadata keys into the assertion.
-		// Empty allowlist projects nothing (mdFingerprint is ""), so the assertion
-		// and cache key are byte-for-byte what they were before this opt-in existed.
-		projected, mdFingerprint, err := projectAssertionMetadata(te.Metadata, credential.AssertionMetadataKeys(spec.Config))
+		// identity as the subject (Workload Identity Federation). Origin verified —
+		// Warden signed it. Minted lazily on a cache miss; fails closed if the
+		// issuer is disabled/not-ready or no audience is available.
+		setup, err := c.buildAssertionSetup(ctx, specName, spec, te, loadSource)
 		if err != nil {
-			return nil, fmt.Errorf("spec %q: %w", specName, err)
+			return nil, err
 		}
 		inputs.SubjectTokenType = credential.TokenTypeJWT
 		inputs.SubjectTokenOrigin = credential.ExchangeOriginVerified
-		// Key the credential cache on the stable identity + audience, NOT the
-		// freshly-minted assertion bytes (which change every request), so one
-		// identity reuses its cached upstream credential. When metadata is projected
-		// into the assertion, fold its fingerprint in too so two tokens sharing
-		// subject+audience but differing in projected metadata stay isolated. The
-		// fragment is appended only when non-empty, so the no-metadata cache key is
-		// byte-for-byte what it was before this opt-in existed.
-		inputs.CacheIdentity = wardenSubject(te) + "\x00" + audience
-		// Fold the resource in beside the audience. Correctness-relevant, not just
-		// defensive: a token-exchange resource can come from source config, which
-		// can change under a fixed specName (the outer cache key). Appended only
-		// when non-empty, so no-resource keys stay byte-for-byte unchanged; kept
-		// before mdFingerprint (marshalled JSON starting with '{'), so the fragments
-		// can never be confused.
-		if resource != "" {
-			inputs.CacheIdentity += "\x00res=" + resource
-		}
-		if mdFingerprint != "" {
-			inputs.CacheIdentity += "\x00" + mdFingerprint
-		}
-		// Defer the assertion mint to a credential-cache MISS. On the hot
-		// path (a cache hit) the assertion would be minted and immediately thrown
-		// away; the Manager invokes this only on a real miss, inside its
-		// singleflight leader, so at most one assertion is minted per miss. The
-		// CacheIdentity above keys the cache, so the fingerprint never needs the
-		// (not-yet-minted) assertion bytes.
-		// The spec selects the assertion signing algorithm (default RS256). The
-		// issuer maintains a keyset per algorithm, so either is available with no
-		// cold start; validation restricts it to a supported alg at spec-create.
-		alg := credential.AssertionAlgorithm(spec.Config)
-		inputs.ResolveSubjectToken = func(ctx context.Context) (string, error) {
-			return issuer.MintIdentityAssertion(ctx, te, AssertionClaims{
-				Audience: audience,
-				TTL:      issuer.AssertionTTL(),
-				Alg:      alg,
-				Metadata: projected,
-				Resource: resource,
-			})
-		}
+		inputs.SubjectCacheIdentity = setup.cacheIdentity
+		inputs.ResolveSubjectToken = setup.resolve
 	default:
 		// SpecRequestsExchange already excluded "none"/absent; any other value
 		// was rejected at spec-validation time.
@@ -1469,6 +1395,19 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		if inputs.ActorTokenType == "" {
 			inputs.ActorTokenType = credential.TokenTypeJWT
 		}
+	case credential.SourceWardenIdentity:
+		// Delegation: Warden signs the agent as the RFC 8693 actor (act), acting on
+		// behalf of the distinct user carried in the subject header (spec validation
+		// requires subject_token_source=header here). Origin verified — Warden minted
+		// it — and, like the subject assertion, minted lazily on a cache miss.
+		setup, err := c.buildAssertionSetup(ctx, specName, spec, te, loadSource)
+		if err != nil {
+			return nil, err
+		}
+		inputs.ActorTokenType = credential.TokenTypeJWT
+		inputs.ActorTokenOrigin = credential.ExchangeOriginVerified
+		inputs.ActorCacheIdentity = setup.cacheIdentity
+		inputs.ResolveActorToken = setup.resolve
 	default:
 		// No actor requested: drop any default type so Validate's pairing holds.
 		inputs.ActorTokenType = ""
@@ -1478,6 +1417,112 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		return nil, err
 	}
 	return inputs, nil
+}
+
+// assertionSetup holds the parts resolveExchangeInputs needs to configure a
+// warden_identity slot (subject or actor): a stable cache fragment that keys the
+// credential cache in place of the per-request-volatile assertion bytes, and the
+// closure that mints the assertion lazily on a cache miss.
+type assertionSetup struct {
+	cacheIdentity string
+	resolve       func(ctx context.Context) (string, error)
+}
+
+// buildAssertionSetup validates the OIDC issuer is ready and derives the
+// audience, resource, and projected metadata for a warden_identity assertion of
+// te, returning a stable cache fragment (identity + audience [+ resource]
+// [+ metadata]) and a lazy mint closure. It is source-type agnostic, so the same
+// setup serves a WIF subject (the agent IS the identity) and a delegation actor
+// (the agent acts for the subject-header user). loadSource is passed in so the
+// spec's source is fetched at most once per request across both slots.
+//
+// It fails closed if the issuer is disabled/not-ready or no audience can be
+// determined. The audience is an explicit spec value or, failing that, one
+// derived from the source; resource is unset→derived, "none"→omitted, else
+// verbatim; metadata is the operator-allowlisted projection (empty→no claim, so
+// the cache key is byte-identical to the no-metadata case).
+func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *credential.CredSpec, te *logical.TokenEntry, loadSource func() (*credential.CredSource, error)) (*assertionSetup, error) {
+	issuer := c.OIDCIssuer()
+	if issuer == nil || !issuer.Ready() {
+		return nil, fmt.Errorf("spec %q requires warden_identity but the OIDC issuer is not enabled/ready", specName)
+	}
+
+	// The assertion audience: an explicit spec value wins; otherwise derive it
+	// from the source (e.g. a GCP federation source derives it from its
+	// workload_identity_provider). Fails closed if neither yields one.
+	audience := spec.Config[credential.ConfigAssertionAudience]
+	if audience == "" {
+		src, err := loadSource()
+		if err != nil {
+			return nil, err
+		}
+		audience, _ = drivers.DeriveAssertionAudience(src.Type, src.Config, spec.Config)
+	}
+	if audience == "" {
+		return nil, fmt.Errorf("spec %q with warden_identity requires %s", specName, credential.ConfigAssertionAudience)
+	}
+
+	// Resolve the single downstream resource to name in the assertion so a
+	// verifier can pin it to one resource. Unset derives it from the source/spec
+	// config (pure, network-free — no live driver is built here); "none" opts out;
+	// any other value is emitted verbatim. Best-effort: a spec with no single
+	// static resource simply carries no warden_resource claim.
+	var resource string
+	switch r := spec.Config[credential.ConfigAssertionResource]; r {
+	case credential.AssertionResourceNone:
+		// opt-out: emit no warden_resource claim
+	case "":
+		src, err := loadSource()
+		if err != nil {
+			return nil, err
+		}
+		resource, _ = drivers.DeriveAssertionResource(src.Type, src.Config, spec.Config)
+	default:
+		resource = r
+	}
+
+	// Project only the operator-allowlisted metadata keys into the assertion.
+	// Empty allowlist projects nothing (mdFingerprint is ""), so the assertion and
+	// cache key are byte-for-byte what they were before this opt-in existed.
+	projected, mdFingerprint, err := projectAssertionMetadata(te.Metadata, credential.AssertionMetadataKeys(spec.Config))
+	if err != nil {
+		return nil, fmt.Errorf("spec %q: %w", specName, err)
+	}
+
+	// Key the credential cache on the stable identity + audience, NOT the
+	// freshly-minted assertion bytes (which change every request), so one identity
+	// reuses its cached upstream credential. Fold in the resource (it can come from
+	// source config, which can change under a fixed specName) and the projected-
+	// metadata fingerprint. Each fragment is appended only when non-empty, so the
+	// no-resource / no-metadata cache keys stay byte-for-byte unchanged; the
+	// resource fragment is kept before mdFingerprint (marshalled JSON starting with
+	// '{') so the fragments can never be confused.
+	cacheIdentity := wardenSubject(te) + "\x00" + audience
+	if resource != "" {
+		cacheIdentity += "\x00res=" + resource
+	}
+	if mdFingerprint != "" {
+		cacheIdentity += "\x00" + mdFingerprint
+	}
+
+	// The spec selects the assertion signing algorithm (default RS256). The issuer
+	// maintains a keyset per algorithm, so either is available with no cold start;
+	// validation restricts it to a supported alg at spec-create. The mint itself is
+	// deferred to a cache MISS (invoked by the Manager's singleflight leader), so at
+	// most one assertion is minted per miss and none on the hot path.
+	alg := credential.AssertionAlgorithm(spec.Config)
+	return &assertionSetup{
+		cacheIdentity: cacheIdentity,
+		resolve: func(ctx context.Context) (string, error) {
+			return issuer.MintIdentityAssertion(ctx, te, AssertionClaims{
+				Audience: audience,
+				TTL:      issuer.AssertionTTL(),
+				Alg:      alg,
+				Metadata: projected,
+				Resource: resource,
+			})
+		},
+	}, nil
 }
 
 // mintCredentialForRequest mints credentials for requests using the credential manager

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2242,13 +2242,20 @@ func TestValidActorSubject(t *testing.T) {
 }
 
 // exchangeResolveEnv wires a credential config store into a minimal Core and
-// creates a local source, so resolveExchangeInputs can read seeded specs.
+// creates a local source plus a token_exchange source, so resolveExchangeInputs
+// can read seeded specs. Actor specs must bind to the token_exchange source
+// (only that driver consumes an actor token — enforced by ValidateSpec), so use
+// seedExchangeSpec for those.
 func exchangeResolveEnv(t *testing.T) (*Core, context.Context) {
 	t.Helper()
 	store, ctx := setupTestCredentialConfigStore(t)
 	c := store.core
 	c.credConfigStore = store
 	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "local-src", Type: "local"}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "sts-src", Type: credential.SourceTypeTokenExchange,
+		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "rfc8693"},
+	}))
 	return c, ctx
 }
 
@@ -2258,6 +2265,18 @@ func seedSpec(t *testing.T, c *Core, ctx context.Context, name string, config ma
 		Name:   name,
 		Type:   "vault_token",
 		Source: "local-src",
+		Config: config,
+	}))
+}
+
+// seedExchangeSpec seeds a spec bound to the token_exchange source, required for
+// any spec that sets an actor token source.
+func seedExchangeSpec(t *testing.T, c *Core, ctx context.Context, name string, config map[string]string) {
+	t.Helper()
+	require.NoError(t, c.credConfigStore.CreateSpec(ctx, &credential.CredSpec{
+		Name:   name,
+		Type:   "vault_token",
+		Source: "sts-src",
 		Config: config,
 	}))
 }
@@ -2402,7 +2421,7 @@ func TestResolveExchangeInputs_SubjectHeader_GuardBypassAttempts(t *testing.T) {
 
 func TestResolveExchangeInputs_ActorHeader_CustomName(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
-	seedSpec(t, c, ctx, "deleg-spec", map[string]string{
+	seedExchangeSpec(t, c, ctx, "deleg-spec", map[string]string{
 		credential.ConfigSubjectTokenSource: credential.SourceHeader,
 		credential.ConfigActorTokenSource:   credential.SourceHeader,
 		credential.ConfigActorTokenHeader:   "X-Actor",
@@ -2421,7 +2440,7 @@ func TestResolveExchangeInputs_ActorHeader_CustomName(t *testing.T) {
 
 func TestResolveExchangeInputs_ActorHeader(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
-	seedSpec(t, c, ctx, "deleg-spec", map[string]string{
+	seedExchangeSpec(t, c, ctx, "deleg-spec", map[string]string{
 		credential.ConfigSubjectTokenSource: credential.SourceHeader,
 		credential.ConfigActorTokenSource:   credential.SourceHeader,
 	})
@@ -2442,7 +2461,7 @@ func TestResolveExchangeInputs_ActorHeader(t *testing.T) {
 func TestResolveExchangeInputs_ActorAuthToken(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
 	// subject via header (a user token), actor via the agent's verified inbound JWT.
-	seedSpec(t, c, ctx, "deleg-auth", map[string]string{
+	seedExchangeSpec(t, c, ctx, "deleg-auth", map[string]string{
 		credential.ConfigSubjectTokenSource: credential.SourceHeader,
 		credential.ConfigActorTokenSource:   credential.SourceAuthToken,
 	})
@@ -2460,7 +2479,7 @@ func TestResolveExchangeInputs_ActorAuthToken(t *testing.T) {
 
 func TestResolveExchangeInputs_ActorAuthToken_OpaqueFailsClosed(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
-	seedSpec(t, c, ctx, "deleg-auth", map[string]string{
+	seedExchangeSpec(t, c, ctx, "deleg-auth", map[string]string{
 		credential.ConfigSubjectTokenSource: credential.SourceHeader,
 		credential.ConfigActorTokenSource:   credential.SourceAuthToken,
 	})
@@ -2474,7 +2493,7 @@ func TestResolveExchangeInputs_ActorAuthToken_OpaqueFailsClosed(t *testing.T) {
 
 func TestResolveExchangeInputs_ActorHeader_MissingFailsClosed(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
-	seedSpec(t, c, ctx, "deleg-spec", map[string]string{
+	seedExchangeSpec(t, c, ctx, "deleg-spec", map[string]string{
 		credential.ConfigSubjectTokenSource: credential.SourceHeader,
 		credential.ConfigActorTokenSource:   credential.SourceHeader,
 	})
@@ -2512,7 +2531,7 @@ func TestResolveExchangeInputs_WardenIdentity_MintDeferred(t *testing.T) {
 	require.NotNil(t, inputs.ResolveSubjectToken, "a lazy subject-token provider must be set")
 	assert.Equal(t, credential.TokenTypeJWT, inputs.SubjectTokenType)
 	assert.Equal(t, credential.ExchangeOriginVerified, inputs.SubjectTokenOrigin)
-	assert.Equal(t, wardenSubject(te)+"\x00"+"https://sts.example/aud", inputs.CacheIdentity)
+	assert.Equal(t, wardenSubject(te)+"\x00"+"https://sts.example/aud", inputs.SubjectCacheIdentity)
 
 	// Invoking the provider mints a real JWT assertion (what the Manager does on a miss).
 	tok, err := inputs.ResolveSubjectToken(ctx)
@@ -2522,7 +2541,52 @@ func TestResolveExchangeInputs_WardenIdentity_MintDeferred(t *testing.T) {
 	// The cache identity is stable across requests and needs no mint to compute.
 	inputs2, err := c.resolveExchangeInputs(ctx, req, te)
 	require.NoError(t, err)
-	assert.Equal(t, inputs.CacheIdentity, inputs2.CacheIdentity, "cache identity must be stable")
+	assert.Equal(t, inputs.SubjectCacheIdentity, inputs2.SubjectCacheIdentity, "cache identity must be stable")
+}
+
+// TestResolveExchangeInputs_ActorWardenIdentity_MintDeferred covers the
+// delegation shape: an eager header subject (the user) paired with a lazily-minted
+// warden_identity actor (the agent), so the STS receives sub=user, act=agent.
+func TestResolveExchangeInputs_ActorWardenIdentity_MintDeferred(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	c.oidcIssuer = newReadyIssuer(t, "https://warden-oidc.example")
+	seedExchangeSpec(t, c, ctx, "obo-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceHeader,
+		credential.ConfigActorTokenSource:   credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:  "https://sts.example/aud",
+	})
+
+	te := &logical.TokenEntry{
+		CredentialSpec: "obo-spec",
+		PrincipalID:    "spiffe://acme/agent/bot",
+		NamespaceID:    "ns1",
+		MountAccessor:  "auth_cert_1",
+	}
+	// cert/SPIFFE agent: the user token rides in the default header; the agent's own
+	// inbound token is an opaque session, distinct from the user token.
+	req := requestWith("s.opaque-session", map[string]string{credential.DefaultSubjectTokenHeader: "eyJ.user"})
+
+	inputs, err := c.resolveExchangeInputs(ctx, req, te)
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+
+	// Subject: the header user token — eager and unverified.
+	assert.Equal(t, "eyJ.user", inputs.SubjectToken)
+	assert.Equal(t, credential.ExchangeOriginUnverified, inputs.SubjectTokenOrigin)
+	assert.Nil(t, inputs.ResolveSubjectToken, "the header subject resolves eagerly")
+
+	// Actor: warden_identity — minted lazily, verified, keyed on the agent identity.
+	assert.Empty(t, inputs.ActorToken, "the actor assertion must not be minted eagerly")
+	require.NotNil(t, inputs.ResolveActorToken, "a lazy actor-token provider must be set")
+	assert.Equal(t, credential.TokenTypeJWT, inputs.ActorTokenType)
+	assert.Equal(t, credential.ExchangeOriginVerified, inputs.ActorTokenOrigin)
+	assert.Equal(t, wardenSubject(te)+"\x00"+"https://sts.example/aud", inputs.ActorCacheIdentity)
+
+	// Invoking the provider mints a real JWT whose sub is the agent (the act.sub).
+	tok, err := inputs.ResolveActorToken(ctx)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(tok, "eyJ"), "the provider must mint a JWT assertion")
+	assert.Equal(t, wardenSubject(te), decodeAssertionClaims(t, tok)["sub"])
 }
 
 // TestResolveExchangeInputs_WardenIdentity_ResourceDerived proves the resource is
@@ -2552,7 +2616,7 @@ func TestResolveExchangeInputs_WardenIdentity_ResourceDerived(t *testing.T) {
 	require.NotNil(t, inputs)
 
 	const wantRes = "aws-secretsmanager:prod/db"
-	assert.Equal(t, wardenSubject(te)+"\x00"+"sts.amazonaws.com"+"\x00res="+wantRes, inputs.CacheIdentity)
+	assert.Equal(t, wardenSubject(te)+"\x00"+"sts.amazonaws.com"+"\x00res="+wantRes, inputs.SubjectCacheIdentity)
 
 	tok, err := inputs.ResolveSubjectToken(ctx)
 	require.NoError(t, err)
@@ -2588,7 +2652,7 @@ func TestResolveExchangeInputs_WardenIdentity_ResourceOverrideAndOptOut(t *testi
 	teOv := newSpecTE("wid-override", "custom:thing")
 	inOv, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), teOv)
 	require.NoError(t, err)
-	assert.Contains(t, inOv.CacheIdentity, "\x00res=custom:thing")
+	assert.Contains(t, inOv.SubjectCacheIdentity, "\x00res=custom:thing")
 	tokOv, err := inOv.ResolveSubjectToken(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "custom:thing", decodeAssertionClaims(t, tokOv)["warden_resource"])
@@ -2597,7 +2661,7 @@ func TestResolveExchangeInputs_WardenIdentity_ResourceOverrideAndOptOut(t *testi
 	teNone := newSpecTE("wid-none", credential.AssertionResourceNone)
 	inNone, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), teNone)
 	require.NoError(t, err)
-	assert.Equal(t, wardenSubject(teNone)+"\x00"+"sts.amazonaws.com", inNone.CacheIdentity)
+	assert.Equal(t, wardenSubject(teNone)+"\x00"+"sts.amazonaws.com", inNone.SubjectCacheIdentity)
 	tokNone, err := inNone.ResolveSubjectToken(ctx)
 	require.NoError(t, err)
 	_, present := decodeAssertionClaims(t, tokNone)["warden_resource"]
@@ -2724,7 +2788,7 @@ func TestResolveExchangeInputs_WardenIdentity_MetadataProjected(t *testing.T) {
 	}
 	inputsStaging, err := c.resolveExchangeInputs(ctx, req, teStaging)
 	require.NoError(t, err)
-	assert.NotEqual(t, inputs.CacheIdentity, inputsStaging.CacheIdentity,
+	assert.NotEqual(t, inputs.SubjectCacheIdentity, inputsStaging.SubjectCacheIdentity,
 		"differing projected metadata must isolate the credential cache")
 }
 

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -711,7 +711,7 @@ func TestAWSDriver_WebIdentity_HappyPath(t *testing.T) {
 
 // TestAWSDriver_WebIdentity_ForwardedSubject_HappyPath drives the auth_token federation
 // topology: the subject is the caller's origin-verified inbound JWT that Warden forwards
-// untouched (not a Warden-minted assertion), so ResolveSubjectToken and CacheIdentity are
+// untouched (not a Warden-minted assertion), so ResolveSubjectToken and SubjectCacheIdentity are
 // unset. The driver treats any verified subject the same, so this must reach STS and
 // forward the token verbatim. It guards the supported contract against a future change
 // that re-gates federation to Warden-minted subjects only.
@@ -755,7 +755,7 @@ func TestAWSDriver_WebIdentity_ForwardedSubject_HappyPath(t *testing.T) {
 		"ttl":         "15m",
 	}}
 	// A forwarded inbound JWT: verified origin, but no ResolveSubjectToken and no
-	// CacheIdentity (the token is eager and stable, so it keys the cache itself).
+	// SubjectCacheIdentity (the token is eager and stable, so it keys the cache itself).
 	inputs := &credential.ExchangeInputs{
 		SubjectToken:       "eyJ.inbound.idp.jwt",
 		SubjectTokenType:   credential.TokenTypeJWT,

--- a/credential/drivers/azure_driver_test.go
+++ b/credential/drivers/azure_driver_test.go
@@ -673,7 +673,7 @@ func TestAzureDriver_MintCredentialWithExchange_HappyPath(t *testing.T) {
 // TestAzureDriver_MintCredentialWithExchange_ForwardedSubject_HappyPath drives the
 // auth_token federation topology: the subject is the caller's origin-verified inbound JWT
 // that Warden forwards untouched (not a Warden-minted assertion), so ResolveSubjectToken
-// and CacheIdentity are unset. The driver treats any verified subject the same, so this
+// and SubjectCacheIdentity are unset. The driver treats any verified subject the same, so this
 // must reach Entra and be presented as the client_assertion verbatim. It guards the
 // supported contract against a future change that re-gates federation to Warden-minted
 // subjects only.
@@ -700,7 +700,7 @@ func TestAzureDriver_MintCredentialWithExchange_ForwardedSubject_HappyPath(t *te
 		"tenant_id":   "00000000-0000-0000-0000-000000000001",
 		"client_id":   "11111111-1111-1111-1111-111111111111",
 	}}
-	// A forwarded inbound JWT: verified origin, no ResolveSubjectToken, no CacheIdentity.
+	// A forwarded inbound JWT: verified origin, no ResolveSubjectToken, no SubjectCacheIdentity.
 	inputs := &credential.ExchangeInputs{
 		SubjectToken:       "eyJ.inbound.idp.jwt",
 		SubjectTokenType:   credential.TokenTypeJWT,

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -33,6 +33,16 @@ const (
 // the cross-app-access flow).
 const tokenTypeIDJAG = "urn:ietf:params:oauth:token-type:id-jag"
 
+// TokenExchangeSupportsActor reports whether a token_exchange source's grant has
+// an RFC 8693 actor slot. jwt_bearer (an assertion grant) has none — the driver
+// rejects any actor there at mint time (see MintCredentialWithExchange) — while
+// rfc8693 and id_jag both carry the actor. It lets the config store reject an
+// actor spec bound to a jwt_bearer source at create time (single source of truth
+// for the grant string, mirroring DeriveAssertionAudience living here).
+func TokenExchangeSupportsActor(sourceCfg map[string]string) bool {
+	return credential.GetString(sourceCfg, "grant", tokenExchangeGrantRFC8693) != tokenExchangeGrantJWTBearer
+}
+
 // Client-authentication methods selected by the source's `client_auth` config.
 // private_key_jwt is added in a later change; the secret methods ship here.
 const (
@@ -510,7 +520,7 @@ func (d *TokenExchangeDriver) addResources(form url.Values, spec *credential.Cre
 // token-exchange spec targets, for the warden_resource assertion claim. Pure:
 // reads config maps only. It reproduces resolve()'s spec-then-source fallback for
 // the `resources` key (which is why the resource can vary with source config, not
-// just spec — see the CacheIdentity note). Only a lone resource is named; zero or
+// just spec — see the SubjectCacheIdentity note). Only a lone resource is named; zero or
 // several yield no claim, since a scalar claim can't express a set.
 func tokenExchangeAssertionResource(sourceCfg, specCfg map[string]string) (string, bool) {
 	raw := credential.GetString(specCfg, "resources", "")
@@ -536,7 +546,13 @@ func (d *TokenExchangeDriver) resolve(spec *credential.CredSpec, key string) str
 
 // subjectMetadata derives the non-secret, audit-logged identity of the exchanged
 // token: the subject (from the minted token's sub claim, falling back to the
-// subject token's), and whether the subject's origin was verified.
+// subject token's) and whether the subject's origin was verified; and — when the
+// exchange carried an actor (delegation) — the actor's sub and whether it was
+// verified, so agent-on-behalf-of delegation is attributable in the credential's
+// audit metadata. The actor sub is read from the actor token's own claims (for an
+// actor_token_source=warden_identity actor that is the Warden-minted wid:… sub);
+// like the subject it is a claim read, never a raw token byte, so no secret is
+// recorded.
 func (d *TokenExchangeDriver) subjectMetadata(resp *oauth2TokenResponse, inputs *credential.ExchangeInputs) map[string]interface{} {
 	meta := map[string]interface{}{
 		"subject_verified": strconv.FormatBool(inputs.SubjectTokenOrigin == credential.ExchangeOriginVerified),
@@ -548,6 +564,14 @@ func (d *TokenExchangeDriver) subjectMetadata(resp *oauth2TokenResponse, inputs 
 	if claims != nil {
 		if sub, ok := scalarClaim(claims["sub"]); ok && sub != "" {
 			meta["subject"] = sub
+		}
+	}
+	if inputs.ActorToken != "" {
+		meta["actor_verified"] = strconv.FormatBool(inputs.ActorTokenOrigin == credential.ExchangeOriginVerified)
+		if actorClaims := unverifiedJWTClaims(inputs.ActorToken); actorClaims != nil {
+			if sub, ok := scalarClaim(actorClaims["sub"]); ok && sub != "" {
+				meta["actor"] = sub
+			}
 		}
 	}
 	return meta

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -236,8 +236,36 @@ func TestTokenExchangeDriver_ActorVerified_Forwarded(t *testing.T) {
 	inputs.ActorTokenType = credential.TokenTypeJWT
 	inputs.ActorTokenOrigin = credential.ExchangeOriginVerified
 
-	_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
+	_, meta, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, inputs)
 	require.NoError(t, err)
+	// The delegation is attributable in the credential metadata: subject=user (act
+	// on behalf of), actor=agent (acting), both marked verified. Never the raw bytes.
+	assert.Equal(t, "user", meta["subject"])
+	assert.Equal(t, "true", meta["subject_verified"])
+	assert.Equal(t, "agent", meta["actor"])
+	assert.Equal(t, "true", meta["actor_verified"])
+	assert.NotContains(t, meta, "actor_token")
+}
+
+// When no actor is present the metadata carries no actor keys at all, so a plain
+// (non-delegated) exchange is not mislabelled as delegation.
+func TestTokenExchangeDriver_NoActor_NoActorMetadata(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user-123"})
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_id": "c", "client_secret": "s",
+	}, sts.Client())
+
+	_, meta, _, _, err := d.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, verifiedSubject(subject))
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", meta["subject"])
+	assert.NotContains(t, meta, "actor")
+	assert.NotContains(t, meta, "actor_verified")
 }
 
 func TestTokenExchangeDriver_ActorHeader_Validated(t *testing.T) {

--- a/credential/exchange.go
+++ b/credential/exchange.go
@@ -110,11 +110,13 @@ const (
 	// source's configured trust.
 	SourceHeader = "header"
 	SourceNone   = "none"
-	// SourceWardenIdentity mints a fresh Warden-signed identity assertion (via
-	// the OIDC issuer) as the subject token. Used for Workload Identity
-	// Federation: Warden re-issues the resolved agent identity so an upstream
-	// federates Warden's issuer once, regardless of how the agent authenticated.
-	// Valid only for the subject source.
+	// SourceWardenIdentity mints a fresh Warden-signed identity assertion (via the
+	// OIDC issuer) of the resolved agent identity, so an upstream federates
+	// Warden's issuer once regardless of how the agent authenticated. As the
+	// subject it is Workload Identity Federation (the agent IS the identity); as
+	// the actor it is RFC 8693 delegation (the agent acts on behalf of a distinct
+	// user carried in the subject header — so actor=warden_identity requires
+	// subject_token_source=header).
 	SourceWardenIdentity = "warden_identity"
 )
 
@@ -232,7 +234,7 @@ type ExchangeInputs struct {
 	// unverified actor must validate it before forwarding, exactly as for a subject.
 	ActorTokenOrigin string
 
-	// CacheIdentity, when non-empty, is the value Fingerprint() keys the
+	// SubjectCacheIdentity, when non-empty, is the value Fingerprint() keys the
 	// credential cache on IN PLACE OF SubjectToken. It exists for subjects whose
 	// SubjectToken is freshly minted on every request (a Warden-signed identity
 	// assertion carries a new jti/iat/exp each time), which would otherwise make
@@ -243,19 +245,37 @@ type ExchangeInputs struct {
 	// It MUST be set only by core (resolveExchangeInputs), never derived from a
 	// caller-supplied value, and it does not travel to drivers as a token. It is
 	// mandatory whenever ResolveSubjectToken is set (enforced by Validate).
-	CacheIdentity string
+	SubjectCacheIdentity string
 
 	// ResolveSubjectToken, when non-nil, produces SubjectToken lazily. It is
 	// invoked by the credential Manager only on a real cache MISS (inside the
 	// singleflight leader), so a per-request-expensive subject token — e.g. a
 	// Warden-signed RS256 identity assertion — is never minted just to be
 	// discarded on a cache hit. When set, SubjectToken may be empty until the
-	// Manager populates it, and CacheIdentity MUST be set so Fingerprint() is
+	// Manager populates it, and SubjectCacheIdentity MUST be set so Fingerprint() is
 	// stable without the token bytes.
 	//
 	// Set only by core (resolveExchangeInputs), never from caller input. It is
 	// not hashed by Fingerprint, never logged, and never persisted.
 	ResolveSubjectToken func(ctx context.Context) (string, error)
+
+	// ActorCacheIdentity mirrors SubjectCacheIdentity for a lazily-minted actor
+	// (actor_token_source=warden_identity): it is the stable value Fingerprint()
+	// keys on in place of the per-request-volatile ActorToken. Mandatory whenever
+	// ResolveActorToken is set (enforced by Validate). Set only by core, never
+	// from caller input; it does not travel to drivers as a token.
+	ActorCacheIdentity string
+
+	// ResolveActorToken mirrors ResolveSubjectToken for the actor slot: when
+	// non-nil it produces ActorToken lazily on a real cache MISS (inside the
+	// Manager's singleflight leader), so a Warden-signed actor assertion is minted
+	// at most once per miss rather than on every cache hit. When set, ActorToken
+	// may be empty until the Manager populates it, and ActorCacheIdentity MUST be
+	// set so Fingerprint() is stable without the token bytes.
+	//
+	// Set only by core (resolveExchangeInputs), never from caller input. It is
+	// not hashed by Fingerprint, never logged, and never persisted.
+	ResolveActorToken func(ctx context.Context) (string, error)
 }
 
 // Validate performs structural checks only. It does not verify token contents
@@ -268,12 +288,17 @@ func (e *ExchangeInputs) Validate() error {
 	if e.ResolveSubjectToken != nil {
 		// Lazy subject: the token is produced on a cache miss, so it may be empty
 		// here — but the fingerprint must not then hash an empty SubjectToken and
-		// collide across identities, so CacheIdentity is mandatory.
-		if e.CacheIdentity == "" {
-			return fmt.Errorf("cache_identity is required when the subject token is resolved lazily")
+		// collide across identities, so SubjectCacheIdentity is mandatory.
+		if e.SubjectCacheIdentity == "" {
+			return fmt.Errorf("subject_cache_identity is required when the subject token is resolved lazily")
 		}
 	} else if e.SubjectToken == "" {
 		return fmt.Errorf("subject_token is required")
+	} else if e.SubjectCacheIdentity != "" {
+		// An eager subject must key the cache on its own bytes; a stand-in cache
+		// identity without a lazy resolver would let two distinct raw subjects share
+		// one cache entry. Unreachable via core today — structural defence-in-depth.
+		return fmt.Errorf("subject_cache_identity is set without a lazy subject resolver")
 	}
 	if e.SubjectTokenType == "" {
 		return fmt.Errorf("subject_token_type is required")
@@ -281,19 +306,38 @@ func (e *ExchangeInputs) Validate() error {
 	if len(e.SubjectToken) > maxExchangeTokenBytes {
 		return fmt.Errorf("subject_token exceeds %d bytes", maxExchangeTokenBytes)
 	}
-	// RFC 8693 §2.1: actor_token_type is required when actor_token is present,
-	// and meaningless without it.
-	if e.ActorToken != "" && e.ActorTokenType == "" {
-		return fmt.Errorf("actor_token_type is required when actor_token is set")
-	}
-	if e.ActorToken == "" && e.ActorTokenType != "" {
-		return fmt.Errorf("actor_token_type set without actor_token")
+	if e.ResolveActorToken != nil {
+		// Lazy actor (warden_identity): the token is minted on a cache miss, so it
+		// may be empty here — the fingerprint keys on ActorCacheIdentity instead, so
+		// that (like the lazy subject) it is mandatory, and the empty-token pairing
+		// checks below would misfire and must be skipped.
+		if e.ActorCacheIdentity == "" {
+			return fmt.Errorf("actor_cache_identity is required when the actor token is resolved lazily")
+		}
+		if e.ActorTokenType == "" {
+			return fmt.Errorf("actor_token_type is required when the actor token is resolved lazily")
+		}
+	} else {
+		// RFC 8693 §2.1: actor_token_type is required when actor_token is present,
+		// and meaningless without it.
+		if e.ActorToken != "" && e.ActorTokenType == "" {
+			return fmt.Errorf("actor_token_type is required when actor_token is set")
+		}
+		if e.ActorToken == "" && e.ActorTokenType != "" {
+			return fmt.Errorf("actor_token_type set without actor_token")
+		}
+		if e.ActorToken == "" && e.ActorTokenOrigin != "" {
+			return fmt.Errorf("actor_token_origin set without actor_token")
+		}
+		if e.ActorToken != "" && e.ActorCacheIdentity != "" {
+			// An eager actor keys on its own bytes; a stand-in cache identity without a
+			// lazy resolver would let two distinct raw actors share one cache entry.
+			// Unreachable via core today — structural defence-in-depth.
+			return fmt.Errorf("actor_cache_identity is set without a lazy actor resolver")
+		}
 	}
 	if len(e.ActorToken) > maxExchangeTokenBytes {
 		return fmt.Errorf("actor_token exceeds %d bytes", maxExchangeTokenBytes)
-	}
-	if e.ActorToken == "" && e.ActorTokenOrigin != "" {
-		return fmt.Errorf("actor_token_origin set without actor_token")
 	}
 	if e.ActorTokenOrigin != "" {
 		switch e.ActorTokenOrigin {
@@ -317,15 +361,15 @@ func (e *ExchangeInputs) Validate() error {
 // combinations can collide by concatenation (e.g. subject "ab"/actor "c" must
 // not hash the same as subject "a"/actor "bc").
 //
-// When CacheIdentity is set, it is hashed in place of SubjectToken (so a
+// When SubjectCacheIdentity is set, it is hashed in place of SubjectToken (so a
 // per-request-volatile assertion does not defeat the cache), under a distinct
-// domain tag so the CacheIdentity path and the raw-subject path can never
+// domain tag so the SubjectCacheIdentity path and the raw-subject path can never
 // collide. Every other field — token type, actor, origins — is always folded
 // in, so a Warden-minted subject and a raw subject that happen to share a value
 // still key differently, and delegation/provenance never share a cache entry.
 //
 // ResolveSubjectToken is intentionally NOT hashed: a lazily-minted subject sets
-// CacheIdentity (mandatory per Validate), which stands in for the token here.
+// SubjectCacheIdentity (mandatory per Validate), which stands in for the token here.
 func (e *ExchangeInputs) Fingerprint() string {
 	h := sha256.New()
 	writeField := func(s string) {
@@ -335,15 +379,23 @@ func (e *ExchangeInputs) Fingerprint() string {
 		h.Write([]byte(s))
 	}
 	writeField(e.SubjectTokenType)
-	if e.CacheIdentity != "" {
-		writeField("cache-identity")
-		writeField(e.CacheIdentity)
+	if e.SubjectCacheIdentity != "" {
+		writeField("subject-cache-identity")
+		writeField(e.SubjectCacheIdentity)
 	} else {
 		writeField("subject-token")
 		writeField(e.SubjectToken)
 	}
 	writeField(e.ActorTokenType)
-	writeField(e.ActorToken)
+	// Tag the actor branch the same way as the subject so a lazy
+	// ActorCacheIdentity can never collide with a raw ActorToken of the same value.
+	if e.ActorCacheIdentity != "" {
+		writeField("actor-cache-identity")
+		writeField(e.ActorCacheIdentity)
+	} else {
+		writeField("actor-token")
+		writeField(e.ActorToken)
+	}
 	writeField(e.SubjectTokenOrigin)
 	writeField(e.ActorTokenOrigin)
 	return hex.EncodeToString(h.Sum(nil))
@@ -363,11 +415,17 @@ func SpecRequestsExchange(config map[string]string) bool {
 func ValidateExchangeSpecConfig(config map[string]string) error {
 	if err := ValidateSchema(config,
 		StringField(ConfigSubjectTokenSource).OneOf(SourceAuthToken, SourceHeader, SourceNone, SourceWardenIdentity),
-		StringField(ConfigActorTokenSource).OneOf(SourceAuthToken, SourceHeader, SourceNone),
+		StringField(ConfigActorTokenSource).OneOf(SourceAuthToken, SourceHeader, SourceNone, SourceWardenIdentity),
 		StringField(ConfigAssertionAlgorithm).OneOf(AssertionAlgRS256, AssertionAlgES256),
 	); err != nil {
 		return err
 	}
+	// The assertion_* keys configure a Warden-minted assertion, which now can be
+	// either the subject or the actor. Since actor=warden_identity requires
+	// subject=header (enforced below), at most one slot is ever warden_identity, so
+	// these keys apply unambiguously to whichever it is.
+	mintsAssertion := config[ConfigSubjectTokenSource] == SourceWardenIdentity ||
+		config[ConfigActorTokenSource] == SourceWardenIdentity
 	// A Warden-minted subject must declare the audience it is minted for — an
 	// empty/absent aud is replayable at any upstream whose trust policy does not pin
 	// aud. That check is source-aware (some source types derive the audience from
@@ -375,20 +433,20 @@ func ValidateExchangeSpecConfig(config map[string]string) error {
 	// config store, not in this source-agnostic structural validator. It is enforced
 	// again at mint time, defence in depth.
 	// Projecting metadata into the assertion only makes sense when Warden mints it;
-	// on a reused/caller-supplied subject Warden does not control the claims.
-	if config[ConfigAssertionMetadataClaims] != "" && config[ConfigSubjectTokenSource] != SourceWardenIdentity {
-		return fmt.Errorf("field '%s': is valid only when '%s' is '%s'",
-			ConfigAssertionMetadataClaims, ConfigSubjectTokenSource, SourceWardenIdentity)
+	// on a reused/caller-supplied token Warden does not control the claims.
+	if config[ConfigAssertionMetadataClaims] != "" && !mintsAssertion {
+		return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s'",
+			ConfigAssertionMetadataClaims, SourceWardenIdentity)
 	}
-	// The assertion algorithm only applies to a Warden-minted subject.
-	if config[ConfigAssertionAlgorithm] != "" && config[ConfigSubjectTokenSource] != SourceWardenIdentity {
-		return fmt.Errorf("field '%s': is valid only when '%s' is '%s'",
-			ConfigAssertionAlgorithm, ConfigSubjectTokenSource, SourceWardenIdentity)
+	// The assertion algorithm only applies to a Warden-minted assertion.
+	if config[ConfigAssertionAlgorithm] != "" && !mintsAssertion {
+		return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s'",
+			ConfigAssertionAlgorithm, SourceWardenIdentity)
 	}
 	// Naming a resource in the assertion only makes sense when Warden mints it.
-	if config[ConfigAssertionResource] != "" && config[ConfigSubjectTokenSource] != SourceWardenIdentity {
-		return fmt.Errorf("field '%s': is valid only when '%s' is '%s'",
-			ConfigAssertionResource, ConfigSubjectTokenSource, SourceWardenIdentity)
+	if config[ConfigAssertionResource] != "" && !mintsAssertion {
+		return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s'",
+			ConfigAssertionResource, SourceWardenIdentity)
 	}
 	// An actor token only has meaning alongside a subject token (RFC 8693 §2.1),
 	// so reject an actor source without a subject source.
@@ -400,6 +458,14 @@ func ValidateExchangeSpecConfig(config map[string]string) error {
 	if config[ConfigSubjectTokenSource] == SourceAuthToken && actorSrc == SourceAuthToken {
 		return fmt.Errorf("field '%s': cannot be '%s' when '%s' is also '%s' (one inbound token cannot be both subject and actor)",
 			ConfigActorTokenSource, SourceAuthToken, ConfigSubjectTokenSource, SourceAuthToken)
+	}
+	// actor=warden_identity is the "agent acting on behalf of a distinct user"
+	// shape: Warden signs the agent as the actor, so the subject must be a distinct
+	// principal — only the header source carries one. auth_token/warden_identity
+	// would both make sub and act the same caller, which is not delegation.
+	if actorSrc == SourceWardenIdentity && config[ConfigSubjectTokenSource] != SourceHeader {
+		return fmt.Errorf("field '%s': '%s' requires '%s' to be '%s' (the subject must be a distinct user token)",
+			ConfigActorTokenSource, SourceWardenIdentity, ConfigSubjectTokenSource, SourceHeader)
 	}
 	// A configured header name is meaningful only for the matching header source,
 	// and must not name an internal auth header.

--- a/credential/exchange_test.go
+++ b/credential/exchange_test.go
@@ -44,10 +44,10 @@ func TestExchangeInputs_Validate(t *testing.T) {
 			name: "lazy subject with cache identity",
 			inputs: &ExchangeInputs{
 				// SubjectToken empty on purpose: resolved lazily on a cache miss.
-				SubjectTokenType:    TokenTypeJWT,
-				SubjectTokenOrigin:  ExchangeOriginVerified,
-				CacheIdentity:       "wid:ns:mount:alice\x00aud",
-				ResolveSubjectToken: stubResolve,
+				SubjectTokenType:     TokenTypeJWT,
+				SubjectTokenOrigin:   ExchangeOriginVerified,
+				SubjectCacheIdentity: "wid:ns:mount:alice\x00aud",
+				ResolveSubjectToken:  stubResolve,
 			},
 		},
 		{
@@ -84,6 +84,44 @@ func TestExchangeInputs_Validate(t *testing.T) {
 				SubjectTokenType:   TokenTypeJWT,
 				ActorTokenType:     TokenTypeJWT,
 				SubjectTokenOrigin: ExchangeOriginVerified,
+			},
+			wantErr: true,
+		},
+		{
+			name: "lazy actor with cache identity",
+			inputs: &ExchangeInputs{
+				// Eager header subject paired with a lazy warden_identity actor:
+				// ActorToken empty on purpose, resolved on a cache miss.
+				SubjectToken:       "eyJ.user",
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginUnverified,
+				ActorTokenType:     TokenTypeJWT,
+				ActorTokenOrigin:   ExchangeOriginVerified,
+				ActorCacheIdentity: "wid:ns:mount:agent\x00aud",
+				ResolveActorToken:  stubResolve,
+			},
+		},
+		{
+			name: "lazy actor without cache identity",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.user",
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginUnverified,
+				ActorTokenType:     TokenTypeJWT,
+				ActorTokenOrigin:   ExchangeOriginVerified,
+				ResolveActorToken:  stubResolve,
+			},
+			wantErr: true,
+		},
+		{
+			name: "lazy actor without token type",
+			inputs: &ExchangeInputs{
+				SubjectToken:       "eyJ.user",
+				SubjectTokenType:   TokenTypeJWT,
+				SubjectTokenOrigin: ExchangeOriginUnverified,
+				ActorTokenOrigin:   ExchangeOriginVerified,
+				ActorCacheIdentity: "wid:ns:mount:agent\x00aud",
+				ResolveActorToken:  stubResolve,
 			},
 			wantErr: true,
 		},
@@ -167,37 +205,37 @@ func TestExchangeInputs_Fingerprint_NoConcatAmbiguity(t *testing.T) {
 	}
 }
 
-// TestExchangeInputs_Fingerprint_CacheIdentity covers the Warden-minted-subject
-// caching contract: the fingerprint keys on CacheIdentity (stable) rather than
+// TestExchangeInputs_Fingerprint_SubjectCacheIdentity covers the Warden-minted-subject
+// caching contract: the fingerprint keys on SubjectCacheIdentity (stable) rather than
 // the volatile SubjectToken, so re-mints of the same identity share a cache
 // entry while distinct identities stay isolated and cannot collide with the
 // raw-subject path.
-func TestExchangeInputs_Fingerprint_CacheIdentity(t *testing.T) {
+func TestExchangeInputs_Fingerprint_SubjectCacheIdentity(t *testing.T) {
 	// Same identity, different (freshly minted) subject bytes -> same fingerprint.
-	a := &ExchangeInputs{SubjectToken: "assertion-mint-1", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified, CacheIdentity: "wid:ns:mount:alice|aud"}
-	b := &ExchangeInputs{SubjectToken: "assertion-mint-2", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified, CacheIdentity: "wid:ns:mount:alice|aud"}
+	a := &ExchangeInputs{SubjectToken: "assertion-mint-1", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified, SubjectCacheIdentity: "wid:ns:mount:alice|aud"}
+	b := &ExchangeInputs{SubjectToken: "assertion-mint-2", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified, SubjectCacheIdentity: "wid:ns:mount:alice|aud"}
 	if a.Fingerprint() != b.Fingerprint() {
-		t.Fatal("same CacheIdentity must fingerprint identically despite different subject bytes")
+		t.Fatal("same SubjectCacheIdentity must fingerprint identically despite different subject bytes")
 	}
 
 	// Different identity -> different fingerprint.
-	c := &ExchangeInputs{SubjectToken: "assertion-mint-1", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified, CacheIdentity: "wid:ns:mount:bob|aud"}
+	c := &ExchangeInputs{SubjectToken: "assertion-mint-1", SubjectTokenType: TokenTypeJWT, SubjectTokenOrigin: ExchangeOriginVerified, SubjectCacheIdentity: "wid:ns:mount:bob|aud"}
 	if c.Fingerprint() == a.Fingerprint() {
-		t.Fatal("distinct CacheIdentity must fingerprint differently")
+		t.Fatal("distinct SubjectCacheIdentity must fingerprint differently")
 	}
 
-	// Domain separation: CacheIdentity="X" must not collide with SubjectToken="X".
-	viaIdentity := &ExchangeInputs{SubjectToken: "assertion", SubjectTokenType: TokenTypeJWT, CacheIdentity: "X"}
+	// Domain separation: SubjectCacheIdentity="X" must not collide with SubjectToken="X".
+	viaIdentity := &ExchangeInputs{SubjectToken: "assertion", SubjectTokenType: TokenTypeJWT, SubjectCacheIdentity: "X"}
 	viaSubject := &ExchangeInputs{SubjectToken: "X", SubjectTokenType: TokenTypeJWT}
 	if viaIdentity.Fingerprint() == viaSubject.Fingerprint() {
-		t.Fatal("CacheIdentity path must be domain-separated from the raw-subject path")
+		t.Fatal("SubjectCacheIdentity path must be domain-separated from the raw-subject path")
 	}
 
-	// Setting CacheIdentity must change the fingerprint vs. keying on the subject.
-	withID := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT, CacheIdentity: "id"}
+	// Setting SubjectCacheIdentity must change the fingerprint vs. keying on the subject.
+	withID := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT, SubjectCacheIdentity: "id"}
 	withoutID := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT}
 	if withID.Fingerprint() == withoutID.Fingerprint() {
-		t.Fatal("CacheIdentity must be folded into the fingerprint")
+		t.Fatal("SubjectCacheIdentity must be folded into the fingerprint")
 	}
 }
 
@@ -206,9 +244,9 @@ func TestExchangeInputs_Fingerprint_CacheIdentity(t *testing.T) {
 // and a would-be follower must key identically so they share one cache entry.
 func TestExchangeInputs_Fingerprint_IgnoresResolveClosure(t *testing.T) {
 	base := ExchangeInputs{
-		SubjectTokenType:   TokenTypeJWT,
-		SubjectTokenOrigin: ExchangeOriginVerified,
-		CacheIdentity:      "wid:ns:mount:alice\x00aud",
+		SubjectTokenType:     TokenTypeJWT,
+		SubjectTokenOrigin:   ExchangeOriginVerified,
+		SubjectCacheIdentity: "wid:ns:mount:alice\x00aud",
 	}
 	withClosure := base
 	withClosure.ResolveSubjectToken = stubResolve
@@ -218,11 +256,51 @@ func TestExchangeInputs_Fingerprint_IgnoresResolveClosure(t *testing.T) {
 	}
 
 	// And a later-populated SubjectToken must also not change the key (the closure
-	// path keys on CacheIdentity, not the minted bytes).
+	// path keys on SubjectCacheIdentity, not the minted bytes).
 	populated := withClosure
 	populated.SubjectToken = "freshly-minted-assertion"
 	if populated.Fingerprint() != base.Fingerprint() {
-		t.Fatal("a lazily-populated SubjectToken must not change the CacheIdentity-keyed fingerprint")
+		t.Fatal("a lazily-populated SubjectToken must not change the SubjectCacheIdentity-keyed fingerprint")
+	}
+}
+
+// TestExchangeInputs_Fingerprint_ActorCacheIdentity mirrors the subject
+// cache-identity contract for a lazily-minted actor (warden_identity delegation):
+// the fingerprint keys on ActorCacheIdentity (stable), the closure and any
+// later-populated ActorToken bytes never enter the key, and the ActorCacheIdentity
+// path is domain-separated from a raw ActorToken of the same value.
+func TestExchangeInputs_Fingerprint_ActorCacheIdentity(t *testing.T) {
+	base := ExchangeInputs{
+		SubjectToken:       "eyJ.user",
+		SubjectTokenType:   TokenTypeJWT,
+		SubjectTokenOrigin: ExchangeOriginUnverified,
+		ActorTokenType:     TokenTypeJWT,
+		ActorTokenOrigin:   ExchangeOriginVerified,
+		ActorCacheIdentity: "wid:ns:mount:agent\x00aud",
+	}
+	withClosure := base
+	withClosure.ResolveActorToken = stubResolve
+	if base.Fingerprint() != withClosure.Fingerprint() {
+		t.Fatal("ResolveActorToken must not affect the fingerprint")
+	}
+	populated := withClosure
+	populated.ActorToken = "freshly-minted-actor-assertion"
+	if populated.Fingerprint() != base.Fingerprint() {
+		t.Fatal("a lazily-populated ActorToken must not change the ActorCacheIdentity-keyed fingerprint")
+	}
+
+	// Distinct actor identity -> distinct fingerprint.
+	other := base
+	other.ActorCacheIdentity = "wid:ns:mount:other-agent\x00aud"
+	if other.Fingerprint() == base.Fingerprint() {
+		t.Fatal("distinct ActorCacheIdentity must fingerprint differently")
+	}
+
+	// Domain separation: ActorCacheIdentity="X" must not collide with ActorToken="X".
+	viaIdentity := ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT, ActorTokenType: TokenTypeJWT, ActorCacheIdentity: "X"}
+	viaToken := ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT, ActorTokenType: TokenTypeJWT, ActorToken: "X"}
+	if viaIdentity.Fingerprint() == viaToken.Fingerprint() {
+		t.Fatal("ActorCacheIdentity path must be domain-separated from the raw-actor path")
 	}
 }
 
@@ -426,6 +504,41 @@ func TestValidateExchangeSpecConfig(t *testing.T) {
 				ConfigActorTokenSource:   SourceHeader,
 				ConfigSubjectTokenHeader: "X-Subject",
 				ConfigActorTokenHeader:   "X-Actor",
+			},
+		},
+		{
+			name: "actor warden_identity with header subject",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigActorTokenSource:   SourceWardenIdentity,
+				ConfigAssertionAudience:  "https://sts.example/aud",
+			},
+		},
+		{
+			name: "actor warden_identity rejects auth_token subject",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceAuthToken,
+				ConfigActorTokenSource:   SourceWardenIdentity,
+				ConfigAssertionAudience:  "https://sts.example/aud",
+			},
+			wantErr: true,
+		},
+		{
+			name: "actor warden_identity rejects warden_identity subject",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceWardenIdentity,
+				ConfigActorTokenSource:   SourceWardenIdentity,
+				ConfigAssertionAudience:  "https://sts.example/aud",
+			},
+			wantErr: true,
+		},
+		{
+			name: "assertion_algorithm valid when actor is warden_identity",
+			config: map[string]string{
+				ConfigSubjectTokenSource: SourceHeader,
+				ConfigActorTokenSource:   SourceWardenIdentity,
+				ConfigAssertionAudience:  "https://sts.example/aud",
+				ConfigAssertionAlgorithm: AssertionAlgES256,
 			},
 		},
 	}

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -144,9 +144,10 @@ func NewManager(
 //   - tokenTTL: The TTL of the session token (used for cache duration)
 //   - inputs: Optional caller-derived token-exchange inputs. When non-nil they
 //     are folded into the cache key so distinct exchange inputs cannot share a
-//     cached credential. When inputs.ResolveSubjectToken is set, the subject
-//     token is materialized only on a cache miss (inside the singleflight),
-//     so a cache hit incurs no subject-mint cost.
+//     cached credential. When inputs.ResolveSubjectToken and/or
+//     inputs.ResolveActorToken is set, that token is materialized only on a cache
+//     miss (inside the singleflight), so a cache hit incurs no mint cost; the two
+//     resolve independently (an eager header subject can pair with a lazy actor).
 //
 // Returns the issued credential or an error
 func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName string, tokenTTL time.Duration, inputs *ExchangeInputs) (*Credential, error) {
@@ -201,6 +202,20 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 				return nil, fmt.Errorf("failed to resolve subject token: %w", rerr)
 			}
 			inputs.SubjectToken = tok
+		}
+
+		// Materialize a lazily-resolved actor token the same way and for the same
+		// reason as the subject above. It is a separate block because the two slots
+		// are independent: a spec can pair an eager header subject with a lazy
+		// warden_identity actor, so the actor may need minting even when the subject
+		// did not. The Fingerprint keyed this entry via ActorCacheIdentity, so the
+		// (not-yet-minted) actor bytes never entered the cache key.
+		if inputs != nil && inputs.ResolveActorToken != nil && inputs.ActorToken == "" {
+			tok, rerr := inputs.ResolveActorToken(ctx)
+			if rerr != nil {
+				return nil, fmt.Errorf("failed to resolve actor token: %w", rerr)
+			}
+			inputs.ActorToken = tok
 		}
 
 		// Issue new credential from source

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -1090,9 +1090,9 @@ func TestManager_IssueCredential_ExchangeInputs_NonExchangeDriver(t *testing.T) 
 // construction, while sharing the counter.
 func lazyExchangeInputsFor(cacheIdentity, token string, mintCount *atomic.Int32) *ExchangeInputs {
 	return &ExchangeInputs{
-		SubjectTokenType:   TokenTypeJWT,
-		SubjectTokenOrigin: ExchangeOriginVerified,
-		CacheIdentity:      cacheIdentity,
+		SubjectTokenType:     TokenTypeJWT,
+		SubjectTokenOrigin:   ExchangeOriginVerified,
+		SubjectCacheIdentity: cacheIdentity,
 		ResolveSubjectToken: func(context.Context) (string, error) {
 			mintCount.Add(1)
 			return token, nil
@@ -1123,6 +1123,46 @@ func TestManager_IssueCredential_LazySubject_MintOnMissZeroOnHit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cred1.CredentialID, cred2.CredentialID, "same identity must hit cache")
 	assert.Equal(t, int32(1), mintCount.Load(), "a cache HIT must not mint")
+	assert.Equal(t, int32(1), factory.driver.exchangeCount.Load(), "a cache HIT must not exchange")
+}
+
+// A lazily-resolved ACTOR token (warden_identity delegation) is minted exactly
+// once on a cache miss, the resolved bytes reach the driver alongside the eager
+// header subject, and a subsequent request for the same identity is served from
+// cache with no further actor mint or exchange.
+func TestManager_IssueCredential_LazyActor_MintOnMissZeroOnHit(t *testing.T) {
+	manager, factory := createExchangeTestManager(t)
+	defer manager.Stop()
+
+	ctx := createNamespaceContext()
+	var actorMint atomic.Int32
+	makeInputs := func(actorTok string) *ExchangeInputs {
+		return &ExchangeInputs{
+			// Eager header subject (the user) paired with a lazy warden_identity actor.
+			SubjectToken:       "eyJ.user",
+			SubjectTokenType:   TokenTypeJWT,
+			SubjectTokenOrigin: ExchangeOriginUnverified,
+			ActorTokenType:     TokenTypeJWT,
+			ActorTokenOrigin:   ExchangeOriginVerified,
+			ActorCacheIdentity: "wid:agent\x00aud",
+			ResolveActorToken: func(context.Context) (string, error) {
+				actorMint.Add(1)
+				return actorTok, nil
+			},
+		}
+	}
+
+	cred1, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, makeInputs("actor-1"))
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), actorMint.Load(), "a cache miss must mint the actor exactly once")
+	assert.Equal(t, "actor-1", factory.driver.gotInputs.ActorToken, "the resolved actor token must reach the driver")
+	assert.Equal(t, "eyJ.user", cred1.Data["username"], "the eager subject reaches the driver unchanged")
+
+	// Fresh inputs (per-request), same identity → cache hit, no further work.
+	cred2, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, makeInputs("actor-2"))
+	require.NoError(t, err)
+	assert.Equal(t, cred1.CredentialID, cred2.CredentialID, "same identity must hit cache")
+	assert.Equal(t, int32(1), actorMint.Load(), "a cache HIT must not mint the actor")
 	assert.Equal(t, int32(1), factory.driver.exchangeCount.Load(), "a cache HIT must not exchange")
 }
 
@@ -1166,9 +1206,9 @@ func TestManager_IssueCredential_LazySubject_SingleflightCoalesces(t *testing.T)
 		go func(i int) {
 			defer wg.Done()
 			in := &ExchangeInputs{
-				SubjectTokenType:   TokenTypeJWT,
-				SubjectTokenOrigin: ExchangeOriginVerified,
-				CacheIdentity:      "id-shared",
+				SubjectTokenType:     TokenTypeJWT,
+				SubjectTokenOrigin:   ExchangeOriginVerified,
+				SubjectCacheIdentity: "id-shared",
 				ResolveSubjectToken: func(context.Context) (string, error) {
 					mintCount.Add(1)
 					time.Sleep(20 * time.Millisecond) // widen the singleflight window
@@ -1203,9 +1243,9 @@ func TestManager_IssueCredential_LazySubject_ResolveErrorNotCached(t *testing.T)
 	var calls atomic.Int32
 	makeInputs := func() *ExchangeInputs {
 		return &ExchangeInputs{
-			SubjectTokenType:   TokenTypeJWT,
-			SubjectTokenOrigin: ExchangeOriginVerified,
-			CacheIdentity:      "id-alice",
+			SubjectTokenType:     TokenTypeJWT,
+			SubjectTokenOrigin:   ExchangeOriginVerified,
+			SubjectCacheIdentity: "id-alice",
 			ResolveSubjectToken: func(context.Context) (string, error) {
 				if calls.Add(1) == 1 {
 					return "", fmt.Errorf("mint boom")


### PR DESCRIPTION
## What

Adds `actor_token_source=warden_identity` so a token-exchange spec yields a downstream token with **`sub` = a user** (from the subject header) and **`act` = the agent** (a Warden-minted OIDC identity assertion) — the RFC 8693 "agent acting on behalf of a user" shape, keyless, for any agent regardless of how it authenticated.

Builds on #468 (configurable `header` source).

## Details

- The actor assertion is minted **lazily** on a credential-cache miss, mirroring the existing `warden_identity` **subject** (WIF) path. Subject and actor resolve independently, so an eager header subject pairs with a lazy actor.
- The cache is keyed on a stable `ActorCacheIdentity`, never the per-request-volatile assertion bytes. For symmetry, `ExchangeInputs.CacheIdentity` is renamed to `SubjectCacheIdentity`, and `ActorCacheIdentity` / `ResolveActorToken` are added.
- `actor=warden_identity` requires `subject_token_source=header` (only the header source carries a distinct user).
- **Any** actor token source is pinned to a `token_exchange` source (only that driver consumes an actor token; every other driver would silently drop it) whose grant has an actor slot (rejected for `jwt_bearer`), and requires a resolvable assertion audience.
- The exchange delegation is recorded in the credential metadata (`actor` / `actor_verified`) for audit attribution; raw token bytes are never logged.

## Testing

- `credential/exchange_test.go`: actor `warden_identity` allowed only with `subject=header` (rejected for `auth_token`/`warden_identity`); lazy-actor `Validate`; `Fingerprint` stable via `ActorCacheIdentity` with domain separation.
- `core/request_handler_test.go`: `actor=warden_identity` sets the lazy resolver + verified origin and mints `sub=wid:…` (the agent).
- `core/credential_config_store_test.go`: accepted on `token_exchange` with explicit audience; rejected on a non-`token_exchange` source, on `jwt_bearer`, and when the audience is missing/underivable; a dedicated test covers header/auth_token actors being pinned too.
- `credential/manager_test.go`: lazy actor materialized once on a miss, reused on a hit.
- `credential/drivers/token_exchange_driver_test.go`: metadata records `actor`/`actor_verified` when an actor is present, and never the raw token bytes.
- `go build ./...`, `go vet`, and the `credential` / `core` suites pass.

Reviewed with an adversarial pass (fingerprint/cache correctness, validation matrix, singleflight lazy materialization, secret hygiene).
