### PR TITLE
fix(core): keep stored secrets when a masked config is resent

### DIFF
--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -368,10 +368,15 @@ func (b *SystemBackend) handleCredentialSourceUpdate(ctx context.Context, req *l
 		mergedConfig[k] = v
 	}
 
-	// Merge new config values
+	// Merge new config values. See the same guard on the spec path: a value equal
+	// to the mask sentinel came from a read, not from the caller, and overwriting a
+	// stored secret with the literal mask would break every mint from this source.
 	if configAny != nil {
 		newConfig := convertToStringMap(configAny)
 		for key, value := range newConfig {
+			if value == maskValue {
+				continue
+			}
 			mergedConfig[key] = value
 		}
 	}
@@ -599,10 +604,18 @@ func (b *SystemBackend) handleCredentialSpecUpdate(ctx context.Context, req *log
 		mergedConfig[k] = v
 	}
 
-	// Merge new config values
+	// Merge new config values. A value equal to the mask sentinel is the one the
+	// caller just read back, not one they typed: reads mask sensitive fields, so an
+	// edit-and-resend of a whole config would otherwise persist the literal mask and
+	// destroy the secret. Skipping it keeps the stored value, which is what the
+	// caller meant by leaving the field as they found it. Clearing a field is still
+	// possible with an empty string, which is not the sentinel.
 	if configAny, ok := d.GetOk("config"); ok {
 		newConfig := convertToStringMap(configAny.(map[string]any))
 		for k, v := range newConfig {
+			if v == maskValue {
+				continue
+			}
 			mergedConfig[k] = v
 		}
 	}

--- a/core/sys_credentials_test.go
+++ b/core/sys_credentials_test.go
@@ -454,6 +454,113 @@ func TestSystemBackend_HandleCredentialSpecUpdate(t *testing.T) {
 	assert.Contains(t, resp.Data["message"], "Successfully updated")
 }
 
+// TestSystemBackend_HandleCredentialSpecUpdate_MaskedValueIsNotPersisted pins the
+// read-edit-resend flow. Reads mask sensitive config, so a caller who reads a spec,
+// changes one field and sends the whole map back is holding the mask sentinel for
+// every field they did not touch. Persisting it would replace the secret with
+// "***********" and break every subsequent mint, while the API reported success.
+func TestSystemBackend_HandleCredentialSpecUpdate_MaskedValueIsNotPersisted(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	sourceSchema := backend.pathCredentials()[0].Fields
+	sourceRaw := map[string]interface{}{"name": "local-src", "type": "local"}
+	sourceFieldData := createFieldData(sourceSchema, sourceRaw)
+	_, err := backend.handleCredentialSourceCreate(ctx,
+		createTestRequest(logical.CreateOperation, "cred/sources/local-src", sourceRaw), sourceFieldData)
+	require.NoError(t, err)
+
+	specSchema := backend.pathCredentials()[2].Fields
+	specRaw := map[string]interface{}{
+		"name":   "masked-spec",
+		"type":   "api_key",
+		"source": "local-src",
+		"config": map[string]interface{}{
+			"api_key":         "sk-real-secret",
+			"organization_id": "org-1",
+		},
+	}
+	specReq := createTestRequest(logical.CreateOperation, "cred/specs/masked-spec", specRaw)
+	_, err = backend.handleCredentialSpecCreate(ctx, specReq, createFieldData(specSchema, specRaw))
+	require.NoError(t, err)
+
+	// Read it back the way a client would: api_key comes out masked.
+	readRaw := map[string]interface{}{"name": "masked-spec"}
+	readResp, err := backend.handleCredentialSpecRead(ctx,
+		createTestRequest(logical.ReadOperation, "cred/specs/masked-spec", readRaw),
+		createFieldData(specSchema, readRaw))
+	require.NoError(t, err)
+	readConfig, ok := readResp.Data["config"].(map[string]string)
+	require.True(t, ok, "config in read response: %#v", readResp.Data["config"])
+	require.Equal(t, maskValue, readConfig["api_key"], "read must mask api_key, else this test proves nothing")
+
+	// Send that config straight back, editing only the non-secret field.
+	resend := make(map[string]interface{}, len(readConfig))
+	for k, v := range readConfig {
+		resend[k] = v
+	}
+	resend["organization_id"] = "org-2"
+
+	updateRaw := map[string]interface{}{"name": "masked-spec", "config": resend}
+	updateResp, err := backend.handleCredentialSpecUpdate(ctx,
+		createTestRequest(logical.UpdateOperation, "cred/specs/masked-spec", updateRaw),
+		createFieldData(specSchema, updateRaw))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, updateResp.StatusCode)
+
+	// The stored secret must survive; the edited field must land.
+	stored, err := backend.core.credConfigStore.GetSpec(ctx, "masked-spec")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-real-secret", stored.Config["api_key"], "resending the mask destroyed the stored secret")
+	assert.Equal(t, "org-2", stored.Config["organization_id"])
+}
+
+// TestSystemBackend_HandleCredentialSourceUpdate_MaskedValueIsNotPersisted is the
+// same hazard on the source path, where the sensitive fields are the driver's.
+func TestSystemBackend_HandleCredentialSourceUpdate_MaskedValueIsNotPersisted(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	sourceSchema := backend.pathCredentials()[0].Fields
+	sourceRaw := map[string]interface{}{
+		"name":            "vault-src",
+		"type":            "hvault",
+		"rotation_period": 86400,
+		"config": map[string]interface{}{
+			"vault_address": "http://localhost:8200",
+			"secret_id":     "real-secret-id",
+		},
+	}
+	_, err := backend.handleCredentialSourceCreate(ctx,
+		createTestRequest(logical.CreateOperation, "cred/sources/vault-src", sourceRaw),
+		createFieldData(sourceSchema, sourceRaw))
+	require.NoError(t, err)
+
+	readRaw := map[string]interface{}{"name": "vault-src"}
+	readResp, err := backend.handleCredentialSourceRead(ctx,
+		createTestRequest(logical.ReadOperation, "cred/sources/vault-src", readRaw),
+		createFieldData(sourceSchema, readRaw))
+	require.NoError(t, err)
+	readConfig, ok := readResp.Data["config"].(map[string]string)
+	require.True(t, ok, "config in read response: %#v", readResp.Data["config"])
+	require.Equal(t, maskValue, readConfig["secret_id"], "read must mask secret_id, else this test proves nothing")
+
+	resend := make(map[string]interface{}, len(readConfig))
+	for k, v := range readConfig {
+		resend[k] = v
+	}
+	resend["vault_address"] = "http://localhost:8300"
+
+	updateRaw := map[string]interface{}{"name": "vault-src", "config": resend}
+	_, err = backend.handleCredentialSourceUpdate(ctx,
+		createTestRequest(logical.UpdateOperation, "cred/sources/vault-src", updateRaw),
+		createFieldData(sourceSchema, updateRaw))
+	require.NoError(t, err)
+
+	stored, err := backend.core.credConfigStore.GetSource(ctx, "vault-src")
+	require.NoError(t, err)
+	assert.Equal(t, "real-secret-id", stored.Config["secret_id"], "resending the mask destroyed the stored secret")
+	assert.Equal(t, "http://localhost:8300", stored.Config["vault_address"])
+}
+
 func TestSystemBackend_HandleCredentialSpecDelete(t *testing.T) {
 	backend, ctx, _ := setupTestSystemBackend(t)
 

--- a/e2e/fullchain/credential_update_test.go
+++ b/e2e/fullchain/credential_update_test.go
@@ -3,11 +3,17 @@
 package fullchain
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
+
+// maskedValue is what a read substitutes for a sensitive config field. It mirrors
+// maskValue in core; duplicated rather than imported because the e2e suites drive
+// the API from outside and must see what a client sees.
+const maskedValue = "***********"
 
 // Whether a configuration change reaches the request path is its own class of
 // question, separate from whether the change was stored. A compiled-policy cache
@@ -63,6 +69,65 @@ func TestFullChain_UpdatedSpecReachesUpstream(t *testing.T) {
 	h.AssertChain(t, upstream, status, body, h.ChainWant{
 		Status:        200,
 		Injected:      map[string]string{"Authorization": "Bearer " + rotated},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestFullChain_ResendingAMaskedConfigKeepsTheSecret drives the read-edit-resend
+// flow an operator or a declarative tool actually performs: read the spec, change
+// something, send the config back.
+//
+// A read masks sensitive config, so the caller is holding "***********" for every
+// field they did not touch. Persisting that would replace the key with the mask
+// and break every subsequent mint — while the write reported success and the next
+// read looked identical, since the stored mask and a masked real key render the
+// same. Only a request driven afterwards can tell the two apart, which is why this
+// row belongs here rather than in a unit test of the merge.
+//
+// No masking assertion existed anywhere in the e2e suites before this row.
+func TestFullChain_ResendingAMaskedConfigKeepsTheSecret(t *testing.T) {
+	ensureEnv(t)
+
+	specPath := "sys/cred/specs/" + splunkEnv.Spec()
+
+	// Read the spec back the way a client would.
+	status, body := h.APIRequest(t, "GET", specPath, leaderPort, "")
+	if status != 200 {
+		t.Fatalf("read spec (status %d): %s", status, body)
+	}
+	readConfig, ok := h.JSONPath(h.ParseJSON(t, body), "data.config").(map[string]any)
+	if !ok {
+		t.Fatalf("no data.config in spec read: %s", body)
+	}
+
+	// The row is only meaningful if the read really masks the key — otherwise
+	// resending it would be resending the real value and prove nothing.
+	if readConfig["api_key"] != maskedValue {
+		t.Fatalf("api_key read back as %v, want the mask %q — this row assumes reads mask it",
+			readConfig["api_key"], maskedValue)
+	}
+
+	// Send the masked config straight back, as an edit of some other field would.
+	resend, err := json.Marshal(map[string]any{"config": readConfig})
+	if err != nil {
+		t.Fatalf("encode update: %v", err)
+	}
+	if status, body := h.APIRequest(t, "PUT", specPath, leaderPort, string(resend)); status != 200 {
+		t.Fatalf("resend masked config (status %d): %s", status, body)
+	}
+
+	// A fresh session mints from the stored spec: the upstream must still see the
+	// real key, not the mask.
+	status, respBody, _ := h.ChainRequest(t, leaderPort, splunkEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         splunkEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, respBody, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + splunkKey},
 		Absent:        h.AlwaysAbsent(),
 		UpstreamCalls: 1,
 	})


### PR DESCRIPTION
Reads mask sensitive credential config, and both update handlers merged whatever the caller sent straight over the stored config. Read-edit-resend — an operator changing one field, or declarative tooling reconciling a whole resource — therefore persisted the literal mask over every secret it had not touched.

Nothing surfaced it. The write returned success, and the next read looked *identical*, because a stored mask and a masked real key render the same. Only a request driven afterwards can tell them apart.

Measured on the splunk full-chain mount: after resending an unmodified read, the upstream received `Authorization: Bearer ***********`.

## The fix

Both handlers now skip a value equal to the mask sentinel and keep the stored one. Clearing a field still works, since an empty string is not the sentinel. This is the guard `mergePublisherConfig` already applies to the OIDC issuer publisher config; the credential paths never got it.

The **source** path had the same bug, not just specs — source secrets include the AppRole `secret_id` and honeycomb's `management_key_secret`.

## Tests

- Unit coverage for both merges, each verified to fail without the guard, with the actual corruption stored.
- `TestFullChain_ResendingAMaskedConfigKeepsTheSecret` — the regression test is a full-chain row rather than a unit test of the merge, because only a request driven after the write can distinguish a stored mask from a masked real key. Verified to fail against the previous binary.

This is also the first e2e coverage of masking anywhere in the suite.

## Noted, not fixed

The *create* response echoes `spec.Config` unmasked, unlike read and list which both go through `maskSpecConfig`. Harmless in that the caller just supplied the value, but it is an inconsistency a client cannot predict.
