### PR TITLE
fix(drivers): keep a rotated-out credential's token out of the cache

### DIFF
--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2/google"
@@ -84,7 +85,13 @@ type GCPDriver struct {
 	// HTTP client for GCP API calls
 	httpClient *http.Client
 
+	// authMu guards credSource.Config and sourceVerified against the rewrite in
+	// CommitRotation. It is held only across those field accesses and never across a
+	// token mint, so a slow acquisition cannot block a config reader.
+	authMu sync.Mutex
+
 	// Flag to track if source credentials have been verified
+	// Protected by authMu
 	sourceVerified bool
 
 	// API hosts, defaulting to the public GCP endpoints. Overridden in tests to
@@ -93,18 +100,38 @@ type GCPDriver struct {
 	iamCredentialsHost string
 }
 
-// Config accessors — single source of truth is credSource.Config.
+// Config accessors — single source of truth is credSource.Config. Each takes authMu,
+// since CommitRotation replaces the whole map underneath them.
 
 func (d *GCPDriver) getServiceAccountKey() string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
 	return credential.GetString(d.credSource.Config, "service_account_key", "")
 }
 
 func (d *GCPDriver) getAuthMethod() string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
 	return credential.GetString(d.credSource.Config, "auth_method", gcpAuthMethodStatic)
 }
 
 func (d *GCPDriver) getWorkloadIdentityProvider() string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
 	return credential.GetString(d.credSource.Config, "workload_identity_provider", "")
+}
+
+// configSnapshot copies the source config under authMu, so a caller reading several
+// keys sees one consistent view rather than racing a rotation between lookups.
+func (d *GCPDriver) configSnapshot() map[string]string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+
+	snapshot := make(map[string]string, len(d.credSource.Config))
+	for k, v := range d.credSource.Config {
+		snapshot[k] = v
+	}
+	return snapshot
 }
 
 func (d *GCPDriver) parseServiceAccountKey() (*serviceAccountKey, error) {
@@ -699,10 +726,7 @@ func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	}
 
 	// Build new config
-	newConfig := make(map[string]string)
-	for k, v := range d.credSource.Config {
-		newConfig[k] = v
-	}
+	newConfig := d.configSnapshot()
 	newConfig["service_account_key"] = newKeyJSON
 
 	cleanupConfig := map[string]string{
@@ -711,7 +735,8 @@ func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 		"project_id":            saKey.ProjectID,
 	}
 
-	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultGCPActivationDelay)
+	// Rotation does not touch activation_delay, so the snapshot carries the live value.
+	activateAfter := credential.GetDuration(newConfig, "activation_delay", DefaultGCPActivationDelay)
 
 	if d.logger != nil {
 		d.logger.Debug("prepared source SA key rotation",
@@ -725,19 +750,26 @@ func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 
 // CommitRotation activates new credentials in the driver
 func (d *GCPDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
-	// Update config (single source of truth for credentials)
+	// Publish the new key and retire every token the old one minted, as one step. The
+	// generation bump follows the config write under the same lock, so a mint already
+	// in flight against the retired key cannot file its result under the new
+	// generation — getSourceToken reads the generation before it reads the key.
+	d.authMu.Lock()
 	d.credSource.Config = newConfig
-
-	// Invalidate all cached tokens from previous generation
 	d.tokenCache.InvalidateGeneration()
 	d.sourceVerified = false
+	d.authMu.Unlock()
 
-	// Verify new credentials work
+	// Verify new credentials work. Deliberately not under authMu: acquireToken reads
+	// the config through the accessors, which take the lock themselves.
 	_, _, err := d.acquireToken(ctx, []string{"https://www.googleapis.com/auth/cloud-platform"})
 	if err != nil {
 		return fmt.Errorf("failed to authenticate with new SA key: %w", err)
 	}
+
+	d.authMu.Lock()
 	d.sourceVerified = true
+	d.authMu.Unlock()
 
 	if d.logger != nil {
 		d.logger.Debug("committed source SA key rotation")
@@ -784,21 +816,28 @@ func (d *GCPDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 func (d *GCPDriver) getSourceToken(ctx context.Context, scopes []string) (string, time.Time, error) {
 	scopeKey := strings.Join(scopes, ",")
 
-	// Check cache (with 60s refresh buffer)
-	if token, expiry, ok := d.tokenCache.Get(scopeKey, 60*time.Second); ok {
-		return token, expiry, nil
+	for {
+		// Read the generation before the SA key, so a rotation landing while the mint
+		// is in flight is always visible as a change by the time we store.
+		gen := d.tokenCache.GetGeneration()
+
+		// Check cache (with 60s refresh buffer)
+		if token, expiry, ok := d.tokenCache.Get(scopeKey, 60*time.Second); ok {
+			return token, expiry, nil
+		}
+
+		// Acquire fresh token
+		token, expiry, err := d.acquireToken(ctx, scopes)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+
+		// A refused store means the SA key rotated during the mint, so this token may
+		// have come from the retired key. Drop it and mint against the current one.
+		if d.tokenCache.SetIfGeneration(scopeKey, token, expiry, gen) {
+			return token, expiry, nil
+		}
 	}
-
-	// Acquire fresh token
-	token, expiry, err := d.acquireToken(ctx, scopes)
-	if err != nil {
-		return "", time.Time{}, err
-	}
-
-	// Cache it
-	d.tokenCache.Set(scopeKey, token, expiry)
-
-	return token, expiry, nil
 }
 
 // acquireToken gets a fresh OAuth2 token using the SA key.

--- a/credential/drivers/gcp_driver_test.go
+++ b/credential/drivers/gcp_driver_test.go
@@ -5,11 +5,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -292,7 +294,7 @@ func TestSplitScopes(t *testing.T) {
 
 // newTestGCPSAKey builds a usable service-account key whose token_uri points at a local
 // server, so the oauth2 library performs a real signed JWT exchange against it.
-func newTestGCPSAKey(t *testing.T, tokenURI string) string {
+func newTestGCPSAKey(t *testing.T, tokenURI, clientEmail string) string {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -305,7 +307,7 @@ func newTestGCPSAKey(t *testing.T, tokenURI string) string {
 		"type":         "service_account",
 		"project_id":   "test-project",
 		"private_key":  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
-		"client_email": "sa@test-project.iam.gserviceaccount.com",
+		"client_email": clientEmail,
 		"token_uri":    tokenURI,
 	}
 	encoded, err := json.Marshal(saKey)
@@ -340,7 +342,7 @@ func TestGCPDriver_RotationDuringMintDiscardsStaleToken(t *testing.T) {
 	d = &GCPDriver{
 		credSource: &credential.CredSource{
 			Type:   credential.SourceTypeGCP,
-			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL)},
+			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL, "sa@test-project.iam.gserviceaccount.com")},
 		},
 		tokenCache: NewTokenCache(),
 		httpClient: &http.Client{Timeout: 5 * time.Second},
@@ -374,12 +376,12 @@ func TestGCPDriver_ConcurrentRotationAndMintIsRaceFree(t *testing.T) {
 	d := &GCPDriver{
 		credSource: &credential.CredSource{
 			Type:   credential.SourceTypeGCP,
-			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL)},
+			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL, "sa@test-project.iam.gserviceaccount.com")},
 		},
 		tokenCache: NewTokenCache(),
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 	}
-	rotatedKey := newTestGCPSAKey(t, srv.URL)
+	rotatedKey := newTestGCPSAKey(t, srv.URL, "sa@test-project.iam.gserviceaccount.com")
 
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
@@ -402,4 +404,85 @@ func TestGCPDriver_ConcurrentRotationAndMintIsRaceFree(t *testing.T) {
 	// Whatever the interleaving, the driver ends on the rotated key and reports verified.
 	assert.Equal(t, rotatedKey, d.getServiceAccountKey())
 	assert.True(t, d.sourceVerified)
+}
+
+// gcpAssertionIssuer reads the client_email out of the signed JWT the oauth2 library
+// sends, so a test server can tell which service-account key minted a given request.
+// The signature is irrelevant here — only which key was used.
+func gcpAssertionIssuer(t *testing.T, r *http.Request) string {
+	t.Helper()
+	require.NoError(t, r.ParseForm())
+
+	parts := strings.Split(r.FormValue("assertion"), ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims struct {
+		Iss string `json:"iss"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	return claims.Iss
+}
+
+// TestGCPDriver_TokenFromRetiredKeyIsNeverServed is the GCP twin of the IBM test: a real
+// CommitRotation lands while a mint's exchange is held open, so the response genuinely
+// carries a token the retired SA key minted. That token must be discarded, not served.
+func TestGCPDriver_TokenFromRetiredKeyIsNeverServed(t *testing.T) {
+	const oldSA = "old-sa@test-project.iam.gserviceaccount.com"
+	const newSA = "new-sa@test-project.iam.gserviceaccount.com"
+
+	mintStarted := make(chan struct{})
+	rotationDone := make(chan struct{})
+	var once sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		issuer := gcpAssertionIssuer(t, r)
+
+		// Hold the outgoing key's exchange open until the rotation has landed; the
+		// rotated key's exchanges (including CommitRotation's own verify) pass through.
+		if issuer == oldSA {
+			once.Do(func() { close(mintStarted) })
+			<-rotationDone
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "token-from-" + issuer,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	d := &GCPDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGCP,
+			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL, oldSA)},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	rotatedKey := newTestGCPSAKey(t, srv.URL, newSA)
+	scopes := []string{"https://www.googleapis.com/auth/cloud-platform"}
+
+	var token string
+	var mintErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		token, _, mintErr = d.getSourceToken(context.TODO(), scopes)
+	}()
+
+	<-mintStarted
+	require.NoError(t, d.CommitRotation(context.TODO(), map[string]string{"service_account_key": rotatedKey}))
+	close(rotationDone)
+	wg.Wait()
+
+	require.NoError(t, mintErr)
+	assert.Equal(t, "token-from-"+newSA, token,
+		"the exchange completed against the retired SA key; its token must be discarded, not served")
 }

--- a/credential/drivers/gcp_driver_test.go
+++ b/credential/drivers/gcp_driver_test.go
@@ -2,6 +2,16 @@ package drivers
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -278,4 +288,118 @@ func TestSplitScopes(t *testing.T) {
 			"https://www.googleapis.com/auth/devstorage.read_only",
 		}, scopes)
 	})
+}
+
+// newTestGCPSAKey builds a usable service-account key whose token_uri points at a local
+// server, so the oauth2 library performs a real signed JWT exchange against it.
+func newTestGCPSAKey(t *testing.T, tokenURI string) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+
+	saKey := map[string]string{
+		"type":         "service_account",
+		"project_id":   "test-project",
+		"private_key":  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
+		"client_email": "sa@test-project.iam.gserviceaccount.com",
+		"token_uri":    tokenURI,
+	}
+	encoded, err := json.Marshal(saKey)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+// TestGCPDriver_RotationDuringMintDiscardsStaleToken pins the generation guard in
+// getSourceToken. The scope key carries nothing about which SA key minted the token, so
+// the generation is the sole barrier: without the guard, a token whose exchange was in
+// flight when CommitRotation landed is stamped with the new generation and served for
+// its full lifetime, defeating the rotation it outlived.
+func TestGCPDriver_RotationDuringMintDiscardsStaleToken(t *testing.T) {
+	var d *GCPDriver
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		// Retire the SA key that is minting this very token, mid-exchange.
+		if n == 1 {
+			d.tokenCache.InvalidateGeneration()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": fmt.Sprintf("token-call-%d", n),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	d = &GCPDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGCP,
+			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL)},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	token, _, err := d.getSourceToken(context.TODO(), []string{"https://www.googleapis.com/auth/cloud-platform"})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&callCount), "the in-flight token belonged to the retired SA key, so it must be minted again")
+	assert.Equal(t, "token-call-2", token, "the retired SA key's token must not be returned")
+}
+
+// TestGCPDriver_ConcurrentRotationAndMintIsRaceFree covers the other half: CommitRotation
+// replaces credSource.Config wholesale while mints are reading it. The assertions are
+// incidental — this test earns its keep under -race, which is what catches the driver
+// losing the lock that makes the swap safe.
+func TestGCPDriver_ConcurrentRotationAndMintIsRaceFree(t *testing.T) {
+	var callCount int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": fmt.Sprintf("token-call-%d", n),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	d := &GCPDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGCP,
+			Config: map[string]string{"service_account_key": newTestGCPSAKey(t, srv.URL)},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	rotatedKey := newTestGCPSAKey(t, srv.URL)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := d.getSourceToken(context.TODO(), []string{"https://www.googleapis.com/auth/cloud-platform"})
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, d.CommitRotation(context.TODO(), map[string]string{"service_account_key": rotatedKey}))
+	}()
+
+	wg.Wait()
+
+	// Whatever the interleaving, the driver ends on the rotated key and reports verified.
+	assert.Equal(t, rotatedKey, d.getServiceAccountKey())
+	assert.True(t, d.sourceVerified)
 }

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -47,9 +47,11 @@ type IBMDriver struct {
 	// HTTP client for IBM Cloud API calls
 	httpClient *http.Client
 
-	// authMu protects iamID, apiKeyID, and credSource.Config writes during rotation.
-	// These fields are read by SupportsRotation/PrepareRotation and written by
-	// CommitRotation/discoverAPIKeyDetails concurrently.
+	// authMu protects iamID, apiKeyID, and credSource.Config — the writes during
+	// rotation and every read of them, including from the mint path. Methods come in
+	// pairs where both are reachable: the plain name takes the lock, the "Locked"
+	// suffix is for a caller that already holds it. It is never held across an
+	// upstream call from the mint path, so a slow exchange cannot block a rotation.
 	authMu sync.Mutex
 
 	// iamID is the IAM identity associated with the source API key
@@ -296,7 +298,7 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	}
 
 	// Get IAM token using current API key
-	iamToken, _, err := d.getIAMToken(ctx)
+	iamToken, _, err := d.getIAMTokenLocked(ctx)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to get IAM token for rotation: %w", err)
 	}
@@ -335,11 +337,12 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 
 // CommitRotation activates new credentials in the driver.
 //
-// Thread-safety: authMu protects credSource.Config writes and iamID/apiKeyID updates.
-// acquireIAMToken also reaches api_key from the uncontended mint path (getIAMToken) —
-// what stops a token minted by the outgoing key from outliving the rotation is not
-// this lock but the generation the cache is keyed on, which the bump below retires
-// and getIAMToken re-checks before it stores.
+// Thread-safety: authMu is held across the whole swap, so the config write, the
+// generation bump and the exchange that verifies the new key are one critical section
+// and no mint can observe a half-applied rotation. The lock alone does not stop a token
+// minted by the outgoing key from outliving the rotation, though — an exchange already
+// in flight holds no lock. That is what the generation retired here is for, which
+// iamToken re-checks before it stores.
 func (d *IBMDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
@@ -354,7 +357,7 @@ func (d *IBMDriver) CommitRotation(ctx context.Context, newConfig map[string]str
 	d.tokenCache.InvalidateGeneration()
 
 	// Verify new credentials work
-	if _, _, err := d.acquireIAMToken(ctx); err != nil {
+	if _, _, err := d.acquireIAMTokenLocked(ctx); err != nil {
 		d.credSource.Config = oldConfig
 		d.tokenCache.InvalidateGeneration()
 		return fmt.Errorf("failed to authenticate with new API key: %w", err)
@@ -406,8 +409,21 @@ func (d *IBMDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 // Token Acquisition
 // ============================================================================
 
-// getIAMToken returns a cached or freshly acquired IAM bearer token.
-// Thread-safe via TokenCache.
+// getIAMToken returns a cached or freshly acquired IAM bearer token, taking authMu to
+// read the source credentials. Callers already holding it use getIAMTokenLocked.
+func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) {
+	return d.iamToken(ctx, d.acquireIAMToken)
+}
+
+// getIAMTokenLocked is getIAMToken for a caller that already holds authMu.
+//
+// Because the caller holds the lock, no rotation can land underneath it: CommitRotation
+// needs the same lock to bump the generation, so the retry below cannot spin.
+func (d *IBMDriver) getIAMTokenLocked(ctx context.Context) (string, time.Time, error) {
+	return d.iamToken(ctx, d.acquireIAMTokenLocked)
+}
+
+// iamToken serves the cached IAM token, minting one with acquire on a miss.
 //
 // The entry is keyed by a fixed string, so the generation is the only thing
 // distinguishing a token minted by the current API key from one minted by a retired
@@ -416,7 +432,7 @@ func (d *IBMDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 // rather than filed under the new generation, where it would be served until its own
 // expiry — IBM does not revoke outstanding IAM tokens when CleanupRotation deletes
 // the key that minted them.
-func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) {
+func (d *IBMDriver) iamToken(ctx context.Context, acquire func(context.Context) (string, time.Time, error)) (string, time.Time, error) {
 	for {
 		gen := d.tokenCache.GetGeneration()
 
@@ -426,7 +442,7 @@ func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) 
 		}
 
 		// Acquire fresh token
-		token, expiry, err := d.acquireIAMToken(ctx)
+		token, expiry, err := acquire(ctx)
 		if err != nil {
 			return "", time.Time{}, err
 		}
@@ -438,10 +454,27 @@ func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) 
 	}
 }
 
-// acquireIAMToken exchanges the source API key for an IAM bearer token.
+// acquireIAMToken exchanges the source API key for an IAM bearer token. The credentials
+// are read under authMu, which is released before the exchange so a slow upstream never
+// blocks a rotation.
 func (d *IBMDriver) acquireIAMToken(ctx context.Context) (string, time.Time, error) {
-	apiKey := credential.GetString(d.credSource.Config, "api_key", "")
-	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, apiKey, d.getIAMEndpoint())
+	d.authMu.Lock()
+	apiKey, iamEndpoint := d.apiKeyLocked(), d.iamEndpointLocked()
+	d.authMu.Unlock()
+
+	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, apiKey, iamEndpoint)
+}
+
+// acquireIAMTokenLocked is acquireIAMToken for a caller that already holds authMu —
+// CommitRotation, which needs the read of the new key and the exchange that verifies it
+// to sit inside the same critical section as the config write.
+func (d *IBMDriver) acquireIAMTokenLocked(ctx context.Context) (string, time.Time, error) {
+	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, d.apiKeyLocked(), d.iamEndpointLocked())
+}
+
+// apiKeyLocked reads the source API key. Caller holds authMu.
+func (d *IBMDriver) apiKeyLocked() string {
+	return credential.GetString(d.credSource.Config, "api_key", "")
 }
 
 // ============================================================================
@@ -459,13 +492,13 @@ func (d *IBMDriver) discoverAPIKeyDetails(ctx context.Context) error {
 // discoverAPIKeyDetailsLocked is the lock-free implementation of discoverAPIKeyDetails.
 // Caller must hold authMu.
 func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
-	iamToken, _, err := d.getIAMToken(ctx)
+	iamToken, _, err := d.getIAMTokenLocked(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get IAM token: %w", err)
 	}
 
-	iamEndpoint := d.getIAMEndpoint()
-	apiKey := credential.GetString(d.credSource.Config, "api_key", "")
+	iamEndpoint := d.iamEndpointLocked()
+	apiKey := d.apiKeyLocked()
 
 	// Use POST with API key in request body (more secure than GET with IAM-Apikey header)
 	reqBody, err := json.Marshal(map[string]string{
@@ -521,9 +554,10 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 	return nil
 }
 
-// createAPIKey creates a new API key for the same IAM identity
+// createAPIKey creates a new API key for the same IAM identity.
+// Caller must hold authMu (PrepareRotation).
 func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, string, error) {
-	iamEndpoint := d.getIAMEndpoint()
+	iamEndpoint := d.iamEndpointLocked()
 	accountID := credential.GetString(d.credSource.Config, "account_id", "")
 
 	reqBody, err := json.Marshal(map[string]interface{}{
@@ -584,8 +618,15 @@ func (d *IBMDriver) deleteAPIKey(ctx context.Context, iamToken, apiKeyID string)
 // Helpers
 // ============================================================================
 
-// getIAMEndpoint returns the configured IAM endpoint or the default
+// getIAMEndpoint returns the configured IAM endpoint or the default. Takes authMu.
 func (d *IBMDriver) getIAMEndpoint() string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	return d.iamEndpointLocked()
+}
+
+// iamEndpointLocked is getIAMEndpoint for a caller that already holds authMu.
+func (d *IBMDriver) iamEndpointLocked() string {
 	return credential.GetString(d.credSource.Config, "iam_endpoint", defaultIBMIAMEndpoint)
 }
 

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -47,12 +47,15 @@ type IBMDriver struct {
 	// HTTP client for IBM Cloud API calls
 	httpClient *http.Client
 
-	// authMu protects iamID, apiKeyID, and credSource.Config — the writes during
-	// rotation and every read of them, including from the mint path. Methods come in
-	// pairs where both are reachable: the plain name takes the lock, the "Locked"
-	// suffix is for a caller that already holds it. It is never held across an
-	// upstream call from the mint path, so a slow exchange cannot block a rotation.
+	// authMu serializes rotation and protects iamID/apiKeyID. It is held across the
+	// upstream calls a rotation makes, which can run to minutes under retry.
 	authMu sync.Mutex
+
+	// configMu guards credSource.Config, which CommitRotation replaces wholesale.
+	// It is deliberately NOT authMu: a mint reads its credentials out of this map, and
+	// sharing the rotation lock would park every concurrent mint behind that rotation's
+	// HTTP work. Held only across the map access itself, never across an upstream call.
+	configMu sync.RWMutex
 
 	// iamID is the IAM identity associated with the source API key
 	// Discovered at creation time, required for rotation
@@ -298,7 +301,7 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	}
 
 	// Get IAM token using current API key
-	iamToken, _, err := d.getIAMTokenLocked(ctx)
+	iamToken, _, err := d.getIAMToken(ctx)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to get IAM token for rotation: %w", err)
 	}
@@ -312,17 +315,15 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	oldAPIKeyID := d.apiKeyID
 
 	// Build new config
-	newConfig := make(map[string]string)
-	for k, v := range d.credSource.Config {
-		newConfig[k] = v
-	}
+	newConfig := d.configSnapshot()
 	newConfig["api_key"] = newAPIKey
 
 	cleanupConfig := map[string]string{
 		"api_key_id": oldAPIKeyID,
 	}
 
-	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultIBMActivationDelay)
+	// Rotation does not touch activation_delay, so the snapshot carries the live value.
+	activateAfter := credential.GetDuration(newConfig, "activation_delay", DefaultIBMActivationDelay)
 
 	if d.logger != nil {
 		d.logger.Debug("prepared source API key rotation",
@@ -348,25 +349,23 @@ func (d *IBMDriver) CommitRotation(ctx context.Context, newConfig map[string]str
 	defer d.authMu.Unlock()
 
 	// Save old config for rollback on failure
-	oldConfig := d.credSource.Config
+	oldConfig := d.configSnapshot()
 
-	// Update config
-	d.credSource.Config = newConfig
-
-	// Invalidate all cached tokens from previous generation
-	d.tokenCache.InvalidateGeneration()
+	// Publish the new key and retire every token the old one minted
+	d.swapConfig(newConfig)
 
 	// Verify new credentials work
-	if _, _, err := d.acquireIAMTokenLocked(ctx); err != nil {
-		d.credSource.Config = oldConfig
-		d.tokenCache.InvalidateGeneration()
+	if _, _, err := d.acquireIAMToken(ctx); err != nil {
+		// Roll back, bumping the generation a second time: discovery may already have
+		// cached a token minted by the key we are abandoning, and it is filed under the
+		// current generation, so restoring the config alone would leave it readable.
+		d.swapConfig(oldConfig)
 		return fmt.Errorf("failed to authenticate with new API key: %w", err)
 	}
 
 	// Re-discover API key details with new key
 	if err := d.discoverAPIKeyDetailsLocked(ctx); err != nil {
-		d.credSource.Config = oldConfig
-		d.tokenCache.InvalidateGeneration()
+		d.swapConfig(oldConfig)
 		return fmt.Errorf("failed to discover new API key details: %w", err)
 	}
 
@@ -409,30 +408,20 @@ func (d *IBMDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 // Token Acquisition
 // ============================================================================
 
-// getIAMToken returns a cached or freshly acquired IAM bearer token, taking authMu to
-// read the source credentials. Callers already holding it use getIAMTokenLocked.
-func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) {
-	return d.iamToken(ctx, d.acquireIAMToken)
-}
-
-// getIAMTokenLocked is getIAMToken for a caller that already holds authMu.
-//
-// Because the caller holds the lock, no rotation can land underneath it: CommitRotation
-// needs the same lock to bump the generation, so the retry below cannot spin.
-func (d *IBMDriver) getIAMTokenLocked(ctx context.Context) (string, time.Time, error) {
-	return d.iamToken(ctx, d.acquireIAMTokenLocked)
-}
-
-// iamToken serves the cached IAM token, minting one with acquire on a miss.
+// getIAMToken returns a cached or freshly acquired IAM bearer token.
 //
 // The entry is keyed by a fixed string, so the generation is the only thing
 // distinguishing a token minted by the current API key from one minted by a retired
-// one. Reading it before the mint and storing conditionally keeps that distinction
-// honest: an exchange that was in flight when CommitRotation landed is discarded
-// rather than filed under the new generation, where it would be served until its own
-// expiry — IBM does not revoke outstanding IAM tokens when CleanupRotation deletes
-// the key that minted them.
-func (d *IBMDriver) iamToken(ctx context.Context, acquire func(context.Context) (string, time.Time, error)) (string, time.Time, error) {
+// one. Reading it before the credentials and storing conditionally keeps that
+// distinction honest: an exchange that was in flight when CommitRotation landed is
+// discarded rather than filed under the new generation, where it would be served until
+// its own expiry — IBM does not revoke outstanding IAM tokens when CleanupRotation
+// deletes the key that minted them.
+//
+// The generation must be read BEFORE the credentials, so that a rotation landing in
+// between is always visible as a change at store time rather than producing a token
+// whose key and generation disagree.
+func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) {
 	for {
 		gen := d.tokenCache.GetGeneration()
 
@@ -442,7 +431,7 @@ func (d *IBMDriver) iamToken(ctx context.Context, acquire func(context.Context) 
 		}
 
 		// Acquire fresh token
-		token, expiry, err := acquire(ctx)
+		token, expiry, err := d.acquireIAMToken(ctx)
 		if err != nil {
 			return "", time.Time{}, err
 		}
@@ -454,27 +443,64 @@ func (d *IBMDriver) iamToken(ctx context.Context, acquire func(context.Context) 
 	}
 }
 
-// acquireIAMToken exchanges the source API key for an IAM bearer token. The credentials
-// are read under authMu, which is released before the exchange so a slow upstream never
-// blocks a rotation.
+// acquireIAMToken exchanges the source API key for an IAM bearer token.
 func (d *IBMDriver) acquireIAMToken(ctx context.Context) (string, time.Time, error) {
-	d.authMu.Lock()
-	apiKey, iamEndpoint := d.apiKeyLocked(), d.iamEndpointLocked()
-	d.authMu.Unlock()
-
-	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, apiKey, iamEndpoint)
+	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, d.getAPIKey(), d.getIAMEndpoint())
 }
 
-// acquireIAMTokenLocked is acquireIAMToken for a caller that already holds authMu —
-// CommitRotation, which needs the read of the new key and the exchange that verifies it
-// to sit inside the same critical section as the config write.
-func (d *IBMDriver) acquireIAMTokenLocked(ctx context.Context) (string, time.Time, error) {
-	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, d.apiKeyLocked(), d.iamEndpointLocked())
-}
+// Config accessors — single source of truth is credSource.Config, read under configMu
+// because CommitRotation replaces the map wholesale.
 
-// apiKeyLocked reads the source API key. Caller holds authMu.
-func (d *IBMDriver) apiKeyLocked() string {
+// getAPIKey reads the source API key.
+func (d *IBMDriver) getAPIKey() string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
 	return credential.GetString(d.credSource.Config, "api_key", "")
+}
+
+// getAccountID reads the configured or discovered account id.
+func (d *IBMDriver) getAccountID() string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return credential.GetString(d.credSource.Config, "account_id", "")
+}
+
+// configSnapshot copies the source config, so a caller reading several keys sees one
+// consistent view rather than racing a rotation between lookups.
+func (d *IBMDriver) configSnapshot() map[string]string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+
+	snapshot := make(map[string]string, len(d.credSource.Config))
+	for k, v := range d.credSource.Config {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
+// setAccountIDIfUnset records an account id learned from discovery, leaving an
+// operator-configured one alone.
+func (d *IBMDriver) setAccountIDIfUnset(accountID string) {
+	if accountID == "" {
+		return
+	}
+	d.configMu.Lock()
+	defer d.configMu.Unlock()
+	if credential.GetString(d.credSource.Config, "account_id", "") == "" {
+		d.credSource.Config["account_id"] = accountID
+	}
+}
+
+// swapConfig publishes a config and retires every token the previous one minted, as one
+// step. The generation bump follows the write under the same lock, so a mint that read
+// the outgoing credentials also captured the outgoing generation and cannot store under
+// the new one.
+func (d *IBMDriver) swapConfig(newConfig map[string]string) {
+	d.configMu.Lock()
+	defer d.configMu.Unlock()
+
+	d.credSource.Config = newConfig
+	d.tokenCache.InvalidateGeneration()
 }
 
 // ============================================================================
@@ -492,13 +518,13 @@ func (d *IBMDriver) discoverAPIKeyDetails(ctx context.Context) error {
 // discoverAPIKeyDetailsLocked is the lock-free implementation of discoverAPIKeyDetails.
 // Caller must hold authMu.
 func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
-	iamToken, _, err := d.getIAMTokenLocked(ctx)
+	iamToken, _, err := d.getIAMToken(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get IAM token: %w", err)
 	}
 
-	iamEndpoint := d.iamEndpointLocked()
-	apiKey := d.apiKeyLocked()
+	iamEndpoint := d.getIAMEndpoint()
+	apiKey := d.getAPIKey()
 
 	// Use POST with API key in request body (more secure than GET with IAM-Apikey header)
 	reqBody, err := json.Marshal(map[string]string{
@@ -540,9 +566,7 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 	d.apiKeyID = detailsResp.ID
 
 	// Set account_id from discovery if not already configured
-	if credential.GetString(d.credSource.Config, "account_id", "") == "" && detailsResp.AccountID != "" {
-		d.credSource.Config["account_id"] = detailsResp.AccountID
-	}
+	d.setAccountIDIfUnset(detailsResp.AccountID)
 
 	if d.logger != nil {
 		d.logger.Trace("discovered IBM API key details",
@@ -557,8 +581,8 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 // createAPIKey creates a new API key for the same IAM identity.
 // Caller must hold authMu (PrepareRotation).
 func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, string, error) {
-	iamEndpoint := d.iamEndpointLocked()
-	accountID := credential.GetString(d.credSource.Config, "account_id", "")
+	iamEndpoint := d.getIAMEndpoint()
+	accountID := d.getAccountID()
 
 	reqBody, err := json.Marshal(map[string]interface{}{
 		"name":        fmt.Sprintf("warden-rotated-%d", time.Now().Unix()),
@@ -618,15 +642,10 @@ func (d *IBMDriver) deleteAPIKey(ctx context.Context, iamToken, apiKeyID string)
 // Helpers
 // ============================================================================
 
-// getIAMEndpoint returns the configured IAM endpoint or the default. Takes authMu.
+// getIAMEndpoint returns the configured IAM endpoint or the default.
 func (d *IBMDriver) getIAMEndpoint() string {
-	d.authMu.Lock()
-	defer d.authMu.Unlock()
-	return d.iamEndpointLocked()
-}
-
-// iamEndpointLocked is getIAMEndpoint for a caller that already holds authMu.
-func (d *IBMDriver) iamEndpointLocked() string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
 	return credential.GetString(d.credSource.Config, "iam_endpoint", defaultIBMIAMEndpoint)
 }
 

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -336,8 +336,10 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 // CommitRotation activates new credentials in the driver.
 //
 // Thread-safety: authMu protects credSource.Config writes and iamID/apiKeyID updates.
-// The rotated field (api_key) is only read by acquireIAMToken, which is always called
-// either under authMu or during initial creation (single-threaded).
+// acquireIAMToken also reaches api_key from the uncontended mint path (getIAMToken) —
+// what stops a token minted by the outgoing key from outliving the rotation is not
+// this lock but the generation the cache is keyed on, which the bump below retires
+// and getIAMToken re-checks before it stores.
 func (d *IBMDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
@@ -406,22 +408,34 @@ func (d *IBMDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 
 // getIAMToken returns a cached or freshly acquired IAM bearer token.
 // Thread-safe via TokenCache.
+//
+// The entry is keyed by a fixed string, so the generation is the only thing
+// distinguishing a token minted by the current API key from one minted by a retired
+// one. Reading it before the mint and storing conditionally keeps that distinction
+// honest: an exchange that was in flight when CommitRotation landed is discarded
+// rather than filed under the new generation, where it would be served until its own
+// expiry — IBM does not revoke outstanding IAM tokens when CleanupRotation deletes
+// the key that minted them.
 func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) {
-	// Check cache (with 30s refresh buffer)
-	if token, expiry, ok := d.tokenCache.Get("iam", 30*time.Second); ok {
-		return token, expiry, nil
+	for {
+		gen := d.tokenCache.GetGeneration()
+
+		// Check cache (with 30s refresh buffer)
+		if token, expiry, ok := d.tokenCache.Get("iam", 30*time.Second); ok {
+			return token, expiry, nil
+		}
+
+		// Acquire fresh token
+		token, expiry, err := d.acquireIAMToken(ctx)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+
+		// Cache it, unless the API key rotated while we were exchanging it
+		if d.tokenCache.SetIfGeneration("iam", token, expiry, gen) {
+			return token, expiry, nil
+		}
 	}
-
-	// Acquire fresh token
-	token, expiry, err := d.acquireIAMToken(ctx)
-	if err != nil {
-		return "", time.Time{}, err
-	}
-
-	// Cache it
-	d.tokenCache.Set("iam", token, expiry)
-
-	return token, expiry, nil
 }
 
 // acquireIAMToken exchanges the source API key for an IAM bearer token.

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -614,22 +615,22 @@ func TestIBMDriver_ImplementsSpecVerifier(t *testing.T) {
 // that minted them, so it would be served for its full hour.
 func TestIBMDriver_RotationDuringMintDiscardsStaleToken(t *testing.T) {
 	var d *IBMDriver
-	callCount := 0
+	var callCount int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/identity/token" {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
-		callCount++
+		n := atomic.AddInt32(&callCount, 1)
 		// Retire the key that is minting this very token, mid-exchange. This is what
 		// CommitRotation does to a mint that is already in flight.
-		if callCount == 1 {
+		if n == 1 {
 			d.tokenCache.InvalidateGeneration()
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token": fmt.Sprintf("token-call-%d", callCount),
+			"access_token": fmt.Sprintf("token-call-%d", n),
 			"token_type":   "Bearer",
 			"expires_in":   3600,
 			"expiration":   time.Now().Add(1 * time.Hour).Unix(),
@@ -643,7 +644,7 @@ func TestIBMDriver_RotationDuringMintDiscardsStaleToken(t *testing.T) {
 	token, _, err := d.getIAMToken(context.TODO())
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, callCount, "the in-flight token belonged to the retired key, so it must be minted again")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&callCount), "the in-flight token belonged to the retired key, so it must be minted again")
 	assert.Equal(t, "token-call-2", token, "the retired key's token must not be returned")
 
 	cached, _, ok := d.tokenCache.Get("iam", 30*time.Second)
@@ -683,16 +684,85 @@ func TestIBMDriver_ConcurrentRotationAndMintIsRaceFree(t *testing.T) {
 
 	wg.Wait()
 
-	d.authMu.Lock()
-	apiKey := d.apiKeyLocked()
-	d.authMu.Unlock()
-	assert.Equal(t, "rotated-key", apiKey, "the driver ends on the rotated key whatever the interleaving")
+	assert.Equal(t, "rotated-key", d.getAPIKey(), "the driver ends on the rotated key whatever the interleaving")
 
 	// Whether an entry survives depends on the interleaving, but if one did it cannot
 	// be the retired key's: the config write and the generation bump share a critical
 	// section, so a mint that read the old key also captured the old generation.
-	if token, _, ok := d.tokenCache.Get("iam", 30*time.Second); ok {
-		assert.Equal(t, "test-iam-token-rotated-key", token,
-			"a token the retired key minted must never remain readable after rotation")
-	}
+	// CommitRotation's own discovery repopulates the entry under the final generation,
+	// so an entry must exist — requiring it keeps this assertion from silently
+	// vanishing if that ever stops being true.
+	token, _, ok := d.tokenCache.Get("iam", 30*time.Second)
+	require.True(t, ok, "rotation leaves a usable entry behind")
+	assert.Equal(t, "test-iam-token-rotated-key", token,
+		"a token the retired key minted must never remain readable after rotation")
+}
+
+// TestIBMDriver_TokenFromRetiredKeyIsNeverServed drives the real interleaving rather
+// than simulating it: a mint's exchange is held open until an actual CommitRotation has
+// swapped the API key underneath it, so the response genuinely carries a token the
+// retired key minted. That token must never be returned or cached — the caller must
+// discard it and mint again against the key now in force.
+func TestIBMDriver_TokenFromRetiredKeyIsNeverServed(t *testing.T) {
+	mintStarted := make(chan struct{})
+	rotationDone := make(chan struct{})
+	var once sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/identity/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		apiKey := r.FormValue("apikey")
+
+		// Hold the outgoing key's exchange open until the rotation has landed. The
+		// rotated key's own exchanges pass straight through, so CommitRotation's
+		// verify is not deadlocked behind this.
+		if apiKey == "test-key" {
+			once.Do(func() { close(mintStarted) })
+			<-rotationDone
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-iam-token-" + apiKey,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"expiration":   time.Now().Add(1 * time.Hour).Unix(),
+		})
+	})
+	mux.HandleFunc("/v1/apikeys/details", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": "ApiKey-12345", "iam_id": "iam-ServiceId-abcdef", "account_id": "acc-123456",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.tokenCache.Clear()
+
+	var token string
+	var mintErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		token, _, mintErr = d.getIAMToken(context.TODO())
+	}()
+
+	<-mintStarted
+	require.NoError(t, d.CommitRotation(context.TODO(), map[string]string{
+		"api_key":      "rotated-key",
+		"iam_endpoint": srv.URL,
+	}))
+	close(rotationDone)
+	wg.Wait()
+
+	require.NoError(t, mintErr)
+	assert.Equal(t, "test-iam-token-rotated-key", token,
+		"the exchange completed against the retired key; its token must be discarded, not served")
+
+	cached, _, ok := d.tokenCache.Get("iam", 30*time.Second)
+	require.True(t, ok)
+	assert.NotEqual(t, "test-iam-token-test-key", cached, "the retired key's token must never reach the cache")
 }

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -648,4 +649,50 @@ func TestIBMDriver_RotationDuringMintDiscardsStaleToken(t *testing.T) {
 	cached, _, ok := d.tokenCache.Get("iam", 30*time.Second)
 	require.True(t, ok, "the re-minted token is cached")
 	assert.Equal(t, "token-call-2", cached, "the retired key's token must never reach the cache")
+}
+
+// TestIBMDriver_ConcurrentRotationAndMintIsRaceFree covers the locking half:
+// CommitRotation replaces credSource.Config while mints read api_key and iam_endpoint
+// out of it. The assertions are modest — this test earns its keep under -race, which is
+// what catches the mint path reading the config without the lock that guards the swap.
+func TestIBMDriver_ConcurrentRotationAndMintIsRaceFree(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.tokenCache.Clear()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := d.getIAMToken(context.TODO())
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, d.CommitRotation(context.TODO(), map[string]string{
+			"api_key":      "rotated-key",
+			"iam_endpoint": srv.URL,
+		}))
+	}()
+
+	wg.Wait()
+
+	d.authMu.Lock()
+	apiKey := d.apiKeyLocked()
+	d.authMu.Unlock()
+	assert.Equal(t, "rotated-key", apiKey, "the driver ends on the rotated key whatever the interleaving")
+
+	// Whether an entry survives depends on the interleaving, but if one did it cannot
+	// be the retired key's: the config write and the generation bump share a critical
+	// section, so a mint that read the old key also captured the old generation.
+	if token, _, ok := d.tokenCache.Get("iam", 30*time.Second); ok {
+		assert.Equal(t, "test-iam-token-rotated-key", token,
+			"a token the retired key minted must never remain readable after rotation")
+	}
 }

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -603,3 +603,49 @@ func TestIBMDriver_MintIAMWithCOS_InvalidKey(t *testing.T) {
 func TestIBMDriver_ImplementsSpecVerifier(t *testing.T) {
 	var _ credential.SpecVerifier = (*IBMDriver)(nil)
 }
+
+// TestIBMDriver_RotationDuringMintDiscardsStaleToken pins the generation guard in
+// getIAMToken. The IAM entry is keyed by a fixed string, so the generation is the only
+// thing separating a token minted by the current API key from one minted by a key that
+// has since been retired. A plain Set stamps the entry with whatever generation is
+// current when it lands, which files the retired key's token under the new generation —
+// and IBM does not revoke outstanding IAM tokens when CleanupRotation deletes the key
+// that minted them, so it would be served for its full hour.
+func TestIBMDriver_RotationDuringMintDiscardsStaleToken(t *testing.T) {
+	var d *IBMDriver
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/identity/token" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		callCount++
+		// Retire the key that is minting this very token, mid-exchange. This is what
+		// CommitRotation does to a mint that is already in flight.
+		if callCount == 1 {
+			d.tokenCache.InvalidateGeneration()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": fmt.Sprintf("token-call-%d", callCount),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"expiration":   time.Now().Add(1 * time.Hour).Unix(),
+		})
+	}))
+	defer srv.Close()
+
+	d = newTestIBMDriver(t, srv.URL)
+	d.tokenCache.Clear()
+
+	token, _, err := d.getIAMToken(context.TODO())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, callCount, "the in-flight token belonged to the retired key, so it must be minted again")
+	assert.Equal(t, "token-call-2", token, "the retired key's token must not be returned")
+
+	cached, _, ok := d.tokenCache.Get("iam", 30*time.Second)
+	require.True(t, ok, "the re-minted token is cached")
+	assert.Equal(t, "token-call-2", cached, "the retired key's token must never reach the cache")
+}

--- a/credential/drivers/token_cache.go
+++ b/credential/drivers/token_cache.go
@@ -63,6 +63,34 @@ func (tc *TokenCache) Set(key string, token string, expiresAt time.Time) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
+	tc.setLocked(key, token, expiresAt)
+}
+
+// SetIfGeneration stores a token only while the cache is still on the generation the
+// caller minted under, reporting whether it did.
+//
+// A caller that reads its source credentials, mints, then stores the result races
+// rotation: the credentials can be retired while the mint is in flight, and Set stamps
+// the entry with whatever generation is current when it lands — so a token minted by
+// the retired credential is filed under the *new* generation and served until it
+// expires of its own accord, long after rotation reported success. Reading the
+// generation before the credentials and passing it here closes that window: the store
+// is refused and the caller mints again against the current credentials.
+func (tc *TokenCache) SetIfGeneration(key string, token string, expiresAt time.Time, generation uint64) bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if tc.generation != generation {
+		return false
+	}
+
+	tc.setLocked(key, token, expiresAt)
+	return true
+}
+
+// setLocked sweeps the entries Get would already refuse and files the new one.
+// The caller holds mu.
+func (tc *TokenCache) setLocked(key string, token string, expiresAt time.Time) {
 	now := time.Now()
 	for k, entry := range tc.cache {
 		if entry.Generation != tc.generation || now.After(entry.ExpiresAt) {
@@ -104,7 +132,9 @@ func (tc *TokenCache) Clear() {
 	tc.cache = make(map[string]*TokenCacheEntry)
 }
 
-// GetGeneration returns the current generation (for testing/debugging)
+// GetGeneration returns the current generation. Callers read it before the
+// credentials they are about to mint with and hand it back to SetIfGeneration, so a
+// rotation landing in between is visible as a change at store time.
 func (tc *TokenCache) GetGeneration() uint64 {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()

--- a/credential/drivers/token_cache_test.go
+++ b/credential/drivers/token_cache_test.go
@@ -86,3 +86,31 @@ func TestTokenCache_SetPrunesSupersededGenerations(t *testing.T) {
 	assert.NotContains(t, tc.cache, "old-generation", "a superseded entry must be swept")
 	assert.Contains(t, tc.cache, "new-generation")
 }
+
+func TestTokenCache_SetIfGenerationRefusesRotatedMint(t *testing.T) {
+	tc := NewTokenCache()
+
+	// A caller reads the generation, then mints. Nothing rotates, so the store lands.
+	gen := tc.GetGeneration()
+	require.True(t, tc.SetIfGeneration("key", "fresh", time.Now().Add(time.Hour), gen))
+
+	token, _, ok := tc.Get("key", 30*time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "fresh", token)
+
+	// Now the credentials rotate while a second mint is in flight: the caller still
+	// holds the pre-rotation generation, so its result must be refused rather than
+	// filed under the new one, where Get would happily serve it.
+	stale := tc.GetGeneration()
+	tc.InvalidateGeneration()
+	assert.False(t, tc.SetIfGeneration("key", "minted-by-retired-credential", time.Now().Add(time.Hour), stale))
+
+	_, _, ok = tc.Get("key", 30*time.Second)
+	assert.False(t, ok, "the retired credential's token must not be readable after rotation")
+
+	// A mint that started after the rotation stores normally.
+	require.True(t, tc.SetIfGeneration("key", "post-rotation", time.Now().Add(time.Hour), tc.GetGeneration()))
+	token, _, ok = tc.Get("key", 30*time.Second)
+	require.True(t, ok)
+	assert.Equal(t, "post-rotation", token)
+}


### PR DESCRIPTION
A driver that mints a source token reads its credentials, performs the exchange, then stores the result. Rotation can land in the middle of that, and `TokenCache.Set` stamps the entry with whatever generation is current *when it lands* — so a token minted by the credential that was just retired gets filed under the **new** generation and served until it expires of its own accord. The generation counter exists to stop exactly this; the check-then-`Set` window is where it fails.

Neither cache carries anything about the minting credential in its key — GCP keys on the requested scopes, IBM on the fixed string `"iam"` — so the generation is the only thing separating a live token from a retired one. That makes the window the whole of the protection rather than a detail of it: rotation reports success while the old key's tokens keep flowing for their full lifetime, and for IBM the upstream does not revoke outstanding IAM tokens when cleanup deletes the key behind them.

Azure already resolves this by re-checking the generation after its HTTP call. These commits give the other two the same guarantee through the cache itself, so the ordering is stated once where it is enforced.

## Commits

**`625fedf` — the generation guard.** Adds `TokenCache.SetIfGeneration`. Callers read the generation *before* the credentials and store conditionally on it; a refused store means rotation happened underneath the mint, so the token is discarded and minted again. GCP also gains an `authMu` it never had — `CommitRotation` was replacing `credSource.Config` while mints read it, a data race the detector flags.

**`176e56a` — IBM's config reads under a lock.** The struct comment claimed `api_key` was only read under `authMu`; `getIAMToken` is the path where it is not, and it is the common one.

**`3760e40` — separating the two locks.** Reusing `authMu` for the config reads was the wrong lock: `PrepareRotation`/`CommitRotation` hold it across three HTTP requests each under a 3-attempt retry, so putting the mint path behind it meant every cache-missing mint parked there for the duration, on a `Lock()` that cannot observe the caller's context. `authMu` now serializes rotation and guards the ids it sequences; `configMu` guards the map a mint reads its credentials out of, held only across the map access. The plain/`Locked` method pairs disappear with it.

## Testing

`go test -race ./credential/...` passes.

Each driver has a test that rotates for real rather than simulating it: a mint's exchange is held open until an actual `CommitRotation` has swapped the key underneath it, so the response genuinely carries a token the retired key minted, and the assertion is that the token which comes back is the new key's. GCP's reads the `client_email` out of the signed assertion to tell the two keys apart. Both were verified to fail without the guard.

An earlier version of these tests bumped the generation from inside the HTTP handler, which exercises the discard-and-retry path but never swaps the key — so the "stale" token was in fact minted by the key still in force, and the property that matters went unpinned. Those remain as cheap mechanism tests alongside the real ones.

Concurrency tests for both drivers cover the locking half; they earn their keep under `-race`, and the IBM one was confirmed to trip the detector when the config read is moved back outside the lock.