### PR TITLE
fix(core,http): carry a non-object JSON request body, and answer 4xx when one is refused

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -617,7 +617,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request, isI
 	// both policy and the audit log.
 	if !isInternalLogin {
 		if err := c.parseRequestBody(req); err != nil {
-			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
+			return logical.ErrorResponse(err), nil, nil
 		}
 	}
 
@@ -807,7 +807,7 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 
 	if !isStreaming {
 		if err := c.parseRequestBody(req); err != nil {
-			return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
+			return logical.ErrorResponse(err), nil, nil
 		}
 		req.ClientToken = extractToken(req.HTTPRequest)
 
@@ -865,7 +865,7 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		// so the streaming handler can still read it.
 		if parser, ok := matchingBackend.(logical.StreamBodyParser); ok && parser.ShouldParseStreamBody(req.HTTPRequest) {
 			if err := c.parseRequestBody(req); err != nil {
-				return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil, err
+				return logical.ErrorResponse(err), nil, nil
 			}
 		}
 
@@ -1200,7 +1200,41 @@ func (c *Core) parseBody(req *logical.Request) error {
 	}
 }
 
-// parseJSONBody parses the JSON body of the request into req.Data
+// readAndRestoreBody buffers the request body under the size cap and puts it back, so
+// everything downstream — the proxy to the upstream, the MCP extractor, audit — still
+// reads it whole.
+//
+// Its errors are coded. A body Warden cannot buffer or parse is the caller's problem,
+// and an uncoded error reaches the wire as a 500 that blames Warden for it.
+func (c *Core) readAndRestoreBody(req *logical.Request) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(req.HTTPRequest.Body, maxRequestBodySize+1))
+	if err != nil {
+		c.logger.Debug("failed to read request body",
+			logger.Err(err),
+			logger.String("path", req.Path),
+		)
+		return nil, logical.ErrBadRequest("failed to read request body")
+	}
+	req.HTTPRequest.Body.Close()
+
+	if int64(len(body)) > maxRequestBodySize {
+		return nil, logical.ErrRequestEntityTooLargef("request body exceeds maximum size of %d bytes", maxRequestBodySize)
+	}
+
+	// Restore body for potential re-reading (audit, streaming, etc.)
+	req.HTTPRequest.Body = io.NopCloser(bytes.NewReader(body))
+
+	return body, nil
+}
+
+// parseJSONBody parses the JSON body of the request into req.Data.
+//
+// Only a top-level object contributes fields. A top-level array or scalar is
+// legitimate JSON — it is the request shape for batch, bulk and series endpoints, and
+// for JSON-RPC batches — so it parses successfully and contributes nothing: req.Data
+// keeps the query params alone, and the body reaches the upstream as the bytes
+// restored above. Decoding straight into req.Data would instead fail those requests
+// against the map's shape, before they were even authorised.
 func (c *Core) parseJSONBody(req *logical.Request) error {
 	if req.HTTPRequest.Body == nil {
 		return nil
@@ -1211,24 +1245,35 @@ func (c *Core) parseJSONBody(req *logical.Request) error {
 		return nil // Not JSON, skip
 	}
 
-	body, err := io.ReadAll(io.LimitReader(req.HTTPRequest.Body, maxRequestBodySize+1))
+	body, err := c.readAndRestoreBody(req)
 	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
+		return err
 	}
-	req.HTTPRequest.Body.Close()
-
-	if int64(len(body)) > maxRequestBodySize {
-		return fmt.Errorf("request body exceeds maximum size of %d bytes", maxRequestBodySize)
-	}
-
-	// Restore body for potential re-reading (audit, streaming, etc.)
-	req.HTTPRequest.Body = io.NopCloser(bytes.NewReader(body))
 
 	if len(body) == 0 {
 		return nil
 	}
 
-	return json.Unmarshal(body, &req.Data)
+	var root any
+	if err := json.Unmarshal(body, &root); err != nil {
+		// The decoder's message names Go types. That is a diagnostic, not an API
+		// contract — keep it in the log and answer with a stable one.
+		c.logger.Debug("request body is not valid JSON",
+			logger.Err(err),
+			logger.String("path", req.Path),
+		)
+		return logical.ErrBadRequest("request body is not valid JSON")
+	}
+
+	obj, ok := root.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for k, v := range obj {
+		req.Data[k] = v
+	}
+
+	return nil
 }
 
 // parseFormBody parses application/x-www-form-urlencoded body into req.Data.
@@ -1238,18 +1283,10 @@ func (c *Core) parseFormBody(req *logical.Request) error {
 		return nil
 	}
 
-	body, err := io.ReadAll(io.LimitReader(req.HTTPRequest.Body, maxRequestBodySize+1))
+	body, err := c.readAndRestoreBody(req)
 	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
+		return err
 	}
-	req.HTTPRequest.Body.Close()
-
-	if int64(len(body)) > maxRequestBodySize {
-		return fmt.Errorf("request body exceeds maximum size of %d bytes", maxRequestBodySize)
-	}
-
-	// Restore body for potential re-reading (audit, streaming, etc.)
-	req.HTTPRequest.Body = io.NopCloser(bytes.NewReader(body))
 
 	if len(body) == 0 {
 		return nil
@@ -1257,7 +1294,11 @@ func (c *Core) parseFormBody(req *logical.Request) error {
 
 	values, err := url.ParseQuery(string(body))
 	if err != nil {
-		return fmt.Errorf("failed to parse form body: %w", err)
+		c.logger.Debug("request body is not valid form data",
+			logger.Err(err),
+			logger.String("path", req.Path),
+		)
+		return logical.ErrBadRequest("request body is not valid form data")
 	}
 
 	for k, v := range values {

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -744,6 +744,87 @@ func TestParseJSONBody(t *testing.T) {
 	})
 }
 
+// TestParseJSONBody_NonObjectTopLevel covers the request shapes that used to die
+// against req.Data's map type: a top-level array — the body of a batch, a bulk write,
+// a metrics series submission, a JSON-RPC batch — and top-level scalars. None of them
+// can contribute fields to a map keyed by string, so none of them does; what matters
+// is that they parse, leave the query params alone, and reach the upstream unchanged.
+func TestParseJSONBody_NonObjectTopLevel(t *testing.T) {
+	core := createTestCore(t)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"array of objects", `[{"any":"array"}]`},
+		{"jsonrpc batch", `[{"jsonrpc":"2.0","id":1,"method":"tools/list"},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]`},
+		{"empty array", `[]`},
+		{"string", `"scalar"`},
+		{"number", `42`},
+		{"bool", `true`},
+		{"null", `null`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpReq := httptest.NewRequest(http.MethodPost, "/v1/test?q=1", strings.NewReader(tc.body))
+			httpReq.Header.Set("Content-Type", "application/json")
+			req := &logical.Request{HTTPRequest: httpReq}
+
+			require.NoError(t, core.parseRequestBody(req))
+			assert.Equal(t, map[string]any{"q": "1"}, req.Data,
+				"a non-object body contributes no fields, and invents none")
+
+			restored, err := io.ReadAll(req.HTTPRequest.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tc.body, string(restored), "the upstream must receive the body unchanged")
+		})
+	}
+}
+
+// TestParseRequestBody_ErrorsAreCodedAndOpaque pins both halves of the answer a caller
+// gets for a body Warden will not take: a status that says whose fault it is, and a
+// message that does not hand them a Go type name as an API contract.
+func TestParseRequestBody_ErrorsAreCodedAndOpaque(t *testing.T) {
+	core := createTestCore(t)
+
+	t.Run("malformed JSON is 400", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(`{"invalid json`))
+		httpReq.Header.Set("Content-Type", "application/json")
+		req := &logical.Request{HTTPRequest: httpReq}
+
+		err := core.parseRequestBody(req)
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, logical.GetErrorCode(err))
+		assert.NotContains(t, err.Error(), "map[string]")
+		assert.NotContains(t, err.Error(), "interface {}")
+	})
+
+	t.Run("malformed form body is 400", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(`name=%zz`))
+		httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req := &logical.Request{HTTPRequest: httpReq}
+
+		err := core.parseRequestBody(req)
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, logical.GetErrorCode(err))
+	})
+
+	// 413, not 400: the request is well-formed, it is only too big, and the caller
+	// needs to know shrinking it is the remedy. An uncoded error here would reach the
+	// wire as a 500 and blame Warden for the caller's payload.
+	t.Run("oversized body is 413", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/test",
+			bytes.NewReader(bytes.Repeat([]byte("a"), maxRequestBodySize+1)))
+		httpReq.Header.Set("Content-Type", "application/json")
+		req := &logical.Request{HTTPRequest: httpReq}
+
+		err := core.parseRequestBody(req)
+		require.Error(t, err)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, logical.GetErrorCode(err))
+	})
+}
+
 // TestIsStreamingRequest tests the isStreamingRequest function
 func TestIsStreamingRequest(t *testing.T) {
 	core := createTestCore(t)

--- a/e2e/fullchain/chain_test.go
+++ b/e2e/fullchain/chain_test.go
@@ -197,6 +197,79 @@ func TestFullChain_AuthorizationNeverReachesUpstream(t *testing.T) {
 	}
 }
 
+// TestFullChain_ArrayBodyIsProxied covers the request shape that no mount could
+// carry: a body whose top-level JSON value is an array. Batch endpoints, bulk
+// writes and metrics series all send one, and the authorization path decoded every
+// body into a string-keyed map — a shape an array cannot satisfy — so the request
+// died with the decoder's own message before it was ever authorised.
+//
+// Two carriers rather than one because the fault was in code every mount shares: a
+// fix that only reached the mount it was tested against would not be one.
+func TestFullChain_ArrayBodyIsProxied(t *testing.T) {
+	ensureEnv(t)
+
+	cases := []struct {
+		env  h.ProviderEnv
+		want map[string]string
+		body string
+	}{
+		{openaiEnv, map[string]string{"Authorization": "Bearer " + openaiKey},
+			`[{"custom_id":"a","method":"POST"},{"custom_id":"b","method":"POST"}]`},
+		{datadogEnv, map[string]string{"DD-API-KEY": datadogAPIKey},
+			`[{"metric":"e2e.probe","points":[[1,2]]}]`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.env.Mount, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, tc.env, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         tc.env.CertRole(),
+				Body:         tc.body,
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Injected:      tc.want,
+				Absent:        h.AlwaysAbsent(),
+				UpstreamCalls: 1,
+			})
+
+			// A 200 would also be returned for a body Warden mangled on the way
+			// through, and an array is only worth carrying if it arrives intact.
+			reqs := upstream.Requests()
+			if got := string(reqs[len(reqs)-1].Body); got != tc.body {
+				t.Errorf("upstream body: got %s, want %s", got, tc.body)
+			}
+		})
+	}
+}
+
+// TestFullChain_MalformedBodyIsARequestError pins what a caller is told when their
+// body is not JSON at all. It used to be a 500 quoting a Go type name: the wrong
+// party blamed, and an internal type handed over as if it were the API contract.
+func TestFullChain_MalformedBodyIsARequestError(t *testing.T) {
+	ensureEnv(t)
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, openaiEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         openaiEnv.CertRole(),
+		Body:         `{"truncated":`,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        400,
+		UpstreamCalls: 0,
+	})
+	if strings.Contains(string(body), "map[string]") || strings.Contains(string(body), "interface {}") {
+		t.Errorf("response hands the caller a Go type name as an API contract: %s", body)
+	}
+}
+
 // TestFullChain_OperatorTokenPlusUserIsRejected pins the gate that fires before
 // any token extractor runs. The operator credential carries no user principal,
 // so combining it with an Authorization credential on a mount that expects one

--- a/e2e/fullchain/mcp_test.go
+++ b/e2e/fullchain/mcp_test.go
@@ -3,6 +3,7 @@
 package fullchain
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -60,7 +61,11 @@ var mcpGitHubEnv = h.ProviderEnv{
 }
 
 func mcpToolCall(tool string) string {
-	return `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + tool + `"}}`
+	return mcpToolCallID(tool, 1)
+}
+
+func mcpToolCallID(tool string, id int) string {
+	return `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"` + tool + `"}}`
 }
 
 // TestMCP_AllowedToolReachesUpstream is the positive half. It also confirms the
@@ -82,6 +87,65 @@ func TestMCP_AllowedToolReachesUpstream(t *testing.T) {
 		Injected:      map[string]string{"Authorization": "Bearer " + mcpAPIKey},
 		Absent:        h.AlwaysAbsent(),
 		UpstreamCalls: 1,
+	})
+}
+
+// TestMCP_BatchIsProxied is the end-to-end half of core's TestMCPE2E_BatchAllAllowed.
+//
+// A JSON-RPC batch is a top-level JSON array, and no mount could carry one: the
+// authorization path decoded every request body into a string-keyed map, which an
+// array cannot be, and the request died there. The unit tests exercised batches by
+// calling the extractor directly, so they passed throughout — this row is the only
+// place the wiring is checked.
+//
+// Every call names the allowed tool, so the batch is allowed whole. It must also
+// arrive whole: a batch that authorised but reached the upstream re-serialised or in
+// pieces would be a different bug wearing the same 200.
+func TestMCP_BatchIsProxied(t *testing.T) {
+	ensureEnv(t)
+	upstream.Reset()
+
+	batch := `[` + mcpToolCallID(mcpAllowedTool, 1) + `,` + mcpToolCallID(mcpAllowedTool, 2) + `]`
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         batch,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + mcpAPIKey},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	reqs := upstream.Requests()
+	if got := string(reqs[len(reqs)-1].Body); got != batch {
+		t.Errorf("upstream body: got %s, want %s", got, batch)
+	}
+}
+
+// TestMCP_BatchWithDeniedCallIsRefused is the counterpart, and the reason the row
+// above is not enough on its own: now that a batch can be carried, the filter has to
+// still read every call in it. One denied tool among allowed ones refuses the whole
+// batch, before anything is forwarded — a filter that inspected only the first call
+// would pass the row above and leak here.
+func TestMCP_BatchWithDeniedCallIsRefused(t *testing.T) {
+	ensureEnv(t)
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpEnv.CertRole(),
+		Body:         `[` + mcpToolCallID(mcpAllowedTool, 1) + `,` + mcpToolCallID(mcpDeniedTool, 2) + `]`,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        403,
+		UpstreamCalls: 0,
 	})
 }
 

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -3,6 +3,7 @@
 package helpers
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/tls"
 	"encoding/json"
@@ -158,6 +159,10 @@ type UpstreamRequest struct {
 	Path     string
 	RawQuery string
 	Header   http.Header
+	// Body is what the upstream was sent, byte for byte. Warden buffers and
+	// re-serves the request body on the way through, so this is the only place
+	// from which "the caller's body survived that round trip" can be checked.
+	Body []byte
 }
 
 // RecordingUpstream stands in for a provider's real API. It keeps what it was
@@ -203,12 +208,18 @@ func StartRecordingUpstream(t *testing.T) *RecordingUpstream {
 	t.Helper()
 	u := &RecordingUpstream{}
 	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Buffer the body to record it, then put it back: a handler installed by
+		// SetHandler reads the same request, and it must not find it drained.
+		body, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
 		u.mu.Lock()
 		u.reqs = append(u.reqs, UpstreamRequest{
 			Method:   r.Method,
 			Path:     r.URL.Path,
 			RawQuery: r.URL.RawQuery,
 			Header:   r.Header.Clone(),
+			Body:     body,
 		})
 		custom := u.handler
 		u.mu.Unlock()

--- a/http/logical.go
+++ b/http/logical.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/middleware"
-	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/core"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
@@ -158,19 +157,14 @@ func extractClientIP(r *http.Request) string {
 }
 
 // errorToStatusCode maps errors to appropriate HTTP status codes.
+//
+// It defers to logical.GetErrorCode rather than keeping its own switch. The two
+// used to be maintained as mirrors, and had drifted: the audit side honours an
+// error carrying its own status, this side did not, so a handler that returned
+// one as its error was recorded with the status it asked for and answered 500 on
+// the wire. Sharing the mapping is what stops that recurring.
 func errorToStatusCode(err error) int {
-	switch {
-	case errors.Is(err, sdklogical.ErrUnsupportedOperation):
-		return http.StatusMethodNotAllowed
-	case errors.Is(err, sdklogical.ErrUnsupportedPath):
-		return http.StatusNotFound
-	case errors.Is(err, sdklogical.ErrPermissionDenied):
-		return http.StatusForbidden
-	case errors.Is(err, sdklogical.ErrInvalidRequest):
-		return http.StatusBadRequest
-	default:
-		return http.StatusInternalServerError
-	}
+	return logical.GetErrorCode(err)
 }
 
 // writeLogicalResponse writes the logical.Response to the HTTP response.

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -662,6 +662,22 @@ func TestErrorToStatusCode_WrappedErrors(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, errorToStatusCode(wrapped4))
 }
 
+// TestErrorToStatusCode_CodedError covers the class this function used to drop on
+// the floor. A handler that returns an error carrying its own status was answered
+// with a 500, while the audit entry for the same request recorded the status the
+// handler asked for — the two mappings had drifted apart. They are one mapping now,
+// so these cases hold by construction rather than by both being edited together.
+func TestErrorToStatusCode_CodedError(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, errorToStatusCode(logical.ErrBadRequest("bad")))
+	assert.Equal(t, http.StatusNotFound, errorToStatusCode(logical.ErrNotFoundf("no handler for path %q", "x")))
+	assert.Equal(t, http.StatusConflict, errorToStatusCode(logical.ErrConflict("exists")))
+	assert.Equal(t, http.StatusUnauthorized, errorToStatusCode(logical.ErrUnauthorized("who")))
+
+	// Wrapped, because a coded error rarely reaches here bare.
+	assert.Equal(t, http.StatusBadRequest,
+		errorToStatusCode(logical.WrapWithCode(http.StatusBadRequest, errors.New("inner"))))
+}
+
 // =============================================================================
 // writeLogicalResponse Tests (Err, Data, Streamed)
 // =============================================================================

--- a/logical/errors.go
+++ b/logical/errors.go
@@ -59,6 +59,11 @@ func ErrNotFoundf(format string, args ...any) *CodedError {
 	return &CodedError{Status: http.StatusNotFound, Message: fmt.Sprintf(format, args...)}
 }
 
+// ErrRequestEntityTooLargef creates a formatted 413 Request Entity Too Large error.
+func ErrRequestEntityTooLargef(format string, args ...any) *CodedError {
+	return &CodedError{Status: http.StatusRequestEntityTooLarge, Message: fmt.Sprintf(format, args...)}
+}
+
 // ErrConflict creates a 409 Conflict error.
 func ErrConflict(message string) *CodedError {
 	return &CodedError{Status: http.StatusConflict, Message: message}

--- a/logical/errors.go
+++ b/logical/errors.go
@@ -127,9 +127,10 @@ func GetErrorCode(err error) int {
 	// Recognise the SDK sentinel errors so their HTTP status survives being
 	// wrapped in an ErrorResponse — otherwise a permission denial (or any
 	// sentinel) recorded in the audit log falls through to 500 even though the
-	// wire response is correct. Mirrors http.errorToStatusCode so the audit
-	// status and the wire status can't drift. errors.Is traverses wrapping,
-	// including multierror, so a wrapped or appended sentinel still matches.
+	// wire response is correct. This is the single mapping: http's
+	// errorToStatusCode calls straight through to it, so the audit status and the
+	// wire status cannot drift. errors.Is traverses wrapping, including
+	// multierror, so a wrapped or appended sentinel still matches.
 	switch {
 	case errors.Is(err, sdklogical.ErrPermissionDenied):
 		return http.StatusForbidden


### PR DESCRIPTION
Stacked on #506 — that PR is the base. Review this one for the three commits it adds.

Closes `e2e/FINDINGS.md` **B2**.

## Problem

A gateway request whose body is a JSON **array** failed on every provider, before reaching the upstream:

| Mount | Body | Result |
|---|---|---|
| `fc-openai` | `[{"any":"array"}]` | **500** `json: cannot unmarshal array into Go value of type map[string]interface {}` |
| `fc-datadog` | `[{"any":"array"}]` | **500**, same message |
| `fc-mcp` | valid JSON-RPC batch | **401**, same message |

Arrays are not an exotic body. They are the request shape for OpenAI batch endpoints, Datadog series submission, bulk writes, and JSON-RPC batches — the last of which Warden's own strict parser supports and `TestMCPE2E_BatchAllAllowed` exercises. No mount could carry any of them, and core's batch tests passed throughout because they call the extractor directly.

## Root cause

One line, in `parseJSONBody`:

```go
return json.Unmarshal(body, &req.Data)
```

`req.Data` is `map[string]any`, so any top-level JSON value that is not an object fails to decode. This runs before `CheckToken` — deliberately, so policy can see the body.

FINDINGS guessed at two causes and got both wrong. There were two, but not those:

- The **`fc-mcp` 401** was not this parse site at all. mcp sets `ParseStreamBody: false`, so it never fires there; its transparent-auth login was decoding the caller's body. That is #506, and it had to be its own change because the same merge was a policy-gating bypass.
- The **500 and the Go type name** were one bug, not two. All three parse sites constructed a 400 *and* returned the error; a non-nil error short-circuits `http/logical.go` before the response is written, so `errorToStatusCode`'s `default` answered 500 with the decoder's message as the body.

## The changes

### `fix(http): give an error the status it carries, not 500`

`errorToStatusCode` and `logical.GetErrorCode` were written as mirrors of each other — the comment on `GetErrorCode` said so — and had drifted. `GetErrorCode` honours a `*logical.CodedError`; `errorToStatusCode` recognised only the four SDK sentinels and answered 500 for everything else. So a handler returning an error that carried its own status was recorded in the audit log with the status it asked for and answered 500 on the wire: two records of one request disagreeing.

Two mappings kept in step by hand is the fault, not either mapping. There is one now — `errorToStatusCode` calls straight through to `GetErrorCode`, which already handled every case it did.

**Status changes reviewers should know about.** Anything returning a coded error *as an error* now gets that status instead of 500. The one live instance found: an unmounted streaming path returned `ErrNotFoundf` and answered 500 rather than 404. Duplicate mounts and duplicate creates return 409 rather than 500; several e2e helpers already accepted 409 as "already exists", so they only become more tolerant.

### `fix(core): carry a request body whose top-level JSON value is not an object`

`parseJSONBody` decodes into an `any` and contributes fields only when the top-level value is an object. An array or scalar parses, leaves `req.Data` holding the query params, and travels on as the bytes already restored.

Object bodies are unaffected: the same decoder produces the same values, and copying them in reproduces the merge-over-query-params the map unmarshal did.

Two things this also settles:

- A `null` body used to nil `req.Data` outright — unmarshalling `null` through a pointer clears the target — silently discarding query params parsed into it a few lines earlier.
- Every parse failure was uncoded, so all of them answered 500 whatever the call site constructed. They carry their status now: **400** for a body that is not JSON or not form data, **413** for one over the size cap. The decoder's own text stays in the debug log, where a Go type name belongs.

The read-and-restore both parsers duplicated is one helper, since both now need it to return the same coded errors.

**Scope limit.** `parseBody` routes an *empty* Content-Type to the JSON parser, so an untyped body that is not JSON — raw text, a binary upload with no Content-Type — still fails, now with a 400 rather than a 500. Only a body with an explicitly non-JSON, non-form Content-Type reaches the pass-through branch. This makes *JSON* bodies of any shape work; it does not make untyped non-JSON bodies proxyable.

### Deliberately not done: a `request.body` CEL binding

An array body carries no `request.data.*` fields, so a condition referencing one hits a missing key and `evalCELCondition` denies — arrays stay fail-closed under existing policy.

The corollary, worth naming rather than discovering later: a mount whose policy gates on `request.data.*` will now **deny** array bodies instead of 500-ing on them, and there is no per-element CEL for a batch. This makes arrays proxyable on mounts that do not gate on body content; mounts that do would need a `request.body` binding, which is a separate decision.

### `test(e2e): assert an array body and a JSON-RPC batch reach the upstream`

The rows FINDINGS said did not exist, because the shapes they cover did not work:

- `TestFullChain_ArrayBodyIsProxied` — two carriers, because the fault was in code every mount shares.
- `TestMCP_BatchIsProxied` and `TestMCP_BatchWithDeniedCallIsRefused` — a filter reading only the first element would pass the positive row and leak on the second.
- `TestFullChain_MalformedBodyIsARequestError` — asserts the caller is told it is their request that is wrong, and is not handed a Go type name as the API contract.

Each asserts the body **arrived intact**, not merely that the request was allowed: a 200 is also what a mangled body would return. That needed the recording upstream to keep request bodies, which it did not; it now records and restores them, so a handler installed by `SetHandler` still finds the body to read.

## Verification

- Full unit suite (`go test ./...`) green.
- Full e2e suite green, twice on this branch, plus a control run on unmodified `main`.
- New unit coverage: `TestParseJSONBody_NonObjectTopLevel` (array, JSON-RPC batch, empty array, string, number, bool, null — each asserting `req.Data` keeps only the query params and the body is byte-identical afterwards) and `TestParseRequestBody_ErrorsAreCodedAndOpaque` (400 / 400 / 413, and no `map[string]` or `interface {}` in the message). All verified to fail against the previous binary.
- `TestErrorToStatusCode_CodedError` covers the class the old switch dropped.

One flake seen and not reproduced: `e2e/provider` failed once with `409 path is already in use at cert/`, which did not recur in a subsequent full run on this branch, does not occur package-by-package, and does not occur on `main`. It looks like a race between `TeardownFullChainCommonBestEffort`'s asynchronous unmount and the HA churn in the packages that run in between — a test-suite issue rather than a product one, noted here so it is not silently forgotten.

## Not included

No doc changes, per the release-prep convention. For that pass: gateway request bodies are no longer required to be JSON objects, and a body Warden rejects answers 400/413 with a stable message.
