### PR TITLE
feat(core): serve RFC 9728 protected resource metadata

### DIFF
--- a/auth/method/jwt/authorization_server_test.go
+++ b/auth/method/jwt/authorization_server_test.go
@@ -1,0 +1,95 @@
+package jwt
+
+import (
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthorizationServerURL covers what this mount will advertise to clients
+// through RFC 9728 protected resource metadata. The value sends a user's browser
+// somewhere to authenticate, so naming the wrong place — or naming anywhere at
+// all when the mount does not actually know an issuer — is worse than staying
+// silent and letting the metadata endpoint 404.
+func TestAuthorizationServerURL(t *testing.T) {
+	newBackend := func(t *testing.T, cfg *JWTAuthConfig) *jwtAuthBackend {
+		t.Helper()
+		b := &jwtAuthBackend{logger: testLogger(), config: cfg}
+		return b
+	}
+
+	t.Run("discovery URL is the issuer", func(t *testing.T) {
+		b := newBackend(t, &JWTAuthConfig{OIDCDiscoveryURL: "https://idp.example.com"})
+		got, ok := b.AuthorizationServerURL()
+		assert.True(t, ok)
+		assert.Equal(t, "https://idp.example.com", got)
+	})
+
+	t.Run("discovery URL wins over bound_issuer", func(t *testing.T) {
+		b := newBackend(t, &JWTAuthConfig{
+			OIDCDiscoveryURL: "https://idp.example.com",
+			BoundIssuer:      "https://other.example.com",
+		})
+		got, _ := b.AuthorizationServerURL()
+		assert.Equal(t, "https://idp.example.com", got,
+			"discovery is by construction somewhere a client can run discovery against")
+	})
+
+	t.Run("bound_issuer is used when it is an absolute https URL", func(t *testing.T) {
+		b := newBackend(t, &JWTAuthConfig{BoundIssuer: "https://issuer.example.com"})
+		got, ok := b.AuthorizationServerURL()
+		assert.True(t, ok)
+		assert.Equal(t, "https://issuer.example.com", got)
+	})
+
+	t.Run("a non-URL bound_issuer names nothing", func(t *testing.T) {
+		// bound_issuer is free-form and often an opaque identifier rather than a
+		// location. Publishing one as somewhere to send credentials would be
+		// meaningless at best.
+		for _, issuer := range []string{
+			"my-issuer",
+			"urn:example:issuer",
+			"http://idp.example.com",
+			"//idp.example.com",
+			"https://",
+		} {
+			b := newBackend(t, &JWTAuthConfig{BoundIssuer: issuer})
+			_, ok := b.AuthorizationServerURL()
+			assert.False(t, ok, "bound_issuer %q must not be advertised", issuer)
+		}
+	})
+
+	t.Run("a JWKS-only or static-key mount names nothing", func(t *testing.T) {
+		// These verify tokens without knowing who issues them. There is nothing
+		// for a client to discover, and guessing would send a user to the wrong
+		// authorization server.
+		for name, cfg := range map[string]*JWTAuthConfig{
+			"jwks only":   {JWKSURL: "https://idp.example.com/keys"},
+			"static keys": {JWTValidationPubKeys: []string{"-----BEGIN PUBLIC KEY-----"}},
+			"empty":       {},
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, ok := newBackend(t, cfg).AuthorizationServerURL()
+				assert.False(t, ok)
+			})
+		}
+	})
+
+	t.Run("an unconfigured backend names nothing", func(t *testing.T) {
+		_, ok := newBackend(t, nil).AuthorizationServerURL()
+		assert.False(t, ok, "a nil config must not panic")
+	})
+
+	t.Run("satisfies the interface the metadata endpoint reaches it through", func(t *testing.T) {
+		// The concrete type is unexported, so core can only reach this via the
+		// interface. If the assertion ever breaks, metadata silently 404s.
+		var b any = newBackend(t, &JWTAuthConfig{OIDCDiscoveryURL: "https://idp.example.com"})
+		provider, ok := b.(logical.AuthorizationServerProvider)
+		require.True(t, ok)
+		got, ok := provider.AuthorizationServerURL()
+		assert.True(t, ok)
+		assert.Equal(t, "https://idp.example.com", got)
+	})
+}

--- a/auth/method/jwt/backend.go
+++ b/auth/method/jwt/backend.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -266,4 +267,52 @@ func verifyJWKSURLReachable(ctx context.Context, jwksURL string, caPEM string) e
 func verifyOIDCDiscoveryURLReachable(ctx context.Context, oidcDiscoveryURL string, caPEM string) error {
 	wellKnown := strings.TrimSuffix(oidcDiscoveryURL, "/") + "/.well-known/openid-configuration"
 	return verifyURLReachable(ctx, wellKnown, caPEM)
+}
+
+// Compile-time assertion: the metadata endpoint reaches this backend only
+// through the interface, since the concrete type is unexported.
+var _ logical.AuthorizationServerProvider = (*jwtAuthBackend)(nil)
+
+// AuthorizationServerURL implements logical.AuthorizationServerProvider.
+//
+// Prefers the OIDC discovery URL, which is by construction the issuer a client
+// can run discovery against. Falls back to bound_issuer when it is an absolute
+// https URL — an operator who pins an issuer without configuring discovery has
+// still named one, and OIDC requires the issuer to host its own discovery
+// document, so a client can proceed from it.
+//
+// Returns ok=false for a mount that verifies with a bare JWKS URL or static
+// public keys: those authenticate tokens without knowing who issues them, so
+// there is nothing for a client to discover and guessing would send it to the
+// wrong authorization server.
+func (b *jwtAuthBackend) AuthorizationServerURL() (string, bool) {
+	b.configMu.RLock()
+	defer b.configMu.RUnlock()
+	if b.config == nil {
+		return "", false
+	}
+	if u := b.config.OIDCDiscoveryURL; u != "" {
+		return u, true
+	}
+	if u := b.config.BoundIssuer; u != "" {
+		if err := validateAuthorizationServerURL(u); err == nil {
+			return u, true
+		}
+	}
+	return "", false
+}
+
+// validateAuthorizationServerURL accepts only an absolute https URL with a
+// host. bound_issuer is a free-form string that is often an opaque identifier
+// rather than a URL, so it must be checked before being published as somewhere
+// a client should send credentials.
+func validateAuthorizationServerURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("not an absolute https URL")
+	}
+	return nil
 }

--- a/cmd/protectedresource/configure.go
+++ b/cmd/protectedresource/configure.go
@@ -1,0 +1,122 @@
+package protectedresource
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var (
+	configureResourceURL string
+	configureAuthServers []string
+	configureDocaURL     string
+	configureCacheTTL    string
+	configureJSON        string
+
+	ConfigureCmd = &cobra.Command{
+		Use:           "configure",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Configure protected resource metadata",
+		Long: `
+Usage: warden protected-resource configure [flags]
+
+  Set the deployment-wide protected resource metadata configuration. Writes are
+  partial: a flag you omit keeps its stored value. Root namespace only.
+
+  -resource-url is the master switch. It must be the external HTTPS address
+  clients actually reach Warden at, because each document's "resource" field is
+  this joined with the mount's API path, and clients compare that literally.
+  Warden never derives it from a request's Host header, which a client controls.
+
+      $ warden protected-resource configure -resource-url=https://warden.example.com
+
+  Leave -authorization-server unset to derive each mount's issuer from the auth
+  method at its user_auth_path — the usual case. Set it only when the derived
+  value is wrong, such as an identity provider behind a proxy.
+
+      $ warden protected-resource configure \
+          -resource-url=https://warden.example.com \
+          -documentation=https://docs.example.com/mcp \
+          -cache-ttl=1h
+
+      $ warden protected-resource configure -json '{"resource_url":"https://warden.example.com"}'
+
+  Combine with -dry-run to preview the request without sending it.
+`,
+		Args: cobra.NoArgs,
+		RunE: runConfigure,
+	}
+)
+
+func init() {
+	ConfigureCmd.Flags().StringVar(&configureResourceURL, "resource-url", "",
+		"External HTTPS base URL clients reach Warden at (enables metadata)")
+	ConfigureCmd.Flags().StringSliceVar(&configureAuthServers, "authorization-server", nil,
+		"Override the advertised authorization server(s); repeatable")
+	ConfigureCmd.Flags().StringVar(&configureDocaURL, "documentation", "",
+		"Optional human-facing documentation URL echoed in every document")
+	ConfigureCmd.Flags().StringVar(&configureCacheTTL, "cache-ttl", "",
+		"Cache-Control max-age of a served document (default: 1h)")
+	ConfigureCmd.Flags().StringVarP(&configureJSON, "json", "j", "",
+		"Full JSON payload — '<json>', '@file.json', or '-' for stdin (mutually exclusive with the field flags)")
+}
+
+func runConfigure(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	jsonPayload, err := helpers.ResolveJSONInput(configureJSON)
+	if err != nil {
+		return err
+	}
+
+	var payload map[string]any
+	if jsonPayload != nil {
+		for _, f := range []string{"resource-url", "authorization-server", "documentation", "cache-ttl"} {
+			if cmd.Flags().Changed(f) {
+				return fmt.Errorf("-json is mutually exclusive with -%s: %w", f, helpers.ErrUsage)
+			}
+		}
+		payload = jsonPayload
+	} else {
+		payload = map[string]any{}
+		// Only send fields the caller actually set: the server treats an absent
+		// field as "keep", so sending zero values would silently clear them.
+		if cmd.Flags().Changed("resource-url") {
+			payload["resource_url"] = configureResourceURL
+		}
+		if cmd.Flags().Changed("authorization-server") {
+			payload["authorization_servers"] = configureAuthServers
+		}
+		if cmd.Flags().Changed("documentation") {
+			payload["resource_documentation"] = configureDocaURL
+		}
+		if cmd.Flags().Changed("cache-ttl") {
+			payload["cache_ttl"] = configureCacheTTL
+		}
+		if len(payload) == 0 {
+			return fmt.Errorf("supply at least one field (or use -json): %w", helpers.ErrUsage)
+		}
+	}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "POST", protectedResourceConfigPath, payload)
+	}
+
+	if _, err := c.Operator().Write(protectedResourceConfigPath, payload); err != nil {
+		return fmt.Errorf("error configuring protected resource metadata: %w", err)
+	}
+
+	resource, err := c.Operator().Read(protectedResourceConfigPath)
+	if err != nil {
+		return fmt.Errorf("error reading back configuration: %w", err)
+	}
+	return helpers.RenderMap(resource.Data, func() {
+		fmt.Println("Success! Protected resource metadata configured.")
+		printConfigTable(resource.Data)
+	})
+}

--- a/cmd/protectedresource/disable.go
+++ b/cmd/protectedresource/disable.go
@@ -1,0 +1,50 @@
+package protectedresource
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var DisableCmd = &cobra.Command{
+	Use:           "disable",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Short:         "Stop serving protected resource metadata",
+	Long: `
+Usage: warden protected-resource disable
+
+  Clear resource_url, so no metadata document is served and every well-known
+  path returns 404. Mounts keep their user_auth_path and continue to accept a
+  user credential — only discovery stops. Root namespace only.
+
+  The rest of the configuration is retained, so a later 'configure
+  -resource-url=...' restores it without re-supplying the other fields.
+
+      $ warden protected-resource disable
+`,
+	Args: cobra.NoArgs,
+	RunE: runDisable,
+}
+
+func runDisable(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]any{"resource_url": ""}
+
+	if helpers.ResolveDryRun() {
+		return helpers.DryRun(c, "POST", protectedResourceConfigPath, payload)
+	}
+
+	if _, err := c.Operator().Write(protectedResourceConfigPath, payload); err != nil {
+		return fmt.Errorf("error disabling protected resource metadata: %w", err)
+	}
+
+	return helpers.RenderMap(map[string]any{"enabled": false}, func() {
+		fmt.Println("Success! Protected resource metadata disabled.")
+	})
+}

--- a/cmd/protectedresource/protectedresource.go
+++ b/cmd/protectedresource/protectedresource.go
@@ -1,0 +1,44 @@
+package protectedresource
+
+import "github.com/spf13/cobra"
+
+// protectedResourceConfigPath is the API path of the global configuration.
+const protectedResourceConfigPath = "sys/protected-resource/config"
+
+var (
+	ProtectedResourceCmd = &cobra.Command{
+		Use:           "protected-resource",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "Configure RFC 9728 protected resource metadata",
+		Long: `
+Usage: warden protected-resource <subcommand> [options]
+
+  Warden publishes, for each opted-in mount, a metadata document naming the
+  authorization server a client should obtain a USER credential from. A client
+  that receives a 401 fetches the document, runs OAuth against that provider,
+  and retries with the user's token on the Authorization header.
+
+  Warden is a resource server only. It never issues user credentials and never
+  serves authorization-server metadata.
+
+  A mount opts in by setting user_auth_path in its own configuration. This
+  command configures the deployment-wide parts: the external base URL clients
+  reach Warden at, and optional overrides. Root namespace only.
+
+      $ warden protected-resource configure -resource-url=https://warden.example.com
+      $ warden protected-resource read
+      $ warden protected-resource disable
+
+  Documents are then served at:
+
+      /.well-known/oauth-protected-resource/v1/<namespace>/<mount>
+`,
+	}
+)
+
+func init() {
+	ProtectedResourceCmd.AddCommand(ConfigureCmd)
+	ProtectedResourceCmd.AddCommand(ReadCmd)
+	ProtectedResourceCmd.AddCommand(DisableCmd)
+}

--- a/cmd/protectedresource/read.go
+++ b/cmd/protectedresource/read.go
@@ -1,0 +1,116 @@
+package protectedresource
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+var ReadCmd = &cobra.Command{
+	Use:           "read",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Short:         "Read the protected resource metadata configuration",
+	Long: `
+Usage: warden protected-resource read
+
+  Show the deployment-wide protected resource metadata configuration. Root
+  namespace only.
+
+      $ warden protected-resource read
+
+  "enabled" reflects whether resource_url is set — no base URL means no document
+  can name a resource, so nothing is served.
+`,
+	Args: cobra.NoArgs,
+	RunE: runRead,
+}
+
+func runRead(cmd *cobra.Command, args []string) error {
+	c, err := helpers.Client()
+	if err != nil {
+		return err
+	}
+
+	resource, err := c.Operator().Read(protectedResourceConfigPath)
+	if err != nil {
+		return fmt.Errorf("error reading protected resource configuration: %w", err)
+	}
+	if resource == nil || resource.Data == nil {
+		fmt.Fprintln(os.Stderr, "No protected resource configuration found.")
+		return nil
+	}
+
+	return helpers.RenderMap(resource.Data, func() {
+		printConfigTable(resource.Data)
+	})
+}
+
+// fieldOrder is the stable display order, most-load-bearing first.
+var fieldOrder = []string{
+	"enabled",
+	"resource_url",
+	"authorization_servers",
+	"resource_documentation",
+	"cache_ttl",
+}
+
+func printConfigTable(data map[string]any) {
+	var rows [][]any
+	for _, k := range fieldOrder {
+		v, ok := data[k]
+		if !ok {
+			continue
+		}
+		rows = append(rows, []any{k, cellString(k, v)})
+	}
+	helpers.PrintTable([]string{"Field", "Value"}, rows)
+}
+
+// cellString renders a value for the table. cache_ttl arrives as integer
+// seconds from the server and is humanised here.
+func cellString(key string, v any) string {
+	switch key {
+	case "cache_ttl":
+		if secs, ok := toSeconds(v); ok {
+			return (time.Duration(secs) * time.Second).String()
+		}
+	case "authorization_servers":
+		if list, ok := v.([]any); ok {
+			if len(list) == 0 {
+				return "(derived per mount)"
+			}
+			parts := make([]string, 0, len(list))
+			for _, item := range list {
+				parts = append(parts, fmt.Sprintf("%v", item))
+			}
+			return strings.Join(parts, ", ")
+		}
+	}
+	if v == nil || v == "" {
+		return "-"
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// toSeconds extracts an integer seconds value from a JSON-decoded number.
+func toSeconds(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/cmd/warden.go
+++ b/cmd/warden.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stephnangue/warden/cmd/oidcissuer"
 	"github.com/stephnangue/warden/cmd/operator"
 	"github.com/stephnangue/warden/cmd/policies"
+	"github.com/stephnangue/warden/cmd/protectedresource"
 	"github.com/stephnangue/warden/cmd/providers"
 	"github.com/stephnangue/warden/cmd/roles"
 	"github.com/stephnangue/warden/cmd/schema"
@@ -76,6 +77,7 @@ func init() {
 	wardenCmd.AddCommand(audit.AuditCmd)
 	wardenCmd.AddCommand(namespaces.NamespacesCmd)
 	wardenCmd.AddCommand(oidcissuer.OIDCIssuerCmd)
+	wardenCmd.AddCommand(protectedresource.ProtectedResourceCmd)
 	wardenCmd.AddCommand(policies.PoliciesCmd)
 	wardenCmd.AddCommand(cred.CredCmd)
 	wardenCmd.AddCommand(schema.SchemaCmd)

--- a/core/core.go
+++ b/core/core.go
@@ -251,6 +251,10 @@ type Core struct {
 	// oidcConfigMu serializes the load-modify-save of the issuer config doc so a
 	// rotation persist and an operator config write cannot lost-update each other.
 	oidcConfigMu sync.Mutex
+
+	// protectedResourceMu serializes load-modify-save of the RFC 9728 metadata
+	// config so two concurrent partial updates cannot lost-update each other.
+	protectedResourceMu sync.Mutex
 	// oidcSetupMu serializes setupOIDCIssuer/stopOIDCIssuer so two concurrent config
 	// writes (or a write racing seal/promotion) cannot interleave loop start/stop and
 	// leak a rotation goroutine that outlives its cancel func. Distinct from oidcConfigMu

--- a/core/protected_resource.go
+++ b/core/protected_resource.go
@@ -1,0 +1,222 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+)
+
+// ProtectedResourceMetadata is the RFC 9728 document describing one mount as an
+// OAuth protected resource: what it is called, and which authorization server a
+// client should obtain a user credential from.
+//
+// Warden is a resource server, never an authorization server — it publishes this
+// so clients go to the operator's identity provider, and deliberately does not
+// serve RFC 8414 authorization-server metadata.
+type ProtectedResourceMetadata struct {
+	// Resource is the canonical identifier of this mount: the external base URL
+	// joined with the mount's API path.
+	Resource string `json:"resource"`
+
+	// AuthorizationServers names the issuer(s) a client runs OAuth against.
+	AuthorizationServers []string `json:"authorization_servers,omitempty"`
+
+	// BearerMethodsSupported is always ["header"]: the user credential rides
+	// Authorization. Warden reads it from no other slot on a non-git mount, and
+	// query/body delivery is never accepted.
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+
+	// ResourceName is the operator's own description of the mount, so a consent
+	// screen can say what the user is authorizing access to.
+	ResourceName string `json:"resource_name,omitempty"`
+
+	// ResourceDocumentation is an optional human-facing URL.
+	ResourceDocumentation string `json:"resource_documentation,omitempty"`
+}
+
+// ErrNotProtectedResource signals that no metadata may be served for a path —
+// the feature is off, the path names no mount, the mount is not opted in, or no
+// authorization server could be derived. Every one of those is reported to a
+// client as a plain 404: which of them applies is operator-facing detail, and
+// distinguishing them would let an unauthenticated caller probe the mount table.
+var ErrNotProtectedResource = fmt.Errorf("not a protected resource")
+
+// ProtectedResourceMetadata builds the RFC 9728 document for the resource named
+// by suffix — the request path after the well-known prefix, e.g.
+// "/v1/team-a/github". Returns ErrNotProtectedResource when none should be
+// served.
+//
+// Namespace and mount are resolved per request rather than cached: the document
+// is derived from live mount configuration, and the config load at unseal
+// happens before mounts exist.
+func (c *Core) ProtectedResourceMetadata(ctx context.Context, suffix string) ([]byte, time.Duration, error) {
+	cfg, err := c.protectedResourceConfig(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !cfg.enabled() {
+		return nil, 0, ErrNotProtectedResource
+	}
+
+	nsCtx, mountPath, err := c.resolveProtectedResourcePath(suffix)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// MatchingMountEntry first, and it does not log on a miss — unlike
+	// MatchingBackend. This endpoint is unauthenticated, so a lookup that logs
+	// per miss would be a log-flooding vector.
+	entry := c.router.MatchingMountEntry(nsCtx, mountPath)
+	if entry == nil {
+		return nil, 0, ErrNotProtectedResource
+	}
+
+	backend := c.router.MatchingBackend(nsCtx, mountPath)
+	if backend == nil {
+		return nil, 0, ErrNotProtectedResource
+	}
+
+	// Opt-in is the mount's own user_auth_path — the same switch that decides
+	// whether Authorization carries a user on this mount. A mount that cannot
+	// validate a user must not advertise that it wants one.
+	userAuthPath, _ := c.resolveUserAuthConfig(nsCtx, backend)
+	if userAuthPath == "" {
+		return nil, 0, ErrNotProtectedResource
+	}
+
+	servers, err := c.authorizationServersFor(nsCtx, cfg, userAuthPath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	doc := &ProtectedResourceMetadata{
+		Resource:               joinResourceURL(cfg.ResourceURL, suffix),
+		AuthorizationServers:   servers,
+		BearerMethodsSupported: []string{"header"},
+		ResourceName:           entry.Description,
+		ResourceDocumentation:  cfg.ResourceDocumentation,
+	}
+	if doc.ResourceName == "" {
+		doc.ResourceName = strings.TrimSuffix(entry.Path, "/")
+	}
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return nil, 0, err
+	}
+	// The cache lifetime comes from the same config generation that produced the
+	// document, so a concurrent write cannot make the two disagree.
+	return body, cfg.cacheTTL(), nil
+}
+
+// resolveProtectedResourcePath splits a "/v1/<ns>/<mount>" suffix into a
+// namespace-bearing context and the mount path within that namespace.
+func (c *Core) resolveProtectedResourcePath(suffix string) (context.Context, string, error) {
+	// The suffix must already be canonical. Go's ServeMux redirects a literal
+	// "/../" before the handler runs, but a percent-encoded one ("%2e%2e")
+	// arrives decoded and intact — so "/v1/github/../plain" would longest-prefix
+	// match the github mount while the document echoed a `resource` that
+	// normalizes to /v1/plain. That would bind one mount's identifier to another
+	// mount's authorization server: a token-confusion primitive for any client
+	// that normalizes `resource` before comparing it. Require canonical form
+	// rather than cleaning, so the identifier we publish is always the one that
+	// was asked for.
+	if suffix != path.Clean(suffix) {
+		return nil, "", ErrNotProtectedResource
+	}
+
+	// The suffix must name an API resource: "/v1/<ns...>/<mount>". Checked as a
+	// literal prefix rather than by trimming, so a path that merely happens to
+	// survive a trim (e.g. "/sys/mcp") is not mistaken for one.
+	const apiPrefix = "/v1/"
+	if !strings.HasPrefix(suffix, apiPrefix) {
+		return nil, "", ErrNotProtectedResource
+	}
+	rel := suffix[len(apiPrefix):]
+	if rel == "" {
+		return nil, "", ErrNotProtectedResource
+	}
+
+	if c.namespaceStore == nil {
+		return nil, "", ErrNotProtectedResource
+	}
+	ns, mountPath := c.namespaceStore.ResolveNamespaceFromRequest("", rel)
+	if ns == nil || mountPath == "" {
+		return nil, "", ErrNotProtectedResource
+	}
+
+	// MatchingMountEntry does a longest-prefix match against router keys, which
+	// carry a trailing slash. A bare mount name would otherwise miss.
+	if !strings.HasSuffix(mountPath, "/") {
+		mountPath += "/"
+	}
+	return namespace.ContextWithNamespace(context.Background(), ns), mountPath, nil
+}
+
+// authorizationServersFor returns the issuer(s) to advertise: the global
+// override when set, else whatever the mount's user auth method can name.
+func (c *Core) authorizationServersFor(ctx context.Context, cfg *protectedResourceConfig, userAuthPath string) ([]string, error) {
+	if len(cfg.AuthorizationServers) > 0 {
+		return cfg.AuthorizationServers, nil
+	}
+
+	// Check the mount exists before MatchingBackend, which logs an error on a
+	// miss. A dangling user_auth_path would otherwise let anonymous fetches
+	// write an error line each.
+	authPath := normalizeAuthPath(userAuthPath)
+	if c.router.MatchingMountEntry(ctx, authPath) == nil {
+		return nil, ErrNotProtectedResource
+	}
+	authBackend := c.router.MatchingBackend(ctx, authPath)
+	if authBackend == nil {
+		return nil, ErrNotProtectedResource
+	}
+	provider, ok := authBackend.(logical.AuthorizationServerProvider)
+	if !ok {
+		return nil, ErrNotProtectedResource
+	}
+	issuer, ok := provider.AuthorizationServerURL()
+	if !ok || issuer == "" {
+		// A mount that authenticates users without knowing an issuer (static
+		// keys, bare JWKS) or an auth method with no OAuth notion at all
+		// (spiffe, kubernetes). There is nothing a client could discover.
+		return nil, ErrNotProtectedResource
+	}
+	// Hold a derived issuer to the same standard as an operator-supplied one: a
+	// client redirects a user's browser there, and the auth mount validates its
+	// discovery URL for reachability, not for scheme. Advertising a plaintext
+	// authorization server would be worse than advertising none.
+	if err := validateExternalHTTPSURL(issuer, "authorization_servers",
+		"a client redirects a user's browser there"); err != nil {
+		return nil, ErrNotProtectedResource
+	}
+	return []string{issuer}, nil
+}
+
+// normalizeAuthPath renders a configured user_auth_path as a router key.
+// Operators write it either way ("auth/user-jwt/" or "auth/user-jwt").
+func normalizeAuthPath(p string) string {
+	if !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	return p
+}
+
+// joinResourceURL concatenates the external base with the resource path,
+// collapsing the slash between them so a base written with or without a
+// trailing slash yields the same identifier. The identifier is compared
+// literally by clients, so it must be stable.
+func joinResourceURL(base, suffix string) string {
+	return strings.TrimSuffix(base, "/") + "/" + strings.TrimPrefix(suffix, "/")
+}
+
+// protectedResourceConfig loads the configuration from its barrier view.
+func (c *Core) protectedResourceConfig(ctx context.Context) (*protectedResourceConfig, error) {
+	view := NewBarrierView(c.barrier, protectedResourceStorePrefix)
+	return loadProtectedResourceConfig(ctx, view)
+}

--- a/core/protected_resource_config.go
+++ b/core/protected_resource_config.go
@@ -1,0 +1,97 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+)
+
+const (
+	// protectedResourceStorePrefix is the barrier-view prefix for the protected
+	// resource metadata configuration. Written through a barrier view, so it is
+	// encrypted at rest.
+	protectedResourceStorePrefix = "core/protected-resource/"
+
+	// protectedResourceConfigPath is the storage key (within that view) of the
+	// configuration.
+	protectedResourceConfigPath = "config"
+
+	// defaultPRMCacheTTL is how long a client or CDN may cache a served metadata
+	// document when the config does not override it. The document is derived from
+	// live mount state, so this is a staleness budget, not just a performance knob.
+	defaultPRMCacheTTL = time.Hour
+)
+
+// protectedResourceConfig is the persisted, barrier-encrypted configuration
+// backing RFC 9728 metadata. Only genuinely global fields live here; everything
+// per-resource is derived from the mount at request time.
+//
+// The feature is off until ResourceURL is set: without an external base URL
+// there is no way to name the resource, so the metadata endpoint 404s.
+type protectedResourceConfig struct {
+	Version int `json:"version"`
+
+	// ResourceURL is the external HTTPS base clients reach Warden at. Its
+	// presence is the master switch. The `resource` field of each document is
+	// this joined with the mount's API path, so it must be the address clients
+	// actually use — never a request's Host header, which a client controls.
+	ResourceURL string `json:"resource_url"`
+
+	// AuthorizationServers overrides the issuer derived from the mount's
+	// user_auth_path. Set it only when the derived value is wrong — a proxy in
+	// front of the IdP, or an issuer that differs from its discovery URL.
+	AuthorizationServers []string `json:"authorization_servers,omitempty"`
+
+	// ResourceDocumentation is an optional human-facing URL echoed in every
+	// document, for clients that surface it to an operator on a failed flow.
+	ResourceDocumentation string `json:"resource_documentation,omitempty"`
+
+	// CacheTTL is the Cache-Control max-age of a served document. Empty ->
+	// defaultPRMCacheTTL.
+	CacheTTL string `json:"cache_ttl,omitempty"`
+}
+
+// cacheTTL returns the configured document cache lifetime, or the default when
+// unset or unparseable. Lenient by design: a bad duration must not take the
+// endpoint down, and the default is safe.
+func (c *protectedResourceConfig) cacheTTL() time.Duration {
+	if c == nil {
+		return defaultPRMCacheTTL
+	}
+	return parseDurationOr(c.CacheTTL, defaultPRMCacheTTL)
+}
+
+// enabled reports whether metadata may be served at all.
+func (c *protectedResourceConfig) enabled() bool {
+	return c != nil && c.ResourceURL != ""
+}
+
+// loadProtectedResourceConfig reads the config, returning (nil, nil) when none
+// is set.
+func loadProtectedResourceConfig(ctx context.Context, storage sdklogical.Storage) (*protectedResourceConfig, error) {
+	entry, err := storage.Get(ctx, protectedResourceConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("protected resource: read config: %w", err)
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var cfg protectedResourceConfig
+	if err := json.Unmarshal(entry.Value, &cfg); err != nil {
+		return nil, fmt.Errorf("protected resource: unmarshal config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// saveProtectedResourceConfig writes the config (barrier-encrypted).
+func saveProtectedResourceConfig(ctx context.Context, storage sdklogical.Storage, cfg *protectedResourceConfig) error {
+	cfg.Version = 1
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("protected resource: marshal config: %w", err)
+	}
+	return storage.Put(ctx, &sdklogical.StorageEntry{Key: protectedResourceConfigPath, Value: data})
+}

--- a/core/protected_resource_test.go
+++ b/core/protected_resource_test.go
@@ -1,0 +1,153 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// prmTestCore builds a core with two provider mounts — one opted into the user
+// leg, one not — and the metadata feature configured.
+func prmTestCore(t *testing.T, cfg *protectedResourceConfig) *Core {
+	t.Helper()
+	core := createTestCore(t)
+
+	mount := func(path, uuid, desc, userAuthPath string) {
+		backend := &mockUnauthPathBackend{userAuthPath: userAuthPath}
+		entry := &MountEntry{
+			Path:        path,
+			Type:        "mcp",
+			Class:       mountClassProvider,
+			UUID:        uuid,
+			Accessor:    uuid + "_acc",
+			Description: desc,
+			NamespaceID: namespace.RootNamespaceID,
+			namespace:   namespace.RootNamespace,
+		}
+		require.NoError(t, core.router.Mount(path, backend, entry, &mockBarrierView{prefix: "provider/" + uuid + "/"}))
+	}
+	mount("github/", "prm-gh", "GitHub for the platform team", "auth/user-jwt/")
+	mount("plain/", "prm-plain", "", "")
+
+	if cfg != nil {
+		view := NewBarrierView(core.barrier, protectedResourceStorePrefix)
+		require.NoError(t, saveProtectedResourceConfig(context.Background(), view, cfg))
+	}
+	return core
+}
+
+func TestProtectedResourceMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled when no resource_url is configured", func(t *testing.T) {
+		core := prmTestCore(t, nil)
+		_, _, err := core.ProtectedResourceMetadata(ctx, "/v1/github")
+		assert.ErrorIs(t, err, ErrNotProtectedResource)
+	})
+
+	cfg := &protectedResourceConfig{
+		ResourceURL:           "https://warden.example.com",
+		AuthorizationServers:  []string{"https://idp.example.com"},
+		ResourceDocumentation: "https://docs.example.com",
+	}
+
+	t.Run("serves an opted-in mount", func(t *testing.T) {
+		core := prmTestCore(t, cfg)
+		body, _, err := core.ProtectedResourceMetadata(ctx, "/v1/github")
+		require.NoError(t, err)
+
+		var doc ProtectedResourceMetadata
+		require.NoError(t, json.Unmarshal(body, &doc))
+		assert.Equal(t, "https://warden.example.com/v1/github", doc.Resource)
+		assert.Equal(t, []string{"https://idp.example.com"}, doc.AuthorizationServers)
+		assert.Equal(t, []string{"header"}, doc.BearerMethodsSupported)
+		assert.Equal(t, "GitHub for the platform team", doc.ResourceName,
+			"the operator's mount description names the resource on a consent screen")
+		assert.Equal(t, "https://docs.example.com", doc.ResourceDocumentation)
+	})
+
+	t.Run("a mount without user_auth_path is not a protected resource", func(t *testing.T) {
+		core := prmTestCore(t, cfg)
+		_, _, err := core.ProtectedResourceMetadata(ctx, "/v1/plain")
+		assert.ErrorIs(t, err, ErrNotProtectedResource,
+			"a mount that cannot validate a user must not advertise that it wants one")
+	})
+
+	t.Run("unknown mount, base path and non-v1 paths yield nothing", func(t *testing.T) {
+		core := prmTestCore(t, cfg)
+		for _, suffix := range []string{"", "/", "/v1/nope", "/github", "/v1/", "/sys/mcp"} {
+			_, _, err := core.ProtectedResourceMetadata(ctx, suffix)
+			assert.ErrorIs(t, err, ErrNotProtectedResource, "suffix %q", suffix)
+		}
+	})
+
+	t.Run("resource identifier is stable across base-URL spellings", func(t *testing.T) {
+		// Clients compare `resource` literally, so a trailing slash on the
+		// configured base must not change the identifier.
+		withSlash := *cfg
+		withSlash.ResourceURL = "https://warden.example.com/"
+		core := prmTestCore(t, &withSlash)
+
+		body, _, err := core.ProtectedResourceMetadata(ctx, "/v1/github")
+		require.NoError(t, err)
+		var doc ProtectedResourceMetadata
+		require.NoError(t, json.Unmarshal(body, &doc))
+		assert.Equal(t, "https://warden.example.com/v1/github", doc.Resource)
+	})
+
+	t.Run("falls back to the mount path when no description is set", func(t *testing.T) {
+		core := prmTestCore(t, cfg)
+		entry := &MountEntry{
+			Path: "nodesc/", Type: "mcp", Class: mountClassProvider,
+			UUID: "prm-nodesc", Accessor: "prm-nodesc_acc",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		}
+		require.NoError(t, core.router.Mount("nodesc/",
+			&mockUnauthPathBackend{userAuthPath: "auth/user-jwt/"}, entry,
+			&mockBarrierView{prefix: "provider/prm-nodesc/"}))
+
+		body, _, err := core.ProtectedResourceMetadata(ctx, "/v1/nodesc")
+		require.NoError(t, err)
+		var doc ProtectedResourceMetadata
+		require.NoError(t, json.Unmarshal(body, &doc))
+		assert.Equal(t, "nodesc", doc.ResourceName)
+	})
+
+	t.Run("non-canonical paths are refused", func(t *testing.T) {
+		// Go's ServeMux redirects a literal "/../" before the handler runs, but a
+		// percent-encoded one arrives decoded and intact. Left unchecked,
+		// "/v1/github/../plain" longest-prefix matches the github mount while the
+		// document echoes a `resource` that normalizes to /v1/plain — binding one
+		// mount's identifier to another mount's authorization server, which is a
+		// token-confusion primitive for any client that normalizes before
+		// comparing.
+		core := prmTestCore(t, cfg)
+		for _, suffix := range []string{
+			"/v1/github/../plain",
+			"/v1/github/..",
+			"/v1/./github",
+			"/v1//github",
+			"/v1/github/",
+		} {
+			_, _, err := core.ProtectedResourceMetadata(ctx, suffix)
+			assert.ErrorIs(t, err, ErrNotProtectedResource,
+				"non-canonical suffix %q must not yield a document", suffix)
+		}
+	})
+
+	t.Run("no derivable authorization server yields nothing", func(t *testing.T) {
+		// No global override, and the user auth mount does not exist — so
+		// nothing can name an issuer. Guessing would send the user's browser to
+		// the wrong authorization server.
+		noOverride := *cfg
+		noOverride.AuthorizationServers = nil
+		core := prmTestCore(t, &noOverride)
+
+		_, _, err := core.ProtectedResourceMetadata(ctx, "/v1/github")
+		assert.ErrorIs(t, err, ErrNotProtectedResource)
+	})
+}

--- a/core/sys_backend.go
+++ b/core/sys_backend.go
@@ -69,6 +69,9 @@ func (b *SystemBackend) paths() []*framework.Path {
 	// OIDC issuer (Workload Identity Federation) — root-namespace-only
 	paths = append(paths, b.pathOIDCIssuer()...)
 
+	// RFC 9728 protected resource metadata — root-namespace-only
+	paths = append(paths, b.pathProtectedResource()...)
+
 	// Skill registry paths
 	paths = append(paths, b.pathSkills()...)
 

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -21,12 +21,27 @@ import (
 // Warden can federate a local upstream (e.g. an OpenBao dev server, which accepts an
 // http loopback jwks_url) without standing up TLS.
 func validateIssuerURL(raw string) error {
+	return validateExternalHTTPSURL(raw, "issuer_url",
+		"AWS/GCP/Azure require HTTPS OIDC providers")
+}
+
+// validateExternalHTTPSURL checks that raw is an absolute https:// URL suitable
+// for publication to an external party. field names the config key in error
+// messages; httpsReason explains, in the caller's terms, why plain http is not
+// acceptable.
+//
+// http is permitted for loopback hosts (127.0.0.1, ::1, localhost) so a dev/test
+// Warden can serve a local consumer without standing up TLS.
+func validateExternalHTTPSURL(raw, field, httpsReason string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return fmt.Errorf("issuer_url is not a valid URL: %w", err)
+		return fmt.Errorf("%s is not a valid URL: %w", field, err)
 	}
 	switch u.Scheme {
 	case "https":
+		if u.Host == "" {
+			return fmt.Errorf("%s must include a host", field)
+		}
 		return nil
 	case "http":
 		host := u.Hostname()
@@ -36,9 +51,9 @@ func validateIssuerURL(raw string) error {
 		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 			return nil
 		}
-		return fmt.Errorf("issuer_url must be https:// (http:// is allowed only for loopback hosts like 127.0.0.1 or localhost)")
+		return fmt.Errorf("%s must be https:// (http:// is allowed only for loopback hosts like 127.0.0.1 or localhost)", field)
 	default:
-		return fmt.Errorf("issuer_url must be https:// (AWS/GCP/Azure require HTTPS OIDC providers)")
+		return fmt.Errorf("%s must be https:// (%s)", field, httpsReason)
 	}
 }
 
@@ -112,20 +127,22 @@ func oidcIssuerReady(c *Core) bool {
 }
 
 // requireRootNamespace returns an error response unless the request is in the
-// root namespace.
-func (b *SystemBackend) requireRootNamespace(ctx context.Context) (*logical.Response, bool) {
+// root namespace. subject names the configuration in the error, so an operator
+// who lands in the wrong namespace is told which global setting they hit.
+func (b *SystemBackend) requireRootNamespace(ctx context.Context, subject string) (*logical.Response, bool) {
 	ns, err := namespace.FromContext(ctx)
 	if err != nil || ns == nil {
 		return logical.ErrorResponse(logical.ErrBadRequest("no namespace in context")), false
 	}
 	if ns.ID != namespace.RootNamespaceID {
-		return logical.ErrorResponse(logical.ErrForbidden("the OIDC issuer is global and can only be configured in the root namespace")), false
+		return logical.ErrorResponse(logical.ErrForbiddenf(
+			"%s is global and can only be configured in the root namespace", subject)), false
 	}
 	return nil, true
 }
 
 func (b *SystemBackend) handleOIDCIssuerConfigRead(ctx context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	if resp, ok := b.requireRootNamespace(ctx); !ok {
+	if resp, ok := b.requireRootNamespace(ctx, "the OIDC issuer"); !ok {
 		return resp, nil
 	}
 
@@ -224,7 +241,7 @@ func (b *SystemBackend) signerSummary() map[string]any {
 }
 
 func (b *SystemBackend) handleOIDCIssuerConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	if resp, ok := b.requireRootNamespace(ctx); !ok {
+	if resp, ok := b.requireRootNamespace(ctx, "the OIDC issuer"); !ok {
 		return resp, nil
 	}
 

--- a/core/sys_protected_resource.go
+++ b/core/sys_protected_resource.go
@@ -1,0 +1,163 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// pathProtectedResource exposes the RFC 9728 protected-resource-metadata
+// configuration. Like the OIDC issuer this is a single GLOBAL setting — the
+// external base URL is a property of the deployment, not of a namespace — so it
+// is root-namespace only. Everything per-resource is derived from the mount.
+func (b *SystemBackend) pathProtectedResource() []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "protected-resource/config",
+			Fields: map[string]*framework.FieldSchema{
+				"resource_url": {
+					Type: framework.TypeString,
+					Description: "External HTTPS base URL clients reach Warden at (e.g. https://warden.example.com). " +
+						"Setting it enables metadata; clearing it disables. Each document's `resource` is this " +
+						"joined with the mount's API path.",
+				},
+				"authorization_servers": {
+					Type: framework.TypeCommaStringSlice,
+					Description: "Override the authorization server(s) advertised to clients. Leave empty to derive " +
+						"each mount's issuer from the auth method at its user_auth_path.",
+				},
+				"resource_documentation": {
+					Type:        framework.TypeString,
+					Description: "Optional human-facing documentation URL echoed in every document.",
+				},
+				"cache_ttl": {
+					Type: framework.TypeString,
+					Description: "Cache-Control max-age of a served document (default: 1h). Documents are derived " +
+						"from live mount config, so this is a staleness budget.",
+				},
+			},
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.handleProtectedResourceConfigRead,
+					Summary:  "Read the protected resource metadata configuration",
+				},
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.handleProtectedResourceConfigWrite,
+					Summary:  "Configure protected resource metadata",
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.handleProtectedResourceConfigWrite,
+					Summary:  "Configure protected resource metadata",
+				},
+			},
+			HelpSynopsis: "Configure RFC 9728 protected resource metadata.",
+			HelpDescription: "Warden publishes, per opted-in mount, a metadata document naming the authorization " +
+				"server a client should obtain a USER credential from. A mount opts in with user_auth_path; " +
+				"the document is served at /.well-known/oauth-protected-resource<mount-api-path>. " +
+				"Warden is a resource server only and never serves authorization-server metadata. " +
+				"Writes are partial: an omitted field keeps its stored value.",
+		},
+	}
+}
+
+func (b *SystemBackend) handleProtectedResourceConfigRead(ctx context.Context, _ *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	if resp, ok := b.requireRootNamespace(ctx, "protected resource metadata"); !ok {
+		return resp, nil
+	}
+
+	cfg, err := b.core.protectedResourceConfig(ctx)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	if cfg == nil {
+		cfg = &protectedResourceConfig{}
+	}
+
+	return &logical.Response{
+		Data: map[string]any{
+			"enabled":                cfg.enabled(),
+			"resource_url":           cfg.ResourceURL,
+			"authorization_servers":  cfg.AuthorizationServers,
+			"resource_documentation": cfg.ResourceDocumentation,
+			"cache_ttl":              int64(cfg.cacheTTL().Seconds()),
+		},
+	}, nil
+}
+
+func (b *SystemBackend) handleProtectedResourceConfigWrite(ctx context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if resp, ok := b.requireRootNamespace(ctx, "protected resource metadata"); !ok {
+		return resp, nil
+	}
+
+	// Load-modify-save under the config mutex so two concurrent partial updates
+	// cannot lost-update each other. A read failure must NOT fall through to an
+	// empty prior: that would turn a partial update into a destructive overwrite.
+	b.core.protectedResourceMu.Lock()
+	defer b.core.protectedResourceMu.Unlock()
+
+	storage := NewBarrierView(b.core.barrier, protectedResourceStorePrefix)
+	prior, err := loadProtectedResourceConfig(ctx, storage)
+	if err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+	cfg := &protectedResourceConfig{}
+	if prior != nil {
+		*cfg = *prior
+	}
+
+	if v, ok := d.GetOk("resource_url"); ok {
+		cfg.ResourceURL = v.(string)
+	}
+	if v, ok := d.GetOk("authorization_servers"); ok {
+		cfg.AuthorizationServers = v.([]string)
+	}
+	if v, ok := d.GetOk("resource_documentation"); ok {
+		cfg.ResourceDocumentation = v.(string)
+	}
+	if v, ok := d.GetOk("cache_ttl"); ok {
+		cfg.CacheTTL = v.(string)
+	}
+
+	// Validate the merged result, not the delta: a partial update must not be
+	// able to leave a stored config that would fail validation as a whole.
+	if cfg.ResourceURL != "" {
+		if err := validateExternalHTTPSURL(cfg.ResourceURL, "resource_url",
+			"clients fetch it over the public internet"); err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+		}
+	}
+	for _, as := range cfg.AuthorizationServers {
+		if err := validateExternalHTTPSURL(as, "authorization_servers",
+			"a client redirects a user's browser there"); err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+		}
+	}
+	if cfg.ResourceDocumentation != "" {
+		if err := validateExternalHTTPSURL(cfg.ResourceDocumentation, "resource_documentation",
+			"it is published to clients"); err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
+		}
+	}
+	if cfg.CacheTTL != "" {
+		if _, err := time.ParseDuration(cfg.CacheTTL); err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequest(
+				"cache_ttl must be a duration string (e.g. '1h', '15m')")), nil
+		}
+	}
+
+	if err := saveProtectedResourceConfig(ctx, storage, cfg); err != nil {
+		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+	}
+
+	return &logical.Response{
+		Data: map[string]any{
+			"enabled":                cfg.enabled(),
+			"resource_url":           cfg.ResourceURL,
+			"authorization_servers":  cfg.AuthorizationServers,
+			"resource_documentation": cfg.ResourceDocumentation,
+			"cache_ttl":              int64(cfg.cacheTTL().Seconds()),
+		},
+	}, nil
+}

--- a/core/sys_protected_resource_test.go
+++ b/core/sys_protected_resource_test.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSysProtectedResourceConfig(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema := backend.pathProtectedResource()[0].Fields
+
+	write := func(t *testing.T, raw map[string]any) *logical.Response {
+		t.Helper()
+		resp, err := backend.handleProtectedResourceConfigWrite(ctx,
+			createTestRequest(logical.UpdateOperation, "protected-resource/config", raw),
+			createFieldData(schema, raw))
+		require.NoError(t, err)
+		return resp
+	}
+	read := func(t *testing.T) *logical.Response {
+		t.Helper()
+		resp, err := backend.handleProtectedResourceConfigRead(ctx,
+			createTestRequest(logical.ReadOperation, "protected-resource/config", nil),
+			createFieldData(schema, nil))
+		require.NoError(t, err)
+		return resp
+	}
+
+	t.Run("disabled until resource_url is set", func(t *testing.T) {
+		resp := read(t)
+		require.False(t, resp.IsError())
+		assert.Equal(t, false, resp.Data["enabled"], "no resource_url means no document can be named")
+	})
+
+	t.Run("rejects a non-https resource_url", func(t *testing.T) {
+		resp := write(t, map[string]any{"resource_url": "http://warden.example.com"})
+		require.True(t, resp.IsError())
+		assert.Contains(t, resp.Err.Error(), "resource_url must be https")
+	})
+
+	t.Run("rejects a bad cache_ttl", func(t *testing.T) {
+		resp := write(t, map[string]any{"resource_url": "https://w.example.com", "cache_ttl": "soon"})
+		require.True(t, resp.IsError())
+		assert.Contains(t, resp.Err.Error(), "cache_ttl must be a duration")
+	})
+
+	t.Run("an invalid write is not persisted", func(t *testing.T) {
+		resp := read(t)
+		assert.Equal(t, false, resp.Data["enabled"], "a rejected write must leave the feature off")
+	})
+
+	t.Run("enable and read back", func(t *testing.T) {
+		resp := write(t, map[string]any{
+			"resource_url":           "https://warden.example.com",
+			"resource_documentation": "https://docs.example.com/mcp",
+			"cache_ttl":              "30m",
+		})
+		require.False(t, resp.IsError(), "unexpected error: %v", resp.Err)
+
+		resp = read(t)
+		assert.Equal(t, true, resp.Data["enabled"])
+		assert.Equal(t, "https://warden.example.com", resp.Data["resource_url"])
+		assert.Equal(t, "https://docs.example.com/mcp", resp.Data["resource_documentation"])
+		assert.Equal(t, int64(1800), resp.Data["cache_ttl"], "durations are reported as seconds")
+	})
+
+	t.Run("partial update keeps untouched fields", func(t *testing.T) {
+		resp := write(t, map[string]any{"cache_ttl": "5m"})
+		require.False(t, resp.IsError())
+
+		resp = read(t)
+		assert.Equal(t, "https://warden.example.com", resp.Data["resource_url"],
+			"an omitted field must keep its stored value")
+		assert.Equal(t, int64(300), resp.Data["cache_ttl"])
+	})
+
+	t.Run("merged result is validated, not just the delta", func(t *testing.T) {
+		// resource_url is already valid in storage; the write only supplies a
+		// bad authorization_servers. Validating the delta alone would let a
+		// partial update persist a config that fails as a whole.
+		resp := write(t, map[string]any{"authorization_servers": "not-a-url"})
+		require.True(t, resp.IsError())
+		assert.Contains(t, resp.Err.Error(), "authorization_servers must be https")
+	})
+
+	t.Run("clearing resource_url disables the feature", func(t *testing.T) {
+		resp := write(t, map[string]any{"resource_url": ""})
+		require.False(t, resp.IsError())
+		assert.Equal(t, false, read(t).Data["enabled"])
+	})
+
+	t.Run("loopback http is allowed for dev", func(t *testing.T) {
+		resp := write(t, map[string]any{"resource_url": "http://127.0.0.1:8200"})
+		require.False(t, resp.IsError(), "a dev deployment must not need TLS")
+	})
+}
+
+func TestSysProtectedResourceConfig_RootNamespaceOnly(t *testing.T) {
+	backend, _, _ := setupTestSystemBackend(t)
+	schema := backend.pathProtectedResource()[0].Fields
+	nsCtx := namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{ID: "child", Path: "/child/"})
+
+	resp, err := backend.handleProtectedResourceConfigRead(nsCtx,
+		createTestRequest(logical.ReadOperation, "protected-resource/config", nil),
+		createFieldData(schema, nil))
+	require.NoError(t, err)
+	require.True(t, resp.IsError())
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, resp.Err.Error(), "root namespace",
+		"the external base URL is a deployment-wide property")
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -80,6 +80,13 @@ func Handler(props *HandlerProperties) http.Handler {
 	mux.Handle(oidcDiscoveryPath, handleOIDCDiscovery(core, log))
 	mux.Handle(oidcJWKSPath, handleOIDCJWKS(core, log))
 
+	// RFC 9728 protected resource metadata. Also origin-root and
+	// unauthenticated — a client fetches it precisely because it has no user
+	// credential yet. Registered twice: the bare path, and the subtree, because
+	// the resource's own path is appended to the well-known prefix.
+	mux.Handle(prmPath, handlePRM(core, log))
+	mux.Handle(prmPath+"/", handlePRM(core, log))
+
 	// MCP discovery interface — Warden answering MCP for its own
 	// capabilities (list_roles, get_skill). Registered before the /v1/sys/
 	// catch-all. Not in standbyAllowedPaths: it reads live mount/skill/
@@ -339,6 +346,24 @@ func (f *standbyForwarder) currentServerName() string {
 // and that check observes the mutated URL in any persistent state.
 func wrapGenericHandler(c *core.Core, handler http.Handler, log *logger.GatedLogger, forwarder *standbyForwarder) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Origin-root well-known documents are resolved FIRST, before the
+		// X-Warden-Provider rewrite below. Those documents live outside /v1/ by
+		// specification, and a client that sets X-Warden-Provider as a
+		// connection-wide default would otherwise have its discovery fetch
+		// rewritten to /v1/.well-known/... and 404 — silently breaking the very
+		// bootstrap the document exists to drive.
+		//
+		// A standby forwards: only the active node holds the signing key and the
+		// live mount table these documents are derived from.
+		if isOIDCIssuerPath(r.URL.Path) || isPRMPath(r.URL.Path) {
+			if c != nil && c.Standby() {
+				forwardToActive(c, forwarder, w, r)
+				return
+			}
+			handler.ServeHTTP(w, r)
+			return
+		}
+
 		// X-Warden-Provider /v1/ exemption. Only rewrites when the
 		// header is non-empty AND the path is missing /v1/. Empty
 		// header values (Header.Get returns "" for both absent and
@@ -361,19 +386,6 @@ func wrapGenericHandler(c *core.Core, handler http.Handler, log *logger.GatedLog
 			// core/request_handler.go:367.
 			r.URL.Path = "/v1" + r.URL.Path
 			r.URL.RawPath = ""
-		}
-
-		// OIDC issuer discovery/JWKS live at the origin root, not under /v1/, so an
-		// upstream can fetch them at the standard well-known path. Exempt them from
-		// the /v1/ check. A standby forwards to the active node (only the active
-		// holds the signing key/config).
-		if isOIDCIssuerPath(r.URL.Path) {
-			if c != nil && c.Standby() {
-				forwardToActive(c, forwarder, w, r)
-				return
-			}
-			handler.ServeHTTP(w, r)
-			return
 		}
 
 		// Validate request path

--- a/http/prm_endpoints.go
+++ b/http/prm_endpoints.go
@@ -1,0 +1,96 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/core"
+	"github.com/stephnangue/warden/logger"
+)
+
+// prmPath is the RFC 9728 well-known prefix. The resource's own path is appended
+// to it — "path insertion" — so one origin can describe many resources:
+//
+//	/.well-known/oauth-protected-resource/v1/team-a/github
+//
+// It lives at the origin root, outside /v1/, because a client fetches it before
+// it has any credential and without knowing Warden's API layout.
+const prmPath = "/.well-known/oauth-protected-resource"
+
+// isPRMPath reports whether p addresses protected-resource metadata: the bare
+// prefix or anything beneath it. Unlike the OIDC issuer paths this is a subtree,
+// since the resource path is carried in the URL.
+func isPRMPath(p string) bool {
+	return p == prmPath || strings.HasPrefix(p, prmPath+"/")
+}
+
+// handlePRM serves RFC 9728 protected resource metadata.
+//
+// Unauthenticated by design: a client fetches this precisely because it has no
+// user credential yet. Every "no document here" case — feature disabled, unknown
+// path, mount not opted in, no derivable authorization server — is a plain 404.
+// Distinguishing them would let an unauthenticated caller probe the mount table,
+// and none of the distinctions are actionable by a client.
+//
+// This deliberately differs from the OIDC issuer endpoints, which return 503
+// when disabled: there, a verifier that reaches a configured issuer URL benefits
+// from knowing the issuer is merely not ready. Here the URL itself is the
+// question being asked.
+func handlePRM(c *core.Core, log *logger.GatedLogger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// HEAD is allowed alongside GET: net/http serves it from the same
+		// handler with the body suppressed, and a client probing for the
+		// document's existence should not have to fetch it.
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			// RFC 9110 requires Allow on a 405.
+			w.Header().Set("Allow", "GET, HEAD")
+			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+
+		// Registered at the origin root, so this handler bypasses the seal check
+		// handleLogical performs. It dereferences the namespace store and mount
+		// table, neither of which exists while sealed.
+		if c == nil || c.Sealed() {
+			respondError(w, http.StatusServiceUnavailable, "warden is sealed")
+			return
+		}
+
+		body, ttl, err := c.ProtectedResourceMetadata(r.Context(), prmSuffix(r.URL.Path))
+		if err != nil {
+			if !errors.Is(err, core.ErrNotProtectedResource) {
+				log.Error("failed to build protected resource metadata",
+					logger.Err(err), logger.String("path", r.URL.Path))
+			}
+			respondError(w, http.StatusNotFound, "no protected resource metadata for this path")
+			return
+		}
+
+		writeJSONBytes(w, body, prmCacheControl(ttl))
+	})
+}
+
+// prmSuffix extracts the resource path a request is asking about — everything
+// after the well-known prefix. Both the bare prefix and its subtree are routed
+// here, so the bare form yields "" and is rejected downstream as naming no
+// resource. The suffix is passed through verbatim, including any non-canonical
+// segments: the core rejects those rather than normalizing, so the identifier
+// published in a document is always the one that was requested.
+func prmSuffix(urlPath string) string {
+	return strings.TrimPrefix(urlPath, prmPath)
+}
+
+// prmCacheControl renders the document lifetime as a Cache-Control value. The
+// document is derived from live mount configuration, so this bounds how long a
+// client may act on a stale authorization server. The TTL is returned alongside
+// the body, from the same config generation, so the header cannot describe a
+// different document than the one being served.
+func prmCacheControl(ttl time.Duration) string {
+	if ttl <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("public, max-age=%d", int(ttl.Seconds()))
+}

--- a/http/prm_endpoints_test.go
+++ b/http/prm_endpoints_test.go
@@ -1,0 +1,136 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPRMPath(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"/.well-known/oauth-protected-resource", true},
+		{"/.well-known/oauth-protected-resource/", true},
+		{"/.well-known/oauth-protected-resource/v1/github", true},
+		{"/.well-known/oauth-protected-resource/v1/team-a/github", true},
+		{"/.well-known/openid-configuration", false},
+		{"/.well-known/oauth-authorization-server", false},
+		// Prefix-adjacent but not beneath it: must not match, or an unrelated
+		// path could bypass the /v1/ requirement.
+		{"/.well-known/oauth-protected-resource-other", false},
+		{"/v1/github", false},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPRMPath(tc.path))
+		})
+	}
+}
+
+// TestPRMEndpoint_MethodAndSeal covers the two guards that must hold before any
+// mount state is touched. The seal guard matters because this handler is
+// registered at the origin root and so bypasses handleLogical's seal check,
+// while dereferencing the namespace store and mount table.
+func TestPRMEndpoint_MethodAndSeal(t *testing.T) {
+	core, log := createTestCoreForHTTP(t)
+	h := handlePRM(core, log)
+
+	t.Run("POST is rejected", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, prmPath+"/v1/github", nil))
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	})
+
+	t.Run("GET while sealed is 503, not a panic", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, prmPath+"/v1/github", nil))
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+}
+
+// TestPRMSuffix pins the hand-off from URL to the resource identifier core
+// resolves. Both the bare prefix and its subtree route to this handler, so the
+// bare form must yield "" (naming no resource) rather than something that could
+// accidentally match a mount.
+func TestPRMSuffix(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{prmPath, ""},
+		{prmPath + "/", "/"},
+		{prmPath + "/v1/github", "/v1/github"},
+		{prmPath + "/v1/team-a/github", "/v1/team-a/github"},
+		// Passed through verbatim: core rejects non-canonical forms rather than
+		// normalizing, so a published identifier is always the one requested.
+		{prmPath + "/v1/github/../plain", "/v1/github/../plain"},
+	} {
+		t.Run(tc.url, func(t *testing.T) {
+			assert.Equal(t, tc.want, prmSuffix(tc.url))
+		})
+	}
+}
+
+// TestPRMCacheControl covers the header rendering. The TTL travels with the
+// document from the same config generation, so the header can never describe a
+// different document than the one being served.
+func TestPRMCacheControl(t *testing.T) {
+	assert.Equal(t, "public, max-age=3600", prmCacheControl(time.Hour))
+	assert.Equal(t, "public, max-age=300", prmCacheControl(5*time.Minute))
+	assert.Empty(t, prmCacheControl(0), "no TTL means no caching directive")
+	assert.Empty(t, prmCacheControl(-time.Second))
+}
+
+// TestPRMEndpoint_ExemptFromV1Prefix pins that metadata paths reach the handler
+// rather than being rejected by the /v1/ prefix check.
+func TestPRMEndpoint_ExemptFromV1Prefix(t *testing.T) {
+	var reached bool
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reached = true })
+	wrapped := wrapGenericHandler(nil, inner, nil, nil)
+
+	for _, p := range []string{
+		prmPath,
+		prmPath + "/v1/github",
+		prmPath + "/v1/team-a/github",
+	} {
+		t.Run(p, func(t *testing.T) {
+			reached = false
+			wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, p, nil))
+			assert.True(t, reached, "metadata path must bypass the /v1/ prefix check")
+		})
+	}
+
+	t.Run("control: an unrelated well-known path is still rejected", func(t *testing.T) {
+		reached = false
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/other", nil))
+		assert.False(t, reached)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+// TestPRMEndpoint_SurvivesProviderHeaderRewrite is the regression test for the
+// ordering bug this endpoint would otherwise hit. wrapGenericHandler rewrites
+// non-/v1/ paths to /v1/... whenever X-Warden-Provider is set, and MCP clients
+// commonly set that header connection-wide. If the rewrite ran first, a
+// discovery fetch would become /v1/.well-known/... and 404 — silently breaking
+// the bootstrap the document exists to drive.
+func TestPRMEndpoint_SurvivesProviderHeaderRewrite(t *testing.T) {
+	for _, p := range []string{
+		prmPath + "/v1/github",
+		"/.well-known/openid-configuration",
+	} {
+		t.Run(p, func(t *testing.T) {
+			var gotPath string
+			inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+			})
+			req := httptest.NewRequest(http.MethodGet, p, nil)
+			req.Header.Set("X-Warden-Provider", "github")
+
+			wrapGenericHandler(nil, inner, nil, nil).ServeHTTP(httptest.NewRecorder(), req)
+			assert.Equal(t, p, gotPath, "the path must reach the handler unrewritten")
+		})
+	}
+}

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -189,6 +189,23 @@ type UserAuthConfigProvider interface {
 	GetUserAuthRole() string
 }
 
+// AuthorizationServerProvider is implemented by auth methods that can name the
+// OAuth authorization server issuing the credentials they accept. It exists so
+// the protected-resource metadata endpoint can derive `authorization_servers`
+// from the auth mount an operator already configured, instead of asking them to
+// restate the issuer.
+//
+// It is an interface rather than a concrete type assertion because auth backends
+// are unexported in their own packages and reached only as logical.Backend.
+type AuthorizationServerProvider interface {
+	// AuthorizationServerURL returns the issuer URL a client should run OAuth
+	// against, and whether one could be determined. ok is false when the mount
+	// verifies tokens without knowing an issuer — a static-key or bare-JWKS
+	// configuration — in which case there is nothing a client could discover
+	// and the metadata endpoint must not guess.
+	AuthorizationServerURL() (string, bool)
+}
+
 // TransparentAuthRoleExtractor can be implemented by providers that extract
 // the auth role from protocol-specific request data (Authorization headers,
 // Basic Auth username, etc.) rather than the URL path. Used by SigV4-compatible

--- a/provider/sdk/httpproxy/mcp_filter_test.go
+++ b/provider/sdk/httpproxy/mcp_filter_test.go
@@ -231,7 +231,9 @@ func BenchmarkFilterMCPListResponse(b *testing.B) {
 		if i%2 == 1 {
 			name = "delete_tool_" + strconv.Itoa(i)
 		}
-		sb.WriteString(`{"name":"` + name + `","description":"a tool that does a thing","inputSchema":{"type":"object","properties":{}}}`)
+		sb.WriteString(`{"name":"`)
+		sb.WriteString(name)
+		sb.WriteString(`","description":"a tool that does a thing","inputSchema":{"type":"object","properties":{}}}`)
 	}
 	sb.WriteString(`]}}`)
 	body := sb.String()


### PR DESCRIPTION
Builds on #487. Publishes, per opted-in mount, an RFC 9728 metadata document
naming the authorization server a client should obtain a **user** credential
from. A client that receives a 401 fetches the document, runs OAuth against
that provider, and retries with the user's token on `Authorization` — the
slot #487 freed.

Warden is a resource server only: it never issues user credentials and
deliberately does not serve RFC 8414 authorization-server metadata.

The 401 that starts the flow is the next PR. This one makes the document
exist and be discoverable.

## Configuration

Deployment-wide and root-namespace only, at `sys/protected-resource/config`.
`resource_url` is the master switch — each document's `resource` is it joined
with the mount's API path, so it must be the external address clients actually
use. It is never derived from a request's `Host` header, which a client
controls.

Writes are partial, and the **merged result** is validated rather than the
delta, so a partial update cannot persist a config that fails as a whole.

Adds `warden protected-resource` (configure / read / disable).

## Everything per-resource is derived live

Opt-in is the mount's own `user_auth_path` — the same switch that decides
whether `Authorization` carries a user — and `resource_name` comes from the
operator's mount description, so a consent screen can say what is being
authorized. Deriving at request time also sidesteps ordering: a load at unseal
would run before mounts exist.

`authorization_servers` is derived from the auth method at `user_auth_path`
via a new `logical.AuthorizationServerProvider`, implemented by the jwt
backend. An interface rather than a type assertion, because auth backends are
unexported in their own packages and reachable only as `logical.Backend`.

It names nothing for a mount that verifies tokens without knowing an issuer
(static keys, bare JWKS) or a method with no OAuth notion at all — guessing
would send a user's browser to the wrong authorization server. A derived
issuer is held to the same https policy as an operator-supplied one, since the
auth mount validates its discovery URL for reachability, not scheme.

## Path canonicalization (security)

The resource path must arrive canonical. Go's `ServeMux` redirects a literal
`/../` before the handler runs, but a **percent-encoded** one arrives decoded
and intact — so `/v1/github/%2e%2e/plain` would longest-prefix match the
`github` mount and emit a document whose `resource` normalizes to `/v1/plain`,
binding one mount's identifier to another mount's authorization server. That
is a cross-mount token-confusion primitive for any client that normalizes
before comparing.

Non-canonical suffixes are refused rather than cleaned, so a published
identifier is always the one that was requested.

## Uniform 404

Every "no document here" case — feature off, unknown path, mount not opted in,
no derivable issuer — is a plain 404. Distinguishing them would let an
unauthenticated caller probe the mount table, and none of the distinctions are
actionable by a client.

This deliberately differs from the OIDC issuer endpoints, which return 503
when disabled: there a verifier that reaches a configured issuer URL benefits
from knowing it is merely not ready. Here the URL itself is the question.

## Routing fix

The well-known exemption in `wrapGenericHandler` now runs **before** the
`X-Warden-Provider` rewrite. MCP clients commonly set that header
connection-wide, and the rewrite would otherwise turn a discovery fetch into
`/v1/.well-known/...` and 404 it — silently breaking the bootstrap the
document exists to drive. This also fixes the same latent bug for OIDC
discovery.

Registered at the origin root, so the handler carries its own seal guard: it
dereferences the namespace store and mount table, neither of which exists
while sealed. The lookup order avoids `MatchingBackend` on a miss, which logs
— a dangling `user_auth_path` would otherwise let anonymous fetches flood the
log.

## Also

`validateIssuerURL` generalized to `validateExternalHTTPSURL` and shared by
both configs; `requireRootNamespace` now names the setting in its error.

## Testing

Full unit suite green. Verified against a live 3-node cluster: 17/17 e2e
packages, 217 tests, including eight covering this endpoint — the traversal
refusal, standby forwarding to the active node, and a fetch with
`X-Warden-Provider` set still reaching the handler. Those three can only be
proven against a real server.
