### PR TITLE
fix(dualgateway): apply the whole config surface, on every path that applies it

### DIFF
--- a/e2e/provider/dualgateway_test.go
+++ b/e2e/provider/dualgateway_test.go
@@ -1,0 +1,327 @@
+//go:build e2e
+
+package provider
+
+import (
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509/pkix"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The dual-mode gateway providers — scaleway, ovh, cloudflare, ibmcloud — were
+// unreachable by this suite until the config apply path was fixed. Two defects
+// closed off every ordering: the upstream URL could only be set at mount time,
+// the agent leg only by a later config write, and that write reset every key it
+// did not name, including the URL.
+//
+// These rows drive scaleway, standing in for all four: they share one SDK, and
+// the config path is entirely inside it.
+
+const (
+	dgMount     = "dg-scaleway"
+	dgRole      = "dg-agent"
+	dgAgentCN   = "dg-agent-cert"
+	dgAccessKey = "SCWE2EACCESSKEY00000"
+	dgSecretKey = "e2e-secret-0000-0000-000000000000"
+)
+
+// setupDualGateway mounts scaleway pointed at upstreamURL and rigs the agent leg
+// that lets a request through it: a cert role bound to a credential spec, and a
+// policy granting the gateway path.
+//
+// extraConfig is merged into the *mount-time* configuration, which is the point
+// of the exercise — a mount arriving fully configured in one step is only
+// possible once mount-time transparent-auth settings are honoured.
+func setupDualGateway(t *testing.T, port int, upstreamURL string, extraConfig map[string]any) string {
+	t.Helper()
+
+	teardownDualGateway(t, port)
+	// Unmounting an auth method and remounting it in the same breath races the
+	// auth table update and answers 500. Other tests in this package tear down
+	// auth/cert on their way out, so this settles before claiming it again.
+	time.Sleep(time.Second)
+
+	caCertPEM, caKey := h.SetupCertAuth(t, port)
+	t.Cleanup(func() { teardownDualGateway(t, port) })
+
+	cfg := map[string]any{
+		"scaleway_url":   upstreamURL,
+		"auto_auth_path": "auth/cert/",
+		"default_role":   dgRole,
+	}
+	for k, v := range extraConfig {
+		cfg[k] = v
+	}
+
+	mustDG(t, port, "POST", "sys/providers/"+dgMount, mustJSONBody(t, map[string]any{
+		"type":        "scaleway",
+		"description": "e2e dual-mode gateway",
+		"config":      cfg,
+	}), "mount scaleway provider")
+	time.Sleep(time.Second)
+
+	mustDG(t, port, "POST", "sys/cred/sources/"+dgMount+"-src",
+		`{"type":"local"}`, "create credential source")
+
+	mustDG(t, port, "POST", "sys/cred/specs/"+dgMount+"-cred", mustJSONBody(t, map[string]any{
+		"type":   "scaleway_keys",
+		"source": dgMount + "-src",
+		"config": map[string]string{
+			"access_key": dgAccessKey,
+			"secret_key": dgSecretKey,
+		},
+	}), "create credential spec")
+
+	policy := fmt.Sprintf(
+		"path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\n"+
+			"path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}\n",
+		dgMount+"/gateway*", dgMount+"/role/+/gateway*")
+	mustDG(t, port, "POST", "sys/policies/cbp/"+dgMount+"-access",
+		mustJSONBody(t, map[string]any{"policy": policy}), "create policy")
+
+	mustDG(t, port, "POST", "auth/cert/role/"+dgRole, mustJSONBody(t, map[string]any{
+		"allowed_common_names": []string{dgAgentCN},
+		"token_policies":       []string{dgMount + "-access"},
+		"cred_spec_name":       dgMount + "-cred",
+		"token_ttl":            3600,
+	}), "create cert role")
+
+	clientCertPEM, _ := h.GenerateClientCert(t, caCertPEM, caKey, dgAgentCN)
+	return clientCertPEM
+}
+
+// teardownDualGateway removes everything setup creates, ignoring what is not
+// there. Run before setup as well as after: a run that failed midway would
+// otherwise turn every later attempt into a 409 and hide the original failure.
+func teardownDualGateway(t *testing.T, port int) {
+	t.Helper()
+	for _, p := range []string{
+		"auth/cert/role/" + dgRole,
+		"sys/policies/cbp/" + dgMount + "-access",
+		"sys/cred/specs/" + dgMount + "-cred",
+		"sys/cred/sources/" + dgMount + "-src",
+		"sys/providers/" + dgMount,
+	} {
+		h.APIRequest(t, "DELETE", p, port, "")
+	}
+	// auth/cert stores a single trusted CA, so leaving it mounted would hand
+	// the next test in this package a CA that does not match its certificates.
+	h.TeardownCertAuth(t, port)
+}
+
+// dgRequest drives the transparent gateway leg: the agent proves itself with a
+// client certificate and the role comes from the URL, so no header carries a
+// token and the mount mints the credential itself.
+func dgRequest(t *testing.T, port int, apiPath, clientCertPEM string) (int, []byte) {
+	t.Helper()
+	u := fmt.Sprintf("%s/v1/%s/role/%s/gateway%s", h.NodeURL(port), dgMount, dgRole, apiPath)
+	return h.DoRequest(t, "GET", u, map[string]string{
+		"X-SSL-Client-Cert": h.URLEncodePEM(clientCertPEM),
+	}, "")
+}
+
+// B5: mount-time configuration carries the agent leg, not just the URL.
+// Accepting auto_auth_path at mount and discarding it left the transparent path
+// unreachable except through a config write.
+func TestDualGateway_MountTimeConfigConfiguresTheAgentLeg(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	upstream := h.StartRecordingUpstream(t)
+	defer upstream.Close()
+
+	clientCertPEM := setupDualGateway(t, port, upstream.URL, map[string]any{
+		"tls_skip_verify": true, // permits the http:// scheme on a local listener
+	})
+
+	status, body := dgRequest(t, port, "/instance/v1/zones/fr-par-1/servers", clientCertPEM)
+	if status != 200 {
+		t.Fatalf("transparent gateway request: status %d, body %s", status, string(body))
+	}
+
+	got := upstream.Last(t)
+	if got.Header.Get("X-Auth-Token") != dgSecretKey {
+		t.Errorf("upstream X-Auth-Token = %q, want the minted secret key",
+			got.Header.Get("X-Auth-Token"))
+	}
+	if got.Path != "/instance/v1/zones/fr-par-1/servers" {
+		t.Errorf("upstream path = %q, want the API path with the gateway prefix stripped", got.Path)
+	}
+}
+
+// B4: a config write names one key; every other key must survive it. Before the
+// fix this sequence repointed the mount at https://api.scaleway.com and reset
+// the timeout, and reported success doing it.
+func TestDualGateway_PartialConfigWritePreservesTheRest(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	upstream := h.StartRecordingUpstream(t)
+	defer upstream.Close()
+
+	clientCertPEM := setupDualGateway(t, port, upstream.URL, map[string]any{
+		"tls_skip_verify": true,
+		"timeout":         "2m",
+	})
+
+	// Name one key, and only that key.
+	mustDG(t, port, "PUT", dgMount+"/config",
+		`{"default_role":"`+dgRole+`"}`, "partial config write")
+
+	status, body := h.APIRequest(t, "GET", dgMount+"/config", port, "")
+	if status != 200 {
+		t.Fatalf("read config: status %d, body %s", status, string(body))
+	}
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal config: %v\nbody: %s", err, string(body))
+	}
+
+	if got := resp.Data["scaleway_url"]; got != upstream.URL {
+		t.Errorf("scaleway_url = %v, want %q — the write reset it", got, upstream.URL)
+	}
+	if got := resp.Data["timeout"]; got != "2m0s" {
+		t.Errorf("timeout = %v, want 2m0s — the write reset it", got)
+	}
+	if got := resp.Data["auto_auth_path"]; got != "auth/cert/" {
+		t.Errorf("auto_auth_path = %v, want auth/cert/", got)
+	}
+
+	// The read agreeing is not enough — a stored value and a served one can
+	// disagree. Only traffic proves the mount still points where it says.
+	upstream.Reset()
+	status, body = dgRequest(t, port, "/instance/v1/zones/fr-par-1/servers", clientCertPEM)
+	if status != 200 {
+		t.Fatalf("request after partial write: status %d, body %s", status, string(body))
+	}
+	if len(upstream.Requests()) == 0 {
+		t.Fatal("request did not reach the local upstream — the mount was repointed")
+	}
+}
+
+// B6: an upstream signed by a private authority. Every mount of every dual-mode
+// provider shared one transport with a fixed TLS config, so ca_data was masked
+// in output while being impossible to set.
+func TestDualGateway_PrivateCAUpstream(t *testing.T) {
+	port := h.GetLeaderPort(t)
+
+	upstream, caData := startPrivateCAUpstream(t)
+	defer upstream.Close()
+
+	clientCertPEM := setupDualGateway(t, port, upstream.URL, map[string]any{
+		"ca_data": caData,
+	})
+
+	status, body := dgRequest(t, port, "/instance/v1/zones/fr-par-1/servers", clientCertPEM)
+	if status != 200 {
+		t.Fatalf("private-CA upstream: status %d, body %s", status, string(body))
+	}
+
+	// The same upstream without the authority must fail, or the row above
+	// proves only that the handshake happened, not that ca_data caused it.
+	mustDG(t, port, "PUT", dgMount+"/config", `{"ca_data":""}`, "drop ca_data")
+
+	status, _ = dgRequest(t, port, "/instance/v1/zones/fr-par-1/servers", clientCertPEM)
+	if status == 200 {
+		t.Error("upstream signed by an untrusted authority was reached anyway")
+	}
+}
+
+// startPrivateCAUpstream serves TLS under a CA no system root store knows,
+// returning it as the base64-encoded PEM the ca_data field takes.
+func startPrivateCAUpstream(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "dualgateway-e2e-ca"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	srvTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	srvDER, err := x509.CreateCertificate(rand.Reader, srvTmpl, caCert, &srvKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+
+	// NewTLSServer generates its own certificate and cannot be handed one, so
+	// the server is built unstarted and its TLS config supplied first.
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{srvDER},
+			PrivateKey:  srvKey,
+		}},
+	}
+	srv.StartTLS()
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	return srv, base64.StdEncoding.EncodeToString(caPEM)
+}
+
+// --- small local helpers ---
+
+func mustDG(t *testing.T, port int, method, path, body, what string) {
+	t.Helper()
+	status, resp := h.APIRequest(t, method, path, port, body)
+	if status < 200 || status >= 300 {
+		t.Fatalf("%s: status %d, body %s", what, status, string(resp))
+	}
+}
+
+func mustJSONBody(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	return string(b)
+}

--- a/framework/config.go
+++ b/framework/config.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -208,6 +210,41 @@ func ValidateTLSConfig(conf map[string]any) error {
 		}
 	}
 	return nil
+}
+
+// NewTLSClientConfig builds the client TLS settings for an upstream connection
+// from the two config fields ValidateTLSConfig checks: a base64-encoded PEM
+// bundle to trust, and whether to verify at all.
+//
+// caData replaces the system roots rather than adding to them: a mount naming a
+// private authority is saying which authority signs its upstream, and silently
+// continuing to accept every public CA would not be that.
+//
+// The caller owns HTTP/2 setup. ConfigureTransport binds to whichever
+// tls.Config is installed when it runs, so a transport must assign the result
+// of this call before configuring h2, never after.
+func NewTLSClientConfig(caData string, skipVerify bool) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ClientSessionCache: tls.NewLRUClientSessionCache(100),
+		InsecureSkipVerify: skipVerify,
+	}
+
+	if caData == "" {
+		return cfg, nil
+	}
+
+	pemBytes, err := base64.StdEncoding.DecodeString(caData)
+	if err != nil {
+		return nil, fmt.Errorf("ca_data is not valid base64: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("ca_data contains no valid PEM certificates")
+	}
+	cfg.RootCAs = pool
+
+	return cfg, nil
 }
 
 // ValidateURL validates that a URL is well-formed with an https:// scheme.

--- a/provider/sdk/dualgateway/apply.go
+++ b/provider/sdk/dualgateway/apply.go
@@ -1,0 +1,150 @@
+package dualgateway
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/stephnangue/warden/framework"
+)
+
+// extraConfigKeys returns the provider-specific config keys this spec declares.
+// A spec may describe them as full field schemas or as bare names; both forms
+// must reach the same set, or a key lands in the config schema while the write
+// path and the allow-list never learn of it.
+func specExtraConfigKeys(spec *ProviderSpec) []string {
+	if len(spec.ExtraConfigFields) > 0 {
+		keys := make([]string, 0, len(spec.ExtraConfigFields))
+		for k := range spec.ExtraConfigFields {
+			keys = append(keys, k)
+		}
+		return keys
+	}
+	return spec.ExtraConfigKeys
+}
+
+func (b *dualgatewayBackend) extraConfigKeys() []string {
+	return specExtraConfigKeys(b.spec)
+}
+
+// applyParsedConfig resolves conf into live backend state and returns the
+// snapshot to persist. It is the only place configuration is applied — mount
+// time, storage load and config write all route through it, so the three can
+// never drift into honouring different subsets of the config surface.
+//
+// Nothing is mutated until every fallible step has succeeded: an unusable
+// ca_data leaves a serving mount exactly as it was, rather than half-moved to a
+// configuration that cannot reach its upstream.
+//
+// The returned snapshot is computed from conf alone rather than read back off
+// the backend, so a writer racing in between resolution and Put cannot tear it.
+//
+// conf must already have passed validateConfig. This applies; it does not
+// validate.
+func (b *dualgatewayBackend) applyParsedConfig(conf map[string]any) (map[string]any, error) {
+	parsed := parseConfig(b.spec, conf)
+
+	// Build the transport first — the one step here that can fail.
+	var (
+		newTransport http.RoundTripper = sharedTransport
+		perMount     *http.Transport
+	)
+	if parsed.TLSSkipVerify || parsed.CAData != "" {
+		t, err := newTransportWithTLS(parsed.CAData, parsed.TLSSkipVerify)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS configuration: %w", err)
+		}
+		newTransport = t
+		perMount = t
+	}
+
+	autoAuthPath := framework.GetConfigString(conf, "auto_auth_path", "")
+	defaultRole := framework.GetConfigString(conf, "default_role", "")
+
+	extraKeys := b.extraConfigKeys()
+	extraRaw := make(map[string]any, len(extraKeys))
+	for _, k := range extraKeys {
+		if v, ok := conf[k]; ok {
+			extraRaw[k] = v
+		}
+	}
+
+	var extraState map[string]any
+	if b.spec.OnConfigParsed != nil {
+		extraState = b.spec.OnConfigParsed(conf)
+	}
+
+	persist := map[string]any{
+		b.spec.URLConfigKey: parsed.ProviderURL,
+		"max_body_size":     parsed.MaxBodySize,
+		"timeout":           parsed.Timeout.String(),
+		"auto_auth_path":    autoAuthPath,
+		"default_role":      defaultRole,
+		"tls_skip_verify":   parsed.TLSSkipVerify,
+		"ca_data":           parsed.CAData,
+	}
+	// Persist what the operator supplied for the extra keys, not what
+	// OnConfigParsed resolved it to. A resolved value is a defaulting decision
+	// made now; storing it would freeze today's default into the mount and
+	// silently exempt it from a later one.
+	for k, v := range extraRaw {
+		persist[k] = v
+	}
+
+	b.mu.Lock()
+	outgoing := b.installedTransport
+	b.providerURL = parsed.ProviderURL
+	b.tlsSkipVerify = parsed.TLSSkipVerify
+	b.caData = parsed.CAData
+	b.extraRaw = extraRaw
+	b.extraState = extraState
+	b.installedTransport = perMount
+	b.mu.Unlock()
+
+	// Framework-side fields carry their own atomics; no lock needed.
+	b.SetMaxBodySize(parsed.MaxBodySize)
+	b.SetTimeout(parsed.Timeout)
+	b.SetTransport(newTransport)
+	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
+		AutoAuthPath:    autoAuthPath,
+		DefaultAuthRole: defaultRole,
+	})
+
+	// Release the connections of the transport just replaced. Only a per-mount
+	// one is ours to close — sharedTransport serves every other mount of every
+	// dual-mode provider. In-flight requests keep the connections they hold;
+	// this reaches only idle ones.
+	if outgoing != nil && outgoing != perMount {
+		outgoing.CloseIdleConnections()
+	}
+
+	return persist, nil
+}
+
+// snapshotForMerge returns live configuration in the shape parseConfig expects,
+// to serve as the base a partial config write is overlaid onto. Without it, a
+// write naming one key would resolve every key it did not name to a default.
+//
+// Every key here must be one validateConfig allows, since the merged result is
+// validated as a whole. Extra keys come from extraRaw — the operator's own
+// values — for the reason applyParsedConfig persists those rather than the
+// resolved ones.
+func (b *dualgatewayBackend) snapshotForMerge() map[string]any {
+	tc := b.TransparentConfig()
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	conf := map[string]any{
+		b.spec.URLConfigKey: b.providerURL,
+		"max_body_size":     b.MaxBodySize(),
+		"timeout":           b.Timeout().String(),
+		"auto_auth_path":    tc.AutoAuthPath,
+		"default_role":      tc.DefaultAuthRole,
+		"tls_skip_verify":   b.tlsSkipVerify,
+		"ca_data":           b.caData,
+	}
+	for k, v := range b.extraRaw {
+		conf[k] = v
+	}
+	return conf
+}

--- a/provider/sdk/dualgateway/backend.go
+++ b/provider/sdk/dualgateway/backend.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/stephnangue/warden/framework"
@@ -20,9 +19,28 @@ type dualgatewayBackend struct {
 	spec     *ProviderSpec
 	s3Signer *v4.Signer // SigV4 signer with DisableURIPathEscaping for S3
 
-	mu          sync.RWMutex   // protects mutable fields below
-	providerURL string         // upstream REST API base URL
-	extraState  map[string]any // provider-specific state from OnConfigParsed
+	// configWriteMu serialises the config-write handler. mu guards individual
+	// field reads and writes; this guards the whole read-merge-apply-persist
+	// sequence, which mu cannot since the apply must not hold it.
+	configWriteMu sync.Mutex
+
+	mu            sync.RWMutex   // protects mutable fields below
+	providerURL   string         // upstream REST API base URL
+	extraState    map[string]any // provider-specific state from OnConfigParsed
+	extraRaw      map[string]any // provider-specific config as the operator gave it
+	tlsSkipVerify bool
+	caData        string
+
+	// installedTransport is the per-mount transport currently in use, or nil
+	// when this mount rides the shared one. The framework's Transport() returns
+	// a stable wrapper rather than what was installed, so a replacement cannot
+	// otherwise be found again to close.
+	installedTransport *http.Transport
+
+	// configErr records a stored configuration that could not be applied at
+	// load. Core logs an Initialize failure and carries on, so without this the
+	// mount would keep serving on spec defaults — the vendor's public endpoint.
+	configErr error
 }
 
 // Compile-time interface assertion
@@ -101,10 +119,6 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 		b.Logger = conf.Logger.WithSubsystem(spec.Name)
 		b.StorageView = conf.StorageView
 
-		// Seed an empty transparent config so isTransparentRequest can route
-		// once auto_auth_path is configured via handleConfigWrite.
-		b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{})
-
 		initTransport()
 		b.StreamingBackend.InitProxy(sharedTransport)
 
@@ -120,20 +134,15 @@ func NewFactory(spec *ProviderSpec) logical.Factory {
 			if err := validateConfig(spec, conf.Config); err != nil {
 				return nil, fmt.Errorf("invalid configuration: %w", err)
 			}
-			parsed := parseConfig(spec, conf.Config)
-			b.providerURL = parsed.ProviderURL
-			b.SetMaxBodySize(parsed.MaxBodySize)
-			b.SetTimeout(parsed.Timeout)
-			if spec.OnConfigParsed != nil {
-				b.extraState = spec.OnConfigParsed(conf.Config)
-			}
 		}
 
-		if b.MaxBodySize() <= 0 {
-			b.SetMaxBodySize(framework.DefaultMaxBodySize)
-		}
-		if b.Timeout() <= 0 {
-			b.SetTimeout(spec.DefaultTimeout)
+		// Applied unconditionally, and only after InitProxy: an empty config
+		// still has to resolve the defaults (a zero max body size reads as
+		// unlimited downstream, not as "use the default"), and applying before
+		// InitProxy would see a mount-time TLS transport overwritten by the
+		// shared one.
+		if _, err := b.applyParsedConfig(conf.Config); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
 		}
 
 		return b, nil
@@ -159,33 +168,22 @@ func (b *dualgatewayBackend) Initialize(ctx context.Context) error {
 		return fmt.Errorf("failed to decode config: %w", err)
 	}
 
+	// The stored entry is authoritative and complete — a config write persists
+	// the whole key set — so it replaces the mount-time configuration wholesale
+	// rather than being layered over it. Routing through applyParsedConfig is
+	// what makes a private CA survive a restart: rebuilt here, or the mount
+	// quietly falls back to the system roots on the next unseal.
+	if _, err := b.applyParsedConfig(config); err != nil {
+		wrapped := fmt.Errorf("failed to apply stored config: %w", err)
+		b.mu.Lock()
+		b.configErr = wrapped
+		b.mu.Unlock()
+		return wrapped
+	}
+
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if urlVal, ok := config[b.spec.URLConfigKey].(string); ok && urlVal != "" {
-		b.providerURL = urlVal
-	}
-
-	if maxSize, ok := config["max_body_size"].(float64); ok && maxSize > 0 {
-		b.SetMaxBodySize(int64(maxSize))
-	}
-
-	if timeoutStr, ok := config["timeout"].(string); ok && timeoutStr != "" {
-		if timeout, err := time.ParseDuration(timeoutStr); err == nil {
-			b.SetTimeout(timeout)
-		}
-	}
-
-	autoAuthPath, _ := config["auto_auth_path"].(string)
-	defaultRole, _ := config["default_role"].(string)
-	b.StreamingBackend.SetTransparentConfig(&framework.TransparentConfig{
-		AutoAuthPath:    autoAuthPath,
-		DefaultAuthRole: defaultRole,
-	})
-
-	if b.spec.OnConfigParsed != nil {
-		b.extraState = b.spec.OnConfigParsed(config)
-	}
+	b.configErr = nil
+	b.mu.Unlock()
 
 	return nil
 }

--- a/provider/sdk/dualgateway/backend_test.go
+++ b/provider/sdk/dualgateway/backend_test.go
@@ -112,6 +112,34 @@ func TestNewFactory_InvalidConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown configuration key")
 }
 
+// B5: the transparent-auth settings are part of mount-time config like any
+// other key. Accepting them and applying only the URL left the agent leg
+// reachable solely through a later config write — which, before B4 was fixed,
+// reset the URL. There was no order that configured both.
+func TestNewFactory_AppliesTransparentConfig(t *testing.T) {
+	b := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+		"test_url":       "https://custom.test.com",
+		"auto_auth_path": "auth/cert/",
+		"default_role":   "reader",
+	})
+
+	tc := b.TransparentConfig()
+	assert.Equal(t, "auth/cert/", tc.AutoAuthPath)
+	assert.Equal(t, "reader", tc.DefaultAuthRole)
+	assert.Equal(t, "https://custom.test.com", b.providerURL, "the URL must not be lost to it")
+}
+
+// An unconfigured mount still has to resolve its defaults. A zero max body size
+// is read downstream as "no limit", not as "use the default", so leaving it
+// unset would silently remove the cap.
+func TestNewFactory_NoConfig_ResolvesDefaults(t *testing.T) {
+	b := createBackendWithConfig(t, headerAuthSpec, nil)
+
+	assert.Equal(t, framework.DefaultMaxBodySize, b.MaxBodySize())
+	assert.Equal(t, 30*time.Second, b.Timeout())
+	assert.Equal(t, "https://api.test.com", b.providerURL)
+}
+
 // --- TransparentAuthRoleExtractor ---
 
 func TestGetAuthRoleFromRequest(t *testing.T) {

--- a/provider/sdk/dualgateway/config.go
+++ b/provider/sdk/dualgateway/config.go
@@ -32,7 +32,7 @@ func validateConfig(spec *ProviderSpec, config map[string]any) error {
 		spec.URLConfigKey, "max_body_size", "timeout", "auto_auth_path", "default_role",
 		"tls_skip_verify", "ca_data",
 	}
-	allowedKeys = append(allowedKeys, spec.ExtraConfigKeys...)
+	allowedKeys = append(allowedKeys, specExtraConfigKeys(spec)...)
 	if err := framework.ValidateAllowedKeys(config, allowedKeys...); err != nil {
 		return err
 	}

--- a/provider/sdk/dualgateway/gateway.go
+++ b/provider/sdk/dualgateway/gateway.go
@@ -61,6 +61,23 @@ func extractAPIPath(fullPath string) string {
 
 // handleGateway auto-detects the request type and delegates accordingly.
 func (b *dualgatewayBackend) handleGateway(ctx context.Context, req *logical.Request) {
+	// A mount whose stored configuration would not load is not a mount with
+	// slightly stale settings — it has fallen back to the spec defaults, which
+	// point at the vendor's public endpoint, while still holding real
+	// credentials to inject. Refuse rather than egress somewhere the operator
+	// never configured.
+	b.mu.RLock()
+	initErr := b.configErr
+	b.mu.RUnlock()
+	if initErr != nil {
+		b.Logger.Error("refusing request: stored configuration failed to load",
+			logger.Err(initErr),
+			logger.String("request_id", req.RequestID),
+		)
+		http.Error(req.ResponseWriter, "Service Unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	if sigv4.IsSigV4Request(req.HTTPRequest) {
 		b.handleS3Request(ctx, req)
 	} else {

--- a/provider/sdk/dualgateway/helpers_test.go
+++ b/provider/sdk/dualgateway/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -86,7 +87,8 @@ func makeFieldData(path *framework.Path, raw map[string]interface{}) *framework.
 
 // --- test specs ---
 
-// headerAuthSpec mimics Scaleway: injects a custom header, doesn't strip Authorization.
+// headerAuthSpec mimics Scaleway: authenticates with a custom header rather
+// than Authorization.
 var headerAuthSpec = &ProviderSpec{
 	Name:           "testprovider",
 	HelpText:       "test provider help",
@@ -105,7 +107,7 @@ var headerAuthSpec = &ProviderSpec{
 	},
 }
 
-// bearerAuthSpec mimics OVH: injects Authorization: Bearer, strips incoming Authorization.
+// bearerAuthSpec mimics OVH: injects its own Authorization: Bearer.
 var bearerAuthSpec = &ProviderSpec{
 	Name:           "testbearer",
 	HelpText:       "test bearer provider help",
@@ -115,13 +117,44 @@ var bearerAuthSpec = &ProviderSpec{
 	DefaultTimeout: 30 * time.Second,
 	UserAgent:      "warden-bearer-proxy",
 	APIAuth: APIAuthStrategy{
-		HeaderName:         "Authorization",
-		HeaderValueFormat:  "Bearer %s",
-		CredentialField:    "api_token",
-		StripAuthorization: true,
+		HeaderName:        "Authorization",
+		HeaderValueFormat: "Bearer %s",
+		CredentialField:   "api_token",
 	},
 	S3Endpoint: func(_ map[string]any, region string) string {
 		return fmt.Sprintf("s3.%s.bearer.net", region)
+	},
+}
+
+// extraKeySpec mimics Cloudflare: a provider-specific config key the S3 endpoint
+// is built from, declared as a full field schema rather than a bare name.
+var extraKeySpec = &ProviderSpec{
+	Name:           "testextra",
+	HelpText:       "test extra-key provider help",
+	CredentialType: "extra_keys",
+	DefaultURL:     "https://api.extra.com",
+	URLConfigKey:   "extra_url",
+	DefaultTimeout: 30 * time.Second,
+	UserAgent:      "warden-extra-proxy",
+	APIAuth: APIAuthStrategy{
+		HeaderName:        "X-Auth-Token",
+		HeaderValueFormat: "%s",
+		CredentialField:   "secret_key",
+	},
+	S3Endpoint: func(state map[string]any, _ string) string {
+		id, _ := state["account_id"].(string)
+		return id + ".s3.extra.cloud"
+	},
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"account_id": {
+			Type:        framework.TypeString,
+			Description: "account ID",
+		},
+	},
+	OnConfigParsed: func(config map[string]any) map[string]any {
+		return map[string]any{
+			"account_id": framework.GetConfigString(config, "account_id", ""),
+		}
 	},
 }
 
@@ -129,11 +162,36 @@ var bearerAuthSpec = &ProviderSpec{
 
 func createBackend(t *testing.T, spec *ProviderSpec) *dualgatewayBackend {
 	t.Helper()
+	return createBackendWithConfig(t, spec, nil)
+}
+
+// createBackendWithConfig mounts a backend with mount-time configuration, the
+// path a provider is enabled through in production.
+func createBackendWithConfig(t *testing.T, spec *ProviderSpec, conf map[string]any) *dualgatewayBackend {
+	t.Helper()
 	factory := NewFactory(spec)
 	b, err := factory(context.Background(), &logical.BackendConfig{
 		StorageView: newInmemStorage(),
 		Logger:      createTestLogger(),
+		Config:      conf,
 	})
 	require.NoError(t, err)
 	return b.(*dualgatewayBackend)
+}
+
+// writeConfig drives the config path the way an operator does, and fails on any
+// non-200 so a test asserting on the result cannot mistake a rejected write for
+// a config that did not change.
+func writeConfig(t *testing.T, b *dualgatewayBackend, raw map[string]any) {
+	t.Helper()
+	resp, err := b.handleConfigWrite(context.Background(), &logical.Request{}, makeFieldData(b.pathConfig(), raw))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "config write rejected: %v", resp.Err)
+}
+
+func readConfig(t *testing.T, b *dualgatewayBackend) map[string]any {
+	t.Helper()
+	resp, err := b.handleConfigRead(context.Background(), &logical.Request{}, makeFieldData(b.pathConfig(), nil))
+	require.NoError(t, err)
+	return resp.Data
 }

--- a/provider/sdk/dualgateway/path_config.go
+++ b/provider/sdk/dualgateway/path_config.go
@@ -36,6 +36,15 @@ func (b *dualgatewayBackend) pathConfig() *framework.Path {
 			Type:        framework.TypeString,
 			Description: "Default auth role when not specified in the request",
 		},
+		"tls_skip_verify": {
+			Type:        framework.TypeBool,
+			Description: "Skip TLS certificate verification (dev/test only).",
+			Default:     false,
+		},
+		"ca_data": {
+			Type:        framework.TypeString,
+			Description: "Base64-encoded PEM CA certificate, for an upstream signed by a private authority.",
+		},
 	}
 
 	// Add provider-specific extra fields
@@ -81,7 +90,12 @@ func (b *dualgatewayBackend) handleConfigRead(ctx context.Context, req *logical.
 		"timeout":           b.Timeout().String(),
 		"auto_auth_path":    tc.AutoAuthPath,
 		"default_role":      tc.DefaultAuthRole,
+		"tls_skip_verify":   b.tlsSkipVerify,
+		"ca_data":           b.caData,
 	}
+	// Extra keys are reported as resolved, which is what the mount is actually
+	// using. A partial write merges against extraRaw instead, so this staying
+	// the resolved view costs nothing.
 	for k, v := range b.extraState {
 		data[k] = v
 	}
@@ -94,83 +108,66 @@ func (b *dualgatewayBackend) handleConfigRead(ctx context.Context, req *logical.
 }
 
 // handleConfigWrite handles writing the provider configuration.
+//
+// The write is a partial update: it starts from what the mount is currently
+// using and overlays only the keys the request actually named. Building the
+// config from the request alone would resolve every unnamed key to its default,
+// so setting a default role on a working mount would repoint it at the vendor's
+// public endpoint and report success.
 func (b *dualgatewayBackend) handleConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	conf := make(map[string]any)
+	// A partial update is a read-modify-write, so two of them racing would lose
+	// one writer's keys against the other's snapshot, and could leave live state
+	// mixing both while storage records only one. Serialising the handler makes
+	// each write see the previous one whole. It is not on any request path.
+	b.configWriteMu.Lock()
+	defer b.configWriteMu.Unlock()
 
-	if val, ok := d.GetOk(b.spec.URLConfigKey); ok {
-		conf[b.spec.URLConfigKey] = val
-	}
-	if val, ok := d.GetOk("max_body_size"); ok {
-		conf["max_body_size"] = val
-	}
-	if val, ok := d.GetOk("timeout"); ok {
-		conf["timeout"] = val
-	}
+	conf := b.snapshotForMerge()
 
-	// Read extra config fields before validation
-	for _, k := range b.spec.ExtraConfigKeys {
+	keys := []string{
+		b.spec.URLConfigKey, "max_body_size", "timeout",
+		"auto_auth_path", "default_role", "tls_skip_verify", "ca_data",
+	}
+	keys = append(keys, b.extraConfigKeys()...)
+	for _, k := range keys {
 		if val, ok := d.GetOk(k); ok {
 			conf[k] = val
+		}
+	}
+
+	// A mount serving only the non-transparent leg has no auto_auth_path and
+	// must stay configurable, so absence is not the failure — clearing one that
+	// was set is, since that silently takes transparent auth away from a mount
+	// serving it. GetOk reports a present-but-empty value as set, which is what
+	// separates the two.
+	if val, ok := d.GetOk("auto_auth_path"); ok {
+		if s, _ := val.(string); s == "" && b.TransparentConfig().AutoAuthPath != "" {
+			return &logical.Response{
+				StatusCode: http.StatusBadRequest,
+				Err:        logical.ErrBadRequest("auto_auth_path cannot be cleared while transparent auth is configured"),
+			}, nil
 		}
 	}
 
 	if err := validateConfig(b.spec, conf); err != nil {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
-			Err:        err,
+			Err:        logical.ErrBadRequest(err.Error()),
 		}, nil
 	}
 
-	parsed := parseConfig(b.spec, conf)
-
-	// Read current transparent config — TransparentConfig() is atomic, no lock needed.
-	current := b.TransparentConfig()
-	tc := &framework.TransparentConfig{
-		AutoAuthPath:    current.AutoAuthPath,
-		DefaultAuthRole: current.DefaultAuthRole,
-	}
-
-	if val, ok := d.GetOk("auto_auth_path"); ok {
-		tc.AutoAuthPath = val.(string)
-	}
-	if val, ok := d.GetOk("default_role"); ok {
-		tc.DefaultAuthRole = val.(string)
-	}
-
-	if tc.AutoAuthPath == "" {
+	persistData, err := b.applyParsedConfig(conf)
+	if err != nil {
 		return &logical.Response{
 			StatusCode: http.StatusBadRequest,
-			Err:        logical.ErrBadRequest("auto_auth_path is required"),
+			Err:        logical.ErrBadRequest(err.Error()),
 		}, nil
 	}
 
-	// All validation passed — apply framework-side atomics then provider-local fields under write lock.
-	b.SetMaxBodySize(parsed.MaxBodySize)
-	b.SetTimeout(parsed.Timeout)
-	b.mu.Lock()
-	b.providerURL = parsed.ProviderURL
-	if b.spec.OnConfigParsed != nil {
-		b.extraState = b.spec.OnConfigParsed(conf)
-	}
-	b.mu.Unlock()
-
-	b.StreamingBackend.SetTransparentConfig(tc)
-
-	// Persist config to storage
+	// Persist what this write resolved to, computed from the merged config
+	// alone — not read back off the backend, where a concurrent writer could
+	// tear it.
 	if b.StorageView != nil {
-		b.mu.RLock()
-		persistData := map[string]any{
-			b.spec.URLConfigKey: b.providerURL,
-			"max_body_size":     b.MaxBodySize(),
-			"timeout":           b.Timeout().String(),
-			"auto_auth_path":    tc.AutoAuthPath,
-			"default_role":      tc.DefaultAuthRole,
-		}
-		for k, v := range b.extraState {
-			persistData[k] = v
-		}
-		b.mu.RUnlock()
-
 		entry, err := sdklogical.StorageEntryJSON("config", persistData)
 		if err != nil {
 			return &logical.Response{

--- a/provider/sdk/dualgateway/path_config_test.go
+++ b/provider/sdk/dualgateway/path_config_test.go
@@ -41,17 +41,84 @@ func TestPathConfig_Write(t *testing.T) {
 	assert.Equal(t, "https://custom.test.com", b.providerURL)
 }
 
-func TestPathConfig_Write_MissingAutoAuthPath(t *testing.T) {
+// A mount serving only the non-transparent leg — X-Warden-Token against
+// gateway/... — never sets auto_auth_path. Rejecting its writes would leave it
+// unable to change its own URL or timeout for the life of the mount.
+func TestPathConfig_Write_WithoutAutoAuthPath_OnNonTransparentMount(t *testing.T) {
 	b := createBackend(t, headerAuthSpec)
-	path := b.pathConfig()
 
-	raw := map[string]interface{}{
-		"test_url": "https://api.test.com",
-	}
+	writeConfig(t, b, map[string]any{"test_url": "https://api.test.com"})
 
-	resp, err := b.handleConfigWrite(context.Background(), &logical.Request{}, makeFieldData(path, raw))
+	assert.Equal(t, "https://api.test.com", readConfig(t, b)["test_url"])
+}
+
+// The rejection that does still apply: taking transparent auth away from a
+// mount serving it. An empty string is a value the caller sent, not an absence.
+func TestPathConfig_Write_CannotClearAutoAuthPath(t *testing.T) {
+	b := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+		"auto_auth_path": "auth/cert/",
+	})
+
+	resp, err := b.handleConfigWrite(context.Background(), &logical.Request{},
+		makeFieldData(b.pathConfig(), map[string]any{"auto_auth_path": ""}))
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	assert.Equal(t, "auth/cert/", readConfig(t, b)["auto_auth_path"],
+		"a rejected write must not have applied anything")
+}
+
+// B4: a write names one key; every key it does not name must survive it.
+// Measured against the exact sequence that repointed a working scaleway mount
+// at the vendor's public endpoint while reporting success.
+func TestPathConfig_Write_PreservesUnnamedKeys(t *testing.T) {
+	b := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+		"test_url":        "http://127.0.0.1:9999",
+		"tls_skip_verify": true,
+		"timeout":         "2m",
+	})
+
+	writeConfig(t, b, map[string]any{"auto_auth_path": "auth/cert/"})
+
+	got := readConfig(t, b)
+	assert.Equal(t, "http://127.0.0.1:9999", got["test_url"])
+	assert.Equal(t, "2m0s", got["timeout"])
+	assert.Equal(t, "auth/cert/", got["auto_auth_path"])
+}
+
+// The same property in the other direction: the transparent settings a mount
+// depends on survive a write that touches only an unrelated key.
+func TestPathConfig_Write_PreservesTransparentConfig(t *testing.T) {
+	b := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+		"auto_auth_path": "auth/cert/",
+		"default_role":   "reader",
+	})
+
+	writeConfig(t, b, map[string]any{"timeout": "45s"})
+
+	got := readConfig(t, b)
+	assert.Equal(t, "auth/cert/", got["auto_auth_path"])
+	assert.Equal(t, "reader", got["default_role"])
+	assert.Equal(t, "45s", got["timeout"])
+}
+
+// Extra keys are provider-specific and merge on the same terms as the rest.
+// account_id is what R2 needs to build an S3 endpoint at all; losing it to an
+// unrelated write would break every object-storage request through the mount.
+func TestPathConfig_Write_PreservesExtraKeys(t *testing.T) {
+	b := createBackendWithConfig(t, extraKeySpec, map[string]any{
+		"account_id": "abc123",
+	})
+
+	writeConfig(t, b, map[string]any{"timeout": "45s"})
+
+	got := readConfig(t, b)
+	assert.Equal(t, "abc123", got["account_id"])
+
+	b.mu.RLock()
+	state := b.extraState["account_id"]
+	b.mu.RUnlock()
+	assert.Equal(t, "abc123", state, "the resolved state the gateway reads must move with it")
 }
 
 func TestPathConfig_UsesSpecURLConfigKey(t *testing.T) {

--- a/provider/sdk/dualgateway/tls_test.go
+++ b/provider/sdk/dualgateway/tls_test.go
@@ -1,0 +1,254 @@
+package dualgateway
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// startPrivateCAServer starts a TLS server whose certificate is signed by a CA
+// no system root store knows about — the shape of a Cloudflare-compatible store
+// or a private IBM COS endpoint. Returns the server and its CA as the
+// base64-encoded PEM the ca_data config field takes.
+func startPrivateCAServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "dualgateway-test-ca"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	srvTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	srvDER, err := x509.CreateCertificate(rand.Reader, srvTmpl, caCert, &srvKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	// httptest.NewTLSServer generates its own certificate and cannot be handed
+	// one, so the server is built unstarted and its TLS config supplied first.
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{srvDER},
+			PrivateKey:  srvKey,
+		}},
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	return srv, base64.StdEncoding.EncodeToString(caPEM)
+}
+
+// B6, and the assertion that matters: the handshake itself. A mount carrying
+// the authority that signed its upstream reaches it; the same mount without one
+// cannot, because the shared transport only ever trusted the system roots.
+func TestTLS_PrivateCAIsTrustedOnlyWhenConfigured(t *testing.T) {
+	srv, caData := startPrivateCAServer(t)
+
+	t.Run("with ca_data", func(t *testing.T) {
+		b := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+			"test_url": srv.URL,
+			"ca_data":  caData,
+		})
+
+		resp, err := roundTrip(t, b, srv.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("without ca_data", func(t *testing.T) {
+		b := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+			"test_url": srv.URL,
+		})
+
+		_, err := roundTrip(t, b, srv.URL)
+		require.Error(t, err, "an unknown authority must not be trusted")
+		assert.Contains(t, err.Error(), "certificate")
+	})
+}
+
+// roundTrip drives the transport the gateway legs use, which is the only thing
+// that distinguishes a mount that trusts its upstream from one that does not.
+func roundTrip(t *testing.T, b *dualgatewayBackend, url string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	return b.Transport().RoundTrip(req)
+}
+
+// The mount rides the shared transport unless it asks for its own. Asserting on
+// b.Transport() could not show this: that returns a stable wrapper, identical
+// before and after any swap.
+func TestTLS_SharedTransportUnlessOverridden(t *testing.T) {
+	b := createBackend(t, headerAuthSpec)
+	assert.Nil(t, b.installedTransport, "no TLS overrides means no per-mount transport")
+
+	writeConfig(t, b, map[string]any{"tls_skip_verify": true})
+	assert.NotNil(t, b.installedTransport, "tls_skip_verify alone earns a per-mount transport")
+
+	// And it is given back when the overrides go away.
+	writeConfig(t, b, map[string]any{"tls_skip_verify": false})
+	assert.Nil(t, b.installedTransport)
+}
+
+// A config write that cannot be applied must change nothing. The transport is
+// built before any state is touched precisely so a mount serving traffic is not
+// left pointing at an upstream it can no longer reach.
+func TestTLS_InvalidCADataLeavesMountUntouched(t *testing.T) {
+	live := createBackendWithConfig(t, headerAuthSpec, map[string]any{
+		"test_url": "https://custom.test.com",
+	})
+
+	// Well-formed base64 carrying a well-formed PEM block that holds no usable
+	// certificate: past validateConfig's pem.Decode, refused by the cert pool.
+	// The failure therefore lands inside the apply, which is where the
+	// build-before-mutate ordering has to hold.
+	resp, err := live.handleConfigWrite(context.Background(), &logical.Request{},
+		makeFieldData(live.pathConfig(), map[string]any{
+			"test_url": "https://moved.test.com",
+			"ca_data":  base64.StdEncoding.EncodeToString([]byte("-----BEGIN CERTIFICATE-----\nbm9wZQ==\n-----END CERTIFICATE-----\n")),
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	assert.Equal(t, "https://custom.test.com", live.providerURL,
+		"a rejected write must not have moved the URL either")
+	assert.Nil(t, live.installedTransport)
+}
+
+// The same input at mount time fails the mount outright rather than producing a
+// backend that cannot reach its upstream.
+func TestTLS_InvalidCADataFailsTheMount(t *testing.T) {
+	factory := NewFactory(headerAuthSpec)
+	_, err := factory(context.Background(), &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      createTestLogger(),
+		Config: map[string]any{
+			"test_url": "https://custom.test.com",
+			"ca_data":  "not-base64-at-all!!",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ca_data")
+}
+
+// A mount whose stored config will not load must refuse traffic. Core logs an
+// Initialize failure and carries on, so the alternative is a mount serving on
+// spec defaults — the vendor's public endpoint — while still injecting real
+// credentials.
+func TestInitialize_UnloadableConfigRefusesRequests(t *testing.T) {
+	storage := newInmemStorage()
+	entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+		"test_url": "https://custom.test.com",
+		// Decodes as base64 into a well-formed PEM block that holds no usable
+		// certificate: past the validator, refused when the pool is built.
+		"ca_data": base64.StdEncoding.EncodeToString(
+			[]byte("-----BEGIN CERTIFICATE-----\nbm9wZQ==\n-----END CERTIFICATE-----\n")),
+	})
+	require.NoError(t, err)
+	require.NoError(t, storage.Put(context.Background(), entry))
+
+	factory := NewFactory(headerAuthSpec)
+	raw, err := factory(context.Background(), &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	})
+	require.NoError(t, err)
+	b := raw.(*dualgatewayBackend)
+
+	require.Error(t, b.Initialize(context.Background()))
+
+	rec := httptest.NewRecorder()
+	b.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httptest.NewRequest("GET", "/gateway/anything", nil),
+		ResponseWriter: rec,
+	})
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"a mount that could not load its config must not fall back to the vendor default")
+}
+
+// Trust must survive a restart. The stored config is replayed through the same
+// apply path on unseal — without that, a private-CA mount works until the first
+// restart and then silently falls back to the system roots.
+func TestTLS_SurvivesInitializeFromStorage(t *testing.T) {
+	srv, caData := startPrivateCAServer(t)
+
+	storage := newInmemStorage()
+	entry, err := sdklogical.StorageEntryJSON("config", map[string]any{
+		"test_url":        srv.URL,
+		"max_body_size":   float64(1048576), // JSON round-trips numbers as float64
+		"timeout":         "45s",
+		"auto_auth_path":  "auth/cert/",
+		"default_role":    "reader",
+		"tls_skip_verify": false,
+		"ca_data":         caData,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storage.Put(context.Background(), entry))
+
+	factory := NewFactory(headerAuthSpec)
+	raw, err := factory(context.Background(), &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      createTestLogger(),
+	})
+	require.NoError(t, err)
+	b := raw.(*dualgatewayBackend)
+	require.NoError(t, b.Initialize(context.Background()))
+
+	resp, err := roundTrip(t, b, srv.URL)
+	require.NoError(t, err, "the stored authority must be rebuilt on load")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The rest of the stored entry must come back with it.
+	got := readConfig(t, b)
+	assert.Equal(t, int64(1048576), got["max_body_size"])
+	assert.Equal(t, "45s", got["timeout"])
+	assert.Equal(t, "auth/cert/", got["auto_auth_path"])
+}

--- a/provider/sdk/dualgateway/transport.go
+++ b/provider/sdk/dualgateway/transport.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
+
+	"github.com/stephnangue/warden/framework"
 )
 
 var (
@@ -22,18 +24,19 @@ func initTransport() {
 	})
 }
 
-func newTransport() *http.Transport {
-	transport := &http.Transport{
+// newBaseTransport builds the pool, dialer and timeout profile every dual-mode
+// gateway transport shares, with neither TLS nor HTTP/2 applied. Both are the
+// caller's to add, in that order: ConfigureTransport binds to whichever
+// tls.Config is installed when it runs, so assigning one afterwards leaves the
+// h2 wiring pointing at the config it replaced.
+func newBaseTransport() *http.Transport {
+	return &http.Transport{
 		MaxIdleConns:        200,
 		MaxIdleConnsPerHost: 100,
 		MaxConnsPerHost:     0,
 		IdleConnTimeout:     90 * time.Second,
 
 		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig: &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			ClientSessionCache: tls.NewLRUClientSessionCache(100),
-		},
 
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
@@ -44,12 +47,40 @@ func newTransport() *http.Transport {
 		ResponseHeaderTimeout: 20 * time.Second,
 		ForceAttemptHTTP2:     true,
 	}
+}
+
+func newTransport() *http.Transport {
+	transport := newBaseTransport()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ClientSessionCache: tls.NewLRUClientSessionCache(100),
+	}
 
 	if err := http2.ConfigureTransport(transport); err != nil {
 		log.Printf("Failed to configure HTTP/2: %v", err)
 	}
 
 	return transport
+}
+
+// newTransportWithTLS builds a transport for one mount whose upstream needs
+// trust settings the shared one cannot carry — a private authority, or
+// verification disabled for a local test endpoint. Same profile as the shared
+// transport in every other respect.
+func newTransportWithTLS(caData string, skipVerify bool) (*http.Transport, error) {
+	tlsConfig, err := framework.NewTLSClientConfig(caData, skipVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := newBaseTransport()
+	transport.TLSClientConfig = tlsConfig
+
+	if err := http2.ConfigureTransport(transport); err != nil {
+		log.Printf("Failed to configure HTTP/2: %v", err)
+	}
+
+	return transport, nil
 }
 
 // ShutdownHTTPTransport should be called during application shutdown.

--- a/provider/sdk/httpproxy/transport.go
+++ b/provider/sdk/httpproxy/transport.go
@@ -2,15 +2,14 @@ package httpproxy
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"time"
 
 	"golang.org/x/net/http2"
+
+	"github.com/stephnangue/warden/framework"
 )
 
 // newBaseTransport creates an HTTP transport with shared pool/dialer/timeout
@@ -64,22 +63,9 @@ func NewTransport() *http.Transport {
 func NewTransportWithTLS(caData string, skipVerify bool) (*http.Transport, error) {
 	t := newBaseTransport()
 
-	tlsConfig := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		ClientSessionCache: tls.NewLRUClientSessionCache(100),
-		InsecureSkipVerify: skipVerify,
-	}
-
-	if caData != "" {
-		pemBytes, err := base64.StdEncoding.DecodeString(caData)
-		if err != nil {
-			return nil, fmt.Errorf("ca_data is not valid base64: %w", err)
-		}
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(pemBytes) {
-			return nil, fmt.Errorf("ca_data contains no valid PEM certificates")
-		}
-		tlsConfig.RootCAs = pool
+	tlsConfig, err := framework.NewTLSClientConfig(caData, skipVerify)
+	if err != nil {
+		return nil, err
 	}
 
 	t.TLSClientConfig = tlsConfig


### PR DESCRIPTION
Fixes B4, B5 and B6 in `e2e/FINDINGS.md`. They read as three bugs but are one defect: the dual-mode gateway SDK declared configuration fields its apply path dropped.

- A config write built its config from the request alone, so naming one key reset every other to its default. Setting a default role on a working mount silently repointed it at the vendor's public endpoint — and reported success.
- Mount-time config reached the URL, body size and timeout but never the transparent-auth settings, so `auto_auth_path` given at mount was accepted, validated and discarded.
- `tls_skip_verify` and `ca_data` were parsed and allow-listed but nothing consumed them, and every mount of every dual-mode provider shared one transport with a fixed TLS config. A private authority could not be trusted at all.

The first two compounded: the URL could only be set at mount time, the agent leg only by a config write, and that write reset the URL. No ordering configured both — which is what put scaleway, ovh, cloudflare and ibmcloud out of reach of the e2e suite.

## Approach

Mount time, storage load and config write now share one `applyParsedConfig`, so the three cannot drift into honouring different subsets again. `snapshotForMerge` gives a partial write its base. This follows `provider/mcp_aws`, which already solved each piece.

A mount builds its own transport only when it sets `tls_skip_verify` or `ca_data`, keeping the shared one otherwise. The transport is built before any state is touched, so an unusable `ca_data` leaves a serving mount exactly as it was.

Two things the shape of the fix turned up:

- Trust has to be rebuilt in `Initialize` too, or a private-CA mount works until the first restart and then falls back to the system roots.
- The TLS config must be assigned *before* `ConfigureTransport` runs — h2 binds to whichever config is installed when it is called, so building on the existing shared transport would have cost every private-CA mount its HTTP/2.

## Also here, because the same apply path forced the questions

- A write leaving `auto_auth_path` empty was refused outright, freezing a mount that serves only the non-transparent leg. Only *clearing* a path that was set is refused now.
- A mount whose stored config will not load refuses traffic instead of serving on spec defaults, which point at the vendor.
- The config-write handler is serialised. It was a read-modify-write with nothing stopping two of them losing each other's keys.

The base64 → PEM → cert-pool work is now `framework.NewTLSClientConfig`, shared with `httpproxy`, which held the only other copy.

## Verification

Full unit suite and all 19 e2e packages pass on a live 3-node cluster.

Every new test was checked against the pre-change binary. The e2e rows fail there with exactly the symptoms the findings describe — `auto_auth_path is required` for the partial write, `no auth mount registered at "" for implicit auth` for the mount-time agent leg.

`e2e/provider/dualgateway_test.go` is the coverage that was previously impossible: it mounts scaleway fully configured in one step, drives a cert-transparent request, then writes one key and proves the mount still points at the local upstream rather than `api.scaleway.com`.