### PR TITLE
feat(credential): mint kubernetes tokens keyless over workload identity federation

### DIFF
--- a/credential/drivers/assertion_claims.go
+++ b/credential/drivers/assertion_claims.go
@@ -33,6 +33,8 @@ func DeriveAssertionResource(sourceType string, sourceCfg, specCfg map[string]st
 		return gcpAssertionResource(sourceCfg, specCfg)
 	case credential.SourceTypeVault:
 		return vaultAssertionResource(sourceCfg, specCfg)
+	case credential.SourceTypeKubernetes:
+		return kubernetesAssertionResource(specCfg)
 	default:
 		return "", false
 	}
@@ -59,9 +61,47 @@ func DeriveAssertionAudience(sourceType string, sourceCfg, specCfg map[string]st
 		return azureAssertionAudience(sourceCfg)
 	case credential.SourceTypeVault:
 		return vaultAssertionAudience(sourceCfg)
+	case credential.SourceTypeKubernetes:
+		return kubernetesAssertionAudience(sourceCfg)
 	default:
 		return "", false
 	}
+}
+
+// kubernetesAssertionAudience derives the warden_identity assertion audience for a
+// keyless Kubernetes source: the source's explicit `audience`, or ("", false) when
+// unset. There is no conventional default — the value must appear in the cluster
+// authenticator's own audiences list, which the operator chooses — so an unset
+// audience forces the spec to set assertion_audience (the spec-create gate enforces
+// this, and mint fails closed otherwise).
+//
+// Gated on auth_method=oidc_federation: only a keyless source federates, so a
+// static source supplies no derived audience even if a stored config record somehow
+// carries one.
+func kubernetesAssertionAudience(sourceCfg map[string]string) (string, bool) {
+	if credential.GetString(sourceCfg, "auth_method", kubernetesAuthMethodStatic) != kubernetesAuthMethodOIDCFederation {
+		return "", false
+	}
+	if aud := credential.GetString(sourceCfg, "audience", ""); aud != "" {
+		return aud, true
+	}
+	return "", false
+}
+
+// kubernetesAssertionResource reports the service account a federation spec mints
+// for, as "namespace/service_account", for the warden_resource claim. Pure: reads
+// spec config only, no network or driver state. The driver has a single mint path,
+// so unlike the multi-engine sources there is no mint_method to dispatch on.
+//
+// The returned value is opaque — never parse it back, since a Kubernetes name can
+// in principle carry the separator.
+func kubernetesAssertionResource(specCfg map[string]string) (string, bool) {
+	namespace := credential.GetString(specCfg, "namespace", "")
+	sa := credential.GetString(specCfg, "service_account", "")
+	if namespace != "" && sa != "" {
+		return namespace + "/" + sa, true
+	}
+	return "", false
 }
 
 // vaultAssertionAudience derives the warden_identity assertion audience for a Vault

--- a/credential/drivers/assertion_claims_test.go
+++ b/credential/drivers/assertion_claims_test.go
@@ -85,6 +85,31 @@ func TestDeriveAssertionAudience(t *testing.T) {
 			wantOK:     false,
 		},
 		{
+			name:       "kubernetes federation derives explicit audience",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"auth_method": "oidc_federation", "audience": "https://kubernetes.example.com"},
+			wantAud:    "https://kubernetes.example.com",
+			wantOK:     true,
+		},
+		{
+			name:       "kubernetes federation without audience derives nothing (no default)",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"auth_method": "oidc_federation"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes static derives nothing even with audience",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"auth_method": "static", "audience": "https://kubernetes.example.com"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes absent auth_method derives nothing",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"audience": "https://kubernetes.example.com"},
+			wantOK:     false,
+		},
+		{
 			name:       "unknown source type derives nothing",
 			sourceType: credential.SourceTypeGitHub,
 			sourceCfg:  map[string]string{"auth_method": "oidc_federation", "audience": "x"},
@@ -188,6 +213,25 @@ func TestDeriveAssertionResource(t *testing.T) {
 			name:       "gcp impersonation without target omits",
 			sourceType: credential.SourceTypeGCP,
 			specCfg:    map[string]string{"mint_method": "impersonated_access_token"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes names the target service account",
+			sourceType: credential.SourceTypeKubernetes,
+			specCfg:    map[string]string{"namespace": "prod", "service_account": "payments"},
+			want:       "prod/payments",
+			wantOK:     true,
+		},
+		{
+			name:       "kubernetes without namespace omits",
+			sourceType: credential.SourceTypeKubernetes,
+			specCfg:    map[string]string{"service_account": "payments"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes without service_account omits",
+			sourceType: credential.SourceTypeKubernetes,
+			specCfg:    map[string]string{"namespace": "prod"},
 			wantOK:     false,
 		},
 		{

--- a/credential/drivers/kubernetes_driver.go
+++ b/credential/drivers/kubernetes_driver.go
@@ -2,8 +2,10 @@ package drivers
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18,10 +20,30 @@ import (
 // k8sMaxResponseBodySize limits response body reads to prevent OOM
 const k8sMaxResponseBodySize = 1 << 20 // 1MB
 
+// kubernetesAuthMethodStatic and kubernetesAuthMethodOIDCFederation select how the
+// source authenticates to the API server. static holds a long-lived bearer token
+// with permission to create tokens for the target service accounts (rotatable);
+// oidc_federation holds no secret and presents the caller's identity assertion as
+// the bearer token on every request. An empty auth_method means static, so records
+// written before federation existed keep working.
+//
+// Federation needs no token-exchange hop: an API server configured to trust
+// Warden's issuer accepts the assertion as an ordinary bearer token and authorizes
+// the claims it maps to a user and groups.
+const (
+	kubernetesAuthMethodStatic         = "static"
+	kubernetesAuthMethodOIDCFederation = "oidc_federation"
+)
+
+// defaultK8sTLSPort is the port a TLS handshake probe dials when kubernetes_url
+// names none.
+const defaultK8sTLSPort = "443"
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*KubernetesDriver)(nil)
 var _ credential.SpecVerifier = (*KubernetesDriver)(nil)
 var _ credential.Rotatable = (*KubernetesDriver)(nil)
+var _ credential.ExchangeMinter = (*KubernetesDriver)(nil)
 
 // KubernetesDriver mints ServiceAccount tokens via the Kubernetes TokenRequest API.
 // It uses raw HTTP calls to POST /api/v1/namespaces/{ns}/serviceaccounts/{sa}/token
@@ -49,7 +71,7 @@ func (f *KubernetesDriverFactory) Type() string {
 
 // ValidateConfig validates Kubernetes driver configuration using declarative schema
 func (f *KubernetesDriverFactory) ValidateConfig(config map[string]string) error {
-	return credential.ValidateSchema(config,
+	if err := credential.ValidateSchema(config,
 		credential.StringField("kubernetes_url").
 			Required().
 			Custom(func(v string) error {
@@ -69,10 +91,18 @@ func (f *KubernetesDriverFactory) ValidateConfig(config map[string]string) error
 			Describe("Kubernetes API server URL").
 			Example("https://my-cluster.example.com:6443"),
 
+		credential.StringField("auth_method").
+			OneOf(kubernetesAuthMethodStatic, kubernetesAuthMethodOIDCFederation).
+			Describe("How the source authenticates: 'static' (stored bearer token) or 'oidc_federation' (keyless, presents the caller's identity assertion)").
+			Example(kubernetesAuthMethodStatic),
+
 		credential.StringField("token").
-			Required().
-			Describe("Bearer token for authenticating to the Kubernetes API server").
+			Describe("Bearer token for authenticating to the Kubernetes API server (required for auth_method=static)").
 			Example("eyJhbGciOiJSUzI1NiIs..."),
+
+		credential.StringField("audience").
+			Describe("Assertion audience; must match an entry in the cluster authenticator's audiences (auth_method=oidc_federation)").
+			Example("https://kubernetes.example.com"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -110,7 +140,37 @@ func (f *KubernetesDriverFactory) ValidateConfig(config map[string]string) error
 			}).
 			Describe("TTL for rotated source tokens (default: 24h, min: 10m, max: 48h)").
 			Example("24h"),
-	)
+	); err != nil {
+		return err
+	}
+
+	// Cross-field rules per auth_method. Each mode rejects the other's fields, so a
+	// half-converted source fails at write rather than behaving as the mode the
+	// operator did not intend.
+	//
+	// Present-but-empty is validated as static, not skipped. GetString returns a
+	// stored "" rather than the default, and the schema pass above skips empty
+	// values too — so a switch that only matched the two named modes would let a
+	// source through carrying neither a token nor a federation config, and it is
+	// static that such a source then behaves as.
+	switch credential.GetString(config, "auth_method", kubernetesAuthMethodStatic) {
+	case "", kubernetesAuthMethodStatic:
+		if credential.GetString(config, "token", "") == "" {
+			return fmt.Errorf("token is required for auth_method=%s", kubernetesAuthMethodStatic)
+		}
+		if credential.GetString(config, "audience", "") != "" {
+			return fmt.Errorf("audience is only valid for auth_method=%s", kubernetesAuthMethodOIDCFederation)
+		}
+	case kubernetesAuthMethodOIDCFederation:
+		// A federation source holds no token of its own, so it has nothing to rotate
+		// and no service account to rotate as.
+		for _, k := range []string{"token", "source_service_account", "source_namespace", "source_token_ttl"} {
+			if config[k] != "" {
+				return fmt.Errorf("field '%s' must not be set for auth_method=%s", k, kubernetesAuthMethodOIDCFederation)
+			}
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -139,10 +199,22 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 	}
 	driver.httpClient = httpClient
 
-	// Verify source credentials by checking API server connectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// A federation source holds no credential, so the eager probe cannot check
+	// authority — but the transport config is still worth checking, and a
+	// handshake does that without one. kubernetes_url and ca_data are typed by
+	// the operator and are the two things most likely to be wrong; catching them
+	// here beats surfacing them at the first mint.
+	if credential.GetString(config, "auth_method", kubernetesAuthMethodStatic) == kubernetesAuthMethodOIDCFederation {
+		if err := driver.probeTLS(ctx); err != nil {
+			return nil, err
+		}
+		return driver, nil
+	}
+
+	// Verify source credentials by checking API server connectivity
 	if err := driver.verifyConnection(ctx); err != nil {
 		return nil, fmt.Errorf("Kubernetes API server connection failed: %w", err)
 	}
@@ -154,7 +226,8 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 // SourceDriver Interface Implementation
 // ============================================================================
 
-// MintCredential creates a new ServiceAccount token via the Kubernetes TokenRequest API.
+// MintCredential creates a new ServiceAccount token via the Kubernetes TokenRequest
+// API, authenticating with the source's stored bearer token.
 //
 // Spec config fields:
 //   - service_account: Target service account name (required)
@@ -162,6 +235,47 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 //   - audiences: Comma-separated token audiences (optional)
 //   - ttl: Token TTL duration, e.g. "1h" (optional, default: 1h)
 func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("kubernetes: a source with auth_method=%s mints only from a caller assertion: set subject_token_source on the spec", kubernetesAuthMethodOIDCFederation)
+	}
+	k8sURL, token := d.configSnapshot()
+	return d.mintServiceAccountToken(ctx, k8sURL, token, spec)
+}
+
+// MintCredentialWithExchange mints a ServiceAccount token over workload identity
+// federation: the caller's identity assertion is the bearer token on the
+// TokenRequest call, so the source stores no credential of its own and the API
+// server sees, and audits, the identity behind each request rather than one shared
+// service account.
+//
+// Unlike the STS-backed drivers there is no exchange hop to make. An API server
+// configured to trust the assertion's issuer accepts it directly, so the assertion
+// is handed to the same mint path a stored token would take.
+//
+// The minted token outliving the assertion is expected and harmless: its lifetime
+// is fixed by the API server when it is issued and does not depend on the assertion
+// that asked for it.
+func (d *KubernetesDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() != kubernetesAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("kubernetes: workload identity federation requires auth_method=%s on the source", kubernetesAuthMethodOIDCFederation)
+	}
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("kubernetes: no subject token in exchange inputs")
+	}
+	k8sURL, _ := d.configSnapshot()
+	return d.mintServiceAccountToken(ctx, k8sURL, inputs.SubjectToken, spec)
+}
+
+// mintServiceAccountToken calls the TokenRequest API for the spec's service account
+// with the given bearer token, which is the source's stored token under static auth
+// and the caller's assertion under federation. Everything below this point is
+// identical in both modes.
+//
+// The URL is passed in rather than read here so that the static path pairs a token
+// with the URL from the same config snapshot: reading them separately would let a
+// rotation land between the two and mint with one config's token against another's
+// address.
+func (d *KubernetesDriver) mintServiceAccountToken(ctx context.Context, k8sURL, bearer string, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	sa := credential.GetString(spec.Config, "service_account", "")
 	namespace := credential.GetString(spec.Config, "namespace", "")
 	audiencesStr := credential.GetString(spec.Config, "audiences", "")
@@ -195,7 +309,7 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 	path := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token",
 		url.PathEscape(namespace), url.PathEscape(sa))
 
-	respBody, statusCode, err := d.doK8sRequest(ctx, http.MethodPost, path, body)
+	respBody, statusCode, err := d.doK8sRequestWith(ctx, k8sURL, bearer, http.MethodPost, path, body)
 	if err != nil {
 		return nil, nil, 0, "", d.mapError(err, statusCode, sa, namespace)
 	}
@@ -300,7 +414,15 @@ func (d *KubernetesDriver) Cleanup(_ context.Context) error {
 }
 
 // VerifySpec validates that the target service account exists.
+//
+// A federation source has no ambient credential to look it up with — assertions
+// are per caller, per request — so verification is skipped and a missing service
+// account surfaces at the first mint instead.
 func (d *KubernetesDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return nil
+	}
+
 	sa := credential.GetString(spec.Config, "service_account", "")
 	namespace := credential.GetString(spec.Config, "namespace", "")
 
@@ -329,7 +451,15 @@ func (d *KubernetesDriver) VerifySpec(ctx context.Context, spec *credential.Cred
 // SupportsRotation returns true if the driver can rotate its source token.
 // Rotation requires source_service_account and source_namespace to be configured
 // so the driver knows which SA to mint a new token for.
+//
+// A federation source holds no token, so there is nothing to rotate. ValidateConfig
+// already keeps the rotation fields off such a source, which would make the check
+// below false anyway; stating it here keeps the invariant independent of that.
 func (d *KubernetesDriver) SupportsRotation() bool {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return false
+	}
+
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 	sa := credential.GetString(d.credSource.Config, "source_service_account", "")
@@ -341,6 +471,10 @@ func (d *KubernetesDriver) SupportsRotation() bool {
 // current (still valid) source token. Kubernetes has immediate consistency,
 // so activateAfter is 0.
 func (d *KubernetesDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return nil, nil, 0, fmt.Errorf("kubernetes: a source with auth_method=%s holds no token to rotate", kubernetesAuthMethodOIDCFederation)
+	}
+
 	// Snapshot config under lock, then release before making HTTP calls.
 	d.authMu.Lock()
 	sa := credential.GetString(d.credSource.Config, "source_service_account", "")
@@ -477,6 +611,67 @@ func buildTokenRequestBody(expirationSeconds int64, audiences []string) ([]byte,
 	return json.Marshal(reqBody)
 }
 
+// getAuthMethod returns the source's configured auth_method, normalising both an
+// absent key and a stored empty string to static — the former so a record written
+// before federation existed keeps its old behaviour, the latter because GetString
+// hands back a stored "" rather than the default. It reads under authMu because
+// CommitRotation swaps the whole config map under that lock.
+func (d *KubernetesDriver) getAuthMethod() string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	if method := credential.GetString(d.credSource.Config, "auth_method", kubernetesAuthMethodStatic); method != "" {
+		return method
+	}
+	return kubernetesAuthMethodStatic
+}
+
+// probeTLS completes a TLS handshake against the API server and closes the
+// connection, sending no HTTP request. It is the credential-free half of
+// verifyConnection: it proves the host resolves and answers, and that its
+// certificate verifies against ca_data, which is all a source with no token of
+// its own can check.
+//
+// It runs only against an https URL. ValidateConfig permits a plain-HTTP
+// kubernetes_url when tls_skip_verify is set, and a handshake with a plain HTTP
+// listener fails whatever InsecureSkipVerify says — so probing one would reject
+// every dev cluster.
+//
+// Known limitation: it dials the host directly and so ignores HTTPS_PROXY, which
+// the client's own transport would honour. A deployment reaching the API server
+// only through a proxy therefore fails source creation here even though its mints
+// would succeed.
+func (d *KubernetesDriver) probeTLS(ctx context.Context) error {
+	k8sURL, _ := d.configSnapshot()
+
+	parsed, err := url.Parse(k8sURL)
+	if err != nil {
+		return fmt.Errorf("kubernetes_url is not a valid URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return nil
+	}
+
+	port := parsed.Port()
+	if port == "" {
+		port = defaultK8sTLSPort
+	}
+
+	// The client carries the CA pool and skip-verify flag built from config. Its
+	// Transport is nil when neither is set (BuildHTTPClient returns a bare client
+	// then), which leaves a nil config and the system roots — the right default.
+	var tlsConfig *tls.Config
+	if transport, ok := d.httpClient.Transport.(*http.Transport); ok && transport != nil {
+		tlsConfig = transport.TLSClientConfig
+	}
+
+	dialer := &tls.Dialer{Config: tlsConfig}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(parsed.Hostname(), port))
+	if err != nil {
+		return fmt.Errorf("cannot establish a TLS connection to the Kubernetes API server at %s: %w (check kubernetes_url and ca_data)", parsed.Host, err)
+	}
+	return conn.Close()
+}
+
 // verifyConnection checks API server connectivity using the /version endpoint,
 // which requires no RBAC permissions.
 func (d *KubernetesDriver) verifyConnection(ctx context.Context) error {
@@ -545,6 +740,14 @@ func defaultK8sRetryConfig() httputil.HTTPRetryConfig {
 func (d *KubernetesDriver) mapError(err error, statusCode int, sa, namespace string) error {
 	switch statusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
+		// Under federation the assertion carries the identity, so a refusal is as
+		// likely to be a trust or audience mismatch as a missing grant. Naming all
+		// three saves an operator from auditing RBAC for what is a config problem.
+		if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+			return fmt.Errorf("kubernetes API server rejected the identity assertion (HTTP %d) when creating a token for service account %q in namespace %q: "+
+				"check that the cluster trusts Warden's issuer, that the source's audience matches the authenticator's audiences, "+
+				"and that the mapped user or groups may create serviceaccounts/token there: %w", statusCode, sa, namespace, err)
+		}
 		return fmt.Errorf("insufficient permissions to create token for service account %q in namespace %q: %w", sa, namespace, err)
 	case http.StatusNotFound:
 		return fmt.Errorf("service account %q not found in namespace %q: %w", sa, namespace, err)

--- a/credential/drivers/kubernetes_driver_test.go
+++ b/credential/drivers/kubernetes_driver_test.go
@@ -95,6 +95,99 @@ func TestKubernetesDriverFactory_ValidateConfig(t *testing.T) {
 	})
 }
 
+func TestKubernetesDriverFactory_ValidateConfig_AuthMethod(t *testing.T) {
+	f := &KubernetesDriverFactory{}
+
+	t.Run("absent auth_method behaves as static", func(t *testing.T) {
+		// The back-compat case: every source written before federation existed.
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"token":          "test-token",
+		}))
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token is required")
+	})
+
+	t.Run("present but empty auth_method is validated as static", func(t *testing.T) {
+		// GetString hands back a stored "" rather than the default, and the schema
+		// pass skips empty values — so an auth_method key set to "" must still be
+		// held to the static rules. Otherwise a source is accepted carrying neither
+		// a token nor a federation config, and every mint 401s with an empty bearer.
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    "",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token is required")
+
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    "",
+			"token":          "test-token",
+		}))
+	})
+
+	t.Run("unknown auth_method rejected", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    "kubeconfig",
+			"token":          "test-token",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth_method")
+	})
+
+	t.Run("static rejects audience", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    kubernetesAuthMethodStatic,
+			"token":          "test-token",
+			"audience":       "https://k8s.example.com",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "audience is only valid")
+	})
+
+	t.Run("federation minimal config", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+		}))
+	})
+
+	t.Run("federation accepts audience", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+			"audience":       "https://k8s.example.com",
+		}))
+	})
+
+	// A keyless source holds nothing to authenticate or rotate with, so every
+	// static field is rejected rather than silently ignored.
+	for _, field := range []string{"token", "source_service_account", "source_namespace", "source_token_ttl"} {
+		t.Run("federation rejects "+field, func(t *testing.T) {
+			config := map[string]string{
+				"kubernetes_url": "https://k8s.example.com",
+				"auth_method":    kubernetesAuthMethodOIDCFederation,
+			}
+			switch field {
+			case "source_token_ttl":
+				config[field] = "24h"
+			default:
+				config[field] = "some-value"
+			}
+			err := f.ValidateConfig(config)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), field)
+			assert.Contains(t, err.Error(), "must not be set")
+		})
+	}
+}
+
 // ============================================================================
 // Mock Server
 // ============================================================================
@@ -812,4 +905,229 @@ func TestKubernetesTokenMetadata(t *testing.T) {
 		assert.NotContains(t, meta, "audiences")
 		assert.NotContains(t, meta, "expiration")
 	})
+}
+
+// ============================================================================
+// Keyless (workload identity federation) Tests
+// ============================================================================
+
+// newFederatedK8sDriver builds a driver backed by the shared mock server with no
+// stored token, the way a keyless source is configured.
+func newFederatedK8sDriver(t *testing.T, serverURL string) *KubernetesDriver {
+	t.Helper()
+	return &KubernetesDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeKubernetes,
+			Config: map[string]string{
+				"kubernetes_url":  serverURL,
+				"auth_method":     kubernetesAuthMethodOIDCFederation,
+				"audience":        "https://k8s.example.com",
+				"tls_skip_verify": "true",
+			},
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestKubernetesDriver_MintCredentialWithExchange_UsesAssertionAsBearer(t *testing.T) {
+	// The assertion the caller presents must be the bearer on the TokenRequest
+	// call — that is the whole of federation here, since there is no exchange hop.
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"kind":       "TokenRequest",
+			"apiVersion": "authentication.k8s.io/v1",
+			"status": map[string]interface{}{
+				"token":               "minted-token-for-payments",
+				"expirationTimestamp": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+		})
+	}))
+	defer server.Close()
+
+	d := newFederatedK8sDriver(t, server.URL)
+	spec := &credential.CredSpec{
+		Name: "payments",
+		Config: map[string]string{
+			"service_account":      "payments",
+			"namespace":            "prod",
+			"subject_token_source": credential.SourceWardenIdentity,
+		},
+	}
+
+	rawData, metadata, ttl, leaseID, err := d.MintCredentialWithExchange(
+		context.Background(), spec, &credential.ExchangeInputs{SubjectToken: "assertion-jwt"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer assertion-jwt", gotAuth)
+	assert.Equal(t, "minted-token-for-payments", rawData["token"])
+	assert.Equal(t, "prod", rawData["namespace"])
+	assert.Equal(t, "payments", rawData["service_account"])
+	assert.Equal(t, "system:serviceaccount:prod:payments", metadata["subject"])
+	assert.InDelta(t, time.Hour.Seconds(), ttl.Seconds(), 5)
+	// A ServiceAccount token cannot be revoked, so there is no lease to hold.
+	assert.Empty(t, leaseID)
+}
+
+func TestKubernetesDriver_ExchangeFailsClosed(t *testing.T) {
+	server := newK8sMockServer(t)
+	defer server.Close()
+
+	spec := &credential.CredSpec{
+		Name:   "app",
+		Config: map[string]string{"service_account": "app-backend", "namespace": "default"},
+	}
+
+	t.Run("MintCredential refuses a federated source", func(t *testing.T) {
+		d := newFederatedK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subject_token_source")
+	})
+
+	t.Run("MintCredentialWithExchange refuses a static source", func(t *testing.T) {
+		d := newTestK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredentialWithExchange(
+			context.Background(), spec, &credential.ExchangeInputs{SubjectToken: "assertion-jwt"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), kubernetesAuthMethodOIDCFederation)
+	})
+
+	t.Run("empty subject token is refused", func(t *testing.T) {
+		d := newFederatedK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredentialWithExchange(
+			context.Background(), spec, &credential.ExchangeInputs{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+	})
+
+	t.Run("nil exchange inputs are refused", func(t *testing.T) {
+		d := newFederatedK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+	})
+}
+
+func TestKubernetesDriver_Federation_RotationAndVerifyDisabled(t *testing.T) {
+	server := newK8sMockServer(t)
+	defer server.Close()
+
+	d := newFederatedK8sDriver(t, server.URL)
+
+	assert.False(t, d.SupportsRotation(), "a source holding no token has nothing to rotate")
+
+	// A stored empty auth_method resolves to static, matching what ValidateConfig
+	// holds such a source to.
+	empty := newTestK8sDriver(t, server.URL)
+	empty.credSource.Config["auth_method"] = ""
+	assert.Equal(t, kubernetesAuthMethodStatic, empty.getAuthMethod())
+
+	_, _, _, err := d.PrepareRotation(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no token to rotate")
+
+	// VerifySpec has no ambient credential to look the account up with, so it is
+	// skipped rather than attempted unauthenticated.
+	require.NoError(t, d.VerifySpec(context.Background(), &credential.CredSpec{
+		Config: map[string]string{"service_account": "not-found-sa", "namespace": "default"},
+	}))
+}
+
+func TestKubernetesDriverFactory_Create_Federation(t *testing.T) {
+	f := &KubernetesDriverFactory{}
+
+	t.Run("no request is sent to the API server", func(t *testing.T) {
+		// Driver creation runs on every mint, not just at source create, so a
+		// federated Create must not depend on a credential it does not have.
+		var calls int
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		d, err := f.Create(map[string]string{
+			"kubernetes_url":  server.URL,
+			"auth_method":     kubernetesAuthMethodOIDCFederation,
+			"audience":        "https://k8s.example.com",
+			"tls_skip_verify": "true",
+		}, newTestLogger(t))
+		require.NoError(t, err)
+		require.NotNil(t, d)
+		assert.Zero(t, calls, "the TLS probe must send no HTTP request")
+	})
+
+	t.Run("rejects a certificate the CA does not verify", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		// httptest signs with its own throwaway CA, which the system roots do not
+		// carry — so verification must fail without tls_skip_verify.
+		_, err := f.Create(map[string]string{
+			"kubernetes_url": server.URL,
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+		}, newTestLogger(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS connection")
+	})
+
+	t.Run("rejects an unreachable host", func(t *testing.T) {
+		_, err := f.Create(map[string]string{
+			"kubernetes_url":  "https://127.0.0.1:1",
+			"auth_method":     kubernetesAuthMethodOIDCFederation,
+			"tls_skip_verify": "true",
+		}, newTestLogger(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS connection")
+	})
+
+	t.Run("plain http is not probed", func(t *testing.T) {
+		// tls_skip_verify permits an http URL for dev clusters; a handshake against
+		// a plain listener would fail regardless of InsecureSkipVerify, so the probe
+		// must skip it. The e2e harness depends on this.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("no request should reach the server")
+		}))
+		defer server.Close()
+
+		_, err := f.Create(map[string]string{
+			"kubernetes_url":  server.URL,
+			"auth_method":     kubernetesAuthMethodOIDCFederation,
+			"tls_skip_verify": "true",
+		}, newTestLogger(t))
+		require.NoError(t, err)
+	})
+
+	t.Run("survives a nil transport", func(t *testing.T) {
+		// With neither ca_data nor tls_skip_verify, BuildHTTPClient returns a bare
+		// client whose Transport is nil — the probe must not panic reaching for it.
+		_, err := f.Create(map[string]string{
+			"kubernetes_url": "https://127.0.0.1:1",
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+		}, newTestLogger(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS connection")
+	})
+}
+
+func TestKubernetesDriver_MapError_Federated(t *testing.T) {
+	server := newK8sMockServer(t)
+	defer server.Close()
+
+	// A federated refusal is as likely to be a trust or audience mismatch as a
+	// missing grant, so the message must name all three.
+	d := newFederatedK8sDriver(t, server.URL)
+	err := d.mapError(fmt.Errorf("forbidden"), http.StatusForbidden, "payments", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer")
+	assert.Contains(t, err.Error(), "audience")
+	assert.Contains(t, err.Error(), "serviceaccounts/token")
+
+	// The static message is unchanged.
+	static := newTestK8sDriver(t, server.URL)
+	err = static.mapError(fmt.Errorf("forbidden"), http.StatusForbidden, "payments", "prod")
+	assert.Contains(t, err.Error(), "insufficient permissions")
 }


### PR DESCRIPTION
The kubernetes source held a long-lived, highly privileged bearer token and used it to create tokens on behalf of every caller. Rotation existed but bootstrapped off the current token, so a lapse left the source dead and needing manual reconfiguration.

`auth_method=oidc_federation` stores nothing: the caller's identity assertion is the bearer token on the TokenRequest call. Unlike the STS-backed sources there is no exchange hop to make — an API server configured to trust the assertion's issuer accepts it directly — so the assertion is handed to the same mint path a stored token would take, and the API server sees, and audits, the identity behind each request rather than one shared service account.

### Federation, not chaining

Chaining (`secret_spec`) would only relocate the standing token; a long-lived token with `create` on `serviceaccounts/token` would still exist and still need rotating. Federation removes it. It also adds a second, independent gate: because each request carries the caller's own role, the cluster — not Warden — decides which ServiceAccounts that role may mint for, via `resourceNames` RBAC keyed on the `warden_role` claim.

### Back-compat

An absent `auth_method` means static, **and so does a stored empty string**: `GetString` hands back the latter rather than the default, so a switch matching only the two named modes would accept a source carrying neither a token nor a federation config. Each mode otherwise rejects the other's fields, so a half-converted source fails at write. That also settles conversion: the update path merges config, so a stored token cannot be removed, and delete-and-recreate is the path.

### Create-time probe

`Create` cannot probe with a credential it does not have, so under federation it completes a TLS handshake and sends no request. That still catches a mistyped `kubernetes_url` or a `ca_data` that does not verify — the two things most likely to be wrong — and it matters beyond source creation, since the driver is rebuilt through the same factory on **every mint**. It runs only against an `https` URL: a handshake with the plain HTTP listener that `tls_skip_verify` permits would fail whatever `InsecureSkipVerify` says.

Known limitation, documented in the code: it dials directly and so ignores `HTTPS_PROXY`, which the client's own transport would honour.

## Scope

Driver only — no core changes. Refusing a `rotation_period` on such a source is the same rule for every source that holds no secret and lives in core; that is #531.

## Verification

`go build ./... && go test ./credential/... && go test ./core/...`

Unit tests cover: the `auth_method` matrix including present-but-empty; `Create` under federation making zero HTTP requests, failing on an unverifiable certificate and on an unreachable host, and surviving a nil `Transport`; the assertion arriving as the bearer; both fail-closed directions; `SupportsRotation` false; and the federated error message naming issuer, audience and RBAC.

End-to-end coverage is #532.