### PR TITLE
test(e2e): cover mcp list filtering against a real upstream response

### DIFF
--- a/e2e/fullchain/mcp_filter_test.go
+++ b/e2e/fullchain/mcp_filter_test.go
@@ -1,0 +1,225 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The other direction of mcp policy. A tools/list is gated on the request side
+// like anything else — the method has to be permitted at all — but its *content*
+// is decided on the way back, by rewriting the response to drop tools the caller
+// may not invoke. Without that, a policy forbids a tool while still advertising
+// it, and an agent discovers capabilities it will be refused. The failure is a
+// confused agent rather than a breach, but the listing is the only thing most
+// clients ever read.
+//
+// Note what decides the filter: a tool survives if the caller could *call* it,
+// so these rows depend on tools/call being permitted by the shared policy block,
+// not merely tools/list. Trimming that block to tools/list alone would empty
+// every listing.
+//
+// The filtering itself is well covered in-process, in core and in the filter
+// package. What those cannot reach is the wiring: a policy written through the
+// API attaching a filter to a real request, and that filter meeting a real
+// upstream response on the way back. They construct the filter directly.
+
+// mcpToolsListBody is what the fake upstream returns: a tools/list result
+// advertising both the tool the policy allows and the one it does not.
+func mcpToolsListBody() string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":%q},{"name":%q}]}}`,
+		mcpAllowedTool, mcpDeniedTool)
+}
+
+// mcpToolsListUpstream answers any request with that listing.
+func mcpToolsListUpstream(body string, contentType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// toolNames pulls the advertised tool names out of a tools/list body.
+func toolNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var env struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("parsing the tools/list response %q: %v", body, err)
+	}
+	names := make([]string, 0, len(env.Result.Tools))
+	for _, tool := range env.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+// TestMCPFilter_DeniedToolIsRemovedFromTheListing drives a tools/list through
+// the chain against an upstream that advertises both tools, and expects the
+// caller to receive only the one the policy allows.
+//
+// The upstream is what makes this a wiring test rather than a repeat of the
+// in-process ones: the bytes the client reads are the bytes a real server
+// produced, rewritten in flight.
+func TestMCPFilter_DeniedToolIsRemovedFromTheListing(t *testing.T) {
+	ensureEnv(t)
+	upstream.SetHandler(t, mcpToolsListUpstream(mcpToolsListBody(), "application/json"))
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	})
+
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body: %s)", status, body)
+	}
+
+	got := toolNames(t, body)
+	if len(got) != 1 || got[0] != mcpAllowedTool {
+		t.Errorf("advertised tools: got %v, want only %q — the denied tool was listed to a "+
+			"caller who cannot invoke it", got, mcpAllowedTool)
+	}
+
+	// The listing came from the upstream rather than from anything Warden
+	// substituted, and the fixture really did offer both tools — so the absence
+	// above is the filter's doing.
+	assertUpstreamServed(t)
+	if offered := toolNames(t, []byte(mcpToolsListBody())); len(offered) != 2 {
+		t.Fatalf("the fixture advertised %v; it must offer both tools for this row to mean "+
+			"anything", offered)
+	}
+}
+
+// assertUpstreamServed confirms the request reached the upstream exactly once.
+//
+// Worth stating explicitly on these rows because the response path and the
+// transport path fail identically: one error handler answers 502 for a filter
+// that refused to forward and for an upstream that could not be reached. Without
+// this, a mount pointed at a dead address would satisfy the fail-closed row.
+func assertUpstreamServed(t *testing.T) {
+	t.Helper()
+	if n := len(upstream.Requests()); n != 1 {
+		t.Fatalf("upstream served %d requests, want 1 — the response never came from it", n)
+	}
+}
+
+// TestMCPFilter_UnparseableListingFailsClosed covers the direction that matters
+// when something goes wrong. A listing the filter cannot parse cannot be proven
+// free of denied tools, so it must not be forwarded — passing the original
+// through on a parse error would turn every malformed response into a way to
+// advertise everything.
+func TestMCPFilter_UnparseableListingFailsClosed(t *testing.T) {
+	ensureEnv(t)
+	upstream.SetHandler(t, mcpToolsListUpstream(`{"jsonrpc":"2.0","id":1,"result":{"tools":`, "application/json"))
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	})
+
+	// 502: the upstream produced something that could not be made safe, which is
+	// a gateway failure rather than the caller's fault. Asserted exactly, since
+	// "not 200" would also be satisfied by an auth or policy rejection — outcomes
+	// meaning the request never reached the filter at all.
+	//
+	// The status alone does not say the *filter* refused: an unreachable upstream
+	// answers 502 through the same error handler. What separates them is that the
+	// upstream was reached and did reply.
+	assertUpstreamServed(t)
+	if status != http.StatusBadGateway {
+		t.Errorf("status: got %d, want 502 for a listing that could not be filtered (body: %s)",
+			status, body)
+	}
+	if names := tryToolNames(body); len(names) > 0 {
+		t.Errorf("the caller received tool names %v from a listing that could not be filtered", names)
+	}
+}
+
+// TestMCPFilter_EventStreamListingIsFiltered covers the shape MCP servers
+// actually use. Streamable HTTP commonly answers a POST with text/event-stream,
+// and the filter dispatches on that content type into a separate branch with its
+// own event framing, its own parsing, and its own rewrite.
+//
+// The JSON row above exercises none of it, so a break confined to the SSE branch
+// would leave every listing unfiltered against a real server while the suite
+// stayed green.
+func TestMCPFilter_EventStreamListingIsFiltered(t *testing.T) {
+	ensureEnv(t)
+
+	// A single SSE event carrying the listing, with the framing a Streamable
+	// HTTP server emits.
+	event := "event: message\ndata: " + mcpToolsListBody() + "\n\n"
+	upstream.SetHandler(t, mcpToolsListUpstream(event, "text/event-stream"))
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	})
+
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body: %s)", status, body)
+	}
+	assertUpstreamServed(t)
+
+	// The event framing must survive — a filter that returned bare JSON would
+	// break the client's parser as surely as one that leaked a tool.
+	if !strings.Contains(string(body), "event: message") {
+		t.Errorf("the SSE framing was lost in rewriting: %s", body)
+	}
+
+	got := sseToolNames(t, body)
+	if len(got) != 1 || got[0] != mcpAllowedTool {
+		t.Errorf("advertised tools over SSE: got %v, want only %q", got, mcpAllowedTool)
+	}
+}
+
+// sseToolNames pulls tool names out of the data line of an SSE listing.
+func sseToolNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	for _, line := range strings.Split(strings.ReplaceAll(string(body), "\r\n", "\n"), "\n") {
+		if payload, ok := strings.CutPrefix(line, "data: "); ok {
+			return toolNames(t, []byte(payload))
+		}
+	}
+	t.Fatalf("no data line in the SSE response: %s", body)
+	return nil
+}
+
+// tryToolNames is toolNames without failing the test when the body is not a
+// listing at all — the fail-closed path returns a plain error, not JSON.
+func tryToolNames(body []byte) []string {
+	var env struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(env.Result.Tools))
+	for _, tool := range env.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}


### PR DESCRIPTION
The other direction of mcp policy. A tools/list is gated on the request
side like anything else, but its content is decided on the way back, by
rewriting the response to drop tools the caller may not invoke. Without
it a policy forbids a tool while still advertising it, and the listing is
the only thing most clients read.

The filtering is covered in core and in the filter package, but those
construct the filter directly. What was missing is the wiring: a policy
written through the API attaching a filter to a live request, and that
filter meeting bytes a real server produced. Verified by removing the
mcp { } block, which lists both tools and fails the rows.

Both response shapes, because they are separate branches. Plain JSON, and
text/event-stream — which Streamable HTTP servers commonly answer with,
and which has its own framing, parsing and rewrite. A break confined to
the SSE branch would leave listings unfiltered against a real server
while a JSON-only suite stayed green; the row also asserts the event
framing survives, since returning bare JSON would break a client's parser
as surely as leaking a tool.

The fail-closed row asserts 502 exactly, and that the upstream was
reached. One error handler answers 502 both for a filter that refused to
forward and for an upstream that could not be reached, so the status
alone would let a mount pointed at a dead address satisfy the row.

resources/list and prompts/list differ only in the array key they read
and the call gate they consult, so they are left uncovered and recorded.

---

**Stack** — part 7 of 9 in the full-chain e2e series. Targets `feat/e2e-fullchain-standby`; retarget to `main` once the parent merges.
