### PR TITLE
feat(credential): opt-in source-scoped cache for chained secrets

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	ristretto "github.com/dgraph-io/ristretto/v2"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -964,6 +965,16 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		}
 		if err := s.validateSecretSpecRef(ctx, chainedRef); err != nil {
 			return err
+		}
+		// secret_cache_ttl (spec or source) must parse as a duration; otherwise a typo
+		// (e.g. "30min") would silently disable caching, so an operator who meant to opt
+		// in gets no signal. GetDuration swallows the parse error at mint, so reject here.
+		for _, cfg := range []map[string]string{spec.Config, source.Config} {
+			if raw, ok := cfg[credential.ConfigSecretCacheTTL]; ok && raw != "" {
+				if _, perr := time.ParseDuration(raw); perr != nil {
+					return logical.ErrBadRequestf("field '%s': %q is not a valid duration: %v", credential.ConfigSecretCacheTTL, raw, perr)
+				}
+			}
 		}
 	}
 

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -468,6 +468,34 @@ func TestCredentialConfigStore_SecretSpecReference_Restrictions(t *testing.T) {
 	assert.Contains(t, err.Error(), "must not also set")
 }
 
+// TestCredentialConfigStore_SecretCacheTTLValidation: an unparsable secret_cache_ttl on
+// a chained consumer is rejected at create (so a typo can't silently disable caching).
+func TestCredentialConfigStore_SecretCacheTTLValidation(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "secret-spec", Type: "vault_token", Source: "src",
+		Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "aud"},
+	}))
+
+	err := store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "bad-ttl", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "secret-spec", credential.ConfigSecretCacheTTL: "30min"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid duration")
+
+	// A valid duration (and "0" to opt out) are accepted.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "ok-ttl", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "secret-spec", credential.ConfigSecretCacheTTL: "30m"},
+	}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "optout-ttl", Type: "vault_token", Source: "src",
+		Config: map[string]string{credential.ConfigSecretSpec: "secret-spec", credential.ConfigSecretCacheTTL: "0"},
+	}))
+}
+
 // TestCredentialConfigStore_CheckSourceReferences tests checking source references
 func TestCredentialConfigStore_CheckSourceReferences(t *testing.T) {
 	store, ctx := setupTestCredentialConfigStore(t)

--- a/credential/chaining.go
+++ b/credential/chaining.go
@@ -23,6 +23,16 @@ const (
 	// chain (one hop only). This also breaks any config-drift reference cycle rather
 	// than letting the recursive mint recurse unboundedly.
 	MaxSecretChainDepth = 1
+
+	// ConfigSecretCacheTTL opts a chained consumer into source-scoped caching of the
+	// fetched secret material for the given duration (parsed with GetDuration, e.g.
+	// "30m"). It may sit on the consuming spec (spec-level, wins) or its source. Unset
+	// or <=0 means no caching — the referenced secret-spec is re-minted on every
+	// consuming-credential cache miss (the default, and the correct choice for a
+	// rotation-sensitive referenced secret such as a single-use refresh token). When
+	// set, the fetched material is shared across a caller's requests (per agent
+	// identity, and per user when the referenced fetch is user-scoped) for the TTL.
+	ConfigSecretCacheTTL = "secret_cache_ttl"
 )
 
 // SecretMaterial carries the referenced secret-spec's minted data to a consuming

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -18,6 +18,9 @@ type mockChainedDriver struct {
 	driverType    string
 	mintFromCalls atomic.Int32
 	lastMaterial  SecretMaterial
+	// rejectIf, when set and returning true for the handed material, makes MintFromSecret
+	// fail with ErrChainedSecretRejected (simulating a downstream rejecting a stale secret).
+	rejectIf func(SecretMaterial) bool
 }
 
 func (d *mockChainedDriver) MintCredential(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
@@ -27,6 +30,9 @@ func (d *mockChainedDriver) MintCredential(_ context.Context, _ *CredSpec) (map[
 func (d *mockChainedDriver) MintFromSecret(_ context.Context, _ *CredSpec, material SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	d.mintFromCalls.Add(1)
 	d.lastMaterial = material
+	if d.rejectIf != nil && d.rejectIf(material) {
+		return nil, nil, 0, "", fmt.Errorf("downstream rejected the secret: %w", ErrChainedSecretRejected)
+	}
 	return map[string]interface{}{"token": "consumer-token:" + material.Secret()}, nil, 0, "", nil
 }
 
@@ -53,12 +59,14 @@ type mockExchangeSecretDriver struct {
 	driverType string
 	gotSubject string
 	gotActor   string
+	mintCalls  atomic.Int32
 }
 
 func (d *mockExchangeSecretDriver) MintCredential(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	return nil, nil, 0, "", fmt.Errorf("mockExchangeSecretDriver: exchange required")
 }
 func (d *mockExchangeSecretDriver) MintCredentialWithExchange(_ context.Context, _ *CredSpec, inputs *ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.mintCalls.Add(1)
 	d.gotSubject = inputs.SubjectToken
 	d.gotActor = inputs.ActorToken
 	return map[string]interface{}{"token": "SECRET-" + inputs.SubjectToken}, nil, 0, "", nil
@@ -301,4 +309,198 @@ func TestChaining_RequiresCallerContext(t *testing.T) {
 	_, err := env.manager.IssueCredential(ctx, caller, "consumer", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires a request caller context")
+}
+
+// exchangeChainCaller builds a Caller whose referenced-spec inputs carry a per-agent
+// SubjectCacheIdentity (so the secret-cache key is per agent identity) and optionally a
+// user principal + UserClaims (so a user-scoped referenced fetch keys per user).
+func exchangeChainCaller(agentToken, agentIdentity, userToken string, userClaims map[string]string) Caller {
+	c := Caller{
+		TokenID:  agentToken,
+		TokenTTL: time.Hour,
+		ResolveInputs: func(_ context.Context, specName string) (*ExchangeInputs, error) {
+			return &ExchangeInputs{
+				SubjectCacheIdentity: agentIdentity,
+				ResolveSubjectToken:  func(_ context.Context) (string, error) { return "subj-" + agentIdentity, nil },
+				UserClaims:           userClaims,
+			}, nil
+		},
+	}
+	if userToken != "" {
+		c.User = &UserContext{TokenID: userToken, TokenTTL: time.Hour}
+	}
+	return c
+}
+
+// TestChaining_CacheSharesAcrossConsumers: with secret_cache_ttl set, two consumer specs
+// referencing the same secret-spec under one caller fetch the secret only ONCE (shared
+// via the secret cache) — versus TestChaining_SecretNotCached's two fetches without a
+// TTL. Also exercises the nil-inputs ("noexchange") cache-key path without panicking.
+func TestChaining_CacheSharesAcrossConsumers(t *testing.T) {
+	env := newChainingEnv(t)
+	ttl := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: ttl})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: ttl})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA") // nil inputs -> "noexchange" key segment
+
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "secret_cache_ttl shares the fetched secret across consumers")
+}
+
+// TestChaining_CacheIsolatesPerAgent: even with caching on, two distinct agent
+// identities never share a cached secret (the per-agent Fingerprint dimension). Two
+// consumer specs referencing the same secret-spec would collapse to one fetch if the
+// cache were agent-blind; keyed per agent they fetch twice.
+func TestChaining_CacheIsolatesPerAgent(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exchange-secret", Type: TypeVaultToken, Source: "exchangesource", Config: map[string]string{}})
+	cfg := map[string]string{ConfigSecretSpec: "exchange-secret", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, exchangeChainCaller("tokA", "agentA", "", nil), "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, exchangeChainCaller("tokB", "agentB", "", nil), "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(), "distinct agents do not share a cached secret")
+}
+
+// TestChaining_CacheIsolatesPerUser (P0 regression): a user-scoped referenced fetch
+// (UserClaims populated) is cached per user. The same user shares across consumer specs;
+// a different user never receives the first user's secret.
+func TestChaining_CacheIsolatesPerUser(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exchange-secret", Type: TypeVaultToken, Source: "exchangesource", Config: map[string]string{}})
+	cfg := map[string]string{ConfigSecretSpec: "exchange-secret", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	claims := map[string]string{"sub": "alice"}
+
+	// User A, two consumer specs, one agent -> shared within the user (one fetch).
+	_, err := env.manager.IssueCredential(ctx, exchangeChainCaller("agentTok", "agentA", "userA", claims), "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, exchangeChainCaller("agentTok", "agentA", "userA", claims), "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), env.exchangeDriver.mintCalls.Load(), "same user shares the cached secret across consumers")
+
+	// User B, same agent + secret-spec -> its own fetch (never served user A's secret).
+	_, err = env.manager.IssueCredential(ctx, exchangeChainCaller("agentTok", "agentA", "userB", map[string]string{"sub": "bob"}), "consumer1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(), "a different user fetches its own secret (no cross-user leak)")
+}
+
+// TestChaining_RetryEvictsStaleCachedSecret: when a cached secret is rejected downstream
+// (ErrChainedSecretRejected), the manager evicts it and retries once with a fresh fetch.
+func TestChaining_RetryEvictsStaleCachedSecret(t *testing.T) {
+	env := newChainingEnv(t)
+	// Secret driver returns "v1" first, "v2" after (a rotation at the source).
+	var fetches atomic.Int32
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		n := fetches.Add(1)
+		val := "v1"
+		if n > 1 {
+			val = "v2"
+		}
+		return map[string]interface{}{"token": val}, nil, 0, "", nil
+	}
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	// Prime the cache with "v1".
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), fetches.Load())
+
+	// Now "v1" is stale: reject it downstream. A second consumer (outer miss) hits the
+	// cached "v1", is rejected, evicts + re-fetches "v2", and succeeds.
+	env.consumerDriver.rejectIf = func(m SecretMaterial) bool { return m.Secret() == "v1" }
+	cred, err := env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), fetches.Load(), "stale cached secret evicted and re-fetched once")
+	assert.Equal(t, "consumer-token:v2", cred.Data["token"], "retry minted from the fresh secret")
+}
+
+// TestChaining_NoRetryWhenSecretFresh: with caching off (ttl<=0) a downstream rejection
+// is NOT retried — the just-fetched secret can't be stale, so re-fetching is pointless.
+func TestChaining_NoRetryWhenSecretFresh(t *testing.T) {
+	env := newChainingEnv(t)
+	env.consumerDriver.rejectIf = func(SecretMaterial) bool { return true } // always reject
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}}) // no secret_cache_ttl
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChainedSecretRejected)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "no cache -> no retry (secret fetched once)")
+	assert.Equal(t, int32(1), env.consumerDriver.mintFromCalls.Load(), "mint attempted once, not retried")
+}
+
+// TestChaining_NoRetryOnFreshFetchWithTTL: even with caching ON, a rejection of a
+// freshly fetched secret (a cache MISS, fromCache=false) is not retried — only a cached
+// (potentially stale) secret is. Guards the fromCache gate.
+func TestChaining_NoRetryOnFreshFetchWithTTL(t *testing.T) {
+	env := newChainingEnv(t)
+	env.consumerDriver.rejectIf = func(SecretMaterial) bool { return true }
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChainedSecretRejected)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "fresh (miss) secret not retried, even with ttl>0")
+	assert.Equal(t, int32(1), env.consumerDriver.mintFromCalls.Load(), "mint attempted once")
+}
+
+// TestChaining_CacheTTLSourceLevel: a source-level secret_cache_ttl enables caching for
+// its consumer specs (no spec-level TTL), resolved spec-then-source.
+func TestChaining_CacheTTLSourceLevel(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSource(&CredSource{Name: "consumersource-cached", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretCacheTTL: "30m"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource-cached",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource-cached",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "source-level secret_cache_ttl caches")
+}
+
+// TestChaining_CacheTTLSpecOptOut: a spec-level secret_cache_ttl "0" opts OUT of a
+// source-level TTL (presence wins), so the secret is fetched every time.
+func TestChaining_CacheTTLSpecOptOut(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSource(&CredSource{Name: "consumersource-cached", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretCacheTTL: "30m"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource-cached",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "0"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource-cached",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "0"}})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(), "spec-level 0 opts out of source TTL")
 }

--- a/credential/errors.go
+++ b/credential/errors.go
@@ -38,4 +38,12 @@ var (
 	// the sealed token may have been rotated by another node, so it should
 	// re-read the latest spec and retry the refresh once.
 	ErrRefreshTokenRejected = errors.New("oauth2 refresh token rejected")
+
+	// ErrChainedSecretRejected is returned (wrapped) by a chained-secret consuming
+	// driver when the downstream rejects the fetched secret — e.g. an OAuth
+	// invalid_client, or a 401 from a resource. It signals the manager that a
+	// cached chained secret may be stale (rotated at the source): the manager
+	// evicts the cache entry and retries the mint once. A consuming driver wraps
+	// it via fmt.Errorf("...: %w", credential.ErrChainedSecretRejected).
+	ErrChainedSecretRejected = errors.New("chained secret rejected by downstream")
 )

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -37,10 +37,18 @@ const DefaultIssuanceTimeout = 30 * time.Second
 //   - DriverCoordinator: Handles driver lifecycle (get/create/close)
 //   - MintingService: Handles credential minting with automatic cleanup
 //   - CredentialParser: Handles credential parsing and validation
+
 type Manager struct {
 	log   *logger.GatedLogger
 	cache *ristretto.Cache[string, *Credential] // key: {namespace-uuid}:{tokenID} -> value: Credential
-	group singleflight.Group
+	// secretCache holds referenced secret-spec material for credential chaining,
+	// opt-in per consumer via ConfigSecretCacheTTL. It is a separate instance from the
+	// credential cache: its entries are keyed by (namespace, secret_spec, agent
+	// identity [, user]) and TTL'd by secret_cache_ttl, not by the credential cache's
+	// per-token/session lifetime. Fetched secrets are held in memory only, never
+	// persisted.
+	secretCache *ristretto.Cache[string, chainedSecret]
+	group       singleflight.Group
 
 	// Focused components (extracted from Manager for better testability)
 	specResolver      *SpecResolver
@@ -99,6 +107,16 @@ type ExpirationRegistrar interface {
 	RegisterCredential(ctx context.Context, credentialID, cacheKey string, ttl time.Duration, leaseID, sourceName, sourceType, specName string, revocable bool) error
 }
 
+// chainedSecret is the cached payload of a referenced secret-spec: the minted
+// credential's Data plus its Type. Type is retained because resolveSecretField uses it
+// for the PrimaryFieldProvider fallback, so a cache hit resolves the secret_field
+// identically to a fresh fetch. It never contains a lease (the referenced spec is
+// static/leaseless) and is held in memory only, never persisted.
+type chainedSecret struct {
+	Data map[string]string
+	Type string
+}
+
 // NewManager creates a new global credential manager
 func NewManager(
 	typeRegistry *TypeRegistry,
@@ -135,6 +153,20 @@ func NewManager(
 	}
 
 	m.cache = cache
+
+	// Separate cache for credential-chaining secret material (opt-in via
+	// ConfigSecretCacheTTL). Entries are (namespace, secret_spec, agent identity [,
+	// user]) tuples — far fewer than issued credentials. Each entry has cost 1, so
+	// MaxCost bounds the entry COUNT; NumCounters is ~10x that for TinyLFU admission.
+	secretCache, err := ristretto.NewCache(&ristretto.Config[string, chainedSecret]{
+		NumCounters: 100_000,
+		MaxCost:     10_000,
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret cache: %w", err)
+	}
+	m.secretCache = secretCache
 
 	return m, nil
 }
@@ -391,9 +423,9 @@ func (m *Manager) secretSpecRef(ctx context.Context, spec *CredSpec) (string, er
 
 // issueChained mints a consuming credential whose secret comes from a referenced
 // cred spec. It mints the referenced spec AS the caller (fresh assertion), extracts
-// the secret material, and hands it to the consuming driver. The fetched secret is
-// never cached: it is minted via the non-caching internal path and discarded after
-// material extraction.
+// the secret material, and hands it to the consuming driver. By default the fetched
+// secret is not cached (re-minted on every consuming-credential miss); a consumer may
+// opt into source-scoped caching via secret_cache_ttl (see resolveChainedSecretData).
 func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpec, secretRef string) (*Credential, error) {
 	// Bound the chain to a single hop (a referenced secret-spec may not itself
 	// chain). This also breaks any config-drift reference cycle rather than letting
@@ -413,21 +445,59 @@ func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpe
 		return nil, fmt.Errorf("secret_spec %q: %w", secretRef, err)
 	}
 
-	// Fetch the referenced secret credential (minted as the caller, never cached).
-	credB, err := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
+	return m.resolveAndMintChained(ctx, caller, spec, secretRef, inputsB,
+		func(ctx context.Context, spec *CredSpec, material SecretMaterial) (*Credential, error) {
+			driver, err := m.driverCoordinator.GetOrCreateDriver(ctx, spec.Source)
+			if err != nil {
+				return nil, err
+			}
+			return m.mintFromSecret(ctx, spec, driver, material)
+		})
+}
+
+// resolveAndMintChained resolves the referenced secret material (through the opt-in
+// source-scoped cache) and mints the consuming credential via mintFn. When the material
+// came from the cache and the downstream rejects it (ErrChainedSecretRejected or the
+// pre-existing ErrRefreshTokenRejected), the cached value may be stale (rotated at the
+// source): it evicts the entry and retries once with a fresh fetch. It does not retry a
+// freshly fetched secret — that would just re-fetch identical data.
+//
+// It is shared by issueChained and (with an exchange-aware mintFn) the token_exchange
+// chaining path, so caching and rejection-retry cover every ChainedSecretMinter driver.
+func (m *Manager) resolveAndMintChained(
+	ctx context.Context,
+	caller Caller,
+	spec *CredSpec,
+	secretRef string,
+	inputsB *ExchangeInputs,
+	mintFn func(ctx context.Context, spec *CredSpec, material SecretMaterial) (*Credential, error),
+) (*Credential, error) {
+	data, typ, fromCache, key, err := m.resolveChainedSecretData(ctx, caller, spec, secretRef, inputsB)
 	if err != nil {
 		return nil, err
 	}
+	material := m.buildSecretMaterial(ctx, spec, data, typ)
 
-	// Extract the secret material and mint the consuming credential from it.
-	field := m.resolveSecretField(ctx, spec, credB)
-	material := SecretMaterial{Data: credB.Data, Field: field}
-
-	driver, err := m.driverCoordinator.GetOrCreateDriver(ctx, spec.Source)
-	if err != nil {
-		return nil, err
+	cred, err := mintFn(ctx, spec, material)
+	if err != nil && fromCache && (errors.Is(err, ErrChainedSecretRejected) || errors.Is(err, ErrRefreshTokenRejected)) {
+		// A cached secret was rejected downstream — evict it and retry once with a
+		// fresh fetch, in case it was rotated at the source after we cached it.
+		m.invalidateChainedSecret(key)
+		data, typ, _, _, rerr := m.resolveChainedSecretData(ctx, caller, spec, secretRef, inputsB)
+		if rerr != nil {
+			return nil, rerr
+		}
+		return mintFn(ctx, spec, m.buildSecretMaterial(ctx, spec, data, typ))
 	}
-	return m.mintFromSecret(ctx, spec, driver, material)
+	return cred, err
+}
+
+// buildSecretMaterial resolves the secret_field for the consuming spec and wraps the
+// fetched data as SecretMaterial. The field is resolved per-consumer (not cached),
+// using a synthetic Credential so resolveSecretField's type-based fallback still works.
+func (m *Manager) buildSecretMaterial(ctx context.Context, spec *CredSpec, data map[string]string, typ string) SecretMaterial {
+	field := m.resolveSecretField(ctx, spec, &Credential{Data: data, Type: typ})
+	return SecretMaterial{Data: data, Field: field}
 }
 
 // fetchChainedSecret mints the referenced secret-spec AS the caller and returns its
@@ -486,6 +556,135 @@ func (m *Manager) fetchChainedSecret(ctx context.Context, caller Caller, secretR
 	}
 
 	return credB, nil
+}
+
+// resolveChainedSecretData returns the referenced secret-spec's material (Data + Type),
+// using the source-scoped secret cache when the consumer opts in via secret_cache_ttl.
+// fromCache is true only when the value came from a pre-existing cache entry (so the
+// caller retries on a downstream rejection only when a stale cached value could be the
+// cause). key is the cache key (empty when caching is disabled), for invalidation on
+// retry. A ttl <= 0, or a context without a namespace, disables caching and fetches
+// directly — the behaviour-preserving default.
+func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, spec *CredSpec, secretRef string, inputsB *ExchangeInputs) (data map[string]string, typ string, fromCache bool, key string, err error) {
+	ttl := m.secretCacheTTL(ctx, spec)
+	if ttl <= 0 {
+		credB, ferr := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
+		if ferr != nil {
+			return nil, "", false, "", ferr
+		}
+		return credB.Data, credB.Type, false, "", nil
+	}
+
+	ns, nerr := namespace.FromContext(ctx)
+	if nerr != nil {
+		// No namespace to scope the cache key (internal/non-request path): fall back to
+		// a direct, uncached fetch rather than risk a cross-namespace key collision.
+		credB, ferr := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
+		if ferr != nil {
+			return nil, "", false, "", ferr
+		}
+		return credB.Data, credB.Type, false, "", nil
+	}
+	key = chainedSecretCacheKey(ns.ID, secretRef, caller, inputsB)
+	if key == "" {
+		// Caching refused for safety (user-scoped fetch without a user principal): fetch
+		// directly, uncached.
+		credB, ferr := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
+		if ferr != nil {
+			return nil, "", false, "", ferr
+		}
+		return credB.Data, credB.Type, false, "", nil
+	}
+
+	if cs, ok := m.secretCache.Get(key); ok {
+		return copyStringMap(cs.Data), cs.Type, true, key, nil
+	}
+
+	// Miss: coalesce concurrent fetches for this key. A followed (non-leader) request
+	// receives the leader's freshly fetched value, so fromCache stays false for the
+	// whole group — the value is fresh this round, not a pre-existing cached entry.
+	v, ferr, _ := m.group.Do(key, func() (interface{}, error) {
+		if cs, ok := m.secretCache.Get(key); ok { // another goroutine populated it
+			return cs, nil
+		}
+		credB, e := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
+		if e != nil {
+			return nil, e
+		}
+		cs := chainedSecret{Data: credB.Data, Type: credB.Type}
+		m.secretCache.SetWithTTL(key, cs, 1, ttl)
+		m.secretCache.Wait() // Ristretto sets are async; shrink the window vs a concurrent Del.
+		return cs, nil
+	})
+	if ferr != nil {
+		return nil, "", false, key, ferr
+	}
+	cs := v.(chainedSecret)
+	return copyStringMap(cs.Data), cs.Type, false, key, nil
+}
+
+// secretCacheTTL resolves ConfigSecretCacheTTL spec-then-source (matching how
+// secret_spec / secret_field resolve). Returns 0 (no caching) when unset. A spec-level
+// value is authoritative by PRESENCE, so an explicit spec-level "0" opts out of a
+// source-level TTL (e.g. a rotation-sensitive consumer under a source that caches).
+func (m *Manager) secretCacheTTL(ctx context.Context, spec *CredSpec) time.Duration {
+	if _, ok := spec.Config[ConfigSecretCacheTTL]; ok {
+		return GetDuration(spec.Config, ConfigSecretCacheTTL, 0)
+	}
+	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil {
+		return GetDuration(src.Config, ConfigSecretCacheTTL, 0)
+	}
+	return 0
+}
+
+// invalidateChainedSecret evicts a cached secret and forgets any in-flight singleflight
+// entry for its key, so an immediate retry re-fetches rather than joining a stale fetch.
+func (m *Manager) invalidateChainedSecret(key string) {
+	if key == "" {
+		return
+	}
+	m.secretCache.Del(key)
+	m.group.Forget(key)
+}
+
+// chainedSecretCacheKey scopes a cached secret to (namespace, secret_spec, agent
+// identity). inputsB.Fingerprint keys on SubjectCacheIdentity — stable across an agent's
+// sessions — so the store's per-agent authorization is honoured (agent B is never served
+// agent A's fetched secret). When the referenced fetch is user-scoped (the referenced
+// spec sets assertion_user_claims, so inputsB.UserClaims is populated), the user token id
+// is folded in so one user's per-user secret is never served to another; a source-global
+// fetch (no user claims) omits it and is shared across users under the agent. A nil
+// inputsB (a referenced spec that requests no exchange) uses a fixed sentinel.
+//
+// It returns "" — meaning "do not cache" — for a user-scoped fetch that lacks the user
+// principal to key on. That combination cannot arise from the current request path, but
+// refusing to cache is the safe failure mode: it never shares one user's secret
+// namespace-wide.
+func chainedSecretCacheKey(nsID, secretRef string, caller Caller, inputsB *ExchangeInputs) string {
+	fp := "noexchange"
+	if inputsB != nil {
+		fp = inputsB.Fingerprint()
+	}
+	if inputsB != nil && len(inputsB.UserClaims) > 0 {
+		if caller.User == nil {
+			return ""
+		}
+		return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + ":u:" + caller.User.TokenID
+	}
+	return "chainsecret:" + nsID + ":" + secretRef + ":" + fp
+}
+
+// copyStringMap returns a shallow copy so a cached secret's Data map is never shared
+// with (and mutated by) a consumer. Returns nil for a nil input.
+func copyStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // resolveSecretField selects which key of the referenced credential's Data carries
@@ -689,6 +888,9 @@ func (m *Manager) SetIssuanceTimeout(timeout time.Duration) {
 // Stop gracefully shuts down the manager
 func (m *Manager) Stop() {
 	m.cache.Close()
+	if m.secretCache != nil {
+		m.secretCache.Close()
+	}
 	m.log.Trace("credential manager cache closed")
 }
 


### PR DESCRIPTION
## What

Add a generic, opt-in caching layer to credential chaining, plus an
evict-and-retry-once when the downstream rejects a fetched secret. Benefits **every**
`ChainedSecretMinter` consumer (GitHub, oauth2, and future secret-in-source drivers).

## Why

The chaining path re-mints the referenced `secret_spec` on every consuming-credential
cache miss and never caches the fetched secret. Consuming credentials are cached
per-identity, so misses are frequent, while the referenced secret rotates rarely — a
redundant secret-store round-trip per miss. This lets a consumer opt into caching the
fetched secret source-wide.

## How

- **`secret_cache_ttl`** (new generic chaining key): resolved spec-then-source, with a
  spec-level value authoritative by presence (an explicit `0` opts out of a source TTL).
  Unset/`<=0` = no caching (fetch every mint) — the safe default, and the correct choice
  for a rotation-sensitive secret such as a single-use refresh token. Validated as a
  duration at create time.
- **Dedicated Ristretto instance** keyed by `(namespace, secret_spec, agent identity)`,
  plus a per-user dimension when the referenced fetch is user-scoped
  (`assertion_user_claims`) — so a source-global secret is shared across users while a
  per-user secret is never served across users. A user-scoped fetch that lacks the user
  principal refuses to cache rather than share namespace-wide.
- Caches `Data` + `Type` (Type preserves `resolveSecretField`'s primary-field fallback on
  a hit); values are copied out, held in memory only, never persisted.
- **`ErrChainedSecretRejected`**: a consuming driver signals a downstream rejection; the
  manager evicts the cached secret and retries once with a fresh fetch (also honoring the
  pre-existing `ErrRefreshTokenRejected`, so chained oauth2 self-heals with no driver
  change). The retry fires only when the secret came from the cache.

## Testing

- `go build ./...`, `go vet`, full `credential` + `core` suites.
- New unit tests: source-global sharing across users; **per-agent** and **per-user**
  isolation (the per-user test is a cross-user-leak regression guard); `ttl<=0`
  behavior-preserving; retry-only-on-cache-hit; spec opt-out; source-level TTL; create-time
  TTL validation.

Second in a stacked series (follows #479).
