### PR TITLE
feat(credential): carry the whole token_exchange client credential through the chain

### DIFF
--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -510,7 +510,9 @@ func TestCredentialConfigStore_ChainedExchangeAccepted(t *testing.T) {
 	}))
 	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
 		Name: "sts-src", Type: credential.SourceTypeTokenExchange,
-		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "rfc8693", "client_id": "warden-gateway", credential.ConfigSecretSpec: "wid-secret"},
+		// No client_id: a chained source holds neither half of the client credential,
+		// so both come from the referenced spec's payload.
+		Config: map[string]string{"token_url": "https://sts.example/token", "grant": "rfc8693", credential.ConfigSecretSpec: "wid-secret"},
 	}))
 
 	// A token_exchange consumer with secret_spec (source-level) + its own subject source

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -97,6 +97,9 @@ type mockChainedExchangeDriver struct {
 	// rejectIf, when set and returning true for the handed material, fails with
 	// ErrChainedSecretRejected (simulating an upstream invalid_client on a stale secret).
 	rejectIf func(SecretMaterial) bool
+	// incompleteIf, when set and returning true, fails with ErrChainedSecretIncomplete
+	// before anything is sent (simulating a payload missing a half of a credential).
+	incompleteIf func(SecretMaterial) bool
 }
 
 func (d *mockChainedExchangeDriver) MintCredential(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
@@ -108,6 +111,9 @@ func (d *mockChainedExchangeDriver) MintCredentialWithExchangeFromSecret(_ conte
 	d.lastMaterial = material
 	if d.rejectIf != nil && d.rejectIf(material) {
 		return nil, nil, 0, "", fmt.Errorf("upstream rejected client auth: %w", ErrChainedSecretRejected)
+	}
+	if d.incompleteIf != nil && d.incompleteIf(material) {
+		return nil, nil, 0, "", fmt.Errorf("payload missing a half: %w", ErrChainedSecretIncomplete)
 	}
 	return map[string]interface{}{"token": "exch:" + inputs.SubjectToken + ":" + material.Secret()}, nil, 0, "", nil
 }
@@ -425,6 +431,65 @@ func TestChaining_ExchangeConsumerRetriesOnRejection(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), fetches.Load(), "stale client secret evicted and re-fetched once")
 	assert.Equal(t, "exch:s2:v2", cred.Data["token"], "exchange retried with the fresh secret")
+}
+
+// TestChaining_ExchangeConsumerRetriesOnIncompletePayload covers the migration case a
+// rejection cannot: a cached payload that is missing a key the driver has since come to
+// need. Nothing downstream refuses it — it never reaches a request — so without its own
+// sentinel the entry would sit in the cache failing every mint for the whole TTL, and
+// completing the secret at the source would have no effect until it expired.
+func TestChaining_ExchangeConsumerRetriesOnIncompletePayload(t *testing.T) {
+	env := newChainingEnv(t)
+	// The referenced spec yields the old payload first, the completed one after.
+	var fetches atomic.Int32
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		val := "old"
+		if fetches.Add(1) > 1 {
+			val = "completed"
+		}
+		return map[string]interface{}{"token": val}, nil, 0, "", nil
+	}
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "exch1", Type: TypeVaultToken, Source: "exchangeconsumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "exch2", Type: TypeVaultToken, Source: "exchangeconsumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	// Prime the cache with the old payload.
+	_, err := env.manager.IssueCredential(ctx, caller, "exch1", &ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), fetches.Load())
+
+	// The driver now needs something the cached payload lacks. The second consumer hits
+	// that entry, reports it incomplete, and the manager refetches once.
+	env.exchangeConsumerDriver.incompleteIf = func(m SecretMaterial) bool { return m.Secret() == "old" }
+	cred, err := env.manager.IssueCredential(ctx, caller, "exch2", &ExchangeInputs{SubjectToken: "s2", SubjectTokenType: TokenTypeJWT})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), fetches.Load(), "incomplete cached payload evicted and re-fetched once")
+	assert.Equal(t, "exch:s2:completed", cred.Data["token"])
+}
+
+// TestChaining_IncompleteFreshPayloadIsNotRetried pins the other half of the contract:
+// only a CACHED payload is worth refetching. Re-reading one just fetched would cost a
+// second read to be told the same thing.
+func TestChaining_IncompleteFreshPayloadIsNotRetried(t *testing.T) {
+	env := newChainingEnv(t)
+	var fetches atomic.Int32
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		fetches.Add(1)
+		return map[string]interface{}{"token": "always-incomplete"}, nil, 0, "", nil
+	}
+	// No secret_cache_ttl: every mint fetches, so the material is never "from cache".
+	env.store.AddSpec(&CredSpec{Name: "exch1", Type: TypeVaultToken, Source: "exchangeconsumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+	env.exchangeConsumerDriver.incompleteIf = func(SecretMaterial) bool { return true }
+
+	_, err := env.manager.IssueCredential(createNamespaceContext(), chainCaller("tokA"), "exch1",
+		&ExchangeInputs{SubjectToken: "s", SubjectTokenType: TokenTypeJWT})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChainedSecretIncomplete)
+	assert.Equal(t, int32(1), fetches.Load(), "a freshly fetched payload is not re-fetched")
 }
 
 // exchangeChainCaller builds a Caller whose referenced-spec inputs carry a per-agent

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -61,6 +61,20 @@ var _ credential.SourceDriver = (*TokenExchangeDriver)(nil)
 var _ credential.ExchangeMinter = (*TokenExchangeDriver)(nil)
 var _ credential.ChainedExchangeMinter = (*TokenExchangeDriver)(nil)
 
+// tokenExchangeChainedAuth carries the client credential a single mint fetched
+// through credential chaining. A nil pointer means the inline source config.
+//
+// secret is whichever half client_auth calls for: the client secret for
+// client_secret_post/basic, or the PEM private key for private_key_jwt. kid is the
+// optional key id naming that private key, and is empty for the secret methods. It
+// holds fetched values only — never the mode — and is threaded by parameter rather than
+// stored on the driver, so concurrent mints resolving different pairs cannot cross.
+type tokenExchangeChainedAuth struct {
+	clientID string
+	secret   string
+	kid      string
+}
+
 // TokenExchangeDriver exchanges a caller-derived identity (a subject token, and
 // optionally an actor token) for a scoped downstream bearer at an RFC 8693 / RFC
 // 7523 token endpoint. It is exchange-only: it never mints from static source
@@ -112,11 +126,11 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("client_secret_post"),
 
 		credential.StringField("client_id").
-			Describe("OAuth2 client ID Warden presents to the token endpoint").
+			Describe("OAuth2 client ID Warden presents to the token endpoint (inline only; omit when secret_spec is set)").
 			Example("warden-gateway"),
 
 		credential.StringField("client_secret").
-			Describe("OAuth2 client secret (masked on read; for client_secret_* auth)").
+			Describe("OAuth2 client secret (masked on read; for client_secret_* auth; omit when secret_spec is set)").
 			Example("****"),
 
 		credential.StringField("private_key").
@@ -127,7 +141,7 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 				_, err := parseRSAPrivateKey(v)
 				return err
 			}).
-			Describe("PEM RSA private key for private_key_jwt client authentication (masked on read)").
+			Describe("PEM RSA private key for private_key_jwt client authentication (masked on read; omit when secret_spec is set)").
 			Example("-----BEGIN PRIVATE KEY----- ..."),
 
 		credential.StringField("client_assertion_alg").
@@ -136,7 +150,7 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("RS256"),
 
 		credential.StringField("client_assertion_kid").
-			Describe("Optional key id (kid) header for the client assertion").
+			Describe("Optional key id (kid) header for the client assertion (inline only; when secret_spec is set it travels in the referenced payload beside the key, under 'client_assertion_kid' or 'kid')").
 			Example("key-1"),
 
 		credential.StringField("ca_data").
@@ -149,12 +163,12 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("false"),
 
 		credential.StringField("secret_spec").
-			Describe("Source the client secret from another cred spec via credential chaining instead of storing it inline (client_secret / private_key then omitted)").
+			Describe("Source the whole client credential from another cred spec via credential chaining instead of storing it inline (client_id and client_secret / private_key then omitted; the referenced payload supplies both)").
 			Example("idp-client-secret"),
 
 		credential.StringField("secret_field").
-			Describe("Which field of the referenced secret_spec's credential holds the client secret (when its payload has multiple keys)").
-			Example("value"),
+			Describe("Which field of the referenced secret_spec's credential holds the client secret (when its payload has multiple keys); the client id travels beside it under 'client_id'").
+			Example("client_secret"),
 
 		credential.StringField("secret_cache_ttl").
 			Describe("Cache the chained client secret source-wide for this duration (e.g. 30m); omit to fetch it on every mint").
@@ -170,24 +184,48 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 		}
 	}
 
-	// Client-auth method determines which credentials are required. When the client
-	// secret is sourced via credential chaining (secret_spec set on the source), the
-	// inline client_secret / private_key is supplied at mint time, so only client_id is
-	// required here.
+	// Client-auth method determines which credentials are required. A source in
+	// chaining mode (secret_spec set) holds NEITHER half of the client credential: the
+	// secret is excluded because a source that reads as keyless must not still store the
+	// very secret chaining exists to remove, and the id follows it because the two
+	// authenticate as a pair. An id kept here beside a secret fetched from the chain
+	// would name one client while presenting another's, which the token endpoint answers
+	// with invalid_client, and which the chained path then reads as a rejected secret and
+	// retries pointlessly.
+	//
+	// Requiring both from the payload also lets one source and one spec serve many
+	// clients, since the pair is resolved per mint rather than pinned to the source.
 	chained := credential.GetString(config, credential.ConfigSecretSpec, "") != ""
 	switch credential.GetString(config, "client_auth", clientAuthSecretPost) {
 	case clientAuthSecretBasic, clientAuthSecretPost, "":
+		if chained {
+			if err := rejectInlineClientCredential(config, "client_secret"); err != nil {
+				return err
+			}
+			break
+		}
 		if credential.GetString(config, "client_id", "") == "" {
 			return fmt.Errorf("client_id is required for a secret-based client_auth")
 		}
-		if !chained && credential.GetString(config, "client_secret", "") == "" {
+		if credential.GetString(config, "client_secret", "") == "" {
 			return fmt.Errorf("client_secret (or secret_spec) is required for a secret-based client_auth")
 		}
 	case clientAuthPrivateKeyJWT:
+		if chained {
+			// The key id goes with the key. A kid identifies one key among the several
+			// an authorization server may hold for a client, so it is only true of the
+			// key it was stored beside — kept here, it would stamp assertions signed by
+			// every agent's key with one agent's kid, and an AS that selects its
+			// verification key by kid would refuse all but that one.
+			if err := rejectInlineClientCredential(config, "private_key", "client_assertion_kid"); err != nil {
+				return err
+			}
+			break
+		}
 		if credential.GetString(config, "client_id", "") == "" {
 			return fmt.Errorf("client_id is required for client_auth=private_key_jwt")
 		}
-		if !chained && credential.GetString(config, "private_key", "") == "" {
+		if credential.GetString(config, "private_key", "") == "" {
 			return fmt.Errorf("private_key (or secret_spec) is required for client_auth=private_key_jwt")
 		}
 	}
@@ -202,6 +240,19 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 	for key := range credential.GetPrefixed(config, "token_param.") {
 		if protected[key] {
 			return fmt.Errorf("token_param.%s cannot override a core token-exchange field", key)
+		}
+	}
+	return nil
+}
+
+// rejectInlineClientCredential refuses anything naming a client left in the config of a
+// source that fetches its client credential per mint. keys are whatever the chosen
+// client_auth calls for; client_id is always checked, since none of the rest are
+// meaningful apart from the client they belong to.
+func rejectInlineClientCredential(config map[string]string, keys ...string) error {
+	for _, key := range append(keys, "client_id") {
+		if credential.GetString(config, key, "") != "" {
+			return fmt.Errorf("%s must be omitted when secret_spec is set; the referenced spec supplies the whole client credential", key)
 		}
 	}
 	return nil
@@ -251,21 +302,93 @@ func (d *TokenExchangeDriver) MintCredentialWithExchange(ctx context.Context, sp
 }
 
 // MintCredentialWithExchangeFromSecret performs the same exchange as
-// MintCredentialWithExchange, but its client-authentication secret comes from
-// credential-chaining material (secret_spec) instead of source config. The relevant
-// field (client_secret for secret_post/basic, or the PEM private_key for
-// private_key_jwt) is taken from material; client_id and everything else stay in config.
+// MintCredentialWithExchange, but its client credential — both halves — comes from
+// credential-chaining material (secret_spec) instead of source config. A chained
+// source stores neither half, so the id and the secret are read together from the
+// fetched payload.
 func (d *TokenExchangeDriver) MintCredentialWithExchangeFromSecret(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	secret := material.Secret()
-	if secret == "" {
-		return nil, nil, 0, "", fmt.Errorf("token_exchange: chained client secret is empty (check the referenced secret_spec and secret_field)")
+	chained, err := tokenExchangeChainedAuthFromMaterial(d.credSource.Config, material)
+	if err != nil {
+		return nil, nil, 0, "", err
 	}
-	return d.mintExchange(ctx, spec, inputs, &secret)
+	return d.mintExchange(ctx, spec, inputs, chained)
 }
 
-// mintExchange runs the exchange for the configured grant. secretOverride, when non-nil,
-// supplies the client-auth secret (from credential chaining) in place of source config.
-func (d *TokenExchangeDriver) mintExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, secretOverride *string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// tokenExchangeChainedAuthFromMaterial reads a whole client credential out of fetched
+// secret material. client_auth decides which half the secret is — a client secret or a
+// PEM private key — and so which conventional key names apply.
+//
+// secret_field names the secret alone, so a field that resolved to nothing is a
+// misconfigured source rather than an invitation to look elsewhere: the conventional
+// keys are consulted only when no field was resolved at all. The id is read by
+// convention for the same reason, and has nowhere to fall back to — a source in
+// chaining mode holds no client_id — so its absence is an error raised here, before any
+// request is sent.
+//
+// Every "the payload lacks what I need" error carries ErrChainedSecretIncomplete, so a
+// cached payload that predates a key it now has to hold is refetched once rather than
+// failing for the rest of its secret_cache_ttl.
+func tokenExchangeChainedAuthFromMaterial(cfg map[string]string, material credential.SecretMaterial) (*tokenExchangeChainedAuth, error) {
+	// The id is never the secret. A payload holding nothing but an id resolves that
+	// lone key as the secret field — the single-key shortcut has no way to know
+	// better — and without this the same value would be spent as both halves of the
+	// pair, which the endpoint answers with invalid_client and the chained path then
+	// misreads as a rotated secret.
+	if material.Field == "client_id" {
+		return nil, fmt.Errorf("token_exchange: the fetched secret material holds a client id but no secret: %w", credential.ErrChainedSecretIncomplete)
+	}
+
+	secret := material.Secret()
+	var kid string
+
+	switch credential.GetString(cfg, "client_auth", clientAuthSecretPost) {
+	case clientAuthSecretPost, clientAuthSecretBasic, "":
+		if secret == "" && material.Field == "" {
+			secret = material.Data["client_secret"]
+		}
+		if secret == "" {
+			if material.Field != "" {
+				return nil, fmt.Errorf("token_exchange: secret_field %q is empty or absent in the fetched secret material: %w", material.Field, credential.ErrChainedSecretIncomplete)
+			}
+			return nil, fmt.Errorf("token_exchange: no client secret in fetched secret material (set secret_field, or store it under 'client_secret'): %w", credential.ErrChainedSecretIncomplete)
+		}
+	case clientAuthPrivateKeyJWT:
+		if secret == "" && material.Field == "" {
+			secret = material.Data["private_key"]
+		}
+		if secret == "" {
+			if material.Field != "" {
+				return nil, fmt.Errorf("token_exchange: secret_field %q is empty or absent in the fetched secret material: %w", material.Field, credential.ErrChainedSecretIncomplete)
+			}
+			return nil, fmt.Errorf("token_exchange: no private key in fetched secret material (set secret_field, or store it under 'private_key'): %w", credential.ErrChainedSecretIncomplete)
+		}
+		// Optional, and read by convention like the id: an authorization server that
+		// resolves the key from the client id alone needs none. When it is present it
+		// has to be the one stored beside this key, which is why a chained source is
+		// refused an inline client_assertion_kid rather than falling back to it.
+		kid = material.Data["client_assertion_kid"]
+		if kid == "" {
+			kid = material.Data["kid"]
+		}
+	default:
+		// A source-config error, not a payload one: refetching cannot change the answer,
+		// so this must not carry the sentinel that asks the manager to try again.
+		return nil, fmt.Errorf("token_exchange: credential chaining supports client_auth=%s, %s or %s, got %q",
+			clientAuthSecretPost, clientAuthSecretBasic, clientAuthPrivateKeyJWT,
+			credential.GetString(cfg, "client_auth", ""))
+	}
+
+	clientID := material.Data["client_id"]
+	if clientID == "" {
+		return nil, fmt.Errorf("token_exchange: no client id in fetched secret material (store it under 'client_id' alongside the secret): %w", credential.ErrChainedSecretIncomplete)
+	}
+
+	return &tokenExchangeChainedAuth{clientID: clientID, secret: secret, kid: kid}, nil
+}
+
+// mintExchange runs the exchange for the configured grant. chained, when non-nil,
+// supplies the client credential (from credential chaining) in place of source config.
+func (d *TokenExchangeDriver) mintExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, chained *tokenExchangeChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	if inputs == nil || inputs.SubjectToken == "" {
 		return nil, nil, 0, "", fmt.Errorf("token_exchange: no subject token in exchange inputs")
 	}
@@ -287,9 +410,9 @@ func (d *TokenExchangeDriver) mintExchange(ctx context.Context, spec *credential
 		err  error
 	)
 	if credential.GetString(d.credSource.Config, "grant", tokenExchangeGrantRFC8693) == tokenExchangeGrantIDJAG {
-		resp, err = d.mintIDJAG(ctx, spec, inputs, secretOverride)
+		resp, err = d.mintIDJAG(ctx, spec, inputs, chained)
 	} else {
-		resp, err = d.exchangeOnce(ctx, spec, inputs, secretOverride)
+		resp, err = d.exchangeOnce(ctx, spec, inputs, chained)
 	}
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -301,21 +424,21 @@ func (d *TokenExchangeDriver) mintExchange(ctx context.Context, spec *credential
 	return accessTokenRawData(resp), d.subjectMetadata(resp, inputs), ttlFromExpiresIn(resp.ExpiresIn), "", nil
 }
 
-// exchangeOnce performs a single-hop exchange (rfc8693 or jwt_bearer). secretOverride,
-// when non-nil, supplies the client-auth secret from credential chaining.
-func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, secretOverride *string) (*oauth2TokenResponse, error) {
+// exchangeOnce performs a single-hop exchange (rfc8693 or jwt_bearer). chained,
+// when non-nil, supplies the client credential from credential chaining.
+func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, chained *tokenExchangeChainedAuth) (*oauth2TokenResponse, error) {
 	form, err := d.buildExchangeForm(spec, inputs)
 	if err != nil {
 		return nil, err
 	}
 	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
 	headers := map[string]string{}
-	if err := d.applyClientAuth(form, headers, tokenURL, secretOverride); err != nil {
+	if err := d.applyClientAuth(form, headers, tokenURL, chained); err != nil {
 		return nil, err
 	}
 	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
 	if err != nil {
-		return nil, chainedClientAuthError(err, secretOverride != nil)
+		return nil, chainedClientAuthError(err, chained != nil)
 	}
 	return resp, nil
 }
@@ -329,7 +452,7 @@ func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential
 //
 // Client auth runs on both legs (each with its own endpoint as the assertion
 // audience). Only the final access token is returned; the ID-JAG is single-use.
-func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, secretOverride *string) (*oauth2TokenResponse, error) {
+func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs, chained *tokenExchangeChainedAuth) (*oauth2TokenResponse, error) {
 	cfg := d.credSource.Config
 
 	// Leg 1: exchange the subject for an ID-JAG at the home IdP. The ID-JAG must be
@@ -354,12 +477,12 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 		leg1.Set(k, v)
 	}
 	h1 := map[string]string{}
-	if err := d.applyClientAuth(leg1, h1, idpURL, secretOverride); err != nil {
+	if err := d.applyClientAuth(leg1, h1, idpURL, chained); err != nil {
 		return nil, err
 	}
 	jag, err := postOAuthTokenForm(ctx, d.httpClient, idpURL, leg1, h1)
 	if err != nil {
-		return nil, chainedClientAuthError(err, secretOverride != nil)
+		return nil, chainedClientAuthError(err, chained != nil)
 	}
 	if jag.AccessToken == "" {
 		return nil, fmt.Errorf("id_jag: leg 1 returned no ID-JAG assertion")
@@ -381,12 +504,12 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 	// leg 2 (the resource-AS redemption), not leg 1 (which mints the ID-JAG).
 	d.addResources(leg2, spec)
 	h2 := map[string]string{}
-	if err := d.applyClientAuth(leg2, h2, resURL, secretOverride); err != nil {
+	if err := d.applyClientAuth(leg2, h2, resURL, chained); err != nil {
 		return nil, err
 	}
 	final, err := postOAuthTokenForm(ctx, d.httpClient, resURL, leg2, h2)
 	if err != nil {
-		return nil, chainedClientAuthError(err, secretOverride != nil)
+		return nil, chainedClientAuthError(err, chained != nil)
 	}
 	return final, nil
 }
@@ -436,15 +559,19 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 
 // applyClientAuth decorates the request with the configured client
 // authentication. tokenEndpoint is the audience for a private_key_jwt assertion
-// (each ID-JAG leg authenticates against its own endpoint). secretOverride, when
-// non-nil, supplies the client-auth secret from credential chaining (the client_secret
-// for secret_post/basic, or the PEM private_key for private_key_jwt) in place of config.
-func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string, tokenEndpoint string, secretOverride *string) error {
+// (each ID-JAG leg authenticates against its own endpoint). chained, when non-nil,
+// supplies the whole client credential from credential chaining in place of config.
+//
+// Both halves move together: an id from config beside a secret from the chain would
+// name one client while presenting another's, which the token endpoint answers with
+// invalid_client.
+func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string, tokenEndpoint string, chained *tokenExchangeChainedAuth) error {
 	cfg := d.credSource.Config
 	clientID := credential.GetString(cfg, "client_id", "")
 	clientSecret := credential.GetString(cfg, "client_secret", "")
-	if secretOverride != nil {
-		clientSecret = *secretOverride
+	if chained != nil {
+		clientID = chained.clientID
+		clientSecret = chained.secret
 	}
 
 	switch credential.GetString(cfg, "client_auth", clientAuthSecretPost) {
@@ -456,7 +583,7 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 		creds := url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)
 		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))
 	case clientAuthPrivateKeyJWT:
-		assertion, err := d.buildClientAssertion(clientID, tokenEndpoint, secretOverride)
+		assertion, err := d.buildClientAssertion(clientID, tokenEndpoint, chained)
 		if err != nil {
 			return err
 		}
@@ -471,12 +598,15 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 
 // buildClientAssertion builds and signs an RFC 7523 client-assertion JWT: a
 // short-lived JWT with iss=sub=client_id and aud=tokenEndpoint, signed with the RSA
-// private key. keyOverride, when non-nil, supplies the PEM key from credential chaining
-// in place of the source-configured private_key.
-func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint string, keyOverride *string) (string, error) {
+// private key. chained, when non-nil, supplies the PEM key and its key id from
+// credential chaining in place of the source-configured ones; clientID is then the
+// chained id its caller already substituted, so the assertion names the client whose key
+// signs it, under the key id that key was stored beside.
+func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint string, chained *tokenExchangeChainedAuth) (string, error) {
 	pemKey := credential.GetString(d.credSource.Config, "private_key", "")
-	if keyOverride != nil {
-		pemKey = *keyOverride
+	kid := credential.GetString(d.credSource.Config, "client_assertion_kid", "")
+	if chained != nil {
+		pemKey, kid = chained.secret, chained.kid
 	}
 	key, err := parseRSAPrivateKey(pemKey)
 	if err != nil {
@@ -488,7 +618,7 @@ func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint strin
 	}
 	now := time.Now()
 	header := map[string]string{}
-	if kid := credential.GetString(d.credSource.Config, "client_assertion_kid", ""); kid != "" {
+	if kid != "" {
 		header["kid"] = kid
 	}
 	claims := map[string]interface{}{
@@ -621,13 +751,16 @@ func classifyExchangeError(err error) error {
 	return fmt.Errorf("token_exchange failed: %w", err)
 }
 
-// chainedClientAuthError classifies a token-endpoint failure, but when the client secret
-// came from credential chaining (chained) and the endpoint rejected the client
+// chainedClientAuthError classifies a token-endpoint failure, but when the client
+// credential came from credential chaining (chained) and the endpoint rejected the client
 // authentication (invalid_client — 400 for client_secret_post, 401 for
 // client_secret_basic, or a rejected private_key_jwt assertion), it wraps
 // credential.ErrChainedSecretRejected so the minting layer evicts the cached secret and
 // retries once with a fresh fetch. This must run BEFORE classifyExchangeError, whose
 // broad 400/401 branch would otherwise mask invalid_client as a subject-token problem.
+//
+// invalid_client does not say which half was refused, and it does not need to: the
+// eviction refetches the payload, so the id and the secret are replaced together.
 func chainedClientAuthError(err error, chained bool) error {
 	if chained {
 		var tee *tokenEndpointError

--- a/credential/drivers/token_exchange_driver_test.go
+++ b/credential/drivers/token_exchange_driver_test.go
@@ -305,6 +305,127 @@ func TestTokenExchangeDriverFactory_ValidateConfig(t *testing.T) {
 	})
 }
 
+// A source in chaining mode holds neither half of the client credential: not the secret,
+// which is what chaining exists to remove, and not the id, which is only meaningful
+// beside the secret it belongs to.
+func TestTokenExchangeDriverFactory_ValidateConfig_Chaining(t *testing.T) {
+	f := &TokenExchangeDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr string
+	}{
+		{
+			name: "secret-based, neither half inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthSecretPost,
+				"secret_spec": "idp-client-secret", "secret_field": "client_secret",
+			},
+		},
+		{
+			name: "secret-based, client_secret still inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthSecretPost,
+				"secret_spec": "idp-client-secret", "client_secret": "s",
+			},
+			wantErr: "client_secret must be omitted when secret_spec is set",
+		},
+		{
+			name: "secret-based, client_id still inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthSecretBasic,
+				"secret_spec": "idp-client-secret", "client_id": "c",
+			},
+			wantErr: "client_id must be omitted when secret_spec is set",
+		},
+		{
+			name: "private_key_jwt, neither half inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthPrivateKeyJWT,
+				"secret_spec": "idp-key", "secret_field": "private_key",
+			},
+		},
+		{
+			name: "private_key_jwt, private_key still inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthPrivateKeyJWT,
+				"secret_spec": "idp-key", "private_key": testRSAPrivateKeyPEM(t),
+			},
+			wantErr: "private_key must be omitted when secret_spec is set",
+		},
+		{
+			name: "private_key_jwt, client_id still inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthPrivateKeyJWT,
+				"secret_spec": "idp-key", "client_id": "c",
+			},
+			wantErr: "client_id must be omitted when secret_spec is set",
+		},
+		{
+			// A kid names one key among several; kept on the source it would be stamped
+			// on assertions signed by every agent's key.
+			name: "private_key_jwt, client_assertion_kid still inline",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthPrivateKeyJWT,
+				"secret_spec": "idp-key", "client_assertion_kid": "key-1",
+			},
+			wantErr: "client_assertion_kid must be omitted when secret_spec is set",
+		},
+		{
+			// kid is meaningless to the secret methods, so it is not policed there.
+			name: "secret-based, an inert kid is left alone",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthSecretPost,
+				"secret_spec": "idp-client-secret", "client_assertion_kid": "key-1",
+			},
+		},
+		{
+			// The chained branch must not short-circuit the rest of validation. This
+			// one matters more when chained than inline: a chained source holds no
+			// client_id, so an unprotected token_param.client_id would be the only
+			// one on the wire.
+			name: "chained, token_param overriding a core field",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthSecretPost,
+				"secret_spec": "idp-client-secret", "token_param.client_id": "sneaky",
+			},
+			wantErr: "cannot override a core token-exchange field",
+		},
+		{
+			name: "chained id_jag without resource_token_url",
+			config: map[string]string{
+				"token_url": "https://idp.example.com/token", "client_auth": clientAuthSecretPost,
+				"grant": tokenExchangeGrantIDJAG, "secret_spec": "idp-client-secret",
+			},
+			wantErr: "resource_token_url is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := f.ValidateConfig(tc.config)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// testRSAPrivateKeyPEM returns a throwaway PEM key, for cases that need a key-shaped
+// value rather than a working signature.
+func testRSAPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
 func TestTokenExchangeDriver_PrivateKeyJWT(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -345,14 +466,26 @@ func TestTokenExchangeDriver_PrivateKeyJWT(t *testing.T) {
 	assert.NotEmpty(t, claims.ID, "assertion should carry a jti")
 }
 
-// chainedMaterial wraps a single secret value as SecretMaterial (as credential chaining
-// would hand it to the driver).
-func chainedMaterial(secret string) credential.SecretMaterial {
-	return credential.SecretMaterial{Data: map[string]string{"value": secret}, Field: "value"}
+// chainedMaterial wraps a whole client credential as SecretMaterial (as credential
+// chaining would hand it to the driver). The secret sits under a field the source named
+// with secret_field; the id travels beside it under the conventional key, which is the
+// only place it can come from once the source stores neither half.
+func chainedMaterial(clientID, secret string) credential.SecretMaterial {
+	return credential.SecretMaterial{
+		Data:  map[string]string{"value": secret, "client_id": clientID},
+		Field: "value",
+	}
 }
 
-// The chained client secret (from secret_spec) is used as client_secret in the form,
-// with no inline client_secret on the source.
+// chainedConventionalMaterial is the same credential with no secret_field resolved, so
+// both halves are read by convention.
+func chainedConventionalMaterial(clientID, secret, secretKey string) credential.SecretMaterial {
+	return credential.SecretMaterial{Data: map[string]string{secretKey: secret, "client_id": clientID}}
+}
+
+// The chained client credential (from secret_spec) is used in the form, with the source
+// holding neither half — so the id reaching the endpoint can only have come from the
+// fetched payload.
 func TestTokenExchangeDriver_ChainedClientSecret_Post(t *testing.T) {
 	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -367,17 +500,18 @@ func TestTokenExchangeDriver_ChainedClientSecret_Post(t *testing.T) {
 	d := newExchangeDriver(map[string]string{
 		"token_url":   server.URL,
 		"client_auth": clientAuthSecretPost,
-		"client_id":   "warden-gateway",
-		"secret_spec": "idp-client-secret", // no inline client_secret
+		"secret_spec": "idp-client-secret", // neither client_id nor client_secret inline
 	}, server.Client())
 
 	rawData, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
-		context.Background(), &credential.CredSpec{}, subjectInputs(subject), chainedMaterial("chained-secret"))
+		context.Background(), &credential.CredSpec{}, subjectInputs(subject),
+		chainedMaterial("warden-gateway", "chained-secret"))
 	require.NoError(t, err)
 	assert.Equal(t, "t", rawData["api_key"])
 }
 
-// The chained secret is used for client_secret_basic (Authorization header).
+// The chained pair is used for client_secret_basic (Authorization header) — both the
+// user and the password halves come from the payload.
 func TestTokenExchangeDriver_ChainedClientSecret_Basic(t *testing.T) {
 	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -393,17 +527,125 @@ func TestTokenExchangeDriver_ChainedClientSecret_Basic(t *testing.T) {
 	d := newExchangeDriver(map[string]string{
 		"token_url":   server.URL,
 		"client_auth": clientAuthSecretBasic,
-		"client_id":   "warden-gateway",
 		"secret_spec": "idp-client-secret",
 	}, server.Client())
 
 	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
-		context.Background(), &credential.CredSpec{}, subjectInputs(subject), chainedMaterial("chained-secret"))
+		context.Background(), &credential.CredSpec{}, subjectInputs(subject),
+		chainedMaterial("warden-gateway", "chained-secret"))
 	require.NoError(t, err)
 }
 
-// For private_key_jwt, the chained material is the PEM key that signs the assertion.
+// For private_key_jwt, the chained material is the PEM key that signs the assertion —
+// and the id it is issued under. The two have to arrive together: an assertion signed
+// with the payload's key while claiming a config-held id would name a client it cannot
+// prove it is.
 func TestTokenExchangeDriver_ChainedPrivateKeyJWT(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+	var gotAssertion, gotClientID string
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Empty(t, r.Form.Get("client_secret"))
+		gotAssertion = r.Form.Get("client_assertion")
+		gotClientID = r.Form.Get("client_id")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":   sts.URL,
+		"client_auth": clientAuthPrivateKeyJWT,
+		"secret_spec": "idp-key", // neither client_id nor private_key inline
+	}, sts.Client())
+
+	_, _, _, _, err = d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})),
+		chainedMaterial("warden-gateway", privPEM))
+	require.NoError(t, err)
+
+	assert.Equal(t, "warden-gateway", gotClientID)
+	require.NotEmpty(t, gotAssertion)
+	parsed, err := josejwt.ParseSigned(gotAssertion)
+	require.NoError(t, err)
+	var claims josejwt.Claims
+	require.NoError(t, parsed.Claims(&priv.PublicKey, &claims), "assertion signed with the chained key")
+	assert.Equal(t, "warden-gateway", claims.Issuer)
+	assert.Equal(t, "warden-gateway", claims.Subject)
+}
+
+// A secret_field that resolved to nothing is a configuration error, surfaced before any
+// token request — and named as a secret_field problem, since the field was the source's
+// own instruction about where to look.
+func TestTokenExchangeDriver_ChainedEmptySecretErrors(t *testing.T) {
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_auth": clientAuthSecretPost, "secret_spec": "s",
+	}, sts.Client())
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})),
+		chainedMaterial("c", ""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+	assert.Contains(t, err.Error(), "secret_field")
+	assert.False(t, called, "no token request when the chained secret is empty")
+}
+
+// A resolved secret_field that is empty must NOT quietly fall back to a conventional
+// key: the field is the source's own statement of where its secret lives, so an empty
+// one is a misconfiguration rather than an invitation to look elsewhere.
+func TestTokenExchangeDriver_ChainedResolvedFieldEmptyDoesNotFallBack(t *testing.T) {
+	called := false
+	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer sts.Close()
+	d := newExchangeDriver(map[string]string{
+		"token_url": sts.URL, "client_auth": clientAuthSecretPost, "secret_spec": "s",
+	}, sts.Client())
+
+	material := credential.SecretMaterial{
+		Data:  map[string]string{"value": "", "client_secret": "would-have-worked", "client_id": "c"},
+		Field: "value",
+	}
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), material)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret_field")
+	assert.False(t, called, "no token request when the named field resolved to nothing")
+}
+
+// With no secret_field resolved, both halves are read by convention.
+func TestTokenExchangeDriver_ChainedConventionalKeys(t *testing.T) {
+	subject := makeUnsignedJWT(map[string]interface{}{"sub": "u"})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "conventional-id", r.Form.Get("client_id"))
+		assert.Equal(t, "conventional-secret", r.Form.Get("client_secret"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+	}))
+	defer server.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":   server.URL,
+		"client_auth": clientAuthSecretPost,
+		"secret_spec": "idp-client-secret",
+	}, server.Client())
+
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), &credential.CredSpec{}, subjectInputs(subject),
+		chainedConventionalMaterial("conventional-id", "conventional-secret", "client_secret"))
+	require.NoError(t, err)
+}
+
+// The private_key_jwt equivalent: the PEM is read by convention too.
+func TestTokenExchangeDriver_ChainedPrivateKeyJWT_ConventionalKey(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	der, err := x509.MarshalPKCS8PrivateKey(priv)
@@ -413,7 +655,6 @@ func TestTokenExchangeDriver_ChainedPrivateKeyJWT(t *testing.T) {
 	var gotAssertion string
 	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, r.ParseForm())
-		assert.Empty(t, r.Form.Get("client_secret"))
 		gotAssertion = r.Form.Get("client_assertion")
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
@@ -423,35 +664,233 @@ func TestTokenExchangeDriver_ChainedPrivateKeyJWT(t *testing.T) {
 	d := newExchangeDriver(map[string]string{
 		"token_url":   sts.URL,
 		"client_auth": clientAuthPrivateKeyJWT,
-		"client_id":   "warden-gateway",
-		"secret_spec": "idp-key", // no inline private_key
+		"secret_spec": "idp-key",
 	}, sts.Client())
 
 	_, _, _, _, err = d.MintCredentialWithExchangeFromSecret(
-		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), chainedMaterial(privPEM))
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})),
+		chainedConventionalMaterial("conventional-id", privPEM, "private_key"))
 	require.NoError(t, err)
 
 	require.NotEmpty(t, gotAssertion)
 	parsed, err := josejwt.ParseSigned(gotAssertion)
 	require.NoError(t, err)
 	var claims josejwt.Claims
-	require.NoError(t, parsed.Claims(&priv.PublicKey, &claims), "assertion signed with the chained key")
-	assert.Equal(t, "warden-gateway", claims.Issuer)
+	require.NoError(t, parsed.Claims(&priv.PublicKey, &claims))
+	assert.Equal(t, "conventional-id", claims.Issuer)
 }
 
-// An empty chained secret is a configuration error, surfaced before any token request.
-func TestTokenExchangeDriver_ChainedEmptySecretErrors(t *testing.T) {
-	called := false
-	sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
-	defer sts.Close()
+// A payload carrying a secret but no id fails before anything is sent. The id has
+// nowhere to fall back to — a chained source holds none — so an absent one and an empty
+// one are the same failure, and neither may reach the endpoint as a half-formed pair.
+func TestTokenExchangeDriver_ChainedPayloadWithoutAnIDFailsBeforeAnyRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		material credential.SecretMaterial
+		config   map[string]string
+		wantErr  string // defaults to the missing-id message
+	}{
+		{
+			name:     "id absent",
+			material: credential.SecretMaterial{Data: map[string]string{"value": "s"}, Field: "value"},
+		},
+		{
+			name:     "id empty",
+			material: chainedMaterial("", "s"),
+		},
+		{
+			name:     "conventional keys, id absent",
+			material: credential.SecretMaterial{Data: map[string]string{"client_secret": "s"}},
+		},
+		{
+			// A payload holding nothing but an id: the single-key shortcut in
+			// resolveSecretField hands it back as the secret field, and without a guard
+			// the one value would be spent as both halves of the pair.
+			name:     "id only, resolved as the secret field",
+			material: credential.SecretMaterial{Data: map[string]string{"client_id": "x"}, Field: "client_id"},
+			wantErr:  "holds a client id but no secret",
+		},
+		{
+			// Both id_jag legs authenticate, so the check has to fire ahead of leg 1
+			// rather than between the two.
+			name:     "id_jag, id absent",
+			material: credential.SecretMaterial{Data: map[string]string{"value": "s"}, Field: "value"},
+			config: map[string]string{
+				"grant":              tokenExchangeGrantIDJAG,
+				"resource_token_url": "https://resource.example/token",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+			defer sts.Close()
+
+			cfg := map[string]string{
+				"token_url": sts.URL, "client_auth": clientAuthSecretPost, "secret_spec": "s",
+			}
+			for k, v := range tc.config {
+				cfg[k] = v
+			}
+			spec := &credential.CredSpec{Config: map[string]string{"audience": "https://resource.example"}}
+
+			d := newExchangeDriver(cfg, sts.Client())
+			_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+				context.Background(), spec, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), tc.material)
+			require.Error(t, err)
+			want := tc.wantErr
+			if want == "" {
+				want = "no client id in fetched secret material"
+			}
+			assert.Contains(t, err.Error(), want)
+			assert.False(t, called, "no request may be sent without a complete pair")
+			// A payload missing a half is refetched once rather than failing for the
+			// rest of its cache TTL.
+			assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		})
+	}
+}
+
+// The key id travels with the key it names. Two agents signing with different keys must
+// present different kids — a source-wide one would name the wrong key for all but one.
+func TestTokenExchangeDriver_ChainedPrivateKeyJWT_KidComesFromThePayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		material func(pem string) credential.SecretMaterial
+		wantKid  string
+	}{
+		{
+			name: "kid under client_assertion_kid",
+			material: func(p string) credential.SecretMaterial {
+				return credential.SecretMaterial{Data: map[string]string{
+					"value": p, "client_id": "agent-a-client", "client_assertion_kid": "key-for-agent-a",
+				}, Field: "value"}
+			},
+			wantKid: "key-for-agent-a",
+		},
+		{
+			name: "kid under the conventional short name",
+			material: func(p string) credential.SecretMaterial {
+				return credential.SecretMaterial{Data: map[string]string{
+					"private_key": p, "client_id": "agent-b-client", "kid": "key-for-agent-b",
+				}}
+			},
+			wantKid: "key-for-agent-b",
+		},
+		{
+			// Optional: an AS resolving the key from the client id alone needs none.
+			name: "no kid in the payload",
+			material: func(p string) credential.SecretMaterial {
+				return credential.SecretMaterial{Data: map[string]string{
+					"value": p, "client_id": "agent-c-client",
+				}, Field: "value"}
+			},
+			wantKid: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			priv, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			der, err := x509.MarshalPKCS8PrivateKey(priv)
+			require.NoError(t, err)
+			privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+			var gotAssertion string
+			sts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				gotAssertion = r.Form.Get("client_assertion")
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "t", "expires_in": 60})
+			}))
+			defer sts.Close()
+
+			// The source names no key and no key id.
+			d := newExchangeDriver(map[string]string{
+				"token_url":   sts.URL,
+				"client_auth": clientAuthPrivateKeyJWT,
+				"secret_spec": "idp-key",
+			}, sts.Client())
+
+			_, _, _, _, err = d.MintCredentialWithExchangeFromSecret(
+				context.Background(), &credential.CredSpec{},
+				subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), tc.material(privPEM))
+			require.NoError(t, err)
+
+			require.NotEmpty(t, gotAssertion)
+			parsed, err := josejwt.ParseSigned(gotAssertion)
+			require.NoError(t, err)
+			require.NoError(t, parsed.Claims(&priv.PublicKey, &josejwt.Claims{}), "signed with the chained key")
+			require.Len(t, parsed.Headers, 1)
+			assert.Equal(t, tc.wantKid, parsed.Headers[0].KeyID)
+		})
+	}
+}
+
+// An incomplete payload asks the manager to refetch; a source misconfigured with an
+// unknown client_auth must not, since a second read cannot change the answer.
+func TestTokenExchangeDriver_ChainedUnknownClientAuthIsNotRefetchable(t *testing.T) {
 	d := newExchangeDriver(map[string]string{
-		"token_url": sts.URL, "client_auth": clientAuthSecretPost, "client_id": "c", "secret_spec": "s",
-	}, sts.Client())
+		"token_url": "https://idp.example.com/token", "client_auth": "mtls", "secret_spec": "s",
+	}, &http.Client{})
+
 	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
-		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})), chainedMaterial(""))
+		context.Background(), &credential.CredSpec{}, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})),
+		chainedMaterial("c", "s"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty")
-	assert.False(t, called, "no token request when the chained secret is empty")
+	assert.Contains(t, err.Error(), "credential chaining supports client_auth")
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+}
+
+// Both ID-JAG legs authenticate, each against its own endpoint, and both do so as the
+// chained client. A build that substituted the pair on only one leg would still mint.
+func TestTokenExchangeDriver_ChainedIDJAG_PairOnBothLegs(t *testing.T) {
+	var leg1ID, leg1Secret, leg2ID, leg2Secret string
+
+	// Leg 2: resource authorization server redeems the ID-JAG.
+	resSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		leg2ID, leg2Secret = r.Form.Get("client_id"), r.Form.Get("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "final", "expires_in": 60})
+	}))
+	defer resSrv.Close()
+
+	// Leg 1: home IdP mints the ID-JAG.
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		leg1ID, leg1Secret = r.Form.Get("client_id"), r.Form.Get("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":      "the-id-jag",
+			"issued_token_type": tokenTypeIDJAG,
+			"expires_in":        60,
+		})
+	}))
+	defer idpSrv.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":          idpSrv.URL,
+		"resource_token_url": resSrv.URL,
+		"grant":              tokenExchangeGrantIDJAG,
+		"client_auth":        clientAuthSecretPost,
+		"secret_spec":        "idp-client-secret",
+	}, &http.Client{})
+
+	spec := &credential.CredSpec{Config: map[string]string{"audience": "https://resource-as.example.com"}}
+	rawData, _, _, _, err := d.MintCredentialWithExchangeFromSecret(
+		context.Background(), spec, subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"})),
+		chainedMaterial("jag-client", "jag-secret"))
+	require.NoError(t, err)
+	assert.Equal(t, "final", rawData["api_key"])
+
+	assert.Equal(t, "jag-client", leg1ID, "leg 1 authenticates as the chained client")
+	assert.Equal(t, "jag-secret", leg1Secret)
+	assert.Equal(t, "jag-client", leg2ID, "leg 2 authenticates as the chained client")
+	assert.Equal(t, "jag-secret", leg2Secret)
 }
 
 // An upstream invalid_client on the CHAINED path maps to ErrChainedSecretRejected (so the
@@ -464,12 +903,13 @@ func TestTokenExchangeDriver_ChainedInvalidClientSentinel(t *testing.T) {
 	}))
 	defer sts.Close()
 
-	cfg := map[string]string{"token_url": sts.URL, "client_auth": clientAuthSecretPost, "client_id": "c"}
+	cfg := map[string]string{"token_url": sts.URL, "client_auth": clientAuthSecretPost}
 	subject := subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u"}))
 
-	// Chained: wraps the sentinel.
+	// Chained: wraps the sentinel. invalid_client does not say which half was refused,
+	// and the eviction refetches both, so a stale id evicts exactly as a stale secret does.
 	dChained := newExchangeDriver(cfg, sts.Client())
-	_, _, _, _, err := dChained.MintCredentialWithExchangeFromSecret(context.Background(), &credential.CredSpec{}, subject, chainedMaterial("stale"))
+	_, _, _, _, err := dChained.MintCredentialWithExchangeFromSecret(context.Background(), &credential.CredSpec{}, subject, chainedMaterial("c", "stale"))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected, "chained invalid_client -> evict-and-retry sentinel")
 

--- a/credential/errors.go
+++ b/credential/errors.go
@@ -58,4 +58,18 @@ var (
 	// evicts the cache entry and retries the mint once. A consuming driver wraps
 	// it via fmt.Errorf("...: %w", credential.ErrChainedSecretRejected).
 	ErrChainedSecretRejected = errors.New("chained secret rejected by downstream")
+
+	// ErrChainedSecretIncomplete is returned (wrapped) by a chained-secret consuming
+	// driver when the fetched payload is missing something the driver needs — a half
+	// of a client credential, say — and so cannot be spent at all. Unlike
+	// ErrChainedSecretRejected nothing downstream refused it; the material never
+	// reached a request.
+	//
+	// It evicts for the same reason a rejection does, and this is the case where the
+	// distinction matters: a cached payload that predates the key it now has to carry
+	// would otherwise fail every mint for the whole of secret_cache_ttl, with the one
+	// mechanism that could recover it never firing. Refetching costs a single read and
+	// answers the question the cache cannot — whether the payload has since been
+	// completed at the source.
+	ErrChainedSecretIncomplete = errors.New("chained secret material is incomplete")
 )

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -523,9 +523,10 @@ func (m *Manager) resolveAndMintChained(
 	material := m.buildSecretMaterial(ctx, spec, data, typ)
 
 	cred, err := mintFn(ctx, spec, material)
-	if err != nil && fromCache && (errors.Is(err, ErrChainedSecretRejected) || errors.Is(err, ErrRefreshTokenRejected)) {
-		// A cached secret was rejected downstream — evict it and retry once with a
-		// fresh fetch, in case it was rotated at the source after we cached it.
+	if err != nil && fromCache && (errors.Is(err, ErrChainedSecretRejected) || errors.Is(err, ErrRefreshTokenRejected) || errors.Is(err, ErrChainedSecretIncomplete)) {
+		// A cached secret was rejected downstream, or turned out to be missing
+		// something the driver needs — evict it and retry once with a fresh fetch, in
+		// case it was rotated or completed at the source after we cached it.
 		m.invalidateChainedSecret(key)
 		data, typ, _, _, rerr := m.resolveChainedSecretData(ctx, caller, spec, secretRef, inputsB)
 		if rerr != nil {

--- a/e2e/fullchain/token_exchange_test.go
+++ b/e2e/fullchain/token_exchange_test.go
@@ -1,0 +1,312 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// token_exchange is the source that mints nothing of its own: it trades the caller's
+// own identity for a downstream bearer at an RFC 8693 endpoint. What a row here can
+// prove that a driver unit test cannot is that the subject travelling to the STS is a
+// real inbound agent token, carried the whole way from the request that asked for the
+// credential.
+//
+// These rows drive the keyless arrangement, where the client credential Warden
+// authenticates with is itself fetched per mint. The source stores neither half of it,
+// so nothing about the source names a client — which is what lets one source, one spec
+// and one role front a different OAuth client for every agent.
+
+const (
+	// One templated path, one client credential per agent beneath it. Each is a
+	// DIFFERENT OAuth client: id and secret both vary, which is the shape the
+	// pair-in-payload design exists to allow and a shared client_id could not express.
+	txPerAgentKeyPath = "e2e/fc-tx-agent-clients"
+
+	txPerAgentSecretSpec = "fc-tx-per-agent-client"
+	txPerAgentSource     = "fc-tx-per-agent-src"
+	txPerAgentSpec       = "fc-tx-per-agent-cred"
+	txPerAgentRole       = "fc-tx-per-agent"
+
+	txAgentA = "e2e-agent"
+	txAgentB = "e2e-pipeline"
+
+	txTokenPath = "/oauth2/token"
+
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+)
+
+// txClient is one tenant's OAuth client, as the stand-in STS sees it.
+type txClient struct {
+	id, secret, bearer string
+}
+
+// txGrant is one exchange the STS was asked to perform.
+type txGrant struct {
+	clientID, clientSecret, subjectToken, grantType string
+}
+
+// serveTokenExchangeSTS stands in for the identity provider performing the exchange. It
+// issues a bearer only to a client whose id AND secret match one it knows, and hands
+// back that client's own token.
+//
+// Matching on the pair is the point: a build that took the id from source config and the
+// secret from the chain would present a mismatched pair here and be refused. The subject
+// token is recorded rather than verified — this is a stand-in, and what the row is about
+// is which client authenticated, not whether Hydra's signature checks out.
+//
+// It is its own listener rather than a handler on the shared recording upstream: the STS
+// is a different host from the API being proxied, and displacing that upstream would
+// change what every other row in the package is talking to.
+func serveTokenExchangeSTS(t *testing.T, clients []txClient) (*httptest.Server, func() []txGrant) {
+	t.Helper()
+
+	var (
+		mu     sync.Mutex
+		grants []txGrant
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(txTokenPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		grants = append(grants, txGrant{
+			clientID:     r.Form.Get("client_id"),
+			clientSecret: r.Form.Get("client_secret"),
+			subjectToken: r.Form.Get("subject_token"),
+			grantType:    r.Form.Get("grant_type"),
+		})
+		mu.Unlock()
+
+		for _, c := range clients {
+			if r.Form.Get("client_id") == c.id && r.Form.Get("client_secret") == c.secret {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"access_token":"` + c.bearer + `","token_type":"Bearer","expires_in":3600}`))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, func() []txGrant {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]txGrant(nil), grants...)
+	}
+}
+
+// setupTokenExchangePerAgentChain parks one client credential per agent under the
+// templated path, then builds a single source and a single spec that both agents mint
+// through.
+//
+// The consuming mount is the one restEnv already stood up: what varies between the two
+// agents is the credential, not the provider, and a mount of its own would only add
+// setup the rows do not exercise.
+func setupTokenExchangePerAgentChain(t *testing.T, stsURL string, clientByAgent map[string]txClient) {
+	t.Helper()
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+txPerAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+txPerAgentSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+txPerAgentSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+txPerAgentSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	// Both halves in one payload, because they authenticate as a pair.
+	for agent, c := range clientByAgent {
+		path := "secret/data/" + txPerAgentKeyPath + "/" + agent
+		body := `{"data":{"client_id":"` + c.id + `","client_secret":"` + c.secret + `"}}`
+		if status, resp := h.VaultDirectRequest(t, "POST", path, body); status >= 400 {
+			t.Fatalf("parking %s's client credential (status %d): %s", agent, status, resp)
+		}
+	}
+
+	// The templated referenced spec. It must be session-pinned — a chained secret is
+	// minted as the caller, which is also what makes {{agent.sub}} resolve to the agent
+	// asking rather than to whoever warmed the cache first.
+	mustWrite("POST", "sys/cred/specs/"+txPerAgentSecretSpec, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"`+txPerAgentKeyPath+`/{{agent.sub}}",
+			"subject_token_source":"agent_identity"}}`,
+		"create the templated client-credential spec")
+
+	// One source for every tenant. It holds neither half, so nothing about it names a
+	// client. tls_skip_verify because the stand-in listens on loopback over http, which
+	// the token_url guard otherwise refuses.
+	mustWrite("POST", "sys/cred/sources/"+txPerAgentSource, fmt.Sprintf(`{
+		"type":"token_exchange","config":{
+			"token_url":%q,"grant":"rfc8693","client_auth":"client_secret_post",
+			"tls_skip_verify":"true",
+			"secret_spec":%q,"secret_field":"client_secret"}}`,
+		stsURL+txTokenPath, txPerAgentSecretSpec),
+		"create the per-agent token_exchange source")
+
+	// The consuming spec still declares its own subject: the exchange needs one, and the
+	// chained credential authenticates Warden to the STS rather than standing in for the
+	// caller.
+	mustWrite("POST", "sys/cred/specs/"+txPerAgentSpec, `{
+		"type":"oauth_bearer_token","source":"`+txPerAgentSource+`","config":{
+			"subject_token_source":"agent_identity",
+			"audience":"https://api.internal.example.com"}}`,
+		"create the per-agent consuming spec")
+
+	mustWrite("POST", "auth/jwt/role/"+txPerAgentRole, `{
+		"token_policies":["`+restEnv.Policy()+`"],"cred_spec_name":"`+txPerAgentSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the shared per-agent role")
+}
+
+// TestTokenExchange_PerAgentOAuthClient drives two agents through one source, one spec
+// and one role, each authenticating to the STS as its own OAuth client.
+//
+// The client credential is resolved per mint from a path templated on the calling
+// agent, so the id and the secret both vary between the two — and the source that
+// fronts them stores neither, which is what lets it front both. A build reading the id
+// from config and the secret from the chain presents a mismatched pair and is refused
+// by the stand-in; one that shared a bearer across tenants proxies the wrong token.
+//
+// Two agents, one role, one spec, one source.
+func TestTokenExchange_PerAgentOAuthClient(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, restEnv)
+
+	clientA := txClient{id: "tx-app-for-agent-a", secret: "tx-secret-a-not-real", bearer: "tx-bearer-for-agent-a"}
+	clientB := txClient{id: "tx-app-for-agent-b", secret: "tx-secret-b-not-real", bearer: "tx-bearer-for-agent-b"}
+
+	sts, grants := serveTokenExchangeSTS(t, []txClient{clientA, clientB})
+	setupTokenExchangePerAgentChain(t, sts.URL, map[string]txClient{
+		txAgentA: clientA,
+		txAgentB: clientB,
+	})
+	upstream.Reset()
+
+	mintAs := func(clientID, secret string) {
+		t.Helper()
+		status, body, _ := h.ChainRequest(t, leaderPort, restEnv, h.ChainOpts{
+			AgentToken: h.GetJWT(t, clientID, secret),
+			Role:       txPerAgentRole,
+		})
+		if status != 200 {
+			t.Fatalf("%s got status %d: %s", clientID, status, body)
+		}
+	}
+
+	// A first, warming every cache on the way, so B has something to be wrongly served
+	// if any of them collapses the two.
+	mintAs(txAgentA, "agent-secret")
+	mintAs(txAgentB, "pipeline-secret")
+
+	// Each agent's exchange presented its own client — the pair reaching the STS
+	// together is what the source cannot supply and the payload must.
+	got := grants()
+	if len(got) != 2 {
+		t.Fatalf("STS received %d exchanges, want one per agent", len(got))
+	}
+	for i, want := range []txClient{clientA, clientB} {
+		if got[i].grantType != grantTypeTokenExchange {
+			t.Errorf("exchange %d used grant_type %q, want %q", i, got[i].grantType, grantTypeTokenExchange)
+		}
+		if got[i].clientID != want.id {
+			t.Errorf("exchange %d presented client_id %q, want %q", i, got[i].clientID, want.id)
+		}
+		if got[i].clientSecret != want.secret {
+			t.Errorf("exchange %d presented client_secret %q, want %q", i, got[i].clientSecret, want.secret)
+		}
+		// The subject is the agent's own inbound token, not anything the source holds.
+		if got[i].subjectToken == "" {
+			t.Errorf("exchange %d carried no subject_token", i)
+		}
+	}
+	// And the two subjects differ, which is what makes them two exchanges rather than
+	// one served twice.
+	if got[0].subjectToken == got[1].subjectToken {
+		t.Error("both exchanges carried the same subject_token; the agents were not told apart")
+	}
+
+	// Each proxied request carried the bearer minted for its own agent's client. B
+	// receiving A's would mean a token was shared across tenants.
+	var injected []string
+	for _, req := range upstream.Requests() {
+		// restEnv's mount is configured to inject under a header of its own, which is
+		// also the one a row there proves is honoured.
+		if got := req.Header.Get("X-Custom-Auth"); got != "" {
+			injected = append(injected, got)
+		}
+	}
+	want := []string{"Token " + clientA.bearer, "Token " + clientB.bearer}
+	if len(injected) != 2 || injected[0] != want[0] || injected[1] != want[1] {
+		t.Errorf("proxied requests carried %v, want %v", injected, want)
+	}
+}
+
+// TestTokenExchange_KeylessSourceRejectsAnInlineClientID pins the create-time half of
+// the rule the row above depends on: a source that fetches its client credential may not
+// also name a client, since an id from config beside a secret from the chain would
+// present a pair belonging to no one.
+func TestTokenExchange_KeylessSourceRejectsAnInlineClientID(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		name       = "fc-tx-inline-id-rejected"
+		secretSpec = "fc-tx-inline-id-secret"
+	)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+secretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	// The reference is resolved before the driver's config is validated, so it has to
+	// exist for the rejection under test to be the one that fires.
+	if status, resp := h.APIRequest(t, "POST", "sys/cred/specs/"+secretSpec, leaderPort, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"`+txPerAgentKeyPath+`/`+txAgentA+`",
+			"subject_token_source":"agent_identity"}}`); status >= 400 {
+		t.Fatalf("create the referenced spec (status %d): %s", status, resp)
+	}
+
+	body := fmt.Sprintf(`{"type":"token_exchange","config":{
+		"token_url":%q,"grant":"rfc8693","client_auth":"client_secret_post",
+		"tls_skip_verify":"true","client_id":"named-anyway",
+		"secret_spec":%q,"secret_field":"client_secret"}}`,
+		"http://127.0.0.1:1"+txTokenPath, secretSpec)
+
+	status, resp := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort, body)
+	if status < 400 {
+		t.Fatalf("a chained source naming a client was accepted (status %d): %s", status, resp)
+	}
+	if !strings.Contains(string(resp), "client_id") ||
+		!strings.Contains(string(resp), "must be omitted when secret_spec is set") {
+		t.Errorf("rejection did not name the offending key: %s", resp)
+	}
+}


### PR DESCRIPTION
A chained `token_exchange` source fetched its client secret but read `client_id` from
config. A source holds one id, so each OAuth client needed its own source and its own
consuming spec — five tenants meant five of each, differing in one string. `gitlab`
already takes both halves from the payload (#520); this brings `token_exchange` to the
same contract.

## The pair

Both halves now come from the fetched payload, and either one left in config is refused
at create time. The id is not withheld because it is secret — it stays unmasked — but
because the two authenticate as a pair. An id in config beside a secret from the chain
names one client while presenting another's, which the token endpoint answers with
`invalid_client`, which the chained path then reads as a stale secret and retries for
nothing.

That failure mode is not hypothetical: reverting the id substitution and re-running the
e2e row reproduces exactly it.

For `private_key_jwt` the gap was sharper. The id is signed into the assertion as `iss`
and `sub`, so a chained key with a config-held id was already claiming a client it could
not prove it was. `client_assertion_kid` follows the key for the same reason — a kid
names one key among the several an authorization server may hold, so it is only true of
the key it was stored beside. Kept on the source it would stamp every agent's assertion
with one agent's kid, and an AS that selects its verification key by kid would refuse
all but that one. A chained `private_key_jwt` source now omits it and reads it from the
payload, under `client_assertion_kid` or `kid`.

## Failing before the wire

The id has nowhere to fall back to, so a payload without one fails before any request —
including before either leg of `id_jag` — rather than surfacing as an opaque rejection.
It is read by convention, since `secret_field` names the secret alone.

A payload holding only an id is caught there too: the single-key shortcut in
`resolveSecretField` would otherwise hand that lone value back as the secret field and
spend the same string as both halves.

## Recovering an incomplete payload

Incompleteness needs its own sentinel to be recoverable. A rejected secret is refused
downstream and evicts; a payload missing a half never reaches a request, so the one
mechanism that could refresh it never fired — and a cached copy predating the key it now
has to carry would fail every mint for the whole of `secret_cache_ttl`. That is exactly
the window this change puts every existing operator through.

`ErrChainedSecretIncomplete` joins the evict-and-retry, for cached material only. An
unknown `client_auth` deliberately stays out: that is a source error, and a second read
cannot change the answer.

## Breaking change

A chained `token_exchange` source must now omit `client_id`, its secret half, and — for
`private_key_jwt` — `client_assertion_kid`. All three move into the referenced spec's
payload.

Migration is zero-downtime in payload-first order: `applyClientAuth` overwrites both
halves unconditionally on the chained path, so inline values are already ignored before
they are removed. An existing source keeps running until its next create or update, then
is refused until the keys are dropped.

## Tests

Driver-level coverage for the pair, the conventional keys, the resolved-but-empty
`secret_field`, the missing id across four shapes including `id_jag`, the kid under both
payload names and absent, and the `ValidateConfig` matrix. Manager-level coverage that
the new sentinel evicts a cached payload and does not refetch a fresh one.

The e2e row drives two agents through one source, one spec and one role, each resolving
its own pair from a path templated on the caller, and asserts the pair reaches the token
endpoint intact and that neither agent is served the other's bearer. It was
mutation-checked: with the id taken from config it fails.

Full e2e suite green (19 packages).

## Not in this PR

- Docs. `credential-drivers/token-exchange.md` still marks `client_id` required and says
  it stays in config, and the `client_assertion_kid` row is now wrong too;
  `federation/credential-chaining.md` and the changelog need the breaking-change entry.
  Held for the release-prep doc pass.
- A `private_key_jwt` e2e row. The e2e uses `client_secret_post`, so the multi-tenant
  pkjwt case the kid fix addresses is pinned at driver level only. It would need RSA
  keygen and an assertion-verifying stand-in in the harness.
