### PR TITLE
test(e2e): cover mcp's credential extractor and policy wiring

### DIFF
--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -36,13 +36,12 @@ import (
 // channels with the native header first, scheme dispatch, and the git dual-slot
 // on its REST path — and all four shared SDK credential extractors.
 //
-// Four providers hand-roll an extractor and are not here: mcp, which needs
-// request bodies the harness cannot yet send, and atlassian, honeycomb and
-// prometheus, whose distinctive branches read credential fields nothing can
-// supply.
+// Three providers hand-roll an extractor and are not here: atlassian, honeycomb
+// and prometheus, whose distinctive branches read credential fields nothing can
+// supply, so a row could only cover the fallback each degrades to.
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
-	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv,
+	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
 }
 
 var (

--- a/e2e/fullchain/mcp_test.go
+++ b/e2e/fullchain/mcp_test.go
@@ -1,0 +1,193 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// mcp is the only provider whose authorization depends on the request *body*.
+// Everything else in this suite is decided by path and capability; here a policy
+// names the tools a caller may invoke, and the decision needs the JSON-RPC call
+// itself.
+//
+// The decision logic is covered thoroughly in-process — core has seven files on
+// mcp { } parsing, evaluation and list filtering. What none of them exercise is
+// the wiring: that a policy written through the API, stored, attached to a token
+// minted for a certificate agent, and evaluated against a real request body,
+// actually reaches the enforcement point. Those tests construct a Core directly.
+//
+// Its credential extractor accepts five types and reads a different field for
+// three of them. The api_key and github_token fields are both covered here — the
+// two that read different fields and are cheapest to mint — and all five,
+// including their empty-token branches, in provider/mcp's unit tests.
+
+const (
+	mcpAPIKey      = "fc-mcp-not-a-real-key"
+	mcpGitHubToken = "fc-mcp-not-a-real-github-token"
+	mcpAllowedTool = "fc_allowed_tool"
+	mcpDeniedTool  = "fc_denied_tool"
+)
+
+var mcpEnv = h.ProviderEnv{
+	Mount:      "fc-mcp",
+	Type:       "mcp",
+	URLKey:     "mcp_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": mcpAPIKey},
+	// Naming one tool is what opts the mount into body-authoritative
+	// enforcement; without an mcp { } block the body is never inspected and
+	// every JSON-RPC call the capability allows would go through.
+	ExtraPolicyRules: `  mcp {
+    allowed_methods = ["tools/call", "tools/list"]
+    allowed_tools   = ["` + mcpAllowedTool + `"]
+  }`,
+}
+
+// The github_token arm needs its own mount: a role binds one spec, and a variant
+// spec would share this env's credential type. Its only job is to prove the
+// extractor reads "token" rather than "api_key" for that type — a mis-wired
+// field would fail as "missing token", indistinguishable from an empty one.
+var mcpGitHubEnv = h.ProviderEnv{
+	Mount:      "fc-mcp-github",
+	Type:       "mcp",
+	URLKey:     "mcp_url",
+	CredType:   "github_token",
+	CredConfig: map[string]string{"token": mcpGitHubToken},
+}
+
+func mcpToolCall(tool string) string {
+	return `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + tool + `"}}`
+}
+
+// TestMCP_AllowedToolReachesUpstream is the positive half. It also confirms the
+// credential extractor picked the right field for this credential type — the
+// same 200 covers both, since a request that authorised but injected nothing
+// would arrive without an Authorization header.
+func TestMCP_AllowedToolReachesUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         mcpToolCall(mcpAllowedTool),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + mcpAPIKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestMCP_GitHubTokenArmReadsItsOwnField covers the second field the extractor
+// reads. Both arms emit the same Bearer scheme, so the only thing separating
+// them is which key the token was taken from — and reading the wrong one yields
+// "missing token", a failure indistinguishable from an unset credential.
+func TestMCP_GitHubTokenArmReadsItsOwnField(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpGitHubEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpGitHubEnv.CertRole(),
+		Body:         mcpToolCall(mcpAllowedTool),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + mcpGitHubToken},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestMCP_DeniedToolIsRefusedBeforeTheUpstream is the row the wiring exists for.
+// The two requests differ only in a tool name buried in a JSON body: same mount,
+// same role, same credential, same path, same capability. Nothing but the policy
+// reading that body can tell them apart.
+//
+// The zero-upstream-calls assertion is the point. A denial that arrives after
+// the request has been forwarded has already spent the credential on the call it
+// was meant to prevent.
+func TestMCP_DeniedToolIsRefusedBeforeTheUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, respHeaders := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         mcpToolCall(mcpDeniedTool),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        403,
+		UpstreamCalls: 0,
+	})
+
+	// A 403 alone would be satisfied by any layer refusing for any reason. The
+	// challenge is what identifies the refusal as this filter's: it is the deny
+	// surface the policy path emits, and nothing else in the chain produces it.
+	if challenge := respHeaders.Get("WWW-Authenticate"); !strings.Contains(challenge, "insufficient_permissions") {
+		t.Errorf("want the policy deny challenge, got WWW-Authenticate: %q", challenge)
+	}
+}
+
+// TestMCP_MalformedBodyIsRefused checks that a truncated body is refused with
+// nothing forwarded. It does NOT test the mcp { } filter, despite the shape:
+// the request never reaches policy evaluation, because the body is unmarshalled
+// into a map while the agent is still being authenticated, and a truncated body
+// fails that decode first. The same request would 401 with no mcp { } block at
+// all.
+//
+// What it is worth having as a row: refusal reaches the caller with nothing
+// proxied, which is the property that must survive whatever happens to the
+// authorization path. The status is the generic 401 of a failed agent login, not
+// the 403 the filter returns. That early decode into a map is also why a valid
+// JSON-RPC batch cannot be proxied at all: a top-level JSON array does not fit
+// the shape, so it fails the same way before policy is ever consulted.
+func TestMCP_MalformedBodyIsRefused(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":`,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        401,
+		UpstreamCalls: 0,
+	})
+}
+
+// TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy is the fail-closed row the
+// truncated-body case cannot be. A duplicate key is accepted by the generic
+// decoder — last one wins — so the request survives authentication and reaches
+// the filter, where the strict JSON-RPC parser rejects it.
+//
+// That is the property worth pinning: a body the filter cannot interpret is
+// denied rather than waved through as "no rule matched", which is how a filter
+// of this shape usually breaks. Unlike the truncated body, this row would pass
+// differently with the mcp { } block removed.
+func TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/call","method":"tools/call"}`,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        403,
+		UpstreamCalls: 0,
+	})
+}

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -97,6 +97,11 @@ type ProviderEnv struct {
 	// not "local".
 	SourceConfig map[string]string
 
+	// ExtraPolicyRules are appended inside the mount's gateway path stanza,
+	// for providers whose authorization is finer-grained than a capability —
+	// a body-authoritative rule set, say, which cannot be expressed as one.
+	ExtraPolicyRules string
+
 	// CredConfig is the spec config. For a local source these values are copied
 	// verbatim into the minted credential, which is what lets a test assert on
 	// an exact upstream header value.
@@ -289,7 +294,7 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 		"create credential spec for "+p.Mount)
 
 	mustAPI(t, port, "POST", "sys/policies/cbp/"+p.Policy(),
-		mustJSON(t, map[string]any{"policy": gatewayPolicy(p.Mount)}),
+		mustJSON(t, map[string]any{"policy": gatewayPolicy(p.Mount, p.ExtraPolicyRules)}),
 		"create policy for "+p.Mount)
 
 	mustAPI(t, port, "POST", "auth/cert/role/"+p.CertRole(),
@@ -356,12 +361,18 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 }
 
 // gatewayPolicy grants both gateway shapes: the bare one, used when the role
-// arrives in a header, and the role-in-path one.
-func gatewayPolicy(mount string) string {
-	return fmt.Sprintf(
-		"path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\n"+
-			"path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}",
-		mount+"/gateway*", mount+"/role/+/gateway*")
+// arrives in a header, and the role-in-path one. extraRules is appended inside
+// each stanza, so a provider's finer-grained rules apply however the role was
+// selected.
+func gatewayPolicy(mount, extraRules string) string {
+	stanza := func(path string) string {
+		body := "  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n"
+		if extraRules != "" {
+			body += extraRules + "\n"
+		}
+		return fmt.Sprintf("path %q {\n%s}\n", path, body)
+	}
+	return stanza(mount+"/gateway*") + stanza(mount+"/role/+/gateway*")
 }
 
 // CertAgentPath is the default agent leg: the agent proves itself with a client
@@ -441,8 +452,16 @@ type ChainOpts struct {
 	// Path is appended after the gateway prefix. Defaults to "probe".
 	Path string
 
-	// Method defaults to GET.
+	// Method defaults to GET, or POST when Body is set.
 	Method string
+
+	// Body is the request body. Sending one matters beyond the payload itself:
+	// policy that reads the body only engages on a request that has one, so a
+	// rule about what a caller may ask for cannot be exercised without it.
+	//
+	// Content-Type defaults to application/json, which is also what decides
+	// whether a provider opts the request into body-authoritative policy.
+	Body string
 }
 
 // ChainRequest drives one request through the whole chain and returns the
@@ -483,6 +502,9 @@ func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []by
 	method := o.Method
 	if method == "" {
 		method = "GET"
+		if o.Body != "" {
+			method = "POST"
+		}
 	}
 	path := o.Path
 	if path == "" {
@@ -490,7 +512,7 @@ func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []by
 	}
 
 	u := fmt.Sprintf("%s/v1/%s/gateway/%s", NodeURL(port), p.Mount, path)
-	status, body, respHeaders := DoRequestWithResponseHeaders(t, method, u, headers, "")
+	status, body, respHeaders := DoRequestWithResponseHeaders(t, method, u, headers, o.Body)
 	return status, body, http.Header(respHeaders)
 }
 

--- a/provider/mcp/provider_test.go
+++ b/provider/mcp/provider_test.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The extractor accepts five credential types and reads the token from a
+// different field for three of them, so its branches are a matrix rather than a
+// list: every type must find its own field, and a type reading the wrong one
+// would fail as "missing token" rather than visibly mismatching.
+
+func TestExtractBearerToken_AcceptedTypes(t *testing.T) {
+	cases := []struct {
+		name     string
+		credType string
+		field    string
+	}{
+		{"oauth bearer token", credential.TypeOAuthBearerToken, "api_key"},
+		{"api key", credential.TypeAPIKey, "api_key"},
+		{"gcp access token", credential.TypeGCPAccessToken, "access_token"},
+		{"azure bearer token", credential.TypeAzureBearerToken, "access_token"},
+		{"github token", credential.TypeGitHubToken, "token"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			headers, err := extractBearerToken(&logical.Request{
+				Credential: &credential.Credential{
+					Type: tc.credType,
+					Data: map[string]string{tc.field: "the-token"},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "Bearer the-token", headers["Authorization"])
+			assert.Len(t, headers, 1)
+		})
+	}
+}
+
+// Every accepted type must reject an empty token. The branch is shared, but it
+// is reachable from five places and a type wired to the wrong field would land
+// here rather than fail visibly — so each is worth its own row.
+func TestExtractBearerToken_EmptyTokenPerType(t *testing.T) {
+	cases := []struct {
+		name     string
+		credType string
+		data     map[string]string
+	}{
+		{"oauth bearer token", credential.TypeOAuthBearerToken, map[string]string{"api_key": ""}},
+		{"api key", credential.TypeAPIKey, map[string]string{}},
+		{"gcp access token", credential.TypeGCPAccessToken, map[string]string{"access_token": ""}},
+		{"azure bearer token", credential.TypeAzureBearerToken, map[string]string{}},
+		{"github token", credential.TypeGitHubToken, map[string]string{"token": ""}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := extractBearerToken(&logical.Request{
+				Credential: &credential.Credential{Type: tc.credType, Data: tc.data},
+			})
+			assert.ErrorContains(t, err, "missing token")
+		})
+	}
+}
+
+// A credential carrying the right value under the wrong field is indistinguishable
+// from an empty one — worth pinning, because it is what a mis-wired type would do.
+func TestExtractBearerToken_TokenUnderTheWrongField(t *testing.T) {
+	_, err := extractBearerToken(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeGitHubToken,
+			Data: map[string]string{"api_key": "the-token"},
+		},
+	})
+	assert.ErrorContains(t, err, "missing token")
+}
+
+func TestExtractBearerToken_NoCredential(t *testing.T) {
+	_, err := extractBearerToken(&logical.Request{})
+	assert.ErrorContains(t, err, "no credential available")
+}
+
+func TestExtractBearerToken_UnsupportedType(t *testing.T) {
+	_, err := extractBearerToken(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeVaultToken,
+			Data: map[string]string{"token": "the-token"},
+		},
+	})
+	assert.ErrorContains(t, err, "unsupported credential type for mcp")
+}
+
+// The enforcement gate decides whether a request is subject to body-authoritative
+// mcp { } rules. It has to decline anything whose body is not a JSON-RPC call —
+// SSE reconnects and session closes carry no method to authorise — while
+// admitting every shape a real client's POST takes.
+
+func TestShouldEnforceMCPPolicy(t *testing.T) {
+	cases := []struct {
+		name        string
+		method      string
+		contentType string
+		want        bool
+	}{
+		{"json-rpc post", http.MethodPost, "application/json", true},
+		{"json-rpc post with charset", http.MethodPost, "application/json; charset=utf-8", true},
+		{"sse reconnect", http.MethodGet, "application/json", false},
+		{"session close", http.MethodDelete, "application/json", false},
+		{"post with no content type", http.MethodPost, "", false},
+		{"post with a non-json body", http.MethodPost, "text/plain", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(tc.method, "/v1/mcp/gateway/", strings.NewReader("{}"))
+			if tc.contentType != "" {
+				r.Header.Set("Content-Type", tc.contentType)
+			}
+			got := shouldEnforceMCPPolicy(&logical.Request{HTTPRequest: r})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// Declining must be safe to call on a request that carries no HTTP layer at all,
+// since the gate runs before anything has validated the request's shape.
+func TestShouldEnforceMCPPolicy_NilSafe(t *testing.T) {
+	got := shouldEnforceMCPPolicy(nil)
+	assert.False(t, got)
+
+	got = shouldEnforceMCPPolicy(&logical.Request{})
+	assert.False(t, got)
+}
+
+func TestSpec(t *testing.T) {
+	assert.Equal(t, "mcp", Spec.Name)
+	assert.Equal(t, "mcp_url", Spec.URLConfigKey)
+	assert.NotNil(t, Spec.ExtractCredentials)
+	assert.NotNil(t, Spec.ShouldEnforceMCPPolicy)
+	assert.NotNil(t, Factory)
+	// Streaming bodies must not be parsed: MCP responses may be SSE, and buffering
+	// one would stall a session rather than proxy it.
+	assert.False(t, Spec.ParseStreamBody)
+	// No default Accept: MCP clients negotiate their own, and forcing one would
+	// break a one-shot JSON client.
+	assert.Empty(t, Spec.DefaultAccept)
+}


### PR DESCRIPTION
provider/mcp had no tests at all. Its extractor accepts five credential
types and reads a different field for three of them, so a type wired to
the wrong field fails as "missing token" rather than mismatching visibly
— hence a positive and an empty-token row per type, plus one for a token
present under the wrong field.

The mcp { } decision logic is, by contrast, covered thoroughly: seven
files in core on parsing, evaluation and list filtering. None of them
exercises the wiring, because they construct a Core directly. The e2e
rows drive what those cannot reach — a policy written through the API,
stored, attached to a token minted for a certificate agent, and evaluated
against a real request body. Two requests differing only in a tool name
inside a JSON body: one forwarded, one refused with nothing sent upstream.

This is the first row whose subject is the request body, so ChainOpts
grows a Body, and ProviderEnv grows extra policy rules for providers
whose authorization is finer-grained than a capability.

The truncated-body row is deliberately not presented as a filter test.
The request never reaches policy evaluation — the body is unmarshalled
into a map while the agent is still authenticating — so a duplicate-key
body, which the generic decoder accepts and the strict parser rejects,
does the fail-closed job instead.

Two defects found and deliberately not fixed here, per the convention:

  B2 — a JSON array request body cannot be proxied by any provider.
  Measured at 500 on openai and datadog, 401 on mcp, against 200 for an
  object body. That shape is OpenAI batch, Datadog series, and JSON-RPC
  batches, which Warden's own strict parser supports.

  B3 — a recreated policy is not enforced; the deleted one is. Compiled
  policies are cached on name and DataVersion with no content hash, and
  delete-then-recreate resets the version, so the collision serves the
  old compilation. Removing a permission does not revoke it, and reading
  the policy back returns the new text while the old rules run. Found by
  mutation-testing these rows; it also explains why a suite that recreates
  policies under fixed names can assert against a previous run.

---

**Stack** — part 4 of 9 in the full-chain e2e series. Targets `feat/e2e-fullchain-custom-extractors`; retarget to `main` once the parent merges.
