### PR TITLE
fix(core): reject rotation_period wherever a credential holds no secret

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -237,7 +237,9 @@ func (s *CredentialConfigStore) CreateSpec(ctx context.Context, spec *credential
 	s.specsByID.Set(cacheKey, spec, 1)
 	s.specsByID.Wait()
 
-	// Register with rotation manager if RotationPeriod is configured
+	// Register with rotation manager if RotationPeriod is configured. A chained
+	// spec never gets this far: the check above rejects that combination, and
+	// re-deriving it here would cost another source read for no new protection.
 	if spec.RotationPeriod > 0 {
 		if s.rotationManager != nil {
 			if err := s.rotationManager.RegisterSpec(ctx, spec.Name, spec.Source, spec.RotationPeriod); err != nil {
@@ -499,8 +501,10 @@ func (s *CredentialConfigStore) CreateSource(ctx context.Context, source *creden
 	s.sourcesByID.Set(cacheKey, source, 1)
 	s.sourcesByID.Wait()
 
-	// Register with rotation manager if RotationPeriod is configured
-	if source.RotationPeriod > 0 {
+	// Register with rotation manager if RotationPeriod is configured. A federated
+	// source is never enrolled: CreateSource rejects the combination outright, so
+	// this only guards a caller that reaches here another way.
+	if source.RotationPeriod > 0 && !isFederationSource(source.Config) {
 		if s.rotationManager != nil {
 			if err := s.rotationManager.RegisterSource(ctx, source.Name, source.Type, source.RotationPeriod); err != nil {
 				s.logger.Warn("failed to register source for rotation",
@@ -983,6 +987,14 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		chainedRef = source.Config[credential.ConfigSecretSpec]
 	}
 	if chainedRef != "" {
+		// A chained spec mints from material fetched at request time, so it embeds no
+		// secret of its own and a rotation_period schedules a rotation that can never
+		// succeed — the same reasoning that rejects one on a token-exchange spec and
+		// on a chained source. Whoever owns the referenced spec rotates it there.
+		if spec.RotationPeriod > 0 {
+			return logical.ErrBadRequestf("rotation_period does not apply to a chained credential spec (secret_spec %q); the referenced spec's owner rotates the secret", chainedRef)
+		}
+
 		// For token_exchange, gitlab and oauth2, chaining is a SOURCE concern: the secret
 		// being chained authenticates the source itself (client auth, a personal access
 		// token), and the factory only sees source config. A spec-level secret_spec
@@ -1136,6 +1148,25 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 	return nil
 }
 
+// authMethodOIDCFederation is the auth_method every federation-capable source type
+// sets. The drivers each define their own copy for their config schema; this is
+// core's, for the rules that hold across types regardless of the provider behind
+// them.
+const authMethodOIDCFederation = "oidc_federation"
+
+// isFederationSource reports whether a source authenticates by presenting a
+// caller's identity assertion. Every such driver — aws, azure, gcp, hvault,
+// kubernetes — spells it the same way, so one predicate covers them all and covers
+// a new one the day it lands.
+//
+// This is narrower than "holds no secret", which also describes a chained source
+// or spec (secret_spec), whose secret lives in the spec it references. Those are
+// gated separately, by the chained-source rule in validateSource and the
+// chained-spec rule in CreateSpec.
+func isFederationSource(config map[string]string) bool {
+	return credential.GetString(config, "auth_method", "") == authMethodOIDCFederation
+}
+
 // ValidateSource validates a source before creation/update
 func (s *CredentialConfigStore) ValidateSource(ctx context.Context, source *credential.CredSource) error {
 	return s.validateSource(ctx, source, false)
@@ -1175,6 +1206,17 @@ func (s *CredentialConfigStore) validateSource(ctx context.Context, source *cred
 	if source.Type == credential.SourceTypeVault && source.RotationPeriod <= 0 &&
 		credential.GetString(source.Config, "auth_method", "") != "oidc_federation" {
 		return logical.ErrBadRequest("rotation_period is required for hvault credential sources (except keyless auth_method=oidc_federation)")
+	}
+
+	// The other direction, and for every type rather than one: a federated source
+	// authenticates with a caller assertion and holds no secret, so its driver
+	// reports SupportsRotation false and the manager can never complete a cycle. It
+	// errors, retries to MaxRotateAttempts, parks the entry as failed, comes back
+	// after FailedMinAge, and repeats for the life of the source.
+	if isFederationSource(source.Config) && source.RotationPeriod > 0 {
+		return logical.ErrBadRequestf(
+			"rotation_period does not apply to a federated credential source (auth_method=%s); it holds no secret of its own to rotate",
+			authMethodOIDCFederation)
 	}
 
 	// Validate rotation_period is within configured bounds

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,10 +46,13 @@ func setupTestCredentialConfigStore(t *testing.T) (*CredentialConfigStore, conte
 	// Create storage view
 	storage := NewBarrierView(barrier, credentialConfigStorePath)
 
-	// Create minimal Core for testing
+	// Create minimal Core for testing. rawConfig must be non-nil even with nothing
+	// stored in it: any validation path that checks rotation-period bounds loads it,
+	// and a nil pointer there panics rather than falling back to the defaults.
 	core := &Core{
-		barrier: barrier,
-		logger:  log,
+		barrier:   barrier,
+		logger:    log,
+		rawConfig: new(atomic.Value),
 	}
 
 	// Create credential config store
@@ -1873,6 +1877,159 @@ func TestCredentialConfigStore_ValidateSource_HvaultRotationPeriod(t *testing.T)
 			}
 		})
 	}
+}
+
+// fakeFederationFactory registers under an arbitrary source type with no-op
+// create/validate, so the cross-type federation rule can be exercised without a
+// live provider behind any of them.
+type fakeFederationFactory struct{ sourceType string }
+
+func (f *fakeFederationFactory) Type() string { return f.sourceType }
+func (f *fakeFederationFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	return &testDriver{}, nil
+}
+func (f *fakeFederationFactory) ValidateConfig(config map[string]string) error { return nil }
+func (f *fakeFederationFactory) SensitiveConfigFields() []string               { return nil }
+func (f *fakeFederationFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeAPIKey, nil
+}
+
+// TestCredentialConfigStore_FederationSourceRejectsRotationPeriod covers the rule
+// across every federation-capable source type, not just the one that prompted it.
+//
+// A federated source holds no secret, so the driver reports SupportsRotation false
+// and the manager can never complete a cycle: it retries, parks the entry as
+// failed, and comes back an hour later, forever. Rejecting at create is what keeps
+// that entry from existing.
+func TestCredentialConfigStore_FederationSourceRejectsRotationPeriod(t *testing.T) {
+	federationTypes := []string{
+		credential.SourceTypeAWS,
+		credential.SourceTypeAzure,
+		credential.SourceTypeGCP,
+		credential.SourceTypeVault,
+		credential.SourceTypeKubernetes,
+	}
+
+	for _, sourceType := range federationTypes {
+		t.Run(sourceType, func(t *testing.T) {
+			store, ctx := setupTestCredentialConfigStore(t)
+			store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+			require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(
+				&fakeFederationFactory{sourceType: sourceType}))
+
+			err := store.CreateSource(ctx, &credential.CredSource{
+				Name:           "fed-src",
+				Type:           sourceType,
+				Config:         map[string]string{"auth_method": "oidc_federation"},
+				RotationPeriod: 48 * time.Hour,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "rotation_period does not apply to a federated credential source")
+
+			// Without the period the same source is fine, and is not enrolled.
+			require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+				Name:   "fed-src",
+				Type:   sourceType,
+				Config: map[string]string{"auth_method": "oidc_federation"},
+			}))
+		})
+	}
+}
+
+// TestCredentialConfigStore_FederationRotationGateRunsOnUpdate pins that the rule
+// is in the shared validator, so an edit cannot slip a rotation_period onto a
+// federated source that create would have refused.
+func TestCredentialConfigStore_FederationRotationGateRunsOnUpdate(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+	require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(
+		&fakeFederationFactory{sourceType: credential.SourceTypeAWS}))
+
+	// The update path presents the whole record, carrying rotation_period over from
+	// the stored entry — so this is the shape every edit of such a source takes.
+	updated := &credential.CredSource{
+		Name:           "fed-src",
+		Type:           credential.SourceTypeAWS,
+		Config:         map[string]string{"auth_method": "oidc_federation", "region": "us-east-1"},
+		RotationPeriod: 48 * time.Hour,
+	}
+
+	err := store.validateSource(ctx, updated, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation_period does not apply to a federated credential source")
+
+	// Clearing the period is what makes the record editable again.
+	updated.RotationPeriod = 0
+	require.NoError(t, store.validateSource(ctx, updated, false))
+}
+
+// TestCredentialConfigStore_ChainedSpecRejectsRotationPeriod covers the spec half
+// of the same rule.
+//
+// A chained source was already refused a rotation_period; a chained *spec* was not,
+// though it embeds no secret either — its material is fetched per request from the
+// spec it references. Such a spec was accepted and enrolled, then failed every
+// cycle because its driver is not a SpecRotatable.
+//
+// Both places a spec can be chained are covered: on the spec itself, and inherited
+// from its source. They resolve spec-over-source, matching the minting path.
+func TestCredentialConfigStore_ChainedSpecRejectsRotationPeriod(t *testing.T) {
+	setup := func(t *testing.T) (*CredentialConfigStore, context.Context) {
+		t.Helper()
+		store, ctx := setupTestCredentialConfigStore(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+		// Session-pinned, as validateSecretSpecRef requires of a referenced spec.
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ref-secret", Type: "vault_token", Source: "src",
+			Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+		}))
+		return store, ctx
+	}
+
+	t.Run("chained on the spec", func(t *testing.T) {
+		store, ctx := setup(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "apikey-src", Type: credential.SourceTypeAPIKey, Config: map[string]string{},
+		}))
+
+		chained := &credential.CredSpec{
+			Name: "chained-rotating", Type: credential.TypeAPIKey, Source: "apikey-src",
+			Config: map[string]string{
+				credential.ConfigSecretSpec:  "ref-secret",
+				credential.ConfigSecretField: "api_key",
+			},
+			RotationPeriod: 24 * time.Hour,
+		}
+		err := store.CreateSpec(ctx, chained)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained credential spec")
+
+		// Without the period the same spec is fine.
+		chained.RotationPeriod = 0
+		require.NoError(t, store.CreateSpec(ctx, chained))
+
+		// And the rule is in the shared validator, so an edit cannot add one back.
+		chained.RotationPeriod = 24 * time.Hour
+		err = store.validateSpec(ctx, chained, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained credential spec")
+	})
+
+	t.Run("chained on the source", func(t *testing.T) {
+		store, ctx := setup(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "apikey-chained-src", Type: credential.SourceTypeAPIKey,
+			Config: map[string]string{credential.ConfigSecretSpec: "ref-secret"},
+		}))
+
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "inherits-chaining", Type: credential.TypeAPIKey, Source: "apikey-chained-src",
+			Config:         map[string]string{credential.ConfigSecretField: "api_key"},
+			RotationPeriod: 24 * time.Hour,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained credential spec")
+	})
 }
 
 // TestCredentialConfigStore_GitLabChaining covers the two gitlab-specific chaining

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -37,7 +37,7 @@ func (b *SystemBackend) pathCredentials() []*framework.Path {
 				},
 				"rotation_period": {
 					Type:        framework.TypeDurationSecond,
-					Description: "Rotation period in seconds for credential source rotation. Required by source types that rotate a long-lived secret (e.g. hvault); not applicable to keyless sources (e.g. AWS auth_method=oidc_federation). Enforced per type at create time.",
+					Description: "Rotation period in seconds for credential source rotation. Required by source types that rotate a long-lived secret (e.g. hvault). Rejected at create time for a source that holds no secret of its own: any auth_method=oidc_federation source, and any source whose secret comes from a referenced spec (secret_spec).",
 					Default:     0,
 				},
 			},


### PR DESCRIPTION
A source or spec that holds no secret of its own cannot be rotated, and the rotation manager cannot discover that in advance: it takes the entry, fails the cycle, retries to `MaxRotateAttempts`, parks the entry as failed, comes back after `FailedMinAge`, and repeats — an hourly failure for the life of the record.

Three ways in were open:

| Record | Was it gated? |
|---|---|
| Federated source — aws, azure, gcp | No rule at all |
| Federated hvault source | Only the opposite direction: required a period unless keyless, but accepted a keyless one carrying one |
| Chained spec (`secret_spec`, on the spec or inherited from its source) | **No** |

The chained-spec case is the one that reads as most surprising, since the analogous rules already existed for a chained *source* and for a token-exchange spec — the spec fell between them. Confirmed by test before fixing: such a spec was accepted, enrolled, and then failed every cycle because its driver is not a `SpecRotatable`.

### Both rules run on update as well as create

They live in the shared validators, alongside the token-exchange and chained-source rules they extend.

**This has a consequence worth deciding on deliberately:** a record written before this and carrying a period is refused on its next edit. The typed update API carries `rotation_period` over from the stored record with no way to clear it, so clearing it means recreating the record. That is the same bargain the token-exchange rule already makes, and the setting it refuses is one that never worked — but it does mean an existing federated source with a stale period cannot be edited until it is recreated.

### Naming

The predicate is `isFederationSource`, named for what it tests. "Keyless" would overclaim: a chained record holds no secret of its own either, and is covered by its own rule rather than that one.

Also corrects the `rotation_period` field description, which used AWS as its example of enforcement that did not exist.

## Verification

`go test ./core/ ./credential/...`

Tests cover all five federation-capable source types, both chaining shapes (on the spec and inherited from the source), and that the rules run through the shared validators rather than only at create.

A `make test-e2e` run on the branch carrying this passes all 20 packages. No existing fixture pairs federation or chaining with a rotation period.