### PR TITLE
fix(core): restore git probe passthrough for certificate agents

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -904,21 +904,14 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 
 		// Check for unauthenticated paths on streaming backends.
 		//
-		// An empty ClientToken alone no longer implies "no agent credential":
-		// on a protected-resource mount the extractor returns an empty agent to
-		// mean "the TLS client certificate is the agent". Treating that as
-		// unauthenticated would skip CheckToken, minting, user capture and
-		// audit for a request that carried two credentials.
-		//
-		// Scoped to userLeg so non-opted-in mounts keep 0.19 behaviour exactly:
-		// only there can a cert produce an empty agent, and public token-less
-		// endpoints (e.g. Vault's PKI CRL paths) must stay reachable from an
-		// mTLS listener or behind a mesh proxy, where a trusted cert is present
-		// on every request. The git providers can also return an empty agent
-		// under a cert on a non-opted-in mount, but githttp's own probe gate
-		// refuses passthrough whenever Authorization is set, which it is there.
-		certIsAgent := userLeg && logical.HasTrustedClientCert(req.HTTPRequest)
-		if req.ClientToken == "" && !certIsAgent {
+		// A user credential is what makes passthrough unsafe: it would skip
+		// CheckToken, minting, user capture and audit for a principal we must
+		// record. A credential-less probe mints and injects nothing, so it
+		// still passes through — git's opening info/refs carries no
+		// Authorization and needs the upstream's challenge to learn to retry
+		// with one. Providers declaring unauthenticated paths must therefore
+		// surface Authorization-borne user credentials from ExtractTokens.
+		if req.ClientToken == "" && userCred == "" {
 			if tmp, ok := matchingBackend.(logical.TransparentModeProvider); ok {
 				relativePath := req.Path
 				if req.MountPoint != "" {
@@ -945,7 +938,9 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 						logger.String("request_id", req.RequestID),
 					)
 
-					return logical.ErrorResponse(logical.ErrUnauthorized(err.Error())), nil, nil
+					errResp := logical.ErrorResponse(logical.ErrUnauthorized(err.Error()))
+					attachGitBasicChallenge(req, errResp)
+					return errResp, nil, nil
 				}
 			}
 		}

--- a/core/request_handler_unauth_gate_test.go
+++ b/core/request_handler_unauth_gate_test.go
@@ -31,19 +31,27 @@ func (m *mockUnauthPathBackend) IsUnauthenticatedPath(_ *http.Request, _ string)
 func (m *mockUnauthPathBackend) GetUserAuthPath() string { return m.userAuthPath }
 func (m *mockUnauthPathBackend) GetUserAuthRole() string { return "" }
 
-// TestStreamUnauthenticatedGate guards the hole opened by letting an empty agent
-// mean "the TLS client certificate is the agent", and pins the scope of that
-// guard.
+// ExtractTokens replaces the base mock's stub, which returns no credentials at
+// all. The gate now turns on the extracted user credential, so a stub would
+// make every case look credential-less and the test would pass regardless of
+// what the gate does.
+func (m *mockUnauthPathBackend) ExtractTokens(r *http.Request, userLeg bool) (agent, user string) {
+	return logical.ExtractTokensDefault(r, userLeg)
+}
+
+// TestStreamUnauthenticatedGate pins what disqualifies a request from
+// passthrough: an extracted user credential, not a client certificate.
 //
 // The gate is entered on ClientToken == "", which used to imply "no credential
-// at all". On a protected-resource mount that is now a routine state, so without
-// the cert check a cert-authenticated request carrying a user credential would
-// be marked StreamUnauthenticated and skip CheckToken, minting, user capture and
-// audit entirely.
+// at all". On a protected-resource mount that is now routine, since an empty
+// agent there means "the certificate is the agent" — so a request carrying a
+// user credential must not be marked StreamUnauthenticated and skip CheckToken,
+// minting, user capture and audit.
 //
-// The check is deliberately scoped to such mounts. Only there can a cert produce
-// an empty agent, and public token-less endpoints must stay reachable from an
-// mTLS listener or behind a mesh proxy, where a trusted cert rides every request.
+// A certificate alone must not disqualify it. Git's opening info/refs probe is
+// exactly that shape — cert agent, no Authorization — and it has to reach the
+// upstream to collect the WWW-Authenticate that teaches the client to retry
+// with credentials. Gating on the certificate broke every cert-agent git clone.
 func TestStreamUnauthenticatedGate(t *testing.T) {
 	core := createTestCore(t)
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
@@ -65,9 +73,12 @@ func TestStreamUnauthenticatedGate(t *testing.T) {
 	mount(t, "protected/", "protected-uuid", "auth/user-jwt/")
 	mount(t, "plain/", "plain-uuid", "")
 
-	newReq := func(mountPath string, withCert bool) *logical.Request {
+	newReq := func(mountPath string, withCert bool, authz string) *logical.Request {
 		p := mountPath + "gateway/messages"
 		hr := httptest.NewRequest(http.MethodPost, "/v1/"+p, nil)
+		if authz != "" {
+			hr.Header.Set("Authorization", authz)
+		}
 		if withCert {
 			hr = hr.WithContext(listener.WithForwardedClientCert(hr.Context(), &x509.Certificate{}))
 		}
@@ -75,27 +86,50 @@ func TestStreamUnauthenticatedGate(t *testing.T) {
 	}
 
 	t.Run("protected resource: no credential and no cert is still unauthenticated", func(t *testing.T) {
-		req := newReq("protected/", false)
+		req := newReq("protected/", false, "")
 		_, _, _ = core.handleNonLoginRequest(ctx, req)
 		assert.True(t, req.StreamUnauthenticated,
 			"a genuinely credential-less probe must keep passing through")
 	})
 
-	t.Run("protected resource: trusted cert disqualifies the unauthenticated path", func(t *testing.T) {
-		req := newReq("protected/", true)
+	t.Run("protected resource: a cert with no user credential still passes through", func(t *testing.T) {
+		// The git probe shape. Nothing is minted or injected, so the upstream
+		// sees an unauthenticated request and answers with the challenge the
+		// client needs. Requiring auth here fails for want of a role, because
+		// for git the role travels in the Basic username the probe has not sent.
+		req := newReq("protected/", true, "")
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+		assert.True(t, req.StreamUnauthenticated,
+			"a credential-less probe must reach the upstream even under a certificate")
+	})
+
+	t.Run("protected resource: a cert plus a user credential disqualifies it", func(t *testing.T) {
+		// The actual hazard: passthrough here would skip CheckToken, minting,
+		// user capture and audit for a request that carried a principal we are
+		// meant to record.
+		req := newReq("protected/", true, "Bearer user-jwt")
 		_, _, _ = core.handleNonLoginRequest(ctx, req)
 		assert.False(t, req.StreamUnauthenticated,
-			"an empty agent means the cert IS the agent; treating it as unauthenticated "+
-				"would skip CheckToken, minting, user capture and audit")
+			"a user credential must never be dropped by an unauthenticated-path match")
 	})
 
 	t.Run("plain mount: a trusted cert does not disqualify it", func(t *testing.T) {
 		// 0.19 behaviour, preserved. A cert cannot yield an empty agent here, so
 		// an empty ClientToken still means "no credential" — and public
 		// token-less endpoints must keep working behind mTLS or a mesh proxy.
-		req := newReq("plain/", true)
+		req := newReq("plain/", true, "")
 		_, _, _ = core.handleNonLoginRequest(ctx, req)
 		assert.True(t, req.StreamUnauthenticated,
-			"scoping the cert check to protected resources keeps non-opted-in mounts byte-identical")
+			"non-opted-in mounts stay byte-identical")
+	})
+
+	t.Run("plain mount: Authorization is the agent, so it does not disqualify it", func(t *testing.T) {
+		// Off the user leg Authorization resolves to the agent, so ClientToken
+		// is non-empty and the gate is never entered — the same outcome as 0.19
+		// but for the agent's sake, not the user's.
+		req := newReq("plain/", false, "Bearer agent-jwt")
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+		assert.False(t, req.StreamUnauthenticated,
+			"an agent credential off the user leg must still be authenticated")
 	})
 }

--- a/core/user_challenge.go
+++ b/core/user_challenge.go
@@ -64,6 +64,23 @@ func (c *Core) attachUserChallenge(ctx context.Context, req *logical.Request, re
 	resp.AddHeader("WWW-Authenticate", challenge)
 }
 
+// attachGitBasicChallenge attaches a Basic challenge to a transparent-auth
+// failure on a git smart-HTTP path.
+//
+// Git's opening info/refs carries no Authorization, so the role (Basic
+// username) and any user credential (Basic password) are both absent and auth
+// fails for want of a role. Where the request passed through instead, the
+// upstream issues this challenge; where an out-of-band agent forced
+// authentication there is no upstream response to relay, and a bare 401 leaves
+// the client nothing to act on. Basic only: the agent is what failed, and the
+// user leg has nothing to fix.
+func attachGitBasicChallenge(req *logical.Request, resp *logical.Response) {
+	if req == nil || resp == nil || !isGitSmartHTTP(req) {
+		return
+	}
+	resp.AddHeader("WWW-Authenticate", `Basic realm="warden"`)
+}
+
 // prmMetadataURL renders the absolute URL of a mount's protected resource
 // metadata, or "" when none would be served.
 //

--- a/core/user_challenge_test.go
+++ b/core/user_challenge_test.go
@@ -290,3 +290,95 @@ func TestAttachUserChallenge(t *testing.T) {
 		assert.Empty(t, otherErr.Headers.Get("WWW-Authenticate"))
 	})
 }
+
+// TestAttachGitBasicChallenge covers the transparent-auth failure, which is a
+// different 401 from the user-required one: the agent is what failed, so there
+// is no metadata pointer to offer. On git the client can still fix it by
+// retrying with Basic, which is where the role and any user credential ride.
+//
+// Reached only when an out-of-band agent forced authentication. A probe with no
+// agent at all passes through and collects the upstream's own challenge.
+func TestAttachGitBasicChallenge(t *testing.T) {
+	newReq := func(path string) *logical.Request {
+		return &logical.Request{
+			Path:        path,
+			MountPoint:  "github/",
+			HTTPRequest: httptest.NewRequest(http.MethodGet, "/v1/"+path, nil),
+		}
+	}
+
+	t.Run("git smart-HTTP gets a Basic challenge", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("missing role"))
+		attachGitBasicChallenge(newReq("github/gateway/o/r.git/info/refs"), resp)
+		assert.Equal(t, `Basic realm="warden"`, resp.Headers.Get("WWW-Authenticate"))
+	})
+
+	t.Run("no Bearer scheme is offered", func(t *testing.T) {
+		// Advertising the user leg here would send the client to acquire an
+		// identity that cannot fix an agent failure.
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("missing role"))
+		attachGitBasicChallenge(newReq("github/gateway/o/r.git/git-upload-pack"), resp)
+		assert.NotContains(t, resp.Headers.Get("WWW-Authenticate"), "Bearer")
+	})
+
+	t.Run("a non-git gateway path gets no challenge", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("missing role"))
+		attachGitBasicChallenge(newReq("github/gateway/user"), resp)
+		assert.Empty(t, resp.Headers.Get("WWW-Authenticate"))
+	})
+
+	t.Run("a non-gateway path ending in a git suffix gets none either", func(t *testing.T) {
+		resp := logical.ErrorResponse(logical.ErrUnauthorized("missing role"))
+		attachGitBasicChallenge(newReq("github/config/o/r.git/info/refs"), resp)
+		assert.Empty(t, resp.Headers.Get("WWW-Authenticate"))
+	})
+
+	t.Run("nil arguments are inert", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			attachGitBasicChallenge(nil, logical.ErrorResponse(logical.ErrUnauthorized("x")))
+			attachGitBasicChallenge(newReq("github/gateway/o/r.git/info/refs"), nil)
+		})
+	})
+}
+
+// TestTransparentAuthFailureCarriesGitChallenge pins the wiring rather than the
+// helper. A request that reaches transparent auth was not passed through, so no
+// upstream response will be relayed and this 401 is the only thing that can tell
+// the client to retry with credentials. Without the header git simply gives up.
+func TestTransparentAuthFailureCarriesGitChallenge(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	// autoAuthPath names a mount that does not exist, so the implicit login
+	// fails — standing in for the real failure, a probe with no resolvable role.
+	backend := &mockTransparentModeProvider{transparentMode: true, autoAuthPath: "auth/agent-jwt/"}
+	require.NoError(t, core.router.Mount("github/", backend, &MountEntry{
+		Path:        "github/",
+		Type:        "github",
+		Class:       mountClassProvider,
+		UUID:        "github-challenge-uuid",
+		Accessor:    "github_challenge_acc",
+		NamespaceID: namespace.RootNamespaceID,
+		namespace:   namespace.RootNamespace,
+	}, &mockBarrierView{prefix: "provider/github-challenge-uuid/"}))
+
+	handle := func(t *testing.T, path string) *logical.Response {
+		t.Helper()
+		hr := httptest.NewRequest(http.MethodGet, "/v1/"+path, nil)
+		resp, _, _ := core.handleNonLoginRequest(ctx,
+			&logical.Request{Path: path, Operation: logical.ReadOperation, HTTPRequest: hr})
+		require.NotNil(t, resp)
+		return resp
+	}
+
+	t.Run("git smart-HTTP failure carries the Basic challenge", func(t *testing.T) {
+		resp := handle(t, "github/gateway/o/r.git/info/refs")
+		assert.Equal(t, `Basic realm="warden"`, resp.Headers.Get("WWW-Authenticate"))
+	})
+
+	t.Run("a non-git failure carries none", func(t *testing.T) {
+		resp := handle(t, "github/gateway/user")
+		assert.Empty(t, resp.Headers.Get("WWW-Authenticate"),
+			"only git needs telling which scheme to retry with")
+	})
+}

--- a/e2e/githttp/git_probe_test.go
+++ b/e2e/githttp/git_probe_test.go
@@ -1,0 +1,163 @@
+//go:build e2e
+
+package githttp
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// basicAuth renders a Basic credential the way git does.
+func basicAuth(user, pass string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}
+
+// gitURL is the full smart-HTTP probe URL for the fixture repository.
+func gitURL() string {
+	return h.NodeURL(leaderPort) + "/v1/" + h.GitSmartHTTPPath()
+}
+
+// certHeaders presents the agent as a client certificate.
+func certHeaders(t *testing.T) map[string]string {
+	t.Helper()
+	return map[string]string{"X-SSL-Client-Cert": h.URLEncodePEM(agentCert(t))}
+}
+
+// TestGitProbePassesThroughUnderCertAgent is the regression test for the bug
+// this suite exists for.
+//
+// Git's opening info/refs carries no Authorization, and for git the role rides
+// in the Basic username and the user credential in the Basic password — so a
+// probe forced through authentication has neither and fails for want of a role.
+// It has to reach the upstream, whose challenge is what teaches git to retry
+// with credentials at all.
+func TestGitProbePassesThroughUnderCertAgent(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, respHeaders := h.DoRequestWithResponseHeaders(t, "GET",
+		gitURL(), certHeaders(t), "")
+
+	require.Equal(t, http.StatusUnauthorized, status,
+		"the upstream's challenge must be relayed, not swallowed: %s", string(body))
+	assert.Contains(t, http.Header(respHeaders).Get("WWW-Authenticate"), "Basic",
+		"without a Basic challenge git cannot know which scheme to retry with")
+
+	reqs := upstream.Requests()
+	require.Len(t, reqs, 1, "the probe must reach the upstream exactly once")
+	assert.Empty(t, reqs[0].Authorization,
+		"a passthrough probe mints nothing and must inject nothing")
+}
+
+// TestGitSecondPassMintsAndWithholdsUserCredential covers the retry git makes
+// after that challenge: the agent stays on the certificate, the role arrives as
+// the Basic username and the user identity as the Basic password.
+//
+// The assertion that matters is the negative one — the user's own credential
+// must never proxy onward. What reaches the upstream is the credential Warden
+// minted for it.
+func TestGitSecondPassMintsAndWithholdsUserCredential(t *testing.T) {
+	ensureEnv(t)
+
+	userJWT := h.UserJWT(t)
+	headers := certHeaders(t)
+	headers["Authorization"] = basicAuth(h.GitAgentCertRole, userJWT)
+
+	status, body := h.DoRequest(t, "GET", gitURL(), headers, "")
+	require.Equal(t, http.StatusOK, status,
+		"cert agent plus a user credential must authenticate: %s", string(body))
+
+	last := upstream.Last(t)
+	assert.Equal(t, basicAuth("x-access-token", h.GitPAT), last.Authorization,
+		"the upstream must receive the minted credential")
+	assert.NotContains(t, last.Authorization, userJWT,
+		"the user's own credential must never proxy upstream")
+
+	for _, header := range []string{"X-Warden-Token", "X-Warden-Agent-Token", "X-Ssl-Client-Cert"} {
+		assert.Empty(t, last.Header.Get(header),
+			"%s must be stripped before the request leaves Warden", header)
+	}
+}
+
+// TestGitPerUserAttribution proves the user principal reached the mint path and
+// was recorded. Attribution is the only record that a clone was performed for a
+// specific person rather than by the agent alone.
+func TestGitPerUserAttribution(t *testing.T) {
+	ensureEnv(t)
+
+	headers := certHeaders(t)
+	headers["Authorization"] = basicAuth(h.GitAgentCertRole, h.UserJWT(t))
+
+	status, body := h.DoRequest(t, "GET", gitURL(), headers, "")
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	nodeNum := h.NodeNumberForPort(leaderPort)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, e := range h.ReadAuditEntries(t, nodeNum, h.GitMount) {
+			if e.Auth != nil && e.Auth.User != nil && strings.Contains(e.Auth.User.Subject, "e2e-pipeline") {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Error("no audit entry attributed the clone to the user — the user principal never reached the mint path")
+}
+
+// TestGitHeaderAgentProbeIsChallenged covers the shape with no passthrough: an
+// agent on X-Warden-Agent-Token is authenticated rather than passed through, so
+// no upstream response will be relayed. Warden must issue the challenge itself,
+// or git is told a request failed with no indication that retrying would help.
+func TestGitHeaderAgentProbeIsChallenged(t *testing.T) {
+	ensureEnv(t)
+	defer restoreEnv(t)
+
+	// Repoint the agent leg at JWT so the header channel is the one in play.
+	h.SetGitAgentPath(t, leaderPort, upstream.URL, "auth/jwt/", h.GitUserAuthMount, "")
+
+	status, body, respHeaders := h.DoRequestWithResponseHeaders(t, "GET", gitURL(),
+		map[string]string{"X-Warden-Agent-Token": h.GetDefaultJWT(t)}, "")
+
+	require.Equal(t, http.StatusUnauthorized, status,
+		"a probe with no resolvable role must fail: %s", string(body))
+	assert.Equal(t, `Basic realm="warden"`, http.Header(respHeaders).Get("WWW-Authenticate"),
+		"RFC 7235 requires a challenge on a 401, and here it is also the only way "+
+			"the client learns to retry with the role in the Basic username")
+
+	assert.Empty(t, upstream.Requests(),
+		"an authenticated agent must not be passed through to the upstream")
+}
+
+// TestGitProbeCompatibilityOffUserLeg pins the unchanged behaviour of a mount
+// that never opted in. There the Basic password is the agent's own credential
+// and no user is captured, exactly as before the user leg existed.
+func TestGitProbeCompatibilityOffUserLeg(t *testing.T) {
+	ensureEnv(t)
+	defer restoreEnv(t)
+
+	h.SetGitAgentPath(t, leaderPort, upstream.URL, "auth/cert/", "", "")
+
+	// The probe still passes through: off the user leg an empty agent has always
+	// meant "no credential", and that is what a probe carries.
+	status, _, respHeaders := h.DoRequestWithResponseHeaders(t, "GET", gitURL(), certHeaders(t), "")
+	require.Equal(t, http.StatusUnauthorized, status)
+	assert.Contains(t, http.Header(respHeaders).Get("WWW-Authenticate"), "Basic")
+
+	upstream.Reset()
+
+	// And the retry authenticates on the Basic password as the agent's own
+	// credential rather than a user's.
+	headers := certHeaders(t)
+	headers["Authorization"] = basicAuth(h.GitAgentCertRole, "x")
+
+	status, body := h.DoRequest(t, "GET", gitURL(), headers, "")
+	require.Equal(t, http.StatusOK, status,
+		"a non-JWT password is git's mandatory placeholder and must be ignored: %s", string(body))
+	assert.Equal(t, basicAuth("x-access-token", h.GitPAT), upstream.Last(t).Authorization)
+}

--- a/e2e/githttp/main_test.go
+++ b/e2e/githttp/main_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+package githttp
+
+import (
+	"crypto/ecdsa"
+	"os"
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The git environment is built once for the package rather than per test: setup
+// mounts an auth method, a provider, a credential source and a spec, so per-test
+// setup would dominate the runtime — and a test that failed mid-setup would
+// leave mounts behind, turning one real failure into a cascade of 409s that
+// hides it.
+//
+// Setup runs under sync.Once from the first test rather than from TestMain,
+// because the helpers report failure with t.Fatalf: a zero-value testing.T
+// cannot be used there, since Fatalf calls runtime.Goexit and deadlocks the
+// process outside a test goroutine. Teardown has no such constraint.
+var (
+	envOnce    sync.Once
+	leaderPort int
+	upstream   *h.GitUpstream
+	agentCAPEM string
+	agentCAKey *ecdsa.PrivateKey
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if leaderPort != 0 {
+		h.TeardownGitEnvBestEffort(leaderPort)
+	}
+	if upstream != nil {
+		upstream.Close()
+	}
+	os.Exit(code)
+}
+
+// ensureEnv builds the shared environment on first use.
+func ensureEnv(t *testing.T) {
+	t.Helper()
+	envOnce.Do(func() {
+		leaderPort = h.GetLeaderPort(t)
+		upstream = h.StartGitUpstream(t)
+		agentCAPEM, agentCAKey = h.SetupGitEnv(t, leaderPort, upstream.URL)
+	})
+	if agentCAPEM == "" {
+		t.Fatal("git environment is not available")
+	}
+	upstream.Reset()
+}
+
+// agentCert mints a client certificate for the agent leg. The common name must
+// match the cert role's allowed_common_names.
+func agentCert(t *testing.T) string {
+	t.Helper()
+	certPEM, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, "agent-git")
+	return certPEM
+}
+
+// restoreEnv puts the mount back to the package default: certificate agent, user
+// leg on. Tests that repoint either must defer this so ordering cannot matter.
+func restoreEnv(t *testing.T) {
+	t.Helper()
+	h.SetGitAgentPath(t, leaderPort, upstream.URL, "auth/cert/", h.GitUserAuthMount, "")
+}

--- a/e2e/githttp/real_clone_test.go
+++ b/e2e/githttp/real_clone_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+package githttp
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRealGitClone drives an actual git client through the mount against a real
+// bare repository served by git-http-backend.
+//
+// Every other test in this package shapes the HTTP itself, which pins what
+// Warden does but cannot show that git accepts the exchange. This one covers the
+// part only a real client can: that it reads the challenge, retries with the
+// credential in the Basic slots, and completes the transfer. That is precisely
+// the step that regressed, and it was found by hand rather than by CI because
+// nothing here drove git.
+//
+// The agent rides X-Warden-Agent-Token rather than a certificate: mTLS to the
+// node would need the agent cert to chain to the listener's configured client
+// CA, which is a different fixture, and the challenge-and-retry cycle under test
+// is identical on both agent channels.
+func TestRealGitClone(t *testing.T) {
+	ensureEnv(t)
+
+	// Skipping is right on a machine without git, but in CI it would quietly
+	// drop the only coverage of a real client acting on the challenge — the
+	// blind spot that let the regression ship. Fail there instead.
+	unavailable := func(reason string) {
+		t.Helper()
+		if os.Getenv("CI") != "" {
+			t.Fatalf("%s — CI must not lose real-client coverage", reason)
+		}
+		t.Skip(reason)
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		unavailable("git is not installed")
+	}
+	realUpstream := h.StartRealGitUpstream(t)
+	if realUpstream == "" {
+		unavailable("git-http-backend is unavailable")
+	}
+
+	defer restoreEnv(t)
+	h.SetGitAgentPath(t, leaderPort, realUpstream, "auth/jwt/", h.GitUserAuthMount, "")
+
+	dest := filepath.Join(t.TempDir(), "clone")
+	cloneURL := fmt.Sprintf("%s/v1/%s/gateway/%s.git",
+		h.NodeURL(leaderPort), h.GitMount, h.GitRepo)
+
+	// The credential goes in the URL only because a test cannot answer a
+	// prompt. Real users should not: git writes the remote verbatim into
+	// .git/config, which is why the provider help says to let git ask.
+	withCreds := strings.Replace(cloneURL, "https://",
+		fmt.Sprintf("https://%s:%s@", h.GitAgentJWTRole, h.UserJWT(t)), 1)
+
+	cmd := exec.Command("git",
+		"-c", "http.sslVerify=false",
+		"-c", "credential.helper=",
+		"-c", "http.extraHeader=X-Warden-Agent-Token: "+h.GetDefaultJWT(t),
+		"clone", "--quiet", withCreds, dest,
+	)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git clone through the mount failed:\n%s", out)
+
+	// A clone that produced no working tree would pass on exit code alone.
+	body, err := os.ReadFile(filepath.Join(dest, "README.md"))
+	require.NoError(t, err, "the clone produced no working tree")
+	assert.Equal(t, "warden e2e fixture\n", string(body))
+}

--- a/e2e/helpers/githttp_helpers.go
+++ b/e2e/helpers/githttp_helpers.go
@@ -1,0 +1,360 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"net/http"
+	"net/http/cgi"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- Git smart-HTTP test environment ---
+//
+// Git is the one transport where both principals ride in a single header: the
+// agent's role in the Basic username, the user credential in the Basic
+// password. It is also the only one whose client refuses to send either until
+// challenged, so the negotiation itself is part of what has to be tested — and
+// none of it is reachable without a git upstream to negotiate with.
+//
+// Two upstreams are provided. The recording one proves what Warden did with a
+// request and, more importantly, what it forwarded: that the user's credential
+// never proxies onward and what arrives is the minted one. The real one proves
+// that git itself accepts the exchange, which no amount of hand-shaped HTTP can
+// establish.
+
+const (
+	// GitMount is the provider mount under test, opted into the user leg.
+	GitMount = "github-git"
+
+	// GitMountDescription is what protected resource metadata reports as
+	// resource_name.
+	GitMountDescription = "GitHub git for the e2e platform team"
+
+	// GitUserAuthMount authenticates USER credentials for the git mount. Held
+	// apart from the userleg package's mount so the two suites cannot leave
+	// state for each other.
+	GitUserAuthMount = "auth/git-user-jwt/"
+
+	// GitUserAuthRole is the role user credentials are validated under.
+	GitUserAuthRole = "e2e-git-user"
+
+	// GitAgentCertRole is the cert-auth role the agent authenticates under. Its
+	// name is also what a client sends as the Basic username.
+	GitAgentCertRole = "e2e-git-agent"
+
+	// GitAgentJWTRole is the equivalent for tests that swap the certificate
+	// agent for one on X-Warden-Agent-Token. The stock e2e roles grant
+	// vault/gateway*, so reusing one would fail authorization rather than
+	// exercise the agent channel under test.
+	GitAgentJWTRole = "e2e-git-jwt-agent"
+
+	// GitPAT is the token the credential spec mints. Static by design: PAT mode
+	// mints without calling GitHub, so the upstream can be a local server.
+	GitPAT = "ghp_e2e_git_smart_http_pat"
+
+	// GitRepo is the repository path served by both upstreams.
+	GitRepo = "acme/widgets"
+)
+
+// GitUpstreamRequest is one request the recording upstream received.
+type GitUpstreamRequest struct {
+	Method        string
+	Path          string
+	RawQuery      string
+	Authorization string
+	Header        http.Header
+}
+
+// GitUpstream is a recording stand-in for GitHub's git smart-HTTP endpoint.
+//
+// It reproduces the one behaviour the negotiation depends on: an unauthenticated
+// request is answered with a Basic challenge rather than served, which is how
+// git learns to retry with credentials at all.
+type GitUpstream struct {
+	URL string
+
+	server *httptest.Server
+	mu     sync.Mutex
+	reqs   []GitUpstreamRequest
+}
+
+// StartGitUpstream starts the recording upstream. The caller owns its lifetime
+// via Close: the mount is configured with its URL once for the whole package, so
+// binding it to the first test's cleanup would leave every later test pointed at
+// a closed listener.
+func StartGitUpstream(t *testing.T) *GitUpstream {
+	t.Helper()
+	u := &GitUpstream{}
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.mu.Lock()
+		u.reqs = append(u.reqs, GitUpstreamRequest{
+			Method:        r.Method,
+			Path:          r.URL.Path,
+			RawQuery:      r.URL.RawQuery,
+			Authorization: r.Header.Get("Authorization"),
+			Header:        r.Header.Clone(),
+		})
+		u.mu.Unlock()
+
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="github"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.WriteHeader(http.StatusOK)
+		// Enough of a packet stream that a client can tell it was served rather
+		// than refused; the tests assert on status and recorded headers, not on
+		// git wire semantics.
+		_, _ = w.Write([]byte("001e# service=git-upload-pack\n0000"))
+	}))
+	u.URL = u.server.URL
+	return u
+}
+
+// Close stops the recording upstream.
+func (u *GitUpstream) Close() {
+	if u.server != nil {
+		u.server.Close()
+	}
+}
+
+// Requests returns every request received so far.
+func (u *GitUpstream) Requests() []GitUpstreamRequest {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]GitUpstreamRequest(nil), u.reqs...)
+}
+
+// Last returns the most recent request. Fails the test if there was none.
+func (u *GitUpstream) Last(t *testing.T) GitUpstreamRequest {
+	t.Helper()
+	reqs := u.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("upstream received no requests")
+	}
+	return reqs[len(reqs)-1]
+}
+
+// Reset clears the recorded requests so one test's traffic cannot be read as
+// another's.
+func (u *GitUpstream) Reset() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.reqs = nil
+}
+
+// GitExecPath returns git's helper directory, or "" when git is unavailable.
+func GitExecPath() string {
+	out, err := exec.Command("git", "--exec-path").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// StartRealGitUpstream serves a genuine bare repository over smart-HTTP via
+// git-http-backend, so a real `git clone` can be driven end to end. Returns the
+// upstream URL, or "" when git-http-backend is unavailable.
+//
+// Requests without Authorization are refused with a Basic challenge, matching
+// the recording upstream and every real host: without it git would clone on the
+// first request and the credential slots would never be exercised.
+func StartRealGitUpstream(t *testing.T) string {
+	t.Helper()
+
+	execPath := GitExecPath()
+	if execPath == "" {
+		return ""
+	}
+	backend := filepath.Join(execPath, "git-http-backend")
+	if _, err := exec.LookPath(backend); err != nil {
+		return ""
+	}
+
+	root := t.TempDir()
+	repoDir := filepath.Join(root, GitRepo+".git")
+	seedBareRepo(t, repoDir)
+
+	handler := &cgi.Handler{
+		Path: backend,
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + root,
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="github"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// seedBareRepo creates a bare repository with one commit, so a clone produces a
+// working tree rather than an empty directory that would pass vacuously.
+func seedBareRepo(t *testing.T, bareDir string) {
+	t.Helper()
+
+	work := t.TempDir()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(cmd.Environ(),
+			"GIT_AUTHOR_NAME=e2e", "GIT_AUTHOR_EMAIL=e2e@example.com",
+			"GIT_COMMITTER_NAME=e2e", "GIT_COMMITTER_EMAIL=e2e@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	run(work, "init", "-q", "-b", "main", work)
+	write(filepath.Join(work, "README.md"), "warden e2e fixture\n")
+	run(work, "add", "README.md")
+	run(work, "commit", "-q", "-m", "seed")
+	run(work, "clone", "-q", "--bare", work, bareDir)
+	// Without this git-http-backend refuses the fetch as a non-exported repo on
+	// hosts where GIT_HTTP_EXPORT_ALL is not honoured.
+	write(filepath.Join(bareDir, "git-daemon-export-ok"), "")
+}
+
+// SetupGitEnv builds a github mount pointed at upstreamURL whose agent is a
+// client certificate and whose user rides the Basic password slot. Returns the
+// CA for minting agent certificates.
+func SetupGitEnv(t *testing.T, port int, upstreamURL string) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	// A previous run that failed mid-setup leaves mounts behind, and every
+	// later attempt would then fail with 409 — turning one real failure into a
+	// cascade that hides it.
+	TeardownGitEnvBestEffort(port)
+
+	caCertPEM, caKey = SetupCertAuth(t, port)
+
+	mustAPI(t, port, "POST", "sys/auth/git-user-jwt", `{"type":"jwt"}`, "mount git-user-jwt auth")
+	time.Sleep(time.Second)
+
+	mustAPI(t, port, "PUT", "auth/git-user-jwt/config",
+		fmt.Sprintf(`{"mode":"oidc","oidc_discovery_url":"%s","bound_issuer":"%s"}`, HydraIssuer, HydraIssuer),
+		"configure git-user-jwt auth")
+
+	mustAPI(t, port, "POST", "auth/git-user-jwt/role/"+GitUserAuthRole,
+		`{"user_claim":"sub","token_ttl":3600}`, "create git user role")
+
+	mustAPI(t, port, "POST", "sys/providers/"+GitMount,
+		fmt.Sprintf(`{"type":"github","description":%q}`, GitMountDescription),
+		"mount github provider")
+	time.Sleep(time.Second)
+
+	// github_url is used verbatim as the git host for anything that is not
+	// api.github.com or a /api/v3 endpoint, which is what lets a local server
+	// stand in for GitHub. tls_skip_verify is what permits the http:// scheme;
+	// both the provider and the credential source reject plain http without it.
+	mustAPI(t, port, "PUT", GitMount+"/config",
+		fmt.Sprintf(`{"github_url":%q,"tls_skip_verify":true,"auto_auth_path":"auth/cert/","user_auth_path":%q,"user_auth_role":%q}`,
+			upstreamURL, GitUserAuthMount, GitUserAuthRole),
+		"configure github provider")
+
+	// PAT mode mints without calling GitHub, so no real credentials are needed
+	// and the upstream can be a local server. Source config is string-valued,
+	// hence the quoted boolean.
+	mustAPI(t, port, "POST", "sys/cred/sources/git-e2e",
+		fmt.Sprintf(`{"type":"github","config":{"github_url":%q,"tls_skip_verify":"true"}}`, upstreamURL),
+		"create git credential source")
+
+	mustAPI(t, port, "POST", "sys/cred/specs/git-e2e-pat",
+		fmt.Sprintf(`{"type":"github_token","source":"git-e2e","config":{"mint_method":"pat","token":%q}}`, GitPAT),
+		"create git credential spec")
+
+	mustAPI(t, port, "POST", "sys/policies/cbp/"+GitMount+"-access",
+		fmt.Sprintf(`{"policy":"path \"%s/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\npath \"%s/role/+/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}"}`,
+			GitMount, GitMount),
+		"create git policy")
+
+	mustAPI(t, port, "POST", "auth/cert/role/"+GitAgentCertRole,
+		fmt.Sprintf(`{"allowed_common_names":["agent-*"],"token_policies":["%s-access"],"cred_spec_name":"git-e2e-pat","token_ttl":3600}`,
+			GitMount),
+		"create git cert role")
+
+	// The JWT counterpart, for the header-agent shapes. Recreated rather than
+	// created, since auth/jwt/ is set up by the suite and survives our teardown.
+	APIRequest(t, "DELETE", "auth/jwt/role/"+GitAgentJWTRole, port, "")
+	mustAPI(t, port, "POST", "auth/jwt/role/"+GitAgentJWTRole,
+		fmt.Sprintf(`{"token_policies":["%s-access"],"cred_spec_name":"git-e2e-pat","user_claim":"sub","token_ttl":3600}`,
+			GitMount),
+		"create git jwt agent role")
+
+	return caCertPEM, caKey
+}
+
+// SetGitAgentPath repoints the mount's AGENT leg while leaving the user leg
+// intact, so a test can swap a certificate agent for a JWT one without
+// rebuilding the environment. An empty userAuthPath opts the mount out of the
+// user leg entirely, which is how the compatibility cases are exercised.
+func SetGitAgentPath(t *testing.T, port int, upstreamURL, autoAuthPath, userAuthPath, defaultRole string) {
+	t.Helper()
+	// user_auth_role is always written, empty when opting out: config writes
+	// merge into the stored config, so leaving a previously-set role behind
+	// while clearing the path is rejected as "user_auth_role requires
+	// user_auth_path".
+	role := ""
+	if userAuthPath != "" {
+		role = GitUserAuthRole
+	}
+	body := fmt.Sprintf(`{"github_url":%q,"tls_skip_verify":true,"auto_auth_path":%q,"user_auth_path":%q,"user_auth_role":%q`,
+		upstreamURL, autoAuthPath, userAuthPath, role)
+	if defaultRole != "" {
+		body += fmt.Sprintf(`,"default_role":%q`, defaultRole)
+	}
+	body += "}"
+	mustAPI(t, port, "POST", GitMount+"/config", body, "configure git mount")
+}
+
+// GitSmartHTTPPath is the info/refs probe path for the fixture repository,
+// relative to the mount.
+func GitSmartHTTPPath() string {
+	return fmt.Sprintf("%s/gateway/%s.git/info/refs?service=git-upload-pack", GitMount, GitRepo)
+}
+
+// TeardownGitEnvBestEffort removes everything SetupGitEnv created. Best-effort
+// throughout: cleanup must not fail a run that already passed.
+func TeardownGitEnvBestEffort(port int) {
+	token := rootTokenBestEffort()
+	del := func(path string) {
+		TryRequest("DELETE", fmt.Sprintf("%s/v1/%s", NodeURL(port), path),
+			map[string]string{"X-Warden-Token": token}, "")
+	}
+	del("auth/cert/role/" + GitAgentCertRole)
+	del("auth/jwt/role/" + GitAgentJWTRole)
+	del("sys/policies/cbp/" + GitMount + "-access")
+	del("sys/cred/specs/git-e2e-pat")
+	del("sys/cred/sources/git-e2e")
+	del("sys/providers/" + GitMount)
+	del("auth/git-user-jwt/role/" + GitUserAuthRole)
+	del("sys/auth/git-user-jwt")
+	del("sys/auth/cert")
+	time.Sleep(time.Second)
+}

--- a/logical/backend.go
+++ b/logical/backend.go
@@ -163,6 +163,12 @@ type TransparentModeProvider interface {
 	// implicit auth. The request reaches the streaming handler with
 	// req.Credential == nil — handlers that previously assumed a credential
 	// is always present must guard accordingly.
+	//
+	// Core consults this only when ExtractTokens yielded neither an agent nor
+	// a user credential. An implementation that declares unauthenticated paths
+	// must therefore surface Authorization-borne user credentials from its
+	// ExtractTokens: one dropped there is discarded here rather than
+	// authenticated, captured and audited.
 	IsUnauthenticatedPath(r *http.Request, path string) bool
 
 	// IsTransparentPath checks if the given path (relative to mount) should trigger

--- a/provider/github/provider.go
+++ b/provider/github/provider.go
@@ -183,9 +183,33 @@ deliberately.
 On a mount configured with user_auth_path the roles shift — the
 certificate becomes the agent and the password slot carries the
 per-request USER identity, while the username keeps naming the
-agent's role:
+agent's role.
 
-  git clone https://<agent-role>:$USER_JWT@<warden-addr>/v1/...
+Git sends no credentials until it is challenged, so the password slot
+is filled only after a 401. Where the agent is a certificate, the
+opening request passes through and the upstream issues that challenge;
+where it arrives on X-Warden-Agent-Token, Warden issues it, since that
+request carries no Basic username to resolve a role from. Either way
+Git retries with the role in the username and the user identity in the
+password. Setting X-Warden-Role or the mount's default_role lets the
+first request succeed outright and skips the round trip.
+
+Keep credentials out of the clone URL. Git writes the remote verbatim
+into .git/config, so anything embedded there persists in plaintext in
+every clone and shows up in "git remote -v" output. Let Git prompt
+instead, and pin an empty credential helper into the clone so a
+short-lived token is not cached and replayed once it expires — a stale
+replay surfaces only as "Authentication failed", indistinguishable
+from a wrong credential:
+
+  git clone --config credential.helper= \
+      https://<agent-role>@<warden-addr>/v1/...
+
+The role may also travel in the path rather than the username. Git's
+helpers ignore the path unless credential.useHttpPath is set, so every
+role then shares one cache entry:
+
+  git clone https://<warden-addr>/v1/github/role/<agent-role>/gateway/...
 
 A cert-authenticated client with no user identity still has to put
 something in the password slot, since Git requires one for Basic

--- a/provider/gitlab/provider.go
+++ b/provider/gitlab/provider.go
@@ -183,9 +183,33 @@ deliberately.
 On a mount configured with user_auth_path the roles shift — the
 certificate becomes the agent and the password slot carries the
 per-request USER identity, while the username keeps naming the
-agent's role:
+agent's role.
 
-  git clone https://<agent-role>:$USER_JWT@<warden-addr>/v1/...
+Git sends no credentials until it is challenged, so the password slot
+is filled only after a 401. Where the agent is a certificate, the
+opening request passes through and the upstream issues that challenge;
+where it arrives on X-Warden-Agent-Token, Warden issues it, since that
+request carries no Basic username to resolve a role from. Either way
+Git retries with the role in the username and the user identity in the
+password. Setting X-Warden-Role or the mount's default_role lets the
+first request succeed outright and skips the round trip.
+
+Keep credentials out of the clone URL. Git writes the remote verbatim
+into .git/config, so anything embedded there persists in plaintext in
+every clone and shows up in "git remote -v" output. Let Git prompt
+instead, and pin an empty credential helper into the clone so a
+short-lived token is not cached and replayed once it expires — a stale
+replay surfaces only as "Authentication failed", indistinguishable
+from a wrong credential:
+
+  git clone --config credential.helper= \
+      https://<agent-role>@<warden-addr>/v1/...
+
+The role may also travel in the path rather than the username. Git's
+helpers ignore the path unless credential.useHttpPath is set, so every
+role then shares one cache entry:
+
+  git clone https://<warden-addr>/v1/gitlab/role/<agent-role>/gateway/...
 
 A cert-authenticated client with no user identity still has to put
 something in the password slot, since Git requires one for Basic

--- a/provider/sdk/githttp/githttp.go
+++ b/provider/sdk/githttp/githttp.go
@@ -209,15 +209,15 @@ func BuildHooks(opts Options) Hooks {
 	// Returns false (so normal auth runs) when r is nil, when r carries any
 	// Authorization header, or when the path is not a Git smart-HTTP
 	// endpoint. The Authorization-header check looks redundant — core only
-	// consults IsUnauthenticatedPath when ClientToken == "", which already
-	// implies ExtractTokens found no usable agent credential. But several
-	// edge cases reach here with Authorization set yet ClientToken empty:
-	// malformed Bearer ("Bearer " with no token), Basic with an empty
-	// password slot, Negotiate (Kerberos) and other unrecognised schemes,
-	// and — on a protected-resource mount — a client certificate acting as
-	// the agent, which leaves the agent empty by design. Without this guard
-	// those all silently get probe-passthrough; with it they fall through to
-	// implicit-auth-fail → 401, which is the honest answer.
+	// consults IsUnauthenticatedPath when ExtractTokens yielded no credential
+	// of either kind. But several edge cases reach here with Authorization
+	// set and still nothing extracted: malformed Bearer ("Bearer " with no
+	// token), Basic with an empty password slot, and Negotiate (Kerberos) or
+	// other unrecognised schemes. Without this guard those all silently get
+	// probe-passthrough; with it they fall through to implicit-auth-fail →
+	// 401, which is the honest answer. A certificate agent presenting a user
+	// credential no longer reaches here at all — the extracted user stops it
+	// at the gate.
 	isUnauthenticatedGitProbe := func(r *http.Request, path string) bool {
 		if r == nil || r.Header.Get("Authorization") != "" {
 			return false


### PR DESCRIPTION
Follows #487, #488, #489. A `git clone` against a mount with `user_auth_path`
failed on its opening `info/refs` with `implicit authentication failed: missing
role`. Found by hand, because nothing in `e2e/` drove a git client.

## The bug

Git sends no `Authorization` on that first request. For git the auth role travels
in the Basic **username** and the user credential in the Basic **password**, so a
probe forced through authentication has neither: it fails for want of a role, and
because the response carried no `WWW-Authenticate` the client never learned to
retry. Before #487 the probe passed through and the upstream issued the challenge
that starts the negotiation.

#487 keyed the passthrough gate on certificate presence. The hazard it guards is a
request carrying a **user credential** that matches a provider's static
unauthenticated-path list, where passthrough would skip `CheckToken`, minting,
user capture and audit. Such a request has an `Authorization` header — and
githttp's probe hook already refuses passthrough whenever one is set. The git hook
was never the exposed surface; the static list was. Keying on the certificate
disabled the probe passthrough as collateral damage.

## The fix

Key the gate on the extracted user credential instead — that is what actually
makes passthrough unsafe. A credential-less probe mints and injects nothing, so it
reaches the upstream and collects the challenge, as before the user leg existed.

Where the agent arrives on `X-Warden-Agent-Token` there is no passthrough and so
no upstream challenge to relay, and that 401 carried no `WWW-Authenticate` at all,
contrary to RFC 7235 — a rule this repo already asserts elsewhere. It now carries
a Basic challenge on git smart-HTTP paths, which also makes the shape self-healing:
git retries with the role in the username and the user identity in the password.
Basic only, since the agent is what failed and the user leg has nothing to fix.

## Behaviour changes, all on opted-in mounts only

| | |
|---|---|
| cert agent, no user credential, unauthenticated path | passes through again — the fix |
| public token-less endpoints behind mTLS | reachable again; #487 had silently subjected them to cert auth |
| those passthroughs | unaudited again, as in 0.19 |
| any `Authorization`-borne user credential | still blocks passthrough — the #487 hole stays shut |

Mounts without `user_auth_path` are unchanged: every extractor structurally
returns an empty user there.

## E2E — the gap that let this ship

`e2e/` had no git coverage at all, so the whole transport was untested. New
`e2e/githttp` package, in two tiers.

A recording upstream (`httptest`) reproduces the one behaviour the negotiation
depends on — an unauthenticated request gets a Basic challenge rather than a
response — and records what Warden forwarded. That is what proves the negative:
the user's own credential never proxies onward, and what reaches the upstream is
the credential Warden minted. Five scenarios: probe passthrough under a cert
agent, the authenticated retry, per-user audit attribution, the header-agent
challenge, and the off-user-leg compatibility case.

The second tier drives a real `git clone` against a real bare repository served by
`git-http-backend` via `net/http/cgi`. Every other test shapes the HTTP itself,
which pins what Warden does but cannot show that git accepts the exchange — and
git's reaction to the challenge is exactly what regressed.

No `docker-compose.yml` change: `deriveGitURL` passes non-GitHub URLs through
unchanged, so the mount points at a server in the test process, and the nodes run
as host processes and reach it directly. Plain http needs `tls_skip_verify` on
both the provider and the credential source.

Missing tooling skips locally but **fails under CI**. A silent skip there would
drop the only coverage of a real client acting on the challenge, recreating the
blind spot this package exists to close.

## Testing

Full unit suite green. Both production changes are mutation-verified at both
levels, and the two are pinned independently rather than one covering the other:

| Mutation | What fails |
|---|---|
| gate back to `!certIsAgent` | `TestGitProbePassesThroughUnderCertAgent`, plus the core gate subtest |
| challenge call removed | `TestGitHeaderAgentProbeIsChallenged` and `TestRealGitClone`, plus the core wiring test |

`TestRealGitClone` covers the challenge rather than the passthrough — it uses a
header agent, which the old gate never affected.

Live 3-node cluster: **18/18 e2e packages, 222 tests**, including all six here.
The one skip is pre-existing and environmental (nginx LB passthrough port).

## Also

The github and gitlab help text presented `https://<agent-role>:$USER_JWT@…` as
working unconditionally. It needs a 401 first, and git writes the remote verbatim
into `.git/config`, so that form persists a short-lived token in plaintext in
every clone. Replaced with the prompt-driven form, plus the credential-helper
caching hazard — a stale replay surfaces only as `Authentication failed`,
indistinguishable from a wrong credential.

`IsUnauthenticatedPath`'s contract now states the invariant the gate rests on: a
provider declaring unauthenticated paths must surface `Authorization`-borne user
credentials from `ExtractTokens`. Verified true for every current declarer; aws,
alicloud and dualgateway return no user but declare no such paths.
