### PR TITLE
test(core): make OIDC rotation propagation-floor tests deterministic

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1285,6 +1285,31 @@ func (c *Core) oidcKeyRotationLoop(ctx context.Context, done chan struct{}, keyS
 // promoted key was persisted as `next` by the previous rotation and the fresh next
 // is persisted here before it can ever be promoted, so Warden never signs with a
 // key absent from storage.
+// propagationFloor returns how long key rotation must wait so a fresh next key is published
+// at least cacheTTL before it signs (giving any CDN cache and verifier time to refresh the
+// JWKS). It returns 0 when there is no external publisher (the built-in endpoint serves
+// live) or cacheTTL <= 0, and 0 once the youngest next key across algorithms is already
+// older than cacheTTL — the steady state, where each next is ~one rotation period old. `now`
+// is passed in so the computation is deterministic and unit-testable without wall-clock.
+// Iterating the supported alg set (not whatever storage held) means a stray/unknown held
+// alg can never break rotation of the healthy ones.
+func propagationFloor(now time.Time, keysets map[string]*algKeyset, publisher JWKSPublisher, cacheTTL time.Duration) (time.Duration, error) {
+	if publisher == nil || cacheTTL <= 0 {
+		return 0, nil
+	}
+	var wait time.Duration
+	for _, alg := range oidcSupportedAlgs {
+		ks := keysets[alg]
+		if ks == nil || ks.next == nil {
+			return 0, fmt.Errorf("oidc issuer: cannot rotate without a next %s key", alg)
+		}
+		if rem := cacheTTL - now.Sub(ks.next.createdAt); rem > wait {
+			wait = rem
+		}
+	}
+	return wait, nil
+}
+
 func (c *Core) rotateOIDCKey(ctx context.Context, keySource oidcKeySource, issuer *OIDCIssuer, publisher JWKSPublisher, cacheTTL, grace time.Duration) error {
 	if issuer == nil || !issuer.Ready() {
 		return nil
@@ -1301,33 +1326,20 @@ func (c *Core) rotateOIDCKey(ctx context.Context, keySource oidcKeySource, issue
 		return fmt.Errorf("oidc issuer: cannot rotate with no keys")
 	}
 
-	// Propagation floor: a fresh next key must be published at least cacheTTL before
-	// it signs, so any CDN cache and verifier have refreshed the JWKS. Wait out the
-	// youngest next key across algorithms (same-age in practice, so usually a single
-	// wait). In steady state each next is ~one rotation period old, so the remainder
-	// is <= 0 and there is no wait; the floor only bites on cold start / a shrunk
-	// period. Skipped when there is no external publisher (the endpoint serves live).
-	// Only the supported algorithms are rotated (each is generatable). Iterating the
-	// supported set rather than whatever storage held means a stray/unknown held alg
-	// can never break rotation of the healthy ones; it is left untouched in the map.
-	if publisher != nil && cacheTTL > 0 {
-		var wait time.Duration
-		for _, alg := range oidcSupportedAlgs {
-			ks := keysets[alg]
-			if ks == nil || ks.next == nil {
-				return fmt.Errorf("oidc issuer: cannot rotate without a next %s key", alg)
-			}
-			if rem := cacheTTL - time.Since(ks.next.createdAt); rem > wait {
-				wait = rem
-			}
-		}
-		if wait > 0 {
-			select {
-			case <-ctx.Done():
-				// Nothing to roll back — the next keys are durable and stay published.
-				return ctx.Err()
-			case <-time.After(wait):
-			}
+	// Propagation floor: a fresh next key must be published at least cacheTTL before it
+	// signs, so any CDN cache and verifier have refreshed the JWKS. propagationFloor
+	// computes how long to wait (0 with no external publisher, or once the next keys are
+	// already old enough — the steady state, where each next is ~one rotation period old).
+	wait, err := propagationFloor(time.Now(), keysets, publisher, cacheTTL)
+	if err != nil {
+		return err
+	}
+	if wait > 0 {
+		select {
+		case <-ctx.Done():
+			// Nothing to roll back — the next keys are durable and stay published.
+			return ctx.Err()
+		case <-time.After(wait):
 		}
 	}
 	// Bail if leadership was lost during the wait — a demoted node must not

--- a/core/oidc_issuer_test.go
+++ b/core/oidc_issuer_test.go
@@ -963,47 +963,79 @@ func TestOIDCKeyRotation_FirstTickAnchor(t *testing.T) {
 	assert.LessOrEqual(t, time.Until(active.createdAt.Add(period)), time.Minute)
 }
 
-// TestRotateOIDCKey_PropagationFloor verifies the floor waits only when the next
-// key is younger than the cache TTL, and skips the wait when it is old enough. The
-// cache TTL is set well above the cost of a rotation (RSA keygen + persist) so the
-// wait/no-wait separation stays robust under parallel test load.
-func TestRotateOIDCKey_PropagationFloor(t *testing.T) {
+// TestRotateOIDCKey_AppliesFloor is the one end-to-end check that the computed floor is
+// actually waited out: a young next key (created ~now) with a publisher must delay rotation
+// by most of the cache TTL. It asserts only a LOWER bound, so a slow/parallel runner can't
+// make it flaky. The floor's *no-wait* cases (which conflated "no floor" with "rotation is
+// fast" and were flaky on loaded runners) are covered deterministically — no wall-clock, no
+// RSA keygen — by TestPropagationFloor below.
+func TestRotateOIDCKey_AppliesFloor(t *testing.T) {
 	const cacheTTL = 600 * time.Millisecond
-
-	t.Run("young next waits", func(t *testing.T) {
-		core := createTestCore(t)
-		defer core.tokenStore.Close()
-		iss := enableIssuer(t, core) // next created ~now
-		start := time.Now()
-		require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
-		assert.GreaterOrEqual(t, time.Since(start), 450*time.Millisecond, "a young next key must wait out most of the floor")
-	})
-
-	t.Run("old next does not wait", func(t *testing.T) {
-		core := createTestCore(t)
-		defer core.tokenStore.Close()
-		iss := enableIssuer(t, core)
-		// Age the next key past the cache TTL so the floor is already satisfied.
-		active, next, retired := rs256Keys(iss)
-		next.createdAt = time.Now().Add(-time.Hour)
-		iss.RestoreKeys(rs256Keyset(active, next, retired))
-		start := time.Now()
-		require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
-		assert.Less(t, time.Since(start), 300*time.Millisecond, "an old-enough next key must not wait")
-	})
-}
-
-// TestRotateOIDCKey_NoFloorWithoutPublisher verifies that with no external
-// publisher the floor is skipped entirely (the built-in endpoint serves live).
-func TestRotateOIDCKey_NoFloorWithoutPublisher(t *testing.T) {
 	core := createTestCore(t)
 	defer core.tokenStore.Close()
 	iss := enableIssuer(t, core) // next created ~now
 	start := time.Now()
-	// Large cache TTL, but publisher == nil -> no wait. The bound sits well below
-	// the TTL yet above a rotation's RSA-keygen cost so the check is not flaky.
-	require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, nil, time.Minute, defaultRetiredKeyGrace))
-	assert.Less(t, time.Since(start), 300*time.Millisecond, "no publisher means no propagation floor")
+	require.NoError(t, core.rotateOIDCKey(context.Background(), localKeySource{}, iss, &spyPublisher{}, cacheTTL, defaultRetiredKeyGrace))
+	assert.GreaterOrEqual(t, time.Since(start), 450*time.Millisecond, "a young next key must wait out most of the floor")
+}
+
+// TestPropagationFloor covers the floor computation deterministically: 0 with no publisher /
+// non-positive TTL / an old-enough next key, the full remaining TTL for a young next key
+// (the youngest across algorithms wins), and an error for a missing next key.
+func TestPropagationFloor(t *testing.T) {
+	const cacheTTL = 600 * time.Millisecond
+	now := time.Now()
+	pub := &spyPublisher{}
+
+	// keysets builds a next key per supported alg, each aged by the given amount.
+	keysets := func(ages map[string]time.Duration) map[string]*algKeyset {
+		m := make(map[string]*algKeyset, len(oidcSupportedAlgs))
+		for _, alg := range oidcSupportedAlgs {
+			m[alg] = &algKeyset{next: &signingKey{createdAt: now.Add(-ages[alg])}}
+		}
+		return m
+	}
+	sameAge := func(age time.Duration) map[string]time.Duration {
+		out := map[string]time.Duration{}
+		for _, alg := range oidcSupportedAlgs {
+			out[alg] = age
+		}
+		return out
+	}
+
+	t.Run("no publisher means no floor", func(t *testing.T) {
+		wait, err := propagationFloor(now, keysets(sameAge(0)), nil, cacheTTL)
+		require.NoError(t, err)
+		assert.Zero(t, wait)
+	})
+	t.Run("non-positive cacheTTL means no floor", func(t *testing.T) {
+		wait, err := propagationFloor(now, keysets(sameAge(0)), pub, 0)
+		require.NoError(t, err)
+		assert.Zero(t, wait)
+	})
+	t.Run("old-enough next key does not wait", func(t *testing.T) {
+		wait, err := propagationFloor(now, keysets(sameAge(time.Hour)), pub, cacheTTL)
+		require.NoError(t, err)
+		assert.Zero(t, wait)
+	})
+	t.Run("young next key waits out the full remaining TTL", func(t *testing.T) {
+		wait, err := propagationFloor(now, keysets(sameAge(0)), pub, cacheTTL)
+		require.NoError(t, err)
+		assert.Equal(t, cacheTTL, wait)
+	})
+	t.Run("youngest next across algorithms wins", func(t *testing.T) {
+		ages := map[string]time.Duration{oidcAlgRS256: 500 * time.Millisecond, oidcAlgES256: 0}
+		wait, err := propagationFloor(now, keysets(ages), pub, cacheTTL)
+		require.NoError(t, err)
+		assert.Equal(t, cacheTTL, wait) // ES256 is youngest → the full TTL remains
+	})
+	t.Run("missing next key is an error", func(t *testing.T) {
+		m := keysets(sameAge(0))
+		m[oidcAlgES256].next = nil
+		_, err := propagationFloor(now, m, pub, cacheTTL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "next")
+	})
 }
 
 // TestOIDCIssuer_Mint_WardenUserAndSubClaims verifies that warden_sub always


### PR DESCRIPTION
Problem
-------
The OIDC key-rotation "no-wait" tests measured the wall-clock elapsed time of a full
`rotateOIDCKey` — which includes RSA-2048 keygen plus a barrier persist — and asserted it
finished in `<300ms`, inferring that the propagation floor did not wait. On a loaded CI
runner that incidental cost exceeded 300ms and the tests flaked (observed 451ms in
`TestRotateOIDCKey_NoFloorWithoutPublisher`). There is no floor bug; the *measurement* was
brittle.

Fix
---
Extract the pure floor computation into `propagationFloor(now, keysets, publisher, cacheTTL)`
and assert it directly, deterministically (no wall-clock, no keygen):

- no publisher, or non-positive `cacheTTL`, or an old-enough next key → `0`
- a young next key → the full remaining TTL (the youngest across algorithms wins)
- a missing next key → error

`rotateOIDCKey` now calls this helper; runtime behavior is byte-identical. The one end-to-end
check that the floor is actually waited out is kept as `TestRotateOIDCKey_AppliesFloor`, which
asserts only a LOWER bound (a slow runner cannot break it).

This is the flake that intermittently reds `unit`/`ci-gate` on unrelated PRs (e.g. #477).