### PR TITLE
fix(core): let an operator require check-and-set on a policy, and answer 4xx when it fails

### DIFF
--- a/core/policy_cas_test.go
+++ b/core/policy_cas_test.go
@@ -1,0 +1,185 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const casTestPolicy = `
+path "secret/*" {
+  capabilities = ["read"]
+}
+`
+
+// writePolicy drives the update handler the way a client does, returning the
+// response so a caller can assert on the refusal as well as the success.
+func writePolicy(t *testing.T, backend *SystemBackend, ctx context.Context, name string, extra map[string]interface{}) *logical.Response {
+	t.Helper()
+	raw := map[string]interface{}{"name": name, "policy": casTestPolicy}
+	for k, v := range extra {
+		raw[k] = v
+	}
+	schema := backend.pathPolicies()[0].Fields
+	resp, err := backend.handlePolicyUpdate(ctx,
+		createTestRequest(logical.UpdateOperation, "policies/cbp/"+name, raw),
+		createFieldData(schema, raw))
+	require.NoError(t, err)
+	return resp
+}
+
+// createPolicy drives the create handler specifically. POST maps to
+// CreateOperation on the wire, and the path registers a separate callback for
+// it, so a test that only ever updates would not notice the create handler
+// losing its assignment.
+func createPolicy(t *testing.T, backend *SystemBackend, ctx context.Context, name string, extra map[string]interface{}) *logical.Response {
+	t.Helper()
+	raw := map[string]interface{}{"name": name, "policy": casTestPolicy}
+	for k, v := range extra {
+		raw[k] = v
+	}
+	schema := backend.pathPolicies()[0].Fields
+	resp, err := backend.handlePolicyCreate(ctx,
+		createTestRequest(logical.CreateOperation, "policies/cbp/"+name, raw),
+		createFieldData(schema, raw))
+	require.NoError(t, err)
+	return resp
+}
+
+func readPolicyVersion(t *testing.T, backend *SystemBackend, ctx context.Context, name string) (int, bool) {
+	t.Helper()
+	raw := map[string]interface{}{"name": name}
+	schema := backend.pathPolicies()[0].Fields
+	resp, err := backend.handlePolicyRead(ctx,
+		createTestRequest(logical.ReadOperation, "policies/cbp/"+name, raw),
+		createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err, "read: %+v", resp.Data)
+	return resp.Data["data_version"].(int), resp.Data["cas_required"].(bool)
+}
+
+// TestPolicyCAS_RequiredIsSettable pins the write half of check-and-set. The
+// store has always honoured a sticky cas_required, but no field carried it, so
+// the flag was never true and every policy write was blind however carefully a
+// client tried to behave.
+func TestPolicyCAS_RequiredIsSettable(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	// Turning the flag on is itself a guarded write: the store ORs the incoming
+	// flag with the stored one before deciding whether a cas is needed, so the
+	// enabling write must carry one. On a policy that does not exist yet that
+	// means -1, the must-not-exist form.
+	resp := writePolicy(t, backend, ctx, "guarded", map[string]interface{}{"cas_required": true})
+	require.NotNil(t, resp.Err, "enabling the flag without a cas must be refused")
+	assert.Contains(t, resp.Err.Error(), "check-and-set parameter required")
+
+	resp = writePolicy(t, backend, ctx, "guarded", map[string]interface{}{"cas": -1, "cas_required": true})
+	require.Nil(t, resp.Err, "enabling at creation with cas=-1: %+v", resp.Data)
+
+	version, required := readPolicyVersion(t, backend, ctx, "guarded")
+	assert.Equal(t, 1, version)
+	assert.True(t, required, "cas_required must be persisted and reported")
+
+	// A blind write is now refused.
+	resp = writePolicy(t, backend, ctx, "guarded", nil)
+	require.NotNil(t, resp.Err, "a blind write must be refused once cas_required is set")
+	assert.Contains(t, resp.Err.Error(), "check-and-set parameter required")
+
+	// The policy is untouched by the refusal.
+	version, _ = readPolicyVersion(t, backend, ctx, "guarded")
+	assert.Equal(t, 1, version)
+
+	// Supplying the current version succeeds.
+	resp = writePolicy(t, backend, ctx, "guarded", map[string]interface{}{"cas": 1, "cas_required": true})
+	require.Nil(t, resp.Err, "matching cas: %+v", resp.Data)
+	version, _ = readPolicyVersion(t, backend, ctx, "guarded")
+	assert.Equal(t, 2, version)
+}
+
+// TestPolicyCAS_RequiredIsSettableAtCreate covers the other write handler. POST
+// maps to CreateOperation and the path registers a separate callback, so the
+// assignment exists twice and only one of them is on the path a client takes to
+// create a policy.
+func TestPolicyCAS_RequiredIsSettableAtCreate(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	resp := createPolicy(t, backend, ctx, "made", map[string]interface{}{"cas": -1, "cas_required": true})
+	require.Nil(t, resp.Err, "create with cas_required: %+v", resp.Data)
+
+	_, required := readPolicyVersion(t, backend, ctx, "made")
+	assert.True(t, required, "the create handler must carry cas_required too")
+
+	// And it binds: a blind write is refused.
+	require.NotNil(t, writePolicy(t, backend, ctx, "made", nil).Err)
+}
+
+// TestPolicyCAS_OmittingRequiredClearsIt pins the consequence of taking the flag
+// from every write: a caller who updates policy text with a valid cas but says
+// nothing about cas_required disarms the guard. That is upstream's behaviour and
+// what makes lifting possible at all, but it is a sharp edge — an operator
+// editing a guarded policy has to keep asserting the flag or lose it.
+func TestPolicyCAS_OmittingRequiredClearsIt(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	require.Nil(t, writePolicy(t, backend, ctx, "sharp", map[string]interface{}{"cas": -1, "cas_required": true}).Err)
+
+	// A correct, careful write that simply does not mention the flag.
+	require.Nil(t, writePolicy(t, backend, ctx, "sharp", map[string]interface{}{"cas": 1}).Err)
+
+	_, required := readPolicyVersion(t, backend, ctx, "sharp")
+	assert.False(t, required, "omitting cas_required clears it — pinned, not endorsed")
+}
+
+// TestPolicyCAS_RequiredCanBeLifted keeps the flag from being a one-way door.
+// It is taken from each write rather than carried over, so clearing it is an
+// ordinary write — which still has to satisfy the requirement it is lifting.
+func TestPolicyCAS_RequiredCanBeLifted(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	require.Nil(t, writePolicy(t, backend, ctx, "liftable", map[string]interface{}{"cas": -1, "cas_required": true}).Err)
+
+	// Lifting it blindly is refused — the flag still applies to this write.
+	resp := writePolicy(t, backend, ctx, "liftable", map[string]interface{}{"cas_required": false})
+	require.NotNil(t, resp.Err, "lifting must itself satisfy the requirement")
+
+	// With a matching cas it is lifted.
+	resp = writePolicy(t, backend, ctx, "liftable", map[string]interface{}{"cas": 1, "cas_required": false})
+	require.Nil(t, resp.Err, "lifting with cas: %+v", resp.Data)
+
+	_, required := readPolicyVersion(t, backend, ctx, "liftable")
+	assert.False(t, required)
+
+	// And blind writes work again.
+	require.Nil(t, writePolicy(t, backend, ctx, "liftable", nil).Err)
+}
+
+// TestPolicyCAS_MismatchIsBadRequest pins the status. A caller who loses a race
+// was told the server broke: the check-and-set errors carried no status of
+// their own, so the wire mapping fell through to its default.
+func TestPolicyCAS_MismatchIsBadRequest(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	require.Nil(t, writePolicy(t, backend, ctx, "raced", nil).Err)
+
+	// All three check-and-set refusals, each previously a 500.
+	cases := []struct {
+		name  string
+		extra map[string]interface{}
+	}{
+		{"stale cas", map[string]interface{}{"cas": 99}},
+		{"create cas on an existing policy", map[string]interface{}{"cas": -1}},
+		{"cas omitted where required", map[string]interface{}{"cas_required": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := writePolicy(t, backend, ctx, "raced", tc.extra)
+			require.NotNil(t, resp.Err, "must be refused")
+			assert.Equal(t, http.StatusBadRequest, logical.GetErrorCode(resp.Err),
+				"a lost race is the caller's problem, not a 500")
+		})
+	}
+}

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -14,6 +14,7 @@ import (
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
 )
 
 const (
@@ -190,17 +191,21 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 		}
 	}
 
+	// A failed check-and-set is the caller's race to lose, not a server fault.
+	// These carry their own status because a plain error falls through the wire
+	// mapping's default and answers 500, which tells a caller who was overtaken
+	// that the server broke.
 	casRequired := existing.CASRequired || p.CASRequired
 	if casVersion == nil && casRequired {
-		return fmt.Errorf("check-and-set parameter required for this call")
+		return logical.ErrBadRequest("check-and-set parameter required for this call")
 	}
 	if casVersion != nil {
 		if *casVersion == -1 && existingEntry != nil {
-			return fmt.Errorf("check-and-set parameter set to -1 on existing entry")
+			return logical.ErrBadRequest("check-and-set parameter set to -1 on existing entry")
 		}
 
 		if *casVersion != -1 && *casVersion != existing.DataVersion {
-			return fmt.Errorf("check-and-set parameter did not match the current version")
+			return logical.ErrBadRequest("check-and-set parameter did not match the current version")
 		}
 	}
 
@@ -578,40 +583,6 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 	}
 
 	return cbp, nil
-}
-
-// loadCBPPolicy is used to load default CBP policies in a specific
-// namespace.
-func (ps *PolicyStore) loadCBPPolicy(ctx context.Context, policyName, policyText string) error {
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Check if the policy already exists
-	policy, err := ps.GetPolicy(ctx, policyName, PolicyTypeCBP)
-	if err != nil {
-		return fmt.Errorf("error fetching %s policy from store: %w", policyName, err)
-	}
-	if policy != nil {
-		if !slices.Contains(immutablePolicies, policyName) || policyText == policy.Raw {
-			return nil
-		}
-	}
-
-	policy, err = ParseCBPPolicy(ns, policyText)
-	if err != nil {
-		return fmt.Errorf("error parsing %s policy: %w", policyName, err)
-	}
-
-	if policy == nil {
-		return fmt.Errorf("parsing %q policy resulted in nil policy", policyName)
-	}
-
-	cas := &policy.DataVersion
-	policy.Name = policyName
-	policy.Type = PolicyTypeCBP
-	return ps.setPolicyInternal(ctx, policy, cas)
 }
 
 func (ps *PolicyStore) sanitizeName(name string) string {

--- a/core/sys_policies.go
+++ b/core/sys_policies.go
@@ -30,6 +30,10 @@ func (b *SystemBackend) pathPolicies() []*framework.Path {
 					Type:        framework.TypeInt,
 					Description: "Check-and-set parameter for optimistic locking",
 				},
+				"cas_required": {
+					Type:        framework.TypeBool,
+					Description: "Require every write to this policy to carry a matching 'cas'. Persisted with the policy, and taken from each write: send false alongside a valid 'cas' to lift it.",
+				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.CreateOperation: &framework.PathOperation{
@@ -100,6 +104,11 @@ func (b *SystemBackend) handlePolicyCreate(ctx context.Context, req *logical.Req
 		casVersion = &v
 	}
 
+	// Taken from the request on every write rather than carried over, so a policy
+	// that requires check-and-set can also stop requiring it — the store still
+	// demands a matching cas for the write that lifts the flag.
+	policy.CASRequired = d.Get("cas_required").(bool)
+
 	// Store the policy
 	if err := b.core.policyStore.SetPolicy(ctx, policy, casVersion); err != nil {
 		return logical.ErrorResponse(err), nil
@@ -160,6 +169,11 @@ func (b *SystemBackend) handlePolicyUpdate(ctx context.Context, req *logical.Req
 		v := cas.(int)
 		casVersion = &v
 	}
+
+	// Taken from the request on every write rather than carried over, so a policy
+	// that requires check-and-set can also stop requiring it — the store still
+	// demands a matching cas for the write that lifts the flag.
+	policy.CASRequired = d.Get("cas_required").(bool)
 
 	// Store the policy
 	if err := b.core.policyStore.SetPolicy(ctx, policy, casVersion); err != nil {


### PR DESCRIPTION
Closes finding C5 in `e2e/FINDINGS.md`, which came out of analysing C4.

Check-and-set on policies was opt-in per request and could not be made mandatory. The store has always honoured a sticky `cas_required` — once set on a policy, later writes must carry a matching `cas` — and the read path has always reported it. But no field on the write path carried it and neither handler ever set it, so the flag was permanently false, the branch reading it unreachable, and every policy write blind however carefully a client behaved.

This is a fork divergence rather than shared behaviour. Upstream declares the field on both of its policy write paths, reads it in the handler, and returns it in both response schemas; its own tests assert the key is present. Only the write half was lost on the way across, so this restores it with upstream's semantics exactly: the flag is taken from each write rather than carried over, which is what keeps it from being a one-way door.

## Three consequences the tests pin

All follow from the existing store logic — it ORs the incoming flag with the stored one before deciding whether a `cas` is needed — rather than from anything added here. All three would otherwise be discovered by an operator as a puzzling refusal:

- **Enabling the flag is itself a guarded write**, so it needs a `cas` — `-1` on a policy that does not exist yet.
- **Lifting it has to satisfy the requirement it removes.**
- **Omitting it on an otherwise correct write clears it.** A caller who updates policy text with a valid `cas` but says nothing about `cas_required` disarms the guard. That is upstream's behaviour and it is what makes lifting possible at all, but it is a sharp edge, so it is pinned rather than endorsed.

The create handler carries its own assignment and its own test row. POST maps to the create callback, and a suite that only drove updates stayed green with that assignment deleted — which is how the second half of a two-handler fix gets lost.

## Fixed alongside, being the same code

**A CAS mismatch answered 500.** The three refusals were plain errors with no status of their own, so the wire mapping fell through its default and told a caller who had merely lost a race that the server broke. Same class as finding B2, where that `default` was the wider fault too.

This was a fork divergence as well: upstream's refusals are also plain errors, but its policy handler funnels them through a helper that maps an uncoded error to a bad request, so an upstream caller has always seen 400 here. The three errors are coded directly rather than adopting that helper, deliberately — the helper also flattens genuine storage faults to 400, and a write that failed because storage is broken is not the caller's mistake.

**`loadCBPPolicy` is gone.** Uncalled — its only caller is an empty no-op — and its `cas := &policy.DataVersion` was the only other check-and-set caller in the tree, which is a misleading thing to leave standing while changing what check-and-set means.

## What this does not do

It does not close C4. A stale `cas` from a superseded incarnation still matches a recreated policy, because `DataVersion` restarts at 1 after a delete. That behaviour is present verbatim upstream — in the policy store and in the KV v2 engine — and is recorded there as by design. What changes here is that a careful caller can ask for check-and-set at all, which is what makes that hazard reachable in the first place.

## Verification

Every assertion was verified failing against the previous binary: the enabling write was accepted and the flag read back false, and every refusal carried a 500.

- `TestPolicyCAS_RequiredIsSettable`
- `TestPolicyCAS_RequiredIsSettableAtCreate`
- `TestPolicyCAS_OmittingRequiredClearsIt`
- `TestPolicyCAS_RequiredCanBeLifted`
- `TestPolicyCAS_MismatchIsBadRequest` — all three refusals

`go test ./core/...` green.
