### PR TITLE
test(e2e): cover the github REST leg through the full chain

### DIFF
--- a/e2e/fullchain/chain_test.go
+++ b/e2e/fullchain/chain_test.go
@@ -29,6 +29,7 @@ var injections = []injection{
 	{anthropicEnv, map[string]string{"x-api-key": anthropicKey}},
 	{newrelicEnv, map[string]string{"Api-Key": newrelicKey}},
 	{elasticEnv, map[string]string{"Authorization": "ApiKey " + elasticKey}},
+	{githubEnv, map[string]string{"Authorization": "token " + githubPAT}},
 }
 
 // TestFullChain_CertAgentWithUser is the reference shape the suite exists for:

--- a/e2e/fullchain/github_test.go
+++ b/e2e/fullchain/github_test.go
@@ -1,0 +1,118 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/base64"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// github and gitlab are the two providers whose credential extractor is selected
+// per request rather than per mount: git smart-HTTP paths get a Basic credential
+// built for git, and every other path falls back to the mount's REST extractor.
+// github is the one the seed set carries; gitlab's REST leg is equally untested
+// end to end and belongs with the rest of that provider's coverage.
+//
+// e2e/githttp covers github's git half in depth — passthrough, minting,
+// attribution, the placeholder-password rule and a real clone — but every one of
+// those drives a smart-HTTP path, so the REST half of the same mount has never
+// been driven end to end.
+//
+// It is also the only member of the seed set using TypedTokenExtractor, the one
+// shared SDK extractor shape the other providers do not reach.
+
+const githubPAT = "fc-github-not-a-real-token"
+
+var githubEnv = h.ProviderEnv{
+	Mount:    "fc-github",
+	Type:     "github",
+	URLKey:   "github_url",
+	CredType: "github_token",
+	// A local source carries the token statically and mints nothing, so only
+	// the field the credential needs is set. mint_method would be required of a
+	// real github source and is not consulted here — the local driver would
+	// simply copy it into the minted credential as a stray field.
+	CredConfig: map[string]string{"token": githubPAT},
+}
+
+// TestGitHub_RESTLegInjectsTokenScheme drives a REST path and pins two things at
+// once: the credential shape, and that the request took the REST branch at all.
+//
+// Nothing positively selects that branch — the git dispatch declines a path it
+// does not recognise and the mount-level extractor applies by fallback — so the
+// evidence is circumstantial and needs two independent signals:
+//
+//   - the scheme. REST authenticates with "token <pat>" where the git leg on
+//     this same mount sends Basic base64("x-access-token:<pat>"), so a misfiring
+//     dispatch would carry the same secret in a visibly different form.
+//   - the REST-only headers. The git dispatch suppresses the default Accept and
+//     the dynamic headers, so their presence is a signal the credential scheme
+//     cannot give on its own. X-GitHub-Api-Version is also the only end-to-end
+//     coverage of DynamicHeaders in this suite.
+func TestGitHub_RESTLegInjectsTokenScheme(t *testing.T) {
+	ensureEnv(t)
+
+	probe := h.ProbePath("github-rest")
+	status, body, _ := h.ChainRequest(t, leaderPort, githubEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         githubEnv.CertRole(),
+		Path:         probe,
+		Headers:      h.InertDecoyHeaders(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		Injected: map[string]string{
+			"Authorization":        "token " + githubPAT,
+			"Accept":               "application/vnd.github+json",
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	// The user is resolved by the same function the git leg uses, here through
+	// its Bearer branch rather than the Basic-password one — the dispatch
+	// changes which credential goes out, not who the request is for.
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}
+
+// TestGitHub_RESTLegAcceptsUserInBasicPassword covers the other slot the user can
+// arrive in. github resolves the second principal through the same helper on
+// every path, and that helper accepts either a Bearer token or a JWT-shaped HTTP
+// Basic password — the latter existing because git can only send credentials that
+// way.
+//
+// Nothing exercises that slot on a REST path: e2e/githttp drives it only on
+// smart-HTTP paths, and the test above supplies a Bearer. The two differ in both
+// the path shape and the credential the upstream receives, so this duplicates
+// neither.
+//
+// The Basic username is the agent's role, which is how a git client selects one
+// with no configuration beyond the clone URL. The certificate is what actually
+// authenticates the agent.
+func TestGitHub_RESTLegAcceptsUserInBasicPassword(t *testing.T) {
+	ensureEnv(t)
+
+	userJWT := h.FullChainUserJWT(t)
+	basic := base64.StdEncoding.EncodeToString([]byte(githubEnv.CertRole() + ":" + userJWT))
+
+	probe := h.ProbePath("github-rest-basic-user")
+	status, body, _ := h.ChainRequest(t, leaderPort, githubEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		RawAuthz:     "Basic " + basic,
+		Role:         githubEnv.CertRole(),
+		Path:         probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "token " + githubPAT},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -33,9 +33,9 @@ import (
 
 // allEnvs is every provider the package sets up, in setup and teardown order.
 // Between them they cover each token-extractor family — default, channels,
-// channels with the native header first, and scheme dispatch — and four
-// different credential extractors.
-var allEnvs = []h.ProviderEnv{openaiEnv, anthropicEnv, newrelicEnv, elasticEnv}
+// channels with the native header first, scheme dispatch, and the git dual-slot
+// on its REST path — and five different credential extractors.
+var allEnvs = []h.ProviderEnv{openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv}
 
 var (
 	envOnce    sync.Once

--- a/provider/github/git.go
+++ b/provider/github/git.go
@@ -9,7 +9,8 @@ import (
 
 // Git smart-HTTP support: the github provider mount carries two protocols
 // at once. REST paths (/repos, /user, /orgs, ...) proxy to api.github.com
-// with a Bearer token. Git smart-HTTP paths (<owner>/<repo>.git/info/refs,
+// under GitHub's own "token" scheme, not Bearer — see the extractor on
+// Spec. Git smart-HTTP paths (<owner>/<repo>.git/info/refs,
 // .git/git-upload-pack, .git/git-receive-pack) proxy to github.com with
 // HTTP Basic Auth carrying the PAT as the password.
 //


### PR DESCRIPTION
github and gitlab are the two providers whose credential extractor is
selected per request rather than per mount: git smart-HTTP paths get a
Basic credential built for git, and every other path falls back to the
mount's REST extractor. e2e/githttp covers github's git half in depth,
but every one of those tests drives a smart-HTTP path, so the REST half
of the same mount had never been driven end to end.

Nothing positively selects the REST branch — the git dispatch declines a
path it does not recognise and the mount-level extractor applies by
fallback — so the evidence is circumstantial and the rows carry two
independent signals: the credential scheme, which is "token <pat>" where
the git leg sends Basic base64("x-access-token:<pat>"), and the REST-only
Accept and X-GitHub-Api-Version headers, which the git dispatch
suppresses. The latter is also this suite's only coverage of
DynamicHeaders.

A second row sends the user credential in the HTTP Basic password rather
than a Bearer. github resolves the second principal through the same
helper on every path and that helper accepts either slot, but nothing
exercised the password slot on a REST path — e2e/githttp reaches it only
over smart-HTTP.

Also corrects a stale comment in the provider: REST paths authenticate
under GitHub's own "token" scheme, not Bearer. It is the comment a
maintainer would otherwise cite to "fix" the scheme these rows guard.

---

**Stack** — part 2 of 9 in the full-chain e2e series. Targets `feat/e2e-fullchain-harness`; retarget to `main` once the parent merges.
