### PR TITLE
feat(logical)!: dual-token extraction — agent and user principals

### DIFF
--- a/audit/device.go
+++ b/audit/device.go
@@ -279,8 +279,8 @@ func (d *device) Initialize(ctx context.Context) error {
 	return nil
 }
 
-func (d *device) ExtractToken(r *http.Request) string {
-	return ""
+func (d *device) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return "", ""
 }
 
 func (d *device) HandleExistenceCheck(ctx context.Context, req *logical.Request) (checkFound bool, exists bool, err error) {

--- a/audit/device_test.go
+++ b/audit/device_test.go
@@ -226,8 +226,8 @@ func TestDeviceBackendMethods(t *testing.T) {
 		t.Errorf("Initialize should return nil: %v", err)
 	}
 
-	if token := d.ExtractToken(&http.Request{}); token != "" {
-		t.Errorf("expected empty token, got %s", token)
+	if agent, user := d.ExtractTokens(&http.Request{}, false); agent != "" || user != "" {
+		t.Errorf("expected empty tokens, got agent=%s user=%s", agent, user)
 	}
 
 	found, exists, err := d.HandleExistenceCheck(context.Background(), nil)

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -867,10 +867,58 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		// the type assertion and skip the extractor entirely.
 		c.extractMCPDescriptor(ctx, req, matchingBackend)
 
-		req.ClientToken = matchingBackend.ExtractToken(req.HTTPRequest)
+		// Resolve the secondary (user) auth config once, before extraction:
+		// whether this mount is a protected resource decides how the extractor
+		// reads Authorization. On a mount with no effective user_auth_path the
+		// rule collapses to the pre-0.20 behaviour and userCred stays empty.
+		userAuthPath, userAuthRole := c.resolveUserAuthConfig(ctx, matchingBackend)
+		userLeg := userAuthPath != ""
 
-		// Check for unauthenticated paths on streaming backends
-		if req.ClientToken == "" {
+		// Reject the one genuinely ambiguous credential combination rather than
+		// resolving it silently. X-Warden-Token is the operator credential and
+		// never carries a user (see logical.ExtractTokensDefault), while on a
+		// protected-resource mount Authorization is where the user rides. A
+		// request bearing both is mixing the operator and workload surfaces:
+		// whichever way the provider's precedence falls, one of the two
+		// credentials gets dropped without comment. Say so instead.
+		//
+		// Presenting X-Warden-Token alone stays valid — that is explicit
+		// (non-transparent) agent auth, and it works here exactly as it does on
+		// a mount that is not a protected resource.
+		if userLeg && req.HTTPRequest != nil &&
+			req.HTTPRequest.Header.Get(logical.HeaderWardenToken) != "" &&
+			req.HTTPRequest.Header.Get("Authorization") != "" {
+			c.logger.Warn("ambiguous credentials on a protected-resource mount",
+				logger.String("path", req.Path),
+				logger.String("request_id", req.RequestID),
+			)
+			return logical.ErrorResponse(logical.ErrBadRequest(
+				"X-Warden-Token cannot be combined with an Authorization credential on a mount " +
+					"with user_auth_path: it is the operator credential and carries no user principal. " +
+					"Present the agent via X-Warden-Agent-Token or a client certificate to let " +
+					"Authorization carry the user, or drop the Authorization header.")), nil, nil
+		}
+
+		var userCred string
+		req.ClientToken, userCred = matchingBackend.ExtractTokens(req.HTTPRequest, userLeg)
+
+		// Check for unauthenticated paths on streaming backends.
+		//
+		// An empty ClientToken alone no longer implies "no agent credential":
+		// on a protected-resource mount the extractor returns an empty agent to
+		// mean "the TLS client certificate is the agent". Treating that as
+		// unauthenticated would skip CheckToken, minting, user capture and
+		// audit for a request that carried two credentials.
+		//
+		// Scoped to userLeg so non-opted-in mounts keep 0.19 behaviour exactly:
+		// only there can a cert produce an empty agent, and public token-less
+		// endpoints (e.g. Vault's PKI CRL paths) must stay reachable from an
+		// mTLS listener or behind a mesh proxy, where a trusted cert is present
+		// on every request. The git providers can also return an empty agent
+		// under a cert on a non-opted-in mount, but githttp's own probe gate
+		// refuses passthrough whenever Authorization is set, which it is there.
+		certIsAgent := userLeg && logical.HasTrustedClientCert(req.HTTPRequest)
+		if req.ClientToken == "" && !certIsAgent {
 			if tmp, ok := matchingBackend.(logical.TransparentModeProvider); ok {
 				relativePath := req.Path
 				if req.MountPoint != "" {
@@ -902,15 +950,15 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 			}
 		}
 
-		// Secondary transparent authentication: resolve the per-request USER
-		// principal (identity only) from a second request header when the
-		// provider or namespace configures user_auth_path. It runs upfront —
-		// before CheckToken and thus before the CBP decision — so the user is a
+		// Secondary transparent authentication: validate the per-request USER
+		// principal (identity only) already extracted above, when the provider
+		// or namespace configures user_auth_path. It runs upfront — before
+		// CheckToken and thus before the CBP decision — so the user is a
 		// first-class, already-validated principal by the time authorization and
 		// minting run. Skipped for stream-unauthenticated requests, which bypass
 		// CheckToken, minting, and audit entirely.
 		if !req.StreamUnauthenticated {
-			if err := c.captureUserContext(ctx, req, matchingBackend); err != nil {
+			if err := c.captureUserContext(ctx, req, userAuthPath, userAuthRole, userCred); err != nil {
 				c.logger.Warn("secondary user authentication failed",
 					logger.Err(err),
 					logger.String("path", req.Path),
@@ -1668,10 +1716,18 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 	return nil
 }
 
-// It checks X-Warden-Token header first, then falls back to Authorization: Bearer.
+// extractToken resolves the agent credential for a NON-streaming request. It
+// checks X-Warden-Token first, then falls back to Authorization: Bearer.
+//
+// The two-principal rule deliberately does not apply here: nothing on the
+// non-streaming path consumes a user credential (captureUserContext runs only in
+// the streaming branch), so reinterpreting Authorization would change agent
+// resolution — on provider config paths and transparent operations alike —
+// while producing a user nobody reads. Streaming gateway requests use the
+// routed backend's ExtractTokens instead.
 func extractToken(r *http.Request) string {
 	// Try X-Warden-Token header first
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
+	if token := r.Header.Get(logical.HeaderWardenToken); token != "" {
 		return token
 	}
 	// Fall back to Authorization: Bearer
@@ -1680,26 +1736,11 @@ func extractToken(r *http.Request) string {
 
 // stripBearer returns the token in an Authorization-style header value, matching
 // the "Bearer " scheme case-insensitively and returning the remainder verbatim
-// (no TrimSpace). It is the single source of truth for the Bearer strip so an
-// Authorization-borne user token (the opt-in user_token_header) is byte-identical
-// to the agent's own auth token when both ride Authorization — which the
-// captureUserContext "user must differ from the agent" guard relies on.
+// (no TrimSpace). It delegates to logical.StripBearer, the single source of
+// truth for the strip, so core and every provider extractor agree byte-for-byte
+// on where a token starts.
 func stripBearer(authHeader string) string {
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
-	}
-	return ""
-}
-
-// resolveHeaderToken reads a token-exchange token from the named (already
-// canonicalized) request header, stripping the Bearer scheme via stripBearer
-// when the header is Authorization, and returning any other header verbatim.
-func resolveHeaderToken(r *http.Request, headerName string) string {
-	v := r.Header.Get(headerName)
-	if headerName == "Authorization" {
-		return stripBearer(v)
-	}
-	return v
+	return logical.StripBearer(authHeader)
 }
 
 // isTransparentRequest checks if this request needs implicit authentication.
@@ -1735,7 +1776,14 @@ func (c *Core) isTransparentRequest(req *logical.Request, backend logical.Backen
 	// Explicit X-Warden-Token means the client wants explicit auth — skip
 	// transparent auth entirely so the standard token-validation path runs.
 	// Mirrors the same short-circuit on the transparent-ops path at line 743.
-	if req.HTTPRequest != nil && req.HTTPRequest.Header.Get("X-Warden-Token") != "" {
+	//
+	// X-Warden-Agent-Token deliberately does NOT short-circuit here. It carries
+	// a JWT or JWT-SVID that still needs a transparent login, and the token
+	// store only looks tokens up — it never logs one in — so skipping this path
+	// would fail every fresh credential presented on that header. An agent
+	// holding an opaque session token has no reason to use it: X-Warden-Token
+	// already frees Authorization for the user under extraction rule 1.
+	if req.HTTPRequest != nil && req.HTTPRequest.Header.Get(logical.HeaderWardenToken) != "" {
 		return false, ""
 	}
 
@@ -1802,18 +1850,14 @@ func (c *Core) handleTransparentAuth(ctx context.Context, req *logical.Request, 
 // unusable: invalid/unauthenticable, cross-namespace, or identical to the agent's
 // own credential. An unset user_auth_path is a no-op — req.User stays nil and the
 // request is byte-identical to before the feature.
-func (c *Core) captureUserContext(ctx context.Context, req *logical.Request, backend logical.Backend) error {
-	userAuthPath, userTokenHeader, userAuthRole := c.resolveUserAuthConfig(ctx, backend)
+// The user credential is supplied by the caller rather than read here: the
+// backend's ExtractTokens already decided which wire slot carries the user for
+// this provider and this request shape, and the two must not disagree.
+func (c *Core) captureUserContext(ctx context.Context, req *logical.Request, userAuthPath, userAuthRole, userCred string) error {
 	if userAuthPath == "" {
 		return nil // per-user auth not configured — feature off
 	}
 
-	if userTokenHeader == "" {
-		userTokenHeader = logical.DefaultUserTokenHeader
-	}
-	userTokenHeader = http.CanonicalHeaderKey(userTokenHeader)
-
-	userCred := resolveHeaderToken(req.HTTPRequest, userTokenHeader)
 	if userCred == "" {
 		// No user credential presented. Leave req.User nil and let a downstream
 		// flow that genuinely needs the user (assertion_user_claims, a templated
@@ -1821,19 +1865,21 @@ func (c *Core) captureUserContext(ctx context.Context, req *logical.Request, bac
 		return nil
 	}
 
-	// Fail closed if the user credential is the agent's own token — a
-	// misconfiguration (or an Authorization-header collision for a JWT-bearer
-	// agent) that would otherwise authenticate the agent as the user.
+	// Fail closed if the user credential is the agent's own token. The two legs
+	// now occupy different wire slots, but a client that defensively sets both
+	// X-Warden-Token and Authorization to the same JWT would otherwise have the
+	// agent double-resolved as its own "user".
 	if userCred == req.ClientToken {
 		return fmt.Errorf("the user credential must differ from the agent credential")
 	}
 
-	// The user credential is a bearer secret. Strip it from the request now that it
-	// is captured, so it never proxies to an upstream or lands in an audit header
-	// copy: this covers a custom user_token_header that the static per-provider
-	// strip lists cannot name, and any forwarding path without a Warden strip list.
-	// req.User.RawToken retains the value for the RFC 8693 subject_token path.
-	req.HTTPRequest.Header.Del(userTokenHeader)
+	// The user credential is a bearer secret riding Authorization (either as a
+	// Bearer token or, for git smart-HTTP, in the Basic password slot). Strip the
+	// header now that it is captured, so it never proxies to an upstream or lands
+	// in an audit header copy — this covers any forwarding path without a Warden
+	// strip list. req.User.RawToken retains the value for the RFC 8693
+	// subject_token path.
+	req.HTTPRequest.Header.Del("Authorization")
 
 	userTE, _, err := c.resolveTransparentIdentity(ctx, req, userAuthPath, userAuthRole, userCred)
 	if err != nil {
@@ -1855,25 +1901,25 @@ func (c *Core) captureUserContext(ctx context.Context, req *logical.Request, bac
 }
 
 // resolveUserAuthConfig resolves the secondary (user) auth configuration for a
-// gateway request. The provider is consulted first (a backend that implements
-// logical.UserAuthConfigProvider), then the request namespace's custom metadata
-// (user_auth_path / user_token_header / user_auth_role) — mirroring how primary
-// transparent auth resolves auto_auth_path from the provider or the namespace.
-// Returns an empty path when per-user auth is not configured anywhere.
-func (c *Core) resolveUserAuthConfig(ctx context.Context, backend logical.Backend) (userAuthPath, userTokenHeader, userAuthRole string) {
+// gateway request from the mount's own config (a backend that implements
+// logical.UserAuthConfigProvider). Returns an empty path when per-user auth is
+// not configured on this mount.
+//
+// Deliberately mount-only, unlike auto_auth_path, which also falls back to the
+// namespace's custom metadata. Agent identity genuinely is namespace-scoped —
+// every workload in a namespace authenticates the same way — but user_auth_path
+// marks THIS mount as a protected resource: it decides whether Authorization
+// carries the user rather than the agent, and it binds one resource to one
+// identity provider and audience. A namespace-wide fallback would opt in every
+// mount in the namespace, including ones that never intended to reinterpret
+// Authorization, and would force a single user_auth_role's bound_audiences to
+// cover every resource at once.
+func (c *Core) resolveUserAuthConfig(_ context.Context, backend logical.Backend) (userAuthPath, userAuthRole string) {
 	if p, ok := backend.(logical.UserAuthConfigProvider); ok {
 		userAuthPath = p.GetUserAuthPath()
-		userTokenHeader = p.GetUserTokenHeader()
 		userAuthRole = p.GetUserAuthRole()
 	}
-	if userAuthPath == "" {
-		if ns, _ := namespace.FromContext(ctx); ns != nil {
-			userAuthPath = ns.CustomMetadata["user_auth_path"]
-			userTokenHeader = ns.CustomMetadata["user_token_header"]
-			userAuthRole = ns.CustomMetadata["user_auth_role"]
-		}
-	}
-	return userAuthPath, userTokenHeader, userAuthRole
+	return userAuthPath, userAuthRole
 }
 
 // performImplicitAuth performs implicit authentication for the PRIMARY principal

--- a/core/request_handler_agent_token_test.go
+++ b/core/request_handler_agent_token_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsTransparentRequest_AgentTokenHeader guards the distinction between the
+// two agent channels.
+//
+// X-Warden-Token is an already-issued session token, so it short-circuits
+// transparent auth and goes to explicit token validation. X-Warden-Agent-Token
+// carries a JWT or JWT-SVID that still needs a transparent LOGIN — the token
+// store only ever looks tokens up, never logs one in, so short-circuiting it
+// would make every fresh credential on that header fail closed. That would
+// break the flagship flow this whole feature exists for: a bearer-JWT agent
+// presenting itself out of band so Authorization is free for the user.
+func TestIsTransparentRequest_AgentTokenHeader(t *testing.T) {
+	core := createTestCore(t)
+
+	backend := &mockTransparentModeProvider{
+		transparentMode: true,
+		autoAuthPath:    "auth/agent-jwt/",
+		defaultAuthRole: "agent",
+	}
+
+	newReq := func(headers map[string]string) *logical.Request {
+		hr := httptest.NewRequest(http.MethodPost, "/v1/mcp/gateway/messages", nil)
+		for k, v := range headers {
+			hr.Header.Set(k, v)
+		}
+		return &logical.Request{Path: "mcp/gateway/messages", HTTPRequest: hr}
+	}
+
+	t.Run("X-Warden-Agent-Token still routes through transparent auth", func(t *testing.T) {
+		req := newReq(map[string]string{
+			"X-Warden-Agent-Token": "eyJ.agent.jwt",
+			"Authorization":        "Bearer user-token",
+		})
+		transparent, _ := core.isTransparentRequest(req, backend)
+		require.True(t, transparent,
+			"a JWT on the agent channel needs a transparent login; skipping it would "+
+				"send an unissued credential to the lookup-only token store and fail closed")
+	})
+
+	t.Run("X-Warden-Token short-circuits to explicit auth", func(t *testing.T) {
+		req := newReq(map[string]string{"X-Warden-Token": "already-issued-session-token"})
+		transparent, _ := core.isTransparentRequest(req, backend)
+		assert.False(t, transparent, "an issued session token wants explicit validation")
+	})
+
+	t.Run("both headers: the session token still wins", func(t *testing.T) {
+		req := newReq(map[string]string{
+			"X-Warden-Token":       "already-issued-session-token",
+			"X-Warden-Agent-Token": "eyJ.agent.jwt",
+		})
+		transparent, _ := core.isTransparentRequest(req, backend)
+		assert.False(t, transparent)
+	})
+}

--- a/core/request_handler_ambiguous_test.go
+++ b/core/request_handler_ambiguous_test.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/listener"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAmbiguousOperatorAndUserCredentials pins that mixing the operator
+// credential with the workload user leg fails loudly.
+//
+// X-Warden-Token authenticates an agent explicitly — "non-transparent mode" —
+// and that stays valid on a gateway path whether or not the mount is a
+// protected resource. What is rejected is presenting it *alongside* an
+// Authorization credential on a mount with user_auth_path: X-Warden-Token
+// carries no user, Authorization is where the user rides, and whichever way a
+// provider's precedence falls one of the two is discarded without comment.
+func TestAmbiguousOperatorAndUserCredentials(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	mount := func(t *testing.T, path, uuid, userAuthPath string) {
+		t.Helper()
+		backend := &mockUnauthPathBackend{userAuthPath: userAuthPath}
+		entry := &MountEntry{
+			Path:        path,
+			Type:        "mcp",
+			Class:       mountClassProvider,
+			UUID:        uuid,
+			Accessor:    uuid + "_acc",
+			NamespaceID: namespace.RootNamespaceID,
+			namespace:   namespace.RootNamespace,
+		}
+		require.NoError(t, core.router.Mount(path, backend, entry, &mockBarrierView{prefix: "provider/" + uuid + "/"}))
+	}
+	mount(t, "protected/", "amb-protected", "auth/user-jwt/")
+	mount(t, "plain/", "amb-plain", "")
+
+	newReq := func(mountPath string, headers map[string]string, cert bool) *logical.Request {
+		p := mountPath + "gateway/messages"
+		hr := httptest.NewRequest(http.MethodPost, "/v1/"+p, nil)
+		for k, v := range headers {
+			hr.Header.Set(k, v)
+		}
+		if cert {
+			hr = hr.WithContext(listener.WithForwardedClientCert(hr.Context(), &x509.Certificate{}))
+		}
+		return &logical.Request{Path: p, Operation: logical.CreateOperation, HTTPRequest: hr}
+	}
+
+	isAmbiguityError := func(resp *logical.Response) bool {
+		return resp != nil && resp.StatusCode == http.StatusBadRequest &&
+			resp.Err != nil && strings.Contains(resp.Err.Error(), "cannot be combined with an Authorization credential")
+	}
+
+	t.Run("rejected: operator token plus a bearer on a protected resource", func(t *testing.T) {
+		resp, _, _ := core.handleNonLoginRequest(ctx, newReq("protected/", map[string]string{
+			"X-Warden-Token": "w", "Authorization": "Bearer u",
+		}, false))
+		assert.True(t, isAmbiguityError(resp), "the dropped credential must be reported, not swallowed")
+	})
+
+	t.Run("rejected: operator token plus a Basic credential", func(t *testing.T) {
+		// Git's shape. Basic also rides Authorization, so it is the same clash.
+		resp, _, _ := core.handleNonLoginRequest(ctx, newReq("protected/", map[string]string{
+			"X-Warden-Token": "w", "Authorization": "Basic cm9sZTpwd2Q=",
+		}, false))
+		assert.True(t, isAmbiguityError(resp))
+	})
+
+	t.Run("allowed: operator token alone on a protected resource", func(t *testing.T) {
+		// Explicit (non-transparent) agent auth. Still a supported mode.
+		resp, _, _ := core.handleNonLoginRequest(ctx, newReq("protected/", map[string]string{
+			"X-Warden-Token": "w",
+		}, false))
+		assert.False(t, isAmbiguityError(resp))
+	})
+
+	t.Run("allowed: operator token plus a bearer on a plain mount", func(t *testing.T) {
+		// No user leg, so nothing is dropped — the provider's own precedence
+		// decides, exactly as it did before 0.20.
+		resp, _, _ := core.handleNonLoginRequest(ctx, newReq("plain/", map[string]string{
+			"X-Warden-Token": "w", "Authorization": "Bearer u",
+		}, false))
+		assert.False(t, isAmbiguityError(resp))
+	})
+
+	t.Run("allowed: agent-token header plus a bearer on a protected resource", func(t *testing.T) {
+		// The supported two-principal shape.
+		resp, _, _ := core.handleNonLoginRequest(ctx, newReq("protected/", map[string]string{
+			"X-Warden-Agent-Token": "a", "Authorization": "Bearer u",
+		}, false))
+		assert.False(t, isAmbiguityError(resp))
+	})
+
+	t.Run("allowed: client cert plus a bearer on a protected resource", func(t *testing.T) {
+		resp, _, _ := core.handleNonLoginRequest(ctx, newReq("protected/", map[string]string{
+			"Authorization": "Bearer u",
+		}, true))
+		assert.False(t, isAmbiguityError(resp))
+	})
+}

--- a/core/request_handler_unauth_gate_test.go
+++ b/core/request_handler_unauth_gate_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/listener"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockUnauthPathBackend declares every path unauthenticated, the way a provider
+// with a configured unauthenticated-path pattern behaves. The base
+// StreamingBackend implementation is pattern-only and never inspects the
+// request, so it cannot itself tell a credential-less probe from a
+// cert-authenticated request.
+type mockUnauthPathBackend struct {
+	mockTransparentModeProvider
+	userAuthPath string
+}
+
+func (m *mockUnauthPathBackend) IsUnauthenticatedPath(_ *http.Request, _ string) bool { return true }
+
+// GetUserAuthPath makes the mount a protected resource when non-empty, which is
+// what turns an empty agent into "the cert is the agent".
+func (m *mockUnauthPathBackend) GetUserAuthPath() string { return m.userAuthPath }
+func (m *mockUnauthPathBackend) GetUserAuthRole() string { return "" }
+
+// TestStreamUnauthenticatedGate guards the hole opened by letting an empty agent
+// mean "the TLS client certificate is the agent", and pins the scope of that
+// guard.
+//
+// The gate is entered on ClientToken == "", which used to imply "no credential
+// at all". On a protected-resource mount that is now a routine state, so without
+// the cert check a cert-authenticated request carrying a user credential would
+// be marked StreamUnauthenticated and skip CheckToken, minting, user capture and
+// audit entirely.
+//
+// The check is deliberately scoped to such mounts. Only there can a cert produce
+// an empty agent, and public token-less endpoints must stay reachable from an
+// mTLS listener or behind a mesh proxy, where a trusted cert rides every request.
+func TestStreamUnauthenticatedGate(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	mount := func(t *testing.T, path, uuid, userAuthPath string) {
+		t.Helper()
+		backend := &mockUnauthPathBackend{userAuthPath: userAuthPath}
+		entry := &MountEntry{
+			Path:        path,
+			Type:        "mcp",
+			Class:       mountClassProvider,
+			UUID:        uuid,
+			Accessor:    uuid + "_acc",
+			NamespaceID: namespace.RootNamespaceID,
+			namespace:   namespace.RootNamespace,
+		}
+		require.NoError(t, core.router.Mount(path, backend, entry, &mockBarrierView{prefix: "provider/" + uuid + "/"}))
+	}
+	mount(t, "protected/", "protected-uuid", "auth/user-jwt/")
+	mount(t, "plain/", "plain-uuid", "")
+
+	newReq := func(mountPath string, withCert bool) *logical.Request {
+		p := mountPath + "gateway/messages"
+		hr := httptest.NewRequest(http.MethodPost, "/v1/"+p, nil)
+		if withCert {
+			hr = hr.WithContext(listener.WithForwardedClientCert(hr.Context(), &x509.Certificate{}))
+		}
+		return &logical.Request{Path: p, Operation: logical.CreateOperation, HTTPRequest: hr}
+	}
+
+	t.Run("protected resource: no credential and no cert is still unauthenticated", func(t *testing.T) {
+		req := newReq("protected/", false)
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+		assert.True(t, req.StreamUnauthenticated,
+			"a genuinely credential-less probe must keep passing through")
+	})
+
+	t.Run("protected resource: trusted cert disqualifies the unauthenticated path", func(t *testing.T) {
+		req := newReq("protected/", true)
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+		assert.False(t, req.StreamUnauthenticated,
+			"an empty agent means the cert IS the agent; treating it as unauthenticated "+
+				"would skip CheckToken, minting, user capture and audit")
+	})
+
+	t.Run("plain mount: a trusted cert does not disqualify it", func(t *testing.T) {
+		// 0.19 behaviour, preserved. A cert cannot yield an empty agent here, so
+		// an empty ClientToken still means "no credential" — and public
+		// token-less endpoints must keep working behind mTLS or a mesh proxy.
+		req := newReq("plain/", true)
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+		assert.True(t, req.StreamUnauthenticated,
+			"scoping the cert check to protected resources keeps non-opted-in mounts byte-identical")
+	})
+}

--- a/core/request_handler_user_test.go
+++ b/core/request_handler_user_test.go
@@ -21,14 +21,12 @@ import (
 // user_auth_path etc. off the backend via logical.UserAuthConfigProvider.
 type mockUserAuthProvider struct {
 	mockTransparentModeProvider
-	userAuthPath    string
-	userTokenHeader string
-	userAuthRole    string
+	userAuthPath string
+	userAuthRole string
 }
 
-func (m *mockUserAuthProvider) GetUserAuthPath() string    { return m.userAuthPath }
-func (m *mockUserAuthProvider) GetUserTokenHeader() string { return m.userTokenHeader }
-func (m *mockUserAuthProvider) GetUserAuthRole() string    { return m.userAuthRole }
+func (m *mockUserAuthProvider) GetUserAuthPath() string { return m.userAuthPath }
+func (m *mockUserAuthProvider) GetUserAuthRole() string { return m.userAuthRole }
 
 // seedUserToken caches a transparent JWT-role token on the given mount so a later
 // resolveTransparentIdentity call resolves it from cache without a login.
@@ -127,23 +125,20 @@ func TestCaptureUserContext(t *testing.T) {
 	}
 
 	t.Run("feature off when no user_auth_path", func(t *testing.T) {
-		backend := &mockUserAuthProvider{} // userAuthPath empty
-		req := newReq("agent-tok", map[string]string{"X-Warden-User-Token": userJWT})
-		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		req := newReq("agent-tok", nil)
+		require.NoError(t, core.captureUserContext(ctx, req, "", "", userJWT))
 		assert.Nil(t, req.User, "unconfigured feature is a no-op")
 	})
 
 	t.Run("absent user credential is not an error", func(t *testing.T) {
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/"}
-		req := newReq("agent-tok", nil) // no user header
-		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		req := newReq("agent-tok", nil)
+		require.NoError(t, core.captureUserContext(ctx, req, "auth/user-jwt/", "", ""))
 		assert.Nil(t, req.User, "no user credential → req.User stays nil, no error")
 	})
 
 	t.Run("valid user credential attaches req.User (identity only)", func(t *testing.T) {
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/", userAuthRole: "slack-user"}
-		req := newReq("agent-primary-token", map[string]string{"X-Warden-User-Token": userJWT})
-		require.NoError(t, core.captureUserContext(ctx, req, backend))
+		req := newReq("agent-primary-token", map[string]string{"Authorization": "Bearer " + userJWT})
+		require.NoError(t, core.captureUserContext(ctx, req, "auth/user-jwt/", "slack-user", userJWT))
 		require.NotNil(t, req.User)
 		assert.Equal(t, userTE.ID, req.User.TokenEntry.ID)
 		assert.Equal(t, userJWT, req.User.RawToken)
@@ -153,62 +148,35 @@ func TestCaptureUserContext(t *testing.T) {
 		assert.Equal(t, "agent-primary-token", req.ClientToken)
 		// The raw user credential is scrubbed from the request so it can't proxy
 		// upstream or land in an audit header copy (req.User.RawToken retains it).
-		assert.Empty(t, req.HTTPRequest.Header.Get("X-Warden-User-Token"), "user header must be stripped after capture")
+		assert.Empty(t, req.HTTPRequest.Header.Get("Authorization"), "Authorization must be stripped after capture")
 	})
 
-	t.Run("custom user_token_header is scrubbed after capture", func(t *testing.T) {
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/", userTokenHeader: "X-User-Jwt", userAuthRole: "slack-user"}
-		req := newReq("agent-primary-token", map[string]string{"X-User-Jwt": userJWT})
-		require.NoError(t, core.captureUserContext(ctx, req, backend))
-		require.NotNil(t, req.User)
-		assert.Empty(t, req.HTTPRequest.Header.Get("X-User-Jwt"), "a custom user header the static strip lists cannot name must still be scrubbed")
-	})
-
-	t.Run("Authorization user header for a cert-authenticated agent", func(t *testing.T) {
-		// A cert agent's ClientToken is its token ID (not a bearer), so the user
-		// token riding Authorization does NOT trip the user==agent guard. This is
-		// the documented cert/SPIFFE opt-in; it only works because the primary cert
-		// path clears any stray Authorization bearer (see the cert dispatch).
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/", userTokenHeader: "Authorization", userAuthRole: "slack-user"}
-		req := newReq("agent-cert-token-id", map[string]string{"Authorization": "Bearer " + userJWT})
-		require.NoError(t, core.captureUserContext(ctx, req, backend))
+	t.Run("git Basic password as the user credential is scrubbed", func(t *testing.T) {
+		// Cert agent + git smart-HTTP: the Basic password slot carries the user
+		// while the username still names the AGENT's role. Both live in
+		// Authorization, so the same scrub covers them.
+		req := newReq("agent-cert-token-id", nil)
+		req.HTTPRequest.SetBasicAuth("agent-role", userJWT)
+		require.NoError(t, core.captureUserContext(ctx, req, "auth/user-jwt/", "slack-user", userJWT))
 		require.NotNil(t, req.User)
 		assert.Equal(t, userTE.ID, req.User.TokenEntry.ID)
-		assert.Empty(t, req.HTTPRequest.Header.Get("Authorization"), "Authorization user header is scrubbed after capture")
-	})
-
-	t.Run("namespace-metadata config drives capture", func(t *testing.T) {
-		nsWithMeta := &namespace.Namespace{
-			ID:   namespace.RootNamespaceID,
-			Path: namespace.RootNamespace.Path,
-			CustomMetadata: map[string]string{
-				"user_auth_path": "auth/user-jwt/",
-				"user_auth_role": "slack-user",
-			},
-		}
-		nsCtx := namespace.ContextWithNamespace(context.Background(), nsWithMeta)
-		// A plain transparent backend that does NOT implement UserAuthConfigProvider,
-		// so the config must come from the namespace metadata.
-		backend := &mockTransparentModeProvider{}
-		req := newReq("agent-primary-token", map[string]string{"X-Warden-User-Token": userJWT})
-		require.NoError(t, core.captureUserContext(nsCtx, req, backend))
-		require.NotNil(t, req.User)
-		assert.Equal(t, userTE.ID, req.User.TokenEntry.ID)
+		assert.Empty(t, req.HTTPRequest.Header.Get("Authorization"), "the Basic slot carrying the user must be stripped after capture")
 	})
 
 	t.Run("user credential equal to the agent credential fails closed", func(t *testing.T) {
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/"}
-		req := newReq(userJWT, map[string]string{"X-Warden-User-Token": userJWT})
-		err := core.captureUserContext(ctx, req, backend)
+		// The two legs occupy different wire slots now, but a client that
+		// defensively sets both to the same JWT must not have the agent
+		// double-resolved as its own user.
+		req := newReq(userJWT, map[string]string{"Authorization": "Bearer " + userJWT})
+		err := core.captureUserContext(ctx, req, "auth/user-jwt/", "", userJWT)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must differ from the agent credential")
 		assert.Nil(t, req.User)
 	})
 
 	t.Run("non-bearer user credential fails closed", func(t *testing.T) {
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-jwt/"}
-		req := newReq("agent-tok", map[string]string{"X-Warden-User-Token": "not-a-jwt"})
-		err := core.captureUserContext(ctx, req, backend)
+		req := newReq("agent-tok", nil)
+		err := core.captureUserContext(ctx, req, "auth/user-jwt/", "", "not-a-jwt")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "user authentication failed")
 		assert.Nil(t, req.User)
@@ -216,46 +184,47 @@ func TestCaptureUserContext(t *testing.T) {
 
 	t.Run("cert-format user mount rejected (bearer required)", func(t *testing.T) {
 		mountStubAuthMethod(t, core, "user-cert/", "cert")
-		backend := &mockUserAuthProvider{userAuthPath: "auth/user-cert/"}
-		req := newReq("agent-tok", map[string]string{"X-Warden-User-Token": userJWT})
-		err := core.captureUserContext(ctx, req, backend)
+		req := newReq("agent-tok", nil)
+		err := core.captureUserContext(ctx, req, "auth/user-cert/", "", userJWT)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "bearer credential")
 		assert.Nil(t, req.User)
 	})
 }
 
-// TestResolveUserAuthConfig covers the provider-then-namespace precedence for the
+// TestResolveUserAuthConfig covers the mount-only resolution of the
 // secondary-user auth configuration.
 func TestResolveUserAuthConfig(t *testing.T) {
 	core := createTestCore(t)
 
-	t.Run("provider config wins", func(t *testing.T) {
+	t.Run("mount config drives it", func(t *testing.T) {
 		ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
-		backend := &mockUserAuthProvider{userAuthPath: "auth/prov/", userTokenHeader: "X-Prov", userAuthRole: "prov-role"}
-		p, h, r := core.resolveUserAuthConfig(ctx, backend)
+		backend := &mockUserAuthProvider{userAuthPath: "auth/prov/", userAuthRole: "prov-role"}
+		p, r := core.resolveUserAuthConfig(ctx, backend)
 		assert.Equal(t, "auth/prov/", p)
-		assert.Equal(t, "X-Prov", h)
 		assert.Equal(t, "prov-role", r)
 	})
 
-	t.Run("namespace metadata fallback", func(t *testing.T) {
+	t.Run("namespace metadata is NOT consulted", func(t *testing.T) {
+		// user_auth_path marks THIS mount a protected resource: it decides
+		// whether Authorization carries the user, and binds one resource to one
+		// identity provider and audience. A namespace-wide fallback would opt in
+		// every mount in the namespace, so it is deliberately absent — unlike
+		// auto_auth_path, where namespace scope is correct.
 		ns := &namespace.Namespace{ID: "ns1", Path: "ns1/", CustomMetadata: map[string]string{
-			"user_auth_path":    "auth/nsuser/",
-			"user_token_header": "X-NS",
-			"user_auth_role":    "ns-role",
+			"user_auth_path": "auth/nsuser/",
+			"user_auth_role": "ns-role",
 		}}
 		ctx := namespace.ContextWithNamespace(context.Background(), ns)
-		p, h, r := core.resolveUserAuthConfig(ctx, &mockUserAuthProvider{}) // provider unset
-		assert.Equal(t, "auth/nsuser/", p)
-		assert.Equal(t, "X-NS", h)
-		assert.Equal(t, "ns-role", r)
+		p, r := core.resolveUserAuthConfig(ctx, &mockUserAuthProvider{}) // mount unset
+		assert.Empty(t, p, "namespace metadata must not opt a mount into the user leg")
+		assert.Empty(t, r)
 	})
 
-	t.Run("unset everywhere yields empty", func(t *testing.T) {
+	t.Run("backend not implementing the interface yields empty", func(t *testing.T) {
 		ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
-		p, _, _ := core.resolveUserAuthConfig(ctx, &mockUserAuthProvider{})
-		assert.Empty(t, p, "no provider/namespace config → feature off")
+		p, _ := core.resolveUserAuthConfig(ctx, &mockTransparentModeProvider{})
+		assert.Empty(t, p, "no mount config → feature off")
 	})
 }
 

--- a/core/sys_introspect_test.go
+++ b/core/sys_introspect_test.go
@@ -87,8 +87,10 @@ func (b *introspectMockBackend) Class() logical.BackendClass          { return l
 func (b *introspectMockBackend) HandleExistenceCheck(ctx context.Context, req *logical.Request) (bool, bool, error) {
 	return false, false, nil
 }
-func (b *introspectMockBackend) SpecialPaths() *logical.Paths        { return nil }
-func (b *introspectMockBackend) ExtractToken(r *http.Request) string { return "" }
+func (b *introspectMockBackend) SpecialPaths() *logical.Paths { return nil }
+func (b *introspectMockBackend) ExtractTokens(r *http.Request, userLeg bool) (string, string) {
+	return "", ""
+}
 
 // jwtRequest builds a system-backend request with an Authorization: Bearer
 // header, which the aggregator interprets as CredentialFormat = "jwt".

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -143,8 +143,8 @@ func (m *mockAuditDevice) SpecialPaths() *logical.Paths {
 	return nil
 }
 
-func (m *mockAuditDevice) ExtractToken(r *http.Request) string {
-	return ""
+func (m *mockAuditDevice) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return "", ""
 }
 
 // mockAuditFactory implements audit.Factory for testing
@@ -404,8 +404,8 @@ func (m *mockAuthMethod) SpecialPaths() *logical.Paths {
 	return nil
 }
 
-func (m *mockAuthMethod) ExtractToken(r *http.Request) string {
-	return ""
+func (m *mockAuthMethod) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return "", ""
 }
 
 func newMockAuthMethod() *mockAuthMethod {
@@ -504,8 +504,8 @@ func (m *mockProvider) SpecialPaths() *logical.Paths {
 	return nil
 }
 
-func (m *mockProvider) ExtractToken(r *http.Request) string {
-	return ""
+func (m *mockProvider) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return "", ""
 }
 
 func newMockProvider() *mockProvider {

--- a/framework/backend.go
+++ b/framework/backend.go
@@ -49,8 +49,9 @@ type Backend struct {
 	// BackendType is a string identifier for the backend type (e.g., "jwt", "aws")
 	BackendType string
 
-	// TokenExtractor is the warden-specific token extraction function
-	TokenExtractor func(r *http.Request) string
+	// TokenExtractor is the warden-specific two-principal extraction function.
+	// Nil means the default rule (logical.ExtractTokensDefault).
+	TokenExtractor func(r *http.Request, userLeg bool) (agent, user string)
 
 	// config stores the backend configuration
 	config  map[string]any
@@ -262,30 +263,19 @@ func (b *Backend) Class() logical.BackendClass {
 	return b.BackendClass
 }
 
-// ExtractToken extracts token from HTTP request using the configured extractor.
-// If no custom extractor is set, uses the default extraction logic:
-// 1. X-Warden-Token header
-// 2. Authorization: Bearer <token>
-func (b *Backend) ExtractToken(r *http.Request) string {
+// ExtractTokens extracts the agent and user principals from an HTTP request
+// using the configured extractor, falling back to the default rule.
+func (b *Backend) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
 	if b.TokenExtractor != nil {
-		return b.TokenExtractor(r)
+		return b.TokenExtractor(r, userLeg)
 	}
-	return DefaultTokenExtractor(r)
+	return DefaultTokenExtractor(r, userLeg)
 }
 
-// DefaultTokenExtractor is the default token extraction function.
-// It checks X-Warden-Token header first, then falls back to Authorization: Bearer.
-func DefaultTokenExtractor(r *http.Request) string {
-	// Try X-Warden-Token header first
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-	// Fall back to Authorization: Bearer
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
-	}
-	return ""
+// DefaultTokenExtractor is the default two-principal extraction function. See
+// logical.ExtractTokensDefault for the rule it implements.
+func DefaultTokenExtractor(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensDefault(r, userLeg)
 }
 
 // Route looks up the path that would be used for a given path string.

--- a/framework/backend_test.go
+++ b/framework/backend_test.go
@@ -308,23 +308,42 @@ func TestBackend_Route(t *testing.T) {
 	})
 }
 
-func TestBackend_ExtractToken(t *testing.T) {
+func TestBackend_ExtractTokens(t *testing.T) {
 	t.Run("default extractor", func(t *testing.T) {
 		b := &Backend{}
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("X-Warden-Token", "my-token")
-		assert.Equal(t, "my-token", b.ExtractToken(req))
+		agent, user := b.ExtractTokens(req, false)
+		assert.Equal(t, "my-token", agent)
+		assert.Empty(t, user)
 	})
 
 	t.Run("custom extractor", func(t *testing.T) {
 		b := &Backend{
-			TokenExtractor: func(r *http.Request) string {
-				return r.Header.Get("X-Custom")
+			TokenExtractor: func(r *http.Request, userLeg bool) (string, string) {
+				return r.Header.Get("X-Custom"), ""
 			},
 		}
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("X-Custom", "custom-token")
-		assert.Equal(t, "custom-token", b.ExtractToken(req))
+		agent, user := b.ExtractTokens(req, false)
+		assert.Equal(t, "custom-token", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("custom extractor receives userLeg", func(t *testing.T) {
+		b := &Backend{
+			TokenExtractor: func(r *http.Request, userLeg bool) (string, string) {
+				if userLeg {
+					return "agent", "user"
+				}
+				return "agent", ""
+			},
+		}
+		req, _ := http.NewRequest("GET", "/", nil)
+		agent, user := b.ExtractTokens(req, true)
+		assert.Equal(t, "agent", agent)
+		assert.Equal(t, "user", user)
 	})
 }
 
@@ -348,7 +367,11 @@ func TestDefaultTokenExtractor(t *testing.T) {
 			for k, v := range tc.headers {
 				req.Header.Set(k, v)
 			}
-			assert.Equal(t, tc.expected, DefaultTokenExtractor(req))
+			// userLeg=false must stay byte-identical to the pre-0.20 rule and
+			// never produce a user.
+			agent, user := DefaultTokenExtractor(req, false)
+			assert.Equal(t, tc.expected, agent)
+			assert.Empty(t, user)
 		})
 	}
 }

--- a/framework/config.go
+++ b/framework/config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"net/textproto"
 	"net/url"
 	"sort"
 	"strconv"
@@ -260,35 +259,19 @@ func ValidateCommonConfig(conf map[string]any) error {
 	return ValidateStringField(conf, "default_role")
 }
 
-// wardenControlHeaders are request headers Warden reads for its own auth/control
-// or token-exchange transport plane. user_token_header must not alias one of these
-// — doing so would either collide with the agent's own credential, feed one header
-// into two consumers, or let a caller smuggle control state. Compared canonicalized.
-// Authorization is intentionally absent: it is a valid (opt-in) user_token_header
-// for cert/SPIFFE-authenticated agents.
-var wardenControlHeaders = map[string]struct{}{
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Token"):         {},
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Role"):          {},
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Namespace"):     {},
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Provider"):      {},
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Request"):       {},
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Subject-Token"): {},
-	textproto.CanonicalMIMEHeaderKey("X-Warden-Actor-Token"):   {},
-}
-
 // ValidateUserAuthConfig validates the secondary (user) transparent-auth config
-// fields: user_auth_path, user_token_header, and user_auth_role. It enforces
-// their types, the user_token_header deny-list, and the user_token_header /
-// user_auth_role → user_auth_path dependency (both are meaningless without a
-// user_auth_path and would otherwise be silently discarded). The bearer-format
-// requirement on the referenced mount (a header cannot carry an X.509 client
+// fields: user_auth_path and user_auth_role. It enforces their types and the
+// user_auth_role → user_auth_path dependency (a role is meaningless without a
+// path and would otherwise be silently discarded). The bearer-format requirement
+// on the referenced mount (the user leg cannot carry an X.509 client
 // certificate) is enforced at runtime, where mount visibility exists — config
 // validation here has none.
+//
+// A persisted user_token_header from a pre-0.20 config is tolerated and ignored:
+// the user credential now always rides Authorization, decided by request
+// transport rather than mount config.
 func ValidateUserAuthConfig(conf map[string]any) error {
 	if err := ValidateStringField(conf, "user_auth_path"); err != nil {
-		return err
-	}
-	if err := ValidateStringField(conf, "user_token_header"); err != nil {
 		return err
 	}
 	if err := ValidateStringField(conf, "user_auth_role"); err != nil {
@@ -296,15 +279,6 @@ func ValidateUserAuthConfig(conf map[string]any) error {
 	}
 
 	path, _ := conf["user_auth_path"].(string)
-
-	if hdr, _ := conf["user_token_header"].(string); hdr != "" {
-		if _, bad := wardenControlHeaders[textproto.CanonicalMIMEHeaderKey(hdr)]; bad {
-			return fmt.Errorf("user_token_header must not alias a Warden control header (%q)", hdr)
-		}
-		if path == "" {
-			return fmt.Errorf("user_token_header requires user_auth_path")
-		}
-	}
 
 	if role, _ := conf["user_auth_role"].(string); role != "" && path == "" {
 		return fmt.Errorf("user_auth_role requires user_auth_path")

--- a/framework/config_test.go
+++ b/framework/config_test.go
@@ -353,10 +353,13 @@ func TestValidateUserAuthConfig(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Authorization is an allowed user_token_header", func(t *testing.T) {
+	t.Run("a persisted user_token_header is tolerated and ignored", func(t *testing.T) {
+		// Retired in 0.20 — the user credential now rides Authorization, decided
+		// by request transport rather than mount config. An existing mount must
+		// still load rather than failing validation on the stale key.
 		err := ValidateUserAuthConfig(map[string]any{
 			"user_auth_path":    "auth/user-jwt/",
-			"user_token_header": "Authorization",
+			"user_token_header": "X-Warden-User-Token",
 		})
 		assert.NoError(t, err)
 	})
@@ -365,27 +368,6 @@ func TestValidateUserAuthConfig(t *testing.T) {
 		err := ValidateUserAuthConfig(map[string]any{"user_auth_path": 123})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "user_auth_path must be a string")
-	})
-
-	t.Run("user_token_header aliasing a control header is rejected", func(t *testing.T) {
-		// Includes the token-exchange transport headers, which Warden also reads.
-		for _, h := range []string{
-			"X-Warden-Token", "x-warden-token", "X-Warden-Role", "X-Warden-Namespace",
-			"X-Warden-Subject-Token", "X-Warden-Actor-Token",
-		} {
-			err := ValidateUserAuthConfig(map[string]any{
-				"user_auth_path":    "auth/user-jwt/",
-				"user_token_header": h,
-			})
-			require.Errorf(t, err, "header %q must be rejected", h)
-			assert.Contains(t, err.Error(), "must not alias a Warden control header")
-		}
-	})
-
-	t.Run("user_token_header without user_auth_path is rejected", func(t *testing.T) {
-		err := ValidateUserAuthConfig(map[string]any{"user_token_header": "X-User-Jwt"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "user_token_header requires user_auth_path")
 	})
 
 	t.Run("user_auth_role without user_auth_path is rejected", func(t *testing.T) {

--- a/framework/streaming_backend.go
+++ b/framework/streaming_backend.go
@@ -64,10 +64,6 @@ type TransparentConfig struct {
 	// disables per-user auth for this provider. See logical.UserAuthConfigProvider.
 	UserAuthPath string
 
-	// UserTokenHeader is the request header carrying the user credential. Empty
-	// means the default (logical.DefaultUserTokenHeader).
-	UserTokenHeader string
-
 	// UserAuthRole is the role used to authenticate the user credential. Empty
 	// falls back to the user auth mount's own default_role.
 	UserAuthRole string
@@ -616,12 +612,12 @@ func (b *StreamingBackend) Class() logical.BackendClass {
 	return logical.ClassUnknown
 }
 
-// ExtractToken delegates to the embedded Backend
-func (b *StreamingBackend) ExtractToken(r *http.Request) string {
+// ExtractTokens delegates to the embedded Backend
+func (b *StreamingBackend) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
 	if b.Backend != nil {
-		return b.Backend.ExtractToken(r)
+		return b.Backend.ExtractTokens(r, userLeg)
 	}
-	return ""
+	return "", ""
 }
 
 // TransparentModeProvider interface implementation
@@ -682,16 +678,6 @@ func (b *StreamingBackend) GetUserAuthPath() string {
 		return ""
 	}
 	return tc.UserAuthPath
-}
-
-// GetUserTokenHeader returns the request header carrying the user credential,
-// or "" for the default (logical.DefaultUserTokenHeader).
-func (b *StreamingBackend) GetUserTokenHeader() string {
-	tc := b.transparentConfig.Load()
-	if tc == nil {
-		return ""
-	}
-	return tc.UserTokenHeader
 }
 
 // GetUserAuthRole returns the role used to authenticate the user credential,

--- a/framework/streaming_methods_test.go
+++ b/framework/streaming_methods_test.go
@@ -114,17 +114,21 @@ func TestStreamingBackend_Cleanup_NilBackend(t *testing.T) {
 	sb.Cleanup(context.Background()) // should not panic
 }
 
-func TestStreamingBackend_ExtractToken(t *testing.T) {
+func TestStreamingBackend_ExtractTokens(t *testing.T) {
 	sb := testStreamingBackend()
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Set("X-Warden-Token", "test-token")
-	assert.Equal(t, "test-token", sb.ExtractToken(req))
+	agent, user := sb.ExtractTokens(req, false)
+	assert.Equal(t, "test-token", agent)
+	assert.Empty(t, user)
 }
 
-func TestStreamingBackend_ExtractToken_NilBackend(t *testing.T) {
+func TestStreamingBackend_ExtractTokens_NilBackend(t *testing.T) {
 	sb := &StreamingBackend{}
 	req, _ := http.NewRequest("GET", "/", nil)
-	assert.Equal(t, "", sb.ExtractToken(req))
+	agent, user := sb.ExtractTokens(req, false)
+	assert.Empty(t, agent)
+	assert.Empty(t, user)
 }
 
 func TestStreamingBackend_HandleExistenceCheck_NilBackend(t *testing.T) {

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -43,11 +43,27 @@ type Backend interface {
 	// at the end.
 	SpecialPaths() *Paths
 
-	// ExtractToken extracts token value from request (just extraction, no validation).
-	// Returns empty string if no token found.
-	// Each provider has it own way to pass token.
-	// This will be used by the core to extract the provided token.
-	ExtractToken(r *http.Request) string
+	// ExtractTokens extracts the two principals a request may carry (just
+	// extraction, no validation). Each provider has its own way to pass them.
+	//
+	//   agent — the primary principal's credential, which authorizes the
+	//           request. "" means either no credential at all or "the TLS
+	//           client certificate is the agent"; the distinction is resolved
+	//           downstream by the core, which reads the cert from the request
+	//           context.
+	//   user  — the secondary, identity-only principal's credential, or "".
+	//
+	// userLeg reports whether this is a streaming gateway request on a mount
+	// with an effective user_auth_path. When userLeg is false an implementation
+	// MUST return user == "" and MUST resolve agent exactly as it did before
+	// the user leg existed, including its own channel precedence.
+	//
+	// One sanctioned exception to that byte-identity rule: Authorization scheme
+	// names are now matched case-insensitively everywhere, per RFC 7235, where
+	// several providers previously compared them exactly. This widens what is
+	// accepted (a lowercase "bearer"/"apikey"/"splunk" now resolves) and never
+	// narrows it, so no request that worked before stops working.
+	ExtractTokens(r *http.Request, userLeg bool) (agent, user string)
 }
 
 // BackendClass is the class of backend that is being implemented
@@ -167,10 +183,6 @@ type UserAuthConfigProvider interface {
 	// credentials (e.g., "auth/user-jwt/"), or "" when per-user auth is not
 	// configured — in which case the feature is off and the request is unchanged.
 	GetUserAuthPath() string
-
-	// GetUserTokenHeader returns the request header carrying the user credential.
-	// Empty means the default (X-Warden-User-Token).
-	GetUserTokenHeader() string
 
 	// GetUserAuthRole returns the role used to authenticate the user credential,
 	// or "" to fall back to the user auth mount's own default_role.

--- a/logical/request.go
+++ b/logical/request.go
@@ -166,12 +166,6 @@ func (r *Request) SetTokenEntry(te *TokenEntry) {
 	r.tokenEntry = te
 }
 
-// DefaultUserTokenHeader is the default request header carrying the secondary
-// (user) credential for secondary transparent authentication. Providers may
-// override it via user_token_header. It is a bearer secret and is stripped from
-// every upstream-forwarding header list.
-const DefaultUserTokenHeader = "X-Warden-User-Token"
-
 // UserPrincipal is a request's secondary (user) principal: a first-class Warden
 // TokenEntry resolved from a second request header via the existing auth methods,
 // exactly as the primary/agent credential is. It carries both the validated token

--- a/logical/tokens.go
+++ b/logical/tokens.go
@@ -1,0 +1,176 @@
+package logical
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+const (
+	// HeaderWardenToken carries a native Warden session token for the primary
+	// (agent) principal.
+	HeaderWardenToken = "X-Warden-Token"
+
+	// HeaderWardenAgentToken carries the agent's credential on a dedicated
+	// channel so that Authorization is free for the user principal. It carries
+	// what Authorization would have carried for a transparent agent: a JWT or a
+	// JWT-SVID, resolved by a transparent login against the mount's
+	// auto_auth_path. Service-mesh and bearer-JWT agents use it when talking to
+	// a protected-resource mount.
+	//
+	// An agent holding an opaque Warden session token uses HeaderWardenToken
+	// instead — that already frees Authorization for the user (rule 1) and is
+	// the only header the explicit-auth path recognises.
+	HeaderWardenAgentToken = "X-Warden-Agent-Token"
+)
+
+// IsJWT reports whether s has the compact-JWS shape ("eyJ", the base64 of the
+// `{"` that opens every JOSE header). It is a shape check, not validation — the
+// auth mount verifies the token. The same prefix test is open-coded in several
+// places in core; this is the shared spelling for new call sites.
+func IsJWT(s string) bool {
+	return strings.HasPrefix(s, "eyJ")
+}
+
+// StripScheme returns the remainder of an Authorization-style header value after
+// a case-insensitive scheme prefix match, verbatim (no TrimSpace). Returns "" if
+// the value does not carry that scheme. scheme must include its trailing space.
+func StripScheme(headerValue, scheme string) string {
+	if len(headerValue) > len(scheme) && strings.EqualFold(headerValue[:len(scheme)], scheme) {
+		return headerValue[len(scheme):]
+	}
+	return ""
+}
+
+// StripBearer returns the token in an Authorization-style header value, matching
+// the "Bearer " scheme case-insensitively and returning the remainder verbatim
+// (no TrimSpace). It is the single source of truth for the Bearer strip, so the
+// agent and user legs cannot disagree about where a token starts.
+func StripBearer(authHeader string) string {
+	return StripScheme(authHeader, "Bearer ")
+}
+
+// HasTrustedClientCert reports whether the request carries a client certificate
+// that Warden trusts as an identity. It covers both direct mTLS peer certs and
+// certs forwarded by a trusted proxy: the API listener's middleware normalizes
+// both into the request context and strips the raw forwarding headers on every
+// branch, so a forged X-Forwarded-Client-Cert / X-SSL-Client-Cert can never
+// reach here. Never read those headers directly.
+func HasTrustedClientCert(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return listener.ForwardedClientCert(r.Context()) != nil
+}
+
+// ExtractTokensDefault is the default two-principal resolution rule, shared by
+// the framework backend, the httpproxy SDK and the core's own extractor so the
+// three cannot drift.
+//
+//  1. X-Warden-Token present                  -> agent = it, never a user
+//  2. userLeg && X-Warden-Agent-Token present -> agent = it, user = authz
+//  3. userLeg && trusted client cert          -> agent = "" (the cert), user = authz
+//  4. otherwise                               -> agent = authz, user = ""
+//
+// Steps 2 and 3 are unreachable when userLeg is false, so a non-opted-in mount
+// resolves exactly as it did before the user leg existed: X-Warden-Token, then
+// Authorization: Bearer, and never a user.
+//
+// Step 1 does not open the user leg, on either leg. X-Warden-Token is the
+// operator credential — a human, a script, the root token — while gateway
+// traffic is the workload surface, where identity arrives as a JWT or a client
+// certificate. The CLI makes that split explicit: it moves a JWT off
+// X-Warden-Token onto Authorization so transparent auth can resolve it. Keeping
+// step 1 out of the user leg leaves exactly two ways to present an agent out of
+// band — the dedicated header and mTLS — and makes step 1 behave identically
+// whether or not the mount is a protected resource.
+//
+// Step 2 deliberately precedes step 3: a service-mesh sidecar makes a forwarded
+// cert present on nearly every request, so testing the cert first would shadow
+// the dedicated agent channel and mis-attribute a mesh workload to the sidecar's
+// identity.
+func ExtractTokensDefault(r *http.Request, userLeg bool) (agent, user string) {
+	if r == nil {
+		return "", ""
+	}
+	authz := StripBearer(r.Header.Get("Authorization"))
+
+	if t := r.Header.Get(HeaderWardenToken); t != "" {
+		return t, ""
+	}
+	if userLeg {
+		if t := r.Header.Get(HeaderWardenAgentToken); t != "" {
+			return t, authz
+		}
+		if HasTrustedClientCert(r) {
+			return "", authz
+		}
+	}
+	return authz, ""
+}
+
+// UserBearer returns the Authorization-borne user credential for a provider
+// whose own agent channel already matched. Providers with a custom extractor
+// call this instead of reaching for the header directly, so the user leg stays
+// consistent with ExtractTokensDefault.
+func UserBearer(r *http.Request, userLeg bool) string {
+	if !userLeg || r == nil {
+		return ""
+	}
+	return StripBearer(r.Header.Get("Authorization"))
+}
+
+// AgentOutOfBand resolves the agent from the two channels that free
+// Authorization for the user: the dedicated X-Warden-Agent-Token header, then a
+// trusted client certificate. It is only consulted when userLeg is true, so a
+// non-opted-in mount never sees either.
+//
+// ok reports whether one of them matched. agent is "" with ok true when the
+// certificate is the agent — the core resolves that from the request context.
+// Header before cert is deliberate: see ExtractTokensDefault.
+func AgentOutOfBand(r *http.Request, userLeg bool) (agent string, ok bool) {
+	if !userLeg || r == nil {
+		return "", false
+	}
+	if t := r.Header.Get(HeaderWardenAgentToken); t != "" {
+		return t, true
+	}
+	if HasTrustedClientCert(r) {
+		return "", true
+	}
+	return "", false
+}
+
+// ExtractTokensWithChannels applies the default rule to a provider that has its
+// own out-of-band agent channels. headers are request headers tried in order
+// before anything else; the first non-empty one is the agent, leaving
+// Authorization to the user. When none match, resolution falls through to
+// X-Warden-Agent-Token, a trusted client cert, and finally Authorization-as-agent
+// exactly as ExtractTokensDefault does.
+//
+// Pass the provider's headers in its existing precedence order: with userLeg
+// false the result must stay byte-identical to the pre-0.20 extractor.
+//
+// X-Warden-Token is special-cased: it may appear in headers to keep a
+// provider's agent precedence intact, but it never opens the user leg. See
+// ExtractTokensDefault. A provider's own native channel (X-Vault-Token,
+// x-api-key, Api-Key, PRIVATE-TOKEN) does open it — those carry a workload's
+// agent credential, not an operator session token.
+func ExtractTokensWithChannels(r *http.Request, userLeg bool, headers ...string) (agent, user string) {
+	if r == nil {
+		return "", ""
+	}
+	for _, h := range headers {
+		if t := r.Header.Get(h); t != "" {
+			if h == HeaderWardenToken {
+				return t, ""
+			}
+			return t, UserBearer(r, userLeg)
+		}
+	}
+	if a, ok := AgentOutOfBand(r, userLeg); ok {
+		return a, StripBearer(r.Header.Get("Authorization"))
+	}
+	return StripBearer(r.Header.Get("Authorization")), ""
+}

--- a/logical/tokens_test.go
+++ b/logical/tokens_test.go
@@ -1,0 +1,157 @@
+package logical
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+// withCert returns r carrying a trusted client certificate the way the API
+// listener's middleware presents one — via the request context, never a header.
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+func newReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/v1/github/gateway/user", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+// TestExtractTokensDefault_UserLegOff is the byte-identity invariant the whole
+// migration rests on: with no effective user_auth_path the rule must resolve the
+// agent exactly as the pre-0.20 extractor did (X-Warden-Token, then
+// Authorization: Bearer) and must never produce a user — no matter what else the
+// request carries.
+func TestExtractTokensDefault_UserLegOff(t *testing.T) {
+	tests := []struct {
+		name      string
+		headers   map[string]string
+		cert      bool
+		wantAgent string
+	}{
+		{"lone bearer is the agent", map[string]string{"Authorization": "Bearer a"}, false, "a"},
+		{"warden token wins over bearer", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer a"}, false, "w"},
+		{"lowercase bearer", map[string]string{"Authorization": "bearer a"}, false, "a"},
+		{"non-bearer scheme ignored", map[string]string{"Authorization": "Basic abc"}, false, ""},
+		{"nothing", nil, false, ""},
+
+		// The two channels that would otherwise free Authorization are inert.
+		{"agent-token header ignored", map[string]string{"X-Warden-Agent-Token": "ag", "Authorization": "Bearer a"}, false, "a"},
+		{"cert does not shift Authorization", map[string]string{"Authorization": "Bearer a"}, true, "a"},
+		{"cert with no bearer", nil, true, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newReq(tc.headers)
+			if tc.cert {
+				r = withCert(r)
+			}
+			agent, user := ExtractTokensDefault(r, false)
+			assert.Equal(t, tc.wantAgent, agent)
+			assert.Empty(t, user, "userLeg=false must never produce a user")
+		})
+	}
+}
+
+func TestExtractTokensDefault_UserLegOn(t *testing.T) {
+	t.Run("warden token does NOT free Authorization for the user", func(t *testing.T) {
+		// X-Warden-Token is the operator credential; gateway traffic is the
+		// workload surface. Leaving it out of the user leg keeps exactly two
+		// out-of-band agent channels — the dedicated header and mTLS — and
+		// makes step 1 behave identically on both legs.
+		agent, user := ExtractTokensDefault(newReq(map[string]string{
+			"X-Warden-Token": "w", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "w", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("agent-token header frees Authorization for the user", func(t *testing.T) {
+		agent, user := ExtractTokensDefault(newReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		// A service-mesh sidecar makes a forwarded cert present on nearly every
+		// request. Testing the cert first would mis-attribute the workload to
+		// the sidecar's identity, so the dedicated channel must win.
+		r := withCert(newReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}))
+		agent, user := ExtractTokensDefault(r, true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("cert is the agent, signalled by an empty agent", func(t *testing.T) {
+		r := withCert(newReq(map[string]string{"Authorization": "Bearer u"}))
+		agent, user := ExtractTokensDefault(r, true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer with no agent channel stays the agent", func(t *testing.T) {
+		// Warden always has an agent; a bare bearer is it, not a user.
+		agent, user := ExtractTokensDefault(newReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user)
+	})
+}
+
+// TestExtractTokensDefault_ForgedCertHeaders proves a client cannot shift
+// Authorization by forging the forwarding headers. Only the request context —
+// populated by the listener middleware after its trusted-proxy check — counts.
+func TestExtractTokensDefault_ForgedCertHeaders(t *testing.T) {
+	for _, h := range []string{"X-SSL-Client-Cert", "X-Forwarded-Client-Cert"} {
+		t.Run(h, func(t *testing.T) {
+			r := newReq(map[string]string{h: "<pem>", "Authorization": "Bearer a"})
+			agent, user := ExtractTokensDefault(r, true)
+			assert.Equal(t, "a", agent, "a forged cert header must not make the bearer a user")
+			assert.Empty(t, user)
+		})
+	}
+}
+
+func TestExtractTokensWithChannels(t *testing.T) {
+	t.Run("first matching channel wins and frees Authorization", func(t *testing.T) {
+		agent, user := ExtractTokensWithChannels(newReq(map[string]string{
+			"X-Vault-Token": "v", "Authorization": "Bearer u",
+		}), true, "X-Warden-Token", "X-Vault-Token")
+		assert.Equal(t, "v", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("channel order is preserved", func(t *testing.T) {
+		agent, _ := ExtractTokensWithChannels(newReq(map[string]string{
+			"Api-Key": "k", "X-Warden-Token": "w",
+		}), false, "Api-Key", "X-Warden-Token")
+		assert.Equal(t, "k", agent, "the provider's own precedence must be honoured")
+	})
+
+	t.Run("falls through to Authorization as agent", func(t *testing.T) {
+		agent, user := ExtractTokensWithChannels(newReq(map[string]string{
+			"Authorization": "Bearer a",
+		}), false, "X-Vault-Token")
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user)
+	})
+}
+
+func TestStripScheme(t *testing.T) {
+	assert.Equal(t, "tok", StripScheme("Bearer tok", "Bearer "))
+	assert.Equal(t, "tok", StripScheme("bearer tok", "Bearer "), "scheme match is case-insensitive")
+	assert.Equal(t, "tok", StripScheme("ApiKey tok", "ApiKey "))
+	assert.Empty(t, StripScheme("Basic abc", "Bearer "))
+	assert.Empty(t, StripScheme("Bearer ", "Bearer "), "an empty remainder is not a token")
+	assert.Equal(t, " tok", StripScheme("Bearer  tok", "Bearer "), "the remainder is verbatim, not trimmed")
+}

--- a/provider/alicloud/agent_only_test.go
+++ b/provider/alicloud/agent_only_test.go
@@ -1,0 +1,40 @@
+package alicloud
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractTokens_AgentOnly pins the scoping decision: Alibaba Cloud never yields a
+// user principal, even on a protected-resource mount and even when the request
+// carries every channel that would free Authorization elsewhere.
+//
+// This is a product decision, not a structural limit — the security-token slot is free in cert-transparent mode, but ACS3/OSS SDK
+// clients have no interactive protected-resource bootstrap — so the
+// assertion exists to make a future change to it deliberate rather than silent.
+func TestExtractTokens_AgentOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		cert    bool
+	}{
+		{"bearer on Authorization", map[string]string{"Authorization": "Bearer b"}, false},
+		{"agent-token header and bearer", map[string]string{"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u"}, false},
+		{"cert and bearer", map[string]string{"Authorization": "Bearer u"}, true},
+		{"warden token and bearer", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer u"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/v1/alicloud/gateway/", nil)
+			for k, v := range tc.headers {
+				r.Header.Set(k, v)
+			}
+			if tc.cert {
+				r = withClientCert(r)
+			}
+			_, user := extractTokens(r, true)
+			assert.Empty(t, user, "alicloud is agent-only; userLeg must not produce a user")
+		})
+	}
+}

--- a/provider/alicloud/extract_compat_test.go
+++ b/provider/alicloud/extract_compat_test.go
@@ -1,0 +1,29 @@
+package alicloud
+
+import (
+	"crypto/x509"
+	"net/http"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}
+
+// withClientCert returns r carrying a trusted client certificate, the way the
+// API listener's middleware presents one. Tests must use this rather than
+// setting X-SSL-Client-Cert / X-Forwarded-Client-Cert: the middleware strips
+// those headers on every request before a provider ever runs, so a raw header
+// proves nothing about production behaviour.
+func withClientCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}

--- a/provider/alicloud/path_gateway.go
+++ b/provider/alicloud/path_gateway.go
@@ -33,11 +33,15 @@ var headersToStrip = []string{
 	HeaderACSSecurityToken,
 	// Warden-specific
 	"X-Warden-Token",
+	"X-Warden-Agent-Token",
+	// Retired in 0.20: the user credential now rides Authorization. Still
+	// stripped so a client that keeps sending the old header cannot leak the
+	// credential to the upstream.
+	"X-Warden-User-Token",
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
-	"X-Warden-User-Token",
 	// Hop-by-hop
 	"Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
 	"Te", "Trailer", "Trailers", "Transfer-Encoding", "Upgrade",

--- a/provider/alicloud/provider.go
+++ b/provider/alicloud/provider.go
@@ -47,30 +47,49 @@ func (b *alicloudBackend) getProxyDomains() []string {
 // (for cert-based implicit auth).
 var _ logical.TransparentAuthRoleExtractor = (*alicloudBackend)(nil)
 
-// extractToken extracts the client token from the request.
-// For Alicloud, the JWT is embedded in Alicloud's own auth protocol (mirroring AWS):
+// extractTokens resolves the principals on an Alibaba Cloud gateway request.
+//
+// Agent-only: the user leg is not wired for Alibaba Cloud in this cut, for the
+// same reason as AWS — the security-token slot is structurally free in
+// cert-transparent mode, but ACS3/OSS SDK clients have no interactive
+// protected-resource bootstrap. Always returns user == "".
+//
+// Handles four implicit auth modes:
 //   - ACS3 JWT: JWT in x-acs-security-token (eyJ prefix)
 //   - ACS3 cert: role name as access_key_id in ACS3 Credential field
 //   - OSS/SigV4 JWT: JWT in X-Amz-Security-Token (eyJ prefix)
 //   - OSS/SigV4 cert: role name as access_key_id in SigV4 Credential field
-func extractToken(r *http.Request) string {
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             -           -          -
+//	X-Warden-Token: w + Bearer u        -           -          -
+//	X-Warden-Agent-Token: a + Bearer u  -           -          -
+//	client cert + Bearer u              -           -          -
+//	client cert only                    -           -          -
+//	x-acs-security-token: eyJn          eyJn        eyJn       -
+//	x-acs-security-token: eyJn + cert   eyJn        eyJn       -
+func extractTokens(r *http.Request, _ bool) (agent, user string) {
 	// ACS3 JWT transparent
 	if tok := r.Header.Get(HeaderACSSecurityToken); strings.HasPrefix(tok, "eyJ") {
-		return tok
+		return tok, ""
 	}
 	// OSS/SigV4 JWT transparent
 	if tok := r.Header.Get("X-Amz-Security-Token"); strings.HasPrefix(tok, "eyJ") {
-		return tok
+		return tok, ""
 	}
 	// ACS3 cert transparent
 	if IsACS3Request(r) {
-		return ExtractACS3AccessKeyID(r.Header.Get(HeaderAuthorization))
+		return ExtractACS3AccessKeyID(r.Header.Get(HeaderAuthorization)), ""
 	}
 	// OSS/SigV4 cert transparent
 	if sigv4.IsSigV4Request(r) {
-		return sigv4.ExtractAccessKeyID(r.Header.Get(HeaderAuthorization))
+		return sigv4.ExtractAccessKeyID(r.Header.Get(HeaderAuthorization)), ""
 	}
-	return ""
+	return "", ""
 }
 
 // GetAuthRoleFromRequest extracts the auth role from the ACS3 or SigV4
@@ -133,7 +152,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			Help:           alicloudBackendHelp,
 			BackendType:    "alicloud",
 			BackendClass:   logical.ClassProvider,
-			TokenExtractor: extractToken,
+			TokenExtractor: extractTokens,
 			Paths:          b.paths(),
 		},
 	}

--- a/provider/anthropic/provider.go
+++ b/provider/anthropic/provider.go
@@ -2,9 +2,9 @@ package anthropic
 
 import (
 	"net/http"
-	"strings"
 	"time"
 
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
@@ -14,20 +14,27 @@ const DefaultAnthropicURL = "https://api.anthropic.com"
 // DefaultAnthropicTimeout is the default request timeout for AI inference
 const DefaultAnthropicTimeout = 120 * time.Second
 
-// extractToken extracts Warden token from X-Warden-Token, x-api-key, or Authorization: Bearer headers.
-// Anthropic clients typically send credentials via x-api-key, so we accept that as a Warden token source.
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-	if token := r.Header.Get("x-api-key"); token != "" {
-		return token
-	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
-	}
-	return ""
+// extractTokens resolves the two principals on an Anthropic gateway request.
+//
+// Agent channels, in the provider's existing order: X-Warden-Token, then the
+// native x-api-key header. On a protected-resource mount an agent presented out
+// of band — X-Warden-Agent-Token or a trusted client certificate — frees
+// Authorization to carry the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+//	x-api-key: n + Bearer u             n           n          u
+//	x-api-key: n + Bearer u + cert      n           n          u
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensWithChannels(r, userLeg, "X-Warden-Token", "x-api-key")
 }
 
 // Spec defines the Anthropic provider configuration for the httpproxy framework.
@@ -40,7 +47,7 @@ var Spec = &httpproxy.ProviderSpec{
 	UserAgent:            "warden-anthropic-proxy",
 	HelpText:             anthropicBackendHelp,
 	ExtractCredentials:   httpproxy.HeaderAPIKeyExtractor("x-api-key"),
-	ExtractToken:         extractToken,
+	ExtractToken:         extractTokens,
 	ExtraHeadersToRemove: []string{"x-api-key", "anthropic-version"},
 	DefaultHeaders:       map[string]string{"anthropic-version": "2023-06-01"},
 }

--- a/provider/anthropic/user_leg_test.go
+++ b/provider/anthropic/user_leg_test.go
@@ -1,0 +1,80 @@
+package anthropic
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func certReq(headers map[string]string) *http.Request {
+	return withCert(plainReq(headers))
+}
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/anthropic/gateway/v1/messages", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens covers both legs. With userLeg false the result must stay
+// byte-identical to the pre-0.20 extractor, including this provider's own
+// channel precedence; with userLeg true an out-of-band agent frees Authorization
+// for the user.
+func TestExtractTokens(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"warden token wins over api key", map[string]string{"X-Warden-Token": "w", "x-api-key": "k"}, "w"},
+			{"api key over bearer", map[string]string{"x-api-key": "k", "Authorization": "Bearer b"}, "k"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("native channel frees Authorization for the user", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{
+			"x-api-key": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("cert agent makes Authorization the user", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{"Authorization": "Bearer u"}), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer stays the agent", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user, "warden always has an agent; a bare bearer is it")
+	})
+}

--- a/provider/aws/agent_only_test.go
+++ b/provider/aws/agent_only_test.go
@@ -1,0 +1,40 @@
+package aws
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractTokens_AgentOnly pins the scoping decision: AWS never yields a
+// user principal, even on a protected-resource mount and even when the request
+// carries every channel that would free Authorization elsewhere.
+//
+// This is a product decision, not a structural limit — the security-token slot is free in cert-transparent mode, but AWS SDK
+// clients have no interactive protected-resource bootstrap — so the
+// assertion exists to make a future change to it deliberate rather than silent.
+func TestExtractTokens_AgentOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		cert    bool
+	}{
+		{"bearer on Authorization", map[string]string{"Authorization": "Bearer b"}, false},
+		{"agent-token header and bearer", map[string]string{"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u"}, false},
+		{"cert and bearer", map[string]string{"Authorization": "Bearer u"}, true},
+		{"warden token and bearer", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer u"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/v1/aws/gateway/", nil)
+			for k, v := range tc.headers {
+				r.Header.Set(k, v)
+			}
+			if tc.cert {
+				r = withClientCert(r)
+			}
+			_, user := extractTokens(r, true)
+			assert.Empty(t, user, "aws is agent-only; userLeg must not produce a user")
+		})
+	}
+}

--- a/provider/aws/extract_compat_test.go
+++ b/provider/aws/extract_compat_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"crypto/x509"
+	"net/http"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}
+
+// withClientCert returns r carrying a trusted client certificate, the way the
+// API listener's middleware presents one. Tests must use this rather than
+// setting X-SSL-Client-Cert / X-Forwarded-Client-Cert: the middleware strips
+// those headers on every request before a provider ever runs, so a raw header
+// proves nothing about production behaviour.
+func withClientCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}

--- a/provider/aws/path_gateway.go
+++ b/provider/aws/path_gateway.go
@@ -110,12 +110,28 @@ func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (
 		return nil, nil, fmt.Errorf("signature mismatch")
 	}
 
-	// Step 5: Clean up security token before re-signing.
+	// Step 5: Clean up inbound credential headers before re-signing.
 	// X-Amz-Security-Token contains the JWT (or is absent for cert auth).
 	// Remove it so it doesn't leak into the proxied request.
 	// The real AWS session token (if any) will be added by resignRequest when
 	// the minted credentials include a SessionToken.
+	//
+	// The X-Warden-* headers are stripped for the same reason: each carries a
+	// caller credential that has no meaning to AWS and must not reach it. AWS
+	// keeps its own list rather than sharing the httpproxy one because its
+	// requests are SigV4-signed — the strip has to happen here, after the
+	// inbound signature has been verified against the original header set and
+	// before resignRequest computes a new signature over the modified one.
 	req.HTTPRequest.Header.Del("X-Amz-Security-Token")
+	for _, h := range []string{
+		"X-Warden-Token",
+		"X-Warden-Agent-Token",
+		"X-Warden-User-Token",
+		"X-Warden-Subject-Token",
+		"X-Warden-Actor-Token",
+	} {
+		req.HTTPRequest.Header.Del(h)
+	}
 
 	// Step 6: Get AWS credentials
 	awsCreds, err := b.getCredentials(req)

--- a/provider/aws/provider.go
+++ b/provider/aws/provider.go
@@ -33,21 +33,42 @@ type awsBackend struct {
 	caData            string
 }
 
-// extractToken extracts the client token from the request.
+// extractTokens resolves the principals on an AWS gateway request.
+//
+// Agent-only: the user leg is not wired for AWS in this cut. Structurally the
+// slot exists — in cert-transparent mode X-Amz-Security-Token is empty and could
+// carry a user JWT while the access_key_id keeps naming the agent's role — but
+// AWS SDK clients have no 401 -> protected-resource-metadata -> OAuth loop, so
+// they would gain the user leg without the interactive bootstrap that motivates
+// it. Always returns user == "".
+//
 // Handles two implicit auth modes:
 //   - JWT transparent: JWT in X-Amz-Security-Token (core detects "eyJ" prefix)
 //   - Cert transparent: access_key_id (role name) from SigV4 header
-func extractToken(r *http.Request) string {
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             -           -          -
+//	X-Warden-Token: w + Bearer u        -           -          -
+//	X-Warden-Agent-Token: a + Bearer u  -           -          -
+//	client cert + Bearer u              -           -          -
+//	client cert only                    -           -          -
+//	X-Amz-Security-Token: eyJn          eyJn        eyJn       -
+//	X-Amz-Security-Token: eyJn + cert   eyJn        eyJn       -
+func extractTokens(r *http.Request, _ bool) (agent, user string) {
 	// JWT auth: JWT in X-Amz-Security-Token
 	if secToken := r.Header.Get("X-Amz-Security-Token"); strings.HasPrefix(secToken, "eyJ") {
-		return secToken
+		return secToken, ""
 	}
 	// Cert transparent: access_key_id (role name) from SigV4 header
 	authHeader := r.Header.Get("Authorization")
 	if !strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256") {
-		return ""
+		return "", ""
 	}
-	return sigv4.ExtractAccessKeyID(authHeader)
+	return sigv4.ExtractAccessKeyID(authHeader), ""
 }
 
 // Compile-time interface assertion
@@ -93,7 +114,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			Help:           awsBackendHelp,
 			BackendType:    "aws",
 			BackendClass:   logical.ClassProvider,
-			TokenExtractor: extractToken,
+			TokenExtractor: extractTokens,
 			Paths:          b.paths(),
 		},
 	}

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -11,6 +11,8 @@ type ProviderConfig struct {
 	MaxBodySize     int64
 	Timeout         time.Duration
 	AutoAuthPath    string
+	UserAuthPath    string
+	UserAuthRole    string
 	DefaultAuthRole string
 	TLSSkipVerify   bool
 	CAData          string
@@ -23,6 +25,8 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		MaxBodySize:     framework.ParseMaxBodySize(conf),
 		Timeout:         framework.ParseTimeout(conf, framework.DefaultTimeout),
 		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
+		UserAuthPath:    framework.GetConfigString(conf, "user_auth_path", ""),
+		UserAuthRole:    framework.GetConfigString(conf, "user_auth_role", ""),
 		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
 		TLSSkipVerify:   tlsSkipVerify,
 		CAData:          caData,

--- a/provider/azure/extract_compat_test.go
+++ b/provider/azure/extract_compat_test.go
@@ -1,0 +1,15 @@
+package azure
+
+import "net/http"
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}

--- a/provider/azure/path_config.go
+++ b/provider/azure/path_config.go
@@ -43,6 +43,14 @@ func (b *azureBackend) pathConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Default role to use when not specified in URL path",
 			},
+			"user_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Auth mount that authenticates the secondary (user) principal, marking this mount a protected resource (bearer/JWT format required)",
+			},
+			"user_auth_role": {
+				Type:        framework.TypeString,
+				Description: "Role used to authenticate the user credential (default: the user auth mount's own default_role)",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -71,6 +79,8 @@ func (b *azureBackend) handleConfigRead(ctx context.Context, req *logical.Reques
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		},
 	}, nil
 }
@@ -130,6 +140,8 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	tc := &framework.TransparentConfig{
 		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
 		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
+		UserAuthPath:    b.TransparentConfig().UserAuthPath,
+		UserAuthRole:    b.TransparentConfig().UserAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -137,12 +149,31 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	if val, ok := d.GetOk("default_role"); ok {
 		tc.DefaultAuthRole = val.(string)
 	}
+	if val, ok := d.GetOk("user_auth_path"); ok {
+		tc.UserAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("user_auth_role"); ok {
+		tc.UserAuthRole = val.(string)
+	}
 
 	// Validate: auto_auth_path required
 	if tc.AutoAuthPath == "" {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
 			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+		}, nil
+	}
+
+	// Validate the secondary (user) auth config: types and the
+	// user_auth_role -> user_auth_path dependency. The bearer-format check on
+	// the referenced mount is enforced at runtime (fail closed).
+	if err := framework.ValidateUserAuthConfig(map[string]any{
+		"user_auth_path": tc.UserAuthPath,
+		"user_auth_role": tc.UserAuthRole,
+	}); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest(err.Error()),
 		}, nil
 	}
 
@@ -157,6 +188,8 @@ func (b *azureBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/azure/path_gateway.go
+++ b/provider/azure/path_gateway.go
@@ -20,11 +20,15 @@ var headersToRemove = []string{
 	// Security headers (will be replaced with Azure Bearer token)
 	"Authorization",
 	"X-Warden-Token",
+	"X-Warden-Agent-Token",
+	// Retired in 0.20: the user credential now rides Authorization. Still
+	// stripped so a client that keeps sending the old header cannot leak the
+	// credential to the upstream.
+	"X-Warden-User-Token",
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
-	"X-Warden-User-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/azure/provider.go
+++ b/provider/azure/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -19,20 +18,24 @@ type azureBackend struct {
 	caData        string
 }
 
-// extractToken extracts Warden token from Authorization Bearer header or X-Warden-Token header
-func extractToken(r *http.Request) string {
-	// First, check X-Warden-Token header (explicit Warden token)
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-
-	// Then check Authorization header for Bearer token
-	authHeader := r.Header.Get("Authorization")
-	if strings.HasPrefix(authHeader, "Bearer ") {
-		return strings.TrimPrefix(authHeader, "Bearer ")
-	}
-
-	return ""
+// extractTokens resolves the two principals on an Azure gateway request.
+//
+// The only agent channel is X-Warden-Token. On a protected-resource mount an
+// agent presented out of band — X-Warden-Agent-Token or a trusted client
+// certificate — frees Authorization to carry the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensWithChannels(r, userLeg, "X-Warden-Token")
 }
 
 // Factory creates a new Azure provider backend using the logical.Factory pattern
@@ -72,7 +75,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			Help:           azureBackendHelp,
 			BackendType:    "azure",
 			BackendClass:   logical.ClassProvider,
-			TokenExtractor: extractToken,
+			TokenExtractor: extractTokens,
 			Paths:          b.paths(),
 		},
 	}
@@ -124,6 +127,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    parsedConfig.AutoAuthPath,
+			UserAuthPath:    parsedConfig.UserAuthPath,
+			UserAuthRole:    parsedConfig.UserAuthRole,
 			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
@@ -149,6 +154,8 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 			TLSSkipVerify   bool   `json:"tls_skip_verify"`
 			CAData          string `json:"ca_data"`
 			AutoAuthPath    string `json:"auto_auth_path"`
+			UserAuthPath    string `json:"user_auth_path"`
+			UserAuthRole    string `json:"user_auth_role"`
 			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
@@ -174,6 +181,8 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    config.AutoAuthPath,
+			UserAuthPath:    config.UserAuthPath,
+			UserAuthRole:    config.UserAuthRole,
 			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
@@ -187,6 +196,8 @@ func (b *azureBackend) Initialize(ctx context.Context) error {
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)
@@ -234,10 +245,16 @@ func (b *azureBackend) handleTransparentGatewayStreaming(ctx context.Context, re
 func ValidateConfig(config map[string]any) error {
 	if err := framework.ValidateAllowedKeys(config,
 		"max_body_size", "timeout", "tls_skip_verify", "ca_data",
-		"auto_auth_path", "default_role"); err != nil {
+		"auto_auth_path", "default_role", "user_auth_path", "user_auth_role"); err != nil {
 		return err
 	}
 	if err := framework.ValidateCommonConfig(config); err != nil {
+		return err
+	}
+	// Validate the secondary (user) auth fields at mount-enable too, not only
+	// on the config-write endpoint, so a role without a path is rejected rather
+	// than silently ignored at runtime.
+	if err := framework.ValidateUserAuthConfig(config); err != nil {
 		return err
 	}
 	return framework.ValidateTLSConfig(config)

--- a/provider/azure/user_leg_test.go
+++ b/provider/azure/user_leg_test.go
@@ -1,0 +1,82 @@
+package azure
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func certReq(headers map[string]string) *http.Request {
+	return withCert(plainReq(headers))
+}
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/azure/gateway/subscriptions", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens covers both legs. With userLeg false the result must stay
+// byte-identical to the pre-0.20 extractor, including this provider's own
+// channel precedence; with userLeg true an out-of-band agent frees Authorization
+// for the user.
+func TestExtractTokens(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"warden token wins", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer b"}, "w"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"lowercase bearer now matches", map[string]string{"Authorization": "bearer b"}, "b"},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("X-Warden-Token does not free Authorization for the user", func(t *testing.T) {
+		// The operator credential never opens the user leg. See
+		// logical.ExtractTokensDefault.
+		agent, user := extractTokens(plainReq(map[string]string{
+			"X-Warden-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("cert agent makes Authorization the user", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{"Authorization": "Bearer u"}), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer stays the agent", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user, "warden always has an agent; a bare bearer is it")
+	})
+}

--- a/provider/elastic/provider.go
+++ b/provider/elastic/provider.go
@@ -35,21 +35,44 @@ func elasticCredentialExtractor(req *logical.Request) (map[string]string, error)
 	}, nil
 }
 
-// extractToken extracts the Warden session token from incoming HTTP requests.
-// It checks X-Warden-Token first, then Authorization: ApiKey (since Elasticsearch
-// clients natively use this format), then falls back to Authorization: Bearer.
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
+// extractTokens resolves the two principals on a Elasticsearch gateway request.
+//
+// Elasticsearch's own agent credential rides Authorization under the native
+// "ApiKey" scheme, so agent and user can share the header only by dispatching
+// on scheme: "ApiKey" is always the agent, "Bearer" is the user once an agent
+// has arrived out of band. Precedence matches the pre-0.20 extractor when
+// userLeg is false — X-Warden-Token, then ApiKey, then Bearer.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+//	Authorization: ApiKey n             n           n          -
+//	Authorization: ApiKey n + cert      n           n          -
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	// X-Warden-Token is the operator credential and never opens the user leg.
+	// See logical.ExtractTokensDefault.
+	if token := r.Header.Get(logical.HeaderWardenToken); token != "" {
+		return token, ""
 	}
 	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && authHeader[:7] == "ApiKey " {
-		return authHeader[7:]
+
+	// The native scheme is the agent's own channel. It occupies Authorization,
+	// so there is no slot left for a user credential on this request.
+	if token := logical.StripScheme(authHeader, "ApiKey "); token != "" {
+		return token, ""
 	}
-	if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
-		return authHeader[7:]
+
+	if a, ok := logical.AgentOutOfBand(r, userLeg); ok {
+		return a, logical.StripBearer(authHeader)
 	}
-	return ""
+	return logical.StripBearer(authHeader), ""
 }
 
 // Spec defines the Elastic provider configuration for the httpproxy framework.
@@ -62,7 +85,7 @@ var Spec = &httpproxy.ProviderSpec{
 	UserAgent:          "warden-elastic-proxy",
 	HelpText:           elasticBackendHelp,
 	ExtractCredentials: elasticCredentialExtractor,
-	ExtractToken:       extractToken,
+	ExtractToken:       extractTokens,
 	ValidateExtraConfig: func(conf map[string]any) error {
 		addr, ok := conf["elastic_url"].(string)
 		if !ok || addr == "" {

--- a/provider/elastic/user_leg_test.go
+++ b/provider/elastic/user_leg_test.go
@@ -1,0 +1,69 @@
+package elastic
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func withClientCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens_SchemeDispatch covers the case where the provider's own
+// agent credential already occupies Authorization. Elasticsearch's native
+// "ApiKey" scheme is always the agent; "Bearer" becomes the user only once an
+// agent has arrived out of band. Without this dispatch one of the two legs
+// would have to be broken.
+func TestExtractTokens_SchemeDispatch(t *testing.T) {
+	newReq := func(headers map[string]string) *http.Request {
+		r := httptest.NewRequest("GET", "/v1/elastic/gateway/_search", nil)
+		for k, v := range headers {
+			r.Header.Set(k, v)
+		}
+		return r
+	}
+
+	t.Run("native ApiKey scheme is the agent and leaves no user slot", func(t *testing.T) {
+		agent, user := extractTokens(newReq(map[string]string{"Authorization": "ApiKey k"}), true)
+		assert.Equal(t, "k", agent)
+		assert.Empty(t, user, "the agent occupies Authorization, so there is no user slot")
+	})
+
+	t.Run("ApiKey wins even under a client cert", func(t *testing.T) {
+		r := withClientCert(newReq(map[string]string{"Authorization": "ApiKey k"}))
+		agent, user := extractTokens(r, true)
+		assert.Equal(t, "k", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("cert agent makes Bearer the user", func(t *testing.T) {
+		r := withClientCert(newReq(map[string]string{"Authorization": "Bearer u"}))
+		agent, user := extractTokens(r, true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header makes Bearer the user", func(t *testing.T) {
+		agent, user := extractTokens(newReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("userLeg off keeps the 0.19 precedence", func(t *testing.T) {
+		for _, tc := range []struct{ header, want string }{
+			{"ApiKey k", "k"},
+			{"Bearer b", "b"},
+		} {
+			agent, user := extractTokens(newReq(map[string]string{"Authorization": tc.header}), false)
+			assert.Equal(t, tc.want, agent)
+			assert.Empty(t, user)
+		}
+	})
+}

--- a/provider/gcp/config.go
+++ b/provider/gcp/config.go
@@ -11,6 +11,8 @@ type ProviderConfig struct {
 	MaxBodySize     int64
 	Timeout         time.Duration
 	AutoAuthPath    string
+	UserAuthPath    string
+	UserAuthRole    string
 	DefaultAuthRole string
 	TLSSkipVerify   bool
 	CAData          string
@@ -23,6 +25,8 @@ func parseConfig(conf map[string]any) ProviderConfig {
 		MaxBodySize:     framework.ParseMaxBodySize(conf),
 		Timeout:         framework.ParseTimeout(conf, framework.DefaultTimeout),
 		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
+		UserAuthPath:    framework.GetConfigString(conf, "user_auth_path", ""),
+		UserAuthRole:    framework.GetConfigString(conf, "user_auth_role", ""),
 		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
 		TLSSkipVerify:   tlsSkipVerify,
 		CAData:          caData,

--- a/provider/gcp/extract_compat_test.go
+++ b/provider/gcp/extract_compat_test.go
@@ -1,0 +1,15 @@
+package gcp
+
+import "net/http"
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}

--- a/provider/gcp/path_config.go
+++ b/provider/gcp/path_config.go
@@ -43,6 +43,14 @@ func (b *gcpBackend) pathConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Default role to use when not specified in URL path",
 			},
+			"user_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Auth mount that authenticates the secondary (user) principal, marking this mount a protected resource (bearer/JWT format required)",
+			},
+			"user_auth_role": {
+				Type:        framework.TypeString,
+				Description: "Role used to authenticate the user credential (default: the user auth mount's own default_role)",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -71,6 +79,8 @@ func (b *gcpBackend) handleConfigRead(ctx context.Context, req *logical.Request,
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		},
 	}, nil
 }
@@ -129,6 +139,8 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 	tc := &framework.TransparentConfig{
 		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
 		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
+		UserAuthPath:    b.TransparentConfig().UserAuthPath,
+		UserAuthRole:    b.TransparentConfig().UserAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -136,12 +148,31 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 	if val, ok := d.GetOk("default_role"); ok {
 		tc.DefaultAuthRole = val.(string)
 	}
+	if val, ok := d.GetOk("user_auth_path"); ok {
+		tc.UserAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("user_auth_role"); ok {
+		tc.UserAuthRole = val.(string)
+	}
 
 	// Validate: auto_auth_path required
 	if tc.AutoAuthPath == "" {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
 			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+		}, nil
+	}
+
+	// Validate the secondary (user) auth config: types and the
+	// user_auth_role -> user_auth_path dependency. The bearer-format check on
+	// the referenced mount is enforced at runtime (fail closed).
+	if err := framework.ValidateUserAuthConfig(map[string]any{
+		"user_auth_path": tc.UserAuthPath,
+		"user_auth_role": tc.UserAuthRole,
+	}); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest(err.Error()),
 		}, nil
 	}
 
@@ -156,6 +187,8 @@ func (b *gcpBackend) handleConfigWrite(ctx context.Context, req *logical.Request
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/gcp/path_gateway.go
+++ b/provider/gcp/path_gateway.go
@@ -20,11 +20,15 @@ var headersToRemove = []string{
 	// Security headers (will be replaced with GCP Bearer token)
 	"Authorization",
 	"X-Warden-Token",
+	"X-Warden-Agent-Token",
+	// Retired in 0.20: the user credential now rides Authorization. Still
+	// stripped so a client that keeps sending the old header cannot leak the
+	// credential to the upstream.
+	"X-Warden-User-Token",
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
-	"X-Warden-User-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/gcp/provider.go
+++ b/provider/gcp/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
@@ -19,20 +18,24 @@ type gcpBackend struct {
 	caData        string
 }
 
-// extractToken extracts Warden token from Authorization Bearer header or X-Warden-Token header
-func extractToken(r *http.Request) string {
-	// First, check X-Warden-Token header (explicit Warden token)
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-
-	// Then check Authorization header for Bearer token
-	authHeader := r.Header.Get("Authorization")
-	if strings.HasPrefix(authHeader, "Bearer ") {
-		return strings.TrimPrefix(authHeader, "Bearer ")
-	}
-
-	return ""
+// extractTokens resolves the two principals on a GCP gateway request.
+//
+// The only agent channel is X-Warden-Token. On a protected-resource mount an
+// agent presented out of band — X-Warden-Agent-Token or a trusted client
+// certificate — frees Authorization to carry the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensWithChannels(r, userLeg, "X-Warden-Token")
 }
 
 // Factory creates a new GCP provider backend using the logical.Factory pattern
@@ -72,7 +75,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			Help:           gcpBackendHelp,
 			BackendType:    "gcp",
 			BackendClass:   logical.ClassProvider,
-			TokenExtractor: extractToken,
+			TokenExtractor: extractTokens,
 			Paths:          b.paths(),
 		},
 	}
@@ -123,6 +126,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    parsedConfig.AutoAuthPath,
+			UserAuthPath:    parsedConfig.UserAuthPath,
+			UserAuthRole:    parsedConfig.UserAuthRole,
 			DefaultAuthRole: parsedConfig.DefaultAuthRole,
 		})
 	}
@@ -148,6 +153,8 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 			TLSSkipVerify   bool   `json:"tls_skip_verify"`
 			CAData          string `json:"ca_data"`
 			AutoAuthPath    string `json:"auto_auth_path"`
+			UserAuthPath    string `json:"user_auth_path"`
+			UserAuthRole    string `json:"user_auth_role"`
 			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
@@ -172,6 +179,8 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    config.AutoAuthPath,
+			UserAuthPath:    config.UserAuthPath,
+			UserAuthRole:    config.UserAuthRole,
 			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	} else {
@@ -185,6 +194,8 @@ func (b *gcpBackend) Initialize(ctx context.Context) error {
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create default config entry: %w", err)
@@ -232,10 +243,16 @@ func (b *gcpBackend) handleTransparentGatewayStreaming(ctx context.Context, req 
 func ValidateConfig(config map[string]any) error {
 	if err := framework.ValidateAllowedKeys(config,
 		"max_body_size", "timeout", "tls_skip_verify", "ca_data",
-		"auto_auth_path", "default_role"); err != nil {
+		"auto_auth_path", "default_role", "user_auth_path", "user_auth_role"); err != nil {
 		return err
 	}
 	if err := framework.ValidateCommonConfig(config); err != nil {
+		return err
+	}
+	// Validate the secondary (user) auth fields at mount-enable too, not only
+	// on the config-write endpoint, so a role without a path is rejected rather
+	// than silently ignored at runtime.
+	if err := framework.ValidateUserAuthConfig(config); err != nil {
 		return err
 	}
 	return framework.ValidateTLSConfig(config)

--- a/provider/gcp/user_leg_test.go
+++ b/provider/gcp/user_leg_test.go
@@ -1,0 +1,82 @@
+package gcp
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func certReq(headers map[string]string) *http.Request {
+	return withCert(plainReq(headers))
+}
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/gcp/gateway/v1/projects", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens covers both legs. With userLeg false the result must stay
+// byte-identical to the pre-0.20 extractor, including this provider's own
+// channel precedence; with userLeg true an out-of-band agent frees Authorization
+// for the user.
+func TestExtractTokens(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"warden token wins", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer b"}, "w"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"lowercase bearer now matches", map[string]string{"Authorization": "bearer b"}, "b"},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("X-Warden-Token does not free Authorization for the user", func(t *testing.T) {
+		// The operator credential never opens the user leg. See
+		// logical.ExtractTokensDefault.
+		agent, user := extractTokens(plainReq(map[string]string{
+			"X-Warden-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("cert agent makes Authorization the user", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{"Authorization": "Bearer u"}), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer stays the agent", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user, "warden always has an agent; a bare bearer is it")
+	})
+}

--- a/provider/github/extract_compat_test.go
+++ b/provider/github/extract_compat_test.go
@@ -1,0 +1,29 @@
+package github
+
+import (
+	"crypto/x509"
+	"net/http"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}
+
+// withClientCert returns r carrying a trusted client certificate, the way the
+// API listener's middleware presents one. Tests must use this rather than
+// setting X-SSL-Client-Cert / X-Forwarded-Client-Cert: the middleware strips
+// those headers on every request before a provider ever runs, so a raw header
+// proves nothing about production behaviour.
+func withClientCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}

--- a/provider/github/git_test.go
+++ b/provider/github/git_test.go
@@ -56,14 +56,27 @@ func TestExtractToken(t *testing.T) {
 		assert.Equal(t, "jwt-as-password", extractToken(r))
 	})
 
-	t.Run("Basic password skipped when X-SSL-Client-Cert set", func(t *testing.T) {
-		// Cert-auth case: Git protocol forces a placeholder password slot, but
-		// the cert is the real credential. Reading the placeholder would hand
-		// it to the JWT validator and break the flow.
+	t.Run("Basic password stays the agent even under a client cert", func(t *testing.T) {
+		// An explicitly-presented credential beats an ambient one. A mesh
+		// sidecar puts a cert on nearly every request; letting it suppress a
+		// JWT the client deliberately placed in the password slot would
+		// mis-attribute the workload to the sidecar. The certificate only takes
+		// over as the agent on a protected-resource mount, where it is presented
+		// to free the slot for the user.
 		r := httptest.NewRequest("GET", "/v1/github/gateway/owner/repo.git/info/refs", nil)
-		r.SetBasicAuth("role-name", "placeholder")
+		r.SetBasicAuth("role-name", "jwt-as-password")
+		assert.Equal(t, "jwt-as-password", extractToken(withClientCert(r)))
+	})
+
+	t.Run("raw cert headers do not suppress Basic", func(t *testing.T) {
+		// The listener middleware strips these before any provider runs, so a
+		// forged header must not influence extraction. Keying the skip on the
+		// header (as this provider used to) made the branch dead code and let
+		// cert-authenticated clients have their placeholder consumed.
+		r := httptest.NewRequest("GET", "/v1/github/gateway/owner/repo.git/info/refs", nil)
+		r.SetBasicAuth("role-name", "jwt-as-password")
 		r.Header.Set("X-SSL-Client-Cert", "<pem>")
-		assert.Empty(t, extractToken(r))
+		assert.Equal(t, "jwt-as-password", extractToken(r))
 	})
 
 	t.Run("no auth → empty", func(t *testing.T) {

--- a/provider/github/provider.go
+++ b/provider/github/provider.go
@@ -2,10 +2,10 @@ package github
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/githttp"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
@@ -16,30 +16,61 @@ const DefaultGitHubURL = "https://api.github.com"
 // DefaultAPIVersion is the default GitHub REST API version
 const DefaultAPIVersion = "2022-11-28"
 
-// extractToken extracts the Warden token from one of:
-//  1. X-Warden-Token header
-//  2. Authorization: Bearer <token>
-//  3. HTTP Basic Auth password (Git smart-HTTP carries the JWT this way)
+// extractTokens resolves the two principals on a GitHub gateway request.
 //
-// The Basic Auth branch is suppressed when X-SSL-Client-Cert is present:
-// cert-based implicit auth takes precedence in the core flow, and the Git
-// protocol requires a placeholder password slot that the JWT validator
-// would otherwise reject. Reading the placeholder would actively harm
-// correctness for cert-authenticated clients.
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
+// Agent channels, in the provider's existing order: X-Warden-Token, then
+// Authorization: Bearer, then the HTTP Basic password (Git smart-HTTP carries
+// the agent JWT that way, with the role in the Basic username).
+//
+// On a protected-resource mount an agent presented out of band —
+// X-Warden-Agent-Token or a trusted client certificate — frees BOTH remaining
+// slots for the user: the Bearer and the Basic password. See
+// githttp.UserCredential.
+//
+// Off the user leg the Basic password is ALWAYS the agent, even under a client
+// certificate. An explicitly-presented credential beats an ambient one: a
+// service-mesh sidecar puts a cert on nearly every request, and letting that
+// suppress a JWT the client deliberately placed in the password slot would
+// mis-attribute the workload to the sidecar — the same hazard that orders
+// X-Warden-Agent-Token ahead of the cert in the shared rule. This is also
+// exactly the pre-0.20 behaviour, so no request that worked before changes.
+//
+// The certificate only takes over as the agent on a protected-resource mount,
+// where it is presented deliberately to free the password slot for the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+// "eyJp" stands for a JWT-shaped secret, "x" for the placeholder git
+// requires when the client has no token for the password slot.
+//
+//	request carries                            agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u                    u           u          -
+//	X-Warden-Token: w + Bearer u               w           w          -
+//	X-Warden-Agent-Token: a + Bearer u         u           a          u
+//	client cert + Bearer u                     u           -          u
+//	client cert only                           -           -          -
+//	Basic role:eyJp (JWT)                      eyJp        eyJp       -
+//	Basic role:eyJp + client cert              eyJp        -          eyJp
+//	Basic role:x (placeholder)                 x           x          -
+//	Basic role:x + client cert                 x           -          -
+//	X-Warden-Agent-Token: a + Basic role:eyJp  eyJp        a          eyJp
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	// X-Warden-Token is the operator credential and never opens the user leg.
+	// See logical.ExtractTokensDefault.
+	if token := r.Header.Get(logical.HeaderWardenToken); token != "" {
+		return token, ""
 	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
+	if a, ok := logical.AgentOutOfBand(r, userLeg); ok {
+		return a, githttp.UserCredential(r)
 	}
-	if r.Header.Get("X-SSL-Client-Cert") == "" {
-		if _, pwd, ok := r.BasicAuth(); ok && pwd != "" {
-			return pwd
-		}
+	if token := logical.StripBearer(r.Header.Get("Authorization")); token != "" {
+		return token, ""
 	}
-	return ""
+	if _, pwd, ok := r.BasicAuth(); ok && pwd != "" {
+		return pwd, ""
+	}
+	return "", ""
 }
 
 // Spec defines the GitHub provider configuration for the httpproxy framework.
@@ -52,7 +83,7 @@ var Spec = &httpproxy.ProviderSpec{
 	UserAgent:          "warden-github-proxy",
 	HelpText:           githubBackendHelp,
 	ExtractCredentials: httpproxy.TypedTokenExtractor(credential.TypeGitHubToken, "token", "Authorization", "token "),
-	ExtractToken:       extractToken,
+	ExtractToken:       extractTokens,
 	DefaultAccept:      "application/vnd.github+json",
 	ExtraConfigFields: map[string]*framework.FieldSchema{
 		"api_version": {
@@ -141,9 +172,27 @@ and the Warden JWT in the password:
   git clone https://<role>:$JWT@<warden-addr>/v1/github/gateway/<owner>/<repo>.git
 
 Git's credential helpers cache on URL + username, so each role gets a
-distinct credential entry. Cert-auth clients pass any placeholder in
-the password slot; the token extractor skips the placeholder when
-X-SSL-Client-Cert is present.
+distinct credential entry.
+
+The password slot always carries the agent credential, including for
+clients that also present a TLS certificate: an explicitly-presented
+credential takes precedence over an ambient one, so a service-mesh
+sidecar certificate never displaces a JWT the client put there
+deliberately.
+
+On a mount configured with user_auth_path the roles shift — the
+certificate becomes the agent and the password slot carries the
+per-request USER identity, while the username keeps naming the
+agent's role:
+
+  git clone https://<agent-role>:$USER_JWT@<warden-addr>/v1/...
+
+A cert-authenticated client with no user identity still has to put
+something in the password slot, since Git requires one for Basic
+auth. Any non-JWT value is treated as that placeholder and ignored,
+so the request proceeds with the agent alone:
+
+  git clone https://<agent-role>:x@<warden-addr>/v1/...
 
 For GitHub Enterprise Server:
   Configure github_url to point to your GHE instance API endpoint

--- a/provider/github/user_leg_test.go
+++ b/provider/github/user_leg_test.go
@@ -1,0 +1,106 @@
+package github
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractTokens_UserLeg covers the git smart-HTTP user leg. When the agent
+// authenticates with a client certificate, neither Basic slot is needed for the
+// agent: the username still names the AGENT's auth role (read separately by
+// GetAuthRoleFromRequest) and the password comes free for the user. That makes
+// https://<agent-role>:<user-token>@host/... work with no client configuration.
+func TestExtractTokens_UserLeg(t *testing.T) {
+	const repo = "/v1/github/gateway/owner/repo.git/info/refs"
+
+	t.Run("cert agent takes the user from the Basic password", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.user.jwt")
+		agent, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "eyJ.user.jwt", user)
+	})
+
+	t.Run("cert agent takes the user from an explicit Bearer", func(t *testing.T) {
+		// Bearer and Basic are the same header, so a request can only ever
+		// carry one of them — this is the http.extraHeader shape, not a
+		// precedence test.
+		r := httptest.NewRequest("GET", repo, nil)
+		r.Header.Set("Authorization", "Bearer bearer-user-token")
+		agent, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, agent)
+		assert.Equal(t, "bearer-user-token", user)
+	})
+
+	t.Run("agent-token header frees both slots for the user", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.user.jwt")
+		r.Header.Set("X-Warden-Agent-Token", "eyJ.agent.jwt")
+		agent, user := extractTokens(r, true)
+		assert.Equal(t, "eyJ.agent.jwt", agent)
+		assert.Equal(t, "eyJ.user.jwt", user)
+	})
+
+	t.Run("Basic agent with no cert has no user leg", func(t *testing.T) {
+		// The unchanged 0.19 shape: the password IS the agent.
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.agent.jwt")
+		agent, user := extractTokens(r, true)
+		assert.Equal(t, "eyJ.agent.jwt", agent)
+		assert.Empty(t, user, "with no out-of-band agent the password stays the agent")
+	})
+
+	t.Run("cert agent with no credential at all yields neither", func(t *testing.T) {
+		// Git's first info/refs probe. Both legs empty; the cert still
+		// authenticates the agent downstream.
+		r := httptest.NewRequest("GET", repo, nil)
+		agent, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("REST path behaves the same", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/v1/github/gateway/user", nil)
+		r.Header.Set("Authorization", "Bearer user-token")
+		agent, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, agent)
+		assert.Equal(t, "user-token", user, "an explicit Bearer is taken verbatim, JWT-shaped or not")
+	})
+}
+
+// TestExtractTokens_PlaceholderPassword pins the escape for cert-authenticated
+// git clients. Git mandates a password whenever it does Basic auth, so a client
+// with no user token still has to send something — conventionally "x". That
+// placeholder must NOT be captured as a user credential: doing so fails
+// validation and 401s a request that proceeds fine on a mount without
+// user_auth_path. Requiring the JWT shape is free, because every mount format
+// that can authenticate the user leg requires a JWT anyway.
+func TestExtractTokens_PlaceholderPassword(t *testing.T) {
+	const repo = "/v1/github/gateway/owner/repo.git/info/refs"
+
+	for _, placeholder := range []string{"x", "placeholder", "unused", "-"} {
+		t.Run(placeholder, func(t *testing.T) {
+			r := httptest.NewRequest("GET", repo, nil)
+			r.SetBasicAuth("agent-role", placeholder)
+			agent, user := extractTokens(withClientCert(r), true)
+			assert.Empty(t, agent, "the cert is the agent")
+			assert.Empty(t, user, "a non-JWT password is a git placeholder, not a user credential")
+		})
+	}
+
+	t.Run("a JWT-shaped password is still taken", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.real.user")
+		_, user := extractTokens(withClientCert(r), true)
+		assert.Equal(t, "eyJ.real.user", user)
+	})
+
+	t.Run("an empty password is also no user", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "")
+		_, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, user)
+	})
+}

--- a/provider/gitlab/extract_compat_test.go
+++ b/provider/gitlab/extract_compat_test.go
@@ -1,0 +1,29 @@
+package gitlab
+
+import (
+	"crypto/x509"
+	"net/http"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}
+
+// withClientCert returns r carrying a trusted client certificate, the way the
+// API listener's middleware presents one. Tests must use this rather than
+// setting X-SSL-Client-Cert / X-Forwarded-Client-Cert: the middleware strips
+// those headers on every request before a provider ever runs, so a raw header
+// proves nothing about production behaviour.
+func withClientCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}

--- a/provider/gitlab/git_test.go
+++ b/provider/gitlab/git_test.go
@@ -45,13 +45,25 @@ func TestExtractToken(t *testing.T) {
 		assert.Equal(t, "jwt-as-password", extractToken(r))
 	})
 
-	t.Run("Basic password skipped when X-SSL-Client-Cert set", func(t *testing.T) {
-		// Cert-auth case: Git protocol forces a placeholder password slot,
-		// but the cert is the real credential.
+	t.Run("Basic password stays the agent even under a client cert", func(t *testing.T) {
+		// An explicitly-presented credential beats an ambient one. A mesh
+		// sidecar puts a cert on nearly every request; letting it suppress a
+		// JWT the client deliberately placed in the password slot would
+		// mis-attribute the workload to the sidecar. The certificate only takes
+		// over as the agent on a protected-resource mount, where it is presented
+		// to free the slot for the user.
 		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
-		r.SetBasicAuth("role-name", "placeholder")
+		r.SetBasicAuth("role-name", "jwt-as-password")
+		assert.Equal(t, "jwt-as-password", extractToken(withClientCert(r)))
+	})
+
+	t.Run("raw cert headers do not suppress Basic", func(t *testing.T) {
+		// The listener middleware strips these before any provider runs, so a
+		// forged header must not influence extraction.
+		r := httptest.NewRequest("GET", "/v1/gitlab/gateway/group/repo.git/info/refs", nil)
+		r.SetBasicAuth("role-name", "jwt-as-password")
 		r.Header.Set("X-SSL-Client-Cert", "<pem>")
-		assert.Empty(t, extractToken(r))
+		assert.Equal(t, "jwt-as-password", extractToken(r))
 	})
 
 	t.Run("empty Basic password → empty (no token extracted)", func(t *testing.T) {

--- a/provider/gitlab/provider.go
+++ b/provider/gitlab/provider.go
@@ -3,42 +3,79 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/githttp"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
-// extractToken extracts the Warden session token from one of:
-//  1. PRIVATE-TOKEN header (GitLab's REST API convention)
-//  2. Authorization: Bearer <token>
-//  3. X-Warden-Token header
-//  4. HTTP Basic Auth password (Git smart-HTTP carries the JWT this way)
+// extractTokens resolves the two principals on a GitLab gateway request.
 //
-// The Basic Auth branch is suppressed when X-SSL-Client-Cert is present:
-// cert-based implicit auth takes precedence in the core flow, and the Git
-// protocol requires a placeholder password slot that the JWT validator
-// would otherwise reject. Reading the placeholder would actively harm
-// correctness for cert-authenticated clients.
-func extractToken(r *http.Request) string {
+// Agent channels, in the provider's existing order: the native PRIVATE-TOKEN
+// header, then Authorization: Bearer, then X-Warden-Token, then the HTTP Basic
+// password (Git smart-HTTP carries the agent JWT that way, with the role in the
+// Basic username). Note that Bearer precedes X-Warden-Token here — that order
+// predates the user leg and must be preserved when userLeg is false.
+//
+// On a protected-resource mount an agent presented out of band —
+// X-Warden-Agent-Token or a trusted client certificate — frees BOTH remaining
+// slots for the user: the Bearer and the Basic password. See
+// githttp.UserCredential.
+//
+// X-Warden-Token keeps its legacy position behind the Bearer, on both legs. It
+// is the operator credential and never opens the user leg, so the ordering
+// cannot cause a user token to be resolved as the agent. See
+// logical.ExtractTokensDefault.
+//
+// Off the user leg the Basic password is ALWAYS the agent, even under a client
+// certificate. An explicitly-presented credential beats an ambient one: a
+// service-mesh sidecar puts a cert on nearly every request, and letting that
+// suppress a JWT the client deliberately placed in the password slot would
+// mis-attribute the workload to the sidecar — the same hazard that orders
+// X-Warden-Agent-Token ahead of the cert in the shared rule. This is also
+// exactly the pre-0.20 behaviour, so no request that worked before changes.
+//
+// The certificate only takes over as the agent on a protected-resource mount,
+// where it is presented deliberately to free the password slot for the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+// "eyJp" stands for a JWT-shaped secret, "x" for the placeholder git
+// requires when the client has no token for the password slot.
+//
+//	request carries                            agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u                    u           u          -
+//	X-Warden-Token: w + Bearer u               u           u          -
+//	X-Warden-Agent-Token: a + Bearer u         u           a          u
+//	client cert + Bearer u                     u           -          u
+//	client cert only                           -           -          -
+//	PRIVATE-TOKEN: n + Bearer u                n           n          u
+//	PRIVATE-TOKEN: n + Bearer u + cert         n           n          u
+//	Basic role:eyJp (JWT)                      eyJp        eyJp       -
+//	Basic role:eyJp + client cert              eyJp        -          eyJp
+//	Basic role:x (placeholder)                 x           x          -
+//	Basic role:x + client cert                 x           -          -
+//	X-Warden-Agent-Token: a + Basic role:eyJp  eyJp        a          eyJp
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
 	if token := r.Header.Get("PRIVATE-TOKEN"); token != "" {
-		return token
+		return token, logical.UserBearer(r, userLeg)
 	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
+	if a, ok := logical.AgentOutOfBand(r, userLeg); ok {
+		return a, githttp.UserCredential(r)
+	}
+	if token := logical.StripBearer(r.Header.Get("Authorization")); token != "" {
+		return token, ""
 	}
 	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
+		return token, ""
 	}
-	if r.Header.Get("X-SSL-Client-Cert") == "" {
-		if _, pwd, ok := r.BasicAuth(); ok && pwd != "" {
-			return pwd
-		}
+	if _, pwd, ok := r.BasicAuth(); ok && pwd != "" {
+		return pwd, ""
 	}
-	return ""
+	return "", ""
 }
 
 // gitHooks bundles the three ProviderSpec hooks the mount wires for git
@@ -66,7 +103,7 @@ var Spec = &httpproxy.ProviderSpec{
 	UserAgent:            "warden-gitlab-proxy",
 	HelpText:             gitlabBackendHelp,
 	ExtractCredentials:   httpproxy.TypedTokenExtractor(credential.TypeGitLabAccessToken, "access_token", "Authorization", "Bearer "),
-	ExtractToken:         extractToken,
+	ExtractToken:         extractTokens,
 	ExtraHeadersToRemove: []string{"PRIVATE-TOKEN"},
 	ExtraConfigFields: map[string]*framework.FieldSchema{
 		"git_max_body_size": githttp.MaxBodySizeField(),
@@ -135,9 +172,27 @@ and the Warden JWT in the password:
   git clone https://<role>:$JWT@<warden-addr>/v1/gitlab/gateway/<group>/<repo>.git
 
 Git's credential helpers cache on URL + username, so each role gets a
-distinct credential entry. Cert-auth clients pass any placeholder in
-the password slot; the token extractor skips the placeholder when
-X-SSL-Client-Cert is present.
+distinct credential entry.
+
+The password slot always carries the agent credential, including for
+clients that also present a TLS certificate: an explicitly-presented
+credential takes precedence over an ambient one, so a service-mesh
+sidecar certificate never displaces a JWT the client put there
+deliberately.
+
+On a mount configured with user_auth_path the roles shift — the
+certificate becomes the agent and the password slot carries the
+per-request USER identity, while the username keeps naming the
+agent's role:
+
+  git clone https://<agent-role>:$USER_JWT@<warden-addr>/v1/...
+
+A cert-authenticated client with no user identity still has to put
+something in the password slot, since Git requires one for Basic
+auth. Any non-JWT value is treated as that placeholder and ignored,
+so the request proceeds with the agent alone:
+
+  git clone https://<agent-role>:x@<warden-addr>/v1/...
 
 Self-hosted GitLab instances are supported by setting gitlab_address to
 the instance URL (e.g., "https://gitlab.example.com"). REST and Git

--- a/provider/gitlab/user_leg_test.go
+++ b/provider/gitlab/user_leg_test.go
@@ -1,0 +1,125 @@
+package gitlab
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractTokens_UserLeg covers GitLab's user leg, including the git
+// smart-HTTP shape where a cert agent frees the Basic password slot while the
+// username still names the AGENT's auth role.
+//
+// GitLab is the provider whose precedence the default rule would have broken:
+// it reads Authorization: Bearer AHEAD of X-Warden-Token. That order predates
+// the user leg and must survive with userLeg false.
+func TestExtractTokens_UserLeg(t *testing.T) {
+	const repo = "/v1/gitlab/gateway/group/repo.git/info/refs"
+	const api = "/v1/gitlab/gateway/api/v4/user"
+
+	t.Run("Bearer still outranks X-Warden-Token with the user leg off", func(t *testing.T) {
+		r := httptest.NewRequest("GET", api, nil)
+		r.Header.Set("Authorization", "Bearer b")
+		r.Header.Set("X-Warden-Token", "w")
+		agent, user := extractTokens(r, false)
+		assert.Equal(t, "b", agent, "the pre-0.20 precedence must be preserved")
+		assert.Empty(t, user)
+	})
+
+	t.Run("PRIVATE-TOKEN frees Authorization for the user", func(t *testing.T) {
+		r := httptest.NewRequest("GET", api, nil)
+		r.Header.Set("PRIVATE-TOKEN", "pt")
+		r.Header.Set("Authorization", "Bearer u")
+		agent, user := extractTokens(r, true)
+		assert.Equal(t, "pt", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("cert agent takes the user from the Basic password", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.user.jwt")
+		agent, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "eyJ.user.jwt", user)
+	})
+
+	t.Run("cert agent takes the user from an explicit Bearer", func(t *testing.T) {
+		// Bearer and Basic are the same header, so a request can only ever
+		// carry one of them — this is the http.extraHeader shape, not a
+		// precedence test.
+		r := httptest.NewRequest("GET", repo, nil)
+		r.Header.Set("Authorization", "Bearer bearer-user-token")
+		agent, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, agent)
+		assert.Equal(t, "bearer-user-token", user)
+	})
+
+	t.Run("agent-token header frees both slots for the user", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.user.jwt")
+		r.Header.Set("X-Warden-Agent-Token", "eyJ.agent.jwt")
+		agent, user := extractTokens(r, true)
+		assert.Equal(t, "eyJ.agent.jwt", agent)
+		assert.Equal(t, "eyJ.user.jwt", user)
+	})
+
+	t.Run("Basic agent with no cert has no user leg", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.agent.jwt")
+		agent, user := extractTokens(r, true)
+		assert.Equal(t, "eyJ.agent.jwt", agent)
+		assert.Empty(t, user, "with no out-of-band agent the password stays the agent")
+	})
+}
+
+// TestExtractTokens_WardenTokenOrderUnchanged pins that GitLab needs no
+// user-leg special case. Its legacy Bearer-before-X-Warden-Token order is safe
+// on both legs precisely because X-Warden-Token never opens the user leg: there
+// is no shape in which a user token could be resolved as the agent here.
+func TestExtractTokens_WardenTokenOrderUnchanged(t *testing.T) {
+	r := httptest.NewRequest("GET", "/v1/gitlab/gateway/api/v4/user", nil)
+	r.Header.Set("X-Warden-Token", "w")
+	r.Header.Set("Authorization", "Bearer u")
+
+	for _, userLeg := range []bool{false, true} {
+		agent, user := extractTokens(r, userLeg)
+		assert.Equal(t, "u", agent, "the legacy Bearer-first order holds on both legs")
+		assert.Empty(t, user)
+	}
+}
+
+// TestExtractTokens_PlaceholderPassword pins the escape for cert-authenticated
+// git clients. Git mandates a password whenever it does Basic auth, so a client
+// with no user token still has to send something — conventionally "x". That
+// placeholder must NOT be captured as a user credential: doing so fails
+// validation and 401s a request that proceeds fine on a mount without
+// user_auth_path. Requiring the JWT shape is free, because every mount format
+// that can authenticate the user leg requires a JWT anyway.
+func TestExtractTokens_PlaceholderPassword(t *testing.T) {
+	const repo = "/v1/gitlab/gateway/group/repo.git/info/refs"
+
+	for _, placeholder := range []string{"x", "placeholder", "unused", "-"} {
+		t.Run(placeholder, func(t *testing.T) {
+			r := httptest.NewRequest("GET", repo, nil)
+			r.SetBasicAuth("agent-role", placeholder)
+			agent, user := extractTokens(withClientCert(r), true)
+			assert.Empty(t, agent, "the cert is the agent")
+			assert.Empty(t, user, "a non-JWT password is a git placeholder, not a user credential")
+		})
+	}
+
+	t.Run("a JWT-shaped password is still taken", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "eyJ.real.user")
+		_, user := extractTokens(withClientCert(r), true)
+		assert.Equal(t, "eyJ.real.user", user)
+	})
+
+	t.Run("an empty password is also no user", func(t *testing.T) {
+		r := httptest.NewRequest("GET", repo, nil)
+		r.SetBasicAuth("agent-role", "")
+		_, user := extractTokens(withClientCert(r), true)
+		assert.Empty(t, user)
+	})
+}

--- a/provider/kubernetes/provider.go
+++ b/provider/kubernetes/provider.go
@@ -6,23 +6,31 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
 // DefaultKubernetesTimeout is the default request timeout for Kubernetes API calls
 const DefaultKubernetesTimeout = 30 * time.Second
 
-// extractToken extracts the Warden session token from incoming HTTP requests.
-// It checks X-Warden-Token first, then falls back to Authorization: Bearer.
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
-		return authHeader[7:]
-	}
-	return ""
+// extractTokens resolves the two principals on a Kubernetes gateway request.
+//
+// The only agent channel is X-Warden-Token. On a protected-resource mount an
+// agent presented out of band — X-Warden-Agent-Token or a trusted client
+// certificate — frees Authorization to carry the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensWithChannels(r, userLeg, "X-Warden-Token")
 }
 
 // Spec defines the Kubernetes provider configuration for the httpproxy framework.
@@ -37,7 +45,7 @@ var Spec = &httpproxy.ProviderSpec{
 	ExtractCredentials: httpproxy.TypedTokenExtractor(
 		credential.TypeKubernetesToken, "token", "Authorization", "Bearer ",
 	),
-	ExtractToken: extractToken,
+	ExtractToken: extractTokens,
 	ValidateExtraConfig: func(conf map[string]any) error {
 		addr, ok := conf["kubernetes_url"].(string)
 		if !ok || addr == "" {

--- a/provider/kubernetes/user_leg_test.go
+++ b/provider/kubernetes/user_leg_test.go
@@ -1,0 +1,82 @@
+package kubernetes
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func certReq(headers map[string]string) *http.Request {
+	return withCert(plainReq(headers))
+}
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/kubernetes/gateway/api/v1/pods", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens covers both legs. With userLeg false the result must stay
+// byte-identical to the pre-0.20 extractor, including this provider's own
+// channel precedence; with userLeg true an out-of-band agent frees Authorization
+// for the user.
+func TestExtractTokens(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"warden token wins", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer b"}, "w"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"lowercase bearer now matches", map[string]string{"Authorization": "bearer b"}, "b"},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("X-Warden-Token does not free Authorization for the user", func(t *testing.T) {
+		// The operator credential never opens the user leg. See
+		// logical.ExtractTokensDefault.
+		agent, user := extractTokens(plainReq(map[string]string{
+			"X-Warden-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("cert agent makes Authorization the user", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{"Authorization": "Bearer u"}), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer stays the agent", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user, "warden always has an agent; a bare bearer is it")
+	})
+}

--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -19,12 +19,16 @@ import (
 var headersToStrip = []string{
 	"Authorization",
 	"X-Warden-Token",
+	"X-Warden-Agent-Token",
+	// Retired in 0.20: the user credential now rides Authorization. Still
+	// stripped so a client that keeps sending the old header cannot leak the
+	// credential to the upstream.
+	"X-Warden-User-Token",
 	"X-Warden-Namespace",
 	"X-Warden-Provider",
 	"X-Warden-Role",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
-	"X-Warden-User-Token",
 	// Cookie carries client session identity that AWS will ignore but that
 	// would otherwise bleed across the trust boundary. Strip explicitly —
 	// sigv4.NormalizeRequest doesn't touch it.

--- a/provider/mcp_aws/path_config.go
+++ b/provider/mcp_aws/path_config.go
@@ -42,6 +42,14 @@ func (b *mcpAWSBackend) pathConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Fallback role when not specified by header or URL path.",
 			},
+			"user_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Auth mount that authenticates the secondary (user) principal, marking this mount a protected resource (bearer/JWT format required).",
+			},
+			"user_auth_role": {
+				Type:        framework.TypeString,
+				Description: "Role used to authenticate the user credential (default: the user auth mount's own default_role).",
+			},
 			"tls_skip_verify": {
 				Type:        framework.TypeBool,
 				Description: "Skip TLS certificate verification (dev/test only).",
@@ -78,6 +86,8 @@ func (b *mcpAWSBackend) handleConfigRead(_ context.Context, _ *logical.Request, 
 		"timeout":         b.Timeout().String(),
 		"auto_auth_path":  tc.AutoAuthPath,
 		"default_role":    tc.DefaultAuthRole,
+		"user_auth_path":  tc.UserAuthPath,
+		"user_auth_role":  tc.UserAuthRole,
 		"tls_skip_verify": b.tlsSkipVerify,
 		"ca_data":         b.caData,
 	}
@@ -100,7 +110,8 @@ func (b *mcpAWSBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 
 	for _, k := range []string{
 		"mcp_aws_url", "region", "max_body_size", "timeout",
-		"auto_auth_path", "default_role", "tls_skip_verify", "ca_data",
+		"auto_auth_path", "default_role", "user_auth_path", "user_auth_role",
+		"tls_skip_verify", "ca_data",
 	} {
 		if val, ok := d.GetOk(k); ok {
 			conf[k] = val
@@ -162,6 +173,8 @@ func (b *mcpAWSBackend) snapshotForMerge() map[string]any {
 		"timeout":         b.Timeout().String(),
 		"auto_auth_path":  tc.AutoAuthPath,
 		"default_role":    tc.DefaultAuthRole,
+		"user_auth_path":  tc.UserAuthPath,
+		"user_auth_role":  tc.UserAuthRole,
 		"tls_skip_verify": b.tlsSkipVerify,
 		"ca_data":         b.caData,
 	}

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -270,6 +270,8 @@ func (b *mcpAWSBackend) applyParsedConfig(conf map[string]any) (map[string]any, 
 		"timeout":         timeout.String(),
 		"auto_auth_path":  parsed.AutoAuthPath,
 		"default_role":    parsed.DefaultAuthRole,
+		"user_auth_path":  parsed.UserAuthPath,
+		"user_auth_role":  parsed.UserAuthRole,
 		"tls_skip_verify": parsed.TLSSkipVerify,
 		"ca_data":         parsed.CAData,
 	}
@@ -294,6 +296,8 @@ func (b *mcpAWSBackend) applyParsedConfig(conf map[string]any) (map[string]any, 
 	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 		AutoAuthPath:    parsed.AutoAuthPath,
 		DefaultAuthRole: parsed.DefaultAuthRole,
+		UserAuthPath:    parsed.UserAuthPath,
+		UserAuthRole:    parsed.UserAuthRole,
 	})
 
 	return persist, nil

--- a/provider/newrelic/provider.go
+++ b/provider/newrelic/provider.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
@@ -13,21 +14,28 @@ const DefaultNewRelicURL = "https://api.newrelic.com"
 // DefaultNewRelicTimeout is the default request timeout for New Relic API calls
 const DefaultNewRelicTimeout = 30 * time.Second
 
-// extractToken extracts the Warden session token from the Api-Key header,
-// allowing New Relic clients to authenticate naturally. Falls back to
-// X-Warden-Token and Authorization: Bearer for standard Warden clients.
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("Api-Key"); token != "" {
-		return token
-	}
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
-		return authHeader[7:]
-	}
-	return ""
+// extractTokens resolves the two principals on a New Relic gateway request.
+//
+// Agent channels, in the provider's existing order: the native Api-Key header
+// first, then X-Warden-Token — Api-Key must keep winning so New Relic clients
+// authenticate naturally. On a protected-resource mount an agent presented out
+// of band — X-Warden-Agent-Token or a trusted client certificate — frees
+// Authorization to carry the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+//	Api-Key: n + Bearer u               n           n          u
+//	Api-Key: n + Bearer u + cert        n           n          u
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensWithChannels(r, userLeg, "Api-Key", "X-Warden-Token")
 }
 
 // Spec defines the New Relic provider configuration for the httpproxy framework.
@@ -36,7 +44,7 @@ var Spec = &httpproxy.ProviderSpec{
 	DefaultURL:         DefaultNewRelicURL,
 	URLConfigKey:       "newrelic_url",
 	DefaultTimeout:     DefaultNewRelicTimeout,
-	ExtractToken:       extractToken,
+	ExtractToken:       extractTokens,
 	ParseStreamBody:    true,
 	UserAgent:          "warden-newrelic-proxy",
 	HelpText:           newrelicBackendHelp,

--- a/provider/newrelic/user_leg_test.go
+++ b/provider/newrelic/user_leg_test.go
@@ -1,0 +1,81 @@
+package newrelic
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func certReq(headers map[string]string) *http.Request {
+	return withCert(plainReq(headers))
+}
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/newrelic/gateway/v2/applications.json", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens covers both legs. With userLeg false the result must stay
+// byte-identical to the pre-0.20 extractor, including this provider's own
+// channel precedence; with userLeg true an out-of-band agent frees Authorization
+// for the user.
+func TestExtractTokens(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"api key wins over warden token", map[string]string{"Api-Key": "k", "X-Warden-Token": "w"}, "k"},
+			{"warden token over bearer", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer b"}, "w"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"lowercase bearer now matches", map[string]string{"Authorization": "bearer b"}, "b"},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("native channel frees Authorization for the user", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{
+			"Api-Key": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("cert agent makes Authorization the user", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{"Authorization": "Bearer u"}), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer stays the agent", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user, "warden always has an agent; a bare bearer is it")
+	})
+}

--- a/provider/prometheus/provider.go
+++ b/provider/prometheus/provider.go
@@ -50,12 +50,12 @@ func prometheusExtractor(req *logical.Request) (map[string]string, error) {
 // (Grafana Mimir, Amazon Managed Prometheus, Thanos, Cortex, VictoriaMetrics)
 // by mounting multiple instances with different prometheus_url values.
 var Spec = &httpproxy.ProviderSpec{
-	Name:            "prometheus",
-	URLConfigKey:    "prometheus_url",
-	DefaultTimeout:  DefaultPrometheusTimeout,
-	ParseStreamBody: true,
-	UserAgent:       "warden-prometheus-proxy",
-	HelpText:        prometheusBackendHelp,
+	Name:               "prometheus",
+	URLConfigKey:       "prometheus_url",
+	DefaultTimeout:     DefaultPrometheusTimeout,
+	ParseStreamBody:    true,
+	UserAgent:          "warden-prometheus-proxy",
+	HelpText:           prometheusBackendHelp,
 	ExtractCredentials: prometheusExtractor,
 }
 

--- a/provider/sdk/dualgateway/agent_only_test.go
+++ b/provider/sdk/dualgateway/agent_only_test.go
@@ -1,0 +1,40 @@
+package dualgateway
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractTokens_AgentOnly pins the scoping decision: the S3-compatible dualgateway never yields a
+// user principal, even on a protected-resource mount and even when the request
+// carries every channel that would free Authorization elsewhere.
+//
+// This is a product decision, not a structural limit — its Authorization does carry standard bearers, checked before the SigV4
+// branch — so the
+// assertion exists to make a future change to it deliberate rather than silent.
+func TestExtractTokens_AgentOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		cert    bool
+	}{
+		{"bearer on Authorization", map[string]string{"Authorization": "Bearer b"}, false},
+		{"agent-token header and bearer", map[string]string{"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u"}, false},
+		{"cert and bearer", map[string]string{"Authorization": "Bearer u"}, true},
+		{"warden token and bearer", map[string]string{"X-Warden-Token": "w", "Authorization": "Bearer u"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/v1/scaleway/gateway/instance/v1/servers", nil)
+			for k, v := range tc.headers {
+				r.Header.Set(k, v)
+			}
+			if tc.cert {
+				r = withClientCert(r)
+			}
+			_, user := extractTokens(r, true)
+			assert.Empty(t, user, "dualgateway is agent-only; userLeg must not produce a user")
+		})
+	}
+}

--- a/provider/sdk/dualgateway/backend.go
+++ b/provider/sdk/dualgateway/backend.go
@@ -93,7 +93,7 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 				Help:           spec.HelpText,
 				BackendType:    spec.Name,
 				BackendClass:   logical.ClassProvider,
-				TokenExtractor: extractToken,
+				TokenExtractor: extractTokens,
 				Paths:          b.paths(),
 			},
 		}

--- a/provider/sdk/dualgateway/extract_compat_test.go
+++ b/provider/sdk/dualgateway/extract_compat_test.go
@@ -1,0 +1,29 @@
+package dualgateway
+
+import (
+	"crypto/x509"
+	"net/http"
+
+	"github.com/stephnangue/warden/listener"
+)
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}
+
+// withClientCert returns r carrying a trusted client certificate, the way the
+// API listener's middleware presents one. Tests must use this rather than
+// setting X-SSL-Client-Cert / X-Forwarded-Client-Cert: the middleware strips
+// those headers on every request before a provider ever runs, so a raw header
+// proves nothing about production behaviour.
+func withClientCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -128,7 +128,7 @@ func (b *dualgatewayBackend) handleAPIRequest(ctx context.Context, req *logical.
 	}
 
 	headersToRemove := []string{
-		"X-Warden-Token", "X-Warden-Role", "X-Warden-Provider",
+		"X-Warden-Token", "X-Warden-Agent-Token", "X-Warden-Role", "X-Warden-Provider",
 		"X-Warden-Subject-Token", "X-Warden-Actor-Token", "X-Warden-User-Token",
 		"Connection", "Keep-Alive", "Transfer-Encoding", "Upgrade",
 		"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto",

--- a/provider/sdk/dualgateway/token.go
+++ b/provider/sdk/dualgateway/token.go
@@ -2,35 +2,47 @@ package dualgateway
 
 import (
 	"net/http"
-	"strings"
 
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/sigv4"
 )
 
-// extractToken extracts the client token from the request.
-// Handles three modes:
-//   - Standard: X-Warden-Token or Authorization: Bearer
-//   - S3 JWT transparent: JWT (eyJ prefix) in SigV4 Credential access_key_id
-//   - S3 Cert transparent: role name from SigV4 Credential access_key_id
-func extractToken(r *http.Request) string {
+// extractTokens resolves the principals on an S3-compatible dualgateway
+// request.
+//
+// Agent-only: S3-compatible clients have no user leg. Note that Authorization
+// here is NOT always a SigV4 signature — X-Warden-Token and a standard Bearer
+// are both checked first — so the scoping is a product decision, not a
+// structural limit. Always returns user == "".
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           u          -
+//	client cert + Bearer u              u           u          -
+//	client cert only                    -           -          -
+func extractTokens(r *http.Request, _ bool) (agent, user string) {
 	// Standard Warden token
 	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
+		return token, ""
 	}
 
 	// Bearer token
 	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
+	if token := logical.StripBearer(authHeader); token != "" {
+		return token, ""
 	}
 
 	// S3 transparent: extract access_key_id from SigV4 header
 	if sigv4.IsSigV4Request(r) {
-		accessKeyID := sigv4.ExtractAccessKeyID(authHeader)
-		if accessKeyID != "" {
-			return accessKeyID
+		if accessKeyID := sigv4.ExtractAccessKeyID(authHeader); accessKeyID != "" {
+			return accessKeyID, ""
 		}
 	}
 
-	return ""
+	return "", ""
 }

--- a/provider/sdk/githttp/githttp.go
+++ b/provider/sdk/githttp/githttp.go
@@ -59,6 +59,47 @@ func IsSmartHTTPPath(apiPath string) bool {
 	return false
 }
 
+// UserCredential returns the user principal's credential from a git
+// smart-HTTP request whose agent already arrived out of band (a trusted client
+// certificate or X-Warden-Agent-Token). Both of the slots git can carry a
+// secret in are then free for the user:
+//
+//   - Authorization: Bearer <token>, for clients configured via
+//     http.extraHeader.
+//   - The HTTP Basic password, which is the native git shape. The Basic
+//     username keeps its usual meaning — the AGENT's auth role, read by
+//     GetAuthRoleFromRequest — so "https://<agent-role>:<user-token>@host/..."
+//     works with no client configuration at all.
+//
+// The two are alternatives, not a precedence: both ride the Authorization
+// header, so a request can only ever carry one. Returns "" when it carries
+// neither.
+//
+// The Basic password is only taken when it is JWT-shaped. Git mandates a
+// password whenever it does Basic auth, so a cert-authenticated client with no
+// user token still has to send something — conventionally a placeholder like
+// "x". Treating that placeholder as a user credential would fail validation and
+// 401 a request that should simply proceed agent-only, which is how the same
+// request behaves on a mount without user_auth_path. Requiring the JWT shape
+// costs nothing: the user leg is bearer-only and every mount format that can
+// authenticate it (jwt, k8s_sa_jwt, a SPIFFE JWT-SVID) requires a JWT, so a
+// non-JWT password could never have resolved to a user anyway.
+//
+// An explicit Authorization: Bearer is taken verbatim. That is unambiguous
+// intent, so a malformed value there fails closed rather than being ignored.
+func UserCredential(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if token := logical.StripBearer(r.Header.Get("Authorization")); token != "" {
+		return token
+	}
+	if _, pwd, ok := r.BasicAuth(); ok && logical.IsJWT(pwd) {
+		return pwd
+	}
+	return ""
+}
+
 // pathAfterGateway extracts the API-shaped path slice from a routed gateway
 // request URL. Wraps the httpproxy helper with a fall-back to the input
 // when no "/gateway" segment is present (defensive — routed gateway
@@ -169,14 +210,14 @@ func BuildHooks(opts Options) Hooks {
 	// Authorization header, or when the path is not a Git smart-HTTP
 	// endpoint. The Authorization-header check looks redundant — core only
 	// consults IsUnauthenticatedPath when ClientToken == "", which already
-	// implies ExtractToken found no usable credential. But several edge
-	// cases reach here with Authorization set yet ClientToken empty:
+	// implies ExtractTokens found no usable agent credential. But several
+	// edge cases reach here with Authorization set yet ClientToken empty:
 	// malformed Bearer ("Bearer " with no token), Basic with an empty
 	// password slot, Negotiate (Kerberos) and other unrecognised schemes,
-	// and Basic when X-SSL-Client-Cert is also present (some providers'
-	// ExtractToken deliberately skips Basic in that case). Without this
-	// guard those all silently get probe-passthrough; with it they fall
-	// through to implicit-auth-fail → 401, which is the honest answer.
+	// and — on a protected-resource mount — a client certificate acting as
+	// the agent, which leaves the agent empty by design. Without this guard
+	// those all silently get probe-passthrough; with it they fall through to
+	// implicit-auth-fail → 401, which is the honest answer.
 	isUnauthenticatedGitProbe := func(r *http.Request, path string) bool {
 		if r == nil || r.Header.Get("Authorization") != "" {
 			return false

--- a/provider/sdk/httpproxy/config.go
+++ b/provider/sdk/httpproxy/config.go
@@ -14,7 +14,6 @@ type BaseConfig struct {
 	AutoAuthPath    string
 	DefaultAuthRole string
 	UserAuthPath    string
-	UserTokenHeader string
 	UserAuthRole    string
 	TLSSkipVerify   bool
 	CAData          string // base64-encoded PEM CA certificate
@@ -31,7 +30,6 @@ func ParseConfig(conf map[string]any, urlKey string, defaultURL string, defaultT
 		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
 		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
 		UserAuthPath:    framework.GetConfigString(conf, "user_auth_path", ""),
-		UserTokenHeader: framework.GetConfigString(conf, "user_token_header", ""),
 		UserAuthRole:    framework.GetConfigString(conf, "user_auth_role", ""),
 		TLSSkipVerify:   tlsSkipVerify,
 		CAData:          caData,
@@ -54,8 +52,8 @@ func ValidateConfig(conf map[string]any, urlKey string) error {
 	}
 
 	// Validate the secondary (user) auth fields at mount-enable too, not only on
-	// the config-write endpoint, so an invalid user_token_header / role→path is
-	// rejected before it can be parsed and applied.
+	// the config-write endpoint, so an invalid role→path pairing is rejected
+	// before it can be parsed and applied.
 	if err := framework.ValidateUserAuthConfig(conf); err != nil {
 		return err
 	}

--- a/provider/sdk/httpproxy/credentials.go
+++ b/provider/sdk/httpproxy/credentials.go
@@ -3,7 +3,6 @@ package httpproxy
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/logical"
@@ -107,15 +106,9 @@ func TypedTokenExtractor(credType string, credField string, headerName string, h
 	}
 }
 
-// DefaultTokenExtractor extracts the Warden session token from X-Warden-Token
-// or Authorization: Bearer headers. This is the default for most providers.
-func DefaultTokenExtractor(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
-	}
-	return ""
+// DefaultTokenExtractor resolves the agent and user principals from the standard
+// Warden channels. This is the default for providers with no native credential
+// header of their own. See logical.ExtractTokensDefault for the rule.
+func DefaultTokenExtractor(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensDefault(r, userLeg)
 }

--- a/provider/sdk/httpproxy/headers.go
+++ b/provider/sdk/httpproxy/headers.go
@@ -6,11 +6,15 @@ var BaseHeadersToRemove = []string{
 	// Security headers (replaced with provider credentials)
 	"Authorization",
 	"X-Warden-Token",
+	"X-Warden-Agent-Token",
+	// Retired in 0.20: the user credential now rides Authorization. Still
+	// stripped so a client that keeps sending the old header cannot leak the
+	// credential to the upstream.
+	"X-Warden-User-Token",
 	"X-Warden-Role",
 	"X-Warden-Provider",
 	"X-Warden-Subject-Token",
 	"X-Warden-Actor-Token",
-	"X-Warden-User-Token",
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -131,7 +131,9 @@ func TestDefaultTokenExtractor(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := mustNewRequest(t, "GET", "/", tc.headers)
-			assert.Equal(t, tc.expected, DefaultTokenExtractor(req))
+			agent, user := DefaultTokenExtractor(req, false)
+			assert.Equal(t, tc.expected, agent)
+			assert.Empty(t, user)
 		})
 	}
 }
@@ -413,8 +415,8 @@ func TestNewFactory_ValidateExtraConfig(t *testing.T) {
 
 func TestNewFactory_CustomTokenExtractor(t *testing.T) {
 	spec := testSpec()
-	spec.ExtractToken = func(r *http.Request) string {
-		return r.Header.Get("X-Custom-Token")
+	spec.ExtractToken = func(r *http.Request, userLeg bool) (string, string) {
+		return r.Header.Get("X-Custom-Token"), ""
 	}
 	b := setupBackend(t, spec)
 	pb := b.(*proxyBackend)

--- a/provider/sdk/httpproxy/path_config.go
+++ b/provider/sdk/httpproxy/path_config.go
@@ -42,10 +42,6 @@ func (b *proxyBackend) pathConfig() *framework.Path {
 			Type:        framework.TypeString,
 			Description: "Auth mount that authenticates the secondary (user) principal from a second request header (bearer/JWT format required)",
 		},
-		"user_token_header": {
-			Type:        framework.TypeString,
-			Description: "Request header carrying the user credential (default: X-Warden-User-Token; 'Authorization' opt-in for cert/SPIFFE agents)",
-		},
 		"user_auth_role": {
 			Type:        framework.TypeString,
 			Description: "Role used to authenticate the user credential (default: the user auth mount's own default_role)",
@@ -95,7 +91,6 @@ func (b *proxyBackend) handleConfigRead(_ context.Context, _ *logical.Request, _
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
 		"user_auth_path":    tc.UserAuthPath,
-		"user_token_header": tc.UserTokenHeader,
 		"user_auth_role":    tc.UserAuthRole,
 		"tls_skip_verify":   b.tlsSkipVerify,
 		"ca_data":           b.caData,
@@ -175,7 +170,6 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		AutoAuthPath:    current.AutoAuthPath,
 		DefaultAuthRole: current.DefaultAuthRole,
 		UserAuthPath:    current.UserAuthPath,
-		UserTokenHeader: current.UserTokenHeader,
 		UserAuthRole:    current.UserAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
@@ -186,9 +180,6 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 	}
 	if val, ok := d.GetOk("user_auth_path"); ok {
 		tc.UserAuthPath = val.(string)
-	}
-	if val, ok := d.GetOk("user_token_header"); ok {
-		tc.UserTokenHeader = val.(string)
 	}
 	if val, ok := d.GetOk("user_auth_role"); ok {
 		tc.UserAuthRole = val.(string)
@@ -201,13 +192,12 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		}, nil
 	}
 
-	// Validate the secondary (user) auth config: types, the user_token_header
-	// deny-list, and the user_auth_role → user_auth_path dependency. The
-	// bearer-format check on the mount is enforced at runtime (fail closed).
+	// Validate the secondary (user) auth config: types and the
+	// user_auth_role → user_auth_path dependency. The bearer-format check on
+	// the referenced mount is enforced at runtime (fail closed).
 	if err := framework.ValidateUserAuthConfig(map[string]any{
-		"user_auth_path":    tc.UserAuthPath,
-		"user_token_header": tc.UserTokenHeader,
-		"user_auth_role":    tc.UserAuthRole,
+		"user_auth_path": tc.UserAuthPath,
+		"user_auth_role": tc.UserAuthRole,
 	}); err != nil {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
@@ -300,7 +290,6 @@ func (b *proxyBackend) handleConfigWrite(ctx context.Context, _ *logical.Request
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
 		"user_auth_path":    tc.UserAuthPath,
-		"user_token_header": tc.UserTokenHeader,
 		"user_auth_role":    tc.UserAuthRole,
 		"tls_skip_verify":   b.tlsSkipVerify,
 		"ca_data":           b.caData,

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -11,11 +11,16 @@ import (
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
 
-// TokenExtractorFunc extracts the Warden session token from an incoming HTTP request.
-type TokenExtractorFunc func(r *http.Request) string
+// TokenExtractorFunc resolves the agent and user principals carried by an
+// incoming HTTP request. See logical.Backend.ExtractTokens for the contract
+// every implementation must honor — in particular, when userLeg is false it
+// MUST return user == "" and MUST resolve agent exactly as it did before the
+// user leg existed.
+type TokenExtractorFunc func(r *http.Request, userLeg bool) (agent, user string)
 
 // Dispatch carries per-request overrides returned by ProviderSpec.ResolveUpstream.
 // Zero values mean "fall through to the spec/mount default." Used by providers
@@ -317,7 +322,6 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 				AutoAuthPath:    parsedConfig.AutoAuthPath,
 				DefaultAuthRole: parsedConfig.DefaultAuthRole,
 				UserAuthPath:    parsedConfig.UserAuthPath,
-				UserTokenHeader: parsedConfig.UserTokenHeader,
 				UserAuthRole:    parsedConfig.UserAuthRole,
 			})
 
@@ -379,13 +383,17 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 		autoAuthPath, _ := config["auto_auth_path"].(string)
 		defaultRole, _ := config["default_role"].(string)
 		userAuthPath, _ := config["user_auth_path"].(string)
-		userTokenHeader, _ := config["user_token_header"].(string)
 		userAuthRole, _ := config["user_auth_role"].(string)
+		// A persisted user_token_header from a pre-0.20 config is ignored: the
+		// user credential now always rides Authorization.
+		if hdr, _ := config["user_token_header"].(string); hdr != "" {
+			b.Logger.Warn("ignoring retired user_token_header config key; the user credential now rides Authorization",
+				logger.String("user_token_header", hdr))
+		}
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    autoAuthPath,
 			DefaultAuthRole: defaultRole,
 			UserAuthPath:    userAuthPath,
-			UserTokenHeader: userTokenHeader,
 			UserAuthRole:    userAuthRole,
 		})
 
@@ -419,7 +427,6 @@ func (b *proxyBackend) Initialize(ctx context.Context) error {
 			"auto_auth_path":    tc.AutoAuthPath,
 			"default_role":      tc.DefaultAuthRole,
 			"user_auth_path":    tc.UserAuthPath,
-			"user_token_header": tc.UserTokenHeader,
 			"user_auth_role":    tc.UserAuthRole,
 			"tls_skip_verify":   b.tlsSkipVerify,
 			"ca_data":           b.caData,

--- a/provider/splunk/provider.go
+++ b/provider/splunk/provider.go
@@ -5,28 +5,51 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
 // DefaultSplunkTimeout is the default request timeout for Splunk API calls
 const DefaultSplunkTimeout = 30 * time.Second
 
-// extractToken extracts the Warden session token from incoming HTTP requests.
-// It checks X-Warden-Token first, then Authorization: Splunk (since Splunk
-// clients natively use this format for session tokens), then falls back to
-// Authorization: Bearer (JWT tokens).
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
+// extractTokens resolves the two principals on a Splunk gateway request.
+//
+// Splunk's own agent credential rides Authorization under the native
+// "Splunk" scheme, so agent and user can share the header only by dispatching
+// on scheme: "Splunk" is always the agent, "Bearer" is the user once an agent
+// has arrived out of band. Precedence matches the pre-0.20 extractor when
+// userLeg is false — X-Warden-Token, then Splunk, then Bearer.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+//	Authorization: Splunk n             n           n          -
+//	Authorization: Splunk n + cert      n           n          -
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	// X-Warden-Token is the operator credential and never opens the user leg.
+	// See logical.ExtractTokensDefault.
+	if token := r.Header.Get(logical.HeaderWardenToken); token != "" {
+		return token, ""
 	}
 	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && authHeader[:7] == "Splunk " {
-		return authHeader[7:]
+
+	// The native scheme is the agent's own channel. It occupies Authorization,
+	// so there is no slot left for a user credential on this request.
+	if token := logical.StripScheme(authHeader, "Splunk "); token != "" {
+		return token, ""
 	}
-	if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
-		return authHeader[7:]
+
+	if a, ok := logical.AgentOutOfBand(r, userLeg); ok {
+		return a, logical.StripBearer(authHeader)
 	}
-	return ""
+	return logical.StripBearer(authHeader), ""
 }
 
 // Spec defines the Splunk provider configuration for the httpproxy framework.
@@ -39,7 +62,7 @@ var Spec = &httpproxy.ProviderSpec{
 	UserAgent:          "warden-splunk-proxy",
 	HelpText:           splunkBackendHelp,
 	ExtractCredentials: httpproxy.BearerAPIKeyExtractor,
-	ExtractToken:       extractToken,
+	ExtractToken:       extractTokens,
 	ValidateExtraConfig: func(conf map[string]any) error {
 		addr, ok := conf["splunk_url"].(string)
 		if !ok || addr == "" {

--- a/provider/splunk/user_leg_test.go
+++ b/provider/splunk/user_leg_test.go
@@ -1,0 +1,87 @@
+package splunk
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/splunk/gateway/services/search/jobs", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens_SchemeDispatch covers the case where the provider's own
+// agent credential already occupies Authorization. Splunk's native "Splunk"
+// scheme is always the agent; "Bearer" becomes the user only once an agent has
+// arrived out of band. Without this dispatch one of the two legs would have to
+// be broken.
+func TestExtractTokens_SchemeDispatch(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"warden token wins", map[string]string{"X-Warden-Token": "w", "Authorization": "Splunk s"}, "w"},
+			{"native Splunk scheme", map[string]string{"Authorization": "Splunk s"}, "s"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"lowercase splunk scheme now matches", map[string]string{"Authorization": "splunk s"}, "s"},
+			{"unknown scheme ignored", map[string]string{"Authorization": "Basic abc"}, ""},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("native Splunk scheme is the agent and leaves no user slot", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Splunk s"}), true)
+		assert.Equal(t, "s", agent)
+		assert.Empty(t, user, "the agent occupies Authorization, so there is no user slot")
+	})
+
+	t.Run("Splunk scheme wins even under a client cert", func(t *testing.T) {
+		agent, user := extractTokens(withCert(plainReq(map[string]string{"Authorization": "Splunk s"})), true)
+		assert.Equal(t, "s", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("cert agent makes Bearer the user", func(t *testing.T) {
+		agent, user := extractTokens(withCert(plainReq(map[string]string{"Authorization": "Bearer u"})), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header makes Bearer the user", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("X-Warden-Token does not free Authorization for the user", func(t *testing.T) {
+		// The operator credential never opens the user leg. See
+		// logical.ExtractTokensDefault.
+		agent, user := extractTokens(plainReq(map[string]string{
+			"X-Warden-Token": "w", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "w", agent)
+		assert.Empty(t, user)
+	})
+}

--- a/provider/vault/config.go
+++ b/provider/vault/config.go
@@ -9,22 +9,30 @@ import (
 
 // ProviderConfig holds parsed configuration for the Vault provider
 type ProviderConfig struct {
-	VaultAddress  string
-	MaxBodySize   int64
-	Timeout       time.Duration
-	TLSSkipVerify bool
-	CAData        string
+	VaultAddress    string
+	MaxBodySize     int64
+	Timeout         time.Duration
+	AutoAuthPath    string
+	DefaultAuthRole string
+	UserAuthPath    string
+	UserAuthRole    string
+	TLSSkipVerify   bool
+	CAData          string
 }
 
 // parseConfig parses configuration from mount config (map[string]any from JSON)
 func parseConfig(conf map[string]any) ProviderConfig {
 	tlsSkipVerify, caData := framework.ParseTLSConfig(conf)
 	return ProviderConfig{
-		VaultAddress:  framework.GetConfigString(conf, "vault_address", ""),
-		MaxBodySize:   framework.ParseMaxBodySize(conf),
-		Timeout:       framework.ParseTimeout(conf, framework.DefaultTimeout),
-		TLSSkipVerify: tlsSkipVerify,
-		CAData:        caData,
+		VaultAddress:    framework.GetConfigString(conf, "vault_address", ""),
+		MaxBodySize:     framework.ParseMaxBodySize(conf),
+		Timeout:         framework.ParseTimeout(conf, framework.DefaultTimeout),
+		AutoAuthPath:    framework.GetConfigString(conf, "auto_auth_path", ""),
+		DefaultAuthRole: framework.GetConfigString(conf, "default_role", ""),
+		UserAuthPath:    framework.GetConfigString(conf, "user_auth_path", ""),
+		UserAuthRole:    framework.GetConfigString(conf, "user_auth_role", ""),
+		TLSSkipVerify:   tlsSkipVerify,
+		CAData:          caData,
 	}
 }
 

--- a/provider/vault/extract_compat_test.go
+++ b/provider/vault/extract_compat_test.go
@@ -1,0 +1,15 @@
+package vault
+
+import "net/http"
+
+// extractToken adapts the two-principal extractor to the single-return shape
+// the pre-0.20 tests were written against. Every assertion made through it is a
+// byte-identity regression test: with userLeg false the agent must resolve
+// exactly as it did before the user leg existed, and no user may be produced.
+func extractToken(r *http.Request) string {
+	agent, user := extractTokens(r, false)
+	if user != "" {
+		panic("extractTokens returned a user credential with userLeg=false")
+	}
+	return agent
+}

--- a/provider/vault/path_config.go
+++ b/provider/vault/path_config.go
@@ -48,6 +48,14 @@ func (b *vaultBackend) pathConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Default role to use when not specified in URL path",
 			},
+			"user_auth_path": {
+				Type:        framework.TypeString,
+				Description: "Auth mount that authenticates the secondary (user) principal, marking this mount a protected resource (bearer/JWT format required)",
+			},
+			"user_auth_role": {
+				Type:        framework.TypeString,
+				Description: "Role used to authenticate the user credential (default: the user auth mount's own default_role)",
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -77,6 +85,8 @@ func (b *vaultBackend) handleConfigRead(ctx context.Context, req *logical.Reques
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		},
 	}, nil
 }
@@ -142,6 +152,8 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	tc := &framework.TransparentConfig{
 		AutoAuthPath:    b.TransparentConfig().AutoAuthPath,
 		DefaultAuthRole: b.TransparentConfig().DefaultAuthRole,
+		UserAuthPath:    b.TransparentConfig().UserAuthPath,
+		UserAuthRole:    b.TransparentConfig().UserAuthRole,
 	}
 	if val, ok := d.GetOk("auto_auth_path"); ok {
 		tc.AutoAuthPath = val.(string)
@@ -149,12 +161,31 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 	if val, ok := d.GetOk("default_role"); ok {
 		tc.DefaultAuthRole = val.(string)
 	}
+	if val, ok := d.GetOk("user_auth_path"); ok {
+		tc.UserAuthPath = val.(string)
+	}
+	if val, ok := d.GetOk("user_auth_role"); ok {
+		tc.UserAuthRole = val.(string)
+	}
 
 	// Validate: auto_auth_path required
 	if tc.AutoAuthPath == "" {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
 			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+		}, nil
+	}
+
+	// Validate the secondary (user) auth config: types and the
+	// user_auth_role -> user_auth_path dependency. The bearer-format check on
+	// the referenced mount is enforced at runtime (fail closed).
+	if err := framework.ValidateUserAuthConfig(map[string]any{
+		"user_auth_path": tc.UserAuthPath,
+		"user_auth_role": tc.UserAuthRole,
+	}); err != nil {
+		return &logical.Response{
+			StatusCode: http.StatusBadRequest,
+			Err:        logical.ErrBadRequest(err.Error()),
 		}, nil
 	}
 
@@ -170,6 +201,8 @@ func (b *vaultBackend) handleConfigWrite(ctx context.Context, req *logical.Reque
 			"ca_data":         b.caData,
 			"auto_auth_path":  tc.AutoAuthPath,
 			"default_role":    tc.DefaultAuthRole,
+			"user_auth_path":  tc.UserAuthPath,
+			"user_auth_role":  tc.UserAuthRole,
 		})
 		if err != nil {
 			return &logical.Response{

--- a/provider/vault/path_gateway.go
+++ b/provider/vault/path_gateway.go
@@ -16,15 +16,19 @@ import (
 // Headers to remove before proxying
 var headersToRemove = []string{
 	// Security headers (will be replaced with real values)
-	"Authorization",          // Remove Warden auth token to prevent leakage
-	"X-Vault-Token",          // Will be replaced with real Vault token
-	"X-Vault-Request",        // Internal Vault header
-	"X-Warden-Token",         // Warden-specific auth header
+	"Authorization",   // Remove Warden auth token to prevent leakage
+	"X-Vault-Token",   // Will be replaced with real Vault token
+	"X-Vault-Request", // Internal Vault header
+	"X-Warden-Token",
+	"X-Warden-Agent-Token", // Warden-specific auth header
+	// Retired in 0.20: the user credential now rides Authorization. Still
+	// stripped so a client that keeps sending the old header cannot leak the
+	// credential to the upstream.
+	"X-Warden-User-Token",
 	"X-Warden-Role",          // Warden role header
 	"X-Warden-Provider",      // Warden provider-mount routing header
 	"X-Warden-Subject-Token", // token-exchange subject token — internal-only, never forwarded
 	"X-Warden-Actor-Token",   // token-exchange actor token — internal-only, never forwarded
-	"X-Warden-User-Token",    // secondary user credential — internal-only, never forwarded
 	// Hop-by-hop headers
 	"Connection",
 	"Keep-Alive",

--- a/provider/vault/provider.go
+++ b/provider/vault/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/framework"
@@ -48,20 +47,27 @@ type vaultBackend struct {
 	caData        string
 }
 
-// extractToken extracts the client token from the request.
-// Checks X-Warden-Token, X-Vault-Token, and Authorization: Bearer.
-func extractToken(r *http.Request) string {
-	if token := r.Header.Get("X-Warden-Token"); token != "" {
-		return token
-	}
-	if token := r.Header.Get("X-Vault-Token"); token != "" {
-		return token
-	}
-	authHeader := r.Header.Get("Authorization")
-	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
-		return authHeader[7:]
-	}
-	return ""
+// extractTokens resolves the two principals on a Vault gateway request.
+//
+// Agent channels, in the provider's existing order: X-Warden-Token, then
+// X-Vault-Token (the native Vault client header). On a protected-resource mount
+// an agent presented out of band — X-Warden-Agent-Token or a trusted client
+// certificate — frees Authorization to carry the user.
+//
+// Extraction matrix. "-" means nothing extracted; an empty agent under a
+// client certificate means the certificate authenticates the agent
+// downstream. Off the user leg there is never a user.
+//
+//	request carries                     agent(off)  agent(on)  user(on)
+//	Authorization: Bearer u             u           u          -
+//	X-Warden-Token: w + Bearer u        w           w          -
+//	X-Warden-Agent-Token: a + Bearer u  u           a          u
+//	client cert + Bearer u              u           -          u
+//	client cert only                    -           -          -
+//	X-Vault-Token: n + Bearer u         n           n          u
+//	X-Vault-Token: n + Bearer u + cert  n           n          u
+func extractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensWithChannels(r, userLeg, "X-Warden-Token", "X-Vault-Token")
 }
 
 // Factory creates a new Vault provider backend using the logical.Factory pattern
@@ -103,7 +109,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			Help:           vaultBackendHelp,
 			BackendType:    "vault",
 			BackendClass:   logical.ClassProvider,
-			TokenExtractor: extractToken,
+			TokenExtractor: extractTokens,
 			Paths:          b.paths(),
 		},
 	}
@@ -113,7 +119,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	b.StorageView = conf.StorageView
 
 	// Seed an empty transparent config so isTransparentRequest can route
-	// once auto_auth_path is configured via handleConfigWrite.
+	// once auto_auth_path is configured via handleConfigWrite. Mount-enable
+	// config, if any, overwrites it below.
 	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
 
 	// Initialize reverse proxy with Vault transport (lazily created on first use)
@@ -141,6 +148,16 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		b.SetTimeout(parsedConfig.Timeout)
 		b.tlsSkipVerify = parsedConfig.TLSSkipVerify
 		b.caData = parsedConfig.CAData
+
+		// Honour transparent + per-user auth supplied at mount-enable time, not
+		// only via the config-write endpoint. Without this the fields are
+		// silently dropped from `warden provider enable vault -json ...`.
+		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+			AutoAuthPath:    parsedConfig.AutoAuthPath,
+			DefaultAuthRole: parsedConfig.DefaultAuthRole,
+			UserAuthPath:    parsedConfig.UserAuthPath,
+			UserAuthRole:    parsedConfig.UserAuthRole,
+		})
 
 		// Update transport if custom TLS config is set
 		if b.tlsSkipVerify || b.caData != "" {
@@ -174,6 +191,8 @@ func (b *vaultBackend) Initialize(ctx context.Context) error {
 			TLSSkipVerify   bool   `json:"tls_skip_verify"`
 			CAData          string `json:"ca_data"`
 			AutoAuthPath    string `json:"auto_auth_path"`
+			UserAuthPath    string `json:"user_auth_path"`
+			UserAuthRole    string `json:"user_auth_role"`
 			DefaultAuthRole string `json:"default_role"`
 		}
 		if err := entry.DecodeJSON(&config); err != nil {
@@ -200,6 +219,8 @@ func (b *vaultBackend) Initialize(ctx context.Context) error {
 
 		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
 			AutoAuthPath:    config.AutoAuthPath,
+			UserAuthPath:    config.UserAuthPath,
+			UserAuthRole:    config.UserAuthRole,
 			DefaultAuthRole: config.DefaultAuthRole,
 		})
 	}

--- a/provider/vault/user_leg_test.go
+++ b/provider/vault/user_leg_test.go
@@ -1,0 +1,82 @@
+package vault
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func certReq(headers map[string]string) *http.Request {
+	return withCert(plainReq(headers))
+}
+
+func plainReq(headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/v1/vault/gateway/v1/secret/data/k", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func withCert(r *http.Request) *http.Request {
+	return r.WithContext(listener.WithForwardedClientCert(r.Context(), &x509.Certificate{}))
+}
+
+// TestExtractTokens covers both legs. With userLeg false the result must stay
+// byte-identical to the pre-0.20 extractor, including this provider's own
+// channel precedence; with userLeg true an out-of-band agent frees Authorization
+// for the user.
+func TestExtractTokens(t *testing.T) {
+	t.Run("agent precedence with the user leg off", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			headers   map[string]string
+			wantAgent string
+		}{
+			{"warden token wins", map[string]string{"X-Warden-Token": "w", "X-Vault-Token": "v", "Authorization": "Bearer b"}, "w"},
+			{"vault token over bearer", map[string]string{"X-Vault-Token": "v", "Authorization": "Bearer b"}, "v"},
+			{"bearer fallback", map[string]string{"Authorization": "Bearer b"}, "b"},
+			{"nothing", nil, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				agent, user := extractTokens(plainReq(tc.headers), false)
+				assert.Equal(t, tc.wantAgent, agent)
+				assert.Empty(t, user, "userLeg=false must never produce a user")
+			})
+		}
+	})
+
+	t.Run("X-Warden-Token does not free Authorization for the user", func(t *testing.T) {
+		// The operator credential never opens the user leg. See
+		// logical.ExtractTokensDefault.
+		agent, user := extractTokens(plainReq(map[string]string{
+			"X-Warden-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Empty(t, user)
+	})
+
+	t.Run("cert agent makes Authorization the user", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{"Authorization": "Bearer u"}), true)
+		assert.Empty(t, agent, "an empty agent means the cert is the agent")
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("agent-token header is not shadowed by an ambient cert", func(t *testing.T) {
+		agent, user := extractTokens(certReq(map[string]string{
+			"X-Warden-Agent-Token": "ag", "Authorization": "Bearer u",
+		}), true)
+		assert.Equal(t, "ag", agent)
+		assert.Equal(t, "u", user)
+	})
+
+	t.Run("lone bearer stays the agent", func(t *testing.T) {
+		agent, user := extractTokens(plainReq(map[string]string{"Authorization": "Bearer a"}), true)
+		assert.Equal(t, "a", agent)
+		assert.Empty(t, user, "warden always has an agent; a bare bearer is it")
+	})
+}


### PR DESCRIPTION
Replaces `Backend.ExtractToken(r) string` with
`ExtractTokens(r, userLeg bool) (agent, user string)` so a request can carry
both principals. On a mount with an effective `user_auth_path`, an agent
presented out of band — `X-Warden-Agent-Token`, or a trusted client
certificate — frees `Authorization` to carry the user.

This is the transport layer only. Nothing yet tells a client that a user is
wanted or where to get one; that is the following two PRs.

## The rule

```
1. X-Warden-Token                  -> agent; never a user
2. userLeg && X-Warden-Agent-Token -> agent; user = authz
3. userLeg && trusted client cert  -> agent = "" (the cert); user = authz
4. otherwise                       -> agent = authz; no user
```

Steps 2 and 3 are unreachable when `userLeg` is false, so **every
non-opted-in mount resolves exactly as before and never produces a user**.
The one sanctioned deviation is that Authorization scheme names are now
matched case-insensitively per RFC 7235 — a widening that never narrows.

Step 1 stays out of the user leg on both legs: `X-Warden-Token` is the
operator credential, while gateway traffic is the workload surface where
identity arrives as a JWT or a certificate. That leaves exactly two
out-of-band agent channels. Presenting it *alongside* an `Authorization`
credential on a protected-resource mount is ambiguous — one of the two would
be dropped silently — so core rejects that combination with a 400 naming the
fix. `X-Warden-Token` alone still works: explicit (non-transparent) agent
auth is unchanged.

Step 2 precedes step 3 deliberately. A sidecar makes a forwarded certificate
present on nearly every request, so cert-first would shadow the dedicated
channel and mis-attribute a mesh workload to the sidecar — the same hazard
`resolveTransparentIdentity` already guards against for JWT-SVIDs.

## Per-provider overrides

Providers may override the whole rule. The contract requires byte-identical
behaviour with `userLeg` false, **including each provider's own channel
precedence** — GitLab reads `Bearer` ahead of `X-Warden-Token`, New Relic
reads `Api-Key` first. elastic and splunk dispatch on scheme, since their
agent already occupies `Authorization` under `ApiKey`/`Splunk`. Each provider
now carries a generated extraction matrix in its godoc.

`user_auth_path` is mount-only. It marks *this* mount a protected resource —
deciding whether `Authorization` carries the user, and binding one resource
to one identity provider and audience — so a namespace-wide fallback would
opt in every mount in the namespace. The mount fields were added to vault,
azure, gcp and mcp_aws, which previously had no other way in.

## Git smart-HTTP gains a user leg

The Basic password is the agent off the user leg, always, including under a
client certificate: an explicitly presented credential beats an ambient one.
With a certificate acting as the agent on a protected-resource mount the
password slot carries the user instead, while the username keeps naming the
agent's role — so `https://<agent-role>:$USER_JWT@host/...` works with no
client configuration. A non-JWT password is the placeholder Git requires when
there is no user token, and is ignored rather than 401'd.

## Bugs found while converting

- The github/gitlab skip-Basic-when-cert branch keyed on the raw
  `X-SSL-Client-Cert` header, which the listener middleware strips on every
  branch before a provider runs. **It never fired.** Cert detection now reads
  the request context, which is what makes the user leg above possible.
- The unauthenticated-path gate entered on `ClientToken == ""`, which used to
  imply "no credential". An empty agent now means "the cert is the agent", so
  a cert-authenticated request matching an unauthenticated pattern would have
  skipped `CheckToken`, minting, user capture **and audit**. It now also
  requires the absence of a trusted cert, scoped to protected-resource mounts
  so token-less public endpoints still work.
- AWS forwarded every `X-Warden-*` header upstream. Now stripped after inbound
  signature verification and before re-signing.

## Retired

`user_token_header` / `X-Warden-User-Token`: the user credential rides
`Authorization`, decided by request transport rather than mount config. A
persisted value loads with a warning and is ignored. The header stays in every
strip list so a client still sending it cannot leak it upstream.

## Breaking changes

- On `user_auth_path` mounts, an `Authorization`-borne agent under an ambient
  client certificate now resolves to the cert identity — move such agents to
  `X-Warden-Agent-Token`.
- `user_token_header` is removed.
- `user_auth_path` / `user_auth_role` are no longer read from namespace
  metadata.

## Testing

Full unit suite green. Every pre-existing provider extraction test now runs
through a compat shim that panics if a user is produced with `userLeg` false,
so the compatibility invariant is asserted by the existing suite rather than
by new tests alone.

Verified against a live 3-node cluster: 17/17 e2e packages, 217 tests. The
203 pre-existing tests all run with the user leg off, which is exactly what
makes them a compatibility check for this change.
