### PR TITLE
feat(credential): source the token_exchange client secret via chaining

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -957,11 +957,28 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		chainedRef = source.Config[credential.ConfigSecretSpec]
 	}
 	if chainedRef != "" {
-		// A chained consumer's identity flows through the referenced secret-spec, so
-		// its own subject/actor exchange config would be silently ignored at mint —
-		// reject the confusing combination rather than accept dead config.
-		if credential.SpecRequestsExchange(spec.Config) {
+		// For token_exchange, client-secret chaining is a SOURCE concern (client auth
+		// lives on the source, and the factory only sees source config). A spec-level
+		// secret_spec would leave the source's inline client_secret as dead config at
+		// mint — reject it with clear guidance.
+		if source.Type == credential.SourceTypeTokenExchange && spec.Config[credential.ConfigSecretSpec] != "" {
+			return logical.ErrBadRequestf("for a token_exchange source, set secret_spec on the source (client authentication is a source concern), not on the spec")
+		}
+		// A chained consumer's identity normally flows through the referenced secret-spec,
+		// so its own subject/actor exchange config would be dead — reject that confusing
+		// combination. The token_exchange driver is the exception: it is itself an
+		// exchange spec whose *client secret* is chained (ChainedExchangeMinter), so it
+		// legitimately sets both. (Driver-free type gate; the ChainedExchangeMinter
+		// capability is asserted in the test-mint block and at mint time.)
+		if credential.SpecRequestsExchange(spec.Config) && source.Type != credential.SourceTypeTokenExchange {
 			return logical.ErrBadRequestf("a chained spec (secret_spec set) must not also set its own subject_token_source/actor_token_source; the caller identity is carried by the referenced secret_spec %q", chainedRef)
+		}
+		// Conversely, a token_exchange spec whose client secret is chained still needs a
+		// subject to exchange: without subject_token_source it would route to the plain
+		// (non-exchange) chaining path and fail with a misleading "does not support
+		// secret_spec chaining" at mint. Guide the operator here instead.
+		if source.Type == credential.SourceTypeTokenExchange && !credential.SpecRequestsExchange(spec.Config) {
+			return logical.ErrBadRequestf("a token_exchange spec whose client secret is chained (source secret_spec %q) must set subject_token_source; the exchange still needs a subject", chainedRef)
 		}
 		if err := s.validateSecretSpecRef(ctx, chainedRef); err != nil {
 			return err
@@ -1016,10 +1033,16 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 
 				// A chained spec (secret_spec) fetches its secret material from a
 				// referenced spec at request time as the caller, so it cannot be
-				// test-minted at create. Its consuming driver must also be able to
-				// mint from that material — reject at create rather than at first use.
+				// test-minted at create. Its consuming driver must also be able to mint
+				// from that material — reject at create rather than at first use. An
+				// exchange consumer (token_exchange) needs ChainedExchangeMinter (exchange
+				// + fetched secret); a plain consumer needs ChainedSecretMinter.
 				if chainedRef != "" {
-					if _, ok := driver.(credential.ChainedSecretMinter); !ok {
+					if credential.SpecRequestsExchange(spec.Config) {
+						if _, ok := driver.(credential.ChainedExchangeMinter); !ok {
+							return logical.ErrBadRequestf("source type %q does not support secret_spec chaining with token exchange", source.Type)
+						}
+					} else if _, ok := driver.(credential.ChainedSecretMinter); !ok {
 						return logical.ErrBadRequestf("source type %q does not support secret_spec chaining", source.Type)
 					}
 					runTestMint = false
@@ -1224,10 +1247,12 @@ func (s *CredentialConfigStore) validateSecretSpecRef(ctx context.Context, ref s
 	// SESSION-PINNED subject: warden_identity (Warden mints an assertion for the
 	// session's principal) or agent_identity (the caller's own inbound JWT). A
 	// user_identity subject is a per-request, per-user token that is NOT tied to the
-	// session token — and a chained consumer's outer cache key carries no exchange
-	// fingerprint (the exchange happens on this referenced spec, not the consumer),
-	// so under a shared session token two principals would collide on that key and
-	// one could be served the other's chained credential. Reject anything else
+	// session token, so it cannot key a stable per-caller secret. (A plain chained
+	// consumer's outer cache key carries no exchange fingerprint — the exchange happens
+	// on this referenced spec, not the consumer — so under a shared session token two
+	// principals would otherwise collide and one could be served the other's chained
+	// credential. A token_exchange chained consumer does carry an :x: fragment, but this
+	// session-pinned requirement is on the REFERENCED spec regardless.) Reject anything else
 	// (including an unset/"none" subject, which would otherwise degrade to the
 	// non-exchange path and fail late with an opaque backend error).
 	switch refSpec.Config[credential.ConfigSubjectTokenSource] {

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -496,6 +496,31 @@ func TestCredentialConfigStore_SecretCacheTTLValidation(t *testing.T) {
 	}))
 }
 
+// TestCredentialConfigStore_ChainedExchangeAccepted: a token_exchange consumer may set
+// BOTH secret_spec (chained client secret) AND its own subject_token_source — the combo
+// that is rejected for any other source type (see consumer-dbl).
+func TestCredentialConfigStore_ChainedExchangeAccepted(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	// Referenced secret-spec: session-pinned (warden_identity), as required. Must exist
+	// before the source that references it.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "wid-secret", Type: "vault_token", Source: "src",
+		Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "sts-src", Type: credential.SourceTypeTokenExchange,
+		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "rfc8693", "client_id": "warden-gateway", credential.ConfigSecretSpec: "wid-secret"},
+	}))
+
+	// A token_exchange consumer with secret_spec (source-level) + its own subject source
+	// is accepted (unlike consumer-dbl on a non-exchange source).
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "internal-api", Type: "oauth_bearer_token", Source: "sts-src",
+		Config: map[string]string{"subject_token_source": "user_identity", "audience": "https://api.internal.example.com"},
+	}))
+}
+
 // TestCredentialConfigStore_CheckSourceReferences tests checking source references
 func TestCredentialConfigStore_CheckSourceReferences(t *testing.T) {
 	store, ctx := setupTestCredentialConfigStore(t)

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -87,14 +87,55 @@ func (f *mockExchangeSecretFactory) InferCredentialType(_ map[string]string) (st
 	return "", fmt.Errorf("n/a")
 }
 
+// mockChainedExchangeDriver implements SourceDriver + ChainedExchangeMinter: it performs
+// an "exchange" using BOTH the caller's exchange inputs and the fetched secret material.
+type mockChainedExchangeDriver struct {
+	driverType   string
+	calls        atomic.Int32
+	gotSubject   string
+	lastMaterial SecretMaterial
+	// rejectIf, when set and returning true for the handed material, fails with
+	// ErrChainedSecretRejected (simulating an upstream invalid_client on a stale secret).
+	rejectIf func(SecretMaterial) bool
+}
+
+func (d *mockChainedExchangeDriver) MintCredential(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", fmt.Errorf("mockChainedExchangeDriver: exchange required")
+}
+func (d *mockChainedExchangeDriver) MintCredentialWithExchangeFromSecret(_ context.Context, _ *CredSpec, inputs *ExchangeInputs, material SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.calls.Add(1)
+	d.gotSubject = inputs.SubjectToken
+	d.lastMaterial = material
+	if d.rejectIf != nil && d.rejectIf(material) {
+		return nil, nil, 0, "", fmt.Errorf("upstream rejected client auth: %w", ErrChainedSecretRejected)
+	}
+	return map[string]interface{}{"token": "exch:" + inputs.SubjectToken + ":" + material.Secret()}, nil, 0, "", nil
+}
+func (d *mockChainedExchangeDriver) Revoke(_ context.Context, _ string) error { return nil }
+func (d *mockChainedExchangeDriver) Type() string                            { return d.driverType }
+func (d *mockChainedExchangeDriver) Cleanup(_ context.Context) error         { return nil }
+
+type mockChainedExchangeFactory struct{ driver *mockChainedExchangeDriver }
+
+func (f *mockChainedExchangeFactory) Type() string { return f.driver.driverType }
+func (f *mockChainedExchangeFactory) Create(_ map[string]string, _ *logger.GatedLogger) (SourceDriver, error) {
+	return f.driver, nil
+}
+func (f *mockChainedExchangeFactory) ValidateConfig(_ map[string]string) error { return nil }
+func (f *mockChainedExchangeFactory) SensitiveConfigFields() []string          { return nil }
+func (f *mockChainedExchangeFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return "", fmt.Errorf("n/a")
+}
+
 // chainingEnv wires a secret source (leaseless, returns {token: THE-SECRET}) and a
 // consumer source that implements ChainedSecretMinter.
 type chainingEnv struct {
-	manager        *Manager
-	store          *mockConfigStore
-	secretDriver   *mockSourceDriver
-	consumerDriver *mockChainedDriver
-	exchangeDriver *mockExchangeSecretDriver
+	manager                *Manager
+	store                  *mockConfigStore
+	secretDriver           *mockSourceDriver
+	consumerDriver         *mockChainedDriver
+	exchangeDriver         *mockExchangeSecretDriver
+	exchangeConsumerDriver *mockChainedExchangeDriver
 }
 
 func newChainingEnv(t *testing.T) *chainingEnv {
@@ -119,6 +160,9 @@ func newChainingEnv(t *testing.T) *chainingEnv {
 	exchange := &mockExchangeSecretDriver{driverType: "exchangesrc"}
 	require.NoError(t, driverRegistry.RegisterFactory(&mockExchangeSecretFactory{driver: exchange}))
 
+	exchangeConsumer := &mockChainedExchangeDriver{driverType: "exchangeconsumersrc"}
+	require.NoError(t, driverRegistry.RegisterFactory(&mockChainedExchangeFactory{driver: exchangeConsumer}))
+
 	store := newMockConfigStore()
 	manager, err := NewManager(typeRegistry, driverRegistry, store, log)
 	require.NoError(t, err)
@@ -130,8 +174,10 @@ func newChainingEnv(t *testing.T) *chainingEnv {
 	store.AddSource(&CredSource{Name: "consumersource", Type: "consumersrc", Config: map[string]string{}})
 	// Exchange-consuming secret source (for materialization tests).
 	store.AddSource(&CredSource{Name: "exchangesource", Type: "exchangesrc", Config: map[string]string{}})
+	// Consumer source whose driver is a ChainedExchangeMinter (token_exchange-shaped).
+	store.AddSource(&CredSource{Name: "exchangeconsumersource", Type: "exchangeconsumersrc", Config: map[string]string{}})
 
-	return &chainingEnv{manager: manager, store: store, secretDriver: secretFactory.driver, consumerDriver: consumer, exchangeDriver: exchange}
+	return &chainingEnv{manager: manager, store: store, secretDriver: secretFactory.driver, consumerDriver: consumer, exchangeDriver: exchange, exchangeConsumerDriver: exchangeConsumer}
 }
 
 // caller with a no-op ResolveInputs (the referenced secret-spec does not request
@@ -309,6 +355,76 @@ func TestChaining_RequiresCallerContext(t *testing.T) {
 	_, err := env.manager.IssueCredential(ctx, caller, "consumer", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires a request caller context")
+}
+
+// TestChaining_ExchangeConsumerRoutes: a chained consumer that ITSELF requests exchange
+// (inputs != nil) routes to issueChainedExchange — the fetched secret becomes the mint
+// material AND the consumer's own subject token drives the exchange.
+func TestChaining_ExchangeConsumerRoutes(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exch-consumer", Type: TypeVaultToken, Source: "exchangeconsumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	inputs := &ExchangeInputs{SubjectToken: "subj-user", SubjectTokenType: TokenTypeJWT}
+	cred, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "exch-consumer", inputs)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), env.exchangeConsumerDriver.calls.Load(), "routed to the exchange-chaining mint")
+	assert.Equal(t, "THE-SECRET", env.exchangeConsumerDriver.lastMaterial.Secret(), "fetched secret handed to the driver")
+	assert.Equal(t, "subj-user", env.exchangeConsumerDriver.gotSubject, "consumer's own subject drove the exchange")
+	assert.Equal(t, "exch:subj-user:THE-SECRET", cred.Data["token"])
+}
+
+// TestChaining_ExchangeConsumerFailsClosed: a chained consumer that requests exchange but
+// whose driver is only a ChainedSecretMinter (not ChainedExchangeMinter) fails closed.
+func TestChaining_ExchangeConsumerFailsClosed(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "bad-exch", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	inputs := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT}
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "bad-exch", inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support secret_spec chaining with token exchange")
+}
+
+// TestChaining_ExchangeConsumerRetriesOnRejection: the exchange path inherits PR2's
+// evict-and-retry — a cached client secret rejected upstream (invalid_client) is evicted
+// and the exchange retries once with a fresh fetch.
+func TestChaining_ExchangeConsumerRetriesOnRejection(t *testing.T) {
+	env := newChainingEnv(t)
+	// Secret driver returns "v1" then "v2" (a rotation at the source).
+	var fetches atomic.Int32
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		val := "v1"
+		if fetches.Add(1) > 1 {
+			val = "v2"
+		}
+		return map[string]interface{}{"token": val}, nil, 0, "", nil
+	}
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "exch1", Type: TypeVaultToken, Source: "exchangeconsumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "exch2", Type: TypeVaultToken, Source: "exchangeconsumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+	inputs1 := &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT}
+
+	// Prime the cache with "v1".
+	_, err := env.manager.IssueCredential(ctx, caller, "exch1", inputs1)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), fetches.Load())
+
+	// "v1" now stale: reject it. A second exchange consumer hits the cached "v1", is
+	// rejected, evicts + re-fetches "v2", and succeeds.
+	env.exchangeConsumerDriver.rejectIf = func(m SecretMaterial) bool { return m.Secret() == "v1" }
+	inputs2 := &ExchangeInputs{SubjectToken: "s2", SubjectTokenType: TokenTypeJWT}
+	cred, err := env.manager.IssueCredential(ctx, caller, "exch2", inputs2)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), fetches.Load(), "stale client secret evicted and re-fetched once")
+	assert.Equal(t, "exch:s2:v2", cred.Data["token"], "exchange retried with the fresh secret")
 }
 
 // exchangeChainCaller builds a Caller whose referenced-spec inputs carry a per-agent

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -59,6 +59,7 @@ const (
 // Compile-time interface assertions.
 var _ credential.SourceDriver = (*TokenExchangeDriver)(nil)
 var _ credential.ExchangeMinter = (*TokenExchangeDriver)(nil)
+var _ credential.ChainedExchangeMinter = (*TokenExchangeDriver)(nil)
 
 // TokenExchangeDriver exchanges a caller-derived identity (a subject token, and
 // optionally an actor token) for a scoped downstream bearer at an RFC 8693 / RFC
@@ -146,6 +147,18 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
+
+		credential.StringField("secret_spec").
+			Describe("Source the client secret from another cred spec via credential chaining instead of storing it inline (client_secret / private_key then omitted)").
+			Example("idp-client-secret"),
+
+		credential.StringField("secret_field").
+			Describe("Which field of the referenced secret_spec's credential holds the client secret (when its payload has multiple keys)").
+			Example("value"),
+
+		credential.StringField("secret_cache_ttl").
+			Describe("Cache the chained client secret source-wide for this duration (e.g. 30m); omit to fetch it on every mint").
+			Example("30m"),
 	); err != nil {
 		return err
 	}
@@ -157,15 +170,25 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 		}
 	}
 
-	// Client-auth method determines which credentials are required.
+	// Client-auth method determines which credentials are required. When the client
+	// secret is sourced via credential chaining (secret_spec set on the source), the
+	// inline client_secret / private_key is supplied at mint time, so only client_id is
+	// required here.
+	chained := credential.GetString(config, credential.ConfigSecretSpec, "") != ""
 	switch credential.GetString(config, "client_auth", clientAuthSecretPost) {
 	case clientAuthSecretBasic, clientAuthSecretPost, "":
-		if credential.GetString(config, "client_id", "") == "" || credential.GetString(config, "client_secret", "") == "" {
-			return fmt.Errorf("client_id and client_secret are required for a secret-based client_auth")
+		if credential.GetString(config, "client_id", "") == "" {
+			return fmt.Errorf("client_id is required for a secret-based client_auth")
+		}
+		if !chained && credential.GetString(config, "client_secret", "") == "" {
+			return fmt.Errorf("client_secret (or secret_spec) is required for a secret-based client_auth")
 		}
 	case clientAuthPrivateKeyJWT:
-		if credential.GetString(config, "client_id", "") == "" || credential.GetString(config, "private_key", "") == "" {
-			return fmt.Errorf("client_id and private_key are required for client_auth=private_key_jwt")
+		if credential.GetString(config, "client_id", "") == "" {
+			return fmt.Errorf("client_id is required for client_auth=private_key_jwt")
+		}
+		if !chained && credential.GetString(config, "private_key", "") == "" {
+			return fmt.Errorf("private_key (or secret_spec) is required for client_auth=private_key_jwt")
 		}
 	}
 
@@ -223,6 +246,26 @@ func (d *TokenExchangeDriver) MintCredential(_ context.Context, _ *credential.Cr
 // MintCredentialWithExchange exchanges the caller-derived subject for a scoped
 // downstream bearer token.
 func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// Client auth comes from source config (client_secret / private_key).
+	return d.mintExchange(ctx, spec, inputs, nil)
+}
+
+// MintCredentialWithExchangeFromSecret performs the same exchange as
+// MintCredentialWithExchange, but its client-authentication secret comes from
+// credential-chaining material (secret_spec) instead of source config. The relevant
+// field (client_secret for secret_post/basic, or the PEM private_key for
+// private_key_jwt) is taken from material; client_id and everything else stay in config.
+func (d *TokenExchangeDriver) MintCredentialWithExchangeFromSecret(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	secret := material.Secret()
+	if secret == "" {
+		return nil, nil, 0, "", fmt.Errorf("token_exchange: chained client secret is empty (check the referenced secret_spec and secret_field)")
+	}
+	return d.mintExchange(ctx, spec, inputs, &secret)
+}
+
+// mintExchange runs the exchange for the configured grant. secretOverride, when non-nil,
+// supplies the client-auth secret (from credential chaining) in place of source config.
+func (d *TokenExchangeDriver) mintExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, secretOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	if inputs == nil || inputs.SubjectToken == "" {
 		return nil, nil, 0, "", fmt.Errorf("token_exchange: no subject token in exchange inputs")
 	}
@@ -244,9 +287,9 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 		err  error
 	)
 	if credential.GetString(d.credSource.Config, "grant", tokenExchangeGrantRFC8693) == tokenExchangeGrantIDJAG {
-		resp, err = d.mintIDJAG(ctx, spec, inputs)
+		resp, err = d.mintIDJAG(ctx, spec, inputs, secretOverride)
 	} else {
-		resp, err = d.exchangeOnce(ctx, spec, inputs)
+		resp, err = d.exchangeOnce(ctx, spec, inputs, secretOverride)
 	}
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -258,20 +301,21 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 	return accessTokenRawData(resp), d.subjectMetadata(resp, inputs), ttlFromExpiresIn(resp.ExpiresIn), "", nil
 }
 
-// exchangeOnce performs a single-hop exchange (rfc8693 or jwt_bearer).
-func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (*oauth2TokenResponse, error) {
+// exchangeOnce performs a single-hop exchange (rfc8693 or jwt_bearer). secretOverride,
+// when non-nil, supplies the client-auth secret from credential chaining.
+func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, secretOverride *string) (*oauth2TokenResponse, error) {
 	form, err := d.buildExchangeForm(spec, inputs)
 	if err != nil {
 		return nil, err
 	}
 	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
 	headers := map[string]string{}
-	if err := d.applyClientAuth(form, headers, tokenURL); err != nil {
+	if err := d.applyClientAuth(form, headers, tokenURL, secretOverride); err != nil {
 		return nil, err
 	}
 	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
 	if err != nil {
-		return nil, classifyExchangeError(err)
+		return nil, chainedClientAuthError(err, secretOverride != nil)
 	}
 	return resp, nil
 }
@@ -285,7 +329,7 @@ func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential
 //
 // Client auth runs on both legs (each with its own endpoint as the assertion
 // audience). Only the final access token is returned; the ID-JAG is single-use.
-func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (*oauth2TokenResponse, error) {
+func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, secretOverride *string) (*oauth2TokenResponse, error) {
 	cfg := d.credSource.Config
 
 	// Leg 1: exchange the subject for an ID-JAG at the home IdP. The ID-JAG must be
@@ -310,12 +354,12 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 		leg1.Set(k, v)
 	}
 	h1 := map[string]string{}
-	if err := d.applyClientAuth(leg1, h1, idpURL); err != nil {
+	if err := d.applyClientAuth(leg1, h1, idpURL, secretOverride); err != nil {
 		return nil, err
 	}
 	jag, err := postOAuthTokenForm(ctx, d.httpClient, idpURL, leg1, h1)
 	if err != nil {
-		return nil, classifyExchangeError(err)
+		return nil, chainedClientAuthError(err, secretOverride != nil)
 	}
 	if jag.AccessToken == "" {
 		return nil, fmt.Errorf("id_jag: leg 1 returned no ID-JAG assertion")
@@ -337,12 +381,12 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 	// leg 2 (the resource-AS redemption), not leg 1 (which mints the ID-JAG).
 	d.addResources(leg2, spec)
 	h2 := map[string]string{}
-	if err := d.applyClientAuth(leg2, h2, resURL); err != nil {
+	if err := d.applyClientAuth(leg2, h2, resURL, secretOverride); err != nil {
 		return nil, err
 	}
 	final, err := postOAuthTokenForm(ctx, d.httpClient, resURL, leg2, h2)
 	if err != nil {
-		return nil, classifyExchangeError(err)
+		return nil, chainedClientAuthError(err, secretOverride != nil)
 	}
 	return final, nil
 }
@@ -392,11 +436,16 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 
 // applyClientAuth decorates the request with the configured client
 // authentication. tokenEndpoint is the audience for a private_key_jwt assertion
-// (each ID-JAG leg authenticates against its own endpoint).
-func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string, tokenEndpoint string) error {
+// (each ID-JAG leg authenticates against its own endpoint). secretOverride, when
+// non-nil, supplies the client-auth secret from credential chaining (the client_secret
+// for secret_post/basic, or the PEM private_key for private_key_jwt) in place of config.
+func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string, tokenEndpoint string, secretOverride *string) error {
 	cfg := d.credSource.Config
 	clientID := credential.GetString(cfg, "client_id", "")
 	clientSecret := credential.GetString(cfg, "client_secret", "")
+	if secretOverride != nil {
+		clientSecret = *secretOverride
+	}
 
 	switch credential.GetString(cfg, "client_auth", clientAuthSecretPost) {
 	case clientAuthSecretPost, "":
@@ -407,7 +456,7 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 		creds := url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)
 		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))
 	case clientAuthPrivateKeyJWT:
-		assertion, err := d.buildClientAssertion(clientID, tokenEndpoint)
+		assertion, err := d.buildClientAssertion(clientID, tokenEndpoint, secretOverride)
 		if err != nil {
 			return err
 		}
@@ -421,10 +470,15 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 }
 
 // buildClientAssertion builds and signs an RFC 7523 client-assertion JWT: a
-// short-lived JWT with iss=sub=client_id and aud=tokenEndpoint, signed with the
-// source's configured RSA private key.
-func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint string) (string, error) {
-	key, err := parseRSAPrivateKey(credential.GetString(d.credSource.Config, "private_key", ""))
+// short-lived JWT with iss=sub=client_id and aud=tokenEndpoint, signed with the RSA
+// private key. keyOverride, when non-nil, supplies the PEM key from credential chaining
+// in place of the source-configured private_key.
+func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint string, keyOverride *string) (string, error) {
+	pemKey := credential.GetString(d.credSource.Config, "private_key", "")
+	if keyOverride != nil {
+		pemKey = *keyOverride
+	}
+	key, err := parseRSAPrivateKey(pemKey)
 	if err != nil {
 		return "", fmt.Errorf("token_exchange: invalid private_key: %w", err)
 	}
@@ -565,4 +619,27 @@ func classifyExchangeError(err error) error {
 		return fmt.Errorf("token_exchange rejected by the IdP (the subject token may be expired or unacceptable; re-authenticate): %w", err)
 	}
 	return fmt.Errorf("token_exchange failed: %w", err)
+}
+
+// chainedClientAuthError classifies a token-endpoint failure, but when the client secret
+// came from credential chaining (chained) and the endpoint rejected the client
+// authentication (invalid_client — 400 for client_secret_post, 401 for
+// client_secret_basic, or a rejected private_key_jwt assertion), it wraps
+// credential.ErrChainedSecretRejected so the minting layer evicts the cached secret and
+// retries once with a fresh fetch. This must run BEFORE classifyExchangeError, whose
+// broad 400/401 branch would otherwise mask invalid_client as a subject-token problem.
+func chainedClientAuthError(err error, chained bool) error {
+	if chained {
+		var tee *tokenEndpointError
+		// invalid_client is reported as HTTP 400 (client_secret_post) or 401
+		// (client_secret_basic / a rejected private_key_jwt assertion); a nonstandard IdP
+		// may return a bare 401 with no error code. Per RFC 6749 §5.2, 401 at the token
+		// endpoint is client-authentication-specific, so on the chained path treat either
+		// signal as a stale-secret rejection. Keep the underlying error (the IdP's code /
+		// description) in the chain alongside the sentinel for legible diagnostics.
+		if errors.As(err, &tee) && (tee.code == "invalid_client" || tee.status == http.StatusUnauthorized) {
+			return fmt.Errorf("token_exchange: client authentication rejected: %w (%w)", credential.ErrChainedSecretRejected, err)
+		}
+	}
+	return classifyExchangeError(err)
 }

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -345,6 +345,142 @@ func TestTokenExchangeDriver_PrivateKeyJWT(t *testing.T) {
 	assert.NotEmpty(t, claims.ID, "assertion should carry a jti")
 }
 
+// chainedMaterial wraps a single secret value as SecretMaterial (as credential chaining
+// would hand it to the driver).
+func chainedMaterial(secret string) credential.SecretMaterial {
+	return credential.SecretMaterial{Data: map[string]string{"value": secret}, Field: "value"}
+}
+
+// The chained client secret (from secret_spec) is used as client_secret in the form,
+// with no inline client_secret on the source.
+func TestTokenExchangeDriver_ChainedClientSecret_Post(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "warden-gateway", r.Form.Get("client_id"))
+		assert.Equal(t, "chained-secret", r.Form.Get("client_secret"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":   server.URL,
+		"client_auth": clientAuthSecretPost,
+		"client_id":   "warden-gateway",
+		"secret_spec": "idp-client-secret", // no inline client_secret
+	}, server.Client())
+
+	rawData, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(subject), chainedMaterial("chained-secret"))
+	require.NoError(t, err)
+	assert.Equal(t, "t", rawData["api_key"])
+}
+
+// The chained secret is used for client_secret_basic (Authorization header).
+func TestTokenExchangeDriver_ChainedClientSecret_Basic(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok, "expected Basic auth header")
+		assert.Equal(t, "warden-gateway", user)
+		assert.Equal(t, "chained-secret", pass)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":   server.URL,
+		"client_auth": clientAuthSecretBasic,
+		"client_id":   "warden-gateway",
+		"secret_spec": "idp-client-secret",
+	}, server.Client())
+
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(subject), chainedMaterial("chained-secret"))
+	require.NoError(t, err)
+}
+
+// For private_key_jwt, the chained material is the PEM key that signs the assertion.
+func TestTokenExchangeDriver_ChainedPrivateKeyJWT(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+	var gotAssertion string
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Empty(t, r.Form.Get("client_secret"))
+		gotAssertion = r.Form.Get("client_assertion")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":   sts.URL,
+		"client_auth": clientAuthPrivateKeyJWT,
+		"client_id":   "warden-gateway",
+		"secret_spec": "idp-key", // no inline private_key
+	}, sts.Client())
+
+	_, _, _, _, err = d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), chainedMaterial(privPEM))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, gotAssertion)
+	parsed, err := josejwt.ParseSigned(gotAssertion)
+	require.NoError(t, err)
+	var claims josejwt.Claims
+	require.NoError(t, parsed.Claims(&priv.PublicKey, &claims), "assertion signed with the chained key")
+	assert.Equal(t, "warden-gateway", claims.Issuer)
+}
+
+// An empty chained secret is a configuration error, surfaced before any token request.
+func TestTokenExchangeDriver_ChainedEmptySecretErrors(t *testing.T) {
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_auth": clientAuthSecretPost, "client_id": "c", "secret_spec": "s",
+	}, sts.Client())
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), chainedMaterial(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+	assert.False(t, called, "no token request when the chained secret is empty")
+}
+
+// An upstream invalid_client on the CHAINED path maps to ErrChainedSecretRejected (so the
+// manager evicts + retries); the non-chained path does NOT wrap the sentinel.
+func TestTokenExchangeDriver_ChainedInvalidClientSentinel(t *testing.T) {
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_client"})
+	}))
+	defer sts.Close()
+
+	cfg := map[string]string{"token_url": sts.URL, "client_auth": clientAuthSecretPost, "client_id": "c"}
+	subject := subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"}))
+
+	// Chained: wraps the sentinel.
+	dChained := newExchangeDriver(cfg, sts.Client())
+	_, _, _, _, err := dChained.MintCredentialWithExchangeFromSecret(context.Background(), &credential.CredSpec{}, subject, chainedMaterial("stale"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected, "chained invalid_client -> evict-and-retry sentinel")
+
+	// Non-chained (inline secret): same upstream error, but NOT the chained sentinel.
+	cfg2 := map[string]string{"token_url": sts.URL, "client_auth": clientAuthSecretPost, "client_id": "c", "client_secret": "s"}
+	dInline := newExchangeDriver(cfg2, sts.Client())
+	_, _, _, _, err = dInline.MintCredentialWithExchange(context.Background(), &credential.CredSpec{}, subject)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected, "non-chained path must not request an evict-and-retry")
+}
+
 func TestTokenExchangeDriver_IDJAG(t *testing.T) {
 	subject := makeUnsignedJWT(map[string]interface{}{"sub": "user"})
 

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -217,9 +217,10 @@ func (m *Manager) IssueCredential(ctx context.Context, caller Caller, specName s
 	// outer key's use of the AGENT's token id (caller.TokenID): both principals are
 	// keyed by token id, not identity, so the entry is bound to the token lifecycle
 	// — revoking or re-logging-in the user yields a new token id and thus a fresh
-	// mint. This dimension is independent of the exchange fingerprint, so a chained
-	// consumer (whose outer key carries no ":x:" fragment) still gets per-user
-	// isolation. Byte-identical when caller.User == nil.
+	// mint. This dimension is independent of the exchange fingerprint, so it applies
+	// whether or not the consumer requested exchange: a plain chained consumer (no
+	// ":x:" fragment) and a chained token-exchange consumer (which does carry ":x:")
+	// both get per-user isolation. Byte-identical when caller.User == nil.
 	if caller.User != nil {
 		cacheKey += ":u:" + caller.User.TokenID
 	}
@@ -370,6 +371,13 @@ func (m *Manager) issueCredential(ctx context.Context, caller Caller, specName s
 		return nil, err
 	}
 	if secretRef != "" {
+		// When the chained consumer is ITSELF an exchange spec (it requested exchange, so
+		// inputs != nil), it needs both its own subject/actor inputs AND a fetched
+		// client-auth secret — route to the exchange-aware chaining path. Otherwise the
+		// plain chaining path (mint directly from the fetched material) applies.
+		if inputs != nil {
+			return m.issueChainedExchange(ctx, caller, spec, secretRef, inputs)
+		}
 		return m.issueChained(ctx, caller, spec, secretRef)
 	}
 
@@ -427,22 +435,9 @@ func (m *Manager) secretSpecRef(ctx context.Context, spec *CredSpec) (string, er
 // secret is not cached (re-minted on every consuming-credential miss); a consumer may
 // opt into source-scoped caching via secret_cache_ttl (see resolveChainedSecretData).
 func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpec, secretRef string) (*Credential, error) {
-	// Bound the chain to a single hop (a referenced secret-spec may not itself
-	// chain). This also breaks any config-drift reference cycle rather than letting
-	// it recurse unboundedly.
-	depth := chainDepth(ctx)
-	if depth+1 > MaxSecretChainDepth {
-		return nil, fmt.Errorf("credential chaining for spec %q exceeds max depth %d (referenced secret_spec %q)", spec.Name, MaxSecretChainDepth, secretRef)
-	}
-	ctx = withChainDepth(ctx, depth+1)
-
-	// Build exchange inputs for the referenced secret-spec, as the caller.
-	if caller.ResolveInputs == nil {
-		return nil, fmt.Errorf("credential chaining for spec %q requires a request caller context", spec.Name)
-	}
-	inputsB, err := caller.ResolveInputs(ctx, secretRef)
+	ctx, inputsB, err := m.chainPreamble(ctx, caller, spec, secretRef)
 	if err != nil {
-		return nil, fmt.Errorf("secret_spec %q: %w", secretRef, err)
+		return nil, err
 	}
 
 	return m.resolveAndMintChained(ctx, caller, spec, secretRef, inputsB,
@@ -453,6 +448,51 @@ func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpe
 			}
 			return m.mintFromSecret(ctx, spec, driver, material)
 		})
+}
+
+// issueChainedExchange mints a consuming credential that is ITSELF a token-exchange spec
+// AND sources its client-auth secret via chaining. It resolves the referenced secret
+// (cached per secret_cache_ttl) and performs the exchange using the consuming spec's own
+// exchange inputs plus the fetched material. Reuses resolveAndMintChained, so caching,
+// per-agent/per-user isolation, and evict-and-retry are inherited from the generic path.
+func (m *Manager) issueChainedExchange(ctx context.Context, caller Caller, spec *CredSpec, secretRef string, inputs *ExchangeInputs) (*Credential, error) {
+	ctx, inputsB, err := m.chainPreamble(ctx, caller, spec, secretRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.resolveAndMintChained(ctx, caller, spec, secretRef, inputsB,
+		func(ctx context.Context, spec *CredSpec, material SecretMaterial) (*Credential, error) {
+			driver, err := m.driverCoordinator.GetOrCreateDriver(ctx, spec.Source)
+			if err != nil {
+				return nil, err
+			}
+			return m.mintFromSecretWithExchange(ctx, spec, driver, inputs, material)
+		})
+}
+
+// chainPreamble enforces the one-hop depth guard and builds the referenced secret-spec's
+// exchange inputs as the caller. It returns a context carrying the incremented chain
+// depth (used by the recursive referenced mint), shared by both the plain and
+// exchange-aware chaining paths.
+func (m *Manager) chainPreamble(ctx context.Context, caller Caller, spec *CredSpec, secretRef string) (context.Context, *ExchangeInputs, error) {
+	// Bound the chain to a single hop (a referenced secret-spec may not itself chain).
+	// This also breaks any config-drift reference cycle rather than recursing unboundedly.
+	depth := chainDepth(ctx)
+	if depth+1 > MaxSecretChainDepth {
+		return nil, nil, fmt.Errorf("credential chaining for spec %q exceeds max depth %d (referenced secret_spec %q)", spec.Name, MaxSecretChainDepth, secretRef)
+	}
+	ctx = withChainDepth(ctx, depth+1)
+
+	// Build exchange inputs for the referenced secret-spec, as the caller.
+	if caller.ResolveInputs == nil {
+		return nil, nil, fmt.Errorf("credential chaining for spec %q requires a request caller context", spec.Name)
+	}
+	inputsB, err := caller.ResolveInputs(ctx, secretRef)
+	if err != nil {
+		return nil, nil, fmt.Errorf("secret_spec %q: %w", secretRef, err)
+	}
+	return ctx, inputsB, nil
 }
 
 // resolveAndMintChained resolves the referenced secret material (through the opt-in
@@ -723,6 +763,23 @@ func (m *Manager) resolveSecretField(ctx context.Context, spec *CredSpec, credB 
 func (m *Manager) mintFromSecret(ctx context.Context, spec *CredSpec, driver SourceDriver, material SecretMaterial) (*Credential, error) {
 	var cred *Credential
 	err := m.mintingService.MintFromSecretWithCleanup(ctx, driver, spec, material, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
+		var parseErr error
+		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
+		return parseErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cred, nil
+}
+
+// mintFromSecretWithExchange mints the consuming credential via the exchange-aware
+// chained path — both the caller's exchange inputs and the fetched client-auth material
+// — with orphaned-lease cleanup on failure. Mirrors mintFromSecret for the
+// token-exchange chaining path.
+func (m *Manager) mintFromSecretWithExchange(ctx context.Context, spec *CredSpec, driver SourceDriver, inputs *ExchangeInputs, material SecretMaterial) (*Credential, error) {
+	var cred *Credential
+	err := m.mintingService.MintFromSecretWithExchangeCleanup(ctx, driver, spec, inputs, material, func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error {
 		var parseErr error
 		cred, parseErr = m.credentialParser.ParseAndValidate(ctx, spec, rawData, metadata, leaseTTL, leaseID, driver)
 		return parseErr

--- a/credential/minting_service.go
+++ b/credential/minting_service.go
@@ -145,6 +145,43 @@ func (s *MintingService) MintFromSecretWithCleanup(
 	return nil
 }
 
+// MintFromSecretWithExchangeCleanup mints a credential from BOTH caller-derived exchange
+// inputs and fetched chained-secret material, with the same orphaned-lease cleanup as
+// MintWithCleanup. The driver must implement ChainedExchangeMinter; a driver that does
+// not fails closed rather than silently minting under a chained token-exchange spec.
+func (s *MintingService) MintFromSecretWithExchangeCleanup(
+	ctx context.Context,
+	driver SourceDriver,
+	spec *CredSpec,
+	inputs *ExchangeInputs,
+	material SecretMaterial,
+	onSuccess func(rawData, metadata map[string]interface{}, leaseTTL time.Duration, leaseID string) error,
+) error {
+	cem, ok := driver.(ChainedExchangeMinter)
+	if !ok {
+		return fmt.Errorf("source driver %q does not support secret_spec chaining with token exchange", driver.Type())
+	}
+
+	rawData, metadata, leaseTTL, leaseID, err := cem.MintCredentialWithExchangeFromSecret(ctx, spec, inputs, material)
+	if err != nil {
+		return fmt.Errorf("failed to mint from secret with exchange: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success && leaseID != "" {
+			s.revokeOrphanedLease(driver, leaseID, spec.Source)
+		}
+	}()
+
+	if err := onSuccess(rawData, metadata, leaseTTL, leaseID); err != nil {
+		return err
+	}
+
+	success = true
+	return nil
+}
+
 // revokeOrphanedLease attempts to revoke a lease that was minted but not successfully processed.
 // This is a best-effort operation that logs errors but does not fail the overall operation.
 // Uses a fresh background context since the original context may have been cancelled.

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -271,6 +271,30 @@ type ExchangeMinter interface {
 //	var _ credential.ChainedSecretMinter = (*GitHubDriver)(nil)
 type ChainedSecretMinter interface {
 	// MintFromSecret mints a credential using the given fetched secret material.
-	// The return contract matches SourceDriver.MintCredential.
+	// The return contract matches SourceDriver.MintCredential. A driver may wrap
+	// credential.ErrChainedSecretRejected when the downstream rejects the fetched
+	// secret, so the minting layer evicts any cached secret and retries once.
 	MintFromSecret(ctx context.Context, spec *CredSpec, material SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
+}
+
+// ChainedExchangeMinter is an ExchangeMinter whose client-authentication secret
+// (client_secret, or the private_key for private_key_jwt) is itself sourced via
+// credential chaining (secret_spec) rather than stored on the source. Warden fetches
+// the referenced secret material and performs the RFC 8693 / 7523 exchange in one call,
+// so nothing about the client secret is stored in Warden.
+//
+// It is distinct from ChainedSecretMinter (which mints directly from the material with
+// no exchange) and from ExchangeMinter (which reads client auth from its own config).
+// A driver implementing it asserts so at compile time:
+//
+//	var _ credential.ChainedExchangeMinter = (*TokenExchangeDriver)(nil)
+//
+// As with the other chained interfaces, a driver may wrap
+// credential.ErrChainedSecretRejected (e.g. mapping an upstream invalid_client) so the
+// minting layer evicts a cached secret and retries once.
+type ChainedExchangeMinter interface {
+	// MintCredentialWithExchangeFromSecret mints a credential using both the caller's
+	// exchange inputs and the fetched client-auth secret. The return contract matches
+	// SourceDriver.MintCredential.
+	MintCredentialWithExchangeFromSecret(ctx context.Context, spec *CredSpec, inputs *ExchangeInputs, material SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error)
 }


### PR DESCRIPTION
## What

Let a `token_exchange` source resolve its OAuth client secret (or the PEM `private_key`
for `private_key_jwt`) from a chained `secret_spec` instead of storing it inline, while
still performing the RFC 8693 / 7523 exchange. The referenced spec authenticates to the
secret store via keyless federation, so nothing about the client secret is stored in
Warden.

## Why

The `token_exchange` client secret sits inline in the source config today. This closes
that gap using the credential-chaining infrastructure: the client secret becomes a
reference to another cred spec, fetched at mint time (and cached per #480).

## How

- **`ChainedExchangeMinter`** interface (exchange + fetched secret); `token_exchange`
  implements it. `MintFromSecretWithExchangeCleanup` type-asserts it and fails closed
  otherwise.
- **Routing**: a chained consumer that itself requests exchange is routed to
  `issueChainedExchange`, reusing #480's `resolveAndMintChained` — so caching,
  per-agent/per-user isolation, and evict-and-retry are inherited. Plain and exchange
  paths share `chainPreamble`.
- **Driver**: `MintCredentialWithExchange` and `MintCredentialWithExchangeFromSecret`
  funnel through `mintExchange` with an optional secret override threaded to
  `applyClientAuth` / `buildClientAssertion` (all three call sites, including both ID-JAG
  legs). An upstream `invalid_client` (or bare `401`) on the chained path maps to
  `ErrChainedSecretRejected` (preserving the IdP detail), so a rotated secret self-heals.
- **Factory**: no longer requires an inline `client_secret` / `private_key` when
  `secret_spec` is set (`client_id` still required); `secret_spec` / `secret_field` /
  `secret_cache_ttl` declared in the schema.
- **Validation**: the `secret_spec` + own-exchange combo is allowed only for
  `token_exchange`; a `token_exchange` chained spec must set `subject_token_source` and
  place `secret_spec` on the source — both rejected with clear guidance otherwise.

## Usage

```bash
# Client secret read from the store via keyless federation (warden_identity)
warden cred spec create idp-client-secret -json '{
  "source": "vault-federated",
  "config": {"subject_token_source": "warden_identity", "assertion_audience": "vault",
             "mint_method": "kv2_read", "secret_path": "secret/data/warden/idp-client-secret"}
}'

# token_exchange source with NO inline client_secret
warden cred source create idp-exchange -json '{
  "type": "token_exchange",
  "config": {"token_url": "https://idp.example.com/oauth2/v1/token",
             "client_auth": "client_secret_post", "client_id": "warden-gateway",
             "secret_spec": "idp-client-secret", "secret_field": "value",
             "secret_cache_ttl": "30m"}
}'

warden cred spec create internal-api -json '{
  "source": "idp-exchange",
  "config": {"subject_token_source": "user_identity", "audience": "https://api.internal.example.com"}
}'
```

## Testing

- `go build ./...`, `go vet`, full `credential` + `core` suites.
- Driver unit tests: chained `client_secret_post` / `client_secret_basic` / `private_key_jwt`
  all read the fetched secret; empty secret errors before any HTTP call; `invalid_client`
  maps to the sentinel on the chained path but NOT on the inline path.
- Manager tests: routing to `issueChainedExchange`; fail-closed on a non-`ChainedExchangeMinter`
  driver; exchange-path evict-and-retry on a stale cached secret.
- Config-store tests: `token_exchange` chained-exchange combo accepted; the non-exchange
  combo still rejected.

Third in a stacked series (follows #479, #480).
