### PR TITLE
feat(credential): per-user credential chaining via secondary transparent auth

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -110,6 +110,25 @@ type Auth struct {
 	// Actor chain — the verified RFC 8693 "act" delegation chain from the
 	// authenticated token (the JWT "act" claim per RFC 8693 §4.1).
 	Actors []ActorRef `json:"actors,omitempty"`
+
+	// User is the secondary (user) principal the agent acted for, captured by
+	// secondary transparent authentication. Present only when a user credential
+	// was resolved for the request; nil otherwise. Identity only — the raw user
+	// credential is never logged.
+	User *UserAttribution `json:"user,omitempty"`
+}
+
+// UserAttribution records the secondary (user) principal in an audit entry so a
+// per-user credential mint is attributable to the human it was performed for. It
+// carries identity only — the raw user credential is never logged.
+type UserAttribution struct {
+	// Subject is the user's raw principal (their auth-method subject, e.g. the
+	// JWT sub) — the same value carried as warden_user.sub in the assertion.
+	Subject string `json:"subject,omitempty"`
+	// TokenID is the user token's hash-based ID (safe to log).
+	TokenID string `json:"token_id,omitempty"`
+	// NamespaceID is the user token's namespace.
+	NamespaceID string `json:"namespace_id,omitempty"`
 }
 
 // ActorRef identifies one party in the RFC 8693 "act" delegation chain

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -293,12 +293,32 @@ func (c *Core) buildRequestAuditEntry(
 		Request:   buildAuditRequest(req, ns),
 		Auth:      buildAuditAuth(auth, te),
 	}
+	stampUserAttribution(entry, req)
 
 	if outerErr != nil {
 		entry.Error = outerErr.Error()
 	}
 
 	return entry
+}
+
+// stampUserAttribution records the secondary (user) principal onto an audit
+// entry's Auth block for per-user attribution — so a mint performed for a user is
+// traceable to that user. It is a no-op when the request carried no user
+// principal. Identity only: the raw user credential is never logged.
+func stampUserAttribution(entry *audit.LogEntry, req *logical.Request) {
+	if entry == nil || req == nil || req.User == nil || req.User.TokenEntry == nil {
+		return
+	}
+	if entry.Auth == nil {
+		entry.Auth = &audit.Auth{}
+	}
+	ute := req.User.TokenEntry
+	entry.Auth.User = &audit.UserAttribution{
+		Subject:     ute.PrincipalID,
+		TokenID:     ute.ID,
+		NamespaceID: ute.NamespaceID,
+	}
 }
 
 // buildResponseAuditEntry creates an audit.LogEntry for a response
@@ -324,6 +344,7 @@ func (c *Core) buildResponseAuditEntry(
 		Auth:      buildAuditAuth(auth, te),
 		Response:  buildAuditResponse(resp, req, cred),
 	}
+	stampUserAttribution(entry, req)
 
 	// Capture error from multiple sources:
 	// 1. outerErr - errors from request processing (e.g., routing errors)

--- a/core/oidc_issuer.go
+++ b/core/oidc_issuer.go
@@ -368,6 +368,13 @@ type AssertionClaims struct {
 	// claim naming the single downstream resource the assertion targets, so a
 	// verifier evaluating bound claims can pin it to one resource. Opaque string.
 	Resource string
+	// UserClaims, when non-empty, is embedded under a single nested "warden_user"
+	// claim identifying the secondary (user) principal the agent acts on behalf of
+	// — its identity "sub" plus operator-allowlisted, size-capped user attributes.
+	// Nested (never splatted at the top level) so it cannot clobber a registered or
+	// warden_* claim. The assertion `sub` stays the AGENT; a verifier's templated
+	// policy scopes the authorized path on warden_user, keeping the agent binding.
+	UserClaims map[string]string
 }
 
 // MintIdentityAssertion signs a short-lived JWT with the alg-selected signing key,
@@ -409,19 +416,26 @@ func (i *OIDCIssuer) MintIdentityAssertion(ctx context.Context, te *logical.Toke
 
 	now := time.Now()
 	claims := map[string]interface{}{
-		"iss":               issuerURL,
+		"iss": issuerURL,
+		// sub is the composite Warden subject "wid:{ns_id}:{mount_accessor}:{principal_id}"; warden_sub below
+		// carries the raw principal id on its own, so a verifier can bind the principal
+		// directly without having to parse the composite sub.
 		"sub":               wardenSubject(te),
 		"aud":               c.Audience,
 		"iat":               now.Unix(),
 		"nbf":               now.Add(-leeway).Unix(),
 		"exp":               now.Add(c.TTL).Unix(),
 		"jti":               jti,
+		"warden_sub":        te.PrincipalID,
 		"warden_role":       te.RoleName,
 		"warden_namespace":  te.NamespacePath,
 		"warden_auth_mount": te.MountAccessor,
 	}
 	if len(c.Metadata) > 0 {
 		claims["warden_metadata"] = c.Metadata
+	}
+	if len(c.UserClaims) > 0 {
+		claims["warden_user"] = c.UserClaims
 	}
 	if c.Resource != "" {
 		claims["warden_resource"] = c.Resource

--- a/core/oidc_issuer_test.go
+++ b/core/oidc_issuer_test.go
@@ -1005,3 +1005,49 @@ func TestRotateOIDCKey_NoFloorWithoutPublisher(t *testing.T) {
 	require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, nil, time.Minute, defaultRetiredKeyGrace))
 	assert.Less(t, time.Since(start), 300*time.Millisecond, "no publisher means no propagation floor")
 }
+
+// TestOIDCIssuer_Mint_WardenUserAndSubClaims verifies that warden_sub always
+// carries the raw agent principal (while sub carries the composite wid subject),
+// and that a UserClaims projection rides under a nested warden_user claim (with the
+// user's own raw sub) while the assertion's own sub/warden_sub stay the agent.
+func TestOIDCIssuer_Mint_WardenUserAndSubClaims(t *testing.T) {
+	const issuerURL = "https://warden-oidc.example.com"
+	iss := newReadyIssuer(t, issuerURL)
+	jwks := serveJWKS(t, iss)
+	te := &logical.TokenEntry{PrincipalID: "agent-principal", RoleName: "r", NamespaceID: "n", MountAccessor: "m"}
+	const audience = "https://vault.example.com"
+
+	ctx := context.Background()
+	keySet, err := jwt.NewJSONWebKeySet(ctx, jwks.URL, "")
+	require.NoError(t, err)
+	validator, err := jwt.NewValidator(keySet)
+	require.NoError(t, err)
+	expected := jwt.Expected{Issuer: issuerURL, Audiences: []string{audience}, SigningAlgorithms: []jwt.Alg{jwt.RS256}}
+
+	// warden_sub is always the raw agent principal; sub carries the composite wid:.
+	base, err := iss.MintIdentityAssertion(ctx, te, AssertionClaims{Audience: audience, TTL: 5 * time.Minute, Alg: oidcAlgRS256})
+	require.NoError(t, err)
+	claims, err := validator.Validate(ctx, base, expected)
+	require.NoError(t, err)
+	assert.Equal(t, "agent-principal", claims["warden_sub"], "warden_sub must be the raw principal")
+	assert.Equal(t, wardenSubject(te), claims["sub"], "sub must be the composite wid subject")
+	_, present := claims["warden_user"]
+	assert.False(t, present, "warden_user must be absent without UserClaims")
+
+	// With UserClaims: nested warden_user carries the user's own sub + projected
+	// claims, while the assertion's sub/warden_sub stay the AGENT.
+	withUser, err := iss.MintIdentityAssertion(ctx, te, AssertionClaims{
+		Audience: audience, TTL: 5 * time.Minute, Alg: oidcAlgRS256,
+		UserClaims: map[string]string{"sub": "alice-raw-sub", "username": "alice"},
+	})
+	require.NoError(t, err)
+	claims, err = validator.Validate(ctx, withUser, expected)
+	require.NoError(t, err)
+	assert.Equal(t, wardenSubject(te), claims["sub"], "assertion sub stays the agent composite")
+	assert.Equal(t, "agent-principal", claims["warden_sub"], "warden_sub stays the agent principal")
+	wu, ok := claims["warden_user"].(map[string]interface{})
+	require.True(t, ok, "warden_user missing or wrong type: %v", claims["warden_user"])
+	assert.Equal(t, "alice-raw-sub", wu["sub"])
+	assert.Equal(t, "alice", wu["username"])
+	assert.Len(t, wu, 2)
+}

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -901,6 +901,24 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 				}
 			}
 		}
+
+		// Secondary transparent authentication: resolve the per-request USER
+		// principal (identity only) from a second request header when the
+		// provider or namespace configures user_auth_path. It runs upfront —
+		// before CheckToken and thus before the CBP decision — so the user is a
+		// first-class, already-validated principal by the time authorization and
+		// minting run. Skipped for stream-unauthenticated requests, which bypass
+		// CheckToken, minting, and audit entirely.
+		if !req.StreamUnauthenticated {
+			if err := c.captureUserContext(ctx, req, matchingBackend); err != nil {
+				c.logger.Warn("secondary user authentication failed",
+					logger.Err(err),
+					logger.String("path", req.Path),
+					logger.String("request_id", req.RequestID),
+				)
+				return logical.ErrorResponse(logical.ErrUnauthorized(err.Error())), nil, nil
+			}
+		}
 	}
 
 	var auth *logical.Auth
@@ -1239,6 +1257,35 @@ func projectAssertionMetadata(md map[string]string, keys []string) (map[string]s
 	return projected, string(encoded), nil
 }
 
+// projectUserClaims selects the operator-allowlisted keys from the secondary
+// (user) principal's login-derived metadata for the nested warden_user assertion
+// claim and for per-user secret_path templating. Unlike projectAssertionMetadata it
+// FAILS CLOSED on an absent key: warden_user scopes a security-sensitive downstream
+// path (a templated policy / a per-user secret path), so a named-but-missing claim
+// must deny rather than silently widen the scope. Returns the projected map, which
+// is empty-key → nil.
+func projectUserClaims(md map[string]string, keys []string) (map[string]string, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	projected := make(map[string]string, len(keys))
+	for _, k := range keys {
+		v, ok := md[k]
+		if !ok {
+			return nil, fmt.Errorf("assertion_user_claims names %q but the user token has no such claim", k)
+		}
+		projected[k] = v
+	}
+	encoded, err := json.Marshal(projected)
+	if err != nil {
+		return nil, fmt.Errorf("marshal user claims: %w", err)
+	}
+	if len(encoded) > maxAssertionMetadataBytes {
+		return nil, fmt.Errorf("user claims exceed %d bytes", maxAssertionMetadataBytes)
+	}
+	return projected, nil
+}
+
 // resolveExchangeInputs derives the token-exchange inputs for the named spec on
 // this request. specName is passed explicitly (rather than taken from te) so it can
 // resolve inputs for a spec other than the caller's bound one — credential chaining
@@ -1288,6 +1335,15 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		return srcCached, nil
 	}
 
+	// The secondary (user) principal, when the request captured one, feeds the
+	// warden_user assertion claim and per-user secret_path templating. Read from the
+	// request — the same object the chaining closure captures, so it is present for a
+	// chained secret-spec too.
+	var userTE *logical.TokenEntry
+	if req.User != nil {
+		userTE = req.User.TokenEntry
+	}
+
 	switch spec.Config[credential.ConfigSubjectTokenSource] {
 	case credential.SourceAuthToken:
 		// Reuse the JWT Warden verified during inbound authentication. It lives
@@ -1319,7 +1375,7 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		// identity as the subject (Workload Identity Federation). Origin verified —
 		// Warden signed it. Minted lazily on a cache miss; fails closed if the
 		// issuer is disabled/not-ready or no audience is available.
-		setup, err := c.buildAssertionSetup(ctx, specName, spec, te, loadSource)
+		setup, err := c.buildAssertionSetup(ctx, specName, spec, te, userTE, loadSource)
 		if err != nil {
 			return nil, err
 		}
@@ -1327,6 +1383,10 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		inputs.SubjectTokenOrigin = credential.ExchangeOriginVerified
 		inputs.SubjectCacheIdentity = setup.cacheIdentity
 		inputs.ResolveSubjectToken = setup.resolve
+		// Surface the projected user claims so the driver can template a per-user
+		// request (e.g. kv2_read's secret_path) — the same projection embedded in the
+		// assertion's warden_user claim. Nil unless the spec set assertion_user_claims.
+		inputs.UserClaims = setup.userClaims
 	default:
 		// SpecRequestsExchange already excluded "none"/absent; any other value
 		// was rejected at spec-validation time.
@@ -1363,7 +1423,7 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		// behalf of the distinct user carried in the subject header (spec validation
 		// requires subject_token_source=header here). Origin verified — Warden minted
 		// it — and, like the subject assertion, minted lazily on a cache miss.
-		setup, err := c.buildAssertionSetup(ctx, specName, spec, te, loadSource)
+		setup, err := c.buildAssertionSetup(ctx, specName, spec, te, userTE, loadSource)
 		if err != nil {
 			return nil, err
 		}
@@ -1371,6 +1431,7 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		inputs.ActorTokenOrigin = credential.ExchangeOriginVerified
 		inputs.ActorCacheIdentity = setup.cacheIdentity
 		inputs.ResolveActorToken = setup.resolve
+		inputs.UserClaims = setup.userClaims
 	default:
 		// No actor requested: drop any default type so Validate's pairing holds.
 		inputs.ActorTokenType = ""
@@ -1384,11 +1445,18 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 
 // assertionSetup holds the parts resolveExchangeInputs needs to configure a
 // warden_identity slot (subject or actor): a stable cache fragment that keys the
-// credential cache in place of the per-request-volatile assertion bytes, and the
-// closure that mints the assertion lazily on a cache miss.
+// credential cache in place of the per-request-volatile assertion bytes, the
+// closure that mints the assertion lazily on a cache miss, and the projected
+// secondary-user claims (empty when the spec discloses no user) that a driver
+// templates its per-user request from.
 type assertionSetup struct {
 	cacheIdentity string
 	resolve       func(ctx context.Context) (string, error)
+	// userClaims is the projected assertion_user_claims map (the same values
+	// embedded in the assertion's warden_user claim), surfaced so the driver can
+	// template a per-user path from them. Nil when the spec sets no
+	// assertion_user_claims.
+	userClaims map[string]string
 }
 
 // buildAssertionSetup validates the OIDC issuer is ready and derives the
@@ -1404,7 +1472,7 @@ type assertionSetup struct {
 // derived from the source; resource is unset→derived, "none"→omitted, else
 // verbatim; metadata is the operator-allowlisted projection (empty→no claim, so
 // the cache key is byte-identical to the no-metadata case).
-func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *credential.CredSpec, te *logical.TokenEntry, loadSource func() (*credential.CredSource, error)) (*assertionSetup, error) {
+func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *credential.CredSpec, te *logical.TokenEntry, userTE *logical.TokenEntry, loadSource func() (*credential.CredSource, error)) (*assertionSetup, error) {
 	issuer := c.OIDCIssuer()
 	if issuer == nil || !issuer.Ready() {
 		return nil, fmt.Errorf("spec %q requires warden_identity but the OIDC issuer is not enabled/ready", specName)
@@ -1452,6 +1520,46 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 		return nil, fmt.Errorf("spec %q: %w", specName, err)
 	}
 
+	// Project the secondary (user) principal into the nested warden_user claim, but
+	// only when the spec opts into disclosure via assertion_user_claims — like
+	// assertion_metadata_claims, a spec that does not ask never leaks user identity
+	// into its assertion. When it asks, a user principal MUST be present and every
+	// named claim MUST resolve; both fail closed, since warden_user scopes a
+	// security-sensitive downstream path. userClaims (the projected values) is
+	// surfaced on the setup so a driver can template a per-user path from it; the
+	// assertion's warden_user additionally carries the user's original sub (the raw
+	// principal, as warden_sub does for the agent — never the Warden composite).
+	// Per-user cache isolation is the manager's ":u:" token-id dimension, so the
+	// user does not enter cacheIdentity here.
+	var userClaims map[string]string
+	if userKeys := credential.AssertionUserClaimKeys(spec.Config); len(userKeys) > 0 {
+		if userTE == nil {
+			return nil, fmt.Errorf("spec %q sets assertion_user_claims but no user principal was presented", specName)
+		}
+		// "sub" names the user's identity principal, not a metadata key — exclude it
+		// from the metadata projection so an operator can list it (to bind
+		// warden_user.sub / template {{user.sub}}) without needing a metadata key
+		// literally named "sub". Listing only "sub" yields an identity-only warden_user.
+		metaKeys := make([]string, 0, len(userKeys))
+		for _, k := range userKeys {
+			if k != "sub" {
+				metaKeys = append(metaKeys, k)
+			}
+		}
+		projectedUser, perr := projectUserClaims(userTE.Metadata, metaKeys)
+		if perr != nil {
+			return nil, fmt.Errorf("spec %q: %w", specName, perr)
+		}
+		// One warden_user map serves BOTH the assertion claim and secret_path
+		// templating, so {{user.sub}} templates exactly the value the policy binds.
+		// The identity sub (the raw principal) is authoritative and set last.
+		userClaims = make(map[string]string, len(projectedUser)+1)
+		for k, v := range projectedUser {
+			userClaims[k] = v
+		}
+		userClaims["sub"] = userTE.PrincipalID
+	}
+
 	// Key the credential cache on the stable identity + audience, NOT the
 	// freshly-minted assertion bytes (which change every request), so one identity
 	// reuses its cached upstream credential. Fold in the resource (it can come from
@@ -1476,13 +1584,15 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 	alg := credential.AssertionAlgorithm(spec.Config)
 	return &assertionSetup{
 		cacheIdentity: cacheIdentity,
+		userClaims:    userClaims,
 		resolve: func(ctx context.Context) (string, error) {
 			return issuer.MintIdentityAssertion(ctx, te, AssertionClaims{
-				Audience: audience,
-				TTL:      issuer.AssertionTTL(),
-				Alg:      alg,
-				Metadata: projected,
-				Resource: resource,
+				Audience:   audience,
+				TTL:        issuer.AssertionTTL(),
+				Alg:        alg,
+				Metadata:   projected,
+				Resource:   resource,
+				UserClaims: userClaims,
 			})
 		},
 	}, nil
@@ -1526,6 +1636,29 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 		tokenTTL = 1 * time.Hour
 	}
 
+	// Identify the secondary (user) principal to the mint pipeline for per-user
+	// credential chaining (identity only). Only the user token id and TTL cross into
+	// the credential package — the token id is the ":u:" cache dimension, and the
+	// manager bounds the credential's cache duration by BOTH principals' TTLs so
+	// revoking or expiring EITHER stops new mints. The user TTL is computed exactly
+	// like the agent's above (1h default for a non-expiring token; expired is an
+	// error). The user's identity/metadata are read from req.User where they are
+	// consumed (the warden_user assertion), not duplicated here.
+	var userCtx *credential.UserContext
+	if req.User != nil && req.User.TokenEntry != nil {
+		ute := req.User.TokenEntry
+		var userTTL time.Duration
+		if !ute.ExpireAt.IsZero() {
+			userTTL = time.Until(ute.ExpireAt)
+			if userTTL <= 0 {
+				return fmt.Errorf("user token has expired")
+			}
+		} else {
+			userTTL = 1 * time.Hour
+		}
+		userCtx = &credential.UserContext{TokenID: ute.ID, TokenTTL: userTTL}
+	}
+
 	// The caller carries the requesting identity through the mint pipeline so a
 	// chained secret-spec (credential chaining) is minted as this same caller.
 	// ResolveInputs resolves token-exchange inputs for an arbitrary spec as this
@@ -1534,6 +1667,7 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 	caller := credential.Caller{
 		TokenID:  te.ID,
 		TokenTTL: tokenTTL,
+		User:     userCtx,
 		ResolveInputs: func(ctx context.Context, specName string) (*credential.ExchangeInputs, error) {
 			return c.resolveExchangeInputs(ctx, req, te, specName)
 		},
@@ -1674,10 +1808,152 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 	return c.performImplicitAuth(ctx, req, autoAuthPath, authRole)
 }
 
-// performImplicitAuth performs implicit authentication by routing through the
-// auth mount the caller's namespace/provider points at, looking up cached
-// tokens, and performing login if needed. Used by both gateway requests and
-// transparent operations.
+// captureUserContext resolves the request's secondary (user) principal and
+// attaches it to req.User when the provider or namespace configures per-user auth
+// (user_auth_path) AND the request actually carries a user credential. It runs
+// upfront — before CheckToken, and therefore before the CBP decision — so the
+// user is a first-class, already-validated principal by the time authorization
+// and minting run. It is IDENTITY-ONLY: it never sets the request's primary token
+// entry (never calls req.SetTokenEntry) and never authorizes the request; the
+// primary/agent token alone does that.
+//
+// A missing user credential is NOT an error here: per-user auth being configured
+// on a provider does not mean every request through it needs a user principal. An
+// absent credential simply leaves req.User nil, and the credential/policy layer
+// fails closed only for flows that actually require the user context (a spec with
+// assertion_user_claims or a templated secret_path). This keeps user-less requests
+// working. What IS fail-closed here is a user credential that is present but
+// unusable: invalid/unauthenticable, cross-namespace, or identical to the agent's
+// own credential. An unset user_auth_path is a no-op — req.User stays nil and the
+// request is byte-identical to before the feature.
+func (c *Core) captureUserContext(ctx context.Context, req *logical.Request, backend logical.Backend) error {
+	userAuthPath, userTokenHeader, userAuthRole := c.resolveUserAuthConfig(ctx, backend)
+	if userAuthPath == "" {
+		return nil // per-user auth not configured — feature off
+	}
+
+	if userTokenHeader == "" {
+		userTokenHeader = logical.DefaultUserTokenHeader
+	}
+	userTokenHeader = http.CanonicalHeaderKey(userTokenHeader)
+
+	userCred := resolveHeaderToken(req.HTTPRequest, userTokenHeader)
+	if userCred == "" {
+		// No user credential presented. Leave req.User nil and let a downstream
+		// flow that genuinely needs the user (assertion_user_claims, a templated
+		// secret_path) fail closed on its own; a flow that does not is unaffected.
+		return nil
+	}
+
+	// Fail closed if the user credential is the agent's own token — a
+	// misconfiguration (or an Authorization-header collision for a JWT-bearer
+	// agent) that would otherwise authenticate the agent as the user.
+	if userCred == req.ClientToken {
+		return fmt.Errorf("the user credential must differ from the agent credential")
+	}
+
+	// The user credential is a bearer secret. Strip it from the request now that it
+	// is captured, so it never proxies to an upstream or lands in an audit header
+	// copy: this covers a custom user_token_header that the static per-provider
+	// strip lists cannot name, and any forwarding path without a Warden strip list.
+	// req.User.RawToken retains the value for the RFC 8693 subject_token path.
+	req.HTTPRequest.Header.Del(userTokenHeader)
+
+	userTE, _, err := c.resolveTransparentIdentity(ctx, req, userAuthPath, userAuthRole, userCred)
+	if err != nil {
+		return fmt.Errorf("user authentication failed: %w", err)
+	}
+
+	// Cross-namespace guard (defense-in-depth): the user must live in the
+	// request's namespace. resolveTransparentIdentity routes through the mount in
+	// the request namespace, so a mismatch should not arise — fail closed if it does.
+	if ns, nsErr := namespace.FromContext(ctx); nsErr == nil && ns != nil && userTE.NamespaceID != ns.ID {
+		return fmt.Errorf("user token namespace %q does not match request namespace %q", userTE.NamespaceID, ns.ID)
+	}
+
+	req.User = &logical.UserPrincipal{
+		TokenEntry: userTE,
+		RawToken:   userCred,
+	}
+	return nil
+}
+
+// resolveUserAuthConfig resolves the secondary (user) auth configuration for a
+// gateway request. The provider is consulted first (a backend that implements
+// logical.UserAuthConfigProvider), then the request namespace's custom metadata
+// (user_auth_path / user_token_header / user_auth_role) — mirroring how primary
+// transparent auth resolves auto_auth_path from the provider or the namespace.
+// Returns an empty path when per-user auth is not configured anywhere.
+func (c *Core) resolveUserAuthConfig(ctx context.Context, backend logical.Backend) (userAuthPath, userTokenHeader, userAuthRole string) {
+	if p, ok := backend.(logical.UserAuthConfigProvider); ok {
+		userAuthPath = p.GetUserAuthPath()
+		userTokenHeader = p.GetUserTokenHeader()
+		userAuthRole = p.GetUserAuthRole()
+	}
+	if userAuthPath == "" {
+		if ns, _ := namespace.FromContext(ctx); ns != nil {
+			userAuthPath = ns.CustomMetadata["user_auth_path"]
+			userTokenHeader = ns.CustomMetadata["user_token_header"]
+			userAuthRole = ns.CustomMetadata["user_auth_role"]
+		}
+	}
+	return userAuthPath, userTokenHeader, userAuthRole
+}
+
+// performImplicitAuth performs implicit authentication for the PRIMARY principal
+// (the agent) by routing the request's own credential through the auth mount the
+// caller's namespace/provider points at. It delegates the credential→TokenEntry
+// resolution to resolveTransparentIdentity and then applies the request mutations
+// that mark the resolved token as this request's primary principal
+// (req.Transparent, req.SetTokenEntry, and the ClientToken assignment). Used by
+// both gateway requests and transparent operations.
+func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, autoAuthPath, authRole string) error {
+	// Mark request as implicit auth
+	req.Transparent = true
+
+	te, clearClientToken, err := c.resolveTransparentIdentity(ctx, req, autoAuthPath, authRole, "")
+	if err != nil {
+		return err
+	}
+
+	// The X.509-SVID case authenticates via a forwarded/TLS cert; drop any stray
+	// non-SVID bearer so the cert-minted token ID becomes ClientToken below.
+	if clearClientToken {
+		req.ClientToken = ""
+	}
+	req.SetTokenEntry(te)
+	// Ensure ClientToken is set so downstream policy checks (fetchCBPAndTokenEntry)
+	// don't short-circuit on the empty-token guard. For JWT transparent auth the
+	// JWT string is already in ClientToken, but for cert transparent auth there is
+	// no token in the request — only a certificate.
+	if req.ClientToken == "" {
+		req.ClientToken = te.ID
+	}
+	return nil
+}
+
+// resolveTransparentIdentity turns a credential into a cached-or-freshly-minted
+// TokenEntry by routing through the auth mount at autoAuthPath: it resolves the
+// mount, selects the registered TransparentTokenType, dispatches on the credential
+// format, checks the transparent-token cache, and performs a singleflight login on
+// a miss. It is the credential→TokenEntry core shared by performImplicitAuth (the
+// primary/agent principal) and the secondary user-principal capture.
+//
+// It performs NO request mutation — no req.Transparent, no req.ClientToken write,
+// no req.SetTokenEntry. Those belong to the primary principal alone and stay in
+// performImplicitAuth; leaking any of them here would promote a secondary principal
+// to primary. req is read only for the login HTTP context (TLS/forwarded cert),
+// client IP, request ID, and cert extraction.
+//
+// credential, when non-empty, is the bearer token to authenticate — the secondary
+// user path passes its header credential here, and the mount must be a bearer
+// format (cert/X.509-SVID are rejected: a header can't carry a client cert). When
+// empty, the credential is taken from the request the way the primary path expects
+// (req.ClientToken for JWT/JWT-SVID, the forwarded/TLS cert for cert/X.509-SVID).
+//
+// clearClientToken is true only for the X.509-SVID (spiffe-cert) case; it signals
+// the primary caller to drop a stray bearer so the cert-minted token ID becomes
+// req.ClientToken. It is meaningless for (and ignored by) the secondary path.
 //
 // Transparent mode precedence rules:
 //
@@ -1714,10 +1990,7 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 //
 // IMPORTANT: The auth role is validated when reusing cached tokens. A token created for
 // credential+Role1 cannot be reused for credential+Role2, as they may have different policies.
-func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, autoAuthPath, authRole string) error {
-	// Mark request as implicit auth
-	req.Transparent = true
-
+func (c *Core) resolveTransparentIdentity(ctx context.Context, req *logical.Request, autoAuthPath, authRole, credential string) (te *TokenEntry, clearClientToken bool, err error) {
 	// Inject client IP into context so validateIPBinding can read it
 	// during cached token lookups. Without this, implicitly-authed tokens
 	// bypass IP binding because the context has no client IP.
@@ -1725,12 +1998,16 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		ctx = context.WithValue(ctx, logical.ClientIPKey, req.ClientIP)
 	}
 
+	// A non-empty credential is the secondary (user) path: the mount must be a
+	// bearer format, and the credential is used verbatim as the bearer token.
+	explicitCred := credential != ""
+
 	// Resolve the auth mount once. mountEntry tells us which TransparentTokenType
 	// serves this mount (via the registry) and supplies the stable mount accessor
 	// that transparent types fold into their cache key.
 	authMountEntry := c.router.MatchingMountEntry(ctx, autoAuthPath)
 	if authMountEntry == nil {
-		return fmt.Errorf("no auth mount registered at %q for implicit auth", autoAuthPath)
+		return nil, false, fmt.Errorf("no auth mount registered at %q for implicit auth", autoAuthPath)
 	}
 	mountAccessor := authMountEntry.Accessor
 
@@ -1740,7 +2017,7 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 	// credential-format sniffing.
 	ttype := c.tokenStore.GetTransparentTokenTypeForAuthMethod(authMountEntry.Type)
 	if ttype == nil {
-		return fmt.Errorf("auth method %q at %q does not support implicit auth", authMountEntry.Type, autoAuthPath)
+		return nil, false, fmt.Errorf("auth method %q at %q does not support implicit auth", authMountEntry.Type, autoAuthPath)
 	}
 
 	var singleflightKey string
@@ -1757,9 +2034,12 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 	// type-specific even when two formats share an extraction case.
 	switch ttype.CredentialFormat() {
 	case "cert":
+		if explicitCred {
+			return nil, false, fmt.Errorf("auth method %q at %q requires a bearer credential, not a TLS client certificate", authMountEntry.Type, autoAuthPath)
+		}
 		clientCert := extractTransparentClientCert(req)
 		if clientCert == nil {
-			return fmt.Errorf("auth method %q at %q requires a TLS client certificate", authMountEntry.Type, autoAuthPath)
+			return nil, false, fmt.Errorf("auth method %q at %q requires a TLS client certificate", authMountEntry.Type, autoAuthPath)
 		}
 		hash := sha256.Sum256(clientCert.Raw)
 		fingerprint := hex.EncodeToString(hash[:])
@@ -1767,14 +2047,23 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		singleflightKey = hex.EncodeToString(sfHash[:])
 		loginData = map[string]any{"role": authRole}
 		credKey = fingerprint
+		// Authenticate via the client certificate, not any bearer. Signal the
+		// primary caller to drop a stray Authorization bearer (ExtractToken falls
+		// back to Authorization, so a cert request that also carries a bearer —
+		// e.g. a secondary user token on Authorization — would otherwise leave that
+		// bearer, not the cert-minted token ID, in ClientToken).
+		clearClientToken = true
 		lookupFunc = func() (*TokenEntry, error) {
 			return c.LookupTransparentTokenWithRole(ctx, ttype, fingerprint, mountAccessor, authRole)
 		}
 
 	case "jwt", "k8s_sa_jwt":
-		clientToken := req.ClientToken
+		clientToken := credential
+		if clientToken == "" {
+			clientToken = req.ClientToken
+		}
 		if !strings.HasPrefix(clientToken, "eyJ") {
-			return fmt.Errorf("auth method %q at %q requires a JWT bearer token", authMountEntry.Type, autoAuthPath)
+			return nil, false, fmt.Errorf("auth method %q at %q requires a JWT bearer token", authMountEntry.Type, autoAuthPath)
 		}
 		sfHash := sha256.Sum256([]byte("jwt:" + mountAccessor + ":" + clientToken + ":" + authRole))
 		singleflightKey = hex.EncodeToString(sfHash[:])
@@ -1792,7 +2081,11 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 		// the JWT path and mis-attribute a JWT-SVID workload to the cert
 		// identity. A JWT-SVID is a bearer JWT whose (unverified) sub is a
 		// spiffe:// ID; the mount re-verifies it against the trust-domain bundle.
-		if clientToken := req.ClientToken; isSPIFFEJWTSVID(clientToken) {
+		clientToken := credential
+		if clientToken == "" {
+			clientToken = req.ClientToken
+		}
+		if isSPIFFEJWTSVID(clientToken) {
 			sfHash := sha256.Sum256([]byte("spiffe-jwt:" + mountAccessor + ":" + clientToken + ":" + authRole))
 			singleflightKey = hex.EncodeToString(sfHash[:])
 			loginData = map[string]any{"jwt": clientToken, "role": authRole}
@@ -1800,6 +2093,10 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 			lookupFunc = func() (*TokenEntry, error) {
 				return c.LookupTransparentTokenWithRole(ctx, ttype, clientToken, mountAccessor, authRole)
 			}
+		} else if explicitCred {
+			// The secondary (user) path is bearer-only; an X.509-SVID can't ride a
+			// header, so a non-SVID credential here is a misconfigured user mount.
+			return nil, false, fmt.Errorf("auth method %q at %q requires a JWT-SVID bearer credential", authMountEntry.Type, autoAuthPath)
 		} else if clientCert := extractTransparentClientCert(req); clientCert != nil {
 			hash := sha256.Sum256(clientCert.Raw)
 			fingerprint := hex.EncodeToString(hash[:])
@@ -1807,19 +2104,19 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 			singleflightKey = hex.EncodeToString(sfHash[:])
 			loginData = map[string]any{"role": authRole}
 			credKey = fingerprint
-			// Authenticate via the X.509-SVID, not any bearer. Clear a stray
-			// non-SVID bearer so the cert-minted token ID becomes ClientToken
-			// downstream (the shared reset below only fires when it is empty).
-			req.ClientToken = ""
+			// Authenticate via the X.509-SVID, not any bearer. Signal the primary
+			// caller to clear a stray non-SVID bearer so the cert-minted token ID
+			// becomes ClientToken (this function performs no request mutation).
+			clearClientToken = true
 			lookupFunc = func() (*TokenEntry, error) {
 				return c.LookupTransparentTokenWithRole(ctx, ttype, fingerprint, mountAccessor, authRole)
 			}
 		} else {
-			return fmt.Errorf("auth method %q at %q requires an X.509-SVID (TLS/forwarded cert) or a JWT-SVID bearer token", authMountEntry.Type, autoAuthPath)
+			return nil, false, fmt.Errorf("auth method %q at %q requires an X.509-SVID (TLS/forwarded cert) or a JWT-SVID bearer token", authMountEntry.Type, autoAuthPath)
 		}
 
 	default:
-		return fmt.Errorf("auth method %q has unsupported credential format %q for implicit auth", authMountEntry.Type, ttype.CredentialFormat())
+		return nil, false, fmt.Errorf("auth method %q has unsupported credential format %q for implicit auth", authMountEntry.Type, ttype.CredentialFormat())
 	}
 
 	// Step 1: Try cached lookup
@@ -1828,21 +2125,15 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 	// the token TTL (default 1h) bounds the exposure window. Explicit login requests
 	// always perform full revocation checks. To reduce exposure for revoked certs,
 	// configure a shorter token_ttl on cert roles.
-	te, err := lookupFunc()
+	te, err = lookupFunc()
 	if err == nil && te != nil {
-		req.SetTokenEntry(te)
-		// For cert auth, ClientToken is empty since the client only sends a certificate.
-		// Set it to the token ID so downstream policy checks don't reject it.
-		if req.ClientToken == "" {
-			req.ClientToken = te.ID
-		}
-		return nil
+		return te, clearClientToken, nil
 	}
 
 	// IP binding violation means the token exists but the client IP doesn't match.
 	// Return the error immediately — don't fall through and create a new token.
 	if err == ErrOriginViolation {
-		return err
+		return nil, false, err
 	}
 
 	// Step 2: Token not found — perform implicit auth with singleflight
@@ -1898,21 +2189,13 @@ func (c *Core) performImplicitAuth(ctx context.Context, req *logical.Request, au
 
 	if err != nil {
 		c.transparentAuthGroup.Forget(singleflightKey)
-		return err
+		return nil, false, err
 	}
 
 	te = result.(*TokenEntry)
 	_ = shared
 
-	req.SetTokenEntry(te)
-	// Ensure ClientToken is set so downstream policy checks (fetchCBPAndTokenEntry)
-	// don't short-circuit on the empty-token guard. For JWT transparent auth the
-	// JWT string is already in ClientToken, but for cert transparent auth there is
-	// no token in the request — only a certificate.
-	if req.ClientToken == "" {
-		req.ClientToken = te.ID
-	}
-	return nil
+	return te, clearClientToken, nil
 }
 
 // isSPIFFEJWTSVID reports whether token is a JWT whose unverified subject is a

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2804,3 +2804,89 @@ func TestResolveExchangeInputs_WardenIdentity_IssuerNotReadyFailsClosed(t *testi
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enabled/ready")
 }
+
+// parseJWTClaimsForTest decodes a JWT's (unverified) claim set for assertions.
+func parseJWTClaimsForTest(t *testing.T, token string) map[string]interface{} {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]interface{}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	return claims
+}
+
+// TestResolveExchangeInputs_WardenUserClaims covers the per-user federation path:
+// a warden_identity subject spec with assertion_user_claims projects the user into
+// inputs.UserClaims (for driver templating) and into the assertion's warden_user
+// claim, while the assertion's own sub stays the AGENT. It also covers the sub-only
+// opt-in and the fail-closed cases.
+func TestResolveExchangeInputs_WardenUserClaims(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	c.oidcIssuer = newReadyIssuer(t, "https://warden-oidc.example")
+	seedSpec(t, c, ctx, "wid-user", map[string]string{
+		credential.ConfigSubjectTokenSource:  credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:   "https://vault.example/aud",
+		credential.ConfigAssertionUserClaims: "username",
+	})
+	seedSpec(t, c, ctx, "wid-subonly", map[string]string{
+		credential.ConfigSubjectTokenSource:  credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:   "https://vault.example/aud",
+		credential.ConfigAssertionUserClaims: "sub",
+	})
+
+	agentTE := &logical.TokenEntry{CredentialSpec: "wid-user", PrincipalID: "agent-bot", NamespaceID: "ns1", MountAccessor: "auth_jwt_1"}
+	userTE := &logical.TokenEntry{PrincipalID: "alice-sub", NamespaceID: "ns1", MountAccessor: "auth_user", Metadata: map[string]string{"username": "alice"}}
+
+	t.Run("projects user claims and emits warden_user; sub stays the agent", func(t *testing.T) {
+		req := requestWith("s.opaque-session", nil)
+		req.User = &logical.UserPrincipal{TokenEntry: userTE}
+		inputs, err := resolveExchangeInputsForTest(c, ctx, req, agentTE)
+		require.NoError(t, err)
+		require.NotNil(t, inputs)
+		// UserClaims (driver templating): projected metadata + the user's raw principal.
+		assert.Equal(t, "alice", inputs.UserClaims["username"])
+		assert.Equal(t, "alice-sub", inputs.UserClaims["sub"], "warden_user.sub is the user's raw principal")
+
+		tok, err := inputs.ResolveSubjectToken(ctx)
+		require.NoError(t, err)
+		claims := parseJWTClaimsForTest(t, tok)
+		assert.Equal(t, wardenSubject(agentTE), claims["sub"], "assertion sub stays the AGENT composite")
+		assert.Equal(t, "agent-bot", claims["warden_sub"], "warden_sub is the agent's raw principal")
+		wu, ok := claims["warden_user"].(map[string]interface{})
+		require.True(t, ok, "warden_user missing: %v", claims["warden_user"])
+		assert.Equal(t, "alice", wu["username"])
+		assert.Equal(t, "alice-sub", wu["sub"])
+	})
+
+	t.Run("sub-only opt-in yields identity-only warden_user", func(t *testing.T) {
+		subOnlyAgent := &logical.TokenEntry{CredentialSpec: "wid-subonly", PrincipalID: "agent-bot", NamespaceID: "ns1", MountAccessor: "auth_jwt_1"}
+		req := requestWith("s.opaque-session", nil)
+		req.User = &logical.UserPrincipal{TokenEntry: userTE}
+		inputs, err := resolveExchangeInputsForTest(c, ctx, req, subOnlyAgent)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"sub": "alice-sub"}, inputs.UserClaims, "sub-only opt-in needs no metadata key named sub")
+	})
+
+	t.Run("assertion_user_claims set but no user principal fails closed", func(t *testing.T) {
+		req := requestWith("s.opaque-session", nil) // no req.User
+		_, err := resolveExchangeInputsForTest(c, ctx, req, agentTE)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no user principal")
+	})
+
+	t.Run("absent named claim fails closed", func(t *testing.T) {
+		seedSpec(t, c, ctx, "wid-missing", map[string]string{
+			credential.ConfigSubjectTokenSource:  credential.SourceWardenIdentity,
+			credential.ConfigAssertionAudience:   "https://vault.example/aud",
+			credential.ConfigAssertionUserClaims: "department",
+		})
+		missAgent := &logical.TokenEntry{CredentialSpec: "wid-missing", PrincipalID: "agent-bot", NamespaceID: "ns1", MountAccessor: "auth_jwt_1"}
+		req := requestWith("s.opaque-session", nil)
+		req.User = &logical.UserPrincipal{TokenEntry: userTE} // has username, not department
+		_, err := resolveExchangeInputsForTest(c, ctx, req, missAgent)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "department")
+	})
+}

--- a/core/request_handler_user_test.go
+++ b/core/request_handler_user_test.go
@@ -1,0 +1,327 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/listener"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockUserAuthProvider extends the transparent-mode mock with the secondary
+// (user) auth config, so captureUserContext / resolveUserAuthConfig can read
+// user_auth_path etc. off the backend via logical.UserAuthConfigProvider.
+type mockUserAuthProvider struct {
+	mockTransparentModeProvider
+	userAuthPath    string
+	userTokenHeader string
+	userAuthRole    string
+}
+
+func (m *mockUserAuthProvider) GetUserAuthPath() string    { return m.userAuthPath }
+func (m *mockUserAuthProvider) GetUserTokenHeader() string { return m.userTokenHeader }
+func (m *mockUserAuthProvider) GetUserAuthRole() string    { return m.userAuthRole }
+
+// seedUserToken caches a transparent JWT-role token on the given mount so a later
+// resolveTransparentIdentity call resolves it from cache without a login.
+func seedUserToken(t *testing.T, core *Core, ctx context.Context, mount *MountEntry, jwt, role, principal string) *TokenEntry {
+	t.Helper()
+	te, err := core.tokenStore.GenerateToken(ctx, TypeJWTRole, &AuthData{
+		TokenValue:    jwt,
+		MountAccessor: mount.Accessor,
+		RoleName:      role,
+		PrincipalID:   principal,
+		ExpireAt:      time.Now().Add(time.Hour),
+		Policies:      []string{"default"},
+	})
+	require.NoError(t, err)
+	return te
+}
+
+// TestResolveTransparentIdentity_NoRequestMutation asserts the factored resolver
+// performs NONE of performImplicitAuth's request mutations: it must not set
+// req.Transparent, must not write req.ClientToken, and must not set the primary
+// token entry. Those belong to the primary principal alone — leaking any would
+// promote the secondary (user) principal to primary.
+func TestResolveTransparentIdentity_NoRequestMutation(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	mount := mountStubAuthMethod(t, core, "user-jwt/", "jwt")
+	userJWT := mintK8sJWT(`{"sub":"alice"}`)
+	userTE := seedUserToken(t, core, ctx, mount, userJWT, "slack-user", "alice")
+
+	const agentToken = "agent-primary-token" // opaque; resolver never reads it
+	req := &logical.Request{
+		ClientToken: agentToken,
+		HTTPRequest: httptest.NewRequest(http.MethodPost, "/v1/slack-mcp/role/agent/gateway", nil),
+	}
+
+	te, clearClientToken, err := core.resolveTransparentIdentity(ctx, req, "auth/user-jwt/", "slack-user", userJWT)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+	assert.Equal(t, userTE.ID, te.ID)
+	assert.False(t, clearClientToken, "the JWT path never signals a ClientToken clear")
+
+	// No request mutation.
+	assert.Nil(t, req.TokenEntry(), "must not set the primary token entry")
+	assert.False(t, req.Transparent, "must not mark the request transparent")
+	assert.Equal(t, agentToken, req.ClientToken, "must not overwrite the agent ClientToken")
+	assert.Nil(t, req.User, "resolveTransparentIdentity does not attach req.User")
+}
+
+// TestPerformImplicitAuth_CertClearsStrayBearer asserts a cert-authenticated
+// primary principal ends up with its cert-minted token ID in ClientToken even when
+// the request also carries a stray Authorization bearer (e.g. a secondary user
+// token). Without the clear, that bearer would pollute ClientToken and, among
+// other things, false-trip the secondary-user "must differ from the agent
+// credential" guard for the documented Authorization opt-in.
+func TestPerformImplicitAuth_CertClearsStrayBearer(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	mount := mountStubAuthMethod(t, core, "cert/", "cert")
+	cert, fingerprint := spiffeFakeCert("agent-cert-der")
+	te, err := core.tokenStore.GenerateToken(ctx, TypeCertRole, &AuthData{
+		TokenValue:    fingerprint,
+		MountAccessor: mount.Accessor,
+		RoleName:      "agent",
+		PrincipalID:   "cn=agent",
+		ExpireAt:      time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/vault/role/agent/gateway", nil)
+	httpReq = httpReq.WithContext(listener.WithForwardedClientCert(httpReq.Context(), cert))
+	strayBearer := mintK8sJWT(`{"sub":"stray-user-token"}`)
+	req := &logical.Request{HTTPRequest: httpReq, ClientToken: strayBearer}
+
+	backend := &mockTransparentModeProvider{transparentMode: true, autoAuthPath: "auth/cert/"}
+	require.NoError(t, core.handleTransparentAuth(ctx, req, backend, "agent"))
+	require.NotNil(t, req.TokenEntry())
+	assert.Equal(t, te.ID, req.TokenEntry().ID)
+	assert.Equal(t, te.ID, req.ClientToken, "cert auth must set ClientToken to the token ID, not the stray bearer")
+}
+
+// TestCaptureUserContext exercises the secondary-user capture fail-closed matrix
+// and the identity-only guarantee.
+func TestCaptureUserContext(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	userMount := mountStubAuthMethod(t, core, "user-jwt/", "jwt")
+	userJWT := mintK8sJWT(`{"sub":"alice"}`)
+	userTE := seedUserToken(t, core, ctx, userMount, userJWT, "slack-user", "alice")
+
+	newReq := func(agentToken string, headers map[string]string) *logical.Request {
+		hr := httptest.NewRequest(http.MethodPost, "/v1/slack-mcp/role/agent/gateway", nil)
+		for k, v := range headers {
+			hr.Header.Set(k, v)
+		}
+		return &logical.Request{ClientToken: agentToken, HTTPRequest: hr}
+	}
+
+	t.Run("feature off when no user_auth_path", func(t *testing.T) {
+		backend := &mockUserAuthProvider{} // userAuthPath empty
+		req := newReq("agent-tok", map[string]string{"X-Warden-User-Token": userJWT})
+		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		assert.Nil(t, req.User, "unconfigured feature is a no-op")
+	})
+
+	t.Run("absent user credential is not an error", func(t *testing.T) {
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/"}
+		req := newReq("agent-tok", nil) // no user header
+		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		assert.Nil(t, req.User, "no user credential → req.User stays nil, no error")
+	})
+
+	t.Run("valid user credential attaches req.User (identity only)", func(t *testing.T) {
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/", userAuthRole: "slack-user"}
+		req := newReq("agent-primary-token", map[string]string{"X-Warden-User-Token": userJWT})
+		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		require.NotNil(t, req.User)
+		assert.Equal(t, userTE.ID, req.User.TokenEntry.ID)
+		assert.Equal(t, userJWT, req.User.RawToken)
+		// Identity-only: the primary principal is untouched.
+		assert.Nil(t, req.TokenEntry(), "user capture must not set the primary token entry")
+		assert.False(t, req.Transparent)
+		assert.Equal(t, "agent-primary-token", req.ClientToken)
+		// The raw user credential is scrubbed from the request so it can't proxy
+		// upstream or land in an audit header copy (req.User.RawToken retains it).
+		assert.Empty(t, req.HTTPRequest.Header.Get("X-Warden-User-Token"), "user header must be stripped after capture")
+	})
+
+	t.Run("custom user_token_header is scrubbed after capture", func(t *testing.T) {
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/", userTokenHeader: "X-User-Jwt", userAuthRole: "slack-user"}
+		req := newReq("agent-primary-token", map[string]string{"X-User-Jwt": userJWT})
+		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		require.NotNil(t, req.User)
+		assert.Empty(t, req.HTTPRequest.Header.Get("X-User-Jwt"), "a custom user header the static strip lists cannot name must still be scrubbed")
+	})
+
+	t.Run("Authorization user header for a cert-authenticated agent", func(t *testing.T) {
+		// A cert agent's ClientToken is its token ID (not a bearer), so the user
+		// token riding Authorization does NOT trip the user==agent guard. This is
+		// the documented cert/SPIFFE opt-in; it only works because the primary cert
+		// path clears any stray Authorization bearer (see the cert dispatch).
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/", userTokenHeader: "Authorization", userAuthRole: "slack-user"}
+		req := newReq("agent-cert-token-id", map[string]string{"Authorization": "Bearer " + userJWT})
+		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		require.NotNil(t, req.User)
+		assert.Equal(t, userTE.ID, req.User.TokenEntry.ID)
+		assert.Empty(t, req.HTTPRequest.Header.Get("Authorization"), "Authorization user header is scrubbed after capture")
+	})
+
+	t.Run("namespace-metadata config drives capture", func(t *testing.T) {
+		nsWithMeta := &namespace.Namespace{
+			ID:   namespace.RootNamespaceID,
+			Path: namespace.RootNamespace.Path,
+			CustomMetadata: map[string]string{
+				"user_auth_path": "auth/user-jwt/",
+				"user_auth_role": "slack-user",
+			},
+		}
+		nsCtx := namespace.ContextWithNamespace(context.Background(), nsWithMeta)
+		// A plain transparent backend that does NOT implement UserAuthConfigProvider,
+		// so the config must come from the namespace metadata.
+		backend := &mockTransparentModeProvider{}
+		req := newReq("agent-primary-token", map[string]string{"X-Warden-User-Token": userJWT})
+		require.NoError(t, core.captureUserContext(nsCtx, req, backend))
+		require.NotNil(t, req.User)
+		assert.Equal(t, userTE.ID, req.User.TokenEntry.ID)
+	})
+
+	t.Run("user credential equal to the agent credential fails closed", func(t *testing.T) {
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/"}
+		req := newReq(userJWT, map[string]string{"X-Warden-User-Token": userJWT})
+		err := core.captureUserContext(ctx, req, backend)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must differ from the agent credential")
+		assert.Nil(t, req.User)
+	})
+
+	t.Run("non-bearer user credential fails closed", func(t *testing.T) {
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/"}
+		req := newReq("agent-tok", map[string]string{"X-Warden-User-Token": "not-a-jwt"})
+		err := core.captureUserContext(ctx, req, backend)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user authentication failed")
+		assert.Nil(t, req.User)
+	})
+
+	t.Run("cert-format user mount rejected (bearer required)", func(t *testing.T) {
+		mountStubAuthMethod(t, core, "user-cert/", "cert")
+		backend := &mockUserAuthProvider{userAuthPath: "auth/user-cert/"}
+		req := newReq("agent-tok", map[string]string{"X-Warden-User-Token": userJWT})
+		err := core.captureUserContext(ctx, req, backend)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bearer credential")
+		assert.Nil(t, req.User)
+	})
+}
+
+// TestResolveUserAuthConfig covers the provider-then-namespace precedence for the
+// secondary-user auth configuration.
+func TestResolveUserAuthConfig(t *testing.T) {
+	core := createTestCore(t)
+
+	t.Run("provider config wins", func(t *testing.T) {
+		ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+		backend := &mockUserAuthProvider{userAuthPath: "auth/prov/", userTokenHeader: "X-Prov", userAuthRole: "prov-role"}
+		p, h, r := core.resolveUserAuthConfig(ctx, backend)
+		assert.Equal(t, "auth/prov/", p)
+		assert.Equal(t, "X-Prov", h)
+		assert.Equal(t, "prov-role", r)
+	})
+
+	t.Run("namespace metadata fallback", func(t *testing.T) {
+		ns := &namespace.Namespace{ID: "ns1", Path: "ns1/", CustomMetadata: map[string]string{
+			"user_auth_path":    "auth/nsuser/",
+			"user_token_header": "X-NS",
+			"user_auth_role":    "ns-role",
+		}}
+		ctx := namespace.ContextWithNamespace(context.Background(), ns)
+		p, h, r := core.resolveUserAuthConfig(ctx, &mockUserAuthProvider{}) // provider unset
+		assert.Equal(t, "auth/nsuser/", p)
+		assert.Equal(t, "X-NS", h)
+		assert.Equal(t, "ns-role", r)
+	})
+
+	t.Run("unset everywhere yields empty", func(t *testing.T) {
+		ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+		p, _, _ := core.resolveUserAuthConfig(ctx, &mockUserAuthProvider{})
+		assert.Empty(t, p, "no provider/namespace config → feature off")
+	})
+}
+
+// TestStampUserAttribution verifies the first observable consumer of req.User:
+// the request audit entry records the user identity for attribution, and never
+// the raw user credential.
+func TestStampUserAttribution(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	userMount := mountStubAuthMethod(t, core, "user-jwt/", "jwt")
+	userJWT := mintK8sJWT(`{"sub":"alice"}`)
+	userTE := seedUserToken(t, core, ctx, userMount, userJWT, "slack-user", "alice")
+
+	t.Run("stamps the user identity when req.User is set", func(t *testing.T) {
+		req := &logical.Request{
+			User: &logical.UserPrincipal{TokenEntry: userTE, RawToken: userJWT},
+		}
+		entry := core.buildRequestAuditEntry(ctx, req, &logical.Auth{}, nil, nil)
+		require.NotNil(t, entry.Auth)
+		require.NotNil(t, entry.Auth.User)
+		// Subject is the user's raw principal (JWT sub), not the wid composite —
+		// it matches warden_user.sub in the minted assertion.
+		assert.Equal(t, userTE.PrincipalID, entry.Auth.User.Subject)
+		assert.NotContains(t, entry.Auth.User.Subject, "wid:", "user attribution must be the raw sub, not the wid composite")
+		assert.Equal(t, userTE.ID, entry.Auth.User.TokenID)
+		assert.Equal(t, userTE.NamespaceID, entry.Auth.User.NamespaceID)
+
+		// The raw user credential must never be serialized into an audit record.
+		blob, err := json.Marshal(entry)
+		require.NoError(t, err)
+		assert.NotContains(t, string(blob), userJWT, "raw user credential must never be serialized")
+	})
+
+	t.Run("no user attribution when req.User is nil", func(t *testing.T) {
+		req := &logical.Request{}
+		entry := core.buildRequestAuditEntry(ctx, req, &logical.Auth{}, nil, nil)
+		if entry.Auth != nil {
+			assert.Nil(t, entry.Auth.User)
+		}
+	})
+}
+
+// TestProjectUserClaims covers the fail-closed user-claim projection: absent keys
+// deny (unlike the metadata projection, which skips), and the size cap holds.
+func TestProjectUserClaims(t *testing.T) {
+	md := map[string]string{"username": "alice", "email": "alice@example.com"}
+
+	t.Run("empty keys projects nothing", func(t *testing.T) {
+		got, err := projectUserClaims(md, nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+	t.Run("projects named keys", func(t *testing.T) {
+		got, err := projectUserClaims(md, []string{"username"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"username": "alice"}, got)
+	})
+	t.Run("absent key fails closed", func(t *testing.T) {
+		_, err := projectUserClaims(md, []string{"username", "department"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "department")
+	})
+	t.Run("oversized projection fails closed", func(t *testing.T) {
+		big := map[string]string{"k": strings.Repeat("x", maxAssertionMetadataBytes)}
+		_, err := projectUserClaims(big, []string{"k"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceed")
+	})
+}

--- a/credential/chaining.go
+++ b/credential/chaining.go
@@ -57,6 +57,37 @@ type Caller struct {
 	// is nil on non-request code paths, in which case a chained secret-spec that
 	// needs exchange fails closed at mint time.
 	ResolveInputs func(ctx context.Context, specName string) (*ExchangeInputs, error)
+
+	// User is the secondary (user) principal for per-user credential chaining, or
+	// nil for an agent-only request. It is identity for scoping only — never an
+	// authorizer — and carries just the user token id, the one datum the manager
+	// (this package) needs and cannot reach across the import boundary. The user's
+	// identity (wardenSubject) and login-derived metadata are NOT duplicated here:
+	// core reads them from the request's user token entry at the point of use (the
+	// warden_user assertion claim and the audit stamp). Built by core.
+	User *UserContext
+}
+
+// UserContext identifies the secondary (user) principal to the mint pipeline. It
+// deliberately carries only the token id and TTL, NOT a *logical.TokenEntry: the
+// logical package already imports credential (logical.Request.Credential is a
+// *credential.Credential), so a token entry on a credential type would form a
+// credential→logical→credential import cycle. Anything richer about the user
+// (identity subject, metadata) is read by core from the request's user token entry
+// where it is consumed (the warden_user assertion claim), not projected here.
+type UserContext struct {
+	// TokenID is the user token's ID — the per-user credential-cache dimension,
+	// mirroring the agent's Caller.TokenID (both principals keyed by token id, not
+	// identity, so the entry is bound to the token lifecycle: revoking or
+	// re-logging-in the user yields a new id and thus a fresh mint).
+	TokenID string
+
+	// TokenTTL is the user token's remaining lifetime, mirroring the agent's
+	// Caller.TokenTTL. The manager bounds the chained credential's cache/lease
+	// duration by it alongside the agent's TokenTTL, so revoking or expiring EITHER
+	// principal evicts the entry and stops new mints. Zero means "no bound from the
+	// user side".
+	TokenTTL time.Duration
 }
 
 // chainDepthCtxKey carries the current secret_spec recursion depth on the context.

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -46,6 +46,7 @@ const (
 var _ credential.SourceDriver = (*OAuth2Driver)(nil)
 var _ credential.SpecVerifier = (*OAuth2Driver)(nil)
 var _ credential.OAuth2Authorizer = (*OAuth2Driver)(nil)
+var _ credential.ChainedSecretMinter = (*OAuth2Driver)(nil)
 
 // OAuth2Driver exchanges OAuth2 credentials for bearer tokens.
 //
@@ -321,6 +322,16 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 spec %q is not connected — run `warden cred spec connect %s`", name, spec.Name, spec.Name)
 	}
 
+	return d.refreshGrant(ctx, spec, refreshToken)
+}
+
+// refreshGrant exchanges a refresh token for a fresh access token
+// (grant_type=refresh_token). The refresh token is passed in explicitly so the
+// same grant serves both the spec-sealed refresh token (mintFromRefreshToken) and
+// a chained refresh token fetched from another spec (MintFromSecret).
+func (d *OAuth2Driver) refreshGrant(ctx context.Context, spec *credential.CredSpec, refreshToken string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	name := d.displayName()
+
 	clientID := d.resolve(spec, "client_id", "")
 	clientSecret := d.resolve(spec, "client_secret", "")
 	if clientID == "" || clientSecret == "" {
@@ -358,6 +369,37 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 		}
 	}
 	return rawData, d.extractMetadata(ctx, spec, tokenResp.AccessToken), ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
+}
+
+// MintFromSecret implements credential.ChainedSecretMinter: it mints a Slack-style
+// OAuth2 access token from a refresh token supplied as chained secret material
+// (e.g. a per-user refresh token read from Vault by an upstream kv2_read spec)
+// rather than from the spec's own sealed config. Rotation write-back is not
+// supported for the chained path (the material is read-only), so this works with
+// non-rotating refresh tokens; a rotated token is surfaced in rawData but the
+// minting layer has nowhere to persist it back to.
+func (d *OAuth2Driver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	refreshToken := material.Secret()
+	if refreshToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 chained mint: the referenced secret_spec yielded no refresh token", d.displayName())
+	}
+	rawData, metadata, ttl, leaseID, err := d.refreshGrant(ctx, spec, refreshToken)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	// The chained refresh token is read-only material fetched from another spec, so
+	// a provider-rotated replacement has nowhere to be persisted back to. Strip the
+	// reserved rotation keys (the chained mint path has no write-back consumer for
+	// them) and warn loudly — this path works only with non-rotating refresh tokens.
+	if _, rotated := rawData[credential.RawRotatedRefreshTokenKey]; rotated {
+		delete(rawData, credential.RawRotatedRefreshTokenKey)
+		delete(rawData, credential.RawRotatedRefreshTokenExpiresAtKey)
+		if d.logger != nil {
+			d.logger.Warn(fmt.Sprintf("%s OAuth2 provider rotated the chained refresh token, but the secret_spec chain cannot persist it; the next mint reuses the stored token and may fail once the provider invalidates the old one", d.displayName()),
+				logger.String("spec", spec.Name))
+		}
+	}
+	return rawData, metadata, ttl, leaseID, nil
 }
 
 // ExchangeAuthorizationCode exchanges an authorization code for tokens using the

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -1363,3 +1363,49 @@ func TestOAuth2Driver_ExtractMetadata_IntrospectionURL_SpecLevelIgnored(t *testi
 	assert.False(t, called, "spec-level introspection_url must not be called")
 	assert.Nil(t, metadata, "opaque token + no source introspection_url → no metadata")
 }
+
+// TestOAuth2Driver_MintFromSecret covers the ChainedSecretMinter path: minting a
+// Slack-style access token from a refresh token supplied as chained secret
+// material (e.g. a per-user refresh token read from Vault), not from spec config.
+func TestOAuth2Driver_MintFromSecret(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		assert.Equal(t, "chained-refresh-token", r.Form.Get("refresh_token"))
+		assert.Equal(t, "test-id", r.Form.Get("client_id"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "slack-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	d := &OAuth2Driver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeOAuth2,
+			Config: map[string]string{
+				"client_id":     "test-id",
+				"client_secret": "test-secret",
+				"token_url":     server.URL,
+			},
+		},
+		httpClient: server.Client(),
+	}
+	spec := &credential.CredSpec{Name: "slack-access", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	t.Run("mints access token from chained refresh token", func(t *testing.T) {
+		material := credential.SecretMaterial{Data: map[string]string{"refresh_token": "chained-refresh-token"}, Field: "refresh_token"}
+		rawData, _, ttl, _, err := d.MintFromSecret(context.Background(), spec, material)
+		require.NoError(t, err)
+		assert.Equal(t, "slack-access-token", rawData["api_key"])
+		assert.Equal(t, 3600*time.Second, ttl)
+	})
+
+	t.Run("empty material fails closed", func(t *testing.T) {
+		_, _, _, _, err := d.MintFromSecret(context.Background(), spec, credential.SecretMaterial{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no refresh token")
+	})
+}

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -355,7 +356,9 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 
 	switch mintMethod {
 	case "static_aws", "static_apikey", "kv2_read":
-		return d.fetchStaticKVSecret(ctx, d.vault, spec)
+		// Non-federation path carries no user context; a templated secret_path here
+		// fails closed in resolveSecretPath (no claims to satisfy {{user.…}}).
+		return d.fetchStaticKVSecret(ctx, d.vault, spec, nil)
 	case "dynamic_aws":
 		return d.fetchDynamicAWSCreds(ctx, d.vault, spec)
 	case "dynamic_gcp":
@@ -448,7 +451,7 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 	)
 	switch mintMethod {
 	case "static_aws", "static_apikey", "kv2_read":
-		rawData, metadata, leaseTTL, _, err = d.fetchStaticKVSecret(ctx, client, spec)
+		rawData, metadata, leaseTTL, _, err = d.fetchStaticKVSecret(ctx, client, spec, inputs.UserClaims)
 		// A static read holds no lease that depends on the login token — best-effort
 		// revoke it so a transient session is not left behind.
 		defer d.revokeLoginToken(loginAuth.Accessor, client)
@@ -555,13 +558,80 @@ func (d *VaultDriver) revokeLoginToken(accessor string, client *api.Client) {
 	}
 }
 
-// fetchStaticKVSecret fetches static secrets from Vault KV v2
-func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Client, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	kv2Mount := credential.GetString(spec.Config, "kv2_mount", "")
-	secretPath := credential.GetString(spec.Config, "secret_path", "")
+// userClaimTemplate matches a {{user.<claim>}} token in secret_path. The claim
+// name is a conservative identifier (letters, digits, '_', '.', '-').
+var userClaimTemplate = regexp.MustCompile(`\{\{user\.([A-Za-z0-9_.-]+)\}\}`)
 
-	if kv2Mount == "" || secretPath == "" {
+// userClaimValuePattern is the strict allow-list a substituted claim value must
+// match before it can be placed into a KV path segment. It excludes '/' (which
+// would let one value span segments) and every other separator. '.' is allowed
+// (e.g. first.last), so a value or adjacent values could still compose a "."/".."
+// segment — that is caught after substitution by the segment check below, not here.
+var userClaimValuePattern = regexp.MustCompile(`^[A-Za-z0-9._@-]+$`)
+
+// resolveSecretPath returns the KV secret path for a kv2_read, substituting any
+// {{user.<claim>}} token from the projected per-user claims. A path with no such
+// token is returned verbatim (byte-identical to the pre-templating behaviour). It
+// FAILS CLOSED when a referenced claim is absent (project it via
+// assertion_user_claims), when a value is empty or not in the strict allow-list,
+// or when the RESOLVED path contains a "." / ".." segment or a leftover template
+// fragment. The last check is the real boundary: the Vault API client runs
+// path.Clean on the request path, so a claim value of "." (which collapses its
+// segment) or two adjacent tokens composing ".." would otherwise silently retarget
+// the read at a shared/parent path — the per-user secret_path must deny instead.
+func resolveSecretPath(rawPath string, userClaims map[string]string) (string, error) {
+	if !strings.Contains(rawPath, "{{user.") {
+		return rawPath, nil
+	}
+	var subErr error
+	resolved := userClaimTemplate.ReplaceAllStringFunc(rawPath, func(match string) string {
+		claim := userClaimTemplate.FindStringSubmatch(match)[1]
+		v, ok := userClaims[claim]
+		if !ok {
+			subErr = fmt.Errorf("secret_path references {{user.%s}} but that claim is absent (project it via assertion_user_claims)", claim)
+			return ""
+		}
+		// The value becomes path bytes: a single non-empty allow-listed token that
+		// cannot span segments (no '/'). Dot-only / traversal segments it might
+		// compose are rejected after substitution.
+		if v == "" || !userClaimValuePattern.MatchString(v) {
+			subErr = fmt.Errorf("secret_path claim %q has a value rejected by the path allow-list", claim)
+			return ""
+		}
+		return v
+	})
+	if subErr != nil {
+		return "", subErr
+	}
+	// A leftover fragment means a malformed token (e.g. a missing brace or an empty
+	// claim name) — fail closed rather than read a literal "{{user.…" path.
+	if strings.Contains(resolved, "{{user.") {
+		return "", fmt.Errorf("secret_path has an unresolved template fragment after substitution")
+	}
+	// Reject any "." or ".." segment the substituted value(s) may have composed —
+	// path.Clean would otherwise resolve it into a different (shared/parent) path.
+	for _, seg := range strings.Split(resolved, "/") {
+		if seg == "." || seg == ".." {
+			return "", fmt.Errorf("secret_path resolves to a %q path segment (traversal)", seg)
+		}
+	}
+	return resolved, nil
+}
+
+// fetchStaticKVSecret fetches static secrets from Vault KV v2. userClaims, when
+// non-nil (a per-user chained mint), supplies the values for any {{user.<claim>}}
+// token in secret_path so the read is scoped to one user's secret.
+func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Client, spec *credential.CredSpec, userClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	kv2Mount := credential.GetString(spec.Config, "kv2_mount", "")
+	rawPath := credential.GetString(spec.Config, "secret_path", "")
+
+	if kv2Mount == "" || rawPath == "" {
 		return nil, nil, 0, "", fmt.Errorf("kv2_mount and secret_path are required for static KV credentials")
+	}
+
+	secretPath, err := resolveSecretPath(rawPath, userClaims)
+	if err != nil {
+		return nil, nil, 0, "", err
 	}
 
 	secret, err := client.KVv2(kv2Mount).Get(ctx, secretPath)

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -1137,3 +1137,48 @@ func TestVaultDriver_MintCredentialWithExchange_UnsupportedMintMethod(t *testing
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not supported over auth_method=oidc_federation")
 }
+
+// TestResolveSecretPath covers per-user secret_path templating and its fail-closed
+// sanitization (the security boundary that keeps one user from reading another's
+// secret or escaping the intended path).
+func TestResolveSecretPath(t *testing.T) {
+	claims := map[string]string{"username": "alice", "email": "alice@example.com", "dept": "eng-team"}
+	tests := []struct {
+		name    string
+		path    string
+		claims  map[string]string
+		want    string
+		wantErr string
+	}{
+		{"no template returned verbatim", "slack/refresh_token", claims, "slack/refresh_token", ""},
+		{"no template needs no claims", "slack/refresh_token", nil, "slack/refresh_token", ""},
+		{"single substitution", "slack/{{user.username}}/refresh_token", claims, "slack/alice/refresh_token", ""},
+		{"multiple tokens resolved", "{{user.username}}/{{user.dept}}", claims, "alice/eng-team", ""},
+		{"email value allowed", "kv/{{user.email}}", claims, "kv/alice@example.com", ""},
+		{"hyphen value allowed", "kv/{{user.dept}}", claims, "kv/eng-team", ""},
+		{"literal dots within a segment allowed", "kv/{{user.username}}", map[string]string{"username": "a..b"}, "kv/a..b", ""},
+		{"absent claim fails closed", "slack/{{user.missing}}/x", claims, "", "absent"},
+		{"nil claims with template fails closed", "slack/{{user.username}}/x", nil, "", "absent"},
+		{"slash in value rejected", "kv/{{user.username}}", map[string]string{"username": "a/b"}, "", "allow-list"},
+		{"curly brace in value rejected", "kv/{{user.username}}", map[string]string{"username": "a{b"}, "", "allow-list"},
+		{"empty value rejected", "kv/{{user.username}}", map[string]string{"username": ""}, "", "allow-list"},
+		// The security boundary: values that compose a "." or ".." segment which the
+		// Vault client's path.Clean would resolve into a shared/parent path.
+		{"dot value collapses a segment", "slack/{{user.username}}/rt", map[string]string{"username": "."}, "", "traversal"},
+		{"dotdot value traverses", "slack/{{user.username}}/rt", map[string]string{"username": ".."}, "", "traversal"},
+		{"adjacent tokens compose dotdot", "slack/{{user.a}}{{user.b}}/rt", map[string]string{"a": ".", "b": "."}, "", "traversal"},
+		{"unresolved fragment fails closed", "slack/{{user.username}/rt", map[string]string{"username": "alice"}, "", "unresolved"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSecretPath(tt.path, tt.claims)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/credential/exchange.go
+++ b/credential/exchange.go
@@ -76,7 +76,8 @@ const (
 // one would either leak the caller's own auth into the exchange or let a caller
 // smuggle a token past validation. Compared canonicalized.
 var internalTokenHeaders = map[string]struct{}{
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Token"): {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Token"):      {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-User-Token"): {},
 }
 
 // SubjectTokenHeaderName returns the canonicalized header name the "header"
@@ -138,7 +139,13 @@ const ConfigAssertionMetadataClaims = "assertion_metadata_claims"
 // value into a de-duplicated, order-preserving list of metadata key names,
 // ignoring blank entries and surrounding whitespace. Returns nil when unset.
 func AssertionMetadataKeys(config map[string]string) []string {
-	raw := config[ConfigAssertionMetadataClaims]
+	return splitClaimKeys(config[ConfigAssertionMetadataClaims])
+}
+
+// splitClaimKeys parses a comma-separated claim-key list into a de-duplicated,
+// order-preserving slice, ignoring blank entries and surrounding whitespace.
+// Returns nil when raw is empty.
+func splitClaimKeys(raw string) []string {
 	if raw == "" {
 		return nil
 	}
@@ -156,6 +163,25 @@ func AssertionMetadataKeys(config map[string]string) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// ConfigAssertionUserClaims is the spec-config key naming which user claims to
+// project into the nested warden_user claim of a warden_identity assertion
+// (comma-separated). warden_user always carries the user's identity "sub" (the raw
+// principal); listing metadata keys additionally projects the user token's
+// login-derived metadata under those names. It scopes a security-sensitive
+// downstream path (a templated Vault policy / a per-user secret_path), so — unlike
+// assertion_metadata_claims — a named-but-absent metadata claim FAILS CLOSED. It is
+// opt-in: absent/empty emits NO warden_user claim (a spec that does not ask never
+// discloses the user); when set it must name at least one claim — list "sub" alone
+// for an identity-only warden_user. Valid only when subject_token_source=warden_identity.
+const ConfigAssertionUserClaims = "assertion_user_claims"
+
+// AssertionUserClaimKeys parses the comma-separated ConfigAssertionUserClaims value
+// into a de-duplicated, order-preserving list of user metadata key names. Returns
+// nil when unset.
+func AssertionUserClaimKeys(config map[string]string) []string {
+	return splitClaimKeys(config[ConfigAssertionUserClaims])
 }
 
 // Assertion signing algorithms selectable per warden_identity spec via
@@ -276,6 +302,14 @@ type ExchangeInputs struct {
 	// Set only by core (resolveExchangeInputs), never from caller input. It is
 	// not hashed by Fingerprint, never logged, and never persisted.
 	ResolveActorToken func(ctx context.Context) (string, error)
+
+	// UserClaims carries the secondary (user) principal's projected claims so a
+	// driver can scope its request per user — the kv2_read driver templates
+	// secret_path from {{user.<claim>}}. Set by core from the same projection that
+	// feeds the warden_user assertion claim. Not hashed by Fingerprint (the cache is
+	// already isolated per user by the ":u:" key dimension); nil for an agent-only
+	// request.
+	UserClaims map[string]string
 }
 
 // Validate performs structural checks only. It does not verify token contents
@@ -437,6 +471,21 @@ func ValidateExchangeSpecConfig(config map[string]string) error {
 	if config[ConfigAssertionMetadataClaims] != "" && !mintsAssertion {
 		return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s'",
 			ConfigAssertionMetadataClaims, SourceWardenIdentity)
+	}
+	// Projecting user claims into the assertion's warden_user claim (which also
+	// scopes a per-user secret_path) only makes sense when Warden mints the assertion.
+	if raw := config[ConfigAssertionUserClaims]; raw != "" {
+		if !mintsAssertion {
+			return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s'",
+				ConfigAssertionUserClaims, SourceWardenIdentity)
+		}
+		// A set-but-empty value (e.g. " , ") parses to zero keys and would silently
+		// disclose nothing while looking configured — reject it. "sub" is allowed: it
+		// is the identity opt-in (warden_user.sub is always the user's raw principal),
+		// projected from identity, not from metadata.
+		if len(AssertionUserClaimKeys(config)) == 0 {
+			return fmt.Errorf("field '%s': must name at least one claim", ConfigAssertionUserClaims)
+		}
 	}
 	// The assertion algorithm only applies to a Warden-minted assertion.
 	if config[ConfigAssertionAlgorithm] != "" && !mintsAssertion {

--- a/credential/exchange_test.go
+++ b/credential/exchange_test.go
@@ -2,6 +2,7 @@ package credential
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -579,5 +580,52 @@ func TestAssertionMetadataKeys(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAssertionUserClaimKeys(t *testing.T) {
+	if got := AssertionUserClaimKeys(map[string]string{}); got != nil {
+		t.Errorf("empty config: got %v, want nil", got)
+	}
+	// Trimmed, de-duplicated, order-preserving.
+	got := AssertionUserClaimKeys(map[string]string{ConfigAssertionUserClaims: " username , email , username "})
+	want := []string{"username", "email"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestValidateExchangeSpecConfig_AssertionUserClaimsGate(t *testing.T) {
+	// Valid: a warden_identity subject mints the assertion the claims ride in.
+	if err := ValidateExchangeSpecConfig(map[string]string{
+		ConfigSubjectTokenSource:  SourceWardenIdentity,
+		ConfigAssertionUserClaims: "username",
+	}); err != nil {
+		t.Fatalf("warden_identity + assertion_user_claims should be valid: %v", err)
+	}
+	// "sub" alone is valid — the identity-only opt-in.
+	if err := ValidateExchangeSpecConfig(map[string]string{
+		ConfigSubjectTokenSource:  SourceWardenIdentity,
+		ConfigAssertionUserClaims: "sub",
+	}); err != nil {
+		t.Fatalf("assertion_user_claims=sub should be valid: %v", err)
+	}
+	// A set-but-empty value (parses to zero keys) is rejected.
+	if err := ValidateExchangeSpecConfig(map[string]string{
+		ConfigSubjectTokenSource:  SourceWardenIdentity,
+		ConfigAssertionUserClaims: " , ",
+	}); err == nil {
+		t.Fatal("whitespace-only assertion_user_claims must be rejected")
+	}
+	// Rejected: a non-minting subject cannot carry warden_user.
+	err := ValidateExchangeSpecConfig(map[string]string{
+		ConfigSubjectTokenSource:  SourceAuthToken,
+		ConfigAssertionUserClaims: "username",
+	})
+	if err == nil {
+		t.Fatal("assertion_user_claims without a warden_identity subject/actor must be rejected")
+	}
+	if !strings.Contains(err.Error(), ConfigAssertionUserClaims) {
+		t.Errorf("error should name the offending field, got: %v", err)
 	}
 }

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -181,6 +181,17 @@ func (m *Manager) IssueCredential(ctx context.Context, caller Caller, specName s
 		cacheKey += ":x:" + inputs.Fingerprint()
 	}
 
+	// Scope the entry to the secondary (user) principal when present, mirroring the
+	// outer key's use of the AGENT's token id (caller.TokenID): both principals are
+	// keyed by token id, not identity, so the entry is bound to the token lifecycle
+	// — revoking or re-logging-in the user yields a new token id and thus a fresh
+	// mint. This dimension is independent of the exchange fingerprint, so a chained
+	// consumer (whose outer key carries no ":x:" fragment) still gets per-user
+	// isolation. Byte-identical when caller.User == nil.
+	if caller.User != nil {
+		cacheKey += ":u:" + caller.User.TokenID
+	}
+
 	// Check cache first. A cached credential that has outlived its lease is
 	// treated as a miss and re-minted: the cache carries no read-time expiry of
 	// its own, and non-revocable credentials (e.g. exchanged bearer tokens) are
@@ -238,24 +249,36 @@ func (m *Manager) IssueCredential(ctx context.Context, caller Caller, specName s
 		cred.TokenID = caller.TokenID
 		cred.SpecName = specName
 
+		// sessionTTL bounds the cached credential's lifetime by the requesting
+		// principals' token lifetimes: the agent (caller.TokenTTL) always caps it,
+		// and for per-user chaining the user (caller.User.TokenTTL) caps it too, so a
+		// cached credential is never served past EITHER principal's expiry. (A
+		// principal revoked mid-session drives no new mint regardless — the request
+		// presenting it fails auth before the cache is consulted.) Zero means "no
+		// session bound" (internal/non-request callers).
+		sessionTTL := caller.TokenTTL
+		if caller.User != nil && caller.User.TokenTTL > 0 && (sessionTTL <= 0 || caller.User.TokenTTL < sessionTTL) {
+			sessionTTL = caller.User.TokenTTL
+		}
+
 		// Cache the credential. Bound a dynamic credential's entry by its remaining
 		// lifetime (capped by the session TTL) so an expired token is actively
 		// evicted rather than lingering; the IsExpired guard on the read path is the
 		// correctness backstop, this keeps memory from accumulating stale entries.
 		if cred.LeaseTTL > 0 {
 			ttl := cred.LeaseTTL
-			if caller.TokenTTL > 0 && caller.TokenTTL < ttl {
-				ttl = caller.TokenTTL
+			if sessionTTL > 0 && sessionTTL < ttl {
+				ttl = sessionTTL
 			}
 			m.cache.SetWithTTL(cacheKey, cred, 1, ttl)
-		} else if caller.TokenTTL > 0 {
+		} else if sessionTTL > 0 {
 			// A static credential (no lease) is still bound to this session: cap its
 			// entry by the session TTL so it self-evicts at session end rather than
 			// lingering until cache pressure. This also bounds a chained static
 			// credential's staleness — a rotated upstream secret is re-fetched at most
 			// one session later. Falls back to an untimed set only when no session TTL
 			// is known (internal/non-request callers).
-			m.cache.SetWithTTL(cacheKey, cred, 1, caller.TokenTTL)
+			m.cache.SetWithTTL(cacheKey, cred, 1, sessionTTL)
 		} else {
 			m.cache.Set(cacheKey, cred, 1)
 		}
@@ -270,7 +293,7 @@ func (m *Manager) IssueCredential(ctx context.Context, caller Caller, specName s
 				ctx,               // Context with namespace
 				cred.CredentialID, // Unique ID for this credential instance (UUID)
 				cacheKey,          // Cache key for cache lookup/deletion
-				caller.TokenTTL,
+				sessionTTL,
 				cred.LeaseID,
 				cred.SourceName,
 				cred.SourceType,

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -1273,3 +1273,39 @@ func TestManager_IssueCredential_LazySubject_ResolveErrorNotCached(t *testing.T)
 	assert.Equal(t, "assertion-ok", cred.Data["username"])
 	assert.Equal(t, int32(1), factory.driver.exchangeCount.Load())
 }
+
+// TestManager_IssueCredential_PerUserCacheDimension verifies the ":u:" cache
+// dimension: two users sharing one agent session token get isolated credentials,
+// the same user hits cache, and a no-user caller keys distinctly (byte-identical
+// to the pre-feature key).
+func TestManager_IssueCredential_PerUserCacheDimension(t *testing.T) {
+	manager, configStore, factory := createTestManager(t)
+	defer manager.Stop()
+
+	configStore.AddSource(&CredSource{Name: "test-source", Type: SourceTypeLocal, Config: map[string]string{}})
+	configStore.AddSpec(&CredSpec{Name: "test-spec", Type: TypeVaultToken, Source: "test-source", Config: map[string]string{}})
+
+	ctx := createNamespaceContext()
+	const agentTok = "shared-agent-token"
+	callerA := Caller{TokenID: agentTok, TokenTTL: time.Hour, User: &UserContext{TokenID: "user-A-tok", TokenTTL: time.Hour}}
+	callerB := Caller{TokenID: agentTok, TokenTTL: time.Hour, User: &UserContext{TokenID: "user-B-tok", TokenTTL: time.Hour}}
+
+	// Same user token → cache hit (one mint).
+	credA1, err := manager.IssueCredential(ctx, callerA, "test-spec", nil)
+	require.NoError(t, err)
+	credA2, err := manager.IssueCredential(ctx, callerA, "test-spec", nil)
+	require.NoError(t, err)
+	assert.Equal(t, credA1.CredentialID, credA2.CredentialID, "same user token should hit cache")
+
+	// Different user token on the SAME agent token → isolated credential.
+	credB, err := manager.IssueCredential(ctx, callerB, "test-spec", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, credA1.CredentialID, credB.CredentialID, "distinct user token must not share a credential")
+
+	// No user principal → keyed without the ":u:" dimension, distinct again.
+	credNoUser, err := manager.IssueCredential(ctx, Caller{TokenID: agentTok, TokenTTL: time.Hour}, "test-spec", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, credA1.CredentialID, credNoUser.CredentialID, "a no-user caller must not reuse a user-scoped entry")
+
+	assert.Equal(t, int32(3), factory.driver.mintCalls.Load(), "three distinct cache keys → three mints")
+}

--- a/framework/config.go
+++ b/framework/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"net/textproto"
 	"net/url"
 	"sort"
 	"strconv"
@@ -257,4 +258,57 @@ func ValidateCommonConfig(conf map[string]any) error {
 		return err
 	}
 	return ValidateStringField(conf, "default_role")
+}
+
+// wardenControlHeaders are request headers Warden reads for its own auth/control
+// or token-exchange transport plane. user_token_header must not alias one of these
+// — doing so would either collide with the agent's own credential, feed one header
+// into two consumers, or let a caller smuggle control state. Compared canonicalized.
+// Authorization is intentionally absent: it is a valid (opt-in) user_token_header
+// for cert/SPIFFE-authenticated agents.
+var wardenControlHeaders = map[string]struct{}{
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Token"):         {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Role"):          {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Namespace"):     {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Provider"):      {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Request"):       {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Subject-Token"): {},
+	textproto.CanonicalMIMEHeaderKey("X-Warden-Actor-Token"):   {},
+}
+
+// ValidateUserAuthConfig validates the secondary (user) transparent-auth config
+// fields: user_auth_path, user_token_header, and user_auth_role. It enforces
+// their types, the user_token_header deny-list, and the user_token_header /
+// user_auth_role → user_auth_path dependency (both are meaningless without a
+// user_auth_path and would otherwise be silently discarded). The bearer-format
+// requirement on the referenced mount (a header cannot carry an X.509 client
+// certificate) is enforced at runtime, where mount visibility exists — config
+// validation here has none.
+func ValidateUserAuthConfig(conf map[string]any) error {
+	if err := ValidateStringField(conf, "user_auth_path"); err != nil {
+		return err
+	}
+	if err := ValidateStringField(conf, "user_token_header"); err != nil {
+		return err
+	}
+	if err := ValidateStringField(conf, "user_auth_role"); err != nil {
+		return err
+	}
+
+	path, _ := conf["user_auth_path"].(string)
+
+	if hdr, _ := conf["user_token_header"].(string); hdr != "" {
+		if _, bad := wardenControlHeaders[textproto.CanonicalMIMEHeaderKey(hdr)]; bad {
+			return fmt.Errorf("user_token_header must not alias a Warden control header (%q)", hdr)
+		}
+		if path == "" {
+			return fmt.Errorf("user_token_header requires user_auth_path")
+		}
+	}
+
+	if role, _ := conf["user_auth_role"].(string); role != "" && path == "" {
+		return fmt.Errorf("user_auth_role requires user_auth_path")
+	}
+
+	return nil
 }

--- a/framework/config_test.go
+++ b/framework/config_test.go
@@ -338,3 +338,59 @@ func TestValidateCommonConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "default_role must be a string")
 	})
 }
+
+func TestValidateUserAuthConfig(t *testing.T) {
+	t.Run("empty config is valid (feature off)", func(t *testing.T) {
+		assert.NoError(t, ValidateUserAuthConfig(map[string]any{}))
+	})
+
+	t.Run("all valid fields", func(t *testing.T) {
+		err := ValidateUserAuthConfig(map[string]any{
+			"user_auth_path":    "auth/user-jwt/",
+			"user_token_header": "X-Warden-User-Token",
+			"user_auth_role":    "slack-user",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Authorization is an allowed user_token_header", func(t *testing.T) {
+		err := ValidateUserAuthConfig(map[string]any{
+			"user_auth_path":    "auth/user-jwt/",
+			"user_token_header": "Authorization",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-string user_auth_path", func(t *testing.T) {
+		err := ValidateUserAuthConfig(map[string]any{"user_auth_path": 123})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user_auth_path must be a string")
+	})
+
+	t.Run("user_token_header aliasing a control header is rejected", func(t *testing.T) {
+		// Includes the token-exchange transport headers, which Warden also reads.
+		for _, h := range []string{
+			"X-Warden-Token", "x-warden-token", "X-Warden-Role", "X-Warden-Namespace",
+			"X-Warden-Subject-Token", "X-Warden-Actor-Token",
+		} {
+			err := ValidateUserAuthConfig(map[string]any{
+				"user_auth_path":    "auth/user-jwt/",
+				"user_token_header": h,
+			})
+			require.Errorf(t, err, "header %q must be rejected", h)
+			assert.Contains(t, err.Error(), "must not alias a Warden control header")
+		}
+	})
+
+	t.Run("user_token_header without user_auth_path is rejected", func(t *testing.T) {
+		err := ValidateUserAuthConfig(map[string]any{"user_token_header": "X-User-Jwt"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user_token_header requires user_auth_path")
+	})
+
+	t.Run("user_auth_role without user_auth_path is rejected", func(t *testing.T) {
+		err := ValidateUserAuthConfig(map[string]any{"user_auth_role": "slack-user"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user_auth_role requires user_auth_path")
+	})
+}

--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -58,6 +58,19 @@ type TransparentConfig struct {
 	// PathRewriter converts transparent paths to standard paths (optional)
 	// If nil, uses DefaultPathRewriter: role/X/gateway/... -> gateway/...
 	PathRewriter func(path string) string
+
+	// UserAuthPath is the auth mount that authenticates the secondary (user)
+	// principal from a second request header (secondary transparent auth). Empty
+	// disables per-user auth for this provider. See logical.UserAuthConfigProvider.
+	UserAuthPath string
+
+	// UserTokenHeader is the request header carrying the user credential. Empty
+	// means the default (logical.DefaultUserTokenHeader).
+	UserTokenHeader string
+
+	// UserAuthRole is the role used to authenticate the user credential. Empty
+	// falls back to the user auth mount's own default_role.
+	UserAuthRole string
 }
 
 // unauthPathsEntry holds parsed unauthenticated paths for efficient matching
@@ -655,6 +668,40 @@ func (b *StreamingBackend) GetDefaultAuthRole() string {
 		return ""
 	}
 	return tc.DefaultAuthRole
+}
+
+// UserAuthConfigProvider interface implementation. A StreamingBackend always
+// satisfies logical.UserAuthConfigProvider; per-user auth is off (all getters
+// return "") until a provider's config sets the fields on TransparentConfig.
+
+// GetUserAuthPath returns the auth mount that authenticates the secondary (user)
+// principal, or "" when per-user auth is not configured.
+func (b *StreamingBackend) GetUserAuthPath() string {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
+		return ""
+	}
+	return tc.UserAuthPath
+}
+
+// GetUserTokenHeader returns the request header carrying the user credential,
+// or "" for the default (logical.DefaultUserTokenHeader).
+func (b *StreamingBackend) GetUserTokenHeader() string {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
+		return ""
+	}
+	return tc.UserTokenHeader
+}
+
+// GetUserAuthRole returns the role used to authenticate the user credential,
+// or "" to fall back to the user auth mount's own default_role.
+func (b *StreamingBackend) GetUserAuthRole() string {
+	tc := b.transparentConfig.Load()
+	if tc == nil {
+		return ""
+	}
+	return tc.UserAuthRole
 }
 
 // RewriteTransparentPath rewrites a transparent path to standard path

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -155,6 +155,28 @@ type TransparentModeProvider interface {
 	IsTransparentPath(path string) bool
 }
 
+// UserAuthConfigProvider is implemented by transparent providers that additionally
+// authenticate a secondary, per-request USER principal from a second request header
+// (secondary transparent authentication). It is deliberately kept separate from
+// TransparentModeProvider so that adding per-user auth does not force every
+// transparent provider (and every test fake) to implement it: a provider that does
+// not opt in simply does not satisfy this interface, and req.User stays nil (feature
+// off, request unchanged).
+type UserAuthConfigProvider interface {
+	// GetUserAuthPath returns the auth mount path that authenticates user
+	// credentials (e.g., "auth/user-jwt/"), or "" when per-user auth is not
+	// configured — in which case the feature is off and the request is unchanged.
+	GetUserAuthPath() string
+
+	// GetUserTokenHeader returns the request header carrying the user credential.
+	// Empty means the default (X-Warden-User-Token).
+	GetUserTokenHeader() string
+
+	// GetUserAuthRole returns the role used to authenticate the user credential,
+	// or "" to fall back to the user auth mount's own default_role.
+	GetUserAuthRole() string
+}
+
 // TransparentAuthRoleExtractor can be implemented by providers that extract
 // the auth role from protocol-specific request data (Authorization headers,
 // Basic Auth username, etc.) rather than the URL path. Used by SigV4-compatible

--- a/logical/request.go
+++ b/logical/request.go
@@ -81,6 +81,16 @@ type Request struct {
 
 	tokenEntry *TokenEntry
 
+	// User is the secondary, per-request principal — the human on whose behalf the
+	// agent acts — resolved by secondary transparent authentication from a second
+	// request header when the provider/namespace configures user_auth_path. It is
+	// IDENTITY-ONLY: it never authorizes the request (the primary/agent token entry
+	// alone does that) and is never SetTokenEntry'd. It scopes per-user credential
+	// chaining: the warden_user assertion claim, the per-user credential-cache
+	// dimension, and audit attribution. Nil when the feature is unconfigured, which
+	// keeps the request byte-identical to before.
+	User *UserPrincipal `json:"-"`
+
 	// TokenMetadata carries the authenticating token's verified, login-derived
 	// Metadata into policy evaluation so token_metadata conditions can match
 	// against it. Set from the token entry at the policy-check seam; never
@@ -154,4 +164,29 @@ func (r *Request) TokenEntry() *TokenEntry {
 
 func (r *Request) SetTokenEntry(te *TokenEntry) {
 	r.tokenEntry = te
+}
+
+// DefaultUserTokenHeader is the default request header carrying the secondary
+// (user) credential for secondary transparent authentication. Providers may
+// override it via user_token_header. It is a bearer secret and is stripped from
+// every upstream-forwarding header list.
+const DefaultUserTokenHeader = "X-Warden-User-Token"
+
+// UserPrincipal is a request's secondary (user) principal: a first-class Warden
+// TokenEntry resolved from a second request header via the existing auth methods,
+// exactly as the primary/agent credential is. It carries both the validated token
+// entry — the source of the user's identity and login-derived metadata — and the
+// raw user credential, which the token-exchange driver forwards verbatim as an
+// RFC 8693 subject_token. It is identity-only: it is never the request's primary
+// principal and never authorizes the request on its own.
+type UserPrincipal struct {
+	// TokenEntry is the validated user token entry — the source of the user's
+	// identity and its login-derived Metadata.
+	TokenEntry *TokenEntry
+
+	// RawToken is the raw user credential as presented in the request header,
+	// retained so the token-exchange driver can forward it as an RFC 8693
+	// subject_token. It is a bearer secret: kept off audit serialization and
+	// stripped from every upstream-forwarding header list.
+	RawToken string
 }

--- a/provider/alicloud/path_gateway.go
+++ b/provider/alicloud/path_gateway.go
@@ -37,6 +37,7 @@ var headersToStrip = []string{
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
+	"X-Warden-User-Token",
 	// Hop-by-hop
 	"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
 	"Te", "Trailer", "Trailers", "Transfer-Encoding", "Upgrade",

--- a/provider/azure/path_gateway.go
+++ b/provider/azure/path_gateway.go
@@ -24,6 +24,7 @@ var headersToRemove = []string{
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
+	"X-Warden-User-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/gcp/path_gateway.go
+++ b/provider/gcp/path_gateway.go
@@ -24,6 +24,7 @@ var headersToRemove = []string{
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
+	"X-Warden-User-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -24,6 +24,7 @@ var headersToStrip = []string{
 	"X-Warden-Role",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
+	"X-Warden-User-Token",
 	// Cookie carries client session identity that AWS will ignore but that
 	// would otherwise bleed across the trust boundary. Strip explicitly —
 	// sigv4.NormalizeRequest doesn't touch it.

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -129,7 +129,7 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 
 	headersToRemove := []string{
 		"X-Warden-Token", "X-Warden-Role", "X-Warden-Provider",
-		"X-Warden-Subject-Token", "X-Warden-Actor-Token",
+		"X-Warden-Subject-Token", "X-Warden-Actor-Token", "X-Warden-User-Token",
 		"Connection", "Keep-Alive", "Transfer-Encoding", "Upgrade",
 		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",
 		"X-Forwarded-Port", "X-Real-Ip", "Forwarded",

--- a/provider/sdk/httpproxy/config.go
+++ b/provider/sdk/httpproxy/config.go
@@ -13,6 +13,9 @@ type BaseConfig struct {
 	Timeout         time.Duration
 	AutoAuthPath    string
 	DefaultAuthRole string
+	UserAuthPath    string
+	UserTokenHeader string
+	UserAuthRole    string
 	TLSSkipVerify   bool
 	CAData          string // base64-encoded PEM CA certificate
 }
@@ -27,6 +30,9 @@ func ParseConfig(conf map[string]any, urlKey string, defaultURL string, defaultT
 		Timeout:         framework.ParseTimeout(conf, defaultTimeout),
 		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
 		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
+		UserAuthPath:    framework.GetConfigString(conf, "user_auth_path", ""),
+		UserTokenHeader: framework.GetConfigString(conf, "user_token_header", ""),
+		UserAuthRole:    framework.GetConfigString(conf, "user_auth_role", ""),
 		TLSSkipVerify:   tlsSkipVerify,
 		CAData:          caData,
 	}
@@ -44,6 +50,13 @@ func ValidateConfig(conf map[string]any, urlKey string) error {
 	}
 
 	if err := framework.ValidateCommonConfig(conf); err != nil {
+		return err
+	}
+
+	// Validate the secondary (user) auth fields at mount-enable too, not only on
+	// the config-write endpoint, so an invalid user_token_header / role→path is
+	// rejected before it can be parsed and applied.
+	if err := framework.ValidateUserAuthConfig(conf); err != nil {
 		return err
 	}
 

--- a/provider/sdk/httpproxy/headers.go
+++ b/provider/sdk/httpproxy/headers.go
@@ -10,6 +10,7 @@ var BaseHeadersToRemove = []string{
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
+	"X-Warden-User-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -954,6 +954,7 @@ func TestPrepareHeaders(t *testing.T) {
 		req.Header.Set("X-Warden-Token", "warden-token")
 		req.Header.Set("X-Warden-Subject-Token", "eyJ.subject")
 		req.Header.Set("X-Warden-Actor-Token", "eyJ.actor")
+		req.Header.Set("X-Warden-User-Token", "user-credential")
 		req.Header.Set("X-Custom-Remove", "should-go")
 		req.Header.Set("X-Keep", "keep-me")
 
@@ -964,6 +965,8 @@ func TestPrepareHeaders(t *testing.T) {
 		// Token-exchange inputs are internal secrets and must never reach upstream.
 		assert.Empty(t, req.Header.Get("X-Warden-Subject-Token"))
 		assert.Empty(t, req.Header.Get("X-Warden-Actor-Token"))
+		// The secondary user credential is a bearer secret and must not proxy upstream.
+		assert.Empty(t, req.Header.Get("X-Warden-User-Token"))
 		assert.Empty(t, req.Header.Get("X-Custom-Remove"))
 		assert.Equal(t, "keep-me", req.Header.Get("X-Keep"))
 	})

--- a/provider/sdk/httpproxy/path_config.go
+++ b/provider/sdk/httpproxy/path_config.go
@@ -38,6 +38,18 @@ func (b *proxyBackend) pathConfig() *framework.Path {
 			Type:        framework.TypeString,
 			Description: "Default role to use when not specified in URL path",
 		},
+		"user_auth_path": {
+			Type:        framework.TypeString,
+			Description: "Auth mount that authenticates the secondary (user) principal from a second request header (bearer/JWT format required)",
+		},
+		"user_token_header": {
+			Type:        framework.TypeString,
+			Description: "Request header carrying the user credential (default: X-Warden-User-Token; 'Authorization' opt-in for cert/SPIFFE agents)",
+		},
+		"user_auth_role": {
+			Type:        framework.TypeString,
+			Description: "Role used to authenticate the user credential (default: the user auth mount's own default_role)",
+		},
 		"tls_skip_verify": {
 			Type:        framework.TypeBool,
 			Description: "Skip TLS certificate verification (for dev/test clusters)",
@@ -82,6 +94,9 @@ func (b *proxyBackend) handleConfigRead(_ context.Context, _ *logical.Request, _
 		"timeout":           b.Timeout().String(),
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
+		"user_auth_path":    tc.UserAuthPath,
+		"user_token_header": tc.UserTokenHeader,
+		"user_auth_role":    tc.UserAuthRole,
 		"tls_skip_verify":   b.tlsSkipVerify,
 		"ca_data":           b.caData,
 	}
@@ -159,6 +174,9 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 	tc := &framework.TransparentConfig{
 		AutoAuthPath:    current.AutoAuthPath,
 		DefaultAuthRole: current.DefaultAuthRole,
+		UserAuthPath:    current.UserAuthPath,
+		UserTokenHeader: current.UserTokenHeader,
+		UserAuthRole:    current.UserAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -166,11 +184,34 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 	if val, ok := d.GetOk("default_role"); ok {
 		tc.DefaultAuthRole = val.(string)
 	}
+	if val, ok := d.GetOk("user_auth_path"); ok {
+		tc.UserAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("user_token_header"); ok {
+		tc.UserTokenHeader = val.(string)
+	}
+	if val, ok := d.GetOk("user_auth_role"); ok {
+		tc.UserAuthRole = val.(string)
+	}
 
 	if tc.AutoAuthPath == "" {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
 			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+		}, nil
+	}
+
+	// Validate the secondary (user) auth config: types, the user_token_header
+	// deny-list, and the user_auth_role → user_auth_path dependency. The
+	// bearer-format check on the mount is enforced at runtime (fail closed).
+	if err := framework.ValidateUserAuthConfig(map[string]any{
+		"user_auth_path":    tc.UserAuthPath,
+		"user_token_header": tc.UserTokenHeader,
+		"user_auth_role":    tc.UserAuthRole,
+	}); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest(err.Error()),
 		}, nil
 	}
 
@@ -258,6 +299,9 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		"timeout":           b.Timeout().String(),
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
+		"user_auth_path":    tc.UserAuthPath,
+		"user_token_header": tc.UserTokenHeader,
+		"user_auth_role":    tc.UserAuthRole,
 		"tls_skip_verify":   b.tlsSkipVerify,
 		"ca_data":           b.caData,
 	}

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -316,6 +316,9 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 			b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 				AutoAuthPath:    parsedConfig.AutoAuthPath,
 				DefaultAuthRole: parsedConfig.DefaultAuthRole,
+				UserAuthPath:    parsedConfig.UserAuthPath,
+				UserTokenHeader: parsedConfig.UserTokenHeader,
+				UserAuthRole:    parsedConfig.UserAuthRole,
 			})
 
 			// Apply TLS configuration if provided
@@ -375,9 +378,15 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 
 		autoAuthPath, _ := config["auto_auth_path"].(string)
 		defaultRole, _ := config["default_role"].(string)
+		userAuthPath, _ := config["user_auth_path"].(string)
+		userTokenHeader, _ := config["user_token_header"].(string)
+		userAuthRole, _ := config["user_auth_role"].(string)
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    autoAuthPath,
 			DefaultAuthRole: defaultRole,
+			UserAuthPath:    userAuthPath,
+			UserTokenHeader: userTokenHeader,
+			UserAuthRole:    userAuthRole,
 		})
 
 		// Load TLS configuration
@@ -409,6 +418,9 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 			"timeout":           b.Timeout().String(),
 			"auto_auth_path":    tc.AutoAuthPath,
 			"default_role":      tc.DefaultAuthRole,
+			"user_auth_path":    tc.UserAuthPath,
+			"user_token_header": tc.UserTokenHeader,
+			"user_auth_role":    tc.UserAuthRole,
 			"tls_skip_verify":   b.tlsSkipVerify,
 			"ca_data":           b.caData,
 		}

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -24,6 +24,7 @@ var headersToRemove = []string{
 	"X-Warden-Provider",      // Warden provider-mount routing header
 	"X-Warden-Subject-Token", // token-exchange subject token — internal-only, never forwarded
 	"X-Warden-Actor-Token",   // token-exchange actor token — internal-only, never forwarded
+	"X-Warden-User-Token",    // secondary user credential — internal-only, never forwarded
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",


### PR DESCRIPTION
## Summary

Resolve a per-request **user** principal via secondary transparent authentication (a second request header authenticated through the existing auth methods) and use it to scope **per-user credential chaining** — without changing agent-only flows. This combines the two foundation pieces of the delegation arc.

### Secondary transparent authentication

- `resolveTransparentIdentity` factored out of implicit auth (no request mutation); the user is captured into `req.User` — identity only, never the primary principal, never an authorizer.
- Provider/namespace `user_auth_path` config (a bearer-format mount is required).
- Fail-closed matrix: an invalid user token, a cross-namespace mount, or user == agent all reject.
- The user-token header is stripped from every upstream-forwarding list.
- Per-request user attribution in the audit record.

### Per-user federation

- Nested `warden_user` assertion claim (plus `warden_sub` carrying the agent principal), gated by `assertion_user_claims` (opt-in; fail-closed on an absent claim).
- Per-user credential-cache dimension, bounded by both principals' token TTLs (`min(agent, user)`).
- Per-user `secret_path` templating (`{{user.<claim>}}`) with strict sanitization (rejects `/`, `.`/`..` segments after substitution, and leftover template fragments).
- oauth2 chained-secret minting (`MintFromSecret`) over a fetched refresh token.

## Depends on

Builds on the credential-chaining foundation already in `main`: #472 (`kv2_read` + `key_value`), #473 (`secret_spec` chaining), #474 (`github` `mint_method`).

## Follow-up

A breaking PR — retiring the caller-supplied `header` token source and reshaping RFC 8693 exchange around the user — stacks on this branch.

## Testing

`go test ./core/... ./credential/... ./framework/...` — new `request_handler_user_test.go`, plus additions to the oidc_issuer, manager, vault_driver, oauth2_driver, exchange, and framework/config test suites.
