### PR TITLE
fix(credential): a credential with no lease handle is not revocable

### DIFF
--- a/credential/types/alicloud_keys.go
+++ b/credential/types/alicloud_keys.go
@@ -138,12 +138,15 @@ func (t *AlicloudKeysCredType) Parse(rawData, metadata map[string]interface{}, l
 	}
 
 	return &credential.Credential{
-		Type:      credential.TypeAlicloudKeys,
-		Category:  credential.CategoryCloudIAM,
-		LeaseTTL:  leaseTTL,
-		LeaseID:   leaseID,
-		IssuedAt:  time.Now(),
-		Revocable: leaseTTL > 0,
+		Type:     credential.TypeAlicloudKeys,
+		Category: credential.CategoryCloudIAM,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		// Revoking means releasing a lease at the source, which needs a handle to
+		// release. The alicloud driver's only mint path returns self-expiring STS
+		// session credentials and no leaseID, so this is always false here.
+		Revocable: leaseTTL > 0 && leaseID != "",
 		Data:      data,
 		Metadata:  meta,
 	}, nil

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -246,12 +246,16 @@ func (t *AWSIAMAccessKeysCredType) Parse(rawData, metadata map[string]interface{
 	}
 
 	cred := &credential.Credential{
-		Type:      credential.TypeAWSAccessKeys,
-		Category:  credential.CategoryCloudIAM,
-		LeaseTTL:  leaseTTL,
-		LeaseID:   leaseID,
-		IssuedAt:  time.Now(),
-		Revocable: leaseTTL > 0, // STS temporary credentials are revocable
+		Type:     credential.TypeAWSAccessKeys,
+		Category: credential.CategoryCloudIAM,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		// Revoking means releasing a lease at the source, which needs a handle to
+		// release. Every AWS path that returns a TTL also returns a leaseID today,
+		// so the second condition changes nothing — it states the invariant rather
+		// than leaving the next mint path to rediscover it.
+		Revocable: leaseTTL > 0 && leaseID != "",
 		Data: map[string]string{
 			"access_key_id":     accessKeyID,
 			"secret_access_key": secretAccessKey,

--- a/credential/types/cloudflare_keys.go
+++ b/credential/types/cloudflare_keys.go
@@ -134,12 +134,17 @@ func (t *CloudflareKeysCredType) Parse(rawData, metadata map[string]interface{},
 	}
 
 	return &credential.Credential{
-		Type:      credential.TypeCloudflareKeys,
-		Category:  credential.CategoryCloudIAM,
-		LeaseTTL:  leaseTTL,
-		LeaseID:   leaseID,
-		IssuedAt:  time.Now(),
-		Revocable: leaseTTL > 0,
+		Type:     credential.TypeCloudflareKeys,
+		Category: credential.CategoryCloudIAM,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		// Revoking means releasing a lease at the source, which needs a handle to
+		// release. Cloudflare keys only come from a local source, which returns
+		// neither a TTL nor a leaseID, so the second condition changes nothing
+		// today — it states the invariant rather than leaving the next mint path to
+		// rediscover it.
+		Revocable: leaseTTL > 0 && leaseID != "",
 		Data:      data,
 		Metadata:  meta,
 	}, nil

--- a/credential/types/ibmcloud_keys.go
+++ b/credential/types/ibmcloud_keys.go
@@ -136,12 +136,15 @@ func (t *IBMCloudKeysCredType) Parse(rawData, metadata map[string]interface{}, l
 	}
 
 	return &credential.Credential{
-		Type:      credential.TypeIBMCloudKeys,
-		Category:  credential.CategoryCloudIAM,
-		LeaseTTL:  leaseTTL,
-		LeaseID:   leaseID,
-		IssuedAt:  time.Now(),
-		Revocable: leaseTTL > 0,
+		Type:     credential.TypeIBMCloudKeys,
+		Category: credential.CategoryCloudIAM,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		// Revoking means releasing a lease at the source, which needs a handle to
+		// release. The IBM driver's own IAM-token paths return no leaseID; only the
+		// Vault dynamic_ibm path carries one.
+		Revocable: leaseTTL > 0 && leaseID != "",
 		Data:      data,
 		Metadata:  meta,
 	}, nil

--- a/credential/types/ovh_keys.go
+++ b/credential/types/ovh_keys.go
@@ -102,12 +102,15 @@ func (t *OVHKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseT
 	}
 
 	return &credential.Credential{
-		Type:      credential.TypeOVHKeys,
-		Category:  credential.CategoryCloudIAM,
-		LeaseTTL:  leaseTTL,
-		LeaseID:   leaseID,
-		IssuedAt:  time.Now(),
-		Revocable: leaseTTL > 0,
+		Type:     credential.TypeOVHKeys,
+		Category: credential.CategoryCloudIAM,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		// Revoking means releasing a lease at the source, which needs a handle to
+		// release. The OVH driver's bare OAuth2-token path returns no leaseID; the
+		// S3 paths carry one.
+		Revocable: leaseTTL > 0 && leaseID != "",
 		Data:      data,
 		Metadata:  meta,
 	}, nil

--- a/credential/types/revocable_test.go
+++ b/credential/types/revocable_test.go
@@ -1,0 +1,122 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Revoking a credential means releasing a lease at the source, which needs a
+// handle to release. A credential carrying a TTL but no leaseID has nothing to
+// release, so it is not revocable however long it lives — the invariant
+// base_token_type.go already states as `t.Revocable && leaseID != ""`.
+//
+// Marking such a credential revocable registered an expiration-manager entry per
+// mint whose revocation reduced to a cache delete the cache's own TTL was going
+// to do anyway, and reported the wrong Revocable in the audit log.
+//
+// Three of these types could actually be handed a TTL with no leaseID; the other
+// three could not, and are covered here so the invariant holds by construction
+// rather than by whichever mint paths happen to exist today.
+func TestRevocableRequiresLeaseID(t *testing.T) {
+	tests := []struct {
+		name string
+		// reachable records whether a driver can currently produce a TTL with no
+		// leaseID for this type. It documents the audit; the assertions below are
+		// the same either way.
+		reachable bool
+		credType  credential.Type
+		rawData   map[string]interface{}
+		leaseID   string
+	}{
+		{
+			// The alicloud driver's only mint path returns self-expiring STS
+			// session credentials and no leaseID.
+			name:      "alicloud_keys",
+			reachable: true,
+			credType:  &AlicloudKeysCredType{},
+			rawData: map[string]interface{}{
+				"access_key_id":     "STS.abc",
+				"access_key_secret": "secret",
+				"security_token":    "token",
+			},
+			leaseID: "sts-session",
+		},
+		{
+			// The IBM driver's own IAM-token paths return no leaseID; only the
+			// Vault dynamic_ibm path carries one.
+			name:      "ibmcloud_keys",
+			reachable: true,
+			credType:  &IBMCloudKeysCredType{},
+			rawData:   map[string]interface{}{"access_token": "test-access-token"},
+			leaseID:   "ibm/creds/role/abc123",
+		},
+		{
+			// The OVH driver's bare OAuth2-token path returns no leaseID; its S3
+			// paths carry one.
+			name:      "ovh_keys",
+			reachable: true,
+			credType:  &OVHKeysCredType{},
+			rawData:   map[string]interface{}{"api_token": "test-api-token"},
+			leaseID:   "project/user/accesskey",
+		},
+		{
+			// Every AWS path returning a TTL also returns a leaseID today.
+			name:      "aws_iam_keys",
+			reachable: false,
+			credType:  &AWSIAMAccessKeysCredType{},
+			rawData: map[string]interface{}{
+				"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+				"secret_access_key": "secret",
+			},
+			leaseID: "sts:AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			// Scaleway's static path returns no TTL; its dynamic path returns a
+			// leaseID.
+			name:      "scaleway_keys",
+			reachable: false,
+			credType:  &ScalewayKeysCredType{},
+			rawData: map[string]interface{}{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			leaseID: "SCWXXXXXXXXXXXXXXXXX",
+		},
+		{
+			// Cloudflare keys only come from a local source, which returns neither
+			// a TTL nor a leaseID.
+			name:      "cloudflare_keys",
+			reachable: false,
+			credType:  &CloudflareKeysCredType{},
+			rawData:   map[string]interface{}{"api_token": "v1.0-test-token"},
+			leaseID:   "cf-lease",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("a TTL with no leaseID is not revocable", func(t *testing.T) {
+				cred, err := tt.credType.Parse(tt.rawData, nil, time.Hour, "")
+				require.NoError(t, err)
+				assert.False(t, cred.Revocable,
+					"nothing to release, so it cannot be revoked (reachable today: %v)", tt.reachable)
+			})
+
+			t.Run("a TTL with a leaseID is revocable", func(t *testing.T) {
+				cred, err := tt.credType.Parse(tt.rawData, nil, time.Hour, tt.leaseID)
+				require.NoError(t, err)
+				assert.True(t, cred.Revocable)
+			})
+
+			t.Run("a static credential is not revocable", func(t *testing.T) {
+				cred, err := tt.credType.Parse(tt.rawData, nil, 0, "")
+				require.NoError(t, err)
+				assert.False(t, cred.Revocable)
+			})
+		})
+	}
+}

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -141,12 +141,17 @@ func (t *ScalewayKeysCredType) Parse(rawData, metadata map[string]interface{}, l
 	}
 
 	return &credential.Credential{
-		Type:      credential.TypeScalewayKeys,
-		Category:  credential.CategoryCloudIAM,
-		LeaseTTL:  leaseTTL,
-		LeaseID:   leaseID,
-		IssuedAt:  time.Now(),
-		Revocable: leaseTTL > 0,
+		Type:     credential.TypeScalewayKeys,
+		Category: credential.CategoryCloudIAM,
+		LeaseTTL: leaseTTL,
+		LeaseID:  leaseID,
+		IssuedAt: time.Now(),
+		// Revoking means releasing a lease at the source, which needs a handle to
+		// release. Scaleway's static path returns no TTL and its dynamic path
+		// returns a leaseID, so the second condition changes nothing today — it
+		// states the invariant rather than leaving the next mint path to
+		// rediscover it.
+		Revocable: leaseTTL > 0 && leaseID != "",
 		Data: map[string]string{
 			"access_key": accessKey,
 			"secret_key": secretKey,


### PR DESCRIPTION
Six credential types set `Revocable` from `leaseTTL` alone. Revoking means releasing a lease at the source, which needs a handle to release — so a credential carrying a TTL but no `leaseID` has nothing to release and is not revocable however long it lives. `base_token_type.go:91` already states the invariant as `t.Revocable && leaseID != ""`; these six did not.

Marking such a credential revocable registers an expiration-manager entry per mint whose revocation reduces to a cache delete the cache's own TTL was going to do anyway (`revokeLeaseAtSource` no-ops on an empty leaseID), and reports the wrong `Revocable` in the audit log.

## The audit

Which types can actually be handed a TTL with no leaseID:

| Type | Verdict |
|---|---|
| `alicloud_keys` | **affected** — `assume_role` returns self-expiring STS credentials and no leaseID, on its only path |
| `ibmcloud_keys` | **affected** — the IBM driver's own IAM-token paths return no leaseID; only Vault's `dynamic_ibm` carries one |
| `ovh_keys` | **affected** — the bare OAuth2-token path returns none; the S3 paths carry one |
| `aws_iam_keys` | unreachable — every path returning a TTL also returns a leaseID |
| `scaleway_keys` | unreachable — the static path returns no TTL, the dynamic path a leaseID |
| `cloudflare_keys` | unreachable — only from a local source, which returns neither |

The guard is applied to all six rather than only the three: it is the correct expression of the invariant either way, and leaving three expressed differently means the next mint path added has to rediscover which form was safe. The three unreachable ones say so in a comment.

## Why this is safe

Nothing else keys off `Revocable` that this could regress. `IsExpired` uses `LeaseTTL`, not `Revocable`, and guards both cache read paths; the cache entry is already bounded by `LeaseTTL`, so it still self-evicts on time. `ShouldRotate` is the only other consumer and **has no callers**.

## Verification

Tests live in one new `credential/types/revocable_test.go` covering all six — this is one invariant, not six changes. Confirmed the test catches the bug by reverting `ibmcloud_keys.go` and watching it fail.