### PR TITLE
test(e2e): cover the remaining shared credential extractors

### DIFF
--- a/e2e/fullchain/chain_test.go
+++ b/e2e/fullchain/chain_test.go
@@ -30,6 +30,11 @@ var injections = []injection{
 	{newrelicEnv, map[string]string{"Api-Key": newrelicKey}},
 	{elasticEnv, map[string]string{"Authorization": "ApiKey " + elasticKey}},
 	{githubEnv, map[string]string{"Authorization": "token " + githubPAT}},
+	{splunkEnv, map[string]string{"Authorization": "Bearer " + splunkKey}},
+	{datadogEnv, map[string]string{"DD-API-KEY": datadogAPIKey}},
+	{restEnv, map[string]string{"X-Custom-Auth": "Token " + restToken}},
+	{dynatraceEnv, map[string]string{"Authorization": "Api-Token " + dynatraceAPIToken}},
+	{dynatraceOAuthEnv, map[string]string{"Authorization": "Bearer " + dynatraceOAuthToken}},
 }
 
 // TestFullChain_CertAgentWithUser is the reference shape the suite exists for:

--- a/e2e/fullchain/datadog_test.go
+++ b/e2e/fullchain/datadog_test.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// datadog is the only user of the multi-field extractor: one required field and
+// one optional, each landing in its own header rather than a single
+// Authorization value. Its inbound side is the plain default extractor, so the
+// rows here are about the outbound shape.
+
+const datadogAPIKey = "fc-datadog-not-a-real-key"
+
+var datadogEnv = h.ProviderEnv{
+	Mount:      "fc-datadog",
+	Type:       "datadog",
+	URLKey:     "datadog_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": datadogAPIKey},
+}
+
+// TestDatadog_RequiredKeyInjected covers the reachable half of the multi-field
+// extractor: the required field lands in its own header rather than in an
+// Authorization value.
+//
+// The optional half cannot be reached. Its field is application_key, and nothing
+// in the tree produces one — api_key, the type datadog's own help text points
+// at, carries only api_key, key_id, key_name, organization_id and project_id, so
+// a spec that sets application_key has it dropped before the credential is
+// built. Covering that branch needs a variant spec and a positive assertion, and
+// neither can be written until the field is carriable.
+//
+// DD-APPLICATION-KEY is deliberately NOT asserted absent. The header is in no
+// strip list and the extractor never injects it, so a caller-supplied value
+// reaches the upstream today — asserting absence without sending one would pass
+// vacuously, and sending one would fail. The assertion belongs here once that
+// passthrough is closed.
+func TestDatadog_RequiredKeyInjected(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, datadogEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         datadogEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:   200,
+		Injected: map[string]string{"DD-API-KEY": datadogAPIKey},
+		// The credential rides its own header, leaving Authorization untouched
+		// by injection — so a leaked caller credential would be visible there
+		// rather than overwritten.
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+}

--- a/e2e/fullchain/dynatrace_test.go
+++ b/e2e/fullchain/dynatrace_test.go
@@ -1,0 +1,103 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// dynatrace is the only provider that accepts two different credential types and
+// emits a different Authorization scheme for each — an API token under
+// Dynatrace's own "Api-Token" scheme, an OAuth token under Bearer. The type
+// decides, so covering it means two mounts rather than two roles on one: a role
+// binds a spec, and the two specs need different types and different sources.
+//
+// Neither arm had any test at all before this.
+
+const (
+	dynatraceAPIToken   = "fc-dynatrace-not-a-real-token"
+	dynatraceOAuthToken = "fc-dynatrace-not-a-real-oauth-token"
+)
+
+var dynatraceEnv = h.ProviderEnv{
+	Mount:      "fc-dynatrace",
+	Type:       "dynatrace",
+	URLKey:     "dynatrace_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": dynatraceAPIToken},
+}
+
+// The OAuth arm needs an oauth_bearer_token credential, which no local source
+// will hold — so it uses an oauth2 source, configured for the one mint path that
+// touches no network.
+//
+// The default grant is client_credentials, which really does call the token
+// endpoint; pointed at the harness's issuer it mints a live token whose value no
+// assertion can predict, and the row would then be testing the OAuth2 driver
+// rather than this provider's extractor. Under authorization_code the driver
+// instead returns the spec's static access token verbatim — the path a provider
+// that issues no refresh token takes — which keeps the assertion exact and the
+// subject the extractor. token_url is required of the source either way and is
+// never called here.
+var dynatraceOAuthEnv = h.ProviderEnv{
+	Mount:      "fc-dynatrace-oauth",
+	Type:       "dynatrace",
+	URLKey:     "dynatrace_url",
+	CredType:   "oauth_bearer_token",
+	SourceType: "oauth2",
+	SourceConfig: map[string]string{
+		"token_url":       h.HydraIssuer + "/oauth2/token",
+		"tls_skip_verify": "true",
+	},
+	// auth_method belongs on the spec, where it is a declared field; the source
+	// schema does not define it and would carry it only because unknown keys are
+	// ignored. access_token is documented as sealed at connect time rather than
+	// operator-set, but IsConnected accepts a hand-written value, so nothing
+	// enforces it — this fixture leans on that gap to mint an OAuth credential
+	// without a network call.
+	CredConfig: map[string]string{
+		"auth_method":  "authorization_code",
+		"access_token": dynatraceOAuthToken,
+	},
+}
+
+// TestDynatrace_CredentialTypeSelectsScheme drives both arms and asserts they
+// differ. Either alone would show only that some credential reached the
+// upstream; together they show the type is what chooses the scheme.
+//
+// The distinction is not cosmetic — Dynatrace rejects an API token presented as
+// a Bearer, so a provider that collapsed the two arms would fail every request
+// with a credential that is itself perfectly valid.
+func TestDynatrace_CredentialTypeSelectsScheme(t *testing.T) {
+	ensureEnv(t)
+
+	cases := []struct {
+		name string
+		env  h.ProviderEnv
+		want string
+	}{
+		{"api token", dynatraceEnv, "Api-Token " + dynatraceAPIToken},
+		{"oauth token", dynatraceOAuthEnv, "Bearer " + dynatraceOAuthToken},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, tc.env, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.env.CertRole(),
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      map[string]string{"Authorization": tc.want},
+				Absent:        h.AlwaysAbsent(),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -34,8 +34,16 @@ import (
 // allEnvs is every provider the package sets up, in setup and teardown order.
 // Between them they cover each token-extractor family — default, channels,
 // channels with the native header first, scheme dispatch, and the git dual-slot
-// on its REST path — and five different credential extractors.
-var allEnvs = []h.ProviderEnv{openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv}
+// on its REST path — and all four shared SDK credential extractors.
+//
+// Four providers hand-roll an extractor and are not here: mcp, which needs
+// request bodies the harness cannot yet send, and atlassian, honeycomb and
+// prometheus, whose distinctive branches read credential fields nothing can
+// supply.
+var allEnvs = []h.ProviderEnv{
+	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
+	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv,
+}
 
 var (
 	envOnce    sync.Once

--- a/e2e/fullchain/rest_test.go
+++ b/e2e/fullchain/rest_test.go
@@ -1,0 +1,74 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// rest is the generic escape hatch: where every other provider compiles its
+// credential shape in, this one takes it from mount config. That inverts what a
+// row here proves — not that the provider knows GitHub's scheme or Datadog's
+// header names, but that an operator's configuration is what actually reaches
+// the upstream.
+//
+// Its extractor is also the only one assembled per request rather than per
+// mount for a reason other than the path, which is why the config values are
+// deliberately unusual: a default-shaped row would pass whether or not the
+// configuration was consulted at all.
+
+const restToken = "fc-rest-not-a-real-token"
+
+var restEnv = h.ProviderEnv{
+	Mount:    "fc-rest",
+	Type:     "rest",
+	URLKey:   "base_url",
+	CredType: "api_key",
+	ExtraConfig: map[string]any{
+		// None of these are defaults. The default would put "Bearer <token>" in
+		// Authorization, which is also what several other providers do — so a
+		// row using it could not tell "configuration honoured" from "provider
+		// happened to behave that way".
+		"token_header": "X-Custom-Auth",
+		"token_prefix": "Token ",
+		"headers":      map[string]any{"X-Tenant": "fc-e2e-tenant"},
+	},
+	CredConfig: map[string]string{"api_key": restToken},
+}
+
+// TestREST_ConfiguredHeaderAndPrefixAreHonoured checks the three parts of the
+// contract together: the token lands in the configured header, under the
+// configured prefix, alongside the configured static headers — and Authorization,
+// where the default would have put it, stays empty.
+func TestREST_ConfiguredHeaderAndPrefixAreHonoured(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, restEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         restEnv.CertRole(),
+		// Both configured headers are also sent by the caller. The mount's
+		// values must replace them, not merge or lose to them — a static header
+		// a caller can overwrite is worth less than no static header, since it
+		// reads as enforced while being caller-controlled.
+		Headers: map[string]string{
+			"X-Tenant":      "attacker-tenant",
+			"X-Custom-Auth": "Token attacker-supplied",
+		},
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		Injected: map[string]string{
+			"X-Custom-Auth": "Token " + restToken,
+			"X-Tenant":      "fc-e2e-tenant",
+		},
+		// Authorization is where the default would have put the credential, and
+		// where the caller's own arrived. Empty here means the configuration was
+		// honoured and the inbound credential was dropped rather than passed on.
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+}

--- a/e2e/fullchain/splunk_test.go
+++ b/e2e/fullchain/splunk_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// splunk is the second scheme-dispatch provider. Its agent credential rides
+// Authorization under Splunk's own scheme, so agent and user share the header
+// and are told apart by which scheme is present — the same shape as elastic, on
+// a different scheme name, which is what makes the pair worth having: a
+// regression in the shared helper would have to break both.
+//
+// Outbound it is the plainest case in the suite, the Bearer extractor ten
+// providers share, so this row also stands in for all of them.
+
+const splunkKey = "fc-splunk-not-a-real-key"
+
+var splunkEnv = h.ProviderEnv{
+	Mount:      "fc-splunk",
+	Type:       "splunk",
+	URLKey:     "splunk_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": splunkKey},
+}
+
+// TestSplunk_NativeSchemeClaimsAgentSlotAndLeavesNoUser mirrors the elastic row.
+// An agent arriving under the Splunk scheme speaks for the header, so no user
+// can be carried, and the certificate that is also present is never consulted.
+//
+// Were the out-of-band agent checked first, the certificate would win, the
+// extractor would return an empty agent, and the certificate login would fail
+// against the bearer-only agent leg this test repoints to — so the 200 is what
+// pins the ordering rather than merely observing a success.
+func TestSplunk_NativeSchemeClaimsAgentSlotAndLeavesNoUser(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, splunkEnv)
+
+	probe := h.ProbePath("splunk-native-scheme")
+	status, body, _ := h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		RawAuthz:     "Splunk " + h.GetDefaultJWT(t),
+		Role:         splunkEnv.JWTAgentRole(),
+		Path:         probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+	h.AssertAuditUser(t, leaderPort, probe, "")
+}

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -81,10 +81,21 @@ type ProviderEnv struct {
 	// JSON, so booleans and numbers keep their types.
 	ExtraConfig map[string]any
 
-	// CredType is the credential type the spec mints, e.g. "api_key". It must
-	// accept a local source — only api_key, github_token, aws_access_keys,
-	// cloudflare_keys and scaleway_keys do.
+	// CredType is the credential type the spec mints, e.g. "api_key".
 	CredType string
+
+	// SourceType is the credential source backing the mount. Defaults to
+	// "local", which holds the credential statically and calls nothing.
+	//
+	// Credential types are validated against their source, and only api_key,
+	// github_token, aws_access_keys, cloudflare_keys and scaleway_keys accept a
+	// local one — so any other type needs a source that will have it. Pick one
+	// whose mint path can be satisfied without a real upstream.
+	SourceType string
+
+	// SourceConfig is the source's own configuration, needed when SourceType is
+	// not "local".
+	SourceConfig map[string]string
 
 	// CredConfig is the spec config. For a local source these values are copied
 	// verbatim into the minted credential, which is what lets a test assert on
@@ -258,8 +269,16 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 	}
 	mustAPI(t, port, "PUT", p.Mount+"/config", mustJSON(t, cfg), "configure "+p.Type+" provider")
 
+	sourceType := p.SourceType
+	if sourceType == "" {
+		sourceType = "local"
+	}
+	source := map[string]any{"type": sourceType}
+	if len(p.SourceConfig) > 0 {
+		source["config"] = p.SourceConfig
+	}
 	mustAPI(t, port, "POST", "sys/cred/sources/"+p.Source(),
-		`{"type":"local"}`, "create credential source for "+p.Mount)
+		mustJSON(t, source), "create credential source for "+p.Mount)
 
 	mustAPI(t, port, "POST", "sys/cred/specs/"+p.Spec(),
 		mustJSON(t, map[string]any{


### PR DESCRIPTION
Adds splunk, datadog, rest and dynatrace to the full-chain suite. Three
of the four had no test file of any kind; splunk had only its token side.
Between them they complete the four shared SDK extractors and add the two
distinctive shapes that had none: the configuration-driven one, and the
only provider emitting a different scheme per credential type.

dynatrace needs two mounts rather than two roles on one, because a role
binds a spec and its two arms need different credential types from
different sources. That drives a small harness addition: a source type
and config on ProviderEnv, since not every credential type accepts the
local source the other providers use. Its OAuth arm mints through the
authorization_code static-token path, which touches no network — the
default grant calls the token endpoint and yields a live token no
assertion can predict, making the row a test of the OAuth2 driver rather
than of this provider's extractor.

Four hand-rolled extractors remain uncovered and the comment on allEnvs
now says which and why, rather than claiming the set is complete.

Driving whole chains turned up production behaviour that units cannot
see, and most of it shares one cause: a credential carries only the
fields its type declares, so four providers read fields nothing can
supply. datadog cannot send an application key, atlassian can never use
the Basic form Atlassian Cloud actually wants, prometheus can never
select Basic auth, and a honeycomb mount configured with a management
key fails every request. Alongside those, a caller's own
DD-APPLICATION-KEY proxies to the upstream beside the minted key —
confirmed by sending one.

None of that is fixed here. Test PRs ship tests; those changes get their
own, weighed on their own merits, once the coverage is complete.

---

**Stack** — part 3 of 9 in the full-chain e2e series. Targets `feat/e2e-fullchain-github-rest`; retarget to `main` once the parent merges.
