### PR TITLE
feat(credential): template a request path on the calling agent's claims

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1350,6 +1350,35 @@ func projectAssertionMetadata(md map[string]string, keys []string) (map[string]s
 	return projected, string(encoded), nil
 }
 
+// projectAgentClaims builds the primary principal's {{agent.<claim>}} template map
+// for a subject source that mints no assertion, and so has no projection to borrow.
+//
+// It mirrors what buildAssertionSetup composes for the warden_identity path — the
+// allow-listed metadata plus an authoritative "sub" — so one spec templates the same
+// way whichever source it uses. Absent keys are skipped rather than rejected, matching
+// projectAssertionMetadata: a claim that is named but missing fails at template time in
+// the driver, and only when a path actually references it.
+func projectAgentClaims(te *logical.TokenEntry, keys []string) (map[string]string, error) {
+	projected, _, err := projectAssertionMetadata(te.Metadata, keys)
+	if err != nil {
+		return nil, err
+	}
+	return agentTemplateClaims(projected, te.PrincipalID), nil
+}
+
+// agentTemplateClaims composes the {{agent.<claim>}} map from an allow-listed
+// metadata projection. Both subject sources compose through here so they cannot
+// drift apart. The identity sub is authoritative and set last: a metadata key
+// literally named "sub" still reaches the assertion, but never the template.
+func agentTemplateClaims(projected map[string]string, principalID string) map[string]string {
+	claims := make(map[string]string, len(projected)+1)
+	for k, v := range projected {
+		claims[k] = v
+	}
+	claims["sub"] = principalID
+	return claims
+}
+
 // projectUserClaims selects the operator-allowlisted keys from the secondary
 // (user) principal's login-derived metadata for the nested warden_user assertion
 // claim and for per-user secret_path templating. Unlike projectAssertionMetadata it
@@ -1447,6 +1476,15 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 			return nil, fmt.Errorf("spec %q requires an inbound JWT subject token but the request was not JWT-authenticated", specName)
 		}
 		inputs.SubjectToken = req.ClientToken
+		// No assertion is minted here, so nothing has projected the agent's claims
+		// yet — do it for templating alone. Read the token entry rather than
+		// re-parsing the JWT: the entry is the auth mount's already-verified view,
+		// and a second parse could disagree with what authenticated the request.
+		agentClaims, err := projectAgentClaims(te, credential.AssertionMetadataKeys(spec.Config))
+		if err != nil {
+			return nil, fmt.Errorf("spec %q: %w", specName, err)
+		}
+		inputs.AgentClaims = agentClaims
 	case credential.SourceUserIdentity:
 		// Forward the secondary (user) principal's own validated credential as the
 		// RFC 8693 subject_token — the standard "agent acting for a user" delegation.
@@ -1473,6 +1511,7 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		// request (e.g. kv2_read's secret_path) — the same projection embedded in the
 		// assertion's warden_user claim. Nil unless the spec set assertion_user_claims.
 		inputs.UserClaims = setup.userClaims
+		inputs.AgentClaims = setup.agentClaims
 	default:
 		// SpecRequestsExchange already excluded "none"/absent; any other value
 		// (including a persisted, now-retired "header") fails closed at mint.
@@ -1504,6 +1543,7 @@ func (c *Core) resolveExchangeInputs(ctx context.Context, req *logical.Request, 
 		inputs.ActorCacheIdentity = setup.cacheIdentity
 		inputs.ResolveActorToken = setup.resolve
 		inputs.UserClaims = setup.userClaims
+		inputs.AgentClaims = setup.agentClaims
 	case credential.SourceNone, "":
 		// No actor requested: drop any default type so Validate's pairing holds.
 		inputs.ActorTokenType = ""
@@ -1533,6 +1573,13 @@ type assertionSetup struct {
 	// template a per-user path from them. Nil when the spec sets no
 	// assertion_user_claims.
 	userClaims map[string]string
+	// agentClaims is the primary principal's template map: the projected
+	// assertion_metadata_claims plus "sub" (the raw principal). Every value is
+	// already embedded in the assertion — warden_metadata and warden_sub — and
+	// already inside cacheIdentity, via mdFingerprint and wardenSubject
+	// respectively, so templating from it discloses nothing the assertion does not
+	// and needs no cache dimension of its own. Never nil: "sub" is unconditional.
+	agentClaims map[string]string
 }
 
 // buildAssertionSetup validates the OIDC issuer is ready and derives the
@@ -1595,6 +1642,11 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 	if err != nil {
 		return nil, fmt.Errorf("spec %q: %w", specName, err)
 	}
+
+	// The same projection serves the assertion claim and {{agent.<claim>}}
+	// templating, so a template resolves exactly the value a downstream policy can
+	// bind — the property the user side states below for warden_user.
+	agentClaims := agentTemplateClaims(projected, te.PrincipalID)
 
 	// Project the secondary (user) principal into the nested warden_user claim, but
 	// only when the spec opts into disclosure via assertion_user_claims — like
@@ -1661,6 +1713,7 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 	return &assertionSetup{
 		cacheIdentity: cacheIdentity,
 		userClaims:    userClaims,
+		agentClaims:   agentClaims,
 		resolve: func(ctx context.Context) (string, error) {
 			return issuer.MintIdentityAssertion(ctx, te, AssertionClaims{
 				Audience:   audience,

--- a/core/request_handler_user_test.go
+++ b/core/request_handler_user_test.go
@@ -294,3 +294,70 @@ func TestProjectUserClaims(t *testing.T) {
 		assert.Contains(t, err.Error(), "exceed")
 	})
 }
+
+// TestProjectAgentClaims covers the primary principal's template map. Unlike the
+// user projection it skips absent keys rather than denying — it shares
+// projectAssertionMetadata's semantics so the two subject sources compose the same
+// map, and a named-but-missing claim fails at template time in the driver instead,
+// and only when a path actually references it.
+func TestProjectAgentClaims(t *testing.T) {
+	te := &logical.TokenEntry{
+		PrincipalID: "build-runner",
+		Metadata:    map[string]string{"team": "platform", "env": "prod"},
+	}
+
+	t.Run("sub needs no allow-list", func(t *testing.T) {
+		got, err := projectAgentClaims(te, nil)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"sub": "build-runner"}, got)
+	})
+	t.Run("projects allow-listed metadata alongside sub", func(t *testing.T) {
+		got, err := projectAgentClaims(te, []string{"team"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"sub": "build-runner", "team": "platform"}, got)
+	})
+	t.Run("unlisted metadata is not templatable", func(t *testing.T) {
+		got, err := projectAgentClaims(te, []string{"team"})
+		require.NoError(t, err)
+		assert.NotContains(t, got, "env",
+			"a claim outside the allow-list is outside mdFingerprint, so templating it would escape the cache key")
+	})
+	t.Run("absent key is skipped, not denied", func(t *testing.T) {
+		got, err := projectAgentClaims(te, []string{"team", "missing"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"sub": "build-runner", "team": "platform"}, got)
+	})
+	t.Run("identity sub wins over a metadata key named sub", func(t *testing.T) {
+		shadowed := &logical.TokenEntry{
+			PrincipalID: "build-runner",
+			Metadata:    map[string]string{"sub": "not-the-principal"},
+		}
+		got, err := projectAgentClaims(shadowed, []string{"sub"})
+		require.NoError(t, err)
+		assert.Equal(t, "build-runner", got["sub"],
+			"{{agent.sub}} must mean the principal, which is what the assertion's warden_sub carries")
+	})
+	t.Run("oversized projection fails closed", func(t *testing.T) {
+		big := &logical.TokenEntry{
+			PrincipalID: "a",
+			Metadata:    map[string]string{"k": strings.Repeat("x", maxAssertionMetadataBytes)},
+		}
+		_, err := projectAgentClaims(big, []string{"k"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceed")
+	})
+}
+
+// The two subject sources must compose the same map from the same inputs, or one
+// spec would template differently depending on how its subject travels.
+func TestAgentTemplateClaims_ComposesIdenticallyForBothSources(t *testing.T) {
+	projected := map[string]string{"team": "platform"}
+
+	fromAssertion := agentTemplateClaims(projected, "build-runner")
+
+	te := &logical.TokenEntry{PrincipalID: "build-runner", Metadata: map[string]string{"team": "platform"}}
+	fromForwardedToken, err := projectAgentClaims(te, []string{"team"})
+	require.NoError(t, err)
+
+	assert.Equal(t, fromAssertion, fromForwardedToken)
+}

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -356,9 +356,10 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 
 	switch mintMethod {
 	case "static_aws", "static_apikey", "kv2_read":
-		// Non-federation path carries no user context; a templated secret_path here
-		// fails closed in resolveSecretPath (no claims to satisfy {{user.…}}).
-		return d.fetchStaticKVSecret(ctx, d.vault, spec, nil)
+		// Non-federation path carries neither principal's claims; a templated
+		// secret_path here fails closed in resolveSecretPath (nothing to satisfy
+		// {{user.…}} or {{agent.…}} with).
+		return d.fetchStaticKVSecret(ctx, d.vault, spec, nil, nil)
 	case "dynamic_aws":
 		return d.fetchDynamicAWSCreds(ctx, d.vault, spec)
 	case "dynamic_gcp":
@@ -368,9 +369,10 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	case "vault_token":
 		return d.fetchDynamicVaultToken(ctx, d.vault, spec)
 	case "oauth2":
-		// Non-federation path carries no user context; a templated credential_name here
-		// fails closed in resolveUserTemplate (no claims to satisfy {{user.…}}).
-		return d.fetchOAuth2Creds(ctx, d.vault, spec, nil)
+		// Non-federation path carries neither principal's claims; a templated
+		// credential_name here fails closed in resolveClaimTemplate (nothing to
+		// satisfy {{user.…}} or {{agent.…}} with).
+		return d.fetchOAuth2Creds(ctx, d.vault, spec, nil, nil)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'kv2_read', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2'", mintMethod)
 	}
@@ -449,7 +451,7 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 	)
 	switch mintMethod {
 	case "static_aws", "static_apikey", "kv2_read":
-		rawData, metadata, leaseTTL, _, err = d.fetchStaticKVSecret(ctx, client, spec, inputs.UserClaims)
+		rawData, metadata, leaseTTL, _, err = d.fetchStaticKVSecret(ctx, client, spec, inputs.UserClaims, inputs.AgentClaims)
 		// A static read holds no lease that depends on the login token — best-effort
 		// revoke it so a transient session is not left behind.
 		defer d.revokeLoginToken(loginAuth.Accessor, client)
@@ -460,7 +462,7 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 	case "dynamic_ibm":
 		rawData, metadata, leaseTTL, _, err = d.fetchDynamicIBMCreds(ctx, client, spec)
 	case "oauth2":
-		rawData, metadata, leaseTTL, _, err = d.fetchOAuth2Creds(ctx, client, spec, inputs.UserClaims)
+		rawData, metadata, leaseTTL, _, err = d.fetchOAuth2Creds(ctx, client, spec, inputs.UserClaims, inputs.AgentClaims)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("vault: mint_method %q is not supported over auth_method=%s (supported: vault_token, static_aws, static_apikey, kv2_read, dynamic_aws, dynamic_gcp, dynamic_ibm, oauth2)", mintMethod, vaultAuthMethodOIDCFederation)
 	}
@@ -556,63 +558,111 @@ func (d *VaultDriver) revokeLoginToken(accessor string, client *api.Client) {
 	}
 }
 
-// userClaimTemplate matches a {{user.<claim>}} token in secret_path. The claim
-// name is a conservative identifier (letters, digits, '_', '.', '-').
-var userClaimTemplate = regexp.MustCompile(`\{\{user\.([A-Za-z0-9_.-]+)\}\}`)
+// claimTemplate matches a {{user.<claim>}} or {{agent.<claim>}} token in a request
+// path. The claim name is a conservative identifier (letters, digits, '_', '.', '-').
+//
+// One expression rather than one per principal: every rule that follows a
+// substitution — the value allow-list, the traversal check, the leftover-fragment
+// check — is the same whichever principal supplied the value, and a single pass makes
+// a path mixing both namespaces order-independent.
+var claimTemplate = regexp.MustCompile(`\{\{(user|agent)\.([A-Za-z0-9_.-]+)\}\}`)
 
-// userClaimValuePattern is the strict allow-list a substituted claim value must
+// claimTemplatePrefixes are the literal openings claimTemplate can match. Both the
+// fast path and the leftover check scan for them, so a malformed token (a missing
+// brace, an empty claim name) is refused rather than sent as literal path bytes.
+var claimTemplatePrefixes = []string{"{{user.", "{{agent."}
+
+// claimValuePattern is the strict allow-list a substituted claim value must
 // match before it can be placed into a KV path segment. It excludes '/' (which
 // would let one value span segments) and every other separator. '.' is allowed
 // (e.g. first.last), so a value or adjacent values could still compose a "."/".."
 // segment — that is caught after substitution by the segment check below, not here.
-var userClaimValuePattern = regexp.MustCompile(`^[A-Za-z0-9._@-]+$`)
+var claimValuePattern = regexp.MustCompile(`^[A-Za-z0-9._@-]+$`)
 
 // resolveSecretPath returns the KV secret path for a kv2_read, substituting any
-// {{user.<claim>}} token from the projected per-user claims. See resolveUserTemplate
-// for the fail-closed rules.
-func resolveSecretPath(rawPath string, userClaims map[string]string) (string, error) {
-	return resolveUserTemplate(rawPath, userClaims, "secret_path")
+// {{user.<claim>}} or {{agent.<claim>}} token from the projected claims. See
+// resolveClaimTemplate for the fail-closed rules.
+func resolveSecretPath(rawPath string, userClaims, agentClaims map[string]string) (string, error) {
+	return resolveClaimTemplate(rawPath, userClaims, agentClaims, "secret_path")
 }
 
-// resolveUserTemplate substitutes any {{user.<claim>}} token in raw from the projected
-// per-user claims, for a Vault request path segment (a KV secret_path, an OAuth engine
-// credential_name, …). A value with no such token is returned verbatim (byte-identical to
-// the pre-templating behaviour). It FAILS CLOSED when a referenced claim is absent (project
-// it via assertion_user_claims), when a value is empty or not in the strict allow-list, or
-// when the RESOLVED value contains a "." / ".." segment or a leftover template fragment. The
-// last check is the real boundary: the Vault API client runs path.Clean on the request path,
-// so a claim value of "." (which collapses its segment) or two adjacent tokens composing
-// ".." would otherwise silently retarget the request at a shared/parent path — the per-user
-// value must deny instead. field names the config key for error messages.
-func resolveUserTemplate(raw string, userClaims map[string]string, field string) (string, error) {
-	if !strings.Contains(raw, "{{user.") {
+// containsClaimTemplate reports whether raw opens either namespace's token.
+func containsClaimTemplate(raw string) bool {
+	for _, prefix := range claimTemplatePrefixes {
+		if strings.Contains(raw, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveClaimTemplate substitutes any {{user.<claim>}} or {{agent.<claim>}} token in
+// raw from the projected claims of the principal each names, for a Vault request path
+// segment (a KV secret_path, an OAuth engine credential_name, …). A value with no such
+// token is returned verbatim (byte-identical to the pre-templating behaviour). It FAILS
+// CLOSED when a referenced claim is absent, when a value is empty or not in the strict
+// allow-list, or when the RESOLVED value contains a "." / ".." segment or a leftover
+// template fragment. The last check is the real boundary: the Vault API client runs
+// path.Clean on the request path, so a claim value of "." (which collapses its segment)
+// or two adjacent tokens composing ".." would otherwise silently retarget the request at
+// a shared/parent path — the per-principal value must deny instead. field names the
+// config key for error messages.
+func resolveClaimTemplate(raw string, userClaims, agentClaims map[string]string, field string) (string, error) {
+	if !containsClaimTemplate(raw) {
 		return raw, nil
 	}
 	// Deliberately NOT an ErrUserRequired case, however tempting: an empty claim
-	// map does not mean the request lacked a user. Claims are projected only when
-	// the spec sets assertion_user_claims, and when it does, core has already
-	// rejected a user-less request before the driver runs — and a present user
+	// map does not mean the request lacked a principal. Claims are projected only
+	// when the spec opts in, and when it does, core has already rejected a
+	// principal-less request before the driver runs — and a present principal
 	// always yields at least "sub". So reaching here with no claims means the
 	// spec structurally cannot project any, which no amount of authenticating
 	// will change. Returning a 401 challenge would send the caller into an OAuth
-	// loop it cannot escape while hiding the real fix from the operator.
+	// loop it cannot escape while hiding the real fix from the operator. That
+	// holds doubly for the agent, which is present on every request.
 	var subErr error
-	resolved := userClaimTemplate.ReplaceAllStringFunc(raw, func(match string) string {
-		claim := userClaimTemplate.FindStringSubmatch(match)[1]
-		v, ok := userClaims[claim]
+	resolved := claimTemplate.ReplaceAllStringFunc(raw, func(match string) string {
+		groups := claimTemplate.FindStringSubmatch(match)
+		principal, claim := groups[1], groups[2]
+
+		claims, fix := userClaims, "list it in assertion_user_claims, which requires subject_token_source=warden_identity"
+		if principal == "agent" {
+			claims = agentClaims
+			switch {
+			case len(agentClaims) == 0:
+				// Nothing was projected at all, so the subject source is the fault,
+				// not the list — and for "sub", which needs no listing, it is the
+				// only possible fault. Sending an operator to the allow-list here
+				// would have them add an entry that changes nothing.
+				fix = "the agent's claims are projected only when subject_token_source is agent_identity or warden_identity"
+			case claim == "sub":
+				// Projection ran and still produced no sub. It is written
+				// unconditionally from the principal, so this is unreachable
+				// short of a construction bug — say that rather than blame config.
+				fix = "the agent's principal is always projected, so this indicates an internal error rather than a configuration one"
+			default:
+				// Projection ran without this claim. Listing it is necessary but
+				// may not be sufficient: an absent metadata key is skipped rather
+				// than rejected, so the login may simply not carry it.
+				fix = "list it in assertion_metadata_claims, and check the agent's login provides it"
+			}
+		}
+
+		v, ok := claims[claim]
 		if !ok {
-			// The user IS present; this claim was simply never projected. Note
-			// that assertion_user_claims only applies to a warden_identity
-			// subject — pairing {{user.…}} with subject_token_source=user_identity
-			// cannot populate claims at all, which is the likelier mistake.
-			subErr = fmt.Errorf("%s references {{user.%s}} but that claim is absent from the user's projected claims "+
-				"(list it in assertion_user_claims, which requires subject_token_source=warden_identity)", field, claim)
+			// The principal IS present; this claim was simply never projected. For
+			// the user, note that assertion_user_claims only applies to a
+			// warden_identity subject — pairing {{user.…}} with
+			// subject_token_source=user_identity cannot populate claims at all,
+			// which is the likelier mistake.
+			subErr = fmt.Errorf("%s references {{%s.%s}} but that claim is absent from the %s's projected claims (%s)",
+				field, principal, claim, principal, fix)
 			return ""
 		}
 		// The value becomes path bytes: a single non-empty allow-listed token that
 		// cannot span segments (no '/'). Dot-only / traversal segments it might
 		// compose are rejected after substitution.
-		if v == "" || !userClaimValuePattern.MatchString(v) {
+		if v == "" || !claimValuePattern.MatchString(v) {
 			subErr = fmt.Errorf("%s claim %q has a value rejected by the allow-list", field, claim)
 			return ""
 		}
@@ -623,7 +673,7 @@ func resolveUserTemplate(raw string, userClaims map[string]string, field string)
 	}
 	// A leftover fragment means a malformed token (e.g. a missing brace or an empty
 	// claim name) — fail closed rather than use a literal "{{user.…" value.
-	if strings.Contains(resolved, "{{user.") {
+	if containsClaimTemplate(resolved) {
 		return "", fmt.Errorf("%s has an unresolved template fragment after substitution", field)
 	}
 	// Reject any "." or ".." segment the substituted value(s) may have composed —
@@ -636,10 +686,11 @@ func resolveUserTemplate(raw string, userClaims map[string]string, field string)
 	return resolved, nil
 }
 
-// fetchStaticKVSecret fetches static secrets from Vault KV v2. userClaims, when
-// non-nil (a per-user chained mint), supplies the values for any {{user.<claim>}}
-// token in secret_path so the read is scoped to one user's secret.
-func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Client, spec *credential.CredSpec, userClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// fetchStaticKVSecret fetches static secrets from Vault KV v2. userClaims and
+// agentClaims, when non-nil, supply the values for any {{user.<claim>}} or
+// {{agent.<claim>}} token in secret_path, so the read is scoped to one
+// principal's secret.
+func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Client, spec *credential.CredSpec, userClaims, agentClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	kv2Mount := credential.GetString(spec.Config, "kv2_mount", "")
 	rawPath := credential.GetString(spec.Config, "secret_path", "")
 
@@ -647,7 +698,7 @@ func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Clien
 		return nil, nil, 0, "", fmt.Errorf("kv2_mount and secret_path are required for static KV credentials")
 	}
 
-	secretPath, err := resolveSecretPath(rawPath, userClaims)
+	secretPath, err := resolveSecretPath(rawPath, userClaims, agentClaims)
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
@@ -825,7 +876,7 @@ func (d *VaultDriver) fetchDynamicGCPCreds(ctx context.Context, client *api.Clie
 
 // fetchOAuth2Creds fetches OAuth2 credentials from an OpenBao/Vault OAuth2 secret engine
 // (compatible with openbao-plugin-secrets-oauthapp)
-func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, client *api.Client, spec *credential.CredSpec, userClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, client *api.Client, spec *credential.CredSpec, userClaims, agentClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	oauth2Mount := credential.GetString(spec.Config, "oauth2_mount", "")
 	rawCredentialName := credential.GetString(spec.Config, "credential_name", "")
 
@@ -833,11 +884,11 @@ func (d *VaultDriver) fetchOAuth2Creds(ctx context.Context, client *api.Client, 
 		return nil, nil, 0, "", fmt.Errorf("oauth2_mount and credential_name are required for oauth2 credentials")
 	}
 
-	// credential_name may template {{user.<claim>}} (per-user OAuth engine credentials): the
-	// federation login resolves it to the caller's own credential, scoped by a templated
-	// OpenBao policy. userClaims is nil on the non-federation path, where a templated name
-	// fails closed (no claims to satisfy it).
-	credentialName, err := resolveUserTemplate(rawCredentialName, userClaims, "credential_name")
+	// credential_name may template {{user.<claim>}} (per-user OAuth engine credentials) or
+	// {{agent.<claim>}} (per-agent ones): the federation login resolves it to the caller's
+	// own credential, scoped by a templated policy on the store side. Both maps are nil on
+	// the non-federation path, where a templated name fails closed.
+	credentialName, err := resolveClaimTemplate(rawCredentialName, userClaims, agentClaims, "credential_name")
 	if err != nil {
 		return nil, nil, 0, "", err
 	}

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -1135,39 +1135,55 @@ func TestVaultDriver_MintCredentialWithExchange_UnsupportedMintMethod(t *testing
 // secret or escaping the intended path).
 func TestResolveSecretPath(t *testing.T) {
 	claims := map[string]string{"username": "alice", "email": "alice@example.com", "dept": "eng-team"}
+	agentClaims := map[string]string{"sub": "build-runner", "team": "platform"}
+
 	tests := []struct {
 		name    string
 		path    string
 		claims  map[string]string
+		agent   map[string]string
 		want    string
 		wantErr string
 	}{
-		{"no template returned verbatim", "slack/refresh_token", claims, "slack/refresh_token", ""},
-		{"no template needs no claims", "slack/refresh_token", nil, "slack/refresh_token", ""},
-		{"single substitution", "slack/{{user.username}}/refresh_token", claims, "slack/alice/refresh_token", ""},
-		{"multiple tokens resolved", "{{user.username}}/{{user.dept}}", claims, "alice/eng-team", ""},
-		{"email value allowed", "kv/{{user.email}}", claims, "kv/alice@example.com", ""},
-		{"hyphen value allowed", "kv/{{user.dept}}", claims, "kv/eng-team", ""},
-		{"literal dots within a segment allowed", "kv/{{user.username}}", map[string]string{"username": "a..b"}, "kv/a..b", ""},
+		{"no template returned verbatim", "slack/refresh_token", claims, agentClaims, "slack/refresh_token", ""},
+		{"no template needs no claims", "slack/refresh_token", nil, agentClaims, "slack/refresh_token", ""},
+		{"single substitution", "slack/{{user.username}}/refresh_token", claims, agentClaims, "slack/alice/refresh_token", ""},
+		{"multiple tokens resolved", "{{user.username}}/{{user.dept}}", claims, agentClaims, "alice/eng-team", ""},
+		{"email value allowed", "kv/{{user.email}}", claims, agentClaims, "kv/alice@example.com", ""},
+		{"hyphen value allowed", "kv/{{user.dept}}", claims, agentClaims, "kv/eng-team", ""},
+		{"literal dots within a segment allowed", "kv/{{user.username}}", map[string]string{"username": "a..b"}, agentClaims, "kv/a..b", ""},
 		// Both are spec/config mismatches, not missing-user cases: claims are
 		// projected only when the spec asks for them, and core rejects a
 		// user-less request before the driver runs. Neither is fixed by
 		// authenticating, so neither may carry a 401 challenge.
-		{"absent claim fails closed", "slack/{{user.missing}}/x", claims, "", "absent"},
-		{"nil claims with template fails closed", "slack/{{user.username}}/x", nil, "", "absent"},
-		{"slash in value rejected", "kv/{{user.username}}", map[string]string{"username": "a/b"}, "", "allow-list"},
-		{"curly brace in value rejected", "kv/{{user.username}}", map[string]string{"username": "a{b"}, "", "allow-list"},
-		{"empty value rejected", "kv/{{user.username}}", map[string]string{"username": ""}, "", "allow-list"},
+		{"absent claim fails closed", "slack/{{user.missing}}/x", claims, agentClaims, "", "absent"},
+		{"nil claims with template fails closed", "slack/{{user.username}}/x", nil, agentClaims, "", "absent"},
+		{"slash in value rejected", "kv/{{user.username}}", map[string]string{"username": "a/b"}, agentClaims, "", "allow-list"},
+		{"curly brace in value rejected", "kv/{{user.username}}", map[string]string{"username": "a{b"}, agentClaims, "", "allow-list"},
+		{"empty value rejected", "kv/{{user.username}}", map[string]string{"username": ""}, agentClaims, "", "allow-list"},
 		// The security boundary: values that compose a "." or ".." segment which the
 		// Vault client's path.Clean would resolve into a shared/parent path.
-		{"dot value collapses a segment", "slack/{{user.username}}/rt", map[string]string{"username": "."}, "", "traversal"},
-		{"dotdot value traverses", "slack/{{user.username}}/rt", map[string]string{"username": ".."}, "", "traversal"},
-		{"adjacent tokens compose dotdot", "slack/{{user.a}}{{user.b}}/rt", map[string]string{"a": ".", "b": "."}, "", "traversal"},
-		{"unresolved fragment fails closed", "slack/{{user.username}/rt", map[string]string{"username": "alice"}, "", "unresolved"},
+		{"dot value collapses a segment", "slack/{{user.username}}/rt", map[string]string{"username": "."}, agentClaims, "", "traversal"},
+		{"dotdot value traverses", "slack/{{user.username}}/rt", map[string]string{"username": ".."}, agentClaims, "", "traversal"},
+		{"adjacent tokens compose dotdot", "slack/{{user.a}}{{user.b}}/rt", map[string]string{"a": ".", "b": "."}, agentClaims, "", "traversal"},
+		{"unresolved fragment fails closed", "slack/{{user.username}/rt", map[string]string{"username": "alice"}, agentClaims, "", "unresolved"},
+
+		// The agent namespace. Same rules and same failure modes — only the map a
+		// value is looked up in differs.
+		{"agent sub substitution", "agents/{{agent.sub}}/key", claims, agentClaims, "agents/build-runner/key", ""},
+		{"agent metadata substitution", "teams/{{agent.team}}/key", claims, agentClaims, "teams/platform/key", ""},
+		{"both namespaces compose", "teams/{{agent.team}}/users/{{user.username}}", claims, agentClaims, "teams/platform/users/alice", ""},
+		{"absent agent claim fails closed", "agents/{{agent.missing}}/k", claims, agentClaims, "", "absent"},
+		{"nil agent claims with template fails closed", "agents/{{agent.sub}}/k", claims, nil, "", "absent"},
+		{"slash in agent value rejected", "kv/{{agent.team}}", claims, map[string]string{"team": "a/b"}, "", "allow-list"},
+		{"empty agent value rejected", "kv/{{agent.team}}", claims, map[string]string{"team": ""}, "", "allow-list"},
+		{"agent dotdot value traverses", "kv/{{agent.team}}/x", claims, map[string]string{"team": ".."}, "", "traversal"},
+		{"agent and user values compose dotdot", "kv/{{agent.team}}{{user.a}}/x", map[string]string{"a": "."}, map[string]string{"team": "."}, "", "traversal"},
+		{"unresolved agent fragment fails closed", "agents/{{agent.sub}/k", claims, agentClaims, "", "unresolved"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveSecretPath(tt.path, tt.claims)
+			got, err := resolveSecretPath(tt.path, tt.claims, tt.agent)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -1224,7 +1240,7 @@ func TestVaultDriver_OAuth2_TemplatedNameFailsClosedWithoutClaims(t *testing.T) 
 	spec := &credential.CredSpec{Name: "s", Config: map[string]string{
 		"mint_method": "oauth2", "oauth2_mount": "oauth2", "credential_name": "{{user.sub}}",
 	}}
-	_, _, _, _, err := driver.fetchOAuth2Creds(context.TODO(), nil, spec, nil)
+	_, _, _, _, err := driver.fetchOAuth2Creds(context.TODO(), nil, spec, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "credential_name")
 	assert.Contains(t, err.Error(), "absent")
@@ -1232,4 +1248,58 @@ func TestVaultDriver_OAuth2_TemplatedNameFailsClosedWithoutClaims(t *testing.T) 
 	// the missing-user sentinel here would turn it into a 401 challenge and send
 	// the caller into an OAuth loop that cannot fix a spec.
 	assert.NotErrorIs(t, err, credential.ErrUserRequired)
+}
+
+// The absent-claim error has to name the config key that fixes it, and the two
+// namespaces are fixed by different keys — an operator who reads "absent" without
+// being told where to list it has to guess.
+func TestResolveSecretPath_AbsentClaimNamesItsOwnConfigKey(t *testing.T) {
+	_, err := resolveSecretPath("kv/{{user.missing}}", map[string]string{"sub": "u"}, map[string]string{"sub": "a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion_user_claims")
+
+	_, err = resolveSecretPath("kv/{{agent.missing}}", map[string]string{"sub": "u"}, map[string]string{"sub": "a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion_metadata_claims")
+	assert.NotContains(t, err.Error(), "assertion_user_claims",
+		"the agent's guidance must not point at the user's config key")
+}
+
+// The guidance has to match which of the three ways it failed, or it sends the
+// operator to a config change that cannot help.
+func TestResolveSecretPath_AgentGuidanceMatchesTheFailure(t *testing.T) {
+	t.Run("nothing projected blames the subject source", func(t *testing.T) {
+		_, err := resolveSecretPath("kv/{{agent.sub}}", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subject_token_source")
+		assert.NotContains(t, err.Error(), "list it in assertion_metadata_claims",
+			"sub needs no allow-list entry, so telling an operator to add one is a dead end")
+	})
+	t.Run("a missing metadata claim blames the list and the login", func(t *testing.T) {
+		_, err := resolveSecretPath("kv/{{agent.team}}", nil, map[string]string{"sub": "a"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assertion_metadata_claims")
+		assert.Contains(t, err.Error(), "login",
+			"listing the claim is necessary but not sufficient — an absent one is skipped, not rejected")
+	})
+}
+
+// A path with no template must come back byte-identical whatever the claim maps
+// hold — the guarantee that adding this feature changed nothing for specs that do
+// not use it.
+func TestResolveSecretPath_UntemplatedIsByteIdentical(t *testing.T) {
+	const raw = "kv/data/service/config"
+	for _, maps := range []struct {
+		name        string
+		user, agent map[string]string
+	}{
+		{"both nil", nil, nil},
+		{"both populated", map[string]string{"sub": "u"}, map[string]string{"sub": "a"}},
+	} {
+		t.Run(maps.name, func(t *testing.T) {
+			got, err := resolveSecretPath(raw, maps.user, maps.agent)
+			require.NoError(t, err)
+			assert.Equal(t, raw, got)
+		})
+	}
 }

--- a/credential/exchange.go
+++ b/credential/exchange.go
@@ -73,11 +73,21 @@ const (
 const ConfigAssertionAudience = "assertion_audience"
 
 // ConfigAssertionMetadataClaims is the spec-config key naming which of the
-// caller's login-derived metadata keys to project into a warden_identity
-// assertion (comma-separated). Absent/empty projects nothing — the assertion
-// crosses a trust boundary to a third-party upstream, so disclosure is opt-in and
-// operator-chosen, never the whole metadata map. Valid only when
-// subject_token_source=warden_identity.
+// caller's login-derived metadata keys to project (comma-separated). Absent/empty
+// projects nothing.
+//
+// It gates two things, which is why it is valid under more than one subject source.
+// Under warden_identity the projection is embedded in the assertion, which crosses
+// a trust boundary to a third-party upstream — so disclosure is opt-in and
+// operator-chosen, never the whole metadata map. On both warden_identity and
+// agent_identity the same list also names which claims a request path may template
+// via {{agent.<claim>}}; there the list is what keeps a templated value inside the
+// cache key, since only the projected set is fingerprinted.
+//
+// The values are the operator's assertion that a claim is fit to select a secret
+// by. Warden verifies them at login and no caller can supply them, but whether a
+// claim is one an agent could influence at its identity provider is a property of
+// that provider, invisible here.
 const ConfigAssertionMetadataClaims = "assertion_metadata_claims"
 
 // AssertionMetadataKeys parses the comma-separated ConfigAssertionMetadataClaims
@@ -246,6 +256,20 @@ type ExchangeInputs struct {
 	// already isolated per user by the ":u:" key dimension); nil for an agent-only
 	// request.
 	UserClaims map[string]string
+
+	// AgentClaims carries the primary (agent) principal's claims so a driver can
+	// scope its request per agent — the same {{agent.<claim>}} templating the user
+	// claims above serve for their own principal. Always carries "sub" (the raw
+	// principal); metadata claims are those the spec allow-listed.
+	//
+	// Not hashed by Fingerprint, for the same reason UserClaims is not, but by a
+	// different mechanism: the agent IS the exchange subject, so every value here is
+	// already a function of what the fingerprint keys on — the raw subject token
+	// under agent_identity, or SubjectCacheIdentity (which folds the same allow-listed
+	// projection) under warden_identity. Anything templatable that fell outside that
+	// coverage could be served across sessions of one principal, which is why the
+	// allow-list and the fingerprinted projection must stay the same set.
+	AgentClaims map[string]string
 }
 
 // Validate performs structural checks only. It does not verify token contents
@@ -385,11 +409,17 @@ func ValidateExchangeSpecConfig(config map[string]string) error {
 	// their own config) and needs the source, so it runs one layer up in the core
 	// config store, not in this source-agnostic structural validator. It is enforced
 	// again at mint time, defence in depth.
-	// Projecting metadata into the assertion only makes sense when Warden mints it;
-	// on a reused/caller-supplied token Warden does not control the claims.
-	if config[ConfigAssertionMetadataClaims] != "" && !mintsAssertion {
-		return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s'",
-			ConfigAssertionMetadataClaims, SourceWardenIdentity)
+	// The key has two jobs, and they permit different subject sources. Projecting
+	// metadata INTO an assertion only makes sense when Warden mints it — on a
+	// reused/caller-supplied token Warden does not control the claims. But the same
+	// list also names which claims may be templated into a request path
+	// ({{agent.<claim>}}), and that holds for a forwarded agent token too: the values
+	// are login-derived and Warden-verified whichever way the subject travels. So
+	// agent_identity is permitted, where it gates templating alone.
+	if config[ConfigAssertionMetadataClaims] != "" &&
+		!mintsAssertion && config[ConfigSubjectTokenSource] != SourceAgentIdentity {
+		return fmt.Errorf("field '%s': is valid only when the subject or actor is '%s', or the subject is '%s'",
+			ConfigAssertionMetadataClaims, SourceWardenIdentity, SourceAgentIdentity)
 	}
 	// Projecting user claims into the assertion's warden_user claim (which also
 	// scopes a per-user secret_path) only makes sense when Warden mints the assertion.

--- a/credential/exchange_test.go
+++ b/credential/exchange_test.go
@@ -366,9 +366,21 @@ func TestValidateExchangeSpecConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "assertion_metadata_claims without warden_identity",
+			// agent_identity mints no assertion, so nothing is projected into one —
+			// but the same list names what {{agent.<claim>}} may template, and that
+			// works on a forwarded agent token too.
+			name: "assertion_metadata_claims with agent_identity",
 			config: map[string]string{
 				ConfigSubjectTokenSource:      SourceAgentIdentity,
+				ConfigAssertionMetadataClaims: "team",
+			},
+		},
+		{
+			// user_identity carries neither job: no assertion is minted, and the
+			// agent's claims are not what a user-subject spec templates on.
+			name: "assertion_metadata_claims with user_identity",
+			config: map[string]string{
+				ConfigSubjectTokenSource:      SourceUserIdentity,
 				ConfigAssertionMetadataClaims: "team",
 			},
 			wantErr: true,

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -2,8 +2,12 @@ package credential
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -705,13 +709,51 @@ func chainedSecretCacheKey(nsID, secretRef string, caller Caller, inputsB *Excha
 	if inputsB != nil {
 		fp = inputsB.Fingerprint()
 	}
+
+	// The agent's claims can select which secret is fetched — a templated path
+	// resolves from them — so they must key the entry that answers for it. The
+	// fingerprint alone does not cover them: where the subject is the agent's raw
+	// token, it hashes the token bytes, while the claims are derived from those
+	// bytes AND the auth role's own mapping (which claim names the principal, which
+	// become metadata). One token presented under two roles therefore resolves two
+	// sets of claims behind one fingerprint, and editing a role's mapping changes
+	// them under a fingerprint that does not move at all.
+	agent := ""
+	if inputsB != nil && len(inputsB.AgentClaims) > 0 {
+		agent = ":a:" + claimsFingerprint(inputsB.AgentClaims)
+	}
+
 	if inputsB != nil && len(inputsB.UserClaims) > 0 {
 		if caller.User == nil {
 			return ""
 		}
-		return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + ":u:" + caller.User.TokenID
+		return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent + ":u:" + caller.User.TokenID
 	}
-	return "chainsecret:" + nsID + ":" + secretRef + ":" + fp
+	return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent
+}
+
+// claimsFingerprint hashes a claim map stably: keys sorted so map order cannot
+// change the result, and each field length-prefixed so no two maps can collide by
+// running their bytes together differently.
+func claimsFingerprint(claims map[string]string) string {
+	keys := make([]string, 0, len(claims))
+	for k := range claims {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	writeField := func(s string) {
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s)))
+		h.Write(lenBuf[:])
+		h.Write([]byte(s))
+	}
+	for _, k := range keys {
+		writeField(k)
+		writeField(claims[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // copyStringMap returns a shallow copy so a cached secret's Data map is never shared

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -1303,3 +1303,80 @@ func TestManager_IssueCredential_PerUserCacheDimension(t *testing.T) {
 
 	assert.Equal(t, int32(3), factory.driver.mintCalls.Load(), "three distinct cache keys → three mints")
 }
+
+// TestChainedSecretCacheKey_AgentClaimsDimension pins the invariant the templating
+// feature depends on: anything that can select which secret is fetched has to key
+// the entry that answers for it.
+//
+// The fingerprint alone does not cover the agent's claims. Where the subject is the
+// agent's raw token it hashes the token bytes, but the claims are derived from those
+// bytes AND the auth role's mapping — so one token under two roles yields two claim
+// sets behind one fingerprint. Without the ":a:" dimension those two share an entry
+// and one is served the other's secret.
+func TestChainedSecretCacheKey_AgentClaimsDimension(t *testing.T) {
+	caller := Caller{TokenID: "agent-token"}
+	base := func(agentClaims map[string]string) *ExchangeInputs {
+		return &ExchangeInputs{
+			SubjectToken:     "the.same.jwt",
+			SubjectTokenType: TokenTypeJWT,
+			AgentClaims:      agentClaims,
+		}
+	}
+
+	t.Run("same token, different resolved claims, different keys", func(t *testing.T) {
+		viaRoleA := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "build-runner"}))
+		viaRoleB := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "deploy-bot"}))
+
+		require.NotEmpty(t, viaRoleA)
+		assert.NotEqual(t, viaRoleA, viaRoleB,
+			"one token presented under two roles resolves two principals; sharing a key would serve one the other's secret")
+	})
+
+	t.Run("same claims give the same key", func(t *testing.T) {
+		first := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "a", "team": "platform"}))
+		second := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"team": "platform", "sub": "a"}))
+		assert.Equal(t, first, second, "map iteration order must not change the key")
+	})
+
+	t.Run("a metadata claim changing moves the key", func(t *testing.T) {
+		before := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "a", "team": "platform"}))
+		after := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "a", "team": "infra"}))
+		assert.NotEqual(t, before, after)
+	})
+
+	t.Run("no agent claims keeps the key byte-identical", func(t *testing.T) {
+		withNone := chainedSecretCacheKey("ns", "ref", caller, base(nil))
+		legacy := "chainsecret:ns:ref:" + base(nil).Fingerprint()
+		assert.Equal(t, legacy, withNone,
+			"a spec not carrying agent claims must not have its cache key perturbed")
+	})
+}
+
+// The agent and user dimensions are independent: a per-user chained fetch under two
+// agents must still separate by agent.
+func TestChainedSecretCacheKey_AgentAndUserDimensionsCompose(t *testing.T) {
+	caller := Caller{TokenID: "agent-token", User: &UserContext{TokenID: "user-token"}}
+	key := func(sub string) string {
+		return chainedSecretCacheKey("ns", "ref", caller, &ExchangeInputs{
+			SubjectToken:     "the.same.jwt",
+			SubjectTokenType: TokenTypeJWT,
+			AgentClaims:      map[string]string{"sub": sub},
+			UserClaims:       map[string]string{"sub": "alice"},
+		})
+	}
+	a, b := key("build-runner"), key("deploy-bot")
+	require.Contains(t, a, ":u:user-token")
+	assert.NotEqual(t, a, b)
+}
+
+// claimsFingerprint must not let two different maps collide by running their bytes
+// together differently.
+func TestClaimsFingerprint_NoConcatenationCollisions(t *testing.T) {
+	assert.NotEqual(t,
+		claimsFingerprint(map[string]string{"ab": "c"}),
+		claimsFingerprint(map[string]string{"a": "bc"}))
+	assert.NotEqual(t,
+		claimsFingerprint(map[string]string{"a": "b", "c": "d"}),
+		claimsFingerprint(map[string]string{"a": "bcd"}))
+	assert.NotContains(t, claimsFingerprint(map[string]string{"sub": "SECRETVALUE"}), "SECRETVALUE")
+}

--- a/e2e/fullchain/github_test.go
+++ b/e2e/fullchain/github_test.go
@@ -409,3 +409,204 @@ func TestGitHub_ChainedAppKeyMintsWithStoreHeldKey(t *testing.T) {
 		}
 	}
 }
+
+// --- per-agent keys via {{agent.sub}} ---
+
+const (
+	// A templated path: each agent reads its own key. The Warden-side spec holds
+	// one string; which secret it resolves to is decided by who is asking.
+	githubPerAgentKeyPath = "e2e/fc-gh-agent-keys"
+
+	githubPerAgentSecretSpec = "fc-gh-per-agent-key"
+	githubPerAgentSpec       = "fc-gh-per-agent-cred"
+
+	// One role, both agents. A role pins the spec its callers mint, and nothing
+	// about it enters a cache key — so sharing it removes the last variable that
+	// could be mistaken for what isolates the two agents.
+	githubPerAgentRole = "fc-gh-per-agent"
+
+	// The two agents. Both are seeded Hydra clients; the second doubles as the
+	// fullchain user principal elsewhere, which is unrelated to its use here.
+	githubAgentA = "e2e-agent"
+	githubAgentB = "e2e-pipeline"
+)
+
+// serveGitHubPerAgentInstallToken answers the installation-token call with a token
+// derived from whichever key signed the assertion. That mapping is what turns the
+// row from "a token came back" into "this agent's own key minted it" — and it is
+// what a cache keyed by anything less than the key would collapse.
+func serveGitHubPerAgentInstallToken(t *testing.T, tokenForKey map[*rsa.PrivateKey]string) {
+	t.Helper()
+	upstream.SetHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodPost && r.URL.Path == githubInstallPath {
+			assertion := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			for key, token := range tokenForKey {
+				if assertionSignedBy(assertion, key) {
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte(`{"token":"` + token +
+						`","expires_at":"` + time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + `"}`))
+					return
+				}
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+}
+
+// setupGitHubPerAgentChain parks one key per agent under the templated path and
+// builds a single consuming spec, reached through a single role, that both agents
+// mint through.
+func setupGitHubPerAgentChain(t *testing.T, env h.ProviderEnv, keyPEMByAgent map[string]string) {
+	t.Helper()
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+githubPerAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+githubPerAgentSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+githubPerAgentSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	for agent, keyPEM := range keyPEMByAgent {
+		body, err := json.Marshal(map[string]any{"data": map[string]string{"private_key": keyPEM}})
+		if err != nil {
+			t.Fatalf("encoding %s's App private key: %v", agent, err)
+		}
+		path := "secret/data/" + githubPerAgentKeyPath + "/" + agent
+		if status, resp := h.VaultDirectRequest(t, "POST", path, string(body)); status >= 400 {
+			t.Fatalf("parking %s's App private key (status %d): %s", agent, status, resp)
+		}
+	}
+
+	// The templated referenced spec. {{agent.sub}} needs no assertion_metadata_claims
+	// entry — the principal is not an opt-in disclosure, and it is already inside the
+	// cache identity, so nothing can be served across agents.
+	mustWrite("POST", "sys/cred/specs/"+githubPerAgentSecretSpec, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"`+githubPerAgentKeyPath+`/{{agent.sub}}",
+			"subject_token_source":"agent_identity"}}`,
+		"create the templated secret spec")
+
+	// secret_cache_ttl belongs to the consumer, which is what the minting layer reads
+	// it from. It routes the fetch through the chained-secret cache rather than
+	// around it, so the row exercises that branch at all — without it the cache is
+	// never consulted here.
+	//
+	// It does not by itself prove the cache key separates two agents: these two
+	// present different tokens, so their fingerprints differ whatever else the key
+	// carries. What the key must ALSO cover is the claims a templated path resolves
+	// from, which are a function of the auth role's mapping and not of the token
+	// alone — two roles over one token would otherwise share an entry. That is
+	// pinned where it can be constructed, in the manager's own tests.
+	mustWrite("POST", "sys/cred/specs/"+githubPerAgentSpec, `{
+		"type":"github_token","source":"`+env.Source()+`","config":{
+			"mint_method":"app","app_id":"`+githubAppID+`",
+			"installation_id":"`+githubInstallationID+`",
+			"secret_spec":"`+githubPerAgentSecretSpec+`","secret_field":"private_key",
+			"secret_cache_ttl":"5m"}}`,
+		"create the per-agent consuming spec")
+
+	// The role binds no subject, so any agent the issuer vouches for reaches this
+	// one spec — which is the arrangement the row is about.
+	mustWrite("POST", "auth/jwt/role/"+githubPerAgentRole, `{
+		"token_policies":["`+env.Policy()+`"],"cred_spec_name":"`+githubPerAgentSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the shared per-agent role")
+}
+
+// TestGitHub_PerAgentChainedKey is what {{agent.sub}} exists for: one spec, holding
+// one path, resolving a different key for each agent that mints through it.
+//
+// Two things are proved at once, and neither is reachable without the other. That
+// the template resolved per agent at all — agent B's assertion is signed by B's
+// key, which lives at a path A's request never touched. And that nothing between
+// the two collapsed them: agent A mints first, warming every cache on the way, so a
+// cache keyed by less than the key material would hand B agent A's token.
+//
+// A JWT agent leg rather than a certificate, because agent_identity forwards the
+// agent's own inbound JWT as the exchange subject and fails closed otherwise.
+func TestGitHub_PerAgentChainedKey(t *testing.T) {
+	ensureEnv(t)
+
+	keyPEMA, keyA := githubAppKeyPEM(t)
+	keyPEMB, keyB := githubAppKeyPEM(t)
+	const tokenA = "ghs_fc_e2e_for_agent_a_not_a_real_token"
+	const tokenB = "ghs_fc_e2e_for_agent_b_not_a_real_token"
+
+	// The mount's own source and spec still need an inline key to be created with;
+	// the per-agent chain below is what the row actually drives.
+	seedPEM, seedKey := githubAppKeyPEM(t)
+	env, _ := setupGitHubAppEnv(t, seedPEM, seedKey)
+	useJWTAgentLeg(t, env)
+
+	serveGitHubPerAgentInstallToken(t, map[*rsa.PrivateKey]string{keyA: tokenA, keyB: tokenB})
+	setupGitHubPerAgentChain(t, env, map[string]string{
+		githubAgentA: keyPEMA,
+		githubAgentB: keyPEMB,
+	})
+	upstream.Reset()
+
+	// Same role, same spec, same path — only the agent differs.
+	mintAs := func(clientID, secret string) {
+		t.Helper()
+		status, body, _ := h.ChainRequest(t, leaderPort, env, h.ChainOpts{
+			AgentToken: h.GetJWT(t, clientID, secret),
+			Role:       githubPerAgentRole,
+		})
+		if status != 200 {
+			t.Fatalf("%s got status %d: %s", clientID, status, body)
+		}
+	}
+
+	mintAs(githubAgentA, "agent-secret")
+	mintAs(githubAgentB, "pipeline-secret")
+
+	// Each agent's proxied request must carry the token minted from its own key.
+	var injected []string
+	for _, req := range upstream.Requests() {
+		if req.Method == http.MethodPost && req.Path == githubInstallPath {
+			continue
+		}
+		if got := req.Header.Get("Authorization"); got != "" {
+			injected = append(injected, got)
+		}
+	}
+	if len(injected) != 2 {
+		t.Fatalf("expected 2 proxied requests, got %d: %v", len(injected), injected)
+	}
+	if injected[0] != "token "+tokenA {
+		t.Errorf("agent A was injected %q, want the token minted from its own key", injected[0])
+	}
+	if injected[1] != "token "+tokenB {
+		t.Errorf("agent B was injected %q, want the token minted from its own key — "+
+			"receiving agent A's would mean a cache collapsed two agents onto one entry", injected[1])
+	}
+
+	// And each mint really ran: two distinct keys cannot share one installation call.
+	var mints int
+	for _, req := range upstream.Requests() {
+		if req.Method == http.MethodPost && req.Path == githubInstallPath {
+			mints++
+		}
+	}
+	if mints != 2 {
+		t.Errorf("upstream saw %d installation-token mints, want one per agent", mints)
+	}
+}

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -435,8 +435,15 @@ vault_api POST "auth/jwt/config" \
 
 # Hydra client-credentials tokens carry an empty aud, so the role binds the
 # subject instead — which for those tokens is the client id.
+#
+# A list rather than one subject, because a chained secret fetched with
+# agent_identity federates as the calling agent: a row proving two agents resolve
+# different secrets needs both of them able to log in here. Still a closed list —
+# an unknown client is refused exactly as before. bound_subject is cleared in the
+# same write on purpose: a role write merges, so leaving it set would silently keep
+# the single-subject restriction in force.
 vault_api POST "auth/jwt/role/warden-e2e-fed" \
-  '{"role_type":"jwt","bound_subject":"e2e-agent","user_claim":"sub","bound_issuer":"http://localhost:4444","token_policies":["e2e-secrets-reader"],"token_ttl":"1h"}'
+  '{"role_type":"jwt","bound_subject":"","bound_claims":{"sub":["e2e-agent","e2e-pipeline"]},"user_claim":"sub","bound_issuer":"http://localhost:4444","token_policies":["e2e-secrets-reader"],"token_ttl":"1h"}'
 
 # Verify the federation login works, so a later gateway 401 is not mistaken for
 # a chaining bug.


### PR DESCRIPTION
Adds `{{agent.<claim>}}` beside the existing `{{user.<claim>}}`, so a referenced spec's `secret_path` can resolve to a different secret per calling agent.

## The gap

A referenced `secret_spec` is minted as the caller, so the store's authorization is already per-agent. But `secret_path` is a fixed string, so every agent sharing a consuming spec resolved the **same** secret. Per-agent divergence could not be expressed at all — which is also why the app-token cache defect fixed in #521 had no end-to-end proof: that needs two agents on one spec holding two different keys.

## What changed

**Under `warden_identity`, the projection already existed and was thrown away.** `buildAssertionSetup` projects the agent's allow-listed metadata, embeds it in the assertion, and folds its fingerprint into the cache identity — but never surfaced it, where the user side surfaces its own for exactly this purpose. It only needed passing through.

**Under `agent_identity` nothing had projected it**, since no assertion is minted, so it is projected there for templating alone.

**No new config key.** `assertion_metadata_claims` names the templatable claims on both paths. Its validation is relaxed to permit `agent_identity`, where the key gates templating rather than assertion contents. `{{agent.sub}}` needs no listing — it is the principal the assertion already carries unconditionally.

One list rather than two is load-bearing, not tidiness: under `warden_identity` that list is exactly the fingerprinted set, so *templatable ⊆ cache-covered* holds by construction. A second list could name a claim outside the fingerprint, and two sessions of one principal differing only in that claim would then share a cache entry.

**One regex covers both namespaces.** Every rule after substitution — the value allow-list, the traversal check, the leftover-fragment check — is the same whichever principal supplied the value, and a single pass lets one path mix them.

## A cache fix this required

The chained-secret cache key now folds the agent's claims. The invariant is that anything selecting *what is fetched* must key the entry that answers for it, and the fingerprint alone does not satisfy it: where the subject is the agent's raw token it hashes the token bytes, while the claims are derived from those bytes **and the auth role's own mapping** — which claim names the principal, which become metadata. One token presented under two roles therefore resolves two paths behind one fingerprint, and editing a role's mapping changes the claims without moving the fingerprint at all.

Byte-identical for any spec carrying no agent claims.

## Security

Path templating is a **selector, never an authorizer**. It chooses which path Warden asks for; the authorizer is the store's policy evaluated against the federated login. For the tenancy boundary to be real, that policy must template on the same claim. With a static subtree grant the boundary rests entirely on Warden's template and cache correctness. The user side has always shared this property; it is a deployment matter, not code.

`{{agent.role}}` is deliberately **not** exposed, despite being the better selector on trust grounds — a role is operator-assigned, so unlike an IdP-supplied claim an agent cannot influence it. `wardenSubject` covers namespace and mount but not role, so one principal under two roles would resolve two paths while sharing one cache identity. Exposing it needs `RoleName` folded into the cache identity, which perturbs every existing key. Worth noting that gap already exists for the assertion itself, independent of this change.

## Testing

Unit tests cover the templating rules per namespace (substitution, composition of both, the value allow-list, traversal, leftover fragments, fail-closed on an absent claim), the projection's semantics including `sub` precedence over a metadata key of the same name, and the cache-key dimension.

The e2e row is what this unblocks: two agents, one role, one spec, one templated path, each resolving its own App private key. It fails against a driver cache keyed by less than the key material — mutation-verified, with agent B receiving agent A's token — which no test could previously show.

## Not included

Docs, per the release-prep convention.
