### PR TITLE
fix(github): key the app token cache by what minted it

### DIFF
--- a/credential/drivers/github_driver.go
+++ b/credential/drivers/github_driver.go
@@ -60,6 +60,13 @@ type appTokenCache struct {
 // change of input is simply a different entry. The inputs are hashed, so a private
 // key never sits in a map key, and length-prefixed so no two input sets can collide
 // by concatenating differently.
+//
+// SHA-256 rather than a password KDF, deliberately: this derives a cache key, not a
+// stored verifier. No digest is kept, nothing is ever compared against one, and the
+// result never leaves this process. The slowness a KDF buys is protection against
+// guessing a low-entropy human password from a stolen digest — here the input is an
+// RSA private key, and anything able to read this key can already read the key it
+// was derived from, so that slowness would cost every lookup and protect nothing.
 func appTokenCacheKey(appID, installationID, keyPEM string) string {
 	h := sha256.New()
 	for _, field := range []string{appID, installationID, keyPEM} {

--- a/credential/drivers/github_driver.go
+++ b/credential/drivers/github_driver.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"crypto"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -35,10 +38,37 @@ var _ credential.SourceDriver = (*GitHubDriver)(nil)
 var _ credential.SpecVerifier = (*GitHubDriver)(nil)
 var _ credential.ChainedSecretMinter = (*GitHubDriver)(nil)
 
-// appTokenCache holds a cached GitHub App installation token for a specific spec
+// appTokenCache holds a cached GitHub App installation token
 type appTokenCache struct {
 	token     string
 	expiresAt time.Time
+}
+
+// appTokenCacheKey keys a cached installation token by the inputs it was minted
+// from, rather than by the spec that asked for it.
+//
+// The spec name alone was sound only while those inputs were fixed for the life of
+// the spec. Two things break that. A chained private key is resolved per mint and
+// can differ between callers, so the first caller's token would be served to the
+// second without their key ever being exercised — and a key revoked upstream would
+// go on working for whoever shares the spec. And the key or installation can change
+// under an unchanged spec name, with nothing here to notice: unlike sources, a spec
+// update does not rebuild the driver, and this driver has no rotation hook to clear
+// a cache from.
+//
+// Deriving the key from the content instead makes both cases self-correcting — any
+// change of input is simply a different entry. The inputs are hashed, so a private
+// key never sits in a map key, and length-prefixed so no two input sets can collide
+// by concatenating differently.
+func appTokenCacheKey(appID, installationID, keyPEM string) string {
+	h := sha256.New()
+	for _, field := range []string{appID, installationID, keyPEM} {
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(field)))
+		h.Write(length[:])
+		h.Write([]byte(field))
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // GitHubDriver mints credentials from GitHub.
@@ -57,7 +87,8 @@ type GitHubDriver struct {
 	logger     *logger.GatedLogger
 	httpClient *http.Client
 
-	// Per-spec App installation token cache (keyed by spec name)
+	// App installation token cache, keyed by appTokenCacheKey over the inputs each
+	// token was minted from
 	appTokens  map[string]*appTokenCache
 	appTokenMu sync.Mutex
 }
@@ -157,7 +188,7 @@ func (d *GitHubDriver) MintCredential(ctx context.Context, spec *credential.Cred
 	}
 	switch mintMethod {
 	case "app":
-		return d.mintAppCredentialWithKey(ctx, spec, credential.GetString(spec.Config, "private_key", ""))
+		return d.mintAppCredentialWithKey(ctx, spec, credential.GetString(spec.Config, "private_key", ""), false)
 	case "pat":
 		return d.mintPATFromToken(credential.GetString(spec.Config, "token", ""))
 	default:
@@ -167,9 +198,13 @@ func (d *GitHubDriver) MintCredential(ctx context.Context, spec *credential.Cred
 
 // MintFromSecret mints a GitHub token from secret material fetched via credential
 // chaining: app mode signs an installation token with the fetched private key; pat
-// mode injects the fetched token. Per-caller authorization was already enforced
-// upstream (the referenced secret-spec was minted as the caller), so the cross-caller
-// app-token cache in mintAppCredentialWithKey remains correct.
+// mode injects the fetched token.
+//
+// Per-caller authorization is enforced before this runs — the referenced spec was
+// minted as the caller, and a caller who may not do that never reaches here. What
+// that does not establish is that the fetched key is the one a cached token was
+// minted from, which is why the cache in mintAppCredentialWithKey keys on the key
+// itself rather than on the spec.
 func (d *GitHubDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod, err := githubMintMethod(spec)
 	if err != nil {
@@ -191,7 +226,7 @@ func (d *GitHubDriver) MintFromSecret(ctx context.Context, spec *credential.Cred
 			}
 			return nil, nil, 0, "", fmt.Errorf("github: no private key in fetched secret material (set secret_field, or store it under 'private_key')")
 		}
-		return d.mintAppCredentialWithKey(ctx, spec, keyPEM)
+		return d.mintAppCredentialWithKey(ctx, spec, keyPEM, true)
 	case "pat":
 		token := material.Secret()
 		if token == "" && material.Field == "" {
@@ -210,14 +245,19 @@ func (d *GitHubDriver) MintFromSecret(ctx context.Context, spec *credential.Cred
 }
 
 // mintAppCredentialWithKey mints a GitHub App installation access token from the
-// given private-key PEM (read from spec config for a direct mint, or fetched via
-// credential chaining).
-func (d *GitHubDriver) mintAppCredentialWithKey(ctx context.Context, spec *credential.CredSpec, keyPEM string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// given private-key PEM. chained says where that PEM came from: spec config for a
+// direct mint, or credential chaining — which decides whether a refusal from the
+// API is worth marking as retryable.
+func (d *GitHubDriver) mintAppCredentialWithKey(ctx context.Context, spec *credential.CredSpec, keyPEM string, chained bool) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	appID := credential.GetString(spec.Config, "app_id", "")
+	installationID := credential.GetString(spec.Config, "installation_id", "")
+	cacheKey := appTokenCacheKey(appID, installationID, keyPEM)
+
 	d.appTokenMu.Lock()
 	defer d.appTokenMu.Unlock()
 
 	// Return cached token if still valid (with 5min buffer)
-	if cached, ok := d.appTokens[spec.Name]; ok && time.Now().Add(5*time.Minute).Before(cached.expiresAt) {
+	if cached, ok := d.appTokens[cacheKey]; ok && time.Now().Add(5*time.Minute).Before(cached.expiresAt) {
 		rawData := map[string]interface{}{
 			"token":      cached.token,
 			"expires_at": cached.expiresAt.Format(time.RFC3339),
@@ -231,17 +271,22 @@ func (d *GitHubDriver) mintAppCredentialWithKey(ctx context.Context, spec *crede
 		return nil, nil, 0, "", fmt.Errorf("failed to parse private key: %w", err)
 	}
 
-	appID := credential.GetString(spec.Config, "app_id", "")
-	installationID := credential.GetString(spec.Config, "installation_id", "")
-
 	// Mint a fresh installation token
-	token, expiresAt, err := d.mintInstallationToken(ctx, key, appID, installationID)
+	token, expiresAt, err := d.mintInstallationToken(ctx, key, appID, installationID, chained)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to mint installation token: %w", err)
 	}
 
-	// Cache per spec
-	d.appTokens[spec.Name] = &appTokenCache{
+	// Entries keyed by content are never read again once any input changes, so
+	// sweep what a read would already refuse rather than leaving one behind per
+	// rotation. This runs only on a cache miss, off the hit path.
+	for k, entry := range d.appTokens {
+		if time.Now().After(entry.expiresAt) {
+			delete(d.appTokens, k)
+		}
+	}
+
+	d.appTokens[cacheKey] = &appTokenCache{
 		token:     token,
 		expiresAt: expiresAt,
 	}
@@ -279,7 +324,7 @@ func (d *GitHubDriver) mintPATFromToken(token string) (map[string]interface{}, m
 }
 
 // mintInstallationToken creates a new installation access token via the GitHub API
-func (d *GitHubDriver) mintInstallationToken(ctx context.Context, key *rsa.PrivateKey, appID, installationID string) (string, time.Time, error) {
+func (d *GitHubDriver) mintInstallationToken(ctx context.Context, key *rsa.PrivateKey, appID, installationID string, chained bool) (string, time.Time, error) {
 	// Generate JWT for GitHub App authentication
 	jwt, err := generateAppJWT(key, appID)
 	if err != nil {
@@ -310,6 +355,17 @@ func (d *GitHubDriver) mintInstallationToken(ctx context.Context, key *rsa.Priva
 	}
 
 	if resp.StatusCode != http.StatusCreated {
+		// A key rotated where it is held leaves the chain handing over one the app
+		// no longer recognises. Marking that refusal is what lets the minting layer
+		// treat its cached copy as stale, evict it and retry once with a fresh
+		// fetch; unmarked, every request under that spec fails until the entry ages
+		// out on its own. Only the chained path can be retried this way — an inline
+		// key has no fresher copy to fetch — so the caller decides by passing
+		// chained.
+		if chained && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+			return "", time.Time{}, fmt.Errorf("github: installation token request rejected: %w (status %d: %s)",
+				credential.ErrChainedSecretRejected, resp.StatusCode, string(respBody))
+		}
 		return "", time.Time{}, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 

--- a/credential/drivers/github_driver_test.go
+++ b/credential/drivers/github_driver_test.go
@@ -2,13 +2,17 @@ package drivers
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -724,4 +728,199 @@ func splitJWT(token string) []string {
 	}
 	parts = append(parts, token[start:])
 	return parts
+}
+
+// --- app installation token cache keying ---
+
+// assertionSignedBy reports whether the App JWT was signed with keyPEM. The
+// stand-in API never sees the private key itself, only what it signed, so this is
+// how a test tells which caller's key actually reached GitHub.
+func assertionSignedBy(t *testing.T, assertion, keyPEM string) bool {
+	t.Helper()
+
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+
+	key, err := parseRSAPrivateKey(keyPEM)
+	require.NoError(t, err)
+
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	return rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sig) == nil
+}
+
+// newCachingGitHubDriver builds a driver against a stand-in API that maps each
+// signing key to its own installation token, so a test can tell which key a
+// returned token was minted from. keyForToken is consulted per request.
+func newCachingGitHubDriver(t *testing.T, tokenFor func(jwtAssertion string) (string, int)) (*GitHubDriver, *int) {
+	t.Helper()
+
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		token, status := tokenFor(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		if status != http.StatusCreated {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      token,
+			"expires_at": time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	return &GitHubDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeGitHub, Config: map[string]string{"github_url": server.URL}},
+		httpClient: server.Client(),
+		appTokens:  make(map[string]*appTokenCache),
+	}, &calls
+}
+
+func githubAppSpec(name string) *credential.CredSpec {
+	return &credential.CredSpec{
+		Name: name,
+		Type: credential.TypeGitHubToken,
+		Config: map[string]string{
+			"mint_method":               "app",
+			"app_id":                    "12345",
+			"installation_id":           "67890",
+			credential.ConfigSecretSpec: "gh-key",
+		},
+	}
+}
+
+// TestGitHubDriver_AppTokenCacheIsKeyedByKey is the crux: two callers of the same
+// spec whose chained private key resolves differently must each mint with their own
+// key. Keyed by spec name, the second is served the first's token and its key is
+// never exercised at all.
+func TestGitHubDriver_AppTokenCacheIsKeyedByKey(t *testing.T) {
+	keyA := generateTestRSAKey(t)
+	keyB := generateTestRSAKey(t)
+
+	// The stand-in cannot see the key, only the assertion signed with it, so it
+	// distinguishes callers by which key verifies the JWT signature.
+	driver, calls := newCachingGitHubDriver(t, func(assertion string) (string, int) {
+		switch {
+		case assertionSignedBy(t, assertion, keyA):
+			return "ghs_from_key_a", http.StatusCreated
+		case assertionSignedBy(t, assertion, keyB):
+			return "ghs_from_key_b", http.StatusCreated
+		default:
+			return "", http.StatusUnauthorized
+		}
+	})
+
+	spec := githubAppSpec("shared-spec")
+	mintWith := func(keyPEM string) map[string]interface{} {
+		rawData, _, _, _, err := driver.MintFromSecret(context.Background(), spec,
+			credential.SecretMaterial{Data: map[string]string{"private_key": keyPEM}, Field: "private_key"})
+		require.NoError(t, err)
+		return rawData
+	}
+
+	assert.Equal(t, "ghs_from_key_a", mintWith(keyA)["token"])
+
+	// Same key again must be served from cache.
+	assert.Equal(t, "ghs_from_key_a", mintWith(keyA)["token"])
+	assert.Equal(t, 1, *calls, "a repeated key must reuse the cached token")
+
+	// A different key must mint its own token, not inherit the first caller's.
+	assert.Equal(t, "ghs_from_key_b", mintWith(keyB)["token"])
+	assert.Equal(t, 2, *calls, "a different key must mint its own token")
+}
+
+// TestGitHubDriver_AppTokenCacheFollowsSpecConfig covers the direct path: a spec
+// edited to point at another installation must not keep serving the old one's
+// token. A spec update does not rebuild the driver, so nothing else would notice.
+func TestGitHubDriver_AppTokenCacheFollowsSpecConfig(t *testing.T) {
+	key := generateTestRSAKey(t)
+
+	var lastInstallation string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastInstallation = strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/app/installations/"), "/access_tokens")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      "ghs_for_installation_" + lastInstallation,
+			"expires_at": time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	driver := &GitHubDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeGitHub, Config: map[string]string{"github_url": server.URL}},
+		httpClient: server.Client(),
+		appTokens:  make(map[string]*appTokenCache),
+	}
+
+	spec := &credential.CredSpec{
+		Name: "edited-spec",
+		Type: credential.TypeGitHubToken,
+		Config: map[string]string{
+			"mint_method": "app", "app_id": "12345",
+			"installation_id": "111", "private_key": key,
+		},
+	}
+	rawData, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_for_installation_111", rawData["token"])
+
+	spec.Config["installation_id"] = "222"
+	rawData, _, _, _, err = driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_for_installation_222", rawData["token"],
+		"a spec repointed at another installation must not be served the old one's token")
+}
+
+// TestGitHubDriver_ChainedKeyRejectionIsRetryable pins the marking that lets the
+// minting layer evict a stale chained key and retry. Without it a key rotated where
+// it is held fails every request under the spec until the entry ages out.
+func TestGitHubDriver_ChainedKeyRejectionIsRetryable(t *testing.T) {
+	driver, _ := newCachingGitHubDriver(t, func(string) (string, int) {
+		return "", http.StatusUnauthorized
+	})
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), githubAppSpec("chained-spec"),
+		credential.SecretMaterial{Data: map[string]string{"private_key": generateTestRSAKey(t)}, Field: "private_key"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+// An inline key has no fresher copy to fetch, so marking its refusal would buy a
+// retry of the identical credentials.
+func TestGitHubDriver_InlineKeyRejectionIsNotRetryable(t *testing.T) {
+	driver, _ := newCachingGitHubDriver(t, func(string) (string, int) {
+		return "", http.StatusUnauthorized
+	})
+
+	spec := &credential.CredSpec{
+		Name: "inline-spec",
+		Type: credential.TypeGitHubToken,
+		Config: map[string]string{
+			"mint_method": "app", "app_id": "12345",
+			"installation_id": "67890", "private_key": generateTestRSAKey(t),
+		},
+	}
+	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+func TestGitHubAppTokenCacheKey(t *testing.T) {
+	assert.Equal(t, appTokenCacheKey("a", "i", "k"), appTokenCacheKey("a", "i", "k"))
+	assert.NotEqual(t, appTokenCacheKey("a", "i", "k"), appTokenCacheKey("a", "i", "k2"))
+	assert.NotEqual(t, appTokenCacheKey("a", "i", "k"), appTokenCacheKey("a", "i2", "k"))
+	assert.NotEqual(t, appTokenCacheKey("a", "i", "k"), appTokenCacheKey("a2", "i", "k"))
+	// Fields that would collide under plain concatenation must not.
+	assert.NotEqual(t, appTokenCacheKey("ab", "c", "d"), appTokenCacheKey("a", "bc", "d"))
+
+	assert.NotContains(t, appTokenCacheKey("app", "inst", "SECRETKEY"), "SECRETKEY",
+		"the private key must not sit in a map key")
 }

--- a/e2e/fullchain/github_test.go
+++ b/e2e/fullchain/github_test.go
@@ -158,9 +158,10 @@ const (
 	githubChainSpec       = "fc-gh-chained-cred"
 	githubChainAgentRole  = "fc-gh-chained-agent"
 
-	// A second role bound to the SAME spec. Logging in through it yields a
-	// distinct caller token, which is what makes the minted-credential cache miss
-	// while the spec — and so a spec-keyed driver cache — stays the same.
+	// A second role bound to the SAME spec, for a second agent to mint through.
+	// A role pins the spec its callers mint, so two agents sharing one spec need
+	// one role each; the role itself does not enter any cache key, so it is the
+	// differing agent, not the differing role, that makes a mint re-run.
 	githubChainAgentRoleB = "fc-gh-chained-agent-b"
 
 	// Where this test parks the App private key. Unlike the gitlab secrets this

--- a/e2e/fullchain/github_test.go
+++ b/e2e/fullchain/github_test.go
@@ -3,8 +3,19 @@
 package fullchain
 
 import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
@@ -115,4 +126,285 @@ func TestGitHub_RESTLegAcceptsUserInBasicPassword(t *testing.T) {
 		UpstreamCalls: 1,
 	})
 	h.AssertAuditUser(t, leaderPort, probe, h.FullChainUserSubject)
+}
+
+// --- credential chaining (app mode) ---
+
+// The github rows above borrow a local source holding a static token, so nothing
+// here had ever driven the github driver's own mint path, let alone its chained
+// one. These rows do both, against the recording upstream standing in for the
+// GitHub API.
+//
+// Chaining attaches differently than it does for gitlab, and that is the point
+// worth pinning. A gitlab source authenticates itself, so its secret_spec sits on
+// the source. A github source holds only a URL — the app id, installation id and
+// private key are per-spec, so several specs can share one source for different
+// installations — so secret_spec sits on the spec instead.
+const (
+	githubAppID          = "fc-gh-app-12345"
+	githubInstallationID = "67890"
+
+	// What the stand-in returns from the installation-token call. Present in no
+	// config: it is minted, not stored.
+	githubMintedToken = "ghs_fc_e2e_minted_not_a_real_token"
+
+	githubInstallPath = "/app/installations/" + githubInstallationID + "/access_tokens"
+
+	// Test-local, for the reason gitlab_test.go gives: a killed run skips
+	// t.Cleanup, and a spec left hanging off a source blocks that source's
+	// deletion, failing the next run's setup.
+	githubChainSecretSpec = "fc-gh-key-from-vault"
+	githubChainSource     = "fc-gh-app-src"
+	githubChainSpec       = "fc-gh-chained-cred"
+	githubChainAgentRole  = "fc-gh-chained-agent"
+
+	// A second role bound to the SAME spec. Logging in through it yields a
+	// distinct caller token, which is what makes the minted-credential cache miss
+	// while the spec — and so a spec-keyed driver cache — stays the same.
+	githubChainAgentRoleB = "fc-gh-chained-agent-b"
+
+	// Where this test parks the App private key. Unlike the gitlab secrets this
+	// is written by the test rather than seeded by setup.sh: the row asserts the
+	// key actually signed the assertion, so the test has to know it, and a
+	// freshly generated one keeps real-looking key material out of the repo.
+	githubKeyVaultPath = "secret/data/e2e/fc-github-app-key"
+)
+
+// githubAppKeyPEM generates an RSA private key in PEM form, plus the parsed key
+// for the handler to verify assertions against.
+func githubAppKeyPEM(t *testing.T) (string, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating an App private key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return string(pemBytes), key
+}
+
+// serveGitHubInstallToken answers the driver's installation-token call, but only
+// for an assertion signed by wantKey — which is what turns this row from "a token
+// came back" into "the key from the store is what signed it". Everything else
+// falls through to the default probe response so the proxied request behaves like
+// every other row's.
+func serveGitHubInstallToken(t *testing.T, wantKey *rsa.PrivateKey) (rotate func(key *rsa.PrivateKey, token string)) {
+	t.Helper()
+
+	// Guarded because the handler runs on the server's goroutines while a test
+	// rotates from its own.
+	var mu sync.Mutex
+	acceptedKey, mintedToken := wantKey, githubMintedToken
+
+	upstream.SetHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodPost && r.URL.Path == githubInstallPath {
+			mu.Lock()
+			key, token := acceptedKey, mintedToken
+			mu.Unlock()
+
+			if !assertionSignedBy(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "), key) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"` + token +
+				`","expires_at":"` + time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + `"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	return func(key *rsa.PrivateKey, token string) {
+		mu.Lock()
+		acceptedKey, mintedToken = key, token
+		mu.Unlock()
+	}
+}
+
+// assertionSignedBy verifies the App JWT's RS256 signature. The stand-in never
+// sees the private key, only what it signed.
+func assertionSignedBy(assertion string, key *rsa.PrivateKey) bool {
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	return rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sig) == nil
+}
+
+// buildGitHubAppEnv points both the mount and a real github source at the
+// upstream, with an inline App key on the mount's own spec — the baseline the
+// chained row is measured against.
+func buildGitHubAppEnv(upstreamURL, keyPEM string) h.ProviderEnv {
+	return h.ProviderEnv{
+		Mount:      "fc-github-app",
+		Type:       "github",
+		URLKey:     "github_url",
+		CredType:   "github_token",
+		SourceType: "github",
+		SourceConfig: map[string]string{
+			"github_url":      upstreamURL,
+			"tls_skip_verify": "true",
+		},
+		CredConfig: map[string]string{
+			"mint_method":     "app",
+			"app_id":          githubAppID,
+			"installation_id": githubInstallationID,
+			"private_key":     keyPEM,
+		},
+	}
+}
+
+// setupGitHubAppEnv orders setup the way gitlab's does and for the same reason:
+// creating a spec test-mints it, and an app-mode mint is a real API call, so the
+// stand-in must be answering first. Recorded traffic is cleared last so setup's
+// own calls are not counted against a row.
+func setupGitHubAppEnv(t *testing.T, keyPEM string, key *rsa.PrivateKey) (h.ProviderEnv, func(*rsa.PrivateKey, string)) {
+	t.Helper()
+
+	rotate := serveGitHubInstallToken(t, key)
+
+	env := buildGitHubAppEnv(upstream.URL, keyPEM)
+	h.SetupFullChainProvider(t, leaderPort, upstream.URL, env)
+	t.Cleanup(func() { h.TeardownFullChainProviderBestEffort(leaderPort, env) })
+
+	upstream.Reset()
+	return env, rotate
+}
+
+// setupGitHubChain parks the App key in the store and builds the keyless consumer
+// that reads it. Cleanup runs consumer-first: a referenced spec cannot be deleted
+// while something names it.
+func writeGitHubAppKey(t *testing.T, keyPEM string) {
+	t.Helper()
+	// Marshalled rather than concatenated: a PEM carries newlines that would
+	// otherwise break the JSON body.
+	body, err := json.Marshal(map[string]any{"data": map[string]string{"private_key": keyPEM}})
+	if err != nil {
+		t.Fatalf("encoding the App private key: %v", err)
+	}
+	if status, resp := h.VaultDirectRequest(t, "POST", githubKeyVaultPath, string(body)); status >= 400 {
+		t.Fatalf("parking the App private key in the store failed (status %d): %s", status, resp)
+	}
+}
+
+func setupGitHubChain(t *testing.T, env h.ProviderEnv, keyPEM string) {
+	t.Helper()
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+githubChainAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+githubChainAgentRoleB, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+githubChainSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+githubChainSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	writeGitHubAppKey(t, keyPEM)
+
+	// The referenced spec. subject_token_source is not optional: a chained secret
+	// is minted as the session-pinned caller, and the store refuses the reference
+	// otherwise.
+	mustWrite("POST", "sys/cred/specs/"+githubChainSecretSpec, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":"e2e/fc-github-app-key",
+			"subject_token_source":"agent_identity"}}`,
+		"create the referenced secret spec")
+
+	// The keyless consumer. secret_spec sits on the SPEC, which is where the key
+	// it replaces would otherwise live — the inverse of gitlab, whose secret
+	// belongs to the source.
+	mustWrite("POST", "sys/cred/specs/"+githubChainSpec, `{
+		"type":"github_token","source":"`+env.Source()+`","config":{
+			"mint_method":"app","app_id":"`+githubAppID+`",
+			"installation_id":"`+githubInstallationID+`",
+			"secret_spec":"`+githubChainSecretSpec+`","secret_field":"private_key"}}`,
+		"create the keyless consuming spec")
+
+	// Two roles bound to the same spec, one per agent: a role pins the spec its
+	// callers mint, and both agents must land on this one.
+	for _, role := range []string{githubChainAgentRole, githubChainAgentRoleB} {
+		mustWrite("POST", "auth/jwt/role/"+role, `{
+			"token_policies":["`+env.Policy()+`"],"cred_spec_name":"`+githubChainSpec+`",
+			"user_claim":"sub","token_ttl":3600}`,
+			"create the keyless agent role "+role)
+	}
+}
+
+// TestGitHub_AppModeInjectsMintedToken pins the inline baseline: the driver signs
+// an assertion with the key in spec config, mints an installation token against
+// it, and that token — not the key — is what goes upstream.
+func TestGitHub_AppModeInjectsMintedToken(t *testing.T) {
+	ensureEnv(t)
+	keyPEM, key := githubAppKeyPEM(t)
+	env, _ := setupGitHubAppEnv(t, keyPEM, key)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, env, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         env.CertRole(),
+	})
+
+	// Two calls: the installation-token mint, then the proxied request. Unlike
+	// gitlab there is no construction-time auth check — a github source holds no
+	// credential to check.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "token " + githubMintedToken},
+		UpstreamCalls: 2,
+	})
+}
+
+// TestGitHub_ChainedAppKeyMintsWithStoreHeldKey is the row this section exists
+// for: a spec holding no key still mints, because the key travelled from the
+// store through federation and MintFromSecret to sign the assertion.
+//
+// The handler refuses any assertion not signed by that key, so a broken link
+// cannot pass — and the injected token appears in no config anywhere, so it can
+// only be right if the mint response was parsed and carried through.
+//
+// A JWT agent leg rather than a certificate, because agent_identity forwards the
+// agent's own inbound JWT as the exchange subject and fails closed otherwise.
+func TestGitHub_ChainedAppKeyMintsWithStoreHeldKey(t *testing.T) {
+	ensureEnv(t)
+	keyPEM, key := githubAppKeyPEM(t)
+	env, _ := setupGitHubAppEnv(t, keyPEM, key)
+	useJWTAgentLeg(t, env)
+	setupGitHubChain(t, env, keyPEM)
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, env, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Role:       githubChainAgentRole,
+	})
+
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "token " + githubMintedToken},
+		UpstreamCalls: 2,
+	})
+
+	// And the key itself never left the store: it signs, it is not sent.
+	for _, req := range upstream.Requests() {
+		if strings.Contains(string(req.Body), "PRIVATE KEY") {
+			t.Errorf("the App private key leaked into an upstream request body: %s", req.Path)
+		}
+	}
 }


### PR DESCRIPTION
The GitHub App installation-token cache was keyed by `spec.Name` alone, which held only while the inputs behind that name were fixed. Two things break it.

## The defect

**A chained private key is resolved per mint and can differ between callers.** The first caller's token was served to the second without their key ever being exercised — so a key revoked upstream kept working for anyone sharing the spec, for as long as the cached token lived (installation tokens are ~1h, served until 5 minutes before expiry).

**The key or installation can change under an unchanged spec name.** A spec update does not rebuild the driver, and this driver has no rotation hook to clear a cache from, so nothing noticed.

Severity is bounded: `app_id` and `installation_id` come from spec config, so divergent keys produce identically-scoped tokens. There is no privilege escalation. What is lost is proof-of-possession — the second caller's key is never validated against GitHub — and therefore the ability to cut an agent off by revoking its key.

## The fix

Key the cache by a length-prefixed hash of `(app_id, installation_id, keyPEM)` — the inputs the token is actually a function of. That makes both cases self-correcting: any change of input is simply a different entry, with no invalidation hook needed. Expired entries are swept on write, since content-derived keys would otherwise strand one per rotation.

Separately, a 401/403 from the installation-token call on the chained path now wraps `credential.ErrChainedSecretRejected`. Without that mapping the minting layer's evict-and-retry could never fire for this driver **at all** — a key rotated where it is held failed every request under the spec until the cached secret aged out on its own. This is the same contract the gitlab and token_exchange drivers already implement.

## Testing

The e2e rows here are the first to drive this driver's own mint path — GitHub's existing coverage borrows a local source holding a static token, so app mode and chaining had never been driven end to end. They pin the inline baseline and the chained one, with the stand-in refusing any assertion it did not sign, so a broken link cannot pass.

Both fixes are mutation-verified: reverting to a spec-name key fails the cache-isolation and spec-update tests, and dropping the sentinel fails the retryability test.

Note that chaining attaches differently here than for gitlab — `secret_spec` sits on the spec rather than the source, because the key is per-spec config. The tests document that.

## Not included

Docs, per the release-prep convention.
