### PR TITLE
test(e2e): cover the response half of the chain

### DIFF
--- a/e2e/fullchain/credential_update_test.go
+++ b/e2e/fullchain/credential_update_test.go
@@ -1,0 +1,113 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// Whether a configuration change reaches the request path is its own class of
+// question, separate from whether the change was stored. A compiled-policy cache
+// once answered it wrongly — the API returned the new policy while the old one
+// was enforced — so the same question is worth asking of credentials, where the
+// stakes are the same: a key rotated because it leaked is only rotated if
+// requests stop carrying the old one.
+
+// setSpecAPIKey rewrites a spec's api_key, restoring the original afterwards so
+// the mount is left as the other rows expect to find it.
+func setSpecAPIKey(t *testing.T, env h.ProviderEnv, key, restore string) {
+	t.Helper()
+
+	write := func(v string) {
+		body := `{"type":"api_key","source":"` + env.Source() + `","config":{"api_key":"` + v + `"}}`
+		status, resp := h.APIRequest(t, "PUT", "sys/cred/specs/"+env.Spec(), leaderPort, body)
+		switch status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("rewrite spec %s (status %d): %s", env.Spec(), status, resp)
+		}
+	}
+
+	write(key)
+	t.Cleanup(func() { write(restore) })
+}
+
+// TestFullChain_UpdatedSpecReachesUpstream checks that rewriting a credential
+// spec changes what a new session sends upstream.
+//
+// The agent presents a fresh certificate, so this is a new session with no
+// credential of its own yet — the case that must always reflect current
+// configuration. A minted credential is cached per session, so an existing
+// session legitimately keeps the credential it was issued; that bound is the
+// subject of the row below, and the two together say when a rotation takes
+// effect.
+func TestFullChain_UpdatedSpecReachesUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	const rotated = "fc-splunk-rotated-not-a-real-key"
+	setSpecAPIKey(t, splunkEnv, rotated, splunkKey)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         splunkEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + rotated},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestFullChain_LiveSessionKeepsItsCredential pins the other half: a session that
+// already holds a minted credential keeps using it after the spec changes.
+//
+// This is deliberate — a credential is issued to a session, and re-minting on
+// every request would defeat the point of issuing one — but it is the part
+// operators are most likely to be surprised by, because it means rewriting a
+// spec does not immediately stop the old secret being sent. What bounds the
+// staleness is the session's own lifetime.
+//
+// Both requests reuse one certificate, which is what makes them one session; the
+// row above mints a fresh one precisely to be a different session.
+func TestFullChain_LiveSessionKeepsItsCredential(t *testing.T) {
+	ensureEnv(t)
+
+	cert := agentCert(t)
+	user := h.FullChainUserJWT(t)
+
+	// Establish the session, and confirm what it currently carries.
+	status, body, _ := h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: cert,
+		Bearer:       user,
+		Role:         splunkEnv.CertRole(),
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	const rotated = "fc-splunk-rotated-mid-session"
+	setSpecAPIKey(t, splunkEnv, rotated, splunkKey)
+
+	upstream.Reset()
+	status, body, _ = h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: cert,
+		Bearer:       user,
+		Role:         splunkEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		// The credential issued to this session, not the rewritten spec.
+		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}

--- a/e2e/fullchain/credential_update_test.go
+++ b/e2e/fullchain/credential_update_test.go
@@ -20,8 +20,12 @@ import (
 func setSpecAPIKey(t *testing.T, env h.ProviderEnv, key, restore string) {
 	t.Helper()
 
+	// PUT, not POST: creating a spec that already exists is a 409. The update
+	// merges config rather than replacing it, which is the same thing here only
+	// because splunk's spec holds api_key and nothing else — a multi-field spec
+	// would need every field it wants to keep.
 	write := func(v string) {
-		body := `{"type":"api_key","source":"` + env.Source() + `","config":{"api_key":"` + v + `"}}`
+		body := `{"config":{"api_key":"` + v + `"}}`
 		status, resp := h.APIRequest(t, "PUT", "sys/cred/specs/"+env.Spec(), leaderPort, body)
 		switch status {
 		case 200, 201, 204:
@@ -69,11 +73,16 @@ func TestFullChain_UpdatedSpecReachesUpstream(t *testing.T) {
 // This is deliberate — a credential is issued to a session, and re-minting on
 // every request would defeat the point of issuing one — but it is the part
 // operators are most likely to be surprised by, because it means rewriting a
-// spec does not immediately stop the old secret being sent. What bounds the
-// staleness is the session's own lifetime.
+// spec does not immediately stop the old secret being sent.
 //
-// Both requests reuse one certificate, which is what makes them one session; the
-// row above mints a fresh one precisely to be a different session.
+// Both the certificate *and* the user JWT are captured once and reused, and both
+// are load-bearing: a minted credential is keyed on the agent token and the user
+// token together, so re-fetching either would change the key and mint afresh.
+// Calling h.FullChainUserJWT at each request site would look harmless and
+// silently turn this into the row above, since every call issues a new JWT.
+//
+// What bounds the staleness is the session's own lifetime: the entry is cached
+// for the session TTL. No row here checks that bound.
 func TestFullChain_LiveSessionKeepsItsCredential(t *testing.T) {
 	ensureEnv(t)
 

--- a/e2e/fullchain/streaming_test.go
+++ b/e2e/fullchain/streaming_test.go
@@ -5,8 +5,10 @@ package fullchain
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,18 +20,27 @@ import (
 // from a buffered one — both end with the same bytes in hand. The difference is
 // only in when they arrive.
 //
-// It matters because the providers carrying model output all set
-// ParseStreamBody, and a proxy that buffered their responses would turn a
-// token-by-token stream into a single reply delivered when generation finished.
-// The request would still succeed, the bytes would still be right, and the
-// feature would be gone.
+// Nothing configures a flush interval on either reverse proxy in the tree, so
+// incremental delivery rests on the standard library's own rule: it auto-flushes
+// a response whose length is unknown, which is what an SSE body is. The wrapper
+// Warden puts around the ResponseWriter therefore has to forward Flush through
+// to the underlying writer, and that is the surface this row guards. A wrapper
+// that swallowed Flush would turn a token-by-token stream into one reply
+// delivered when generation finished — same status, same bytes, feature gone.
 
-// streamChunkGap is how long the fake upstream waits between chunks. It has to
-// beat scheduling noise on a loaded CI box without making the row slow.
+// streamChunkGap is how long the fake upstream waits between chunks. It only has
+// to be long enough to be unambiguous; the assertion does not compare against it.
 const streamChunkGap = 400 * time.Millisecond
 
-// sseUpstream emits three SSE events, flushing and pausing between each.
-func sseUpstream(t *testing.T) http.HandlerFunc {
+// streamProbe is an upstream that emits SSE events and records when it finished
+// producing them. Comparing that instant against the client's first chunk is
+// what makes the assertion threshold-free.
+type streamProbe struct {
+	mu         sync.Mutex
+	lastSentAt time.Time
+}
+
+func (s *streamProbe) handler(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -42,27 +53,46 @@ func sseUpstream(t *testing.T) http.HandlerFunc {
 		flusher.Flush()
 
 		for i := 1; i <= 3; i++ {
-			fmt.Fprintf(w, "data: chunk-%d\n\n", i)
-			flusher.Flush()
-			if i < 3 {
+			if i > 1 {
 				time.Sleep(streamChunkGap)
 			}
+			fmt.Fprintf(w, "data: chunk-%d\n\n", i)
+			flusher.Flush()
 		}
+
+		s.mu.Lock()
+		s.lastSentAt = time.Now()
+		s.mu.Unlock()
 	}
+}
+
+func (s *streamProbe) finishedAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSentAt
 }
 
 // TestStreaming_ResponseArrivesIncrementally proves the chain forwards a
 // streamed response as it is produced rather than buffering it.
 //
-// The upstream pauses between chunks, so a proxy that buffered would deliver all
-// three at the end and the first chunk's arrival would land near the total
-// duration. Streaming shows up as the first chunk arriving while the upstream is
-// still asleep before the second.
+// The assertion is the definition rather than a threshold: the client held
+// chunk-1 before the upstream had finished writing chunk-3. That ordering cannot
+// be manufactured by load — a slow machine delays both sides — so unlike a
+// "chunks arrived N apart" bound there is no margin to tune and nothing to go
+// flaky.
+//
+// What it catches is a response withheld until complete. It does not distinguish
+// degrees of lag: a proxy that released each chunk only when the next arrived
+// would still deliver chunk-1 early and still pass, which is defensible, since
+// such a proxy is streaming — just one chunk behind. Verified by mutation in both
+// directions: removing the upstream's flushes fails this row, while flushing one
+// chunk late passes it.
 func TestStreaming_ResponseArrivesIncrementally(t *testing.T) {
 	ensureEnv(t)
-	upstream.SetHandler(t, sseUpstream(t))
 
-	start := time.Now()
+	probe := &streamProbe{}
+	upstream.SetHandler(t, probe.handler(t))
+
 	resp := h.ChainStream(t, leaderPort, anthropicEnv, h.ChainOpts{
 		AgentCertPEM: agentCert(t),
 		Bearer:       h.FullChainUserJWT(t),
@@ -77,16 +107,18 @@ func TestStreaming_ResponseArrivesIncrementally(t *testing.T) {
 		t.Errorf("Content-Type: got %q, want the upstream's text/event-stream", ct)
 	}
 
-	var arrivals []time.Duration
 	var chunks []string
+	var firstArrival time.Time
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
+		if firstArrival.IsZero() {
+			firstArrival = time.Now()
+		}
 		chunks = append(chunks, line)
-		arrivals = append(arrivals, time.Since(start))
 	}
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("reading the stream: %v", err)
@@ -101,23 +133,32 @@ func TestStreaming_ResponseArrivesIncrementally(t *testing.T) {
 		}
 	}
 
-	// The load-bearing assertion. Buffering would push the first chunk out to
-	// roughly the same instant as the last; streaming separates them by the
-	// upstream's own pauses.
-	firstToLast := arrivals[len(arrivals)-1] - arrivals[0]
-	if firstToLast < streamChunkGap {
-		t.Errorf("chunks arrived %v apart, want at least %v — the response was buffered, "+
-			"not streamed (arrivals: %v)", firstToLast, streamChunkGap, arrivals)
+	finished := probe.finishedAt()
+	if finished.IsZero() {
+		t.Fatal("the upstream never recorded finishing; it did not run to completion")
+	}
+	if !firstArrival.Before(finished) {
+		t.Errorf("the first chunk reached the client at %v, not before the upstream finished "+
+			"producing at %v — the response was buffered rather than streamed",
+			firstArrival, finished)
 	}
 }
 
-// TestStreaming_CredentialStillInjected guards the seam between the two halves:
-// a streamed response must not come at the cost of the request side. The chunks
-// only flow because the upstream was reached, and it is reached only with the
-// minted credential.
-func TestStreaming_CredentialStillInjected(t *testing.T) {
+// TestStreaming_HelperCarriesTheSameRequest checks the streaming helper, not the
+// server. Credential injection is request-side and finishes before the upstream
+// writes a byte, so the server path is identical whichever shape the response
+// takes — the injection itself is already covered by the anthropic rows.
+//
+// What is worth checking is that the hand-rolled request in ChainStream carries
+// the same credentials and decoys as the buffered path, and that an upstream
+// with a replaced handler still records what it received. A divergence here
+// would make every future streaming row test something subtly different from its
+// non-streaming neighbours.
+func TestStreaming_HelperCarriesTheSameRequest(t *testing.T) {
 	ensureEnv(t)
-	upstream.SetHandler(t, sseUpstream(t))
+
+	probe := &streamProbe{}
+	upstream.SetHandler(t, probe.handler(t))
 
 	resp := h.ChainStream(t, leaderPort, anthropicEnv, h.ChainOpts{
 		AgentCertPEM: agentCert(t),
@@ -130,8 +171,10 @@ func TestStreaming_CredentialStillInjected(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", resp.StatusCode)
 	}
-	// Drain so the upstream finishes and the exchange is recorded whole.
-	_, _ = bufio.NewReader(resp.Body).WriteTo(discard{})
+	// Drained so the upstream handler runs to completion and does not outlive the
+	// test. The request was recorded on arrival, before the handler ran, so this
+	// is about the server goroutine rather than about the recording.
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	got := upstream.Last(t).Header
 	if v := got.Get("x-api-key"); v != anthropicKey {
@@ -143,7 +186,3 @@ func TestStreaming_CredentialStillInjected(t *testing.T) {
 		}
 	}
 }
-
-type discard struct{}
-
-func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/e2e/fullchain/streaming_test.go
+++ b/e2e/fullchain/streaming_test.go
@@ -1,0 +1,149 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The response half of the chain. Every other row in this package reads the body
+// to completion and asserts on the bytes, which cannot tell a streamed response
+// from a buffered one — both end with the same bytes in hand. The difference is
+// only in when they arrive.
+//
+// It matters because the providers carrying model output all set
+// ParseStreamBody, and a proxy that buffered their responses would turn a
+// token-by-token stream into a single reply delivered when generation finished.
+// The request would still succeed, the bytes would still be right, and the
+// feature would be gone.
+
+// streamChunkGap is how long the fake upstream waits between chunks. It has to
+// beat scheduling noise on a loaded CI box without making the row slow.
+const streamChunkGap = 400 * time.Millisecond
+
+// sseUpstream emits three SSE events, flushing and pausing between each.
+func sseUpstream(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream ResponseWriter cannot flush; the test cannot emit a stream")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		for i := 1; i <= 3; i++ {
+			fmt.Fprintf(w, "data: chunk-%d\n\n", i)
+			flusher.Flush()
+			if i < 3 {
+				time.Sleep(streamChunkGap)
+			}
+		}
+	}
+}
+
+// TestStreaming_ResponseArrivesIncrementally proves the chain forwards a
+// streamed response as it is produced rather than buffering it.
+//
+// The upstream pauses between chunks, so a proxy that buffered would deliver all
+// three at the end and the first chunk's arrival would land near the total
+// duration. Streaming shows up as the first chunk arriving while the upstream is
+// still asleep before the second.
+func TestStreaming_ResponseArrivesIncrementally(t *testing.T) {
+	ensureEnv(t)
+	upstream.SetHandler(t, sseUpstream(t))
+
+	start := time.Now()
+	resp := h.ChainStream(t, leaderPort, anthropicEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         anthropicEnv.CertRole(),
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("Content-Type: got %q, want the upstream's text/event-stream", ct)
+	}
+
+	var arrivals []time.Duration
+	var chunks []string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		chunks = append(chunks, line)
+		arrivals = append(arrivals, time.Since(start))
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("reading the stream: %v", err)
+	}
+
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks %q, want 3", len(chunks), chunks)
+	}
+	for i, want := range []string{"data: chunk-1", "data: chunk-2", "data: chunk-3"} {
+		if chunks[i] != want {
+			t.Errorf("chunk %d: got %q, want %q", i+1, chunks[i], want)
+		}
+	}
+
+	// The load-bearing assertion. Buffering would push the first chunk out to
+	// roughly the same instant as the last; streaming separates them by the
+	// upstream's own pauses.
+	firstToLast := arrivals[len(arrivals)-1] - arrivals[0]
+	if firstToLast < streamChunkGap {
+		t.Errorf("chunks arrived %v apart, want at least %v — the response was buffered, "+
+			"not streamed (arrivals: %v)", firstToLast, streamChunkGap, arrivals)
+	}
+}
+
+// TestStreaming_CredentialStillInjected guards the seam between the two halves:
+// a streamed response must not come at the cost of the request side. The chunks
+// only flow because the upstream was reached, and it is reached only with the
+// minted credential.
+func TestStreaming_CredentialStillInjected(t *testing.T) {
+	ensureEnv(t)
+	upstream.SetHandler(t, sseUpstream(t))
+
+	resp := h.ChainStream(t, leaderPort, anthropicEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         anthropicEnv.CertRole(),
+		Headers:      h.InertDecoyHeaders(),
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	// Drain so the upstream finishes and the exchange is recorded whole.
+	_, _ = bufio.NewReader(resp.Body).WriteTo(discard{})
+
+	got := upstream.Last(t).Header
+	if v := got.Get("x-api-key"); v != anthropicKey {
+		t.Errorf("upstream x-api-key: got %q, want the minted credential %q", v, anthropicKey)
+	}
+	for _, name := range h.AlwaysAbsent() {
+		if v := got.Get(name); v != "" {
+			t.Errorf("%s should not have been forwarded, got %q", name, v)
+		}
+	}
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -4,8 +4,10 @@ package helpers
 
 import (
 	"crypto/ecdsa"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -158,16 +160,39 @@ type UpstreamRequest struct {
 	Header   http.Header
 }
 
-// RecordingUpstream stands in for a provider's real API. It answers everything
-// with a canned 200 and keeps what it was sent, which is the only vantage point
-// from which "the minted credential went out and the caller's did not" can be
-// checked.
+// RecordingUpstream stands in for a provider's real API. It keeps what it was
+// sent, which is the only vantage point from which "the minted credential went
+// out and the caller's did not" can be checked, and by default answers a canned
+// 200.
+//
+// A test that cares about the response half of the chain can replace the handler
+// with SetHandler — streaming, in particular, cannot be observed through a
+// buffered canned reply.
 type RecordingUpstream struct {
 	URL string
 
-	server *httptest.Server
-	mu     sync.Mutex
-	reqs   []UpstreamRequest
+	server  *httptest.Server
+	mu      sync.Mutex
+	reqs    []UpstreamRequest
+	handler http.HandlerFunc
+}
+
+// SetHandler replaces what the upstream returns, for the remainder of the test
+// that sets it. Requests are still recorded. Passing nil restores the default.
+//
+// Registered as a cleanup rather than left in place: the upstream is shared by
+// the whole package, so a handler that outlived its test would silently change
+// what every later row is proxying.
+func (u *RecordingUpstream) SetHandler(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	u.mu.Lock()
+	u.handler = h
+	u.mu.Unlock()
+	t.Cleanup(func() {
+		u.mu.Lock()
+		u.handler = nil
+		u.mu.Unlock()
+	})
 }
 
 // StartRecordingUpstream starts the upstream. The caller owns its lifetime via
@@ -185,7 +210,13 @@ func StartRecordingUpstream(t *testing.T) *RecordingUpstream {
 			RawQuery: r.URL.RawQuery,
 			Header:   r.Header.Clone(),
 		})
+		custom := u.handler
 		u.mu.Unlock()
+
+		if custom != nil {
+			custom(w, r)
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -207,6 +238,21 @@ func (u *RecordingUpstream) Requests() []UpstreamRequest {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	return append([]UpstreamRequest(nil), u.reqs...)
+}
+
+// Last returns the most recent request. Fails the test if there was none.
+//
+// Most rows go through AssertChain, which inspects the last request itself. This
+// is for the streaming rows, where the response has to be read before the
+// exchange is complete, so the request cannot be asserted in the same breath as
+// the status.
+func (u *RecordingUpstream) Last(t *testing.T) UpstreamRequest {
+	t.Helper()
+	reqs := u.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("upstream received no requests")
+	}
+	return reqs[len(reqs)-1]
 }
 
 // Reset clears the recorded requests so one test's traffic cannot be read as
@@ -464,11 +510,9 @@ type ChainOpts struct {
 	Body string
 }
 
-// ChainRequest drives one request through the whole chain and returns the
-// response status, body and headers. Response headers matter here because the
-// user leg is largely a header protocol: WWW-Authenticate carries the challenge
-// that says which principal was rejected.
-func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []byte, http.Header) {
+// chainHeaders turns the credential-bearing options into request headers. Shared
+// by the buffered and streaming paths so a row means the same thing either way.
+func chainHeaders(t *testing.T, o ChainOpts) map[string]string {
 	t.Helper()
 
 	headers := map[string]string{}
@@ -498,22 +542,84 @@ func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []by
 	for k, v := range o.Headers {
 		headers[k] = v
 	}
+	return headers
+}
 
-	method := o.Method
-	if method == "" {
-		method = "GET"
-		if o.Body != "" {
-			method = "POST"
-		}
+func chainMethod(o ChainOpts) string {
+	if o.Method != "" {
+		return o.Method
 	}
+	if o.Body != "" {
+		return "POST"
+	}
+	return "GET"
+}
+
+func chainURL(port int, p ProviderEnv, o ChainOpts) string {
 	path := o.Path
 	if path == "" {
 		path = "probe"
 	}
+	return fmt.Sprintf("%s/v1/%s/gateway/%s", NodeURL(port), p.Mount, path)
+}
 
-	u := fmt.Sprintf("%s/v1/%s/gateway/%s", NodeURL(port), p.Mount, path)
+func chainBody(o ChainOpts) io.Reader {
+	if o.Body == "" {
+		return nil
+	}
+	return strings.NewReader(o.Body)
+}
+
+// ChainRequest drives one request through the whole chain and returns the
+// response status, body and headers. Response headers matter here because the
+// user leg is largely a header protocol: WWW-Authenticate carries the challenge
+// that says which principal was rejected.
+func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []byte, http.Header) {
+	t.Helper()
+
+	headers := chainHeaders(t, o)
+	method := chainMethod(o)
+	u := chainURL(port, p, o)
 	status, body, respHeaders := DoRequestWithResponseHeaders(t, method, u, headers, o.Body)
 	return status, body, http.Header(respHeaders)
+}
+
+// ChainStream drives a full-chain request and returns the live response without
+// reading its body, so a test can observe chunks as they arrive.
+//
+// Every other row reads the body to completion, which cannot tell a streamed
+// response from a buffered one: both end with the same bytes in hand. The
+// difference is only visible in when they arrive, so it needs the response open.
+//
+// The caller owns resp.Body and must close it.
+func ChainStream(t *testing.T, port int, p ProviderEnv, o ChainOpts) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(chainMethod(o), chainURL(port, p, o), chainBody(o))
+	if err != nil {
+		t.Fatalf("build streaming request: %v", err)
+	}
+	for k, v := range chainHeaders(t, o) {
+		req.Header.Set(k, v)
+	}
+	if o.Body != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed e2e cert
+			// Compression would coalesce the upstream's chunks, hiding exactly
+			// the boundaries this exists to observe.
+			DisableCompression: true,
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("streaming request failed: %v", err)
+	}
+	return resp
 }
 
 // ChainWant is what a full-chain request is expected to have produced.


### PR DESCRIPTION
Two properties nothing tested, both about timing rather than bytes.

Streaming. Every existing row reads the body to completion and asserts on
the result, which cannot tell a streamed response from a buffered one —
both end with the same bytes in hand. The difference is only in when they
arrive, so the upstream now paces its chunks and the row reads them
incrementally, asserting the first arrives well before the last. Verified
by making the upstream stop flushing: the chunks then land 4us apart at
the very end and the row fails. This matters because the providers
carrying model output all set ParseStreamBody, and a proxy that buffered
would turn a token-by-token stream into one reply delivered when
generation finished — same status, same bytes, feature gone.

Credential visibility. A compiled-policy cache recently answered "has
this configuration change taken effect?" wrongly, returning the new
policy from the API while enforcing the old one, so the same question is
asked of credentials. A new session sends what the spec now says; a
session already holding a minted credential keeps it. The second is
deliberate — re-minting per request would defeat issuing a credential at
all — but it is the part an operator is most likely to be surprised by,
because rewriting a spec does not immediately stop the old secret going
out. The pair says when a rotation takes effect; each fails if given the
other's expectation.

The recording upstream grows a replaceable handler, restored per test
since it is shared package-wide, and a streaming request helper that
leaves the response open. Last() returns, now that a caller needs the
request after the response has been read rather than alongside it.

Also worth noting for whoever picks up the transport work: standby and
failover are better covered than earlier notes claimed, and what is
actually missing is the two-principal chain arriving at a follower.

The timing bound was "chunks arrived at least 400ms apart", which needed a
margin and only caught a response withheld entirely. Replaced with the
property itself: the upstream records when it finished producing, and the
row asserts the client held the first chunk before that instant. Nothing
to tune, and load cannot manufacture the ordering since it delays both
sides.

The comment claimed the new form also catches partial buffering. It does
not, and mutation says so: flushing one chunk late still delivers chunk-1
early and still passes — defensibly, because that is streaming one chunk
behind rather than buffering. Corrected to claim only what it catches,
with both mutation directions recorded.

Three further comments described mechanisms that were not the ones at
work:

  - ParseStreamBody was named as the motivation, but it governs request
    body parsing for policy evaluation. Response streaming rests on the
    standard library auto-flushing a body of unknown length, since no
    flush interval is configured on either proxy in the tree — so what
    this row guards is Warden's ResponseWriter wrapper forwarding Flush.

  - The live-session row credited the reused certificate alone. A minted
    credential is keyed on the agent token and the user token together,
    so the captured user JWT is equally load-bearing — and re-fetching it
    per request would look harmless while silently turning that row into
    its neighbour.

  - The drain in the second streaming row was described as making the
    exchange recordable. Requests are recorded on arrival, before the
    handler runs; the drain only stops the upstream goroutine outliving
    the test. That row also no longer claims to guard credential
    injection, which is request-side and already covered — it checks the
    streaming helper builds the same request as the buffered one.

Spec updates now send only the field they change, with a note that the
update merges rather than replaces. Two gaps this work exposed remain
open: streaming is covered only through the leader, not the standby hop,
and nothing tests the session-TTL bound on credential staleness.

---

**Stack** — part 5 of 9 in the full-chain e2e series. Targets `feat/e2e-fullchain-mcp`; retarget to `main` once the parent merges.
