### PR TITLE
test(e2e): full-chain provider coverage across both extractor ends

### DIFF
--- a/e2e/fullchain/anthropic_test.go
+++ b/e2e/fullchain/anthropic_test.go
@@ -1,0 +1,106 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// anthropic stands for the channels token extractor in its ordinary order:
+// X-Warden-Token first, then the native x-api-key header. Outbound it is the
+// case where the credential lands in a custom header while a static default
+// header is applied as well.
+
+// No vendor prefix — see the note in openai_test.go.
+const anthropicKey = "fc-anthropic-not-a-real-key"
+
+var anthropicEnv = h.ProviderEnv{
+	Mount:      "fc-anthropic",
+	Type:       "anthropic",
+	URLKey:     "anthropic_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": anthropicKey},
+}
+
+// TestAnthropic_DefaultHeaderCoexistsWithCredential guards an ordering hazard:
+// the provider's static headers are applied after the credential headers, so a
+// static header whose name collided with a credential header would silently
+// overwrite the credential. Nothing collides today; this is what would notice if
+// something started to.
+func TestAnthropic_DefaultHeaderCoexistsWithCredential(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, anthropicEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         anthropicEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		Injected: map[string]string{
+			"x-api-key":         anthropicKey,
+			"anthropic-version": "2023-06-01",
+		},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestAnthropic_OperatorTokenOutranksNativeChannel is the mirror of
+// TestNewRelic_NativeChannelOutranksOperatorToken, and the reason both exist:
+// anthropic consults X-Warden-Token *first* and x-api-key second, so the same
+// pair of headers resolves the other way round. See that test for why neither
+// request can succeed and why the failure shape is the observable.
+//
+// Here the operator token wins the agent slot. It resolves, so the request gets
+// as far as the mint and dies there for want of a bound credential spec — a 400,
+// where newrelic's unresolvable JWT produces a 403.
+func TestAnthropic_OperatorTokenOutranksNativeChannel(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, anthropicEnv)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, anthropicEnv, h.ChainOpts{
+		WardenToken: h.RootToken(t),
+		Role:        anthropicEnv.JWTAgentRole(),
+		Headers:     map[string]string{"x-api-key": h.GetDefaultJWT(t)},
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        400,
+		UpstreamCalls: 0,
+	})
+	// The operator token got far enough to be resolved — which is what says it,
+	// and not the x-api-key JWT, occupied the agent slot.
+	if !strings.Contains(string(body), "credential spec") {
+		t.Errorf("want the mint to fail for a missing credential spec, got: %s", body)
+	}
+}
+
+// TestAnthropic_NativeChannelCarriesAgent puts the agent in the native channel
+// rather than a certificate. x-api-key is consulted second, after
+// X-Warden-Token, and unlike X-Warden-Token it leaves the user slot open — so
+// both principals resolve from a request carrying no certificate at all.
+func TestAnthropic_NativeChannelCarriesAgent(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, anthropicEnv)
+
+	probe := h.ProbePath("anthropic-native-channel")
+	status, body, _ := h.ChainRequest(t, leaderPort, anthropicEnv, h.ChainOpts{
+		Bearer:  h.FullChainUserJWT(t),
+		Role:    anthropicEnv.JWTAgentRole(),
+		Headers: map[string]string{"x-api-key": h.GetDefaultJWT(t)},
+		Path:    probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"x-api-key": anthropicKey},
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}

--- a/e2e/fullchain/chain_test.go
+++ b/e2e/fullchain/chain_test.go
@@ -1,0 +1,295 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The rows here are provider-independent: they check the chain itself rather
+// than any one extractor. Where a single carrier is needed they use openai for
+// the plain cases and newrelic where the assertion depends on the credential
+// landing somewhere other than Authorization. Per-provider behaviour lives in
+// the file named for that provider.
+
+// injection is what a provider's credential extractor must have produced.
+type injection struct {
+	env  h.ProviderEnv
+	want map[string]string
+}
+
+// injections pins one positive credential-extractor branch per provider. The
+// header names differ by provider by design: that difference is most of what the
+// credential extractors do.
+var injections = []injection{
+	{openaiEnv, map[string]string{"Authorization": "Bearer " + openaiKey}},
+	{anthropicEnv, map[string]string{"x-api-key": anthropicKey}},
+	{newrelicEnv, map[string]string{"Api-Key": newrelicKey}},
+	{elasticEnv, map[string]string{"Authorization": "ApiKey " + elasticKey}},
+}
+
+// TestFullChain_CertAgentWithUser is the reference shape the suite exists for:
+// the agent arrives out of band as a certificate, leaving Authorization free to
+// carry a user. Both principals resolve, the minted credential goes upstream,
+// and neither inbound credential does.
+func TestFullChain_CertAgentWithUser(t *testing.T) {
+	ensureEnv(t)
+
+	for _, tc := range injections {
+		t.Run(tc.env.Mount, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, tc.env, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.env.CertRole(),
+				// Sent so the AlwaysAbsent entries for them are load-bearing: a
+				// header the request never carried is trivially absent upstream,
+				// and would stay absent however broken the strip list became.
+				Headers: h.InertDecoyHeaders(),
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      tc.want,
+				Absent:        h.AlwaysAbsent(),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}
+
+// TestFullChain_UserIsAttributedInAudit proves the Bearer credential was
+// captured as a user principal rather than silently ignored. Without this, a
+// provider that dropped the user entirely would still pass every header
+// assertion above.
+func TestFullChain_UserIsAttributedInAudit(t *testing.T) {
+	ensureEnv(t)
+
+	probe := h.ProbePath("audit-user")
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         openaiEnv.CertRole(),
+		Path:         probe,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + openaiKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}
+
+// TestFullChain_AgentOnlyCapturesNoUser is the counterpart: with no
+// Authorization at all the request still succeeds, and must not acquire a user
+// principal from anywhere. An agent-only request that picked one up would
+// attribute actions to someone who never made them.
+func TestFullChain_AgentOnlyCapturesNoUser(t *testing.T) {
+	ensureEnv(t)
+
+	probe := h.ProbePath("audit-agent-only")
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Role:         openaiEnv.CertRole(),
+		Path:         probe,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + openaiKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	h.AssertAuditUser(t, leaderPort, probe, "")
+}
+
+// TestFullChain_AgentTokenHeaderWithUser covers the dedicated agent channel. It
+// exists so an agent that cannot present a certificate still leaves
+// Authorization free for the user, and it deliberately outranks a certificate —
+// a sidecar makes a certificate present on nearly every request, so letting the
+// certificate win would make the explicit channel unusable.
+//
+// The certificate is sent precisely because it must lose. The mount's agent leg
+// is bearer-only here, so if the certificate were consulted first the extractor
+// would yield an empty agent and the certificate login would fail against a JWT
+// mount — the 200 below is what pins the ordering. Without the certificate the
+// test would show only that the channel works in isolation.
+func TestFullChain_AgentTokenHeaderWithUser(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, openaiEnv)
+
+	probe := h.ProbePath("agent-token-header")
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		AgentToken:   h.GetDefaultJWT(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         openaiEnv.JWTAgentRole(),
+		Path:         probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + openaiKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}
+
+// TestFullChain_AuthorizationNeverReachesUpstream checks that a user credential
+// never proxies onward, with and without a user present.
+//
+// It covers the guarantee, not both implementations of it. Two layers remove the
+// header — core deletes it once a user is captured, and this provider's strip
+// list removes it unconditionally — and the second masks the first: deleting
+// core's Del would not fail either subtest, because the strip list still catches
+// it. Core's layer is only observable where no strip list applies (streaming and
+// git paths), and is pinned at unit level in core/request_handler_user_test.go.
+// Do not read a pass here as covering it.
+//
+// newrelic is the carrier because it injects into Api-Key, leaving Authorization
+// untouched by the credential extractor — so whatever arrives there arrived by
+// leak rather than by injection overwriting the evidence.
+func TestFullChain_AuthorizationNeverReachesUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	cases := []struct {
+		name     string
+		withUser bool
+	}{
+		{"user captured", true},
+		{"no user", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			opts := h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Role:         newrelicEnv.CertRole(),
+			}
+			if tc.withUser {
+				opts.Bearer = h.FullChainUserJWT(t)
+			}
+
+			status, body, _ := h.ChainRequest(t, leaderPort, newrelicEnv, opts)
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      map[string]string{"Api-Key": newrelicKey},
+				Absent:        h.AlwaysAbsent("Authorization"),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}
+
+// TestFullChain_OperatorTokenPlusUserIsRejected pins the gate that fires before
+// any token extractor runs. The operator credential carries no user principal,
+// so combining it with an Authorization credential on a mount that expects one
+// is ambiguous rather than merely unusual — and it is refused as a request
+// error, not silently resolved one way.
+func TestFullChain_OperatorTokenPlusUserIsRejected(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		WardenToken: h.RootToken(t),
+		Bearer:      h.FullChainUserJWT(t),
+		Role:        openaiEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        400,
+		UpstreamCalls: 0,
+	})
+	// The message must name the way out, or the caller has a rejection with no
+	// remedy.
+	if !strings.Contains(string(body), "X-Warden-Agent-Token") {
+		t.Errorf("rejection should name X-Warden-Agent-Token as the fix, got: %s", body)
+	}
+}
+
+// TestFullChain_NonOptedInMountIsUnaffected is the control for the test above.
+// The same header combination on a mount without a user leg must not be
+// rejected as ambiguous: there is no second principal to be ambiguous about, and
+// the pre-existing single-principal behaviour has to survive the feature. Without
+// this, a 400 raised for some unrelated reason would look like the gate working.
+func TestFullChain_NonOptedInMountIsUnaffected(t *testing.T) {
+	ensureEnv(t)
+
+	h.SetFullChainLegs(t, leaderPort, upstream.URL, anthropicEnv, h.CertAgentPath, "")
+	t.Cleanup(func() { h.ResetFullChainLegs(t, leaderPort, upstream.URL, anthropicEnv) })
+
+	status, body, _ := h.ChainRequest(t, leaderPort, anthropicEnv, h.ChainOpts{
+		WardenToken: h.RootToken(t),
+		Bearer:      h.FullChainUserJWT(t),
+		Role:        anthropicEnv.CertRole(),
+	})
+
+	// The request still fails, but further along and for an unrelated reason: an
+	// operator token binds no credential spec, so there is nothing to mint.
+	//
+	// That failure is also a 400 — the same status the ambiguity gate returns —
+	// so the status alone cannot tell the two apart and the body has to. Both
+	// halves are needed: the positive check proves the request reached the mint,
+	// which it could only do by passing the gate, and the negative check proves
+	// the gate did not fire on the way. Asserting only the negative would let
+	// anything that failed earlier pass as if the gate had stayed quiet.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        400,
+		UpstreamCalls: 0,
+	})
+	if !strings.Contains(string(body), "credential spec") {
+		t.Errorf("request did not reach the mint, so it proves nothing about the gate: %s", body)
+	}
+	if strings.Contains(string(body), "X-Warden-Agent-Token") {
+		t.Errorf("mount without a user leg raised the ambiguity error: %s", body)
+	}
+}
+
+// TestFullChain_PolicyDenialStopsBeforeUpstream checks that authorization is
+// decided before forwarding. The role authenticates and mints exactly as the
+// allowed one does; only its policy differs — so a request that reached the
+// upstream anyway would have leaked the credential on a denied call.
+func TestFullChain_PolicyDenialStopsBeforeUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         openaiEnv.DenyRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        403,
+		UpstreamCalls: 0,
+	})
+}
+
+// TestFullChain_UntrustedAgentCertIsRejected mints a well-formed certificate
+// from a CA the auth mount does not trust. It fails as an agent, and nothing is
+// forwarded.
+func TestFullChain_UntrustedAgentCertIsRejected(t *testing.T) {
+	ensureEnv(t)
+
+	otherCAPEM, otherCAKey := h.GenerateTestCA(t)
+	rogueCert, _ := h.GenerateClientCert(t, otherCAPEM, otherCAKey, h.FullChainAgentCN)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: rogueCert,
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         openaiEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        401,
+		UpstreamCalls: 0,
+	})
+}

--- a/e2e/fullchain/elastic_test.go
+++ b/e2e/fullchain/elastic_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/base64"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// elastic is scheme dispatch: its own agent credential rides Authorization under
+// the native ApiKey scheme, so agent and user can share the header only by
+// dispatching on which scheme is present. It is the one provider where a user
+// credential is sometimes structurally impossible rather than merely absent.
+
+// The credential is the base64 id:key pair the cluster issued, and the extractor
+// must pass it through rather than encode it again — so the value has to be
+// genuinely encoded, not merely opaque.
+//
+// Assembled rather than written out. A literal base64 blob of this length reads
+// as a real credential to a secret scanner however synthetic its contents, and
+// unlike the other providers here the encoding means a reviewer cannot see at a
+// glance that it is fake.
+var elasticKey = base64.StdEncoding.EncodeToString([]byte("fc-elastic-id:fc-elastic-not-a-real-secret"))
+
+var elasticEnv = h.ProviderEnv{
+	Mount:      "fc-elastic",
+	Type:       "elastic",
+	URLKey:     "elastic_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": elasticKey},
+}
+
+// TestElastic_NativeSchemeClaimsAgentSlotAndLeavesNoUser is the row elastic is
+// here for. When the agent arrives under the ApiKey scheme the header is spoken
+// for, and the request succeeds with an agent and no user rather than misreading
+// the agent as one.
+//
+// A certificate is presented deliberately and must change nothing, which is what
+// makes this row discriminating: the scheme is checked before the out-of-band
+// agent, so the certificate is never consulted. Were the order reversed the
+// extractor would yield an empty agent, the certificate login would be attempted
+// against the bearer-only agent leg this test repoints to, and the request would
+// 401 instead of succeeding.
+//
+// The contrasting shape — certificate as agent, plain Bearer as user, and a user
+// duly captured — is TestFullChain_CertAgentWithUser/fc-elastic. Note it differs
+// in the agent leg as well as the scheme, so the pair brackets the behaviour
+// rather than isolating a single variable.
+func TestElastic_NativeSchemeClaimsAgentSlotAndLeavesNoUser(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, elasticEnv)
+
+	probe := h.ProbePath("elastic-native-scheme")
+	status, body, _ := h.ChainRequest(t, leaderPort, elasticEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		RawAuthz:     "ApiKey " + h.GetDefaultJWT(t),
+		Role:         elasticEnv.JWTAgentRole(),
+		Path:         probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "ApiKey " + elasticKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+	h.AssertAuditUser(t, leaderPort, probe, "")
+}

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"crypto/ecdsa"
+	"os"
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// Each test in this package drives one request through the whole chain — token
+// extraction, role resolution, policy, mint, credential injection — and checks
+// both ends against a recording upstream.
+//
+// Layout: one file per provider, holding that provider's environment, its
+// credential constants and the rows that exist because of how *it* behaves.
+// chain_test.go holds the provider-independent rows. Adding a provider is
+// therefore a new file plus one line in allEnvs.
+//
+// The environment is built once for the package rather than per test: setup
+// mounts two auth methods and, for each provider, a mount, a credential source,
+// one or more specs, policies and roles. Per-test setup would dominate the
+// runtime — and a test that failed mid-setup would leave mounts behind, turning
+// one real failure into a cascade of 409s that hides it.
+//
+// Setup runs under sync.Once from the first test rather than from TestMain,
+// because the helpers report failure with t.Fatalf: a zero-value testing.T
+// cannot be used there, since Fatalf calls runtime.Goexit and deadlocks the
+// process outside a test goroutine. Teardown has no such constraint.
+
+// allEnvs is every provider the package sets up, in setup and teardown order.
+// Between them they cover each token-extractor family — default, channels,
+// channels with the native header first, and scheme dispatch — and four
+// different credential extractors.
+var allEnvs = []h.ProviderEnv{openaiEnv, anthropicEnv, newrelicEnv, elasticEnv}
+
+var (
+	envOnce    sync.Once
+	envReady   bool
+	leaderPort int
+	upstream   *h.RecordingUpstream
+	agentCAPEM string
+	agentCAKey *ecdsa.PrivateKey
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if leaderPort != 0 {
+		for _, env := range allEnvs {
+			h.TeardownFullChainProviderBestEffort(leaderPort, env)
+		}
+		h.TeardownFullChainCommonBestEffort(leaderPort)
+	}
+	if upstream != nil {
+		upstream.Close()
+	}
+	os.Exit(code)
+}
+
+// ensureEnv builds the shared environment on first use.
+func ensureEnv(t *testing.T) {
+	t.Helper()
+	envOnce.Do(func() {
+		leaderPort = h.GetLeaderPort(t)
+		upstream = h.StartRecordingUpstream(t)
+		agentCAPEM, agentCAKey = h.SetupFullChainCommon(t, leaderPort)
+		for _, env := range allEnvs {
+			h.SetupFullChainProvider(t, leaderPort, upstream.URL, env)
+		}
+		// Last statement, so a setup that fatals partway leaves this false. A
+		// t.Fatalf inside the closure unwinds via runtime.Goexit, which still
+		// marks the Once done — without this flag every later test would run
+		// against a half-built environment and fail with unrelated 404s, burying
+		// the one failure that mattered.
+		envReady = true
+	})
+	if !envReady {
+		t.Fatal("full-chain environment is not available")
+	}
+	// Recorded traffic is per-test: one test's requests must never be readable
+	// as another's, and the assertions count requests exactly.
+	upstream.Reset()
+}
+
+// agentCert mints a client certificate for the agent leg. The common name must
+// match the cert roles' allowed_common_names.
+func agentCert(t *testing.T) string {
+	t.Helper()
+	certPEM, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, h.FullChainAgentCN)
+	return certPEM
+}
+
+// useJWTAgentLeg repoints a mount to authenticate agents by bearer token for the
+// duration of one test.
+//
+// A certificate is only one of the ways an agent can arrive beside a user; the
+// rest carry a token in a header, and a mount whose agent leg is auth/cert
+// cannot validate one. Tests using this present the agent and the user as
+// different clients — identical credentials in both slots are rejected outright,
+// and would prove nothing about attribution either way.
+func useJWTAgentLeg(t *testing.T, p h.ProviderEnv) {
+	t.Helper()
+	h.SetFullChainLegs(t, leaderPort, upstream.URL, p, h.JWTAgentPath, h.FullChainUserAuthMount)
+	t.Cleanup(func() { h.ResetFullChainLegs(t, leaderPort, upstream.URL, p) })
+}

--- a/e2e/fullchain/newrelic_test.go
+++ b/e2e/fullchain/newrelic_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// newrelic is the inverted channel order: the native Api-Key header is consulted
+// *before* X-Warden-Token. It is also the one provider whose inbound agent
+// channel and outbound credential header share a name, which makes it the
+// sharpest leak test in the suite — and the reason the cross-cutting
+// Authorization row uses it as its carrier.
+
+// No vendor prefix — see the note in openai_test.go.
+const newrelicKey = "fc-newrelic-not-a-real-key"
+
+var newrelicEnv = h.ProviderEnv{
+	Mount:      "fc-newrelic",
+	Type:       "newrelic",
+	URLKey:     "newrelic_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": newrelicKey},
+}
+
+// TestNewRelic_ClientApiKeyNeverReachesUpstream sends a caller-supplied value in
+// the very header the credential extractor writes to. Forwarding rather than
+// replacing it would send the caller's value upstream under the mount's
+// identity.
+func TestNewRelic_ClientApiKeyNeverReachesUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, newrelicEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         newrelicEnv.CertRole(),
+		Headers:      map[string]string{"Api-Key": "attacker-supplied-not-a-real-key"},
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Api-Key": newrelicKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestNewRelic_NativeChannelOutranksOperatorToken pins the ordering that makes
+// newrelic different from every other channels provider: Api-Key is consulted
+// *before* X-Warden-Token, where anthropic and the rest consult X-Warden-Token
+// first. Read it together with its mirror,
+// TestAnthropic_OperatorTokenOutranksNativeChannel — neither means much alone.
+//
+// Both headers are sent, and which one the extractor picks decides which of two
+// distinct failures follows. Neither request can succeed: presenting
+// X-Warden-Token at all makes core skip transparent authentication entirely,
+// whatever the extractor chose, so no agent gets authenticated either way. What
+// differs is the shape of the failure, and that is the observable:
+//
+//	Api-Key wins here            → agent is a JWT, looked up as an opaque
+//	                               operator token, resolves to nothing → 403
+//	X-Warden-Token wins (anthropic) → agent is the operator token, which resolves
+//	                               but binds no credential spec → 400
+//
+// Reorder the varargs in either provider's extractor and these two swap. No
+// Bearer is sent — with one, the ambiguity gate would reject the request before
+// any extractor ran and the ordering would stay unobserved.
+func TestNewRelic_NativeChannelOutranksOperatorToken(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, newrelicEnv)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, newrelicEnv, h.ChainOpts{
+		WardenToken: h.RootToken(t),
+		Role:        newrelicEnv.JWTAgentRole(),
+		Headers:     map[string]string{"Api-Key": h.GetDefaultJWT(t)},
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        403,
+		UpstreamCalls: 0,
+	})
+	// Distinguishes this from anthropic's outcome: had the operator token been
+	// selected it would have resolved, and the request would have died at the
+	// mint with "no credential spec" instead.
+	if strings.Contains(string(body), "credential spec") {
+		t.Errorf("operator token appears to have won the agent slot; want the Api-Key value: %s", body)
+	}
+}
+
+// TestNewRelic_NativeChannelCarriesAgentAndLeavesUserSlotOpen is the row
+// newrelic is in this suite for. The agent arrives in Api-Key and, unlike
+// X-Warden-Token, that header does not close the user slot — so both principals
+// resolve from headers alone.
+//
+// The same request is the strongest form of the leak test above: here the header
+// really does arrive carrying a Warden agent token, not a decoy.
+func TestNewRelic_NativeChannelCarriesAgentAndLeavesUserSlotOpen(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, newrelicEnv)
+
+	probe := h.ProbePath("newrelic-native-channel")
+	status, body, _ := h.ChainRequest(t, leaderPort, newrelicEnv, h.ChainOpts{
+		Bearer:  h.FullChainUserJWT(t),
+		Role:    newrelicEnv.JWTAgentRole(),
+		Headers: map[string]string{"Api-Key": h.GetDefaultJWT(t)},
+		Path:    probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Api-Key": newrelicKey},
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}

--- a/e2e/fullchain/openai_test.go
+++ b/e2e/fullchain/openai_test.go
@@ -1,0 +1,132 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// openai stands for the default token extractor — no native channel, no scheme
+// dispatch — paired with the credential extractor that has the most positive
+// branches. Because its inbound side is the plain case, it is also what the
+// cross-cutting rows in chain_test.go use as their carrier.
+
+// Deliberately carrying no "sk-" prefix. Nothing in the chain parses the shape
+// of a credential — it is copied from the spec to the upstream header verbatim —
+// so a realistic prefix would buy no coverage while making every one of these
+// files trip a secret scanner. Keep test credentials unmistakably synthetic.
+const (
+	openaiKey     = "fc-openai-not-a-real-key"
+	openaiOrg     = "fc-e2e-organization"
+	openaiProject = "fc-e2e-project"
+)
+
+// Each optional field needs its own spec, because a role binds exactly one —
+// hence the variants rather than one spec mutated between rows.
+var openaiEnv = h.ProviderEnv{
+	Mount:      "fc-openai",
+	Type:       "openai",
+	URLKey:     "openai_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": openaiKey},
+	Variants: map[string]map[string]string{
+		"org":  {"api_key": openaiKey, "organization_id": openaiOrg},
+		"proj": {"api_key": openaiKey, "project_id": openaiProject},
+		"both": {"api_key": openaiKey, "organization_id": openaiOrg, "project_id": openaiProject},
+	},
+}
+
+// TestOpenAI_OptionalHeaderCombinations covers every positive branch of the
+// credential extractor with the most of them: a bearer key plus two headers that
+// appear only when their field is set. An extractor that emitted an empty header
+// instead of omitting it would still return the right key, so the absent
+// assertions are the point.
+func TestOpenAI_OptionalHeaderCombinations(t *testing.T) {
+	ensureEnv(t)
+
+	auth := "Bearer " + openaiKey
+	cases := []struct {
+		name   string
+		role   string
+		want   map[string]string
+		absent []string
+	}{
+		{
+			name:   "key only",
+			role:   openaiEnv.CertRole(),
+			want:   map[string]string{"Authorization": auth},
+			absent: []string{"OpenAI-Organization", "OpenAI-Project"},
+		},
+		{
+			name:   "with organization",
+			role:   openaiEnv.VariantRole("org"),
+			want:   map[string]string{"Authorization": auth, "OpenAI-Organization": openaiOrg},
+			absent: []string{"OpenAI-Project"},
+		},
+		{
+			name:   "with project",
+			role:   openaiEnv.VariantRole("proj"),
+			want:   map[string]string{"Authorization": auth, "OpenAI-Project": openaiProject},
+			absent: []string{"OpenAI-Organization"},
+		},
+		{
+			name: "with both",
+			role: openaiEnv.VariantRole("both"),
+			want: map[string]string{
+				"Authorization":       auth,
+				"OpenAI-Organization": openaiOrg,
+				"OpenAI-Project":      openaiProject,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.role,
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      tc.want,
+				Absent:        h.AlwaysAbsent(tc.absent...),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}
+
+// TestOpenAI_ClientSuppliedOrgAndProjectAreStripped checks the headers the
+// provider declares it removes. A caller that could set its own organization
+// would be choosing which account the minted key bills against.
+func TestOpenAI_ClientSuppliedOrgAndProjectAreStripped(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         openaiEnv.VariantRole("both"),
+		Headers: map[string]string{
+			"OpenAI-Organization": "org-attacker",
+			"OpenAI-Project":      "proj-attacker",
+		},
+	})
+
+	// The mount's own values must win outright — not merge, not append.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		Injected: map[string]string{
+			"Authorization":       "Bearer " + openaiKey,
+			"OpenAI-Organization": openaiOrg,
+			"OpenAI-Project":      openaiProject,
+		},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -1,0 +1,784 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/audit"
+)
+
+// auditResponseEntry is the entry an audited request emits once it has been
+// fully processed — the point at which every principal is stamped.
+const auditResponseEntry = string(audit.EntryTypeResponse)
+
+// --- Full-chain provider test environment ---
+//
+// A gateway request crosses six layers: the provider's token extractor splits
+// the inbound headers into an agent and a user principal, core resolves a role
+// and evaluates policy, the credential engine mints, and the provider's
+// credential extractor turns that mint into upstream auth headers. Each end is
+// per-provider; neither can be checked in isolation, because the extractor's
+// output is what the mint operates on and the mint's output is what the
+// credential extractor operates on.
+//
+// What makes the whole chain observable is a recording upstream: it is the only
+// place that can prove what Warden actually forwarded, as opposed to what it
+// accepted. A response status says a request was authorized; only the recorded
+// headers say the minted credential went out and the caller's own did not.
+//
+// Providers are set up individually against one shared pair of auth mounts.
+// Splitting it that way matters because auth/cert is global — its trusted CA is
+// a single stored value — so a per-provider SetupCertAuth would have each mount
+// silently invalidate the certificates minted for the last one.
+
+const (
+	// FullChainUserAuthMount authenticates USER credentials for every full-chain
+	// mount. Held apart from the userleg and githttp suites' mounts so the three
+	// cannot leave state for each other.
+	FullChainUserAuthMount = "auth/fullchain-user-jwt/"
+
+	// FullChainUserAuthRole is the role user credentials are validated under.
+	FullChainUserAuthRole = "e2e-fullchain-user"
+
+	// FullChainAgentCN is the common name on agent certificates. It must match
+	// the allowed_common_names pattern every full-chain cert role is created
+	// with.
+	FullChainAgentCN = "agent-fullchain"
+)
+
+// ProviderEnv describes one provider mount under test: where its upstream is,
+// what credential it mints, and which header the mint is expected to land in.
+//
+// The two extractor axes are both parameters here. Inbound behaviour is
+// determined by Type (each provider's token extractor is compiled in), and
+// outbound behaviour by CredType plus CredConfig, which together decide what the
+// credential extractor is handed.
+type ProviderEnv struct {
+	// Mount is the provider mount path. Prefix it so a full-chain mount can
+	// never collide with one another suite owns.
+	Mount string
+
+	// Type is the provider type, e.g. "openai".
+	Type string
+
+	// URLKey is the config key carrying the upstream base URL, e.g.
+	// "openai_url". Every httpproxy provider declares exactly one.
+	URLKey string
+
+	// ExtraConfig is merged into the mount config write. Values are emitted as
+	// JSON, so booleans and numbers keep their types.
+	ExtraConfig map[string]any
+
+	// CredType is the credential type the spec mints, e.g. "api_key". It must
+	// accept a local source — only api_key, github_token, aws_access_keys,
+	// cloudflare_keys and scaleway_keys do.
+	CredType string
+
+	// CredConfig is the spec config. For a local source these values are copied
+	// verbatim into the minted credential, which is what lets a test assert on
+	// an exact upstream header value.
+	CredConfig map[string]string
+
+	// Variants are additional credential specs on the same mount, each with its
+	// own cert role. A credential extractor with optional fields has several
+	// positive branches, and a role binds exactly one spec — so covering them
+	// means several specs, but not several mounts. Keyed by variant name.
+	//
+	// "denied" is reserved: it would produce the same role name as DenyRole and
+	// fail setup with a confusing 409. SetupFullChainProvider rejects it.
+	Variants map[string]map[string]string
+}
+
+// CertRole is the cert-auth role the agent authenticates under.
+func (p ProviderEnv) CertRole() string { return p.Mount + "-agent" }
+
+// Policy is the CBP policy granting gateway access to the mount.
+func (p ProviderEnv) Policy() string { return p.Mount + "-access" }
+
+// Source is the credential source backing the mount.
+func (p ProviderEnv) Source() string { return p.Mount + "-src" }
+
+// Spec is the credential spec the cert role mints from.
+func (p ProviderEnv) Spec() string { return p.Mount + "-cred" }
+
+// VariantSpec is the credential spec for a named variant.
+func (p ProviderEnv) VariantSpec(name string) string { return p.Mount + "-cred-" + name }
+
+// VariantRole is the cert role bound to a named variant's spec. Pass it as
+// ChainOpts.Role to select that variant.
+func (p ProviderEnv) VariantRole(name string) string { return p.Mount + "-agent-" + name }
+
+// DenyRole authenticates the same certificate but carries a policy with no
+// gateway capability, so a request under it must be refused before it is
+// forwarded. Pass it as ChainOpts.Role.
+func (p ProviderEnv) DenyRole() string { return p.Mount + "-agent-denied" }
+
+// DenyPolicy is the policy DenyRole carries.
+func (p ProviderEnv) DenyPolicy() string { return p.Mount + "-denied" }
+
+// JWTAgentRole authenticates the agent by bearer token instead of certificate.
+// Needed for every shape where the agent arrives in a header — the dedicated
+// agent channel, or a provider's own native channel — because those carry a
+// token, and a mount whose agent leg is auth/cert cannot validate one.
+func (p ProviderEnv) JWTAgentRole() string { return p.Mount + "-jwt-agent" }
+
+// UpstreamRequest is one request the recording upstream received.
+type UpstreamRequest struct {
+	Method   string
+	Path     string
+	RawQuery string
+	Header   http.Header
+}
+
+// RecordingUpstream stands in for a provider's real API. It answers everything
+// with a canned 200 and keeps what it was sent, which is the only vantage point
+// from which "the minted credential went out and the caller's did not" can be
+// checked.
+type RecordingUpstream struct {
+	URL string
+
+	server *httptest.Server
+	mu     sync.Mutex
+	reqs   []UpstreamRequest
+}
+
+// StartRecordingUpstream starts the upstream. The caller owns its lifetime via
+// Close: mounts are configured with its URL once for the whole package, so
+// binding it to the first test's cleanup would leave every later test pointed at
+// a closed listener.
+func StartRecordingUpstream(t *testing.T) *RecordingUpstream {
+	t.Helper()
+	u := &RecordingUpstream{}
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.mu.Lock()
+		u.reqs = append(u.reqs, UpstreamRequest{
+			Method:   r.Method,
+			Path:     r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+			Header:   r.Header.Clone(),
+		})
+		u.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	u.URL = u.server.URL
+	return u
+}
+
+// Close stops the upstream.
+func (u *RecordingUpstream) Close() {
+	if u.server != nil {
+		u.server.Close()
+	}
+}
+
+// Requests returns every request received so far.
+func (u *RecordingUpstream) Requests() []UpstreamRequest {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]UpstreamRequest(nil), u.reqs...)
+}
+
+// Reset clears the recorded requests so one test's traffic cannot be read as
+// another's.
+func (u *RecordingUpstream) Reset() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.reqs = nil
+}
+
+// SetupFullChainCommon mounts the auth methods every full-chain provider shares:
+// certificates for the agent leg, and a JWT mount for the user leg. Returns the
+// CA for minting agent certificates.
+//
+// Call once per package. auth/cert stores a single trusted CA, so calling it
+// again mid-run would invalidate every certificate already minted.
+func SetupFullChainCommon(t *testing.T, port int) (caCertPEM string, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	// A previous run that failed mid-setup leaves mounts behind, and every later
+	// attempt would then fail with 409 — turning one real failure into a cascade
+	// that hides it.
+	TeardownFullChainCommonBestEffort(port)
+
+	caCertPEM, caKey = SetupCertAuth(t, port)
+
+	mustAPI(t, port, "POST", "sys/auth/fullchain-user-jwt", `{"type":"jwt"}`, "mount fullchain-user-jwt auth")
+	time.Sleep(time.Second)
+
+	mustAPI(t, port, "PUT", "auth/fullchain-user-jwt/config",
+		fmt.Sprintf(`{"mode":"oidc","oidc_discovery_url":%q,"bound_issuer":%q}`, HydraIssuer, HydraIssuer),
+		"configure fullchain-user-jwt auth")
+
+	mustAPI(t, port, "POST", "auth/fullchain-user-jwt/role/"+FullChainUserAuthRole,
+		`{"user_claim":"sub","token_ttl":3600}`, "create fullchain user role")
+
+	return caCertPEM, caKey
+}
+
+// SetupFullChainProvider builds one provider mount pointed at upstreamURL, with
+// a local credential source so the mint needs no upstream of its own, and a cert
+// role bound to the resulting spec.
+func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p ProviderEnv) {
+	t.Helper()
+
+	TeardownFullChainProviderBestEffort(port, p)
+
+	mustAPI(t, port, "POST", "sys/providers/"+p.Mount,
+		fmt.Sprintf(`{"type":%q,"description":"e2e full-chain %s"}`, p.Type, p.Type),
+		"mount "+p.Type+" provider")
+	time.Sleep(time.Second)
+
+	// tls_skip_verify is what permits the http:// scheme on the upstream URL —
+	// without it the config write is rejected outright, whatever the URL points
+	// at.
+	cfg := map[string]any{
+		p.URLKey:          upstreamURL,
+		"tls_skip_verify": true,
+		"auto_auth_path":  "auth/cert/",
+		"user_auth_path":  FullChainUserAuthMount,
+		"user_auth_role":  FullChainUserAuthRole,
+	}
+	for k, v := range p.ExtraConfig {
+		cfg[k] = v
+	}
+	mustAPI(t, port, "PUT", p.Mount+"/config", mustJSON(t, cfg), "configure "+p.Type+" provider")
+
+	mustAPI(t, port, "POST", "sys/cred/sources/"+p.Source(),
+		`{"type":"local"}`, "create credential source for "+p.Mount)
+
+	mustAPI(t, port, "POST", "sys/cred/specs/"+p.Spec(),
+		mustJSON(t, map[string]any{
+			"type":   p.CredType,
+			"source": p.Source(),
+			"config": p.CredConfig,
+		}),
+		"create credential spec for "+p.Mount)
+
+	mustAPI(t, port, "POST", "sys/policies/cbp/"+p.Policy(),
+		mustJSON(t, map[string]any{"policy": gatewayPolicy(p.Mount)}),
+		"create policy for "+p.Mount)
+
+	mustAPI(t, port, "POST", "auth/cert/role/"+p.CertRole(),
+		mustJSON(t, map[string]any{
+			"allowed_common_names": []string{FullChainAgentCN},
+			"token_policies":       []string{p.Policy()},
+			"cred_spec_name":       p.Spec(),
+			"token_ttl":            3600,
+		}),
+		"create cert role for "+p.Mount)
+
+	// The denial counterpart: same certificate, same credential spec, a policy
+	// that grants an unrelated path. Authentication therefore succeeds and only
+	// authorization fails, which is the case worth asserting — a request refused
+	// because it could not authenticate proves nothing about policy.
+	mustAPI(t, port, "POST", "sys/policies/cbp/"+p.DenyPolicy(),
+		mustJSON(t, map[string]any{
+			"policy": "path \"sys/health\" {\n  capabilities = [\"read\"]\n}",
+		}),
+		"create deny policy for "+p.Mount)
+
+	mustAPI(t, port, "POST", "auth/cert/role/"+p.DenyRole(),
+		mustJSON(t, map[string]any{
+			"allowed_common_names": []string{FullChainAgentCN},
+			"token_policies":       []string{p.DenyPolicy()},
+			"cred_spec_name":       p.Spec(),
+			"token_ttl":            3600,
+		}),
+		"create deny cert role for "+p.Mount)
+
+	// The bearer-agent counterpart. Recreated rather than created, because
+	// auth/jwt/ is set up by the suite as a whole and survives our teardown.
+	APIRequest(t, "DELETE", "auth/jwt/role/"+p.JWTAgentRole(), port, "")
+	mustAPI(t, port, "POST", "auth/jwt/role/"+p.JWTAgentRole(),
+		mustJSON(t, map[string]any{
+			"token_policies": []string{p.Policy()},
+			"cred_spec_name": p.Spec(),
+			"user_claim":     "sub",
+			"token_ttl":      3600,
+		}),
+		"create jwt agent role for "+p.Mount)
+
+	for name, cfg := range p.Variants {
+		if p.VariantRole(name) == p.DenyRole() {
+			t.Fatalf("provider %s: variant %q collides with the built-in deny role", p.Mount, name)
+		}
+		mustAPI(t, port, "POST", "sys/cred/specs/"+p.VariantSpec(name),
+			mustJSON(t, map[string]any{
+				"type":   p.CredType,
+				"source": p.Source(),
+				"config": cfg,
+			}),
+			"create credential spec "+name+" for "+p.Mount)
+
+		mustAPI(t, port, "POST", "auth/cert/role/"+p.VariantRole(name),
+			mustJSON(t, map[string]any{
+				"allowed_common_names": []string{FullChainAgentCN},
+				"token_policies":       []string{p.Policy()},
+				"cred_spec_name":       p.VariantSpec(name),
+				"token_ttl":            3600,
+			}),
+			"create cert role "+name+" for "+p.Mount)
+	}
+}
+
+// gatewayPolicy grants both gateway shapes: the bare one, used when the role
+// arrives in a header, and the role-in-path one.
+func gatewayPolicy(mount string) string {
+	return fmt.Sprintf(
+		"path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\n"+
+			"path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}",
+		mount+"/gateway*", mount+"/role/+/gateway*")
+}
+
+// CertAgentPath is the default agent leg: the agent proves itself with a client
+// certificate, leaving every header free.
+const CertAgentPath = "auth/cert/"
+
+// JWTAgentPath is the agent leg for the shapes where the agent arrives as a
+// bearer token in some header.
+const JWTAgentPath = "auth/jwt/"
+
+// SetFullChainLegs repoints a mount's two auth legs without rebuilding the
+// environment, so one mount can be driven through several agent shapes. An empty
+// userAuthPath opts the mount out of the user leg entirely, which is how the
+// not-a-protected-resource cases are exercised.
+func SetFullChainLegs(t *testing.T, port int, upstreamURL string, p ProviderEnv, autoAuthPath, userAuthPath string) {
+	t.Helper()
+
+	// user_auth_role is always written, empty when opting out: config writes
+	// merge into the stored config, so clearing the path while leaving a role
+	// behind is rejected as "user_auth_role requires user_auth_path".
+	role := ""
+	if userAuthPath != "" {
+		role = FullChainUserAuthRole
+	}
+	cfg := map[string]any{
+		p.URLKey:          upstreamURL,
+		"tls_skip_verify": true,
+		"auto_auth_path":  autoAuthPath,
+		"user_auth_path":  userAuthPath,
+		"user_auth_role":  role,
+	}
+	for k, v := range p.ExtraConfig {
+		cfg[k] = v
+	}
+	mustAPI(t, port, "POST", p.Mount+"/config", mustJSON(t, cfg), "repoint auth legs for "+p.Mount)
+}
+
+// ResetFullChainLegs restores the package default: certificate agent, user leg
+// on. Tests that repoint must defer this so ordering cannot matter.
+func ResetFullChainLegs(t *testing.T, port int, upstreamURL string, p ProviderEnv) {
+	t.Helper()
+	SetFullChainLegs(t, port, upstreamURL, p, CertAgentPath, FullChainUserAuthMount)
+}
+
+// ChainOpts describes how a full-chain request presents its credentials. Every
+// field maps to one inbound channel, so a test row reads as the combination it
+// is exercising.
+type ChainOpts struct {
+	// AgentCertPEM presents the agent as a client certificate, forwarded as a
+	// header. It is honoured because the e2e listeners trust 127.0.0.1 as a
+	// proxy; a client cannot forge it from anywhere else.
+	AgentCertPEM string
+
+	// WardenToken sets X-Warden-Token — the operator credential, which never
+	// carries a user principal on either leg.
+	WardenToken string
+
+	// AgentToken sets X-Warden-Agent-Token, the dedicated agent channel that
+	// leaves Authorization free for the user.
+	AgentToken string
+
+	// Bearer sets Authorization to a Bearer token.
+	Bearer string
+
+	// RawAuthz sets Authorization verbatim, for the providers whose agent rides
+	// a native scheme such as "ApiKey " or "Splunk ".
+	RawAuthz string
+
+	// Role sets X-Warden-Role. It overrides every other role selector, and is
+	// always stripped before the upstream.
+	Role string
+
+	// Headers are merged in last: native agent channels, and the decoys a test
+	// expects the provider to strip.
+	Headers map[string]string
+
+	// Path is appended after the gateway prefix. Defaults to "probe".
+	Path string
+
+	// Method defaults to GET.
+	Method string
+}
+
+// ChainRequest drives one request through the whole chain and returns the
+// response status, body and headers. Response headers matter here because the
+// user leg is largely a header protocol: WWW-Authenticate carries the challenge
+// that says which principal was rejected.
+func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []byte, http.Header) {
+	t.Helper()
+
+	headers := map[string]string{}
+	if o.AgentCertPEM != "" {
+		headers["X-SSL-Client-Cert"] = URLEncodePEM(o.AgentCertPEM)
+	}
+	if o.WardenToken != "" {
+		headers["X-Warden-Token"] = o.WardenToken
+	}
+	if o.AgentToken != "" {
+		headers["X-Warden-Agent-Token"] = o.AgentToken
+	}
+	// Both write Authorization, so setting both would silently discard one and
+	// the row would test something other than what it reads as.
+	if o.Bearer != "" && o.RawAuthz != "" {
+		t.Fatal("ChainOpts: set Bearer or RawAuthz, not both — they both write Authorization")
+	}
+	if o.Bearer != "" {
+		headers["Authorization"] = "Bearer " + o.Bearer
+	}
+	if o.RawAuthz != "" {
+		headers["Authorization"] = o.RawAuthz
+	}
+	if o.Role != "" {
+		headers["X-Warden-Role"] = o.Role
+	}
+	for k, v := range o.Headers {
+		headers[k] = v
+	}
+
+	method := o.Method
+	if method == "" {
+		method = "GET"
+	}
+	path := o.Path
+	if path == "" {
+		path = "probe"
+	}
+
+	u := fmt.Sprintf("%s/v1/%s/gateway/%s", NodeURL(port), p.Mount, path)
+	status, body, respHeaders := DoRequestWithResponseHeaders(t, method, u, headers, "")
+	return status, body, http.Header(respHeaders)
+}
+
+// ChainWant is what a full-chain request is expected to have produced.
+type ChainWant struct {
+	// Status is the response status the caller must have received.
+	Status int
+
+	// Injected are headers the upstream must have received, with exactly these
+	// values. This is where a credential extractor's positive branch is pinned.
+	Injected map[string]string
+
+	// Absent are headers the upstream must not have received at all — the
+	// caller's own credential, Warden's internal headers, and any decoy the
+	// provider claims to strip.
+	Absent []string
+
+	// UpstreamCalls is how many requests the upstream should have seen. Set it
+	// to 0 for a denial: a policy that rejects after the request has already
+	// been forwarded is not a policy.
+	UpstreamCalls int
+}
+
+// AssertChain checks a full-chain outcome: the caller's status, and what the
+// upstream was and was not sent.
+func AssertChain(t *testing.T, up *RecordingUpstream, status int, body []byte, want ChainWant) {
+	t.Helper()
+
+	if status != want.Status {
+		t.Fatalf("status: got %d, want %d (body: %s)", status, want.Status, truncate(body))
+	}
+
+	reqs := up.Requests()
+	if len(reqs) != want.UpstreamCalls {
+		t.Fatalf("upstream received %d requests, want %d", len(reqs), want.UpstreamCalls)
+	}
+	if want.UpstreamCalls == 0 {
+		return
+	}
+
+	// Only the last request's headers are inspected, which is why every row so
+	// far expects exactly one. A row expecting several would need to say which.
+	got := reqs[len(reqs)-1].Header
+	failed := false
+	fail := func(format string, args ...any) {
+		failed = true
+		t.Errorf(format, args...)
+	}
+
+	for name, wantValue := range want.Injected {
+		if wantValue == "" {
+			// Get returns "" for a header that never arrived, so an empty
+			// expectation would be satisfied by absence. Absence belongs in
+			// Absent, where it is stated as such.
+			fail("Injected[%s] is empty; use Absent to assert a header is not forwarded", name)
+			continue
+		}
+		// Values, not Get: a leak that appends to a header the provider also
+		// injects leaves the injected value first, so Get would report success
+		// while the caller's credential rode along behind it.
+		switch gotValues := got.Values(name); {
+		case len(gotValues) == 0:
+			fail("upstream header %s: not forwarded, want %q", name, wantValue)
+		case len(gotValues) > 1:
+			fail("upstream header %s: got %d values %q, want exactly one (%q)", name, len(gotValues), gotValues, wantValue)
+		case gotValues[0] != wantValue:
+			fail("upstream header %s: got %q, want %q", name, gotValues[0], wantValue)
+		}
+	}
+	for _, name := range want.Absent {
+		if gotValues := got.Values(name); len(gotValues) > 0 {
+			fail("upstream header %s should not have been forwarded, got %q", name, gotValues)
+		}
+	}
+	// Guarded on this call's own failures: t.Failed() would also be true for an
+	// unrelated earlier failure, attaching a header dump that explains nothing.
+	if failed {
+		t.Logf("upstream received headers: %s", formatHeaders(got))
+	}
+}
+
+// AlwaysAbsent lists the headers no provider may ever forward: every internal
+// channel that carries a token or selects an identity, plus the forwarded client
+// certificate.
+//
+// An absence assertion only bites when the header was actually sent inbound —
+// otherwise it holds however broken the strip list is. Pair this with
+// InertDecoyHeaders on at least one row per provider so the claim is tested
+// rather than merely stated.
+//
+// Authorization is deliberately not in the list. Several providers inject their
+// credential into it, so asserting it absent is only meaningful where they do
+// not — pass it explicitly there.
+func AlwaysAbsent(extra ...string) []string {
+	base := []string{
+		"X-Warden-Token",
+		"X-Warden-Agent-Token",
+		"X-Warden-User-Token",
+		"X-Warden-Role",
+		"X-Warden-Provider",
+		"X-Warden-Subject-Token",
+		"X-Warden-Actor-Token",
+		"X-SSL-Client-Cert",
+	}
+	return append(base, extra...)
+}
+
+// InertDecoyHeaders are internal channels a caller can set that carry no inbound
+// meaning on a gateway request. Sending them is what turns the corresponding
+// AlwaysAbsent entries from free into load-bearing: without them the strip list
+// could drop these names entirely and every row would still pass.
+//
+// The internal headers NOT here all have inbound meaning, so sending them as
+// decoys would change what is under test rather than exercise the strip:
+//   - X-Warden-Agent-Token authenticates the agent, and is exercised as a real
+//     credential instead.
+//   - X-Warden-Token is the operator credential. With Authorization it trips the
+//     ambiguity gate; alone it binds no credential spec — so no request carrying
+//     it ever reaches an upstream to be inspected.
+//   - X-Warden-Role selects the role, and every row already sends it.
+//   - X-Warden-Provider selects the mount: it puts the request into
+//     header-routing mode, so a decoy value reroutes it to a mount that does not
+//     exist.
+//
+// Those four are therefore covered by the rows that use them for real, not here.
+func InertDecoyHeaders() map[string]string {
+	return map[string]string{
+		"X-Warden-User-Token":    "decoy-user-token",
+		"X-Warden-Subject-Token": "decoy-subject-token",
+		"X-Warden-Actor-Token":   "decoy-actor-token",
+	}
+}
+
+var (
+	// runNonce separates this process's requests from every earlier run's.
+	runNonce = strconv.FormatInt(time.Now().UnixNano(), 36)
+	// probeSeq separates repeated calls within one process, which the nonce
+	// alone cannot: -count=2 re-runs every test in the same process.
+	probeSeq atomic.Uint64
+)
+
+// ProbePath returns a gateway sub-path unique to this call, for a test that will
+// later look its request up in the audit log.
+//
+// The audit log is append-only and outlives a single `go test` invocation, so a
+// fixed path matches every previous run's entries too. An assertion could then
+// be satisfied by an entry written minutes ago — passing without the current
+// request having been audited at all, and silently ignoring a regression that
+// only affects the request just made.
+//
+// Call it ONCE per request and keep the result in a variable; calling it again
+// for the same request yields a different path that matches nothing. Uniqueness
+// is per call rather than per name so that -count=2 cannot let the second run's
+// assertion be satisfied by the first run's entries.
+func ProbePath(name string) string {
+	return fmt.Sprintf("%s-%s-%d", name, runNonce, probeSeq.Add(1))
+}
+
+// AssertAuditUser checks how a request was attributed. wantUser is a substring
+// of the user principal's subject, or "" to assert that no user was captured —
+// the agent-only case, which must not silently acquire one.
+//
+// pathSubstr must come from ProbePath, or the lookup may match an earlier run.
+//
+// Polls, because audit writes are not synchronous with the response. Both cases
+// wait for the response-phase entry rather than the first entry that appears.
+// For the positive case that is merely the earliest point the user is certain to
+// have been stamped; for the negative case it is what makes the assertion mean
+// anything at all. Concluding "no user" from the request-phase entry would rest
+// on the user being captured before that entry is written — true today, but a
+// silent invariant, and if it ever changed every no-user assertion here would
+// pass unconditionally rather than fail.
+func AssertAuditUser(t *testing.T, port int, pathSubstr, wantUser string) {
+	t.Helper()
+
+	nodeNum := NodeNumberForPort(port)
+	deadline := time.Now().Add(10 * time.Second)
+
+	// Tracked across iterations so a timeout can say which of the three things
+	// went wrong: nothing was written, the response half never arrived, or it
+	// arrived carrying the wrong principal. Reporting the first when it was the
+	// third sends the reader looking at the audit device instead of at the
+	// principal that never got captured.
+	var everSawAuth, everSawResponse bool
+
+	for time.Now().Before(deadline) {
+		var sawResponse bool
+		var gotUser string
+		for _, e := range ReadAuditEntries(t, nodeNum, pathSubstr) {
+			if e.Auth == nil {
+				continue
+			}
+			everSawAuth = true
+			if e.Type == auditResponseEntry {
+				sawResponse = true
+			}
+			if e.Auth.User != nil && e.Auth.User.Subject != "" {
+				gotUser = e.Auth.User.Subject
+			}
+		}
+		everSawResponse = everSawResponse || sawResponse
+
+		if sawResponse {
+			switch {
+			case wantUser == "" && gotUser != "":
+				t.Errorf("request %q was attributed to user %q, want no user principal", pathSubstr, gotUser)
+			case wantUser == "":
+				// Fully audited, no user captured — as intended.
+			case strings.Contains(gotUser, wantUser):
+				// Attributed to the expected user.
+			case gotUser == "":
+				t.Errorf("request %q was audited but attributed to no user; want one containing %q", pathSubstr, wantUser)
+			default:
+				t.Errorf("request %q: audit user %q does not contain %q", pathSubstr, gotUser, wantUser)
+			}
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	switch {
+	case everSawResponse:
+		t.Errorf("request %q was audited but never attributed to a user containing %q", pathSubstr, wantUser)
+	case everSawAuth:
+		t.Errorf("request %q was audited but its response entry never arrived within the deadline", pathSubstr)
+	default:
+		t.Errorf("no audit entry with authentication context matched %q within the deadline", pathSubstr)
+	}
+}
+
+// FullChainUserSubject is the subject carried by FullChainUserJWT. Asserted as a
+// substring, since the auth method may qualify it.
+const FullChainUserSubject = "e2e-pipeline"
+
+// FullChainUserJWT returns a JWT for the USER principal — a different client,
+// and therefore a different subject, than the agent's.
+func FullChainUserJWT(t *testing.T) string {
+	t.Helper()
+	return GetJWT(t, "e2e-pipeline", "pipeline-secret")
+}
+
+// TeardownFullChainProviderBestEffort removes everything SetupFullChainProvider
+// created. Best-effort throughout: cleanup must not fail a run that passed.
+func TeardownFullChainProviderBestEffort(port int, p ProviderEnv) {
+	del := bestEffortDeleter(port)
+	for name := range p.Variants {
+		del("auth/cert/role/" + p.VariantRole(name))
+		del("sys/cred/specs/" + p.VariantSpec(name))
+	}
+	del("auth/jwt/role/" + p.JWTAgentRole())
+	del("auth/cert/role/" + p.DenyRole())
+	del("sys/policies/cbp/" + p.DenyPolicy())
+	del("auth/cert/role/" + p.CertRole())
+	del("sys/policies/cbp/" + p.Policy())
+	del("sys/cred/specs/" + p.Spec())
+	del("sys/cred/sources/" + p.Source())
+	del("sys/providers/" + p.Mount)
+}
+
+// TeardownFullChainCommonBestEffort removes the shared auth mounts.
+func TeardownFullChainCommonBestEffort(port int) {
+	del := bestEffortDeleter(port)
+	del("auth/fullchain-user-jwt/role/" + FullChainUserAuthRole)
+	del("sys/auth/fullchain-user-jwt")
+	del("sys/auth/cert")
+	time.Sleep(time.Second)
+}
+
+func bestEffortDeleter(port int) func(string) {
+	token := rootTokenBestEffort()
+	return func(path string) {
+		TryRequest("DELETE", fmt.Sprintf("%s/v1/%s", NodeURL(port), path),
+			map[string]string{"X-Warden-Token": token}, "")
+	}
+}
+
+// mustJSON marshals a config body, failing the test rather than returning an
+// error: a test that cannot express its own fixture has nothing left to check.
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	return string(b)
+}
+
+// formatHeaders renders received headers in a stable order, so a failure
+// message can be read against the expectation that produced it.
+func formatHeaders(h http.Header) string {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		fmt.Fprintf(&b, "\n  %s: %s", name, strings.Join(h[name], ", "))
+	}
+	return b.String()
+}
+
+func truncate(body []byte) string {
+	const max = 512
+	if len(body) <= max {
+		return string(body)
+	}
+	return string(body[:max]) + "..."
+}

--- a/provider/elastic/credentials_test.go
+++ b/provider/elastic/credentials_test.go
@@ -1,0 +1,71 @@
+package elastic
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Assembled rather than written out as a literal: a base64 blob of this length
+// reads as a real credential to a secret scanner however synthetic its contents,
+// and the encoding hides from a reviewer that it is fake.
+var encodedKey = base64.StdEncoding.EncodeToString([]byte("elastic-id:elastic-not-a-real-secret"))
+
+// Elasticsearch authenticates under its own "ApiKey" scheme rather than Bearer,
+// which is also why the token extractor has to dispatch on scheme. The value is
+// carried through verbatim: it is already the base64 id:key pair the cluster
+// issued, so the extractor must not re-encode it.
+
+func TestElasticCredentialExtractor_Success(t *testing.T) {
+	headers, err := elasticCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"api_key": encodedKey},
+		},
+	})
+	require.NoError(t, err)
+	// Passed through verbatim: the value is already the encoded id:key pair the
+	// cluster issued, so encoding it again would produce a credential the
+	// upstream cannot read.
+	assert.Equal(t, "ApiKey "+encodedKey, headers["Authorization"])
+	assert.Len(t, headers, 1)
+}
+
+func TestElasticCredentialExtractor_NoCredential(t *testing.T) {
+	_, err := elasticCredentialExtractor(&logical.Request{})
+	assert.ErrorContains(t, err, "no credential available")
+}
+
+func TestElasticCredentialExtractor_WrongType(t *testing.T) {
+	_, err := elasticCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeOAuthBearerToken,
+			Data: map[string]string{"api_key": "encoded"},
+		},
+	})
+	assert.ErrorContains(t, err, "unsupported credential type")
+}
+
+func TestElasticCredentialExtractor_MissingAPIKey(t *testing.T) {
+	_, err := elasticCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{},
+		},
+	})
+	assert.ErrorContains(t, err, "missing api_key")
+}
+
+func TestElasticCredentialExtractor_EmptyAPIKey(t *testing.T) {
+	_, err := elasticCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"api_key": ""},
+		},
+	})
+	assert.ErrorContains(t, err, "missing api_key")
+}

--- a/provider/openai/provider_test.go
+++ b/provider/openai/provider_test.go
@@ -1,0 +1,145 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The extractor has two optional fields, so its positive branches are a lattice
+// rather than a single case: each optional header must appear when its field is
+// set and be absent — not empty — when it is not. An empty header would still
+// carry the key, and would still read as "present" to the upstream.
+
+func TestOpenAICredentialExtractor_KeyOnly(t *testing.T) {
+	headers, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"api_key": "openai-not-a-real-key"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer openai-not-a-real-key", headers["Authorization"])
+	assert.NotContains(t, headers, "OpenAI-Organization")
+	assert.NotContains(t, headers, "OpenAI-Project")
+}
+
+func TestOpenAICredentialExtractor_WithOrganization(t *testing.T) {
+	headers, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"api_key":         "openai-not-a-real-key",
+				"organization_id": "org-abc123",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer openai-not-a-real-key", headers["Authorization"])
+	assert.Equal(t, "org-abc123", headers["OpenAI-Organization"])
+	assert.NotContains(t, headers, "OpenAI-Project")
+}
+
+func TestOpenAICredentialExtractor_WithProject(t *testing.T) {
+	headers, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"api_key":    "openai-not-a-real-key",
+				"project_id": "proj-xyz789",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "proj-xyz789", headers["OpenAI-Project"])
+	assert.NotContains(t, headers, "OpenAI-Organization")
+}
+
+func TestOpenAICredentialExtractor_WithBoth(t *testing.T) {
+	headers, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"api_key":         "openai-not-a-real-key",
+				"organization_id": "org-abc123",
+				"project_id":      "proj-xyz789",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"Authorization":       "Bearer openai-not-a-real-key",
+		"OpenAI-Organization": "org-abc123",
+		"OpenAI-Project":      "proj-xyz789",
+	}, headers)
+}
+
+// An explicitly empty optional field takes the same branch as an absent one.
+// Worth pinning separately: a credential source that returns a field it could
+// not populate must not turn into a header that overrides the account default.
+func TestOpenAICredentialExtractor_EmptyOptionalFieldsOmitted(t *testing.T) {
+	headers, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"api_key":         "openai-not-a-real-key",
+				"organization_id": "",
+				"project_id":      "",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, headers, "OpenAI-Organization")
+	assert.NotContains(t, headers, "OpenAI-Project")
+}
+
+func TestOpenAICredentialExtractor_NoCredential(t *testing.T) {
+	_, err := openaiCredentialExtractor(&logical.Request{})
+	assert.ErrorContains(t, err, "no credential available")
+}
+
+func TestOpenAICredentialExtractor_WrongType(t *testing.T) {
+	_, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeVaultToken,
+			Data: map[string]string{"api_key": "openai-not-a-real-key"},
+		},
+	})
+	assert.ErrorContains(t, err, "unsupported credential type")
+}
+
+func TestOpenAICredentialExtractor_MissingAPIKey(t *testing.T) {
+	_, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"organization_id": "org-abc123"},
+		},
+	})
+	assert.ErrorContains(t, err, "missing api_key")
+}
+
+func TestOpenAICredentialExtractor_EmptyAPIKey(t *testing.T) {
+	_, err := openaiCredentialExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"api_key": ""},
+		},
+	})
+	assert.ErrorContains(t, err, "missing api_key")
+}
+
+// The optional headers are also the ones a caller could otherwise set for
+// itself, so the spec must list them for removal — the extractor injecting them
+// is only half of the guarantee.
+func TestSpec(t *testing.T) {
+	assert.Equal(t, "openai", Spec.Name)
+	assert.Equal(t, "openai_url", Spec.URLConfigKey)
+	assert.NotNil(t, Spec.ExtractCredentials)
+	assert.NotNil(t, Factory)
+	assert.ElementsMatch(t,
+		[]string{"OpenAI-Organization", "OpenAI-Project"},
+		Spec.ExtraHeadersToRemove)
+}

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -177,10 +177,24 @@ func TestHeaderAPIKeyExtractor(t *testing.T) {
 		_, err := extractor(&logical.Request{})
 		assert.Error(t, err)
 	})
+	t.Run("wrong type", func(t *testing.T) {
+		_, err := extractor(&logical.Request{Credential: &credential.Credential{Type: "other"}})
+		assert.ErrorContains(t, err, "unsupported credential type")
+	})
+	t.Run("missing api_key", func(t *testing.T) {
+		_, err := extractor(&logical.Request{
+			Credential: &credential.Credential{Type: credential.TypeAPIKey, Data: map[string]string{}},
+		})
+		assert.ErrorContains(t, err, "missing api_key")
+	})
 }
 
 func TestTypedTokenExtractor(t *testing.T) {
 	extractor := TypedTokenExtractor(credential.TypeGitHubToken, "token", "Authorization", "token ")
+	t.Run("nil credential", func(t *testing.T) {
+		_, err := extractor(&logical.Request{})
+		assert.ErrorContains(t, err, "no credential")
+	})
 	t.Run("valid", func(t *testing.T) {
 		headers, err := extractor(&logical.Request{
 			Credential: &credential.Credential{Type: credential.TypeGitHubToken, Data: map[string]string{"token": "ghp_abc"}},
@@ -228,12 +242,23 @@ func TestMultiFieldAPIKeyExtractor(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "key1", headers["X-Api-Key"])
 		assert.Empty(t, headers["X-Org"])
+		// Omitted rather than emitted empty: an empty header still reaches the
+		// upstream as a set value.
+		assert.NotContains(t, headers, "X-Org")
 	})
 	t.Run("required missing", func(t *testing.T) {
 		_, err := extractor(&logical.Request{
 			Credential: &credential.Credential{Type: credential.TypeAPIKey, Data: map[string]string{}},
 		})
 		assert.ErrorContains(t, err, "missing api_key")
+	})
+	t.Run("nil credential", func(t *testing.T) {
+		_, err := extractor(&logical.Request{})
+		assert.ErrorContains(t, err, "no credential")
+	})
+	t.Run("wrong type", func(t *testing.T) {
+		_, err := extractor(&logical.Request{Credential: &credential.Credential{Type: "other"}})
+		assert.ErrorContains(t, err, "unsupported credential type")
 	})
 }
 


### PR DESCRIPTION
A gateway request crosses six layers and no test crossed more than two.
Both ends are per-provider: the token extractor splits inbound headers
into an agent and a user principal, and the credential extractor turns
the mint into upstream auth headers. Neither is checkable alone, since
each one's output is what the next operates on.

Adds a harness where every test drives one request through the whole
chain against a recording upstream, asserting which header became which
principal and which credential reached the far side. Seeded with four
providers covering every token-extractor family — default, channels,
channels with the native header ahead of X-Warden-Token, and scheme
dispatch — and four different credential extractors, two of which had no
tests at all.

Layout is one file per provider plus one for the provider-independent
rows, so adding a provider is a new file and a line in allEnvs.

Notable rows:

  - the caller's credential never proxies onward, checked on a provider
    that injects somewhere other than Authorization so injection cannot
    mask a leak
  - policy denial refuses before anything is forwarded
  - X-Warden-Token beside an Authorization credential is rejected as
    ambiguous, with a non-opted-in mount as the control
  - channel ordering, pinned via the differing failure each ordering
    produces; presenting X-Warden-Token skips transparent auth outright,
    so no such request can succeed either way

Audit assertions use a per-call unique probe path. The audit log is
append-only and outlives a run, so a fixed path is matched by earlier
runs' entries and the assertion passes without the current request
having been audited at all.

Also fills the credential-extractor branches with no unit coverage:
openai and elastic in full, plus the five missing SDK branches.

---

**Stack** — part 1 of 9 in the full-chain e2e series. Targets `main`; retarget to `main` once the parent merges.
