### PR TITLE
feat(gitlab): credential chaining for oauth2 sources

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -994,7 +994,7 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 			case credential.SourceTypeTokenExchange:
 				return logical.ErrBadRequestf("for a token_exchange source, set secret_spec on the source (client authentication is a source concern), not on the spec")
 			case credential.SourceTypeGitLab:
-				return logical.ErrBadRequestf("for a gitlab source, set secret_spec on the source (the personal access token authenticates the source), not on the spec")
+				return logical.ErrBadRequestf("for a gitlab source, set secret_spec on the source (the chained secret — a personal access token, or an OAuth application secret — authenticates the source), not on the spec")
 			}
 		}
 		// A chained consumer's identity normally flows through the referenced secret-spec,

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -935,6 +935,14 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 // The inputs are hashed rather than used raw — a map key outlives the request in
 // memory and surfaces in dumps and test output — and length-prefixed so no two
 // pairs can collide by concatenating differently.
+//
+// SHA-256 rather than a password KDF, deliberately: this derives a cache key, not a
+// stored verifier. No digest is kept, nothing is ever compared against one, and the
+// result never leaves this process. The slowness a KDF buys is protection against
+// guessing a low-entropy human password from a stolen digest — here the input is a
+// high-entropy machine credential, and anything able to read this key can already
+// read the secret it was derived from, so that slowness would cost every lookup and
+// protect nothing.
 func oauth2CacheKey(applicationID, clientSecret string) string {
 	h := sha256.New()
 	for _, field := range []string{applicationID, clientSecret} {

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -58,6 +58,20 @@ type GitLabDriver struct {
 	configMu sync.Mutex
 }
 
+// gitlabChainedAuth carries the per-mint values fetched via credential chaining.
+//
+// A single value sufficed while only the personal access token was chained. An
+// oauth2 source needs both halves of a client credential, and they have to come
+// from the same place: pairing an application id held in config with a secret from
+// the chain would authenticate as one application using another's secret.
+//
+// nil still means "inline source", and the auth method still lives in config —
+// this carries fetched values only, so it duplicates neither.
+type gitlabChainedAuth struct {
+	secret        string
+	applicationID string // oauth2 only; empty in pat mode, which has no id
+}
+
 // GitLabDriverFactory creates GitLabDriver instances
 type GitLabDriverFactory struct{}
 
@@ -108,7 +122,7 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 	// Validate credential-chaining fields
 	if err := credential.ValidateSchema(config,
 		credential.StringField("secret_spec").
-			Describe("Source the secret that authenticates this source from another cred spec via credential chaining instead of storing it inline; the inline key it replaces (personal_access_token, or application_secret in oauth2 mode) is then omitted").
+			Describe("Source the credentials that authenticate this source from another cred spec via credential chaining instead of storing them inline; the keys they replace are then omitted — personal_access_token in pat mode, and both application_id and application_secret in oauth2 mode, where the referenced spec supplies the whole client credential").
 			Example("gitlab-pat-from-store"),
 
 		credential.StringField("secret_field").
@@ -154,20 +168,25 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 				Example("glpat-xxxxx"),
 		)
 	case "oauth2":
-		// As in pat mode, a chained source must not also keep the secret inline: it
-		// would read as keyless while still storing the very secret chaining exists to
-		// remove. The application id is an identifier rather than a secret, so it stays
-		// inline and remains required — the client-credentials grant needs both halves.
+		// A chained source holds NEITHER half of the client credential. The secret is
+		// excluded for the reason pat mode excludes its token — a source would read as
+		// keyless while storing the very secret chaining removes — and the id follows
+		// it, for a different reason: the two authenticate as a pair. An id kept here
+		// beside a secret fetched from the chain would name one application while
+		// presenting another's secret, which the token endpoint answers with
+		// invalid_client, and which the chained path then reads as a rejected secret
+		// and retries pointlessly.
+		//
+		// Requiring both from the payload also lets one source and one spec serve many
+		// applications, since the pair is resolved per mint rather than pinned to the
+		// source.
 		if chained {
-			if credential.GetString(config, "application_secret", "") != "" {
-				return fmt.Errorf("application_secret must be omitted when secret_spec is set; the secret is supplied by the referenced spec")
+			for _, key := range []string{"application_secret", "application_id"} {
+				if credential.GetString(config, key, "") != "" {
+					return fmt.Errorf("%s must be omitted when secret_spec is set; the referenced spec supplies both halves of the client credential", key)
+				}
 			}
-			return credential.ValidateSchema(config,
-				credential.StringField("application_id").
-					Required().
-					Describe("GitLab OAuth2 application ID").
-					Example("app-id"),
-			)
+			return nil
 		}
 		return credential.ValidateSchema(config,
 			credential.StringField("application_id").
@@ -251,12 +270,12 @@ func (d *GitLabDriver) isChained() bool {
 }
 
 // verifyAuth validates the source credentials by calling a simple GitLab API endpoint
-func (d *GitLabDriver) verifyAuth(ctx context.Context, chainedSecret *string) error {
-	_, _, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil, chainedSecret)
+func (d *GitLabDriver) verifyAuth(ctx context.Context, chained *gitlabChainedAuth) error {
+	_, _, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil, chained)
 	if err != nil {
 		// For OAuth2 mode, try a different endpoint
 		if d.getAuthMethod() == "oauth2" {
-			_, _, err = d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/user", nil, chainedSecret)
+			_, _, err = d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/user", nil, chained)
 		}
 	}
 	return err
@@ -348,8 +367,8 @@ func (d *GitLabDriver) resolveExpiry(spec *credential.CredSpec) (string, time.Du
 // end together, so dropping the lease removes a revoke call that would have found
 // the token already dead. What is genuinely given up is early revocation on
 // demand, which is not something that happens today.
-func mintLeaseID(tokenType, resourceID, tokenID string, chainedSecret *string) string {
-	if chainedSecret != nil {
+func mintLeaseID(tokenType, resourceID, tokenID string, chained *gitlabChainedAuth) string {
+	if chained != nil {
 		return ""
 	}
 	return fmt.Sprintf("%s:%s:%s", tokenType, resourceID, tokenID)
@@ -363,8 +382,8 @@ func mintLeaseID(tokenType, resourceID, tokenID string, chainedSecret *string) s
 // In oauth2 mode a stale secret is refused by the token endpoint instead, one call
 // earlier. That path marks the error itself and reaches here with status 0, which
 // falls through the branch below — so the two paths cannot both mark it.
-func mintError(msg string, err error, status int, chainedSecret *string) error {
-	if chainedSecret != nil && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+func mintError(msg string, err error, status int, chained *gitlabChainedAuth) error {
+	if chained != nil && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
 		return fmt.Errorf("gitlab: %s: %w (%w)", msg, credential.ErrChainedSecretRejected, err)
 	}
 	return fmt.Errorf("%s: %w", msg, err)
@@ -387,6 +406,7 @@ func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.Cred
 // secret in oauth2 mode.
 func (d *GitLabDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	secret := material.Secret()
+	var applicationID string
 
 	// Each method names its secret differently, so the conventional keys and the
 	// guidance in the error differ. In both, fall back to a conventional key ONLY
@@ -418,6 +438,18 @@ func (d *GitLabDriver) MintFromSecret(ctx context.Context, spec *credential.Cred
 			}
 			return nil, nil, 0, "", fmt.Errorf("gitlab: no application secret in fetched secret material (set secret_field, or store it under 'application_secret')")
 		}
+
+		// The id travels with its secret. secret_field names the secret alone, so the
+		// id is read by convention — and there is nowhere to fall back to, since a
+		// chained source is refused an inline one. Absent and empty are the same
+		// failure for that reason.
+		applicationID = material.Data["application_id"]
+		if applicationID == "" {
+			applicationID = material.Data["client_id"]
+		}
+		if applicationID == "" {
+			return nil, nil, 0, "", fmt.Errorf("gitlab: no application id in fetched secret material (store it under 'application_id' alongside the secret)")
+		}
 	default:
 		// auth_method is validated to one of the two above, so reaching here means
 		// config drifted after creation. The material's meaning is defined by the
@@ -425,19 +457,19 @@ func (d *GitLabDriver) MintFromSecret(ctx context.Context, spec *credential.Cred
 		return nil, nil, 0, "", fmt.Errorf("gitlab: credential chaining supports auth_method=pat or oauth2, got %q", d.getAuthMethod())
 	}
 
-	return d.mint(ctx, spec, &secret)
+	return d.mint(ctx, spec, &gitlabChainedAuth{secret: secret, applicationID: applicationID})
 }
 
-// mint dispatches on the spec's mint_method. chainedSecret is nil for an inline
+// mint dispatches on the spec's mint_method. chained is nil for an inline
 // source and set for a chained one.
-func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, chainedSecret *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, chained *gitlabChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
 	case "project_access_token":
-		return d.mintProjectAccessToken(ctx, spec, chainedSecret)
+		return d.mintProjectAccessToken(ctx, spec, chained)
 	case "group_access_token":
-		return d.mintGroupAccessToken(ctx, spec, chainedSecret)
+		return d.mintGroupAccessToken(ctx, spec, chained)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GitLab driver; use 'project_access_token' or 'group_access_token'", mintMethod)
 	}
@@ -445,9 +477,9 @@ func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, chai
 
 // mintProjectAccessToken creates a project access token via the GitLab API.
 //
-// chainedSecret carries the source secret fetched via credential chaining (nil
-// for an inline source). A chained mint is also leaseless: see mintLeaseID.
-func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec, chainedSecret *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// chained carries the source credentials fetched via credential chaining (nil for
+// an inline source). A chained mint is also leaseless: see mintLeaseID.
+func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec, chained *gitlabChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	projectID := credential.GetString(spec.Config, "project_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -468,9 +500,9 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	}
 
 	path := fmt.Sprintf("/api/v4/projects/%s/access_tokens", url.PathEscape(projectID))
-	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, chainedSecret)
+	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, chained)
 	if err != nil {
-		return nil, nil, 0, "", mintError("failed to create project access token", err, status, chainedSecret)
+		return nil, nil, 0, "", mintError("failed to create project access token", err, status, chained)
 	}
 
 	var result struct {
@@ -489,7 +521,7 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
-	leaseID := mintLeaseID("project_access_token", projectID, tokenIDStr, chainedSecret)
+	leaseID := mintLeaseID("project_access_token", projectID, tokenIDStr, chained)
 
 	rawData := map[string]interface{}{
 		"access_token": result.Token,
@@ -511,9 +543,9 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 
 // mintGroupAccessToken creates a group access token via the GitLab API.
 //
-// chainedSecret carries the source secret fetched via credential chaining (nil
-// for an inline source). A chained mint is also leaseless: see mintLeaseID.
-func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec, chainedSecret *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// chained carries the source credentials fetched via credential chaining (nil for
+// an inline source). A chained mint is also leaseless: see mintLeaseID.
+func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec, chained *gitlabChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	groupID := credential.GetString(spec.Config, "group_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -534,9 +566,9 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	}
 
 	path := fmt.Sprintf("/api/v4/groups/%s/access_tokens", url.PathEscape(groupID))
-	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, chainedSecret)
+	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, chained)
 	if err != nil {
-		return nil, nil, 0, "", mintError("failed to create group access token", err, status, chainedSecret)
+		return nil, nil, 0, "", mintError("failed to create group access token", err, status, chained)
 	}
 
 	var result struct {
@@ -555,7 +587,7 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
-	leaseID := mintLeaseID("group_access_token", groupID, tokenIDStr, chainedSecret)
+	leaseID := mintLeaseID("group_access_token", groupID, tokenIDStr, chained)
 
 	rawData := map[string]interface{}{
 		"access_token": result.Token,
@@ -820,19 +852,19 @@ func (d *GitLabDriver) CleanupRotation(_ context.Context, cleanupConfig map[stri
 
 // doGitLabRequest executes an HTTP request to the GitLab API with authentication.
 //
-// chainedSecret supplies the source secret for a single request instead of reading
-// it from source config, which is how a chained mint passes the secret fetched from
+// chained supplies the source credentials for a single request instead of reading
+// them from source config, which is how a chained mint passes what it fetched from
 // its referenced spec without touching shared driver state. Nil means "use the
-// inline secret", the behaviour for every non-chained call site.
+// inline credentials", the behaviour for every non-chained call site.
 //
-// What that secret is depends on the auth method: in pat mode it authenticates the
-// request directly, in oauth2 mode it is the application secret the request's bearer
-// is granted from.
+// What it carries depends on the auth method: in pat mode a token that authenticates
+// the request directly, in oauth2 mode the application id and secret the request's
+// bearer is granted from.
 //
 // The response status is returned alongside the body because the retry helper
 // reports failures as an opaque message; a caller that must distinguish an
 // authentication rejection from any other error has no other way to see it.
-func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte, chainedSecret *string) ([]byte, int, error) {
+func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte, chained *gitlabChainedAuth) ([]byte, int, error) {
 	apiURL := d.getGitLabAddress() + path
 
 	// Prepare headers
@@ -845,13 +877,13 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 	var bearerKey string
 	switch d.getAuthMethod() {
 	case "pat":
-		if chainedSecret != nil {
-			headers["PRIVATE-TOKEN"] = *chainedSecret
+		if chained != nil {
+			headers["PRIVATE-TOKEN"] = chained.secret
 		} else {
 			headers["PRIVATE-TOKEN"] = d.getPAT()
 		}
 	case "oauth2":
-		token, key, err := d.getOAuth2Token(ctx, chainedSecret)
+		token, key, err := d.getOAuth2Token(ctx, chained)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to set auth: %w", err)
 		}
@@ -933,13 +965,17 @@ func isClientSecretRejection(err error) bool {
 // with the cache key holding it so the caller can evict that entry if the upstream
 // later refuses the bearer.
 //
-// chainedSecret, when non-nil, supplies the application secret in place of the one
-// in source config.
-func (d *GitLabDriver) getOAuth2Token(ctx context.Context, chainedSecret *string) (string, string, error) {
+// chained, when non-nil, supplies BOTH halves of the client credential in place of
+// source config. Never one from each: a chained source holds neither half — config
+// validation refuses both — so an id read from config there would be empty, and one
+// mixed in from a source that still had it would name a different application than
+// the secret belongs to.
+func (d *GitLabDriver) getOAuth2Token(ctx context.Context, chained *gitlabChainedAuth) (string, string, error) {
 	applicationID := credential.GetString(d.credSource.Config, "application_id", "")
 	applicationSecret := credential.GetString(d.credSource.Config, "application_secret", "")
-	if chainedSecret != nil {
-		applicationSecret = *chainedSecret
+	if chained != nil {
+		applicationID = chained.applicationID
+		applicationSecret = chained.secret
 	}
 	cacheKey := oauth2CacheKey(applicationID, applicationSecret)
 
@@ -960,7 +996,7 @@ func (d *GitLabDriver) getOAuth2Token(ctx context.Context, chainedSecret *string
 		// stale — rotated wherever it is held — so mark it and let the minting layer
 		// evict its copy and retry once with a fresh fetch. There is nothing to evict
 		// here: the grant only runs on a cache miss.
-		if chainedSecret != nil && isClientSecretRejection(err) {
+		if chained != nil && isClientSecretRejection(err) {
 			return "", "", fmt.Errorf("gitlab: OAuth2 token endpoint rejected the chained application secret: %w (%w)", credential.ErrChainedSecretRejected, err)
 		}
 		return "", "", fmt.Errorf("OAuth2 token request failed: %w", err)

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -2,9 +2,12 @@ package drivers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -105,15 +108,15 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 	// Validate credential-chaining fields
 	if err := credential.ValidateSchema(config,
 		credential.StringField("secret_spec").
-			Describe("Source the personal access token from another cred spec via credential chaining instead of storing it inline (personal_access_token then omitted)").
-			Example("gitlab-pat-from-vault"),
+			Describe("Source the secret that authenticates this source from another cred spec via credential chaining instead of storing it inline; the inline key it replaces (personal_access_token, or application_secret in oauth2 mode) is then omitted").
+			Example("gitlab-pat-from-store"),
 
 		credential.StringField("secret_field").
-			Describe("Which field of the referenced secret_spec's credential holds the personal access token (when its payload has multiple keys)").
+			Describe("Which field of the referenced secret_spec's credential holds that secret (when its payload has multiple keys)").
 			Example("pat"),
 
 		credential.StringField("secret_cache_ttl").
-			Describe("Cache the chained personal access token source-wide for this duration (e.g. 30m); omit to fetch it on every mint").
+			Describe("Cache the chained secret source-wide for this duration (e.g. 30m); omit to fetch it on every mint").
 			Example("30m"),
 	); err != nil {
 		return err
@@ -151,13 +154,20 @@ func (f *GitLabDriverFactory) ValidateConfig(config map[string]string) error {
 				Example("glpat-xxxxx"),
 		)
 	case "oauth2":
-		// The client-credentials flow caches one bearer token per driver under a fixed
-		// key, which is only sound while the application secret is a single
-		// source-level constant. A chained secret can resolve per user, so a cached
-		// bearer minted for one caller would be served to the next. Until that cache is
-		// keyed by the resolved secret, chaining stays PAT-only.
+		// As in pat mode, a chained source must not also keep the secret inline: it
+		// would read as keyless while still storing the very secret chaining exists to
+		// remove. The application id is an identifier rather than a secret, so it stays
+		// inline and remains required — the client-credentials grant needs both halves.
 		if chained {
-			return fmt.Errorf("credential chaining (secret_spec) is supported only for auth_method=pat, not oauth2")
+			if credential.GetString(config, "application_secret", "") != "" {
+				return fmt.Errorf("application_secret must be omitted when secret_spec is set; the secret is supplied by the referenced spec")
+			}
+			return credential.ValidateSchema(config,
+				credential.StringField("application_id").
+					Required().
+					Describe("GitLab OAuth2 application ID").
+					Example("app-id"),
+			)
 		}
 		return credential.ValidateSchema(config,
 			credential.StringField("application_id").
@@ -241,12 +251,12 @@ func (d *GitLabDriver) isChained() bool {
 }
 
 // verifyAuth validates the source credentials by calling a simple GitLab API endpoint
-func (d *GitLabDriver) verifyAuth(ctx context.Context, patOverride *string) error {
-	_, _, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil, patOverride)
+func (d *GitLabDriver) verifyAuth(ctx context.Context, chainedSecret *string) error {
+	_, _, err := d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/personal_access_tokens/self", nil, chainedSecret)
 	if err != nil {
 		// For OAuth2 mode, try a different endpoint
 		if d.getAuthMethod() == "oauth2" {
-			_, _, err = d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/user", nil, patOverride)
+			_, _, err = d.doGitLabRequest(ctx, http.MethodGet, "/api/v4/user", nil, chainedSecret)
 		}
 	}
 	return err
@@ -338,19 +348,23 @@ func (d *GitLabDriver) resolveExpiry(spec *credential.CredSpec) (string, time.Du
 // end together, so dropping the lease removes a revoke call that would have found
 // the token already dead. What is genuinely given up is early revocation on
 // demand, which is not something that happens today.
-func mintLeaseID(tokenType, resourceID, tokenID string, patOverride *string) string {
-	if patOverride != nil {
+func mintLeaseID(tokenType, resourceID, tokenID string, chainedSecret *string) string {
+	if chainedSecret != nil {
 		return ""
 	}
 	return fmt.Sprintf("%s:%s:%s", tokenType, resourceID, tokenID)
 }
 
 // mintError wraps a failed mint, marking an authentication rejection on the
-// chained path so the minting layer treats a cached token as stale, evicts it and
-// retries once with a fresh fetch. Without this a token rotated at its source
+// chained path so the minting layer treats a cached secret as stale, evicts it and
+// retries once with a fresh fetch. Without this a secret rotated at its source
 // would fail every request until the cache entry aged out on its own.
-func mintError(msg string, err error, status int, patOverride *string) error {
-	if patOverride != nil && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+//
+// In oauth2 mode a stale secret is refused by the token endpoint instead, one call
+// earlier. That path marks the error itself and reaches here with status 0, which
+// falls through the branch below — so the two paths cannot both mark it.
+func mintError(msg string, err error, status int, chainedSecret *string) error {
+	if chainedSecret != nil && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
 		return fmt.Errorf("gitlab: %s: %w (%w)", msg, credential.ErrChainedSecretRejected, err)
 	}
 	return fmt.Errorf("%s: %w", msg, err)
@@ -367,45 +381,63 @@ func (d *GitLabDriver) MintCredential(ctx context.Context, spec *credential.Cred
 	return d.mint(ctx, spec, nil)
 }
 
-// MintFromSecret mints a token using a personal access token fetched via
-// credential chaining, rather than one stored in source config.
+// MintFromSecret mints a token using the source secret fetched via credential
+// chaining, rather than one stored in source config. Which secret that is depends
+// on the auth method: a personal access token in pat mode, the OAuth application
+// secret in oauth2 mode.
 func (d *GitLabDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	// Config could have drifted to oauth2 after creation, where validation rejects
-	// chaining. The fetched material is a personal access token and means nothing to
-	// the client-credentials flow, so stop rather than authenticate with it.
-	if d.getAuthMethod() != "pat" {
-		return nil, nil, 0, "", fmt.Errorf("gitlab: credential chaining requires auth_method=pat, got %q", d.getAuthMethod())
+	secret := material.Secret()
+
+	// Each method names its secret differently, so the conventional keys and the
+	// guidance in the error differ. In both, fall back to a conventional key ONLY
+	// when no field was resolved: a field that resolved to empty is a misconfigured
+	// secret_field — say so, rather than silently authenticating with some other
+	// value from the payload.
+	switch d.getAuthMethod() {
+	case "pat":
+		if secret == "" && material.Field == "" {
+			if secret = material.Data["personal_access_token"]; secret == "" {
+				secret = material.Data["pat"]
+			}
+		}
+		if secret == "" {
+			if material.Field != "" {
+				return nil, nil, 0, "", fmt.Errorf("gitlab: secret_field %q is empty or absent in the fetched secret material", material.Field)
+			}
+			return nil, nil, 0, "", fmt.Errorf("gitlab: no personal access token in fetched secret material (set secret_field, or store it under 'personal_access_token')")
+		}
+	case "oauth2":
+		if secret == "" && material.Field == "" {
+			if secret = material.Data["application_secret"]; secret == "" {
+				secret = material.Data["client_secret"]
+			}
+		}
+		if secret == "" {
+			if material.Field != "" {
+				return nil, nil, 0, "", fmt.Errorf("gitlab: secret_field %q is empty or absent in the fetched secret material", material.Field)
+			}
+			return nil, nil, 0, "", fmt.Errorf("gitlab: no application secret in fetched secret material (set secret_field, or store it under 'application_secret')")
+		}
+	default:
+		// auth_method is validated to one of the two above, so reaching here means
+		// config drifted after creation. The material's meaning is defined by the
+		// method, so with an unknown method there is no safe way to use it.
+		return nil, nil, 0, "", fmt.Errorf("gitlab: credential chaining supports auth_method=pat or oauth2, got %q", d.getAuthMethod())
 	}
 
-	pat := material.Secret()
-	// Fall back to a conventional key ONLY when no field was resolved. A field that
-	// resolved to empty is a misconfigured secret_field — say so, rather than
-	// silently authenticating with some other value from the payload.
-	if pat == "" && material.Field == "" {
-		if pat = material.Data["personal_access_token"]; pat == "" {
-			pat = material.Data["pat"]
-		}
-	}
-	if pat == "" {
-		if material.Field != "" {
-			return nil, nil, 0, "", fmt.Errorf("gitlab: secret_field %q is empty or absent in the fetched secret material", material.Field)
-		}
-		return nil, nil, 0, "", fmt.Errorf("gitlab: no personal access token in fetched secret material (set secret_field, or store it under 'personal_access_token')")
-	}
-
-	return d.mint(ctx, spec, &pat)
+	return d.mint(ctx, spec, &secret)
 }
 
-// mint dispatches on the spec's mint_method. patOverride is nil for an inline
+// mint dispatches on the spec's mint_method. chainedSecret is nil for an inline
 // source and set for a chained one.
-func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, patOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, chainedSecret *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
 	case "project_access_token":
-		return d.mintProjectAccessToken(ctx, spec, patOverride)
+		return d.mintProjectAccessToken(ctx, spec, chainedSecret)
 	case "group_access_token":
-		return d.mintGroupAccessToken(ctx, spec, patOverride)
+		return d.mintGroupAccessToken(ctx, spec, chainedSecret)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GitLab driver; use 'project_access_token' or 'group_access_token'", mintMethod)
 	}
@@ -413,9 +445,9 @@ func (d *GitLabDriver) mint(ctx context.Context, spec *credential.CredSpec, patO
 
 // mintProjectAccessToken creates a project access token via the GitLab API.
 //
-// patOverride carries the token fetched via credential chaining (nil for an inline
-// source). A chained mint is also leaseless: see mintLeaseID.
-func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec, patOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// chainedSecret carries the source secret fetched via credential chaining (nil
+// for an inline source). A chained mint is also leaseless: see mintLeaseID.
+func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credential.CredSpec, chainedSecret *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	projectID := credential.GetString(spec.Config, "project_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -436,9 +468,9 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	}
 
 	path := fmt.Sprintf("/api/v4/projects/%s/access_tokens", url.PathEscape(projectID))
-	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, patOverride)
+	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, chainedSecret)
 	if err != nil {
-		return nil, nil, 0, "", mintError("failed to create project access token", err, status, patOverride)
+		return nil, nil, 0, "", mintError("failed to create project access token", err, status, chainedSecret)
 	}
 
 	var result struct {
@@ -457,7 +489,7 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
-	leaseID := mintLeaseID("project_access_token", projectID, tokenIDStr, patOverride)
+	leaseID := mintLeaseID("project_access_token", projectID, tokenIDStr, chainedSecret)
 
 	rawData := map[string]interface{}{
 		"access_token": result.Token,
@@ -479,9 +511,9 @@ func (d *GitLabDriver) mintProjectAccessToken(ctx context.Context, spec *credent
 
 // mintGroupAccessToken creates a group access token via the GitLab API.
 //
-// patOverride carries the token fetched via credential chaining (nil for an inline
-// source). A chained mint is also leaseless: see mintLeaseID.
-func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec, patOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// chainedSecret carries the source secret fetched via credential chaining (nil
+// for an inline source). A chained mint is also leaseless: see mintLeaseID.
+func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credential.CredSpec, chainedSecret *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	groupID := credential.GetString(spec.Config, "group_id", "")
 	tokenName := credential.GetString(spec.Config, "token_name", "warden-minted")
 	scopes := credential.GetString(spec.Config, "scopes", "api")
@@ -502,9 +534,9 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	}
 
 	path := fmt.Sprintf("/api/v4/groups/%s/access_tokens", url.PathEscape(groupID))
-	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, patOverride)
+	respBody, status, err := d.doGitLabRequest(ctx, http.MethodPost, path, bodyBytes, chainedSecret)
 	if err != nil {
-		return nil, nil, 0, "", mintError("failed to create group access token", err, status, patOverride)
+		return nil, nil, 0, "", mintError("failed to create group access token", err, status, chainedSecret)
 	}
 
 	var result struct {
@@ -523,7 +555,7 @@ func (d *GitLabDriver) mintGroupAccessToken(ctx context.Context, spec *credentia
 	expiresAt, ttl = grantedExpiry(time.Now(), expiresAt, ttl, result.ExpiresAt)
 
 	tokenIDStr := strconv.Itoa(result.ID)
-	leaseID := mintLeaseID("group_access_token", groupID, tokenIDStr, patOverride)
+	leaseID := mintLeaseID("group_access_token", groupID, tokenIDStr, chainedSecret)
 
 	rawData := map[string]interface{}{
 		"access_token": result.Token,
@@ -788,15 +820,19 @@ func (d *GitLabDriver) CleanupRotation(_ context.Context, cleanupConfig map[stri
 
 // doGitLabRequest executes an HTTP request to the GitLab API with authentication.
 //
-// patOverride supplies the token for a single request instead of reading it from
-// source config, which is how a chained mint passes the token fetched from its
-// referenced spec without touching shared driver state. Nil means "use the inline
-// token", the behaviour for every non-chained call site.
+// chainedSecret supplies the source secret for a single request instead of reading
+// it from source config, which is how a chained mint passes the secret fetched from
+// its referenced spec without touching shared driver state. Nil means "use the
+// inline secret", the behaviour for every non-chained call site.
+//
+// What that secret is depends on the auth method: in pat mode it authenticates the
+// request directly, in oauth2 mode it is the application secret the request's bearer
+// is granted from.
 //
 // The response status is returned alongside the body because the retry helper
 // reports failures as an opaque message; a caller that must distinguish an
 // authentication rejection from any other error has no other way to see it.
-func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte, patOverride *string) ([]byte, int, error) {
+func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte, chainedSecret *string) ([]byte, int, error) {
 	apiURL := d.getGitLabAddress() + path
 
 	// Prepare headers
@@ -806,19 +842,21 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 	}
 
 	// Set authentication based on auth method
+	var bearerKey string
 	switch d.getAuthMethod() {
 	case "pat":
-		if patOverride != nil {
-			headers["PRIVATE-TOKEN"] = *patOverride
+		if chainedSecret != nil {
+			headers["PRIVATE-TOKEN"] = *chainedSecret
 		} else {
 			headers["PRIVATE-TOKEN"] = d.getPAT()
 		}
 	case "oauth2":
-		token, err := d.getOAuth2Token(ctx)
+		token, key, err := d.getOAuth2Token(ctx, chainedSecret)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to set auth: %w", err)
 		}
 		headers["Authorization"] = "Bearer " + token
+		bearerKey = key
 	}
 
 	// Configure retry behavior (only retry on rate limiting)
@@ -838,64 +876,106 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 	}
 
 	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+
+	// A 401 means the bearer itself was refused — revoked, or granted from a secret
+	// that has since been rotated. Left cached it would fail every call until it
+	// expired on its own; dropping it makes the next call run a fresh grant. A 403 is
+	// deliberately excluded: it means the authenticated application lacks the
+	// permission, which granting the same bearer again cannot change.
+	if bearerKey != "" && status == http.StatusUnauthorized {
+		d.tokenCache.Delete(bearerKey)
+	}
+
 	if err != nil && d.logger != nil {
 		d.logger.Warn("GitLab API request failed", logger.String("error", err.Error()))
 	}
 	return respBody, status, err
 }
 
-// getOAuth2Token returns a cached or fresh OAuth2 access token
-func (d *GitLabDriver) getOAuth2Token(ctx context.Context) (string, error) {
-	const cacheKey = "oauth2_token"
+// oauth2CacheKey keys a cached bearer by the credentials it was granted from, so a
+// bearer is only ever served to a caller whose credentials resolve to the same pair.
+//
+// The client-credentials grant takes no caller-specific input, which is what once
+// made a single fixed key per driver correct. Credential chaining breaks that: the
+// application secret is resolved per mint and can differ between callers, so a
+// fixed key would hand one caller's bearer to the next.
+//
+// The inputs are hashed rather than used raw — a map key outlives the request in
+// memory and surfaces in dumps and test output — and length-prefixed so no two
+// pairs can collide by concatenating differently.
+func oauth2CacheKey(applicationID, clientSecret string) string {
+	h := sha256.New()
+	for _, field := range []string{applicationID, clientSecret} {
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(field)))
+		h.Write(length[:])
+		h.Write([]byte(field))
+	}
+	return "oauth2:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// isClientSecretRejection reports whether a token-endpoint error means the client
+// credentials were refused: an explicit invalid_client code, or — when the body
+// carried no code to read — the statuses this driver already treats as an
+// authentication rejection elsewhere (see mintError).
+func isClientSecretRejection(err error) bool {
+	var endpointErr *tokenEndpointError
+	if !errors.As(err, &endpointErr) {
+		return false
+	}
+	if endpointErr.code != "" {
+		return endpointErr.code == "invalid_client"
+	}
+	return endpointErr.status == http.StatusUnauthorized || endpointErr.status == http.StatusForbidden
+}
+
+// getOAuth2Token returns a cached or freshly granted OAuth2 access token, along
+// with the cache key holding it so the caller can evict that entry if the upstream
+// later refuses the bearer.
+//
+// chainedSecret, when non-nil, supplies the application secret in place of the one
+// in source config.
+func (d *GitLabDriver) getOAuth2Token(ctx context.Context, chainedSecret *string) (string, string, error) {
+	applicationID := credential.GetString(d.credSource.Config, "application_id", "")
+	applicationSecret := credential.GetString(d.credSource.Config, "application_secret", "")
+	if chainedSecret != nil {
+		applicationSecret = *chainedSecret
+	}
+	cacheKey := oauth2CacheKey(applicationID, applicationSecret)
 
 	// Check cache (with 30s refresh buffer)
 	if token, _, ok := d.tokenCache.Get(cacheKey, 30*time.Second); ok {
-		return token, nil
+		return token, cacheKey, nil
 	}
 
-	// Acquire new token via client credentials flow
-	applicationID := credential.GetString(d.credSource.Config, "application_id", "")
-	applicationSecret := credential.GetString(d.credSource.Config, "application_secret", "")
-
-	tokenURL := d.getGitLabAddress() + "/oauth/token"
 	form := url.Values{
 		"grant_type":    {"client_credentials"},
 		"client_id":     {applicationID},
 		"client_secret": {applicationSecret},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	tokenResp, err := postOAuthTokenForm(ctx, d.httpClient, d.getGitLabAddress()+"/oauth/token", form, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create OAuth2 token request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := d.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("OAuth2 token request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, gitlabMaxResponseBodySize))
-	if err != nil {
-		return "", fmt.Errorf("failed to read OAuth2 token response: %w", err)
+		// A refused secret on the chained path means the chained material may be
+		// stale — rotated wherever it is held — so mark it and let the minting layer
+		// evict its copy and retry once with a fresh fetch. There is nothing to evict
+		// here: the grant only runs on a cache miss.
+		if chainedSecret != nil && isClientSecretRejection(err) {
+			return "", "", fmt.Errorf("gitlab: OAuth2 token endpoint rejected the chained application secret: %w (%w)", credential.ErrChainedSecretRejected, err)
+		}
+		return "", "", fmt.Errorf("OAuth2 token request failed: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("OAuth2 token request failed with status %d: %s", resp.StatusCode, string(respBody))
+	if tokenResp.AccessToken == "" {
+		return "", "", fmt.Errorf("OAuth2 token response contained no access_token")
 	}
 
-	var tokenResp struct {
-		AccessToken string `json:"access_token"`
-		ExpiresIn   int    `json:"expires_in"`
-	}
-	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
-		return "", fmt.Errorf("failed to parse OAuth2 token response: %w", err)
+	// Without expires_in there is no lifetime to cache against, and an entry written
+	// with a zero expiry is one Get always refuses. Grant per call instead.
+	if tokenResp.ExpiresIn > 0 {
+		expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+		d.tokenCache.Set(cacheKey, tokenResp.AccessToken, expiresAt)
 	}
 
-	// Cache the token
-	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
-	d.tokenCache.Set(cacheKey, tokenResp.AccessToken, expiresAt)
-
-	return tokenResp.AccessToken, nil
+	return tokenResp.AccessToken, cacheKey, nil
 }

--- a/credential/drivers/gitlab_driver_test.go
+++ b/credential/drivers/gitlab_driver_test.go
@@ -848,11 +848,12 @@ func TestGitLabDriverFactory_ValidateConfig_Chaining(t *testing.T) {
 			errMsg:  "must be omitted when secret_spec is set",
 		},
 		{
-			name: "oauth2 chained without an inline secret",
+			// A chained oauth2 source holds neither half: the referenced spec
+			// supplies the pair.
+			name: "oauth2 chained holding neither half",
 			config: map[string]string{
 				"gitlab_address": "https://gitlab.example.com",
 				"auth_method":    "oauth2",
-				"application_id": "app-123",
 				"secret_spec":    "gitlab-app-secret",
 			},
 			wantErr: false,
@@ -862,7 +863,6 @@ func TestGitLabDriverFactory_ValidateConfig_Chaining(t *testing.T) {
 			config: map[string]string{
 				"gitlab_address":     "https://gitlab.example.com",
 				"auth_method":        "oauth2",
-				"application_id":     "app-123",
 				"application_secret": "secret-456",
 				"secret_spec":        "gitlab-app-secret",
 			},
@@ -870,16 +870,17 @@ func TestGitLabDriverFactory_ValidateConfig_Chaining(t *testing.T) {
 			errMsg:  "application_secret must be omitted when secret_spec is set",
 		},
 		{
-			// The id is not a secret and the grant needs it, so chaining does not
-			// excuse leaving it out.
-			name: "oauth2 chained without an application id",
+			// The id follows the secret out of config. Keeping it would name one
+			// application while presenting a secret fetched for another.
+			name: "oauth2 chained but id still inline",
 			config: map[string]string{
 				"gitlab_address": "https://gitlab.example.com",
 				"auth_method":    "oauth2",
+				"application_id": "app-123",
 				"secret_spec":    "gitlab-app-secret",
 			},
 			wantErr: true,
-			errMsg:  "application_id",
+			errMsg:  "application_id must be omitted when secret_spec is set",
 		},
 	}
 
@@ -1176,6 +1177,7 @@ type gitlabOAuth2Fake struct {
 	bearerForSecret map[string]string
 
 	grantSecrets []string // client_secret seen on each /oauth/token call
+	grantIDs     []string // client_id seen on each /oauth/token call
 	mintBearers  []string // Authorization seen on each mint call
 	mintStatus   int      // when non-zero, the status the mint answers instead of 200
 }
@@ -1199,6 +1201,7 @@ func (f *gitlabOAuth2Fake) server(t *testing.T) *httptest.Server {
 			assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
 			secret := r.Form.Get("client_secret")
 			f.grantSecrets = append(f.grantSecrets, secret)
+			f.grantIDs = append(f.grantIDs, r.Form.Get("client_id"))
 
 			if secret != f.acceptedSecret {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -1245,6 +1248,14 @@ func (f *gitlabOAuth2Fake) snapshot() (grants []string, mints []string) {
 	return append([]string(nil), f.grantSecrets...), append([]string(nil), f.mintBearers...)
 }
 
+func (f *gitlabOAuth2Fake) grantClientIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.grantIDs...)
+}
+
+// A chained oauth2 source carries neither half of the client credential — config
+// validation refuses both — so the fixture holds no application_id either.
 func newChainedOAuth2GitLabDriver(server *httptest.Server) *GitLabDriver {
 	return &GitLabDriver{
 		credSource: &credential.CredSource{
@@ -1252,7 +1263,6 @@ func newChainedOAuth2GitLabDriver(server *httptest.Server) *GitLabDriver {
 			Config: map[string]string{
 				"gitlab_address": server.URL,
 				"auth_method":    "oauth2",
-				"application_id": "app-123",
 				"secret_spec":    "gitlab-app-secret",
 			},
 		},
@@ -1261,12 +1271,20 @@ func newChainedOAuth2GitLabDriver(server *httptest.Server) *GitLabDriver {
 	}
 }
 
+// chainedPair is the payload a chained oauth2 source expects: both halves together.
+func chainedPair(applicationID, secret string) credential.SecretMaterial {
+	return credential.SecretMaterial{Data: map[string]string{
+		"application_id":     applicationID,
+		"application_secret": secret,
+	}}
+}
+
 func TestGitLabDriver_MintFromSecret_OAuth2_ChainedSecretReachesGrant(t *testing.T) {
 	fake := newGitLabOAuth2Fake("app-secret-from-store", "bearer-for-store-secret")
 	driver := newChainedOAuth2GitLabDriver(fake.server(t))
 
 	rawData, _, ttl, leaseID, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
-		credential.SecretMaterial{Data: map[string]string{"application_secret": "app-secret-from-store"}})
+		chainedPair("app-123", "app-secret-from-store"))
 	require.NoError(t, err)
 
 	grants, mints := fake.snapshot()
@@ -1291,7 +1309,7 @@ func TestGitLabDriver_OAuth2CacheKeyIsolation(t *testing.T) {
 
 	mintWith := func(secret string) error {
 		_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
-			credential.SecretMaterial{Data: map[string]string{"application_secret": secret}})
+			chainedPair("app-123", secret))
 		return err
 	}
 
@@ -1323,7 +1341,7 @@ func TestGitLabDriver_OAuth2ChainedSecretRejectionIsRetryable(t *testing.T) {
 	driver := newChainedOAuth2GitLabDriver(fake.server(t))
 
 	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
-		credential.SecretMaterial{Data: map[string]string{"application_secret": "stale-secret"}})
+		chainedPair("app-123", "stale-secret"))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
 }
@@ -1360,7 +1378,7 @@ func TestGitLabDriver_OAuth2BearerEvictedOnUnauthorized(t *testing.T) {
 	fake := newGitLabOAuth2Fake("app-secret", "bearer-one")
 	driver := newChainedOAuth2GitLabDriver(fake.server(t))
 
-	material := credential.SecretMaterial{Data: map[string]string{"application_secret": "app-secret"}}
+	material := chainedPair("app-123", "app-secret")
 
 	// First mint: grant succeeds and caches a bearer with a long expiry, but the
 	// upstream refuses it — as it would for a bearer revoked out of band.
@@ -1394,4 +1412,104 @@ func TestGitLabOAuth2CacheKey(t *testing.T) {
 	assert.NotEqual(t, oauth2CacheKey("ab", "c"), oauth2CacheKey("a", "bc"))
 
 	assert.NotContains(t, oauth2CacheKey("app", "secret"), "secret", "the raw secret must not sit in the key")
+}
+
+// --- the client id travels with its secret ---
+
+// TestGitLabDriver_OAuth2_ChainedPairReachesGrant is what carrying the id in the
+// payload is for: the grant presents a client identity that appears in no config at
+// all, so one source and one spec can front many applications.
+func TestGitLabDriver_OAuth2_ChainedPairReachesGrant(t *testing.T) {
+	fake := newGitLabOAuth2Fake("secret-from-store", "bearer-for-store")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+		chainedPair("app-from-store", "secret-from-store"))
+	require.NoError(t, err)
+
+	grants, _ := fake.snapshot()
+	require.Len(t, grants, 1)
+	assert.Equal(t, "secret-from-store", grants[0])
+	assert.Equal(t, []string{"app-from-store"}, fake.grantClientIDs(),
+		"the grant must present the payload's id; the source holds none")
+}
+
+// Two applications over one source and one spec — the arrangement the pair-in-payload
+// design exists to allow. Their bearers must not be shared: the cache key covers both
+// halves, so a differing id alone is enough to separate them.
+func TestGitLabDriver_OAuth2_DistinctClientsDoNotShareABearer(t *testing.T) {
+	fake := newGitLabOAuth2Fake("shared-secret", "bearer-a")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	mintAs := func(appID string) error {
+		_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+			chainedPair(appID, "shared-secret"))
+		return err
+	}
+
+	require.NoError(t, mintAs("app-one"))
+	require.NoError(t, mintAs("app-one"))
+	grants, _ := fake.snapshot()
+	assert.Len(t, grants, 1, "the same pair must reuse the cached bearer")
+
+	require.NoError(t, mintAs("app-two"))
+	assert.Equal(t, []string{"app-one", "app-two"}, fake.grantClientIDs(),
+		"a different application must grant its own bearer even when the secret matches")
+}
+
+// The id has nowhere to fall back to, so a payload without one is a broken payload —
+// caught before any request rather than surfacing as an opaque invalid_client.
+func TestGitLabDriver_OAuth2_PayloadWithoutAnIDFailsBeforeAnyRequest(t *testing.T) {
+	fake := newGitLabOAuth2Fake("secret", "bearer")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	for _, tc := range []struct {
+		name string
+		data map[string]string
+	}{
+		{"id absent", map[string]string{"application_secret": "secret"}},
+		{"id present but empty", map[string]string{"application_secret": "secret", "application_id": ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+				credential.SecretMaterial{Data: tc.data})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no application id in fetched secret material")
+
+			grants, _ := fake.snapshot()
+			assert.Empty(t, grants, "a payload missing the id must not reach the token endpoint")
+		})
+	}
+}
+
+// client_id is accepted as the conventional alternative, mirroring client_secret.
+func TestGitLabDriver_OAuth2_ClientIDIsAConventionalAlternative(t *testing.T) {
+	fake := newGitLabOAuth2Fake("s", "b")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+		credential.SecretMaterial{Data: map[string]string{"client_id": "app-alt", "client_secret": "s"}})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app-alt"}, fake.grantClientIDs())
+}
+
+// A payload carrying both conventional names is ambiguous, and the order the driver
+// tries them decides which application it authenticates as — so pin it rather than
+// leave a silent grant-as-the-wrong-client available to a reordering.
+func TestGitLabDriver_OAuth2_ConventionalKeyPrecedence(t *testing.T) {
+	fake := newGitLabOAuth2Fake("secret-preferred", "bearer")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+		credential.SecretMaterial{Data: map[string]string{
+			"application_id":     "app-preferred",
+			"client_id":          "app-fallback",
+			"application_secret": "secret-preferred",
+			"client_secret":      "secret-fallback",
+		}})
+	require.NoError(t, err)
+
+	grants, _ := fake.snapshot()
+	assert.Equal(t, []string{"secret-preferred"}, grants, "application_secret precedes client_secret")
+	assert.Equal(t, []string{"app-preferred"}, fake.grantClientIDs(), "application_id precedes client_id")
 }

--- a/credential/drivers/gitlab_driver_test.go
+++ b/credential/drivers/gitlab_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -588,8 +589,11 @@ func TestGitLabDriver_PrepareRotation_OAuth2_FastPath(t *testing.T) {
 		httpClient: server.Client(),
 	}
 
-	// Pre-set a cached OAuth2 token so the driver can authenticate API calls
-	driver.tokenCache.Set("oauth2_token", "cached-bearer-token", time.Now().Add(1*time.Hour))
+	// Pre-set a cached OAuth2 token so the driver can authenticate API calls without
+	// the test server having to serve the grant. The key is the fingerprint of the
+	// credentials the bearer was granted from, so it must be built the same way the
+	// driver builds it.
+	driver.tokenCache.Set(oauth2CacheKey("app-123", "old-secret"), "cached-bearer-token", time.Now().Add(1*time.Hour))
 
 	newConfig, cleanupConfig, activateAfter, err := driver.PrepareRotation(context.Background())
 	require.NoError(t, err)
@@ -844,7 +848,17 @@ func TestGitLabDriverFactory_ValidateConfig_Chaining(t *testing.T) {
 			errMsg:  "must be omitted when secret_spec is set",
 		},
 		{
-			name: "oauth2 cannot chain",
+			name: "oauth2 chained without an inline secret",
+			config: map[string]string{
+				"gitlab_address": "https://gitlab.example.com",
+				"auth_method":    "oauth2",
+				"application_id": "app-123",
+				"secret_spec":    "gitlab-app-secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "oauth2 chained but secret still inline",
 			config: map[string]string{
 				"gitlab_address":     "https://gitlab.example.com",
 				"auth_method":        "oauth2",
@@ -853,7 +867,19 @@ func TestGitLabDriverFactory_ValidateConfig_Chaining(t *testing.T) {
 				"secret_spec":        "gitlab-app-secret",
 			},
 			wantErr: true,
-			errMsg:  "only for auth_method=pat",
+			errMsg:  "application_secret must be omitted when secret_spec is set",
+		},
+		{
+			// The id is not a secret and the grant needs it, so chaining does not
+			// excuse leaving it out.
+			name: "oauth2 chained without an application id",
+			config: map[string]string{
+				"gitlab_address": "https://gitlab.example.com",
+				"auth_method":    "oauth2",
+				"secret_spec":    "gitlab-app-secret",
+			},
+			wantErr: true,
+			errMsg:  "application_id",
 		},
 	}
 
@@ -1047,10 +1073,22 @@ func TestGitLabDriver_MintFromSecret_Errors(t *testing.T) {
 			errMsg:   "no personal access token in fetched secret material",
 		},
 		{
-			name:       "auth_method drifted to oauth2",
+			name:       "oauth2 resolved field is empty",
 			authMethod: "oauth2",
+			material:   credential.SecretMaterial{Data: map[string]string{"application_secret": "", "other": "wrong"}, Field: "application_secret"},
+			errMsg:     `secret_field "application_secret" is empty or absent`,
+		},
+		{
+			name:       "oauth2 with no field and no conventional key",
+			authMethod: "oauth2",
+			material:   credential.SecretMaterial{Data: map[string]string{"unexpected": "wrong"}},
+			errMsg:     "no application secret in fetched secret material",
+		},
+		{
+			name:       "auth_method drifted to something neither method understands",
+			authMethod: "mtls",
 			material:   credential.SecretMaterial{Data: map[string]string{"pat": "glpat-from-vault"}, Field: "pat"},
-			errMsg:     "requires auth_method=pat",
+			errMsg:     "supports auth_method=pat or oauth2",
 		},
 	}
 
@@ -1122,4 +1160,238 @@ func TestGitLabDriver_SupportsRotation_ChainedSourceOwnsNothing(t *testing.T) {
 			assert.False(t, driver.SupportsRotation())
 		})
 	}
+}
+
+// --- oauth2 credential chaining ---
+
+// gitlabOAuth2Fake stands in for the GitLab instance across the oauth2 chaining
+// tests: it grants a bearer per application secret and accepts that bearer on the
+// mint. Both halves are swappable so a test can rotate the secret mid-run, and both
+// call counts are recorded because the point of most of these tests is how many
+// grants happened.
+type gitlabOAuth2Fake struct {
+	mu sync.Mutex
+
+	acceptedSecret  string
+	bearerForSecret map[string]string
+
+	grantSecrets []string // client_secret seen on each /oauth/token call
+	mintBearers  []string // Authorization seen on each mint call
+	mintStatus   int      // when non-zero, the status the mint answers instead of 200
+}
+
+func newGitLabOAuth2Fake(acceptedSecret, bearer string) *gitlabOAuth2Fake {
+	return &gitlabOAuth2Fake{
+		acceptedSecret:  acceptedSecret,
+		bearerForSecret: map[string]string{acceptedSecret: bearer},
+	}
+}
+
+func (f *gitlabOAuth2Fake) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		switch {
+		case r.URL.Path == "/oauth/token":
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
+			secret := r.Form.Get("client_secret")
+			f.grantSecrets = append(f.grantSecrets, secret)
+
+			if secret != f.acceptedSecret {
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid_client"})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": f.bearerForSecret[secret],
+				"token_type":   "bearer",
+				"expires_in":   7200,
+			})
+
+		default:
+			f.mintBearers = append(f.mintBearers, r.Header.Get("Authorization"))
+			if f.mintStatus != 0 {
+				w.WriteHeader(f.mintStatus)
+				json.NewEncoder(w).Encode(map[string]interface{}{"message": "401 Unauthorized"})
+				return
+			}
+			if got, want := r.Header.Get("Authorization"), "Bearer "+f.bearerForSecret[f.acceptedSecret]; got != want {
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(map[string]interface{}{"message": "401 Unauthorized"})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 99, "token": "glpat-minted-token"})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// rotate swaps the secret the fake accepts and the bearer it grants for it,
+// standing in for the secret being rotated wherever it is held.
+func (f *gitlabOAuth2Fake) rotate(secret, bearer string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acceptedSecret = secret
+	f.bearerForSecret[secret] = bearer
+}
+
+func (f *gitlabOAuth2Fake) snapshot() (grants []string, mints []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.grantSecrets...), append([]string(nil), f.mintBearers...)
+}
+
+func newChainedOAuth2GitLabDriver(server *httptest.Server) *GitLabDriver {
+	return &GitLabDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGitLab,
+			Config: map[string]string{
+				"gitlab_address": server.URL,
+				"auth_method":    "oauth2",
+				"application_id": "app-123",
+				"secret_spec":    "gitlab-app-secret",
+			},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: server.Client(),
+	}
+}
+
+func TestGitLabDriver_MintFromSecret_OAuth2_ChainedSecretReachesGrant(t *testing.T) {
+	fake := newGitLabOAuth2Fake("app-secret-from-store", "bearer-for-store-secret")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	rawData, _, ttl, leaseID, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+		credential.SecretMaterial{Data: map[string]string{"application_secret": "app-secret-from-store"}})
+	require.NoError(t, err)
+
+	grants, mints := fake.snapshot()
+	require.Len(t, grants, 1, "the mint must be preceded by exactly one grant")
+	assert.Equal(t, "app-secret-from-store", grants[0],
+		"the grant must carry the chained secret, which appears in no config")
+	require.Len(t, mints, 1)
+	assert.Equal(t, "Bearer bearer-for-store-secret", mints[0])
+
+	assert.Equal(t, "glpat-minted-token", rawData["access_token"])
+	assert.GreaterOrEqual(t, ttl, 24*time.Hour)
+	assert.Empty(t, leaseID, "a chained mint is leaseless: it has no secret of its own to revoke with")
+}
+
+func TestGitLabDriver_OAuth2CacheKeyIsolation(t *testing.T) {
+	// The bearer cache is keyed by the credentials it was granted from. Two callers
+	// whose chained secret resolves differently must each get their own grant —
+	// under a single fixed key the second would be served the first's bearer.
+	fake := newGitLabOAuth2Fake("secret-a", "bearer-a")
+	fake.bearerForSecret["secret-b"] = "bearer-b"
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	mintWith := func(secret string) error {
+		_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+			credential.SecretMaterial{Data: map[string]string{"application_secret": secret}})
+		return err
+	}
+
+	require.NoError(t, mintWith("secret-a"))
+
+	// Same secret again: this one must be served from cache.
+	require.NoError(t, mintWith("secret-a"))
+	grants, _ := fake.snapshot()
+	assert.Len(t, grants, 1, "a repeated secret must reuse the cached bearer")
+
+	// A different secret must not reuse it. Accept it upstream so the mint succeeds
+	// and the bearer it carried can be inspected.
+	fake.rotate("secret-b", "bearer-b")
+	require.NoError(t, mintWith("secret-b"))
+
+	grants, mints := fake.snapshot()
+	require.Len(t, grants, 2, "a different secret must trigger its own grant")
+	assert.Equal(t, []string{"secret-a", "secret-b"}, grants)
+	require.Len(t, mints, 3)
+	assert.Equal(t, "Bearer bearer-b", mints[2], "the second caller must not be served the first's bearer")
+}
+
+func TestGitLabDriver_OAuth2ChainedSecretRejectionIsRetryable(t *testing.T) {
+	// A secret rotated where it is held goes stale in the chained-secret cache. The
+	// token endpoint is where that surfaces in oauth2 mode — one call earlier than
+	// in pat mode — so the marking has to happen there for the minting layer to
+	// evict and retry.
+	fake := newGitLabOAuth2Fake("current-secret", "bearer-current")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(),
+		credential.SecretMaterial{Data: map[string]string{"application_secret": "stale-secret"}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+func TestGitLabDriver_OAuth2InlineSecretRejectionIsNotRetryable(t *testing.T) {
+	// An inline source owns its secret: nothing upstream can refetch a fresher one,
+	// so marking the error would buy a pointless retry of the same credentials.
+	fake := newGitLabOAuth2Fake("current-secret", "bearer-current")
+	server := fake.server(t)
+
+	driver := &GitLabDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeGitLab,
+			Config: map[string]string{
+				"gitlab_address":     server.URL,
+				"auth_method":        "oauth2",
+				"application_id":     "app-123",
+				"application_secret": "stale-secret",
+			},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: server.Client(),
+	}
+
+	_, _, _, _, err := driver.MintCredential(context.Background(), projectTokenSpec())
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+func TestGitLabDriver_OAuth2BearerEvictedOnUnauthorized(t *testing.T) {
+	// A bearer the upstream refuses must not stay cached: the minting layer's one
+	// retry would replay it and fail identically, and an inline source would keep
+	// failing until the bearer expired on its own.
+	fake := newGitLabOAuth2Fake("app-secret", "bearer-one")
+	driver := newChainedOAuth2GitLabDriver(fake.server(t))
+
+	material := credential.SecretMaterial{Data: map[string]string{"application_secret": "app-secret"}}
+
+	// First mint: grant succeeds and caches a bearer with a long expiry, but the
+	// upstream refuses it — as it would for a bearer revoked out of band.
+	fake.mu.Lock()
+	fake.mintStatus = http.StatusUnauthorized
+	fake.mu.Unlock()
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), projectTokenSpec(), material)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+
+	// Second mint with the same secret: the cached bearer is gone, so this must
+	// re-grant rather than reuse it.
+	fake.mu.Lock()
+	fake.mintStatus = 0
+	fake.mu.Unlock()
+
+	_, _, _, _, err = driver.MintFromSecret(context.Background(), projectTokenSpec(), material)
+	require.NoError(t, err)
+
+	grants, _ := fake.snapshot()
+	assert.Len(t, grants, 2, "the refused bearer must have been evicted, forcing a fresh grant")
+}
+
+func TestGitLabOAuth2CacheKey(t *testing.T) {
+	// The key must separate every distinct pair, including pairs that would collide
+	// if the two fields were simply concatenated.
+	assert.Equal(t, oauth2CacheKey("app", "secret"), oauth2CacheKey("app", "secret"))
+	assert.NotEqual(t, oauth2CacheKey("app", "secret"), oauth2CacheKey("app", "other"))
+	assert.NotEqual(t, oauth2CacheKey("app", "secret"), oauth2CacheKey("other", "secret"))
+	assert.NotEqual(t, oauth2CacheKey("ab", "c"), oauth2CacheKey("a", "bc"))
+
+	assert.NotContains(t, oauth2CacheKey("app", "secret"), "secret", "the raw secret must not sit in the key")
 }

--- a/credential/drivers/token_cache.go
+++ b/credential/drivers/token_cache.go
@@ -52,16 +52,41 @@ func (tc *TokenCache) Get(key string, refreshBuffer time.Duration) (string, time
 	return entry.Token, entry.ExpiresAt, true
 }
 
-// Set stores a token in the cache with its expiry time
+// Set stores a token in the cache with its expiry time.
+//
+// Entries Get would already refuse — expired, or from a superseded generation —
+// are swept first. A caller may key entries by a fingerprint of the credentials
+// that minted them, in which case a retired credential's entry is never read
+// again and would otherwise sit in the map for the process lifetime. Set runs
+// once per token acquisition, so the sweep stays off the read path.
 func (tc *TokenCache) Set(key string, token string, expiresAt time.Time) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
+
+	now := time.Now()
+	for k, entry := range tc.cache {
+		if entry.Generation != tc.generation || now.After(entry.ExpiresAt) {
+			delete(tc.cache, k)
+		}
+	}
 
 	tc.cache[key] = &TokenCacheEntry{
 		Token:      token,
 		ExpiresAt:  expiresAt,
 		Generation: tc.generation,
 	}
+}
+
+// Delete removes a single cached token.
+//
+// Callers use this when the upstream has refused a token that has not yet
+// expired: without it the cache keeps serving the dead token until its expiry,
+// failing every request in between.
+func (tc *TokenCache) Delete(key string) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	delete(tc.cache, key)
 }
 
 // InvalidateGeneration bumps the generation counter, effectively invalidating

--- a/credential/drivers/token_cache_test.go
+++ b/credential/drivers/token_cache_test.go
@@ -1,0 +1,88 @@
+package drivers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCache_GetSet(t *testing.T) {
+	tc := NewTokenCache()
+
+	_, _, ok := tc.Get("absent", 0)
+	assert.False(t, ok)
+
+	expiresAt := time.Now().Add(time.Hour)
+	tc.Set("key", "token", expiresAt)
+
+	token, gotExpiry, ok := tc.Get("key", 30*time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "token", token)
+	assert.WithinDuration(t, expiresAt, gotExpiry, time.Second)
+}
+
+func TestTokenCache_RefreshBufferRefusesImminentExpiry(t *testing.T) {
+	tc := NewTokenCache()
+	tc.Set("key", "token", time.Now().Add(10*time.Second))
+
+	_, _, ok := tc.Get("key", 30*time.Second)
+	assert.False(t, ok, "a token expiring inside the refresh buffer must not be served")
+
+	_, _, ok = tc.Get("key", 0)
+	assert.True(t, ok, "without a buffer the same token is still valid")
+}
+
+func TestTokenCache_InvalidateGeneration(t *testing.T) {
+	tc := NewTokenCache()
+	tc.Set("key", "token", time.Now().Add(time.Hour))
+
+	tc.InvalidateGeneration()
+
+	_, _, ok := tc.Get("key", 0)
+	assert.False(t, ok, "a superseded generation must not be served")
+}
+
+func TestTokenCache_Delete(t *testing.T) {
+	tc := NewTokenCache()
+	tc.Set("keep", "token-keep", time.Now().Add(time.Hour))
+	tc.Set("drop", "token-drop", time.Now().Add(time.Hour))
+
+	tc.Delete("drop")
+
+	_, _, ok := tc.Get("drop", 0)
+	assert.False(t, ok, "a deleted entry must not be served even before it expires")
+
+	_, _, ok = tc.Get("keep", 0)
+	assert.True(t, ok, "deleting one entry must leave the others alone")
+}
+
+func TestTokenCache_SetPrunesDeadEntries(t *testing.T) {
+	// Entries keyed by a credential fingerprint are never read again once that
+	// credential is retired, so Set sweeps what Get would already refuse rather than
+	// letting the map grow for the process lifetime.
+	tc := NewTokenCache()
+	tc.Set("live", "token", time.Now().Add(time.Hour))
+	// Expire an entry behind Set's back, so the sweep is what removes it rather
+	// than it never having been stored.
+	tc.Set("expired", "token", time.Now().Add(time.Hour))
+	tc.cache["expired"].ExpiresAt = time.Now().Add(-time.Minute)
+
+	tc.Set("fresh", "token", time.Now().Add(time.Hour))
+
+	assert.NotContains(t, tc.cache, "expired", "an expired entry must be swept")
+	assert.Contains(t, tc.cache, "live", "a live entry must survive the sweep")
+	assert.Contains(t, tc.cache, "fresh")
+}
+
+func TestTokenCache_SetPrunesSupersededGenerations(t *testing.T) {
+	tc := NewTokenCache()
+	tc.Set("old-generation", "token", time.Now().Add(time.Hour))
+
+	tc.InvalidateGeneration()
+	tc.Set("new-generation", "token", time.Now().Add(time.Hour))
+
+	assert.NotContains(t, tc.cache, "old-generation", "a superseded entry must be swept")
+	assert.Contains(t, tc.cache, "new-generation")
+}

--- a/e2e/fullchain/gitlab_test.go
+++ b/e2e/fullchain/gitlab_test.go
@@ -5,6 +5,7 @@ package fullchain
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -75,6 +76,41 @@ const (
 	// data path. The cache row writes here to simulate a rotation happening at
 	// the source, behind Warden's back.
 	gitlabPATVaultPath = "secret/data/e2e/gitlab-pat"
+
+	// --- oauth2 chaining ---
+
+	// The application id a keyless oauth2 source authenticates as. Unlike the
+	// secret it pairs with, it is not sensitive and stays in source config.
+	gitlabApplicationID = "e2e-gl-app-id"
+
+	// Written to secret/data/e2e/gitlab-app-secret by setup.sh. Where the pat
+	// rows' chained value authenticates the mint directly, this one is spent on
+	// the token grant, and the bearer that grant returns authenticates the mint.
+	gitlabChainedAppSecret = "e2e-gl-app-secret-not-a-real-secret"
+
+	// What the stand-in grants for the seeded secret, and for the rotated one.
+	// Neither is in any config: like the minted token, they are issued.
+	gitlabAppBearer        = "e2e-gl-bearer-for-seeded-secret"
+	gitlabRotatedAppBearer = "e2e-gl-bearer-for-rotated-secret"
+
+	// What the application secret is rotated to mid-test on the oauth2 cache row.
+	gitlabRotatedAppSecret = "e2e-gl-rotated-app-secret-not-a-real-secret"
+
+	gitlabTokenPath          = "/oauth/token"
+	gitlabAppSecretVaultPath = "secret/data/e2e/gitlab-app-secret"
+
+	// The oauth2 rows' own chains, test-local for the same reason the pat ones are.
+	gitlabOAuthSecretSpec = "fc-gl-oauth-secret-from-vault"
+	gitlabOAuthSource     = "fc-gl-oauth-keyless-src"
+	gitlabOAuthSpec       = "fc-gl-oauth-keyless-cred"
+	gitlabOAuthAgentRole  = "fc-gl-oauth-keyless-agent"
+
+	gitlabOAuthCacheSecretSpec = "fc-gl-oauth-cache-secret-from-vault"
+	gitlabOAuthCacheSource     = "fc-gl-oauth-cache-src"
+	gitlabOAuthCacheSpecA      = "fc-gl-oauth-cache-cred-a"
+	gitlabOAuthCacheSpecB      = "fc-gl-oauth-cache-cred-b"
+	gitlabOAuthCacheAgentRoleA = "fc-gl-oauth-cache-agent-a"
+	gitlabOAuthCacheAgentRoleB = "fc-gl-oauth-cache-agent-b"
 )
 
 // setupGitLabEnv builds the mount and its inline source, per test rather than
@@ -209,7 +245,32 @@ type gitlabChainConsumer struct {
 // exist is refused at create, and a referenced spec cannot be deleted while
 // something names it — so cleanup runs consumer-first, and the same order clears
 // whatever a killed run left behind.
-func setupGitLabChain(t *testing.T, gitlabEnv h.ProviderEnv, secretSpec, source, cacheTTL string, consumers []gitlabChainConsumer) {
+// gitlabChainMode describes what a keyless source chains and how it spends it.
+// The two modes differ only in which secret is fetched and which config keys the
+// source carries; everything else about the chain is identical, which is the point
+// worth holding constant between the pat rows and the oauth2 ones.
+type gitlabChainMode struct {
+	secretPath  string // KV2 path setup.sh seeded
+	secretField string // which field of that secret holds the value
+	authConfig  string // the source's auth keys, as a JSON fragment
+}
+
+var (
+	gitlabPATChain = gitlabChainMode{
+		secretPath:  "e2e/gitlab-pat",
+		secretField: "pat",
+		authConfig:  `"auth_method":"pat"`,
+	}
+	gitlabOAuth2Chain = gitlabChainMode{
+		secretPath:  "e2e/gitlab-app-secret",
+		secretField: "application_secret",
+		// The application id is an identifier rather than a secret, so it stays in
+		// config; only the secret half is chained.
+		authConfig: `"auth_method":"oauth2","application_id":"` + gitlabApplicationID + `"`,
+	}
+)
+
+func setupGitLabChain(t *testing.T, gitlabEnv h.ProviderEnv, mode gitlabChainMode, secretSpec, source, cacheTTL string, consumers []gitlabChainConsumer) {
 	t.Helper()
 
 	mustWrite := func(method, path, body, what string) {
@@ -235,23 +296,24 @@ func setupGitLabChain(t *testing.T, gitlabEnv h.ProviderEnv, secretSpec, source,
 	// The referenced spec. subject_token_source is not optional: a chained secret
 	// must be minted as the session-pinned caller, and the store refuses the
 	// reference otherwise.
-	mustWrite("POST", "sys/cred/specs/"+secretSpec, `{
+	mustWrite("POST", "sys/cred/specs/"+secretSpec, fmt.Sprintf(`{
 		"type":"key_value","source":"vault-fed-e2e","config":{
-			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":"e2e/gitlab-pat",
-			"subject_token_source":"agent_identity"}}`,
+			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":%q,
+			"subject_token_source":"agent_identity"}}`, mode.secretPath),
 		"create the referenced secret spec")
 
-	// The keyless source: same address as the inline one, but carrying no
-	// personal_access_token — validation rejects a source that keeps one while
-	// also naming a chain.
+	// The keyless source: same address as the inline one, but carrying none of the
+	// secret its auth method would normally need — validation rejects a source
+	// that keeps one while also naming a chain.
 	ttlField := ""
 	if cacheTTL != "" {
 		ttlField = fmt.Sprintf(`,"secret_cache_ttl":%q`, cacheTTL)
 	}
 	mustWrite("POST", "sys/cred/sources/"+source, fmt.Sprintf(`{
 		"type":"gitlab","config":{
-			"gitlab_address":%q,"auth_method":"pat",
-			"secret_spec":%q,"secret_field":"pat"%s}}`, upstream.URL, secretSpec, ttlField),
+			"gitlab_address":%q,%s,
+			"secret_spec":%q,"secret_field":%q%s}}`,
+		upstream.URL, mode.authConfig, secretSpec, mode.secretField, ttlField),
 		"create the keyless gitlab source")
 
 	for _, c := range consumers {
@@ -277,7 +339,7 @@ func setupGitLabChain(t *testing.T, gitlabEnv h.ProviderEnv, secretSpec, source,
 // keyless rows use.
 func setupGitLabKeylessChain(t *testing.T, gitlabEnv h.ProviderEnv) {
 	t.Helper()
-	setupGitLabChain(t, gitlabEnv, gitlabChainSecretSpec, gitlabChainSource, "",
+	setupGitLabChain(t, gitlabEnv, gitlabPATChain, gitlabChainSecretSpec, gitlabChainSource, "",
 		[]gitlabChainConsumer{{gitlabChainSpec, gitlabChainAgentRole}})
 }
 
@@ -398,7 +460,7 @@ func TestGitLab_StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
 	ensureEnv(t)
 	gitlabEnv := setupGitLabEnv(t)
 	useJWTAgentLeg(t, gitlabEnv)
-	setupGitLabChain(t, gitlabEnv, gitlabCacheSecretSpec, gitlabCacheSource, "5m",
+	setupGitLabChain(t, gitlabEnv, gitlabPATChain, gitlabCacheSecretSpec, gitlabCacheSource, "5m",
 		[]gitlabChainConsumer{
 			{gitlabCacheSpecA, gitlabCacheAgentRoleA},
 			{gitlabCacheSpecB, gitlabCacheAgentRoleB},
@@ -508,5 +570,250 @@ func TestGitLab_StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
 	// by evicting the stale entry and reading Vault again.
 	if got := mints[1].Header.Get("PRIVATE-TOKEN"); got != gitlabRotatedPAT {
 		t.Errorf("retried mint authenticated with %q, want the freshly fetched token %q", got, gitlabRotatedPAT)
+	}
+}
+
+// serveGitLabOAuth2 makes the stand-in behave like an OAuth application's GitLab:
+// it grants a bearer to whoever presents the secret it currently accepts, and
+// accepts on the mint only the bearer it last granted. Both halves move together
+// through setAccepted, because a rotated secret's defining property is that the
+// old one stops working — and so does anything granted from it.
+//
+// The guard is for the race detector: the handler runs on the server's goroutines
+// while the test rotates from its own.
+func serveGitLabOAuth2(t *testing.T, secret, bearer string) (setAccepted func(secret, bearer string)) {
+	t.Helper()
+
+	var mu sync.Mutex
+	acceptedSecret, acceptedBearer := secret, bearer
+
+	upstream.SetHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == gitlabTokenPath:
+			if err := r.ParseForm(); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			ok := r.Form.Get("client_secret") == acceptedSecret
+			granted := acceptedBearer
+			mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"` + granted + `","token_type":"bearer","expires_in":7200}`))
+
+		case r.Method == http.MethodPost && r.URL.Path == gitlabMintPath:
+			mu.Lock()
+			ok := r.Header.Get("Authorization") == "Bearer "+acceptedBearer
+			mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":99,"token":"` + gitlabMintedToken + `"}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}
+	})
+
+	return func(secret, bearer string) {
+		mu.Lock()
+		acceptedSecret, acceptedBearer = secret, bearer
+		mu.Unlock()
+	}
+}
+
+// gitlabGrantForm parses a recorded token-grant call's form body. The upstream
+// records bodies byte for byte, so the grant's parameters have to be decoded here
+// rather than read off a parsed request.
+func gitlabGrantForm(t *testing.T, req h.UpstreamRequest) url.Values {
+	t.Helper()
+	form, err := url.ParseQuery(string(req.Body))
+	if err != nil {
+		t.Fatalf("token grant body is not a form: %v (body %q)", err, req.Body)
+	}
+	return form
+}
+
+// gitlabRequestsTo returns every recorded call to one path, in order.
+func gitlabRequestsTo(path string) []h.UpstreamRequest {
+	var found []h.UpstreamRequest
+	for _, req := range upstream.Requests() {
+		if req.Method == http.MethodPost && req.Path == path {
+			found = append(found, req)
+		}
+	}
+	return found
+}
+
+// TestGitLab_OAuth2KeylessChainMintsWithVaultHeldSecret is the oauth2 counterpart
+// of the pat keyless row, and it proves the chain reaches one call further back.
+//
+// In pat mode the chained value authenticates the mint, so the mint's header is
+// where the chain shows up. Here the chained value is spent on the token grant
+// instead, and what authenticates the mint is a bearer the stand-in issued — so
+// the row only passes if the secret travelled from Vault to the grant, and the
+// grant's answer travelled on to the mint.
+func TestGitLab_OAuth2KeylessChainMintsWithVaultHeldSecret(t *testing.T) {
+	ensureEnv(t)
+	gitlabEnv := setupGitLabEnv(t)
+	useJWTAgentLeg(t, gitlabEnv)
+	serveGitLabOAuth2(t, gitlabChainedAppSecret, gitlabAppBearer)
+	setupGitLabChain(t, gitlabEnv, gitlabOAuth2Chain, gitlabOAuthSecretSpec, gitlabOAuthSource, "",
+		[]gitlabChainConsumer{{gitlabOAuthSpec, gitlabOAuthAgentRole}})
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Role:       gitlabOAuthAgentRole,
+	})
+
+	// Three calls where the pat keyless row makes two. The extra one is the grant:
+	// a pat source spends its chained secret directly, an oauth2 source has to
+	// trade it for a bearer first. Still no construction-time check, which is what
+	// keeps this at three rather than the inline row's four.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 3,
+	})
+
+	grants := gitlabRequestsTo(gitlabTokenPath)
+	if len(grants) != 1 {
+		t.Fatalf("upstream received %d token grants, want exactly 1", len(grants))
+	}
+	// The half no driver test can show: the secret the grant spent came out of
+	// Vault, not out of config.
+	if got := gitlabGrantForm(t, grants[0]).Get("client_secret"); got != gitlabChainedAppSecret {
+		t.Errorf("grant presented %q, want the Vault-held application secret %q", got, gitlabChainedAppSecret)
+	}
+	if got := gitlabGrantForm(t, grants[0]).Get("client_id"); got != gitlabApplicationID {
+		t.Errorf("grant presented client_id %q, want the source's %q", got, gitlabApplicationID)
+	}
+
+	// And the mint rode the bearer that grant returned, not the secret itself.
+	mint := findGitLabMint(t)
+	if got := mint.Header.Get("Authorization"); got != "Bearer "+gitlabAppBearer {
+		t.Errorf("mint authenticated with %q, want the granted bearer %q", got, "Bearer "+gitlabAppBearer)
+	}
+	if strings.Contains(string(mint.Body), gitlabChainedAppSecret) {
+		t.Errorf("the application secret leaked into the mint body: %s", mint.Body)
+	}
+}
+
+// TestGitLab_OAuth2StaleCachedSecretIsEvictedAndRetried is the oauth2 counterpart
+// of the pat stale-secret row, and it covers a join that mode does not have.
+//
+// Two caches sit between a rotation and a successful mint here, not one. The
+// minting layer caches the fetched application secret for secret_cache_ttl, and
+// the driver caches the bearer it granted from that secret for the grant's
+// expires_in — which the stand-in sets long enough to outlive this test. So the
+// first mint after a rotation goes out under a bearer that is doubly stale, and
+// what this row pins is that the caller never sees it: the 401 is marked as a
+// rejected chained secret, the minting layer evicts and refetches, and the retry
+// succeeds.
+//
+// It does not pin the driver's own eviction of the refused bearer. Once the
+// refetch returns the rotated secret the bearer cache key changes with it, so the
+// grant re-runs whether or not the old entry was dropped. The eviction matters for
+// a bearer refused while its secret is unchanged — no key rollover to save it —
+// and that case is pinned in the driver's unit tests, where the secret is held
+// constant.
+//
+// The two-specs-one-JWT arrangement is the pat row's, for the reasons it gives.
+func TestGitLab_OAuth2StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
+	ensureEnv(t)
+	gitlabEnv := setupGitLabEnv(t)
+	useJWTAgentLeg(t, gitlabEnv)
+	setAccepted := serveGitLabOAuth2(t, gitlabChainedAppSecret, gitlabAppBearer)
+	setupGitLabChain(t, gitlabEnv, gitlabOAuth2Chain, gitlabOAuthCacheSecretSpec, gitlabOAuthCacheSource, "5m",
+		[]gitlabChainConsumer{
+			{gitlabOAuthCacheSpecA, gitlabOAuthCacheAgentRoleA},
+			{gitlabOAuthCacheSpecB, gitlabOAuthCacheAgentRoleB},
+		})
+
+	// Shared state, restored before anything can rewrite it — see the pat row.
+	t.Cleanup(func() {
+		if status, resp := h.VaultDirectRequest(t, "POST", gitlabAppSecretVaultPath,
+			`{"data":{"application_secret":"`+gitlabChainedAppSecret+`"}}`); status >= 400 {
+			t.Errorf("restoring the seeded gitlab application secret in Vault failed (status %d): %s — later gitlab rows will grant with the wrong secret", status, resp)
+		}
+	})
+	upstream.Reset()
+
+	jwt := h.GetDefaultJWT(t)
+
+	// The priming request: fetches the secret from Vault into the minting layer's
+	// cache, grants a bearer into the driver's, and spends it. It proves nothing
+	// about eviction — it plants both entries the second request must trip over.
+	status, body, _ := h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentToken: jwt,
+		Role:       gitlabOAuthCacheAgentRoleA,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 3,
+	})
+
+	// The rotation happens where a real one would: at the source, with Warden not
+	// told. The stand-in stops honouring the old secret and the bearer granted
+	// from it at the same moment.
+	if status, resp := h.VaultDirectRequest(t, "POST", gitlabAppSecretVaultPath,
+		`{"data":{"application_secret":"`+gitlabRotatedAppSecret+`"}}`); status >= 400 {
+		t.Fatalf("rotating the gitlab application secret in Vault failed (status %d): %s", status, resp)
+	}
+	setAccepted(gitlabRotatedAppSecret, gitlabRotatedAppBearer)
+	upstream.Reset()
+
+	// Four calls where the priming request made three: the mint under the stale
+	// bearer that fails, the grant that replaces it, the mint that succeeds, and
+	// the proxied request. Note there is no grant before the first mint — the
+	// driver had a cached bearer and saw no reason to ask for another, which is
+	// exactly the state this row exists to get into.
+	status, body, _ = h.ChainRequest(t, leaderPort, gitlabEnv, h.ChainOpts{
+		AgentToken: jwt,
+		Role:       gitlabOAuthCacheAgentRoleB,
+	})
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + gitlabMintedToken},
+		UpstreamCalls: 4,
+	})
+
+	mints := gitlabRequestsTo(gitlabMintPath)
+	if len(mints) != 2 {
+		t.Fatalf("second request made %d mint attempts, want 2 (rejected then retried)", len(mints))
+	}
+	// The first attempt carrying the stale bearer is the proof both caches were
+	// consulted: without the driver's, the mint would have been preceded by a
+	// fresh grant and succeeded first try, and this row would pass against a
+	// build that caches nothing.
+	if got := mints[0].Header.Get("Authorization"); got != "Bearer "+gitlabAppBearer {
+		t.Errorf("first mint attempt authenticated with %q, want the stale cached bearer %q", got, "Bearer "+gitlabAppBearer)
+	}
+	if got := mints[1].Header.Get("Authorization"); got != "Bearer "+gitlabRotatedAppBearer {
+		t.Errorf("retried mint authenticated with %q, want the freshly granted bearer %q", got, "Bearer "+gitlabRotatedAppBearer)
+	}
+
+	// And exactly one grant, carrying the rotated secret — which the driver can
+	// only have gotten by the minting layer evicting its cached copy and reading
+	// Vault again.
+	grants := gitlabRequestsTo(gitlabTokenPath)
+	if len(grants) != 1 {
+		t.Fatalf("second request made %d token grants, want exactly 1 (after the stale bearer was evicted)", len(grants))
+	}
+	if got := gitlabGrantForm(t, grants[0]).Get("client_secret"); got != gitlabRotatedAppSecret {
+		t.Errorf("grant presented %q, want the freshly fetched application secret %q", got, gitlabRotatedAppSecret)
 	}
 }

--- a/e2e/fullchain/gitlab_test.go
+++ b/e2e/fullchain/gitlab_test.go
@@ -79,8 +79,9 @@ const (
 
 	// --- oauth2 chaining ---
 
-	// The application id a keyless oauth2 source authenticates as. Unlike the
-	// secret it pairs with, it is not sensitive and stays in source config.
+	// The application id a keyless oauth2 source authenticates as. Written to the
+	// store beside its secret and absent from every config, because the two
+	// authenticate as a pair and a chained source is refused either half.
 	gitlabApplicationID = "e2e-gl-app-id"
 
 	// Written to secret/data/e2e/gitlab-app-secret by setup.sh. Where the pat
@@ -262,11 +263,13 @@ var (
 		authConfig:  `"auth_method":"pat"`,
 	}
 	gitlabOAuth2Chain = gitlabChainMode{
-		secretPath:  "e2e/gitlab-app-secret",
+		secretPath: "e2e/gitlab-app-secret",
+		// secret_field names the secret; the id travels beside it under a
+		// conventional key, because the two authenticate as a pair.
 		secretField: "application_secret",
-		// The application id is an identifier rather than a secret, so it stays in
-		// config; only the secret half is chained.
-		authConfig: `"auth_method":"oauth2","application_id":"` + gitlabApplicationID + `"`,
+		// The source carries neither half — that is what makes one source able to
+		// front several applications, since the pair is resolved per mint.
+		authConfig: `"auth_method":"oauth2"`,
 	}
 )
 
@@ -573,6 +576,16 @@ func TestGitLab_StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
 	}
 }
 
+// gitlabAppSecretPayload is the store payload a chained oauth2 source expects: the
+// whole client credential, not just its secret half.
+//
+// A write to the store replaces the entry's data outright, so a rotation that sent
+// only the secret would silently drop the id and leave the next mint unable to name
+// an application at all.
+func gitlabAppSecretPayload(secret string) string {
+	return `{"data":{"application_id":"` + gitlabApplicationID + `","application_secret":"` + secret + `"}}`
+}
+
 // serveGitLabOAuth2 makes the stand-in behave like an OAuth application's GitLab:
 // it grants a bearer to whoever presents the secret it currently accepts, and
 // accepts on the mint only the bearer it last granted. Both halves move together
@@ -692,13 +705,16 @@ func TestGitLab_OAuth2KeylessChainMintsWithVaultHeldSecret(t *testing.T) {
 	if len(grants) != 1 {
 		t.Fatalf("upstream received %d token grants, want exactly 1", len(grants))
 	}
-	// The half no driver test can show: the secret the grant spent came out of
-	// Vault, not out of config.
-	if got := gitlabGrantForm(t, grants[0]).Get("client_secret"); got != gitlabChainedAppSecret {
-		t.Errorf("grant presented %q, want the Vault-held application secret %q", got, gitlabChainedAppSecret)
+	// The half no driver test can show: BOTH halves the grant spent came out of the
+	// store. Neither appears in any spec or source config, so the row fails if
+	// either link breaks — and the id being fetched rather than configured is what
+	// lets one source front several applications.
+	form := gitlabGrantForm(t, grants[0])
+	if got := form.Get("client_secret"); got != gitlabChainedAppSecret {
+		t.Errorf("grant presented %q, want the store-held application secret %q", got, gitlabChainedAppSecret)
 	}
-	if got := gitlabGrantForm(t, grants[0]).Get("client_id"); got != gitlabApplicationID {
-		t.Errorf("grant presented client_id %q, want the source's %q", got, gitlabApplicationID)
+	if got := form.Get("client_id"); got != gitlabApplicationID {
+		t.Errorf("grant presented client_id %q, want the store-held application id %q", got, gitlabApplicationID)
 	}
 
 	// And the mint rode the bearer that grant returned, not the secret itself.
@@ -745,8 +761,8 @@ func TestGitLab_OAuth2StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
 	// Shared state, restored before anything can rewrite it — see the pat row.
 	t.Cleanup(func() {
 		if status, resp := h.VaultDirectRequest(t, "POST", gitlabAppSecretVaultPath,
-			`{"data":{"application_secret":"`+gitlabChainedAppSecret+`"}}`); status >= 400 {
-			t.Errorf("restoring the seeded gitlab application secret in Vault failed (status %d): %s — later gitlab rows will grant with the wrong secret", status, resp)
+			gitlabAppSecretPayload(gitlabChainedAppSecret)); status >= 400 {
+			t.Errorf("restoring the seeded gitlab client credential failed (status %d): %s — later gitlab rows will grant with the wrong secret", status, resp)
 		}
 	})
 	upstream.Reset()
@@ -770,8 +786,8 @@ func TestGitLab_OAuth2StaleCachedSecretIsEvictedAndRetried(t *testing.T) {
 	// told. The stand-in stops honouring the old secret and the bearer granted
 	// from it at the same moment.
 	if status, resp := h.VaultDirectRequest(t, "POST", gitlabAppSecretVaultPath,
-		`{"data":{"application_secret":"`+gitlabRotatedAppSecret+`"}}`); status >= 400 {
-		t.Fatalf("rotating the gitlab application secret in Vault failed (status %d): %s", status, resp)
+		gitlabAppSecretPayload(gitlabRotatedAppSecret)); status >= 400 {
+		t.Fatalf("rotating the gitlab application secret in the store failed (status %d): %s", status, resp)
 	}
 	setAccepted(gitlabRotatedAppSecret, gitlabRotatedAppBearer)
 	upstream.Reset()

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -325,11 +325,15 @@ vault_api POST "secret/data/e2e/gitlab-pat" \
   '{"data":{"pat":"e2e-gl-chained-not-a-real-pat"}}'
 
 # The same arrangement for a gitlab source authenticating as an OAuth application
-# instead. What is chained here is the application secret, which the driver spends
-# on a token grant rather than on the mint itself — so the oauth2 rows prove the
-# chain reached one call earlier than the pat rows do.
+# instead. What is chained here is the whole client credential, which the driver
+# spends on a token grant rather than on the mint itself — so the oauth2 rows prove
+# the chain reached one call earlier than the pat rows do.
+#
+# Both halves, because they authenticate as a pair: a chained oauth2 source is
+# refused an inline application_id precisely so an id cannot name one application
+# while the secret beside it belongs to another.
 vault_api POST "secret/data/e2e/gitlab-app-secret" \
-  '{"data":{"application_secret":"e2e-gl-app-secret-not-a-real-secret"}}'
+  '{"data":{"application_id":"e2e-gl-app-id","application_secret":"e2e-gl-app-secret-not-a-real-secret"}}'
 
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -324,6 +324,13 @@ vault_api POST "secret/data/e2e/datadog-keys" \
 vault_api POST "secret/data/e2e/gitlab-pat" \
   '{"data":{"pat":"e2e-gl-chained-not-a-real-pat"}}'
 
+# The same arrangement for a gitlab source authenticating as an OAuth application
+# instead. What is chained here is the application secret, which the driver spends
+# on a token grant rather than on the mint itself — so the oauth2 rows prove the
+# chain reached one call earlier than the pat rows do.
+vault_api POST "secret/data/e2e/gitlab-app-secret" \
+  '{"data":{"application_secret":"e2e-gl-app-secret-not-a-real-secret"}}'
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \


### PR DESCRIPTION
Extends GitLab credential chaining from `auth_method=pat` to `oauth2`, and makes a chained oauth2 source hold no part of its client credential.

## Why it was blocked

The client-credentials bearer was cached under a fixed key per driver. That is sound only while the application secret is one source-level constant — a chained secret resolves per caller, so a bearer minted from one caller's secret could be served to the next. The old code documented this and refused the combination outright.

## What changed

**The cache key.** Keyed by a length-prefixed hash of the credentials the bearer was granted from, rather than a fixed string. The inline path moves to the same scheme so there are not two that can diverge. Hashed rather than raw: a map key outlives the request and surfaces in dumps and test output.

**Two rejection points, not one.** In pat mode a stale chained secret fails at the mint; in oauth2 it fails one call earlier, at the token endpoint. That rejection is now classified and marked so the minting layer evicts and retries. Separately, a bearer the API answers 401 for is dropped from the cache — without that, the retry replays the dead bearer and fails identically.

**The whole client credential travels together.** `application_id` and `application_secret` both come from the fetched payload, and a chained source is validated to hold neither. They authenticate as a pair: an id in config beside a secret from the chain names one application while presenting another's secret, which surfaces as `invalid_client` and drives a pointless refetch. Requiring both from one place makes that unreachable and settles it at create time rather than at mint.

A consequence worth stating: one source and one spec can now front many OAuth applications, since the pair is resolved per mint rather than pinned to the source.

**Shared token POST.** `getOAuth2Token` now uses `postOAuthTokenForm`, which is what makes `invalid_client` matchable off a typed error instead of string-matching.

## Behaviour changes

- The token POST gains 429/5xx retries. It previously had none — a bare `httpClient.Do`.
- Inline oauth2 bearers are evicted on a 401 instead of poisoning calls until expiry.
- A token response without `expires_in` now grants per call instead of writing a cache entry that `Get` would always refuse.

## Testing

Unit tests cover the cache-key isolation, both rejection paths, the bearer eviction, and the client-credential resolution rules. Each load-bearing decision was mutation-tested — reverting to a fixed cache key, dropping the eviction, dropping the sentinel, allowing an inline id, and ignoring the payload id each fail their intended test and nothing else.

E2E adds two rows: a keyless oauth2 chain proving both halves reach the grant from the store and appear in no config, and a stale-secret row proving the evict-and-retry recovers a rotation invisibly to the caller. The existing pat rows are unchanged, which is the regression check that the threading rename altered no behaviour.

## Not included

Docs, per the release-prep convention: the chaining doc's GitLab row and the driver doc still describe pat-only chaining, and the three behaviour changes above want a CHANGELOG entry.
