### PR TITLE
feat(credential): keyless api_key driver via credential chaining

### DIFF
--- a/credential/drivers/static_apikey_driver.go
+++ b/credential/drivers/static_apikey_driver.go
@@ -29,6 +29,7 @@ const (
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*StaticAPIKeyDriver)(nil)
 var _ credential.SpecVerifier = (*StaticAPIKeyDriver)(nil)
+var _ credential.ChainedSecretMinter = (*StaticAPIKeyDriver)(nil)
 
 // StaticAPIKeyDriver provides API key credentials configured entirely via
 // the source config map. Auth credentials (api_key) live in the credential
@@ -161,14 +162,51 @@ func (d *StaticAPIKeyDriver) getAPIURL() string {
 	return strings.TrimRight(credential.GetString(d.credSource.Config, "api_url", ""), "/")
 }
 
-// MintCredential returns the API key from spec config.
-// The key is static — no TTL, no lease.
+// MintCredential returns the API key from spec config, minting directly from the
+// inline secret. Chained specs (secret_spec set on the spec or its source) mint through
+// MintFromSecret instead — the Manager routes them there and never calls this — so
+// reaching here with secret_spec set is a misuse and fails closed rather than reading a
+// missing inline key. Non-chained specs are unaffected. The key is static — no TTL, no lease.
 func (d *StaticAPIKeyDriver) MintCredential(_ context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if spec.Config[credential.ConfigSecretSpec] != "" || d.credSource.Config[credential.ConfigSecretSpec] != "" {
+		return nil, nil, 0, "", fmt.Errorf("%s: spec uses secret_spec (credential chaining); it must mint from fetched secret material, not directly", d.displayName())
+	}
+
 	apiKey := credential.GetString(spec.Config, "api_key", "")
 	if apiKey == "" {
 		return nil, nil, 0, "", fmt.Errorf("no %s API key configured in spec", d.displayName())
 	}
 
+	return d.buildAPIKeyData(spec, apiKey), nil, 0, "", nil // Static — no TTL, no lease
+}
+
+// MintFromSecret mints an API key credential from secret material fetched via credential
+// chaining (secret_spec), instead of reading it inline from spec config. Per-caller
+// authorization was already enforced upstream (the referenced secret-spec was minted as
+// the caller). The key is static — no TTL, no lease.
+func (d *StaticAPIKeyDriver) MintFromSecret(_ context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	apiKey := material.Secret()
+	// Fall back to the conventional key name ONLY when no field was resolved
+	// (single-key auto-detect failed / no secret_field). If a field WAS resolved but
+	// is empty, that's a misconfigured secret_field — fail loudly rather than silently
+	// substituting a different key.
+	if apiKey == "" && material.Field == "" {
+		apiKey = material.Data["api_key"]
+	}
+	if apiKey == "" {
+		if material.Field != "" {
+			return nil, nil, 0, "", fmt.Errorf("%s: secret_field %q is empty or absent in the fetched secret material", d.displayName(), material.Field)
+		}
+		return nil, nil, 0, "", fmt.Errorf("%s: no API key in fetched secret material (set secret_field, or store it under 'api_key')", d.displayName())
+	}
+
+	return d.buildAPIKeyData(spec, apiKey), nil, 0, "", nil // Static — no TTL, no lease
+}
+
+// buildAPIKeyData assembles the credential data map from the resolved API key plus any
+// optional metadata fields copied from spec config. Shared by the inline and chained
+// mint paths.
+func (d *StaticAPIKeyDriver) buildAPIKeyData(spec *credential.CredSpec, apiKey string) map[string]interface{} {
 	rawData := map[string]interface{}{
 		"api_key": apiKey,
 	}
@@ -180,7 +218,7 @@ func (d *StaticAPIKeyDriver) MintCredential(_ context.Context, spec *credential.
 		}
 	}
 
-	return rawData, nil, 0, "", nil // Static — no TTL, no lease
+	return rawData
 }
 
 // Revoke is a no-op for static API keys.

--- a/credential/drivers/static_apikey_driver_test.go
+++ b/credential/drivers/static_apikey_driver_test.go
@@ -282,6 +282,100 @@ func TestStaticAPIKeyDriver_MintCredential_OptionalMetadata(t *testing.T) {
 }
 
 // =============================================================================
+// Chained Secret (MintFromSecret) Tests
+// =============================================================================
+
+func TestStaticAPIKeyDriver_ImplementsChainedSecretMinter(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{})
+	var sd credential.SourceDriver = d
+	_, ok := sd.(credential.ChainedSecretMinter)
+	assert.True(t, ok, "StaticAPIKeyDriver should implement credential.ChainedSecretMinter")
+}
+
+func TestStaticAPIKeyDriver_MintFromSecret(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{})
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Type:   credential.TypeAPIKey,
+		Config: map[string]string{"secret_spec": "openai-key-in-vault", "secret_field": "api_key"},
+	}
+	material := credential.SecretMaterial{
+		Data:  map[string]string{"api_key": "sk-chained-key"},
+		Field: "api_key",
+	}
+	rawData, _, ttl, leaseID, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-chained-key", rawData["api_key"])
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Empty(t, leaseID)
+}
+
+func TestStaticAPIKeyDriver_MintFromSecret_AutoDetectSingleKey(t *testing.T) {
+	// No secret_field resolved (Field == ""): fall back to the conventional "api_key" key.
+	d := createTestAPIKeyDriver(t, map[string]string{})
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{"secret_spec": "ref"}}
+	material := credential.SecretMaterial{Data: map[string]string{"api_key": "sk-fallback"}, Field: ""}
+	rawData, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-fallback", rawData["api_key"])
+}
+
+func TestStaticAPIKeyDriver_MintFromSecret_OptionalMetadata(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "organization_id"})
+	spec := &credential.CredSpec{
+		Name: "test",
+		Config: map[string]string{
+			"secret_spec":     "ref",
+			"secret_field":    "api_key",
+			"organization_id": "org-999",
+		},
+	}
+	material := credential.SecretMaterial{Data: map[string]string{"api_key": "sk-x"}, Field: "api_key"}
+	rawData, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-x", rawData["api_key"])
+	assert.Equal(t, "org-999", rawData["organization_id"])
+}
+
+func TestStaticAPIKeyDriver_MintFromSecret_EmptyField(t *testing.T) {
+	// secret_field resolved but empty/absent → fail loudly, do NOT fall back.
+	d := createTestAPIKeyDriver(t, map[string]string{"display_name": "OpenAI"})
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{"secret_spec": "ref", "secret_field": "api_key"}}
+	material := credential.SecretMaterial{Data: map[string]string{"other": "x"}, Field: "api_key"}
+	_, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `secret_field "api_key"`)
+}
+
+func TestStaticAPIKeyDriver_MintFromSecret_NoKey(t *testing.T) {
+	// No field resolved and no conventional "api_key" key present.
+	d := createTestAPIKeyDriver(t, map[string]string{"display_name": "OpenAI"})
+	spec := &credential.CredSpec{Name: "test", Config: map[string]string{"secret_spec": "ref"}}
+	material := credential.SecretMaterial{Data: map[string]string{"token": "x"}, Field: ""}
+	_, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no API key in fetched secret material")
+}
+
+func TestStaticAPIKeyDriver_MintCredential_ChainedFailsClosed(t *testing.T) {
+	t.Run("spec-level secret_spec", func(t *testing.T) {
+		d := createTestAPIKeyDriver(t, map[string]string{})
+		spec := &credential.CredSpec{Name: "test", Config: map[string]string{"secret_spec": "ref"}}
+		_, _, _, _, err := d.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential chaining")
+	})
+
+	t.Run("source-level secret_spec", func(t *testing.T) {
+		d := createTestAPIKeyDriver(t, map[string]string{"secret_spec": "ref"})
+		spec := &credential.CredSpec{Name: "test", Config: map[string]string{}}
+		_, _, _, _, err := d.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential chaining")
+	})
+}
+
+// =============================================================================
 // VerifySpec Tests
 // =============================================================================
 

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -105,6 +105,20 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("version_id").
 			Describe("Specific Secrets Manager version ID (optional)").
 			Example("uuid-version-id"),
+
+		// Credential chaining (apikey source): source the api_key from another cred spec
+		// instead of storing it inline, making the spec keyless.
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Name of a cred spec that yields the api_key instead of storing it inline (credential chaining)").
+			Example("openai-key-in-vault"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Which key of the referenced secret_spec's data holds the api_key; optional when the payload is single-key").
+			Example("api_key"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("Cache the chained api_key source-wide for this duration (e.g. 30m); omit to fetch on every mint").
+			Example("30m"),
 	}
 }
 
@@ -125,6 +139,14 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 	schema := t.ConfigSchema()
 	if err := credential.ValidateSchema(config, schema...); err != nil {
 		return err
+	}
+
+	// Credential chaining is only meaningful for the apikey source, whose key is
+	// otherwise stored inline in the spec. The other source types fetch the key from
+	// their own backend (Vault KV / Secrets Manager), and local has no keyless path —
+	// reject secret_spec there rather than letting it fail late at mint time.
+	if config[credential.ConfigSecretSpec] != "" && sourceType != credential.SourceTypeAPIKey {
+		return fmt.Errorf("secret_spec (credential chaining) is not supported with a %s source", sourceType)
 	}
 
 	// Step 3: Source-specific validation
@@ -149,7 +171,15 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 		}
 		return validateAWSSecretsManagerSpecConfig(config)
 	default:
-		if config["api_key"] == "" {
+		// apikey source: the api_key lives inline in the spec, unless it is sourced from
+		// another cred spec via credential chaining (secret_spec) — the two are mutually
+		// exclusive. (local reaches here only when secret_spec is unset; the guard above
+		// rejects a chained local spec.)
+		if config[credential.ConfigSecretSpec] != "" {
+			if config["api_key"] != "" {
+				return fmt.Errorf("'api_key' and 'secret_spec' are mutually exclusive (the key is fetched from the referenced secret_spec)")
+			}
+		} else if config["api_key"] == "" {
 			return fmt.Errorf("'api_key' is required")
 		}
 	}

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -206,6 +206,55 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			wantErr:    true,
 			errMsg:     "'secret_path' is required",
 		},
+		// --- Credential chaining (secret_spec) ---
+		{
+			name: "apikey source - chained (secret_spec, no api_key)",
+			config: map[string]string{
+				"secret_spec":  "openai-key-in-vault",
+				"secret_field": "api_key",
+			},
+			sourceType: credential.SourceTypeAPIKey,
+			wantErr:    false,
+		},
+		{
+			name: "apikey source - chained without secret_field (single-key auto-detect)",
+			config: map[string]string{
+				"secret_spec": "openai-key-in-vault",
+			},
+			sourceType: credential.SourceTypeAPIKey,
+			wantErr:    false,
+		},
+		{
+			name: "apikey source - api_key and secret_spec are mutually exclusive",
+			config: map[string]string{
+				"api_key":     "sk-inline",
+				"secret_spec": "openai-key-in-vault",
+			},
+			sourceType: credential.SourceTypeAPIKey,
+			wantErr:    true,
+			errMsg:     "mutually exclusive",
+		},
+		{
+			name: "local source - secret_spec not supported",
+			config: map[string]string{
+				"secret_spec": "openai-key-in-vault",
+			},
+			sourceType: credential.SourceTypeLocal,
+			wantErr:    true,
+			errMsg:     "not supported with a local source",
+		},
+		{
+			name: "vault source - secret_spec not supported",
+			config: map[string]string{
+				"mint_method": "static_apikey",
+				"kv2_mount":   "secret",
+				"secret_path": "apikeys/my-service",
+				"secret_spec": "openai-key-in-vault",
+			},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "not supported with a hvault source",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

The `apikey` credential driver read its secret straight from the spec's inline `api_key`. This lets an `api_key` spec source its key from another cred spec via **credential chaining** (`secret_spec`) instead of storing it inline — making it **keyless**, the same pattern the `github` and `oauth2` drivers already use via `ChainedSecretMinter`.

## Changes

- **Driver** (`credential/drivers/static_apikey_driver.go`): implement `credential.ChainedSecretMinter`.
  - `MintFromSecret` resolves the key from fetched material (resolved `secret_field`, single-key auto-detect, or the conventional `api_key` key), failing loudly on an empty/misconfigured field.
  - `MintCredential` fails closed when `secret_spec` is set (spec- or source-level) — the manager routes chained specs to `MintFromSecret`.
  - Shared `buildAPIKeyData` carries the `optional_metadata` copy through both mint paths.
- **Spec type** (`credential/types/api_key.go`): accept `secret_spec` / `secret_field` / `secret_cache_ttl`; relax the inline-`api_key` requirement when chained (mutually exclusive); reject `secret_spec` on `local`/`vault`/`aws` sources, which already fetch the key out-of-band.
- **Tests**: `MintFromSecret` (field resolution, single-key auto-detect, optional-metadata passthrough, empty-field/no-key errors, fail-closed guard, interface assertion) and type-validation cases (chained-without-`api_key`, mutual exclusion, local/vault rejection).

No manager or core changes are needed — the existing chaining orchestration routes chained specs to `MintFromSecret` automatically, and the store already requires `ChainedSecretMinter` for a chained non-exchange spec.

## Verification

- `go build ./...`, `go vet ./credential/...`
- `go test ./credential/...` (driver, types, and manager-level chaining tests) and `go test ./core/ -run 'Chain|SecretSpec|CredentialConfigStore'`

## Follow-ups (not in this PR)

- Docs (`apikey.md` keyless section + config rows, and the "chained specs skip create-time verification" / `secret_cache_ttl` staleness caveats) are deferred to the release doc-prep pass.
- No chaining e2e scenario exists yet; adding one is a from-scratch task.
