### PR TITLE
feat(gitlab): mint keyless via credential chaining

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -983,12 +983,19 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		chainedRef = source.Config[credential.ConfigSecretSpec]
 	}
 	if chainedRef != "" {
-		// For token_exchange, client-secret chaining is a SOURCE concern (client auth
-		// lives on the source, and the factory only sees source config). A spec-level
-		// secret_spec would leave the source's inline client_secret as dead config at
-		// mint — reject it with clear guidance.
-		if source.Type == credential.SourceTypeTokenExchange && spec.Config[credential.ConfigSecretSpec] != "" {
-			return logical.ErrBadRequestf("for a token_exchange source, set secret_spec on the source (client authentication is a source concern), not on the spec")
+		// For token_exchange and gitlab, chaining is a SOURCE concern: the secret being
+		// chained authenticates the source itself (client auth, a personal access
+		// token), and the factory only sees source config. A spec-level secret_spec
+		// would leave the source's inline secret as dead config at mint, and would
+		// slip past the source-level validation that gates which auth methods may
+		// chain at all — so reject it with clear guidance.
+		if spec.Config[credential.ConfigSecretSpec] != "" {
+			switch source.Type {
+			case credential.SourceTypeTokenExchange:
+				return logical.ErrBadRequestf("for a token_exchange source, set secret_spec on the source (client authentication is a source concern), not on the spec")
+			case credential.SourceTypeGitLab:
+				return logical.ErrBadRequestf("for a gitlab source, set secret_spec on the source (the personal access token authenticates the source), not on the spec")
+			}
 		}
 		// A chained consumer's identity normally flows through the referenced secret-spec,
 		// so its own subject/actor exchange config would be dead — reject that confusing
@@ -1130,6 +1137,13 @@ func (s *CredentialConfigStore) validateSource(ctx context.Context, source *cred
 	if ref := source.Config[credential.ConfigSecretSpec]; ref != "" {
 		if err := s.validateSecretSpecRef(ctx, ref); err != nil {
 			return err
+		}
+		// A chained source holds no secret of its own, so there is nothing here to
+		// rotate — the referenced spec's owner rotates it at the source of truth.
+		// Accepting a rotation_period would schedule a rotation that either no-ops or
+		// invalidates someone else's secret.
+		if source.RotationPeriod > 0 {
+			return logical.ErrBadRequestf("rotation_period does not apply to a chained source (secret_spec %q); the referenced spec's owner rotates the secret", ref)
 		}
 	}
 

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -1872,3 +1872,70 @@ func TestCredentialConfigStore_ValidateSource_HvaultRotationPeriod(t *testing.T)
 		})
 	}
 }
+
+// TestCredentialConfigStore_GitLabChaining covers the two gitlab-specific chaining
+// guards: chaining is a source concern (never spec-level), and a chained source
+// owns no secret so it has nothing to rotate.
+func TestCredentialConfigStore_GitLabChaining(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	// Referenced secret-spec: session-pinned, as validateSecretSpecRef requires.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gl-pat", Type: "vault_token", Source: "src",
+		Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+	}))
+
+	gitlabSource := func(name string, extra map[string]string) *credential.CredSource {
+		cfg := map[string]string{
+			"gitlab_address":            "https://gitlab.example.com",
+			"auth_method":               "pat",
+			credential.ConfigSecretSpec: "gl-pat",
+		}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		return &credential.CredSource{Name: name, Type: credential.SourceTypeGitLab, Config: cfg}
+	}
+
+	// A chained gitlab source carries no inline token and is accepted.
+	require.NoError(t, store.CreateSource(ctx, gitlabSource("gl-keyless", nil)))
+
+	// Rotation belongs to whoever owns the referenced secret, not to this source.
+	rotating := gitlabSource("gl-rotating", nil)
+	rotating.RotationPeriod = 24 * time.Hour
+	err := store.CreateSource(ctx, rotating)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation_period does not apply to a chained source")
+
+	specConfig := func(extra map[string]string) map[string]string {
+		cfg := map[string]string{
+			"mint_method":  "project_access_token",
+			"project_id":   "42",
+			"token_name":   "warden-minted",
+			"scopes":       "api",
+			"access_level": "30",
+		}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		return cfg
+	}
+
+	// An ordinary spec on a chained source is unchanged — it inherits the chain from
+	// the source and needs no chaining config of its own.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gl-backend", Type: credential.TypeGitLabAccessToken, Source: "gl-keyless",
+		Config: specConfig(nil),
+	}))
+
+	// Spec-level secret_spec would leave the source's inline token as dead config
+	// and slip past the source-level auth_method gate, so it is rejected with
+	// guidance rather than silently accepted.
+	err = store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gl-spec-level", Type: credential.TypeGitLabAccessToken, Source: "gl-keyless",
+		Config: specConfig(map[string]string{credential.ConfigSecretSpec: "gl-pat"}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set secret_spec on the source")
+}

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -33,6 +33,7 @@ const maxTokenLifetime = 365 * 24 * time.Hour
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GitLabDriver)(nil)
 var _ credential.Rotatable = (*GitLabDriver)(nil)
+var _ credential.ChainedSecretMinter = (*GitLabDriver)(nil)
 
 // GitLabDriver mints credentials from GitLab (project and group access tokens).
 //
@@ -101,6 +102,23 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 		return err
 	}
 
+	// Validate credential-chaining fields
+	if err := credential.ValidateSchema(config,
+		credential.StringField("secret_spec").
+			Describe("Source the personal access token from another cred spec via credential chaining instead of storing it inline (personal_access_token then omitted)").
+			Example("gitlab-pat-from-vault"),
+
+		credential.StringField("secret_field").
+			Describe("Which field of the referenced secret_spec's credential holds the personal access token (when its payload has multiple keys)").
+			Example("pat"),
+
+		credential.StringField("secret_cache_ttl").
+			Describe("Cache the chained personal access token source-wide for this duration (e.g. 30m); omit to fetch it on every mint").
+			Example("30m"),
+	); err != nil {
+		return err
+	}
+
 	// Validate auth_method and conditional fields
 	authMethod := credential.GetString(config, "auth_method", "pat")
 	if err := credential.ValidateSchema(config,
@@ -113,8 +131,19 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 	}
 
 	// Validate auth-method-specific fields
+	chained := credential.GetString(config, credential.ConfigSecretSpec, "") != ""
 	switch authMethod {
 	case "pat":
+		// A chained source is handed its token per-request, so the inline one is not
+		// required — and must not be present. Keeping a live token in config while
+		// minting from the chain would leave a source that reads as keyless but still
+		// stores the very secret chaining exists to remove.
+		if chained {
+			if credential.GetString(config, "personal_access_token", "") != "" {
+				return fmt.Errorf("personal_access_token must be omitted when secret_spec is set; the token is supplied by the referenced spec")
+			}
+			return nil
+		}
 		return credential.ValidateSchema(config,
 			credential.StringField("personal_access_token").
 				Required().
@@ -122,6 +151,14 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 				Example("glpat-xxxxx"),
 		)
 	case "oauth2":
+		// The client-credentials flow caches one bearer token per driver under a fixed
+		// key, which is only sound while the application secret is a single
+		// source-level constant. A chained secret can resolve per user, so a cached
+		// bearer minted for one caller would be served to the next. Until that cache is
+		// keyed by the resolved secret, chaining stays PAT-only.
+		if chained {
+			return fmt.Errorf("credential chaining (secret_spec) is supported only for auth_method=pat, not oauth2")
+		}
 		return credential.ValidateSchema(config,
 			credential.StringField("application_id").
 				Required().
@@ -165,11 +202,18 @@ func (f *GitLabDriverFactory) Create(config map[string]string, log *logger.Gated
 	}
 	driver.httpClient = httpClient
 
+	// A chained source holds no token to verify with: the token belongs to the
+	// referenced spec and is minted per-request as the caller, who does not exist
+	// yet. Skip the eager check and let the first mint surface a bad address or CA.
+	if driver.isChained() {
+		return driver, nil
+	}
+
 	// Verify credentials by calling the API
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := driver.verifyAuth(ctx); err != nil {
+	if err := driver.verifyAuth(ctx, nil); err != nil {
 		return nil, fmt.Errorf("GitLab authentication failed: %w", err)
 	}
 
@@ -190,13 +234,19 @@ func (d *GitLabDriver) getPAT() string {
 	return credential.GetString(d.credSource.Config, "personal_access_token", "")
 }
 
+// isChained reports whether this source draws its token from another cred spec
+// rather than holding one inline.
+func (d *GitLabDriver) isChained() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
 // verifyAuth validates the source credentials by calling a simple GitLab API endpoint
-func (d *GitLabDriver) verifyAuth(ctx context.Context) error {
-	_, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil)
+func (d *GitLabDriver) verifyAuth(ctx context.Context, patOverride *string) error {
+	_, _, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil, patOverride)
 	if err != nil {
 		// For OAuth2 mode, try a different endpoint
 		if d.getAuthMethod() == "oauth2" {
-			_, err = d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/user", nil)
+			_, _, err = d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/user", nil, patOverride)
 		}
 	}
 	return err
@@ -274,22 +324,98 @@ func (d *GitLabDriver) resolveExpiry(spec *credential.CredSpec) (string, time.Du
 	return tokenExpiry(time.Now(), credential.GetDuration(spec.Config, "ttl", 24*time.Hour))
 }
 
+// mintLeaseID builds the lease ID for a freshly minted token, or returns "" for a
+// chained mint.
+//
+// Revocation runs when the lease expires, long after the request that created it:
+// Revoke receives only a lease ID, with no caller and no way to re-fetch the token
+// that would authorise the delete. A chained source has no token of its own, so it
+// cannot honour a lease it hands out. It therefore hands out none, and the token
+// expires on its own expires_at instead.
+//
+// That costs nothing, because the reported lease TTL already equals the token's
+// real validity (see tokenExpiry): the lease and the token were always going to
+// end together, so dropping the lease removes a revoke call that would have found
+// the token already dead. What is genuinely given up is early revocation on
+// demand, which is not something that happens today.
+func mintLeaseID(tokenType, resourceID, tokenID string, patOverride *string) string {
+	if patOverride != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s:%s", tokenType, resourceID, tokenID)
+}
+
+// mintError wraps a failed mint, marking an authentication rejection on the
+// chained path so the minting layer treats a cached token as stale, evicts it and
+// retries once with a fresh fetch. Without this a token rotated at its source
+// would fail every request until the cache entry aged out on its own.
+func mintError(msg string, err error, status int, patOverride *string) error {
+	if patOverride != nil && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+		return fmt.Errorf("gitlab: %s: %w (%w)", msg, credential.ErrChainedSecretRejected, err)
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
 // MintCredential mints credentials based on the spec's mint_method
 func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A chained spec must mint through MintFromSecret, which the manager routes it
+	// to; arriving here means that routing was bypassed. Fail rather than fall
+	// through to an inline token that a chained source does not have.
+	if spec.Config[credential.ConfigSecretSpec] != "" || d.isChained() {
+		return nil, nil, 0, "", fmt.Errorf("gitlab: source uses secret_spec (credential chaining); it must mint from fetched secret material, not directly")
+	}
+	return d.mint(ctx, spec, nil)
+}
+
+// MintFromSecret mints a token using a personal access token fetched via
+// credential chaining, rather than one stored in source config.
+func (d *GitLabDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// Config could have drifted to oauth2 after creation, where validation rejects
+	// chaining. The fetched material is a personal access token and means nothing to
+	// the client-credentials flow, so stop rather than authenticate with it.
+	if d.getAuthMethod() != "pat" {
+		return nil, nil, 0, "", fmt.Errorf("gitlab: credential chaining requires auth_method=pat, got %q", d.getAuthMethod())
+	}
+
+	pat := material.Secret()
+	// Fall back to a conventional key ONLY when no field was resolved. A field that
+	// resolved to empty is a misconfigured secret_field — say so, rather than
+	// silently authenticating with some other value from the payload.
+	if pat == "" && material.Field == "" {
+		if pat = material.Data["personal_access_token"]; pat == "" {
+			pat = material.Data["pat"]
+		}
+	}
+	if pat == "" {
+		if material.Field != "" {
+			return nil, nil, 0, "", fmt.Errorf("gitlab: secret_field %q is empty or absent in the fetched secret material", material.Field)
+		}
+		return nil, nil, 0, "", fmt.Errorf("gitlab: no personal access token in fetched secret material (set secret_field, or store it under 'personal_access_token')")
+	}
+
+	return d.mint(ctx, spec, &pat)
+}
+
+// mint dispatches on the spec's mint_method. patOverride is nil for an inline
+// source and set for a chained one.
+func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, patOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
 	case "project_access_token":
-		return d.mintProjectAccessToken(ctx, spec)
+		return d.mintProjectAccessToken(ctx, spec, patOverride)
 	case "group_access_token":
-		return d.mintGroupAccessToken(ctx, spec)
+		return d.mintGroupAccessToken(ctx, spec, patOverride)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GitLab driver; use 'project_access_token' or 'group_access_token'", mintMethod)
 	}
 }
 
-// mintProjectAccessToken creates a project access token via the GitLab API
-func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// mintProjectAccessToken creates a project access token via the GitLab API.
+//
+// patOverride carries the token fetched via credential chaining (nil for an inline
+// source). A chained mint is also leaseless: see mintLeaseID.
+func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec, patOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	projectID := credential.GetString(spec.Config, "project_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -310,9 +436,9 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	}
 
 	path := fmt.Sprintf("/api/v4/projects/%s/access_tokens", url.PathEscape(projectID))
-	respBody, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes)
+	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, patOverride)
 	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to create project access token: %w", err)
+		return nil, nil, 0, "", mintError("failed to create project access token", err, status, patOverride)
 	}
 
 	var result struct {
@@ -331,7 +457,7 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
-	leaseID := fmt.Sprintf("project_access_token:%s:%s", projectID, tokenIDStr)
+	leaseID := mintLeaseID("project_access_token", projectID, tokenIDStr, patOverride)
 
 	rawData := map[string]interface{}{
 		"access_token": result.Token,
@@ -351,8 +477,11 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	return rawData, nil, ttl, leaseID, nil
 }
 
-// mintGroupAccessToken creates a group access token via the GitLab API
-func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// mintGroupAccessToken creates a group access token via the GitLab API.
+//
+// patOverride carries the token fetched via credential chaining (nil for an inline
+// source). A chained mint is also leaseless: see mintLeaseID.
+func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec, patOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	groupID := credential.GetString(spec.Config, "group_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -373,9 +502,9 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	}
 
 	path := fmt.Sprintf("/api/v4/groups/%s/access_tokens", url.PathEscape(groupID))
-	respBody, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes)
+	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, patOverride)
 	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to create group access token: %w", err)
+		return nil, nil, 0, "", mintError("failed to create group access token", err, status, patOverride)
 	}
 
 	var result struct {
@@ -394,7 +523,7 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
-	leaseID := fmt.Sprintf("group_access_token:%s:%s", groupID, tokenIDStr)
+	leaseID := mintLeaseID("group_access_token", groupID, tokenIDStr, patOverride)
 
 	rawData := map[string]interface{}{
 		"access_token": result.Token,
@@ -440,7 +569,7 @@ func (d *GitLabDriver) Revoke(ctx context.Context, leaseID string) error {
 		return fmt.Errorf("unknown token type in lease ID: %s", tokenType)
 	}
 
-	_, err := d.doGitLabRequest(ctx, http.MethodDelete, path, nil)
+	_, _, err := d.doGitLabRequest(ctx, http.MethodDelete, path, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to revoke %s: %w", tokenType, err)
 	}
@@ -473,6 +602,12 @@ func (d *GitLabDriver) Cleanup(_ context.Context) error {
 // PAT mode supports rotation via the PAT rotate API.
 // OAuth2 mode supports rotation via the application secret rotation API.
 func (d *GitLabDriver) SupportsRotation() bool {
+	// A chained source does not own its token — the referenced spec's owner does,
+	// and rotates it there. Rotating here would invalidate someone else's secret and
+	// write the replacement into config that is no longer read.
+	if d.isChained() {
+		return false
+	}
 	return d.getAuthMethod() == "pat" || d.getAuthMethod() == "oauth2"
 }
 
@@ -496,7 +631,7 @@ func (d *GitLabDriver) PrepareRotation(ctx context.Context) (newConfig, cleanupC
 // immediately valid and the old one is already revoked.
 func (d *GitLabDriver) preparePATRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
 	// First, get the current token's ID
-	respBody, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil)
+	respBody, _, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil, nil)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to get current PAT info: %w", err)
 	}
@@ -510,7 +645,7 @@ func (d *GitLabDriver) preparePATRotation(ctx context.Context) (map[string]strin
 
 	// Rotate the PAT
 	path := fmt.Sprintf("/api/v4/personal_access_tokens/%d/rotate", tokenInfo.ID)
-	respBody, err = d.doGitLabRequest(ctx, http.MethodPost, path, nil)
+	respBody, _, err = d.doGitLabRequest(ctx, http.MethodPost, path, nil, nil)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to rotate PAT: %w", err)
 	}
@@ -563,7 +698,7 @@ func (d *GitLabDriver) prepareOAuth2Rotation(ctx context.Context) (map[string]st
 
 	// Rotate the application secret via admin API
 	path := fmt.Sprintf("/api/v4/applications/%s/renew-secret", url.PathEscape(applicationID))
-	respBody, err := d.doGitLabRequest(ctx, http.MethodPost, path, nil)
+	respBody, _, err := d.doGitLabRequest(ctx, http.MethodPost, path, nil, nil)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to rotate OAuth2 application secret: %w", err)
 	}
@@ -616,7 +751,7 @@ func (d *GitLabDriver) CommitRotation(ctx context.Context, newConfig map[string]
 	d.tokenCache.InvalidateGeneration()
 
 	// Verify new credentials work
-	if err := d.verifyAuth(ctx); err != nil {
+	if err := d.verifyAuth(ctx, nil); err != nil {
 		return fmt.Errorf("new credentials verification failed: %w", err)
 	}
 
@@ -641,7 +776,16 @@ func (d *GitLabDriver) CleanupRotation(_ context.Context, cleanupConfig map[stri
 // --- HTTP helpers ---
 
 // doGitLabRequest executes an HTTP request to the GitLab API with authentication.
-func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+//
+// patOverride supplies the token for a single request instead of reading it from
+// source config, which is how a chained mint passes the token fetched from its
+// referenced spec without touching shared driver state. Nil means "use the inline
+// token", the behaviour for every non-chained call site.
+//
+// The response status is returned alongside the body because the retry helper
+// reports failures as an opaque message; a caller that must distinguish an
+// authentication rejection from any other error has no other way to see it.
+func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte, patOverride *string) ([]byte, int, error) {
 	apiURL := d.getGitLabAddress() + path
 
 	// Prepare headers
@@ -653,11 +797,15 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 	// Set authentication based on auth method
 	switch d.getAuthMethod() {
 	case "pat":
-		headers["PRIVATE-TOKEN"] = d.getPAT()
+		if patOverride != nil {
+			headers["PRIVATE-TOKEN"] = *patOverride
+		} else {
+			headers["PRIVATE-TOKEN"] = d.getPAT()
+		}
 	case "oauth2":
 		token, err := d.getOAuth2Token(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to set auth: %w", err)
+			return nil, 0, fmt.Errorf("failed to set auth: %w", err)
 		}
 		headers["Authorization"] = "Bearer " + token
 	}
@@ -678,11 +826,11 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 		Headers: headers,
 	}
 
-	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil && d.logger != nil {
 		d.logger.Warn("GitLab API request failed", logger.String("error", err.Error()))
 	}
-	return respBody, err
+	return respBody, status, err
 }
 
 // getOAuth2Token returns a cached or fresh OAuth2 access token

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -543,7 +543,18 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	return rawData, nil, ttl, leaseID, nil
 }
 
-// Revoke revokes a previously minted access token
+// Revoke revokes a previously minted access token.
+//
+// It authenticates with the source's inline token, which is the only one it can
+// reach: revocation runs when a lease expires, with no caller to mint a chained
+// token as. Chained sources therefore issue no leases and never arrive here.
+//
+// One case does: a source converted from inline to chained, whose leases were
+// issued before the conversion. Those revocations fail with a 401, since the
+// inline token is gone by then, and the tokens they name stay live until their own
+// expires_at. Nothing can be done about it here — the token that would authorise
+// the delete no longer exists anywhere Warden can read it — and the exposure is
+// bounded by the expiry already set on them.
 func (d *GitLabDriver) Revoke(ctx context.Context, leaseID string) error {
 	if leaseID == "" {
 		return nil

--- a/credential/drivers/gitlab_driver_test.go
+++ b/credential/drivers/gitlab_driver_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -794,4 +795,331 @@ func TestGitLabDriver_MintHonoursServerExpiry(t *testing.T) {
 	assert.Equal(t, clamped, rawData["expires_at"], "the server's date must be the one reported")
 	assert.Less(t, ttl, 48*time.Hour, "the lease must follow the server's date, not the request")
 	assert.Greater(t, ttl, time.Duration(0))
+}
+
+func TestGitLabDriverFactory_ValidateConfig_Chaining(t *testing.T) {
+	factory := &GitLabDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "chained PAT source needs no inline token",
+			config: map[string]string{
+				"gitlab_address": "https://gitlab.example.com",
+				"auth_method":    "pat",
+				"secret_spec":    "gitlab-pat-from-vault",
+				"secret_field":   "pat",
+			},
+		},
+		{
+			name: "chained source accepts a cache ttl",
+			config: map[string]string{
+				"gitlab_address":   "https://gitlab.example.com",
+				"secret_spec":      "gitlab-pat-from-vault",
+				"secret_cache_ttl": "30m",
+			},
+		},
+		{
+			name: "non-chained source still requires the inline token",
+			config: map[string]string{
+				"gitlab_address": "https://gitlab.example.com",
+				"auth_method":    "pat",
+			},
+			wantErr: true,
+			errMsg:  "personal_access_token",
+		},
+		{
+			name: "chaining plus an inline token leaves a secret at rest",
+			config: map[string]string{
+				"gitlab_address":        "https://gitlab.example.com",
+				"auth_method":           "pat",
+				"secret_spec":           "gitlab-pat-from-vault",
+				"personal_access_token": "glpat-still-here",
+			},
+			wantErr: true,
+			errMsg:  "must be omitted when secret_spec is set",
+		},
+		{
+			name: "oauth2 cannot chain",
+			config: map[string]string{
+				"gitlab_address":     "https://gitlab.example.com",
+				"auth_method":        "oauth2",
+				"application_id":     "app-123",
+				"application_secret": "secret-456",
+				"secret_spec":        "gitlab-app-secret",
+			},
+			wantErr: true,
+			errMsg:  "only for auth_method=pat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGitLabDriverFactory_Create_ChainedSkipsVerifyAuth(t *testing.T) {
+	// A chained source has no token at construction time, so Create must not try to
+	// authenticate — there is nothing to authenticate with until a request arrives.
+	var calls int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	factory := &GitLabDriverFactory{}
+	driver, err := factory.Create(map[string]string{
+		"gitlab_address":  server.URL,
+		"auth_method":     "pat",
+		"secret_spec":     "gitlab-pat-from-vault",
+		"tls_skip_verify": "true",
+	}, log)
+
+	require.NoError(t, err)
+	require.NotNil(t, driver)
+	assert.Zero(t, calls, "chained Create must not call the API")
+}
+
+func TestGitLabDriver_MintCredential_FailsClosedWhenChained(t *testing.T) {
+	// The manager routes chained specs to MintFromSecret. Reaching MintCredential
+	// means that routing was bypassed, so it must not fall through to an inline
+	// token the source does not have.
+	tests := []struct {
+		name         string
+		sourceConfig map[string]string
+		specConfig   map[string]string
+	}{
+		{
+			name: "secret_spec on the source",
+			sourceConfig: map[string]string{
+				"gitlab_address": "https://gitlab.example.com",
+				"auth_method":    "pat",
+				"secret_spec":    "gitlab-pat-from-vault",
+			},
+			specConfig: map[string]string{"mint_method": "project_access_token", "project_id": "42"},
+		},
+		{
+			name: "secret_spec on the spec",
+			sourceConfig: map[string]string{
+				"gitlab_address":        "https://gitlab.example.com",
+				"auth_method":           "pat",
+				"personal_access_token": "test-pat",
+			},
+			specConfig: map[string]string{
+				"mint_method": "project_access_token",
+				"project_id":  "42",
+				"secret_spec": "gitlab-pat-from-vault",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := &GitLabDriver{
+				credSource: &credential.CredSource{Type: credential.SourceTypeGitLab, Config: tt.sourceConfig},
+				httpClient: &http.Client{Timeout: 30 * time.Second},
+			}
+			spec := &credential.CredSpec{Name: "test-spec", Type: credential.TypeGitLabAccessToken, Config: tt.specConfig}
+
+			_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must mint from fetched secret material")
+		})
+	}
+}
+
+// newChainedGitLabDriver builds a chained (secret_spec, no inline token) driver
+// pointed at the given test server.
+func newChainedGitLabDriver(server *httptest.Server) *GitLabDriver {
+	return &GitLabDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGitLab,
+			Config: map[string]string{
+				"gitlab_address": server.URL,
+				"auth_method":    "pat",
+				"secret_spec":    "gitlab-pat-from-vault",
+			},
+		},
+		httpClient: server.Client(),
+	}
+}
+
+func projectTokenSpec() *credential.CredSpec {
+	return &credential.CredSpec{
+		Name: "test-spec",
+		Type: credential.TypeGitLabAccessToken,
+		Config: map[string]string{
+			"mint_method":  "project_access_token",
+			"project_id":   "42",
+			"token_name":   "warden-test",
+			"scopes":       "api",
+			"access_level": "30",
+			"ttl":          "24h",
+		},
+	}
+}
+
+func TestGitLabDriver_MintFromSecret(t *testing.T) {
+	var gotToken string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("PRIVATE-TOKEN")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 99, "token": "glpat-minted-token"})
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name      string
+		material  credential.SecretMaterial
+		wantToken string
+	}{
+		{
+			name:      "resolved field",
+			material:  credential.SecretMaterial{Data: map[string]string{"pat": "glpat-from-vault"}, Field: "pat"},
+			wantToken: "glpat-from-vault",
+		},
+		{
+			name:      "conventional key when no field resolved",
+			material:  credential.SecretMaterial{Data: map[string]string{"personal_access_token": "glpat-conventional"}},
+			wantToken: "glpat-conventional",
+		},
+		{
+			name:      "short conventional key when no field resolved",
+			material:  credential.SecretMaterial{Data: map[string]string{"pat": "glpat-short"}},
+			wantToken: "glpat-short",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToken = ""
+			driver := newChainedGitLabDriver(server)
+
+			rawData, _, ttl, leaseID, err := driver.MintFromSecret(context.Background(), projectTokenSpec(), tt.material)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantToken, gotToken, "fetched token must authenticate the mint")
+			assert.Equal(t, "glpat-minted-token", rawData["access_token"])
+			assert.GreaterOrEqual(t, ttl, 24*time.Hour)
+			// Chained mints are leaseless: revocation runs with no caller and could
+			// not re-fetch the token needed to authenticate the delete.
+			assert.Empty(t, leaseID)
+		})
+	}
+}
+
+func TestGitLabDriver_MintFromSecret_Errors(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("must not reach the API without a token")
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name       string
+		authMethod string
+		material   credential.SecretMaterial
+		errMsg     string
+	}{
+		{
+			// A resolved-but-empty field is a misconfigured secret_field, not an
+			// invitation to authenticate with some other value in the payload.
+			name:     "resolved field is empty",
+			material: credential.SecretMaterial{Data: map[string]string{"pat": "", "other": "glpat-wrong"}, Field: "pat"},
+			errMsg:   `secret_field "pat" is empty or absent`,
+		},
+		{
+			name:     "no field and no conventional key",
+			material: credential.SecretMaterial{Data: map[string]string{"unexpected": "glpat-wrong"}},
+			errMsg:   "no personal access token in fetched secret material",
+		},
+		{
+			name:       "auth_method drifted to oauth2",
+			authMethod: "oauth2",
+			material:   credential.SecretMaterial{Data: map[string]string{"pat": "glpat-from-vault"}, Field: "pat"},
+			errMsg:     "requires auth_method=pat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := newChainedGitLabDriver(server)
+			if tt.authMethod != "" {
+				driver.credSource.Config["auth_method"] = tt.authMethod
+			}
+
+			_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(), tt.material)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestGitLabDriver_MintFromSecret_RejectedTokenIsRetryable(t *testing.T) {
+	// A token rotated at its source goes stale in the chained-secret cache. Marking
+	// the rejection lets the minting layer evict it and retry once, instead of
+	// failing every request until the entry ages out.
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+
+			driver := newChainedGitLabDriver(server)
+			material := credential.SecretMaterial{Data: map[string]string{"pat": "glpat-stale"}, Field: "pat"}
+
+			_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(), material)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+		})
+	}
+}
+
+func TestGitLabDriver_MintFromSecret_OtherFailuresAreNotRetryable(t *testing.T) {
+	// Only an authentication rejection implicates the fetched token. A 404 means the
+	// project is wrong; evicting and refetching would not help.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	driver := newChainedGitLabDriver(server)
+	material := credential.SecretMaterial{Data: map[string]string{"pat": "glpat-fine"}, Field: "pat"}
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(), material)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+func TestGitLabDriver_SupportsRotation_ChainedSourceOwnsNothing(t *testing.T) {
+	for _, authMethod := range []string{"pat", "oauth2"} {
+		t.Run(authMethod, func(t *testing.T) {
+			driver := &GitLabDriver{
+				credSource: &credential.CredSource{
+					Type: credential.SourceTypeGitLab,
+					Config: map[string]string{
+						"gitlab_address": "https://gitlab.example.com",
+						"auth_method":    authMethod,
+						"secret_spec":    "gitlab-pat-from-vault",
+					},
+				},
+				httpClient: &http.Client{Timeout: 30 * time.Second},
+			}
+			assert.False(t, driver.SupportsRotation())
+		})
+	}
 }

--- a/e2e/fullchain/gitlab_test.go
+++ b/e2e/fullchain/gitlab_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
@@ -55,6 +56,25 @@ const (
 	gitlabChainSource     = "fc-gl-keyless-src"
 	gitlabChainSpec       = "fc-gl-keyless-cred"
 	gitlabChainAgentRole  = "fc-gl-keyless-agent"
+
+	// The cache row's own chain. It cannot share the keyless row's resources:
+	// its source must carry secret_cache_ttl, and it needs two consuming specs
+	// where that row needs one.
+	gitlabCacheSecretSpec = "fc-gl-cache-pat-from-vault"
+	gitlabCacheSource     = "fc-gl-cache-src"
+	gitlabCacheSpecA      = "fc-gl-cache-cred-a"
+	gitlabCacheSpecB      = "fc-gl-cache-cred-b"
+	gitlabCacheAgentRoleA = "fc-gl-cache-agent-a"
+	gitlabCacheAgentRoleB = "fc-gl-cache-agent-b"
+
+	// What the Vault secret is rotated to mid-test on the cache row. Like the
+	// seeded value, it appears in no config anywhere.
+	gitlabRotatedPAT = "e2e-gl-rotated-not-a-real-pat"
+
+	// Where setup.sh seeds the chained token in the harness Vault, as a KV2
+	// data path. The cache row writes here to simulate a rotation happening at
+	// the source, behind Warden's back.
+	gitlabPATVaultPath = "secret/data/e2e/gitlab-pat"
 )
 
 // setupGitLabEnv builds the mount and its inline source, per test rather than
@@ -173,14 +193,23 @@ func TestGitLab_RESTLegInjectsMintedToken(t *testing.T) {
 	}
 }
 
-// setupGitLabKeylessChain builds the keyless half: a source holding no token,
-// naming a spec that reads one out of Vault.
+// gitlabChainConsumer names one consuming spec and the JWT agent role bound to
+// it, for setupGitLabChain.
+type gitlabChainConsumer struct {
+	spec, role string
+}
+
+// setupGitLabChain builds a keyless chain: a source holding no token, naming a
+// spec that reads one out of Vault, and one consuming spec plus agent role per
+// entry in consumers. cacheTTL, when non-empty, becomes the source's
+// secret_cache_ttl, so every consumer under it shares the fetched token for
+// that long.
 //
 // Order is load-bearing both ways — a source naming a secret_spec that does not
 // exist is refused at create, and a referenced spec cannot be deleted while
 // something names it — so cleanup runs consumer-first, and the same order clears
 // whatever a killed run left behind.
-func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
+func setupGitLabChain(t *testing.T, gitlabEnv h.ProviderEnv, secretSpec, source, cacheTTL string, consumers []gitlabChainConsumer) {
 	t.Helper()
 
 	mustWrite := func(method, path, body, what string) {
@@ -193,10 +222,12 @@ func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
 	}
 
 	clear := func() {
-		h.APIRequest(t, "DELETE", "auth/jwt/role/"+gitlabChainAgentRole, leaderPort, "")
-		h.APIRequest(t, "DELETE", "sys/cred/specs/"+gitlabChainSpec, leaderPort, "")
-		h.APIRequest(t, "DELETE", "sys/cred/sources/"+gitlabChainSource, leaderPort, "")
-		h.APIRequest(t, "DELETE", "sys/cred/specs/"+gitlabChainSecretSpec, leaderPort, "")
+		for _, c := range consumers {
+			h.APIRequest(t, "DELETE", "auth/jwt/role/"+c.role, leaderPort, "")
+			h.APIRequest(t, "DELETE", "sys/cred/specs/"+c.spec, leaderPort, "")
+		}
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+source, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+secretSpec, leaderPort, "")
 	}
 	clear()
 	t.Cleanup(clear)
@@ -204,7 +235,7 @@ func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
 	// The referenced spec. subject_token_source is not optional: a chained secret
 	// must be minted as the session-pinned caller, and the store refuses the
 	// reference otherwise.
-	mustWrite("POST", "sys/cred/specs/"+gitlabChainSecretSpec, `{
+	mustWrite("POST", "sys/cred/specs/"+secretSpec, `{
 		"type":"key_value","source":"vault-fed-e2e","config":{
 			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":"e2e/gitlab-pat",
 			"subject_token_source":"agent_identity"}}`,
@@ -213,27 +244,41 @@ func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
 	// The keyless source: same address as the inline one, but carrying no
 	// personal_access_token — validation rejects a source that keeps one while
 	// also naming a chain.
-	mustWrite("POST", "sys/cred/sources/"+gitlabChainSource, fmt.Sprintf(`{
+	ttlField := ""
+	if cacheTTL != "" {
+		ttlField = fmt.Sprintf(`,"secret_cache_ttl":%q`, cacheTTL)
+	}
+	mustWrite("POST", "sys/cred/sources/"+source, fmt.Sprintf(`{
 		"type":"gitlab","config":{
 			"gitlab_address":%q,"auth_method":"pat",
-			"secret_spec":%q,"secret_field":"pat"}}`, upstream.URL, gitlabChainSecretSpec),
+			"secret_spec":%q,"secret_field":"pat"%s}}`, upstream.URL, secretSpec, ttlField),
 		"create the keyless gitlab source")
 
-	// The consuming spec is ordinary: it inherits the chain from its source and
-	// carries no chaining config of its own, which is what source-level chaining
-	// means.
-	mustWrite("POST", "sys/cred/specs/"+gitlabChainSpec, `{
-		"type":"gitlab_access_token","source":"`+gitlabChainSource+`","config":{
-			"mint_method":"project_access_token","project_id":"`+gitlabProjectID+`",
-			"token_name":"warden-e2e-keyless","scopes":"api","access_level":"30","ttl":"24h"}}`,
-		"create the keyless consuming spec")
+	for _, c := range consumers {
+		// The consuming spec is ordinary: it inherits the chain from its source and
+		// carries no chaining config of its own, which is what source-level chaining
+		// means.
+		mustWrite("POST", "sys/cred/specs/"+c.spec, `{
+			"type":"gitlab_access_token","source":"`+source+`","config":{
+				"mint_method":"project_access_token","project_id":"`+gitlabProjectID+`",
+				"token_name":"warden-e2e-keyless","scopes":"api","access_level":"30","ttl":"24h"}}`,
+			"create the keyless consuming spec "+c.spec)
 
-	// The mount's own role binds its default spec, so this row needs one bound to
-	// the keyless spec instead.
-	mustWrite("POST", "auth/jwt/role/"+gitlabChainAgentRole, `{
-		"token_policies":["`+gitlabEnv.Policy()+`"],"cred_spec_name":"`+gitlabChainSpec+`",
-		"user_claim":"sub","token_ttl":3600}`,
-		"create the keyless agent role")
+		// The mount's own role binds its default spec, so each consumer needs one
+		// bound to its own spec instead.
+		mustWrite("POST", "auth/jwt/role/"+c.role, `{
+			"token_policies":["`+gitlabEnv.Policy()+`"],"cred_spec_name":"`+c.spec+`",
+			"user_claim":"sub","token_ttl":3600}`,
+			"create the keyless agent role "+c.role)
+	}
+}
+
+// setupGitLabKeylessChain builds the single-consumer, uncached chain the
+// keyless rows use.
+func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
+	t.Helper()
+	setupGitLabChain(t, gitlabEnv, gitlabChainSecretSpec, gitlabChainSource, "",
+		[]gitlabChainConsumer{{gitlabChainSpec, gitlabChainAgentRole}})
 }
 
 // TestGitLab_KeylessChainMintsWithVaultHeldToken is the row this file exists
@@ -328,5 +373,140 @@ func TestGitLab_KeylessSourceRefusesConfigThatContradictsIt(t *testing.T) {
 				t.Errorf("error should mention %q, got: %s", tt.errMsg, body)
 			}
 		})
+	}
+}
+
+// TestGitLab_StaleCachedSecretIsEvictedAndRetried covers the join that makes
+// the driver's ErrChainedSecretRejected worth returning at all: the driver's
+// unit test stops at the error value, and the minting layer's eviction tests
+// reject from a fake driver, so no test anywhere shows a real 401 from the API
+// turning into an eviction, a fresh Vault read and a mint that succeeds. Without
+// that join, a token rotated at its source would fail every request under it
+// until the cache entry aged out on its own.
+//
+// Two consuming specs on one source, deliberately. A minted credential is
+// cached per (caller, spec), so a second request against the same spec would be
+// answered from that cache and never reach the mint this row exists to observe;
+// a different spec under the same caller misses it while still sharing the
+// source-scoped secret cache, whose key carries no spec name.
+//
+// One JWT for both requests, also deliberately. The secret cache's per-agent
+// dimension is the agent's inbound JWT itself, and Hydra issues a fresh token
+// per call — fetched twice, the second request would read as a different agent
+// and miss the cache, and the row would pass without the cache ever being hit.
+func TestGitLab_StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
+	ensureEnv(t)
+	gitlabEnv := setupGitLabEnv(t)
+	useJWTAgentLeg(t, gitlabEnv)
+	setupGitLabChain(t, gitlabEnv, gitlabCacheSecretSpec, gitlabCacheSource, "5m",
+		[]gitlabChainConsumer{
+			{gitlabCacheSpecA, gitlabCacheAgentRoleA},
+			{gitlabCacheSpecB, gitlabCacheAgentRoleB},
+		})
+
+	// The Vault secret is shared state: the other rows here, and every later
+	// run, expect the seeded value. Registered before anything can rewrite it,
+	// so a failure between the rotation below and the end of the test still
+	// puts it back.
+	t.Cleanup(func() {
+		if status, resp := h.VaultDirectRequest(t, "POST", gitlabPATVaultPath,
+			`{"data":{"pat":"`+gitlabChainedPAT+`"}}`); status >= 400 {
+			t.Errorf("restoring the seeded gitlab pat in Vault failed (status %d): %s — later gitlab rows will mint with the wrong token", status, resp)
+		}
+	})
+
+	// Unlike serveGitLabMint, this handler checks the mint's token: the whole
+	// row turns on the upstream accepting only the token Vault currently holds,
+	// so which value that is has to change mid-test when the secret rotates.
+	// The guard is for the race detector — the handler runs on the server's
+	// goroutines.
+	var mu sync.Mutex
+	acceptedPAT := gitlabChainedPAT
+	setAcceptedPAT := func(pat string) { mu.Lock(); acceptedPAT = pat; mu.Unlock() }
+	upstream.SetHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == gitlabMintPath {
+			mu.Lock()
+			ok := r.Header.Get("PRIVATE-TOKEN") == acceptedPAT
+			mu.Unlock()
+			if !ok {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":99,"token":"` + gitlabMintedToken + `"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	upstream.Reset()
+
+	jwt := h.GetDefaultJWT(t)
+
+	// The first request populates the secret cache on its way through: the
+	// token is fetched from Vault, cached under the chain's key, and spent on
+	// the mint. Fresh fetches are not retried on rejection, so this request
+	// proves nothing about eviction — it exists to plant the entry the second
+	// request must trip over.
+	status, body, _ := h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentToken: jwt,
+		Role:       gitlabCacheAgentRoleA,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 2,
+	})
+	if got := findGitLabMint(t).Header.Get("PRIVATE-TOKEN"); got != gitlabChainedPAT {
+		t.Fatalf("cache-populating mint authenticated with %q, want the Vault-held token %q", got, gitlabChainedPAT)
+	}
+
+	// The rotation happens where a real one would: at the source, with Warden
+	// not told. The upstream flips with it, because a rotated token's defining
+	// property is that the old one stops working.
+	if status, resp := h.VaultDirectRequest(t, "POST", gitlabPATVaultPath,
+		`{"data":{"pat":"`+gitlabRotatedPAT+`"}}`); status >= 400 {
+		t.Fatalf("rotating the gitlab pat in Vault failed (status %d): %s", status, resp)
+	}
+	setAcceptedPAT(gitlabRotatedPAT)
+	upstream.Reset()
+
+	// Three calls where the first request made two: the mint that fails, the
+	// mint that succeeds after the eviction, and the proxied request. The
+	// caller sees none of it — the retry has to make the rotation invisible.
+	status, body, _ = h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentToken: jwt,
+		Role:       gitlabCacheAgentRoleB,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 3,
+	})
+
+	var mints []h.UpstreamRequest
+	for _, req := range upstream.Requests() {
+		if req.Method == http.MethodPost && req.Path == gitlabMintPath {
+			mints = append(mints, req)
+		}
+	}
+	if len(mints) != 2 {
+		t.Fatalf("second request made %d mint attempts, want 2 (rejected then retried)", len(mints))
+	}
+	// The first attempt must carry the token Vault no longer holds. That is the
+	// proof the cache was consulted at all — on a miss the fetch would have
+	// found the rotated token and the mint would have succeeded first try, and
+	// the row would pass against a build with no cache in it.
+	if got := mints[0].Header.Get("PRIVATE-TOKEN"); got != gitlabChainedPAT {
+		t.Errorf("first mint attempt authenticated with %q, want the stale cached token %q", got, gitlabChainedPAT)
+	}
+	// And the second must carry the rotated one, which it can only have gotten
+	// by evicting the stale entry and reading Vault again.
+	if got := mints[1].Header.Get("PRIVATE-TOKEN"); got != gitlabRotatedPAT {
+		t.Errorf("retried mint authenticated with %q, want the freshly fetched token %q", got, gitlabRotatedPAT)
 	}
 }

--- a/e2e/fullchain/gitlab_test.go
+++ b/e2e/fullchain/gitlab_test.go
@@ -1,0 +1,332 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// gitlab is the second of the two providers whose credential extractor is
+// selected per request rather than per mount, and github_test.go notes its REST
+// leg had never been driven end to end. It is also the only provider here that
+// mints through a driver calling a real API, so the recording upstream stands in
+// for GitLab itself: the source's gitlab_address and the mount's both point at
+// it, and a handler answers the mint POST.
+//
+// That is what makes the keyless row below possible at all. Its point is the
+// join no driver test can reach — a personal access token that exists only
+// inside Vault travelling through federation, a KV read and MintFromSecret to
+// authenticate a mint, whose result then comes back out as the credential the
+// provider injects. Each half is covered in isolation; only a full chain shows
+// them meeting.
+//
+// Unlike github, gitlab cannot borrow a local source: gitlab_access_token
+// validates that its source is a gitlab one, so both rows here mint for real.
+// The two differ only in where the driver's token comes from — inline config, or
+// the chain — which is exactly the comparison worth drawing.
+
+const (
+	// The token the driver authenticates its mint with on the inline row.
+	gitlabInlinePAT = "e2e-gl-inline-not-a-real-pat"
+
+	// Written to secret/data/e2e/gitlab-pat by setup.sh, and the token the
+	// driver authenticates with on the keyless row. It appears in no spec or
+	// source config anywhere, so an assertion on it can only pass if the whole
+	// chain ran.
+	gitlabChainedPAT = "e2e-gl-chained-not-a-real-pat"
+
+	// What the stand-in API returns from the mint call. Also present in no
+	// config: it is minted, not stored.
+	gitlabMintedToken = "glpat-e2e-minted-not-a-real-token"
+
+	gitlabProjectID = "42"
+	gitlabMintPath  = "/api/v4/projects/" + gitlabProjectID + "/access_tokens"
+
+	// Test-local, the source included, for the reason credential_chaining_test.go
+	// gives: a killed run skips t.Cleanup, and a spec left hanging off a shared
+	// source would block that source from being deleted, failing the next run's
+	// setup before it reaches the cleanup that would have cleared it.
+	gitlabChainSecretSpec = "fc-gl-pat-from-vault"
+	gitlabChainSource     = "fc-gl-keyless-src"
+	gitlabChainSpec       = "fc-gl-keyless-cred"
+	gitlabChainAgentRole  = "fc-gl-keyless-agent"
+)
+
+// setupGitLabEnv builds the mount and its inline source, per test rather than
+// once for the package.
+//
+// The ordering is the reason. Creating a spec test-mints it, and gitlab's mint is
+// a real API call, so the stand-in has to be answering before the spec is
+// written — and the handler that answers it belongs to a test, not to the
+// package. Every other provider mints from a local source that calls nothing, so
+// none of them has this constraint and all of them are set up in ensureEnv.
+//
+// Recorded traffic is cleared last: setup's own calls — the source's auth check,
+// the spec's test-mint — would otherwise be counted against the row's
+// expectations.
+func setupGitLabEnv(t *testing.T) h.ProviderEnv {
+	t.Helper()
+
+	serveGitLabMint(t)
+
+	env := buildGitLabEnv(upstream.URL)
+	h.SetupFullChainProvider(t, leaderPort, upstream.URL, env)
+	t.Cleanup(func() { h.TeardownFullChainProviderBestEffort(leaderPort, env) })
+
+	upstream.Reset()
+	return env
+}
+
+// buildGitLabEnv needs the upstream's URL for the source config, not just the
+// mount config, since the driver calls it to mint.
+func buildGitLabEnv(upstreamURL string) h.ProviderEnv {
+	return h.ProviderEnv{
+		Mount:      "fc-gitlab",
+		Type:       "gitlab",
+		URLKey:     "gitlab_address",
+		CredType:   "gitlab_access_token",
+		SourceType: "gitlab",
+		SourceConfig: map[string]string{
+			"gitlab_address":        upstreamURL,
+			"auth_method":           "pat",
+			"personal_access_token": gitlabInlinePAT,
+		},
+		CredConfig: map[string]string{
+			"mint_method":  "project_access_token",
+			"project_id":   gitlabProjectID,
+			"token_name":   "warden-e2e",
+			"scopes":       "api",
+			"access_level": "30",
+			"ttl":          "24h",
+		},
+	}
+}
+
+// serveGitLabMint makes the upstream answer the driver's mint call, and leave
+// every other path to the default probe response so the proxied request still
+// behaves like every other row's.
+func serveGitLabMint(t *testing.T) {
+	t.Helper()
+	upstream.SetHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == gitlabMintPath {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":99,"token":"` + gitlabMintedToken + `"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+}
+
+// findGitLabMint returns the mint call the driver made, failing if it never
+// happened — which is the interesting failure on the keyless row, since a chain
+// that broke before the driver ran would otherwise present only as a 5xx.
+func findGitLabMint(t *testing.T) h.UpstreamRequest {
+	t.Helper()
+	for _, req := range upstream.Requests() {
+		if req.Method == http.MethodPost && req.Path == gitlabMintPath {
+			return req
+		}
+	}
+	t.Fatalf("upstream never received the mint call %s %s", http.MethodPost, gitlabMintPath)
+	return h.UpstreamRequest{}
+}
+
+// TestGitLab_RESTLegInjectsMintedToken drives the REST half of the mount that
+// github_test.go records as uncovered, and pins the inline baseline the keyless
+// row is measured against: the driver authenticates its mint with the token in
+// source config, and the token it mints back comes out as a Bearer credential.
+//
+// Three upstream calls, where every other provider here makes one. Unlike them
+// the mint is itself a request, and an inline source makes two: constructing the
+// driver checks the token it was configured with, then the mint spends it, then
+// the proxied request goes out. The keyless row below makes two, and the missing
+// one is that construction check — a chained source has no token to check yet.
+//
+// The Bearer value is minted rather than stored, so it can only be right if the
+// mint response was actually parsed and carried through.
+func TestGitLab_RESTLegInjectsMintedToken(t *testing.T) {
+	ensureEnv(t)
+	gitlabEnv := setupGitLabEnv(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         gitlabEnv.CertRole(),
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 3,
+	})
+
+	if got := findGitLabMint(t).Header.Get("PRIVATE-TOKEN"); got != gitlabInlinePAT {
+		t.Errorf("mint call authenticated with %q, want the source's inline token %q", got, gitlabInlinePAT)
+	}
+}
+
+// setupGitLabKeylessChain builds the keyless half: a source holding no token,
+// naming a spec that reads one out of Vault.
+//
+// Order is load-bearing both ways — a source naming a secret_spec that does not
+// exist is refused at create, and a referenced spec cannot be deleted while
+// something names it — so cleanup runs consumer-first, and the same order clears
+// whatever a killed run left behind.
+func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
+	t.Helper()
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+gitlabChainAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+gitlabChainSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+gitlabChainSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+gitlabChainSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	// The referenced spec. subject_token_source is not optional: a chained secret
+	// must be minted as the session-pinned caller, and the store refuses the
+	// reference otherwise.
+	mustWrite("POST", "sys/cred/specs/"+gitlabChainSecretSpec, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":"e2e/gitlab-pat",
+			"subject_token_source":"agent_identity"}}`,
+		"create the referenced secret spec")
+
+	// The keyless source: same address as the inline one, but carrying no
+	// personal_access_token — validation rejects a source that keeps one while
+	// also naming a chain.
+	mustWrite("POST", "sys/cred/sources/"+gitlabChainSource, fmt.Sprintf(`{
+		"type":"gitlab","config":{
+			"gitlab_address":%q,"auth_method":"pat",
+			"secret_spec":%q,"secret_field":"pat"}}`, upstream.URL, gitlabChainSecretSpec),
+		"create the keyless gitlab source")
+
+	// The consuming spec is ordinary: it inherits the chain from its source and
+	// carries no chaining config of its own, which is what source-level chaining
+	// means.
+	mustWrite("POST", "sys/cred/specs/"+gitlabChainSpec, `{
+		"type":"gitlab_access_token","source":"`+gitlabChainSource+`","config":{
+			"mint_method":"project_access_token","project_id":"`+gitlabProjectID+`",
+			"token_name":"warden-e2e-keyless","scopes":"api","access_level":"30","ttl":"24h"}}`,
+		"create the keyless consuming spec")
+
+	// The mount's own role binds its default spec, so this row needs one bound to
+	// the keyless spec instead.
+	mustWrite("POST", "auth/jwt/role/"+gitlabChainAgentRole, `{
+		"token_policies":["`+gitlabEnv.Policy()+`"],"cred_spec_name":"`+gitlabChainSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the keyless agent role")
+}
+
+// TestGitLab_KeylessChainMintsWithVaultHeldToken is the row this file exists
+// for: a source that stores no token still mints.
+//
+// Both asserted values are absent from every spec and source config — one lives
+// only in Vault, the other only in the mint response — so the row fails if any
+// link breaks: the federation login, the KV read, the material reaching
+// MintFromSecret, the mint itself, or the extractor.
+//
+// A JWT agent leg rather than the usual certificate, because agent_identity
+// forwards the agent's own inbound JWT as the exchange subject and fails closed
+// on a cert-authenticated request.
+func TestGitLab_KeylessChainMintsWithVaultHeldToken(t *testing.T) {
+	ensureEnv(t)
+	gitlabEnv := setupGitLabEnv(t)
+	useJWTAgentLeg(t, gitlabEnv)
+	setupGitLabKeylessChain(t, gitlabEnv)
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Role:       gitlabChainAgentRole,
+	})
+
+	// Two calls, not the inline row's three: no construction-time auth check,
+	// because at construction a chained source has nothing to check with.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 2,
+	})
+
+	// The half a driver test cannot show: the token the mint authenticated with
+	// came out of Vault, not out of config.
+	mint := findGitLabMint(t)
+	if got := mint.Header.Get("PRIVATE-TOKEN"); got != gitlabChainedPAT {
+		t.Errorf("mint call authenticated with %q, want the Vault-held token %q", got, gitlabChainedPAT)
+	}
+	// And it really was the chained path: a source keeping an inline token
+	// alongside a chain is refused at create, so the inline value must be absent.
+	if strings.Contains(string(mint.Body), gitlabInlinePAT) {
+		t.Errorf("the inline token leaked into the keyless mint body: %s", mint.Body)
+	}
+}
+
+// TestGitLab_KeylessSourceRefusesConfigThatContradictsIt pins the two shapes a
+// keyless source must not take, at the point they are written rather than at
+// first use.
+//
+// Both are cases where the config would read as sensible and behave as neither
+// thing: a rotation_period asks Warden to rotate a secret it does not own, on
+// behalf of whoever does; an inline token alongside a chain leaves a source that
+// presents as keyless while still storing the very secret the chain exists to
+// remove.
+func TestGitLab_KeylessSourceRefusesConfigThatContradictsIt(t *testing.T) {
+	ensureEnv(t)
+	gitlabEnv := setupGitLabEnv(t)
+	setupGitLabKeylessChain(t, gitlabEnv)
+
+	tests := []struct {
+		name   string
+		body   string
+		errMsg string
+	}{
+		{
+			name: "rotation_period on a source owning no secret",
+			body: fmt.Sprintf(`{"type":"gitlab","rotation_period":86400,"config":{
+				"gitlab_address":%q,"auth_method":"pat",
+				"secret_spec":%q,"secret_field":"pat"}}`, upstream.URL, gitlabChainSecretSpec),
+			errMsg: "rotation_period does not apply",
+		},
+		{
+			name: "an inline token kept alongside the chain",
+			body: fmt.Sprintf(`{"type":"gitlab","config":{
+				"gitlab_address":%q,"auth_method":"pat","personal_access_token":%q,
+				"secret_spec":%q,"secret_field":"pat"}}`, upstream.URL, gitlabInlinePAT, gitlabChainSecretSpec),
+			errMsg: "must be omitted when secret_spec is set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := "fc-gl-refused-" + strings.ReplaceAll(tt.name, " ", "-")
+			t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "") })
+
+			status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort, tt.body)
+			if status < 400 {
+				t.Fatalf("got status %d, want a failure (body: %s)", status, body)
+			}
+			if !strings.Contains(string(body), tt.errMsg) {
+				t.Errorf("error should mention %q, got: %s", tt.errMsg, body)
+			}
+		})
+	}
+}

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -316,6 +316,14 @@ vault_api POST "secret/data/e2e/database" \
 vault_api POST "secret/data/e2e/datadog-keys" \
   '{"data":{"api_key":"e2e-dd-chained-not-a-real-key","application_key":"e2e-dd-chained-not-a-real-app-key","owner":"e2e-undeclared-field"}}'
 
+# The personal access token a keyless gitlab source mints with. Chained the same
+# way as the datadog keys above, but consumed by a driver that calls an API with
+# it rather than one that passes it through — so what the gitlab row in
+# e2e/fullchain/gitlab_test.go proves is that this value authenticated a real
+# mint, having reached the driver from here and nowhere else.
+vault_api POST "secret/data/e2e/gitlab-pat" \
+  '{"data":{"pat":"e2e-gl-chained-not-a-real-pat"}}'
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \


### PR DESCRIPTION
> **Stacked on #517.** Base is `fix/gitlab-token-expiry-utc`, so the diff here is chaining only. #517 first because this PR's leaseless design rests on the expiry math it corrects. GitHub retargets this to `main` once #517 merges.

A `gitlab` source had to store its personal access token inline, and its only answer to that standing secret was rotating it. This lets the source name another cred spec instead: the token lives wherever the operator keeps it, Warden mints that spec as the caller at use time, uses the token, and keeps nothing.

## Why the gitlab driver and not `apikey`

`apikey` already supports chaining, but it is not a substitute.

The `gitlab` provider pins `TypeGitLabAccessToken` and its extractors reject any other type, so an `api_key` credential only works through the generic `rest` provider — losing git smart-HTTP, the upload/receive-pack split, `PRIVATE-TOKEN` scrubbing and the GitLab skill.

More importantly `apikey` is a pass-through, so it would hand agents the operator's PAT verbatim. A minted project access token is strictly narrower: confined to one project, backed by a non-billable bot user, at a per-token `access_level`, and per GitLab's docs it *"cannot… create other group, project, or personal access tokens"* — so a leak cannot bootstrap persistence. The two options differ by the entire privilege reduction, not by plumbing.

## Design

**Chaining is source-level**, following `token_exchange` rather than spec-level like github/apikey: the token authenticates the source itself, and the factory only sees source config. A spec-level `secret_spec` is rejected with guidance, since it would leave the source's inline token as dead config and slip past the `auth_method` gate. A chained source must also omit the inline token — keeping one leaves a source that reads as keyless while still storing the very secret chaining exists to remove.

**Scope is `auth_method=pat`.** The client-credentials flow caches one bearer token per driver under a fixed key, which holds only while the application secret is a single source-level constant; a chained secret can resolve per user, so a bearer minted for one caller would be served to the next. Chaining on `oauth2` is rejected until that cache is keyed by the resolved secret.

**A chained source owns no secret**, and two things follow. It cannot rotate one, so `SupportsRotation` reports false and `rotation_period` is rejected at create. And it cannot honour a lease: revocation runs long after the request, with no caller and no way to re-fetch the token that would authorise the delete. Chained mints are therefore leaseless and the token expires on its own `expires_at` — which costs nothing, because after #517 the reported lease TTL already equals the token's real validity, so the two were always going to end together.

**Construction no longer authenticates eagerly when chained**, there being no token to authenticate with and no caller yet. The cost is that a bad address or CA surfaces at first mint rather than at create, matching `token_exchange`.

An authentication rejection on the chained path is marked so the minting layer evicts a cached token and retries once; otherwise a token rotated at its source would fail every request until the cache entry aged out.

## Usage

```bash
# 1. The referenced spec: reads the PAT from Vault, minted as the session-pinned caller.
warden cred spec create gitlab-pat-from-vault -json '{
  "source": "vault-fed",
  "config": {
    "mint_method": "kv2_read", "kv2_mount": "secret",
    "secret_path": "gitlab/warden-pat", "subject_token_source": "agent_identity"
  }
}'

# 2. The keyless source — no personal_access_token, no rotation_period.
warden cred source create gitlab-keyless -json '{
  "type": "gitlab",
  "config": {
    "gitlab_address": "https://gitlab.example.com", "auth_method": "pat",
    "secret_spec": "gitlab-pat-from-vault", "secret_field": "pat",
    "secret_cache_ttl": "10m"
  }
}'

# 3. The consuming spec — unchanged shape.
warden cred spec create gitlab-backend -json '{
  "source": "gitlab-keyless",
  "config": {
    "mint_method": "project_access_token", "project_id": "42",
    "token_name": "warden-minted", "scopes": "api,read_repository,write_repository",
    "access_level": "30", "ttl": "24h"
  }
}'
```

## Verification

20 driver subtests, a config-store guard test, and a new full-chain e2e suite. The e2e is the part worth calling out: driver tests build `SecretMaterial` by hand, so they show `MintFromSecret` uses what it is given but not that anything gives it the right thing. The keyless row drives a PAT that exists only inside Vault through federation and a KV read, into a real mint, and back out as the injected credential — both asserted values appear in no spec or source config, so the row fails if any link breaks.

`gitlab` is the first provider here whose mint is itself an API call, so the recording upstream stands in for the API. That forces its environment to be built per test rather than in `ensureEnv`: creating a spec test-mints it, so the stand-in has to be answering before the spec is written. An inline row runs beside the keyless one and doubles as coverage of the REST leg `github_test.go` records as never having been driven.

Full `e2e/...` suite green, plus `go build ./...`, `go vet` (including `-tags e2e`) and the unit suites.

## Follow-ups, deliberately not here

- **Docs** land at release prep per project convention. The capability matrix is already stale — it omits `apikey` and `oauth2` chaining, both shipped.
- **OAuth2 chaining**, which needs the bearer-token cache keyed by the resolved secret.
- **Mint-time cleanup of expired tokens** was designed and rejected: GitLab deletes tokens on the *inactive* clock, so revoking an already-expired one changes nothing. The safe filter and the useful filter are disjoint.