### PR TITLE
test(e2e): make a Host entry in a header map reach the server

### DIFF
--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -610,9 +610,7 @@ func ChainRequest(t *testing.T, port int, p ProviderEnv, o ChainOpts) (int, []by
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	for k, v := range chainHeaders(t, o) {
-		req.Header.Set(k, v)
-	}
+	applyHeaders(req, chainHeaders(t, o))
 	if o.Body != "" && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -648,9 +646,7 @@ func ChainStream(t *testing.T, port int, p ProviderEnv, o ChainOpts) *http.Respo
 	if err != nil {
 		t.Fatalf("build streaming request: %v", err)
 	}
-	for k, v := range chainHeaders(t, o) {
-		req.Header.Set(k, v)
-	}
+	applyHeaders(req, chainHeaders(t, o))
 	if o.Body != "" && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -59,6 +59,27 @@ func NodeURL(port int) string {
 
 // --- HTTP Helpers ---
 
+// applyHeaders copies a header map onto req.
+//
+// A "Host" entry is applied to req.Host rather than to the header map. net/http
+// reads the Host from that field and silently drops a "Host" header, so a caller
+// asking for one would otherwise get no host and no error — the request would go
+// out named after whatever the URL says. Honouring it is what lets a test present
+// the foreign Host a real client sends: an Alicloud or AWS gateway request names
+// its service host, and the provider resolves its target from exactly that.
+//
+// Every request builder in this package goes through here, so the trap cannot be
+// reintroduced by adding another one.
+func applyHeaders(req *http.Request, headers map[string]string) {
+	for k, v := range headers {
+		if http.CanonicalHeaderKey(k) == "Host" {
+			req.Host = v
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+}
+
 // DoRequest makes an HTTP request and returns status code and body.
 // Fatals on connection errors — use TryRequest when the node may be down.
 func DoRequest(t *testing.T, method, rawURL string, headers map[string]string, body string) (int, []byte) {
@@ -87,9 +108,7 @@ func doHTTP(method, rawURL string, headers map[string]string, body string) (int,
 	if err != nil {
 		return 0, nil, err
 	}
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
+	applyHeaders(req, headers)
 	if body != "" && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -673,9 +692,7 @@ func doLBHTTP(method, rawURL string, headers map[string]string, body string, cli
 	if err != nil {
 		return 0, nil, err
 	}
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
+	applyHeaders(req, headers)
 	if body != "" && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -828,9 +845,7 @@ func doMTLSHTTP(method, rawURL string, headers map[string]string, body string, c
 	if err != nil {
 		return 0, nil, err
 	}
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
+	applyHeaders(req, headers)
 	if body != "" && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/e2e/helpers/helpers_host_test.go
+++ b/e2e/helpers/helpers_host_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A "Host" entry in a header map must reach the server as the request's Host.
+//
+// net/http reads the Host from the request field, not the header map, and drops a
+// "Host" header set through Header.Set — so before applyHeaders existed a caller
+// asking for one got no host and no error, and the request went out named after
+// the URL. That is not a hypothetical: a gateway test passed
+// "Host: ecs.cn-hangzhou.aliyuncs.com" and reached Warden as 127.0.0.1.
+//
+// It matters because a provider can resolve its upstream target from the inbound
+// Host — provider/alicloud does exactly that — so a test that cannot set one
+// cannot drive that provider at all.
+func TestApplyHeaders_HostReachesTheServer(t *testing.T) {
+	const wantHost = "ecs.cn-hangzhou.aliyuncs.com"
+
+	var gotHost, gotHostHeader, gotOther string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		gotHostHeader = r.Header.Get("Host")
+		gotOther = r.Header.Get("X-Warden-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	status, _ := DoRequest(t, "GET", srv.URL, map[string]string{
+		"Host":           wantHost,
+		"X-Warden-Token": "not-a-real-token",
+	}, "")
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if gotHost != wantHost {
+		t.Errorf("r.Host = %q, want %q — a Host entry must set the request field", gotHost, wantHost)
+	}
+	// Go moves Host out of the header map on the way in, so the server sees it
+	// only on the field. Asserted so the mechanism is not mistaken for a bug.
+	if gotHostHeader != "" {
+		t.Errorf("r.Header[Host] = %q, want empty", gotHostHeader)
+	}
+	if gotOther != "not-a-real-token" {
+		t.Errorf("other headers must be unaffected, got %q", gotOther)
+	}
+}
+
+// The key is matched however it is cased, since a header map is not canonicalised
+// until it is applied.
+func TestApplyHeaders_HostIsCaseInsensitive(t *testing.T) {
+	for _, key := range []string{"Host", "host", "HOST"} {
+		t.Run(key, func(t *testing.T) {
+			var gotHost string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHost = r.Host
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			DoRequest(t, "GET", srv.URL, map[string]string{key: "oss-cn-hangzhou.aliyuncs.com"}, "")
+
+			if gotHost != "oss-cn-hangzhou.aliyuncs.com" {
+				t.Errorf("r.Host = %q, want the value passed under %q", gotHost, key)
+			}
+		})
+	}
+}
+
+// Without a Host entry the request is named after its URL, as before.
+func TestApplyHeaders_NoHostEntryLeavesTheURLHost(t *testing.T) {
+	var gotHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	DoRequest(t, "GET", srv.URL, map[string]string{"X-Warden-Token": "not-a-real-token"}, "")
+
+	// srv.URL is http://127.0.0.1:<port>; the server sees that authority.
+	if gotHost == "" {
+		t.Error("r.Host is empty, want the URL's authority")
+	}
+}

--- a/e2e/helpers/userleg_helpers.go
+++ b/e2e/helpers/userleg_helpers.go
@@ -229,9 +229,7 @@ func DoRequestWithResponseHeaders(t *testing.T, method, rawURL string, headers m
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
+	applyHeaders(req, headers)
 	if body != "" && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}


### PR DESCRIPTION
net/http reads a request's Host from the `Host` field, not the header map, and silently drops a `"Host"` header set through `Header.Set`. Every request builder in `e2e/helpers` applied headers with that loop, so a caller asking for a Host got no host **and no error** — the request went out named after whatever the URL said.

That is not hypothetical. A gateway test passed `Host: ecs.cn-hangzhou.aliyuncs.com` and the request reached Warden as `127.0.0.1`, which the test could not see because it was asserting on an earlier hop.

It matters because a provider can resolve its upstream target from the inbound Host — `provider/alicloud` does exactly that, requiring a `*.aliyuncs.com` suffix — so a test that cannot set one cannot drive such a provider at all.

## What changed

The trap was in **six** request builders, not one: `helpers.go` (×3), `fullchain_helpers.go` (×2) and `userleg_helpers.go` (×1), each with the identical loop. Fixing only `DoRequest` would have left five. All six now route through a single `applyHeaders`, so it cannot be reintroduced by adding a seventh.

Honouring the key rather than rejecting it is the useful choice: the next test that needs the foreign Host a real client sends now just works. Matching is case-insensitive, since a header map is not canonicalised until applied.

## Risk

No existing caller passes `"Host"`, so nothing in the tree changes behaviour today — the new tests pin it for what comes next.

## Verification

- New `e2e/helpers/helpers_host_test.go` **fails without the fix** with `r.Host = "127.0.0.1:60581"` — the actual bug, confirmed by reverting.
- Full e2e suite: 20 packages, 0 failures.