### PR TITLE
feat(credential): credential chaining — a spec's secret from another cred spec (secret_spec)

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -29,6 +29,7 @@ var (
 	ErrSourceNotFound        = errors.New("credential source not found")
 	ErrSourceAlreadyExists   = errors.New("credential source already exists")
 	ErrSourceInUse           = errors.New("credential source is referenced by specs")
+	ErrSpecInUse             = errors.New("credential spec is referenced via secret_spec")
 	ErrNamespaceNotInContext = errors.New("namespace not found in context")
 )
 
@@ -381,6 +382,16 @@ func (s *CredentialConfigStore) DeleteSpec(ctx context.Context, name string) err
 	ns, err := s.getNamespaceFromContext(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Prevent deleting a spec still referenced as a chaining secret source
+	// (secret_spec) by another source or spec.
+	refs, err := s.CheckSpecReferences(ctx, name)
+	if err != nil {
+		return err
+	}
+	if len(refs) > 0 {
+		return ErrSpecInUse
 	}
 
 	// Unregister from rotation manager first (if registered)
@@ -914,6 +925,29 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		}
 	}
 
+	// Credential chaining: when this spec (spec-level, wins) or its source
+	// (source-level) references another cred spec as its secret source, validate the
+	// referenced secret-spec. The consuming driver's eligibility (it must implement
+	// ChainedSecretMinter) is checked in the test-mint block below as a create-time
+	// fail-fast; that block is skipped when verification is disabled or the source is
+	// local, so the authoritative eligibility guard is at mint time
+	// (MintFromSecretWithCleanup fails closed if the driver isn't a ChainedSecretMinter).
+	chainedRef := spec.Config[credential.ConfigSecretSpec]
+	if chainedRef == "" {
+		chainedRef = source.Config[credential.ConfigSecretSpec]
+	}
+	if chainedRef != "" {
+		// A chained consumer's identity flows through the referenced secret-spec, so
+		// its own subject/actor exchange config would be silently ignored at mint —
+		// reject the confusing combination rather than accept dead config.
+		if credential.SpecRequestsExchange(spec.Config) {
+			return logical.ErrBadRequestf("a chained spec (secret_spec set) must not also set its own subject_token_source/actor_token_source; the caller identity is carried by the referenced secret_spec %q", chainedRef)
+		}
+		if err := s.validateSecretSpecRef(ctx, chainedRef); err != nil {
+			return err
+		}
+	}
+
 	// Test credential minting if driver registry is available.
 	// This catches invalid auth credentials early (e.g., wrong GitHub app_id,
 	// expired PAT, invalid private key) rather than failing at gateway time.
@@ -947,6 +981,17 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				// time, so it cannot be test-minted here — it mints only on a live
 				// request that carries the exchange inputs.
 				if credential.SpecRequestsExchange(spec.Config) {
+					runTestMint = false
+				}
+
+				// A chained spec (secret_spec) fetches its secret material from a
+				// referenced spec at request time as the caller, so it cannot be
+				// test-minted at create. Its consuming driver must also be able to
+				// mint from that material — reject at create rather than at first use.
+				if chainedRef != "" {
+					if _, ok := driver.(credential.ChainedSecretMinter); !ok {
+						return logical.ErrBadRequestf("source type %q does not support secret_spec chaining", source.Type)
+					}
 					runTestMint = false
 				}
 
@@ -999,6 +1044,14 @@ func (s *CredentialConfigStore) validateSource(ctx context.Context, source *cred
 
 	if source.Type == "" {
 		return logical.ErrBadRequest("source type cannot be empty")
+	}
+
+	// Credential chaining: a source-level secret_spec makes every spec on this
+	// source draw its secret from the referenced spec. Validate that reference.
+	if ref := source.Config[credential.ConfigSecretSpec]; ref != "" {
+		if err := s.validateSecretSpecRef(ctx, ref); err != nil {
+			return err
+		}
 	}
 
 	// Validate rotation_period is set for source types that require it. A keyless
@@ -1074,6 +1127,88 @@ func (s *CredentialConfigStore) CheckSourceReferences(ctx context.Context, sourc
 	}
 
 	return refs, nil
+}
+
+// CheckSpecReferences returns the names of sources and specs that reference the
+// given spec as their credential-chaining secret source (secret_spec). It scans
+// both sources (source-level secret_spec) and specs (spec-level secret_spec) so a
+// referenced secret-spec cannot be deleted while any consumer still points at it.
+func (s *CredentialConfigStore) CheckSpecReferences(ctx context.Context, specName string) ([]string, error) {
+	sources, err := s.ListSources(ctx)
+	if err != nil {
+		return nil, err
+	}
+	specs, err := s.ListSpecs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []string
+	for _, src := range sources {
+		if src.Config[credential.ConfigSecretSpec] == specName {
+			refs = append(refs, "source/"+src.Name)
+		}
+	}
+	for _, spec := range specs {
+		if spec.Name == specName {
+			continue // a spec never references itself
+		}
+		if spec.Config[credential.ConfigSecretSpec] == specName {
+			refs = append(refs, "spec/"+spec.Name)
+		}
+	}
+
+	return refs, nil
+}
+
+// validateSecretSpecRef validates a credential-chaining reference: the named
+// secret-spec must exist, must not itself chain (one hop only), and must be minted
+// as the caller (subject_token_source set) so it federates per request rather than
+// degrading to the non-exchange path and failing late with an opaque backend error.
+//
+// It deliberately does NOT assert the referenced spec is leaseless here: that would
+// need per-type mint-method introspection this layer lacks, and the authoritative
+// guard is at mint time — issueChained revokes and fails closed if a referenced spec
+// ever returns a lease (including after a config-drift edit this check couldn't see).
+func (s *CredentialConfigStore) validateSecretSpecRef(ctx context.Context, ref string) error {
+	refSpec, err := s.GetSpec(ctx, ref)
+	if err != nil {
+		if errors.Is(err, ErrSpecNotFound) {
+			return logical.ErrBadRequestf("secret_spec %q not found (create the secret-yielding spec first)", ref)
+		}
+		return fmt.Errorf("failed to validate secret_spec %q: %w", ref, err)
+	}
+
+	if refSpec.Config[credential.ConfigSecretSpec] != "" {
+		return logical.ErrBadRequestf("secret_spec %q must not itself set secret_spec (chaining is limited to one hop)", ref)
+	}
+	refSource, err := s.GetSource(ctx, refSpec.Source)
+	if err != nil {
+		return fmt.Errorf("secret_spec %q: failed to load its source %q: %w", ref, refSpec.Source, err)
+	}
+	if refSource.Config[credential.ConfigSecretSpec] != "" {
+		return logical.ErrBadRequestf("secret_spec %q's source must not set secret_spec (chaining is limited to one hop)", ref)
+	}
+
+	// The referenced secret-spec must be minted as the requesting caller with a
+	// SESSION-PINNED subject: warden_identity (Warden mints an assertion for the
+	// session's principal) or auth_token (the caller's own inbound JWT). A
+	// header-sourced subject is a per-request, caller-supplied token that is NOT tied
+	// to the session token — and a chained consumer's outer cache key carries no
+	// exchange fingerprint (the exchange happens on this referenced spec, not the
+	// consumer), so under a shared session token two principals would collide on that
+	// key and one could be served the other's chained credential. Reject anything
+	// else (including an unset/"none" subject, which would otherwise degrade to the
+	// non-exchange path and fail late with an opaque backend error).
+	switch refSpec.Config[credential.ConfigSubjectTokenSource] {
+	case credential.SourceWardenIdentity, credential.SourceAuthToken:
+		// session-pinned — safe
+	default:
+		return logical.ErrBadRequestf("secret_spec %q must set subject_token_source=%s or %s (got %q); a chained secret must be minted as the session-pinned caller",
+			ref, credential.SourceWardenIdentity, credential.SourceAuthToken, refSpec.Config[credential.ConfigSubjectTokenSource])
+	}
+
+	return nil
 }
 
 // ============================================================================

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -376,6 +376,93 @@ func TestCredentialConfigStore_DeleteSource(t *testing.T) {
 	}
 }
 
+// TestCredentialConfigStore_SecretSpecReference covers credential chaining guards:
+// a referenced secret-spec cannot be deleted while a consumer points at it, and
+// the reference is validated at create time (must exist, one hop, request exchange).
+func TestCredentialConfigStore_SecretSpecReference(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	// Referencing a non-existent secret-spec is rejected.
+	badConsumer := &credential.CredSpec{
+		Name: "bad", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "missing"},
+	}
+	err := store.CreateSpec(ctx, badConsumer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// A secret-spec that does not request exchange is rejected as a reference.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "plain-secret", Type: "vault_token", Source: "src", Config: map[string]string{},
+	}))
+	err = store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "bad2", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "plain-secret"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject_token_source")
+
+	// A valid referenced secret-spec requests exchange (minted as the caller).
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "secret-spec", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			"subject_token_source": "warden_identity",
+			"assertion_audience":   "test-aud",
+		},
+	}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "consumer", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "secret-spec"},
+	}))
+
+	// Deleting the referenced secret-spec is blocked while a consumer points at it.
+	err = store.DeleteSpec(ctx, "secret-spec")
+	require.ErrorIs(t, err, ErrSpecInUse)
+
+	// After removing the consumer, the secret-spec can be deleted.
+	require.NoError(t, store.DeleteSpec(ctx, "consumer"))
+	require.NoError(t, store.DeleteSpec(ctx, "secret-spec"))
+}
+
+// TestCredentialConfigStore_SecretSpecReference_Restrictions covers the security
+// restrictions on a chained reference: the referenced spec must use a session-pinned
+// subject (not header), and a chained consumer must not carry its own exchange config.
+func TestCredentialConfigStore_SecretSpecReference_Restrictions(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	// A header-sourced referenced spec is not session-pinned → rejected as a reference.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "header-secret", Type: "vault_token", Source: "src",
+		Config: map[string]string{"subject_token_source": "header"},
+	}))
+	err := store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "consumer-hdr", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "header-secret"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session-pinned")
+
+	// A valid warden_identity referenced spec.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "wid-secret", Type: "vault_token", Source: "src",
+		Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "aud"},
+	}))
+	// A chained consumer that ALSO sets its own exchange config is rejected.
+	err = store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "consumer-dbl", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			credential.ConfigSecretSpec: "wid-secret",
+			"subject_token_source":      "warden_identity",
+			"assertion_audience":        "aud",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not also set")
+}
+
 // TestCredentialConfigStore_CheckSourceReferences tests checking source references
 func TestCredentialConfigStore_CheckSourceReferences(t *testing.T) {
 	store, ctx := setupTestCredentialConfigStore(t)

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1239,9 +1239,12 @@ func projectAssertionMetadata(md map[string]string, keys []string) (map[string]s
 	return projected, string(encoded), nil
 }
 
-// resolveExchangeInputs derives the token-exchange inputs for a request from the
-// credential spec's configuration. It returns (nil, nil) when the spec does not
-// opt into exchange, so the non-exchange mint path is completely unaffected.
+// resolveExchangeInputs derives the token-exchange inputs for the named spec on
+// this request. specName is passed explicitly (rather than taken from te) so it can
+// resolve inputs for a spec other than the caller's bound one — credential chaining
+// reuses it to mint a referenced secret-spec as the same caller. It returns
+// (nil, nil) when the spec does not opt into exchange, so the non-exchange mint path
+// is completely unaffected.
 //
 // The plumbing never verifies token contents — it only records provenance via
 // SubjectTokenOrigin/ActorTokenOrigin. Every configured-but-missing input fails
@@ -1252,8 +1255,7 @@ func projectAssertionMetadata(md map[string]string, keys []string) (map[string]s
 // cache hit pays no signing cost; the issuer-ready and audience checks stay eager
 // and fail closed. The subject and actor resolve independently — an eager header
 // subject can pair with a lazily-minted warden_identity actor.
-func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, te *logical.TokenEntry) (*credential.ExchangeInputs, error) {
-	specName := te.CredentialSpec
+func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, te *logical.TokenEntry, specName string) (*credential.ExchangeInputs, error) {
 	spec, err := c.credConfigStore.GetSpec(ctx, specName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load credential spec: %w", err)
@@ -1524,16 +1526,29 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 		tokenTTL = 1 * time.Hour
 	}
 
+	// The caller carries the requesting identity through the mint pipeline so a
+	// chained secret-spec (credential chaining) is minted as this same caller.
+	// ResolveInputs resolves token-exchange inputs for an arbitrary spec as this
+	// caller (nil for non-exchange specs), reused both for the outer spec below and
+	// for any referenced secret-spec by the Manager.
+	caller := credential.Caller{
+		TokenID:  te.ID,
+		TokenTTL: tokenTTL,
+		ResolveInputs: func(ctx context.Context, specName string) (*credential.ExchangeInputs, error) {
+			return c.resolveExchangeInputs(ctx, req, te, specName)
+		},
+	}
+
 	// Resolve any caller-supplied token-exchange inputs the spec opts into.
 	// Returns nil for non-exchange specs, leaving the mint path unchanged.
-	inputs, err := c.resolveExchangeInputs(ctx, req, te)
+	inputs, err := caller.ResolveInputs(ctx, te.CredentialSpec)
 	if err != nil {
 		return logical.ErrBadRequestf("token exchange input resolution failed: %s", err.Error())
 	}
 
 	// Issue credential using the credential manager
 	// Credentials are cache-only (not persisted) - ExpirationEntry handles lease revocation
-	cred, err := c.credentialManager.IssueCredential(ctx, te.ID, te.CredentialSpec, tokenTTL, inputs)
+	cred, err := c.credentialManager.IssueCredential(ctx, caller, te.CredentialSpec, inputs)
 	if err != nil {
 		return fmt.Errorf("failed to issue credential: %w", err)
 	}

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2279,11 +2279,17 @@ func TestCreateSpec_RejectsInvalidExchangeConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "token-exchange config")
 }
 
+// resolveExchangeInputsForTest adapts the pre-chaining calling convention
+// (spec taken from te.CredentialSpec) to the per-spec signature these tests target.
+func resolveExchangeInputsForTest(c *Core, ctx context.Context, req *logical.Request, te *logical.TokenEntry) (*credential.ExchangeInputs, error) {
+	return c.resolveExchangeInputs(ctx, req, te, te.CredentialSpec)
+}
+
 func TestResolveExchangeInputs_NoExchangeConfig(t *testing.T) {
 	c, ctx := exchangeResolveEnv(t)
 	seedSpec(t, c, ctx, "plain", map[string]string{})
 
-	inputs, err := c.resolveExchangeInputs(ctx, requestWith("opaque-token", nil), teForSpec("plain"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, requestWith("opaque-token", nil), teForSpec("plain"))
 	require.NoError(t, err)
 	assert.Nil(t, inputs, "non-exchange specs must yield nil inputs")
 }
@@ -2294,7 +2300,7 @@ func TestResolveExchangeInputs_AuthToken_JWT(t *testing.T) {
 		credential.ConfigSubjectTokenSource: credential.SourceAuthToken,
 	})
 
-	inputs, err := c.resolveExchangeInputs(ctx, requestWith("eyJhbGciOi.payload.sig", nil), teForSpec("auth-spec"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, requestWith("eyJhbGciOi.payload.sig", nil), teForSpec("auth-spec"))
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 	assert.Equal(t, "eyJhbGciOi.payload.sig", inputs.SubjectToken)
@@ -2309,7 +2315,7 @@ func TestResolveExchangeInputs_AuthToken_OpaqueFailsClosed(t *testing.T) {
 		credential.ConfigSubjectTokenSource: credential.SourceAuthToken,
 	})
 
-	_, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque-session-token", nil), teForSpec("auth-spec"))
+	_, err := resolveExchangeInputsForTest(c, ctx, requestWith("s.opaque-session-token", nil), teForSpec("auth-spec"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not JWT-authenticated")
 }
@@ -2321,7 +2327,7 @@ func TestResolveExchangeInputs_HeaderSource(t *testing.T) {
 	})
 
 	req := requestWith("opaque-token", map[string]string{headerSubjectToken: "eyJ.caller.subject"})
-	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("hdr-spec"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("hdr-spec"))
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 	assert.Equal(t, "eyJ.caller.subject", inputs.SubjectToken)
@@ -2336,7 +2342,7 @@ func TestResolveExchangeInputs_HeaderSource_MissingFailsClosed(t *testing.T) {
 		credential.ConfigSubjectTokenSource: credential.SourceHeader,
 	})
 
-	_, err := c.resolveExchangeInputs(ctx, requestWith("opaque-token", nil), teForSpec("hdr-spec"))
+	_, err := resolveExchangeInputsForTest(c, ctx, requestWith("opaque-token", nil), teForSpec("hdr-spec"))
 	require.Error(t, err)
 }
 
@@ -2350,7 +2356,7 @@ func TestResolveExchangeInputs_SubjectHeader_Authorization(t *testing.T) {
 	// A cert/SPIFFE-authenticated agent: ClientToken is not the user token, so the
 	// standard Authorization header is free to carry the subject. Bearer is stripped.
 	req := requestWith("spiffe-session", map[string]string{"Authorization": "Bearer eyJ.user"})
-	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("authz-spec"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("authz-spec"))
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 	assert.Equal(t, "eyJ.user", inputs.SubjectToken, "Bearer scheme stripped from Authorization")
@@ -2367,7 +2373,7 @@ func TestResolveExchangeInputs_SubjectHeader_FailsClosedWhenEqualsCallerToken(t 
 	// A JWT-authed agent used the Authorization spec: Authorization carries its OWN
 	// auth token, so the subject would be the agent, not a distinct user. Fail closed.
 	req := requestWith("eyJ.agent", map[string]string{"Authorization": "Bearer eyJ.agent"})
-	_, err := c.resolveExchangeInputs(ctx, req, teForSpec("authz-spec"))
+	_, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("authz-spec"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not equal the caller's own authentication token")
 }
@@ -2384,7 +2390,7 @@ func TestResolveExchangeInputs_SubjectHeader_GuardBypassAttempts(t *testing.T) {
 	// leading space), byte-identical to what Warden's own token extractor sets as
 	// ClientToken at auth time — so the guard still trips and cannot be bypassed.
 	req := requestWith(" eyJ.agent", map[string]string{"Authorization": "Bearer  eyJ.agent"})
-	_, err := c.resolveExchangeInputs(ctx, req, teForSpec("authz-spec"))
+	_, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("authz-spec"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not equal the caller's own authentication token")
 }
@@ -2401,7 +2407,7 @@ func TestResolveExchangeInputs_ActorHeader_CustomName(t *testing.T) {
 		credential.DefaultSubjectTokenHeader: "eyJ.subject",
 		"X-Actor":                            "eyJ.actor",
 	})
-	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("deleg-spec"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("deleg-spec"))
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 	assert.Equal(t, "eyJ.actor", inputs.ActorToken)
@@ -2419,7 +2425,7 @@ func TestResolveExchangeInputs_ActorHeader(t *testing.T) {
 		headerSubjectToken: "eyJ.subject",
 		headerActorToken:   "eyJ.actor",
 	})
-	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("deleg-spec"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("deleg-spec"))
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 	assert.Equal(t, "eyJ.subject", inputs.SubjectToken)
@@ -2437,7 +2443,7 @@ func TestResolveExchangeInputs_ActorAuthToken(t *testing.T) {
 	})
 
 	req := requestWith("eyJ.agent-jwt", map[string]string{headerSubjectToken: "eyJ.user"})
-	inputs, err := c.resolveExchangeInputs(ctx, req, teForSpec("deleg-auth"))
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("deleg-auth"))
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 	assert.Equal(t, "eyJ.user", inputs.SubjectToken)
@@ -2456,7 +2462,7 @@ func TestResolveExchangeInputs_ActorAuthToken_OpaqueFailsClosed(t *testing.T) {
 
 	// Non-JWT (opaque) inbound token cannot serve as the actor.
 	req := requestWith("s.opaque-session", map[string]string{headerSubjectToken: "eyJ.user"})
-	_, err := c.resolveExchangeInputs(ctx, req, teForSpec("deleg-auth"))
+	_, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("deleg-auth"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not JWT-authenticated")
 }
@@ -2469,7 +2475,7 @@ func TestResolveExchangeInputs_ActorHeader_MissingFailsClosed(t *testing.T) {
 	})
 
 	req := requestWith("opaque-token", map[string]string{headerSubjectToken: "eyJ.subject"})
-	_, err := c.resolveExchangeInputs(ctx, req, teForSpec("deleg-spec"))
+	_, err := resolveExchangeInputsForTest(c, ctx, req, teForSpec("deleg-spec"))
 	require.Error(t, err)
 }
 
@@ -2490,7 +2496,7 @@ func TestResolveExchangeInputs_WardenIdentity_MintDeferred(t *testing.T) {
 	// The inbound token is opaque (not a JWT): warden_identity does not reuse it.
 	req := requestWith("s.opaque-session", nil)
 
-	inputs, err := c.resolveExchangeInputs(ctx, req, te)
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, te)
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 
@@ -2509,7 +2515,7 @@ func TestResolveExchangeInputs_WardenIdentity_MintDeferred(t *testing.T) {
 	assert.True(t, strings.HasPrefix(tok, "eyJ"), "the provider must mint a JWT assertion")
 
 	// The cache identity is stable across requests and needs no mint to compute.
-	inputs2, err := c.resolveExchangeInputs(ctx, req, te)
+	inputs2, err := resolveExchangeInputsForTest(c, ctx, req, te)
 	require.NoError(t, err)
 	assert.Equal(t, inputs.SubjectCacheIdentity, inputs2.SubjectCacheIdentity, "cache identity must be stable")
 }
@@ -2536,7 +2542,7 @@ func TestResolveExchangeInputs_ActorWardenIdentity_MintDeferred(t *testing.T) {
 	// inbound token is an opaque session, distinct from the user token.
 	req := requestWith("s.opaque-session", map[string]string{credential.DefaultSubjectTokenHeader: "eyJ.user"})
 
-	inputs, err := c.resolveExchangeInputs(ctx, req, te)
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, te)
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 
@@ -2581,7 +2587,7 @@ func TestResolveExchangeInputs_WardenIdentity_ResourceDerived(t *testing.T) {
 	}))
 
 	te := &logical.TokenEntry{CredentialSpec: "wid-res", PrincipalID: "p", NamespaceID: "n", MountAccessor: "m"}
-	inputs, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), te)
+	inputs, err := resolveExchangeInputsForTest(c, ctx, requestWith("s.opaque", nil), te)
 	require.NoError(t, err)
 	require.NotNil(t, inputs)
 
@@ -2620,7 +2626,7 @@ func TestResolveExchangeInputs_WardenIdentity_ResourceOverrideAndOptOut(t *testi
 
 	// Explicit override wins over derivation, verbatim.
 	teOv := newSpecTE("wid-override", "custom:thing")
-	inOv, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), teOv)
+	inOv, err := resolveExchangeInputsForTest(c, ctx, requestWith("s.opaque", nil), teOv)
 	require.NoError(t, err)
 	assert.Contains(t, inOv.SubjectCacheIdentity, "\x00res=custom:thing")
 	tokOv, err := inOv.ResolveSubjectToken(ctx)
@@ -2629,7 +2635,7 @@ func TestResolveExchangeInputs_WardenIdentity_ResourceOverrideAndOptOut(t *testi
 
 	// Opt-out suppresses the claim despite a derivable secret_id.
 	teNone := newSpecTE("wid-none", credential.AssertionResourceNone)
-	inNone, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), teNone)
+	inNone, err := resolveExchangeInputsForTest(c, ctx, requestWith("s.opaque", nil), teNone)
 	require.NoError(t, err)
 	assert.Equal(t, wardenSubject(teNone)+"\x00"+"sts.amazonaws.com", inNone.SubjectCacheIdentity)
 	tokNone, err := inNone.ResolveSubjectToken(ctx)
@@ -2693,7 +2699,7 @@ func TestResolveExchangeInputs_WardenIdentity_Algorithm(t *testing.T) {
 			seedSpec(t, c, ctx, specName, cfg)
 			te.CredentialSpec = specName
 
-			inputs, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), te)
+			inputs, err := resolveExchangeInputsForTest(c, ctx, requestWith("s.opaque", nil), te)
 			require.NoError(t, err)
 			require.NotNil(t, inputs.ResolveSubjectToken)
 
@@ -2732,7 +2738,7 @@ func TestResolveExchangeInputs_WardenIdentity_MetadataProjected(t *testing.T) {
 	}
 	req := requestWith("s.opaque-session", nil)
 
-	inputs, err := c.resolveExchangeInputs(ctx, req, teProd)
+	inputs, err := resolveExchangeInputsForTest(c, ctx, req, teProd)
 	require.NoError(t, err)
 	require.NotNil(t, inputs.ResolveSubjectToken)
 
@@ -2756,7 +2762,7 @@ func TestResolveExchangeInputs_WardenIdentity_MetadataProjected(t *testing.T) {
 		MountAccessor:  "auth_jwt_1",
 		Metadata:       map[string]string{"team": "payments", "env": "staging"},
 	}
-	inputsStaging, err := c.resolveExchangeInputs(ctx, req, teStaging)
+	inputsStaging, err := resolveExchangeInputsForTest(c, ctx, req, teStaging)
 	require.NoError(t, err)
 	assert.NotEqual(t, inputs.SubjectCacheIdentity, inputsStaging.SubjectCacheIdentity,
 		"differing projected metadata must isolate the credential cache")
@@ -2780,7 +2786,7 @@ func TestResolveExchangeInputs_WardenIdentity_MetadataOverCapFailsClosed(t *test
 	}
 	req := requestWith("s.opaque-session", nil)
 
-	_, err := c.resolveExchangeInputs(ctx, req, te)
+	_, err := resolveExchangeInputsForTest(c, ctx, req, te)
 	require.Error(t, err, "an over-cap metadata projection must fail closed")
 	assert.Contains(t, err.Error(), "assertion metadata exceeds")
 }
@@ -2794,7 +2800,7 @@ func TestResolveExchangeInputs_WardenIdentity_IssuerNotReadyFailsClosed(t *testi
 	})
 
 	te := &logical.TokenEntry{CredentialSpec: "wid-spec", PrincipalID: "p", NamespaceID: "n", MountAccessor: "m"}
-	_, err := c.resolveExchangeInputs(ctx, requestWith("s.opaque", nil), te)
+	_, err := resolveExchangeInputsForTest(c, ctx, requestWith("s.opaque", nil), te)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enabled/ready")
 }

--- a/credential/chaining.go
+++ b/credential/chaining.go
@@ -1,0 +1,76 @@
+package credential
+
+import (
+	"context"
+	"time"
+)
+
+// Credential-chaining config keys. A consuming source/spec that needs a standing
+// secret does not store it; it names another cred spec whose minted credential IS
+// that secret ("secret_spec"), and Warden mints that spec as the same caller at
+// use time, extracts the material, and hands it to the consuming driver.
+const (
+	// ConfigSecretSpec names a cred spec that yields the secret material. It may sit
+	// on the consuming spec (spec-level, wins) or its source (source-level).
+	ConfigSecretSpec = "secret_spec"
+
+	// ConfigSecretField names which key of the referenced credential's Data carries
+	// the single secret value. Optional: a single-key payload auto-detects, and a
+	// typed referenced credential can fall back to its primary field.
+	ConfigSecretField = "secret_field"
+
+	// MaxSecretChainDepth bounds chaining: a referenced secret-spec may not itself
+	// chain (one hop only). This also breaks any config-drift reference cycle rather
+	// than letting the recursive mint recurse unboundedly.
+	MaxSecretChainDepth = 1
+)
+
+// SecretMaterial carries the referenced secret-spec's minted data to a consuming
+// driver's MintFromSecret. Data is the full key/value map (so a multi-secret driver
+// can read several named keys directly); Field is the resolved single-secret key
+// (may be empty when the consumer reads Data directly).
+type SecretMaterial struct {
+	Data  map[string]string
+	Field string
+}
+
+// Secret returns the selected single secret value (Data[Field]), or "" when no
+// field was resolved. Multi-secret consumers ignore this and read Data by name.
+func (m SecretMaterial) Secret() string {
+	if m.Field == "" {
+		return ""
+	}
+	return m.Data[m.Field]
+}
+
+// Caller carries the requesting principal through the mint pipeline so a chained
+// mint can re-mint a referenced secret-spec AS that caller (same tokenID for cache
+// scoping, same identity for the assertion). Built by core; the credential package
+// never derives it from caller-supplied input.
+type Caller struct {
+	// TokenID is the session token the minted credential is bound to and cached under.
+	TokenID string
+	// TokenTTL bounds a dynamic credential's cache/lease lifetime.
+	TokenTTL time.Duration
+	// ResolveInputs builds ExchangeInputs for an arbitrary spec name as this caller
+	// (a nil result means the spec does not request exchange). Set only by core; it
+	// is nil on non-request code paths, in which case a chained secret-spec that
+	// needs exchange fails closed at mint time.
+	ResolveInputs func(ctx context.Context, specName string) (*ExchangeInputs, error)
+}
+
+// chainDepthCtxKey carries the current secret_spec recursion depth on the context.
+type chainDepthCtxKey struct{}
+
+// withChainDepth returns a context carrying the given chain depth.
+func withChainDepth(ctx context.Context, depth int) context.Context {
+	return context.WithValue(ctx, chainDepthCtxKey{}, depth)
+}
+
+// chainDepth reads the current secret_spec recursion depth (0 when unset).
+func chainDepth(ctx context.Context) int {
+	if d, ok := ctx.Value(chainDepthCtxKey{}).(int); ok {
+		return d
+	}
+	return 0
+}

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -1,0 +1,305 @@
+package credential
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChainedDriver implements SourceDriver + ChainedSecretMinter. It records the
+// material handed to MintFromSecret and echoes the selected secret into a token.
+type mockChainedDriver struct {
+	driverType    string
+	mintFromCalls atomic.Int32
+	lastMaterial  SecretMaterial
+}
+
+func (d *mockChainedDriver) MintCredential(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", fmt.Errorf("mockChainedDriver: direct mint not supported")
+}
+
+func (d *mockChainedDriver) MintFromSecret(_ context.Context, _ *CredSpec, material SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.mintFromCalls.Add(1)
+	d.lastMaterial = material
+	return map[string]interface{}{"token": "consumer-token:" + material.Secret()}, nil, 0, "", nil
+}
+
+func (d *mockChainedDriver) Revoke(_ context.Context, _ string) error { return nil }
+func (d *mockChainedDriver) Type() string                            { return d.driverType }
+func (d *mockChainedDriver) Cleanup(_ context.Context) error         { return nil }
+
+type mockChainedFactory struct{ driver *mockChainedDriver }
+
+func (f *mockChainedFactory) Type() string { return f.driver.driverType }
+func (f *mockChainedFactory) Create(_ map[string]string, _ *logger.GatedLogger) (SourceDriver, error) {
+	return f.driver, nil
+}
+func (f *mockChainedFactory) ValidateConfig(_ map[string]string) error   { return nil }
+func (f *mockChainedFactory) SensitiveConfigFields() []string            { return nil }
+func (f *mockChainedFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return "", fmt.Errorf("n/a")
+}
+
+// mockExchangeSecretDriver is a referenced-spec driver that consumes exchange inputs
+// (ExchangeMinter). It records the subject/actor tokens it received so a test can
+// assert they were materialized before the referenced mint.
+type mockExchangeSecretDriver struct {
+	driverType string
+	gotSubject string
+	gotActor   string
+}
+
+func (d *mockExchangeSecretDriver) MintCredential(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", fmt.Errorf("mockExchangeSecretDriver: exchange required")
+}
+func (d *mockExchangeSecretDriver) MintCredentialWithExchange(_ context.Context, _ *CredSpec, inputs *ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.gotSubject = inputs.SubjectToken
+	d.gotActor = inputs.ActorToken
+	return map[string]interface{}{"token": "SECRET-" + inputs.SubjectToken}, nil, 0, "", nil
+}
+func (d *mockExchangeSecretDriver) Revoke(_ context.Context, _ string) error { return nil }
+func (d *mockExchangeSecretDriver) Type() string                            { return d.driverType }
+func (d *mockExchangeSecretDriver) Cleanup(_ context.Context) error         { return nil }
+
+type mockExchangeSecretFactory struct{ driver *mockExchangeSecretDriver }
+
+func (f *mockExchangeSecretFactory) Type() string { return f.driver.driverType }
+func (f *mockExchangeSecretFactory) Create(_ map[string]string, _ *logger.GatedLogger) (SourceDriver, error) {
+	return f.driver, nil
+}
+func (f *mockExchangeSecretFactory) ValidateConfig(_ map[string]string) error { return nil }
+func (f *mockExchangeSecretFactory) SensitiveConfigFields() []string          { return nil }
+func (f *mockExchangeSecretFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return "", fmt.Errorf("n/a")
+}
+
+// chainingEnv wires a secret source (leaseless, returns {token: THE-SECRET}) and a
+// consumer source that implements ChainedSecretMinter.
+type chainingEnv struct {
+	manager        *Manager
+	store          *mockConfigStore
+	secretDriver   *mockSourceDriver
+	consumerDriver *mockChainedDriver
+	exchangeDriver *mockExchangeSecretDriver
+}
+
+func newChainingEnv(t *testing.T) *chainingEnv {
+	t.Helper()
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	typeRegistry := NewTypeRegistry()
+	require.NoError(t, typeRegistry.Register(newMockCredentialType(TypeVaultToken, CategoryAPI)))
+
+	driverRegistry := NewDriverRegistry(nil)
+
+	secretFactory := newMockSourceDriverFactory("secretsrc")
+	// Leaseless secret material (kv-read shape): no lease, static.
+	secretFactory.driver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"token": "THE-SECRET"}, nil, 0, "", nil
+	}
+	require.NoError(t, driverRegistry.RegisterFactory(secretFactory))
+
+	consumer := &mockChainedDriver{driverType: "consumersrc"}
+	require.NoError(t, driverRegistry.RegisterFactory(&mockChainedFactory{driver: consumer}))
+
+	exchange := &mockExchangeSecretDriver{driverType: "exchangesrc"}
+	require.NoError(t, driverRegistry.RegisterFactory(&mockExchangeSecretFactory{driver: exchange}))
+
+	store := newMockConfigStore()
+	manager, err := NewManager(typeRegistry, driverRegistry, store, log)
+	require.NoError(t, err)
+
+	// Secret source + spec.
+	store.AddSource(&CredSource{Name: "secretsource", Type: "secretsrc", Config: map[string]string{}})
+	store.AddSpec(&CredSpec{Name: "secret-spec", Type: TypeVaultToken, Source: "secretsource", Config: map[string]string{}})
+	// Consumer source.
+	store.AddSource(&CredSource{Name: "consumersource", Type: "consumersrc", Config: map[string]string{}})
+	// Exchange-consuming secret source (for materialization tests).
+	store.AddSource(&CredSource{Name: "exchangesource", Type: "exchangesrc", Config: map[string]string{}})
+
+	return &chainingEnv{manager: manager, store: store, secretDriver: secretFactory.driver, consumerDriver: consumer, exchangeDriver: exchange}
+}
+
+// caller with a no-op ResolveInputs (the referenced secret-spec does not request
+// exchange in these tests, so nil inputs are correct).
+func chainCaller(tokenID string) Caller {
+	return Caller{
+		TokenID:  tokenID,
+		TokenTTL: time.Hour,
+		ResolveInputs: func(_ context.Context, _ string) (*ExchangeInputs, error) {
+			return nil, nil
+		},
+	}
+}
+
+func TestChaining_MaterialFlowsToConsumer(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	cred, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "THE-SECRET", env.consumerDriver.lastMaterial.Secret(), "consumer received the fetched secret")
+	assert.Equal(t, "consumer-token:THE-SECRET", cred.Data["token"], "consumer minted from the material")
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "secret fetched once")
+}
+
+// TestChaining_SecretNotCached proves the fetched secret is not cached: a second
+// consumer spec referencing the SAME secret-spec triggers a fresh secret fetch
+// (its own outer-cache miss), rather than reusing a cached secret.
+func TestChaining_SecretNotCached(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	// Same caller + same outer spec: outer cache hit, no new secret fetch.
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "outer cache hit: secret not re-fetched")
+
+	// Different outer spec, same secret-spec: outer miss re-fetches the secret,
+	// proving the secret itself was never cached/shared.
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(), "secret re-read on a separate outer miss")
+}
+
+// TestChaining_PerCaller proves per-caller isolation: a different caller re-fetches
+// the secret (its own outer key), never reusing another caller's fetch.
+func TestChaining_PerCaller(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, chainCaller("tokB"), "consumer", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(), "each caller fetches its own secret")
+}
+
+func TestChaining_DepthGuard(t *testing.T) {
+	env := newChainingEnv(t)
+	// secret-spec-2 is the terminal secret; secret-spec-1 illegally chains to it.
+	env.store.AddSpec(&CredSpec{Name: "secret-spec-2", Type: TypeVaultToken, Source: "secretsource", Config: map[string]string{}})
+	env.store.AddSpec(&CredSpec{Name: "secret-spec-1", Type: TypeVaultToken, Source: "secretsource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec-2"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec-1"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max depth")
+}
+
+// TestChaining_FailsClosedNonChainedDriver: a consumer whose driver does not
+// implement ChainedSecretMinter fails closed.
+func TestChaining_FailsClosedNonChainedDriver(t *testing.T) {
+	env := newChainingEnv(t)
+	// "secretsource" driver (mockSourceDriver) does not implement ChainedSecretMinter.
+	env.store.AddSpec(&CredSpec{Name: "bad-consumer", Type: TypeVaultToken, Source: "secretsource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "bad-consumer", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support secret_spec chaining")
+}
+
+// TestChaining_LeaselessBackstop: a referenced secret-spec that returns a lease is
+// rejected (config-drift backstop).
+func TestChaining_LeaselessBackstop(t *testing.T) {
+	env := newChainingEnv(t)
+	// Make the secret driver return a lease.
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"token": "THE-SECRET"}, nil, time.Hour, "lease-xyz", nil
+	}
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "static/leaseless")
+}
+
+// TestChaining_SecretFieldSelection covers multi-key payloads: an explicit
+// secret_field selects the value; a single-key payload auto-detects.
+func TestChaining_SecretFieldSelection(t *testing.T) {
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"alpha": "A", "beta": "B"}, nil, 0, "", nil
+	}
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretField: "beta"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "B", env.consumerDriver.lastMaterial.Secret(), "secret_field selects the value")
+	assert.Equal(t, "A", env.consumerDriver.lastMaterial.Data["alpha"], "full payload available for multi-secret drivers")
+}
+
+// TestChaining_MaterializesSubjectAndActor proves issueChained materializes BOTH the
+// lazy subject and actor tokens before the referenced (exchange) mint — otherwise the
+// driver would see empty tokens (subject fails closed; actor silently dropped).
+func TestChaining_MaterializesSubjectAndActor(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exchange-secret", Type: TypeVaultToken, Source: "exchangesource", Config: map[string]string{}})
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "exchange-secret"}})
+
+	caller := Caller{
+		TokenID:  "tokA",
+		TokenTTL: time.Hour,
+		ResolveInputs: func(_ context.Context, specName string) (*ExchangeInputs, error) {
+			// Inputs for the referenced spec, with lazy subject + actor resolvers
+			// (as core would build for warden_identity subject + actor).
+			return &ExchangeInputs{
+				SubjectTokenOrigin:   ExchangeOriginVerified,
+				SubjectCacheIdentity: "id:" + specName,
+				ResolveSubjectToken:  func(_ context.Context) (string, error) { return "resolved-subject", nil },
+				ActorCacheIdentity:   "actor:" + specName,
+				ResolveActorToken:    func(_ context.Context) (string, error) { return "resolved-actor", nil },
+			}, nil
+		},
+	}
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "resolved-subject", env.exchangeDriver.gotSubject, "subject token materialized before referenced mint")
+	assert.Equal(t, "resolved-actor", env.exchangeDriver.gotActor, "actor token materialized before referenced mint")
+	assert.Equal(t, "SECRET-resolved-subject", env.consumerDriver.lastMaterial.Secret())
+}
+
+// TestChaining_RequiresCallerContext: a nil ResolveInputs (non-request path) fails
+// closed rather than minting the referenced spec without a caller.
+func TestChaining_RequiresCallerContext(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	caller := Caller{TokenID: "tokA", TokenTTL: time.Hour} // ResolveInputs nil
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a request caller context")
+}

--- a/credential/drivers/github_driver.go
+++ b/credential/drivers/github_driver.go
@@ -33,6 +33,7 @@ const githubMaxRetryAttempts = 3
 // App mode tokens are ephemeral (1h TTL), and GitHub has no API to rotate PATs.
 var _ credential.SourceDriver = (*GitHubDriver)(nil)
 var _ credential.SpecVerifier = (*GitHubDriver)(nil)
+var _ credential.ChainedSecretMinter = (*GitHubDriver)(nil)
 
 // appTokenCache holds a cached GitHub App installation token for a specific spec
 type appTokenCache struct {
@@ -130,22 +131,71 @@ func (d *GitHubDriver) getGitHubURL() string {
 	return strings.TrimRight(credential.GetString(d.credSource.Config, "github_url", "https://api.github.com"), "/")
 }
 
-// MintCredential returns a GitHub token for the given spec.
-// Auth credentials are read from spec.Config, not from the source.
+// MintCredential returns a GitHub token for the given spec, minting directly from
+// the secret in spec.Config. Chained specs (secret_spec set) mint through
+// MintFromSecret instead — the Manager routes them there and never calls this — so
+// reaching here with secret_spec set is a misuse and fails closed rather than
+// reading a missing inline secret. Non-chained specs are unaffected.
 func (d *GitHubDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if spec.Config[credential.ConfigSecretSpec] != "" {
+		return nil, nil, 0, "", fmt.Errorf("github: spec uses secret_spec (credential chaining); it must mint from fetched secret material, not directly")
+	}
 	authMethod := credential.GetString(spec.Config, "auth_method", "app")
 	switch authMethod {
 	case "app":
-		return d.mintAppCredential(ctx, spec)
+		return d.mintAppCredentialWithKey(ctx, spec, credential.GetString(spec.Config, "private_key", ""))
 	case "pat":
-		return d.mintPATCredential(spec)
+		return d.mintPATFromToken(credential.GetString(spec.Config, "token", ""))
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported auth_method '%s'", authMethod)
 	}
 }
 
-// mintAppCredential mints a GitHub App installation access token using spec config
-func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// MintFromSecret mints a GitHub token from secret material fetched via credential
+// chaining: app mode signs an installation token with the fetched private key; pat
+// mode injects the fetched token. Per-caller authorization was already enforced
+// upstream (the referenced secret-spec was minted as the caller), so the cross-caller
+// app-token cache in mintAppCredentialWithKey remains correct.
+func (d *GitHubDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	authMethod := credential.GetString(spec.Config, "auth_method", "app")
+	switch authMethod {
+	case "app":
+		keyPEM := material.Secret()
+		// Fall back to the conventional key name ONLY when no field was resolved
+		// (single-key auto-detect failed / no secret_field). If a field WAS resolved
+		// but is empty, that's a misconfigured secret_field — fail loudly rather than
+		// silently substituting a different key.
+		if keyPEM == "" && material.Field == "" {
+			keyPEM = material.Data["private_key"]
+		}
+		if keyPEM == "" {
+			if material.Field != "" {
+				return nil, nil, 0, "", fmt.Errorf("github: secret_field %q is empty or absent in the fetched secret material", material.Field)
+			}
+			return nil, nil, 0, "", fmt.Errorf("github: no private key in fetched secret material (set secret_field, or store it under 'private_key')")
+		}
+		return d.mintAppCredentialWithKey(ctx, spec, keyPEM)
+	case "pat":
+		token := material.Secret()
+		if token == "" && material.Field == "" {
+			token = material.Data["token"]
+		}
+		if token == "" {
+			if material.Field != "" {
+				return nil, nil, 0, "", fmt.Errorf("github: secret_field %q is empty or absent in the fetched secret material", material.Field)
+			}
+			return nil, nil, 0, "", fmt.Errorf("github: no token in fetched secret material (set secret_field, or store it under 'token')")
+		}
+		return d.mintPATFromToken(token)
+	default:
+		return nil, nil, 0, "", fmt.Errorf("unsupported auth_method '%s'", authMethod)
+	}
+}
+
+// mintAppCredentialWithKey mints a GitHub App installation access token from the
+// given private-key PEM (read from spec config for a direct mint, or fetched via
+// credential chaining).
+func (d *GitHubDriver) mintAppCredentialWithKey(ctx context.Context, spec *credential.CredSpec, keyPEM string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	d.appTokenMu.Lock()
 	defer d.appTokenMu.Unlock()
 
@@ -159,11 +209,9 @@ func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.C
 		return rawData, nil, ttl, "", nil
 	}
 
-	// Parse private key from spec config
-	keyPEM := credential.GetString(spec.Config, "private_key", "")
 	key, err := parseRSAPrivateKey(keyPEM)
 	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to parse private key from spec: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	appID := credential.GetString(spec.Config, "app_id", "")
@@ -198,11 +246,11 @@ func (d *GitHubDriver) mintAppCredential(ctx context.Context, spec *credential.C
 	return rawData, nil, ttl, "", nil
 }
 
-// mintPATCredential returns the PAT from spec config as a credential
-func (d *GitHubDriver) mintPATCredential(spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	token := credential.GetString(spec.Config, "token", "")
+// mintPATFromToken returns the given PAT as a credential (from spec config for a
+// direct mint, or fetched via credential chaining).
+func (d *GitHubDriver) mintPATFromToken(token string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	if token == "" {
-		return nil, nil, 0, "", fmt.Errorf("no GitHub PAT configured in spec")
+		return nil, nil, 0, "", fmt.Errorf("no GitHub PAT configured")
 	}
 
 	rawData := map[string]interface{}{

--- a/credential/drivers/github_driver_test.go
+++ b/credential/drivers/github_driver_test.go
@@ -197,6 +197,102 @@ func TestGitHubDriver_MintPATCredential_EmptyToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "no GitHub PAT configured")
 }
 
+func TestGitHubDriver_MintCredential_FailsClosedWhenChained(t *testing.T) {
+	driver := &GitHubDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeGitHub, Config: map[string]string{"github_url": "https://api.github.com"}},
+		appTokens:  make(map[string]*appTokenCache),
+	}
+	spec := &credential.CredSpec{
+		Name: "chained",
+		Type: credential.TypeGitHubToken,
+		Config: map[string]string{
+			"auth_method":               "pat",
+			credential.ConfigSecretSpec: "gh-secret",
+		},
+	}
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret_spec")
+}
+
+func TestGitHubDriver_MintFromSecret_PAT(t *testing.T) {
+	driver := &GitHubDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeGitHub, Config: map[string]string{"github_url": "https://api.github.com"}},
+		appTokens:  make(map[string]*appTokenCache),
+	}
+	spec := &credential.CredSpec{
+		Name:   "chained-pat",
+		Type:   credential.TypeGitHubToken,
+		Config: map[string]string{"auth_method": "pat", credential.ConfigSecretSpec: "gh-secret"},
+	}
+	material := credential.SecretMaterial{Data: map[string]string{"token": "ghp_fetched"}, Field: "token"}
+
+	rawData, _, ttl, leaseID, err := driver.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "ghp_fetched", rawData["token"])
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Equal(t, "", leaseID)
+}
+
+// A resolved secret_field that is empty/absent must fail loudly rather than silently
+// falling back to the conventional key name (which would mask the misconfiguration).
+func TestGitHubDriver_MintFromSecret_MisconfiguredFieldFailsClosed(t *testing.T) {
+	driver := &GitHubDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeGitHub, Config: map[string]string{"github_url": "https://api.github.com"}},
+		appTokens:  make(map[string]*appTokenCache),
+	}
+	spec := &credential.CredSpec{
+		Name:   "chained-pat",
+		Type:   credential.TypeGitHubToken,
+		Config: map[string]string{"auth_method": "pat", credential.ConfigSecretSpec: "gh-secret"},
+	}
+	// secret_field points at "wrong", but the payload carries the token under the
+	// conventional "token" key. The old fallback would have used it silently.
+	material := credential.SecretMaterial{Data: map[string]string{"token": "ghp_fetched"}, Field: "wrong"}
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, material)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong")
+}
+
+func TestGitHubDriver_MintFromSecret_App(t *testing.T) {
+	testKey := generateTestRSAKey(t)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/app/installations/67890/access_tokens")
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      "ghs_from_fetched_key",
+			"expires_at": time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	driver := &GitHubDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeGitHub, Config: map[string]string{"github_url": server.URL}},
+		httpClient: server.Client(),
+		appTokens:  make(map[string]*appTokenCache),
+	}
+	// App identifiers inline (non-secret); private key comes from fetched material.
+	spec := &credential.CredSpec{
+		Name: "chained-app",
+		Type: credential.TypeGitHubToken,
+		Config: map[string]string{
+			"auth_method":               "app",
+			"app_id":                    "12345",
+			"installation_id":           "67890",
+			credential.ConfigSecretSpec: "gh-secret",
+		},
+	}
+	material := credential.SecretMaterial{Data: map[string]string{"private_key": testKey}, Field: "private_key"}
+
+	rawData, _, ttl, _, err := driver.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_from_fetched_key", rawData["token"])
+	assert.True(t, ttl > 0)
+}
+
 func TestGitHubDriver_MintCredential_UnsupportedAuthMethod(t *testing.T) {
 	driver := &GitHubDriver{
 		credSource: &credential.CredSource{

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -48,6 +48,11 @@ type Manager struct {
 	mintingService    *MintingService
 	credentialParser  *CredentialParser
 
+	// typeRegistry is retained for credential-chaining field discovery: resolving a
+	// referenced credential's primary field (PrimaryFieldProvider) when no explicit
+	// secret_field is set and its payload has more than one key.
+	typeRegistry *TypeRegistry
+
 	// configStore persists rotated refresh tokens back into the spec config.
 	configStore ConfigStoreAccessor
 
@@ -114,6 +119,7 @@ func NewManager(
 		mintingService:    mintingService,
 		credentialParser:  credentialParser,
 		configStore:       configStore,
+		typeRegistry:      typeRegistry,
 		issuanceTimeout:   DefaultIssuanceTimeout,
 	}
 
@@ -133,15 +139,16 @@ func NewManager(
 	return m, nil
 }
 
-// IssueCredential issues a credential for the given spec, token, and TTL.
+// IssueCredential issues a credential for the given spec on behalf of a caller.
 // Credentials are cached in memory but not persisted to storage.
 // On cache miss, a new credential is issued from the source.
 //
 // Parameters:
 //   - ctx: Context with namespace information
-//   - tokenID: The session token ID to bind the credential to
+//   - caller: The requesting principal — its TokenID binds and caches the
+//     credential, its TokenTTL bounds the cache duration, and its ResolveInputs is
+//     used by credential chaining to mint a referenced secret-spec as this caller.
 //   - specName: The name of the credential spec to use
-//   - tokenTTL: The TTL of the session token (used for cache duration)
 //   - inputs: Optional caller-derived token-exchange inputs. When non-nil they
 //     are folded into the cache key so distinct exchange inputs cannot share a
 //     cached credential. When inputs.ResolveSubjectToken and/or
@@ -150,7 +157,7 @@ func NewManager(
 //     resolve independently (an eager header subject can pair with a lazy actor).
 //
 // Returns the issued credential or an error
-func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName string, tokenTTL time.Duration, inputs *ExchangeInputs) (*Credential, error) {
+func (m *Manager) IssueCredential(ctx context.Context, caller Caller, specName string, inputs *ExchangeInputs) (*Credential, error) {
 	// Apply issuance timeout to prevent slow drivers from blocking indefinitely
 	ctx, cancel := context.WithTimeout(ctx, m.issuanceTimeout)
 	defer cancel()
@@ -163,7 +170,7 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 
 	// Build namespace-aware cache key: {namespace-uuid}:{tokenID}:{specName}
 	// Including specName allows access backends to mint different specs for the same token.
-	cacheKey := fmt.Sprintf("%s:%s:%s", ns.ID, tokenID, specName)
+	cacheKey := fmt.Sprintf("%s:%s:%s", ns.ID, caller.TokenID, specName)
 
 	// When the request carries token-exchange inputs, fold their fingerprint into
 	// the key so two callers sharing one session token (e.g. an opaque service
@@ -218,8 +225,8 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 			inputs.ActorToken = tok
 		}
 
-		// Issue new credential from source
-		cred, err := m.issueCredential(ctx, specName, inputs)
+		// Issue a new credential
+		cred, err := m.issueCredential(ctx, caller, specName, inputs)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +235,7 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 		cred.CredentialID = uuid.New().String()
 
 		// Bind credential to token and spec
-		cred.TokenID = tokenID
+		cred.TokenID = caller.TokenID
 		cred.SpecName = specName
 
 		// Cache the credential. Bound a dynamic credential's entry by its remaining
@@ -237,10 +244,18 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 		// correctness backstop, this keeps memory from accumulating stale entries.
 		if cred.LeaseTTL > 0 {
 			ttl := cred.LeaseTTL
-			if tokenTTL > 0 && tokenTTL < ttl {
-				ttl = tokenTTL
+			if caller.TokenTTL > 0 && caller.TokenTTL < ttl {
+				ttl = caller.TokenTTL
 			}
 			m.cache.SetWithTTL(cacheKey, cred, 1, ttl)
+		} else if caller.TokenTTL > 0 {
+			// A static credential (no lease) is still bound to this session: cap its
+			// entry by the session TTL so it self-evicts at session end rather than
+			// lingering until cache pressure. This also bounds a chained static
+			// credential's staleness — a rotated upstream secret is re-fetched at most
+			// one session later. Falls back to an untimed set only when no session TTL
+			// is known (internal/non-request callers).
+			m.cache.SetWithTTL(cacheKey, cred, 1, caller.TokenTTL)
 		} else {
 			m.cache.Set(cacheKey, cred, 1)
 		}
@@ -255,7 +270,7 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 				ctx,               // Context with namespace
 				cred.CredentialID, // Unique ID for this credential instance (UUID)
 				cacheKey,          // Cache key for cache lookup/deletion
-				tokenTTL,
+				caller.TokenTTL,
 				cred.LeaseID,
 				cred.SourceName,
 				cred.SourceType,
@@ -282,12 +297,25 @@ func (m *Manager) IssueCredential(ctx context.Context, tokenID string, specName 
 	return v.(*Credential), nil
 }
 
-// issueCredential performs the actual credential issuance from the source
-func (m *Manager) issueCredential(ctx context.Context, specName string, inputs *ExchangeInputs) (*Credential, error) {
+// issueCredential performs the actual credential issuance from the source. It runs
+// on a real cache miss (or, for a chained secret-spec, on the non-caching path so
+// the fetched secret is never cached).
+func (m *Manager) issueCredential(ctx context.Context, caller Caller, specName string, inputs *ExchangeInputs) (*Credential, error) {
 	// Step 1: Resolve credential spec using SpecResolver
 	spec, err := m.specResolver.ResolveSpec(ctx, specName)
 	if err != nil {
 		return nil, err
+	}
+
+	// Credential chaining: when the spec (or its source) references another cred
+	// spec as its secret source, mint that referenced spec as the same caller and
+	// mint this credential from the fetched material. Spec-level reference wins.
+	secretRef, err := m.secretSpecRef(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	if secretRef != "" {
+		return m.issueChained(ctx, caller, spec, secretRef)
 	}
 
 	// Step 2: Get or create source driver using DriverCoordinator
@@ -312,6 +340,152 @@ func (m *Manager) issueCredential(ctx context.Context, specName string, inputs *
 func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver SourceDriver, inputs *ExchangeInputs) (*Credential, error) {
 	var cred *Credential
 	err := m.mintingService.MintWithCleanup(ctx, driver, spec, inputs, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+		var parseErr error
+		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
+		return parseErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cred, nil
+}
+
+// secretSpecRef returns the referenced secret-spec name for credential chaining:
+// spec-level (ConfigSecretSpec on the spec) wins over source-level (on the source).
+// Returns "" when the spec is not chained. A source-read failure is returned rather
+// than swallowed, so a transient error can't silently route a chained spec down the
+// direct (non-chained) mint path.
+func (m *Manager) secretSpecRef(ctx context.Context, spec *CredSpec) (string, error) {
+	if ref := spec.Config[ConfigSecretSpec]; ref != "" {
+		return ref, nil
+	}
+	src, err := m.configStore.GetSource(ctx, spec.Source)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve source %q for credential chaining: %w", spec.Source, err)
+	}
+	return src.Config[ConfigSecretSpec], nil
+}
+
+// issueChained mints a consuming credential whose secret comes from a referenced
+// cred spec. It mints the referenced spec AS the caller (fresh assertion), extracts
+// the secret material, and hands it to the consuming driver. The fetched secret is
+// never cached: it is minted via the non-caching internal path and discarded after
+// material extraction.
+func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpec, secretRef string) (*Credential, error) {
+	// Bound the chain to a single hop (a referenced secret-spec may not itself
+	// chain). This also breaks any config-drift reference cycle rather than letting
+	// it recurse unboundedly.
+	depth := chainDepth(ctx)
+	if depth+1 > MaxSecretChainDepth {
+		return nil, fmt.Errorf("credential chaining for spec %q exceeds max depth %d (referenced secret_spec %q)", spec.Name, MaxSecretChainDepth, secretRef)
+	}
+	ctx = withChainDepth(ctx, depth+1)
+
+	// Build exchange inputs for the referenced secret-spec, as the caller.
+	if caller.ResolveInputs == nil {
+		return nil, fmt.Errorf("credential chaining for spec %q requires a request caller context", spec.Name)
+	}
+	inputsB, err := caller.ResolveInputs(ctx, secretRef)
+	if err != nil {
+		return nil, fmt.Errorf("secret_spec %q: %w", secretRef, err)
+	}
+
+	// Materialize any lazily-minted subject/actor tokens here: the referenced spec is
+	// minted via the non-caching internal path, which — unlike the caching wrapper —
+	// does not run ResolveSubjectToken/ResolveActorToken, so a warden_identity subject
+	// or actor would otherwise be forwarded empty (the driver would fail closed on the
+	// subject; a delegation actor would be silently dropped).
+	if inputsB != nil && inputsB.ResolveSubjectToken != nil && inputsB.SubjectToken == "" {
+		tok, rerr := inputsB.ResolveSubjectToken(ctx)
+		if rerr != nil {
+			return nil, fmt.Errorf("secret_spec %q: failed to resolve subject token: %w", secretRef, rerr)
+		}
+		inputsB.SubjectToken = tok
+	}
+	if inputsB != nil && inputsB.ResolveActorToken != nil && inputsB.ActorToken == "" {
+		tok, rerr := inputsB.ResolveActorToken(ctx)
+		if rerr != nil {
+			return nil, fmt.Errorf("secret_spec %q: failed to resolve actor token: %w", secretRef, rerr)
+		}
+		inputsB.ActorToken = tok
+	}
+
+	// Mint the secret AS the caller via the non-caching path — never cached; it
+	// lives only for this mint and is discarded after material extraction below.
+	credB, err := m.issueCredential(ctx, caller, secretRef, inputsB)
+	if err != nil {
+		return nil, fmt.Errorf("secret_spec %q: %w", secretRef, err)
+	}
+
+	// A referenced secret-spec must be static/leaseless: this path skips expiration
+	// registration, so a leased credential would orphan its lease. The create-time
+	// guard forbids this; fail closed (best-effort revoke) if config drift produced
+	// one anyway.
+	if credB.LeaseID != "" || credB.LeaseTTL > 0 {
+		if credB.LeaseID != "" {
+			// Best-effort revoke on a fresh context (the request ctx may be near its
+			// issuance deadline); log rather than drop the outcome.
+			revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if drv, derr := m.driverCoordinator.GetOrCreateDriver(ctx, credB.SourceName); derr == nil {
+				if rerr := drv.Revoke(revokeCtx, credB.LeaseID); rerr != nil {
+					m.log.Warn("failed to revoke orphaned lease from a leased secret_spec",
+						logger.String("secret_spec", secretRef),
+						logger.String("lease_id", credB.LeaseID),
+						logger.Err(rerr))
+				}
+			}
+			cancel()
+		}
+		return nil, fmt.Errorf("secret_spec %q must reference a static/leaseless credential, but it returned a lease", secretRef)
+	}
+
+	// Extract the secret material and mint the consuming credential from it.
+	field := m.resolveSecretField(ctx, spec, credB)
+	material := SecretMaterial{Data: credB.Data, Field: field}
+
+	driver, err := m.driverCoordinator.GetOrCreateDriver(ctx, spec.Source)
+	if err != nil {
+		return nil, err
+	}
+	return m.mintFromSecret(ctx, spec, driver, material)
+}
+
+// resolveSecretField selects which key of the referenced credential's Data carries
+// the single secret: an explicit secret_field (spec-level then source-level), else a
+// single-key payload, else the referenced type's primary field. Returns "" when it
+// cannot determine one — a multi-secret consumer reads Data directly and ignores it;
+// a single-secret consumer surfaces the "set secret_field" error at use.
+func (m *Manager) resolveSecretField(ctx context.Context, spec *CredSpec, credB *Credential) string {
+	if f := spec.Config[ConfigSecretField]; f != "" {
+		return f
+	}
+	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil {
+		if f := src.Config[ConfigSecretField]; f != "" {
+			return f
+		}
+	}
+	if len(credB.Data) == 1 {
+		for k := range credB.Data {
+			return k
+		}
+	}
+	if m.typeRegistry != nil {
+		if ct, err := m.typeRegistry.GetByName(credB.Type); err == nil {
+			if pfp, ok := ct.(PrimaryFieldProvider); ok {
+				if pf := pfp.PrimaryField(); pf != "" {
+					return pf
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// mintFromSecret mints the consuming credential from fetched secret material, with
+// orphaned-lease cleanup on failure. Mirrors mintAndParse for the chaining path.
+func (m *Manager) mintFromSecret(ctx context.Context, spec *CredSpec, driver SourceDriver, material SecretMaterial) (*Credential, error) {
+	var cred *Credential
+	err := m.mintingService.MintFromSecretWithCleanup(ctx, driver, spec, material, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 		var parseErr error
 		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
 		return parseErr

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// issueForTest adapts the pre-chaining IssueCredential calling convention
+// (tokenID + tokenTTL scalars) to the Caller-based signature, so existing tests
+// read unchanged.
+func issueForTest(m *Manager, ctx context.Context, tokenID, specName string, tokenTTL time.Duration, inputs *ExchangeInputs) (*Credential, error) {
+	return m.IssueCredential(ctx, Caller{TokenID: tokenID, TokenTTL: tokenTTL}, specName, inputs)
+}
+
 // ============================================================================
 // Mock Implementations
 // ============================================================================
@@ -343,7 +350,7 @@ func TestManager_IssueCredential_Success(t *testing.T) {
 	tokenID := "token-123"
 	tokenTTL := time.Hour
 
-	cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	cred, err := issueForTest(manager, ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 
@@ -377,11 +384,11 @@ func TestManager_IssueCredential_CacheHit(t *testing.T) {
 	tokenTTL := time.Hour
 
 	// First call - should mint
-	cred1, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	cred1, err := issueForTest(manager, ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 
 	// Second call - should use cache
-	cred2, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	cred2, err := issueForTest(manager, ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 
 	// Should be the same credential
@@ -410,18 +417,18 @@ func TestManager_IssueCredential_ExpiredNotServed(t *testing.T) {
 	tokenID := "token-expiry"
 	tokenTTL := time.Hour
 
-	_, err := manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	_, err := issueForTest(manager, ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), factory.driver.mintCalls.Load())
 
 	// Within the lease: cache hit, no re-mint.
-	_, err = manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	_, err = issueForTest(manager, ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), factory.driver.mintCalls.Load(), "should serve from cache before expiry")
 
 	// After the lease elapses: the expired entry is not served — re-mint.
 	time.Sleep(80 * time.Millisecond)
-	_, err = manager.IssueCredential(ctx, tokenID, "test-spec", tokenTTL, nil)
+	_, err = issueForTest(manager, ctx, tokenID, "test-spec", tokenTTL, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), factory.driver.mintCalls.Load(), "expired credential must be re-minted, not served stale")
 }
@@ -432,7 +439,7 @@ func TestManager_IssueCredential_SpecNotFound(t *testing.T) {
 
 	ctx := createNamespaceContext()
 
-	_, err := manager.IssueCredential(ctx, "token-123", "nonexistent-spec", time.Hour, nil)
+	_, err := issueForTest(manager, ctx, "token-123", "nonexistent-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -451,7 +458,7 @@ func TestManager_IssueCredential_SourceNotFound(t *testing.T) {
 
 	ctx := createNamespaceContext()
 
-	_, err := manager.IssueCredential(ctx, "token-123", "test-spec", time.Hour, nil)
+	_, err := issueForTest(manager, ctx, "token-123", "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source")
 	assert.Contains(t, err.Error(), "not found")
@@ -476,7 +483,7 @@ func TestManager_IssueCredential_NoNamespace(t *testing.T) {
 	// Context without namespace
 	ctx := context.Background()
 
-	_, err := manager.IssueCredential(ctx, "token-123", "test-spec", time.Hour, nil)
+	_, err := issueForTest(manager, ctx, "token-123", "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "namespace")
 }
@@ -500,7 +507,7 @@ func TestManager_RevokeByExpiration_Success(t *testing.T) {
 	ctx := createNamespaceContext()
 
 	// Issue a credential first
-	cred, err := manager.IssueCredential(ctx, "token-revoke", "test-spec", time.Hour, nil)
+	cred, err := issueForTest(manager, ctx, "token-revoke", "test-spec", time.Hour, nil)
 	require.NoError(t, err)
 
 	// Driver is automatically created during IssueCredential, no need to manually create it
@@ -615,7 +622,7 @@ func TestManager_IssueCredential_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour, nil)
+			cred, err := issueForTest(manager, ctx, tokenID, "test-spec", time.Hour, nil)
 			results[idx] = cred
 			errs[idx] = err
 		}(i)
@@ -680,7 +687,7 @@ func TestManager_IssueCredential_Timeout(t *testing.T) {
 
 	ctx := createNamespaceContext()
 
-	_, err := manager.IssueCredential(ctx, "token-timeout", "test-spec", time.Hour, nil)
+	_, err := issueForTest(manager, ctx, "token-timeout", "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 }
@@ -718,12 +725,12 @@ func TestManager_IssueCredential_ErrorNotCached(t *testing.T) {
 	}
 
 	// First request should fail
-	_, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour, nil)
+	_, err := issueForTest(manager, ctx, tokenID, "test-spec", time.Hour, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "transient error")
 
 	// Second request should succeed (error not cached)
-	cred, err := manager.IssueCredential(ctx, tokenID, "test-spec", time.Hour, nil)
+	cred, err := issueForTest(manager, ctx, tokenID, "test-spec", time.Hour, nil)
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 
@@ -818,7 +825,7 @@ func TestManager_WriteBack_StripsReservedKeyAndPersists(t *testing.T) {
 		}, nil, time.Hour, "", nil
 	}
 
-	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
+	cred, err := issueForTest(manager, createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 
 	// The reserved rotated-token keys must be stripped before parsing.
@@ -847,7 +854,7 @@ func TestManager_WriteBack_RotatingWithoutExpiry_KeepsPriorExpiry(t *testing.T) 
 		return map[string]interface{}{"api_key": "at-new", RawRotatedRefreshTokenKey: "rt-new"}, nil, time.Hour, "", nil
 	}
 
-	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
+	_, err := issueForTest(manager, createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 
 	require.Len(t, configStore.persisted, 1)
@@ -866,7 +873,7 @@ func TestManager_WriteBack_NonRotating_NoPersist(t *testing.T) {
 		return map[string]interface{}{"api_key": "at-1"}, nil, time.Hour, "", nil
 	}
 
-	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
+	_, err := issueForTest(manager, createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 	assert.Empty(t, configStore.persisted, "non-rotating mint must not persist")
 }
@@ -892,7 +899,7 @@ func TestManager_InvalidGrant_RetriesOnceWithReloadedSpec(t *testing.T) {
 		return map[string]interface{}{"api_key": "at-ok"}, nil, time.Hour, "", nil
 	}
 
-	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
+	cred, err := issueForTest(manager, createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "at-ok", cred.Data["api_key"])
 	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts), "must mint exactly twice (one retry)")
@@ -909,7 +916,7 @@ func TestManager_InvalidGrant_RetryFailsOnce_SurfacesError(t *testing.T) {
 		return nil, nil, 0, "", ErrRefreshTokenRejected // never recovers
 	}
 
-	_, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
+	_, err := issueForTest(manager, createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrRefreshTokenRejected))
 	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts), "retry is bounded to exactly one extra attempt")
@@ -926,7 +933,7 @@ func TestManager_WriteBack_PersistError_DoesNotFailIssuance(t *testing.T) {
 	}
 
 	// A persist failure must not fail issuance — the access token is still valid.
-	cred, err := manager.IssueCredential(createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
+	cred, err := issueForTest(manager, createNamespaceContext(), "tok-1", "gh", time.Hour, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "at-new", cred.Data["api_key"])
 }
@@ -1049,11 +1056,11 @@ func TestManager_IssueCredential_ExchangeInputs_DistinctCache(t *testing.T) {
 	inA := exchangeInputsFor("subject-A")
 	inB := exchangeInputsFor("subject-B")
 
-	credA1, err := manager.IssueCredential(ctx, sharedToken, "ex-spec", time.Hour, inA)
+	credA1, err := issueForTest(manager, ctx, sharedToken, "ex-spec", time.Hour, inA)
 	require.NoError(t, err)
-	credA2, err := manager.IssueCredential(ctx, sharedToken, "ex-spec", time.Hour, inA)
+	credA2, err := issueForTest(manager, ctx, sharedToken, "ex-spec", time.Hour, inA)
 	require.NoError(t, err)
-	credB, err := manager.IssueCredential(ctx, sharedToken, "ex-spec", time.Hour, inB)
+	credB, err := issueForTest(manager, ctx, sharedToken, "ex-spec", time.Hour, inB)
 	require.NoError(t, err)
 
 	// Same inputs → cached (one mint); different inputs → separate credential.
@@ -1074,12 +1081,12 @@ func TestManager_IssueCredential_ExchangeInputs_NonExchangeDriver(t *testing.T) 
 	configStore.AddSpec(&CredSpec{Name: "test-spec", Type: TypeVaultToken, Source: "test-source", Config: map[string]string{}})
 
 	ctx := createNamespaceContext()
-	_, err := manager.IssueCredential(ctx, "tok", "test-spec", time.Hour, exchangeInputsFor("s"))
+	_, err := issueForTest(manager, ctx, "tok", "test-spec", time.Hour, exchangeInputsFor("s"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not accept token-exchange inputs")
 
 	// Nothing should have been cached; a retry must error again (not serve a stale entry).
-	_, err = manager.IssueCredential(ctx, "tok", "test-spec", time.Hour, exchangeInputsFor("s"))
+	_, err = issueForTest(manager, ctx, "tok", "test-spec", time.Hour, exchangeInputsFor("s"))
 	require.Error(t, err)
 	assert.Equal(t, int32(0), factory.driver.mintCalls.Load(), "plain mint must never run for exchange inputs")
 }
@@ -1111,14 +1118,14 @@ func TestManager_IssueCredential_LazySubject_MintOnMissZeroOnHit(t *testing.T) {
 	ctx := createNamespaceContext()
 	var mintCount atomic.Int32
 
-	cred1, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour,
+	cred1, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour,
 		lazyExchangeInputsFor("id-alice", "assertion-1", &mintCount))
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), mintCount.Load(), "a cache miss must mint exactly once")
 	assert.Equal(t, "assertion-1", cred1.Data["username"], "the resolved token must reach the driver")
 
 	// Fresh inputs (per-request), same identity → cache hit.
-	cred2, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour,
+	cred2, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour,
 		lazyExchangeInputsFor("id-alice", "assertion-2", &mintCount))
 	require.NoError(t, err)
 	assert.Equal(t, cred1.CredentialID, cred2.CredentialID, "same identity must hit cache")
@@ -1152,14 +1159,14 @@ func TestManager_IssueCredential_LazyActor_MintOnMissZeroOnHit(t *testing.T) {
 		}
 	}
 
-	cred1, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, makeInputs("actor-1"))
+	cred1, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour, makeInputs("actor-1"))
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), actorMint.Load(), "a cache miss must mint the actor exactly once")
 	assert.Equal(t, "actor-1", factory.driver.gotInputs.ActorToken, "the resolved actor token must reach the driver")
 	assert.Equal(t, "eyJ.user", cred1.Data["username"], "the eager subject reaches the driver unchanged")
 
 	// Fresh inputs (per-request), same identity → cache hit, no further work.
-	cred2, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, makeInputs("actor-2"))
+	cred2, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour, makeInputs("actor-2"))
 	require.NoError(t, err)
 	assert.Equal(t, cred1.CredentialID, cred2.CredentialID, "same identity must hit cache")
 	assert.Equal(t, int32(1), actorMint.Load(), "a cache HIT must not mint the actor")
@@ -1174,10 +1181,10 @@ func TestManager_IssueCredential_LazySubject_DistinctIdentities(t *testing.T) {
 	ctx := createNamespaceContext()
 	var mintCount atomic.Int32
 
-	credA, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour,
+	credA, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour,
 		lazyExchangeInputsFor("id-alice", "assertion-A", &mintCount))
 	require.NoError(t, err)
-	credB, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour,
+	credB, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour,
 		lazyExchangeInputsFor("id-bob", "assertion-B", &mintCount))
 	require.NoError(t, err)
 
@@ -1216,7 +1223,7 @@ func TestManager_IssueCredential_LazySubject_SingleflightCoalesces(t *testing.T)
 				},
 			}
 			<-start
-			results[i], errs[i] = manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, in)
+			results[i], errs[i] = issueForTest(manager, ctx, "tok", "ex-spec", time.Hour, in)
 		}(i)
 	}
 	close(start)
@@ -1255,13 +1262,13 @@ func TestManager_IssueCredential_LazySubject_ResolveErrorNotCached(t *testing.T)
 		}
 	}
 
-	_, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, makeInputs())
+	_, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour, makeInputs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to resolve subject token")
 	assert.Equal(t, int32(0), factory.driver.exchangeCount.Load(), "driver must not run when the mint fails")
 
 	// The error was not cached: a retry re-runs the closure and succeeds.
-	cred, err := manager.IssueCredential(ctx, "tok", "ex-spec", time.Hour, makeInputs())
+	cred, err := issueForTest(manager, ctx, "tok", "ex-spec", time.Hour, makeInputs())
 	require.NoError(t, err)
 	assert.Equal(t, "assertion-ok", cred.Data["username"])
 	assert.Equal(t, int32(1), factory.driver.exchangeCount.Load())

--- a/credential/minting_service.go
+++ b/credential/minting_service.go
@@ -109,6 +109,42 @@ func (s *MintingService) MintWithCleanup(
 	return nil
 }
 
+// MintFromSecretWithCleanup mints a credential from secret material Warden fetched
+// via credential chaining, with the same orphaned-lease cleanup as MintWithCleanup.
+// The driver must implement ChainedSecretMinter; a driver that does not fails closed
+// rather than silently minting under a chained-config spec.
+func (s *MintingService) MintFromSecretWithCleanup(
+	ctx context.Context,
+	driver SourceDriver,
+	spec *CredSpec,
+	material SecretMaterial,
+	onSuccess func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error,
+) error {
+	csm, ok := driver.(ChainedSecretMinter)
+	if !ok {
+		return fmt.Errorf("source driver %q does not support secret_spec chaining", driver.Type())
+	}
+
+	rawData, metadata, leaseTTL, leaseID, err := csm.MintFromSecret(ctx, spec, material)
+	if err != nil {
+		return fmt.Errorf("failed to mint from secret: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success && leaseID != "" {
+			s.revokeOrphanedLease(driver, leaseID, spec.Source)
+		}
+	}()
+
+	if err := onSuccess(rawData, metadata, leaseTTL, leaseID); err != nil {
+		return err
+	}
+
+	success = true
+	return nil
+}
+
 // revokeOrphanedLease attempts to revoke a lease that was minted but not successfully processed.
 // This is a best-effort operation that logs errors but does not fail the overall operation.
 // Uses a fresh background context since the original context may have been cancelled.

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -257,3 +257,20 @@ type ExchangeMinter interface {
 	// inputs. The return contract matches SourceDriver.MintCredential.
 	MintCredentialWithExchange(ctx context.Context, spec *CredSpec, inputs *ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
 }
+
+// ChainedSecretMinter is an optional interface for secret-backed drivers that can
+// mint a credential from secret material Warden fetched on their behalf via
+// credential chaining (secret_spec). Instead of holding a standing secret, the
+// consuming spec references another cred spec; the minting layer mints that spec as
+// the caller, extracts the material, and hands it here. The minting layer
+// type-asserts for this interface and fails closed if a chained spec targets a
+// driver that does not implement it.
+//
+// A driver implementing this interface asserts it at compile time:
+//
+//	var _ credential.ChainedSecretMinter = (*GitHubDriver)(nil)
+type ChainedSecretMinter interface {
+	// MintFromSecret mints a credential using the given fetched secret material.
+	// The return contract matches SourceDriver.MintCredential.
+	MintFromSecret(ctx context.Context, spec *CredSpec, material SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
+}

--- a/credential/type.go
+++ b/credential/type.go
@@ -92,6 +92,17 @@ type Type interface {
 	FieldSchemas() map[string]*CredentialFieldSchema
 }
 
+// PrimaryFieldProvider is an optional interface a credential Type implements to
+// expose its primary data field. Credential chaining's field discovery uses it as a
+// fallback: when a consuming spec sets no secret_field and the referenced
+// credential has more than one data key, the referenced type's primary field
+// selects the secret (e.g. api_key). Types with no single primary field (like the
+// generic key_value type) simply do not implement it.
+type PrimaryFieldProvider interface {
+	// PrimaryField returns the name of the type's primary data field, or "".
+	PrimaryField() string
+}
+
 // ConnectGated is an optional interface a credential Type implements when some of
 // its specs require a one-time interactive `cred spec connect` step before they
 // can mint (e.g. OAuth2 authorization_code). Connect-gating is derived from the

--- a/credential/types/base_token_type.go
+++ b/credential/types/base_token_type.go
@@ -129,3 +129,9 @@ func (t *BaseTokenType) Revoke(ctx context.Context, cred *credential.Credential,
 func (t *BaseTokenType) FieldSchemas() map[string]*credential.CredentialFieldSchema {
 	return t.FieldConfig.FieldSchemas
 }
+
+// PrimaryField returns the type's primary data field (credential.PrimaryFieldProvider),
+// used by credential-chaining field discovery as a fallback secret selector.
+func (t *BaseTokenType) PrimaryField() string {
+	return t.FieldConfig.PrimaryField
+}

--- a/credential/types/github_token.go
+++ b/credential/types/github_token.go
@@ -92,6 +92,12 @@ func (t *GitHubTokenCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("permissions").
 			Describe("Comma-separated list of permissions for App installation tokens").
 			Example("contents:read,issues:write"),
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Name of a credential spec that yields the secret (App private key or PAT) instead of storing it inline (credential chaining)").
+			Example("github-app-key"),
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Which key of the referenced secret_spec's data holds the secret; optional when the payload is single-key").
+			Example("private_key"),
 	}
 }
 
@@ -115,7 +121,11 @@ func (t *GitHubTokenCredType) ValidateConfig(config map[string]string, sourceTyp
 
 	// Step 3: Conditional validation based on source and auth_method
 	if sourceType == credential.SourceTypeLocal {
-		// Local source: must have static token, auth_method not needed
+		// Local source: must have static token, auth_method not needed. A local
+		// source has no keyless path, so credential chaining does not apply.
+		if config[credential.ConfigSecretSpec] != "" {
+			return fmt.Errorf("secret_spec (credential chaining) is not supported with a local source")
+		}
 		if config["token"] == "" {
 			return fmt.Errorf("'token' is required for local source")
 		}
@@ -128,23 +138,35 @@ func (t *GitHubTokenCredType) ValidateConfig(config map[string]string, sourceTyp
 		return fmt.Errorf("'auth_method' is required for github source")
 	}
 
+	// When secret_spec is set, the secret (App private key or PAT) is fetched from
+	// the referenced spec at mint time rather than stored inline; the inline secret
+	// field must then be absent.
+	chained := config[credential.ConfigSecretSpec] != ""
+
 	// Conditional validation based on auth_method
 	switch authMethod {
 	case "app":
-		// Validate required App fields
+		// App identifiers are non-secret and always required.
 		if config["app_id"] == "" {
 			return fmt.Errorf("'app_id' is required when auth_method is app")
-		}
-		if config["private_key"] == "" {
-			return fmt.Errorf("'private_key' is required when auth_method is app")
 		}
 		if config["installation_id"] == "" {
 			return fmt.Errorf("'installation_id' is required when auth_method is app")
 		}
+		if chained {
+			if config["private_key"] != "" {
+				return fmt.Errorf("'private_key' and 'secret_spec' are mutually exclusive (the private key is fetched from the referenced secret_spec)")
+			}
+		} else if config["private_key"] == "" {
+			return fmt.Errorf("'private_key' (or 'secret_spec') is required when auth_method is app")
+		}
 	case "pat":
-		// Validate required PAT field
-		if config["token"] == "" {
-			return fmt.Errorf("'token' is required when auth_method is pat")
+		if chained {
+			if config["token"] != "" {
+				return fmt.Errorf("'token' and 'secret_spec' are mutually exclusive (the token is fetched from the referenced secret_spec)")
+			}
+		} else if config["token"] == "" {
+			return fmt.Errorf("'token' (or 'secret_spec') is required when auth_method is pat")
 		}
 	}
 

--- a/credential/types/github_token_test.go
+++ b/credential/types/github_token_test.go
@@ -102,6 +102,61 @@ func TestGitHubTokenCredType_ValidateConfig(t *testing.T) {
 			wantErr:    true,
 			errMsg:     "must be valid PEM format",
 		},
+		// --- GitHub source: credential chaining (secret_spec) ---
+		{
+			name: "github app chained - valid (no inline private_key)",
+			config: map[string]string{
+				"auth_method":               "app",
+				"app_id":                    "12345",
+				"installation_id":           "67890",
+				credential.ConfigSecretSpec: "gh-key-secret",
+			},
+			sourceType: credential.SourceTypeGitHub,
+			wantErr:    false,
+		},
+		{
+			name: "github app chained - inline private_key and secret_spec are mutually exclusive",
+			config: map[string]string{
+				"auth_method":               "app",
+				"app_id":                    "12345",
+				"installation_id":           "67890",
+				"private_key":               testPEM,
+				credential.ConfigSecretSpec: "gh-key-secret",
+			},
+			sourceType: credential.SourceTypeGitHub,
+			wantErr:    true,
+			errMsg:     "mutually exclusive",
+		},
+		{
+			name: "github pat chained - valid (no inline token)",
+			config: map[string]string{
+				"auth_method":               "pat",
+				credential.ConfigSecretSpec: "gh-pat-secret",
+			},
+			sourceType: credential.SourceTypeGitHub,
+			wantErr:    false,
+		},
+		{
+			name: "github pat chained - inline token and secret_spec are mutually exclusive",
+			config: map[string]string{
+				"auth_method":               "pat",
+				"token":                     "ghp_xxxxxxx",
+				credential.ConfigSecretSpec: "gh-pat-secret",
+			},
+			sourceType: credential.SourceTypeGitHub,
+			wantErr:    true,
+			errMsg:     "mutually exclusive",
+		},
+		{
+			name: "local source rejects secret_spec",
+			config: map[string]string{
+				"token":                     "ghp_xxxxxxx",
+				credential.ConfigSecretSpec: "gh-pat-secret",
+			},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    true,
+			errMsg:     "not supported with a local source",
+		},
 		// --- GitHub source: pat mode ---
 		{
 			name: "github pat - valid config",


### PR DESCRIPTION
## Summary

Makes the **secret-backed** credential providers keyless *at Warden*. A consuming source/spec references another cred spec via **`secret_spec`**; Warden mints that referenced spec **as the same caller** (fresh `warden_identity` assertion), extracts the secret material, and hands it to the consuming driver through a new **`ChainedSecretMinter`** interface. The fetched secret is **never cached** — it is minted via the non-caching internal path and discarded after material extraction.

## Why (benefits)

- **No standing secret at rest** in Warden's barrier for chained specs — no key trove to dump if the process is compromised (defeats the LiteLLM-honeypot class); the secret only transits memory at mint time.
- **Custody, rotation, revocation move to the backend.** Warden stores no copy, so a rotated upstream secret takes effect on the next mint with no Warden change, and there is no long-lived credential to steal.
- **Blast radius splits across trust domains:** Warden mints identity, the backend enforces policy. With spec-level per-target scoping the assertion carries `warden_resource`, so a role binds to exactly one resource.
- **Real attribution + audit:** the referenced spec is minted with the caller's `warden_identity`, so the backend's audit/policy see the actual caller, and every read is an active, per-request, authorized, audited event.
- Reuses the entire spec/source/mint/cache/federation stack — no bespoke resolver framework; any secret backend works by being referenced.

## What's in it

- `credential/chaining.go` — `secret_spec`/`secret_field` keys, `SecretMaterial`, `Caller`, one-hop depth guard.
- Manager `issueChained` — mints the referenced spec via the non-caching path, materializes subject+actor tokens, leaseless backstop, secret-field discovery. Static-credential cache entries are now capped at the session TTL.
- New interfaces: `ChainedSecretMinter` (`MintFromSecret`) and `PrimaryFieldProvider`.
- Config-store guards — create-time (session-pinned subject, one hop, no double-exchange, consumer eligibility) and a delete guard (`ErrSpecInUse`).
- **GitHub reference implementation** (app + pat) via `MintFromSecret`.

## Threat model

Eliminates secret-at-rest exposure for chained specs. Does **not** protect against a fully-compromised running Warden (it can still mint assertions and pull any secret its roles allow) — the reduction is that reads become active, audited, policy- and time-bounded, and the identity key can be externalized to a separate trust domain from the secrets.

## Tests

Material flow, the no-cache invariant, per-caller isolation, depth guard, fail-closed on non-chained drivers, leaseless backstop, secret-field selection, and the create/delete guards.

## Stack

Second of three stacked PRs (base: **#472**, now merged → this targets `main`):
1. ~~kv2_read + key_value~~ (#472, merged)
2. **this PR** — credential chaining + GitHub reference
3. GitHub `auth_method` → `mint_method` rename (follows)

_Note: a `[Unreleased]` New Features CHANGELOG entry for chaining is not yet included._