### PR TITLE
fix(core): keep an internal login off the caller's body and query

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -606,9 +606,19 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request, isI
 		req.MountAccessor = entry.Accessor
 	}
 
-	// Parse request body before CheckToken since req.Data may be used during token validation
-	if err := c.parseRequestBody(req); err != nil {
-		return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
+	// Parse request body before CheckToken since req.Data may be used during token validation.
+	//
+	// An internal login is exempt: its Data is not the caller's, it is the credential
+	// and role this request's own auth precedence resolved, and the HTTP request it
+	// carries belongs to the gateway call that triggered the login. Parsing here would
+	// merge that caller's query params and body keys into the resolved map — a body of
+	// {"role":"other"} or a ?role=other would pick the role the login authenticates
+	// against, through a channel that never reaches req.Path and so is invisible to
+	// both policy and the audit log.
+	if !isInternalLogin {
+		if err := c.parseRequestBody(req); err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
+		}
 	}
 
 	// Do an unauth check.

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -893,6 +893,75 @@ func TestHandleLoginRequest(t *testing.T) {
 	})
 }
 
+// TestHandleLoginRequest_InternalLoginIgnoresCallerBody pins the boundary between an
+// internal login's resolved Data and the caller's HTTP request.
+//
+// An internal login is built with Data already holding the credential and role that
+// the gateway request's own auth precedence resolved, and it reuses that request's
+// *http.Request for its TLS and forwarded-cert context. Parsing the body here would
+// merge the caller's query params and body keys into that resolved map, letting a
+// request body pick the role the login authenticates against. The substitution would
+// be invisible: unlike X-Warden-Role or a /role/{name}/ path segment, it never reaches
+// req.Path, so neither policy nor the audit entry would record which role was used.
+func TestHandleLoginRequest_InternalLoginIgnoresCallerBody(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	cases := []struct {
+		name   string
+		target string
+		body   string
+	}{
+		{"role in body", "/v1/gw/gateway/mcp", `{"role":"escalated"}`},
+		{"role in query", "/v1/gw/gateway/mcp?role=escalated", `{}`},
+		{"jwt in body", "/v1/gw/gateway/mcp", `{"jwt":"attacker-supplied"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The shape resolveTransparentIdentity builds.
+			httpReq := httptest.NewRequest(http.MethodPost, tc.target, strings.NewReader(tc.body))
+			httpReq.Header.Set("Content-Type", "application/json")
+			req := &logical.Request{
+				Path:        "auth/jwt/login",
+				Operation:   logical.UpdateOperation,
+				HTTPRequest: httpReq,
+				Data:        map[string]any{"jwt": "resolved-jwt", "role": "resolved-role"},
+			}
+
+			// The login itself fails — no mount is registered here — but the parse
+			// decision is made before that, which is what this asserts.
+			_, _, _ = core.handleLoginRequest(ctx, req, true)
+
+			assert.Equal(t, "resolved-role", req.Data["role"])
+			assert.Equal(t, "resolved-jwt", req.Data["jwt"])
+			assert.Len(t, req.Data, 2, "internal login Data must carry only what Warden resolved")
+		})
+	}
+}
+
+// TestHandleLoginRequest_ExplicitLoginParsesBody is the counterpart, and guards
+// against fixing the above too broadly: a real POST to auth/<mount>/login arrives with
+// no Data at all, and its body is the only place its credentials can come from.
+func TestHandleLoginRequest_ExplicitLoginParsesBody(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/auth/jwt/login",
+		strings.NewReader(`{"jwt":"caller-jwt","role":"caller-role"}`))
+	httpReq.Header.Set("Content-Type", "application/json")
+	req := &logical.Request{
+		Path:        "auth/jwt/login",
+		Operation:   logical.UpdateOperation,
+		HTTPRequest: httpReq,
+	}
+
+	_, _, _ = core.handleLoginRequest(ctx, req, false)
+
+	assert.Equal(t, "caller-jwt", req.Data["jwt"])
+	assert.Equal(t, "caller-role", req.Data["role"])
+}
+
 // TestHandleNonLoginRequest_ParsesBody tests that handleNonLoginRequest parses body before CheckToken
 func TestHandleNonLoginRequest_ParsesBody(t *testing.T) {
 	core := createTestCore(t)

--- a/e2e/fullchain/mcp_test.go
+++ b/e2e/fullchain/mcp_test.go
@@ -139,22 +139,18 @@ func TestMCP_DeniedToolIsRefusedBeforeTheUpstream(t *testing.T) {
 }
 
 // TestMCP_MalformedBodyIsRefused checks that a truncated body is refused with
-// nothing forwarded. It does NOT test the mcp { } filter, despite the shape:
-// the request never reaches policy evaluation, because the body is unmarshalled
-// into a map while the agent is still being authenticated, and a truncated body
-// fails that decode first. The same request would 401 with no mcp { } block at
-// all.
+// nothing forwarded, and that the refusal comes from the filter.
 //
-// What it is worth having as a row: refusal reaches the caller with nothing
-// proxied, which is the property that must survive whatever happens to the
-// authorization path. The status is the generic 401 of a failed agent login, not
-// the 403 the filter returns. That early decode into a map is also why a valid
-// JSON-RPC batch cannot be proxied at all: a top-level JSON array does not fit
-// the shape, so it fails the same way before policy is ever consulted.
+// It used to answer 401. The agent's implicit login reused the caller's HTTP
+// request and decoded its body while resolving the agent's identity, so a body
+// the generic decoder could not read failed the login — telling the caller to
+// renew a credential that was never the problem. The login no longer reads the
+// caller's body, so the request authenticates and the strict JSON-RPC parser is
+// what rejects it: a 403 carrying the policy deny challenge.
 func TestMCP_MalformedBodyIsRefused(t *testing.T) {
 	ensureEnv(t)
 
-	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+	status, body, respHeaders := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
 		AgentCertPEM: agentCert(t),
 		Bearer:       h.FullChainUserJWT(t),
 		Role:         mcpEnv.CertRole(),
@@ -162,20 +158,26 @@ func TestMCP_MalformedBodyIsRefused(t *testing.T) {
 	})
 
 	h.AssertChain(t, upstream, status, body, h.ChainWant{
-		Status:        401,
+		Status:        403,
 		UpstreamCalls: 0,
 	})
+
+	// Without this the row would pass on any refusal for any reason, which is
+	// exactly how it read as correct while answering 401.
+	if challenge := respHeaders.Get("WWW-Authenticate"); !strings.Contains(challenge, "insufficient_permissions") {
+		t.Errorf("want the policy deny challenge, got WWW-Authenticate: %q", challenge)
+	}
 }
 
-// TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy is the fail-closed row the
-// truncated-body case cannot be. A duplicate key is accepted by the generic
-// decoder — last one wins — so the request survives authentication and reaches
-// the filter, where the strict JSON-RPC parser rejects it.
+// TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy pins the same fail-closed
+// property from the other side: a body that is well-formed JSON but not
+// well-formed JSON-RPC. A duplicate key is what separates the two parsers —
+// last-one-wins for a generic decoder, a refusal for the strict one.
 //
 // That is the property worth pinning: a body the filter cannot interpret is
 // denied rather than waved through as "no rule matched", which is how a filter
-// of this shape usually breaks. Unlike the truncated body, this row would pass
-// differently with the mcp { } block removed.
+// of this shape usually breaks. This row would pass differently with the
+// mcp { } block removed.
 func TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy(t *testing.T) {
 	ensureEnv(t)
 


### PR DESCRIPTION
## Problem

An implicit-auth (transparent mode) login is built by Warden, not by the caller: its `Data` holds the credential and role that the gateway request's own auth precedence resolved, and it reuses that request's `*http.Request` for TLS and forwarded-cert context.

`handleLoginRequest` then parsed that HTTP request into the same map. `parseRequestBody` saw a non-nil `Data`, skipped the re-init, and merged the caller's query params and then their body keys over it. A gateway request with `{"role":"other"}` in its body, or `?role=other` in its URL, therefore picked the role its own login authenticated against.

The override is consumed end to end: the JWT backend reads `roleName := d.Get("role")` and validates against that role's bound claims, and the post-login lookup reads `loginResp.Auth.RoleName` — which the backend set from the overridden value — so it follows the override and returns the escalated token as the request's primary principal.

## Scope of the impact

Stated plainly, because it is narrower than it first looks:

- The caller reaches only roles their own credential already satisfies (`bound_subject` / `bound_audiences` / `bound_claims`). It is role **selection**, not unbounded escalation.
- The pre-login cache lookup keys on the originally resolved role, so a cache hit skips the override. It still fires reliably on a fresh credential, because the minted token is stored under the *overridden* role key and the original-role cache stays cold.

What makes it worth closing is the channel asymmetry. Role selection via `X-Warden-Role` or a `/role/{name}/` path segment is reflected in `req.Path` and visible to CEL conditions and to the audit entry. This one changes only the internal login and leaves `req.Path` pointing at the innocuous role — so neither policy nor audit records which role was actually used.

## The change

`handleLoginRequest` already took an `isInternalLogin bool`, passed `true` from exactly this call site. The parse is gated on it.

Explicit `POST /v1/auth/<mount>/login` requests are untouched — their body is the only place their credentials come from — and the cert/TLS context the auth mounts read still travels on `req.HTTPRequest`.

## Behavioural change reviewers should know about

`TestMCP_MalformedBodyIsRefused` moves from **401 to 403**, and is updated here.

mcp sets `ParseStreamBody: false`, so the generic body parse never ran for it — the *login* was what decoded the caller's body. A malformed JSON-RPC body failed that decode and surfaced as a failed agent login: a 401 telling the caller to renew a credential that was never the problem. With the login off the caller's body the request authenticates, and the strict JSON-RPC parser is what refuses it — a 403 carrying the policy deny challenge, which the row now asserts rather than accepting any refusal for any reason.

That row had documented the 401 as expected behaviour, which is how a misleading status survives a suite.

## Verification

- `TestHandleLoginRequest_InternalLoginIgnoresCallerBody` — role via body, role via query, `jwt` via body. All three verified to fail against the previous binary.
- `TestHandleLoginRequest_ExplicitLoginParsesBody` — the counterpart, guarding against fixing this too broadly. Passes before and after.
- Full unit suite (`go test ./...`) and full e2e suite green.

Found while investigating `e2e/FINDINGS.md` B2. The array-body half of that finding is a separate PR stacked on this one.
