### PR TITLE
fix(credential): key the cache identity on the caller's role

### DIFF
--- a/core/oidc_issuer_test.go
+++ b/core/oidc_issuer_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 
@@ -1082,4 +1083,74 @@ func TestOIDCIssuer_Mint_WardenUserAndSubClaims(t *testing.T) {
 	assert.Equal(t, "alice-raw-sub", wu["sub"])
 	assert.Equal(t, "alice", wu["username"])
 	assert.Len(t, wu, 2)
+}
+
+// TestMintIdentityAssertion_ClaimRoster is a tripwire, not a behaviour test.
+//
+// Every claim below is something a downstream may bind its authorization to, so
+// every one of them has to be inside a cache key — otherwise a cached answer can be
+// served to a caller who would have been told something different. warden_role was
+// exactly that defect: minted, documented as bindable, and in no key, so one
+// principal's two roles shared a chained-secret entry.
+//
+// Adding a claim without a matching cache dimension re-opens that class, and nothing
+// else would notice. This fails when the roster changes, so whoever adds a claim has
+// to come here and record which dimension covers it.
+//
+// It can only see what this mint emits, so a claim gated behind a new input would
+// ship past it silently: enable any new conditional claim in the mint below, or the
+// tripwire is blind to exactly the case it exists for.
+//
+//	iss/iat/nbf/exp/jti  volatile or constant by design — the reason cacheIdentity
+//	                     exists at all, rather than keying on the assertion bytes
+//	sub                  cacheIdentity's first fragment (wardenSubject)
+//	aud                  cacheIdentity's second fragment
+//	warden_sub           inside wardenSubject
+//	warden_namespace     inside wardenSubject, which carries the namespace ID while
+//	                     this claim carries the path — sound only because a namespace
+//	                     cannot be renamed, so path and ID move together (a rename API
+//	                     would make this claim uncovered)
+//	warden_auth_mount    inside wardenSubject
+//	warden_role          cacheIdentity's "role=" fragment
+//	warden_resource      cacheIdentity's "res=" fragment
+//	warden_metadata      cacheIdentity's metadata fingerprint
+//	warden_user          the ":u:" token-id dimension on the manager's cache keys,
+//	                     deliberately not in cacheIdentity (see buildAssertionSetup)
+func TestMintIdentityAssertion_ClaimRoster(t *testing.T) {
+	iss := newReadyIssuer(t, "https://warden-oidc.example")
+	te := &logical.TokenEntry{
+		PrincipalID:   "spiffe://acme.internal/agent/refund-bot",
+		RoleName:      "payments-agent",
+		NamespaceID:   "ns-1234",
+		NamespacePath: "/acme/prod/",
+		MountAccessor: "auth_jwt_abc",
+	}
+
+	// Every optional claim populated, so the roster is the full surface rather than
+	// whatever a minimal mint happens to emit.
+	token, err := iss.MintIdentityAssertion(context.Background(), te, AssertionClaims{
+		Audience:   "https://sts.example/aud",
+		TTL:        5 * time.Minute,
+		Alg:        oidcAlgRS256,
+		Metadata:   map[string]string{"team": "payments"},
+		Resource:   "https://api.example/db",
+		UserClaims: map[string]string{"sub": "alice"},
+	})
+	require.NoError(t, err)
+
+	claims := decodeAssertionClaims(t, token)
+
+	got := make([]string, 0, len(claims))
+	for k := range claims {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"aud", "exp", "iat", "iss", "jti", "nbf", "sub",
+		"warden_auth_mount", "warden_metadata", "warden_namespace",
+		"warden_resource", "warden_role", "warden_sub", "warden_user",
+	}
+	assert.Equal(t, want, got,
+		"the assertion's claims changed: add the new claim to a cache dimension (see the table above), then update this roster")
 }

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -1584,8 +1584,8 @@ type assertionSetup struct {
 
 // buildAssertionSetup validates the OIDC issuer is ready and derives the
 // audience, resource, and projected metadata for a warden_identity assertion of
-// te, returning a stable cache fragment (identity + audience [+ resource]
-// [+ metadata]) and a lazy mint closure. It is source-type agnostic, so the same
+// te, returning a stable cache fragment (identity + audience [+ role]
+// [+ resource] [+ metadata]) and a lazy mint closure. It is source-type agnostic, so the same
 // setup serves a WIF subject (the agent IS the identity) and a delegation actor
 // (the agent acts for the subject-header user). loadSource is passed in so the
 // spec's source is fetched at most once per request across both slots.
@@ -1694,9 +1694,32 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 	// source config, which can change under a fixed specName) and the projected-
 	// metadata fingerprint. Each fragment is appended only when non-empty, so the
 	// no-resource / no-metadata cache keys stay byte-for-byte unchanged; the
-	// resource fragment is kept before mdFingerprint (marshalled JSON starting with
-	// '{') so the fragments can never be confused.
+	// fragments carry mutually non-prefix leads — "role=", "res=", and the '{' of
+	// the marshalled metadata JSON — so one fragment's start cannot be read as
+	// another's.
+	//
+	// That disambiguates starts, not contents: a value holding a NUL could spell a
+	// later fragment that is itself absent. Nothing can reach it — role names are
+	// restricted to word characters at creation, and audience and resource come from
+	// one spec's config — so the alternative, length-prefixing every fragment, would
+	// buy an unreachable case at the cost of changing every existing key.
+	//
+	// The role is folded in because the assertion asserts it (warden_role) and a
+	// downstream is invited to authorize on it, so the answer it gives can differ
+	// per role while subject, audience, resource and metadata are all identical.
+	// Leaving it out let a caller be served a secret fetched under a role it never
+	// presented — the chained-secret cache shares a fetch across an agent's
+	// sessions by design, and without this fragment two roles are one agent to it.
+	// Appended only when set. Minting needs a principal, not a role, so a role-less
+	// entry can mint — every auth method simply requires a role at login today, which
+	// is what makes the empty case unreachable rather than anything here. Should that
+	// ever change, role-less tokens share one key and assert an empty role, which is
+	// still consistent; and until then the conditional keeps every key that predates
+	// this fragment byte-identical.
 	cacheIdentity := wardenSubject(te) + "\x00" + audience
+	if te.RoleName != "" {
+		cacheIdentity += "\x00role=" + te.RoleName
+	}
 	if resource != "" {
 		cacheIdentity += "\x00res=" + resource
 	}
@@ -1728,6 +1751,27 @@ func (c *Core) buildAssertionSetup(ctx context.Context, specName string, spec *c
 }
 
 // mintCredentialForRequest mints credentials for requests using the credential manager
+// callerFor carries the requesting identity through the mint pipeline so a chained
+// secret-spec (credential chaining) is minted as this same caller.
+//
+// ResolveInputs resolves token-exchange inputs for an arbitrary spec as this caller
+// (nil for non-exchange specs), reused both for the request's own spec and, by the
+// Manager, for any referenced secret-spec. It must resolve from THIS token entry:
+// the identity it derives keys the chained-secret cache, which shares one fetch
+// across an agent's sessions rather than asking the store again, so an entry
+// reconstructed from anything less than the live one — losing the role, say — would
+// hand a caller a secret fetched under an identity it never presented.
+func (c *Core) callerFor(req *logical.Request, te *logical.TokenEntry, tokenTTL time.Duration, userCtx *credential.UserContext) credential.Caller {
+	return credential.Caller{
+		TokenID:  te.ID,
+		TokenTTL: tokenTTL,
+		User:     userCtx,
+		ResolveInputs: func(ctx context.Context, specName string) (*credential.ExchangeInputs, error) {
+			return c.resolveExchangeInputs(ctx, req, te, specName)
+		},
+	}
+}
+
 func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Request, te *logical.TokenEntry) error {
 	if te == nil {
 		return logical.ErrInternal("cannot mint credential since token entry is nil")
@@ -1788,19 +1832,7 @@ func (c *Core) mintCredentialForRequest(ctx context.Context, req *logical.Reques
 		userCtx = &credential.UserContext{TokenID: ute.ID, TokenTTL: userTTL}
 	}
 
-	// The caller carries the requesting identity through the mint pipeline so a
-	// chained secret-spec (credential chaining) is minted as this same caller.
-	// ResolveInputs resolves token-exchange inputs for an arbitrary spec as this
-	// caller (nil for non-exchange specs), reused both for the outer spec below and
-	// for any referenced secret-spec by the Manager.
-	caller := credential.Caller{
-		TokenID:  te.ID,
-		TokenTTL: tokenTTL,
-		User:     userCtx,
-		ResolveInputs: func(ctx context.Context, specName string) (*credential.ExchangeInputs, error) {
-			return c.resolveExchangeInputs(ctx, req, te, specName)
-		},
-	}
+	caller := c.callerFor(req, te, tokenTTL, userCtx)
 
 	// Resolve any caller-supplied token-exchange inputs the spec opts into.
 	// Returns nil for non-exchange specs, leaving the mint path unchanged.

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -2984,3 +2984,182 @@ func TestResolveExchangeInputs_RetiredSourceFailsClosedAtMint(t *testing.T) {
 		assert.Contains(t, err.Error(), "header")
 	})
 }
+
+// TestResolveExchangeInputs_WardenIdentity_RoleIsolatesCacheIdentity pins the role
+// fragment. The assertion asserts warden_role and a downstream is invited to
+// authorize on it, so two roles can get different answers from the same store while
+// subject, audience, resource and metadata are identical — and the chained-secret
+// cache shares a fetch across an agent's sessions rather than asking again. Without
+// this fragment those two roles are one agent to it.
+func TestResolveExchangeInputs_WardenIdentity_RoleIsolatesCacheIdentity(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	c.oidcIssuer = newReadyIssuer(t, "https://warden-oidc.example")
+	seedSpec(t, c, ctx, "wid-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:  "https://sts.example/aud",
+	})
+
+	req := requestWith("s.opaque-session", nil)
+	entry := func(role string) *logical.TokenEntry {
+		return &logical.TokenEntry{
+			CredentialSpec: "wid-spec",
+			PrincipalID:    "spiffe://acme/agent/bot",
+			NamespaceID:    "ns1",
+			MountAccessor:  "auth_jwt_1",
+			RoleName:       role,
+		}
+	}
+	identityFor := func(te *logical.TokenEntry) *credential.ExchangeInputs {
+		t.Helper()
+		inputs, err := resolveExchangeInputsForTest(c, ctx, req, te)
+		require.NoError(t, err)
+		return inputs
+	}
+
+	readTE, writeTE := entry("reader"), entry("writer")
+	read, write := identityFor(readTE), identityFor(writeTE)
+
+	assert.Equal(t,
+		wardenSubject(readTE)+"\x00"+"https://sts.example/aud"+"\x00role=reader",
+		read.SubjectCacheIdentity)
+	assert.NotEqual(t, read.SubjectCacheIdentity, write.SubjectCacheIdentity,
+		"one principal under two roles must not share a cache identity")
+
+	// The fingerprint is what the caches actually key on, so the isolation has to
+	// survive that far — a fragment the fingerprint ignored would prove nothing.
+	assert.NotEqual(t, read.Fingerprint(), write.Fingerprint())
+
+	// A token carrying no role keeps the pre-fragment bytes. This is the byte
+	// stability the conditional buys, and what lets every older pinned literal in
+	// this file stand unchanged.
+	noRole := entry("")
+	assert.Equal(t,
+		wardenSubject(noRole)+"\x00"+"https://sts.example/aud",
+		identityFor(noRole).SubjectCacheIdentity)
+}
+
+// A role value shaped like another fragment's lead must not be readable as that
+// fragment. Each carries a fixed, mutually non-prefix prefix for exactly this.
+func TestResolveExchangeInputs_WardenIdentity_RoleCannotImpersonateAnotherFragment(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	c.oidcIssuer = newReadyIssuer(t, "https://warden-oidc.example")
+	seedSpec(t, c, ctx, "wid-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:  "https://sts.example/aud",
+		credential.ConfigAssertionResource:  "https://api.example/db",
+	})
+
+	req := requestWith("s.opaque-session", nil)
+	base := func(role string) *logical.TokenEntry {
+		return &logical.TokenEntry{
+			CredentialSpec: "wid-spec",
+			PrincipalID:    "spiffe://acme/agent/bot",
+			NamespaceID:    "ns1",
+			MountAccessor:  "auth_jwt_1",
+			RoleName:       role,
+		}
+	}
+	identity := func(te *logical.TokenEntry) string {
+		t.Helper()
+		inputs, err := resolveExchangeInputsForTest(c, ctx, req, te)
+		require.NoError(t, err)
+		return inputs.SubjectCacheIdentity
+	}
+
+	// Ordering is part of the contract: role precedes the resource fragment.
+	spoof := base("x\x00res=https://api.example/other")
+	assert.Equal(t,
+		wardenSubject(spoof)+"\x00"+"https://sts.example/aud"+
+			"\x00role=x\x00res=https://api.example/other"+
+			"\x00res=https://api.example/db",
+		identity(spoof),
+		"a role carrying another fragment's lead must still sit behind its own prefix")
+
+	assert.NotEqual(t, identity(base("x")), identity(spoof))
+}
+
+// The delegation shape keys the actor on the same identity, so the fragment has to
+// reach it too — the agent whose role varies is the actor there, not the subject.
+func TestResolveExchangeInputs_ActorWardenIdentity_RoleIsolatesCacheIdentity(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	c.oidcIssuer = newReadyIssuer(t, "https://warden-oidc.example")
+	// An actor token requires a token_exchange source, so seed that shape.
+	seedExchangeSpec(t, c, ctx, "deleg-spec", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceUserIdentity,
+		credential.ConfigActorTokenSource:   credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:  "https://sts.example/aud",
+	})
+
+	req := requestWith("s.opaque-session", nil)
+	req.User = &logical.UserPrincipal{TokenEntry: &logical.TokenEntry{}, RawToken: "eyJ.user"}
+
+	actorIdentity := func(role string) string {
+		t.Helper()
+		te := &logical.TokenEntry{
+			CredentialSpec: "deleg-spec",
+			PrincipalID:    "spiffe://acme/agent/bot",
+			NamespaceID:    "ns1",
+			MountAccessor:  "auth_jwt_1",
+			RoleName:       role,
+		}
+		inputs, err := resolveExchangeInputsForTest(c, ctx, req, te)
+		require.NoError(t, err)
+		return inputs.ActorCacheIdentity
+	}
+
+	assert.NotEqual(t, actorIdentity("reader"), actorIdentity("writer"),
+		"the actor slot keys on the same identity, so the role must isolate it too")
+}
+
+// TestResolveExchangeInputs_ChainedReferencedSpec_CarriesCallerRole pins the seam
+// the per-role isolation actually depends on.
+//
+// A chained mint resolves the REFERENCED spec's inputs through the caller closure,
+// with a spec name that is not the caller's own. The manager keys the chained-secret
+// cache on whatever identity that returns, and treats it opaquely — so if this
+// resolution ever stopped carrying the live token entry (re-fetching it, or
+// rebuilding one from principal and mount without the role), two roles would collapse
+// to one cached secret again while every other test stayed green: the direct-path
+// tests would still pass, and the manager's own tests build identities by hand.
+func TestResolveExchangeInputs_ChainedReferencedSpec_CarriesCallerRole(t *testing.T) {
+	c, ctx := exchangeResolveEnv(t)
+	c.oidcIssuer = newReadyIssuer(t, "https://warden-oidc.example")
+
+	// The consumer chains; the referenced spec is what mints the assertion.
+	seedSpec(t, c, ctx, "referenced-secret", map[string]string{
+		credential.ConfigSubjectTokenSource: credential.SourceWardenIdentity,
+		credential.ConfigAssertionAudience:  "https://sts.example/aud",
+	})
+	seedSpec(t, c, ctx, "consumer", map[string]string{
+		credential.ConfigSecretSpec: "referenced-secret",
+	})
+
+	req := requestWith("s.opaque-session", nil)
+	referencedInputs := func(role string) *credential.ExchangeInputs {
+		t.Helper()
+		te := &logical.TokenEntry{
+			CredentialSpec: "consumer",
+			PrincipalID:    "spiffe://acme/agent/bot",
+			NamespaceID:    "ns1",
+			MountAccessor:  "auth_jwt_1",
+			RoleName:       role,
+		}
+		// Through the caller the mint pipeline actually builds, resolving the
+		// REFERENCED spec rather than the caller's own — the shape the closure
+		// exists for. Calling resolveExchangeInputs directly would bypass the very
+		// seam this pins.
+		inputs, err := c.callerFor(req, te, time.Hour, nil).ResolveInputs(ctx, "referenced-secret")
+		require.NoError(t, err)
+		require.NotNil(t, inputs)
+		return inputs
+	}
+
+	reader, writer := referencedInputs("reader"), referencedInputs("writer")
+
+	// Format-independent: the manager only ever sees the fingerprint, so that is
+	// what has to diverge. Asserting bytes here would restate core's own literals.
+	assert.NotEqual(t, reader.Fingerprint(), writer.Fingerprint(),
+		"a chained fetch must resolve a different identity per caller role")
+	assert.Equal(t, reader.Fingerprint(), referencedInputs("reader").Fingerprint(),
+		"the same role must resolve a stable identity, or the cache could never share")
+}

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -620,3 +620,44 @@ func TestChaining_CacheTTLSpecOptOut(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(), "spec-level 0 opts out of source TTL")
 }
+
+// TestChaining_CacheIsolatesPerRole: one principal authenticating under two roles
+// must not share a cached secret, even though everything else about its identity
+// matches.
+//
+// This is the cache that shares a fetch across an agent's sessions rather than
+// asking the store again, so "agent identity" has to mean everything the store was
+// shown. The assertion asserts warden_role and a downstream is invited to authorize
+// on it, so the answer can differ per role — and the second role would otherwise
+// receive a secret fetched under the first's authorization without the store ever
+// being asked. Core folds the role into the cache identity for exactly this; here
+// that shows up as the differing identity the two callers carry.
+func TestChaining_CacheIsolatesPerRole(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exchange-secret", Type: TypeVaultToken, Source: "exchangesource", Config: map[string]string{}})
+	cfg := map[string]string{ConfigSecretSpec: "exchange-secret", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+
+	// The identities differ only by the role fragment core appends — same subject,
+	// same audience, same everything else.
+	const subject = "wid:ns1:auth_jwt_1:bot\x00https://sts.example/aud"
+	reader := exchangeChainCaller("tokReader", subject+"\x00role=reader", "", nil)
+	writer := exchangeChainCaller("tokWriter", subject+"\x00role=writer", "", nil)
+
+	_, err := env.manager.IssueCredential(ctx, reader, "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, writer, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(),
+		"a second role must fetch its own secret, not inherit the first role's")
+
+	// The same role across sessions still shares — dropping that would trade this
+	// bug for the loss of the cross-session sharing the cache exists to provide.
+	_, err = env.manager.IssueCredential(ctx, exchangeChainCaller("tokReader2", subject+"\x00role=reader", "", nil), "consumer1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(),
+		"one role across two sessions must still share its cached secret")
+}

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -694,7 +694,15 @@ func (m *Manager) invalidateChainedSecret(key string) {
 // chainedSecretCacheKey scopes a cached secret to (namespace, secret_spec, agent
 // identity). inputsB.Fingerprint keys on SubjectCacheIdentity — stable across an agent's
 // sessions — so the store's per-agent authorization is honoured (agent B is never served
-// agent A's fetched secret). When the referenced fetch is user-scoped (the referenced
+// agent A's fetched secret).
+//
+// "Agent identity" has to mean everything the store was shown, since sharing a fetch
+// across sessions means never asking it again. Where an assertion is minted, that is
+// what SubjectCacheIdentity carries: subject, audience, role, resource and the projected
+// metadata — every claim a store may bind. Where the agent's own token is forwarded
+// instead, the store reads that token and the fingerprint hashes its bytes, so the only
+// inputs left to cover are the claims a templated path resolves from, which the agent
+// dimension below carries. When the referenced fetch is user-scoped (the referenced
 // spec sets assertion_user_claims, so inputsB.UserClaims is populated), the user token id
 // is folded in so one user's per-user secret is never served to another; a source-global
 // fetch (no user claims) omits it and is shared across users under the agent. A nil


### PR DESCRIPTION
The minted identity assertion asserts `warden_role`, and the docs invite a downstream store to authorize on it. The identity its results were cached under did not carry it.

## The defect

`cacheIdentity` was `wardenSubject(te)` + audience, plus conditional resource and metadata-fingerprint fragments — and `wardenSubject` is `wid:{nsID}:{mountAccessor}:{principalID}`. No role. That identity feeds `ExchangeInputs.Fingerprint()`, which keys both credential caches.

The **consumer credential cache was never exposed**: its key carries `caller.TokenID`, and two logins are two tokens. The **chained-secret cache is**, because `chainedSecretCacheKey` deliberately omits that token id so an agent's repeated sessions share one fetch rather than asking the store again.

Sharing a fetch that way means "agent identity" has to mean everything the store was shown. The role was missing from it, so one principal authenticating under two roles produced a byte-identical key: **role B was served the secret role A was authorized for, and the store was never asked whether role B may have it.**

Preconditions, all required — which is why this was latent rather than routine: two roles on one mount accepting one subject (the role is a login parameter, so nothing forbids it); a chained consuming spec whose referenced spec uses `warden_identity`; `secret_cache_ttl` set, since that cache is opt-in; and a store policy that actually distinguishes the roles.

#522's `:a:` agent-claims dimension narrowed this — it separates the keys when the two roles map a different `user_claim` or different allow-listed metadata — but left the common shape open: two roles differing only in policies, with no `assertion_metadata_claims` on the chained spec.

## The fix

One conditional `"\x00role=" + te.RoleName` fragment in `cacheIdentity`, ahead of the resource fragment. It reaches both the subject and actor slots and both caches through the single fingerprint, so no new dimension is needed in `chainedSecretCacheKey` — and the manager, which holds no token entry, does not grow one to duplicate a covered dimension.

`wardenSubject` is deliberately untouched: it is the assertion's `sub`, and its own doc records that operators bind trust policies to a prefix of it. This was a cache-side problem.

**Conditional, and that is load-bearing.** No pre-existing test needed editing — the pinned identity literals all use role-less entries, so they pass unchanged and now double as the empty-role byte-stability pin. Upgrade cost is one cache miss per identity after restart; `cacheIdentity` is in-memory only and never persisted.

`agent_identity` needs nothing. There the store is shown the raw inbound JWT — identical bytes under either role — and the role never reaches it, so the only role-dependent inputs are the projected claims #522 already covers.

## Guarding the class, not just the instance

`warden_role` was the only assertion claim outside every cache key. The general rule — every claim a store may bind must sit inside the cache identity — now has a tripwire: `TestMintIdentityAssertion_ClaimRoster` pins the minted claim set against a table mapping each claim to the dimension covering it, so a new claim fails until its author records one. This is the third defect of this shape in this area, after the github and gitlab driver caches.

## Testing

Role isolation on both slots, a fragment-confusion case, a per-role chaining isolation test at the manager layer, and the roster tripwire.

Every load-bearing decision is mutation-verified: deleting the fragment, making it unconditional, reusing the `res=` prefix, reordering it after the metadata fingerprint, moving the role into `wardenSubject`, and dropping `warden_role` from the mint each fail their own test and nothing else.

One test needed a second pass worth mentioning. The core↔manager seam — whether the chaining closure delivers a per-role identity — was first covered by a test that called `resolveExchangeInputs` directly and therefore bypassed the closure it meant to pin; simulating the refactor it guards against passed. `callerFor` is extracted so that seam is named and reachable, and the test now goes through it and fails on that mutation.

## Not included

Docs, per the release-prep convention: a note in `federation/assertion-claims.md` that every bindable claim isolates the caches, and a CHANGELOG line that cache identities now include the role, so the first request per identity after upgrade re-mints.
