### PR TITLE
test(e2e): drive the full chain across the forwarded hop

### DIFF
--- a/e2e/fullchain/credential_update_test.go
+++ b/e2e/fullchain/credential_update_test.go
@@ -4,6 +4,7 @@ package fullchain
 
 import (
 	"testing"
+	"time"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
@@ -81,8 +82,8 @@ func TestFullChain_UpdatedSpecReachesUpstream(t *testing.T) {
 // Calling h.FullChainUserJWT at each request site would look harmless and
 // silently turn this into the row above, since every call issues a new JWT.
 //
-// What bounds the staleness is the session's own lifetime: the entry is cached
-// for the session TTL. No row here checks that bound.
+// What bounds the staleness is the session's own lifetime, which the row below
+// checks.
 func TestFullChain_LiveSessionKeepsItsCredential(t *testing.T) {
 	ensureEnv(t)
 
@@ -116,6 +117,74 @@ func TestFullChain_LiveSessionKeepsItsCredential(t *testing.T) {
 		Status: 200,
 		// The credential issued to this session, not the rewritten spec.
 		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestFullChain_CredentialStalenessIsBoundedBySessionTTL pins the bound an
+// operator actually experiences: with the same certificate presented throughout,
+// a rewritten spec takes effect once the session expires, rather than never.
+//
+// The row above shows a live session keeping its credential, which on its own is
+// equally consistent with caching it forever — the difference between a rotation
+// delayed and one that never happens. A role whose tokens last two seconds
+// settles that.
+//
+// It pins the observable bound, not the mechanism. Once the token expires the
+// next request authenticates afresh and mints under a new cache key, so a
+// manager that also kept the old entry indefinitely would pass this row
+// identically. Distinguishing the key becoming unreachable from the entry being
+// evicted on its own TTL is an in-process question, not one a client can ask.
+func TestFullChain_CredentialStalenessIsBoundedBySessionTTL(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		shortRole  = "fc-splunk-shorttl"
+		rotated    = "fc-splunk-rotated-after-expiry"
+		sessionTTL = 2 * time.Second
+	)
+
+	// A dedicated role, so shortening the session cannot affect other rows.
+	h.APIRequest(t, "DELETE", "auth/cert/role/"+shortRole, leaderPort, "")
+	status, resp := h.APIRequest(t, "POST", "auth/cert/role/"+shortRole, leaderPort,
+		`{"allowed_common_names":["`+h.FullChainAgentCN+`"],`+
+			`"token_policies":["`+splunkEnv.Policy()+`"],`+
+			`"cred_spec_name":"`+splunkEnv.Spec()+`","token_ttl":2}`)
+	switch status {
+	case 200, 201, 204:
+	default:
+		t.Fatalf("create short-TTL role (status %d): %s", status, resp)
+	}
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "auth/cert/role/"+shortRole, leaderPort, "") })
+
+	cert := agentCert(t)
+	user := h.FullChainUserJWT(t)
+
+	// Establish the session against the current spec.
+	status, body, _ := h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: cert, Bearer: user, Role: shortRole,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
+		UpstreamCalls: 1,
+	})
+
+	setSpecAPIKey(t, splunkEnv, rotated, splunkKey)
+
+	// Past the session's lifetime, the cached credential can no longer be
+	// reached — the token it was keyed to has expired — so the next request
+	// mints against the spec as it now stands.
+	time.Sleep(sessionTTL + time.Second)
+
+	upstream.Reset()
+	status, body, _ = h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: cert, Bearer: user, Role: shortRole,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + rotated},
 		Absent:        h.AlwaysAbsent(),
 		UpstreamCalls: 1,
 	})

--- a/e2e/fullchain/standby_test.go
+++ b/e2e/fullchain/standby_test.go
@@ -1,0 +1,202 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// A request that arrives at a follower crosses a second reverse proxy on its way
+// to the leader, and that hop has to carry the client certificate onward: the
+// listener takes it off the request and the forwarder puts it back for the
+// internal hop.
+//
+// That makes the follower path a different chain, not the same chain further
+// along. Existing coverage reaches parts of it — e2e/forwarding drives SigV4
+// gateway requests through a follower, e2e/provider covers cert-transparent —
+// but nothing carries two principals across it, and nothing carries a streamed
+// response back through it.
+//
+// One property these rows deliberately do not claim: that the forwarder
+// re-encodes the certificate it *parsed* rather than passing the client's header
+// through. Requests here come from an address the listeners trust as a proxy, so
+// the header is parsed rather than verified and the re-encoded bytes are
+// identical to what was sent — the two behaviours are indistinguishable from
+// outside. Telling them apart needs an in-process test at the listener.
+
+// standbyPort resolves a follower, per test rather than cached: which node is
+// following is not fixed, and an earlier row may have caused an election. The
+// port is chosen by live health, so it is a follower by construction.
+func standbyPort(t *testing.T) int {
+	t.Helper()
+	return h.GetStandbyPort(t)
+}
+
+// currentLeaderPort resolves the leader now, for reads that go to a specific
+// node's own files rather than through the API.
+//
+// The package caches leaderPort at setup, which is fine for requests — a
+// follower forwards them — but wrong for the audit log, which is written on
+// whichever node served the request and read straight off that node's disk. An
+// election between setup and here would send the read to the wrong file, and the
+// row would fail after a ten-second poll reporting that nothing was audited,
+// which is not what went wrong.
+func currentLeaderPort(t *testing.T) int {
+	t.Helper()
+	return h.GetLeaderPort(t)
+}
+
+// TestStandby_TwoPrincipalChainIsForwarded drives the full chain at a follower.
+//
+// Both principals have to survive the extra hop, and they survive differently:
+// the user rides Authorization, which is forwarded as-is, while the agent's
+// certificate was consumed by the follower's listener and must be reconstructed
+// for the internal request. A forwarder that dropped it would fail the agent; one
+// that forwarded the client's original header instead of the verified
+// certificate would accept a forged one.
+func TestStandby_TwoPrincipalChainIsForwarded(t *testing.T) {
+	ensureEnv(t)
+
+	standby := standbyPort(t)
+	probe := h.ProbePath("standby-two-principal")
+	status, body, _ := h.ChainRequest(t, standby, splunkEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         splunkEnv.CertRole(),
+		Path:         probe,
+		Headers:      h.InertDecoyHeaders(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	// The audit record is written where the request was served, which is the
+	// leader — not the follower the client talked to.
+	h.AssertAuditUser(t, currentLeaderPort(t), probe, h.FullChainUserSubject)
+
+	// And it is written only there. Asserted rather than assumed: if the
+	// follower also audited a request it merely forwarded, the same action would
+	// appear twice across the cluster.
+	if entries := h.ReadAuditEntries(t, h.NodeNumberForPort(standby), probe); len(entries) != 0 {
+		t.Errorf("the follower audited a request it forwarded: %d entries", len(entries))
+	}
+}
+
+// TestStandby_UntrustedCertificateIsRefusedAtTheFollower checks that entering
+// through a follower confers no trust: a certificate is still validated against
+// the cert mount's CA, and a request bearing an untrusted one reaches no
+// upstream.
+//
+// The certificate is well-formed and correctly named but signed by a CA the
+// mount does not trust — the same shape the leader-side row refuses, arriving by
+// the other door. Read against its neighbour above, which succeeds with a
+// trusted certificate over the same hop, the pair says the hop carries a
+// certificate without laundering it.
+//
+// It does not distinguish *where* the refusal happened, only that it did and
+// that nothing was forwarded. That is the honest limit: validation lives at the
+// leader's cert mount either way.
+func TestStandby_UntrustedCertificateIsRefusedAtTheFollower(t *testing.T) {
+	ensureEnv(t)
+
+	standby := standbyPort(t)
+	otherCAPEM, otherCAKey := h.GenerateTestCA(t)
+	rogue, _ := h.GenerateClientCert(t, otherCAPEM, otherCAKey, h.FullChainAgentCN)
+
+	status, body, respHeaders := h.ChainRequest(t, standby, splunkEnv, h.ChainOpts{
+		AgentCertPEM: rogue,
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         splunkEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        401,
+		UpstreamCalls: 0,
+	})
+
+	// Which principal was rejected matters: a user-leg failure would also be a
+	// 401, and would mean the agent's certificate had been accepted.
+	if challenge := respHeaders.Get("WWW-Authenticate"); strings.Contains(challenge, "invalid_token") {
+		t.Errorf("the refusal names the user credential (%q); the agent's certificate should be "+
+			"what was rejected", challenge)
+	}
+}
+
+// TestStandby_StreamingPassesThroughTheForwardedHop sends a streamed response
+// back along the follower path.
+//
+// The response now crosses two reverse proxies, neither of which configures a
+// flush interval, so both rely on the standard library auto-flushing a body of
+// unknown length. The leader-only row cannot see the second one: a follower that
+// buffered would leave every direct request streaming correctly while silently
+// breaking the same request made one node over.
+func TestStandby_StreamingPassesThroughTheForwardedHop(t *testing.T) {
+	ensureEnv(t)
+
+	standby := standbyPort(t)
+	probe := &streamProbe{}
+	upstream.SetHandler(t, probe.handler(t))
+
+	resp := h.ChainStream(t, standby, anthropicEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         anthropicEnv.CertRole(),
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var chunks []string
+	var firstArrival time.Time
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if firstArrival.IsZero() {
+			firstArrival = time.Now()
+		}
+		chunks = append(chunks, line)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("reading the stream: %v", err)
+	}
+
+	// Mirrors the leader row's assertions, not just the count: a hop that
+	// mangled payloads or dropped the content type while preserving cadence
+	// would otherwise pass here and fail only there.
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("Content-Type: got %q, want the upstream's text/event-stream", ct)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks %q, want 3", len(chunks), chunks)
+	}
+	for i, want := range []string{"data: chunk-1", "data: chunk-2", "data: chunk-3"} {
+		if chunks[i] != want {
+			t.Errorf("chunk %d: got %q, want %q", i+1, chunks[i], want)
+		}
+	}
+
+	finished := probe.finishedAt()
+	if finished.IsZero() {
+		t.Fatal("the upstream never recorded finishing; it did not run to completion")
+	}
+	if !firstArrival.Before(finished) {
+		t.Errorf("through a follower the first chunk reached the client at %v, not before the "+
+			"upstream finished producing at %v — the forwarded hop buffered the response",
+			firstArrival, finished)
+	}
+}

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -577,11 +577,31 @@ func chainBody(o ChainOpts) io.Reader {
 func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []byte, http.Header) {
 	t.Helper()
 
-	headers := chainHeaders(t, o)
-	method := chainMethod(o)
-	u := chainURL(port, p, o)
-	status, body, respHeaders := DoRequestWithResponseHeaders(t, method, u, headers, o.Body)
-	return status, body, http.Header(respHeaders)
+	req, err := http.NewRequest(chainMethod(o), chainURL(port, p, o), chainBody(o))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	for k, v := range chainHeaders(t, o) {
+		req.Header.Set(k, v)
+	}
+	if o.Body != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Deliberately not DoRequestWithResponseHeaders: that client is shared with
+	// other suites and follows redirects, which would hide a follower falling
+	// back to one. See chainClient.
+	resp, err := chainClient().Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	return resp.StatusCode, body, resp.Header
 }
 
 // ChainStream drives a full-chain request and returns the live response without
@@ -606,20 +626,35 @@ func ChainStream(t *testing.T, port int, p ProviderEnv, o ChainOpts) *http.Respo
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed e2e cert
-			// Compression would coalesce the upstream's chunks, hiding exactly
-			// the boundaries this exists to observe.
-			DisableCompression: true,
-		},
-	}
-	resp, err := client.Do(req)
+	resp, err := chainClient().Do(req)
 	if err != nil {
 		t.Fatalf("streaming request failed: %v", err)
 	}
 	return resp
+}
+
+// chainClient is the HTTP client both chain paths use.
+//
+// Redirects are surfaced rather than followed. A follower that cannot reach the
+// leader answers 307 pointing at the leader's own address, and Go would follow
+// it — re-sending Authorization, and X-SSL-Client-Cert too, since that is not a
+// header Go treats as sensitive. Every row aimed at a follower would then
+// quietly exercise the direct path and still pass, unable to fail for the
+// absence of the hop it exists to cover. Surfaced, the 307 fails the status
+// assertion instead.
+func chainClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed e2e cert
+			// Compression would coalesce an upstream's chunks, hiding the
+			// boundaries the streaming rows exist to observe.
+			DisableCompression: true,
+		},
+	}
 }
 
 // ChainWant is what a full-chain request is expected to have produced.


### PR DESCRIPTION
A request arriving at a follower crosses a second reverse proxy on its way
to the leader, which makes it a different chain rather than the same chain
further along. Nothing carried two principals across it, and nothing
carried a streamed response back through it.

Three rows: both principals survive the hop, with the user attributed in
the leader's audit log and nowhere else; an untrusted-CA certificate is
refused with nothing forwarded, and the challenge names the agent rather
than the user; and a streamed response comes back incrementally, which the
leader-only row cannot see, since the follower is a second proxy that also
configures no flush interval.

The chain helpers stop following redirects. A follower that cannot reach
the leader answers 307 to the leader's own address, and Go would follow
it — re-sending Authorization, and the certificate header too, since Go
does not treat it as sensitive. Every row aimed at a follower would then
exercise the direct path and still pass, unable to fail for the absence
of the hop it exists to cover.

The audit assertion resolves the leader afresh. The package caches it at
setup, which is fine for requests, since a follower forwards them, but
wrong for a log read that goes to one node's own disk.

Two claims are deliberately not made. These rows do not show the
forwarder re-encoding the certificate it parsed rather than passing the
client's header: requests come from an address the listeners trust as a
proxy, so the header is parsed rather than verified and the re-encoded
bytes are identical to what was sent. That property needs an in-process
test at the listener. And the session-TTL row pins the bound
an operator experiences — same certificate, staleness ends at session
expiry — not which internal mechanism produces it, since after expiry the
next request mints under a new key regardless.

---

**Stack** — part 6 of 9 in the full-chain e2e series. Targets `feat/e2e-fullchain-transport`; retarget to `main` once the parent merges.
