### PR TITLE
feat(credential): carry the whole oauth2 client credential through the chain

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -983,8 +983,8 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		chainedRef = source.Config[credential.ConfigSecretSpec]
 	}
 	if chainedRef != "" {
-		// For token_exchange and gitlab, chaining is a SOURCE concern: the secret being
-		// chained authenticates the source itself (client auth, a personal access
+		// For token_exchange, gitlab and oauth2, chaining is a SOURCE concern: the secret
+		// being chained authenticates the source itself (client auth, a personal access
 		// token), and the factory only sees source config. A spec-level secret_spec
 		// would leave the source's inline secret as dead config at mint, and would
 		// slip past the source-level validation that gates which auth methods may
@@ -995,6 +995,27 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				return logical.ErrBadRequestf("for a token_exchange source, set secret_spec on the source (client authentication is a source concern), not on the spec")
 			case credential.SourceTypeGitLab:
 				return logical.ErrBadRequestf("for a gitlab source, set secret_spec on the source (the chained secret — a personal access token, or an OAuth application secret — authenticates the source), not on the spec")
+			case credential.SourceTypeOAuth2:
+				return logical.ErrBadRequestf("for an oauth2 source, set secret_spec on the source (the chained client credential authenticates the source), not on the spec")
+			}
+		}
+		// An oauth2 source that chains its client credential resolves the pair per mint,
+		// as the calling agent. Two spec-level settings cannot survive that.
+		if source.Type == credential.SourceTypeOAuth2 && source.Config[credential.ConfigSecretSpec] != "" {
+			// The consent steps that seal an authorization_code grant run on the system
+			// backend with no caller, so they have no identity to fetch the chained pair
+			// as and would fall back to a client credential the source does not hold.
+			// Read from config rather than through ConnectGated: credType is nil when the
+			// type registry is unavailable, and this guard must not be the one that skips.
+			if credential.GetString(spec.Config, "auth_method", "") == "authorization_code" {
+				return logical.ErrBadRequestf("a chained oauth2 source (secret_spec %q) supports auth_method=client_credentials only; the consent flow runs without a caller and cannot fetch the chained client credential", chainedRef)
+			}
+			// client_id/client_secret resolve spec-over-source, so a half left here would
+			// be presented against the other half fetched from the chain.
+			for _, key := range []string{"client_id", "client_secret"} {
+				if credential.GetString(spec.Config, key, "") != "" {
+					return logical.ErrBadRequestf("%s must be omitted when the source sets secret_spec (%q); the referenced spec supplies the whole client credential", key, chainedRef)
+				}
 			}
 		}
 		// A chained consumer's identity normally flows through the referenced secret-spec,

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -1941,3 +1941,76 @@ func TestCredentialConfigStore_GitLabChaining(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "set secret_spec on the source")
 }
+
+// TestCredentialConfigStore_OAuth2Chaining covers the guards on an oauth2 source that
+// fetches its whole client credential per mint: chaining is a source concern, the pair
+// must not be half-configured, and the consent flow cannot reach chained material.
+func TestCredentialConfigStore_OAuth2Chaining(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	// Referenced secret-spec: session-pinned, as validateSecretSpecRef requires.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "idp-client-credential", Type: "vault_token", Source: "src",
+		Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+	}))
+
+	// The keyless source stores neither half of the client credential.
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "oauth-keyless", Type: credential.SourceTypeOAuth2,
+		Config: map[string]string{
+			"token_url":                  "https://identity.example.com/oauth/token",
+			credential.ConfigSecretSpec:  "idp-client-credential",
+			credential.ConfigSecretField: "client_secret",
+		},
+	}))
+
+	// Rotation belongs to whoever owns the referenced secret, not to this source.
+	rotating := &credential.CredSource{
+		Name: "oauth-rotating", Type: credential.SourceTypeOAuth2,
+		Config: map[string]string{
+			"token_url":                 "https://identity.example.com/oauth/token",
+			credential.ConfigSecretSpec: "idp-client-credential",
+		},
+		RotationPeriod: 24 * time.Hour,
+	}
+	err := store.CreateSource(ctx, rotating)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation_period does not apply to a chained source")
+
+	// An ordinary spec on a chained source inherits the chain and needs no chaining
+	// config of its own.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "api", Type: credential.TypeOAuthBearerToken, Source: "oauth-keyless",
+		Config: map[string]string{"scope": "read"},
+	}))
+
+	// Spec-level secret_spec would shadow the source's and leave the mint with no
+	// client credential.
+	err = store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "spec-level", Type: credential.TypeOAuthBearerToken, Source: "oauth-keyless",
+		Config: map[string]string{credential.ConfigSecretSpec: "idp-client-credential"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "for an oauth2 source, set secret_spec on the source")
+
+	// The consent steps run on the system backend with no caller, so they have no
+	// identity to fetch the chained pair as.
+	err = store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "consent", Type: credential.TypeOAuthBearerToken, Source: "oauth-keyless",
+		Config: map[string]string{"auth_method": "authorization_code"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "supports auth_method=client_credentials only")
+
+	// client_id/client_secret resolve spec-over-source, so a half left on the spec
+	// would be presented against the other half fetched from the chain.
+	for _, key := range []string{"client_id", "client_secret"} {
+		err = store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "inline-" + key, Type: credential.TypeOAuthBearerToken, Source: "oauth-keyless",
+			Config: map[string]string{key: "inline-value"},
+		})
+		require.Error(t, err, key)
+		assert.Contains(t, err.Error(), key+" must be omitted when the source sets secret_spec")
+	}
+}

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -54,13 +54,23 @@ var _ credential.ChainedSecretMinter = (*OAuth2Driver)(nil)
 // required; auth_url, default_scopes, verify_url, verify_method, auth_header_type,
 // auth_header_name, display_name, ca_data, tls_skip_verify optional). client_id and
 // client_secret may live on the source (client_credentials) or the spec, resolved
-// spec-over-source. The spec's auth_method selects the flow (default
+// spec-over-source, or be fetched per mint from another cred spec (secret_spec,
+// source-level). The spec's auth_method selects the flow (default
 // client_credentials); the driver POSTs to the token endpoint and returns the
 // resulting access_token as an api_key field.
 type OAuth2Driver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
 	httpClient *http.Client
+}
+
+// oauth2ChainedAuth carries the client credential a single mint fetched through
+// credential chaining. It is threaded by parameter rather than held on the driver,
+// which is shared: two concurrent mints resolving different pairs must not see each
+// other's. nil means the credential comes from config.
+type oauth2ChainedAuth struct {
+	clientID     string
+	clientSecret string
 }
 
 // OAuth2DriverFactory creates OAuth2Driver instances.
@@ -73,7 +83,8 @@ func (f *OAuth2DriverFactory) Type() string {
 
 // ValidateConfig validates source configuration. token_url is required.
 // client_id/client_secret are optional here because the authorization_code flow
-// keeps them on the spec; presence is checked at mint time.
+// keeps them on the spec, and a chained source (secret_spec) holds neither;
+// presence is checked at mint time.
 func (f *OAuth2DriverFactory) ValidateConfig(config map[string]string) error {
 	if err := credential.ValidateSchema(config,
 		credential.StringField("client_id").
@@ -156,8 +167,44 @@ func (f *OAuth2DriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
+
+		credential.StringField("secret_spec").
+			Describe("Source the whole client credential from another cred spec via credential chaining instead of storing it inline (client_id and client_secret then omitted; the referenced payload supplies both). client_credentials only").
+			Example("idp-client-credential"),
+
+		credential.StringField("secret_field").
+			Describe("Which field of the referenced secret_spec's credential holds the client secret (when its payload has multiple keys); the client id travels beside it under 'client_id'").
+			Example("client_secret"),
+
+		credential.StringField("secret_cache_ttl").
+			Describe("Cache the chained client credential source-wide for this duration (e.g. 30m); omit to fetch it on every mint").
+			Example("30m"),
 	); err != nil {
 		return err
+	}
+
+	// A source in chaining mode holds NEITHER half of the client credential. The secret
+	// is excluded because a source that reads as keyless must not still store the very
+	// secret chaining exists to remove, and the id follows it because the two
+	// authenticate as a pair: an id kept here beside a secret fetched from the chain
+	// would name one client while presenting another's, which the token endpoint answers
+	// with invalid_client and the chained path then reads as a rejected secret and
+	// retries pointlessly.
+	//
+	// Requiring both from the payload also lets one source and one spec serve many
+	// clients, since the pair is resolved per mint rather than pinned to the source.
+	if credential.GetString(config, credential.ConfigSecretSpec, "") != "" {
+		if err := rejectInlineClientCredential(config, "client_secret"); err != nil {
+			return err
+		}
+		// auth_method resolves spec-over-source, and the spec-side rule lives in the
+		// config store, which sees only spec config. Catch the source side here, or a
+		// source setting it would leave every spec beneath it creating cleanly and
+		// failing at mint.
+		if am := credential.GetString(config, "auth_method", ""); am != "" && am != oauth2AuthMethodClientCredentials {
+			return fmt.Errorf("auth_method=%s is not supported when secret_spec is set (chaining supports %s only); the consent flow runs without a caller and cannot fetch the chained client credential",
+				am, oauth2AuthMethodClientCredentials)
+		}
 	}
 
 	// Validate token_param.* keys don't override core form fields
@@ -251,13 +298,33 @@ func (d *OAuth2Driver) resolve(spec *credential.CredSpec, key, def string) strin
 	return credential.GetString(d.credSource.Config, key, def)
 }
 
+// rejectConsentOnChainedSource refuses the consent steps on a source that fetches its
+// client credential per mint. They run on the system backend with no caller, so they
+// have no identity to fetch the pair as — and without this an operator could complete a
+// whole consent dance and seal tokens that no mint could ever spend, since minting from
+// such a source is client_credentials only.
+func (d *OAuth2Driver) rejectConsentOnChainedSource() error {
+	if credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != "" {
+		return fmt.Errorf("%s OAuth2 source uses secret_spec (credential chaining), which supports auth_method=%s only; the consent flow runs without a caller and cannot fetch the chained client credential",
+			d.displayName(), oauth2AuthMethodClientCredentials)
+	}
+	return nil
+}
+
 // MintCredential mints a bearer token using the flow selected by auth_method
 // (default client_credentials).
 func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A chained source holds no client credential, so minting here would fail on a
+	// missing pair rather than saying why. Reaching this means the manager routed a
+	// chained spec down the direct path; fail closed and name the cause.
+	if credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != "" {
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 source uses secret_spec (credential chaining); it must mint from fetched secret material, not directly", d.displayName())
+	}
+
 	authMethod := d.resolve(spec, "auth_method", oauth2AuthMethodClientCredentials)
 	switch authMethod {
 	case oauth2AuthMethodClientCredentials:
-		return d.mintFromClientCredentials(ctx, spec)
+		return d.mintFromClientCredentials(ctx, spec, nil)
 	case oauth2AuthMethodAuthorizationCode:
 		return d.mintFromRefreshToken(ctx, spec)
 	default:
@@ -265,13 +332,25 @@ func (d *OAuth2Driver) MintCredential(ctx context.Context, spec *credential.Cred
 	}
 }
 
-// mintFromClientCredentials exchanges client credentials for a bearer token.
-func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+// mintFromClientCredentials exchanges client credentials for a bearer token. chained,
+// when non-nil, supplies both halves of the pair from credential-chaining material
+// instead of config.
+func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *credential.CredSpec, chained *oauth2ChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	config := d.credSource.Config
 	name := d.displayName()
 
 	clientID := d.resolve(spec, "client_id", "")
 	clientSecret := d.resolve(spec, "client_secret", "")
+	if chained != nil {
+		// Validation refuses a chained source or spec that also names a client, so a
+		// leftover here means config drifted past it. Refusing beats presenting a pair
+		// half from config and half from the chain, which the endpoint rejects as
+		// invalid_client and the chained path then misreads as a stale secret.
+		if clientID != "" || clientSecret != "" {
+			return nil, nil, 0, "", fmt.Errorf("%s OAuth2 chained mint: client_id/client_secret must not be configured when secret_spec is set; the referenced spec supplies the whole client credential", name)
+		}
+		clientID, clientSecret = chained.clientID, chained.clientSecret
+	}
 	if clientID == "" || clientSecret == "" {
 		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 source missing client_id or client_secret", name)
 	}
@@ -296,7 +375,7 @@ func (d *OAuth2Driver) mintFromClientCredentials(ctx context.Context, spec *cred
 
 	tokenResp, err := d.postTokenRequest(ctx, d.tokenURL(), form)
 	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, err)
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 token exchange failed: %w", name, oauth2ChainedClientAuthError(err, chained != nil))
 	}
 	if tokenResp.AccessToken == "" {
 		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 token response missing access_token", name)
@@ -326,9 +405,8 @@ func (d *OAuth2Driver) mintFromRefreshToken(ctx context.Context, spec *credentia
 }
 
 // refreshGrant exchanges a refresh token for a fresh access token
-// (grant_type=refresh_token). The refresh token is passed in explicitly so the
-// same grant serves both the spec-sealed refresh token (mintFromRefreshToken) and
-// a chained refresh token fetched from another spec (MintFromSecret).
+// (grant_type=refresh_token). The refresh token is passed in explicitly rather than
+// read from the spec so the sealing and the spending stay separable.
 func (d *OAuth2Driver) refreshGrant(ctx context.Context, spec *credential.CredSpec, refreshToken string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	name := d.displayName()
 
@@ -371,41 +449,131 @@ func (d *OAuth2Driver) refreshGrant(ctx context.Context, spec *credential.CredSp
 	return rawData, d.extractMetadata(ctx, spec, tokenResp.AccessToken), ttlFromExpiresIn(tokenResp.ExpiresIn), "", nil
 }
 
-// MintFromSecret implements credential.ChainedSecretMinter: it mints a Slack-style
-// OAuth2 access token from a refresh token supplied as chained secret material
-// (e.g. a per-user refresh token read from Vault by an upstream kv2_read spec)
-// rather than from the spec's own sealed config. Rotation write-back is not
-// supported for the chained path (the material is read-only), so this works with
-// non-rotating refresh tokens; a rotated token is surfaced in rawData but the
-// minting layer has nowhere to persist it back to.
+// MintFromSecret implements credential.ChainedSecretMinter: it mints a bearer token
+// whose client credential — both halves — comes from credential-chaining material
+// (source-level secret_spec) instead of source config. A chained source stores
+// neither half, so the id and the secret are read together from the fetched payload,
+// which lets one source and one spec serve an OAuth client per agent.
 func (d *OAuth2Driver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	refreshToken := material.Secret()
-	if refreshToken == "" {
-		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 chained mint: the referenced secret_spec yielded no refresh token", d.displayName())
+	name := d.displayName()
+
+	// Chaining on an oauth2 spec used to mean "the material is a refresh token"; it now
+	// means the client credential, and it is a source concern, so validation keeps the
+	// reference on the source. A spec written before that change still carries the key,
+	// and would otherwise fail here reporting a payload with no client id — say what
+	// actually has to move instead.
+	if credential.GetString(spec.Config, credential.ConfigSecretSpec, "") != "" {
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 spec %q sets %s: chaining a refresh token is no longer supported, and a chained client credential belongs on the source; move %s to the source and clear it from the spec",
+			name, spec.Name, credential.ConfigSecretSpec, credential.ConfigSecretSpec)
 	}
-	rawData, metadata, ttl, leaseID, err := d.refreshGrant(ctx, spec, refreshToken)
+
+	// The consent steps that seal an authorization_code grant run without a caller, so
+	// they cannot reach chained material and validation refuses the combination. Reaching
+	// it means config drifted past that check.
+	if authMethod := d.resolve(spec, "auth_method", oauth2AuthMethodClientCredentials); authMethod != oauth2AuthMethodClientCredentials {
+		// A source-config error, not a payload one: refetching cannot change the answer,
+		// so this must not carry the sentinel that asks the manager to try again.
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 credential chaining supports auth_method=%s only, got %q",
+			name, oauth2AuthMethodClientCredentials, authMethod)
+	}
+
+	chained, err := oauth2ChainedAuthFromMaterial(material)
 	if err != nil {
-		return nil, nil, 0, "", err
+		// %w, so the ErrChainedSecretIncomplete the manager acts on survives the wrap.
+		return nil, nil, 0, "", fmt.Errorf("%s OAuth2 chained mint: %w", name, err)
 	}
-	// The chained refresh token is read-only material fetched from another spec, so
-	// a provider-rotated replacement has nowhere to be persisted back to. Strip the
-	// reserved rotation keys (the chained mint path has no write-back consumer for
-	// them) and warn loudly — this path works only with non-rotating refresh tokens.
-	if _, rotated := rawData[credential.RawRotatedRefreshTokenKey]; rotated {
-		delete(rawData, credential.RawRotatedRefreshTokenKey)
-		delete(rawData, credential.RawRotatedRefreshTokenExpiresAtKey)
-		if d.logger != nil {
-			d.logger.Warn(fmt.Sprintf("%s OAuth2 provider rotated the chained refresh token, but the secret_spec chain cannot persist it; the next mint reuses the stored token and may fail once the provider invalidates the old one", d.displayName()),
-				logger.String("spec", spec.Name))
+	return d.mintFromClientCredentials(ctx, spec, chained)
+}
+
+// oauth2ChainedAuthFromMaterial reads a whole client credential out of fetched secret
+// material.
+//
+// secret_field names the secret alone, so a field that resolved to nothing is a
+// misconfigured source rather than an invitation to look elsewhere: the conventional
+// client_secret key is consulted only when no field was resolved at all. The id is read
+// by convention for the same reason, and has nowhere to fall back to — a source in
+// chaining mode holds no client_id — so its absence is an error raised here, before any
+// request is sent.
+//
+// Every "the payload lacks what I need" error carries ErrChainedSecretIncomplete, so a
+// cached payload that predates a key it now has to hold is refetched once rather than
+// failing for the rest of its secret_cache_ttl.
+func oauth2ChainedAuthFromMaterial(material credential.SecretMaterial) (*oauth2ChainedAuth, error) {
+	// The id is never the secret. A payload holding nothing but an id resolves that lone
+	// key as the secret field — the single-key shortcut has no way to know better — and
+	// without this the same value would be spent as both halves of the pair, which the
+	// endpoint answers with invalid_client and the chained path then misreads as a
+	// rotated secret.
+	if material.Field == "client_id" {
+		return nil, fmt.Errorf("secret_field resolved to 'client_id', which names the id and never the secret: %w", credential.ErrChainedSecretIncomplete)
+	}
+
+	secret := material.Secret()
+	if secret == "" && material.Field == "" {
+		secret = material.Data["client_secret"]
+	}
+	if secret == "" {
+		if material.Field != "" {
+			return nil, fmt.Errorf("secret_field %q is empty or absent in the fetched secret material: %w", material.Field, credential.ErrChainedSecretIncomplete)
 		}
+		return nil, fmt.Errorf("no client secret in fetched secret material (set secret_field, or store it under 'client_secret'): %w", credential.ErrChainedSecretIncomplete)
 	}
-	return rawData, metadata, ttl, leaseID, nil
+
+	clientID := material.Data["client_id"]
+	if clientID == "" {
+		return nil, fmt.Errorf("no client id in fetched secret material (store it under 'client_id' alongside the secret): %w", credential.ErrChainedSecretIncomplete)
+	}
+
+	return &oauth2ChainedAuth{clientID: clientID, clientSecret: secret}, nil
+}
+
+// oauth2ChainedClientAuthError reports a token endpoint error as a rejected chained
+// client credential, or returns it unchanged when it is anything else. Wrapping
+// ErrChainedSecretRejected asks the minting layer to evict the cached secret and retry
+// once with a fresh fetch.
+//
+// This is deliberately narrower than isRefreshTokenRejection, which treats a bare 400 as
+// a rejected grant: on this path a bare 400 is far more likely invalid_scope or
+// unsupported_grant_type, and refetching the secret cannot fix either.
+//
+// invalid_client does not say which half was refused, and it does not need to: the
+// eviction refetches the payload, so the id and the secret are replaced together.
+func oauth2ChainedClientAuthError(err error, chained bool) error {
+	if chained && isChainedClientAuthRejection(err) {
+		// Keep the underlying error (the IdP's code / description) in the chain
+		// alongside the sentinel for legible diagnostics.
+		return fmt.Errorf("client authentication rejected: %w (%w)", credential.ErrChainedSecretRejected, err)
+	}
+	return err
+}
+
+// isChainedClientAuthRejection reports whether a token endpoint error says the client
+// credential itself was refused, rather than something about the grant being asked for.
+//
+// invalid_client is reported as HTTP 400 (credentials in the form body) or 401; a
+// nonstandard IdP may return a bare 401 with no error code. Per RFC 6749 §5.2, 401 at the
+// token endpoint is client-authentication-specific, so either signal counts.
+//
+// A bare 400 deliberately does not: on a chained path it is far more likely invalid_scope
+// or unsupported_grant_type, and refetching the secret cannot fix either. That is what
+// separates this from isRefreshTokenRejection, which is about the grant and does count a
+// bare 400.
+func isChainedClientAuthRejection(err error) bool {
+	var tee *tokenEndpointError
+	if !errors.As(err, &tee) {
+		return false
+	}
+	return tee.code == "invalid_client" || tee.status == http.StatusUnauthorized
 }
 
 // ExchangeAuthorizationCode exchanges an authorization code for tokens using the
 // client secret the server holds, and returns the spec-config keys to seal.
 func (d *OAuth2Driver) ExchangeAuthorizationCode(ctx context.Context, spec *credential.CredSpec, code, redirectURI, codeVerifier string) (map[string]string, error) {
 	name := d.displayName()
+
+	if err := d.rejectConsentOnChainedSource(); err != nil {
+		return nil, err
+	}
 
 	clientID := d.resolve(spec, "client_id", "")
 	clientSecret := d.resolve(spec, "client_secret", "")
@@ -453,6 +621,10 @@ func (d *OAuth2Driver) ExchangeAuthorizationCode(ctx context.Context, spec *cred
 // BuildAuthorizeURL assembles the provider authorize URL. Scopes are read as
 // already-normalized (space-separated) but commas are tolerated defensively.
 func (d *OAuth2Driver) BuildAuthorizeURL(spec *credential.CredSpec, redirectURI, state, codeChallenge string) (string, error) {
+	if err := d.rejectConsentOnChainedSource(); err != nil {
+		return "", err
+	}
+
 	authURL := credential.GetString(d.credSource.Config, "auth_url", "")
 	if authURL == "" {
 		return "", fmt.Errorf("%s OAuth2 source missing auth_url (required for authorization_code)", d.displayName())

--- a/credential/drivers/oauth2_driver_test.go
+++ b/credential/drivers/oauth2_driver_test.go
@@ -255,6 +255,52 @@ func TestOAuth2DriverFactory_ValidateConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "token_param.client_id cannot override core OAuth2 field",
 		},
+		{
+			// A keyless source: neither half of the client credential is stored.
+			name: "chained, no inline client credential",
+			config: map[string]string{
+				"token_url":        "https://auth.example.com/token",
+				"secret_spec":      "idp-client-credential",
+				"secret_field":     "client_secret",
+				"secret_cache_ttl": "30m",
+			},
+			wantErr: false,
+		},
+		{
+			name: "chained, client_secret still inline",
+			config: map[string]string{
+				"token_url":     "https://auth.example.com/token",
+				"client_secret": "test-client-secret",
+				"secret_spec":   "idp-client-credential",
+			},
+			wantErr: true,
+			errMsg:  "client_secret must be omitted when secret_spec is set",
+		},
+		{
+			// The id follows the secret: the two authenticate as a pair, so an id kept
+			// here would name one client while presenting another's.
+			name: "chained, client_id still inline",
+			config: map[string]string{
+				"token_url":   "https://auth.example.com/token",
+				"client_id":   "test-client-id",
+				"secret_spec": "idp-client-credential",
+			},
+			wantErr: true,
+			errMsg:  "client_id must be omitted when secret_spec is set",
+		},
+		{
+			// auth_method resolves spec-over-source; the spec side is caught by the
+			// config store, which never sees source config. Catching it here keeps a
+			// source from creating cleanly and failing every mint beneath it.
+			name: "chained, source-level authorization_code",
+			config: map[string]string{
+				"token_url":   "https://auth.example.com/token",
+				"auth_method": "authorization_code",
+				"secret_spec": "idp-client-credential",
+			},
+			wantErr: true,
+			errMsg:  "auth_method=authorization_code is not supported when secret_spec is set",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1364,21 +1410,305 @@ func TestOAuth2Driver_ExtractMetadata_IntrospectionURL_SpecLevelIgnored(t *testi
 	assert.Nil(t, metadata, "opaque token + no source introspection_url → no metadata")
 }
 
-// TestOAuth2Driver_MintFromSecret covers the ChainedSecretMinter path: minting a
-// Slack-style access token from a refresh token supplied as chained secret
-// material (e.g. a per-user refresh token read from Vault), not from spec config.
-func TestOAuth2Driver_MintFromSecret(t *testing.T) {
+// chainedClientCredential builds the payload a referenced spec yields for a keyless
+// oauth2 source: both halves together, the secret named by secret_field.
+func chainedClientCredential(clientID, secret string) credential.SecretMaterial {
+	return credential.SecretMaterial{
+		Data:  map[string]string{"client_id": clientID, "client_secret": secret},
+		Field: "client_secret",
+	}
+}
+
+// keylessOAuth2Driver builds a driver over a source that stores neither half of the
+// client credential — everything comes from the fetched payload.
+func keylessOAuth2Driver(t *testing.T, tokenURL string, client *http.Client) *OAuth2Driver {
+	t.Helper()
+	return &OAuth2Driver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeOAuth2,
+			Config: map[string]string{
+				"token_url":   tokenURL,
+				"secret_spec": "idp-client-credential",
+			},
+		},
+		httpClient: client,
+	}
+}
+
+func TestOAuth2Driver_MintFromSecret_ChainedClientCredential(t *testing.T) {
+	var gotForm url.Values
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, r.ParseForm())
-		assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
-		assert.Equal(t, "chained-refresh-token", r.Form.Get("refresh_token"))
-		assert.Equal(t, "test-id", r.Form.Get("client_id"))
+		gotForm = r.Form
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token": "slack-access-token",
+			"access_token": "pagerduty-access-token",
 			"token_type":   "Bearer",
 			"expires_in":   3600,
 		})
+	}))
+	defer server.Close()
+
+	d := keylessOAuth2Driver(t, server.URL, server.Client())
+	d.credSource.Config["default_scopes"] = "read"
+	d.credSource.Config["token_param.account"] = "acct-1"
+	spec := &credential.CredSpec{Name: "pagerduty-api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	rawData, _, ttl, _, err := d.MintFromSecret(context.Background(), spec, chainedClientCredential("agent-client-id", "agent-client-secret"))
+	require.NoError(t, err)
+	assert.Equal(t, "pagerduty-access-token", rawData["api_key"])
+	assert.Equal(t, 3600*time.Second, ttl)
+
+	// The pair travels together, and the rest of the source config still applies.
+	assert.Equal(t, "client_credentials", gotForm.Get("grant_type"))
+	assert.Equal(t, "agent-client-id", gotForm.Get("client_id"))
+	assert.Equal(t, "agent-client-secret", gotForm.Get("client_secret"))
+	assert.Equal(t, "read", gotForm.Get("scope"))
+	assert.Equal(t, "acct-1", gotForm.Get("account"))
+}
+
+// The pair is resolved per mint, not pinned to the source, so one source and one spec
+// serve a distinct OAuth client per caller.
+func TestOAuth2Driver_MintFromSecret_PairIsPerMint(t *testing.T) {
+	var seen []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		seen = append(seen, r.Form.Get("client_id")+":"+r.Form.Get("client_secret"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "tok", "expires_in": 60})
+	}))
+	defer server.Close()
+
+	d := keylessOAuth2Driver(t, server.URL, server.Client())
+	spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	for _, agent := range []string{"alice", "bob"} {
+		_, _, _, _, err := d.MintFromSecret(context.Background(), spec, chainedClientCredential(agent+"-id", agent+"-secret"))
+		require.NoError(t, err)
+	}
+	assert.Equal(t, []string{"alice-id:alice-secret", "bob-id:bob-secret"}, seen)
+}
+
+func TestOAuth2Driver_MintFromSecret_IncompletePayload(t *testing.T) {
+	// No request must be sent for any of these — the payload is judged first.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("token endpoint must not be called for an incomplete payload")
+	}))
+	defer server.Close()
+
+	d := keylessOAuth2Driver(t, server.URL, server.Client())
+	spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	tests := []struct {
+		name     string
+		material credential.SecretMaterial
+		errMsg   string
+	}{
+		{
+			// A single-key payload resolves its lone key as the secret field; without
+			// the guard the id would be spent as both halves.
+			name:     "id resolved as the secret field",
+			material: credential.SecretMaterial{Data: map[string]string{"client_id": "abc"}, Field: "client_id"},
+			errMsg:   "'client_id', which names the id and never the secret",
+		},
+		{
+			name:     "named field empty",
+			material: credential.SecretMaterial{Data: map[string]string{"client_id": "abc", "client_secret": ""}, Field: "client_secret"},
+			errMsg:   `secret_field "client_secret" is empty or absent`,
+		},
+		{
+			// A resolved field that named nothing is a misconfigured source, not an
+			// invitation to look elsewhere.
+			name:     "named field absent, conventional key present",
+			material: credential.SecretMaterial{Data: map[string]string{"client_id": "abc", "client_secret": "s"}, Field: "secret"},
+			errMsg:   `secret_field "secret" is empty or absent`,
+		},
+		{
+			name:     "no secret at all",
+			material: credential.SecretMaterial{Data: map[string]string{"client_id": "abc"}},
+			errMsg:   "no client secret in fetched secret material",
+		},
+		{
+			name:     "secret without an id",
+			material: credential.SecretMaterial{Data: map[string]string{"client_secret": "s"}, Field: "client_secret"},
+			errMsg:   "no client id in fetched secret material",
+		},
+		{
+			name:     "empty material",
+			material: credential.SecretMaterial{},
+			errMsg:   "no client secret in fetched secret material",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, _, err := d.MintFromSecret(context.Background(), spec, tt.material)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+			// The sentinel asks the manager to refetch once: a cached payload that
+			// predates a key it now has to hold should not fail for its whole TTL.
+			assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		})
+	}
+}
+
+// With no secret_field resolved at all, the conventional key is the fallback.
+func TestOAuth2Driver_MintFromSecret_ConventionalKeys(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "conv-id", r.Form.Get("client_id"))
+		assert.Equal(t, "conv-secret", r.Form.Get("client_secret"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "tok", "expires_in": 60})
+	}))
+	defer server.Close()
+
+	d := keylessOAuth2Driver(t, server.URL, server.Client())
+	spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	_, _, _, _, err := d.MintFromSecret(context.Background(), spec,
+		credential.SecretMaterial{Data: map[string]string{"client_id": "conv-id", "client_secret": "conv-secret"}})
+	require.NoError(t, err)
+}
+
+func TestOAuth2Driver_MintFromSecret_RejectionSentinel(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantsRetry bool
+	}{
+		{
+			name:       "invalid_client at 400",
+			status:     http.StatusBadRequest,
+			body:       `{"error":"invalid_client","error_description":"bad secret"}`,
+			wantsRetry: true,
+		},
+		{
+			name:       "invalid_client at 401",
+			status:     http.StatusUnauthorized,
+			body:       `{"error":"invalid_client"}`,
+			wantsRetry: true,
+		},
+		{
+			// RFC 6749 §5.2: a 401 at the token endpoint is client-authentication
+			// specific, so a nonstandard IdP omitting the code still means the pair.
+			name:       "bare 401 with no code",
+			status:     http.StatusUnauthorized,
+			body:       `not json`,
+			wantsRetry: true,
+		},
+		{
+			// A bare 400 is far more likely invalid_scope or unsupported_grant_type;
+			// refetching the secret cannot fix either.
+			name:       "bare 400 with no code",
+			status:     http.StatusBadRequest,
+			body:       `not json`,
+			wantsRetry: false,
+		},
+		{
+			name:       "invalid_scope",
+			status:     http.StatusBadRequest,
+			body:       `{"error":"invalid_scope"}`,
+			wantsRetry: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			d := keylessOAuth2Driver(t, server.URL, server.Client())
+			spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+			_, _, _, _, err := d.MintFromSecret(context.Background(), spec, chainedClientCredential("id", "stale-secret"))
+			require.Error(t, err)
+			if tt.wantsRetry {
+				assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+			} else {
+				assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+			}
+		})
+	}
+}
+
+// The consent steps run without a caller, so they cannot fetch the chained pair.
+// Validation refuses the combination; this is the guard behind it.
+func TestOAuth2Driver_MintFromSecret_AuthorizationCodeRejected(t *testing.T) {
+	d := keylessOAuth2Driver(t, "https://auth.example.com/token", nil)
+	spec := &credential.CredSpec{
+		Name: "api", Type: credential.TypeOAuthBearerToken,
+		Config: map[string]string{"auth_method": "authorization_code"},
+	}
+
+	_, _, _, _, err := d.MintFromSecret(context.Background(), spec, chainedClientCredential("id", "secret"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "supports auth_method=client_credentials only")
+	// A source-config error: refetching cannot change the answer, so the manager must
+	// not be asked to try again.
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+// Chaining on an oauth2 spec used to mean "the material is a refresh token". A spec
+// written before that changed still carries the key; say what has to move.
+func TestOAuth2Driver_MintFromSecret_SpecLevelRefIsRetired(t *testing.T) {
+	d := keylessOAuth2Driver(t, "https://auth.example.com/token", nil)
+	spec := &credential.CredSpec{
+		Name: "slack-access", Type: credential.TypeOAuthBearerToken,
+		Config: map[string]string{"secret_spec": "user-refresh-token"},
+	}
+
+	_, _, _, _, err := d.MintFromSecret(context.Background(), spec,
+		credential.SecretMaterial{Data: map[string]string{"refresh_token": "rt"}, Field: "refresh_token"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chaining a refresh token is no longer supported")
+	assert.Contains(t, err.Error(), "belongs on the source")
+}
+
+// A chained source holds no client credential, so the direct path has nothing to mint
+// with; fail closed naming the cause rather than reporting a missing pair.
+func TestOAuth2Driver_MintCredential_ChainedSourceFailsClosed(t *testing.T) {
+	d := keylessOAuth2Driver(t, "https://auth.example.com/token", nil)
+	spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must mint from fetched secret material, not directly")
+}
+
+// The consent steps run on the system backend with no caller, so a chained source must
+// refuse them outright: without this an operator could complete a whole consent dance and
+// seal tokens that no mint could ever spend.
+func TestOAuth2Driver_ConsentRefusedOnChainedSource(t *testing.T) {
+	d := keylessOAuth2Driver(t, "https://auth.example.com/token", nil)
+	d.credSource.Config["auth_url"] = "https://auth.example.com/authorize"
+	spec := &credential.CredSpec{
+		Name: "api", Type: credential.TypeOAuthBearerToken,
+		Config: map[string]string{"auth_method": "authorization_code"},
+	}
+
+	_, err := d.BuildAuthorizeURL(spec, "http://127.0.0.1:9999/cb", "state", "challenge")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot fetch the chained client credential")
+
+	_, err = d.ExchangeAuthorizationCode(context.Background(), spec, "code", "http://127.0.0.1:9999/cb", "verifier")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot fetch the chained client credential")
+}
+
+// The rejection sentinel belongs to the chained path alone: a non-chained mint that the
+// endpoint refuses must not ask the manager to evict a secret it never fetched.
+func TestOAuth2Driver_InvalidClientIsNotASentinelWhenUnchained(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid_client"}`))
 	}))
 	defer server.Close()
 
@@ -1386,26 +1716,26 @@ func TestOAuth2Driver_MintFromSecret(t *testing.T) {
 		credSource: &credential.CredSource{
 			Type: credential.SourceTypeOAuth2,
 			Config: map[string]string{
-				"client_id":     "test-id",
-				"client_secret": "test-secret",
-				"token_url":     server.URL,
+				"client_id": "id", "client_secret": "secret", "token_url": server.URL,
 			},
 		},
 		httpClient: server.Client(),
 	}
-	spec := &credential.CredSpec{Name: "slack-access", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+	spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
 
-	t.Run("mints access token from chained refresh token", func(t *testing.T) {
-		material := credential.SecretMaterial{Data: map[string]string{"refresh_token": "chained-refresh-token"}, Field: "refresh_token"}
-		rawData, _, ttl, _, err := d.MintFromSecret(context.Background(), spec, material)
-		require.NoError(t, err)
-		assert.Equal(t, "slack-access-token", rawData["api_key"])
-		assert.Equal(t, 3600*time.Second, ttl)
-	})
+	_, _, _, _, err := d.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
 
-	t.Run("empty material fails closed", func(t *testing.T) {
-		_, _, _, _, err := d.MintFromSecret(context.Background(), spec, credential.SecretMaterial{})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no refresh token")
-	})
+// Config drifting past validation must not present a pair half from config and half
+// from the chain.
+func TestOAuth2Driver_MintFromSecret_InlinePairRefused(t *testing.T) {
+	d := keylessOAuth2Driver(t, "https://auth.example.com/token", nil)
+	d.credSource.Config["client_id"] = "stale-inline-id"
+	spec := &credential.CredSpec{Name: "api", Type: credential.TypeOAuthBearerToken, Config: map[string]string{}}
+
+	_, _, _, _, err := d.MintFromSecret(context.Background(), spec, chainedClientCredential("chained-id", "chained-secret"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be configured when secret_spec is set")
 }

--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -762,17 +762,13 @@ func classifyExchangeError(err error) error {
 // invalid_client does not say which half was refused, and it does not need to: the
 // eviction refetches the payload, so the id and the secret are replaced together.
 func chainedClientAuthError(err error, chained bool) error {
-	if chained {
-		var tee *tokenEndpointError
-		// invalid_client is reported as HTTP 400 (client_secret_post) or 401
-		// (client_secret_basic / a rejected private_key_jwt assertion); a nonstandard IdP
-		// may return a bare 401 with no error code. Per RFC 6749 §5.2, 401 at the token
-		// endpoint is client-authentication-specific, so on the chained path treat either
-		// signal as a stale-secret rejection. Keep the underlying error (the IdP's code /
-		// description) in the chain alongside the sentinel for legible diagnostics.
-		if errors.As(err, &tee) && (tee.code == "invalid_client" || tee.status == http.StatusUnauthorized) {
-			return fmt.Errorf("token_exchange: client authentication rejected: %w (%w)", credential.ErrChainedSecretRejected, err)
-		}
+	// The rejection test itself is shared with the oauth2 driver
+	// (isChainedClientAuthRejection); here it covers client_secret_post's 400,
+	// client_secret_basic's 401, and a rejected private_key_jwt assertion. Keep the
+	// underlying error (the IdP's code / description) in the chain alongside the sentinel
+	// for legible diagnostics.
+	if chained && isChainedClientAuthRejection(err) {
+		return fmt.Errorf("token_exchange: client authentication rejected: %w (%w)", credential.ErrChainedSecretRejected, err)
 	}
 	return classifyExchangeError(err)
 }

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -502,10 +502,13 @@ func (m *Manager) chainPreamble(ctx context.Context, caller Caller, spec *CredSp
 
 // resolveAndMintChained resolves the referenced secret material (through the opt-in
 // source-scoped cache) and mints the consuming credential via mintFn. When the material
-// came from the cache and the downstream rejects it (ErrChainedSecretRejected or the
-// pre-existing ErrRefreshTokenRejected), the cached value may be stale (rotated at the
-// source): it evicts the entry and retries once with a fresh fetch. It does not retry a
-// freshly fetched secret — that would just re-fetch identical data.
+// came from the cache and the downstream rejects it, the cached value may be stale
+// (rotated at the source): it evicts the entry and retries once with a fresh fetch. It
+// does not retry a freshly fetched secret — that would just re-fetch identical data.
+//
+// ErrRefreshTokenRejected is kept in the retry set defensively: no chained minter
+// returns it today (the oauth2 driver's chained path mints from a client credential, not
+// a refresh token), but a driver chaining a refresh grant would want the same eviction.
 //
 // It is shared by issueChained and (with an exchange-aware mintFn) the token_exchange
 // chaining path, so caching and rejection-retry cover every ChainedSecretMinter driver.

--- a/e2e/fullchain/oauth2_chain_test.go
+++ b/e2e/fullchain/oauth2_chain_test.go
@@ -1,0 +1,345 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The oauth2 source can fetch the client credential it authenticates with per mint
+// instead of storing it. The source then names no client at all, which is what lets one
+// source, one spec and one role front a different OAuth client for every agent.
+//
+// What a row here can prove that a driver unit test cannot is that the pair reaching the
+// token endpoint was resolved from the identity of the agent that asked — carried the
+// whole way from the inbound request, through a path templated on it, to the grant.
+
+const (
+	// One templated path, one client credential per agent beneath it. Each is a
+	// DIFFERENT OAuth client: id and secret both vary, which is the shape the
+	// pair-in-payload design exists to allow and a shared client_id could not express.
+	oaPerAgentKeyPath = "e2e/fc-oauth2-agent-clients"
+
+	oaPerAgentSecretSpec = "fc-oauth2-per-agent-client"
+	oaPerAgentSource     = "fc-oauth2-per-agent-src"
+	oaPerAgentSpec       = "fc-oauth2-per-agent-cred"
+	oaPerAgentRole       = "fc-oauth2-per-agent"
+
+	oaAgentA = "e2e-agent"
+	oaAgentB = "e2e-pipeline"
+
+	oaTokenPath = "/oauth2/token"
+)
+
+// oaClient is one tenant's OAuth client, as the stand-in provider sees it.
+type oaClient struct {
+	id, secret, bearer string
+}
+
+// oaGrant is one client_credentials grant the provider was asked to perform.
+type oaGrant struct {
+	clientID, clientSecret, grantType, scope string
+}
+
+// serveOAuth2Provider stands in for the identity provider issuing the bearer. It answers
+// only a client whose id AND secret match one it knows, and hands back that client's own
+// token.
+//
+// Matching on the pair is the point: a build that took the id from source config and the
+// secret from the chain would present a mismatched pair here and be refused with the
+// invalid_client the chained path reads as a stale secret.
+//
+// It is its own listener rather than a handler on the shared recording upstream: the
+// provider is a different host from the API being proxied, and displacing that upstream
+// would change what every other row in the package is talking to.
+func serveOAuth2Provider(t *testing.T, clients []oaClient) (*httptest.Server, func() []oaGrant) {
+	t.Helper()
+
+	var (
+		mu     sync.Mutex
+		grants []oaGrant
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(oaTokenPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		grants = append(grants, oaGrant{
+			clientID:     r.Form.Get("client_id"),
+			clientSecret: r.Form.Get("client_secret"),
+			grantType:    r.Form.Get("grant_type"),
+			scope:        r.Form.Get("scope"),
+		})
+		mu.Unlock()
+
+		for _, c := range clients {
+			if r.Form.Get("client_id") == c.id && r.Form.Get("client_secret") == c.secret {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"access_token":"` + c.bearer + `","token_type":"Bearer","expires_in":3600}`))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, func() []oaGrant {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]oaGrant(nil), grants...)
+	}
+}
+
+// setupOAuth2PerAgentChain parks one client credential per agent under the templated
+// path, then builds a single source and a single spec that both agents mint through.
+//
+// The consuming mount is the one restEnv already stood up: what varies between the two
+// agents is the credential, not the provider, and a mount of its own would only add
+// setup the rows do not exercise.
+func setupOAuth2PerAgentChain(t *testing.T, providerURL string, clientByAgent map[string]oaClient) {
+	t.Helper()
+
+	mustWrite := func(method, path, body, what string) {
+		t.Helper()
+		switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+		case 200, 201, 204:
+		default:
+			t.Fatalf("%s (status %d): %s", what, status, resp)
+		}
+	}
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+oaPerAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+oaPerAgentSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+oaPerAgentSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+oaPerAgentSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	// Both halves in one payload, because they authenticate as a pair.
+	for agent, c := range clientByAgent {
+		path := "secret/data/" + oaPerAgentKeyPath + "/" + agent
+		body := `{"data":{"client_id":"` + c.id + `","client_secret":"` + c.secret + `"}}`
+		if status, resp := h.VaultDirectRequest(t, "POST", path, body); status >= 400 {
+			t.Fatalf("parking %s's client credential (status %d): %s", agent, status, resp)
+		}
+	}
+
+	// The templated referenced spec. It must be session-pinned — a chained secret is
+	// minted as the caller, which is also what makes {{agent.sub}} resolve to the agent
+	// asking rather than to whoever warmed the cache first.
+	mustWrite("POST", "sys/cred/specs/"+oaPerAgentSecretSpec, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"`+oaPerAgentKeyPath+`/{{agent.sub}}",
+			"subject_token_source":"agent_identity"}}`,
+		"create the templated client-credential spec")
+
+	// One source for every tenant. It holds neither half, so nothing about it names a
+	// client. tls_skip_verify because the stand-in listens on loopback over http, which
+	// the token_url guard otherwise refuses.
+	mustWrite("POST", "sys/cred/sources/"+oaPerAgentSource, fmt.Sprintf(`{
+		"type":"oauth2","config":{
+			"token_url":%q,"default_scopes":"read","tls_skip_verify":"true",
+			"secret_spec":%q,"secret_field":"client_secret"}}`,
+		providerURL+oaTokenPath, oaPerAgentSecretSpec),
+		"create the per-agent oauth2 source")
+
+	// The consuming spec declares no identity of its own: the caller's is carried by the
+	// referenced spec, and the chained credential authenticates Warden to the provider.
+	mustWrite("POST", "sys/cred/specs/"+oaPerAgentSpec, `{
+		"type":"oauth_bearer_token","source":"`+oaPerAgentSource+`","config":{
+			"scope":"read"}}`,
+		"create the per-agent consuming spec")
+
+	mustWrite("POST", "auth/jwt/role/"+oaPerAgentRole, `{
+		"token_policies":["`+restEnv.Policy()+`"],"cred_spec_name":"`+oaPerAgentSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the shared per-agent role")
+}
+
+// TestOAuth2_PerAgentClientCredential drives two agents through one source, one spec and
+// one role, each authenticating to the provider as its own OAuth client.
+//
+// The client credential is resolved per mint from a path templated on the calling agent,
+// so the id and the secret both vary between the two — and the source that fronts them
+// stores neither, which is what lets it front both. A build reading the id from config
+// and the secret from the chain presents a mismatched pair and is refused; one that
+// shared a bearer across tenants proxies the wrong token.
+//
+// Two agents, one role, one spec, one source.
+func TestOAuth2_PerAgentClientCredential(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, restEnv)
+
+	clientA := oaClient{id: "oa-app-for-agent-a", secret: "oa-secret-a-not-real", bearer: "oa-bearer-for-agent-a"}
+	clientB := oaClient{id: "oa-app-for-agent-b", secret: "oa-secret-b-not-real", bearer: "oa-bearer-for-agent-b"}
+
+	idp, grants := serveOAuth2Provider(t, []oaClient{clientA, clientB})
+	setupOAuth2PerAgentChain(t, idp.URL, map[string]oaClient{
+		oaAgentA: clientA,
+		oaAgentB: clientB,
+	})
+	upstream.Reset()
+
+	mintAs := func(clientID, secret string) {
+		t.Helper()
+		status, body, _ := h.ChainRequest(t, leaderPort, restEnv, h.ChainOpts{
+			AgentToken: h.GetJWT(t, clientID, secret),
+			Role:       oaPerAgentRole,
+		})
+		if status != 200 {
+			t.Fatalf("%s got status %d: %s", clientID, status, body)
+		}
+	}
+
+	// A first, warming every cache on the way, so B has something to be wrongly served
+	// if any of them collapses the two.
+	mintAs(oaAgentA, "agent-secret")
+	mintAs(oaAgentB, "pipeline-secret")
+
+	// Each grant presented its own client — the pair reaching the provider together is
+	// what the source cannot supply and the payload must.
+	got := grants()
+	if len(got) != 2 {
+		t.Fatalf("provider received %d grants, want one per agent", len(got))
+	}
+	for i, want := range []oaClient{clientA, clientB} {
+		if got[i].grantType != "client_credentials" {
+			t.Errorf("grant %d used grant_type %q, want client_credentials", i, got[i].grantType)
+		}
+		if got[i].clientID != want.id {
+			t.Errorf("grant %d presented client_id %q, want %q", i, got[i].clientID, want.id)
+		}
+		if got[i].clientSecret != want.secret {
+			t.Errorf("grant %d presented client_secret %q, want %q", i, got[i].clientSecret, want.secret)
+		}
+		// Chaining replaces the client credential and nothing else: the rest of the
+		// source config still reaches the endpoint.
+		if got[i].scope != "read" {
+			t.Errorf("grant %d requested scope %q, want the source's default_scopes", i, got[i].scope)
+		}
+	}
+
+	// Each proxied request carried the bearer minted for its own agent's client. B
+	// receiving A's would mean a token was shared across tenants.
+	var injected []string
+	for _, req := range upstream.Requests() {
+		// restEnv's mount is configured to inject under a header of its own, which is
+		// also the one a row there proves is honoured.
+		if got := req.Header.Get("X-Custom-Auth"); got != "" {
+			injected = append(injected, got)
+		}
+	}
+	want := []string{"Token " + clientA.bearer, "Token " + clientB.bearer}
+	if len(injected) != 2 || injected[0] != want[0] || injected[1] != want[1] {
+		t.Errorf("proxied requests carried %v, want %v", injected, want)
+	}
+}
+
+// TestOAuth2_KeylessSourceRejectsAnInlineClientID pins the create-time half of the rule
+// the row above depends on: a source that fetches its client credential may not also name
+// a client, since an id from config beside a secret from the chain would present a pair
+// belonging to no one.
+func TestOAuth2_KeylessSourceRejectsAnInlineClientID(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		name       = "fc-oauth2-inline-id-rejected"
+		secretSpec = "fc-oauth2-inline-id-secret"
+	)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+secretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	// The reference is resolved before the driver's config is validated, so it has to
+	// exist for the rejection under test to be the one that fires.
+	if status, resp := h.APIRequest(t, "POST", "sys/cred/specs/"+secretSpec, leaderPort, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"`+oaPerAgentKeyPath+`/`+oaAgentA+`",
+			"subject_token_source":"agent_identity"}}`); status >= 400 {
+		t.Fatalf("create the referenced spec (status %d): %s", status, resp)
+	}
+
+	body := fmt.Sprintf(`{"type":"oauth2","config":{
+		"token_url":%q,"tls_skip_verify":"true","client_id":"named-anyway",
+		"secret_spec":%q,"secret_field":"client_secret"}}`,
+		"http://127.0.0.1:1"+oaTokenPath, secretSpec)
+
+	status, resp := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort, body)
+	if status < 400 {
+		t.Fatalf("a chained source naming a client was accepted (status %d): %s", status, resp)
+	}
+	if !strings.Contains(string(resp), "client_id") ||
+		!strings.Contains(string(resp), "must be omitted when secret_spec is set") {
+		t.Errorf("rejection did not name the offending key: %s", resp)
+	}
+}
+
+// TestOAuth2_KeylessSourceRejectsTheConsentFlow pins the other create-time rule: the
+// consent steps that seal an authorization_code grant run on the system backend with no
+// caller, so they have no identity to fetch the chained pair as. Accepting the spec would
+// defer that to a connect attempt that could only fail.
+func TestOAuth2_KeylessSourceRejectsTheConsentFlow(t *testing.T) {
+	ensureEnv(t)
+
+	const (
+		source     = "fc-oauth2-consent-rejected-src"
+		spec       = "fc-oauth2-consent-rejected"
+		secretSpec = "fc-oauth2-consent-secret"
+	)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+spec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+source, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+secretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	if status, resp := h.APIRequest(t, "POST", "sys/cred/specs/"+secretSpec, leaderPort, `{
+		"type":"key_value","source":"vault-fed-e2e","config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"`+oaPerAgentKeyPath+`/`+oaAgentA+`",
+			"subject_token_source":"agent_identity"}}`); status >= 400 {
+		t.Fatalf("create the referenced spec (status %d): %s", status, resp)
+	}
+
+	if status, resp := h.APIRequest(t, "POST", "sys/cred/sources/"+source, leaderPort, fmt.Sprintf(`{
+		"type":"oauth2","config":{
+			"token_url":%q,"auth_url":%q,"tls_skip_verify":"true",
+			"secret_spec":%q,"secret_field":"client_secret"}}`,
+		"http://127.0.0.1:1"+oaTokenPath, "http://127.0.0.1:1/authorize", secretSpec)); status >= 400 {
+		t.Fatalf("create the keyless source (status %d): %s", status, resp)
+	}
+
+	status, resp := h.APIRequest(t, "POST", "sys/cred/specs/"+spec, leaderPort, `{
+		"type":"oauth_bearer_token","source":"`+source+`","config":{
+			"auth_method":"authorization_code"}}`)
+	if status < 400 {
+		t.Fatalf("a consent-gated spec on a chained source was accepted (status %d): %s", status, resp)
+	}
+	if !strings.Contains(string(resp), "auth_method=client_credentials only") {
+		t.Errorf("rejection did not name the restriction: %s", resp)
+	}
+}


### PR DESCRIPTION
An oauth2 source stored the `client_id` and `client_secret` it authenticated with, so one source could front exactly one OAuth client. A source-level `secret_spec` now fetches both halves from a referenced spec per mint, which lets one source, one spec and one role front a different client for every agent — the arrangement `token_exchange` gained in #525.

```bash
# The referenced spec: one client credential per agent, both halves in one
# payload, path templated on the calling agent.
warden cred spec create idp-client-credential -json '{
  "type": "key_value",
  "source": "vault-fed",
  "config": {
    "mint_method": "kv2_read",
    "kv2_mount": "secret",
    "secret_path": "oauth-clients/{{agent.sub}}",
    "subject_token_source": "agent_identity"
  }
}'

# The keyless source — holds neither half.
warden cred source create pagerduty-oauth -json '{
  "type": "oauth2",
  "config": {
    "token_url": "https://identity.pagerduty.com/oauth/token",
    "default_scopes": "read",
    "secret_spec": "idp-client-credential",
    "secret_field": "client_secret",
    "secret_cache_ttl": "30m"
  }
}'

# The consuming spec — no client material anywhere.
warden cred spec create pagerduty-api -json '{
  "type": "oauth_bearer_token",
  "source": "pagerduty-oauth",
  "config": { "scope": "read" }
}'
```

## The pair travels together

The id is read by convention from `client_id`, the secret by `secret_field` — with the conventional key consulted only when no field resolved at all, since a field that resolved to nothing is a misconfigured source rather than an invitation to look elsewhere. A source in chaining mode is refused either half inline: an id from config beside a secret from the chain would name one client while presenting another's, which the token endpoint answers with `invalid_client` and the chained path would then misread as a stale secret and refetch pointlessly.

The pair is threaded by parameter, never held on the driver, so two concurrent mints resolving different pairs cannot cross.

## Breaking change

Chaining is a source concern here, so a spec-level `secret_spec` is rejected the way it already is for `token_exchange` and `gitlab`. That retires what a spec-level reference used to mean for oauth2 — chaining a refresh token. **An oauth2 spec chaining a refresh token no longer mints**; it gets an error naming what has to move. Nothing in the tree used it.

The sealed `authorization_code` connect flow, `refreshGrant` and the refresh-token write-back are untouched.

## Client credentials only

The consent steps run on the system backend with no `credential.Caller`, and `chainPreamble` fails closed without one, so chained material is structurally unreachable there. A keyless source now rejects `auth_method=authorization_code` at create — on the spec *and* on the source, since `auth_method` resolves spec-over-source and the store sees only spec config — and `BuildAuthorizeURL`/`ExchangeAuthorizationCode` refuse a chained source outright, rather than letting an operator complete a consent dance and seal tokens no mint could spend.

## No manager or cache changes

A chained oauth2 consumer never requests exchange, so `inputs == nil` and the existing `issueChained` → `MintFromSecretWithCleanup` → `ChainedSecretMinter` route already carried this. The chained-secret cache key already folds in the referenced-spec fingerprint and the agent's claims, so `secret_cache_ttl` on a keyless source cannot bleed one agent's client credential to another.

The one shared change is `isChainedClientAuthRejection`, extracted from `token_exchange`'s classifier — the `invalid_client`-or-401 test both drivers need. A bare 400 deliberately does not count: on a chained path it is far more likely `invalid_scope`, and refetching the secret cannot fix that. `manager.go` is a comment correction only.

## Testing

- Driver unit tests: keyless mint, per-mint pair resolution, the incomplete-payload table (which fails if the token endpoint is called at all), rejection-sentinel classification including the deliberate bare-400 divergence, the retired-path message, and the consent refusal.
- `TestCredentialConfigStore_OAuth2Chaining` mirrors the gitlab chaining test.
- E2E `TestOAuth2_PerAgentClientCredential` drives two agents through one source, spec and role against a stand-in IdP that answers only a matching pair, asserting each gets its own bearer and neither is served the other's. Plus create-time rejection rows for an inline `client_id` and for the consent flow.

Full `./e2e/...` suite green.
