### PR TITLE
feat(credential): kv2_read mint method + generic key_value credential type

### DIFF
--- a/credential/credential.go
+++ b/credential/credential.go
@@ -23,6 +23,7 @@ const (
 	TypeCloudflareKeys    = "cloudflare_keys"
 	TypeIBMCloudKeys      = "ibmcloud_keys"
 	TypeAlicloudKeys      = "alicloud_keys"
+	TypeKeyValue          = "key_value"
 )
 
 // Source type constants

--- a/credential/drivers/assertion_claims.go
+++ b/credential/drivers/assertion_claims.go
@@ -101,7 +101,7 @@ func vaultAssertionResource(sourceCfg, specCfg map[string]string) (string, bool)
 		if role != "" {
 			return role, true
 		}
-	case "static_aws", "static_apikey":
+	case "static_aws", "static_apikey", "kv2_read":
 		mount := credential.GetString(specCfg, "kv2_mount", "")
 		path := credential.GetString(specCfg, "secret_path", "")
 		if mount != "" && path != "" {

--- a/credential/drivers/assertion_claims_test.go
+++ b/credential/drivers/assertion_claims_test.go
@@ -241,6 +241,13 @@ func TestDeriveAssertionResource(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "vault kv2_read names the KV path",
+			sourceType: credential.SourceTypeVault,
+			specCfg:    map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
+			want:       "secret/github/ci",
+			wantOK:     true,
+		},
+		{
 			name:       "vault dynamic_aws names the engine role",
 			sourceType: credential.SourceTypeVault,
 			specCfg:    map[string]string{"mint_method": "dynamic_aws", "aws_mount": "aws", "role_name": "dev-role"},

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -240,6 +240,8 @@ func (f *VaultDriverFactory) InferCredentialType(specConfig map[string]string) (
 		return credential.TypeAWSAccessKeys, nil
 	case "static_apikey":
 		return credential.TypeAPIKey, nil
+	case "kv2_read":
+		return credential.TypeKeyValue, nil
 	case "dynamic_gcp":
 		return credential.TypeGCPAccessToken, nil
 	case "dynamic_ibm":
@@ -352,7 +354,7 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
-	case "static_aws", "static_apikey":
+	case "static_aws", "static_apikey", "kv2_read":
 		return d.fetchStaticKVSecret(ctx, d.vault, spec)
 	case "dynamic_aws":
 		return d.fetchDynamicAWSCreds(ctx, d.vault, spec)
@@ -365,7 +367,7 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	case "oauth2":
 		return d.fetchOAuth2Creds(ctx, d.vault, spec)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'kv2_read', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2'", mintMethod)
 	}
 }
 
@@ -445,7 +447,7 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 		leaseTTL time.Duration
 	)
 	switch mintMethod {
-	case "static_aws", "static_apikey":
+	case "static_aws", "static_apikey", "kv2_read":
 		rawData, metadata, leaseTTL, _, err = d.fetchStaticKVSecret(ctx, client, spec)
 		// A static read holds no lease that depends on the login token — best-effort
 		// revoke it so a transient session is not left behind.
@@ -459,7 +461,7 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 	case "oauth2":
 		rawData, metadata, leaseTTL, _, err = d.fetchOAuth2Creds(ctx, client, spec)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("vault: mint_method %q is not supported over auth_method=%s (supported: vault_token, static_aws, static_apikey, dynamic_aws, dynamic_gcp, dynamic_ibm, oauth2)", mintMethod, vaultAuthMethodOIDCFederation)
+		return nil, nil, 0, "", fmt.Errorf("vault: mint_method %q is not supported over auth_method=%s (supported: vault_token, static_aws, static_apikey, kv2_read, dynamic_aws, dynamic_gcp, dynamic_ibm, oauth2)", mintMethod, vaultAuthMethodOIDCFederation)
 	}
 	if err != nil {
 		return nil, nil, 0, "", err

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -589,6 +589,7 @@ func TestVaultDriverFactory_InferCredentialType(t *testing.T) {
 		{"static_aws", "static_aws", credential.TypeAWSAccessKeys, false},
 		{"dynamic_aws", "dynamic_aws", credential.TypeAWSAccessKeys, false},
 		{"static_apikey", "static_apikey", credential.TypeAPIKey, false},
+		{"kv2_read", "kv2_read", credential.TypeKeyValue, false},
 		{"dynamic_gcp", "dynamic_gcp", credential.TypeGCPAccessToken, false},
 		{"dynamic_ibm", "dynamic_ibm", credential.TypeIBMCloudKeys, false},
 		{"oauth2", "oauth2", credential.TypeOAuthBearerToken, false},

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -79,5 +79,10 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
+	// Register generic key/value type (e.g. Vault KV v2 read via kv2_read)
+	if err := registry.Register(NewKeyValueCredType()); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/credential/types/key_value.go
+++ b/credential/types/key_value.go
@@ -1,0 +1,139 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
+)
+
+// KeyValueCredType is a generic, structure-agnostic credential type: its Data is
+// the arbitrary key/value map returned by the source (e.g. a Vault KV v2 read via
+// mint_method=kv2_read), with no required primary field. It lets a referenced
+// "secret spec" (credential chaining) carry secret material under its natural key
+// names instead of being forced into a typed shape like api_key.
+//
+// It deliberately does NOT embed BaseTokenType: that base requires a primary field
+// and copies only the primary + listed optional fields, dropping every other key —
+// which would discard the arbitrary payload this type exists to preserve.
+type KeyValueCredType struct{}
+
+// NewKeyValueCredType creates a new key/value credential type.
+func NewKeyValueCredType() *KeyValueCredType { return &KeyValueCredType{} }
+
+// Metadata returns the type's metadata.
+func (t *KeyValueCredType) Metadata() credential.TypeMetadata {
+	return credential.TypeMetadata{
+		Name:        credential.TypeKeyValue,
+		Category:    credential.CategoryAPI,
+		Description: "Generic key/value secret material with arbitrary fields (e.g. a Vault KV v2 read via mint_method=kv2_read)",
+		DefaultTTL:  0, // static read, no default TTL
+	}
+}
+
+// ConfigSchema returns the declarative schema for key/value credential config.
+// (Unknown keys such as exchange config are ignored by ValidateSchema and validated
+// elsewhere, so they need not be listed here.)
+func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
+	return []*credential.FieldValidator{
+		credential.StringField("mint_method").
+			OneOf("kv2_read").
+			Describe("Mint method (kv2_read reads a Vault KV v2 secret verbatim)").
+			Example("kv2_read"),
+
+		credential.StringField("kv2_mount").
+			Describe("Vault KV v2 mount path").
+			Example("secret"),
+
+		credential.StringField("secret_path").
+			Describe("Path to the secret within the KV v2 mount").
+			Example("github/ci"),
+	}
+}
+
+// ValidateConfig validates the Config for a key/value credential spec. Only an
+// hvault source is supported (the KV v2 read lives on the Vault driver).
+func (t *KeyValueCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	if sourceType != credential.SourceTypeVault {
+		return fmt.Errorf("key_value credentials require an hvault source, got: %s", sourceType)
+	}
+
+	if err := credential.ValidateSchema(config, t.ConfigSchema()...); err != nil {
+		return err
+	}
+
+	if config["mint_method"] != "kv2_read" {
+		return fmt.Errorf("'mint_method' must be 'kv2_read' for a key_value credential, got: %s", config["mint_method"])
+	}
+	if config["kv2_mount"] == "" {
+		return fmt.Errorf("'kv2_mount' is required for mint_method=kv2_read")
+	}
+	if config["secret_path"] == "" {
+		return fmt.Errorf("'secret_path' is required for mint_method=kv2_read")
+	}
+
+	return nil
+}
+
+// Parse copies ALL string-valued keys from rawData into the credential Data
+// (lenient — unlike BaseTokenType, which keeps only the primary + optional fields).
+func (t *KeyValueCredType) Parse(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) (*credential.Credential, error) {
+	if len(rawData) == 0 {
+		return nil, fmt.Errorf("%w: key_value credential has no data", credential.ErrInvalidCredential)
+	}
+
+	data := make(map[string]string, len(rawData))
+	for k, v := range rawData {
+		if s, ok := v.(string); ok {
+			data[k] = s
+		}
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("%w: key_value credential has no string-valued fields", credential.ErrInvalidCredential)
+	}
+
+	meta, err := helper.ToStringMap(metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credential.Credential{
+		Type:      credential.TypeKeyValue,
+		Category:  credential.CategoryAPI,
+		LeaseTTL:  leaseTTL,
+		LeaseID:   leaseID,
+		IssuedAt:  time.Now(),
+		Revocable: false,
+		Data:      data,
+		Metadata:  meta,
+	}, nil
+}
+
+// Validate is lenient: any non-empty Data map is well-formed (no required field).
+func (t *KeyValueCredType) Validate(cred *credential.Credential) error {
+	if cred.Type != credential.TypeKeyValue {
+		return fmt.Errorf("%w: expected type %s, got %s",
+			credential.ErrInvalidCredential, credential.TypeKeyValue, cred.Type)
+	}
+	if len(cred.Data) == 0 {
+		return fmt.Errorf("%w: key_value credential has no data", credential.ErrInvalidCredential)
+	}
+	return nil
+}
+
+// Revoke is a no-op — a KV read holds no lease.
+func (t *KeyValueCredType) Revoke(_ context.Context, _ *credential.Credential, _ credential.SourceDriver) error {
+	return nil
+}
+
+// RequiresSpecRotation returns false — the secret lives in the backend, not the spec.
+func (t *KeyValueCredType) RequiresSpecRotation() bool { return false }
+
+// SensitiveConfigFields returns nil — the secret lives only in minted Data, never
+// in persisted spec config (kv2_mount/secret_path are non-secret locators).
+func (t *KeyValueCredType) SensitiveConfigFields() []string { return nil }
+
+// FieldSchemas returns nil — the field set is arbitrary and unknown at type level.
+func (t *KeyValueCredType) FieldSchemas() map[string]*credential.CredentialFieldSchema { return nil }

--- a/credential/types/key_value_test.go
+++ b/credential/types/key_value_test.go
@@ -1,0 +1,160 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyValueCredType_Metadata(t *testing.T) {
+	ct := NewKeyValueCredType()
+	md := ct.Metadata()
+
+	assert.Equal(t, credential.TypeKeyValue, md.Name)
+	assert.Equal(t, credential.CategoryAPI, md.Category)
+	assert.Equal(t, time.Duration(0), md.DefaultTTL)
+}
+
+func TestKeyValueCredType_ValidateConfig(t *testing.T) {
+	ct := NewKeyValueCredType()
+
+	tests := []struct {
+		name       string
+		config     map[string]string
+		sourceType string
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:       "valid kv2_read",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
+		},
+		{
+			name:       "unsupported source type",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "require an hvault source",
+		},
+		{
+			name:       "wrong mint_method",
+			config:     map[string]string{"mint_method": "static_apikey", "kv2_mount": "secret", "secret_path": "github/ci"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "kv2_read",
+		},
+		{
+			name:       "missing kv2_mount",
+			config:     map[string]string{"mint_method": "kv2_read", "secret_path": "github/ci"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "kv2_mount",
+		},
+		{
+			name:       "missing secret_path",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "secret_path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, tt.sourceType)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestKeyValueCredType_Parse_PreservesAllKeys is the crux: unlike BaseTokenType,
+// key_value must copy every string field verbatim (no primary field, no dropping).
+func TestKeyValueCredType_Parse_PreservesAllKeys(t *testing.T) {
+	ct := NewKeyValueCredType()
+
+	rawData := map[string]interface{}{
+		"admin_token": "glsa_ABC",
+		"private_key": "-----BEGIN...",
+		"note":        "arbitrary",
+		"count":       42, // non-string values are skipped, not errored
+	}
+
+	cred, err := ct.Parse(rawData, nil, 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+
+	assert.Equal(t, credential.TypeKeyValue, cred.Type)
+	assert.False(t, cred.Revocable)
+	assert.Equal(t, time.Duration(0), cred.LeaseTTL)
+	assert.Equal(t, "glsa_ABC", cred.Data["admin_token"])
+	assert.Equal(t, "-----BEGIN...", cred.Data["private_key"])
+	assert.Equal(t, "arbitrary", cred.Data["note"])
+	_, hasCount := cred.Data["count"]
+	assert.False(t, hasCount, "non-string values should be skipped")
+	assert.Len(t, cred.Data, 3)
+}
+
+func TestKeyValueCredType_Parse_Errors(t *testing.T) {
+	ct := NewKeyValueCredType()
+
+	t.Run("empty rawData", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{}, nil, 0, "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrInvalidCredential)
+	})
+
+	t.Run("no string fields", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{"n": 1, "b": true}, nil, 0, "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrInvalidCredential)
+	})
+}
+
+func TestKeyValueCredType_Validate(t *testing.T) {
+	ct := NewKeyValueCredType()
+
+	t.Run("valid", func(t *testing.T) {
+		err := ct.Validate(&credential.Credential{
+			Type: credential.TypeKeyValue,
+			Data: map[string]string{"anything": "x"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		err := ct.Validate(&credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"anything": "x"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected type key_value")
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		err := ct.Validate(&credential.Credential{
+			Type: credential.TypeKeyValue,
+			Data: map[string]string{},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestKeyValueCredType_NoSecretInConfig(t *testing.T) {
+	ct := NewKeyValueCredType()
+	assert.False(t, ct.RequiresSpecRotation())
+	// The secret lives only in minted Data, never in persisted config.
+	assert.Nil(t, ct.SensitiveConfigFields())
+	assert.Nil(t, ct.FieldSchemas())
+}


### PR DESCRIPTION
## Summary

Adds two reusable Vault primitives, independent of any consumer:

- **`mint_method=kv2_read`** on the Vault (`hvault`) driver — a KV v2 read that returns the stored payload verbatim, leaseless (`leaseID=""`, `leaseTTL=0`), over both AppRole and OIDC-federation auth. Removes the old constraint that a KV read be shoehorned through `static_apikey` (which forced an `api_key` key).
- **`credential.TypeKeyValue`** (`"key_value"`) — a generic key-value credential type that carries an arbitrary `map[string]string` with no required primary field. It implements the `Type` interface directly (not via `BaseTokenType`, which would demand a primary field and drop unlisted keys), copying **all** string keys into `Data`. `SensitiveConfigFields()` is nil — the secret lives only in minted `Data`, never in persisted config, so a `key_value` spec holds no secret at rest by construction.

The `warden_resource` assertion claim for `kv2_read` reuses the existing `static_aws`/`static_apikey` case (bare `<mount>/<path>`), so a Vault JWT role bound on `warden_resource` treats them identically.

## Why

Standalone value: a clean generic KV v2 read + key-value type. It is also the primitive the credential-chaining work builds on (a referenced secret-spec can hold arbitrary key names with no secret persisted in its config), but this PR has no chaining dependency and is independently useful.

## Tests

`TypeKeyValue` parse/round-trip (multi-key payload preserved), `kv2_read` `InferCredentialType`, and the assertion-resource case.

## Stack

First of three stacked PRs:
1. **this PR** — `kv2_read` + `key_value`
2. credential chaining (`secret_spec`) + GitHub reference
3. GitHub `auth_method` → `mint_method` rename