### PR TITLE
fix(gitlab): compute token expiry in UTC and bound it to what the API grants

### DIFF
--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -23,6 +23,13 @@ const gitlabMaxResponseBodySize = 1 << 20 // 1MB
 // gitlabMaxRetryAttempts for retryable API operations
 const gitlabMaxRetryAttempts = 3
 
+// maxTokenLifetime bounds the expiry date a mint may ask for. The server rejects
+// anything beyond its configured maximum token lifetime, which defaults to 365
+// days; an administrator can change it, so this is the documented default rather
+// than a value we can know. Asking for less than an instance permits costs at most
+// a day of lifetime, where asking for more fails the mint outright.
+const maxTokenLifetime = 365 * 24 * time.Hour
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GitLabDriver)(nil)
 var _ credential.Rotatable = (*GitLabDriver)(nil)
@@ -195,6 +202,78 @@ func (d *GitLabDriver) verifyAuth(ctx context.Context) error {
 	return err
 }
 
+// tokenExpiry resolves a requested lifetime to the expiry date the API accepts and
+// the lifetime that date actually grants.
+//
+// expires_at is an ISO date and the token dies at midnight UTC on it, so the
+// granted lifetime lands on a UTC day boundary and is never exactly the requested
+// ttl. Two consequences.
+//
+// The boundary is computed in UTC, not the server's local zone: a server running
+// ahead of UTC otherwise names the wrong day.
+//
+// The boundary is rounded up — the earliest midnight at or after now+ttl — making
+// ttl a floor. Rounding down is the tempting alternative, since it never grants
+// more than asked, but it can grant almost nothing: a 24h request issued at 23:00
+// would truncate to a boundary one hour out. A token that dies long before its
+// stated lifetime is a harder failure than one that outlives it by under a day, so
+// the floor wins. Callers therefore get a lifetime in [ttl, ttl+24h).
+//
+// Rounding up is capped at maxTokenLifetime, because it can otherwise push a
+// request past the limit the server enforces on expires_at and turn a mint that
+// used to succeed into a 400. The cap costs the floor only for a ttl within a day
+// of the limit, where the shortfall is under a day out of a year.
+//
+// The returned duration is what the caller reports as the lease TTL when the
+// server does not say otherwise. It is a request, not a fact: an instance
+// configured with a shorter limit may hand back a nearer date, which is why
+// callers derive the lease from the response's expires_at and fall back to this.
+func tokenExpiry(now time.Time, ttl time.Duration) (string, time.Duration) {
+	now = now.UTC()
+
+	deadline := now.Add(ttl)
+	if limit := now.Add(maxTokenLifetime); deadline.After(limit) {
+		deadline = limit
+	}
+
+	expiry := time.Date(deadline.Year(), deadline.Month(), deadline.Day(), 0, 0, 0, 0, time.UTC)
+	if expiry.Before(deadline) {
+		next := expiry.AddDate(0, 0, 1)
+		// Only round up while that stays inside the limit. At the very top of the
+		// range the truncated date is the best available answer.
+		if !next.After(now.Add(maxTokenLifetime)) {
+			expiry = next
+		}
+	}
+
+	return expiry.Format("2006-01-02"), expiry.Sub(now)
+}
+
+// grantedExpiry reports what the server actually granted, given the date it
+// returned and what we asked for.
+//
+// The response carries its own expires_at, and it is authoritative: an instance
+// whose maximum token lifetime is shorter than the request answers with a nearer
+// date. Deriving the lease from the request instead would leave the credential
+// cached past the point the token stops working — the one failure the expiry math
+// exists to prevent. An absent or unparseable date falls back to the request,
+// which is the best available answer and no worse than not looking.
+func grantedExpiry(now time.Time, requested string, requestedTTL time.Duration, granted string) (string, time.Duration) {
+	if granted == "" || granted == requested {
+		return requested, requestedTTL
+	}
+	parsed, err := time.ParseInLocation("2006-01-02", granted, time.UTC)
+	if err != nil {
+		return requested, requestedTTL
+	}
+	return granted, parsed.Sub(now.UTC())
+}
+
+// resolveExpiry applies tokenExpiry to a spec's requested ttl.
+func (d *GitLabDriver) resolveExpiry(spec *credential.CredSpec) (string, time.Duration) {
+	return tokenExpiry(time.Now(), credential.GetDuration(spec.Config, "ttl", 24*time.Hour))
+}
+
 // MintCredential mints credentials based on the spec's mint_method
 func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
@@ -216,13 +295,7 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	scopes := credential.GetString(spec.Config, "scopes", "api")
 	accessLevel := credential.GetInt(spec.Config, "access_level", 30) // 30 = developer
 
-	// Calculate expiry: default 1 day, max 365 days
-	ttlStr := credential.GetString(spec.Config, "ttl", "24h")
-	ttl, err := time.ParseDuration(ttlStr)
-	if err != nil {
-		ttl = 24 * time.Hour
-	}
-	expiresAt := time.Now().Add(ttl).Format("2006-01-02")
+	expiresAt, ttl := d.resolveExpiry(spec)
 
 	body := map[string]interface{}{
 		"name":         tokenName,
@@ -243,8 +316,9 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	}
 
 	var result struct {
-		ID    int    `json:"id"`
-		Token string `json:"token"`
+		ID        int    `json:"id"`
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
 	}
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to parse response: %w", err)
@@ -253,6 +327,8 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	if result.Token == "" {
 		return nil, nil, 0, "", fmt.Errorf("GitLab API returned empty token")
 	}
+
+	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
 	leaseID := fmt.Sprintf("project_access_token:%s:%s", projectID, tokenIDStr)
@@ -282,12 +358,7 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	scopes := credential.GetString(spec.Config, "scopes", "api")
 	accessLevel := credential.GetInt(spec.Config, "access_level", 30)
 
-	ttlStr := credential.GetString(spec.Config, "ttl", "24h")
-	ttl, err := time.ParseDuration(ttlStr)
-	if err != nil {
-		ttl = 24 * time.Hour
-	}
-	expiresAt := time.Now().Add(ttl).Format("2006-01-02")
+	expiresAt, ttl := d.resolveExpiry(spec)
 
 	body := map[string]interface{}{
 		"name":         tokenName,
@@ -308,8 +379,9 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	}
 
 	var result struct {
-		ID    int    `json:"id"`
-		Token string `json:"token"`
+		ID        int    `json:"id"`
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
 	}
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to parse response: %w", err)
@@ -318,6 +390,8 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	if result.Token == "" {
 		return nil, nil, 0, "", fmt.Errorf("GitLab API returned empty token")
 	}
+
+	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
 	leaseID := fmt.Sprintf("group_access_token:%s:%s", groupID, tokenIDStr)

--- a/credential/drivers/gitlab_driver_test.go
+++ b/credential/drivers/gitlab_driver_test.go
@@ -304,7 +304,10 @@ func TestGitLabDriver_MintProjectAccessToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "glpat-minted-token", rawData["access_token"])
 	assert.Equal(t, "99", rawData["token_id"])
-	assert.Equal(t, 24*time.Hour, ttl)
+	// Expiry is a date, so the lease runs to the first UTC midnight at or after the
+	// requested 24h — at least the request, under a day more.
+	assert.GreaterOrEqual(t, ttl, 24*time.Hour)
+	assert.Less(t, ttl, 48*time.Hour)
 	assert.Equal(t, "project_access_token:42:99", leaseID)
 }
 
@@ -600,4 +603,195 @@ func TestGitLabDriver_PrepareRotation_OAuth2_FastPath(t *testing.T) {
 	assert.Equal(t, "new-rotated-secret", driver.credSource.Config["application_secret"],
 		"driver config must be eagerly updated since old secret is already invalidated")
 	// Token cache generation should be invalidated (internal state, can't easily test directly)
+}
+
+func TestGitLabTokenExpiry(t *testing.T) {
+	// The API expresses expiry as a date and kills the token at midnight UTC on it,
+	// so the granted lifetime always lands on a day boundary at or after now+ttl.
+	tests := []struct {
+		name        string
+		now         time.Time
+		ttl         time.Duration
+		wantDate    string
+		wantGranted time.Duration
+	}{
+		{
+			name:        "deadline already on a boundary grants exactly the ttl",
+			now:         time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC),
+			ttl:         24 * time.Hour,
+			wantDate:    "2026-08-25",
+			wantGranted: 24 * time.Hour,
+		},
+		{
+			name:        "mid-day deadline rounds up to the next boundary",
+			now:         time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+			ttl:         24 * time.Hour,
+			wantDate:    "2026-08-26",
+			wantGranted: 39 * time.Hour,
+		},
+		{
+			name:        "late-day mint still clears the requested ttl",
+			now:         time.Date(2026, 8, 24, 23, 0, 0, 0, time.UTC),
+			ttl:         24 * time.Hour,
+			wantDate:    "2026-08-26",
+			wantGranted: 25 * time.Hour,
+		},
+		{
+			// Truncating instead of rounding up would name today's midnight, which
+			// has already passed — a token dead on arrival.
+			name:        "sub-day ttl lands on tomorrow, never a past boundary",
+			now:         time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+			ttl:         time.Hour,
+			wantDate:    "2026-08-25",
+			wantGranted: 15 * time.Hour,
+		},
+		{
+			name:        "multi-day ttl",
+			now:         time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+			ttl:         72 * time.Hour,
+			wantDate:    "2026-08-28",
+			wantGranted: 87 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date, granted := tokenExpiry(tt.now, tt.ttl)
+			assert.Equal(t, tt.wantDate, date)
+			assert.Equal(t, tt.wantGranted, granted)
+		})
+	}
+}
+
+func TestGitLabTokenExpiry_IgnoresServerTimezone(t *testing.T) {
+	// Formatting in the server's local zone rather than UTC lands on the wrong day
+	// for a server running ahead of UTC. Same instant, two zones, one answer.
+	instant := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	ahead := instant.In(time.FixedZone("UTC+10", 10*60*60))
+	behind := instant.In(time.FixedZone("UTC-7", -7*60*60))
+
+	wantDate, wantGranted := tokenExpiry(instant, 24*time.Hour)
+
+	for name, now := range map[string]time.Time{"ahead": ahead, "behind": behind} {
+		t.Run(name, func(t *testing.T) {
+			date, granted := tokenExpiry(now, 24*time.Hour)
+			assert.Equal(t, wantDate, date)
+			assert.Equal(t, wantGranted, granted)
+		})
+	}
+}
+
+func TestGitLabTokenExpiry_Invariants(t *testing.T) {
+	// Across every mint hour and a spread of ttls: the token always outlives the
+	// requested ttl, by under a day, and the date is always in the future.
+	for hour := 0; hour < 24; hour++ {
+		now := time.Date(2026, 8, 24, hour, 30, 0, 0, time.UTC)
+		for _, ttl := range []time.Duration{time.Minute, time.Hour, 12 * time.Hour, 24 * time.Hour, 72 * time.Hour} {
+			date, granted := tokenExpiry(now, ttl)
+
+			assert.GreaterOrEqual(t, granted, ttl,
+				"hour=%d ttl=%s: token must live at least the requested ttl", hour, ttl)
+			assert.Less(t, granted, ttl+24*time.Hour,
+				"hour=%d ttl=%s: overshoot must stay under a day", hour, ttl)
+
+			parsed, err := time.ParseInLocation("2006-01-02", date, time.UTC)
+			require.NoError(t, err)
+			assert.True(t, parsed.After(now),
+				"hour=%d ttl=%s: expiry %s must be in the future", hour, ttl, date)
+		}
+	}
+}
+
+func TestGitLabTokenExpiry_StaysInsideTheLifetimeLimit(t *testing.T) {
+	// Rounding up must not push the request past the maximum lifetime the server
+	// enforces: a ttl at the limit used to mint fine, and asking for a day more
+	// would fail it outright.
+	now := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+
+	for _, ttl := range []time.Duration{maxTokenLifetime - time.Hour, maxTokenLifetime, maxTokenLifetime + 30*24*time.Hour} {
+		t.Run(ttl.String(), func(t *testing.T) {
+			date, granted := tokenExpiry(now, ttl)
+
+			parsed, err := time.ParseInLocation("2006-01-02", date, time.UTC)
+			require.NoError(t, err)
+			assert.False(t, parsed.After(now.Add(maxTokenLifetime)),
+				"expiry %s exceeds the limit %s", date, now.Add(maxTokenLifetime).Format("2006-01-02"))
+			assert.True(t, parsed.After(now), "expiry %s must be in the future", date)
+			assert.Equal(t, parsed.Sub(now), granted)
+		})
+	}
+}
+
+func TestGitLabGrantedExpiry(t *testing.T) {
+	// The response's expires_at is authoritative: an instance with a shorter
+	// maximum lifetime answers with a nearer date, and a lease derived from the
+	// request would then outlive the token it names.
+	now := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	const requested = "2026-08-26"
+	requestedTTL := 39 * time.Hour
+
+	tests := []struct {
+		name        string
+		granted     string
+		wantDate    string
+		wantGranted time.Duration
+	}{
+		{"server agrees", "2026-08-26", requested, requestedTTL},
+		{"server says nothing", "", requested, requestedTTL},
+		{"server clamps to a nearer date", "2026-08-25", "2026-08-25", 15 * time.Hour},
+		{"server grants a later date", "2026-08-28", "2026-08-28", 87 * time.Hour},
+		{"unparseable falls back to the request", "not-a-date", requested, requestedTTL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date, granted := grantedExpiry(now, requested, requestedTTL, tt.granted)
+			assert.Equal(t, tt.wantDate, date)
+			assert.Equal(t, tt.wantGranted, granted)
+		})
+	}
+}
+
+func TestGitLabDriver_MintHonoursServerExpiry(t *testing.T) {
+	// End to end through a mint: a server that clamps the date must shorten the
+	// lease and the reported expires_at with it, not leave the credential cached
+	// past the point it stops working.
+	clamped := time.Now().UTC().Add(24 * time.Hour).Format("2006-01-02")
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": 99, "token": "glpat-minted-token", "expires_at": clamped,
+		})
+	}))
+	defer server.Close()
+
+	driver := &GitLabDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGitLab,
+			Config: map[string]string{
+				"gitlab_address":        server.URL,
+				"auth_method":           "pat",
+				"personal_access_token": "test-pat",
+			},
+		},
+		httpClient: server.Client(),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "test-spec", Type: credential.TypeGitLabAccessToken,
+		Config: map[string]string{
+			"mint_method": "project_access_token", "project_id": "42",
+			"token_name": "warden-test", "scopes": "api", "access_level": "30",
+			// Long enough that the driver would have asked for a much later date.
+			"ttl": "720h",
+		},
+	}
+
+	rawData, _, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+
+	assert.Equal(t, clamped, rawData["expires_at"], "the server's date must be the one reported")
+	assert.Less(t, ttl, 48*time.Hour, "the lease must follow the server's date, not the request")
+	assert.Greater(t, ttl, time.Duration(0))
 }

--- a/credential/types/gitlab_access_token.go
+++ b/credential/types/gitlab_access_token.go
@@ -86,9 +86,9 @@ func (t *GitLabAccessTokenCredType) ConfigSchema() []*credential.FieldValidator 
 			Example("30"),
 
 		// Optional fields
-		credential.DurationField("expires_in").
-			Describe("Token expiration duration from now").
-			Example("720h"),
+		credential.DurationField("ttl").
+			Describe("Minimum token lifetime. Expiry is a date, so the token lives until the first UTC midnight at or after this").
+			Example("24h"),
 	}
 }
 


### PR DESCRIPTION
Access token expiry is an ISO date and the token dies at midnight UTC on it, but the driver computed the date with `time.Now().Add(ttl)` formatted in the **server's local zone**. Three defects followed, all on the existing inline path.

### A server ahead of UTC named the wrong day

The token expired up to the zone offset away from where the operator expected.

### Any sub-day `ttl` minted a credential that never worked

A `ttl` shorter than the remainder of the local day named a midnight that had already passed. The API rejects that or hands back an already-dead token — while the lease reported the full `ttl`, so nothing surfaced until the agent's first request failed.

### The lease could outlive the token

The mint response carries its own `expires_at` and it was being discarded, the lease derived from what was *asked for* instead. An instance whose maximum token lifetime is shorter than the request answers with a nearer date, leaving the credential cached past the point it stopped working.

## What changed

Compute the boundary in UTC and round it **up** to the earliest midnight at or after `now+ttl`, making `ttl` a floor. Rounding down never grants more than asked but can grant almost nothing — a 24h request issued at 23:00 truncates to a boundary an hour out — and a token that dies long before its stated lifetime is the harder failure. Lifetimes land in `[ttl, ttl+24h)`.

Cap that rounding at the maximum lifetime the server enforces. A `ttl` of 365 days asks for exactly the documented limit and mints fine, where rounding would turn it into a day beyond and fail outright. The cap costs the floor only within a day of the limit.

Read the granted `expires_at` and derive the lease from it, falling back to the request when absent or unparseable.

Also declare `ttl` in the credential type's schema. It advertised `expires_in`, which nothing reads; the driver has always read `ttl`, and unknown keys pass validation silently, so the documented key was inert.

## Behaviour change

This changes the `expires_at` a given `ttl` produces. Existing sources keep working; tokens may now expire a day later than before, and a spec with `ttl` under a day starts producing a usable credential where it previously produced a dead one.

## Verification

Six tests covering exact rounding cases, the timezone invariance (same instant in UTC+10 and UTC-7 yields one answer), a property sweep over all 24 mint hours × five TTLs, the lifetime-limit boundary, the granted-date table, and an end-to-end mint against a clamping server. `go build ./...`, `go vet`, and the `credential/...` + `core/...` suites pass.

Verified against GitLab's documented behaviour: [expires_at is an ISO date](https://docs.gitlab.com/api/project_access_tokens/), and [tokens expire at midnight UTC on the expiry date](https://docs.gitlab.com/user/project/settings/project_access_tokens/).