### PR TITLE
fix(honeycomb): make management-key mode reachable, and strip its native header

### DIFF
--- a/e2e/fullchain/honeycomb_test.go
+++ b/e2e/fullchain/honeycomb_test.go
@@ -1,0 +1,123 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// honeycomb is the one provider whose credential data selects between two
+// entirely different auth headers rather than two shapes of the same one. Which
+// makes the mode selector — key_id — the thing worth pinning: it changes both the
+// header name and the value's construction.
+//
+// The management branch used to be unreachable. It required a key_secret field no
+// source could produce, so a mount configured for a management key answered every
+// request with 401 rather than degrading to the ingest branch. It now reads the
+// secret from api_key, which the credential type guarantees.
+
+const (
+	honeycombIngestKey = "fc-honeycomb-not-a-real-ingest-key"
+	honeycombKeyID     = "fc-honeycomb-key-id"
+	honeycombKeySecret = "fc-honeycomb-not-a-real-key-secret"
+)
+
+// The apikey source is deliberate, not incidental. On a local source every field
+// of the spec config reaches the credential, so a management row would pass
+// without naming key_id anywhere — and would hide the fact that the apikey driver
+// carries only api_key plus the fields optional_metadata lists. Getting that wrong
+// is silent: the credential mints, key_id is absent, and the mount quietly serves
+// the ingest branch instead.
+var honeycombEnv = h.ProviderEnv{
+	Mount:        "fc-honeycomb",
+	Type:         "honeycomb",
+	URLKey:       "honeycomb_url",
+	CredType:     "api_key",
+	SourceType:   "apikey",
+	SourceConfig: map[string]string{"optional_metadata": "key_id"},
+	CredConfig:   map[string]string{"api_key": honeycombIngestKey},
+	Variants: map[string]map[string]string{
+		"mgmt": {"api_key": honeycombKeySecret, "key_id": honeycombKeyID},
+	},
+}
+
+// TestHoneycomb_AuthModeFollowsKeyID drives both branches through one mount,
+// changing only which spec the role binds.
+//
+// Each row asserts the other mode's header absent, which is where the value is:
+// an extractor that emitted both would satisfy an injection-only assertion while
+// sending the ingest key to an endpoint that must not receive it.
+func TestHoneycomb_AuthModeFollowsKeyID(t *testing.T) {
+	ensureEnv(t)
+
+	cases := []struct {
+		name   string
+		role   string
+		want   map[string]string
+		absent []string
+	}{
+		{
+			name:   "ingest key, no key_id",
+			role:   honeycombEnv.CertRole(),
+			want:   map[string]string{"X-Honeycomb-Team": honeycombIngestKey},
+			absent: []string{"Authorization"},
+		},
+		{
+			name: "management key, key_id selects the mode",
+			role: honeycombEnv.VariantRole("mgmt"),
+			want: map[string]string{
+				"Authorization": "Bearer " + honeycombKeyID + ":" + honeycombKeySecret,
+			},
+			absent: []string{"X-Honeycomb-Team"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, honeycombEnv, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.role,
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      tc.want,
+				Absent:        h.AlwaysAbsent(tc.absent...),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}
+
+// TestHoneycomb_ClientSuppliedTeamHeaderIsStripped covers the strip, and it only
+// bites in management mode: there the provider injects Authorization and never
+// touches X-Honeycomb-Team, so without a strip list a caller's own value would
+// ride to the upstream beside Warden's credential — an inbound credential
+// proxying onward under the mount's identity.
+//
+// In ingest mode the same header is overwritten by injection, so a row there
+// would pass whether or not the strip existed.
+func TestHoneycomb_ClientSuppliedTeamHeaderIsStripped(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, honeycombEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         honeycombEnv.VariantRole("mgmt"),
+		Headers:      map[string]string{"X-Honeycomb-Team": "caller-supplied-team-key"},
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		Injected: map[string]string{
+			"Authorization": "Bearer " + honeycombKeyID + ":" + honeycombKeySecret,
+		},
+		Absent:        h.AlwaysAbsent("X-Honeycomb-Team"),
+		UpstreamCalls: 1,
+	})
+}

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -36,13 +36,15 @@ import (
 // channels with the native header first, scheme dispatch, and the git dual-slot
 // on its REST path — and all four shared SDK credential extractors.
 //
-// Three providers hand-roll an extractor and are not here: atlassian, honeycomb
-// and prometheus, whose distinctive branches read credential fields nothing can
-// supply, so a row could only cover the fallback each degrades to.
+// Two providers hand-roll an extractor and are not here: atlassian and
+// prometheus, whose distinctive branches read credential fields nothing can
+// supply, so a row could only cover the fallback each degrades to. honeycomb was
+// in that group until its management branch stopped requiring an uncarriable
+// field.
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
-	mcpAWSEnv, mcpAWSWrongCredEnv,
+	mcpAWSEnv, mcpAWSWrongCredEnv, honeycombEnv,
 }
 
 var (

--- a/provider/honeycomb/provider.go
+++ b/provider/honeycomb/provider.go
@@ -16,14 +16,21 @@ const DefaultHoneycombURL = "https://api.honeycomb.io"
 // DefaultHoneycombTimeout is the default request timeout for Honeycomb API calls.
 const DefaultHoneycombTimeout = 30 * time.Second
 
-// honeycombExtractor injects credentials as the appropriate Honeycomb auth header
-// depending on the credential data fields:
+// honeycombExtractor injects credentials as the appropriate Honeycomb auth header.
+// key_id selects the mode; api_key carries the secret in both:
 //
-//   - key_id + key_secret present → Authorization: Bearer <key_id>:<key_secret>
-//     Used for: Management key operations (V2 key management API).
+//   - key_id present → Authorization: Bearer <key_id>:<api_key>
+//     Used for: Management key operations (V2 key management API), where
+//     Honeycomb's own UI calls api_key the "key secret".
 //
-//   - api_key only → X-Honeycomb-Team: <api_key>
+//   - key_id absent → X-Honeycomb-Team: <api_key>
 //     Used for: Ingest and Configuration key operations (V1/V2 data APIs).
+//
+// The secret half is api_key rather than a separate key_secret field because
+// api_key is what the credential type carries as its secret, and the type
+// guarantees it is non-empty. A distinct key_secret would have to travel
+// alongside a meaningless api_key just to satisfy that guarantee, so management
+// mode could never be configured without one.
 func honeycombExtractor(req *logical.Request) (map[string]string, error) {
 	if req.Credential == nil {
 		return nil, fmt.Errorf("no credential available")
@@ -32,22 +39,19 @@ func honeycombExtractor(req *logical.Request) (map[string]string, error) {
 		return nil, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
 	}
 
-	// Management key mode: key_id + key_secret
-	if keyID := req.Credential.Data["key_id"]; keyID != "" {
-		keySecret := req.Credential.Data["key_secret"]
-		if keySecret == "" {
-			return nil, fmt.Errorf("management key credential missing key_secret field")
-		}
-		return map[string]string{
-			"Authorization": "Bearer " + keyID + ":" + keySecret,
-		}, nil
-	}
-
-	// Ingest/configuration key mode: api_key → X-Honeycomb-Team header
 	apiKey := req.Credential.Data["api_key"]
 	if apiKey == "" {
 		return nil, fmt.Errorf("credential missing api_key field")
 	}
+
+	// Management key mode: key_id names the key, api_key is its secret.
+	if keyID := req.Credential.Data["key_id"]; keyID != "" {
+		return map[string]string{
+			"Authorization": "Bearer " + keyID + ":" + apiKey,
+		}, nil
+	}
+
+	// Ingest/configuration key mode: api_key → X-Honeycomb-Team header
 	return map[string]string{"X-Honeycomb-Team": apiKey}, nil
 }
 
@@ -65,6 +69,13 @@ var Spec = &httpproxy.ProviderSpec{
 	UserAgent:          "warden-honeycomb-proxy",
 	HelpText:           honeycombBackendHelp,
 	ExtractCredentials: honeycombExtractor,
+
+	// X-Honeycomb-Team is injected only in ingest mode, so in management mode a
+	// caller's own value would otherwise ride through untouched alongside the
+	// Authorization header Warden sets — an inbound credential reaching the
+	// upstream under the mount's identity. Headers injected on every branch need
+	// no strip, since injection overwrites; conditionally injected ones do.
+	ExtraHeadersToRemove: []string{"X-Honeycomb-Team"},
 }
 
 // Factory creates a new Honeycomb provider backend.
@@ -78,15 +89,24 @@ Warden performs implicit authentication on every request and obtains a
 Honeycomb credential from the credential manager, injecting it into the
 proxied request. Auth mode is detected automatically from the credential data:
 
-  Ingest/Configuration key (default):
+  Ingest/Configuration key (default, no key_id on the credential):
     Injected as X-Honeycomb-Team header.
     Used for: sending events, querying data, managing datasets, triggers,
     boards, SLOs, and other environment-scoped operations.
 
-  Management key (key_id + key_secret present):
-    Injected as Authorization: Bearer <key_id>:<key_secret> header.
+  Management key (key_id present on the credential):
+    Injected as Authorization: Bearer <key_id>:<api_key> header.
     Used for: creating, listing, and deleting API keys via the V2
     key management API.
+
+    Put Honeycomb's "Key ID" in key_id and its "Key Secret" in api_key --
+    api_key is the credential's secret field whichever mode is in use.
+
+    key_id is what selects the mode, so setting it on an ingest credential
+    switches the mount to management mode. On an apikey source it must also
+    be listed in the source's optional_metadata, since that driver copies
+    only api_key and the fields named there into the credential; a local
+    source carries it without further configuration.
 
 This provider supports both Honeycomb regions by mounting multiple
 instances with different honeycomb_url values:

--- a/provider/honeycomb/provider_test.go
+++ b/provider/honeycomb/provider_test.go
@@ -28,8 +28,8 @@ func TestHoneycombExtractor_ManagementKey(t *testing.T) {
 		Credential: &credential.Credential{
 			Type: credential.TypeAPIKey,
 			Data: map[string]string{
-				"key_id":     "hcxmk_01abc123",
-				"key_secret": "mgmt-secret-value",
+				"key_id":  "hcxmk_01abc123",
+				"api_key": "mgmt-secret-value",
 			},
 		},
 	})
@@ -38,7 +38,30 @@ func TestHoneycombExtractor_ManagementKey(t *testing.T) {
 	assert.Empty(t, headers["X-Honeycomb-Team"])
 }
 
-func TestHoneycombExtractor_ManagementKey_MissingSecret(t *testing.T) {
+// TestHoneycombExtractor_ManagementKeyNeedsNoSeparateSecret pins the reason
+// management mode is reachable at all: the secret half is api_key, which the
+// credential type guarantees. Reading a distinct key_secret made this branch
+// unconfigurable — the field could not be carried, so a mount with key_id set
+// failed every request with "missing key_secret field".
+func TestHoneycombExtractor_ManagementKeyNeedsNoSeparateSecret(t *testing.T) {
+	headers, err := honeycombExtractor(&logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{
+				"key_id":  "hcxmk_01abc123",
+				"api_key": "mgmt-secret-value",
+				// No key_secret, and none needed.
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer hcxmk_01abc123:mgmt-secret-value", headers["Authorization"])
+}
+
+// TestHoneycombExtractor_ManagementKeyWithoutAPIKey fails closed rather than
+// emitting "Bearer <key_id>:". Not reachable in production — Parse and Validate
+// both require a non-empty api_key — but the extractor must not assume it.
+func TestHoneycombExtractor_ManagementKeyWithoutAPIKey(t *testing.T) {
 	_, err := honeycombExtractor(&logical.Request{
 		Credential: &credential.Credential{
 			Type: credential.TypeAPIKey,
@@ -47,7 +70,7 @@ func TestHoneycombExtractor_ManagementKey_MissingSecret(t *testing.T) {
 			},
 		},
 	})
-	assert.ErrorContains(t, err, "missing key_secret")
+	assert.ErrorContains(t, err, "missing api_key")
 }
 
 func TestHoneycombExtractor_NoCredential(t *testing.T) {
@@ -78,4 +101,12 @@ func TestSpec(t *testing.T) {
 	assert.Equal(t, "honeycomb_url", Spec.URLConfigKey)
 	assert.NotNil(t, Spec.ExtractCredentials)
 	assert.NotNil(t, Factory)
+}
+
+// TestSpec_StripsNativeCredentialHeader pins the strip. X-Honeycomb-Team is
+// injected only in ingest mode, so without it a caller's own value would reach
+// the upstream in management mode, pairing an inbound credential with the
+// mount's identity.
+func TestSpec_StripsNativeCredentialHeader(t *testing.T) {
+	assert.Contains(t, Spec.ExtraHeadersToRemove, "X-Honeycomb-Team")
 }


### PR DESCRIPTION
Setting `key_id` selected management-key mode and then required a `key_secret` field no source can produce, so a mount configured for a management key answered **every** request with a bare 401 rather than degrading to the ingest branch. A configuration that looks valid, is accepted, and cannot work.

## Why not just carry `key_secret`

It would not have helped. `BaseTokenType.Parse` requires the credential's primary field and `APIKeyCredType.ValidateConfig` requires `api_key` non-empty, so a management-key spec would have needed a *meaningless* `api_key` alongside `key_id` and `key_secret` merely to mint.

The extractor now reads `api_key` as the secret half — `Bearer <key_id>:<api_key>` — which the type already guarantees is present. `key_id` alone selects a mode that works. Honeycomb's "Key Secret" goes in `api_key`, and the help text says so.

## The header strip

`X-Honeycomb-Team` joins `ExtraHeadersToRemove`. It is injected only in ingest mode, so in management mode a caller's own value rode to the upstream beside the `Authorization` header Warden sets — an inbound credential proxying onward under the mount's identity.

The general rule, worth applying to any new provider: **a header injected on only some branches must be stripped.** Unconditional ones are safe because `prepareHeaders` uses `Header.Set`. A sweep of the httpproxy providers found only this one and datadog's `DD-APPLICATION-KEY` outstanding.

## Tests

`e2e/fullchain/honeycomb_test.go` covers both branches plus the strip. Both rows verified to fail against the previous binary — the management row with the opaque 401, the strip row with `X-Honeycomb-Team: caller-supplied-team-key` arriving upstream.

The env uses an apikey source deliberately. On a local source `key_id` reaches the credential without being declared anywhere, so the row would pass while hiding that an apikey source must name it.

## Merge note

The help text here names `optional_metadata`, which `feat/credential-field-carriage` renames to `credential_fields`. Whichever of the two lands second needs that one string updated.
