### PR TITLE
fix(core): stop serving compiled policy from a stale cache

### DIFF
--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -47,11 +48,18 @@ func TestCBP_ConditionIsIdentityIndependent(t *testing.T) {
 	assert.False(t, cbp.AllowOperation(ctx, req, dev, false).Allowed)
 }
 
-// TestCBP_CompiledConditionCacheSharedAcrossCallers confirms a conditioned policy
-// set compiles once and the cached compiled CBP is reused across callers — the
-// compiled program is keyed by the policy set, not by any token identity (the
-// no-templated-policies invariant).
-func TestCBP_CompiledConditionCacheSharedAcrossCallers(t *testing.T) {
+// TestCBP_CompiledConditionSharedAcrossCallers confirms a conditioned policy is
+// parsed — and therefore its CEL program compiled — exactly once, and reused by
+// every caller. That reuse is what the no-templated-policies invariant buys: the
+// compiled program depends on the policy set alone, never on token identity, so
+// one copy can serve everyone.
+//
+// The CBP assembled from those policies is deliberately *not* shared. Building it
+// is microseconds, and a cache of assembled CBPs previously outlived the policy
+// it was built from, so a deleted grant went on being enforced. What must be
+// shared is the expensive part; what must be fresh is the part that has to
+// reflect the current policy.
+func TestCBP_CompiledConditionSharedAcrossCallers(t *testing.T) {
 	core := createTestCore(t)
 	ps := core.policyStore
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
@@ -66,7 +74,16 @@ func TestCBP_CompiledConditionCacheSharedAcrossCallers(t *testing.T) {
 	require.NoError(t, err)
 	second, err := ps.CBP(ctx, names)
 	require.NoError(t, err)
-	assert.Same(t, first, second, "same policy set → one cached compiled CBP, shared regardless of caller")
+
+	assert.NotSame(t, first, second, "each caller assembles its own CBP from the current policies")
+
+	// Both assemblies drew on the same parsed policy, which is what holds the
+	// compiled CEL program — so the condition was compiled once, not per call.
+	cached, ok := ps.tokenPoliciesLRU.Get(ps.cacheKey(namespace.RootNamespace, "cond"))
+	require.True(t, ok, "the parsed policy must stay cached")
+	require.Len(t, cached.Paths, 1)
+	assert.NotEmpty(t, cached.Paths[0].Permissions.Conditions,
+		"the cached policy carries the compiled condition shared by every caller")
 }
 
 // =============================================================================
@@ -1188,70 +1205,105 @@ func TestCBP_ParsesAdditionalPolicyWithoutPaths(t *testing.T) {
 }
 
 // =============================================================================
-// Compiled-CBP cache
+// CBP compilation is never served from a stale cache
 // =============================================================================
 
-// TestCBP_CompiledCacheHit verifies that compiling the same policy set twice
-// returns the cached compiled CBP (identical pointer) instead of recompiling.
-func TestCBP_CompiledCacheHit(t *testing.T) {
-	core := createTestCore(t)
-	ps := core.policyStore
-	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
-
-	p := testParsePolicy(t, `path "secret/a" { capabilities = ["read"] }`)
-	p.Name = "cached-set"
+// setStoredPolicy writes a policy under the given name and returns nothing —
+// the point is the side effect on the store, which is what these tests vary.
+func setStoredPolicy(t *testing.T, ps *PolicyStore, ctx context.Context, name, rules string) {
+	t.Helper()
+	p := testParsePolicy(t, rules)
+	p.Name = name
 	p.Type = PolicyTypeCBP
 	require.NoError(t, ps.SetPolicy(ctx, p, nil))
-
-	names := map[string][]string{namespace.RootNamespaceID: {"cached-set"}}
-	first, err := ps.CBP(ctx, names)
-	require.NoError(t, err)
-	second, err := ps.CBP(ctx, names)
-	require.NoError(t, err)
-
-	assert.Same(t, first, second, "identical policy set should return the cached compiled CBP")
 }
 
-// TestCBP_CompiledCacheInvalidatesOnVersionBump verifies that editing a policy
-// (which bumps its DataVersion) yields a new key, so the stale compiled CBP is
-// never served.
-func TestCBP_CompiledCacheInvalidatesOnVersionBump(t *testing.T) {
+// TestCBP_RecreatedPolicyIsEnforced is the regression test for a compiled-policy
+// cache that was keyed on policy identity and version. Deleting a policy resets
+// its version, so recreating it under the same name collided with the entry
+// compiled before the delete — and the deleted policy went on being enforced.
+//
+// The consequence was that removing a permission did not revoke it, while
+// reading the policy back returned the new text: the stored policy and the
+// enforced policy disagreed, and the API confirmed the operator's intent.
+func TestCBP_RecreatedPolicyIsEnforced(t *testing.T) {
 	core := createTestCore(t)
 	ps := core.policyStore
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
-	p := testParsePolicy(t, `path "secret/a" { capabilities = ["read"] }`)
-	p.Name = "versioned"
-	p.Type = PolicyTypeCBP
-	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+	names := map[string][]string{namespace.RootNamespaceID: {"recreated"}}
 
-	names := map[string][]string{namespace.RootNamespaceID: {"versioned"}}
+	setStoredPolicy(t, ps, ctx, "recreated", `path "secret/old" { capabilities = ["read"] }`)
 	first, err := ps.CBP(ctx, names)
 	require.NoError(t, err)
-	assert.Contains(t, first.Capabilities(ctx, "secret/a"), ReadCapability)
+	require.Contains(t, first.Capabilities(ctx, "secret/old"), ReadCapability)
 
-	// Edit the policy: now grants secret/b instead. SetPolicy bumps DataVersion.
-	updated := testParsePolicy(t, `path "secret/b" { capabilities = ["read"] }`)
-	updated.Name = "versioned"
-	updated.Type = PolicyTypeCBP
-	require.NoError(t, ps.SetPolicy(ctx, updated, nil))
+	// Delete and recreate under the same name with a different grant. The
+	// version counter restarts here, which is what made the old key collide.
+	require.NoError(t, ps.DeletePolicy(ctx, "recreated", PolicyTypeCBP))
+	setStoredPolicy(t, ps, ctx, "recreated", `path "secret/new" { capabilities = ["read"] }`)
 
 	second, err := ps.CBP(ctx, names)
 	require.NoError(t, err)
-	assert.NotSame(t, first, second, "version bump must recompile")
+	assert.Contains(t, second.Capabilities(ctx, "secret/new"), ReadCapability,
+		"the recreated policy must be the one enforced")
+	assert.NotContains(t, second.Capabilities(ctx, "secret/old"), ReadCapability,
+		"the deleted policy's grant must not survive its deletion")
+}
+
+// TestCBP_DeletedPolicyIsNotEnforced covers the plainer half: a deletion with no
+// replacement. The policy simply leaves the set, and nothing it granted remains.
+func TestCBP_DeletedPolicyIsNotEnforced(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	setStoredPolicy(t, ps, ctx, "keeper", `path "secret/keep" { capabilities = ["read"] }`)
+	setStoredPolicy(t, ps, ctx, "goner", `path "secret/gone" { capabilities = ["read"] }`)
+
+	names := map[string][]string{namespace.RootNamespaceID: {"keeper", "goner"}}
+	before, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	require.Contains(t, before.Capabilities(ctx, "secret/gone"), ReadCapability)
+
+	require.NoError(t, ps.DeletePolicy(ctx, "goner", PolicyTypeCBP))
+
+	after, err := ps.CBP(ctx, map[string][]string{namespace.RootNamespaceID: {"keeper"}})
+	require.NoError(t, err)
+	assert.Contains(t, after.Capabilities(ctx, "secret/keep"), ReadCapability)
+	assert.NotContains(t, after.Capabilities(ctx, "secret/gone"), ReadCapability)
+}
+
+// TestCBP_EditedPolicyIsEnforced pins the case that always worked, so a
+// regression in the ordinary edit path is not mistaken for the delete-recreate
+// bug returning.
+func TestCBP_EditedPolicyIsEnforced(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	names := map[string][]string{namespace.RootNamespaceID: {"edited"}}
+
+	setStoredPolicy(t, ps, ctx, "edited", `path "secret/a" { capabilities = ["read"] }`)
+	_, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+
+	setStoredPolicy(t, ps, ctx, "edited", `path "secret/b" { capabilities = ["read"] }`)
+	second, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+
 	assert.Contains(t, second.Capabilities(ctx, "secret/b"), ReadCapability)
 	assert.NotContains(t, second.Capabilities(ctx, "secret/a"), ReadCapability)
 }
 
-// TestCBP_CompiledCacheExpiresWithPath verifies that a per-path expiration
-// bounds the cached compiled CBP: once it elapses the entry is recompiled and
-// the expired path is dropped.
-func TestCBP_CompiledCacheExpiresWithPath(t *testing.T) {
+// TestCBP_ExpiredPathIsDropped verifies a per-path expiration takes effect. This
+// was previously entangled with a cache time-bound; without the cache it is just
+// a property of compilation, which is where it belonged.
+func TestCBP_ExpiredPathIsDropped(t *testing.T) {
 	core := createTestCore(t)
 	ps := core.policyStore
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
-	exp := time.Now().Add(50 * time.Millisecond)
 	p := &Policy{
 		Name:      "expiring",
 		Type:      PolicyTypeCBP,
@@ -1260,68 +1312,35 @@ func TestCBP_CompiledCacheExpiresWithPath(t *testing.T) {
 			Path:         "secret/temp",
 			Capabilities: []string{ReadCapability},
 			Permissions:  &CBPPermissions{CapabilitiesBitmap: ReadCapabilityInt},
-			Expiration:   exp,
+			Expiration:   time.Now().Add(50 * time.Millisecond),
 		}},
 	}
-	idx := ps.cacheKey(namespace.RootNamespace, "expiring")
-	ps.tokenPoliciesLRU.Add(idx, p)
+	ps.tokenPoliciesLRU.Add(ps.cacheKey(namespace.RootNamespace, "expiring"), p)
 
 	names := map[string][]string{namespace.RootNamespaceID: {"expiring"}}
 	first, err := ps.CBP(ctx, names)
 	require.NoError(t, err)
-	assert.Contains(t, first.Capabilities(ctx, "secret/temp"), ReadCapability)
+	require.Contains(t, first.Capabilities(ctx, "secret/temp"), ReadCapability)
 
-	// The cached entry must carry a time bound derived from the path expiration.
-	entry, ok := ps.compiledCBPLRU.Get(compiledCBPCacheKey([]*Policy{p}))
-	require.True(t, ok)
-	assert.False(t, entry.validUntil.IsZero(), "entry should carry a validUntil bound")
-
-	// After the path expires, the entry is recompiled and the path is gone.
 	time.Sleep(80 * time.Millisecond)
+
 	second, err := ps.CBP(ctx, names)
 	require.NoError(t, err)
-	assert.NotSame(t, first, second, "expired entry must be recompiled")
 	assert.NotContains(t, second.Capabilities(ctx, "secret/temp"), ReadCapability,
-		"expired path must be dropped after recompile")
+		"an expired path must not be granted")
 }
 
-// TestCBP_CompiledCacheBypassedWithAdditionalPolicies verifies that prefetched
-// policies bypass the compiled cache entirely (no sharing, no caching).
-func TestCBP_CompiledCacheBypassedWithAdditionalPolicies(t *testing.T) {
+// TestCBP_ConcurrentCompilation exercises compilation and evaluation from many
+// goroutines at once, under the race detector.
+func TestCBP_ConcurrentCompilation(t *testing.T) {
 	core := createTestCore(t)
 	ps := core.policyStore
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
-	extra := &Policy{
-		Name:      "prefetched",
-		Type:      PolicyTypeCBP,
-		Raw:       `path "secret/extra" { capabilities = ["read"] }`,
-		namespace: namespace.RootNamespace,
-	}
-
-	first, err := ps.CBP(ctx, map[string][]string{}, extra)
-	require.NoError(t, err)
-	second, err := ps.CBP(ctx, map[string][]string{}, extra)
-	require.NoError(t, err)
-
-	assert.NotSame(t, first, second, "additional policies must bypass the compiled cache")
-	assert.Equal(t, 0, ps.compiledCBPLRU.Len(), "nothing should be cached when additional policies are present")
-}
-
-// TestCBP_CompiledCacheConcurrent exercises concurrent CBP() compilation and
-// evaluation of a shared cached CBP under the race detector.
-func TestCBP_CompiledCacheConcurrent(t *testing.T) {
-	core := createTestCore(t)
-	ps := core.policyStore
-	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
-
-	p := testParsePolicy(t, `
+	setStoredPolicy(t, ps, ctx, "concurrent", `
 		path "secret/a" { capabilities = ["read", "list"] }
 		path "secret/b/*" { capabilities = ["read"] }
 	`)
-	p.Name = "concurrent"
-	p.Type = PolicyTypeCBP
-	require.NoError(t, ps.SetPolicy(ctx, p, nil))
 
 	names := map[string][]string{namespace.RootNamespaceID: {"concurrent"}}
 
@@ -1341,4 +1360,40 @@ func TestCBP_CompiledCacheConcurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// BenchmarkNewCBP measures what a compiled-CBP cache would save. It is kept so
+// the next person to propose one has the number: a cache here previously cost a
+// revocation bug, and the work it avoided is small enough to be noise beside the
+// credential mint and upstream round trip on the same request.
+func BenchmarkNewCBP(b *testing.B) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	rules := `
+path "prov/gateway*" {
+  capabilities = ["read","create","update","delete","list"]
+}
+path "prov/role/+/gateway*" {
+  capabilities = ["read","create","update","delete","list"]
+}
+path "other/*" { capabilities = ["read"] }
+`
+	for _, n := range []int{1, 3} {
+		policies := make([]*Policy, 0, n)
+		for i := 0; i < n; i++ {
+			p, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+			if err != nil {
+				b.Fatal(err)
+			}
+			p.Name = fmt.Sprintf("p%d", i)
+			policies = append(policies, p)
+		}
+		b.Run(fmt.Sprintf("%d-policies", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := NewCBP(ctx, policies); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -1397,3 +1397,62 @@ path "other/*" { capabilities = ["read"] }
 		})
 	}
 }
+
+// TestCBP_CompilationIsOrderIndependent pins that a token's policies compile to
+// the same result however they were gathered.
+//
+// Compilation is not commutative: for a given path, the first policy carrying a
+// list_scan_response_keys_filter_path wins. Policies are gathered by ranging a
+// map keyed by namespace, so when a token draws policies from more than one
+// namespace their relative order is randomised per call — and two policies
+// disagreeing on that field would otherwise yield a different filter from one
+// request to the next.
+//
+// Within a single namespace the order comes from a slice and is already stable,
+// which is why this test spans two.
+func TestCBP_CompilationIsOrderIndependent(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	rootCtx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	otherNS := &namespace.Namespace{Path: "other/"}
+	require.NoError(t, core.namespaceStore.SetNamespace(rootCtx, otherNS))
+	otherCtx := namespace.ContextWithNamespace(context.Background(), otherNS)
+
+	filterPolicy := func(which string) string {
+		return `
+path "secret/shared" {
+  capabilities = ["list"]
+  list_scan_response_keys_filter_path = "secret/from-` + which + `/{{ .key }}"
+}`
+	}
+
+	// One policy per namespace, disagreeing on the filter for the same path.
+	setStoredPolicy(t, ps, rootCtx, "filter-root", filterPolicy("root"))
+
+	otherPolicy := testParsePolicy(t, filterPolicy("other"))
+	otherPolicy.Name = "filter-other"
+	otherPolicy.Type = PolicyTypeCBP
+	otherPolicy.namespace = otherNS
+	require.NoError(t, ps.SetPolicy(otherCtx, otherPolicy, nil))
+
+	names := map[string][]string{
+		namespace.RootNamespaceID: {"filter-root"},
+		otherNS.ID:                {"filter-other"},
+	}
+
+	// Repeat: an order-dependent result shows up as disagreement across runs,
+	// since the map range that gathers these is randomised each time.
+	seen := map[string]int{}
+	for i := 0; i < 64; i++ {
+		cbp, err := ps.CBP(rootCtx, names)
+		require.NoError(t, err)
+		res := cbp.AllowOperation(rootCtx,
+			&logical.Request{Operation: logical.ListOperation, Path: "secret/shared"}, nil, false)
+		require.True(t, res.Allowed, "the shared path must be listable")
+		seen[res.ResponseKeysFilterPath]++
+	}
+
+	assert.Len(t, seen, 1,
+		"the filter path must not depend on the order policies were gathered in, got %v", seen)
+}

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -27,15 +27,6 @@ const (
 
 	// policyCacheSize is the number of policies that are kept cached
 	policyCacheSize = 1024
-
-	// compiledCBPCacheSize is the number of compiled CBP objects kept cached.
-	// Unlike the policy cache, which is keyed per individual policy (bounded by
-	// how many policies are authored), this cache is keyed per policy SET — the
-	// sorted tuple of all policies a token carries. Distinct policy-set ×
-	// version combinations are combinatorial and typically outnumber distinct
-	// policies, so it is sized larger. Correctness never depends on the size: a
-	// miss simply recompiles, so this is purely a hit-rate tuning knob.
-	compiledCBPCacheSize = 4096
 )
 
 var (
@@ -50,28 +41,24 @@ var (
 type PolicyStore struct {
 	core *Core
 
+	// tokenPoliciesLRU caches parsed policies by namespace and name. Parsing is
+	// the expensive step — it compiles every CEL condition — and this cache is
+	// kept correct by explicit maintenance: a write replaces the entry, a delete
+	// removes it.
+	//
+	// Compiled CBPs are deliberately NOT cached. Building one from already-parsed
+	// policies costs single-digit microseconds (see BenchmarkNewCBP), which is
+	// noise beside the credential mint and upstream round trip on the same
+	// request. A cache keyed on policy identity previously served a compiled CBP
+	// belonging to a policy that had since been deleted and recreated, so
+	// removing a permission did not revoke it. Any future cache here must be keyed
+	// so that no sequence of writes and deletes can produce a stale hit — content,
+	// not identity — and must carry a benchmark showing it earns that risk.
 	tokenPoliciesLRU *lru.TwoQueueCache[string, *Policy]
-
-	// compiledCBPLRU caches compiled CBP objects keyed by the policy set they
-	// were built from (see compiledCBPCacheKey). A policy edit bumps its
-	// DataVersion, which changes the key, so stale entries are never served and
-	// age out via the LRU. Entries also carry a time-validity bound to honour
-	// per-path expirations (see compiledCBPEntry).
-	compiledCBPLRU *lru.TwoQueueCache[string, *compiledCBPEntry]
 
 	modifyLock *sync.RWMutex
 
 	logger *logger.GatedLogger
-}
-
-// compiledCBPEntry is a cached compiled CBP together with the instant after
-// which it must be recomputed. validUntil is the earliest future per-path
-// expiration across the policy set; a zero value means no path expires, so the
-// entry never times out (it can still be evicted by the LRU or superseded by a
-// version bump).
-type compiledCBPEntry struct {
-	cbp        *CBP
-	validUntil time.Time
 }
 
 // PolicyEntry is used to store a policy by name
@@ -96,9 +83,6 @@ func NewPolicyStore(ctx context.Context, core *Core, logger *logger.GatedLogger)
 
 	cache, _ := lru.New2Q[string, *Policy](policyCacheSize)
 	ps.tokenPoliciesLRU = cache
-
-	compiledCache, _ := lru.New2Q[string, *compiledCBPEntry](compiledCBPCacheSize)
-	ps.compiledCBPLRU = compiledCache
 
 	return ps, nil
 }
@@ -561,83 +545,15 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 		}
 	}
 
-	// Serve a previously compiled CBP when the exact same policy set (by name
-	// and version) was already compiled. Prefetched policies are not keyed from
-	// storage and may be ephemeral, so the cache is bypassed when any are given.
-	cacheable := len(additionalPolicies) == 0 && ps.compiledCBPLRU != nil
-	var cacheKey string
-	if cacheable {
-		cacheKey = compiledCBPCacheKey(allPolicies)
-		if entry, ok := ps.compiledCBPLRU.Get(cacheKey); ok {
-			if entry.validUntil.IsZero() || time.Now().Before(entry.validUntil) {
-				return entry.cbp, nil
-			}
-			// A per-path expiration has elapsed; drop and recompile.
-			ps.compiledCBPLRU.Remove(cacheKey)
-		}
-	}
-
-	// Construct the CBP
+	// Compiled fresh every time. The policies themselves come from a cache; only
+	// the assembly is repeated, and it is cheap enough that caching it bought
+	// less than the staleness it risked.
 	cbp, err := NewCBP(ctx, allPolicies)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct CBP: %w", err)
 	}
 
-	if cacheable {
-		ps.compiledCBPLRU.Add(cacheKey, &compiledCBPEntry{
-			cbp:        cbp,
-			validUntil: earliestPathExpiration(allPolicies),
-		})
-	}
-
 	return cbp, nil
-}
-
-// compiledCBPCacheKey builds a stable, order-independent key identifying a
-// policy set. Each policy contributes its namespace, name, data version, and
-// policy-level expiration; a version bump therefore yields a new key so edits
-// are never served from a stale compiled CBP. Per-path expirations are not part
-// of the key (they are time-driven, not version-driven) and are handled via the
-// entry's validUntil bound instead.
-func compiledCBPCacheKey(policies []*Policy) string {
-	tuples := make([]string, 0, len(policies))
-	for _, p := range policies {
-		if p == nil {
-			continue
-		}
-		nsUUID := ""
-		if p.namespace != nil {
-			nsUUID = p.namespace.UUID
-		}
-		tuples = append(tuples, fmt.Sprintf("%s\x1f%s\x1f%d\x1f%d",
-			nsUUID, p.Name, p.DataVersion, p.Expiration.Unix()))
-	}
-	slices.Sort(tuples)
-	return strings.Join(tuples, "\x1e")
-}
-
-// earliestPathExpiration returns the soonest future per-path expiration across
-// the policy set, which bounds how long a compiled CBP stays valid (NewCBP
-// drops already-expired paths at compile time). Already-elapsed expirations are
-// ignored. A zero return means no path expires, so the compiled CBP has no time
-// bound.
-func earliestPathExpiration(policies []*Policy) time.Time {
-	now := time.Now()
-	var earliest time.Time
-	for _, p := range policies {
-		if p == nil {
-			continue
-		}
-		for _, pc := range p.Paths {
-			if pc.Expiration.IsZero() || !pc.Expiration.After(now) {
-				continue
-			}
-			if earliest.IsZero() || pc.Expiration.Before(earliest) {
-				earliest = pc.Expiration
-			}
-		}
-	}
-	return earliest
 }
 
 // loadCBPPolicy is used to load default CBP policies in a specific

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -501,6 +501,15 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 	return nil
 }
 
+// policyNamespaceUUID returns a policy's namespace UUID, or "" when it carries
+// no namespace, so ordering stays total over a mixed set.
+func policyNamespaceUUID(p *Policy) string {
+	if p == nil || p.namespace == nil {
+		return ""
+	}
+	return p.namespace.UUID
+}
+
 // CBP is used to return an CBP which is built using the
 // named policies and pre-fetched policies if given.
 func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string, additionalPolicies ...*Policy) (*CBP, error) {
@@ -527,7 +536,22 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 		}
 	}
 
-	// Append any pre-fetched policies that were given
+	// Order the named policies before anything depends on their sequence. They
+	// were gathered by ranging a map, so their order is randomised per call, and
+	// compilation is not order-independent: the first policy carrying a
+	// list_scan_response_keys_filter_path for a path wins. Left unordered, a
+	// token whose policies disagree on that field would get a different filter
+	// from one request to the next.
+	slices.SortFunc(allPolicies, func(a, b *Policy) int {
+		if c := strings.Compare(policyNamespaceUUID(a), policyNamespaceUUID(b)); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// Pre-fetched policies keep their caller-given order, appended after the
+	// named ones. The caller chose that sequence; sorting it would be discarding
+	// information rather than adding determinism.
 	allPolicies = append(allPolicies, additionalPolicies...)
 
 	for i, policy := range allPolicies {


### PR DESCRIPTION
Removing a permission did not revoke it.

## The bug

Compiled CBPs were cached under a key of namespace, policy name, `DataVersion`
and expiration. That key identifies a policy set by identity and version, and
rests on versions never repeating — but deleting a policy resets its version to
1. Recreating one under the same name therefore collided with whatever had been
compiled at that version before, and the cached compilation won.

Measured on a mount whose policy names one allowed and one denied tool:

| `DataVersion` | Policy grants | `allowed_tool` | `denied_tool` |
|---|---|---|---|
| 7 (fresh) | allowed | 200 | 403 ✅ |
| 8 (fresh) | denied | 403 | 200 ✅ |
| 1 (recreated) | denied | **200** | **403** ❌ |

Reading the policy back returned the new text while the deleted policy stayed in
force, so the stored and enforced policies disagreed and the API confirmed the
operator's intent either way. It persisted until the entry fell out of a
4096-entry LRU or the node restarted.

## The fix

Removes the cache rather than re-keying it.

Assembling a CBP from policies that are already parsed costs 2.2µs for one
policy and 5.0µs for three — noise beside the credential mint and upstream round
trip on the same request. The expensive step is parsing, which compiles every CEL
condition, and that stays cached in `tokenPoliciesLRU`, kept correct by explicit
maintenance: a write replaces the entry, a delete removes it. That is also the
shape upstream settled on, which builds its ACL fresh per request and caches only
parsed policies.

Content-addressing the key was the alternative. It would have worked, but it
keeps a mechanism whose correctness depends on getting invalidation right, in
exchange for microseconds — and it carried its own hazards: a hash weak or
truncated enough to collide would let a policy author make the API report a
tightened policy while the permissive one is enforced. Removing the cache retires
the whole class. The benchmark stays in the tree so the next proposal has the
number.

## Second commit: policy ordering

Removing the cache exposed a second defect it had been masking.

Compilation is not commutative: for a given path, the first policy carrying a
`list_scan_response_keys_filter_path` wins. Policies were gathered by ranging a
map keyed by namespace, so a token drawing policies from more than one namespace
got them in a random order, and two policies disagreeing on that field yielded a
different filter from one request to the next. The cache had frozen whichever
ordering compiled first, turning a per-request coin flip into one stable wrong
answer per policy set.

Within a single namespace the order comes from a slice and was already stable,
which is why this went unnoticed. The new test spans two namespaces to reach the
randomised path, and fails on every run without the sort.

## Tests

`core/policy_cbp_test.go` replaces the cache-behaviour tests with tests of the
property the cache was supposed to preserve:

- `TestCBP_RecreatedPolicyIsEnforced` — the regression above
- `TestCBP_DeletedPolicyIsNotEnforced`
- `TestCBP_EditedPolicyIsEnforced`
- `TestCBP_ExpiredPathIsDropped`
- `TestCBP_ConcurrentCompilation`
- `TestCBP_CompilationIsOrderIndependent` — two namespaces
- `BenchmarkNewCBP`

## Found by

Mutation-testing the full-chain e2e suite. It also explains why a suite that
recreates policies under fixed names could assert against a previous run's state.
