### PR TITLE
test(e2e): enable the OIDC issuer as part of the harness

### DIFF
--- a/e2e/oidc_signer/oidc_signer_test.go
+++ b/e2e/oidc_signer/oidc_signer_test.go
@@ -1,10 +1,11 @@
 //go:build e2e
 
 // Package oidc_signer exercises the OIDC issuer's external signer (remote signing):
-// the private signing key lives in Vault transit and never leaves it. It proves the
-// keys are provisioned in transit and are non-exportable, and that an HA promotion
-// serves the same JWKS without moving any key material (the promoted node just
-// points at the same transit keys).
+// the private signing key lives in Vault transit and never leaves it. The harness
+// enables the issuer (e2e/setup.sh step 9j); this suite proves the keys it
+// provisioned are in transit and non-exportable, that re-applying the config
+// regenerates nothing, and that an HA promotion serves the same JWKS without moving
+// any key material (the promoted node just points at the same transit keys).
 package oidc_signer
 
 import (
@@ -68,12 +69,16 @@ func waitForIssuerReady(t *testing.T, port int) map[string]string {
 func TestOIDCSigner_RemoteTransit_And_HAPromotion(t *testing.T) {
 	leader := h.GetLeaderPort(t)
 
-	// 1. Enable the issuer on the active node. With the signer "transit" stanza in
-	//    each node's config, this provisions the signing keys IN transit — the
-	//    private key is created there and never enters Warden.
-	body := `{"enabled":true,"issuer_url":"` + h.NodeURL(leader) + `","key_rotation_period":0}`
+	// 1. Re-apply the enable the harness already performed (e2e/setup.sh step 9j).
+	//    issuer_url is deliberately absent: a config write is a partial update, so
+	//    the harness value survives for every other suite, and validation runs on
+	//    the merged config rather than the request. The stored keyset is complete,
+	//    so nothing is regenerated — the kids captured below are the ones setup
+	//    provisioned. Re-applying is the point: it proves an operator re-enable
+	//    leaves key material alone, which step 3 then depends on.
+	body := `{"enabled":true,"key_rotation_period":0}`
 	if status, resp := h.APIRequest(t, "POST", "sys/oidc-issuer/config", leader, body); status != 200 {
-		t.Fatalf("enable issuer = %d: %s", status, resp)
+		t.Fatalf("re-apply issuer config = %d: %s", status, resp)
 	}
 	kids := waitForIssuerReady(t, leader)
 

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -65,9 +65,22 @@ fi
 
 if [ ! -f "$NGINX_CERT_DIR/server.crt" ]; then
   echo "Generating nginx server certificate..."
+  # SANs matter: a client that verifies rejects a certificate carrying only a CN,
+  # so without them this certificate is usable only with -k. The issuer documents
+  # are served through this listener, and a verifier fetching them (a Kubernetes
+  # API server, say) does verify. e2e-nginx/nginx are the container name and
+  # service alias, for a verifier inside the compose network.
   openssl ecparam -genkey -name prime256v1 -noout -out "$NGINX_CERT_DIR/server.key" 2>/dev/null
-  openssl req -x509 -new -key "$NGINX_CERT_DIR/server.key" -out "$NGINX_CERT_DIR/server.crt" \
-    -days 365 -subj "/CN=e2e-nginx-lb" 2>/dev/null
+  openssl req -new -key "$NGINX_CERT_DIR/server.key" -out "$NGINX_CERT_DIR/server.csr" \
+    -subj "/CN=e2e-nginx-lb" 2>/dev/null
+  openssl x509 -req -sha256 -in "$NGINX_CERT_DIR/server.csr" -signkey "$NGINX_CERT_DIR/server.key" \
+    -out "$NGINX_CERT_DIR/server.crt" -days 365 \
+    -extfile <(printf "subjectAltName=IP:127.0.0.1,DNS:localhost,DNS:e2e-nginx,DNS:nginx") 2>/dev/null
+  rm -f "$NGINX_CERT_DIR/server.csr"
+  if [ ! -s "$NGINX_CERT_DIR/server.crt" ]; then
+    echo "ERROR: failed to generate nginx server certificate"
+    exit 1
+  fi
 fi
 
 # Step 1: Start infrastructure (PostgreSQL + Vault + Hydra + Nginx)
@@ -523,6 +536,35 @@ warden_api POST "auth/jwt/role/e2e-reader" \
 echo "  Enabling transparent mode..."
 warden_api POST "vault/config" \
   '{"auto_auth_path":"auth/jwt/"}'
+
+# 9j. Enable Warden's own OIDC issuer (workload identity federation).
+#
+# Suites minting Warden-signed identity assertions (subject_token_source=
+# warden_identity) need the issuer enabled and ready. With the signer "transit"
+# stanza in every node's config, this write provisions the signing keys IN
+# transit — the private key is created there and never enters Warden. The write
+# is a partial update and idempotent: re-applying it regenerates no keys, so the
+# JWKS kids stay stable across setup re-runs.
+#
+# issuer_url is the `iss` claim and the origin verifiers fetch discovery/JWKS
+# from, so it must outlive any single node: the load balancer fronts all three
+# and proxies every path, whereas a node origin goes dark whenever that node is
+# killed — which the HA suites do deliberately.
+#
+# Unlike the checks above this one aborts rather than warns. The issuer is part
+# of the harness contract now, and a silent failure here surfaces far from its
+# cause: suites that re-apply the config without an issuer_url would fail with
+# "issuer_url is required", saying nothing about setup having skipped this step.
+echo "  Enabling Warden OIDC issuer..."
+ISSUER_RESULT=$(warden_api POST "sys/oidc-issuer/config" \
+  '{"enabled":true,"issuer_url":"https://127.0.0.1:8000"}')
+if echo "$ISSUER_RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['ready'] is True" 2>/dev/null; then
+  echo "  OIDC issuer enabled and ready."
+else
+  echo "ERROR: OIDC issuer enable failed or not ready"
+  echo "  $ISSUER_RESULT"
+  exit 1
+fi
 
 # Step 10: Verify Vault integration
 echo ""


### PR DESCRIPTION
The OIDC issuer was enabled only from inside the `oidc_signer` suite, so any other suite needing a Warden-signed identity assertion (`subject_token_source=warden_identity`) had to duplicate that enable against shared, root-namespace-only state. This makes it part of the harness contract, alongside the Hydra clients and Vault sources it sits with.

### `issuer_url` points at the load balancer, not a node

The `iss` claim is where verifiers fetch discovery and JWKS from, so it has to outlive any single node — and a node origin does not, since the HA suites kill nodes deliberately. Verified: killing node 1 takes `https://127.0.0.1:8500/oidc/jwks` down while the LB origin keeps serving.

### `oidc_signer` no longer rewrites `issuer_url`

It set the value to whichever node happened to be leading. Package order is not contractual under `-p 1`, so a suite binding the issuer string could see a mutated one. A config write is a partial update and validation runs on the merged result, so re-enabling without it keeps the stored value — the re-apply is kept deliberately, since it proves an operator re-enable leaves key material alone, which the suite's HA-promotion assertion depends on.

### The nginx certificate had no SANs

It carried only a CN, which a client that verifies rejects outright — it passed until now only because every caller uses `curl -sk`. The issuer documents are served through that listener, and a real verifier (a Kubernetes API server, say) does verify. Now `IP:127.0.0.1,DNS:localhost,DNS:e2e-nginx,DNS:nginx`, generated with the CSR + `-extfile` form the node certificate already uses, and signed with SHA-256 rather than the openssl default.

There is no local-key vs transit decision here: the signing-key location is fixed by each node's HCL `signer "transit"` stanza, not by the API write, so this provisions keys in transit — exactly the state `oidc_signer` asserts.

## Verification

- `bash e2e/setup.sh` prints "OIDC issuer enabled and ready"
- `curl --cacert e2e/loadbalancer/certs/server.crt https://127.0.0.1:8000/oidc/jwks` succeeds **verifying**, which the old certificate could not
- discovery reports `issuer=https://127.0.0.1:8000`; all three node origins serve the JWKS
- config readback shows `"signer":{"mode":"external_kms","backend":"transit"}`, transit key non-exportable
- `make test-e2e`: all 20 packages pass