### PR TITLE
feat(prometheus): move auth_type from credential data to mount config

### DIFF
--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -36,13 +36,15 @@ import (
 // channels with the native header first, scheme dispatch, and the git dual-slot
 // on its REST path — and all four shared SDK credential extractors.
 //
-// Three providers hand-roll an extractor and are not here: atlassian, honeycomb
-// and prometheus, whose distinctive branches read credential fields nothing can
-// supply, so a row could only cover the fallback each degrades to.
+// Two providers hand-roll an extractor and are not here: atlassian and
+// honeycomb, whose distinctive branches read credential fields nothing can
+// supply, so a row could only cover the fallback each degrades to. prometheus was
+// in that group until its scheme moved from credential data to mount config,
+// which is also why it appears twice — the scheme is per mount.
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
-	mcpAWSEnv, mcpAWSWrongCredEnv,
+	mcpAWSEnv, mcpAWSWrongCredEnv, prometheusEnv, prometheusBasicEnv,
 }
 
 var (

--- a/e2e/fullchain/prometheus_test.go
+++ b/e2e/fullchain/prometheus_test.go
@@ -1,0 +1,139 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// prometheus is the provider whose auth scheme is a property of the deployment
+// rather than of the credential: a self-hosted server started with
+// --web.config.file speaks Basic, a managed one speaks Bearer, and the same key
+// cannot mean both. So the scheme sits in mount config beside prometheus_url,
+// which already forced one mount per deployment.
+//
+// That is why these are two mounts rather than two specs. Testing it any other
+// way would be testing something the provider no longer does — the scheme used to
+// be read from credential data, where nothing could set it, so the Basic branch
+// was unreachable and every mount sent Bearer whatever it was configured for.
+
+const (
+	prometheusBearerKey = "fc-prometheus-not-a-real-bearer-token"
+	// Pre-encoded base64("admin:secret"). Prometheus basic auth takes the
+	// encoded pair as the credential, so Warden brokers it verbatim.
+	prometheusBasicKey = "YWRtaW46c2VjcmV0"
+)
+
+var prometheusEnv = h.ProviderEnv{
+	Mount:      "fc-prometheus",
+	Type:       "prometheus",
+	URLKey:     "prometheus_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": prometheusBearerKey},
+	// No auth_type: the default must be bearer, and a mount that says nothing
+	// is the case an upgrade produces.
+}
+
+var prometheusBasicEnv = h.ProviderEnv{
+	Mount:       "fc-prometheus-basic",
+	Type:        "prometheus",
+	URLKey:      "prometheus_url",
+	CredType:    "api_key",
+	ExtraConfig: map[string]any{"auth_type": "basic"},
+	CredConfig:  map[string]string{"api_key": prometheusBasicKey},
+}
+
+// TestPrometheus_SchemeFollowsMountConfig drives both mounts with the same shape
+// of credential and checks that the scheme differs.
+//
+// The two rows are what distinguish a working config switch from a provider that
+// ignores it: before, both would have said "Bearer".
+func TestPrometheus_SchemeFollowsMountConfig(t *testing.T) {
+	ensureEnv(t)
+
+	cases := []struct {
+		name string
+		env  h.ProviderEnv
+		want string
+	}{
+		{
+			name: "unconfigured mount defaults to bearer",
+			env:  prometheusEnv,
+			want: "Bearer " + prometheusBearerKey,
+		},
+		{
+			name: "auth_type=basic switches the scheme",
+			env:  prometheusBasicEnv,
+			want: "Basic " + prometheusBasicKey,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, tc.env, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.env.CertRole(),
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      map[string]string{"Authorization": tc.want},
+				Absent:        h.AlwaysAbsent(),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}
+
+// TestPrometheus_ConfigReadReportsTheSchemeInForce checks the operator-visible
+// half. A mount whose scheme is wrong and a mount that reports the wrong scheme
+// fail the same way from outside — the request works or it does not — so the
+// read has to agree with what the request path uses.
+func TestPrometheus_ConfigReadReportsTheSchemeInForce(t *testing.T) {
+	ensureEnv(t)
+
+	for _, tc := range []struct {
+		mount string
+		want  string
+	}{
+		{prometheusEnv.Mount, "bearer"},
+		{prometheusBasicEnv.Mount, "basic"},
+	} {
+		status, body := h.APIRequest(t, "GET", tc.mount+"/config", leaderPort, "")
+		if status != 200 {
+			t.Fatalf("read %s config (status %d): %s", tc.mount, status, body)
+		}
+		got := h.JSONPath(h.ParseJSON(t, body), "data.auth_type")
+		if got != tc.want {
+			t.Errorf("%s auth_type: got %v, want %q", tc.mount, got, tc.want)
+		}
+	}
+}
+
+// TestPrometheus_InvalidSchemeIsRejected pins the hand-written enum check. The
+// framework's AllowedValues reaches the OpenAPI document and nothing else, so
+// without an explicit guard a typo would be stored and silently serve Bearer —
+// a mount configured for Basic, reporting Basic, sending Bearer.
+func TestPrometheus_InvalidSchemeIsRejected(t *testing.T) {
+	ensureEnv(t)
+
+	status, body := h.APIRequest(t, "PUT", prometheusEnv.Mount+"/config", leaderPort,
+		`{"auth_type":"basci"}`)
+	if status < 400 || status >= 500 {
+		t.Fatalf("writing auth_type=basci: got status %d, want a 4xx (body: %s)", status, body)
+	}
+
+	// And the mount is unchanged, rather than left half-written.
+	status, body = h.APIRequest(t, "GET", prometheusEnv.Mount+"/config", leaderPort, "")
+	if status != 200 {
+		t.Fatalf("read config after rejected write (status %d): %s", status, body)
+	}
+	if got := h.JSONPath(h.ParseJSON(t, body), "data.auth_type"); got != "bearer" {
+		t.Errorf("auth_type after rejected write: got %v, want bearer", got)
+	}
+}

--- a/provider/prometheus/provider.go
+++ b/provider/prometheus/provider.go
@@ -2,9 +2,11 @@ package prometheus
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
@@ -12,34 +14,63 @@ import (
 // DefaultPrometheusTimeout is the default request timeout for Prometheus API calls.
 const DefaultPrometheusTimeout = 30 * time.Second
 
-// prometheusExtractor injects credentials as Bearer or Basic Auth depending on
-// the auth_type field in the credential data:
+// Auth schemes a mount can be configured for. Which one a Prometheus deployment
+// speaks is a property of that deployment — how the server was started — not of
+// the credential brokered to it, so it lives in mount config beside the URL that
+// determines it.
+const (
+	authTypeBearer = "bearer"
+	authTypeBasic  = "basic"
+)
+
+// prometheusExtractor injects the brokered key into Authorization under the
+// mount's configured scheme.
 //
-//   - auth_type=basic → Authorization: Basic <api_key>
-//     api_key must be the base64-encoded "username:password" string.
-//     Used for: self-hosted Prometheus with --web.config.file basic auth.
-//
-//   - auth_type=bearer (or unset) → Authorization: Bearer <api_key>
+//   - bearer (default) → Authorization: Bearer <api_key>
 //     Used for: managed Prometheus services (Grafana Mimir, Amazon Managed
 //     Prometheus, Thanos, Cortex) that accept bearer tokens.
 //
-// To forward the auth_type field from a spec config into credential data,
-// configure the apikey source with optional_metadata=auth_type.
-func prometheusExtractor(req *logical.Request) (map[string]string, error) {
-	if req.Credential == nil {
-		return nil, fmt.Errorf("no credential available")
+//   - basic → Authorization: Basic <api_key>
+//     api_key must be the base64-encoded "username:password" string.
+//     Used for: self-hosted Prometheus with --web.config.file basic auth.
+func prometheusExtractor(scheme string) httpproxy.CredentialExtractor {
+	return func(req *logical.Request) (map[string]string, error) {
+		if req.Credential == nil {
+			return nil, fmt.Errorf("no credential available")
+		}
+		if req.Credential.Type != credential.TypeAPIKey {
+			return nil, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+		}
+		apiKey := req.Credential.Data["api_key"]
+		if apiKey == "" {
+			return nil, fmt.Errorf("credential missing api_key field")
+		}
+		if scheme == authTypeBasic {
+			return map[string]string{"Authorization": "Basic " + apiKey}, nil
+		}
+		return map[string]string{"Authorization": "Bearer " + apiKey}, nil
 	}
-	if req.Credential.Type != credential.TypeAPIKey {
-		return nil, fmt.Errorf("unsupported credential type: %s", req.Credential.Type)
+}
+
+// validateAuthType rejects anything but the two schemes. Enforced by hand in
+// both write paths because framework.FieldSchema.AllowedValues is documentation
+// only — it reaches the OpenAPI document and nothing else — so a typo would
+// otherwise be stored and silently read back as bearer.
+func validateAuthType(v string) error {
+	switch v {
+	case "", authTypeBearer, authTypeBasic:
+		return nil
+	default:
+		return fmt.Errorf("auth_type must be %q or %q, got %q", authTypeBearer, authTypeBasic, v)
 	}
-	apiKey := req.Credential.Data["api_key"]
-	if apiKey == "" {
-		return nil, fmt.Errorf("credential missing api_key field")
+}
+
+// stateAuthType returns the mount's configured scheme, defaulting to bearer.
+func stateAuthType(state map[string]any) string {
+	if s, _ := state["auth_type"].(string); s != "" {
+		return s
 	}
-	if req.Credential.Data["auth_type"] == "basic" {
-		return map[string]string{"Authorization": "Basic " + apiKey}, nil
-	}
-	return map[string]string{"Authorization": "Bearer " + apiKey}, nil
+	return authTypeBearer
 }
 
 // Spec defines the Prometheus provider configuration for the httpproxy framework.
@@ -50,13 +81,57 @@ func prometheusExtractor(req *logical.Request) (map[string]string, error) {
 // (Grafana Mimir, Amazon Managed Prometheus, Thanos, Cortex, VictoriaMetrics)
 // by mounting multiple instances with different prometheus_url values.
 var Spec = &httpproxy.ProviderSpec{
-	Name:               "prometheus",
-	URLConfigKey:       "prometheus_url",
-	DefaultTimeout:     DefaultPrometheusTimeout,
-	ParseStreamBody:    true,
-	UserAgent:          "warden-prometheus-proxy",
-	HelpText:           prometheusBackendHelp,
-	ExtractCredentials: prometheusExtractor,
+	Name:            "prometheus",
+	URLConfigKey:    "prometheus_url",
+	DefaultTimeout:  DefaultPrometheusTimeout,
+	ParseStreamBody: true,
+	UserAgent:       "warden-prometheus-proxy",
+	HelpText:        prometheusBackendHelp,
+
+	// Defensive default. ResolveUpstream always supplies a state-derived
+	// extractor, so this is never consulted; it only guards against a nil-func
+	// call if that ever changes.
+	ExtractCredentials: prometheusExtractor(authTypeBearer),
+
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"auth_type": {
+			Type:          framework.TypeString,
+			Default:       authTypeBearer,
+			AllowedValues: []interface{}{authTypeBearer, authTypeBasic},
+			Description:   "Authorization scheme the upstream speaks: bearer (default) or basic",
+		},
+	},
+
+	ResolveUpstream: func(_ *http.Request, _ string, state map[string]any) (httpproxy.Dispatch, bool) {
+		return httpproxy.Dispatch{ExtractCredentials: prometheusExtractor(stateAuthType(state))}, true
+	},
+
+	OnConfigWrite: func(d *framework.FieldData, state map[string]any) (map[string]any, error) {
+		if v, ok := d.GetOk("auth_type"); ok {
+			s := v.(string)
+			if err := validateAuthType(s); err != nil {
+				return nil, err
+			}
+			state["auth_type"] = s
+		}
+		return state, nil
+	},
+
+	OnConfigRead: func(state map[string]any) map[string]any {
+		return map[string]any{"auth_type": stateAuthType(state)}
+	},
+
+	OnInitialize: func(config map[string]any, state map[string]any) map[string]any {
+		if v, ok := config["auth_type"].(string); ok && v != "" {
+			state["auth_type"] = v
+		}
+		return state
+	},
+
+	ValidateExtraConfig: func(conf map[string]any) error {
+		v, _ := conf["auth_type"].(string)
+		return validateAuthType(v)
+	},
 }
 
 // Factory creates a new Prometheus provider backend.
@@ -68,9 +143,10 @@ with automatic credential management and auth header injection.
 
 Warden performs implicit authentication on every request and obtains a
 Prometheus credential from the credential manager, injecting it into the
-proxied request. Auth mode is detected automatically from the credential data:
+proxied request's Authorization header. Which scheme it uses is a property of
+the deployment, so it is set on the mount alongside prometheus_url:
 
-  Bearer (default, auth_type=bearer or unset):
+  Bearer (default, auth_type=bearer):
     Used for managed Prometheus services (Grafana Mimir, Amazon Managed
     Prometheus, Thanos, Cortex, VictoriaMetrics) that accept bearer tokens.
 
@@ -78,8 +154,9 @@ proxied request. Auth mode is detected automatically from the credential data:
     Used for self-hosted Prometheus instances configured with
     --web.config.file basic auth. api_key must be the base64-encoded
     "username:password" string (e.g. base64("admin:secret")).
-    Configure your apikey source with optional_metadata=auth_type and
-    set auth_type=basic on the credential spec.
+
+  Two deployments needing different schemes are two mounts, which they already
+  had to be: each has its own prometheus_url.
 
 This provider type supports the full Prometheus ecosystem by mounting
 multiple instances with different prometheus_url values:
@@ -114,11 +191,10 @@ Example API paths:
 
 Credential source type:
 - apikey: Static bearer token or pre-encoded basic auth credentials.
-  For basic auth, set optional_metadata=auth_type on the source and
-  include auth_type=basic in the spec config.
 
 Configuration:
 - prometheus_url: Prometheus API base URL (required — no universal default)
+- auth_type: Authorization scheme the upstream speaks: bearer (default) or basic
 - max_body_size: Maximum request body size (default: 10MB, max: 100MB)
 - timeout: Request timeout duration (default: 30s)
 - auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')

--- a/provider/prometheus/provider_test.go
+++ b/provider/prometheus/provider_test.go
@@ -1,81 +1,172 @@
 package prometheus
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrometheusExtractor_Bearer_Default(t *testing.T) {
-	headers, err := prometheusExtractor(&logical.Request{
+func apiKeyRequest(key string) *logical.Request {
+	return &logical.Request{
 		Credential: &credential.Credential{
 			Type: credential.TypeAPIKey,
-			Data: map[string]string{
-				"api_key": "my-bearer-token",
-			},
+			Data: map[string]string{"api_key": key},
 		},
-	})
+	}
+}
+
+func TestPrometheusExtractor_Bearer_Default(t *testing.T) {
+	headers, err := prometheusExtractor(authTypeBearer)(apiKeyRequest("my-bearer-token"))
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer my-bearer-token", headers["Authorization"])
 }
 
-func TestPrometheusExtractor_Bearer_Explicit(t *testing.T) {
-	headers, err := prometheusExtractor(&logical.Request{
-		Credential: &credential.Credential{
-			Type: credential.TypeAPIKey,
-			Data: map[string]string{
-				"api_key":   "my-bearer-token",
-				"auth_type": "bearer",
-			},
-		},
-	})
+// An unset scheme is bearer: stateAuthType defaults, and an extractor built with
+// an empty string must not fall through to some third behaviour.
+func TestPrometheusExtractor_UnsetSchemeIsBearer(t *testing.T) {
+	headers, err := prometheusExtractor("")(apiKeyRequest("my-bearer-token"))
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer my-bearer-token", headers["Authorization"])
 }
 
 func TestPrometheusExtractor_BasicAuth(t *testing.T) {
 	// api_key is pre-encoded base64("admin:secret") = "YWRtaW46c2VjcmV0"
-	headers, err := prometheusExtractor(&logical.Request{
-		Credential: &credential.Credential{
-			Type: credential.TypeAPIKey,
-			Data: map[string]string{
-				"api_key":   "YWRtaW46c2VjcmV0",
-				"auth_type": "basic",
-			},
-		},
-	})
+	headers, err := prometheusExtractor(authTypeBasic)(apiKeyRequest("YWRtaW46c2VjcmV0"))
 	require.NoError(t, err)
 	assert.Equal(t, "Basic YWRtaW46c2VjcmV0", headers["Authorization"])
 }
 
 func TestPrometheusExtractor_NoCredential(t *testing.T) {
-	_, err := prometheusExtractor(&logical.Request{})
+	_, err := prometheusExtractor(authTypeBearer)(&logical.Request{})
 	assert.ErrorContains(t, err, "no credential available")
 }
 
 func TestPrometheusExtractor_WrongType(t *testing.T) {
-	_, err := prometheusExtractor(&logical.Request{
+	_, err := prometheusExtractor(authTypeBearer)(&logical.Request{
 		Credential: &credential.Credential{Type: "vault_token"},
 	})
 	assert.ErrorContains(t, err, "unsupported credential type")
 }
 
 func TestPrometheusExtractor_MissingAPIKey(t *testing.T) {
-	_, err := prometheusExtractor(&logical.Request{
+	_, err := prometheusExtractor(authTypeBasic)(&logical.Request{
 		Credential: &credential.Credential{
 			Type: credential.TypeAPIKey,
-			Data: map[string]string{"auth_type": "basic"},
+			Data: map[string]string{},
 		},
 	})
 	assert.ErrorContains(t, err, "missing api_key")
+}
+
+// TestPrometheusExtractor_IgnoresCredentialAuthType pins that the scheme comes
+// from the mount and nowhere else. auth_type used to be read from credential
+// data, where nothing could set it; a credential still carrying the field must
+// not resurrect that path.
+func TestPrometheusExtractor_IgnoresCredentialAuthType(t *testing.T) {
+	req := &logical.Request{
+		Credential: &credential.Credential{
+			Type: credential.TypeAPIKey,
+			Data: map[string]string{"api_key": "k", "auth_type": "basic"},
+		},
+	}
+	headers, err := prometheusExtractor(authTypeBearer)(req)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer k", headers["Authorization"], "credential data must not select the scheme")
+}
+
+// TestResolveUpstream_SelectsSchemeFromState covers the wiring between mount
+// config and the extractor actually used for a request.
+func TestResolveUpstream_SelectsSchemeFromState(t *testing.T) {
+	require.NotNil(t, Spec.ResolveUpstream)
+
+	cases := []struct {
+		name  string
+		state map[string]any
+		want  string
+	}{
+		{"unset defaults to bearer", map[string]any{}, "Bearer k"},
+		{"bearer", map[string]any{"auth_type": authTypeBearer}, "Bearer k"},
+		{"basic", map[string]any{"auth_type": authTypeBasic}, "Basic k"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := Spec.ResolveUpstream(&http.Request{}, "", tc.state)
+			require.True(t, ok)
+			require.NotNil(t, d.ExtractCredentials)
+
+			headers, err := d.ExtractCredentials(apiKeyRequest("k"))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, headers["Authorization"])
+		})
+	}
+}
+
+// TestValidateAuthType_RejectsTypos is the reason the enum is enforced by hand:
+// framework.FieldSchema.AllowedValues only reaches the OpenAPI document, so
+// without this a misspelt scheme would be stored and read back as bearer — the
+// mount would speak the wrong scheme and say it was configured correctly.
+func TestValidateAuthType_RejectsTypos(t *testing.T) {
+	assert.NoError(t, validateAuthType(""))
+	assert.NoError(t, validateAuthType(authTypeBearer))
+	assert.NoError(t, validateAuthType(authTypeBasic))
+
+	for _, bad := range []string{"basci", "Basic", "none", "digest"} {
+		assert.ErrorContains(t, validateAuthType(bad), "auth_type must be", "value %q", bad)
+	}
+}
+
+// Both write paths must reject it: OnConfigWrite guards a config write on a live
+// mount, ValidateExtraConfig guards the config supplied at enable time.
+func TestConfigWritePaths_RejectInvalidAuthType(t *testing.T) {
+	require.NotNil(t, Spec.OnConfigWrite)
+	require.NotNil(t, Spec.ValidateExtraConfig)
+
+	fd := &framework.FieldData{
+		Raw:    map[string]interface{}{"auth_type": "basci"},
+		Schema: Spec.ExtraConfigFields,
+	}
+	_, err := Spec.OnConfigWrite(fd, map[string]any{})
+	assert.ErrorContains(t, err, "auth_type must be")
+
+	assert.ErrorContains(t, Spec.ValidateExtraConfig(map[string]any{"auth_type": "basci"}), "auth_type must be")
+	assert.NoError(t, Spec.ValidateExtraConfig(map[string]any{"auth_type": authTypeBasic}))
+	assert.NoError(t, Spec.ValidateExtraConfig(map[string]any{}), "an unset auth_type is the bearer default")
+}
+
+// A config write that does not mention auth_type must leave the stored one
+// alone, rather than resetting the mount to bearer.
+func TestOnConfigWrite_LeavesUnmentionedSchemeAlone(t *testing.T) {
+	state := map[string]any{"auth_type": authTypeBasic}
+	fd := &framework.FieldData{Raw: map[string]interface{}{}, Schema: Spec.ExtraConfigFields}
+
+	got, err := Spec.OnConfigWrite(fd, state)
+	require.NoError(t, err)
+	assert.Equal(t, authTypeBasic, stateAuthType(got))
+}
+
+// OnInitialize applies mount-time config; OnConfigRead reports what is in force.
+func TestConfigRoundTrip(t *testing.T) {
+	require.NotNil(t, Spec.OnInitialize)
+	require.NotNil(t, Spec.OnConfigRead)
+
+	state := Spec.OnInitialize(map[string]any{"auth_type": authTypeBasic}, map[string]any{})
+	assert.Equal(t, authTypeBasic, Spec.OnConfigRead(state)["auth_type"])
+
+	empty := Spec.OnInitialize(map[string]any{}, map[string]any{})
+	assert.Equal(t, authTypeBearer, Spec.OnConfigRead(empty)["auth_type"],
+		"a mount that never set auth_type reads back as bearer, not empty")
 }
 
 func TestSpec(t *testing.T) {
 	assert.Equal(t, "prometheus", Spec.Name)
 	assert.Equal(t, "prometheus_url", Spec.URLConfigKey)
 	assert.NotNil(t, Spec.ExtractCredentials)
+	assert.Contains(t, Spec.ExtraConfigFields, "auth_type")
 	assert.NotNil(t, Factory)
 }


### PR DESCRIPTION
The extractor selected Basic when `Data["auth_type"]` was `"basic"`, but nothing could put `auth_type` in credential data — so the Basic branch was unreachable and every mount sent Bearer whatever it was configured for.

## Why it moves rather than being made carriable

`auth_type` is not credential material. Which scheme a Prometheus deployment speaks is a property of how that server was started, not of the key brokered to it, and one key cannot mean both. It now sits in mount config beside `prometheus_url`, which already forced one mount per deployment.

The shape follows the `rest` provider: `ExtraConfigFields` declares it, `OnConfigWrite`/`OnInitialize`/`OnConfigRead` carry it in `extraState`, and `ResolveUpstream` returns a `Dispatch` whose extractor is derived from that state.

## The enum is enforced by hand, deliberately

`framework.FieldSchema.AllowedValues` is documentation only — it reaches the OpenAPI document and nothing else. Declaring the enum there and stopping would have let `auth_type=basci` be stored and read back, so a mount configured for Basic would report Basic and send Bearer. The check runs in both write paths, `OnConfigWrite` and `ValidateExtraConfig`.

## Tests

`e2e/fullchain/prometheus_test.go` drives both schemes across two mounts, since the scheme is now per mount, and asserts the config read agrees with what the request path uses.

Both rows verified to fail against the previous binary: the Basic mount sending `Bearer`, and the invalid scheme accepted with 200 "configuration updated".
