### PR TITLE
fix(credential,core): enforce the OAuth spec-config keys documented as sealed

### DIFF
--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -234,6 +234,45 @@ func (b *SystemBackend) maskSourceConfig(sourceType string, config map[string]st
 	return masked
 }
 
+// checkSystemManagedSpecConfig refuses an operator write to a spec-config key
+// the credential type declares the server owns. existing is the stored config,
+// or nil on create.
+//
+// A key passes when the caller is not really setting it: absent, empty (an
+// explicit clear, which cannot forge anything), identical to what is stored, or
+// the mask sentinel standing in for a stored secret the caller read back. Any
+// other value is refused, because on create there is nothing to have read back
+// and on update it differs from what the server sealed.
+func (b *SystemBackend) checkSystemManagedSpecConfig(specType string, incoming, existing map[string]string) error {
+	if b.core.credentialTypeRegistry == nil {
+		return nil
+	}
+	credType, err := b.core.credentialTypeRegistry.GetByName(specType)
+	if err != nil {
+		// An unknown type is rejected by validation further along, with a better
+		// message than this check could give.
+		return nil
+	}
+	managed, ok := credType.(credential.SystemManagedConfig)
+	if !ok {
+		return nil
+	}
+
+	for _, key := range managed.SystemManagedConfigFields() {
+		value, present := incoming[key]
+		if !present || value == "" || value == existing[key] {
+			continue
+		}
+		if value == maskValue && existing[key] != "" {
+			continue
+		}
+		return logical.ErrBadRequestf(
+			"config key %q is sealed by the server and cannot be set through this API; "+
+				"run `warden cred spec connect` to establish it", key)
+	}
+	return nil
+}
+
 // maskSpecConfig masks sensitive config fields based on the credential type
 func (b *SystemBackend) maskSpecConfig(specType string, config map[string]string) map[string]string {
 	if config == nil {
@@ -508,6 +547,12 @@ func (b *SystemBackend) handleCredentialSpecCreate(ctx context.Context, req *log
 		}
 	}
 
+	// Refuse operator-set values for keys the server seals. Checked once the type
+	// is known, since the type is what declares them.
+	if err := b.checkSystemManagedSpecConfig(specType, specConfig, nil); err != nil {
+		return logical.ErrorResponse(err), nil
+	}
+
 	b.logger.Info("creating credential spec",
 		logger.String("name", name),
 		logger.String("type", specType),
@@ -619,6 +664,11 @@ func (b *SystemBackend) handleCredentialSpecUpdate(ctx context.Context, req *log
 	// possible with an empty string, which is not the sentinel.
 	if configAny, ok := d.GetOk("config"); ok {
 		newConfig := convertToStringMap(configAny.(map[string]any))
+		// Refuse operator-set values for keys the server seals, before merging —
+		// afterwards the caller's input and the stored value are indistinguishable.
+		if err := b.checkSystemManagedSpecConfig(spec.Type, newConfig, spec.Config); err != nil {
+			return logical.ErrorResponse(err), nil
+		}
 		for k, v := range newConfig {
 			if v == maskValue {
 				continue

--- a/core/sys_credentials_test.go
+++ b/core/sys_credentials_test.go
@@ -835,3 +835,152 @@ func TestSystemBackend_HandleCredentialSpecAuthorize_PinnedRedirectURI(t *testin
 	require.NotNil(t, resp.Err)
 	assert.Contains(t, resp.Err.Error(), "does not match")
 }
+
+// --- sealed spec-config keys ---
+
+// connectedOAuthSpec creates an authorization_code spec and runs a real connect
+// against a mock token endpoint, so the sealed keys arrive the way the server
+// writes them rather than the way a test would.
+func connectedOAuthSpec(t *testing.T, backend *SystemBackend, ctx context.Context, name string) {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "at", "refresh_token": "rt-sealed", "expires_in": 28800})
+	}))
+	t.Cleanup(server.Close)
+
+	createOAuth2Source(t, backend, ctx, name+"-src", "https://example.com/authorize", server.URL, true)
+	createAuthCodeSpec(t, backend, ctx, name, name+"-src", nil)
+
+	schema := backend.pathCredentials()[5].Fields // .../connect
+	raw := map[string]interface{}{
+		"name":          name,
+		"code":          "the-code",
+		"redirect_uri":  "http://127.0.0.1:8765/callback",
+		"code_verifier": "the-verifier",
+	}
+	resp, err := backend.handleCredentialSpecConnect(ctx, createTestRequest(logical.CreateOperation, "cred/specs/"+name+"/connect", raw), createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "connect must still work — enforcement guards the operator path only: %+v", resp.Data)
+}
+
+// TestSystemBackend_HandleCredentialSpecCreate_RejectsSealedKeys pins that the
+// keys documented as sealed at connect time cannot be supplied at create. Before
+// this guard a hand-written access_token made a spec report itself connected and
+// mint that token verbatim, so a documented invariant was not one.
+func TestSystemBackend_HandleCredentialSpecCreate_RejectsSealedKeys(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	createOAuth2Source(t, backend, ctx, "oauth-src", "https://example.com/authorize", "https://example.com/token", false)
+
+	schema := backend.pathCredentials()[2].Fields
+	for _, key := range []string{"refresh_token", "access_token", "refresh_token_expires_at", "access_token_expires_at"} {
+		t.Run(key, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"name":   "forged-" + key,
+				"type":   "oauth_bearer_token",
+				"source": "oauth-src",
+				"config": map[string]interface{}{
+					"auth_method": "authorization_code",
+					"client_id":   "cid",
+					key:           "forged-value",
+				},
+			}
+			resp, err := backend.handleCredentialSpecCreate(ctx,
+				createTestRequest(logical.CreateOperation, "cred/specs/forged", raw),
+				createFieldData(schema, raw))
+			require.NoError(t, err)
+			require.NotNil(t, resp.Err, "create must be refused")
+			assert.Equal(t, http.StatusBadRequest, logical.GetErrorCode(resp.Err))
+			assert.Contains(t, resp.Err.Error(), key)
+
+			// And nothing was stored under that name.
+			_, err = backend.core.credConfigStore.GetSpec(ctx, "forged-"+key)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestSystemBackend_HandleCredentialSpecUpdate_RejectsSealedKeys pins the same
+// on update, where the stored value is what an operator would be overwriting.
+func TestSystemBackend_HandleCredentialSpecUpdate_RejectsSealedKeys(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	connectedOAuthSpec(t, backend, ctx, "gh")
+
+	schema := backend.pathCredentials()[2].Fields
+	raw := map[string]interface{}{
+		"name":   "gh",
+		"config": map[string]interface{}{"refresh_token": "rt-forged"},
+	}
+	resp, err := backend.handleCredentialSpecUpdate(ctx,
+		createTestRequest(logical.UpdateOperation, "cred/specs/gh", raw),
+		createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Err, "update must be refused")
+	assert.Equal(t, http.StatusBadRequest, logical.GetErrorCode(resp.Err))
+	assert.Contains(t, resp.Err.Error(), "refresh_token")
+
+	// The sealed value is untouched.
+	spec, err := backend.core.credConfigStore.GetSpec(ctx, "gh")
+	require.NoError(t, err)
+	assert.Equal(t, "rt-sealed", spec.Config["refresh_token"])
+}
+
+// TestSystemBackend_HandleCredentialSpecUpdate_SealedKeysSurviveResend is the
+// over-rejection guard: a caller who reads a spec, edits one field and sends the
+// whole map back is holding the mask sentinel for the sealed secret. Refusing
+// that would make read-edit-resend impossible on every connected spec.
+func TestSystemBackend_HandleCredentialSpecUpdate_SealedKeysSurviveResend(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	connectedOAuthSpec(t, backend, ctx, "gh")
+
+	schema := backend.pathCredentials()[2].Fields
+	readRaw := map[string]interface{}{"name": "gh"}
+	readResp, err := backend.handleCredentialSpecRead(ctx,
+		createTestRequest(logical.ReadOperation, "cred/specs/gh", readRaw),
+		createFieldData(schema, readRaw))
+	require.NoError(t, err)
+	readConfig, ok := readResp.Data["config"].(map[string]string)
+	require.True(t, ok, "config in read response: %#v", readResp.Data["config"])
+	require.Equal(t, maskValue, readConfig["refresh_token"], "read must mask refresh_token, else this test proves nothing")
+
+	// Resend the read verbatim, changing only a field the operator owns.
+	resend := make(map[string]interface{}, len(readConfig))
+	for k, v := range readConfig {
+		resend[k] = v
+	}
+	resend["scope"] = "read:everything"
+	updateRaw := map[string]interface{}{"name": "gh", "config": resend}
+	resp, err := backend.handleCredentialSpecUpdate(ctx,
+		createTestRequest(logical.UpdateOperation, "cred/specs/gh", updateRaw),
+		createFieldData(schema, updateRaw))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "resending a masked read must be accepted: %+v", resp.Data)
+
+	spec, err := backend.core.credConfigStore.GetSpec(ctx, "gh")
+	require.NoError(t, err)
+	assert.Equal(t, "rt-sealed", spec.Config["refresh_token"], "the secret must survive the round trip")
+	assert.Equal(t, "read:everything", spec.Config["scope"])
+}
+
+// TestSystemBackend_HandleCredentialSpecUpdate_SealedKeyCanBeCleared keeps the
+// one operator lever that does not forge anything: emptying a sealed key
+// disconnects the spec without deleting it.
+func TestSystemBackend_HandleCredentialSpecUpdate_SealedKeyCanBeCleared(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	connectedOAuthSpec(t, backend, ctx, "gh")
+
+	schema := backend.pathCredentials()[2].Fields
+	raw := map[string]interface{}{
+		"name":   "gh",
+		"config": map[string]interface{}{"refresh_token": ""},
+	}
+	resp, err := backend.handleCredentialSpecUpdate(ctx,
+		createTestRequest(logical.UpdateOperation, "cred/specs/gh", raw),
+		createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "clearing must stay possible: %+v", resp.Data)
+
+	spec, err := backend.core.credConfigStore.GetSpec(ctx, "gh")
+	require.NoError(t, err)
+	assert.Empty(t, spec.Config["refresh_token"])
+}

--- a/credential/type.go
+++ b/credential/type.go
@@ -133,3 +133,21 @@ type ConfigSensitivity interface {
 	// implementation must include everything that list would have returned.
 	SensitiveConfigFieldsFor(config map[string]string) []string
 }
+
+// SystemManagedConfig is an optional interface a credential Type implements when
+// some of its spec-config keys are written by the server rather than by an
+// operator — sealed during an interactive connect, or replaced by the mint
+// pipeline as it rotates them. Such a key is documented as not operator-set, and
+// this is what makes that documentation true.
+//
+// Enforcement belongs to the spec create and update handlers, because they are
+// the only place the caller's own input is still distinguishable from stored
+// state; by the time a write reaches the config store the two have merged.
+// Internal writers therefore bypass it by construction rather than by opting
+// out. Any new operator-facing surface that writes spec config must route
+// through the same check, or the guarantee is only as wide as the paths that
+// remember it.
+type SystemManagedConfig interface {
+	// SystemManagedConfigFields returns the spec-config keys the server owns.
+	SystemManagedConfigFields() []string
+}

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -177,6 +177,27 @@ func (t *OAuthBearerTokenCredType) SensitiveConfigFields() []string {
 // Compile-time assertion that the type is connect-gated for authorization_code.
 var _ credential.ConnectGated = (*OAuthBearerTokenCredType)(nil)
 
+// Compile-time assertion that the sealed keys are enforced, not just documented.
+var _ credential.SystemManagedConfig = (*OAuthBearerTokenCredType)(nil)
+
+// SystemManagedConfigFields returns the keys sealed by `cred spec connect` and
+// by the refresh-token write-back. They are the credential itself: an operator
+// who could set one could mint against a token the server never issued, and the
+// spec would report itself connected on the strength of it.
+//
+// These four are read from the spec config directly at mint time, never resolved
+// spec-over-source, which is why guarding the spec write paths is sufficient. A
+// change that starts resolving any of them from the source would need the source
+// write path guarded too.
+func (t *OAuthBearerTokenCredType) SystemManagedConfigFields() []string {
+	return []string{
+		"refresh_token",
+		"access_token",
+		"refresh_token_expires_at",
+		"access_token_expires_at",
+	}
+}
+
 // RequiresConnect reports whether the spec uses the authorization_code flow, which
 // needs a one-time `cred spec connect` before it can mint.
 func (t *OAuthBearerTokenCredType) RequiresConnect(config map[string]string) bool {

--- a/credential/types/oauth_bearer_token_test.go
+++ b/credential/types/oauth_bearer_token_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -314,4 +315,33 @@ func TestOAuthBearerTokenCredType_FieldSchemas(t *testing.T) {
 
 	assert.Contains(t, schemas, "token_type")
 	assert.False(t, schemas["token_type"].Sensitive)
+}
+
+// TestOAuthBearerTokenCredType_SystemManagedFields pins the sealed keys against
+// the schema that documents them. The declaration is a plain slice and the
+// enforcement it drives is elsewhere, so nothing else would notice a fifth
+// sealed field being added to ConfigSchema and left off this list — it would
+// simply ship operator-settable.
+func TestOAuthBearerTokenCredType_SystemManagedFields(t *testing.T) {
+	ct := NewOAuthBearerTokenCredType()
+
+	managed := make(map[string]bool)
+	for _, f := range ct.SystemManagedConfigFields() {
+		managed[f] = true
+	}
+
+	assert.Equal(t, map[string]bool{
+		"refresh_token":            true,
+		"access_token":             true,
+		"refresh_token_expires_at": true,
+		"access_token_expires_at":  true,
+	}, managed)
+
+	// Every field whose description calls itself sealed must be in the list.
+	for _, field := range ct.ConfigSchema() {
+		if strings.Contains(field.Description(), "not operator-set") {
+			assert.True(t, managed[field.FieldName()],
+				"%q is documented as sealed but is not declared system-managed", field.FieldName())
+		}
+	}
 }

--- a/e2e/fullchain/chain_test.go
+++ b/e2e/fullchain/chain_test.go
@@ -19,22 +19,29 @@ import (
 type injection struct {
 	env  h.ProviderEnv
 	want map[string]string
+
+	// wantPrefix is used instead of want when the credential is minted live and
+	// its value cannot be a constant. The scheme is still pinned exactly; only
+	// the token after it is left open, and the provider's own file carries the
+	// stronger assertions about what that token may not be.
+	wantPrefix map[string]string
 }
 
 // injections pins one positive credential-extractor branch per provider. The
 // header names differ by provider by design: that difference is most of what the
 // credential extractors do.
 var injections = []injection{
-	{openaiEnv, map[string]string{"Authorization": "Bearer " + openaiKey}},
-	{anthropicEnv, map[string]string{"x-api-key": anthropicKey}},
-	{newrelicEnv, map[string]string{"Api-Key": newrelicKey}},
-	{elasticEnv, map[string]string{"Authorization": "ApiKey " + elasticKey}},
-	{githubEnv, map[string]string{"Authorization": "token " + githubPAT}},
-	{splunkEnv, map[string]string{"Authorization": "Bearer " + splunkKey}},
-	{datadogEnv, map[string]string{"DD-API-KEY": datadogAPIKey}},
-	{restEnv, map[string]string{"X-Custom-Auth": "Token " + restToken}},
-	{dynatraceEnv, map[string]string{"Authorization": "Api-Token " + dynatraceAPIToken}},
-	{dynatraceOAuthEnv, map[string]string{"Authorization": "Bearer " + dynatraceOAuthToken}},
+	{env: openaiEnv, want: map[string]string{"Authorization": "Bearer " + openaiKey}},
+	{env: anthropicEnv, want: map[string]string{"x-api-key": anthropicKey}},
+	{env: newrelicEnv, want: map[string]string{"Api-Key": newrelicKey}},
+	{env: elasticEnv, want: map[string]string{"Authorization": "ApiKey " + elasticKey}},
+	{env: githubEnv, want: map[string]string{"Authorization": "token " + githubPAT}},
+	{env: splunkEnv, want: map[string]string{"Authorization": "Bearer " + splunkKey}},
+	{env: datadogEnv, want: map[string]string{"DD-API-KEY": datadogAPIKey}},
+	{env: restEnv, want: map[string]string{"X-Custom-Auth": "Token " + restToken}},
+	{env: dynatraceEnv, want: map[string]string{"Authorization": "Api-Token " + dynatraceAPIToken}},
+	// Minted live against the harness issuer, so only the scheme is a constant.
+	{env: dynatraceOAuthEnv, wantPrefix: map[string]string{"Authorization": "Bearer "}},
 }
 
 // TestFullChain_CertAgentWithUser is the reference shape the suite exists for:
@@ -64,6 +71,13 @@ func TestFullChain_CertAgentWithUser(t *testing.T) {
 				Absent:        h.AlwaysAbsent(),
 				UpstreamCalls: 1,
 			})
+
+			for header, prefix := range tc.wantPrefix {
+				got := upstream.Last(t).Header.Get(header)
+				if !strings.HasPrefix(got, prefix) || got == prefix {
+					t.Errorf("upstream %s = %q, want %q followed by a credential", header, got, prefix)
+				}
+			}
 		})
 	}
 }

--- a/e2e/fullchain/dynatrace_test.go
+++ b/e2e/fullchain/dynatrace_test.go
@@ -3,6 +3,8 @@
 package fullchain
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
@@ -17,8 +19,11 @@ import (
 // Neither arm had any test at all before this.
 
 const (
-	dynatraceAPIToken   = "fc-dynatrace-not-a-real-token"
-	dynatraceOAuthToken = "fc-dynatrace-not-a-real-oauth-token"
+	dynatraceAPIToken = "fc-dynatrace-not-a-real-token"
+
+	// The harness issuer's client secret for the OAuth arm. Asserted against, so
+	// that handing it through unexchanged cannot pass for a minted token.
+	dynatraceOAuthClientSecret = "agent-secret"
 )
 
 var dynatraceEnv = h.ProviderEnv{
@@ -30,17 +35,17 @@ var dynatraceEnv = h.ProviderEnv{
 }
 
 // The OAuth arm needs an oauth_bearer_token credential, which no local source
-// will hold — so it uses an oauth2 source, configured for the one mint path that
-// touches no network.
+// will hold — so it uses an oauth2 source against the harness issuer and mints
+// for real, under the default client_credentials grant.
 //
-// The default grant is client_credentials, which really does call the token
-// endpoint; pointed at the harness's issuer it mints a live token whose value no
-// assertion can predict, and the row would then be testing the OAuth2 driver
-// rather than this provider's extractor. Under authorization_code the driver
-// instead returns the spec's static access token verbatim — the path a provider
-// that issues no refresh token takes — which keeps the assertion exact and the
-// subject the extractor. token_url is required of the source either way and is
-// never called here.
+// It used to take the authorization_code path instead, whose driver returns the
+// spec's static access_token verbatim, because that made the proxied header an
+// exact constant. That relied on writing access_token into the spec by hand —
+// a key the server seals at connect time and now refuses from an operator, so
+// the shortcut is gone along with the hole it depended on. A live mint costs the
+// exact assertion and buys a real token-endpoint round trip; what this row is
+// actually for, that the credential *type* selects the scheme, is carried by the
+// Bearer prefix, which no api_key credential would ever produce.
 var dynatraceOAuthEnv = h.ProviderEnv{
 	Mount:      "fc-dynatrace-oauth",
 	Type:       "dynatrace",
@@ -49,17 +54,9 @@ var dynatraceOAuthEnv = h.ProviderEnv{
 	SourceType: "oauth2",
 	SourceConfig: map[string]string{
 		"token_url":       h.HydraIssuer + "/oauth2/token",
+		"client_id":       "e2e-agent",
+		"client_secret":   dynatraceOAuthClientSecret,
 		"tls_skip_verify": "true",
-	},
-	// auth_method belongs on the spec, where it is a declared field; the source
-	// schema does not define it and would carry it only because unknown keys are
-	// ignored. access_token is documented as sealed at connect time rather than
-	// operator-set, but IsConnected accepts a hand-written value, so nothing
-	// enforces it — this fixture leans on that gap to mint an OAuth credential
-	// without a network call.
-	CredConfig: map[string]string{
-		"auth_method":  "authorization_code",
-		"access_token": dynatraceOAuthToken,
 	},
 }
 
@@ -73,31 +70,100 @@ var dynatraceOAuthEnv = h.ProviderEnv{
 func TestDynatrace_CredentialTypeSelectsScheme(t *testing.T) {
 	ensureEnv(t)
 
-	cases := []struct {
-		name string
-		env  h.ProviderEnv
-		want string
-	}{
-		{"api token", dynatraceEnv, "Api-Token " + dynatraceAPIToken},
-		{"oauth token", dynatraceOAuthEnv, "Bearer " + dynatraceOAuthToken},
-	}
+	// The API arm's credential is a constant, so the whole header is.
+	t.Run("api token", func(t *testing.T) {
+		upstream.Reset()
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			upstream.Reset()
+		status, body, _ := h.ChainRequest(t, leaderPort, dynatraceEnv, h.ChainOpts{
+			AgentCertPEM: agentCert(t),
+			Bearer:       h.FullChainUserJWT(t),
+			Role:         dynatraceEnv.CertRole(),
+		})
 
-			status, body, _ := h.ChainRequest(t, leaderPort, tc.env, h.ChainOpts{
-				AgentCertPEM: agentCert(t),
-				Bearer:       h.FullChainUserJWT(t),
-				Role:         tc.env.CertRole(),
+		h.AssertChain(t, upstream, status, body, h.ChainWant{
+			Status:        200,
+			Injected:      map[string]string{"Authorization": "Api-Token " + dynatraceAPIToken},
+			Absent:        h.AlwaysAbsent(),
+			UpstreamCalls: 1,
+		})
+	})
+
+	// The OAuth arm's is whatever the issuer minted this run, so the assertions
+	// are on shape: the scheme, which is the thing under test, and enough about
+	// the value to rule out anything the request already carried arriving in its
+	// place.
+	t.Run("oauth token", func(t *testing.T) {
+		upstream.Reset()
+
+		status, body, _ := h.ChainRequest(t, leaderPort, dynatraceOAuthEnv, h.ChainOpts{
+			AgentCertPEM: agentCert(t),
+			Bearer:       h.FullChainUserJWT(t),
+			Role:         dynatraceOAuthEnv.CertRole(),
+		})
+
+		h.AssertChain(t, upstream, status, body, h.ChainWant{
+			Status:        200,
+			Absent:        h.AlwaysAbsent(),
+			UpstreamCalls: 1,
+		})
+
+		authz := upstream.Last(t).Header.Get("Authorization")
+		token, ok := strings.CutPrefix(authz, "Bearer ")
+		if !ok || token == "" {
+			t.Fatalf("Authorization = %q, want a Bearer token — the scheme is what the credential type selects", authz)
+		}
+		if token == h.FullChainUserJWT(t) {
+			t.Error("the caller's own JWT was forwarded as the credential")
+		}
+		if token == dynatraceOAuthClientSecret {
+			t.Error("the client secret was forwarded unexchanged")
+		}
+		// The harness issuer signs JWTs, so a minted token is one. Anything else
+		// means the mint was skipped and some other value rode through.
+		if !strings.HasPrefix(token, "ey") {
+			t.Errorf("credential %q is not a minted JWT", token)
+		}
+	})
+}
+
+// TestDynatrace_SealedOAuthKeysAreRefused pins the guard the fixture above used
+// to depend on. access_token is documented as sealed at connect time; until the
+// write path enforced that, this create returned 200 and the spec reported
+// itself connected on the strength of a value an operator had typed.
+//
+// It is here rather than beside the other credential rows because this is the
+// mount whose fixture the guard cost — leaving the two apart is how the reason
+// for the conversion above gets lost.
+func TestDynatrace_SealedOAuthKeysAreRefused(t *testing.T) {
+	ensureEnv(t)
+
+	for _, key := range []string{"access_token", "refresh_token"} {
+		t.Run(key, func(t *testing.T) {
+			specName := "fc-dynatrace-forged-" + key
+			// A create that is refused leaves nothing, which is the point of the
+			// row. Clean up anyway: on a binary without the guard it succeeds, and
+			// the spec left behind pins the source and breaks the next run's setup
+			// with a 409 rather than a readable failure.
+			t.Cleanup(func() {
+				h.APIRequest(t, "DELETE", "sys/cred/specs/"+specName, leaderPort, "")
 			})
 
-			h.AssertChain(t, upstream, status, body, h.ChainWant{
-				Status:        200,
-				Injected:      map[string]string{"Authorization": tc.want},
-				Absent:        h.AlwaysAbsent(),
-				UpstreamCalls: 1,
-			})
+			payload := fmt.Sprintf(
+				`{"type":"oauth_bearer_token","source":%q,"config":{"auth_method":"authorization_code","client_id":"e2e-agent",%q:"forged-by-the-operator"}}`,
+				dynatraceOAuthEnv.Source(), key)
+
+			status, body := h.APIRequest(t, "POST", "sys/cred/specs/"+specName, leaderPort, payload)
+
+			if status != 400 {
+				t.Fatalf("spec create with a sealed %s: status %d, want 400 — body %s", key, status, body)
+			}
+			// The status alone is not enough. A forged refresh_token also draws a
+			// 400 from the create-time test-mint, which fails when the issuer
+			// rejects it — so a row asserting only the code would pass against a
+			// binary with no guard at all. The refusal has to be this one.
+			if !strings.Contains(string(body), "sealed") || !strings.Contains(string(body), key) {
+				t.Errorf("want the sealed-key refusal naming %s; body = %s", key, body)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes finding C3 in `e2e/FINDINGS.md`.

`refresh_token`, `access_token` and their two expiry stamps are documented on the OAuth credential type as sealed at connect time and not operator-set. Nothing enforced it: a hand-written `access_token` made a spec report itself connected and mint that value verbatim.

## The finding named the wrong fix

C3 proposed hardening `IsConnected`. That would have closed nothing — minting never consults it. The driver reads the raw spec config and the manager routes on whether a refresh token is present, so a forged token still mints.

The forgery enters through the **write path**. The spec create and update handlers are the only place the caller's own input is still distinguishable from stored state; by the time a write reaches the config store the two have merged. That is where the guard belongs.

## Shape

A credential type now declares which of its config keys the server owns, via a new optional `SystemManagedConfig` interface. It is written as a sibling of the existing `ConfigSensitivity` interface, which already had exactly this shape — an optional interface on the type, resolved through the type registry in the sys handlers.

A key still passes when the caller is not really setting it:

- absent
- empty — an explicit clear, which cannot forge anything and is the one disconnect lever short of deleting the spec
- identical to what is stored — a read resent unchanged
- the mask sentinel over a non-empty stored value — a masked read resent

Anything else is a 400 naming the key. Read-edit-resend therefore keeps working, which matters because reads mask two of the four.

The whole spec write surface is six call sites and only two are operator-facing. The connect seal and the refresh-token rotation write-back never pass through those handlers, so they are untouched by construction rather than by opting out.

`IsConnected` is unchanged. With the write path closed, a separate connected marker would be guarded by the same mechanism and would only add states that can disagree with each other.

## The e2e fixture this cost

The dynatrace full-chain fixture leaned on the gap deliberately — it wrote a static `access_token` so the OAuth arm minted offline with a predictable value, and said so in a comment. Its create now returns 400.

It does a real `client_credentials` mint against the harness issuer instead. The assertion moves from an exact token to the scheme plus enough shape to rule out the caller's own JWT or the client secret arriving in its place — which is all that arm was ever testing, since no `api_key` credential produces a Bearer. Exact-value coverage of the static-token path stays in the driver's unit tests, where it belongs.

The shared `injections` table grew a prefix mode for the same reason, so the mount stays in the decoy-stripping sweep rather than dropping out of it.

## Two things the shape of the fix turned up

The four sealed keys are read from the spec config directly and never resolved spec-over-source, which is what makes guarding the spec handlers sufficient — the source update path does the same verbatim merge but a source-level value is inert. A change that starts resolving any of them from the source would need the source path guarded too; that is recorded on the declaration itself.

A first cut of the e2e row asserted only the status. A forged `refresh_token` also draws a 400 from the create-time test-mint when the issuer rejects it, so the row passed against an unguarded binary. It asserts the refusal, not the code.

## Verification

Verified on a live 3-node cluster against the previous binary: the forged `access_token` create returned 201, with the spec stored and reporting itself connected.

- `TestSystemBackend_HandleCredentialSpecCreate_RejectsSealedKeys` — all four keys
- `TestSystemBackend_HandleCredentialSpecUpdate_RejectsSealedKeys`
- `TestSystemBackend_HandleCredentialSpecUpdate_SealedKeysSurviveResend` — the over-rejection guard
- `TestSystemBackend_HandleCredentialSpecUpdate_SealedKeyCanBeCleared`
- `TestOAuthBearerTokenCredType_SystemManagedFields` — cross-checks the declared list against the schema fields documented as sealed
- `TestDynatrace_SealedOAuthKeysAreRefused` — end to end

Existing connect tests stay green, which is the proof the seal path is untouched. Full `e2e/fullchain` suite green against a live cluster.
