### PR TITLE
test(e2e): drive the keyless kubernetes source through the full chain

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -237,7 +237,9 @@ func (s *CredentialConfigStore) CreateSpec(ctx context.Context, spec *credential
 	s.specsByID.Set(cacheKey, spec, 1)
 	s.specsByID.Wait()
 
-	// Register with rotation manager if RotationPeriod is configured
+	// Register with rotation manager if RotationPeriod is configured. A chained
+	// spec never gets this far: the check above rejects that combination, and
+	// re-deriving it here would cost another source read for no new protection.
 	if spec.RotationPeriod > 0 {
 		if s.rotationManager != nil {
 			if err := s.rotationManager.RegisterSpec(ctx, spec.Name, spec.Source, spec.RotationPeriod); err != nil {
@@ -499,8 +501,10 @@ func (s *CredentialConfigStore) CreateSource(ctx context.Context, source *creden
 	s.sourcesByID.Set(cacheKey, source, 1)
 	s.sourcesByID.Wait()
 
-	// Register with rotation manager if RotationPeriod is configured
-	if source.RotationPeriod > 0 {
+	// Register with rotation manager if RotationPeriod is configured. A federated
+	// source is never enrolled: CreateSource rejects the combination outright, so
+	// this only guards a caller that reaches here another way.
+	if source.RotationPeriod > 0 && !isFederationSource(source.Config) {
 		if s.rotationManager != nil {
 			if err := s.rotationManager.RegisterSource(ctx, source.Name, source.Type, source.RotationPeriod); err != nil {
 				s.logger.Warn("failed to register source for rotation",
@@ -983,6 +987,14 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		chainedRef = source.Config[credential.ConfigSecretSpec]
 	}
 	if chainedRef != "" {
+		// A chained spec mints from material fetched at request time, so it embeds no
+		// secret of its own and a rotation_period schedules a rotation that can never
+		// succeed — the same reasoning that rejects one on a token-exchange spec and
+		// on a chained source. Whoever owns the referenced spec rotates it there.
+		if spec.RotationPeriod > 0 {
+			return logical.ErrBadRequestf("rotation_period does not apply to a chained credential spec (secret_spec %q); the referenced spec's owner rotates the secret", chainedRef)
+		}
+
 		// For token_exchange, gitlab and oauth2, chaining is a SOURCE concern: the secret
 		// being chained authenticates the source itself (client auth, a personal access
 		// token), and the factory only sees source config. A spec-level secret_spec
@@ -1136,6 +1148,25 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 	return nil
 }
 
+// authMethodOIDCFederation is the auth_method every federation-capable source type
+// sets. The drivers each define their own copy for their config schema; this is
+// core's, for the rules that hold across types regardless of the provider behind
+// them.
+const authMethodOIDCFederation = "oidc_federation"
+
+// isFederationSource reports whether a source authenticates by presenting a
+// caller's identity assertion. Every such driver — aws, azure, gcp, hvault,
+// kubernetes — spells it the same way, so one predicate covers them all and covers
+// a new one the day it lands.
+//
+// This is narrower than "holds no secret", which also describes a chained source
+// or spec (secret_spec), whose secret lives in the spec it references. Those are
+// gated separately, by the chained-source rule in validateSource and the
+// chained-spec rule in CreateSpec.
+func isFederationSource(config map[string]string) bool {
+	return credential.GetString(config, "auth_method", "") == authMethodOIDCFederation
+}
+
 // ValidateSource validates a source before creation/update
 func (s *CredentialConfigStore) ValidateSource(ctx context.Context, source *credential.CredSource) error {
 	return s.validateSource(ctx, source, false)
@@ -1175,6 +1206,17 @@ func (s *CredentialConfigStore) validateSource(ctx context.Context, source *cred
 	if source.Type == credential.SourceTypeVault && source.RotationPeriod <= 0 &&
 		credential.GetString(source.Config, "auth_method", "") != "oidc_federation" {
 		return logical.ErrBadRequest("rotation_period is required for hvault credential sources (except keyless auth_method=oidc_federation)")
+	}
+
+	// The other direction, and for every type rather than one: a federated source
+	// authenticates with a caller assertion and holds no secret, so its driver
+	// reports SupportsRotation false and the manager can never complete a cycle. It
+	// errors, retries to MaxRotateAttempts, parks the entry as failed, comes back
+	// after FailedMinAge, and repeats for the life of the source.
+	if isFederationSource(source.Config) && source.RotationPeriod > 0 {
+		return logical.ErrBadRequestf(
+			"rotation_period does not apply to a federated credential source (auth_method=%s); it holds no secret of its own to rotate",
+			authMethodOIDCFederation)
 	}
 
 	// Validate rotation_period is within configured bounds

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,10 +46,13 @@ func setupTestCredentialConfigStore(t *testing.T) (*CredentialConfigStore, conte
 	// Create storage view
 	storage := NewBarrierView(barrier, credentialConfigStorePath)
 
-	// Create minimal Core for testing
+	// Create minimal Core for testing. rawConfig must be non-nil even with nothing
+	// stored in it: any validation path that checks rotation-period bounds loads it,
+	// and a nil pointer there panics rather than falling back to the defaults.
 	core := &Core{
-		barrier: barrier,
-		logger:  log,
+		barrier:   barrier,
+		logger:    log,
+		rawConfig: new(atomic.Value),
 	}
 
 	// Create credential config store
@@ -1873,6 +1877,159 @@ func TestCredentialConfigStore_ValidateSource_HvaultRotationPeriod(t *testing.T)
 			}
 		})
 	}
+}
+
+// fakeFederationFactory registers under an arbitrary source type with no-op
+// create/validate, so the cross-type federation rule can be exercised without a
+// live provider behind any of them.
+type fakeFederationFactory struct{ sourceType string }
+
+func (f *fakeFederationFactory) Type() string { return f.sourceType }
+func (f *fakeFederationFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	return &testDriver{}, nil
+}
+func (f *fakeFederationFactory) ValidateConfig(config map[string]string) error { return nil }
+func (f *fakeFederationFactory) SensitiveConfigFields() []string               { return nil }
+func (f *fakeFederationFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeAPIKey, nil
+}
+
+// TestCredentialConfigStore_FederationSourceRejectsRotationPeriod covers the rule
+// across every federation-capable source type, not just the one that prompted it.
+//
+// A federated source holds no secret, so the driver reports SupportsRotation false
+// and the manager can never complete a cycle: it retries, parks the entry as
+// failed, and comes back an hour later, forever. Rejecting at create is what keeps
+// that entry from existing.
+func TestCredentialConfigStore_FederationSourceRejectsRotationPeriod(t *testing.T) {
+	federationTypes := []string{
+		credential.SourceTypeAWS,
+		credential.SourceTypeAzure,
+		credential.SourceTypeGCP,
+		credential.SourceTypeVault,
+		credential.SourceTypeKubernetes,
+	}
+
+	for _, sourceType := range federationTypes {
+		t.Run(sourceType, func(t *testing.T) {
+			store, ctx := setupTestCredentialConfigStore(t)
+			store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+			require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(
+				&fakeFederationFactory{sourceType: sourceType}))
+
+			err := store.CreateSource(ctx, &credential.CredSource{
+				Name:           "fed-src",
+				Type:           sourceType,
+				Config:         map[string]string{"auth_method": "oidc_federation"},
+				RotationPeriod: 48 * time.Hour,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "rotation_period does not apply to a federated credential source")
+
+			// Without the period the same source is fine, and is not enrolled.
+			require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+				Name:   "fed-src",
+				Type:   sourceType,
+				Config: map[string]string{"auth_method": "oidc_federation"},
+			}))
+		})
+	}
+}
+
+// TestCredentialConfigStore_FederationRotationGateRunsOnUpdate pins that the rule
+// is in the shared validator, so an edit cannot slip a rotation_period onto a
+// federated source that create would have refused.
+func TestCredentialConfigStore_FederationRotationGateRunsOnUpdate(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+	require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(
+		&fakeFederationFactory{sourceType: credential.SourceTypeAWS}))
+
+	// The update path presents the whole record, carrying rotation_period over from
+	// the stored entry — so this is the shape every edit of such a source takes.
+	updated := &credential.CredSource{
+		Name:           "fed-src",
+		Type:           credential.SourceTypeAWS,
+		Config:         map[string]string{"auth_method": "oidc_federation", "region": "us-east-1"},
+		RotationPeriod: 48 * time.Hour,
+	}
+
+	err := store.validateSource(ctx, updated, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation_period does not apply to a federated credential source")
+
+	// Clearing the period is what makes the record editable again.
+	updated.RotationPeriod = 0
+	require.NoError(t, store.validateSource(ctx, updated, false))
+}
+
+// TestCredentialConfigStore_ChainedSpecRejectsRotationPeriod covers the spec half
+// of the same rule.
+//
+// A chained source was already refused a rotation_period; a chained *spec* was not,
+// though it embeds no secret either — its material is fetched per request from the
+// spec it references. Such a spec was accepted and enrolled, then failed every
+// cycle because its driver is not a SpecRotatable.
+//
+// Both places a spec can be chained are covered: on the spec itself, and inherited
+// from its source. They resolve spec-over-source, matching the minting path.
+func TestCredentialConfigStore_ChainedSpecRejectsRotationPeriod(t *testing.T) {
+	setup := func(t *testing.T) (*CredentialConfigStore, context.Context) {
+		t.Helper()
+		store, ctx := setupTestCredentialConfigStore(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+		// Session-pinned, as validateSecretSpecRef requires of a referenced spec.
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ref-secret", Type: "vault_token", Source: "src",
+			Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+		}))
+		return store, ctx
+	}
+
+	t.Run("chained on the spec", func(t *testing.T) {
+		store, ctx := setup(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "apikey-src", Type: credential.SourceTypeAPIKey, Config: map[string]string{},
+		}))
+
+		chained := &credential.CredSpec{
+			Name: "chained-rotating", Type: credential.TypeAPIKey, Source: "apikey-src",
+			Config: map[string]string{
+				credential.ConfigSecretSpec:  "ref-secret",
+				credential.ConfigSecretField: "api_key",
+			},
+			RotationPeriod: 24 * time.Hour,
+		}
+		err := store.CreateSpec(ctx, chained)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained credential spec")
+
+		// Without the period the same spec is fine.
+		chained.RotationPeriod = 0
+		require.NoError(t, store.CreateSpec(ctx, chained))
+
+		// And the rule is in the shared validator, so an edit cannot add one back.
+		chained.RotationPeriod = 24 * time.Hour
+		err = store.validateSpec(ctx, chained, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained credential spec")
+	})
+
+	t.Run("chained on the source", func(t *testing.T) {
+		store, ctx := setup(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "apikey-chained-src", Type: credential.SourceTypeAPIKey,
+			Config: map[string]string{credential.ConfigSecretSpec: "ref-secret"},
+		}))
+
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "inherits-chaining", Type: credential.TypeAPIKey, Source: "apikey-chained-src",
+			Config:         map[string]string{credential.ConfigSecretField: "api_key"},
+			RotationPeriod: 24 * time.Hour,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained credential spec")
+	})
 }
 
 // TestCredentialConfigStore_GitLabChaining covers the two gitlab-specific chaining

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -37,7 +37,7 @@ func (b *SystemBackend) pathCredentials() []*framework.Path {
 				},
 				"rotation_period": {
 					Type:        framework.TypeDurationSecond,
-					Description: "Rotation period in seconds for credential source rotation. Required by source types that rotate a long-lived secret (e.g. hvault); not applicable to keyless sources (e.g. AWS auth_method=oidc_federation). Enforced per type at create time.",
+					Description: "Rotation period in seconds for credential source rotation. Required by source types that rotate a long-lived secret (e.g. hvault). Rejected at create time for a source that holds no secret of its own: any auth_method=oidc_federation source, and any source whose secret comes from a referenced spec (secret_spec).",
 					Default:     0,
 				},
 			},

--- a/credential/drivers/assertion_claims.go
+++ b/credential/drivers/assertion_claims.go
@@ -33,6 +33,8 @@ func DeriveAssertionResource(sourceType string, sourceCfg, specCfg map[string]st
 		return gcpAssertionResource(sourceCfg, specCfg)
 	case credential.SourceTypeVault:
 		return vaultAssertionResource(sourceCfg, specCfg)
+	case credential.SourceTypeKubernetes:
+		return kubernetesAssertionResource(specCfg)
 	default:
 		return "", false
 	}
@@ -59,9 +61,47 @@ func DeriveAssertionAudience(sourceType string, sourceCfg, specCfg map[string]st
 		return azureAssertionAudience(sourceCfg)
 	case credential.SourceTypeVault:
 		return vaultAssertionAudience(sourceCfg)
+	case credential.SourceTypeKubernetes:
+		return kubernetesAssertionAudience(sourceCfg)
 	default:
 		return "", false
 	}
+}
+
+// kubernetesAssertionAudience derives the warden_identity assertion audience for a
+// keyless Kubernetes source: the source's explicit `audience`, or ("", false) when
+// unset. There is no conventional default — the value must appear in the cluster
+// authenticator's own audiences list, which the operator chooses — so an unset
+// audience forces the spec to set assertion_audience (the spec-create gate enforces
+// this, and mint fails closed otherwise).
+//
+// Gated on auth_method=oidc_federation: only a keyless source federates, so a
+// static source supplies no derived audience even if a stored config record somehow
+// carries one.
+func kubernetesAssertionAudience(sourceCfg map[string]string) (string, bool) {
+	if credential.GetString(sourceCfg, "auth_method", kubernetesAuthMethodStatic) != kubernetesAuthMethodOIDCFederation {
+		return "", false
+	}
+	if aud := credential.GetString(sourceCfg, "audience", ""); aud != "" {
+		return aud, true
+	}
+	return "", false
+}
+
+// kubernetesAssertionResource reports the service account a federation spec mints
+// for, as "namespace/service_account", for the warden_resource claim. Pure: reads
+// spec config only, no network or driver state. The driver has a single mint path,
+// so unlike the multi-engine sources there is no mint_method to dispatch on.
+//
+// The returned value is opaque — never parse it back, since a Kubernetes name can
+// in principle carry the separator.
+func kubernetesAssertionResource(specCfg map[string]string) (string, bool) {
+	namespace := credential.GetString(specCfg, "namespace", "")
+	sa := credential.GetString(specCfg, "service_account", "")
+	if namespace != "" && sa != "" {
+		return namespace + "/" + sa, true
+	}
+	return "", false
 }
 
 // vaultAssertionAudience derives the warden_identity assertion audience for a Vault

--- a/credential/drivers/assertion_claims_test.go
+++ b/credential/drivers/assertion_claims_test.go
@@ -85,6 +85,31 @@ func TestDeriveAssertionAudience(t *testing.T) {
 			wantOK:     false,
 		},
 		{
+			name:       "kubernetes federation derives explicit audience",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"auth_method": "oidc_federation", "audience": "https://kubernetes.example.com"},
+			wantAud:    "https://kubernetes.example.com",
+			wantOK:     true,
+		},
+		{
+			name:       "kubernetes federation without audience derives nothing (no default)",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"auth_method": "oidc_federation"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes static derives nothing even with audience",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"auth_method": "static", "audience": "https://kubernetes.example.com"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes absent auth_method derives nothing",
+			sourceType: credential.SourceTypeKubernetes,
+			sourceCfg:  map[string]string{"audience": "https://kubernetes.example.com"},
+			wantOK:     false,
+		},
+		{
 			name:       "unknown source type derives nothing",
 			sourceType: credential.SourceTypeGitHub,
 			sourceCfg:  map[string]string{"auth_method": "oidc_federation", "audience": "x"},
@@ -188,6 +213,25 @@ func TestDeriveAssertionResource(t *testing.T) {
 			name:       "gcp impersonation without target omits",
 			sourceType: credential.SourceTypeGCP,
 			specCfg:    map[string]string{"mint_method": "impersonated_access_token"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes names the target service account",
+			sourceType: credential.SourceTypeKubernetes,
+			specCfg:    map[string]string{"namespace": "prod", "service_account": "payments"},
+			want:       "prod/payments",
+			wantOK:     true,
+		},
+		{
+			name:       "kubernetes without namespace omits",
+			sourceType: credential.SourceTypeKubernetes,
+			specCfg:    map[string]string{"service_account": "payments"},
+			wantOK:     false,
+		},
+		{
+			name:       "kubernetes without service_account omits",
+			sourceType: credential.SourceTypeKubernetes,
+			specCfg:    map[string]string{"namespace": "prod"},
 			wantOK:     false,
 		},
 		{

--- a/credential/drivers/kubernetes_driver.go
+++ b/credential/drivers/kubernetes_driver.go
@@ -2,8 +2,10 @@ package drivers
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18,10 +20,30 @@ import (
 // k8sMaxResponseBodySize limits response body reads to prevent OOM
 const k8sMaxResponseBodySize = 1 << 20 // 1MB
 
+// kubernetesAuthMethodStatic and kubernetesAuthMethodOIDCFederation select how the
+// source authenticates to the API server. static holds a long-lived bearer token
+// with permission to create tokens for the target service accounts (rotatable);
+// oidc_federation holds no secret and presents the caller's identity assertion as
+// the bearer token on every request. An empty auth_method means static, so records
+// written before federation existed keep working.
+//
+// Federation needs no token-exchange hop: an API server configured to trust
+// Warden's issuer accepts the assertion as an ordinary bearer token and authorizes
+// the claims it maps to a user and groups.
+const (
+	kubernetesAuthMethodStatic         = "static"
+	kubernetesAuthMethodOIDCFederation = "oidc_federation"
+)
+
+// defaultK8sTLSPort is the port a TLS handshake probe dials when kubernetes_url
+// names none.
+const defaultK8sTLSPort = "443"
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*KubernetesDriver)(nil)
 var _ credential.SpecVerifier = (*KubernetesDriver)(nil)
 var _ credential.Rotatable = (*KubernetesDriver)(nil)
+var _ credential.ExchangeMinter = (*KubernetesDriver)(nil)
 
 // KubernetesDriver mints ServiceAccount tokens via the Kubernetes TokenRequest API.
 // It uses raw HTTP calls to POST /api/v1/namespaces/{ns}/serviceaccounts/{sa}/token
@@ -49,7 +71,7 @@ func (f *KubernetesDriverFactory) Type() string {
 
 // ValidateConfig validates Kubernetes driver configuration using declarative schema
 func (f *KubernetesDriverFactory) ValidateConfig(config map[string]string) error {
-	return credential.ValidateSchema(config,
+	if err := credential.ValidateSchema(config,
 		credential.StringField("kubernetes_url").
 			Required().
 			Custom(func(v string) error {
@@ -69,10 +91,18 @@ func (f *KubernetesDriverFactory) ValidateConfig(config map[string]string) error
 			Describe("Kubernetes API server URL").
 			Example("https://my-cluster.example.com:6443"),
 
+		credential.StringField("auth_method").
+			OneOf(kubernetesAuthMethodStatic, kubernetesAuthMethodOIDCFederation).
+			Describe("How the source authenticates: 'static' (stored bearer token) or 'oidc_federation' (keyless, presents the caller's identity assertion)").
+			Example(kubernetesAuthMethodStatic),
+
 		credential.StringField("token").
-			Required().
-			Describe("Bearer token for authenticating to the Kubernetes API server").
+			Describe("Bearer token for authenticating to the Kubernetes API server (required for auth_method=static)").
 			Example("eyJhbGciOiJSUzI1NiIs..."),
+
+		credential.StringField("audience").
+			Describe("Assertion audience; must match an entry in the cluster authenticator's audiences (auth_method=oidc_federation)").
+			Example("https://kubernetes.example.com"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -110,7 +140,37 @@ func (f *KubernetesDriverFactory) ValidateConfig(config map[string]string) error
 			}).
 			Describe("TTL for rotated source tokens (default: 24h, min: 10m, max: 48h)").
 			Example("24h"),
-	)
+	); err != nil {
+		return err
+	}
+
+	// Cross-field rules per auth_method. Each mode rejects the other's fields, so a
+	// half-converted source fails at write rather than behaving as the mode the
+	// operator did not intend.
+	//
+	// Present-but-empty is validated as static, not skipped. GetString returns a
+	// stored "" rather than the default, and the schema pass above skips empty
+	// values too — so a switch that only matched the two named modes would let a
+	// source through carrying neither a token nor a federation config, and it is
+	// static that such a source then behaves as.
+	switch credential.GetString(config, "auth_method", kubernetesAuthMethodStatic) {
+	case "", kubernetesAuthMethodStatic:
+		if credential.GetString(config, "token", "") == "" {
+			return fmt.Errorf("token is required for auth_method=%s", kubernetesAuthMethodStatic)
+		}
+		if credential.GetString(config, "audience", "") != "" {
+			return fmt.Errorf("audience is only valid for auth_method=%s", kubernetesAuthMethodOIDCFederation)
+		}
+	case kubernetesAuthMethodOIDCFederation:
+		// A federation source holds no token of its own, so it has nothing to rotate
+		// and no service account to rotate as.
+		for _, k := range []string{"token", "source_service_account", "source_namespace", "source_token_ttl"} {
+			if config[k] != "" {
+				return fmt.Errorf("field '%s' must not be set for auth_method=%s", k, kubernetesAuthMethodOIDCFederation)
+			}
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -139,10 +199,22 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 	}
 	driver.httpClient = httpClient
 
-	// Verify source credentials by checking API server connectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// A federation source holds no credential, so the eager probe cannot check
+	// authority — but the transport config is still worth checking, and a
+	// handshake does that without one. kubernetes_url and ca_data are typed by
+	// the operator and are the two things most likely to be wrong; catching them
+	// here beats surfacing them at the first mint.
+	if credential.GetString(config, "auth_method", kubernetesAuthMethodStatic) == kubernetesAuthMethodOIDCFederation {
+		if err := driver.probeTLS(ctx); err != nil {
+			return nil, err
+		}
+		return driver, nil
+	}
+
+	// Verify source credentials by checking API server connectivity
 	if err := driver.verifyConnection(ctx); err != nil {
 		return nil, fmt.Errorf("Kubernetes API server connection failed: %w", err)
 	}
@@ -154,7 +226,8 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 // SourceDriver Interface Implementation
 // ============================================================================
 
-// MintCredential creates a new ServiceAccount token via the Kubernetes TokenRequest API.
+// MintCredential creates a new ServiceAccount token via the Kubernetes TokenRequest
+// API, authenticating with the source's stored bearer token.
 //
 // Spec config fields:
 //   - service_account: Target service account name (required)
@@ -162,6 +235,47 @@ func (f *KubernetesDriverFactory) Create(config map[string]string, log *logger.G
 //   - audiences: Comma-separated token audiences (optional)
 //   - ttl: Token TTL duration, e.g. "1h" (optional, default: 1h)
 func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("kubernetes: a source with auth_method=%s mints only from a caller assertion: set subject_token_source on the spec", kubernetesAuthMethodOIDCFederation)
+	}
+	k8sURL, token := d.configSnapshot()
+	return d.mintServiceAccountToken(ctx, k8sURL, token, spec)
+}
+
+// MintCredentialWithExchange mints a ServiceAccount token over workload identity
+// federation: the caller's identity assertion is the bearer token on the
+// TokenRequest call, so the source stores no credential of its own and the API
+// server sees, and audits, the identity behind each request rather than one shared
+// service account.
+//
+// Unlike the STS-backed drivers there is no exchange hop to make. An API server
+// configured to trust the assertion's issuer accepts it directly, so the assertion
+// is handed to the same mint path a stored token would take.
+//
+// The minted token outliving the assertion is expected and harmless: its lifetime
+// is fixed by the API server when it is issued and does not depend on the assertion
+// that asked for it.
+func (d *KubernetesDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() != kubernetesAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("kubernetes: workload identity federation requires auth_method=%s on the source", kubernetesAuthMethodOIDCFederation)
+	}
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("kubernetes: no subject token in exchange inputs")
+	}
+	k8sURL, _ := d.configSnapshot()
+	return d.mintServiceAccountToken(ctx, k8sURL, inputs.SubjectToken, spec)
+}
+
+// mintServiceAccountToken calls the TokenRequest API for the spec's service account
+// with the given bearer token, which is the source's stored token under static auth
+// and the caller's assertion under federation. Everything below this point is
+// identical in both modes.
+//
+// The URL is passed in rather than read here so that the static path pairs a token
+// with the URL from the same config snapshot: reading them separately would let a
+// rotation land between the two and mint with one config's token against another's
+// address.
+func (d *KubernetesDriver) mintServiceAccountToken(ctx context.Context, k8sURL, bearer string, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	sa := credential.GetString(spec.Config, "service_account", "")
 	namespace := credential.GetString(spec.Config, "namespace", "")
 	audiencesStr := credential.GetString(spec.Config, "audiences", "")
@@ -195,7 +309,7 @@ func (d *KubernetesDriver) MintCredential(ctx context.Context, spec *credential.
 	path := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token",
 		url.PathEscape(namespace), url.PathEscape(sa))
 
-	respBody, statusCode, err := d.doK8sRequest(ctx, http.MethodPost, path, body)
+	respBody, statusCode, err := d.doK8sRequestWith(ctx, k8sURL, bearer, http.MethodPost, path, body)
 	if err != nil {
 		return nil, nil, 0, "", d.mapError(err, statusCode, sa, namespace)
 	}
@@ -300,7 +414,15 @@ func (d *KubernetesDriver) Cleanup(_ context.Context) error {
 }
 
 // VerifySpec validates that the target service account exists.
+//
+// A federation source has no ambient credential to look it up with — assertions
+// are per caller, per request — so verification is skipped and a missing service
+// account surfaces at the first mint instead.
 func (d *KubernetesDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return nil
+	}
+
 	sa := credential.GetString(spec.Config, "service_account", "")
 	namespace := credential.GetString(spec.Config, "namespace", "")
 
@@ -329,7 +451,15 @@ func (d *KubernetesDriver) VerifySpec(ctx context.Context, spec *credential.Cred
 // SupportsRotation returns true if the driver can rotate its source token.
 // Rotation requires source_service_account and source_namespace to be configured
 // so the driver knows which SA to mint a new token for.
+//
+// A federation source holds no token, so there is nothing to rotate. ValidateConfig
+// already keeps the rotation fields off such a source, which would make the check
+// below false anyway; stating it here keeps the invariant independent of that.
 func (d *KubernetesDriver) SupportsRotation() bool {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return false
+	}
+
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 	sa := credential.GetString(d.credSource.Config, "source_service_account", "")
@@ -341,6 +471,10 @@ func (d *KubernetesDriver) SupportsRotation() bool {
 // current (still valid) source token. Kubernetes has immediate consistency,
 // so activateAfter is 0.
 func (d *KubernetesDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+		return nil, nil, 0, fmt.Errorf("kubernetes: a source with auth_method=%s holds no token to rotate", kubernetesAuthMethodOIDCFederation)
+	}
+
 	// Snapshot config under lock, then release before making HTTP calls.
 	d.authMu.Lock()
 	sa := credential.GetString(d.credSource.Config, "source_service_account", "")
@@ -477,6 +611,67 @@ func buildTokenRequestBody(expirationSeconds int64, audiences []string) ([]byte,
 	return json.Marshal(reqBody)
 }
 
+// getAuthMethod returns the source's configured auth_method, normalising both an
+// absent key and a stored empty string to static — the former so a record written
+// before federation existed keeps its old behaviour, the latter because GetString
+// hands back a stored "" rather than the default. It reads under authMu because
+// CommitRotation swaps the whole config map under that lock.
+func (d *KubernetesDriver) getAuthMethod() string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	if method := credential.GetString(d.credSource.Config, "auth_method", kubernetesAuthMethodStatic); method != "" {
+		return method
+	}
+	return kubernetesAuthMethodStatic
+}
+
+// probeTLS completes a TLS handshake against the API server and closes the
+// connection, sending no HTTP request. It is the credential-free half of
+// verifyConnection: it proves the host resolves and answers, and that its
+// certificate verifies against ca_data, which is all a source with no token of
+// its own can check.
+//
+// It runs only against an https URL. ValidateConfig permits a plain-HTTP
+// kubernetes_url when tls_skip_verify is set, and a handshake with a plain HTTP
+// listener fails whatever InsecureSkipVerify says — so probing one would reject
+// every dev cluster.
+//
+// Known limitation: it dials the host directly and so ignores HTTPS_PROXY, which
+// the client's own transport would honour. A deployment reaching the API server
+// only through a proxy therefore fails source creation here even though its mints
+// would succeed.
+func (d *KubernetesDriver) probeTLS(ctx context.Context) error {
+	k8sURL, _ := d.configSnapshot()
+
+	parsed, err := url.Parse(k8sURL)
+	if err != nil {
+		return fmt.Errorf("kubernetes_url is not a valid URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return nil
+	}
+
+	port := parsed.Port()
+	if port == "" {
+		port = defaultK8sTLSPort
+	}
+
+	// The client carries the CA pool and skip-verify flag built from config. Its
+	// Transport is nil when neither is set (BuildHTTPClient returns a bare client
+	// then), which leaves a nil config and the system roots — the right default.
+	var tlsConfig *tls.Config
+	if transport, ok := d.httpClient.Transport.(*http.Transport); ok && transport != nil {
+		tlsConfig = transport.TLSClientConfig
+	}
+
+	dialer := &tls.Dialer{Config: tlsConfig}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(parsed.Hostname(), port))
+	if err != nil {
+		return fmt.Errorf("cannot establish a TLS connection to the Kubernetes API server at %s: %w (check kubernetes_url and ca_data)", parsed.Host, err)
+	}
+	return conn.Close()
+}
+
 // verifyConnection checks API server connectivity using the /version endpoint,
 // which requires no RBAC permissions.
 func (d *KubernetesDriver) verifyConnection(ctx context.Context) error {
@@ -545,6 +740,14 @@ func defaultK8sRetryConfig() httputil.HTTPRetryConfig {
 func (d *KubernetesDriver) mapError(err error, statusCode int, sa, namespace string) error {
 	switch statusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
+		// Under federation the assertion carries the identity, so a refusal is as
+		// likely to be a trust or audience mismatch as a missing grant. Naming all
+		// three saves an operator from auditing RBAC for what is a config problem.
+		if d.getAuthMethod() == kubernetesAuthMethodOIDCFederation {
+			return fmt.Errorf("kubernetes API server rejected the identity assertion (HTTP %d) when creating a token for service account %q in namespace %q: "+
+				"check that the cluster trusts Warden's issuer, that the source's audience matches the authenticator's audiences, "+
+				"and that the mapped user or groups may create serviceaccounts/token there: %w", statusCode, sa, namespace, err)
+		}
 		return fmt.Errorf("insufficient permissions to create token for service account %q in namespace %q: %w", sa, namespace, err)
 	case http.StatusNotFound:
 		return fmt.Errorf("service account %q not found in namespace %q: %w", sa, namespace, err)

--- a/credential/drivers/kubernetes_driver_test.go
+++ b/credential/drivers/kubernetes_driver_test.go
@@ -95,6 +95,99 @@ func TestKubernetesDriverFactory_ValidateConfig(t *testing.T) {
 	})
 }
 
+func TestKubernetesDriverFactory_ValidateConfig_AuthMethod(t *testing.T) {
+	f := &KubernetesDriverFactory{}
+
+	t.Run("absent auth_method behaves as static", func(t *testing.T) {
+		// The back-compat case: every source written before federation existed.
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"token":          "test-token",
+		}))
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token is required")
+	})
+
+	t.Run("present but empty auth_method is validated as static", func(t *testing.T) {
+		// GetString hands back a stored "" rather than the default, and the schema
+		// pass skips empty values — so an auth_method key set to "" must still be
+		// held to the static rules. Otherwise a source is accepted carrying neither
+		// a token nor a federation config, and every mint 401s with an empty bearer.
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    "",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "token is required")
+
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    "",
+			"token":          "test-token",
+		}))
+	})
+
+	t.Run("unknown auth_method rejected", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    "kubeconfig",
+			"token":          "test-token",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth_method")
+	})
+
+	t.Run("static rejects audience", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    kubernetesAuthMethodStatic,
+			"token":          "test-token",
+			"audience":       "https://k8s.example.com",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "audience is only valid")
+	})
+
+	t.Run("federation minimal config", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+		}))
+	})
+
+	t.Run("federation accepts audience", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"kubernetes_url": "https://k8s.example.com",
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+			"audience":       "https://k8s.example.com",
+		}))
+	})
+
+	// A keyless source holds nothing to authenticate or rotate with, so every
+	// static field is rejected rather than silently ignored.
+	for _, field := range []string{"token", "source_service_account", "source_namespace", "source_token_ttl"} {
+		t.Run("federation rejects "+field, func(t *testing.T) {
+			config := map[string]string{
+				"kubernetes_url": "https://k8s.example.com",
+				"auth_method":    kubernetesAuthMethodOIDCFederation,
+			}
+			switch field {
+			case "source_token_ttl":
+				config[field] = "24h"
+			default:
+				config[field] = "some-value"
+			}
+			err := f.ValidateConfig(config)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), field)
+			assert.Contains(t, err.Error(), "must not be set")
+		})
+	}
+}
+
 // ============================================================================
 // Mock Server
 // ============================================================================
@@ -812,4 +905,229 @@ func TestKubernetesTokenMetadata(t *testing.T) {
 		assert.NotContains(t, meta, "audiences")
 		assert.NotContains(t, meta, "expiration")
 	})
+}
+
+// ============================================================================
+// Keyless (workload identity federation) Tests
+// ============================================================================
+
+// newFederatedK8sDriver builds a driver backed by the shared mock server with no
+// stored token, the way a keyless source is configured.
+func newFederatedK8sDriver(t *testing.T, serverURL string) *KubernetesDriver {
+	t.Helper()
+	return &KubernetesDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeKubernetes,
+			Config: map[string]string{
+				"kubernetes_url":  serverURL,
+				"auth_method":     kubernetesAuthMethodOIDCFederation,
+				"audience":        "https://k8s.example.com",
+				"tls_skip_verify": "true",
+			},
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestKubernetesDriver_MintCredentialWithExchange_UsesAssertionAsBearer(t *testing.T) {
+	// The assertion the caller presents must be the bearer on the TokenRequest
+	// call — that is the whole of federation here, since there is no exchange hop.
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"kind":       "TokenRequest",
+			"apiVersion": "authentication.k8s.io/v1",
+			"status": map[string]interface{}{
+				"token":               "minted-token-for-payments",
+				"expirationTimestamp": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+		})
+	}))
+	defer server.Close()
+
+	d := newFederatedK8sDriver(t, server.URL)
+	spec := &credential.CredSpec{
+		Name: "payments",
+		Config: map[string]string{
+			"service_account":      "payments",
+			"namespace":            "prod",
+			"subject_token_source": credential.SourceWardenIdentity,
+		},
+	}
+
+	rawData, metadata, ttl, leaseID, err := d.MintCredentialWithExchange(
+		context.Background(), spec, &credential.ExchangeInputs{SubjectToken: "assertion-jwt"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer assertion-jwt", gotAuth)
+	assert.Equal(t, "minted-token-for-payments", rawData["token"])
+	assert.Equal(t, "prod", rawData["namespace"])
+	assert.Equal(t, "payments", rawData["service_account"])
+	assert.Equal(t, "system:serviceaccount:prod:payments", metadata["subject"])
+	assert.InDelta(t, time.Hour.Seconds(), ttl.Seconds(), 5)
+	// A ServiceAccount token cannot be revoked, so there is no lease to hold.
+	assert.Empty(t, leaseID)
+}
+
+func TestKubernetesDriver_ExchangeFailsClosed(t *testing.T) {
+	server := newK8sMockServer(t)
+	defer server.Close()
+
+	spec := &credential.CredSpec{
+		Name:   "app",
+		Config: map[string]string{"service_account": "app-backend", "namespace": "default"},
+	}
+
+	t.Run("MintCredential refuses a federated source", func(t *testing.T) {
+		d := newFederatedK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subject_token_source")
+	})
+
+	t.Run("MintCredentialWithExchange refuses a static source", func(t *testing.T) {
+		d := newTestK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredentialWithExchange(
+			context.Background(), spec, &credential.ExchangeInputs{SubjectToken: "assertion-jwt"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), kubernetesAuthMethodOIDCFederation)
+	})
+
+	t.Run("empty subject token is refused", func(t *testing.T) {
+		d := newFederatedK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredentialWithExchange(
+			context.Background(), spec, &credential.ExchangeInputs{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+	})
+
+	t.Run("nil exchange inputs are refused", func(t *testing.T) {
+		d := newFederatedK8sDriver(t, server.URL)
+		_, _, _, _, err := d.MintCredentialWithExchange(context.Background(), spec, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+	})
+}
+
+func TestKubernetesDriver_Federation_RotationAndVerifyDisabled(t *testing.T) {
+	server := newK8sMockServer(t)
+	defer server.Close()
+
+	d := newFederatedK8sDriver(t, server.URL)
+
+	assert.False(t, d.SupportsRotation(), "a source holding no token has nothing to rotate")
+
+	// A stored empty auth_method resolves to static, matching what ValidateConfig
+	// holds such a source to.
+	empty := newTestK8sDriver(t, server.URL)
+	empty.credSource.Config["auth_method"] = ""
+	assert.Equal(t, kubernetesAuthMethodStatic, empty.getAuthMethod())
+
+	_, _, _, err := d.PrepareRotation(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no token to rotate")
+
+	// VerifySpec has no ambient credential to look the account up with, so it is
+	// skipped rather than attempted unauthenticated.
+	require.NoError(t, d.VerifySpec(context.Background(), &credential.CredSpec{
+		Config: map[string]string{"service_account": "not-found-sa", "namespace": "default"},
+	}))
+}
+
+func TestKubernetesDriverFactory_Create_Federation(t *testing.T) {
+	f := &KubernetesDriverFactory{}
+
+	t.Run("no request is sent to the API server", func(t *testing.T) {
+		// Driver creation runs on every mint, not just at source create, so a
+		// federated Create must not depend on a credential it does not have.
+		var calls int
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		d, err := f.Create(map[string]string{
+			"kubernetes_url":  server.URL,
+			"auth_method":     kubernetesAuthMethodOIDCFederation,
+			"audience":        "https://k8s.example.com",
+			"tls_skip_verify": "true",
+		}, newTestLogger(t))
+		require.NoError(t, err)
+		require.NotNil(t, d)
+		assert.Zero(t, calls, "the TLS probe must send no HTTP request")
+	})
+
+	t.Run("rejects a certificate the CA does not verify", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		// httptest signs with its own throwaway CA, which the system roots do not
+		// carry — so verification must fail without tls_skip_verify.
+		_, err := f.Create(map[string]string{
+			"kubernetes_url": server.URL,
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+		}, newTestLogger(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS connection")
+	})
+
+	t.Run("rejects an unreachable host", func(t *testing.T) {
+		_, err := f.Create(map[string]string{
+			"kubernetes_url":  "https://127.0.0.1:1",
+			"auth_method":     kubernetesAuthMethodOIDCFederation,
+			"tls_skip_verify": "true",
+		}, newTestLogger(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS connection")
+	})
+
+	t.Run("plain http is not probed", func(t *testing.T) {
+		// tls_skip_verify permits an http URL for dev clusters; a handshake against
+		// a plain listener would fail regardless of InsecureSkipVerify, so the probe
+		// must skip it. The e2e harness depends on this.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("no request should reach the server")
+		}))
+		defer server.Close()
+
+		_, err := f.Create(map[string]string{
+			"kubernetes_url":  server.URL,
+			"auth_method":     kubernetesAuthMethodOIDCFederation,
+			"tls_skip_verify": "true",
+		}, newTestLogger(t))
+		require.NoError(t, err)
+	})
+
+	t.Run("survives a nil transport", func(t *testing.T) {
+		// With neither ca_data nor tls_skip_verify, BuildHTTPClient returns a bare
+		// client whose Transport is nil — the probe must not panic reaching for it.
+		_, err := f.Create(map[string]string{
+			"kubernetes_url": "https://127.0.0.1:1",
+			"auth_method":    kubernetesAuthMethodOIDCFederation,
+		}, newTestLogger(t))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS connection")
+	})
+}
+
+func TestKubernetesDriver_MapError_Federated(t *testing.T) {
+	server := newK8sMockServer(t)
+	defer server.Close()
+
+	// A federated refusal is as likely to be a trust or audience mismatch as a
+	// missing grant, so the message must name all three.
+	d := newFederatedK8sDriver(t, server.URL)
+	err := d.mapError(fmt.Errorf("forbidden"), http.StatusForbidden, "payments", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer")
+	assert.Contains(t, err.Error(), "audience")
+	assert.Contains(t, err.Error(), "serviceaccounts/token")
+
+	// The static message is unchanged.
+	static := newTestK8sDriver(t, server.URL)
+	err = static.mapError(fmt.Errorf("forbidden"), http.StatusForbidden, "payments", "prod")
+	assert.Contains(t, err.Error(), "insufficient permissions")
 }

--- a/e2e/fullchain/kubernetes_test.go
+++ b/e2e/fullchain/kubernetes_test.go
@@ -1,0 +1,523 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The keyless kubernetes source is the one mount here that authenticates upstream
+// with nothing of its own: it presents the caller's identity assertion as the
+// bearer token on the TokenRequest call. There is no exchange hop, because an API
+// server configured to trust the assertion's issuer accepts it directly.
+//
+// That makes this package's recording upstream unusually well placed. It stands in
+// for the API server for BOTH hops — the mint (Warden calling TokenRequest with the
+// assertion) and the gateway request that follows (the caller reaching the cluster
+// with the minted ServiceAccount token) — so one server sees the whole chain, and
+// the two can be told apart by path.
+//
+// What is NOT covered here is the cluster's half: that a real kube-apiserver
+// accepts the assertion under an AuthenticationConfiguration, maps warden_role to
+// groups, and enforces the resourceNames RBAC. That needs a live cluster. What this
+// pins instead is that the assertion Warden sends is one such a cluster would
+// accept — verified against the issuer's published JWKS, audience and all.
+
+const (
+	// kubernetesAudience is the source's assertion audience. In a real cluster it
+	// must appear in the authenticator's own audiences list.
+	kubernetesAudience = "https://kubernetes.e2e.example.com"
+
+	// The namespace/service-account pairs the specs mint for. Distinct per variant
+	// so the TokenRequest path itself distinguishes them.
+	k8sReadonlyNamespace = "prod"
+	k8sReadonlySA        = "payments-readonly"
+	k8sDeployNamespace   = "prod"
+	k8sDeploySA          = "deployer"
+
+	// k8sAgentVariant mints from the agent's own inbound JWT rather than a
+	// Warden-signed assertion.
+	k8sAgentVariant = "agentidentity"
+	// k8sDeployVariant is the second access level, on the same source.
+	k8sDeployVariant = "deploy"
+
+	k8sTokenRequestSuffix = "/token"
+
+	// wardenIssuerURL is what the harness configures the issuer with (e2e/setup.sh
+	// step 9j). A cluster authenticator pins iss to exactly this.
+	wardenIssuerURL = "https://127.0.0.1:8000"
+)
+
+// kubernetesEnv is built in ensureEnv rather than here: its SourceConfig needs the
+// recording upstream's URL, which does not exist until the listener is up.
+var kubernetesEnv h.ProviderEnv
+
+// buildKubernetesEnv describes the keyless mount. The source holds no token — that
+// is the point — and tls_skip_verify is what lets it name the plain-HTTP recording
+// upstream, the same allowance every dev cluster uses.
+func buildKubernetesEnv(upstreamURL string) h.ProviderEnv {
+	return h.ProviderEnv{
+		Mount:      "fc-kubernetes",
+		Type:       "kubernetes",
+		URLKey:     "kubernetes_url",
+		CredType:   "kubernetes_token",
+		SourceType: "kubernetes",
+		SourceConfig: map[string]string{
+			"kubernetes_url":  upstreamURL,
+			"auth_method":     "oidc_federation",
+			"audience":        kubernetesAudience,
+			"tls_skip_verify": "true",
+		},
+		// The mount's default spec has to request exchange like the rest: a
+		// non-exchange spec on a keyless source is refused at create by the
+		// test-mint, which would fatal the whole package's setup.
+		CredConfig: map[string]string{
+			"subject_token_source": "warden_identity",
+			"service_account":      k8sReadonlySA,
+			"namespace":            k8sReadonlyNamespace,
+			// No audiences: the minted token is destined for the API server, so it
+			// inherits the cluster's own. This is the outbound audience, unrelated
+			// to the source's inbound assertion audience above.
+			"ttl": "1h",
+		},
+		Variants: map[string]map[string]string{
+			// A second access level on the same source. Nothing about the source
+			// changes — only which service account is minted for.
+			k8sDeployVariant: {
+				"subject_token_source": "warden_identity",
+				"service_account":      k8sDeploySA,
+				"namespace":            k8sDeployNamespace,
+				"ttl":                  "15m",
+			},
+			// agent_identity forwards the agent's own inbound JWT as the assertion.
+			// It gets a cert role here like every variant, but no row uses that
+			// role: the subject source fails closed on a cert-authenticated
+			// request, so the rows below drive it through a JWT agent leg instead.
+			k8sAgentVariant: {
+				"subject_token_source": "agent_identity",
+				"service_account":      k8sReadonlySA,
+				"namespace":            k8sReadonlyNamespace,
+				"ttl":                  "1h",
+			},
+		},
+	}
+}
+
+// serveTokenRequest answers the TokenRequest hop with a canned response and lets
+// every other path through as a plain 200.
+//
+// Installing this is not optional for any row on this mount: the upstream's default
+// reply carries no status.token, which the mint rejects outright.
+func serveTokenRequest(t *testing.T) {
+	t.Helper()
+	upstream.SetHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if !isTokenRequest(r.URL.Path) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kind":       "TokenRequest",
+			"apiVersion": "authentication.k8s.io/v1",
+			"status": map[string]any{
+				"token":               mintedTokenFor(r.URL.Path),
+				"expirationTimestamp": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+		})
+	})
+}
+
+func isTokenRequest(path string) bool {
+	return strings.HasPrefix(path, "/api/v1/namespaces/") && strings.HasSuffix(path, k8sTokenRequestSuffix)
+}
+
+// mintedTokenFor derives a token value from the path it was requested at, so a row
+// asserting on the gateway hop is really asserting that the credential came from
+// the service account its spec names.
+func mintedTokenFor(path string) string {
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(path, "/api/v1/namespaces/"), k8sTokenRequestSuffix)
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 3 {
+		return "minted-token"
+	}
+	return "minted-token-for-" + parts[0] + "-" + parts[2]
+}
+
+// splitHops separates the two requests the upstream saw. The mint hop and the
+// gateway hop both land here, so a row must say which one it means — and their
+// count varies with the credential cache, which is why no row on this mount asserts
+// on a total.
+func splitHops(t *testing.T) (mint, gateway []h.UpstreamRequest) {
+	t.Helper()
+	for _, req := range upstream.Requests() {
+		if isTokenRequest(req.Path) {
+			mint = append(mint, req)
+			continue
+		}
+		gateway = append(gateway, req)
+	}
+	return mint, gateway
+}
+
+// TestKubernetes_KeylessMintPresentsWardenAssertion is the row this file exists
+// for. It checks the assertion Warden sent to the API server the way the API server
+// would: verified against the issuer's published JWKS.
+//
+// A shape check would pass on a token no cluster would accept. Checking the
+// signature against the JWKS, the audience against the source's, and the claims a
+// cluster maps to a user and groups is what makes this meaningful.
+func TestKubernetes_KeylessMintPresentsWardenAssertion(t *testing.T) {
+	ensureEnv(t)
+	serveTokenRequest(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, kubernetesEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Role:         kubernetesEnv.CertRole(),
+	})
+	if status != 200 {
+		t.Fatalf("status: got %d, want 200 (body: %s)", status, body)
+	}
+
+	mint, gateway := splitHops(t)
+	if len(mint) != 1 {
+		t.Fatalf("expected exactly one TokenRequest hop, got %d", len(mint))
+	}
+	if len(gateway) != 1 {
+		t.Fatalf("expected exactly one gateway hop, got %d", len(gateway))
+	}
+
+	// The mint hop went to the spec's service account, carrying the assertion.
+	wantPath := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token", k8sReadonlyNamespace, k8sReadonlySA)
+	if mint[0].Path != wantPath {
+		t.Errorf("TokenRequest path: got %q, want %q", mint[0].Path, wantPath)
+	}
+
+	assertion := bearerOf(t, mint[0].Header.Get("Authorization"))
+	claims := verifyAssertion(t, assertion)
+
+	if got := claims["aud"]; got != kubernetesAudience {
+		t.Errorf("assertion aud: got %v, want %q — a cluster pinning its audiences would reject this", got, kubernetesAudience)
+	}
+	if sub, _ := claims["sub"].(string); !strings.HasPrefix(sub, "wid:") {
+		t.Errorf("assertion sub: got %q, want the wid: identity shape", sub)
+	}
+	// The claim a cluster maps to groups, and so the one an RBAC binding keys on.
+	if got, _ := claims["warden_role"].(string); got != kubernetesEnv.CertRole() {
+		t.Errorf("warden_role: got %q, want %q", got, kubernetesEnv.CertRole())
+	}
+	// A cluster pins the issuer exactly and rejects anything expired, so checking
+	// both here is part of "would a real authenticator take this".
+	if got, _ := claims["iss"].(string); got != wardenIssuerURL {
+		t.Errorf("assertion iss: got %q, want %q", got, wardenIssuerURL)
+	}
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		t.Error("assertion carries no exp; a verifier would reject it outright")
+	} else if time.Until(time.Unix(int64(exp), 0)) <= 0 {
+		t.Errorf("assertion already expired at %s", time.Unix(int64(exp), 0))
+	}
+
+	// The gateway hop carries the minted ServiceAccount token — not the assertion,
+	// and not the caller's own credential.
+	gotAuth := gateway[0].Header.Get("Authorization")
+	want := "Bearer " + mintedTokenFor(wantPath)
+	if gotAuth != want {
+		t.Errorf("gateway Authorization: got %q, want %q", gotAuth, want)
+	}
+	if strings.Contains(gotAuth, assertion) {
+		t.Error("the assertion reached the gateway hop; only the minted token should")
+	}
+}
+
+// TestKubernetes_AccessLevelsMintTheirOwnServiceAccount pins what separates two
+// access levels on one keyless source: the spec, and nothing else.
+//
+// The source is identical for both — no token, one audience. Which service account
+// a caller ends up as is decided by the spec its role binds, which is what a
+// cluster-side resourceNames rule then constrains.
+func TestKubernetes_AccessLevelsMintTheirOwnServiceAccount(t *testing.T) {
+	ensureEnv(t)
+	serveTokenRequest(t)
+
+	status, body, _ := h.ChainRequest(t, leaderPort, kubernetesEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Role:         kubernetesEnv.VariantRole(k8sDeployVariant),
+	})
+	if status != 200 {
+		t.Fatalf("status: got %d, want 200 (body: %s)", status, body)
+	}
+
+	mint, gateway := splitHops(t)
+	if len(mint) != 1 {
+		t.Fatalf("expected exactly one TokenRequest hop, got %d", len(mint))
+	}
+
+	wantPath := fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token", k8sDeployNamespace, k8sDeploySA)
+	if mint[0].Path != wantPath {
+		t.Errorf("TokenRequest path: got %q, want %q — the deploy role must not mint the read-only account", mint[0].Path, wantPath)
+	}
+
+	if len(gateway) != 1 {
+		t.Fatalf("expected exactly one gateway hop, got %d", len(gateway))
+	}
+	if got, want := gateway[0].Header.Get("Authorization"), "Bearer "+mintedTokenFor(wantPath); got != want {
+		t.Errorf("gateway Authorization: got %q, want %q", got, want)
+	}
+}
+
+// TestKubernetes_AgentIdentityForwardsTheAgentsOwnToken covers the other subject
+// source: the agent's inbound JWT goes to the API server unchanged, so the cluster
+// federates the agent's own issuer rather than Warden's.
+//
+// A JWT agent leg, not the usual certificate: agent_identity reuses the token
+// Warden verified at the door, and fails closed when there was none.
+func TestKubernetes_AgentIdentityForwardsTheAgentsOwnToken(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, kubernetesEnv)
+	serveTokenRequest(t)
+
+	agentJWT := h.GetDefaultJWT(t)
+
+	// The mount's own JWT agent role binds its default spec, so this needs one
+	// bound to the agent_identity variant instead.
+	jwtRole := "fc-k8s-agentidentity"
+	// Checked rather than fired and forgotten: a role that failed to create would
+	// surface as a chain 4xx below, blaming the request for a missing fixture.
+	if status, body := h.APIRequest(t, "POST", "auth/jwt/role/"+jwtRole, leaderPort, `{
+		"token_policies":["`+kubernetesEnv.Policy()+`"],
+		"cred_spec_name":"`+kubernetesEnv.VariantSpec(k8sAgentVariant)+`",
+		"user_claim":"sub","token_ttl":3600}`); status >= 400 {
+		t.Fatalf("create the agent_identity jwt role = %d: %s", status, body)
+	}
+	t.Cleanup(func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+jwtRole, leaderPort, "")
+	})
+
+	status, body, _ := h.ChainRequest(t, leaderPort, kubernetesEnv, h.ChainOpts{
+		AgentToken: agentJWT,
+		Role:       jwtRole,
+	})
+	if status != 200 {
+		t.Fatalf("status: got %d, want 200 (body: %s)", status, body)
+	}
+
+	mint, _ := splitHops(t)
+	if len(mint) != 1 {
+		t.Fatalf("expected exactly one TokenRequest hop, got %d", len(mint))
+	}
+
+	// Byte-equal to the agent's own token: nothing was minted or re-signed on the
+	// way through.
+	if got := bearerOf(t, mint[0].Header.Get("Authorization")); got != agentJWT {
+		t.Errorf("TokenRequest bearer is not the agent's own JWT (got %d bytes, want %d)", len(got), len(agentJWT))
+	}
+}
+
+// TestKubernetes_NonExchangeSpecIsRefusedAtCreate pins where the fail-closed guard
+// bites.
+//
+// A spec that names no subject source has nothing to authenticate the mint with on
+// a keyless source. That is caught at spec create by the test-mint, not deferred to
+// the first request — so the operator learns immediately rather than at 3am.
+func TestKubernetes_NonExchangeSpecIsRefusedAtCreate(t *testing.T) {
+	ensureEnv(t)
+
+	name := "fc-k8s-nonexchange"
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/specs/"+name, leaderPort, "") })
+
+	status, body := h.APIRequest(t, "POST", "sys/cred/specs/"+name, leaderPort, `{
+		"type":"kubernetes_token","source":"`+kubernetesEnv.Source()+`","config":{
+			"service_account":"`+k8sReadonlySA+`","namespace":"`+k8sReadonlyNamespace+`"}}`)
+	if status < 400 {
+		t.Fatalf("creating a non-exchange spec on a keyless source returned %d, want a rejection: %s", status, body)
+	}
+	if !strings.Contains(string(body), "subject_token_source") {
+		t.Errorf("rejection does not name what is missing: %s", body)
+	}
+}
+
+// TestKubernetes_RotationPeriodRefusedOnKeylessSource pins the gate that keeps a
+// keyless source out of the rotation manager. Without it the source would be
+// enrolled for a rotation the driver refuses on every cycle, forever.
+func TestKubernetes_RotationPeriodRefusedOnKeylessSource(t *testing.T) {
+	ensureEnv(t)
+
+	name := "fc-k8s-rotating"
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "") })
+
+	status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort, `{
+		"type":"kubernetes","rotation_period":86400,"config":{
+			"kubernetes_url":"`+upstream.URL+`","auth_method":"oidc_federation",
+			"audience":"`+kubernetesAudience+`","tls_skip_verify":"true"}}`)
+	if status < 400 {
+		t.Fatalf("creating a keyless source with a rotation_period returned %d, want a rejection: %s", status, body)
+	}
+	if !strings.Contains(string(body), "rotation_period") {
+		t.Errorf("rejection does not name rotation_period: %s", body)
+	}
+}
+
+// ============================================================================
+// Assertion verification
+// ============================================================================
+
+// bearerOf strips the scheme from an Authorization header.
+func bearerOf(t *testing.T, header string) string {
+	t.Helper()
+	if !strings.HasPrefix(header, "Bearer ") {
+		t.Fatalf("Authorization is not a bearer credential: %q", header)
+	}
+	return strings.TrimPrefix(header, "Bearer ")
+}
+
+// verifyAssertion checks a Warden-minted assertion against the issuer's published
+// JWKS and returns its claims — the same two steps a cluster's JWT authenticator
+// takes, which is why this is worth doing here rather than decoding and trusting.
+func verifyAssertion(t *testing.T, token string) map[string]any {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("assertion is not a three-part JWT (%d parts)", len(parts))
+	}
+
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(decodeSegment(t, parts[0]), &header); err != nil {
+		t.Fatalf("parse assertion header: %v", err)
+	}
+
+	key := jwksKey(t, header.Kid, header.Alg)
+	signed := parts[0] + "." + parts[1]
+	verifySignature(t, header.Alg, key, signed, decodeSegment(t, parts[2]))
+
+	var claims map[string]any
+	if err := json.Unmarshal(decodeSegment(t, parts[1]), &claims); err != nil {
+		t.Fatalf("parse assertion claims: %v", err)
+	}
+	return claims
+}
+
+func decodeSegment(t *testing.T, segment string) []byte {
+	t.Helper()
+	decoded, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		t.Fatalf("decode JWT segment: %v", err)
+	}
+	return decoded
+}
+
+// jwksKey fetches the issuer's published JWKS and rebuilds the key the assertion
+// names. Going through the published document rather than any internal handle is
+// the point: it is what a cluster would fetch.
+func jwksKey(t *testing.T, kid, alg string) any {
+	t.Helper()
+
+	status, body := h.DoRequest(t, "GET", h.NodeURL(leaderPort)+"/oidc/jwks", nil, "")
+	if status != 200 {
+		t.Fatalf("GET /oidc/jwks = %d: %s", status, body)
+	}
+
+	var doc struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+			Alg string `json:"alg"`
+			Kty string `json:"kty"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+			Crv string `json:"crv"`
+			X   string `json:"x"`
+			Y   string `json:"y"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("parse jwks: %v (%s)", err, body)
+	}
+
+	for _, k := range doc.Keys {
+		if k.Kid != kid {
+			continue
+		}
+		switch k.Kty {
+		case "RSA":
+			return &rsa.PublicKey{
+				N: new(big.Int).SetBytes(decodeSegment(t, k.N)),
+				E: int(new(big.Int).SetBytes(decodeSegment(t, k.E)).Int64()),
+			}
+		case "EC":
+			return &ecdsa.PublicKey{
+				Curve: ecCurve(t, k.Crv),
+				X:     new(big.Int).SetBytes(decodeSegment(t, k.X)),
+				Y:     new(big.Int).SetBytes(decodeSegment(t, k.Y)),
+			}
+		default:
+			t.Fatalf("jwk %s has unsupported kty %q", kid, k.Kty)
+		}
+	}
+
+	t.Fatalf("assertion names kid %q (alg %s), which the published JWKS does not carry", kid, alg)
+	return nil
+}
+
+func ecCurve(t *testing.T, crv string) elliptic.Curve {
+	t.Helper()
+	if crv != "P-256" {
+		t.Fatalf("unsupported EC curve %q", crv)
+	}
+	return elliptic.P256()
+}
+
+// verifySignature checks the assertion's signature with the published key. A
+// cluster that could not do this would reject the token, so a row that skipped it
+// could pass on an assertion no cluster would accept.
+func verifySignature(t *testing.T, alg string, key any, signed string, sig []byte) {
+	t.Helper()
+
+	digest := sha256.Sum256([]byte(signed))
+
+	switch alg {
+	case "RS256":
+		pub, ok := key.(*rsa.PublicKey)
+		if !ok {
+			t.Fatalf("alg RS256 but the JWKS key is %T", key)
+		}
+		if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], sig); err != nil {
+			t.Fatalf("assertion signature does not verify against the published JWKS: %v", err)
+		}
+	case "ES256":
+		pub, ok := key.(*ecdsa.PublicKey)
+		if !ok {
+			t.Fatalf("alg ES256 but the JWKS key is %T", key)
+		}
+		// JWS packs ES256 as r||s fixed-width, not as the ASN.1 form ecdsa.Verify
+		// would take.
+		if len(sig) != 64 {
+			t.Fatalf("ES256 signature is %d bytes, want 64", len(sig))
+		}
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		if !ecdsa.Verify(pub, digest[:], r, s) {
+			t.Fatal("assertion signature does not verify against the published JWKS")
+		}
+	default:
+		t.Fatalf("unsupported assertion alg %q", alg)
+	}
+}

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -44,7 +44,9 @@ import (
 // its scheme is mount config, so covering both means two mounts.
 // The four dual-mode gateways join the list from ensureEnv rather than here:
 // ibmcloud's source needs the IAM stub's URL, which is not known until the stub
-// is listening. Keeping all four together makes the reason legible.
+// is listening. Keeping all four together makes the reason legible. kubernetes
+// joins there for the same reason — its keyless source names the recording
+// upstream as its API server, so it cannot be described until that is up.
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
@@ -97,6 +99,11 @@ func ensureEnv(t *testing.T) {
 		ibmIAMStub = startIBMIAMStub()
 		ibmcloudEnv = buildIBMCloudEnv(ibmIAMStub.URL)
 		allEnvs = append(allEnvs, ibmcloudEnv)
+
+		// The keyless kubernetes source names the recording upstream as its API
+		// server, so like ibmcloud its env cannot be built until the listener is up.
+		kubernetesEnv = buildKubernetesEnv(upstream.URL)
+		allEnvs = append(allEnvs, kubernetesEnv)
 
 		// vault's source is the one that authenticates against something real: it
 		// verifies its AppRole role and logs in while being created, so the role

--- a/e2e/oidc_signer/oidc_signer_test.go
+++ b/e2e/oidc_signer/oidc_signer_test.go
@@ -1,10 +1,11 @@
 //go:build e2e
 
 // Package oidc_signer exercises the OIDC issuer's external signer (remote signing):
-// the private signing key lives in Vault transit and never leaves it. It proves the
-// keys are provisioned in transit and are non-exportable, and that an HA promotion
-// serves the same JWKS without moving any key material (the promoted node just
-// points at the same transit keys).
+// the private signing key lives in Vault transit and never leaves it. The harness
+// enables the issuer (e2e/setup.sh step 9j); this suite proves the keys it
+// provisioned are in transit and non-exportable, that re-applying the config
+// regenerates nothing, and that an HA promotion serves the same JWKS without moving
+// any key material (the promoted node just points at the same transit keys).
 package oidc_signer
 
 import (
@@ -68,12 +69,16 @@ func waitForIssuerReady(t *testing.T, port int) map[string]string {
 func TestOIDCSigner_RemoteTransit_And_HAPromotion(t *testing.T) {
 	leader := h.GetLeaderPort(t)
 
-	// 1. Enable the issuer on the active node. With the signer "transit" stanza in
-	//    each node's config, this provisions the signing keys IN transit — the
-	//    private key is created there and never enters Warden.
-	body := `{"enabled":true,"issuer_url":"` + h.NodeURL(leader) + `","key_rotation_period":0}`
+	// 1. Re-apply the enable the harness already performed (e2e/setup.sh step 9j).
+	//    issuer_url is deliberately absent: a config write is a partial update, so
+	//    the harness value survives for every other suite, and validation runs on
+	//    the merged config rather than the request. The stored keyset is complete,
+	//    so nothing is regenerated — the kids captured below are the ones setup
+	//    provisioned. Re-applying is the point: it proves an operator re-enable
+	//    leaves key material alone, which step 3 then depends on.
+	body := `{"enabled":true,"key_rotation_period":0}`
 	if status, resp := h.APIRequest(t, "POST", "sys/oidc-issuer/config", leader, body); status != 200 {
-		t.Fatalf("enable issuer = %d: %s", status, resp)
+		t.Fatalf("re-apply issuer config = %d: %s", status, resp)
 	}
 	kids := waitForIssuerReady(t, leader)
 

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -65,9 +65,22 @@ fi
 
 if [ ! -f "$NGINX_CERT_DIR/server.crt" ]; then
   echo "Generating nginx server certificate..."
+  # SANs matter: a client that verifies rejects a certificate carrying only a CN,
+  # so without them this certificate is usable only with -k. The issuer documents
+  # are served through this listener, and a verifier fetching them (a Kubernetes
+  # API server, say) does verify. e2e-nginx/nginx are the container name and
+  # service alias, for a verifier inside the compose network.
   openssl ecparam -genkey -name prime256v1 -noout -out "$NGINX_CERT_DIR/server.key" 2>/dev/null
-  openssl req -x509 -new -key "$NGINX_CERT_DIR/server.key" -out "$NGINX_CERT_DIR/server.crt" \
-    -days 365 -subj "/CN=e2e-nginx-lb" 2>/dev/null
+  openssl req -new -key "$NGINX_CERT_DIR/server.key" -out "$NGINX_CERT_DIR/server.csr" \
+    -subj "/CN=e2e-nginx-lb" 2>/dev/null
+  openssl x509 -req -sha256 -in "$NGINX_CERT_DIR/server.csr" -signkey "$NGINX_CERT_DIR/server.key" \
+    -out "$NGINX_CERT_DIR/server.crt" -days 365 \
+    -extfile <(printf "subjectAltName=IP:127.0.0.1,DNS:localhost,DNS:e2e-nginx,DNS:nginx") 2>/dev/null
+  rm -f "$NGINX_CERT_DIR/server.csr"
+  if [ ! -s "$NGINX_CERT_DIR/server.crt" ]; then
+    echo "ERROR: failed to generate nginx server certificate"
+    exit 1
+  fi
 fi
 
 # Step 1: Start infrastructure (PostgreSQL + Vault + Hydra + Nginx)
@@ -523,6 +536,35 @@ warden_api POST "auth/jwt/role/e2e-reader" \
 echo "  Enabling transparent mode..."
 warden_api POST "vault/config" \
   '{"auto_auth_path":"auth/jwt/"}'
+
+# 9j. Enable Warden's own OIDC issuer (workload identity federation).
+#
+# Suites minting Warden-signed identity assertions (subject_token_source=
+# warden_identity) need the issuer enabled and ready. With the signer "transit"
+# stanza in every node's config, this write provisions the signing keys IN
+# transit — the private key is created there and never enters Warden. The write
+# is a partial update and idempotent: re-applying it regenerates no keys, so the
+# JWKS kids stay stable across setup re-runs.
+#
+# issuer_url is the `iss` claim and the origin verifiers fetch discovery/JWKS
+# from, so it must outlive any single node: the load balancer fronts all three
+# and proxies every path, whereas a node origin goes dark whenever that node is
+# killed — which the HA suites do deliberately.
+#
+# Unlike the checks above this one aborts rather than warns. The issuer is part
+# of the harness contract now, and a silent failure here surfaces far from its
+# cause: suites that re-apply the config without an issuer_url would fail with
+# "issuer_url is required", saying nothing about setup having skipped this step.
+echo "  Enabling Warden OIDC issuer..."
+ISSUER_RESULT=$(warden_api POST "sys/oidc-issuer/config" \
+  '{"enabled":true,"issuer_url":"https://127.0.0.1:8000"}')
+if echo "$ISSUER_RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['data']['ready'] is True" 2>/dev/null; then
+  echo "  OIDC issuer enabled and ready."
+else
+  echo "ERROR: OIDC issuer enable failed or not ready"
+  echo "  $ISSUER_RESULT"
+  exit 1
+fi
 
 # Step 10: Verify Vault integration
 echo ""


### PR DESCRIPTION
End-to-end coverage for the keyless kubernetes source.

**Merge last.** This branch merges #529, #530 and #531; once those land, its diff narrows to the two e2e files. It cannot be verified in isolation, which is inherent to an e2e-of-a-new-feature PR.

### Why the recording upstream fits unusually well here

It stands in for the API server on **both hops** — the mint, where Warden calls TokenRequest with the caller's assertion, and the gateway request that follows with the minted ServiceAccount token — so one server sees the whole chain and the two are told apart by path.

Rows assert on the hops separately rather than on a total: `AssertChain` compares `len(reqs)` exactly and inspects only the last request, and how many the upstream sees depends on the credential cache.

### The assertion is verified, not just recorded

Signature against the issuer's published JWKS, then `iss`, `aud`, `exp`, and the claims a cluster maps to a user and groups. A shape check would pass on a token no cluster would accept. (I checked separately that the verification is not inert — a tampered payload fails it.)

### `agent_identity` needs a JWT agent leg

`Variants` only creates `auth/cert` roles, and that subject source fails closed on a cert-authenticated request — it reuses the token Warden verified at the door. Driven through `useJWTAgentLeg` plus a test-local `auth/jwt` role, the way `credential_chaining_test.go` already does. Its row asserts the bearer that reached the upstream is byte-equal to the agent's own token, so nothing was re-signed on the way.

### Negatives record where they bite

A spec naming no subject source is refused at **spec create**, by the test-mint, not at first request. A `rotation_period` on a keyless source is refused at **source create** — that rule is #531's.

## Not covered

The cluster's half: that a real kube-apiserver accepts the assertion under an `AuthenticationConfiguration`, maps `warden_role` to groups, and enforces the `resourceNames` RBAC. That needs a live cluster — a k3s container would fit docker-compose but needs privileged mode, CA plumbing and start-order sequencing. Its own piece of work; verified manually in the meantime.

## Verification

`make test-e2e` — all 20 packages pass, plus `./e2e/loadbalancer/` re-run with `-count=1` since Go had cached it and #529 changes the nginx certificate.