### PR TITLE
fix(aws,httpproxy): guard the two latent nil dereferences in the request path

### DIFF
--- a/provider/aws/path_config_test.go
+++ b/provider/aws/path_config_test.go
@@ -401,6 +401,15 @@ func TestGetCredentials(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported")
 	})
+
+	// A request reaches the backend without a credential whenever nothing minted
+	// one — an unauthenticated branch, or a mint core declined to run. The caller
+	// turns this error into a 401; without the guard the type switch panics.
+	t.Run("nil credential", func(t *testing.T) {
+		_, err := b.getCredentials(&logical.Request{Credential: nil})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no credential available")
+	})
 }
 
 // --- extractAccessKeyID tests ---

--- a/provider/aws/path_gateway.go
+++ b/provider/aws/path_gateway.go
@@ -244,6 +244,10 @@ func (b *awsBackend) processRequest(ctx context.Context, req *logical.Request) (
 }
 
 func (b *awsBackend) getCredentials(req *logical.Request) (awssdk.Credentials, error) {
+	if req.Credential == nil {
+		return awssdk.Credentials{}, fmt.Errorf("no credential available")
+	}
+
 	switch req.Credential.Type {
 	case credential.TypeAWSAccessKeys:
 		if req.Credential.LeaseTTL == 0 {

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -209,8 +209,36 @@ type proxyBackend struct {
 	caData        string
 }
 
+// ValidateSpec checks that required ProviderSpec fields are set.
+//
+// DefaultURL is deliberately not required: an empty value is how a provider
+// declares that its upstream is per-deployment and must be configured on the
+// mount, and buildTargetURL refuses a request that arrives with neither.
+func ValidateSpec(spec *ProviderSpec) error {
+	if spec == nil {
+		return fmt.Errorf("provider spec is nil")
+	}
+	if spec.Name == "" {
+		return fmt.Errorf("provider spec Name is required")
+	}
+	if spec.URLConfigKey == "" {
+		return fmt.Errorf("provider spec URLConfigKey is required")
+	}
+	if spec.ExtractCredentials == nil {
+		return fmt.Errorf("provider spec ExtractCredentials is required")
+	}
+	return nil
+}
+
 // NewFactory creates a logical.Factory from a ProviderSpec.
 func NewFactory(spec *ProviderSpec) logical.Factory {
+	if err := ValidateSpec(spec); err != nil {
+		// Return a factory that always fails — catches spec bugs at mount time
+		return func(_ context.Context, _ *logical.BackendConfig) (logical.Backend, error) {
+			return nil, err
+		}
+	}
+
 	newTransport := spec.NewTransport
 	if newTransport == nil {
 		newTransport = DefaultNewTransport

--- a/provider/sdk/httpproxy/registered_specs_test.go
+++ b/provider/sdk/httpproxy/registered_specs_test.go
@@ -1,0 +1,73 @@
+// This file is an external test package on purpose: it imports the provider
+// packages, which themselves import httpproxy.
+package httpproxy_test
+
+import (
+	"testing"
+
+	"github.com/stephnangue/warden/provider/ansible_tower"
+	"github.com/stephnangue/warden/provider/anthropic"
+	"github.com/stephnangue/warden/provider/atlassian"
+	"github.com/stephnangue/warden/provider/cohere"
+	"github.com/stephnangue/warden/provider/datadog"
+	"github.com/stephnangue/warden/provider/dynatrace"
+	"github.com/stephnangue/warden/provider/elastic"
+	"github.com/stephnangue/warden/provider/github"
+	"github.com/stephnangue/warden/provider/gitlab"
+	"github.com/stephnangue/warden/provider/grafana"
+	"github.com/stephnangue/warden/provider/honeycomb"
+	"github.com/stephnangue/warden/provider/kubernetes"
+	"github.com/stephnangue/warden/provider/mcp"
+	"github.com/stephnangue/warden/provider/mistral"
+	"github.com/stephnangue/warden/provider/newrelic"
+	"github.com/stephnangue/warden/provider/openai"
+	"github.com/stephnangue/warden/provider/pagerduty"
+	"github.com/stephnangue/warden/provider/prometheus"
+	"github.com/stephnangue/warden/provider/rest"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
+	"github.com/stephnangue/warden/provider/sentry"
+	"github.com/stephnangue/warden/provider/servicenow"
+	"github.com/stephnangue/warden/provider/slack"
+	"github.com/stephnangue/warden/provider/splunk"
+	"github.com/stephnangue/warden/provider/tfe"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRegisteredProviderSpecsValid asserts every shipped spec satisfies the
+// contract the factory enforces. A provider added without an extractor fails
+// here rather than at the first request it serves; a provider added without
+// being listed here is caught by the count.
+func TestRegisteredProviderSpecsValid(t *testing.T) {
+	specs := map[string]*httpproxy.ProviderSpec{
+		"ansible_tower": ansible_tower.Spec,
+		"anthropic":     anthropic.Spec,
+		"atlassian":     atlassian.Spec,
+		"cohere":        cohere.Spec,
+		"datadog":       datadog.Spec,
+		"dynatrace":     dynatrace.Spec,
+		"elastic":       elastic.Spec,
+		"github":        github.Spec,
+		"gitlab":        gitlab.Spec,
+		"grafana":       grafana.Spec,
+		"honeycomb":     honeycomb.Spec,
+		"kubernetes":    kubernetes.Spec,
+		"mcp":           mcp.Spec,
+		"mistral":       mistral.Spec,
+		"newrelic":      newrelic.Spec,
+		"openai":        openai.Spec,
+		"pagerduty":     pagerduty.Spec,
+		"prometheus":    prometheus.Spec,
+		"rest":          rest.Spec,
+		"sentry":        sentry.Spec,
+		"servicenow":    servicenow.Spec,
+		"slack":         slack.Spec,
+		"splunk":        splunk.Spec,
+		"tfe":           tfe.Spec,
+	}
+
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t, httpproxy.ValidateSpec(spec))
+		})
+	}
+}

--- a/provider/sdk/httpproxy/spec_validation_test.go
+++ b/provider/sdk/httpproxy/spec_validation_test.go
@@ -1,0 +1,73 @@
+package httpproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Spec validation tests ---
+
+func TestValidateSpec(t *testing.T) {
+	t.Run("nil spec", func(t *testing.T) {
+		assert.Error(t, ValidateSpec(nil))
+	})
+
+	t.Run("missing Name", func(t *testing.T) {
+		s := *testSpec()
+		s.Name = ""
+		assert.Contains(t, ValidateSpec(&s).Error(), "Name")
+	})
+
+	t.Run("missing URLConfigKey", func(t *testing.T) {
+		s := *testSpec()
+		s.URLConfigKey = ""
+		assert.Contains(t, ValidateSpec(&s).Error(), "URLConfigKey")
+	})
+
+	t.Run("missing ExtractCredentials", func(t *testing.T) {
+		s := *testSpec()
+		s.ExtractCredentials = nil
+		assert.Contains(t, ValidateSpec(&s).Error(), "ExtractCredentials")
+	})
+
+	// An empty DefaultURL is how a provider says its upstream is per-deployment.
+	// Nine of the shipped specs are in that shape, so requiring it here would
+	// refuse to mount every instance-specific product we carry.
+	t.Run("empty DefaultURL is valid", func(t *testing.T) {
+		s := *testSpec()
+		s.DefaultURL = ""
+		assert.NoError(t, ValidateSpec(&s))
+	})
+
+	t.Run("valid spec", func(t *testing.T) {
+		assert.NoError(t, ValidateSpec(testSpec()))
+	})
+}
+
+func TestNewFactory_InvalidSpec(t *testing.T) {
+	factory := NewFactory(&ProviderSpec{}) // empty spec
+	_, err := factory(context.Background(), &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Name")
+}
+
+// A spec that mounts but has no extractor panics on the first authenticated
+// request rather than failing at mount, which is the failure this guards.
+func TestNewFactory_MissingExtractorFailsAtMount(t *testing.T) {
+	spec := testSpec()
+	spec.ExtractCredentials = nil
+	factory := NewFactory(spec)
+	_, err := factory(context.Background(), &logical.BackendConfig{
+		StorageView: newInmemStorage(),
+		Logger:      testLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ExtractCredentials")
+}


### PR DESCRIPTION
Closes findings C1 and C2 in `e2e/FINDINGS.md`. Both are guards against a panic no current configuration reaches, with no behaviour change for any correct config, which is why they ship together.

## C1 — aws dereferences a nil credential

`getCredentials` switched on `req.Credential.Type` with no nil check. A sweep of the whole provider tree found it was the only unguarded dereference left; every sibling already has the identical guard.

Nothing reaches it today — the mint fails with a 400 before the backend is invoked, and aws declares no unauthenticated branch — but the guard costs one line and the sole caller already maps the error to 401. No `StreamUnauthenticated` wrap was needed to go with it: unlike vault, azure and gcp, aws has no unauthenticated stream path.

## C2 — the httpproxy factory validated nothing

A spec without a credential extractor mounted cleanly and panicked on its first authenticated request. `NewFactory` now validates up front and returns an always-failing factory, the shape `dualgateway` already had — no signature change needed, since a factory already returns an error.

Required: `Name`, `URLConfigKey`, `ExtractCredentials`. **Not `DefaultURL`** — an empty value is how a provider declares a per-deployment upstream, and nine of the twenty-four ship one (ansible_tower, dynatrace, elastic, gitlab, kubernetes, mcp, rest, servicenow, splunk). Copying dualgateway's validator wholesale would have refused all nine at mount.

The validator is exported so a walk over every registered spec can assert the same contract from outside the package. That is what turns the next provider added without an extractor into a failed build rather than a panic on its first request.

## Verification

Both regression tests were confirmed failing against the previous binary:

- `TestGetCredentials/nil_credential` — panics with a nil-pointer dereference at the type switch
- `TestNewFactory_MissingExtractorFailsAtMount` — the factory builds a backend with no error

`go test ./provider/...` green.
