### PR TITLE
fix(credential): key a chained secret on the claims and the config that select it

### DIFF
--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -37,8 +37,8 @@ func (d *mockChainedDriver) MintFromSecret(_ context.Context, _ *CredSpec, mater
 }
 
 func (d *mockChainedDriver) Revoke(_ context.Context, _ string) error { return nil }
-func (d *mockChainedDriver) Type() string                            { return d.driverType }
-func (d *mockChainedDriver) Cleanup(_ context.Context) error         { return nil }
+func (d *mockChainedDriver) Type() string                             { return d.driverType }
+func (d *mockChainedDriver) Cleanup(_ context.Context) error          { return nil }
 
 type mockChainedFactory struct{ driver *mockChainedDriver }
 
@@ -46,8 +46,8 @@ func (f *mockChainedFactory) Type() string { return f.driver.driverType }
 func (f *mockChainedFactory) Create(_ map[string]string, _ *logger.GatedLogger) (SourceDriver, error) {
 	return f.driver, nil
 }
-func (f *mockChainedFactory) ValidateConfig(_ map[string]string) error   { return nil }
-func (f *mockChainedFactory) SensitiveConfigFields() []string            { return nil }
+func (f *mockChainedFactory) ValidateConfig(_ map[string]string) error { return nil }
+func (f *mockChainedFactory) SensitiveConfigFields() []string          { return nil }
 func (f *mockChainedFactory) InferCredentialType(_ map[string]string) (string, error) {
 	return "", fmt.Errorf("n/a")
 }
@@ -72,8 +72,8 @@ func (d *mockExchangeSecretDriver) MintCredentialWithExchange(_ context.Context,
 	return map[string]interface{}{"token": "SECRET-" + inputs.SubjectToken}, nil, 0, "", nil
 }
 func (d *mockExchangeSecretDriver) Revoke(_ context.Context, _ string) error { return nil }
-func (d *mockExchangeSecretDriver) Type() string                            { return d.driverType }
-func (d *mockExchangeSecretDriver) Cleanup(_ context.Context) error         { return nil }
+func (d *mockExchangeSecretDriver) Type() string                             { return d.driverType }
+func (d *mockExchangeSecretDriver) Cleanup(_ context.Context) error          { return nil }
 
 type mockExchangeSecretFactory struct{ driver *mockExchangeSecretDriver }
 
@@ -118,8 +118,8 @@ func (d *mockChainedExchangeDriver) MintCredentialWithExchangeFromSecret(_ conte
 	return map[string]interface{}{"token": "exch:" + inputs.SubjectToken + ":" + material.Secret()}, nil, 0, "", nil
 }
 func (d *mockChainedExchangeDriver) Revoke(_ context.Context, _ string) error { return nil }
-func (d *mockChainedExchangeDriver) Type() string                            { return d.driverType }
-func (d *mockChainedExchangeDriver) Cleanup(_ context.Context) error         { return nil }
+func (d *mockChainedExchangeDriver) Type() string                             { return d.driverType }
+func (d *mockChainedExchangeDriver) Cleanup(_ context.Context) error          { return nil }
 
 type mockChainedExchangeFactory struct{ driver *mockChainedExchangeDriver }
 
@@ -654,6 +654,93 @@ func TestChaining_CacheIsolatesPerAgentClaims(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(),
 		"two principals behind one fingerprint must not share a fetch")
+}
+
+// TestChaining_EditingTheReferencedSpecInvalidates drives the referenced-spec dimension
+// through IssueCredential. The spec name is a label: editing what it points at — here a
+// templated secret_path — must move the key, or the entry filled from the old location
+// keeps answering under a name that did not change.
+func TestChaining_EditingTheReferencedSpecInvalidates(t *testing.T) {
+	env := newChainingEnv(t)
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	for _, name := range []string{"consumer1", "consumer2", "consumer3"} {
+		env.store.AddSpec(&CredSpec{Name: name, Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	}
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	// Distinct consumer specs throughout: one consumer asked twice is answered by the
+	// consumer credential cache and never reaches the chained fetch at all.
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.secretDriver.mintCalls.Load())
+
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "unchanged config still shares the entry")
+
+	// The operator repoints the referenced spec at a different location.
+	env.store.AddSpec(&CredSpec{Name: "secret-spec", Type: TypeVaultToken, Source: "secretsource",
+		Config: map[string]string{"secret_path": "prod-teams/{{user.team}}/db"}})
+
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"the fetch now resolves elsewhere, so the previous location's material must not answer for it")
+}
+
+// The same holds one level out: moving the source the referenced spec names changes
+// where the fetch lands even when the spec itself is untouched.
+func TestChaining_EditingTheReferencedSourceInvalidates(t *testing.T) {
+	env := newChainingEnv(t)
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.secretDriver.mintCalls.Load())
+
+	env.store.AddSource(&CredSource{Name: "secretsource", Type: "secretsrc",
+		Config: map[string]string{"vault_address": "https://vault-dr.internal:8200"}})
+
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"a source pointed somewhere else is a different fetch")
+}
+
+// TestChaining_RotatingTheSourceCredentialDoesNotInvalidate is the other half, and the
+// reason the fingerprint excludes proof material rather than hashing the config
+// wholesale. Rotation replaces an authenticator, not the identity it authenticates, so
+// dumping every secret cached under the source would be pure churn.
+func TestChaining_RotatingTheSourceCredentialDoesNotInvalidate(t *testing.T) {
+	env := newChainingEnv(t)
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSource(&CredSource{Name: "secretsource", Type: "secretsrc",
+		Config: map[string]string{"vault_address": "https://vault.internal:8200", "secret_id": "sid-1"}})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.secretDriver.mintCalls.Load())
+
+	// A routine source rotation: same address, new proof.
+	env.store.AddSource(&CredSource{Name: "secretsource", Type: "secretsrc",
+		Config: map[string]string{"vault_address": "https://vault.internal:8200", "secret_id": "sid-2"}})
+
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(),
+		"rotating the source's own credential reaches the same secret in the same place")
 }
 
 // TestChaining_RetryEvictsStaleCachedSecret: when a cached secret is rejected downstream

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -686,8 +686,16 @@ func TestChaining_EditingTheReferencedSpecInvalidates(t *testing.T) {
 
 	_, err = env.manager.IssueCredential(ctx, caller, "consumer3", nil)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+	require.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
 		"the fetch now resolves elsewhere, so the previous location's material must not answer for it")
+
+	// The new key must itself be shared, or the test above would also pass with caching
+	// simply switched off — every path that declines to cache mints every time.
+	env.store.AddSpec(&CredSpec{Name: "consumer4", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer4", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"the edit moved the key to a new entry, it did not stop the cache working")
 }
 
 // The same holds one level out: moving the source the referenced spec names changes
@@ -710,8 +718,14 @@ func TestChaining_EditingTheReferencedSourceInvalidates(t *testing.T) {
 
 	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+	require.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
 		"a source pointed somewhere else is a different fetch")
+
+	env.store.AddSpec(&CredSpec{Name: "consumer3", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"the edit moved the key to a new entry, it did not stop the cache working")
 }
 
 // TestChaining_RotatingTheSourceCredentialDoesNotInvalidate is the other half, and the
@@ -741,6 +755,43 @@ func TestChaining_RotatingTheSourceCredentialDoesNotInvalidate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(),
 		"rotating the source's own credential reaches the same secret in the same place")
+}
+
+// TestChaining_EditingPassThroughSpecMaterialInvalidates is the sharpest form of the
+// defect. Several drivers vend the referenced spec's config as the credential itself —
+// the local driver returns spec.Config wholesale, a static api-key spec returns its
+// api_key, a github PAT spec its token. Replacing a leaked value there changes what the
+// fetch returns, so the key has to move: nothing downstream will reject the old value
+// (these drivers validate nothing), so no retry can rescue it and the leaked credential
+// would be handed out for the rest of the TTL.
+func TestChaining_EditingPassThroughSpecMaterialInvalidates(t *testing.T) {
+	env := newChainingEnv(t)
+	// The referenced spec's own config carries the material, under the conventional name.
+	env.secretDriver.mintFunc = func(_ context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"token": spec.Config["api_key"]}, nil, 0, "", nil
+	}
+	env.store.AddSpec(&CredSpec{Name: "secret-spec", Type: TypeVaultToken, Source: "secretsource",
+		Config: map[string]string{"api_key": "key-v1"}})
+
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	cred, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, "consumer-token:key-v1", cred.Data["token"])
+
+	// The key leaks; the operator replaces it in place.
+	env.store.AddSpec(&CredSpec{Name: "secret-spec", Type: TypeVaultToken, Source: "secretsource",
+		Config: map[string]string{"api_key": "key-v2"}})
+
+	cred, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "consumer-token:key-v2", cred.Data["token"],
+		"the replaced credential must be the one vended, not the leaked one it replaced")
 }
 
 // TestChaining_RetryEvictsStaleCachedSecret: when a cached secret is rejected downstream

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -578,6 +578,84 @@ func TestChaining_CacheIsolatesPerUser(t *testing.T) {
 	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(), "a different user fetches its own secret (no cross-user leak)")
 }
 
+// TestChaining_CacheIsolatesPerUserClaims covers what the token id cannot: the same
+// user, the same token id, different claims.
+//
+// TestChaining_CacheIsolatesPerUser above proves two *users* never share an entry, and
+// the token id is what proves it. But a token id hashes the presented credential, the
+// mount and the role name — not the role's claim mapping. When an operator edits that
+// mapping, a user re-authenticating gets the identical token id while their claims, and
+// so the path a templated fetch renders, have moved. Keyed on the token id alone the
+// entry the old claims filled would keep answering for the new ones.
+func TestChaining_CacheIsolatesPerUserClaims(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exchange-secret", Type: TypeVaultToken, Source: "exchangesource", Config: map[string]string{}})
+	cfg := map[string]string{ConfigSecretSpec: "exchange-secret", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+
+	// Alice, on the platform team, fills the cache.
+	_, err := env.manager.IssueCredential(ctx,
+		exchangeChainCaller("agentTok", "agentA", "userA", map[string]string{"sub": "alice", "team": "platform"}),
+		"consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.exchangeDriver.mintCalls.Load())
+
+	// The role is remapped to infra. Same user, same token id, different claims.
+	_, err = env.manager.IssueCredential(ctx,
+		exchangeChainCaller("agentTok", "agentA", "userA", map[string]string{"sub": "alice", "team": "infra"}),
+		"consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(),
+		"remapped claims resolve a different secret, so the entry the old ones filled must not answer for them")
+}
+
+// agentClaimsChainCaller pins the agent's cache identity while varying the claims a
+// templated path resolves from — the one token, two roles case, which the fingerprint
+// alone cannot tell apart.
+func agentClaimsChainCaller(agentToken, agentIdentity string, agentClaims map[string]string) Caller {
+	return Caller{
+		TokenID:  agentToken,
+		TokenTTL: time.Hour,
+		ResolveInputs: func(_ context.Context, _ string) (*ExchangeInputs, error) {
+			return &ExchangeInputs{
+				SubjectCacheIdentity: agentIdentity,
+				ResolveSubjectToken:  func(_ context.Context) (string, error) { return "subj-" + agentIdentity, nil },
+				AgentClaims:          agentClaims,
+			}, nil
+		},
+	}
+}
+
+// TestChaining_CacheIsolatesPerAgentClaims drives the agent dimension through
+// IssueCredential rather than asserting on the key function. The unit tests pin what
+// chainedSecretCacheKey computes; this pins that the manager actually keys the fetch on
+// it, so dropping the dimension is caught here even where the key literal is not read.
+func TestChaining_CacheIsolatesPerAgentClaims(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSpec(&CredSpec{Name: "exchange-secret", Type: TypeVaultToken, Source: "exchangesource", Config: map[string]string{}})
+	cfg := map[string]string{ConfigSecretSpec: "exchange-secret", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+
+	// Identical cache identity — so an identical fingerprint — but the claims behind it
+	// name two different principals, as one token presented under two roles does.
+	_, err := env.manager.IssueCredential(ctx,
+		agentClaimsChainCaller("agentTok", "agentA", map[string]string{"sub": "build-runner"}), "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.exchangeDriver.mintCalls.Load())
+
+	_, err = env.manager.IssueCredential(ctx,
+		agentClaimsChainCaller("agentTok", "agentA", map[string]string{"sub": "deploy-bot"}), "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(),
+		"two principals behind one fingerprint must not share a fetch")
+}
+
 // TestChaining_RetryEvictsStaleCachedSecret: when a cached secret is rejected downstream
 // (ErrChainedSecretRejected), the manager evicts it and retries once with a fresh fetch.
 func TestChaining_RetryEvictsStaleCachedSecret(t *testing.T) {

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -799,6 +799,10 @@ func writeHashField(h hash.Hash, s string) {
 
 // hashStringMap folds a map into h with its keys sorted, so iteration order cannot
 // change the result. Keys present in exclude are skipped.
+//
+// The entry count is written first: without it the fields run together with whatever
+// surrounds them, so a config key named like an adjacent literal could move a pair across
+// that boundary without changing the digest.
 func hashStringMap(h hash.Hash, m map[string]string, exclude map[string]struct{}) {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -809,31 +813,33 @@ func hashStringMap(h hash.Hash, m map[string]string, exclude map[string]struct{}
 	}
 	sort.Strings(keys)
 
+	var countBuf [4]byte
+	binary.BigEndian.PutUint32(countBuf[:], uint32(len(keys)))
+	h.Write(countBuf[:])
+
 	for _, k := range keys {
 		writeHashField(h, k)
 		writeHashField(h, m[k])
 	}
 }
 
-// rotatedProofFields are config keys carrying proof of an identity rather than naming
-// what is fetched or where it lives. Each is rewritten by a rotation — source-side by a
-// driver's PrepareRotation, spec-side by the refresh-token write-back — while the
-// credential goes on reaching the same secret in the same place.
+// rotatedSourceProofFields are SOURCE config keys carrying proof of an identity rather
+// than naming what is fetched or where it lives. Every one is written back by some
+// driver's PrepareRotation while the source goes on reaching the same secret in the same
+// place, so hashing them would dump every secret cached under a source each time that
+// source rotated, buying nothing: the Rotatable contract is that a rotation replaces an
+// authenticator, never the identity it authenticates.
 //
-// They are excluded from chainedSpecFingerprint for two reasons. Including them would
-// dump every secret cached under a source each time that source rotated, buying nothing:
-// the Rotatable contract is that a rotation replaces an authenticator, never the identity
-// it authenticates. And for a referenced spec whose refresh_token rotates on every use it
-// would be worse than churn — the key would move on each fetch, so no entry would ever be
-// read once, and caching would be silently dead for exactly the specs that ask for it.
+// This set applies to the SOURCE side only. Key names do not mean the same thing on both
+// sides — on the spec side several of these ARE the fetch coordinate or the vended
+// material itself (see perMintSpecFields), and excluding them there would serve an
+// operator the value they had just replaced.
 //
 // Drift is safe in the direction it drifts: a rotating field missing from this set is
 // fingerprinted, which costs cache churn, never a stale secret.
-var rotatedProofFields = map[string]struct{}{
-	"refresh_token":         {}, // spec-side write-back (persistRotatedRefreshToken)
+var rotatedSourceProofFields = map[string]struct{}{
 	"secret_id":             {}, // vault approle, azure client secret id
 	"secret_id_accessor":    {}, // vault approle
-	"token":                 {}, // vault token auth
 	"client_secret":         {}, // azure
 	"access_key_id":         {}, // aws, alicloud — rotated in lockstep with its secret
 	"secret_access_key":     {}, // aws
@@ -847,9 +853,32 @@ var rotatedProofFields = map[string]struct{}{
 	"management_secret_key": {}, // scaleway
 }
 
+// perMintSpecFields are the only SPEC config keys excluded from the fingerprint, and they
+// are excluded because the refresh-token write-back rewrites them on every single mint
+// (persistRotatedRefreshToken). Hashing them would move the key on each fetch, so no entry
+// would ever be read once and caching would be silently dead for exactly the specs that
+// ask for it — worse than the churn the source-side set avoids.
+//
+// Nothing else is excluded on this side. A spec's config is frequently the fetch
+// coordinate (a Secrets Manager secret_id, a templated secret_path) or the vended material
+// itself (a static api_key, a PAT under "token", anything at all for the local driver,
+// which returns spec.Config wholesale), so an exclusion here means an operator replacing a
+// leaked credential keeps handing out the leaked one until the entry expires. Scheduled
+// spec rotation (SpecRotatable) does move the key, which is correct rather than churn:
+// rotated spec material is genuinely different material being vended.
+//
+// The residual: reconnecting a spec to a DIFFERENT account changes only the refresh token,
+// so the key does not move and the previous account's material is served for the rest of
+// the TTL. Keying cannot close that — it needs eviction on the write-back, or a stable
+// grant identifier captured at connect time.
+var perMintSpecFields = map[string]struct{}{
+	"refresh_token":            {},
+	"refresh_token_expires_at": {},
+}
+
 // chainedSpecFingerprint hashes what the referenced spec and its source say about which
 // secret is fetched and where it lives: the spec's type, the source it names, and both
-// configs minus the proof material above.
+// configs — the spec's entire, the source's minus the credentials rotation rewrites.
 //
 // The spec NAME alone cannot stand for this. A name is a label an operator can point
 // somewhere else — editing secret_path, swapping the mount, repointing the spec at
@@ -868,12 +897,12 @@ func chainedSpecFingerprint(spec *CredSpec, src *CredSource) string {
 		writeHashField(h, "spec")
 		writeHashField(h, spec.Type)
 		writeHashField(h, spec.Source)
-		hashStringMap(h, spec.Config, rotatedProofFields)
+		hashStringMap(h, spec.Config, perMintSpecFields)
 	}
 	if src != nil {
 		writeHashField(h, "src")
 		writeHashField(h, src.Type)
-		hashStringMap(h, src.Config, rotatedProofFields)
+		hashStringMap(h, src.Config, rotatedSourceProofFields)
 	}
 
 	return hex.EncodeToString(h.Sum(nil))

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -705,8 +705,10 @@ func (m *Manager) invalidateChainedSecret(key string) {
 // inputs left to cover are the claims a templated path resolves from, which the agent
 // dimension below carries. When the referenced fetch is user-scoped (the referenced
 // spec sets assertion_user_claims, so inputsB.UserClaims is populated), the user token id
-// is folded in so one user's per-user secret is never served to another; a source-global
-// fetch (no user claims) omits it and is shared across users under the agent. A nil
+// and a fingerprint of those claims are folded in — the first so one user's per-user
+// secret is never served to another, the second so a user whose claims have changed
+// under a stable token id is not served what the old ones fetched; a source-global
+// fetch (no user claims) omits both and is shared across users under the agent. A nil
 // inputsB (a referenced spec that requests no exchange) uses a fixed sentinel.
 //
 // It returns "" — meaning "do not cache" — for a user-scoped fetch that lacks the user
@@ -732,11 +734,20 @@ func chainedSecretCacheKey(nsID, secretRef string, caller Caller, inputsB *Excha
 		agent = ":a:" + claimsFingerprint(inputsB.AgentClaims)
 	}
 
+	// The user's claims select a path the same way the agent's do, so they key the
+	// entry the same way. The user token id alone is a proxy, not a cover: it hashes
+	// the presented credential, the mount and the role name, but not the role's
+	// mapping. Re-authenticating after an operator edits that mapping returns the
+	// identical token id carrying different claims, which renders a different path
+	// under a key that never moved. The token id stays because it is what binds the
+	// entry to a principal's lifecycle; the fingerprint is what tracks what the
+	// store was actually shown.
 	if inputsB != nil && len(inputsB.UserClaims) > 0 {
 		if caller.User == nil {
 			return ""
 		}
-		return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent + ":u:" + caller.User.TokenID
+		return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent +
+			":u:" + caller.User.TokenID + ":uc:" + claimsFingerprint(inputsB.UserClaims)
 	}
 	return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent
 }

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"sort"
 	"sync"
 	"time"
@@ -613,32 +614,36 @@ func (m *Manager) fetchChainedSecret(ctx context.Context, caller Caller, secretR
 func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, spec *CredSpec, secretRef string, inputsB *ExchangeInputs) (data map[string]string, typ string, fromCache bool, key string, err error) {
 	ttl := m.secretCacheTTL(ctx, spec)
 	if ttl <= 0 {
-		credB, ferr := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
-		if ferr != nil {
-			return nil, "", false, "", ferr
-		}
-		return credB.Data, credB.Type, false, "", nil
+		return m.fetchUncached(ctx, caller, secretRef, inputsB)
 	}
 
 	ns, nerr := namespace.FromContext(ctx)
 	if nerr != nil {
 		// No namespace to scope the cache key (internal/non-request path): fall back to
 		// a direct, uncached fetch rather than risk a cross-namespace key collision.
-		credB, ferr := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
-		if ferr != nil {
-			return nil, "", false, "", ferr
-		}
-		return credB.Data, credB.Type, false, "", nil
+		return m.fetchUncached(ctx, caller, secretRef, inputsB)
 	}
-	key = chainedSecretCacheKey(ns.ID, secretRef, caller, inputsB)
+
+	// The referenced spec's own config decides which secret is fetched and from where,
+	// so it has to key the entry that answers for it — resolve it before keying. Both
+	// reads are served from the config store's cache, which this request has already
+	// populated (resolveExchangeInputs read the same spec to build inputsB). If either
+	// cannot be resolved, decline to cache rather than key on an identity we could not
+	// establish; the fetch below reports the real error.
+	specB, serr := m.specResolver.ResolveSpec(ctx, secretRef)
+	if serr != nil {
+		return m.fetchUncached(ctx, caller, secretRef, inputsB)
+	}
+	srcB, serr := m.configStore.GetSource(ctx, specB.Source)
+	if serr != nil {
+		return m.fetchUncached(ctx, caller, secretRef, inputsB)
+	}
+
+	key = chainedSecretCacheKey(ns.ID, secretRef, chainedSpecFingerprint(specB, srcB), caller, inputsB)
 	if key == "" {
 		// Caching refused for safety (user-scoped fetch without a user principal): fetch
 		// directly, uncached.
-		credB, ferr := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
-		if ferr != nil {
-			return nil, "", false, "", ferr
-		}
-		return credB.Data, credB.Type, false, "", nil
+		return m.fetchUncached(ctx, caller, secretRef, inputsB)
 	}
 
 	if cs, ok := m.secretCache.Get(key); ok {
@@ -668,6 +673,17 @@ func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, s
 	return copyStringMap(cs.Data), cs.Type, false, key, nil
 }
 
+// fetchUncached performs the referenced fetch without consulting or populating the
+// cache, for every path that declines to cache. It reports fromCache=false and an empty
+// key, so the caller neither retries on a rejection nor tries to invalidate.
+func (m *Manager) fetchUncached(ctx context.Context, caller Caller, secretRef string, inputsB *ExchangeInputs) (map[string]string, string, bool, string, error) {
+	credB, err := m.fetchChainedSecret(ctx, caller, secretRef, inputsB)
+	if err != nil {
+		return nil, "", false, "", err
+	}
+	return credB.Data, credB.Type, false, "", nil
+}
+
 // secretCacheTTL resolves ConfigSecretCacheTTL spec-then-source (matching how
 // secret_spec / secret_field resolve). Returns 0 (no caching) when unset. A spec-level
 // value is authoritative by PRESENCE, so an explicit spec-level "0" opts out of a
@@ -692,8 +708,8 @@ func (m *Manager) invalidateChainedSecret(key string) {
 	m.group.Forget(key)
 }
 
-// chainedSecretCacheKey scopes a cached secret to (namespace, secret_spec, agent
-// identity). inputsB.Fingerprint keys on SubjectCacheIdentity — stable across an agent's
+// chainedSecretCacheKey scopes a cached secret to (namespace, secret_spec, what that
+// spec fetches, agent identity). inputsB.Fingerprint keys on SubjectCacheIdentity — stable across an agent's
 // sessions — so the store's per-agent authorization is honoured (agent B is never served
 // agent A's fetched secret).
 //
@@ -711,11 +727,22 @@ func (m *Manager) invalidateChainedSecret(key string) {
 // fetch (no user claims) omits both and is shared across users under the agent. A nil
 // inputsB (a referenced spec that requests no exchange) uses a fixed sentinel.
 //
+// refFP is chainedSpecFingerprint over the referenced spec and its source: the spec name
+// says which entry to look under, and refFP says what that name resolved to when the
+// entry was filled, so an operator repointing the name does not inherit the old answer.
+//
 // It returns "" — meaning "do not cache" — for a user-scoped fetch that lacks the user
-// principal to key on. That combination cannot arise from the current request path, but
+// principal to key on, or a referenced spec that could not be resolved. That combination cannot arise from the current request path, but
 // refusing to cache is the safe failure mode: it never shares one user's secret
 // namespace-wide.
-func chainedSecretCacheKey(nsID, secretRef string, caller Caller, inputsB *ExchangeInputs) string {
+func chainedSecretCacheKey(nsID, secretRef, refFP string, caller Caller, inputsB *ExchangeInputs) string {
+	// No fingerprint means the referenced spec could not be resolved, so there is no
+	// identity to key on. Refuse to cache rather than share an entry across whatever
+	// the name points at now.
+	if refFP == "" {
+		return ""
+	}
+
 	fp := "noexchange"
 	if inputsB != nil {
 		fp = inputsB.Fingerprint()
@@ -746,33 +773,109 @@ func chainedSecretCacheKey(nsID, secretRef string, caller Caller, inputsB *Excha
 		if caller.User == nil {
 			return ""
 		}
-		return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent +
+		return "chainsecret:" + nsID + ":" + secretRef + ":s:" + refFP + ":" + fp + agent +
 			":u:" + caller.User.TokenID + ":uc:" + claimsFingerprint(inputsB.UserClaims)
 	}
-	return "chainsecret:" + nsID + ":" + secretRef + ":" + fp + agent
+	return "chainsecret:" + nsID + ":" + secretRef + ":s:" + refFP + ":" + fp + agent
 }
 
 // claimsFingerprint hashes a claim map stably: keys sorted so map order cannot
 // change the result, and each field length-prefixed so no two maps can collide by
 // running their bytes together differently.
 func claimsFingerprint(claims map[string]string) string {
-	keys := make([]string, 0, len(claims))
-	for k := range claims {
+	h := sha256.New()
+	hashStringMap(h, claims, nil)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// writeHashField writes s into h length-prefixed, so no two sequences of fields can
+// collide by running their bytes together differently.
+func writeHashField(h hash.Hash, s string) {
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s)))
+	h.Write(lenBuf[:])
+	h.Write([]byte(s))
+}
+
+// hashStringMap folds a map into h with its keys sorted, so iteration order cannot
+// change the result. Keys present in exclude are skipped.
+func hashStringMap(h hash.Hash, m map[string]string, exclude map[string]struct{}) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if _, skip := exclude[k]; skip {
+			continue
+		}
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	h := sha256.New()
-	writeField := func(s string) {
-		var lenBuf [4]byte
-		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s)))
-		h.Write(lenBuf[:])
-		h.Write([]byte(s))
-	}
 	for _, k := range keys {
-		writeField(k)
-		writeField(claims[k])
+		writeHashField(h, k)
+		writeHashField(h, m[k])
 	}
+}
+
+// rotatedProofFields are config keys carrying proof of an identity rather than naming
+// what is fetched or where it lives. Each is rewritten by a rotation — source-side by a
+// driver's PrepareRotation, spec-side by the refresh-token write-back — while the
+// credential goes on reaching the same secret in the same place.
+//
+// They are excluded from chainedSpecFingerprint for two reasons. Including them would
+// dump every secret cached under a source each time that source rotated, buying nothing:
+// the Rotatable contract is that a rotation replaces an authenticator, never the identity
+// it authenticates. And for a referenced spec whose refresh_token rotates on every use it
+// would be worse than churn — the key would move on each fetch, so no entry would ever be
+// read once, and caching would be silently dead for exactly the specs that ask for it.
+//
+// Drift is safe in the direction it drifts: a rotating field missing from this set is
+// fingerprinted, which costs cache churn, never a stale secret.
+var rotatedProofFields = map[string]struct{}{
+	"refresh_token":         {}, // spec-side write-back (persistRotatedRefreshToken)
+	"secret_id":             {}, // vault approle, azure client secret id
+	"secret_id_accessor":    {}, // vault approle
+	"token":                 {}, // vault token auth
+	"client_secret":         {}, // azure
+	"access_key_id":         {}, // aws, alicloud — rotated in lockstep with its secret
+	"secret_access_key":     {}, // aws
+	"access_key_secret":     {}, // alicloud
+	"api_key":               {}, // elastic, ibm
+	"api_key_id":            {}, // elastic
+	"service_account_key":   {}, // gcp
+	"application_secret":    {}, // gitlab oauth application
+	"personal_access_token": {}, // gitlab
+	"management_access_key": {}, // scaleway
+	"management_secret_key": {}, // scaleway
+}
+
+// chainedSpecFingerprint hashes what the referenced spec and its source say about which
+// secret is fetched and where it lives: the spec's type, the source it names, and both
+// configs minus the proof material above.
+//
+// The spec NAME alone cannot stand for this. A name is a label an operator can point
+// somewhere else — editing secret_path, swapping the mount, repointing the spec at
+// another source, or moving the source to a different address all change what a fetch
+// returns while the name stays put, and the entry filled before the edit would go on
+// answering for it. Deriving the key from the content instead makes every such edit
+// self-correcting, on every node, with no invalidation to coordinate — the same standard
+// the driver-level token caches are held to.
+//
+// Config values are only ever hashed, never placed in the key in the clear.
+func chainedSpecFingerprint(spec *CredSpec, src *CredSource) string {
+	h := sha256.New()
+	writeHashField(h, "chained-spec-v1")
+
+	if spec != nil {
+		writeHashField(h, "spec")
+		writeHashField(h, spec.Type)
+		writeHashField(h, spec.Source)
+		hashStringMap(h, spec.Config, rotatedProofFields)
+	}
+	if src != nil {
+		writeHashField(h, "src")
+		writeHashField(h, src.Type)
+		hashStringMap(h, src.Config, rotatedProofFields)
+	}
+
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -1324,8 +1324,8 @@ func TestChainedSecretCacheKey_AgentClaimsDimension(t *testing.T) {
 	}
 
 	t.Run("same token, different resolved claims, different keys", func(t *testing.T) {
-		viaRoleA := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "build-runner"}))
-		viaRoleB := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "deploy-bot"}))
+		viaRoleA := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "build-runner"}))
+		viaRoleB := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "deploy-bot"}))
 
 		require.NotEmpty(t, viaRoleA)
 		assert.NotEqual(t, viaRoleA, viaRoleB,
@@ -1333,20 +1333,20 @@ func TestChainedSecretCacheKey_AgentClaimsDimension(t *testing.T) {
 	})
 
 	t.Run("same claims give the same key", func(t *testing.T) {
-		first := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "a", "team": "platform"}))
-		second := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"team": "platform", "sub": "a"}))
+		first := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "a", "team": "platform"}))
+		second := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"team": "platform", "sub": "a"}))
 		assert.Equal(t, first, second, "map iteration order must not change the key")
 	})
 
 	t.Run("a metadata claim changing moves the key", func(t *testing.T) {
-		before := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "a", "team": "platform"}))
-		after := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "a", "team": "infra"}))
+		before := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "a", "team": "platform"}))
+		after := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "a", "team": "infra"}))
 		assert.NotEqual(t, before, after)
 	})
 
 	t.Run("no agent claims keeps the key byte-identical", func(t *testing.T) {
-		withNone := chainedSecretCacheKey("ns", "ref", caller, base(nil))
-		legacy := "chainsecret:ns:ref:" + base(nil).Fingerprint()
+		withNone := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(nil))
+		legacy := "chainsecret:ns:ref:s:" + testRefFP + ":" + base(nil).Fingerprint()
 		assert.Equal(t, legacy, withNone,
 			"a spec not carrying agent claims must not have its cache key perturbed")
 	})
@@ -1357,7 +1357,7 @@ func TestChainedSecretCacheKey_AgentClaimsDimension(t *testing.T) {
 func TestChainedSecretCacheKey_AgentAndUserDimensionsCompose(t *testing.T) {
 	caller := Caller{TokenID: "agent-token", User: &UserContext{TokenID: "user-token"}}
 	key := func(sub string) string {
-		return chainedSecretCacheKey("ns", "ref", caller, &ExchangeInputs{
+		return chainedSecretCacheKey("ns", "ref", testRefFP, caller, &ExchangeInputs{
 			SubjectToken:     "the.same.jwt",
 			SubjectTokenType: TokenTypeJWT,
 			AgentClaims:      map[string]string{"sub": sub},
@@ -1390,8 +1390,8 @@ func TestChainedSecretCacheKey_UserClaimsDimension(t *testing.T) {
 	}
 
 	t.Run("same user token, remapped claims, different keys", func(t *testing.T) {
-		beforeEdit := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice", "team": "platform"}))
-		afterEdit := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice", "team": "infra"}))
+		beforeEdit := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "alice", "team": "platform"}))
+		afterEdit := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "alice", "team": "infra"}))
 
 		require.NotEmpty(t, beforeEdit)
 		assert.NotEqual(t, beforeEdit, afterEdit,
@@ -1399,31 +1399,128 @@ func TestChainedSecretCacheKey_UserClaimsDimension(t *testing.T) {
 	})
 
 	t.Run("same claims give the same key", func(t *testing.T) {
-		first := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice", "team": "platform"}))
-		second := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"team": "platform", "sub": "alice"}))
+		first := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "alice", "team": "platform"}))
+		second := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"team": "platform", "sub": "alice"}))
 		assert.Equal(t, first, second, "map iteration order must not change the key")
 	})
 
 	t.Run("two users still separate", func(t *testing.T) {
 		other := Caller{TokenID: "agent-token", User: &UserContext{TokenID: "other-user-token"}}
-		mine := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice"}))
-		theirs := chainedSecretCacheKey("ns", "ref", other, base(map[string]string{"sub": "alice"}))
+		mine := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(map[string]string{"sub": "alice"}))
+		theirs := chainedSecretCacheKey("ns", "ref", testRefFP, other, base(map[string]string{"sub": "alice"}))
 		assert.NotEqual(t, mine, theirs,
 			"the token id still binds the entry to a principal even when claims coincide")
 	})
 
 	t.Run("no user claims keeps the key byte-identical", func(t *testing.T) {
-		withNone := chainedSecretCacheKey("ns", "ref", caller, base(nil))
-		legacy := "chainsecret:ns:ref:" + base(nil).Fingerprint()
+		withNone := chainedSecretCacheKey("ns", "ref", testRefFP, caller, base(nil))
+		legacy := "chainsecret:ns:ref:s:" + testRefFP + ":" + base(nil).Fingerprint()
 		assert.Equal(t, legacy, withNone,
 			"a source-global fetch must not have its cache key perturbed")
 	})
 
 	t.Run("a user-scoped fetch with no user principal refuses to cache", func(t *testing.T) {
 		agentOnly := Caller{TokenID: "agent-token"}
-		assert.Empty(t, chainedSecretCacheKey("ns", "ref", agentOnly, base(map[string]string{"sub": "alice"})),
+		assert.Empty(t, chainedSecretCacheKey("ns", "ref", testRefFP, agentOnly, base(map[string]string{"sub": "alice"})),
 			"sharing a user-scoped fetch namespace-wide is never the safe failure mode")
 	})
+}
+
+// testRefFP stands in for chainedSpecFingerprint in the subtests above, which pin the
+// agent and user dimensions and must be unaffected by the referenced-spec one.
+const testRefFP = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// TestChainedSpecFingerprint pins what the referenced spec contributes to the key. The
+// spec NAME is a label an operator can repoint; the fingerprint is what the name
+// resolved to when the entry was filled, so an edit cannot inherit the old answer.
+func TestChainedSpecFingerprint(t *testing.T) {
+	spec := func(cfg map[string]string) *CredSpec {
+		return &CredSpec{Name: "ref", Type: TypeVaultToken, Source: "vault-main", Config: cfg}
+	}
+	src := func(cfg map[string]string) *CredSource {
+		return &CredSource{Name: "vault-main", Type: "vault", Config: cfg}
+	}
+	basePath := map[string]string{"kv2_mount": "kv", "secret_path": "teams/{{user.team}}/db"}
+	baseSrc := map[string]string{"vault_address": "https://vault.internal:8200", "approle_mount": "approle"}
+
+	t.Run("editing the templated path moves the fingerprint", func(t *testing.T) {
+		before := chainedSpecFingerprint(spec(basePath), src(baseSrc))
+		after := chainedSpecFingerprint(spec(map[string]string{
+			"kv2_mount": "kv", "secret_path": "prod-teams/{{user.team}}/db",
+		}), src(baseSrc))
+		assert.NotEqual(t, before, after,
+			"the fetch moved to a different location, so the entry filled from the old one must not answer for it")
+	})
+
+	t.Run("repointing the spec at another source moves it", func(t *testing.T) {
+		other := &CredSpec{Name: "ref", Type: TypeVaultToken, Source: "vault-other", Config: basePath}
+		assert.NotEqual(t, chainedSpecFingerprint(spec(basePath), src(baseSrc)),
+			chainedSpecFingerprint(other, src(baseSrc)))
+	})
+
+	t.Run("moving the source itself moves it", func(t *testing.T) {
+		moved := src(map[string]string{"vault_address": "https://vault-dr.internal:8200", "approle_mount": "approle"})
+		assert.NotEqual(t, chainedSpecFingerprint(spec(basePath), src(baseSrc)),
+			chainedSpecFingerprint(spec(basePath), moved))
+	})
+
+	t.Run("rotating the source credential does not move it", func(t *testing.T) {
+		before := chainedSpecFingerprint(spec(basePath), src(map[string]string{
+			"vault_address": "https://vault.internal:8200", "approle_mount": "approle",
+			"secret_id": "sid-1", "secret_id_accessor": "acc-1",
+		}))
+		after := chainedSpecFingerprint(spec(basePath), src(map[string]string{
+			"vault_address": "https://vault.internal:8200", "approle_mount": "approle",
+			"secret_id": "sid-2", "secret_id_accessor": "acc-2",
+		}))
+		assert.Equal(t, before, after,
+			"a rotation replaces an authenticator, not the identity it authenticates — dumping the cache buys nothing")
+	})
+
+	t.Run("a rotating refresh_token does not move it", func(t *testing.T) {
+		// This one is not merely churn: refresh_token is rewritten on every use, so a
+		// moving key would mean no entry is ever read once and caching is silently dead.
+		withRT := func(rt string) *CredSpec {
+			return spec(map[string]string{"oauth2_mount": "oauth2", "credential_name": "cred", "refresh_token": rt})
+		}
+		assert.Equal(t, chainedSpecFingerprint(withRT("rt-1"), src(baseSrc)),
+			chainedSpecFingerprint(withRT("rt-2"), src(baseSrc)))
+	})
+
+	t.Run("stable across map iteration order", func(t *testing.T) {
+		a := chainedSpecFingerprint(spec(map[string]string{"kv2_mount": "kv", "secret_path": "p"}), src(baseSrc))
+		b := chainedSpecFingerprint(spec(map[string]string{"secret_path": "p", "kv2_mount": "kv"}), src(baseSrc))
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("config values never appear in the clear", func(t *testing.T) {
+		fp := chainedSpecFingerprint(
+			spec(map[string]string{"secret_path": "teams/SECRETPATH/db"}),
+			src(map[string]string{"vault_address": "https://SECRETHOST:8200"}))
+		assert.NotContains(t, fp, "SECRETPATH")
+		assert.NotContains(t, fp, "SECRETHOST")
+	})
+
+	t.Run("no concatenation collisions across sections", func(t *testing.T) {
+		// The same k/v moved between the spec's config and the source's must not
+		// produce the same digest.
+		inSpec := chainedSpecFingerprint(spec(map[string]string{"mount": "kv"}), src(nil))
+		inSrc := chainedSpecFingerprint(spec(nil), src(map[string]string{"mount": "kv"}))
+		assert.NotEqual(t, inSpec, inSrc)
+
+		// Nor may a value bleed into the neighbouring field.
+		assert.NotEqual(t,
+			chainedSpecFingerprint(&CredSpec{Type: "ab", Source: "c", Config: nil}, nil),
+			chainedSpecFingerprint(&CredSpec{Type: "a", Source: "bc", Config: nil}, nil))
+	})
+}
+
+// An unresolvable referenced spec has no identity to key on, so the key function must
+// refuse to cache rather than let whatever the name points at now share one entry.
+func TestChainedSecretCacheKey_NoFingerprintRefusesToCache(t *testing.T) {
+	caller := Caller{TokenID: "agent-token"}
+	assert.Empty(t, chainedSecretCacheKey("ns", "ref", "", caller,
+		&ExchangeInputs{SubjectToken: "jwt", SubjectTokenType: TokenTypeJWT}))
 }
 
 // claimsFingerprint must not let two different maps collide by running their bytes

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -1369,6 +1369,63 @@ func TestChainedSecretCacheKey_AgentAndUserDimensionsCompose(t *testing.T) {
 	assert.NotEqual(t, a, b)
 }
 
+// TestChainedSecretCacheKey_UserClaimsDimension is the user-side mirror of
+// TestChainedSecretCacheKey_AgentClaimsDimension, and it closes the same hole.
+//
+// The user token id looks like it already covers this, but it hashes the presented
+// credential, the mount and the role *name* — not the role's claim mapping. An operator
+// editing that mapping leaves every token id untouched while changing what the claims
+// resolve to, so a templated path renders somewhere new under a key that never moved,
+// and the previous location's secret keeps being served for the rest of the cache TTL.
+// Unlike the consumer credential cache, the chained-secret TTL is not bounded by either
+// principal's token lifetime, so nothing else closes the window.
+func TestChainedSecretCacheKey_UserClaimsDimension(t *testing.T) {
+	caller := Caller{TokenID: "agent-token", User: &UserContext{TokenID: "user-token"}}
+	base := func(userClaims map[string]string) *ExchangeInputs {
+		return &ExchangeInputs{
+			SubjectToken:     "the.same.jwt",
+			SubjectTokenType: TokenTypeJWT,
+			UserClaims:       userClaims,
+		}
+	}
+
+	t.Run("same user token, remapped claims, different keys", func(t *testing.T) {
+		beforeEdit := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice", "team": "platform"}))
+		afterEdit := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice", "team": "infra"}))
+
+		require.NotEmpty(t, beforeEdit)
+		assert.NotEqual(t, beforeEdit, afterEdit,
+			"the same user token resolving a different team must not read the old team's secret")
+	})
+
+	t.Run("same claims give the same key", func(t *testing.T) {
+		first := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice", "team": "platform"}))
+		second := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"team": "platform", "sub": "alice"}))
+		assert.Equal(t, first, second, "map iteration order must not change the key")
+	})
+
+	t.Run("two users still separate", func(t *testing.T) {
+		other := Caller{TokenID: "agent-token", User: &UserContext{TokenID: "other-user-token"}}
+		mine := chainedSecretCacheKey("ns", "ref", caller, base(map[string]string{"sub": "alice"}))
+		theirs := chainedSecretCacheKey("ns", "ref", other, base(map[string]string{"sub": "alice"}))
+		assert.NotEqual(t, mine, theirs,
+			"the token id still binds the entry to a principal even when claims coincide")
+	})
+
+	t.Run("no user claims keeps the key byte-identical", func(t *testing.T) {
+		withNone := chainedSecretCacheKey("ns", "ref", caller, base(nil))
+		legacy := "chainsecret:ns:ref:" + base(nil).Fingerprint()
+		assert.Equal(t, legacy, withNone,
+			"a source-global fetch must not have its cache key perturbed")
+	})
+
+	t.Run("a user-scoped fetch with no user principal refuses to cache", func(t *testing.T) {
+		agentOnly := Caller{TokenID: "agent-token"}
+		assert.Empty(t, chainedSecretCacheKey("ns", "ref", agentOnly, base(map[string]string{"sub": "alice"})),
+			"sharing a user-scoped fetch namespace-wide is never the safe failure mode")
+	})
+}
+
 // claimsFingerprint must not let two different maps collide by running their bytes
 // together differently.
 func TestClaimsFingerprint_NoConcatenationCollisions(t *testing.T) {

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -1464,6 +1464,44 @@ func TestChainedSpecFingerprint(t *testing.T) {
 			chainedSpecFingerprint(spec(basePath), moved))
 	})
 
+	t.Run("an arbitrary spec config key moves it", func(t *testing.T) {
+		// The named cases below are the ones we thought of. This is the general rule:
+		// anything an operator can put in a referenced spec's config can change what the
+		// fetch returns, so a regression to an allow-list of known fields fails here.
+		assert.NotEqual(t,
+			chainedSpecFingerprint(spec(map[string]string{"anything": "1"}), src(baseSrc)),
+			chainedSpecFingerprint(spec(map[string]string{"anything": "2"}), src(baseSrc)))
+	})
+
+	t.Run("an arbitrary source config key moves it", func(t *testing.T) {
+		assert.NotEqual(t,
+			chainedSpecFingerprint(spec(basePath), src(map[string]string{"anything": "1"})),
+			chainedSpecFingerprint(spec(basePath), src(map[string]string{"anything": "2"})))
+	})
+
+	t.Run("the spec type moves it", func(t *testing.T) {
+		other := &CredSpec{Name: "ref", Type: TypeAPIKey, Source: "vault-main", Config: basePath}
+		assert.NotEqual(t, chainedSpecFingerprint(spec(basePath), src(baseSrc)),
+			chainedSpecFingerprint(other, src(baseSrc)))
+	})
+
+	// Several names are proof material on the source side and the fetch coordinate — or
+	// the vended credential itself — on the spec side. Excluding them from the spec's
+	// config would serve an operator the value they had just replaced.
+	t.Run("spec-side names that are content are not excluded", func(t *testing.T) {
+		for _, field := range []string{
+			"secret_id", // names which AWS Secrets Manager secret to fetch
+			"api_key",   // IS the credential a static_apikey spec vends
+			"token",     // IS the credential a github PAT-mode spec vends
+			"anything",  // the local driver returns spec.Config wholesale
+		} {
+			assert.NotEqual(t,
+				chainedSpecFingerprint(spec(map[string]string{field: "old"}), src(baseSrc)),
+				chainedSpecFingerprint(spec(map[string]string{field: "new"}), src(baseSrc)),
+				"replacing a spec's %q must not keep serving the old value", field)
+		}
+	})
+
 	t.Run("rotating the source credential does not move it", func(t *testing.T) {
 		before := chainedSpecFingerprint(spec(basePath), src(map[string]string{
 			"vault_address": "https://vault.internal:8200", "approle_mount": "approle",
@@ -1477,14 +1515,30 @@ func TestChainedSpecFingerprint(t *testing.T) {
 			"a rotation replaces an authenticator, not the identity it authenticates — dumping the cache buys nothing")
 	})
 
-	t.Run("a rotating refresh_token does not move it", func(t *testing.T) {
-		// This one is not merely churn: refresh_token is rewritten on every use, so a
-		// moving key would mean no entry is ever read once and caching is silently dead.
-		withRT := func(rt string) *CredSpec {
-			return spec(map[string]string{"oauth2_mount": "oauth2", "credential_name": "cred", "refresh_token": rt})
+	t.Run("the per-mint refresh fields do not move it", func(t *testing.T) {
+		// Not merely churn: both are rewritten on every use by the refresh-token
+		// write-back, so a moving key would mean no entry is ever read once and caching
+		// is silently dead. They must be excluded together — one alone still moves it.
+		withRT := func(rt, exp string) *CredSpec {
+			return spec(map[string]string{
+				"oauth2_mount": "oauth2", "credential_name": "cred",
+				"refresh_token": rt, "refresh_token_expires_at": exp,
+			})
 		}
-		assert.Equal(t, chainedSpecFingerprint(withRT("rt-1"), src(baseSrc)),
-			chainedSpecFingerprint(withRT("rt-2"), src(baseSrc)))
+		assert.Equal(t,
+			chainedSpecFingerprint(withRT("rt-1", "2030-01-01T00:00:00Z"), src(baseSrc)),
+			chainedSpecFingerprint(withRT("rt-2", "2031-01-01T00:00:00Z"), src(baseSrc)))
+	})
+
+	t.Run("a pinned digest, so nondeterminism cannot creep in", func(t *testing.T) {
+		// The iteration-order subtest compares two calls in one process, which a
+		// per-process-seeded hash would satisfy. This pins the bytes themselves.
+		fp := chainedSpecFingerprint(
+			&CredSpec{Name: "ref", Type: "vault_token", Source: "vault-main",
+				Config: map[string]string{"kv2_mount": "kv", "secret_path": "teams/a/db"}},
+			&CredSource{Name: "vault-main", Type: "vault",
+				Config: map[string]string{"vault_address": "https://vault.internal:8200"}})
+		assert.Equal(t, "858b2859308fc79fa46a539f40e6110c56ed111994f7e08c8867ced2a63116b0", fp)
 	})
 
 	t.Run("stable across map iteration order", func(t *testing.T) {


### PR DESCRIPTION
Three fixes to the chained-secret cache key, all the same shape: something that decides which secret is fetched was not inside the key that answers for it, so an operator change moved what a fetch returns while the key stayed put and the previous value kept being served for the rest of `secret_cache_ttl`.

This is the class `e7dbae9` (github app-token cache) and `741e219` (#524, the caller's role) were fixed for, and the standard they set is the one adopted here: derive the key from the content that determines the result, so a change of input is simply a different entry.

## Commits

**`a1b858a` — the user's claims.** The agent dimension keyed claim *values*; the user dimension keyed only the user's token id. But a token id hashes the presented credential, the mount and the role *name* — not the role's claim *mapping*. An operator editing that mapping leaves every token id byte-identical while changing what the claims resolve to, so a templated `{{user.<claim>}}` path renders somewhere new under a key that never moved. Reachable because the chained-secret TTL is bounded by `secret_cache_ttl`, not by either principal's token lifetime — which is precisely why the consumer credential cache does not have the same hole.

**`dfc32d9` — what the spec name resolves to.** The key carried the referenced spec's *name*. A name is a label an operator can repoint: edit `secret_path`, swap the mount, aim the spec at another source, move that source. The referenced spec and its source are now resolved before the key is computed and folded in as a fingerprint. Explicit invalidation from the config store was rejected as the alternative — it only ever reaches the node that served the write, so in a cluster every other node keeps serving the old location.

**`8d58389` — scoping the exclusions.** The fingerprint excludes the fields rotation rewrites, so a routine source rotation does not dump every secret cached under it. That set shipped as one flat list applied to both the spec's config and the source's, which was wrong: on the spec side four of those names are the very thing being tracked — `secret_id` names which Secrets Manager secret an AWS spec fetches, `api_key` *is* what a static api-key spec vends, `token` *is* what a github PAT spec vends, and the local driver returns `spec.Config` wholesale. Replacing a leaked credential in place kept vending the leaked one. The set now splits by side.

## Notes on the design

**The resolved path is not keyed directly**, though it is what actually selects the secret. It cannot replace the identity dimensions: two agents whose claims differ can render the same path, and on the federation path the store authorizes each separately, so sharing that entry would answer for an agent the store was never asked about. As an addition it is already implied — the render is a pure function of the template text (in the config hashed here) and the claims (already carried by `:a:` and `:uc:`). Keying on inputs can only over-split, which costs a fetch; keying on the render could under-split, which costs a secret.

**Two residuals, documented in the code rather than left implicit:**

- Reconnecting a spec to a *different account* changes only the refresh token, which must stay excluded because the write-back rewrites it on every mint. Keying cannot close this — it needs eviction on the write-back, or a stable grant identifier captured at connect time.
- The self-correcting property holds within a node. A remote node computes the fingerprint from its own config cache, which has no TTL and no cross-node invalidation, and the driver instance is keyed by source name alone.

## Testing

`go test -race ./credential/... ./core/...` passes; `go vet ./credential/...` clean.

Every new test was verified to fail with the corresponding fix reverted, and to fail on the intended assertion. That check is what caught two problems in the tests themselves: asking one consumer spec twice is answered by the *consumer credential* cache and never reaches the chained path, so the flow tests were passing without exercising anything; and the invalidation tests could not distinguish "the key moved" from "caching stopped working" until they issued one more consumer after the edit.

The unit coverage now includes arbitrary-key cases on both config sides rather than only the fields we had thought of — the gap that let `8d58389`'s bug through — plus a pinned digest and a flow test that edits a pass-through spec's material end to end.
