### PR TITLE
feat(credential): carry the adjunct fields a source declares

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -615,6 +616,15 @@ func (s *CredentialConfigStore) UpdateSource(ctx context.Context, source *creden
 		return logical.ErrBadRequestf("cannot change the type of source %q (%s → %s); source type is immutable", source.Name, existing.Type, source.Type)
 	}
 
+	// Narrowing optional_metadata strands the specs that relied on it. The
+	// spec-level guard cannot catch this: it runs when a spec is written, and here
+	// the specs are untouched — they simply start minting without a field, and the
+	// provider takes its fallback branch. Reject rather than let a source edit
+	// silently narrow credentials bound to it.
+	if err := s.checkBoundSpecsStillCarried(ctx, source); err != nil {
+		return err
+	}
+
 	// Close old driver instance since config has changed
 	// This ensures the driver will be recreated with the new config on next use
 	if err := s.core.credentialManager.CloseDriver(ctx, source.Name); err != nil {
@@ -869,6 +879,22 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		} else {
 			if err := credType.ValidateConfig(spec.Config, source.Type); err != nil {
 				return logical.ErrBadRequestf("invalid config for type '%s': %s", spec.Type, err.Error())
+			}
+
+			// A credential field the source will not carry is dead config: the
+			// spec mints without it and the provider takes its fallback branch,
+			// which looks like a working mount rather than a misconfigured one.
+			// Rejecting here is the only point that sees both the spec and its
+			// source, and so the only one that can say what to add.
+			if missing, carriable := credential.UncarriedAdjunctFields(credType, spec.Config, source.Config, source.Type); len(missing) > 0 {
+				if !carriable {
+					return logical.ErrBadRequestf(
+						"spec sets credential field(s) %s, but a '%s' source carries only the credential's primary field: use an apikey source and name them in its optional_metadata",
+						strings.Join(missing, ", "), source.Type)
+				}
+				return logical.ErrBadRequestf(
+					"spec sets credential field(s) %s that source '%s' does not carry: add them to the source's optional_metadata (currently %q)",
+					strings.Join(missing, ", "), spec.Source, source.Config["optional_metadata"])
 			}
 
 			// A token-exchange spec (subject_token_source set) is minted fresh per
@@ -1180,6 +1206,45 @@ func (s *CredentialConfigStore) CheckSourceReferences(ctx context.Context, sourc
 	}
 
 	return refs, nil
+}
+
+// checkBoundSpecsStillCarried rejects a source edit that would stop a bound spec's
+// credential fields from travelling.
+//
+// The spec-level guard runs when a spec is written and so cannot see this: the
+// specs are not being touched. Without the check, removing a name from
+// optional_metadata leaves every spec that set that field minting without it —
+// and the symptom is a provider using its fallback branch, which reads as a
+// working mount. The operator is told which specs to fix.
+//
+// Widening is always fine; only a name that disappears can strand anything.
+func (s *CredentialConfigStore) checkBoundSpecsStillCarried(ctx context.Context, source *credential.CredSource) error {
+	if s.core == nil || s.core.credentialTypeRegistry == nil {
+		return nil
+	}
+
+	refs, err := s.CheckSourceReferences(ctx, source.Name)
+	if err != nil {
+		// A listing failure must not block an unrelated source edit; the
+		// spec-level guard still covers every future write.
+		s.logger.Warn("could not check specs bound to this source for uncarried fields",
+			logger.String("source_name", source.Name), logger.Err(err))
+		return nil
+	}
+
+	for _, spec := range refs {
+		credType, err := s.core.credentialTypeRegistry.GetByName(spec.Type)
+		if err != nil {
+			continue
+		}
+		missing, _ := credential.UncarriedAdjunctFields(credType, spec.Config, source.Config, source.Type)
+		if len(missing) > 0 {
+			return logical.ErrBadRequestf(
+				"spec %q sets credential field(s) %s that this source would no longer carry: keep them in optional_metadata, or remove them from the spec first",
+				spec.Name, strings.Join(missing, ", "))
+		}
+	}
+	return nil
 }
 
 // CheckSpecReferences returns the names of sources and specs that reference the

--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -616,7 +616,7 @@ func (s *CredentialConfigStore) UpdateSource(ctx context.Context, source *creden
 		return logical.ErrBadRequestf("cannot change the type of source %q (%s → %s); source type is immutable", source.Name, existing.Type, source.Type)
 	}
 
-	// Narrowing optional_metadata strands the specs that relied on it. The
+	// Narrowing credential_fields strands the specs that relied on it. The
 	// spec-level guard cannot catch this: it runs when a spec is written, and here
 	// the specs are untouched — they simply start minting without a field, and the
 	// provider takes its fallback branch. Reject rather than let a source edit
@@ -889,12 +889,12 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 			if missing, carriable := credential.UncarriedAdjunctFields(credType, spec.Config, source.Config, source.Type); len(missing) > 0 {
 				if !carriable {
 					return logical.ErrBadRequestf(
-						"spec sets credential field(s) %s, but a '%s' source carries only the credential's primary field: use an apikey source and name them in its optional_metadata",
+						"spec sets credential field(s) %s, but a '%s' source carries only the credential's primary field: use an apikey source and name them in its credential_fields",
 						strings.Join(missing, ", "), source.Type)
 				}
 				return logical.ErrBadRequestf(
-					"spec sets credential field(s) %s that source '%s' does not carry: add them to the source's optional_metadata (currently %q)",
-					strings.Join(missing, ", "), spec.Source, source.Config["optional_metadata"])
+					"spec sets credential field(s) %s that source '%s' does not carry: add them to the source's credential_fields (currently %q)",
+					strings.Join(missing, ", "), spec.Source, source.Config["credential_fields"])
 			}
 
 			// A token-exchange spec (subject_token_source set) is minted fresh per
@@ -1213,7 +1213,7 @@ func (s *CredentialConfigStore) CheckSourceReferences(ctx context.Context, sourc
 //
 // The spec-level guard runs when a spec is written and so cannot see this: the
 // specs are not being touched. Without the check, removing a name from
-// optional_metadata leaves every spec that set that field minting without it —
+// credential_fields leaves every spec that set that field minting without it —
 // and the symptom is a provider using its fallback branch, which reads as a
 // working mount. The operator is told which specs to fix.
 //
@@ -1240,7 +1240,7 @@ func (s *CredentialConfigStore) checkBoundSpecsStillCarried(ctx context.Context,
 		missing, _ := credential.UncarriedAdjunctFields(credType, spec.Config, source.Config, source.Type)
 		if len(missing) > 0 {
 			return logical.ErrBadRequestf(
-				"spec %q sets credential field(s) %s that this source would no longer carry: keep them in optional_metadata, or remove them from the spec first",
+				"spec %q sets credential field(s) %s that this source would no longer carry: keep them in credential_fields, or remove them from the spec first",
 				spec.Name, strings.Join(missing, ", "))
 		}
 	}

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -240,11 +240,18 @@ func (b *SystemBackend) maskSpecConfig(specType string, config map[string]string
 		return nil
 	}
 
-	// Get sensitive config fields from credential type
+	// Get sensitive config fields from credential type. A type whose specs can
+	// carry operator-declared fields decides per config instead of from a fixed
+	// list — it cannot know in advance whether an adjunct someone added is a
+	// second secret, so it errs towards masking.
 	var sensitiveFields []string
 	if b.core.credentialTypeRegistry != nil {
 		if credType, err := b.core.credentialTypeRegistry.GetByName(specType); err == nil {
-			sensitiveFields = credType.SensitiveConfigFields()
+			if dynamic, ok := credType.(credential.ConfigSensitivity); ok {
+				sensitiveFields = dynamic.SensitiveConfigFieldsFor(config)
+			} else {
+				sensitiveFields = credType.SensitiveConfigFields()
+			}
 		}
 	}
 

--- a/credential/carriage.go
+++ b/credential/carriage.go
@@ -1,0 +1,192 @@
+package credential
+
+import "strings"
+
+// Adjunct carriage: how a credential comes to hold more than its primary field.
+//
+// A credential type declares one primary field and, historically, a fixed list of
+// extra ones. That list is a constant, so a provider needing a field the type's
+// author did not anticipate reads something no configuration can supply — the
+// branch is live code with no reachable input.
+//
+// The apikey source already lets an operator name extra fields (optional_metadata)
+// and copies them into rawData. What was missing is that the type filter then
+// discarded them. Carriage closes that gap: the driver records which names it
+// resolved under RawAdjunctFieldsKey, and the parser copies exactly those into the
+// credential after the type has parsed it.
+//
+// The operator names the fields; the type decides what they mean. Nothing travels
+// that nobody asked for, which is why the denylist below is a sanity check rather
+// than the thing keeping secrets out of credential data.
+
+// AdjunctCarrier is an optional interface a credential Type implements when its
+// specs may carry operator-declared adjunct fields. It exists so a spec that sets
+// a credential field the source will not carry is rejected at write time, rather
+// than minting a credential quietly missing it — the failure that follows is a
+// provider taking its fallback branch, which looks like a working mount.
+type AdjunctCarrier interface {
+	// KnownAdjunctFields returns the spec-config keys that describe the
+	// credential rather than the mint. Only these are checked; a key the type
+	// has never heard of is left alone, since it may belong to a mechanism this
+	// type does not model.
+	KnownAdjunctFields() []string
+}
+
+// UncarriedAdjunctFields returns the credential fields a spec sets that its
+// source will not carry, along with the reason, so the caller can reject the spec
+// and say what to do about it.
+//
+// Two different failures, and telling them apart matters. A source that could
+// carry the field but was not told to needs a line adding to its
+// optional_metadata. A source whose driver has no such mechanism cannot carry it
+// at all, and pointing that operator at optional_metadata would send them to add
+// a key that changes nothing — the same silent divergence this check exists to
+// prevent, one layer up.
+//
+// Returns nothing for a type that does not carry adjuncts.
+func UncarriedAdjunctFields(credType interface{}, specConfig, sourceConfig map[string]string, sourceType string) (fields []string, carriable bool) {
+	carrier, ok := credType.(AdjunctCarrier)
+	if !ok {
+		return nil, true
+	}
+
+	// Only the apikey driver resolves optional_metadata and tells the parser what
+	// it carried; the parser honours the declaration from that driver alone.
+	carriable = sourceType == SourceTypeAPIKey
+
+	declared := make(map[string]bool)
+	if carriable {
+		for _, name := range ParseAdjunctNames(sourceConfig["optional_metadata"]) {
+			declared[name] = true
+		}
+	}
+
+	for _, field := range carrier.KnownAdjunctFields() {
+		if specConfig[field] != "" && !declared[field] {
+			fields = append(fields, field)
+		}
+	}
+	return fields, carriable
+}
+
+// reservedSpecConfigKeys are spec-config keys that address the mint itself —
+// where to fetch, what to fetch, how to chain — rather than describing the
+// credential. They are never carriable, and never masked on read either, since a
+// locator is not a secret.
+//
+// Derived from the exported Config* constants where those exist. The store-backed
+// locators do not have constants: they are string literals in the drivers, so
+// they are listed here by name. A constants-only derivation would silently miss
+// them — json_key_map in particular is a legitimate api_key spec key.
+//
+// Adding a spec-config key anywhere in the tree means adding it here.
+var reservedSpecConfigKeys = map[string]struct{}{
+	// Credential chaining.
+	ConfigSecretSpec:     {},
+	ConfigSecretField:    {},
+	ConfigSecretCacheTTL: {},
+
+	// Token exchange.
+	ConfigSubjectTokenSource:      {},
+	ConfigSubjectTokenType:        {},
+	ConfigActorTokenSource:        {},
+	ConfigActorTokenType:          {},
+	ConfigAssertionAudience:       {},
+	ConfigAssertionMetadataClaims: {},
+	ConfigAssertionUserClaims:     {},
+	ConfigAssertionAlgorithm:      {},
+	ConfigAssertionResource:       {},
+
+	// Store-backed mint locators (string literals in the drivers).
+	"mint_method":     {},
+	"kv2_mount":       {},
+	"secret_path":     {},
+	"secret_id":       {},
+	"role_arn":        {},
+	"version_stage":   {},
+	"version_id":      {},
+	"credential_type": {},
+	"json_key_map":    {},
+}
+
+// reservedRawDataPrefix marks keys that belong to the mint pipeline rather than
+// to the credential — RawAdjunctFieldsKey and the rotated-refresh-token keys. No
+// operator-declared field may use it, and no such key may be carried.
+const reservedRawDataPrefix = "__"
+
+// IsReservedSpecConfigName reports whether a name is one of the known mint-
+// configuration keys — a locator or a chaining reference. These describe how to
+// mint rather than what was minted, so they are neither carriable nor secret.
+func IsReservedSpecConfigName(name string) bool {
+	_, reserved := reservedSpecConfigKeys[name]
+	return reserved
+}
+
+// IsReservedSpecConfigKey reports whether a name may be declared as an adjunct or
+// carried into a credential. It covers the known mint keys plus the whole "__"
+// namespace, which belongs to the mint pipeline.
+//
+// Use IsReservedSpecConfigName instead when deciding whether a key is *safe to
+// display*: nothing stops an operator from putting a key called "__whatever" in a
+// spec config, and treating the prefix as trusted there would print it in the
+// clear.
+func IsReservedSpecConfigKey(name string) bool {
+	return strings.HasPrefix(name, reservedRawDataPrefix) || IsReservedSpecConfigName(name)
+}
+
+// ParseAdjunctNames splits a comma-separated declaration, trimming blanks. Shared
+// by the driver that writes the declaration and the parser that reads it, so the
+// two cannot disagree about what a name is.
+func ParseAdjunctNames(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var names []string
+	for _, n := range strings.Split(raw, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// takeAdjunctNames removes the declaration from rawData and returns the names it
+// held. It always removes, whatever the driver: a fetched secret payload reaches
+// the parser verbatim, so the key may be a field of someone's Vault secret rather
+// than something Warden wrote. Leaving it would let a lenient type copy it into
+// the credential's Data.
+func takeAdjunctNames(rawData map[string]interface{}) []string {
+	raw, present := rawData[RawAdjunctFieldsKey]
+	if !present {
+		return nil
+	}
+	delete(rawData, RawAdjunctFieldsKey)
+	s, _ := raw.(string)
+	return ParseAdjunctNames(s)
+}
+
+// applyAdjunctCarriage copies the declared fields from rawData into the parsed
+// credential. Called only for drivers that own the declaration.
+//
+// A field is skipped when the type already produced it, so carriage can never
+// overwrite the primary field or anything the type's own Parse decided; when it
+// is reserved, so the denylist holds even against a driver that ignored it; and
+// when it is absent or empty, since a credential field with no value is worse
+// than none — a provider reading it would build a malformed header rather than
+// fall back.
+func applyAdjunctCarriage(cred *Credential, rawData map[string]interface{}, names []string) {
+	for _, name := range names {
+		if IsReservedSpecConfigKey(name) {
+			continue
+		}
+		if _, taken := cred.Data[name]; taken {
+			continue
+		}
+		if v, ok := rawData[name].(string); ok && v != "" {
+			if cred.Data == nil {
+				cred.Data = make(map[string]string, len(names))
+			}
+			cred.Data[name] = v
+		}
+	}
+}

--- a/credential/carriage.go
+++ b/credential/carriage.go
@@ -9,7 +9,7 @@ import "strings"
 // author did not anticipate reads something no configuration can supply — the
 // branch is live code with no reachable input.
 //
-// The apikey source already lets an operator name extra fields (optional_metadata)
+// The apikey source already lets an operator name extra fields (credential_fields)
 // and copies them into rawData. What was missing is that the type filter then
 // discarded them. Carriage closes that gap: the driver records which names it
 // resolved under RawAdjunctFieldsKey, and the parser copies exactly those into the
@@ -38,8 +38,8 @@ type AdjunctCarrier interface {
 //
 // Two different failures, and telling them apart matters. A source that could
 // carry the field but was not told to needs a line adding to its
-// optional_metadata. A source whose driver has no such mechanism cannot carry it
-// at all, and pointing that operator at optional_metadata would send them to add
+// credential_fields. A source whose driver has no such mechanism cannot carry it
+// at all, and pointing that operator at credential_fields would send them to add
 // a key that changes nothing — the same silent divergence this check exists to
 // prevent, one layer up.
 //
@@ -50,13 +50,13 @@ func UncarriedAdjunctFields(credType interface{}, specConfig, sourceConfig map[s
 		return nil, true
 	}
 
-	// Only the apikey driver resolves optional_metadata and tells the parser what
+	// Only the apikey driver resolves credential_fields and tells the parser what
 	// it carried; the parser honours the declaration from that driver alone.
 	carriable = sourceType == SourceTypeAPIKey
 
 	declared := make(map[string]bool)
 	if carriable {
-		for _, name := range ParseAdjunctNames(sourceConfig["optional_metadata"]) {
+		for _, name := range ParseAdjunctNames(sourceConfig["credential_fields"]) {
 			declared[name] = true
 		}
 	}

--- a/credential/carriage_test.go
+++ b/credential/carriage_test.go
@@ -1,0 +1,295 @@
+package credential
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// carriageParser builds a parser over a lenient mock type — one whose Parse
+// copies every string key it is handed, like the real key_value type. That
+// leniency is what makes the stripping tests meaningful: if the reserved key were
+// still in rawData when Parse ran, it would land in the credential's Data.
+func carriageParser(t *testing.T) *CredentialParser {
+	t.Helper()
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	reg := NewTypeRegistry()
+	require.NoError(t, reg.Register(newMockCredentialType(TypeVaultToken, CategoryAPI)))
+	return NewCredentialParser(reg, log)
+}
+
+// strictCarriageType copies only its primary field, like BaseTokenType. The
+// lenient mock cannot show what carriage did and did not add, since its Parse
+// copies everything in rawData; anything reaching Data under this type came from
+// carriage.
+type strictCarriageType struct{ *mockCredentialType }
+
+func (t strictCarriageType) Parse(rawData, _ map[string]interface{}, leaseTTL time.Duration, leaseID string) (*Credential, error) {
+	token, _ := rawData["token"].(string)
+	if token == "" {
+		return nil, fmt.Errorf("%w: missing token", ErrInvalidCredential)
+	}
+	return &Credential{
+		Type:     t.name,
+		Category: t.category,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		Data:     map[string]string{"token": token},
+	}, nil
+}
+
+func strictCarriageParser(t *testing.T) *CredentialParser {
+	t.Helper()
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	reg := NewTypeRegistry()
+	require.NoError(t, reg.Register(strictCarriageType{newMockCredentialType(TypeVaultToken, CategoryAPI)}))
+	return NewCredentialParser(reg, log)
+}
+
+func carriageSpec() *CredSpec {
+	return &CredSpec{Name: "spec", Type: TypeVaultToken, Source: "src"}
+}
+
+func carriageDriver(driverType string) *mockSourceDriver {
+	return newMockSourceDriverFactory(driverType).driver
+}
+
+// TestCarriage_DeclaredFieldReachesData is the mechanism working: the apikey
+// driver names what it resolved, and those fields become credential data.
+func TestCarriage_DeclaredFieldReachesData(t *testing.T) {
+	rawData := map[string]interface{}{
+		"token":             "the-secret",
+		"application_key":   "app-key",
+		"email":             "svc@corp.com",
+		RawAdjunctFieldsKey: "application_key,email",
+	}
+
+	// Strict, so anything beyond the primary field can only have come from
+	// carriage. Under the lenient type this would pass with carriage deleted.
+	cred, err := strictCarriageParser(t).ParseAndValidate(
+		t.Context(), carriageSpec(), rawData, nil, 0, "", carriageDriver(SourceTypeAPIKey))
+	require.NoError(t, err)
+
+	assert.Equal(t, "app-key", cred.Data["application_key"])
+	assert.Equal(t, "svc@corp.com", cred.Data["email"])
+	assert.NotContains(t, cred.Data, RawAdjunctFieldsKey, "the declaration is plumbing, not a credential field")
+}
+
+// TestCarriage_ForgedDeclarationFromAnotherDriverIsIgnored is the security
+// property of the whole mechanism.
+//
+// The vault and aws drivers return fetched secret payloads verbatim, so this key
+// can arrive from someone's stored secret rather than from Warden. Honouring it
+// there would let whoever writes that secret decide what becomes credential data
+// — and would reopen the route deliberately left unsupported, where a Vault
+// secret's fields cannot be carried because nothing declares them.
+//
+// It must also be stripped, not merely disregarded: the lenient type here would
+// otherwise copy the key itself into Data.
+func TestCarriage_ForgedDeclarationFromAnotherDriverIsIgnored(t *testing.T) {
+	for _, driverType := range []string{SourceTypeVault, SourceTypeLocal, SourceTypeAWS} {
+		t.Run(driverType, func(t *testing.T) {
+			rawData := func() map[string]interface{} {
+				return map[string]interface{}{
+					"token":             "the-secret",
+					"owner":             "someone",
+					"application_key":   "app-key",
+					RawAdjunctFieldsKey: "application_key,owner",
+				}
+			}
+
+			// Under a strict type, anything beyond the primary field in Data can
+			// only have come from carriage — so this is what shows the forged
+			// declaration was disregarded, not merely deleted.
+			strict := rawData()
+			cred, err := strictCarriageParser(t).ParseAndValidate(
+				t.Context(), carriageSpec(), strict, nil, 0, "", carriageDriver(driverType))
+			require.NoError(t, err)
+			assert.NotContains(t, cred.Data, "application_key",
+				"a declaration from a driver that does not own optional_metadata must not be honoured")
+			assert.NotContains(t, cred.Data, "owner")
+			assert.Len(t, cred.Data, 1)
+
+			// Under a lenient type — key_value's shape — the key must also be gone
+			// from rawData before Parse runs, or Parse copies it into Data itself.
+			lenient := rawData()
+			cred, err = carriageParser(t).ParseAndValidate(
+				t.Context(), carriageSpec(), lenient, nil, 0, "", carriageDriver(driverType))
+			require.NoError(t, err)
+			assert.NotContains(t, cred.Data, RawAdjunctFieldsKey,
+				"the reserved key must be stripped whatever the driver, or a lenient Parse copies it")
+			assert.NotContains(t, lenient, RawAdjunctFieldsKey, "stripped from rawData itself")
+		})
+	}
+}
+
+// TestCarriage_ReservedNamesAreNeverCarried holds the denylist at mint time, not
+// only at config-write time: a source stored before the check existed, or edited
+// around it, must still not be able to move a mint locator into credential data
+// where a provider reading that field name would send it upstream.
+func TestCarriage_ReservedNamesAreNeverCarried(t *testing.T) {
+	rawData := map[string]interface{}{
+		"token":             "the-secret",
+		"secret_path":       "apikeys/prod",
+		ConfigSecretSpec:    "another-spec",
+		"__something":       "internal",
+		RawAdjunctFieldsKey: "secret_path," + ConfigSecretSpec + ",__something",
+	}
+
+	cred, err := strictCarriageParser(t).ParseAndValidate(
+		t.Context(), carriageSpec(), rawData, nil, 0, "", carriageDriver(SourceTypeAPIKey))
+	require.NoError(t, err)
+
+	assert.NotContains(t, cred.Data, "secret_path")
+	assert.NotContains(t, cred.Data, ConfigSecretSpec)
+	assert.NotContains(t, cred.Data, "__something")
+}
+
+// TestCarriage_NeverOverwritesWhatParseProduced protects the primary field above
+// all: a declaration naming it must not be able to replace the credential's own
+// secret with some other value from rawData.
+func TestCarriage_NeverOverwritesWhatParseProduced(t *testing.T) {
+	// The two values must differ, or the assertion holds whether carriage skips
+	// the field or overwrites it with an identical string.
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	reg := NewTypeRegistry()
+	require.NoError(t, reg.Register(rewritingCarriageType{newMockCredentialType(TypeVaultToken, CategoryAPI)}))
+
+	rawData := map[string]interface{}{
+		"token":             "raw-value",
+		RawAdjunctFieldsKey: "token",
+	}
+
+	cred, err := NewCredentialParser(reg, log).ParseAndValidate(
+		t.Context(), carriageSpec(), rawData, nil, 0, "", carriageDriver(SourceTypeAPIKey))
+	require.NoError(t, err)
+	assert.Equal(t, "parsed-value", cred.Data["token"],
+		"a declaration naming a field the type produced must not replace it")
+}
+
+// rewritingCarriageType produces a value of its own rather than echoing rawData,
+// so a carriage overwrite is visible.
+type rewritingCarriageType struct{ *mockCredentialType }
+
+func (t rewritingCarriageType) Parse(_, _ map[string]interface{}, leaseTTL time.Duration, leaseID string) (*Credential, error) {
+	return &Credential{
+		Type:     t.name,
+		Category: t.category,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		Data:     map[string]string{"token": "parsed-value"},
+	}, nil
+}
+
+// A declared field that resolved to nothing is skipped rather than written empty.
+// An empty credential field is worse than an absent one: a provider reading it
+// builds a malformed header instead of taking its fallback branch.
+func TestCarriage_AbsentOrEmptyDeclaredFieldIsSkipped(t *testing.T) {
+	rawData := map[string]interface{}{
+		"token":             "the-secret",
+		"blank":             "",
+		RawAdjunctFieldsKey: "blank,never_resolved",
+	}
+
+	cred, err := strictCarriageParser(t).ParseAndValidate(
+		t.Context(), carriageSpec(), rawData, nil, 0, "", carriageDriver(SourceTypeAPIKey))
+	require.NoError(t, err)
+
+	assert.NotContains(t, cred.Data, "blank")
+	assert.NotContains(t, cred.Data, "never_resolved")
+}
+
+// Without a declaration nothing changes, which is what every existing credential
+// type and driver relies on.
+func TestCarriage_NoDeclarationLeavesParseUntouched(t *testing.T) {
+	rawData := map[string]interface{}{"token": "the-secret", "extra": "value"}
+
+	cred, err := carriageParser(t).ParseAndValidate(
+		t.Context(), carriageSpec(), rawData, nil, 0, "", carriageDriver(SourceTypeAPIKey))
+	require.NoError(t, err)
+
+	// The lenient mock type copies everything, so "extra" is here because Parse
+	// put it there — not because carriage did.
+	assert.Equal(t, "value", cred.Data["extra"])
+}
+
+func TestIsReservedSpecConfigKey(t *testing.T) {
+	reserved := []string{
+		ConfigSecretSpec, ConfigSecretField, ConfigSecretCacheTTL,
+		ConfigSubjectTokenSource, ConfigSubjectTokenType,
+		ConfigActorTokenSource, ConfigActorTokenType,
+		ConfigAssertionAudience, ConfigAssertionMetadataClaims,
+		ConfigAssertionUserClaims, ConfigAssertionAlgorithm, ConfigAssertionResource,
+		"mint_method", "kv2_mount", "secret_path", "secret_id", "role_arn",
+		"version_stage", "version_id", "credential_type", "json_key_map",
+		RawAdjunctFieldsKey, RawRotatedRefreshTokenKey, "__anything",
+	}
+	for _, k := range reserved {
+		assert.True(t, IsReservedSpecConfigKey(k), "%q must be reserved", k)
+	}
+
+	for _, k := range []string{"api_key", "organization_id", "email", "application_key", "username"} {
+		assert.False(t, IsReservedSpecConfigKey(k), "%q must not be reserved", k)
+	}
+}
+
+func TestParseAdjunctNames(t *testing.T) {
+	assert.Nil(t, ParseAdjunctNames(""))
+	assert.Nil(t, ParseAdjunctNames("  ,, "))
+	assert.Equal(t, []string{"a", "b"}, ParseAdjunctNames("a,b"))
+	assert.Equal(t, []string{"a", "b"}, ParseAdjunctNames(" a , b "))
+}
+
+// TestUncarriedAdjunctFields covers the write-time guard that turns a field the
+// source will not carry into a rejected spec rather than a credential quietly
+// missing it — and distinguishes the two reasons, since only one of them has a
+// fix the operator can apply to the source they already have.
+func TestUncarriedAdjunctFields(t *testing.T) {
+	carrier := stubAdjunctCarrier{fields: []string{"organization_id", "email"}}
+
+	// An apikey source declaring nothing: fixable where it stands.
+	fields, carriable := UncarriedAdjunctFields(carrier,
+		map[string]string{"api_key": "k", "organization_id": "org", "email": "a@b.c"},
+		map[string]string{}, SourceTypeAPIKey)
+	assert.ElementsMatch(t, []string{"organization_id", "email"}, fields)
+	assert.True(t, carriable)
+
+	// Declared: carried, so not reported.
+	fields, _ = UncarriedAdjunctFields(carrier,
+		map[string]string{"api_key": "k", "organization_id": "org"},
+		map[string]string{"optional_metadata": "organization_id"}, SourceTypeAPIKey)
+	assert.Empty(t, fields)
+
+	// A source whose driver has no declaration mechanism cannot carry the field
+	// however it is configured, so a declaration on it must not satisfy the check
+	// — following that advice would change nothing and look like it had.
+	for _, srcType := range []string{SourceTypeLocal, SourceTypeVault, SourceTypeAWS} {
+		fields, carriable = UncarriedAdjunctFields(carrier,
+			map[string]string{"api_key": "k", "organization_id": "org"},
+			map[string]string{"optional_metadata": "organization_id"}, srcType)
+		assert.Equal(t, []string{"organization_id"}, fields, "source type %q", srcType)
+		assert.False(t, carriable, "source type %q", srcType)
+	}
+
+	// Unset fields are not reported, and neither is a key the type does not know.
+	fields, _ = UncarriedAdjunctFields(carrier,
+		map[string]string{"api_key": "k", "some_other_key": "v"},
+		map[string]string{}, SourceTypeAPIKey)
+	assert.Empty(t, fields)
+
+	// A type that does not carry adjuncts is left alone entirely.
+	fields, carriable = UncarriedAdjunctFields(struct{}{},
+		map[string]string{"organization_id": "org"}, map[string]string{}, SourceTypeLocal)
+	assert.Nil(t, fields)
+	assert.True(t, carriable)
+}
+
+type stubAdjunctCarrier struct{ fields []string }
+
+func (s stubAdjunctCarrier) KnownAdjunctFields() []string { return s.fields }

--- a/credential/carriage_test.go
+++ b/credential/carriage_test.go
@@ -111,7 +111,7 @@ func TestCarriage_ForgedDeclarationFromAnotherDriverIsIgnored(t *testing.T) {
 				t.Context(), carriageSpec(), strict, nil, 0, "", carriageDriver(driverType))
 			require.NoError(t, err)
 			assert.NotContains(t, cred.Data, "application_key",
-				"a declaration from a driver that does not own optional_metadata must not be honoured")
+				"a declaration from a driver that does not own credential_fields must not be honoured")
 			assert.NotContains(t, cred.Data, "owner")
 			assert.Len(t, cred.Data, 1)
 
@@ -263,7 +263,7 @@ func TestUncarriedAdjunctFields(t *testing.T) {
 	// Declared: carried, so not reported.
 	fields, _ = UncarriedAdjunctFields(carrier,
 		map[string]string{"api_key": "k", "organization_id": "org"},
-		map[string]string{"optional_metadata": "organization_id"}, SourceTypeAPIKey)
+		map[string]string{"credential_fields": "organization_id"}, SourceTypeAPIKey)
 	assert.Empty(t, fields)
 
 	// A source whose driver has no declaration mechanism cannot carry the field
@@ -272,7 +272,7 @@ func TestUncarriedAdjunctFields(t *testing.T) {
 	for _, srcType := range []string{SourceTypeLocal, SourceTypeVault, SourceTypeAWS} {
 		fields, carriable = UncarriedAdjunctFields(carrier,
 			map[string]string{"api_key": "k", "organization_id": "org"},
-			map[string]string{"optional_metadata": "organization_id"}, srcType)
+			map[string]string{"credential_fields": "organization_id"}, srcType)
 		assert.Equal(t, []string{"organization_id"}, fields, "source type %q", srcType)
 		assert.False(t, carriable, "source type %q", srcType)
 	}

--- a/credential/credential_parser.go
+++ b/credential/credential_parser.go
@@ -66,7 +66,7 @@ func (p *CredentialParser) warnUncarried(credType Type, spec *CredSpec, rawData 
 		return
 	}
 
-	p.logger.Warn("credential field(s) available but not carried; declare them in the source's optional_metadata (an apikey source is required to carry them)",
+	p.logger.Warn("credential field(s) available but not carried; declare them in the source's credential_fields (an apikey source is required to carry them)",
 		logger.String("spec", spec.Name),
 		logger.String("source", spec.Source),
 		logger.String("fields", strings.Join(dropped, ",")),
@@ -111,7 +111,7 @@ func (p *CredentialParser) ParseAndValidate(
 	// Step 2: Take the driver's adjunct declaration out of rawData before parsing.
 	//
 	// Removal is unconditional, but the names are honoured only from the driver
-	// that owns optional_metadata. Both halves are load-bearing. The vault and aws
+	// that owns credential_fields. Both halves are load-bearing. The vault and aws
 	// drivers return fetched secret payloads verbatim, so this key can arrive from
 	// someone's stored secret rather than from Warden — honouring it there would
 	// let whoever writes that secret decide what becomes credential data. And

--- a/credential/credential_parser.go
+++ b/credential/credential_parser.go
@@ -3,6 +3,7 @@ package credential
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/logger"
@@ -35,6 +36,41 @@ func NewCredentialParser(typeRegistry *TypeRegistry, logger *logger.GatedLogger)
 		typeRegistry: typeRegistry,
 		logger:       logger,
 	}
+}
+
+// warnUncarried logs the credential fields a mint had available but did not
+// carry, so an upgrade that silently narrows a credential leaves a trace.
+//
+// Only names the type recognises as credential material are reported: an
+// arbitrary key of a fetched secret is not a field anyone expected to travel, and
+// warning about every one of them would bury the cases that matter.
+func (p *CredentialParser) warnUncarried(credType Type, spec *CredSpec, rawData map[string]interface{}, cred *Credential) {
+	if p.logger == nil {
+		return
+	}
+	carrier, ok := credType.(AdjunctCarrier)
+	if !ok {
+		return
+	}
+
+	var dropped []string
+	for _, field := range carrier.KnownAdjunctFields() {
+		if _, carried := cred.Data[field]; carried {
+			continue
+		}
+		if v, ok := rawData[field].(string); ok && v != "" {
+			dropped = append(dropped, field)
+		}
+	}
+	if len(dropped) == 0 {
+		return
+	}
+
+	p.logger.Warn("credential field(s) available but not carried; declare them in the source's optional_metadata (an apikey source is required to carry them)",
+		logger.String("spec", spec.Name),
+		logger.String("source", spec.Source),
+		logger.String("fields", strings.Join(dropped, ",")),
+	)
 }
 
 // ParseAndValidate parses raw credential data and validates the result.
@@ -72,17 +108,49 @@ func (p *CredentialParser) ParseAndValidate(
 		return nil, fmt.Errorf("credential type '%s' not found: %w", spec.Type, err)
 	}
 
-	// Step 2: Parse raw data and its metadata into structured credential
+	// Step 2: Take the driver's adjunct declaration out of rawData before parsing.
+	//
+	// Removal is unconditional, but the names are honoured only from the driver
+	// that owns optional_metadata. Both halves are load-bearing. The vault and aws
+	// drivers return fetched secret payloads verbatim, so this key can arrive from
+	// someone's stored secret rather than from Warden — honouring it there would
+	// let whoever writes that secret decide what becomes credential data. And
+	// key_value's Parse copies every string key it is handed, so a key still in
+	// rawData at parse time would land in the credential's Data itself.
+	adjuncts := takeAdjunctNames(rawData)
+	if driver.Type() != SourceTypeAPIKey {
+		adjuncts = nil
+	}
+
+	// Step 3: Parse raw data and its metadata into structured credential
 	cred, err := credType.Parse(rawData, metadata, leaseTTL, leaseID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse credential: %w", err)
 	}
 
-	// Step 3: Set source information
+	// Step 4: Set source information
 	cred.SourceName = spec.Source
 	cred.SourceType = driver.Type()
 
-	// Step 4: Validate credential
+	// Step 5: Carry the declared adjuncts. After Parse, so the type's own fields
+	// win; before Validate, so validation sees the finished credential.
+	applyAdjunctCarriage(cred, rawData, adjuncts)
+
+	// Step 5b: say so when a field that looks like credential material was
+	// available and did not travel.
+	//
+	// Before adjunct carriage, some types copied a fixed set of extra fields from
+	// whatever rawData any driver produced — so a spec on a local source, or a
+	// Vault secret holding an organization id beside its key, carried them without
+	// anyone declaring anything. Those credentials now mint without the field.
+	// The spec-level guard cannot reach that case: it runs on write, and for a
+	// fetched payload the field never appears in spec config at all.
+	//
+	// The failure is a provider quietly taking its fallback branch, which is
+	// indistinguishable from a working mount. A log line is the only channel left.
+	p.warnUncarried(credType, spec, rawData, cred)
+
+	// Step 6: Validate credential
 	if err := credType.Validate(cred); err != nil {
 		return nil, fmt.Errorf("credential validation failed: %w", err)
 	}

--- a/credential/drivers/static_apikey_driver.go
+++ b/credential/drivers/static_apikey_driver.go
@@ -81,7 +81,7 @@ func (f *StaticAPIKeyDriverFactory) ValidateConfig(config map[string]string) err
 			Example("anthropic-version:2023-06-01"),
 
 		credential.StringField("optional_metadata").
-			Describe("Comma-separated spec config fields to copy into credential data").
+			Describe("Comma-separated field names to carry into credential data beside api_key. Each resolves from the fetched secret material first, then spec config. Mint locators (mint_method, secret_path, ...) are rejected").
 			Example("organization_id,project_id"),
 
 		credential.StringField("display_name").
@@ -111,6 +111,17 @@ func (f *StaticAPIKeyDriverFactory) ValidateConfig(config map[string]string) err
 	if raw := credential.GetString(config, "extra_headers", ""); raw != "" {
 		if _, err := parseExtraHeaders(raw); err != nil {
 			return err
+		}
+	}
+
+	// optional_metadata names credential fields, so it must not name a mint
+	// locator or a chaining key. Nothing travels unless an operator wrote its
+	// name down, which makes this a typo check rather than a security boundary —
+	// but a locator copied into credential data would be sent upstream by
+	// whichever provider reads that field name.
+	for _, field := range parseOptionalMetadata(config) {
+		if credential.IsReservedSpecConfigKey(field) {
+			return fmt.Errorf("optional_metadata cannot name %q: it configures the mint rather than describing the credential", field)
 		}
 	}
 
@@ -177,7 +188,8 @@ func (d *StaticAPIKeyDriver) MintCredential(_ context.Context, spec *credential.
 		return nil, nil, 0, "", fmt.Errorf("no %s API key configured in spec", d.displayName())
 	}
 
-	return d.buildAPIKeyData(spec, apiKey), nil, 0, "", nil // Static — no TTL, no lease
+	// No fetched material on the inline path — every adjunct resolves from spec config.
+	return d.buildAPIKeyData(spec, apiKey, credential.SecretMaterial{}), nil, 0, "", nil // Static — no TTL, no lease
 }
 
 // MintFromSecret mints an API key credential from secret material fetched via credential
@@ -200,22 +212,60 @@ func (d *StaticAPIKeyDriver) MintFromSecret(_ context.Context, spec *credential.
 		return nil, nil, 0, "", fmt.Errorf("%s: no API key in fetched secret material (set secret_field, or store it under 'api_key')", d.displayName())
 	}
 
-	return d.buildAPIKeyData(spec, apiKey), nil, 0, "", nil // Static — no TTL, no lease
+	// The whole payload is passed on, not just the selected value: a multi-field
+	// credential stored as one secret has its other fields in there, and the
+	// declaration decides which of them travel.
+	return d.buildAPIKeyData(spec, apiKey, material), nil, 0, "", nil // Static — no TTL, no lease
 }
 
-// buildAPIKeyData assembles the credential data map from the resolved API key plus any
-// optional metadata fields copied from spec config. Shared by the inline and chained
-// mint paths.
-func (d *StaticAPIKeyDriver) buildAPIKeyData(spec *credential.CredSpec, apiKey string) map[string]interface{} {
+// buildAPIKeyData assembles the credential data map from the resolved API key plus
+// the optional_metadata fields the source declares. Shared by the inline and
+// chained mint paths; material is the zero value on the inline one, whose nil map
+// reads safely.
+//
+// Each declared field resolves from the fetched secret material first and from
+// spec config second. That order is what lets one declaration serve both shapes: a
+// keyless spec whose whole credential lives in one Vault secret, and a spec that
+// keeps a non-secret adjunct inline while the secrets come from the vault.
+//
+// The names actually resolved are recorded under RawAdjunctFieldsKey. Without it
+// the parser would have to guess which rawData keys were meant as credential
+// fields — and for a fetched payload it cannot, since every key of someone's
+// secret arrives the same way.
+func (d *StaticAPIKeyDriver) buildAPIKeyData(
+	spec *credential.CredSpec, apiKey string, material credential.SecretMaterial,
+) map[string]interface{} {
 	rawData := map[string]interface{}{
 		"api_key": apiKey,
 	}
 
-	// Copy optional metadata from spec config
+	var carried []string
 	for _, field := range parseOptionalMetadata(d.credSource.Config) {
-		if val := credential.GetString(spec.Config, field, ""); val != "" {
-			rawData[field] = val
+		if credential.IsReservedSpecConfigKey(field) {
+			// Rejected at source-config write; skipped here too, so a source
+			// stored before that check cannot smuggle a locator into the
+			// credential.
+			continue
 		}
+		if _, taken := rawData[field]; taken {
+			// Never rewrite the resolved key. On the chained path the payload
+			// may hold an api_key alongside the one secret_field selected, and
+			// overwriting here would silently mint a different secret than the
+			// spec asked for — before Parse, so the parser's own overwrite guard
+			// could not see it.
+			continue
+		}
+		val := material.Data[field]
+		if val == "" {
+			val = credential.GetString(spec.Config, field, "")
+		}
+		if val != "" {
+			rawData[field] = val
+			carried = append(carried, field)
+		}
+	}
+	if len(carried) > 0 {
+		rawData[credential.RawAdjunctFieldsKey] = strings.Join(carried, ",")
 	}
 
 	return rawData
@@ -328,19 +378,10 @@ func parseExtraHeaders(raw string) (map[string]string, error) {
 }
 
 // parseOptionalMetadata parses comma-separated field names from source config.
+// Delegates to the shared splitter so the names this driver writes into the
+// declaration are split exactly as the parser splits them reading it back.
 func parseOptionalMetadata(config map[string]string) []string {
-	raw := credential.GetString(config, "optional_metadata", "")
-	if raw == "" {
-		return nil
-	}
-	var fields []string
-	for _, f := range strings.Split(raw, ",") {
-		f = strings.TrimSpace(f)
-		if f != "" {
-			fields = append(fields, f)
-		}
-	}
-	return fields
+	return credential.ParseAdjunctNames(credential.GetString(config, "optional_metadata", ""))
 }
 
 // validateAPIKeyOptionalURL validates that api_url, if non-empty, is a well-formed HTTPS URL.

--- a/credential/drivers/static_apikey_driver.go
+++ b/credential/drivers/static_apikey_driver.go
@@ -80,7 +80,7 @@ func (f *StaticAPIKeyDriverFactory) ValidateConfig(config map[string]string) err
 			Describe("Additional static headers as comma-separated key:value pairs").
 			Example("anthropic-version:2023-06-01"),
 
-		credential.StringField("optional_metadata").
+		credential.StringField("credential_fields").
 			Describe("Comma-separated field names to carry into credential data beside api_key. Each resolves from the fetched secret material first, then spec config. Mint locators (mint_method, secret_path, ...) are rejected").
 			Example("organization_id,project_id"),
 
@@ -114,14 +114,22 @@ func (f *StaticAPIKeyDriverFactory) ValidateConfig(config map[string]string) err
 		}
 	}
 
-	// optional_metadata names credential fields, so it must not name a mint
+	// optional_metadata was this key's former name. It is not accepted silently:
+	// an ignored config key would leave the source declaring nothing, its specs
+	// minting without the fields they set, and the providers reading them taking
+	// their fallback branch — a working-looking mount. Fail on the write instead.
+	if _, ok := config["optional_metadata"]; ok {
+		return fmt.Errorf("optional_metadata has been renamed to credential_fields (the fields land in the credential's data, which may be secret, not in its non-secret metadata)")
+	}
+
+	// credential_fields names credential fields, so it must not name a mint
 	// locator or a chaining key. Nothing travels unless an operator wrote its
 	// name down, which makes this a typo check rather than a security boundary —
 	// but a locator copied into credential data would be sent upstream by
 	// whichever provider reads that field name.
-	for _, field := range parseOptionalMetadata(config) {
+	for _, field := range parseCredentialFields(config) {
 		if credential.IsReservedSpecConfigKey(field) {
-			return fmt.Errorf("optional_metadata cannot name %q: it configures the mint rather than describing the credential", field)
+			return fmt.Errorf("credential_fields cannot name %q: it configures the mint rather than describing the credential", field)
 		}
 	}
 
@@ -219,7 +227,7 @@ func (d *StaticAPIKeyDriver) MintFromSecret(_ context.Context, spec *credential.
 }
 
 // buildAPIKeyData assembles the credential data map from the resolved API key plus
-// the optional_metadata fields the source declares. Shared by the inline and
+// the credential_fields fields the source declares. Shared by the inline and
 // chained mint paths; material is the zero value on the inline one, whose nil map
 // reads safely.
 //
@@ -240,7 +248,7 @@ func (d *StaticAPIKeyDriver) buildAPIKeyData(
 	}
 
 	var carried []string
-	for _, field := range parseOptionalMetadata(d.credSource.Config) {
+	for _, field := range parseCredentialFields(d.credSource.Config) {
 		if credential.IsReservedSpecConfigKey(field) {
 			// Rejected at source-config write; skipped here too, so a source
 			// stored before that check cannot smuggle a locator into the
@@ -377,11 +385,11 @@ func parseExtraHeaders(raw string) (map[string]string, error) {
 	return headers, nil
 }
 
-// parseOptionalMetadata parses comma-separated field names from source config.
+// parseCredentialFields parses comma-separated field names from source config.
 // Delegates to the shared splitter so the names this driver writes into the
 // declaration are split exactly as the parser splits them reading it back.
-func parseOptionalMetadata(config map[string]string) []string {
-	return credential.ParseAdjunctNames(credential.GetString(config, "optional_metadata", ""))
+func parseCredentialFields(config map[string]string) []string {
+	return credential.ParseAdjunctNames(credential.GetString(config, "credential_fields", ""))
 }
 
 // validateAPIKeyOptionalURL validates that api_url, if non-empty, is a well-formed HTTPS URL.

--- a/credential/drivers/static_apikey_driver_test.go
+++ b/credential/drivers/static_apikey_driver_test.go
@@ -335,6 +335,122 @@ func TestStaticAPIKeyDriver_MintFromSecret_OptionalMetadata(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "sk-x", rawData["api_key"])
 	assert.Equal(t, "org-999", rawData["organization_id"])
+	assert.Equal(t, "organization_id", rawData[credential.RawAdjunctFieldsKey],
+		"the driver must name what it resolved, or the parser cannot tell a credential field from a payload key")
+}
+
+// TestStaticAPIKeyDriver_MintFromSecret_AdjunctFromMaterial covers the keyless
+// shape: a multi-field credential living entirely in one fetched secret, with
+// nothing in the spec. Before, MintFromSecret took the selected value and
+// discarded the rest of the payload, so the second field was unreachable.
+func TestStaticAPIKeyDriver_MintFromSecret_AdjunctFromMaterial(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "application_key"})
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{"secret_spec": "ref"},
+	}
+	material := credential.SecretMaterial{Data: map[string]string{
+		"api_key":         "sk-from-vault",
+		"application_key": "app-from-vault",
+		"owner":           "not-declared",
+	}}
+
+	rawData, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-from-vault", rawData["api_key"])
+	assert.Equal(t, "app-from-vault", rawData["application_key"])
+	assert.NotContains(t, rawData, "owner", "an undeclared payload field is not credential material")
+	assert.Equal(t, "application_key", rawData[credential.RawAdjunctFieldsKey])
+}
+
+// The fetched payload wins over spec config, which is what lets one declaration
+// serve both a keyless spec and one that pins a value inline.
+func TestStaticAPIKeyDriver_MintFromSecret_MaterialBeatsSpecConfig(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "application_key"})
+	spec := &credential.CredSpec{
+		Name: "test",
+		Config: map[string]string{
+			"secret_spec":     "ref",
+			"application_key": "app-from-spec",
+		},
+	}
+	material := credential.SecretMaterial{Data: map[string]string{
+		"api_key":         "sk-from-vault",
+		"application_key": "app-from-vault",
+	}}
+
+	rawData, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "app-from-vault", rawData["application_key"])
+}
+
+// The mixed shape: secrets from the vault, a non-secret adjunct inline. The
+// declared field is absent from the payload, so it falls back to spec config.
+func TestStaticAPIKeyDriver_MintFromSecret_AdjunctFallsBackToSpecConfig(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "email"})
+	spec := &credential.CredSpec{
+		Name: "test",
+		Config: map[string]string{
+			"secret_spec": "ref",
+			"email":       "svc@corp.com",
+		},
+	}
+	material := credential.SecretMaterial{Data: map[string]string{"api_key": "sk-from-vault"}}
+
+	rawData, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-from-vault", rawData["api_key"])
+	assert.Equal(t, "svc@corp.com", rawData["email"])
+}
+
+// TestStaticAPIKeyDriver_MintFromSecret_DeclaredAPIKeyCannotClobberSelection is
+// the reason the loop skips a field rawData already holds.
+//
+// api_key is not a reserved name — an operator may declare it — and on the chained
+// path the payload can hold an api_key alongside whatever secret_field selected.
+// Copying it would silently mint a different secret than the spec asked for, and
+// the parser's own overwrite guard cannot see it: the damage is done before Parse.
+func TestStaticAPIKeyDriver_MintFromSecret_DeclaredAPIKeyCannotClobberSelection(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "api_key"})
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{"secret_spec": "ref", "secret_field": "prod_key"},
+	}
+	material := credential.SecretMaterial{
+		Data:  map[string]string{"prod_key": "sk-selected", "api_key": "sk-other"},
+		Field: "prod_key",
+	}
+
+	rawData, _, _, _, err := d.MintFromSecret(context.Background(), spec, material)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-selected", rawData["api_key"], "secret_field's selection must survive the declaration")
+}
+
+// A source whose optional_metadata names a mint locator is rejected at write.
+// The driver skips it at mint too, so a source stored before that check cannot
+// move a locator into credential data.
+func TestStaticAPIKeyDriver_ValidateConfig_RejectsReservedOptionalMetadata(t *testing.T) {
+	f := &StaticAPIKeyDriverFactory{}
+
+	for _, name := range []string{"secret_path", "mint_method", "secret_spec", "json_key_map", "__adjunct_fields"} {
+		err := f.ValidateConfig(map[string]string{"optional_metadata": name})
+		assert.ErrorContains(t, err, "optional_metadata cannot name", "name %q", name)
+	}
+
+	assert.NoError(t, f.ValidateConfig(map[string]string{"optional_metadata": "organization_id,email"}))
+}
+
+func TestStaticAPIKeyDriver_MintCredential_SkipsReservedOptionalMetadata(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "secret_path"})
+	spec := &credential.CredSpec{
+		Name:   "test",
+		Config: map[string]string{"api_key": "sk-x", "secret_path": "apikeys/prod"},
+	}
+
+	rawData, _, _, _, err := d.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.NotContains(t, rawData, "secret_path")
+	assert.NotContains(t, rawData, credential.RawAdjunctFieldsKey, "nothing carried, so nothing declared")
 }
 
 func TestStaticAPIKeyDriver_MintFromSecret_EmptyField(t *testing.T) {

--- a/credential/drivers/static_apikey_driver_test.go
+++ b/credential/drivers/static_apikey_driver_test.go
@@ -62,7 +62,7 @@ func TestStaticAPIKeyDriverFactory_ValidateConfig(t *testing.T) {
 				"auth_header_type":  "custom_header",
 				"auth_header_name":  "x-api-key",
 				"extra_headers":     "anthropic-version:2023-06-01",
-				"optional_metadata": "organization_id",
+				"credential_fields": "organization_id",
 				"display_name":      "Anthropic",
 			},
 			wantErr: false,
@@ -231,13 +231,13 @@ func TestStaticAPIKeyDriver_GetAPIURL_Empty(t *testing.T) {
 }
 
 // =============================================================================
-// Optional Metadata Tests
+// Credential Fields Tests
 // =============================================================================
 
-func TestStaticAPIKeyDriver_MintCredential_OptionalMetadata(t *testing.T) {
+func TestStaticAPIKeyDriver_MintCredential_CredentialFields(t *testing.T) {
 	t.Run("copies configured metadata fields", func(t *testing.T) {
 		d := createTestAPIKeyDriver(t, map[string]string{
-			"optional_metadata": "organization_id,project_id",
+			"credential_fields": "organization_id,project_id",
 		})
 		spec := &credential.CredSpec{
 			Name: "test",
@@ -255,7 +255,7 @@ func TestStaticAPIKeyDriver_MintCredential_OptionalMetadata(t *testing.T) {
 
 	t.Run("skips empty metadata fields", func(t *testing.T) {
 		d := createTestAPIKeyDriver(t, map[string]string{
-			"optional_metadata": "organization_id",
+			"credential_fields": "organization_id",
 		})
 		spec := &credential.CredSpec{
 			Name:   "test",
@@ -320,8 +320,8 @@ func TestStaticAPIKeyDriver_MintFromSecret_AutoDetectSingleKey(t *testing.T) {
 	assert.Equal(t, "sk-fallback", rawData["api_key"])
 }
 
-func TestStaticAPIKeyDriver_MintFromSecret_OptionalMetadata(t *testing.T) {
-	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "organization_id"})
+func TestStaticAPIKeyDriver_MintFromSecret_CredentialFields(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"credential_fields": "organization_id"})
 	spec := &credential.CredSpec{
 		Name: "test",
 		Config: map[string]string{
@@ -344,7 +344,7 @@ func TestStaticAPIKeyDriver_MintFromSecret_OptionalMetadata(t *testing.T) {
 // nothing in the spec. Before, MintFromSecret took the selected value and
 // discarded the rest of the payload, so the second field was unreachable.
 func TestStaticAPIKeyDriver_MintFromSecret_AdjunctFromMaterial(t *testing.T) {
-	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "application_key"})
+	d := createTestAPIKeyDriver(t, map[string]string{"credential_fields": "application_key"})
 	spec := &credential.CredSpec{
 		Name:   "test",
 		Config: map[string]string{"secret_spec": "ref"},
@@ -366,7 +366,7 @@ func TestStaticAPIKeyDriver_MintFromSecret_AdjunctFromMaterial(t *testing.T) {
 // The fetched payload wins over spec config, which is what lets one declaration
 // serve both a keyless spec and one that pins a value inline.
 func TestStaticAPIKeyDriver_MintFromSecret_MaterialBeatsSpecConfig(t *testing.T) {
-	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "application_key"})
+	d := createTestAPIKeyDriver(t, map[string]string{"credential_fields": "application_key"})
 	spec := &credential.CredSpec{
 		Name: "test",
 		Config: map[string]string{
@@ -387,7 +387,7 @@ func TestStaticAPIKeyDriver_MintFromSecret_MaterialBeatsSpecConfig(t *testing.T)
 // The mixed shape: secrets from the vault, a non-secret adjunct inline. The
 // declared field is absent from the payload, so it falls back to spec config.
 func TestStaticAPIKeyDriver_MintFromSecret_AdjunctFallsBackToSpecConfig(t *testing.T) {
-	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "email"})
+	d := createTestAPIKeyDriver(t, map[string]string{"credential_fields": "email"})
 	spec := &credential.CredSpec{
 		Name: "test",
 		Config: map[string]string{
@@ -411,7 +411,7 @@ func TestStaticAPIKeyDriver_MintFromSecret_AdjunctFallsBackToSpecConfig(t *testi
 // Copying it would silently mint a different secret than the spec asked for, and
 // the parser's own overwrite guard cannot see it: the damage is done before Parse.
 func TestStaticAPIKeyDriver_MintFromSecret_DeclaredAPIKeyCannotClobberSelection(t *testing.T) {
-	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "api_key"})
+	d := createTestAPIKeyDriver(t, map[string]string{"credential_fields": "api_key"})
 	spec := &credential.CredSpec{
 		Name:   "test",
 		Config: map[string]string{"secret_spec": "ref", "secret_field": "prod_key"},
@@ -426,22 +426,39 @@ func TestStaticAPIKeyDriver_MintFromSecret_DeclaredAPIKeyCannotClobberSelection(
 	assert.Equal(t, "sk-selected", rawData["api_key"], "secret_field's selection must survive the declaration")
 }
 
-// A source whose optional_metadata names a mint locator is rejected at write.
+// A source whose credential_fields names a mint locator is rejected at write.
 // The driver skips it at mint too, so a source stored before that check cannot
 // move a locator into credential data.
-func TestStaticAPIKeyDriver_ValidateConfig_RejectsReservedOptionalMetadata(t *testing.T) {
+// TestStaticAPIKeyDriverFactory_RejectsFormerKeyName keeps a rename from being a
+// silent narrowing.
+//
+// optional_metadata was this key's former name. Ignoring it as an unknown key
+// would leave the source declaring nothing, its specs minting without the fields
+// they set, and the providers reading those fields taking their fallback branch —
+// which looks like a working mount. The write fails instead.
+func TestStaticAPIKeyDriverFactory_RejectsFormerKeyName(t *testing.T) {
+	f := &StaticAPIKeyDriverFactory{}
+
+	err := f.ValidateConfig(map[string]string{"optional_metadata": "organization_id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential_fields", "the error must name the key to use instead")
+
+	assert.NoError(t, f.ValidateConfig(map[string]string{"credential_fields": "organization_id"}))
+}
+
+func TestStaticAPIKeyDriver_ValidateConfig_RejectsReservedCredentialFields(t *testing.T) {
 	f := &StaticAPIKeyDriverFactory{}
 
 	for _, name := range []string{"secret_path", "mint_method", "secret_spec", "json_key_map", "__adjunct_fields"} {
-		err := f.ValidateConfig(map[string]string{"optional_metadata": name})
-		assert.ErrorContains(t, err, "optional_metadata cannot name", "name %q", name)
+		err := f.ValidateConfig(map[string]string{"credential_fields": name})
+		assert.ErrorContains(t, err, "credential_fields cannot name", "name %q", name)
 	}
 
-	assert.NoError(t, f.ValidateConfig(map[string]string{"optional_metadata": "organization_id,email"}))
+	assert.NoError(t, f.ValidateConfig(map[string]string{"credential_fields": "organization_id,email"}))
 }
 
-func TestStaticAPIKeyDriver_MintCredential_SkipsReservedOptionalMetadata(t *testing.T) {
-	d := createTestAPIKeyDriver(t, map[string]string{"optional_metadata": "secret_path"})
+func TestStaticAPIKeyDriver_MintCredential_SkipsReservedCredentialFields(t *testing.T) {
+	d := createTestAPIKeyDriver(t, map[string]string{"credential_fields": "secret_path"})
 	spec := &credential.CredSpec{
 		Name:   "test",
 		Config: map[string]string{"api_key": "sk-x", "secret_path": "apikeys/prod"},

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -221,6 +221,21 @@ const RawRotatedRefreshTokenKey = "__rotated_refresh_token"
 // is parsed — so it never reaches the credential's Data map.
 const RawRotatedRefreshTokenExpiresAtKey = "__rotated_refresh_token_expires_at"
 
+// RawAdjunctFieldsKey is a reserved key a driver sets in the rawData returned by
+// MintCredential to name the fields it resolved beyond the credential's primary
+// one — the comma-separated names an operator declared in optional_metadata.
+//
+// The parser consumes and strips it before the credential is parsed, then copies
+// exactly those fields into the credential's Data map. Stripping first matters:
+// a lenient type such as key_value copies every string key it is given, so a key
+// left in rawData would land in Data itself.
+//
+// Only the apikey driver sets it, and the parser honours it only from that
+// driver. Two drivers return fetched secret payloads verbatim, so a key appearing
+// in rawData is not proof that Warden put it there — it may be a field of someone's
+// Vault secret.
+const RawAdjunctFieldsKey = "__adjunct_fields"
+
 // OAuth2Authorizer is an optional interface for drivers that support an OAuth2
 // authorization-code consent flow. The CLI captures only the authorization code
 // on a loopback redirect; the server builds the authorize URL and performs the

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -223,7 +223,7 @@ const RawRotatedRefreshTokenExpiresAtKey = "__rotated_refresh_token_expires_at"
 
 // RawAdjunctFieldsKey is a reserved key a driver sets in the rawData returned by
 // MintCredential to name the fields it resolved beyond the credential's primary
-// one — the comma-separated names an operator declared in optional_metadata.
+// one — the comma-separated names an operator declared in credential_fields.
 //
 // The parser consumes and strips it before the credential is parsed, then copies
 // exactly those fields into the credential's Data map. Stripping first matters:

--- a/credential/type.go
+++ b/credential/type.go
@@ -117,3 +117,19 @@ type ConnectGated interface {
 	// config (e.g. a refresh token or static access token has been sealed).
 	IsConnected(config map[string]string) bool
 }
+
+// ConfigSensitivity is an optional interface a credential Type implements when
+// which of its spec-config keys are secret depends on the config itself.
+//
+// SensitiveConfigFields is a fixed list, which is enough for a type whose config
+// keys are all known at compile time. It is not enough for a type an operator can
+// extend: a spec may carry adjunct fields the type has never heard of, and one of
+// them may be a second secret. A type implementing this decides per config, and
+// should fail safe — mask what it cannot vouch for, since over-masking costs a
+// reader some clarity while under-masking leaks a key.
+type ConfigSensitivity interface {
+	// SensitiveConfigFieldsFor returns the spec-config keys to mask for this
+	// config. It supersedes SensitiveConfigFields rather than adding to it, so an
+	// implementation must include everything that list would have returned.
+	SensitiveConfigFieldsFor(config map[string]string) []string
+}

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -28,7 +28,7 @@ func NewAPIKeyCredType() *APIKeyCredType {
 				// Empty by design. api_key is the only field this type owns;
 				// every adjunct — an organization, a second key, an account
 				// identity — is named by the operator in the source's
-				// optional_metadata and carried by the parser.
+				// credential_fields and carried by the parser.
 				//
 				// A fixed list here could only hold fields anticipated when the
 				// type was written, which is what left several provider
@@ -61,7 +61,7 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		// one here documents it and marks it known — which is what keeps it
 		// readable, since masking treats an undeclared spec-config key as a
 		// possible secret. Declaring does NOT carry it: on an apikey source a field
-		// travels only when the source's optional_metadata names it.
+		// travels only when the source's credential_fields names it.
 		credential.StringField("organization_id").
 			Describe("Organization ID (optional)").
 			Example("org-xxxxxxxxxxxx"),
@@ -215,7 +215,7 @@ func (t *APIKeyCredType) RequiresSpecRotation() bool {
 // instead of minting a credential silently missing it.
 //
 // A provider needing a field absent from this list still works — the operator
-// names it in optional_metadata and it is carried. The list only decides which
+// names it in credential_fields and it is carried. The list only decides which
 // names Warden can give a helpful error about.
 var apiKeyAdjunctFields = []string{
 	"organization_id", "project_id", "key_id", "key_name", "email", "application_key",

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -24,27 +24,23 @@ func NewAPIKeyCredType() *APIKeyCredType {
 			FieldConfig: TokenFieldConfig{
 				PrimaryField:      "api_key",
 				AlternativeFields: []string{},
-				OptionalFields:    []string{"key_id", "key_name", "organization_id", "project_id"},
+
+				// Empty by design. api_key is the only field this type owns;
+				// every adjunct — an organization, a second key, an account
+				// identity — is named by the operator in the source's
+				// optional_metadata and carried by the parser.
+				//
+				// A fixed list here could only hold fields anticipated when the
+				// type was written, which is what left several provider
+				// extractors reading credential data nothing could supply. The
+				// declared route has no such ceiling: a new provider field costs
+				// no change to this type.
+				OptionalFields: []string{},
+
 				FieldSchemas: map[string]*credential.CredentialFieldSchema{
 					"api_key": {
 						Description: "API key for authentication",
 						Sensitive:   true,
-					},
-					"key_id": {
-						Description: "Key identifier (if available from provider)",
-						Sensitive:   false,
-					},
-					"key_name": {
-						Description: "Human-readable key name",
-						Sensitive:   false,
-					},
-					"organization_id": {
-						Description: "Organization identifier",
-						Sensitive:   false,
-					},
-					"project_id": {
-						Description: "Project identifier",
-						Sensitive:   false,
 					},
 				},
 			},
@@ -61,6 +57,11 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 			Describe("API key for provider authentication").
 			Example("sk-xxxxxxxxxxxxxxxxxxxx"),
 
+		// Adjunct fields: everything a credential carries beyond api_key. Declaring
+		// one here documents it and marks it known — which is what keeps it
+		// readable, since masking treats an undeclared spec-config key as a
+		// possible secret. Declaring does NOT carry it: on an apikey source a field
+		// travels only when the source's optional_metadata names it.
 		credential.StringField("organization_id").
 			Describe("Organization ID (optional)").
 			Example("org-xxxxxxxxxxxx"),
@@ -68,6 +69,22 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("project_id").
 			Describe("Project ID (optional)").
 			Example("proj-xxxxxxxxxxxx"),
+
+		credential.StringField("key_id").
+			Describe("Key identifier (optional; honeycomb uses it to select management-key mode)").
+			Example("hcaik_xxxxxxxxxxxx"),
+
+		credential.StringField("key_name").
+			Describe("Human-readable key name (optional)").
+			Example("warden-prod"),
+
+		credential.StringField("email").
+			Describe("Account identity paired with the key (optional; atlassian uses it for Basic auth)").
+			Example("svc@example.com"),
+
+		credential.StringField("application_key").
+			Describe("Second API key some providers require alongside api_key (optional; datadog)").
+			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
 		// Store-backed sources (vault static_apikey, aws secrets_manager)
 		credential.StringField("mint_method").
@@ -192,7 +209,58 @@ func (t *APIKeyCredType) RequiresSpecRotation() bool {
 	return false
 }
 
-// SensitiveConfigFields returns spec config keys that should be masked in output
+// apiKeyAdjunctFields are the spec-config keys that describe the credential
+// rather than the mint. Declared in ConfigSchema so they read back unmasked, and
+// listed here so a spec setting one that its source will not carry is rejected
+// instead of minting a credential silently missing it.
+//
+// A provider needing a field absent from this list still works — the operator
+// names it in optional_metadata and it is carried. The list only decides which
+// names Warden can give a helpful error about.
+var apiKeyAdjunctFields = []string{
+	"organization_id", "project_id", "key_id", "key_name", "email", "application_key",
+}
+
+// KnownAdjunctFields implements credential.AdjunctCarrier.
+func (t *APIKeyCredType) KnownAdjunctFields() []string { return apiKeyAdjunctFields }
+
+// SensitiveConfigFields returns spec config keys that should be masked in output.
+// The known secrets — see SensitiveConfigFieldsFor for the fields an operator adds
+// that this list cannot anticipate.
 func (t *APIKeyCredType) SensitiveConfigFields() []string {
-	return []string{"api_key"}
+	return []string{"api_key", "application_key"}
+}
+
+// SensitiveConfigFieldsFor masks the known secrets plus every spec-config key the
+// type does not recognise (credential.ConfigSensitivity).
+//
+// An api_key spec may carry adjunct fields declared by the operator rather than by
+// this type, so a fixed list cannot say which are secret. An unrecognised key is
+// therefore masked: it was put there to be part of the credential, and the type
+// has no basis for calling it public. Declaring a field in ConfigSchema is how it
+// becomes readable — which is why the non-secret adjuncts are declared there.
+//
+// Reserved keys stay visible: mint locators and chaining references address the
+// mint rather than describing the credential, and masking a secret_path would hide
+// where a credential comes from while protecting nothing.
+func (t *APIKeyCredType) SensitiveConfigFieldsFor(config map[string]string) []string {
+	fields := t.SensitiveConfigFields()
+
+	known := make(map[string]bool, len(t.ConfigSchema()))
+	for _, v := range t.ConfigSchema() {
+		known[v.FieldName()] = true
+	}
+
+	for key := range config {
+		// Named reserved keys only. IsReservedSpecConfigKey also matches the "__"
+		// prefix, which is right for carriage — those belong to the mint pipeline
+		// — but wrong here: nothing rejects a spec-config key called "__whatever",
+		// so exempting the prefix would leave the one shape of unknown key that
+		// reads back in the clear.
+		if known[key] || credential.IsReservedSpecConfigName(key) {
+			continue
+		}
+		fields = append(fields, key)
+	}
+	return fields
 }

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -352,11 +352,17 @@ func TestAPIKeyCredType_Parse(t *testing.T) {
 	}
 }
 
-func TestAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
+// TestAPIKeyCredType_Parse_CarriesOnlyTheKey pins that this type owns exactly one
+// field. Adjuncts reach a credential through operator-declared carriage, applied
+// by the parser after Parse — not through a list here, which could only ever hold
+// the fields anticipated when the type was written.
+//
+// The inversion is the point: these same names used to be copied, and a
+// reinstated OptionalFields list would make this test fail rather than silently
+// reintroduce the ceiling that left provider extractors unreachable.
+func TestAPIKeyCredType_Parse_CarriesOnlyTheKey(t *testing.T) {
 	ct := NewAPIKeyCredType()
 
-	// The static-API-key driver places these descriptive fields in rawData; the
-	// api_key type's OptionalFields copy them into cred.Data (matching production).
 	rawData := map[string]interface{}{
 		"api_key":         "sk-xxxxxxxxxxxxxxxxxxxx",
 		"key_id":          "key-123",
@@ -369,10 +375,7 @@ func TestAPIKeyCredType_Parse_OptionalFields(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "sk-xxxxxxxxxxxxxxxxxxxx", cred.Data["api_key"])
-	assert.Equal(t, "key-123", cred.Data["key_id"])
-	assert.Equal(t, "production-key", cred.Data["key_name"])
-	assert.Equal(t, "org-456", cred.Data["organization_id"])
-	assert.Equal(t, "proj-789", cred.Data["project_id"])
+	assert.Len(t, cred.Data, 1, "Parse must carry api_key and nothing else: %v", cred.Data)
 }
 
 func TestAPIKeyCredType_Validate(t *testing.T) {
@@ -450,8 +453,59 @@ func TestAPIKeyCredType_RequiresSpecRotation(t *testing.T) {
 func TestAPIKeyCredType_SensitiveConfigFields(t *testing.T) {
 	ct := NewAPIKeyCredType()
 	fields := ct.SensitiveConfigFields()
-	assert.Len(t, fields, 1)
+	assert.Len(t, fields, 2)
 	assert.Contains(t, fields, "api_key")
+	// A second secret, so it must be named: masking is the one thing an operator
+	// cannot be asked to declare, since forgetting would print the key.
+	assert.Contains(t, fields, "application_key")
+}
+
+// TestAPIKeyCredType_SensitiveConfigFieldsFor covers the three outcomes of
+// config-aware masking, which a fixed list cannot express.
+func TestAPIKeyCredType_SensitiveConfigFieldsFor(t *testing.T) {
+	ct := NewAPIKeyCredType()
+
+	fields := ct.SensitiveConfigFieldsFor(map[string]string{
+		"api_key":         "sk-xxxx",
+		"application_key": "app-xxxx",
+		"organization_id": "org-1",
+		"mint_method":     "static_apikey",
+		"secret_path":     "apikeys/thing",
+		"totally_unknown": "could be anything",
+	})
+
+	// Known secrets.
+	assert.Contains(t, fields, "api_key")
+	assert.Contains(t, fields, "application_key")
+
+	// Declared adjunct: readable, because the type knows what it is.
+	assert.NotContains(t, fields, "organization_id")
+
+	// Mint locators: readable, because masking where a credential comes from
+	// hides useful information and protects nothing.
+	assert.NotContains(t, fields, "mint_method")
+	assert.NotContains(t, fields, "secret_path")
+
+	// Undeclared: the type cannot vouch for it, so it fails safe.
+	assert.Contains(t, fields, "totally_unknown")
+}
+
+// TestAPIKeyCredType_SensitiveConfigFieldsFor_UnderscorePrefixIsNotTrusted pins
+// the one exemption that must not apply here.
+//
+// The "__" namespace belongs to the mint pipeline, and carriage treats it as
+// reserved for exactly that reason. Spec config is different: nothing rejects a
+// key called "__whatever", so trusting the prefix would leave the single shape of
+// unknown key that reads back in the clear.
+func TestAPIKeyCredType_SensitiveConfigFieldsFor_UnderscorePrefixIsNotTrusted(t *testing.T) {
+	ct := NewAPIKeyCredType()
+	fields := ct.SensitiveConfigFieldsFor(map[string]string{
+		"api_key":          "sk-xxxx",
+		"__adjunct_fields": "organization_id",
+		"__anything":       "could be a secret",
+	})
+	assert.Contains(t, fields, "__adjunct_fields")
+	assert.Contains(t, fields, "__anything")
 }
 
 func TestAPIKeyCredType_FieldSchemas(t *testing.T) {
@@ -462,15 +516,25 @@ func TestAPIKeyCredType_FieldSchemas(t *testing.T) {
 	assert.True(t, schemas["api_key"].Sensitive)
 	assert.NotEmpty(t, schemas["api_key"].Description)
 
-	assert.Contains(t, schemas, "key_id")
-	assert.False(t, schemas["key_id"].Sensitive)
+	// The adjuncts are no longer type-owned data fields, so they have no schema
+	// here — they are declared in ConfigSchema, which is what documents them and
+	// keeps them readable on a spec read.
+	assert.Len(t, schemas, 1)
+}
 
-	assert.Contains(t, schemas, "key_name")
-	assert.False(t, schemas["key_name"].Sensitive)
+// TestAPIKeyCredType_KnownAdjunctFieldsAreDeclared keeps the two lists in step.
+// A name in KnownAdjunctFields but not in ConfigSchema would be rejected as
+// undeclared when set, yet masked as unknown when read — a field the type both
+// insists on and refuses to recognise.
+func TestAPIKeyCredType_KnownAdjunctFieldsAreDeclared(t *testing.T) {
+	ct := NewAPIKeyCredType()
 
-	assert.Contains(t, schemas, "organization_id")
-	assert.False(t, schemas["organization_id"].Sensitive)
+	declared := make(map[string]bool)
+	for _, v := range ct.ConfigSchema() {
+		declared[v.FieldName()] = true
+	}
 
-	assert.Contains(t, schemas, "project_id")
-	assert.False(t, schemas["project_id"].Sensitive)
+	for _, field := range ct.KnownAdjunctFields() {
+		assert.True(t, declared[field], "adjunct %q must be declared in ConfigSchema", field)
+	}
 }

--- a/e2e/fullchain/atlassian_test.go
+++ b/e2e/fullchain/atlassian_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/base64"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// atlassian picks between two auth schemes on the presence of a second
+// credential field, and unusually it is the *fallback* that was reachable: with
+// no way to carry an email, every mount sent Bearer, while Atlassian Cloud API
+// tokens authenticate with Basic email:token. The branch that works against the
+// real service was the dead one.
+//
+// Both rows drive the same mount and the same token, differing only in which
+// spec the role binds — so what they isolate is the field, not the setup.
+
+const (
+	atlassianToken = "fc-atlassian-not-a-real-token"
+	atlassianEmail = "fc-svc@example.com"
+)
+
+// The source declares email; api_key is the only field the credential type
+// carries on its own. The default spec deliberately omits it, so the Bearer
+// fallback stays covered rather than becoming unreachable in turn.
+var atlassianEnv = h.ProviderEnv{
+	Mount:        "fc-atlassian",
+	Type:         "atlassian",
+	URLKey:       "atlassian_url",
+	CredType:     "api_key",
+	SourceType:   "apikey",
+	SourceConfig: map[string]string{"optional_metadata": "email"},
+	CredConfig:   map[string]string{"api_key": atlassianToken},
+	Variants: map[string]map[string]string{
+		"basic": {"api_key": atlassianToken, "email": atlassianEmail},
+	},
+}
+
+// TestAtlassian_SchemeFollowsTheEmailField covers both branches of the
+// extractor.
+//
+// The Basic value is asserted as the exact encoded pair rather than merely
+// "starts with Basic": the whole point of the field is which identity the token
+// authenticates as, and an extractor that encoded the wrong half — or encoded
+// the token alone — would pass a prefix check while authenticating as nobody.
+func TestAtlassian_SchemeFollowsTheEmailField(t *testing.T) {
+	ensureEnv(t)
+
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte(atlassianEmail+":"+atlassianToken))
+
+	cases := []struct {
+		name string
+		role string
+		want string
+	}{
+		{
+			name: "token only falls back to Bearer",
+			role: atlassianEnv.CertRole(),
+			want: "Bearer " + atlassianToken,
+		},
+		{
+			name: "an email switches to Basic",
+			role: atlassianEnv.VariantRole("basic"),
+			want: basic,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, atlassianEnv, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.role,
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      map[string]string{"Authorization": tc.want},
+				Absent:        h.AlwaysAbsent(),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}

--- a/e2e/fullchain/atlassian_test.go
+++ b/e2e/fullchain/atlassian_test.go
@@ -32,7 +32,7 @@ var atlassianEnv = h.ProviderEnv{
 	URLKey:       "atlassian_url",
 	CredType:     "api_key",
 	SourceType:   "apikey",
-	SourceConfig: map[string]string{"optional_metadata": "email"},
+	SourceConfig: map[string]string{"credential_fields": "email"},
 	CredConfig:   map[string]string{"api_key": atlassianToken},
 	Variants: map[string]map[string]string{
 		"basic": {"api_key": atlassianToken, "email": atlassianEmail},

--- a/e2e/fullchain/carriage_test.go
+++ b/e2e/fullchain/carriage_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // A credential carries api_key plus whatever its source declares in
-// optional_metadata. Everything here is about the boundary of that declaration:
+// credential_fields. Everything here is about the boundary of that declaration:
 // what an operator can put in it, and what happens to a field nobody declared.
 //
 // The rows drive the public API rather than the parser, because the interesting
@@ -35,7 +35,7 @@ func TestCarriage_ReservedNameIsRejectedOnTheSource(t *testing.T) {
 
 	for _, field := range []string{"secret_path", "mint_method", "secret_spec", "__adjunct_fields"} {
 		status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort,
-			`{"type":"apikey","config":{"optional_metadata":"`+field+`"}}`)
+			`{"type":"apikey","config":{"credential_fields":"`+field+`"}}`)
 		if status < 400 || status >= 500 {
 			t.Errorf("declaring %q as a credential field: got status %d, want a 4xx (body: %s)", field, status, body)
 			h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "")
@@ -78,7 +78,7 @@ func TestCarriage_UndeclaredAdjunctIsRejectedOnTheSpec(t *testing.T) {
 
 	// Following the advice makes the same spec valid.
 	mustWrite("PUT", "sys/cred/sources/"+srcName,
-		`{"config":{"optional_metadata":"organization_id"}}`, "declare organization_id on the source")
+		`{"config":{"credential_fields":"organization_id"}}`, "declare organization_id on the source")
 	mustWrite("POST", "sys/cred/specs/"+specName, specBody, "spec with a declared credential field")
 }
 
@@ -86,7 +86,7 @@ func TestCarriage_UndeclaredAdjunctIsRejectedOnTheSpec(t *testing.T) {
 // guard.
 //
 // That guard runs when a spec is written. Removing a name from the source's
-// optional_metadata touches no spec at all, so every spec that set the field would
+// credential_fields touches no spec at all, so every spec that set the field would
 // quietly start minting without it — the guard's own failure mode, reached through
 // the front door. Widening stays free; only a disappearing name can strand anything.
 func TestCarriage_NarrowingASourceStrandsNothing(t *testing.T) {
@@ -111,16 +111,16 @@ func TestCarriage_NarrowingASourceStrandsNothing(t *testing.T) {
 	}
 
 	mustWrite("POST", "sys/cred/sources/"+srcName,
-		`{"type":"apikey","config":{"optional_metadata":"organization_id"}}`, "create source")
+		`{"type":"apikey","config":{"credential_fields":"organization_id"}}`, "create source")
 	mustWrite("POST", "sys/cred/specs/"+specName,
 		`{"type":"api_key","source":"`+srcName+`","config":{"api_key":"k","organization_id":"org-1"}}`,
 		"create spec")
 
 	// Dropping the declaration the spec depends on.
 	status, body := h.APIRequest(t, "PUT", "sys/cred/sources/"+srcName, leaderPort,
-		`{"config":{"optional_metadata":""}}`)
+		`{"config":{"credential_fields":""}}`)
 	if status < 400 || status >= 500 {
-		t.Fatalf("narrowing optional_metadata under a bound spec: got status %d, want a 4xx (body: %s)", status, body)
+		t.Fatalf("narrowing credential_fields under a bound spec: got status %d, want a 4xx (body: %s)", status, body)
 	}
 	if !strings.Contains(string(body), specName) {
 		t.Errorf("the error must name the spec left stranded, got: %s", body)
@@ -128,16 +128,16 @@ func TestCarriage_NarrowingASourceStrandsNothing(t *testing.T) {
 
 	// Widening is unaffected.
 	mustWrite("PUT", "sys/cred/sources/"+srcName,
-		`{"config":{"optional_metadata":"organization_id,project_id"}}`, "widen optional_metadata")
+		`{"config":{"credential_fields":"organization_id,project_id"}}`, "widen credential_fields")
 }
 
 // TestCarriage_NonAPIKeySourceCannotCarryAdjuncts covers the failure the guard
 // would otherwise describe wrongly.
 //
-// Only the apikey driver resolves optional_metadata and tells the parser what it
+// Only the apikey driver resolves credential_fields and tells the parser what it
 // carried. A local source has no such mechanism, so a credential field set beside
 // api_key can never travel — and an error pointing that operator at
-// optional_metadata would send them to add a key that changes nothing, which is
+// credential_fields would send them to add a key that changes nothing, which is
 // the same silent divergence one layer up. The rejection has to name the source
 // type, and a declaration on such a source must not satisfy it.
 func TestCarriage_NonAPIKeySourceCannotCarryAdjuncts(t *testing.T) {
@@ -155,7 +155,7 @@ func TestCarriage_NonAPIKeySourceCannotCarryAdjuncts(t *testing.T) {
 	// A local source that declares the field anyway. The declaration is inert
 	// here, and the spec must still be refused.
 	status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+srcName, leaderPort,
-		`{"type":"local","config":{"optional_metadata":"organization_id"}}`)
+		`{"type":"local","config":{"credential_fields":"organization_id"}}`)
 	switch status {
 	case 200, 201, 204:
 	default:

--- a/e2e/fullchain/carriage_test.go
+++ b/e2e/fullchain/carriage_test.go
@@ -1,0 +1,182 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// A credential carries api_key plus whatever its source declares in
+// optional_metadata. Everything here is about the boundary of that declaration:
+// what an operator can put in it, and what happens to a field nobody declared.
+//
+// The rows drive the public API rather than the parser, because the interesting
+// question is not whether the parser filters correctly — unit tests settle that,
+// including a declaration forged into a fetched secret payload — but whether an
+// operator can reach a state where a credential is quietly missing a field. The
+// symptom of that is a provider taking its fallback branch, which from outside
+// looks exactly like a working mount.
+
+// TestCarriage_ReservedNameIsRejectedOnTheSource: a source cannot declare a mint
+// locator as a credential field.
+//
+// A typo guard rather than a security boundary — nothing travels unless an
+// operator writes its name down — but a locator copied into credential data would
+// be sent upstream by whichever provider reads that field name, so it is refused
+// where it is written instead of skipped silently at mint.
+func TestCarriage_ReservedNameIsRejectedOnTheSource(t *testing.T) {
+	ensureEnv(t)
+
+	const name = "fc-carriage-reserved-src"
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "") })
+
+	for _, field := range []string{"secret_path", "mint_method", "secret_spec", "__adjunct_fields"} {
+		status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort,
+			`{"type":"apikey","config":{"optional_metadata":"`+field+`"}}`)
+		if status < 400 || status >= 500 {
+			t.Errorf("declaring %q as a credential field: got status %d, want a 4xx (body: %s)", field, status, body)
+			h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "")
+		}
+	}
+}
+
+// TestCarriage_UndeclaredAdjunctIsRejectedOnTheSpec is the guard that makes the
+// declaration discoverable, and the round trip that shows the error is actionable:
+// reject, follow the advice, accept.
+func TestCarriage_UndeclaredAdjunctIsRejectedOnTheSpec(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		srcName  = "fc-carriage-undeclared-src"
+		specName = "fc-carriage-undeclared-spec"
+	)
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+specName, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+srcName, leaderPort, "")
+	})
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	// An apikey source declaring nothing.
+	mustWrite("POST", "sys/cred/sources/"+srcName, `{"type":"apikey"}`, "create source")
+
+	specBody := `{"type":"api_key","source":"` + srcName + `","config":{"api_key":"k","organization_id":"org-1"}}`
+	status, body := h.APIRequest(t, "POST", "sys/cred/specs/"+specName, leaderPort, specBody)
+	if status < 400 || status >= 500 {
+		t.Fatalf("spec with an uncarried credential field: got status %d, want a 4xx (body: %s)", status, body)
+	}
+
+	// Following the advice makes the same spec valid.
+	mustWrite("PUT", "sys/cred/sources/"+srcName,
+		`{"config":{"optional_metadata":"organization_id"}}`, "declare organization_id on the source")
+	mustWrite("POST", "sys/cred/specs/"+specName, specBody, "spec with a declared credential field")
+}
+
+// TestCarriage_NarrowingASourceStrandsNothing closes the way round the spec-level
+// guard.
+//
+// That guard runs when a spec is written. Removing a name from the source's
+// optional_metadata touches no spec at all, so every spec that set the field would
+// quietly start minting without it — the guard's own failure mode, reached through
+// the front door. Widening stays free; only a disappearing name can strand anything.
+func TestCarriage_NarrowingASourceStrandsNothing(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		srcName  = "fc-carriage-narrow-src"
+		specName = "fc-carriage-narrow-spec"
+	)
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+specName, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+srcName, leaderPort, "")
+	})
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	mustWrite("POST", "sys/cred/sources/"+srcName,
+		`{"type":"apikey","config":{"optional_metadata":"organization_id"}}`, "create source")
+	mustWrite("POST", "sys/cred/specs/"+specName,
+		`{"type":"api_key","source":"`+srcName+`","config":{"api_key":"k","organization_id":"org-1"}}`,
+		"create spec")
+
+	// Dropping the declaration the spec depends on.
+	status, body := h.APIRequest(t, "PUT", "sys/cred/sources/"+srcName, leaderPort,
+		`{"config":{"optional_metadata":""}}`)
+	if status < 400 || status >= 500 {
+		t.Fatalf("narrowing optional_metadata under a bound spec: got status %d, want a 4xx (body: %s)", status, body)
+	}
+	if !strings.Contains(string(body), specName) {
+		t.Errorf("the error must name the spec left stranded, got: %s", body)
+	}
+
+	// Widening is unaffected.
+	mustWrite("PUT", "sys/cred/sources/"+srcName,
+		`{"config":{"optional_metadata":"organization_id,project_id"}}`, "widen optional_metadata")
+}
+
+// TestCarriage_NonAPIKeySourceCannotCarryAdjuncts covers the failure the guard
+// would otherwise describe wrongly.
+//
+// Only the apikey driver resolves optional_metadata and tells the parser what it
+// carried. A local source has no such mechanism, so a credential field set beside
+// api_key can never travel — and an error pointing that operator at
+// optional_metadata would send them to add a key that changes nothing, which is
+// the same silent divergence one layer up. The rejection has to name the source
+// type, and a declaration on such a source must not satisfy it.
+func TestCarriage_NonAPIKeySourceCannotCarryAdjuncts(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		srcName  = "fc-carriage-local-src"
+		specName = "fc-carriage-local-spec"
+	)
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+specName, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+srcName, leaderPort, "")
+	})
+
+	// A local source that declares the field anyway. The declaration is inert
+	// here, and the spec must still be refused.
+	status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+srcName, leaderPort,
+		`{"type":"local","config":{"optional_metadata":"organization_id"}}`)
+	switch status {
+	case 200, 201, 204:
+	default:
+		t.Fatalf("create local source (status %d): %s", status, body)
+	}
+
+	status, body = h.APIRequest(t, "POST", "sys/cred/specs/"+specName, leaderPort,
+		`{"type":"api_key","source":"`+srcName+`","config":{"api_key":"k","organization_id":"org-1"}}`)
+	if status < 400 || status >= 500 {
+		t.Fatalf("local-source spec with a credential field: got status %d, want a 4xx (body: %s)", status, body)
+	}
+	if !strings.Contains(string(body), "apikey source") {
+		t.Errorf("the error must say which source type to use, got: %s", body)
+	}
+
+	// The same spec without the field is fine: api_key alone always travels.
+	status, body = h.APIRequest(t, "POST", "sys/cred/specs/"+specName, leaderPort,
+		`{"type":"api_key","source":"`+srcName+`","config":{"api_key":"k"}}`)
+	switch status {
+	case 200, 201, 204:
+	default:
+		t.Fatalf("local-source spec carrying only api_key (status %d): %s", status, body)
+	}
+}

--- a/e2e/fullchain/credential_chaining_test.go
+++ b/e2e/fullchain/credential_chaining_test.go
@@ -1,0 +1,236 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// Credential chaining: a spec that stores no secret of its own and names another
+// spec that yields one. Here the referenced spec reads a Vault KV secret holding a
+// whole multi-field credential, and the consuming spec's source declares which of
+// those fields travel beyond api_key.
+//
+// The driver tests cover the same shape against a hand-built SecretMaterial. What
+// only a full chain can show is the rest of it: the reference resolving to a real
+// Vault read over federation, the payload reaching MintFromSecret, the declaration
+// surviving Parse, and the declared field arriving as an upstream header. Joins
+// like those are where a provider ends up reading a credential field nothing can
+// supply — each layer correct alone, and unreachable together.
+//
+// Why this needs its own Vault source: a referenced spec must be minted as the
+// session-pinned caller, which forces the exchange path, which on an hvault source
+// requires auth_method=oidc_federation. The AppRole source every other suite uses
+// cannot back a chained secret at all.
+
+const (
+	// Written to secret/data/e2e/datadog-keys by setup.sh. Nothing in any spec
+	// config carries these values, so an assertion on them can only pass if the
+	// whole chain ran.
+	chainedAPIKey = "e2e-dd-chained-not-a-real-key"
+	chainedAppKey = "e2e-dd-chained-not-a-real-app-key"
+
+	chainedSecretSpec = "fc-chain-vault-keys"
+
+	// Every resource here is test-local, the source included. Hanging the
+	// consuming spec off the datadog mount's own source would be less setup, but a
+	// killed run — Ctrl-C, a timeout panic — skips t.Cleanup, and the leftover spec
+	// would then block that source from being deleted. The next run's environment
+	// setup could not re-create it, would 409, and would fatal every test in the
+	// package *before* reaching the cleanup that would have cleared the leftover.
+	// Nothing recovers from that without hand-deleting a spec. Test-local
+	// resources can only ever strand themselves.
+	chainedSource    = "fc-chain-decl-src"
+	chainedSpec      = "fc-chain-decl-cred"
+	chainedAgentRole = "fc-chain-decl-agent"
+
+	// A second source over the same Vault secret, declaring nothing. It is the
+	// control: same payload, same referenced spec, same mount and policy, so the
+	// declaration is the only difference between the two rows.
+	undeclaredSource    = "fc-chain-nodecl-src"
+	undeclaredSpec      = "fc-chain-nodecl-cred"
+	undeclaredAgentRole = "fc-chain-nodecl-agent"
+)
+
+// setupChainedSpecs builds two chains over one Vault secret, differing only in
+// whether their source declares the second field. Both drive the datadog mount,
+// which supplies the extractor that turns each carried field into its own header.
+//
+// Order is load-bearing in both directions. A spec naming a secret_spec that does
+// not exist is refused at create, and a referenced spec cannot be deleted while a
+// consumer still names it, so cleanup runs consumer-first.
+func setupChainedSpecs(t *testing.T) {
+	t.Helper()
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	// Consumers first, then what they reference. Same order as cleanup, and for
+	// the same reason — this clears anything a killed run left behind, which would
+	// otherwise 409 the creates below.
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+chainedAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+undeclaredAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+chainedSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+undeclaredSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+chainedSecretSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+chainedSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+undeclaredSource, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	// The referenced spec: the whole credential, read from one Vault secret.
+	// subject_token_source is not optional here — a chained secret must be minted
+	// as the caller, and the store refuses the reference otherwise.
+	mustWrite("POST", "sys/cred/specs/"+chainedSecretSpec, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":"e2e/datadog-keys",
+			"subject_token_source":"agent_identity"}}`,
+		"create the referenced secret spec")
+
+	// The declaring source. api_key travels because it is the credential; the
+	// application key travels because this names it.
+	mustWrite("POST", "sys/cred/sources/"+chainedSource,
+		`{"type":"apikey","config":{"credential_fields":"application_key"}}`,
+		"create the declaring source")
+
+	// The consuming spec holds no api_key: it is mutually exclusive with
+	// secret_spec. secret_field is explicit — the fallback would find api_key by
+	// name anyway, but a test should not lean on a fallback to choose the secret.
+	mustWrite("POST", "sys/cred/specs/"+chainedSpec, `{
+		"type":"api_key","source":"`+chainedSource+`","config":{
+			"secret_spec":"`+chainedSecretSpec+`","secret_field":"api_key"}}`,
+		"create the chained consuming spec")
+
+	// The mount's own JWT agent role binds its default spec, so this row needs one
+	// bound to the chained spec instead.
+	mustWrite("POST", "auth/jwt/role/"+chainedAgentRole, `{
+		"token_policies":["`+datadogEnv.Policy()+`"],"cred_spec_name":"`+chainedSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the chained agent role")
+
+	// The control source, identical but for the missing declaration.
+	mustWrite("POST", "sys/cred/sources/"+undeclaredSource,
+		`{"type":"apikey","config":{}}`,
+		"create the undeclaring source")
+
+	mustWrite("POST", "sys/cred/specs/"+undeclaredSpec, `{
+		"type":"api_key","source":"`+undeclaredSource+`","config":{
+			"secret_spec":"`+chainedSecretSpec+`","secret_field":"api_key"}}`,
+		"create the chained spec on the undeclaring source")
+
+	mustWrite("POST", "auth/jwt/role/"+undeclaredAgentRole, `{
+		"token_policies":["`+datadogEnv.Policy()+`"],"cred_spec_name":"`+undeclaredSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the undeclared agent role")
+}
+
+// TestChaining_VaultBackedCredentialCarriesItsDeclaredField is the row this
+// exists for: two secrets living in one Vault entry, arriving as two upstream
+// headers.
+//
+// Both asserted values appear in no spec config anywhere — they exist only inside
+// the Vault secret — so the row fails if any link breaks: the federation login,
+// the KV read, the material reaching the consuming driver, the declaration
+// surviving Parse, or the extractor.
+//
+// A JWT agent leg rather than the usual certificate, because agent_identity
+// forwards the agent's own inbound JWT as the exchange subject and fails closed
+// on a cert-authenticated request.
+func TestChaining_VaultBackedCredentialCarriesItsDeclaredField(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, datadogEnv)
+	setupChainedSpecs(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, datadogEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Role:       chainedAgentRole,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		Injected: map[string]string{
+			"DD-API-KEY":         chainedAPIKey,
+			"DD-APPLICATION-KEY": chainedAppKey,
+		},
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+}
+
+// TestChaining_ReferencedSecretCannotBeDeletedWhileConsumed pins the protection
+// this file's own cleanup order depends on.
+//
+// Deleting the secret-yielding spec out from under its consumers would not fail
+// until the next mint, and would fail there as a credential error rather than
+// anything naming the spec that went missing. The refusal is what keeps a chain
+// from being dismantled halfway.
+func TestChaining_ReferencedSecretCannotBeDeletedWhileConsumed(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, datadogEnv)
+	setupChainedSpecs(t)
+
+	status, body := h.APIRequest(t, "DELETE", "sys/cred/specs/"+chainedSecretSpec, leaderPort, "")
+	if status < 400 {
+		t.Fatalf("deleting a referenced secret spec: got status %d, want a failure (body: %s)", status, body)
+	}
+	if !strings.Contains(string(body), "referenced") {
+		t.Errorf("the error should say the spec is still referenced, got: %s", body)
+	}
+
+	// Still mintable afterwards — the refusal left the chain intact rather than
+	// half-deleted.
+	reqStatus, reqBody, _ := h.ChainRequest(t, leaderPort, datadogEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Role:       chainedAgentRole,
+	})
+	h.AssertChain(t, upstream, reqStatus, reqBody, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"DD-API-KEY": chainedAPIKey},
+		UpstreamCalls: 1,
+	})
+}
+
+// TestChaining_UndeclaredPayloadFieldStaysInTheVault is what makes the row above
+// mean something.
+//
+// It drives the identical chain — same Vault secret, same referenced spec, same
+// mount — through a source that declares nothing. The application key is right
+// there in the payload, and it must not travel: a fetched secret is a shared blob
+// an operator may keep notes, owners or rotation timestamps in, and copying it
+// wholesale would send whichever of them a provider happens to read.
+//
+// The assertion is on DD-APPLICATION-KEY rather than some inert extra key,
+// deliberately. An undeclared field that no extractor maps could never appear in a
+// header whatever carriage did, so a row asserting *that* absence would pass
+// against any implementation — including one that copies the whole payload. Only a
+// field the provider would emit if it had it can tell the two apart.
+func TestChaining_UndeclaredPayloadFieldStaysInTheVault(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, datadogEnv)
+	setupChainedSpecs(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, datadogEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Role:       undeclaredAgentRole,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		// The primary field always travels: it is the credential.
+		Injected: map[string]string{"DD-API-KEY": chainedAPIKey},
+		// The second secret is in the same payload and stays there.
+		Absent:        h.AlwaysAbsent("Authorization", "DD-APPLICATION-KEY"),
+		UpstreamCalls: 1,
+	})
+}

--- a/e2e/fullchain/datadog_test.go
+++ b/e2e/fullchain/datadog_test.go
@@ -12,49 +12,111 @@ import (
 // one optional, each landing in its own header rather than a single
 // Authorization value. Its inbound side is the plain default extractor, so the
 // rows here are about the outbound shape.
+//
+// Both halves of the optional field are covered together, and they belong
+// together: it is injected only when the credential carries one, so on a spec
+// without an application key the same header arriving from a caller would ride
+// through untouched. Reachable inbound and unstripped outbound were one problem.
 
-const datadogAPIKey = "fc-datadog-not-a-real-key"
+const (
+	datadogAPIKey = "fc-datadog-not-a-real-key"
+	datadogAppKey = "fc-datadog-not-a-real-app-key"
+)
 
+// The apikey source declares the second field; api_key is the only one the
+// credential type carries on its own. One declaration serves both specs.
 var datadogEnv = h.ProviderEnv{
-	Mount:      "fc-datadog",
-	Type:       "datadog",
-	URLKey:     "datadog_url",
-	CredType:   "api_key",
-	CredConfig: map[string]string{"api_key": datadogAPIKey},
+	Mount:        "fc-datadog",
+	Type:         "datadog",
+	URLKey:       "datadog_url",
+	CredType:     "api_key",
+	SourceType:   "apikey",
+	SourceConfig: map[string]string{"optional_metadata": "application_key"},
+	CredConfig:   map[string]string{"api_key": datadogAPIKey},
+	Variants: map[string]map[string]string{
+		"app": {"api_key": datadogAPIKey, "application_key": datadogAppKey},
+	},
 }
 
-// TestDatadog_RequiredKeyInjected covers the reachable half of the multi-field
-// extractor: the required field lands in its own header rather than in an
-// Authorization value.
+// TestDatadog_KeyHeadersFollowTheCredential covers both branches of the
+// multi-field extractor: the required field always lands in its own header, and
+// the optional one appears only when the credential has it.
 //
-// The optional half cannot be reached. Its field is application_key, and nothing
-// in the tree produces one — api_key, the type datadog's own help text points
-// at, carries only api_key, key_id, key_name, organization_id and project_id, so
-// a spec that sets application_key has it dropped before the credential is
-// built. Covering that branch needs a variant spec and a positive assertion, and
-// neither can be written until the field is carriable.
+// The absent assertion on the required-only row is what makes the pair
+// meaningful — an extractor that emitted an empty DD-APPLICATION-KEY would
+// satisfy an injection-only check while sending Datadog a header it must not
+// receive.
+func TestDatadog_KeyHeadersFollowTheCredential(t *testing.T) {
+	ensureEnv(t)
+
+	cases := []struct {
+		name   string
+		role   string
+		want   map[string]string
+		absent []string
+	}{
+		{
+			name: "api key only",
+			role: datadogEnv.CertRole(),
+			want: map[string]string{"DD-API-KEY": datadogAPIKey},
+			// The credential rides its own header, leaving Authorization
+			// untouched by injection — so a leaked caller credential would be
+			// visible there rather than overwritten.
+			absent: []string{"Authorization", "DD-APPLICATION-KEY"},
+		},
+		{
+			name: "with an application key",
+			role: datadogEnv.VariantRole("app"),
+			want: map[string]string{
+				"DD-API-KEY":         datadogAPIKey,
+				"DD-APPLICATION-KEY": datadogAppKey,
+			},
+			absent: []string{"Authorization"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, datadogEnv, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.role,
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      tc.want,
+				Absent:        h.AlwaysAbsent(tc.absent...),
+				UpstreamCalls: 1,
+			})
+		})
+	}
+}
+
+// TestDatadog_ClientSuppliedApplicationKeyIsStripped is the other half of the
+// pair, and the reason the strip cannot wait.
 //
-// DD-APPLICATION-KEY is deliberately NOT asserted absent. The header is in no
-// strip list and the extractor never injects it, so a caller-supplied value
-// reaches the upstream today — asserting absence without sending one would pass
-// vacuously, and sending one would fail. The assertion belongs here once that
-// passthrough is closed.
-func TestDatadog_RequiredKeyInjected(t *testing.T) {
+// The header is conditionally injected, so without a strip list a caller could
+// pair an application key of their own with the mount's API key — an inbound
+// credential proxying onward under the mount's identity. The row drives the
+// required-only spec deliberately: on the variant that carries one, injection
+// would overwrite the caller's value and the assertion would hold either way.
+func TestDatadog_ClientSuppliedApplicationKeyIsStripped(t *testing.T) {
 	ensureEnv(t)
 
 	status, body, _ := h.ChainRequest(t, leaderPort, datadogEnv, h.ChainOpts{
 		AgentCertPEM: agentCert(t),
 		Bearer:       h.FullChainUserJWT(t),
 		Role:         datadogEnv.CertRole(),
+		Headers:      map[string]string{"DD-APPLICATION-KEY": "caller-supplied-app-key"},
 	})
 
 	h.AssertChain(t, upstream, status, body, h.ChainWant{
-		Status:   200,
-		Injected: map[string]string{"DD-API-KEY": datadogAPIKey},
-		// The credential rides its own header, leaving Authorization untouched
-		// by injection — so a leaked caller credential would be visible there
-		// rather than overwritten.
-		Absent:        h.AlwaysAbsent("Authorization"),
+		Status:        200,
+		Injected:      map[string]string{"DD-API-KEY": datadogAPIKey},
+		Absent:        h.AlwaysAbsent("Authorization", "DD-APPLICATION-KEY"),
 		UpstreamCalls: 1,
 	})
 }

--- a/e2e/fullchain/datadog_test.go
+++ b/e2e/fullchain/datadog_test.go
@@ -31,7 +31,7 @@ var datadogEnv = h.ProviderEnv{
 	URLKey:       "datadog_url",
 	CredType:     "api_key",
 	SourceType:   "apikey",
-	SourceConfig: map[string]string{"optional_metadata": "application_key"},
+	SourceConfig: map[string]string{"credential_fields": "application_key"},
 	CredConfig:   map[string]string{"api_key": datadogAPIKey},
 	Variants: map[string]map[string]string{
 		"app": {"api_key": datadogAPIKey, "application_key": datadogAppKey},

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -36,13 +36,14 @@ import (
 // channels with the native header first, scheme dispatch, and the git dual-slot
 // on its REST path — and all four shared SDK credential extractors.
 //
-// Three providers hand-roll an extractor and are not here: atlassian, honeycomb
-// and prometheus, whose distinctive branches read credential fields nothing can
-// supply, so a row could only cover the fallback each degrades to.
+// Two providers hand-roll an extractor and are not here: honeycomb and
+// prometheus. atlassian used to be a third — its Basic branch read a credential
+// field nothing could supply, so a row could only cover the Bearer fallback it
+// degraded to.
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
-	mcpAWSEnv, mcpAWSWrongCredEnv,
+	mcpAWSEnv, mcpAWSWrongCredEnv, atlassianEnv,
 }
 
 var (

--- a/e2e/fullchain/openai_test.go
+++ b/e2e/fullchain/openai_test.go
@@ -25,12 +25,20 @@ const (
 
 // Each optional field needs its own spec, because a role binds exactly one —
 // hence the variants rather than one spec mutated between rows.
+//
+// The apikey source with optional_metadata is the documented shape for a
+// credential carrying more than a key, and the only one that carries adjuncts:
+// api_key owns exactly one field, and everything beside it travels because the
+// source names it. Four specs share one declaration, which is the point of
+// putting it on the source.
 var openaiEnv = h.ProviderEnv{
-	Mount:      "fc-openai",
-	Type:       "openai",
-	URLKey:     "openai_url",
-	CredType:   "api_key",
-	CredConfig: map[string]string{"api_key": openaiKey},
+	Mount:        "fc-openai",
+	Type:         "openai",
+	URLKey:       "openai_url",
+	CredType:     "api_key",
+	SourceType:   "apikey",
+	SourceConfig: map[string]string{"optional_metadata": "organization_id,project_id"},
+	CredConfig:   map[string]string{"api_key": openaiKey},
 	Variants: map[string]map[string]string{
 		"org":  {"api_key": openaiKey, "organization_id": openaiOrg},
 		"proj": {"api_key": openaiKey, "project_id": openaiProject},

--- a/e2e/fullchain/openai_test.go
+++ b/e2e/fullchain/openai_test.go
@@ -26,7 +26,7 @@ const (
 // Each optional field needs its own spec, because a role binds exactly one —
 // hence the variants rather than one spec mutated between rows.
 //
-// The apikey source with optional_metadata is the documented shape for a
+// The apikey source with credential_fields is the documented shape for a
 // credential carrying more than a key, and the only one that carries adjuncts:
 // api_key owns exactly one field, and everything beside it travels because the
 // source names it. Four specs share one declaration, which is the point of
@@ -37,7 +37,7 @@ var openaiEnv = h.ProviderEnv{
 	URLKey:       "openai_url",
 	CredType:     "api_key",
 	SourceType:   "apikey",
-	SourceConfig: map[string]string{"optional_metadata": "organization_id,project_id"},
+	SourceConfig: map[string]string{"credential_fields": "organization_id,project_id"},
 	CredConfig:   map[string]string{"api_key": openaiKey},
 	Variants: map[string]map[string]string{
 		"org":  {"api_key": openaiKey, "organization_id": openaiOrg},

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -306,6 +306,16 @@ vault_api POST "secret/data/e2e/app-config" \
 vault_api POST "secret/data/e2e/database" \
   '{"data":{"username":"e2e-user","password":"e2e-password-secure","host":"db.example.com","port":"5432"}}'
 
+# A whole multi-field credential in one secret, for credential chaining: an
+# api_key spec references this and its source declares which of the other keys
+# travel. "owner" is the sort of bookkeeping operators keep beside a key, here so
+# the payload is a realistic blob rather than exactly what one consumer wants.
+# What proves undeclared fields stay behind is the control row in
+# e2e/fullchain/credential_chaining_test.go, which drives this same secret through
+# a source declaring nothing and asserts the application key never ships.
+vault_api POST "secret/data/e2e/datadog-keys" \
+  '{"data":{"api_key":"e2e-dd-chained-not-a-real-key","application_key":"e2e-dd-chained-not-a-real-app-key","owner":"e2e-undeclared-field"}}'
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \
@@ -386,6 +396,49 @@ else
   echo "  $JWT_RESPONSE"
 fi
 
+# Vault JWT auth trusting Hydra, for workload-identity federation.
+#
+# Configured here rather than with the rest of the Vault setup because Vault
+# fetches the JWKS when this is written, and Hydra is only known-responsive once
+# the token above has been issued.
+#
+# A credential spec referenced through secret_spec must be minted as the
+# session-pinned caller, which forces the exchange path — and on an hvault source
+# that path requires auth_method=oidc_federation. So the AppRole source above
+# cannot back a chained secret; this is the second, keyless source that can.
+echo "  Enabling Vault JWT auth (workload identity federation)..."
+vault_api POST "sys/auth/jwt" '{"type":"jwt"}' || true
+
+# The issuer is what Hydra stamps into its tokens; the JWKS is fetched over the
+# compose network, where that hostname does not resolve. They differ on purpose.
+vault_api POST "auth/jwt/config" \
+  '{"jwks_url":"http://hydra:4444/.well-known/jwks.json","bound_issuer":"http://localhost:4444"}'
+
+# Hydra client-credentials tokens carry an empty aud, so the role binds the
+# subject instead — which for those tokens is the client id.
+vault_api POST "auth/jwt/role/warden-e2e-fed" \
+  '{"role_type":"jwt","bound_subject":"e2e-agent","user_claim":"sub","bound_issuer":"http://localhost:4444","token_policies":["e2e-secrets-reader"],"token_ttl":"1h"}'
+
+# Verify the federation login works, so a later gateway 401 is not mistaken for
+# a chaining bug.
+echo "  Verifying Vault JWT federation login..."
+# `|| true` is not decoration: under `set -euo pipefail` a failed decode would
+# abort the whole script here, so a transient Hydra hiccup — which the issuance
+# check above deliberately treats as a warning — would silently skip every
+# remaining step and leave a half-configured cluster.
+FED_TOKEN=$(echo "$JWT_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null || true)
+if [ -z "$FED_TOKEN" ]; then
+  echo "  WARNING: no JWT to verify federation login with (see the issuance warning above)"
+else
+  FED_LOGIN=$(vault_api POST "auth/jwt/login" "{\"role\":\"warden-e2e-fed\",\"jwt\":\"$FED_TOKEN\"}")
+  if echo "$FED_LOGIN" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('auth',{}).get('client_token')" 2>/dev/null; then
+    echo "  Vault JWT federation login verified."
+  else
+    echo "  WARNING: Vault JWT federation login failed"
+    echo "  $FED_LOGIN"
+  fi
+fi
+
 # Step 9: Configure Warden with Vault provider
 echo ""
 echo "[9/10] Configuring Warden with Vault provider..."
@@ -405,6 +458,14 @@ warden_api PUT "vault/config" \
 echo "  Creating credential source 'vault-e2e'..."
 warden_api POST "sys/cred/sources/vault-e2e" \
   "{\"type\":\"hvault\",\"rotation_period\":300,\"config\":{\"vault_address\":\"$VAULT_ADDR\",\"auth_method\":\"approle\",\"role_id\":\"$VAULT_APPROLE_ROLE_ID\",\"secret_id\":\"$VAULT_APPROLE_SECRET_ID\",\"approle_mount\":\"e2e_approle\",\"role_name\":\"warden-e2e-role\"}}"
+
+# 9c-bis. Keyless federation source, for credential chaining.
+#
+# No rotation_period and no role_id/secret_id: a keyless source has no shared
+# session to rotate, and the driver rejects the AppRole fields outright.
+echo "  Creating credential source 'vault-fed-e2e' (OIDC federation)..."
+warden_api POST "sys/cred/sources/vault-fed-e2e" \
+  "{\"type\":\"hvault\",\"config\":{\"vault_address\":\"$VAULT_ADDR\",\"auth_method\":\"oidc_federation\",\"jwt_role\":\"warden-e2e-fed\",\"jwt_mount\":\"jwt\"}}"
 
 # 9d. Create credential spec (mint Vault tokens via token role)
 echo "  Creating credential spec 'vault-token-reader'..."

--- a/provider/atlassian/provider.go
+++ b/provider/atlassian/provider.go
@@ -28,8 +28,10 @@ const DefaultAtlassianTimeout = 30 * time.Second
 //     Used for: Atlassian Data Center Personal Access Tokens (PATs),
 //     OAuth 2.0 access tokens, and Atlassian Admin API org keys.
 //
-// To forward the email field from a spec config into credential data, configure
-// the apikey source with optional_metadata=email.
+// api_key is the only field the credential type carries on its own, so email
+// reaches the credential because the apikey source declares it in
+// optional_metadata. Its value resolves from a chained secret's payload first,
+// then from spec config.
 func atlassianExtractor(req *logical.Request) (map[string]string, error) {
 	if req.Credential == nil {
 		return nil, fmt.Errorf("no credential available")
@@ -77,8 +79,41 @@ proxied request. Auth mode is detected automatically from the credential data:
 
   Basic Auth (email + api_key):
     Used for Atlassian Cloud personal API tokens, Bitbucket app passwords,
-    and Data Center basic auth. Configure your apikey source with
-    optional_metadata=email to forward the email field into credential data.
+    and Data Center basic auth — which is what Atlassian Cloud tokens
+    require, so this is the usual mode rather than the exception.
+
+    api_key is the only field a credential carries on its own, so the email
+    must be declared on the source:
+
+      warden cred source create atlassian -type=apikey \
+        -config=api_url=https://<domain>.atlassian.net \
+        -config=optional_metadata=email
+
+      warden cred spec create jira-svc -source=atlassian \
+        -config=api_key=<ATLASSIAN_TOKEN> \
+        -config=email=svc@example.com
+
+    Without the declaration the spec is rejected at write, rather than
+    minting a credential with no email and quietly falling back to Bearer.
+
+    To keep the token in a vault, reference it with credential chaining. The
+    spec still sits on the apikey source — that is what declares email and
+    resolves it — while the referenced spec holds the secret:
+
+      warden cred spec create atlassian-token -type=key_value \
+        -source=corp-vault -config=mint_method=kv2_read \
+        -config=kv2_mount=secret -config=secret_path=apikeys/atlassian
+
+      warden cred spec create jira-keyless -source=atlassian \
+        -config=secret_spec=atlassian-token \
+        -config=email=svc@example.com
+
+    A declared field resolves from the fetched secret first and from spec
+    config second, so the email can stay inline as above, or move into the
+    secret alongside the token. What will not work is mint_method=static_apikey
+    against the hvault source directly: there the hvault source mints the
+    credential, the apikey driver is never in the path, and nothing can
+    declare a second field.
 
   Bearer (api_key only):
     Used for Atlassian Data Center Personal Access Tokens (PATs, DC 8.14+/7.9+),
@@ -124,8 +159,9 @@ Example API paths (Bitbucket Cloud):
 
 Credential source type:
 - apikey: Static Atlassian API token, PAT, app password, or OAuth access token.
-  For Cloud personal tokens, set optional_metadata=email on the source and
-  include email in the spec config to enable Basic Auth mode.
+  For Cloud personal tokens, declare optional_metadata=email on the source and
+  set email on the spec to enable Basic Auth mode; the token itself may be
+  inline or reached from a vault by credential chaining (see above).
 
 Configuration:
 - atlassian_url: Atlassian product API base URL (required — no universal default)

--- a/provider/atlassian/provider.go
+++ b/provider/atlassian/provider.go
@@ -30,7 +30,7 @@ const DefaultAtlassianTimeout = 30 * time.Second
 //
 // api_key is the only field the credential type carries on its own, so email
 // reaches the credential because the apikey source declares it in
-// optional_metadata. Its value resolves from a chained secret's payload first,
+// credential_fields. Its value resolves from a chained secret's payload first,
 // then from spec config.
 func atlassianExtractor(req *logical.Request) (map[string]string, error) {
 	if req.Credential == nil {
@@ -87,7 +87,7 @@ proxied request. Auth mode is detected automatically from the credential data:
 
       warden cred source create atlassian -type=apikey \
         -config=api_url=https://<domain>.atlassian.net \
-        -config=optional_metadata=email
+        -config=credential_fields=email
 
       warden cred spec create jira-svc -source=atlassian \
         -config=api_key=<ATLASSIAN_TOKEN> \
@@ -159,7 +159,7 @@ Example API paths (Bitbucket Cloud):
 
 Credential source type:
 - apikey: Static Atlassian API token, PAT, app password, or OAuth access token.
-  For Cloud personal tokens, declare optional_metadata=email on the source and
+  For Cloud personal tokens, declare credential_fields=email on the source and
   set email on the spec to enable Basic Auth mode; the token itself may be
   inline or reached from a vault by credential chaining (see above).
 

--- a/provider/datadog/provider.go
+++ b/provider/datadog/provider.go
@@ -25,6 +25,13 @@ var Spec = &httpproxy.ProviderSpec{
 		map[string]string{"api_key": "DD-API-KEY"},
 		map[string]string{"application_key": "DD-APPLICATION-KEY"},
 	),
+
+	// DD-APPLICATION-KEY is injected only when the credential carries one, so on
+	// a spec without an application key a caller's own value would otherwise
+	// reach the upstream beside Warden's DD-API-KEY — pairing an inbound
+	// credential with the mount's identity. DD-API-KEY needs no strip: it is
+	// injected on every request, and injection overwrites.
+	ExtraHeadersToRemove: []string{"DD-APPLICATION-KEY"},
 }
 
 // Factory creates a new Datadog provider backend.
@@ -57,11 +64,54 @@ the URL path:
 Request body parsing is enabled, allowing policies to evaluate Datadog
 request fields for fine-grained access control.
 
-Two credential source types are supported:
-- apikey: Static API key (stored in spec config as api_key) with an optional
-  application_key for endpoints that require it
-- hvault: Vault/OpenBao KV v2 secret containing api_key (and optionally
-  application_key); use mint_method=static_apikey on the spec
+Credential source types:
+- apikey: Static API key in spec config, optionally with an application_key
+- hvault: Vault/OpenBao KV v2 secret holding the API key; use
+  mint_method=static_apikey on the spec
+
+A large part of the Datadog API needs an application key alongside the API
+key. Both travel in one credential, and the source declares the second one:
+
+  warden cred source create datadog -type=apikey \
+    -config=api_url=https://api.datadoghq.com \
+    -config=optional_metadata=application_key
+
+  warden cred spec create datadog-prod -source=datadog \
+    -config=api_key=<DD_API_KEY> \
+    -config=application_key=<DD_APP_KEY>
+
+api_key is the only field a credential carries on its own; anything beside it
+travels because optional_metadata names it, and a spec setting application_key
+against a source that does not declare it is rejected at write.
+
+Only the apikey source resolves optional_metadata, so the spec that Warden
+mints must sit on one. Keeping the keys in a vault does not change that — it
+changes where the values come from. Point the spec at a referenced secret with
+credential chaining, and the apikey source resolves its declared fields from
+the fetched payload:
+
+  # holds both keys; lives on the hvault source
+  warden cred spec create datadog-keys -type=key_value -source=corp-vault \
+    -config=mint_method=kv2_read -config=kv2_mount=secret \
+    -config=secret_path=apikeys/datadog
+
+  # minted on the apikey source, which is what declares application_key
+  warden cred spec create datadog-keyless -source=datadog \
+    -config=secret_spec=datadog-keys
+
+No secret_field is needed when the secret stores the keys under their own
+names: api_key is found by name, and application_key is carried because the
+apikey source declares it.
+
+What will not work is mint_method=static_apikey against the hvault source
+directly. There the hvault source mints the credential itself, the apikey
+driver is never in the path, and nothing can declare a second field — the
+credential arrives holding api_key alone.
+
+Warden strips any DD-APPLICATION-KEY the caller sent before proxying, and
+injects its own only when the credential carries one. A caller therefore
+cannot supply an application key of their own to be used alongside the
+mount's API key.
 
 Configuration:
 - datadog_url: Datadog API base URL (default: https://api.datadoghq.com)

--- a/provider/datadog/provider.go
+++ b/provider/datadog/provider.go
@@ -74,17 +74,17 @@ key. Both travel in one credential, and the source declares the second one:
 
   warden cred source create datadog -type=apikey \
     -config=api_url=https://api.datadoghq.com \
-    -config=optional_metadata=application_key
+    -config=credential_fields=application_key
 
   warden cred spec create datadog-prod -source=datadog \
     -config=api_key=<DD_API_KEY> \
     -config=application_key=<DD_APP_KEY>
 
 api_key is the only field a credential carries on its own; anything beside it
-travels because optional_metadata names it, and a spec setting application_key
+travels because credential_fields names it, and a spec setting application_key
 against a source that does not declare it is rejected at write.
 
-Only the apikey source resolves optional_metadata, so the spec that Warden
+Only the apikey source resolves credential_fields, so the spec that Warden
 mints must sit on one. Keeping the keys in a vault does not change that — it
 changes where the values come from. Point the spec at a referenced secret with
 credential chaining, and the apikey source resolves its declared fields from

--- a/provider/prometheus/provider.go
+++ b/provider/prometheus/provider.go
@@ -24,7 +24,7 @@ const DefaultPrometheusTimeout = 30 * time.Second
 //     Prometheus, Thanos, Cortex) that accept bearer tokens.
 //
 // To forward the auth_type field from a spec config into credential data,
-// configure the apikey source with optional_metadata=auth_type.
+// configure the apikey source with credential_fields=auth_type.
 func prometheusExtractor(req *logical.Request) (map[string]string, error) {
 	if req.Credential == nil {
 		return nil, fmt.Errorf("no credential available")
@@ -78,7 +78,7 @@ proxied request. Auth mode is detected automatically from the credential data:
     Used for self-hosted Prometheus instances configured with
     --web.config.file basic auth. api_key must be the base64-encoded
     "username:password" string (e.g. base64("admin:secret")).
-    Configure your apikey source with optional_metadata=auth_type and
+    Configure your apikey source with credential_fields=auth_type and
     set auth_type=basic on the credential spec.
 
 This provider type supports the full Prometheus ecosystem by mounting
@@ -114,7 +114,7 @@ Example API paths:
 
 Credential source type:
 - apikey: Static bearer token or pre-encoded basic auth credentials.
-  For basic auth, set optional_metadata=auth_type on the source and
+  For basic auth, set credential_fields=auth_type on the source and
   include auth_type=basic in the spec config.
 
 Configuration:


### PR DESCRIPTION
Closes findings A1, A2 and B1, and records B8.

Four provider extractors read credential fields nothing could supply. The mechanism operators are told to use already existed and already worked — up to the last step. `optional_metadata` is documented as "spec config fields to copy into credential data", the apikey driver honours it, and three provider help texts instruct operators to set it. Then `Parse` ran and discarded everything outside the credential type's hardcoded list.

**The fix is to stop discarding it**, not to invent a mechanism.

## The mechanism (`3f0fe46`)

The driver records which names it resolved under a reserved rawData key, and the parser copies exactly those into the credential — the pattern the OAuth2 rotated-refresh-token keys already use. `api_key`'s `OptionalFields` is emptied: the type owns one field, every adjunct is declared, and a new provider field costs no change to the type. That is what closes the *class* rather than these four instances.

Every documented configuration already declares its adjuncts, so the emptied list breaks nothing documented — `local.md` shows `api_key` alone, and the apikey/openai/anthropic/mistral docs all show the declaration.

Two guards, both load-bearing and both verified by mutation:

- The declaration is **stripped before `Parse`**, because a lenient type such as `key_value` copies every key it is handed.
- It is honoured **only from the apikey driver**, because the vault and aws drivers return fetched secret payloads verbatim — so the key can arrive from a stored secret, and honouring it there would let whoever writes that secret decide what becomes credential data.

Three guards on configuration, because a credential quietly missing a field surfaces as a provider taking its fallback branch, which looks exactly like a working mount:

- A spec setting a field its source will not carry is rejected, with the fix in the message — and distinguishing "not declared" from "this source type cannot declare at all", since pointing a local-source operator at the declaration would send them to add a key that changes nothing.
- Narrowing a source's declaration under a bound spec is rejected, naming the stranded spec.
- A mint that had a known field available but did not carry it logs a warning — the only channel for a field arriving in a fetched payload, which no write-time check sees.

## The rename (`2618c4b`) — breaking

`optional_metadata` becomes `credential_fields`. "metadata" already means the opposite here: `Credential.Metadata` holds non-secret attributes that audit logs **in clear**, and says so — "Never put secret material here — that belongs in Data, which audit HMAC-salts". The fields this key names land in `Data`, and the flagship example is datadog's `application_key`, a secret.

No alias. An accepted-but-ignored key would leave the source declaring nothing and its specs minting without the fields they set. A source still using the old name is **rejected on write** with the new one named, and the mint-time warning covers deployments that are never re-written.

## The providers (`f639c90`)

datadog's `application_key` and atlassian's `email` now reach their extractors. datadog also strips `DD-APPLICATION-KEY`: it is injected only when the credential carries one, so a caller could otherwise pair an application key of their own with the mount's API key. Reachable inbound and unstripped outbound were one problem.

## The e2e (`68b8cb1`)

First coverage of `secret_spec` chaining anywhere in the suite: a whole datadog credential in one Vault KV secret, asserting both keys arrive as two upstream headers, plus a control driving the identical chain through a source that declares nothing.

The control asserts on `DD-APPLICATION-KEY` rather than an inert extra key, and that distinction is the row. A first attempt seeded an undeclared `owner` field and asserted no header carried it — which passed *with the field explicitly declared*, because datadog's extractor maps no such name. Only a field the provider would emit if it had it separates filtering the payload from copying it.

This needed `setup.sh` work, for a reason recorded as **B8**: a referenced spec must be minted as the session-pinned caller, which forces the exchange path, which on an hvault source requires `auth_method=oidc_federation`. The AppRole source every suite and tutorial uses **cannot** back a chained secret — a real constraint that no documentation states. Vault now has a JWT auth mount trusting Hydra and a second keyless source beside it, the suite's first use of workload identity federation.

## Verification

All unit suites plus e2e fullchain, credential, rotation, provider, userleg, auth, audit and namespace pass. Every new test was verified to fail against the unfixed binary before being trusted.

## Merge notes

- `fix/honeycomb-management-key` has one help-text line naming `optional_metadata`; whichever lands second needs it updated.
- `fix/spec-update-mask-roundtrip` touches `core/sys_credentials.go` in different functions — expect a textual conflict that resolves by keeping both.
- Five site docs still name `optional_metadata`. They are on the release-prep doc checklist, but the rename makes them wrong rather than merely stale.
