### PR TITLE
test(e2e): cover the vault provider end to end, and make a rotation observable

### DIFF
--- a/e2e/configs/node1.hcl
+++ b/e2e/configs/node1.hcl
@@ -1,7 +1,10 @@
 log_format  = "standard"
 log_level   = "trace"
 
-min_cred_source_rotation_period = "5m"
+# A source floor low enough that a test can watch a rotation complete rather than
+# infer it from configuration. The scheduler ticks every 5s, so a 15s-period
+# source rotates within about 25s of being created.
+min_cred_source_rotation_period = "10s"
 min_cred_spec_rotation_period   = "5m"
 
 ip_binding_policy = "disabled"

--- a/e2e/configs/node2.hcl
+++ b/e2e/configs/node2.hcl
@@ -1,7 +1,10 @@
 log_format  = "standard"
 log_level   = "trace"
 
-min_cred_source_rotation_period = "5m"
+# A source floor low enough that a test can watch a rotation complete rather than
+# infer it from configuration. The scheduler ticks every 5s, so a 15s-period
+# source rotates within about 25s of being created.
+min_cred_source_rotation_period = "10s"
 min_cred_spec_rotation_period   = "5m"
 
 ip_binding_policy = "disabled"

--- a/e2e/configs/node3.hcl
+++ b/e2e/configs/node3.hcl
@@ -1,7 +1,10 @@
 log_format  = "standard"
 log_level   = "trace"
 
-min_cred_source_rotation_period = "5m"
+# A source floor low enough that a test can watch a rotation complete rather than
+# infer it from configuration. The scheduler ticks every 5s, so a 15s-period
+# source rotates within about 25s of being created.
+min_cred_source_rotation_period = "10s"
 min_cred_spec_rotation_period   = "5m"
 
 ip_binding_policy = "disabled"

--- a/e2e/fullchain/chain_test.go
+++ b/e2e/fullchain/chain_test.go
@@ -42,6 +42,9 @@ var injections = []injection{
 	{env: dynatraceEnv, want: map[string]string{"Authorization": "Api-Token " + dynatraceAPIToken}},
 	// Minted live against the harness issuer, so only the scheme is a constant.
 	{env: dynatraceOAuthEnv, wantPrefix: map[string]string{"Authorization": "Bearer "}},
+	// Minted live against the harness Vault, so likewise. vault_test.go is where
+	// the token is checked against Vault itself.
+	{env: vaultEnv, wantPrefix: map[string]string{"X-Vault-Token": vaultServiceTokenPrefix}},
 }
 
 // TestFullChain_CertAgentWithUser is the reference shape the suite exists for:

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -51,6 +51,7 @@ var allEnvs = []h.ProviderEnv{
 	mcpAWSEnv, mcpAWSWrongCredEnv, atlassianEnv, honeycombEnv,
 	prometheusEnv, prometheusBasicEnv,
 	scalewayEnv, cloudflareEnv, ovhEnv,
+	vaultEnv,
 }
 
 var (
@@ -96,6 +97,11 @@ func ensureEnv(t *testing.T) {
 		ibmIAMStub = startIBMIAMStub()
 		ibmcloudEnv = buildIBMCloudEnv(ibmIAMStub.URL)
 		allEnvs = append(allEnvs, ibmcloudEnv)
+
+		// vault's source is the one that authenticates against something real: it
+		// verifies its AppRole role and logs in while being created, so the role
+		// has to exist in Vault before the setup loop reaches that mount.
+		seedVaultApproleRole(t, vaultApproleRole, vaultRoleID, vaultSecretID)
 
 		agentCAPEM, agentCAKey = h.SetupFullChainCommon(t, leaderPort)
 		for _, env := range allEnvs {

--- a/e2e/fullchain/vault_test.go
+++ b/e2e/fullchain/vault_test.go
@@ -1,0 +1,601 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// vault is the channels token extractor with the native header second, like
+// anthropic — and the only mount in the package whose credential is real.
+//
+// Every other provider here mints from a local source, so its "credential" is a
+// constant copied out of a spec config. vault_token refuses a local source, so
+// this mount's source has to trade an AppRole secret for a service token at the
+// harness Vault on :8200 while the mount itself proxies to the recording
+// upstream. Two addresses, deliberately: the recorder says what was forwarded,
+// and the real Vault says whether what was forwarded was ever a token at all.
+// That second half is what no other file in this package can assert.
+//
+// It also carries the outbound shapes no other provider has: a path rewritten on
+// the way through, and a set of paths forwarded with no credential whatsoever.
+
+const (
+	vaultAddr         = "http://127.0.0.1:8200"
+	vaultApproleMount = "e2e_approle"
+
+	// Token role seeded by setup.sh. Its minted tokens carry exactly one policy,
+	// which is what makes the lookup in T1 an assertion rather than a ping.
+	vaultTokenRole   = "e2e-secrets-reader"
+	vaultTokenPolicy = "e2e-secrets-reader"
+
+	// The suite's own AppRole role, not the shared warden-e2e-role several other
+	// suites drive. A rotating source destroys the secret_id it replaces, so two
+	// suites sharing one role can strand each other's credential between runs.
+	// A suite-local role can only ever strand itself.
+	vaultApproleRole = "fc-warden-vault"
+	vaultRoleID      = "fc-vault-role-id-not-a-real-id"
+	vaultSecretID    = "fc-vault-secret-id-not-a-real-secret"
+
+	// The rotation row's own everything, down to a second AppRole role: it
+	// rotates every 15s once created, and must not be able to pull the secret out
+	// from under the mount every other test here drives.
+	vaultRotApproleRole = "fc-warden-vault-rot"
+	vaultRotRoleID      = "fc-vault-rot-role-id-not-a-real-id"
+	vaultRotSecretID    = "fc-vault-rot-secret-id-not-a-real-secret"
+	vaultRotSource      = "fc-vault-rot-src"
+	vaultRotSpec        = "fc-vault-rot-cred"
+	vaultRotAgentRole   = "fc-vault-rot-agent"
+
+	// The wrong-credential-type row's locals.
+	vaultWrongCredSource = "fc-vault-wrongcred-src"
+	vaultWrongCredSpec   = "fc-vault-wrongcred"
+	vaultWrongCredRole   = "fc-vault-wrongcred-agent"
+	vaultWrongCredKey    = "fc-vault-not-a-vault-token"
+
+	// Service tokens are prefixed. A minted credential that does not start with
+	// this is not a token this mount could have got from Vault.
+	vaultServiceTokenPrefix = "hvs."
+)
+
+var vaultEnv = h.ProviderEnv{
+	Mount:      "fc-vault",
+	Type:       "vault",
+	URLKey:     "vault_address",
+	CredType:   "vault_token",
+	SourceType: "hvault",
+	SourceConfig: map[string]string{
+		"vault_address": vaultAddr,
+		"auth_method":   "approle",
+		"role_id":       vaultRoleID,
+		"secret_id":     vaultSecretID,
+		"approle_mount": vaultApproleMount,
+		// Required for the source to be rotatable at all, and the store refuses an
+		// approle source that is not.
+		"role_name": vaultApproleRole,
+	},
+	// Deliberately a day. The store requires a period on this source type, and a
+	// source that carries one really does rotate — a short one here would fire
+	// partway through an unrelated test in this package and change its credential
+	// mid-run. The row that means to watch a rotation brings its own source.
+	SourceRotationPeriod: 86400,
+	CredConfig: map[string]string{
+		"mint_method": "vault_token",
+		"token_role":  vaultTokenRole,
+	},
+}
+
+// seedVaultApproleRole creates one AppRole role in the harness Vault with a
+// pinned role_id and secret_id, mirroring what setup.sh does for the shared role.
+//
+// It runs from the test rather than from setup.sh so the suite stays runnable
+// against a cluster that is already up: adding it to the harness script instead
+// would leave every existing cluster unable to run this package until it was torn
+// down and rebuilt. Re-running is safe — role and role_id writes are updates, and
+// the secret_id is registered best-effort.
+//
+// The policies match setup.sh's: e2e-warden-service is what lets the source both
+// mint tokens and rotate its own secret_id.
+func seedVaultApproleRole(t *testing.T, role, roleID, secretID string) {
+	t.Helper()
+
+	mustVault := func(path, body, what string) {
+		t.Helper()
+		switch status, resp := h.VaultDirectRequest(t, "POST", path, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	mustVault("auth/"+vaultApproleMount+"/role/"+role, `{
+		"token_policies":["default","e2e-warden-service"],
+		"token_ttl":"3600","token_period":"3600","token_type":"service","bind_secret_id":true}`,
+		"create the suite AppRole role "+role)
+
+	mustVault("auth/"+vaultApproleMount+"/role/"+role+"/role-id",
+		`{"role_id":"`+roleID+`"}`,
+		"pin the role_id for "+role)
+
+	// Not mustVault: a re-run against a cluster that still holds this secret_id
+	// gets a refusal, and that refusal means the secret is already there — which
+	// is the state the caller wanted. A run whose secret really is missing fails
+	// at the source create instead, where the error names the login.
+	h.VaultDirectRequest(t, "POST", "auth/"+vaultApproleMount+"/role/"+role+"/custom-secret-id",
+		`{"secret_id":"`+secretID+`"}`)
+}
+
+// mintedVaultToken returns the token the upstream received, having established
+// that it is a service token and none of the credentials the caller sent.
+//
+// The second half is the point. A provider that forwarded the caller's own header
+// untouched would satisfy any assertion that merely finds a token upstream.
+func mintedVaultToken(t *testing.T, inbound ...string) string {
+	t.Helper()
+
+	got := upstream.Last(t).Header.Get("X-Vault-Token")
+	if !strings.HasPrefix(got, vaultServiceTokenPrefix) {
+		t.Fatalf("upstream X-Vault-Token = %q, want a service token (%q prefix)", got, vaultServiceTokenPrefix)
+	}
+	for _, sent := range inbound {
+		if sent != "" && got == sent {
+			t.Fatalf("upstream X-Vault-Token is a credential the caller sent, not a minted one")
+		}
+	}
+	return got
+}
+
+// assertVaultTokenUsable looks the token up in the real Vault and checks the
+// policy it carries.
+//
+// This is the assertion the rest of the package cannot make: it passes only if
+// the AppRole login, the token-role mint and the injection all happened against a
+// live Vault, and it fails for a well-formed string that was never issued.
+func assertVaultTokenUsable(t *testing.T, token string) {
+	t.Helper()
+
+	status, body := h.VaultDirectRequest(t, "POST", "auth/token/lookup", `{"token":"`+token+`"}`)
+	if status != 200 {
+		t.Fatalf("looking the minted token up in Vault: status %d, body: %s", status, body)
+	}
+
+	policies, _ := h.JSONPath(h.ParseJSON(t, body), "data.policies").([]interface{})
+	for _, p := range policies {
+		if p == vaultTokenPolicy {
+			return
+		}
+	}
+	t.Errorf("minted token carries policies %v, want one of them to be %q", policies, vaultTokenPolicy)
+}
+
+// TestVault_MintedServiceTokenReachesUpstream is this mount's reference shape,
+// and the only row in the package that closes the loop on a real credential.
+//
+// The decoys are the inert ones only. X-Vault-Token is this provider's native
+// agent channel, so sending it as a decoy would occupy the agent slot rather than
+// exercise the strip — the same reason anthropic does not decoy x-api-key. That
+// header's replacement is pinned by TestVault_NativeChannelCarriesAgent instead.
+func TestVault_MintedServiceTokenReachesUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	userJWT := h.FullChainUserJWT(t)
+	probe := h.ProbePath("vault-kv")
+	decoys := h.InertDecoyHeaders()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       userJWT,
+		Role:         vaultEnv.CertRole(),
+		Path:         probe,
+		Headers:      decoys,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status: 200,
+		// This provider does not put its credential in Authorization, so the
+		// caller's Bearer must not survive the hop.
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+
+	inbound := []string{userJWT}
+	for _, v := range decoys {
+		inbound = append(inbound, v)
+	}
+	assertVaultTokenUsable(t, mintedVaultToken(t, inbound...))
+
+	if got, want := upstream.Last(t).Path, "/v1/"+probe; got != want {
+		t.Errorf("upstream path = %q, want %q", got, want)
+	}
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}
+
+// TestVault_GatewayPrependsV1Exactly pins the path rewrite, which only a
+// recording upstream can see.
+//
+// Vault's API lives under /v1, and a caller may or may not have spelled it. The
+// hazard is symmetric: a gateway that never prepends breaks every bare path, and
+// one that always prepends turns a spelled-out path into /v1/v1/... — which
+// Vault answers with a 404 that looks like a missing secret rather than a
+// mangled request.
+func TestVault_GatewayPrependsV1Exactly(t *testing.T) {
+	ensureEnv(t)
+
+	bare := "secret/data/" + h.ProbePath("vault-bare")
+	spelled := "v1/secret/data/" + h.ProbePath("vault-v1")
+
+	cases := []struct {
+		name string
+		send string
+		want string
+	}{
+		{"a bare path gains /v1", bare, "/v1/" + bare},
+		{"a spelled-out /v1 is not doubled", spelled, "/" + spelled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+				AgentCertPEM: agentCert(t),
+				Bearer:       h.FullChainUserJWT(t),
+				Role:         vaultEnv.CertRole(),
+				Path:         tc.send,
+			})
+
+			h.AssertChain(t, upstream, status, body, h.ChainWant{
+				Status:        200,
+				Absent:        h.AlwaysAbsent("Authorization"),
+				UpstreamCalls: 1,
+			})
+			if got := upstream.Last(t).Path; got != tc.want {
+				t.Errorf("sent %q, upstream saw %q, want %q", tc.send, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVault_NativeChannelCarriesAgent puts the agent in X-Vault-Token rather
+// than a certificate. It is consulted after X-Warden-Token and leaves
+// Authorization free, so both principals resolve from a request carrying no
+// certificate at all.
+//
+// It is also where the strip of the native header becomes load-bearing: the same
+// header name arrives carrying the caller's JWT and leaves carrying a minted
+// Vault token, so a provider that forwarded it untouched would hand the upstream
+// a credential that is not a Vault token at all.
+func TestVault_NativeChannelCarriesAgent(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, vaultEnv)
+
+	agentJWT := h.GetDefaultJWT(t)
+	probe := h.ProbePath("vault-native-channel")
+
+	status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		Bearer:  h.FullChainUserJWT(t),
+		Role:    vaultEnv.JWTAgentRole(),
+		Headers: map[string]string{"X-Vault-Token": agentJWT},
+		Path:    probe,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+	assertVaultTokenUsable(t, mintedVaultToken(t, agentJWT))
+	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}
+
+// TestVault_OperatorTokenOutranksNativeChannel is the vault copy of the
+// anthropic row: X-Warden-Token is consulted first, X-Vault-Token second, so a
+// request carrying both resolves the operator token into the agent slot.
+//
+// Neither credential can produce a successful request, which is why the failure
+// shape is the observable. The operator token resolves and dies at the mint for
+// want of a bound spec — a 400. Had the JWT won the slot instead, it would have
+// resolved to the mount's own role and the request would have succeeded.
+func TestVault_OperatorTokenOutranksNativeChannel(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, vaultEnv)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		WardenToken: h.RootToken(t),
+		Role:        vaultEnv.JWTAgentRole(),
+		Headers:     map[string]string{"X-Vault-Token": h.GetDefaultJWT(t)},
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        400,
+		UpstreamCalls: 0,
+	})
+	if !strings.Contains(string(body), "credential spec") {
+		t.Errorf("want the mint to fail for a missing credential spec, got: %s", body)
+	}
+}
+
+// TestVault_PolicyDenialStopsBeforeUpstream is the general denial row, and it
+// matters more on this mount than on any other: the credential a forwarded
+// request would carry is a live Vault token with real read capability, so a
+// policy that refused only after forwarding would have already issued and leaked
+// one. The upstream call count is the assertion, not the status.
+func TestVault_PolicyDenialStopsBeforeUpstream(t *testing.T) {
+	ensureEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         vaultEnv.DenyRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        403,
+		UpstreamCalls: 0,
+	})
+}
+
+// setupVaultWrongCredEnv binds an api_key spec to a role on the vault mount:
+// everything about the request is right except the type of credential it mints.
+func setupVaultWrongCredEnv(t *testing.T) {
+	t.Helper()
+
+	mustWrite := func(path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, "POST", path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	// Consumers before what they reference, which is also what clears anything a
+	// killed run left behind — a leftover would 409 the creates below.
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/cert/role/"+vaultWrongCredRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+vaultWrongCredSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+vaultWrongCredSource, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	mustWrite("sys/cred/sources/"+vaultWrongCredSource, `{"type":"local"}`,
+		"create the wrong-type source")
+
+	mustWrite("sys/cred/specs/"+vaultWrongCredSpec, `{
+		"type":"api_key","source":"`+vaultWrongCredSource+`",
+		"config":{"api_key":"`+vaultWrongCredKey+`"}}`,
+		"create the wrong-type spec")
+
+	// The mount's own policy, so authorization succeeds and the credential type is
+	// the only thing left that can refuse the request.
+	mustWrite("auth/cert/role/"+vaultWrongCredRole, `{
+		"allowed_common_names":["`+h.FullChainAgentCN+`"],
+		"token_policies":["`+vaultEnv.Policy()+`"],
+		"cred_spec_name":"`+vaultWrongCredSpec+`","token_ttl":3600}`,
+		"create the wrong-type agent role")
+}
+
+// TestVault_NonVaultTokenCredentialIsRefused pins the provider's credential-type
+// gate.
+//
+// An operator can bind any spec to any role, so a mount can be handed a
+// credential it has no way to use. The only safe answer is to refuse: the
+// alternative is forwarding the request with no token, which Vault would answer
+// with its own 403 — turning a misconfiguration into what reads like a
+// permissions problem at the far end, and doing it after the request left.
+func TestVault_NonVaultTokenCredentialIsRefused(t *testing.T) {
+	ensureEnv(t)
+	setupVaultWrongCredEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         vaultWrongCredRole,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        401,
+		UpstreamCalls: 0,
+	})
+}
+
+// TestVault_UnauthenticatedPKIPathCarriesNoToken covers the one shape in the
+// package where a request is forwarded with no credential at all.
+//
+// Vault serves a handful of PKI read paths — CA certificates, CRLs — without
+// authentication, and clients fetch them without a token. Warden forwards those
+// verbatim and lets Vault's own ACL decide, so the assertion is the absence of a
+// token upstream: a gateway that helpfully minted one would be issuing a
+// credential for a request that never authenticated.
+//
+// The path list is anchored on v1/, matched after the gateway prefix, so these
+// requests spell the v1 out.
+func TestVault_UnauthenticatedPKIPathCarriesNoToken(t *testing.T) {
+	ensureEnv(t)
+
+	t.Run("a listed PKI path is forwarded without credentials", func(t *testing.T) {
+		upstream.Reset()
+
+		status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+			Path: "v1/pki/ca/pem",
+		})
+
+		h.AssertChain(t, upstream, status, body, h.ChainWant{
+			Status:        200,
+			Absent:        h.AlwaysAbsent("Authorization", "X-Vault-Token"),
+			UpstreamCalls: 1,
+		})
+		if got, want := upstream.Last(t).Path, "/v1/pki/ca/pem"; got != want {
+			t.Errorf("upstream path = %q, want %q", got, want)
+		}
+	})
+
+	// Without this the row above would pass against a mount that had stopped
+	// authenticating anything at all.
+	t.Run("an unlisted path without credentials is refused", func(t *testing.T) {
+		upstream.Reset()
+
+		status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+			Path: "v1/secret/data/" + h.ProbePath("vault-noauth"),
+		})
+
+		h.AssertChain(t, upstream, status, body, h.ChainWant{
+			Status:        401,
+			UpstreamCalls: 0,
+		})
+	})
+}
+
+// setupVaultRotationEnv builds a second, throwaway chain over its own AppRole
+// role, rotating as fast as the cluster's configured floor allows.
+//
+// Everything is test-local, the AppRole role included. Rotation destroys the
+// secret_id it replaces, so a rotator pointed at the package's shared role would
+// invalidate the credential every other test in this file depends on.
+func setupVaultRotationEnv(t *testing.T) {
+	t.Helper()
+
+	seedVaultApproleRole(t, vaultRotApproleRole, vaultRotRoleID, vaultRotSecretID)
+
+	mustWrite := func(path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, "POST", path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/cert/role/"+vaultRotAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+vaultRotSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+vaultRotSource, leaderPort, "")
+	}
+	clear()
+	// Deleting the source is what unregisters it from the scheduler; without this
+	// it would keep rotating for the rest of the package's run.
+	t.Cleanup(clear)
+
+	mustWrite("sys/cred/sources/"+vaultRotSource, `{
+		"type":"hvault","rotation_period":15,
+		"config":{"vault_address":"`+vaultAddr+`","auth_method":"approle",
+			"role_id":"`+vaultRotRoleID+`","secret_id":"`+vaultRotSecretID+`",
+			"approle_mount":"`+vaultApproleMount+`","role_name":"`+vaultRotApproleRole+`"}}`,
+		"create the rotating source")
+
+	mustWrite("sys/cred/specs/"+vaultRotSpec, `{
+		"type":"vault_token","source":"`+vaultRotSource+`",
+		"config":{"mint_method":"vault_token","token_role":"`+vaultTokenRole+`"}}`,
+		"create the rotating source's spec")
+
+	// A short token_ttl so the request made after the rotation is a new session
+	// that has to mint again, rather than one served from the cache the first
+	// request populated.
+	mustWrite("auth/cert/role/"+vaultRotAgentRole, `{
+		"allowed_common_names":["`+h.FullChainAgentCN+`"],
+		"token_policies":["`+vaultEnv.Policy()+`"],
+		"cred_spec_name":"`+vaultRotSpec+`","token_ttl":60}`,
+		"create the rotating agent role")
+}
+
+// vaultSecretIDCount returns how many secret_id accessors an AppRole role holds.
+func vaultSecretIDCount(t *testing.T, role string) int {
+	t.Helper()
+
+	status, body := h.VaultDirectRequest(t, "GET",
+		"auth/"+vaultApproleMount+"/role/"+role+"/secret-id?list=true", "")
+	if status == 404 {
+		// Vault answers a role with no secret_ids with a 404 rather than an empty
+		// list.
+		return 0
+	}
+	if status != 200 {
+		t.Fatalf("listing secret_id accessors for %s: status %d, body: %s", role, status, body)
+	}
+	keys, _ := h.JSONPath(h.ParseJSON(t, body), "data.keys").([]interface{})
+	return len(keys)
+}
+
+// TestVault_FastPathRotationRemintsWithoutStaging is the row nothing in the repo
+// covers today: a rotation actually completing, observed from both ends.
+//
+// The two-stage design splits rotation into prepare and activate, and lets a
+// driver ask for a delay between them for upstreams that need one to converge.
+// Vault needs none, so its prepare reports a zero delay and the whole rotation
+// finishes inside one job. That is the branch under test, and last_rotation is
+// what distinguishes it: the delayed path parks the entry in a staged state and
+// leaves last_rotation unset until a second job runs, so a stamped last_rotation
+// can only mean prepare and activate both completed.
+//
+// Then the harder half. Rotation replaces the secret the source authenticates
+// with, so the interesting failure is not the rotation reporting success — it is
+// the source being unable to log in afterwards, which would surface much later as
+// a mint failure on somebody else's request. A fresh session minting a usable
+// token after the rotation is what rules that out.
+func TestVault_FastPathRotationRemintsWithoutStaging(t *testing.T) {
+	ensureEnv(t)
+	setupVaultRotationEnv(t)
+
+	// Before: the chain works, and the source holds whatever secret_ids it was
+	// created with.
+	status, body, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         vaultRotAgentRole,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+	assertVaultTokenUsable(t, mintedVaultToken(t))
+	accessorsBefore := vaultSecretIDCount(t, vaultRotApproleRole)
+
+	// last_rotation is absent until one completes, so this waits for the field to
+	// appear rather than for a value to change.
+	deadline := time.Now().Add(90 * time.Second)
+	rotated := false
+	for time.Now().Before(deadline) {
+		readStatus, readBody := h.APIRequest(t, "GET", "sys/cred/sources/"+vaultRotSource, leaderPort, "")
+		if readStatus == 200 {
+			if last, _ := h.JSONPath(h.ParseJSON(t, readBody), "data.last_rotation").(string); last != "" {
+				rotated = true
+				break
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !rotated {
+		t.Fatalf("source %s never recorded a completed rotation within the deadline", vaultRotSource)
+	}
+
+	// A new certificate and a new user token, so nothing about this request can be
+	// served from the session the first one established.
+	upstream.Reset()
+	afterStatus, afterBody, _ := h.ChainRequest(t, leaderPort, vaultEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         vaultRotAgentRole,
+	})
+	h.AssertChain(t, upstream, afterStatus, afterBody, h.ChainWant{
+		Status:        200,
+		Absent:        h.AlwaysAbsent("Authorization"),
+		UpstreamCalls: 1,
+	})
+	assertVaultTokenUsable(t, mintedVaultToken(t))
+
+	// Growth rather than replacement, deliberately. The first cycle has no prior
+	// accessor to clean up — the source was created from a secret_id registered by
+	// hand, so nothing recorded the accessor that would have been destroyed — and
+	// cleanup on an empty accessor does nothing. Asserting a replacement would be
+	// asserting behaviour the first cycle does not have.
+	if after := vaultSecretIDCount(t, vaultRotApproleRole); after <= accessorsBefore {
+		t.Errorf("AppRole role %s holds %d secret_id accessors, want more than the %d it held before rotating",
+			vaultRotApproleRole, after, accessorsBefore)
+	}
+}

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -100,6 +100,14 @@ type ProviderEnv struct {
 	// not "local".
 	SourceConfig map[string]string
 
+	// SourceRotationPeriod is emitted as rotation_period, in seconds. Zero omits
+	// the field, which is what every static source wants. Some source types
+	// refuse to exist without one, so it is not optional for them — and a source
+	// that carries a period really does rotate, so keep it long enough that the
+	// package's shared environment never rotates out from under an unrelated
+	// test. A test that means to observe a rotation brings its own source.
+	SourceRotationPeriod int
+
 	// ExtraPolicyRules are appended inside the mount's gateway path stanza,
 	// for providers whose authorization is finer-grained than a capability —
 	// a body-authoritative rule set, say, which cannot be expressed as one.
@@ -345,6 +353,9 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 	source := map[string]any{"type": sourceType}
 	if len(p.SourceConfig) > 0 {
 		source["config"] = p.SourceConfig
+	}
+	if p.SourceRotationPeriod > 0 {
+		source["rotation_period"] = p.SourceRotationPeriod
 	}
 	mustAPI(t, port, "POST", "sys/cred/sources/"+p.Source(),
 		mustJSON(t, source), "create credential source for "+p.Mount)

--- a/e2e/rotation/rotation_test.go
+++ b/e2e/rotation/rotation_test.go
@@ -39,12 +39,18 @@ func TestVaultSourceRotationConfig(t *testing.T) {
 	cleanupSource(t, port, "e2e-rot-test")
 }
 
-// TestRotationPeriodBelowMinimum verifies rotation_period below 5m (300s) is rejected (T-034).
+// TestRotationPeriodBelowMinimum verifies a rotation_period below the configured
+// floor is rejected (T-034).
+//
+// The floor is min_cred_source_rotation_period in the node config, and this
+// cluster runs a deliberately low one so other suites can watch a rotation
+// complete rather than infer it. The period below is therefore small; keep it
+// under whatever that config says, or this stops testing a refusal.
 func TestRotationPeriodBelowMinimum(t *testing.T) {
 	port := h.GetLeaderPort(t)
 	cleanupSource(t, port, "e2e-rot-invalid")
 
-	body := `{"type":"hvault","rotation_period":10,"config":{"vault_address":"http://127.0.0.1:8200","auth_method":"approle","role_id":"e2e-approle-role-id-1234","secret_id":"e2e-approle-secret-id-5678","approle_mount":"e2e_approle","role_name":"warden-e2e-role"}}`
+	body := `{"type":"hvault","rotation_period":5,"config":{"vault_address":"http://127.0.0.1:8200","auth_method":"approle","role_id":"e2e-approle-role-id-1234","secret_id":"e2e-approle-secret-id-5678","approle_mount":"e2e_approle","role_name":"warden-e2e-role"}}`
 	status, _ := h.APIRequest(t, "POST", "sys/cred/sources/e2e-rot-invalid", port, body)
 	if status != 400 {
 		t.Fatalf("expected 400 for rotation_period below minimum, got %d", status)


### PR DESCRIPTION
## What

Adds `e2e/fullchain/vault_test.go` — the Vault provider joins the fullchain suite as its 22nd mount, and the first whose credential is real.

Every other fullchain credential is a constant copied out of a spec config. `vault_token` refuses a local source, so this mount's source trades an AppRole secret for live service tokens at the harness Vault on `:8200` while the mount itself proxies to the recording upstream. Two addresses, deliberately: the recorder says what was forwarded, and Vault says whether what was forwarded was ever a token at all.

## Coverage

| Test | Pins |
|---|---|
| `MintedServiceTokenReachesUpstream` | the minted token reaches the upstream, differs from every inbound credential, and **resolves against the real Vault carrying the token role's policy** |
| `GatewayPrependsV1Exactly` | a bare path gains `/v1`; a spelled-out one is not doubled |
| `NativeChannelCarriesAgent` | the agent arrives in `X-Vault-Token` and leaves replaced — the strip becomes load-bearing |
| `OperatorTokenOutranksNativeChannel` | `X-Warden-Token` is consulted before the native channel |
| `PolicyDenialStopsBeforeUpstream` | denial before forwarding — this mount would otherwise have issued a live Vault token |
| `NonVaultTokenCredentialIsRefused` | the credential-type gate refuses rather than forwarding token-less |
| `UnauthenticatedPKIPathCarriesNoToken` | listed PKI paths forwarded with no token; unlisted ones still refused |
| `FastPathRotationRemintsWithoutStaging` | **a rotation completing** — the first such observation in the repo |

## Why the config change

Rotation was untestable rather than untested: the only trigger is the scheduler reaching `NextAction`, and the e2e floor was 5m.

That floor is harness configuration, not a code constraint — the server accepts any positive duration — so `min_cred_source_rotation_period` drops to `10s` in the three node configs and the rotation row completes in ~20s. No production code changes. `TestRotationPeriodBelowMinimum` moves with the floor; it asserts a refusal below the floor, not a specific floor.

An on-demand rotate endpoint was considered and rejected for this purpose — it would have bought what one config line buys. It remains worth building as an operator capability, and if it is, two things need fixing first: queuing a `StateFailed` entry must replicate `tick`'s bookkeeping or `failedCount` leaks permanently, and closing the race with `tick` requires changing `tick` itself, since its guard is a `LoadInt32` outside `entry.mu` followed by a blind `StoreInt32`.

## Notes

- **Suite-local AppRole roles.** Rotation destroys the `secret_id` it replaces, so suites sharing one role can strand each other — the rotation row gets a third role of its own. Seeding runs from the test rather than `setup.sh`, so an already-running cluster can execute this package without being rebuilt.
- **`ProviderEnv.SourceRotationPeriod`** is new because the store requires a period on an approle source. Zero omits it, so the other 21 envs are untouched. The shared vault env uses a day: a source that carries a period really does rotate, and a short one would fire partway through an unrelated test.

## Testing

Full `./e2e/...` sweep green (19 packages, chaos suites included). The vault tests pass in 60s; `fullchain` 109s, `rotation` 38s.
