### PR TITLE
feat(credential): 401 + WWW-Authenticate when a user principal is required

### DIFF
--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -1460,3 +1460,86 @@ func TestJSONFormatCredentialMetadata(t *testing.T) {
 		}
 	})
 }
+
+// TestJSONFormatPreservesUserAttribution guards a whole class of silent data
+// loss: the formatter clones every entry before serialising, so any field
+// Clone() forgets is set correctly in memory and then dropped on the way to
+// disk. Per-user attribution was lost this way from the day it was added —
+// invisible to tests that assert on the in-memory entry, because those sit
+// above the layer that loses it.
+func TestJSONFormatPreservesUserAttribution(t *testing.T) {
+	format := NewJSONFormat()
+
+	newEntry := func() *LogEntry {
+		return &LogEntry{
+			Timestamp: time.Now(),
+			Request:   &Request{ID: "req-1", Operation: "read", Path: "/v1/vault/gateway/x"},
+			Auth: &Auth{
+				TokenID:     "agent-token",
+				PrincipalID: "agent-workload",
+				User: &UserAttribution{
+					Subject:     "alice@example.com",
+					TokenID:     "user-token",
+					NamespaceID: "root",
+				},
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		format func(*LogEntry) ([]byte, error)
+	}{
+		{"request", func(e *LogEntry) ([]byte, error) {
+			return format.FormatRequest(context.Background(), e)
+		}},
+		{"response", func(e *LogEntry) ([]byte, error) {
+			return format.FormatResponse(context.Background(), e)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.format(newEntry())
+			if err != nil {
+				t.Fatalf("format: %v", err)
+			}
+			var out LogEntry
+			if err := json.Unmarshal(data, &out); err != nil {
+				t.Fatalf("unmarshal: %v\n%s", err, string(data))
+			}
+			if out.Auth == nil || out.Auth.User == nil {
+				t.Fatalf("user attribution lost between the entry and the wire: %s", string(data))
+			}
+			if out.Auth.User.Subject != "alice@example.com" {
+				t.Errorf("subject = %q, want alice@example.com", out.Auth.User.Subject)
+			}
+			// The agent must still be there: attribution records the user
+			// alongside the agent, never in place of it.
+			if out.Auth.PrincipalID != "agent-workload" {
+				t.Errorf("agent principal lost: %s", string(data))
+			}
+		})
+	}
+}
+
+// TestCloneCopiesUserAttribution pins the specific omission at its source, so a
+// future field added to Auth without a matching Clone() line fails here rather
+// than silently vanishing from every audit log.
+func TestCloneCopiesUserAttribution(t *testing.T) {
+	orig := &LogEntry{
+		Auth: &Auth{User: &UserAttribution{Subject: "alice", TokenID: "t", NamespaceID: "root"}},
+	}
+	clone := orig.Clone()
+
+	if clone.Auth == nil || clone.Auth.User == nil {
+		t.Fatal("Clone dropped Auth.User")
+	}
+	if clone.Auth.User.Subject != "alice" {
+		t.Errorf("subject = %q, want alice", clone.Auth.User.Subject)
+	}
+	// Must be a copy, not a shared pointer: entries are cloned precisely so
+	// parallel devices cannot race on them.
+	clone.Auth.User.Subject = "mallory"
+	if orig.Auth.User.Subject != "alice" {
+		t.Error("Clone shares the UserAttribution pointer, defeating the race protection it exists for")
+	}
+}

--- a/audit/types.go
+++ b/audit/types.go
@@ -335,6 +335,14 @@ func (e *LogEntry) Clone() *LogEntry {
 			clone.Auth.Actors = make([]ActorRef, len(e.Auth.Actors))
 			copy(clone.Auth.Actors, e.Auth.Actors)
 		}
+		// The secondary (user) principal. Omitting it here silently dropped
+		// per-user attribution from every written entry, because the JSON
+		// formatter clones before serialising — the field was set correctly in
+		// memory and lost on the way to disk.
+		if e.Auth.User != nil {
+			user := *e.Auth.User
+			clone.Auth.User = &user
+		}
 	}
 
 	return clone

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -964,7 +964,12 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 					logger.String("path", req.Path),
 					logger.String("request_id", req.RequestID),
 				)
-				return logical.ErrorResponse(logical.ErrUnauthorized(err.Error())), nil, nil
+				// A user credential WAS presented and rejected, so the challenge
+				// carries error="invalid_token" — the client should replace it
+				// rather than assume it simply forgot to send one.
+				errResp := logical.ErrorResponse(logical.ErrUnauthorized(err.Error()))
+				c.attachUserChallenge(ctx, req, errResp, true)
+				return errResp, nil, nil
 			}
 		}
 	}
@@ -1067,7 +1072,9 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 				logger.Err(err),
 				logger.String("path", req.Path),
 			)
-			return logical.ErrorResponse(err), auth, nil
+			errResp := logical.ErrorResponse(err)
+			c.attachUserRequiredChallenge(ctx, req, errResp, err)
+			return errResp, auth, nil
 		}
 	}
 
@@ -1093,7 +1100,7 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		if err := c.mintCredentialForRequest(ctx, req, te); err != nil {
 			c.logger.Error("failed to mint credential for access request",
 				logger.Err(err), logger.String("path", req.Path))
-			return logical.ErrorResponse(err), auth, nil
+			return logical.ErrorResponse(accessPathMintError(err)), auth, nil
 		}
 		resp.Data = ad.ResponseBuilder(req.Credential)
 		resp.AccessData = nil
@@ -1401,7 +1408,7 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		// forwards it as-is. Fail closed when no user principal was captured: this is
 		// spec-opt-in delegation, never a silent fallback to the agent's identity.
 		if req.User == nil || req.User.RawToken == "" {
-			return nil, fmt.Errorf("spec %q requires subject_token_source=user_identity but no user principal was presented", specName)
+			return nil, fmt.Errorf("spec %q requires subject_token_source=user_identity: %w", specName, credential.ErrUserRequired)
 		}
 		inputs.SubjectToken = req.User.RawToken
 	case credential.SourceWardenIdentity:
@@ -1557,7 +1564,7 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 	var userClaims map[string]string
 	if userKeys := credential.AssertionUserClaimKeys(spec.Config); len(userKeys) > 0 {
 		if userTE == nil {
-			return nil, fmt.Errorf("spec %q sets assertion_user_claims but no user principal was presented", specName)
+			return nil, fmt.Errorf("spec %q sets assertion_user_claims: %w", specName, credential.ErrUserRequired)
 		}
 		// "sub" names the user's identity principal, not a metadata key — exclude it
 		// from the metadata projection so an operator can list it (to bind
@@ -1700,7 +1707,7 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 	// Returns nil for non-exchange specs, leaving the mint path unchanged.
 	inputs, err := caller.ResolveInputs(ctx, te.CredentialSpec)
 	if err != nil {
-		return logical.ErrBadRequestf("token exchange input resolution failed: %s", err.Error())
+		return exchangeInputError(err)
 	}
 
 	// Issue credential using the credential manager

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2348,7 +2348,9 @@ func TestResolveExchangeInputs_UserIdentity_MissingFailsClosed(t *testing.T) {
 	// silently falling back to the agent's identity.
 	_, err := resolveExchangeInputsForTest(c, ctx, requestWith("opaque-token", nil), teForSpec("user-spec"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no user principal was presented")
+	// The sentinel is what carries the 401 and the WWW-Authenticate challenge, so
+	// assert on it rather than on prose.
+	assert.ErrorIs(t, err, credential.ErrUserRequired)
 }
 
 func TestResolveExchangeInputs_ActorAgentIdentity(t *testing.T) {
@@ -2777,7 +2779,7 @@ func TestResolveExchangeInputs_WardenUserClaims(t *testing.T) {
 		req := requestWith("s.opaque-session", nil) // no req.User
 		_, err := resolveExchangeInputsForTest(c, ctx, req, agentTE)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no user principal")
+		assert.ErrorIs(t, err, credential.ErrUserRequired)
 	})
 
 	t.Run("absent named claim fails closed", func(t *testing.T) {

--- a/core/user_challenge.go
+++ b/core/user_challenge.go
@@ -1,0 +1,185 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/githttp"
+)
+
+// attachUserChallenge adds an RFC 6750 WWW-Authenticate header to a response
+// that failed for want of a usable USER principal, pointing the client at the
+// mount's protected resource metadata so it can go acquire one and retry.
+//
+// This is what turns a dead end into a bootstrap: without the challenge a client
+// sees only a 401 and has nowhere to go. It is attached to the response rather
+// than rendered at the HTTP layer because only here are the namespace and mount
+// in hand, and writeLogicalResponse copies resp.Headers before writing.
+//
+// invalidToken distinguishes the two cases RFC 6750 separates: a credential was
+// presented and rejected (error="invalid_token"), versus none was presented at
+// all, where the bare challenge is correct and an error code would be a lie.
+//
+// A no-op when the mount is not a protected resource or metadata is not
+// configured: pointing at a document that will 404 is worse than pointing
+// nowhere. A missing or invalid AGENT never reaches here — that is a plain
+// 401/403 with nothing for the user leg to fix.
+func (c *Core) attachUserChallenge(ctx context.Context, req *logical.Request, resp *logical.Response, invalidToken bool) {
+	if resp == nil || req == nil {
+		return
+	}
+	params := make([]string, 0, 2)
+	if invalidToken {
+		params = append(params, `error="invalid_token"`)
+	}
+	// Omitted when no document would be served — a mount that is not opted in,
+	// or metadata not configured. Naming a URL that 404s is worse than naming
+	// none: the client follows it and the bootstrap dies silently. RFC 7235 still
+	// requires *a* challenge on a 401, so the bare scheme is emitted regardless.
+	if metadataURL := c.prmMetadataURL(ctx, req.MountPoint); metadataURL != "" {
+		params = append(params, fmt.Sprintf("resource_metadata=%q", metadataURL))
+	}
+
+	challenge := "Bearer"
+	if len(params) > 0 {
+		challenge += " " + strings.Join(params, ", ")
+	}
+
+	// Git speaks Basic, not Bearer. On a smart-HTTP path a bare Bearer challenge
+	// is unactionable: the client needs to be told to retry with credentials, and
+	// on a protected-resource mount the Basic password slot is where the user
+	// credential rides. RFC 9110 permits multiple challenges — libcurl picks a
+	// scheme it supports, a metadata-aware client picks the other.
+	if isGitSmartHTTP(req) {
+		challenge = `Basic realm="warden", ` + challenge
+	}
+
+	resp.AddHeader("WWW-Authenticate", challenge)
+}
+
+// prmMetadataURL renders the absolute URL of a mount's protected resource
+// metadata, or "" when none would be served.
+//
+// Built from the configured external base, never from the request's Host header:
+// a client controls Host, and this URL is where it will go to authenticate.
+// Deriving it from an attacker-supplied value would let a request point its own
+// challenge at an attacker's document.
+//
+// The URL is confirmed by asking the metadata builder for the very document the
+// client would fetch, and returning "" if it would not serve one. Re-deriving
+// the conditions here instead would let the two drift: the endpoint also
+// requires the mount to exist, to be opted in, and to have a derivable
+// authorization server. A challenge naming a URL that 404s is worse than no
+// challenge, because the client follows it and the bootstrap dies silently.
+func (c *Core) prmMetadataURL(ctx context.Context, mountPoint string) string {
+	if mountPoint == "" {
+		return ""
+	}
+	ns, err := namespace.FromContext(ctx)
+	if err != nil || ns == nil {
+		return ""
+	}
+
+	// The suffix must match what the metadata endpoint serves, which is the
+	// namespace-qualified API path with no trailing slash.
+	suffix := "/v1/" + strings.TrimSuffix(ns.Path+mountPoint, "/")
+	body, _, err := c.ProtectedResourceMetadata(ctx, suffix)
+	if err != nil {
+		return ""
+	}
+
+	// The external base comes from the document just built rather than a second
+	// config read: its `resource` is that base joined with this same suffix, so
+	// deriving it back guarantees the challenge and the document agree even if
+	// the configuration changes underneath.
+	var doc ProtectedResourceMetadata
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return ""
+	}
+	base := strings.TrimSuffix(doc.Resource, suffix)
+	if base == doc.Resource {
+		// The identifier did not end with the suffix, so the two were built
+		// differently and any URL derived here would be a guess.
+		return ""
+	}
+	return base + PRMWellKnownPath + suffix
+}
+
+// PRMWellKnownPath is the RFC 9728 well-known prefix. Exported so the HTTP layer
+// registers exactly the path this challenge points at — a challenge naming a URL
+// nothing serves would break the bootstrap silently.
+const PRMWellKnownPath = "/.well-known/oauth-protected-resource"
+
+// isGitSmartHTTP reports whether the request targets a Git smart-HTTP endpoint,
+// where the client negotiates with Basic auth rather than Bearer.
+//
+// IsSmartHTTPPath is documented to take the path after "/gateway" and is a pure
+// suffix match, so the gateway segment is checked here too — otherwise any path
+// merely ending in ".git/info/refs" would draw a spurious Basic challenge.
+func isGitSmartHTTP(req *logical.Request) bool {
+	// Matched as a segment, not a substring: "foo/gateway-prod/r.git/info/refs"
+	// is not a gateway path. The git suffix always follows "gateway/", so this is
+	// strictly tighter without losing any genuine path.
+	if !strings.Contains(req.Path, "/gateway/") {
+		return false
+	}
+	return githttp.IsSmartHTTPPath(req.Path)
+}
+
+// exchangeInputError assigns the HTTP status for a token-exchange input
+// resolution failure.
+//
+// A missing user principal is a 401: the caller can acquire a user identity and
+// retry, which is exactly what the paired WWW-Authenticate challenge tells it to
+// do. Everything else reaching here is a malformed or unsupported spec, which
+// stays the 400 it has always been.
+//
+// Both branches are load-bearing. Returning the error un-coded would push the
+// non-user failures to 500, since GetErrorCode falls through for a plain error;
+// coding them all 400 would mask the 401 and stop discovery before it starts.
+func exchangeInputError(err error) error {
+	if errors.Is(err, credential.ErrUserRequired) {
+		return logical.WrapWithCode(http.StatusUnauthorized, err)
+	}
+	return logical.ErrBadRequestf("token exchange input resolution failed: %s", err.Error())
+}
+
+// accessPathMintError restates a missing-user failure on the access path, where
+// it can only ever be an operator misconfiguration.
+//
+// AccessData is returned solely by non-streaming access backends, and
+// captureUserContext runs solely in the streaming branch — so req.User is
+// structurally nil on every request here. A spec bound to an access mount that
+// requires a user therefore fails permanently, and 401 would be a lie twice
+// over: it tells the client to authenticate when it already has, and RFC 7235
+// would demand a challenge naming somewhere to go, of which there is none.
+//
+// 500 is the honest answer: the caller did nothing wrong and can do nothing
+// about it. The message names the actual fix so it reaches an operator rather
+// than sending a client round an authentication loop.
+func accessPathMintError(err error) error {
+	if !errors.Is(err, credential.ErrUserRequired) {
+		return err
+	}
+	return logical.ErrInternalf(
+		"credential spec requires a user principal, but access-path requests cannot carry one "+
+			"(per-request user capture runs only on gateway requests): %s", err.Error())
+}
+
+// attachUserRequiredChallenge attaches the challenge only when err is the
+// missing-user case. Mint can fail for many reasons — an unreachable upstream, a
+// malformed spec — and none of those are fixed by acquiring a user identity, so
+// pointing at metadata there would send a client on a pointless OAuth round trip.
+func (c *Core) attachUserRequiredChallenge(ctx context.Context, req *logical.Request, resp *logical.Response, err error) {
+	if !errors.Is(err, credential.ErrUserRequired) {
+		return
+	}
+	c.attachUserChallenge(ctx, req, resp, false)
+}

--- a/core/user_challenge_test.go
+++ b/core/user_challenge_test.go
@@ -1,0 +1,292 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrUserRequiredMapsTo401 pins the status the whole bootstrap depends on.
+// Clients begin metadata discovery on a 401 specifically; at 400 or 500 a
+// spec-compliant client stops, and the challenge never gets read.
+func TestErrUserRequiredMapsTo401(t *testing.T) {
+	assert.Equal(t, http.StatusUnauthorized, logical.GetErrorCode(credential.ErrUserRequired))
+
+	// It must survive the wrapping it actually travels through: the mint path
+	// wraps with %w, and errors.Is traverses any depth.
+	wrapped := fmt.Errorf("failed to issue credential: %w",
+		fmt.Errorf("spec %q: %w", "s", credential.ErrUserRequired))
+	assert.Equal(t, http.StatusUnauthorized, logical.GetErrorCode(wrapped))
+	assert.Equal(t, http.StatusUnauthorized, logical.ErrorResponse(wrapped).StatusCode)
+}
+
+// TestInputResolutionStatusCodes guards the regression the conditional wrap
+// exists to prevent. Returning the error un-coded would push the non-user
+// failures from 400 to 500; coding them all 400 would mask the 401.
+func TestInputResolutionStatusCodes(t *testing.T) {
+	t.Run("missing user is 401", func(t *testing.T) {
+		got := exchangeInputError(fmt.Errorf("spec %q: %w", "s", credential.ErrUserRequired))
+		assert.Equal(t, http.StatusUnauthorized, logical.GetErrorCode(got))
+		assert.ErrorIs(t, got, credential.ErrUserRequired,
+			"the sentinel must survive so the challenge can be attached downstream")
+	})
+
+	t.Run("every other resolution failure stays 400", func(t *testing.T) {
+		got := exchangeInputError(fmt.Errorf("unsupported subject_token_source"))
+		assert.Equal(t, http.StatusBadRequest, logical.GetErrorCode(got),
+			"a malformed spec is not something a client fixes by authenticating")
+	})
+
+	t.Run("a plain error never falls through to 500", func(t *testing.T) {
+		// Returning the error un-coded would regress every non-user failure from
+		// 400 to 500, since GetErrorCode has no rule for a bare error.
+		assert.Equal(t, http.StatusInternalServerError,
+			logical.GetErrorCode(fmt.Errorf("bare")),
+			"guards the assumption the 400 branch exists to satisfy")
+	})
+}
+
+// challengeTestCore mounts an opted-in mount and a plain one, and optionally
+// enables metadata. Mirrors prmTestCore so a challenge and the document it names
+// are produced from the same shape.
+func challengeTestCore(t *testing.T, enabled bool) *Core {
+	t.Helper()
+	core := createTestCore(t)
+
+	mount := func(path, uuid, userAuthPath string) {
+		entry := &MountEntry{
+			Path: path, Type: "mcp", Class: mountClassProvider,
+			UUID: uuid, Accessor: uuid + "_acc",
+			NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace,
+		}
+		require.NoError(t, core.router.Mount(path,
+			&mockUnauthPathBackend{userAuthPath: userAuthPath}, entry,
+			&mockBarrierView{prefix: "provider/" + uuid + "/"}))
+	}
+	mount("github/", "chal-gh", "auth/user-jwt/")
+	mount("plain/", "chal-plain", "")
+
+	if enabled {
+		view := NewBarrierView(core.barrier, protectedResourceStorePrefix)
+		require.NoError(t, saveProtectedResourceConfig(context.Background(), view,
+			&protectedResourceConfig{
+				ResourceURL:          "https://warden.example.com",
+				AuthorizationServers: []string{"https://idp.example.com"},
+			}))
+	}
+	return core
+}
+
+func TestPRMMetadataURL(t *testing.T) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	t.Run("empty when metadata is not configured", func(t *testing.T) {
+		assert.Empty(t, challengeTestCore(t, false).prmMetadataURL(ctx, "github/"))
+	})
+
+	t.Run("built from the configured external base", func(t *testing.T) {
+		assert.Equal(t,
+			"https://warden.example.com/.well-known/oauth-protected-resource/v1/github",
+			challengeTestCore(t, true).prmMetadataURL(ctx, "github/"))
+	})
+
+	t.Run("empty for a mount the endpoint would not serve", func(t *testing.T) {
+		// The plain mount has no user_auth_path, so the metadata endpoint 404s
+		// it. Naming that URL would send the client to a dead document and kill
+		// the bootstrap silently — worse than sending no challenge at all.
+		assert.Empty(t, challengeTestCore(t, true).prmMetadataURL(ctx, "plain/"),
+			"the challenge must not name a URL that 404s")
+	})
+
+	t.Run("empty for an unknown mount", func(t *testing.T) {
+		assert.Empty(t, challengeTestCore(t, true).prmMetadataURL(ctx, "nope/"))
+	})
+
+	t.Run("empty for a request with no mount", func(t *testing.T) {
+		assert.Empty(t, challengeTestCore(t, true).prmMetadataURL(ctx, ""))
+	})
+}
+
+// TestAccessPathMintError pins that a user requirement on the access path is
+// reported as the operator misconfiguration it is, not as a 401.
+//
+// AccessData comes only from non-streaming backends, where captureUserContext
+// never runs, so req.User is structurally nil on every such request. A 401 there
+// would tell a client to authenticate when it already has, and no retry could
+// ever change the outcome.
+func TestAccessPathMintError(t *testing.T) {
+	t.Run("a missing user becomes a server-side error", func(t *testing.T) {
+		got := accessPathMintError(fmt.Errorf("mint: %w", credential.ErrUserRequired))
+		assert.Equal(t, http.StatusInternalServerError, logical.GetErrorCode(got),
+			"401 would invite a retry that cannot succeed on this path")
+		assert.Contains(t, got.Error(), "access-path requests cannot carry one",
+			"the message must reach an operator, not send a client round a loop")
+	})
+
+	t.Run("every other error passes through untouched", func(t *testing.T) {
+		orig := logical.ErrBadRequest("malformed spec")
+		assert.Same(t, orig, accessPathMintError(orig))
+	})
+}
+
+// TestChallengeURLIsActuallyServed is the anti-drift check: the URL a challenge
+// names must be one the metadata endpoint resolves. The two are derived
+// independently, and a mismatch fails silently — the client follows the link,
+// gets a 404, and never learns where to authenticate.
+func TestChallengeURLIsActuallyServed(t *testing.T) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	core := challengeTestCore(t, true)
+
+	url := core.prmMetadataURL(ctx, "github/")
+	require.NotEmpty(t, url)
+
+	const base = "https://warden.example.com" + PRMWellKnownPath
+	require.True(t, len(url) > len(base) && url[:len(base)] == base)
+	suffix := url[len(base):]
+
+	body, _, err := core.ProtectedResourceMetadata(ctx, suffix)
+	require.NoError(t, err, "the endpoint must serve exactly the suffix the challenge names")
+	assert.NotEmpty(t, body)
+}
+
+// TestChallengeURLInChildNamespace covers the ns.Path + mountPoint concatenation,
+// which is the part of the URL that would drift silently: the root namespace has
+// an empty path, so a bug there is invisible until a real namespace is used.
+func TestChallengeURLInChildNamespace(t *testing.T) {
+	core := createTestCore(t)
+
+	// Namespaces are created from the root context; the store assigns ID/UUID.
+	rootCtx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	child := &namespace.Namespace{Path: "team-a/"}
+	require.NoError(t, core.namespaceStore.SetNamespace(rootCtx, child))
+
+	ctx := namespace.ContextWithNamespace(context.Background(), child)
+
+	entry := &MountEntry{
+		Path: "github/", Type: "mcp", Class: mountClassProvider,
+		UUID: "ns-gh", Accessor: "ns-gh_acc",
+		NamespaceID: child.ID, namespace: child,
+	}
+	// Mount prepends the entry's namespace path itself, so the prefix here is
+	// namespace-relative.
+	require.NoError(t, core.router.Mount("github/",
+		&mockUnauthPathBackend{userAuthPath: "auth/user-jwt/"}, entry,
+		&mockBarrierView{prefix: "provider/ns-gh/"}))
+
+	view := NewBarrierView(core.barrier, protectedResourceStorePrefix)
+	require.NoError(t, saveProtectedResourceConfig(ctx, view,
+		&protectedResourceConfig{
+			ResourceURL:          "https://warden.example.com",
+			AuthorizationServers: []string{"https://idp.example.com"},
+		}))
+
+	assert.Equal(t,
+		"https://warden.example.com"+PRMWellKnownPath+"/v1/team-a/github",
+		core.prmMetadataURL(ctx, "github/"),
+		"the namespace must appear in the URL exactly once, matching what the endpoint serves")
+}
+
+func TestAttachUserChallenge(t *testing.T) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	newReq := func(path, mount string) *logical.Request {
+		return &logical.Request{
+			Path:        path,
+			MountPoint:  mount,
+			HTTPRequest: httptest.NewRequest(http.MethodGet, "/v1/"+path, nil),
+		}
+	}
+
+	t.Run("points at the mount's metadata", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, true).attachUserChallenge(ctx, newReq("github/gateway/user", "github/"), resp, false)
+
+		got := resp.Headers.Get("WWW-Authenticate")
+		assert.Equal(t,
+			`Bearer resource_metadata="https://warden.example.com/.well-known/oauth-protected-resource/v1/github"`,
+			got)
+		assert.NotContains(t, got, "invalid_token",
+			"no credential was presented, so naming one invalid would be a lie")
+	})
+
+	t.Run("a rejected credential is marked invalid_token", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, true).attachUserChallenge(ctx, newReq("github/gateway/user", "github/"), resp, true)
+		assert.Contains(t, resp.Headers.Get("WWW-Authenticate"), `error="invalid_token"`)
+	})
+
+	t.Run("git smart-HTTP also gets a Basic challenge", func(t *testing.T) {
+		// A bare Bearer challenge is unactionable for git, which negotiates with
+		// Basic. RFC 9110 permits multiple challenges.
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, true).attachUserChallenge(ctx,
+			newReq("github/gateway/o/r.git/info/refs", "github/"), resp, false)
+
+		got := resp.Headers.Get("WWW-Authenticate")
+		assert.Contains(t, got, `Basic realm="warden"`)
+		assert.Contains(t, got, "resource_metadata=")
+	})
+
+	t.Run("a non-gateway path ending in a git suffix gets no Basic challenge", func(t *testing.T) {
+		// IsSmartHTTPPath is a pure suffix match, so the gateway segment has to
+		// be checked too or any such path draws a spurious Basic challenge.
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, true).attachUserChallenge(ctx,
+			newReq("github/config/o/r.git/info/refs", "github/"), resp, false)
+		assert.NotContains(t, resp.Headers.Get("WWW-Authenticate"), "Basic")
+	})
+
+	// RFC 7235 requires a challenge on every 401, so the scheme is always
+	// emitted — but resource_metadata is omitted whenever no document would be
+	// served, since a client that follows a 404 learns nothing and the bootstrap
+	// dies silently.
+	t.Run("metadata not configured: bare challenge, no URL", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, false).attachUserChallenge(ctx, newReq("github/gateway/user", "github/"), resp, false)
+
+		got := resp.Headers.Get("WWW-Authenticate")
+		assert.Equal(t, "Bearer", got)
+		assert.NotContains(t, got, "resource_metadata")
+	})
+
+	t.Run("mount not a protected resource: bare challenge, no URL", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, true).attachUserChallenge(ctx, newReq("plain/gateway/x", "plain/"), resp, false)
+
+		got := resp.Headers.Get("WWW-Authenticate")
+		assert.NotContains(t, got, "resource_metadata",
+			"a mount with no user_auth_path serves no document, so there is nothing to name")
+		assert.Contains(t, got, "Bearer", "a 401 must still carry a challenge")
+	})
+
+	t.Run("invalid token with no servable metadata still reports the cause", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("nope"))
+		challengeTestCore(t, false).attachUserChallenge(ctx, newReq("github/gateway/user", "github/"), resp, true)
+
+		got := resp.Headers.Get("WWW-Authenticate")
+		assert.Equal(t, `Bearer error="invalid_token"`, got)
+	})
+
+	t.Run("only the missing-user error draws a challenge", func(t *testing.T) {
+		core := challengeTestCore(t, true)
+		req := newReq("github/gateway/user", "github/")
+
+		userErr := logical.ErrorResponse(fmt.Errorf("mint: %w", credential.ErrUserRequired))
+		core.attachUserRequiredChallenge(ctx, req, userErr, fmt.Errorf("mint: %w", credential.ErrUserRequired))
+		assert.NotEmpty(t, userErr.Headers.Get("WWW-Authenticate"))
+
+		// An unreachable upstream is not fixed by acquiring a user identity, so
+		// sending the client on an OAuth round trip would be pointless.
+		otherErr := logical.ErrorResponse(fmt.Errorf("upstream unreachable"))
+		core.attachUserRequiredChallenge(ctx, req, otherErr, fmt.Errorf("upstream unreachable"))
+		assert.Empty(t, otherErr.Headers.Get("WWW-Authenticate"))
+	})
+}

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -588,12 +588,25 @@ func resolveUserTemplate(raw string, userClaims map[string]string, field string)
 	if !strings.Contains(raw, "{{user.") {
 		return raw, nil
 	}
+	// Deliberately NOT an ErrUserRequired case, however tempting: an empty claim
+	// map does not mean the request lacked a user. Claims are projected only when
+	// the spec sets assertion_user_claims, and when it does, core has already
+	// rejected a user-less request before the driver runs — and a present user
+	// always yields at least "sub". So reaching here with no claims means the
+	// spec structurally cannot project any, which no amount of authenticating
+	// will change. Returning a 401 challenge would send the caller into an OAuth
+	// loop it cannot escape while hiding the real fix from the operator.
 	var subErr error
 	resolved := userClaimTemplate.ReplaceAllStringFunc(raw, func(match string) string {
 		claim := userClaimTemplate.FindStringSubmatch(match)[1]
 		v, ok := userClaims[claim]
 		if !ok {
-			subErr = fmt.Errorf("%s references {{user.%s}} but that claim is absent (project it via assertion_user_claims)", field, claim)
+			// The user IS present; this claim was simply never projected. Note
+			// that assertion_user_claims only applies to a warden_identity
+			// subject — pairing {{user.…}} with subject_token_source=user_identity
+			// cannot populate claims at all, which is the likelier mistake.
+			subErr = fmt.Errorf("%s references {{user.%s}} but that claim is absent from the user's projected claims "+
+				"(list it in assertion_user_claims, which requires subject_token_source=warden_identity)", field, claim)
 			return ""
 		}
 		// The value becomes path bytes: a single non-empty allow-listed token that

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -1149,6 +1149,10 @@ func TestResolveSecretPath(t *testing.T) {
 		{"email value allowed", "kv/{{user.email}}", claims, "kv/alice@example.com", ""},
 		{"hyphen value allowed", "kv/{{user.dept}}", claims, "kv/eng-team", ""},
 		{"literal dots within a segment allowed", "kv/{{user.username}}", map[string]string{"username": "a..b"}, "kv/a..b", ""},
+		// Both are spec/config mismatches, not missing-user cases: claims are
+		// projected only when the spec asks for them, and core rejects a
+		// user-less request before the driver runs. Neither is fixed by
+		// authenticating, so neither may carry a 401 challenge.
 		{"absent claim fails closed", "slack/{{user.missing}}/x", claims, "", "absent"},
 		{"nil claims with template fails closed", "slack/{{user.username}}/x", nil, "", "absent"},
 		{"slash in value rejected", "kv/{{user.username}}", map[string]string{"username": "a/b"}, "", "allow-list"},
@@ -1224,4 +1228,8 @@ func TestVaultDriver_OAuth2_TemplatedNameFailsClosedWithoutClaims(t *testing.T) 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "credential_name")
 	assert.Contains(t, err.Error(), "absent")
+	// A spec that cannot project claims is an operator config error. Carrying
+	// the missing-user sentinel here would turn it into a 401 challenge and send
+	// the caller into an OAuth loop that cannot fix a spec.
+	assert.NotErrorIs(t, err, credential.ErrUserRequired)
 }

--- a/credential/errors.go
+++ b/credential/errors.go
@@ -39,6 +39,18 @@ var (
 	// re-read the latest spec and retry the refresh once.
 	ErrRefreshTokenRejected = errors.New("oauth2 refresh token rejected")
 
+	// ErrUserRequired is returned (wrapped) when a spec needs a USER principal
+	// and the request carried none. It is a sentinel rather than a status because
+	// this package cannot import logical — that would cycle — so the HTTP status
+	// is attached where the error surfaces: GetErrorCode maps it to 401, and the
+	// request handler pairs that with a WWW-Authenticate challenge pointing at
+	// the mount's protected resource metadata.
+	//
+	// 401 rather than 400 because it is exactly the "you need to authenticate,
+	// here is where" case: a client that can acquire a user identity should be
+	// able to, retry, and succeed. A malformed spec is a different failure.
+	ErrUserRequired = errors.New("a user principal is required but none was presented")
+
 	// ErrChainedSecretRejected is returned (wrapped) by a chained-secret consuming
 	// driver when the downstream rejects the fetched secret — e.g. an OAuth
 	// invalid_client, or a 401 from a resource. It signals the manager that a

--- a/e2e/helpers/userleg_helpers.go
+++ b/e2e/helpers/userleg_helpers.go
@@ -1,0 +1,273 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"crypto/ecdsa"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- Per-user (secondary principal) test environment ---
+//
+// These build the one shape the user leg needs and the rest of the e2e suite
+// never exercises: a mount whose AGENT arrives out of band (a client
+// certificate) while Authorization is free to carry a USER credential.
+//
+// Two distinct Hydra clients stand in for the two principals — the agent
+// authenticates by certificate, the user by JWT — so per-user attribution is
+// provable rather than assumed: the two have different `sub` values.
+
+const (
+	// UserLegMount is the provider mount opted into the user leg.
+	UserLegMount = "vault-user"
+
+	// UserLegMountDescription is asserted as `resource_name` in the protected
+	// resource metadata document.
+	UserLegMountDescription = "Vault for the e2e platform team"
+
+	// UserLegAuthMount is the auth mount that authenticates USER credentials.
+	// Deliberately separate from auth/jwt/ (the agent mount) so a token valid
+	// for one leg is not silently valid for the other.
+	UserLegAuthMount = "auth/user-jwt/"
+
+	// UserLegAuthRole is the role user credentials are validated under.
+	UserLegAuthRole = "e2e-user"
+
+	// UserLegResourceURL is the external base advertised in metadata. Pinned to
+	// node 1 because the setting is deployment-wide while the cluster has three
+	// nodes; document *content* is node-independent, so standby tests still work.
+	UserLegResourceURL = "https://127.0.0.1:8500"
+
+	// HydraIssuer is what the user auth mount's OIDC discovery URL resolves to,
+	// and therefore what metadata advertises as the authorization server.
+	HydraIssuer = "http://localhost:4444"
+)
+
+// UserJWT returns a JWT for the USER principal — a different Hydra client, and
+// therefore a different `sub`, than GetDefaultJWT's agent.
+func UserJWT(t *testing.T) string {
+	t.Helper()
+	return GetJWT(t, "e2e-pipeline", "pipeline-secret")
+}
+
+// SetupUserLegEnv builds a provider mount whose agent is a client certificate
+// and whose user rides Authorization, plus the protected resource metadata
+// configuration. Returns the CA for minting agent certificates.
+//
+// Reuses SetupCertAuth for the agent leg: a certificate is the cleanest way to
+// occupy the agent slot without touching Authorization, which is exactly the
+// shape the feature exists to enable.
+func SetupUserLegEnv(t *testing.T, port int) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	// Best-effort cleanup first. A previous run that failed mid-setup leaves
+	// mounts behind, and every subsequent attempt would then fail with 409 —
+	// turning one real failure into a cascade that hides it.
+	TeardownUserLegEnv(t, port)
+
+	caCertPEM, caKey = SetupCertAuth(t, port)
+
+	// User auth mount — same Hydra issuer, separate mount from the agent's, so a
+	// token valid for one leg is not silently valid for the other.
+	mustAPI(t, port, "POST", "sys/auth/user-jwt", `{"type":"jwt"}`, "mount user-jwt auth")
+	time.Sleep(time.Second)
+
+	mustAPI(t, port, "PUT", "auth/user-jwt/config",
+		fmt.Sprintf(`{"mode":"oidc","oidc_discovery_url":"%s","bound_issuer":"%s"}`, HydraIssuer, HydraIssuer),
+		"configure user-jwt auth")
+
+	mustAPI(t, port, "POST", "auth/user-jwt/role/"+UserLegAuthRole,
+		`{"user_claim":"sub","token_ttl":3600}`, "create user role")
+
+	// Provider mount. The description becomes `resource_name` in metadata.
+	mustAPI(t, port, "POST", "sys/providers/"+UserLegMount,
+		fmt.Sprintf(`{"type":"vault","description":%q}`, UserLegMountDescription),
+		"mount provider")
+	time.Sleep(time.Second)
+
+	// Address and auth config go in one write: the vault provider rejects a
+	// config that does not carry auto_auth_path, so they cannot be split.
+	mustAPI(t, port, "PUT", UserLegMount+"/config",
+		fmt.Sprintf(`{"vault_address":"http://127.0.0.1:8200","tls_skip_verify":true,"timeout":"30s",`+
+			`"auto_auth_path":"auth/cert/","user_auth_path":%q,"user_auth_role":%q}`,
+			UserLegAuthMount, UserLegAuthRole),
+		"configure provider")
+
+	mustAPI(t, port, "POST", "sys/policies/cbp/"+UserLegMount+"-access",
+		fmt.Sprintf(`{"policy":"path \"%s/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\npath \"%s/role/+/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}"}`,
+			UserLegMount, UserLegMount),
+		"create policy")
+
+	// Cert role for the agent, bound to a credential spec so a successful
+	// request actually mints something.
+	mustAPI(t, port, "POST", "auth/cert/role/e2e-userleg-agent",
+		fmt.Sprintf(`{"allowed_common_names":["agent-*"],"token_policies":["%s-access"],"cred_spec_name":"vault-token-reader","token_ttl":3600}`,
+			UserLegMount),
+		"create cert role")
+
+	EnableProtectedResourceMetadata(t, port)
+
+	return caCertPEM, caKey
+}
+
+// UserLegJWTRole is a JWT role scoped to the user-leg mount, for tests that
+// swap the certificate agent for a JWT one. The stock e2e-reader role grants
+// vault/gateway*, so reusing it would fail authorization instead of exercising
+// the agent channel under test.
+const UserLegJWTRole = "e2e-userleg-jwt"
+
+// CreateUserLegJWTRole creates that role. Idempotent.
+func CreateUserLegJWTRole(t *testing.T, port int) {
+	t.Helper()
+	APIRequest(t, "DELETE", "auth/jwt/role/"+UserLegJWTRole, port, "")
+	mustAPI(t, port, "POST", "auth/jwt/role/"+UserLegJWTRole,
+		fmt.Sprintf(`{"token_policies":["%s-access"],"cred_spec_name":"vault-token-reader","user_claim":"sub","token_ttl":3600}`,
+			UserLegMount),
+		"create user-leg jwt role")
+}
+
+// SetUserLegAgentPath repoints the mount's AGENT leg while leaving the user leg
+// intact. Lets a test swap a certificate agent for a JWT one without rebuilding
+// the whole environment.
+func SetUserLegAgentPath(t *testing.T, port int, autoAuthPath, defaultRole string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"auto_auth_path":%q,"user_auth_path":%q,"user_auth_role":%q`,
+		autoAuthPath, UserLegAuthMount, UserLegAuthRole)
+	if defaultRole != "" {
+		body += fmt.Sprintf(`,"default_role":%q`, defaultRole)
+	}
+	body += "}"
+	mustAPI(t, port, "POST", UserLegMount+"/config", body, "configure user leg")
+}
+
+// mustAPI issues an API request and fails the test unless it succeeded.
+// Accepts 201 as well as 200/204 — role creation returns Created.
+func mustAPI(t *testing.T, port int, method, path, body, what string) {
+	t.Helper()
+	status, resp := APIRequest(t, method, path, port, body)
+	switch status {
+	case 200, 201, 204:
+		return
+	default:
+		t.Fatalf("%s (status %d): %s", what, status, string(resp))
+	}
+}
+
+// TeardownUserLegEnv removes everything SetupUserLegEnv created.
+func TeardownUserLegEnv(t *testing.T, port int) {
+	t.Helper()
+	TeardownUserLegEnvBestEffort(port)
+}
+
+// TeardownUserLegEnvBestEffort is TeardownUserLegEnv without a *testing.T, for
+// use from TestMain — where a zero-value T cannot be used, because t.Fatalf
+// calls runtime.Goexit and deadlocks the process outside a test goroutine.
+// Every call is best-effort: cleanup must not fail a run that already passed.
+func TeardownUserLegEnvBestEffort(port int) {
+	token := rootTokenBestEffort()
+	del := func(path string) {
+		TryRequest("DELETE", fmt.Sprintf("%s/v1/%s", NodeURL(port), path),
+			map[string]string{"X-Warden-Token": token}, "")
+	}
+	TryRequest("POST", fmt.Sprintf("%s/v1/sys/protected-resource/config", NodeURL(port)),
+		map[string]string{"X-Warden-Token": token}, `{"resource_url":""}`)
+	del("auth/cert/role/e2e-userleg-agent")
+	del("sys/policies/cbp/" + UserLegMount + "-access")
+	del("sys/providers/" + UserLegMount)
+	del("auth/user-jwt/role/" + UserLegAuthRole)
+	del("sys/auth/user-jwt")
+	del("sys/auth/cert")
+	time.Sleep(time.Second)
+}
+
+// rootTokenBestEffort reads the root token without a *testing.T.
+func rootTokenBestEffort() string {
+	b, err := os.ReadFile(filepath.Join(E2EDir(), ".root_token"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// EnableProtectedResourceMetadata turns on RFC 9728 metadata publication.
+func EnableProtectedResourceMetadata(t *testing.T, port int) {
+	t.Helper()
+	status, body := APIRequest(t, "POST", "sys/protected-resource/config", port,
+		fmt.Sprintf(`{"resource_url":%q,"cache_ttl":"1h"}`, UserLegResourceURL))
+	if status != 200 && status != 204 {
+		t.Fatalf("enable protected resource metadata (status %d): %s", status, string(body))
+	}
+}
+
+// DisableProtectedResourceMetadata clears the master switch, so every metadata
+// path 404s while mounts keep their user_auth_path.
+func DisableProtectedResourceMetadata(t *testing.T, port int) {
+	t.Helper()
+	APIRequest(t, "POST", "sys/protected-resource/config", port, `{"resource_url":""}`)
+}
+
+// DoRequestWithResponseHeaders is DoRequest plus the response headers. The user
+// leg is largely a header protocol — WWW-Authenticate carries the challenge,
+// Cache-Control bounds document staleness — so asserting only status and body
+// would miss most of what these tests exist to check.
+func DoRequestWithResponseHeaders(t *testing.T, method, rawURL string, headers map[string]string, body string) (int, []byte, map[string][]string) {
+	t.Helper()
+
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if body != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed e2e cert
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, respBody, resp.Header
+}
+
+// PRMPath builds the well-known URL for a mount's metadata on a given node.
+func PRMPath(port int, mount string) string {
+	return fmt.Sprintf("%s/.well-known/oauth-protected-resource/v1/%s", NodeURL(port), mount)
+}
+
+// UserLegRequest makes a gateway request to the user-leg mount with the agent
+// presented as a client certificate and the given headers merged in.
+func UserLegRequest(t *testing.T, port int, agentCertPEM string, headers map[string]string) (int, []byte) {
+	t.Helper()
+	all := map[string]string{"X-Warden-Role": "e2e-userleg-agent"}
+	if agentCertPEM != "" {
+		all["X-SSL-Client-Cert"] = URLEncodePEM(agentCertPEM)
+	}
+	for k, v := range headers {
+		all[k] = v
+	}
+	u := fmt.Sprintf("%s/v1/%s/gateway/v1/secret/data/e2e/app-config", NodeURL(port), UserLegMount)
+	return DoRequest(t, "GET", u, all, "")
+}

--- a/e2e/userleg/main_test.go
+++ b/e2e/userleg/main_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+package userleg
+
+import (
+	"crypto/ecdsa"
+	"os"
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The user-leg environment is built once for the package rather than per test.
+// Setup mounts an auth method and a provider and waits for both to settle, so
+// per-test setup would dominate the runtime — and a test that failed mid-setup
+// would leave mounts behind, turning one real failure into a cascade of 409s
+// that hides it.
+//
+// Setup runs under sync.Once from the first test rather than from TestMain,
+// because the helpers report failure with t.Fatalf: a zero-value testing.T
+// cannot be used there, since Fatalf calls runtime.Goexit and deadlocks the
+// process outside a test goroutine. Teardown has no such constraint and runs
+// from TestMain on a best-effort basis.
+var (
+	envOnce    sync.Once
+	leaderPort int
+	agentCAPEM string
+	agentCAKey *ecdsa.PrivateKey
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if leaderPort != 0 {
+		h.TeardownUserLegEnvBestEffort(leaderPort)
+	}
+	os.Exit(code)
+}
+
+// ensureEnv builds the shared environment on first use.
+func ensureEnv(t *testing.T) {
+	t.Helper()
+	envOnce.Do(func() {
+		leaderPort = h.GetLeaderPort(t)
+		agentCAPEM, agentCAKey = h.SetupUserLegEnv(t, leaderPort)
+	})
+	if agentCAPEM == "" {
+		t.Fatal("user-leg environment is not available")
+	}
+}
+
+// agentCert mints a client certificate for the agent leg.
+func agentCert(t *testing.T) string {
+	t.Helper()
+	certPEM, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, "agent-userleg")
+	return certPEM
+}
+
+// restoreEnv puts the mount back to the package default: certificate agent,
+// metadata enabled. Tests that mutate either must defer this so ordering between
+// them cannot matter.
+func restoreEnv(t *testing.T) {
+	t.Helper()
+	h.SetUserLegAgentPath(t, leaderPort, "auth/cert/", "")
+	h.EnableProtectedResourceMetadata(t, leaderPort)
+}

--- a/e2e/userleg/prm_test.go
+++ b/e2e/userleg/prm_test.go
@@ -1,0 +1,214 @@
+//go:build e2e
+
+package userleg
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// =============================================================================
+// RFC 9728 Protected Resource Metadata
+// =============================================================================
+//
+// The document tells a client which authorization server issues the USER
+// credential for a mount. Everything here runs against a live cluster because
+// the unit tests cover the builder and the handler separately — the seam between
+// them, and the routing that gets a request to it, are only exercised here.
+
+type prmDoc struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported"`
+	ResourceName           string   `json:"resource_name"`
+	ResourceDocumentation  string   `json:"resource_documentation"`
+}
+
+func fetchPRM(t *testing.T, port int, mount string) (int, prmDoc, map[string][]string) {
+	t.Helper()
+	status, body, hdrs := h.DoRequestWithResponseHeaders(t, "GET", h.PRMPath(port, mount), nil, "")
+	var doc prmDoc
+	if status == 200 {
+		if err := json.Unmarshal(body, &doc); err != nil {
+			t.Fatalf("metadata is not valid JSON (status %d): %v\n%s", status, err, string(body))
+		}
+	}
+	return status, doc, hdrs
+}
+
+// TestPRM_ServesOptedInMount is the shape a client actually consumes.
+func TestPRM_ServesOptedInMount(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	status, doc, hdrs := fetchPRM(t, port, h.UserLegMount)
+	if status != 200 {
+		t.Fatalf("expected 200 for an opted-in mount, got %d", status)
+	}
+
+	want := h.UserLegResourceURL + "/v1/" + h.UserLegMount
+	if doc.Resource != want {
+		t.Errorf("resource = %q, want %q", doc.Resource, want)
+	}
+
+	// Derived from the auth method at user_auth_path — the operator states the
+	// issuer once, on the mount, and never restates it here.
+	if len(doc.AuthorizationServers) != 1 || doc.AuthorizationServers[0] != h.HydraIssuer {
+		t.Errorf("authorization_servers = %v, want [%s]", doc.AuthorizationServers, h.HydraIssuer)
+	}
+
+	if len(doc.BearerMethodsSupported) != 1 || doc.BearerMethodsSupported[0] != "header" {
+		t.Errorf("bearer_methods_supported = %v, want [header]", doc.BearerMethodsSupported)
+	}
+
+	// The operator's mount description, so a consent screen can name what the
+	// user is authorizing access to.
+	if doc.ResourceName != h.UserLegMountDescription {
+		t.Errorf("resource_name = %q, want %q", doc.ResourceName, h.UserLegMountDescription)
+	}
+
+	if cc := hdrs["Cache-Control"]; len(cc) == 0 || !strings.Contains(cc[0], "max-age=") {
+		t.Errorf("Cache-Control = %v, want a max-age directive", cc)
+	}
+}
+
+// TestPRM_NotServedWhereItShouldNotBe covers every "no document here" case. All
+// are a plain 404: distinguishing them would let an unauthenticated caller probe
+// the mount table, and none of the distinctions are actionable by a client.
+func TestPRM_NotServedWhereItShouldNotBe(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	base := h.NodeURL(port) + "/.well-known/oauth-protected-resource"
+	for _, tc := range []struct{ name, url string }{
+		{"mount without user_auth_path", base + "/v1/vault"},
+		{"unknown mount", base + "/v1/does-not-exist"},
+		{"bare well-known prefix", base},
+		{"prefix with trailing slash only", base + "/"},
+		{"agent-only discovery surface", base + "/v1/sys/mcp"},
+		{"path missing the /v1/ segment", base + "/vault-user"},
+		// Warden is a resource server, never an authorization server.
+		{"authorization-server metadata", h.NodeURL(port) + "/.well-known/oauth-authorization-server"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _ := h.DoRequest(t, "GET", tc.url, nil, "")
+			if status != 404 {
+				t.Errorf("expected 404, got %d for %s", status, tc.url)
+			}
+		})
+	}
+}
+
+// TestPRM_RejectsNonCanonicalPaths guards a cross-mount confusion primitive.
+// Go's ServeMux redirects a literal "/../" before the handler, but a
+// percent-encoded one arrives decoded and intact — so "/v1/vault-user/%2e%2e/vault"
+// would longest-prefix match the opted-in mount while the document echoed a
+// `resource` normalizing to a different mount, binding one mount's identifier to
+// another's authorization server.
+func TestPRM_RejectsNonCanonicalPaths(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	base := h.NodeURL(port) + "/.well-known/oauth-protected-resource"
+	for _, suffix := range []string{
+		"/v1/" + h.UserLegMount + "/%2e%2e/vault",
+		"/v1/" + h.UserLegMount + "/%2e%2e",
+		"/v1/%2e/" + h.UserLegMount,
+	} {
+		t.Run(suffix, func(t *testing.T) {
+			status, body := h.DoRequest(t, "GET", base+suffix, nil, "")
+			if status != 404 {
+				t.Errorf("expected 404 for a non-canonical path, got %d: %s", status, string(body))
+			}
+		})
+	}
+}
+
+// TestPRM_SurvivesProviderHeader is the regression test for the routing order
+// that MCP clients actually trip: they commonly set X-Warden-Provider
+// connection-wide, and the /v1/ rewrite would otherwise turn a discovery fetch
+// into /v1/.well-known/... and 404 it, breaking the bootstrap silently.
+func TestPRM_SurvivesProviderHeader(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	status, body := h.DoRequest(t, "GET", h.PRMPath(port, h.UserLegMount),
+		map[string]string{"X-Warden-Provider": h.UserLegMount}, "")
+	if status != 200 {
+		t.Fatalf("expected 200 with X-Warden-Provider set, got %d: %s", status, string(body))
+	}
+}
+
+// TestPRM_ServedFromStandby verifies a standby forwards to the active node: the
+// document is derived from the live mount table, which only the active node has.
+func TestPRM_ServedFromStandby(t *testing.T) {
+	ensureEnv(t)
+	standby := h.GetStandbyPort(t)
+	status, doc, _ := fetchPRM(t, standby, h.UserLegMount)
+	if status != 200 {
+		t.Fatalf("standby should forward metadata to the active node, got %d", status)
+	}
+	// Content is node-independent by construction: the resource identifier comes
+	// from the configured external base, never the request's host.
+	if want := h.UserLegResourceURL + "/v1/" + h.UserLegMount; doc.Resource != want {
+		t.Errorf("resource = %q, want %q", doc.Resource, want)
+	}
+}
+
+// TestPRM_MethodNotAllowed pins GET/HEAD only, with the Allow header RFC 9110
+// requires on a 405.
+func TestPRM_MethodNotAllowed(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	status, _, hdrs := h.DoRequestWithResponseHeaders(t, "POST", h.PRMPath(port, h.UserLegMount), nil, "")
+	if status != 405 {
+		t.Fatalf("expected 405 for POST, got %d", status)
+	}
+	if allow := hdrs["Allow"]; len(allow) == 0 {
+		t.Error("405 must carry an Allow header")
+	}
+}
+
+// TestPRM_DisableStopsServing verifies resource_url is the master switch, and
+// that turning it off leaves mounts otherwise untouched.
+func TestPRM_DisableStopsServing(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	defer restoreEnv(t)
+
+	if status, _, _ := fetchPRM(t, port, h.UserLegMount); status != 200 {
+		t.Fatalf("precondition: expected 200, got %d", status)
+	}
+
+	h.DisableProtectedResourceMetadata(t, port)
+	if status, _, _ := fetchPRM(t, port, h.UserLegMount); status != 404 {
+		t.Errorf("expected 404 once resource_url is cleared, got %d", status)
+	}
+
+	h.EnableProtectedResourceMetadata(t, port)
+	if status, _, _ := fetchPRM(t, port, h.UserLegMount); status != 200 {
+		t.Errorf("expected 200 after re-enabling, got %d", status)
+	}
+}
+
+// TestPRM_UnauthenticatedAccess pins that no credential is needed. A client
+// fetches this precisely because it has none yet, so requiring one would make
+// the document useless.
+func TestPRM_UnauthenticatedAccess(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	status, body := h.DoRequest(t, "GET", h.PRMPath(port, h.UserLegMount), nil, "")
+	if status != 200 {
+		t.Fatalf("metadata must be reachable with no credential, got %d: %s", status, string(body))
+	}
+	if strings.Contains(string(body), "secret") {
+		t.Error(fmt.Sprintf("metadata leaked something secret-looking: %s", string(body)))
+	}
+}

--- a/e2e/userleg/user_leg_test.go
+++ b/e2e/userleg/user_leg_test.go
@@ -1,0 +1,259 @@
+//go:build e2e
+
+package userleg
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// =============================================================================
+// The user leg: two principals on one request
+// =============================================================================
+//
+// The agent arrives out of band — a client certificate, or X-Warden-Agent-Token
+// — which frees Authorization to carry a USER credential. These are the only
+// tests in the suite that run with an effective user_auth_path, so without them
+// the entire feature could regress unnoticed.
+
+// challengeOf returns the WWW-Authenticate header, failing if absent.
+func challengeOf(t *testing.T, hdrs map[string][]string) string {
+	t.Helper()
+	v := hdrs["Www-Authenticate"]
+	if len(v) == 0 {
+		t.Fatal("expected a WWW-Authenticate header; RFC 7235 requires one on a 401")
+	}
+	return v[0]
+}
+
+// TestUserLeg_MissingUserChallengesWithDiscoverableMetadata is the bootstrap the
+// whole feature exists for: a request that needs a user but has none must not
+// merely fail — it must say where to go, and that URL must actually resolve.
+//
+// The second half is the part only e2e can check. The challenge URL and the
+// metadata endpoint are built independently; if they drift, a client follows the
+// link, gets a 404, and never learns where to authenticate.
+func TestUserLeg_MissingUserChallengesWithDiscoverableMetadata(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+	cert := agentCert(t)
+
+	// A spec requiring a user is not configured on this mount, so a plain
+	// request succeeds; what we assert here is the challenge shape when the
+	// user leg is engaged but no user credential is present. Use an explicitly
+	// invalid user token to force the user-authentication failure path.
+	status, _, hdrs := h.DoRequestWithResponseHeaders(t, "GET",
+		h.NodeURL(port)+"/v1/"+h.UserLegMount+"/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{
+			"X-Warden-Role":     "e2e-userleg-agent",
+			"X-SSL-Client-Cert": h.URLEncodePEM(cert),
+			"Authorization":     "Bearer not-a-valid-user-token",
+		}, "")
+
+	if status != 401 {
+		t.Fatalf("an unusable user credential must be 401 (clients begin discovery there), got %d", status)
+	}
+
+	challenge := challengeOf(t, hdrs)
+	if !strings.Contains(challenge, "resource_metadata=") {
+		t.Fatalf("challenge must name where to authenticate: %q", challenge)
+	}
+	if !strings.Contains(challenge, `error="invalid_token"`) {
+		t.Errorf("a presented-and-rejected credential should say so: %q", challenge)
+	}
+
+	// Follow the link exactly as a client would.
+	url := extractResourceMetadata(t, challenge)
+	fetchStatus, body := h.DoRequest(t, "GET", url, nil, "")
+	if fetchStatus != 200 {
+		t.Fatalf("the challenge named %s, which returned %d — the bootstrap dies here", url, fetchStatus)
+	}
+
+	var doc prmDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("challenge pointed at something that is not a metadata document: %v", err)
+	}
+	if len(doc.AuthorizationServers) == 0 {
+		t.Error("the document a challenge names must tell the client which authorization server to use")
+	}
+}
+
+// extractResourceMetadata pulls the URL out of a WWW-Authenticate challenge the
+// way a client would.
+func extractResourceMetadata(t *testing.T, challenge string) string {
+	t.Helper()
+	const key = `resource_metadata="`
+	i := strings.Index(challenge, key)
+	if i < 0 {
+		t.Fatalf("no resource_metadata in %q", challenge)
+	}
+	rest := challenge[i+len(key):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		t.Fatalf("unterminated resource_metadata in %q", challenge)
+	}
+	return rest[:j]
+}
+
+// TestUserLeg_CertAgentWithUserSucceeds is the happy path, and the only place
+// the two principals are proven distinct end to end: the audit entry must
+// attribute the request to the USER, not the agent.
+func TestUserLeg_CertAgentWithUserSucceeds(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+	cert := agentCert(t)
+	userJWT := h.UserJWT(t)
+
+	status, body := h.UserLegRequest(t, port, cert, map[string]string{
+		"Authorization": "Bearer " + userJWT,
+	})
+	if status != 200 {
+		t.Fatalf("cert agent + valid user should succeed, got %d: %s", status, string(body))
+	}
+
+	// The user principal is identity-only and never authorizes the request, so
+	// the audit trail is where its effect is observable.
+	assertUserAttributed(t, port, "e2e-pipeline")
+}
+
+// TestUserLeg_AgentTokenHeaderWithUserSucceeds covers the non-mTLS shape: an
+// agent that presents a JWT on the dedicated header, leaving Authorization for
+// the user. This is the flow a bearer-JWT or service-mesh agent uses.
+func TestUserLeg_AgentTokenHeaderWithUserSucceeds(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	// Repoint the mount's agent leg at the JWT auth mount, leaving the user leg
+	// intact. Restored afterwards so test ordering cannot matter.
+	//
+	// A dedicated role is needed: e2e-reader's policy grants vault/gateway*, not
+	// this mount, so reusing it would fail authorization rather than exercise the
+	// agent channel.
+	h.CreateUserLegJWTRole(t, port)
+	h.SetUserLegAgentPath(t, port, "auth/jwt/", h.UserLegJWTRole)
+	defer restoreEnv(t)
+
+	status, body := h.DoRequest(t, "GET",
+		h.NodeURL(port)+"/v1/"+h.UserLegMount+"/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{
+			"X-Warden-Agent-Token": h.GetDefaultJWT(t),
+			"Authorization":        "Bearer " + h.UserJWT(t),
+			"X-Warden-Role":        h.UserLegJWTRole,
+		}, "")
+
+	if status != 200 {
+		t.Fatalf("agent-token header + user on Authorization should succeed, got %d: %s", status, string(body))
+	}
+	assertUserAttributed(t, port, "e2e-pipeline")
+}
+
+// TestUserLeg_OperatorTokenPlusUserIsRejected pins the one genuinely ambiguous
+// combination. X-Warden-Token is the operator credential and carries no user;
+// Authorization is where the user rides. Presenting both means one of the two is
+// silently discarded, so it is refused with an explanation instead.
+func TestUserLeg_OperatorTokenPlusUserIsRejected(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	rootToken := h.RootToken(t)
+	status, body := h.DoRequest(t, "GET",
+		h.NodeURL(port)+"/v1/"+h.UserLegMount+"/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{
+			"X-Warden-Token": rootToken,
+			"Authorization":  "Bearer " + h.UserJWT(t),
+		}, "")
+
+	if status != 400 {
+		t.Fatalf("operator token + user credential must be refused with 400, got %d: %s", status, string(body))
+	}
+	if !strings.Contains(string(body), "X-Warden-Agent-Token") {
+		t.Errorf("the error should name the fix, got: %s", string(body))
+	}
+}
+
+// TestUserLeg_NonOptedInMountUnchanged is the compatibility half stated as a
+// test: on a mount without user_auth_path the same headers must behave exactly
+// as they did before the feature existed — Authorization is the agent, and no
+// ambiguity rejection fires.
+func TestUserLeg_NonOptedInMountUnchanged(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	// vault/ has auto_auth_path but no user_auth_path.
+	status, body := h.DoRequest(t, "GET",
+		h.NodeURL(port)+"/v1/vault/role/e2e-reader/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{"Authorization": "Bearer " + h.GetDefaultJWT(t)}, "")
+
+	if status != 200 {
+		t.Fatalf("a bearer JWT must still authenticate the agent on a non-opted-in mount, got %d: %s",
+			status, string(body))
+	}
+
+	// And the ambiguity rejection must NOT fire here. Asserted on the message
+	// rather than the status: this mount can 400 for unrelated reasons (a root
+	// token carries no credential spec), and a bare status check would pass or
+	// fail for the wrong reason.
+	_, body = h.DoRequest(t, "GET",
+		h.NodeURL(port)+"/v1/vault/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{
+			"X-Warden-Token": h.RootToken(t),
+			"Authorization":  "Bearer " + h.GetDefaultJWT(t),
+		}, "")
+	if strings.Contains(string(body), "cannot be combined with an Authorization credential") {
+		t.Error("the ambiguity rejection must be scoped to protected-resource mounts")
+	}
+}
+
+// TestUserLeg_ChallengeOmitsMetadataWhenUnconfigured verifies the challenge
+// degrades honestly: RFC 7235 still requires a challenge on a 401, but naming a
+// document that would 404 is worse than naming none.
+func TestUserLeg_ChallengeOmitsMetadataWhenUnconfigured(t *testing.T) {
+	ensureEnv(t)
+	port := leaderPort
+
+	h.DisableProtectedResourceMetadata(t, port)
+	defer restoreEnv(t)
+
+	cert := agentCert(t)
+	status, _, hdrs := h.DoRequestWithResponseHeaders(t, "GET",
+		h.NodeURL(port)+"/v1/"+h.UserLegMount+"/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{
+			"X-Warden-Role":     "e2e-userleg-agent",
+			"X-SSL-Client-Cert": h.URLEncodePEM(cert),
+			"Authorization":     "Bearer not-a-valid-user-token",
+		}, "")
+
+	if status != 401 {
+		t.Fatalf("expected 401, got %d", status)
+	}
+	challenge := challengeOf(t, hdrs)
+	if strings.Contains(challenge, "resource_metadata=") {
+		t.Errorf("no document is served, so none should be named: %q", challenge)
+	}
+	if !strings.Contains(challenge, "Bearer") {
+		t.Errorf("a 401 must still carry a challenge: %q", challenge)
+	}
+}
+
+// assertUserAttributed polls the audit log for an entry attributing a request to
+// the given user subject. Polls because audit writes are not synchronous with
+// the response, matching how the existing audit tests read the log.
+func assertUserAttributed(t *testing.T, port int, wantSubject string) {
+	t.Helper()
+	nodeNum := h.NodeNumberForPort(port)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, e := range h.ReadAuditEntries(t, nodeNum, h.UserLegMount) {
+			if e.Auth != nil && e.Auth.User != nil && strings.Contains(e.Auth.User.Subject, wantSubject) {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Errorf("no audit entry attributed the request to user %q — the user principal never reached the mint path", wantSubject)
+}

--- a/http/prm_endpoints.go
+++ b/http/prm_endpoints.go
@@ -18,7 +18,11 @@ import (
 //
 // It lives at the origin root, outside /v1/, because a client fetches it before
 // it has any credential and without knowing Warden's API layout.
-const prmPath = "/.well-known/oauth-protected-resource"
+//
+// Taken from core rather than restated: core builds the WWW-Authenticate
+// challenge that points here, and a challenge naming a URL this layer does not
+// serve would break the bootstrap silently.
+const prmPath = core.PRMWellKnownPath
 
 // isPRMPath reports whether p addresses protected-resource metadata: the bare
 // prefix or anything beneath it. Unlike the OIDC issuer paths this is a subtree,

--- a/logical/errors.go
+++ b/logical/errors.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/credential"
 )
 
 // CodedError is an error that carries an HTTP status code.
@@ -138,6 +139,13 @@ func GetErrorCode(err error) int {
 		return http.StatusNotFound
 	case errors.Is(err, sdklogical.ErrInvalidRequest):
 		return http.StatusBadRequest
+	// A spec that needs a user principal and got none. The credential package
+	// cannot construct a CodedError (logical imports credential, so the reverse
+	// would cycle), so the status is attached here. 401 is what lets a client
+	// acquire a user identity and retry; core pairs it with a WWW-Authenticate
+	// challenge naming where to go.
+	case errors.Is(err, credential.ErrUserRequired):
+		return http.StatusUnauthorized
 	}
 	// Check if the error wraps a CodedError. Only recurse when there is an inner
 	// error: an error that implements Unwrap() but returns nil (e.g. a token


### PR DESCRIPTION
Completes the series (#487, #488). A spec that needs a **user** principal and
gets none now fails with a 401 carrying an RFC 6750 challenge naming the
mount's protected resource metadata. That is what turns a dead end into a
bootstrap: the client discovers where to authenticate, acquires a user
identity, and retries.

Previously these failures were a 400, and a spec-compliant client stopped
there — discovery begins on a 401 specifically.

Three commits, reviewable independently:

| | |
|---|---|
| `bdb5804` | the 401 + challenge |
| `ffc4951` | **an unrelated pre-existing audit bug** — see below |
| `c6caa5e` | e2e coverage for the whole feature |

## The typed error

`credential` gains an `ErrUserRequired` sentinel — a sentinel rather than a
coded error, because the package cannot import `logical` without cycling —
emitted at exactly the two places where a request genuinely carried no user:
`subject_token_source=user_identity`, and `assertion_user_claims`.
`GetErrorCode` maps it to 401 through any depth of `%w` wrapping.

Deliberately **not** emitted from the vault driver's `{{user.…}}` templating.
An empty claim map does not mean the request lacked a user: claims are
projected only when a spec sets `assertion_user_claims`, and when it does,
core has already rejected a user-less request before the driver runs, while a
present user always yields at least `sub`. So no claims means the spec
structurally cannot project any — an operator config error that no amount of
authenticating fixes. A 401 there would send the caller into a loop it cannot
escape while hiding the real fix. The message now names that fix, including
that `assertion_user_claims` requires a `warden_identity` subject — the caveat
that made the old advice unfollowable in the combination most likely to
produce it.

Both branches of the input-resolution wrap are load-bearing, so the decision
is its own function with its own tests: returning the error un-coded would
push every non-user failure from 400 to 500, since `GetErrorCode` has no rule
for a bare error, while coding them all 400 would mask the 401 and stop
discovery before it starts.

## The challenge

Attached in core rather than rendered at the HTTP layer: only there are the
namespace and mount in hand, and `writeLogicalResponse` copies `resp.Headers`.

It distinguishes the two cases RFC 6750 separates — a credential presented and
rejected gets `error="invalid_token"`, while none presented gets the bare
challenge, since naming a token invalid when there was no token would be a
lie. On git smart-HTTP paths a `Basic` challenge is prepended: a bare `Bearer`
is unactionable for a client that negotiates with Basic, and on a
protected-resource mount the Basic password slot is where the user credential
rides. RFC 9110 permits multiple challenges.

`resource_metadata` is included **only when the metadata endpoint would
actually serve that document** — confirmed by asking the builder, not by
re-deriving its conditions, which would let the two drift. A challenge naming
a URL that 404s is worse than none: the client follows it and the bootstrap
dies silently. RFC 7235 still requires a challenge on every 401, so the bare
scheme is emitted regardless.

The access path gets no challenge and no 401. `AccessData` comes only from
non-streaming backends, where `captureUserContext` never runs, so `req.User`
is structurally nil there: a user-requiring spec bound to such a mount fails
permanently. 401 would tell a client to authenticate when it already has, and
there would be nowhere to point it. It is reported as the server-side
misconfiguration it is.

## The audit bug (independent, pre-existing)

`LogEntry.Clone()` deep-copied `Auth` by enumerating its fields and omitted
`User`, so per-user attribution was dropped from **every written audit entry**.
Both JSON formatters clone before serialising — to avoid races when several
devices log the same entry in parallel — which put the omission squarely on
the write path: the field was set correctly in memory and never reached disk.

Present since the field was introduced in #475. It survived because the
existing test asserts on the in-memory entry, one layer above where the data is
lost, and because core's unit tests use mock audit managers that never clone.
The per-user gateway flow is the first thing to read `auth.user` back from an
actual audit file, which is how it surfaced.

Attribution is the only record that a request was performed *for* a specific
user rather than by the agent alone, so losing it silently defeats the point of
capturing the principal at all.

`ffc4951` is independent of this feature and cherry-pickable to `main` on its
own if you would rather fast-track it — the only reason it sits here is that
the e2e test asserting per-user attribution needs it to pass.

## E2E coverage

`user_auth_path` appeared nowhere in `e2e`, so all 203 existing tests ran with
the user leg off. That made the suite a strong check on the compatibility half
of this series and **no check at all** on the new behaviour — nothing in CI
would have noticed if the whole thing regressed.

Fourteen scenarios. Three can only be proven against a live server:

- the challenge URL is followed and returns a real document. The challenge and
  the metadata endpoint derive their paths independently; if they drift a
  client gets a 404 and never learns where to authenticate.
- a percent-encoded traversal is refused (`ServeMux` redirects a literal
  `/../` before the handler, so only a real server shows what arrives).
- a standby forwards metadata to the active node.

Plus per-user attribution end to end, the ambiguity rejection, the
bare-`Bearer` degradation, and the compatibility invariant on a non-opted-in
mount.

## Testing

Full unit suite green. Verified against a live 3-node cluster: **17/17 e2e
packages, 217 tests**.
