### PR TITLE
fix(alicloud): reject 4xx responses that carry no error envelope

### DIFF
--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -67,8 +68,9 @@ type AlicloudDriver struct {
 	logger     *logger.GatedLogger
 	httpClient *http.Client
 
-	// configMu protects credSource.Config against concurrent reads and writes
-	// (for future rotation support).
+	// configMu protects credSource.Config against concurrent reads and writes:
+	// CommitRotation replaces the whole map while mint and rotation calls are
+	// reading it. Every accessor of credSource.Config must hold it.
 	configMu sync.RWMutex
 }
 
@@ -158,25 +160,30 @@ func (d *AlicloudDriver) Cleanup(_ context.Context) error {
 	return nil
 }
 
-func (d *AlicloudDriver) mgmtAccessKey() (string, string) {
+// stsCallConfig returns the STS endpoint and the management key pair from a
+// single config snapshot. Endpoint and credentials are read together rather than
+// through separate accessors so a rotation committing between two reads cannot
+// pair one config's key with another config's address.
+func (d *AlicloudDriver) stsCallConfig() (endpoint, keyID, keySecret string) {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
-	return credential.GetString(d.credSource.Config, "access_key_id", ""),
+	return d.endpointLocked("sts_endpoint", DefaultAlicloudSTSEndpoint),
+		credential.GetString(d.credSource.Config, "access_key_id", ""),
 		credential.GetString(d.credSource.Config, "access_key_secret", "")
 }
 
-func (d *AlicloudDriver) stsEndpoint() string {
-	return strings.TrimRight(
-		credential.GetString(d.credSource.Config, "sts_endpoint", DefaultAlicloudSTSEndpoint),
-		"/",
-	)
+// ramCallConfig is stsCallConfig for the RAM management API.
+func (d *AlicloudDriver) ramCallConfig() (endpoint, keyID, keySecret string) {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.endpointLocked("ram_endpoint", DefaultAlicloudRAMEndpoint),
+		credential.GetString(d.credSource.Config, "access_key_id", ""),
+		credential.GetString(d.credSource.Config, "access_key_secret", "")
 }
 
-func (d *AlicloudDriver) ramEndpoint() string {
-	return strings.TrimRight(
-		credential.GetString(d.credSource.Config, "ram_endpoint", DefaultAlicloudRAMEndpoint),
-		"/",
-	)
+// endpointLocked reads and normalises one endpoint key. Caller must hold configMu.
+func (d *AlicloudDriver) endpointLocked(key, fallback string) string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, key, fallback), "/")
 }
 
 // MintCredential returns Alicloud credentials for the given spec.
@@ -192,7 +199,7 @@ func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.Cr
 
 // mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
 func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	mgmtID, mgmtSecret := d.mgmtAccessKey()
+	stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
 	if mgmtID == "" || mgmtSecret == "" {
 		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
 	}
@@ -221,7 +228,7 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		params.Set("Policy", p)
 	}
 
-	respBody, err := d.callSignedJSON(ctx, http.MethodPost, d.stsEndpoint(), params, mgmtID, mgmtSecret, "")
+	respBody, err := d.callSignedJSON(ctx, http.MethodPost, stsEndpoint, params, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed: %w", err)
 	}
@@ -281,7 +288,7 @@ func (d *AlicloudDriver) VerifySpec(ctx context.Context, spec *credential.CredSp
 		if roleARN == "" {
 			return fmt.Errorf("role_arn is required for assume_role")
 		}
-		mgmtID, mgmtSecret := d.mgmtAccessKey()
+		stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
 		if mgmtID == "" || mgmtSecret == "" {
 			return fmt.Errorf("source must have management access_key_id/access_key_secret for assume_role")
 		}
@@ -297,7 +304,7 @@ func (d *AlicloudDriver) VerifySpec(ctx context.Context, spec *credential.CredSp
 		params.Set("RoleSessionName", "warden-verify")
 		params.Set("DurationSeconds", fmt.Sprintf("%d", int(alicloudMinSTSDuration.Seconds())))
 
-		if _, err := d.callSignedJSON(verifyCtx, http.MethodPost, d.stsEndpoint(), params, mgmtID, mgmtSecret, ""); err != nil {
+		if _, err := d.callSignedJSON(verifyCtx, http.MethodPost, stsEndpoint, params, mgmtID, mgmtSecret, ""); err != nil {
 			return fmt.Errorf("alicloud pre-flight AssumeRole failed: %w", err)
 		}
 		return nil
@@ -337,13 +344,59 @@ func parseAlicloudEnvelope(body []byte) (alicloudErrorEnvelope, bool) {
 	return env, env.Code != ""
 }
 
-// alicloudErrorFromEnvelope wraps an Alicloud error envelope into a Go error
+// alicloudAPIError carries a parsed error envelope so callers can branch on the
+// upstream Code rather than matching substrings of a formatted message. Rotation
+// cleanup, for instance, treats an already-deleted key (EntityNotExist.*) as
+// success while still failing on anything else.
+type alicloudAPIError struct {
+	alicloudErrorEnvelope
+}
+
+// Error formats Code, Message, and RequestId for operator triage.
+func (e *alicloudAPIError) Error() string {
+	if e.RequestId != "" {
+		return fmt.Sprintf("%s: %s (RequestId=%s)", e.Code, e.Message, e.RequestId)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// alicloudErrorFromEnvelope wraps an Alicloud error envelope into a typed error
 // whose message carries Code, Message, and RequestId for operator triage.
 func alicloudErrorFromEnvelope(env alicloudErrorEnvelope) error {
-	if env.RequestId != "" {
-		return fmt.Errorf("%s: %s (RequestId=%s)", env.Code, env.Message, env.RequestId)
+	return &alicloudAPIError{alicloudErrorEnvelope: env}
+}
+
+// alicloudBodyPreviewLen bounds how much of an unrecognised response body is
+// quoted back in an error. Enough to tell an HTML error page from a JSON one and
+// read the first line of either, short enough not to flood a log line.
+const alicloudBodyPreviewLen = 256
+
+// alicloudBodyPreview renders an unrecognised response body as a single-line
+// excerpt for an error message. Whitespace is collapsed because the bodies this
+// is reached for are typically multi-line HTML, which would otherwise break the
+// error across a dozen log lines.
+func alicloudBodyPreview(body []byte) string {
+	if len(body) == 0 {
+		return "<empty>"
 	}
-	return fmt.Errorf("%s: %s", env.Code, env.Message)
+	preview := strings.Join(strings.Fields(string(body)), " ")
+	if len(preview) > alicloudBodyPreviewLen {
+		preview = preview[:alicloudBodyPreviewLen] + "..."
+	}
+	return preview
+}
+
+// alicloudErrorHasCodePrefix reports whether err carries an Alicloud error
+// envelope whose Code equals prefix or begins with prefix + ".". Alicloud groups
+// related codes that way (EntityNotExist.User, EntityNotExist.User.AccessKey),
+// so matching the family is the useful test; the dotted form keeps
+// "EntityNotExist" from also matching a hypothetical "EntityNotExistent".
+func alicloudErrorHasCodePrefix(err error, prefix string) bool {
+	var apiErr *alicloudAPIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.Code == prefix || strings.HasPrefix(apiErr.Code, prefix+".")
 }
 
 // callSignedJSON builds and sends an ACS3-signed request to an Alicloud
@@ -448,6 +501,17 @@ func (d *AlicloudDriver) callSignedJSON(
 			return nil, alicloudErrorFromEnvelope(env)
 		}
 
+		// The 4xx statuses above are marked OK only to get their bodies back for
+		// envelope classification, never to accept the outcome. A 4xx whose body
+		// is not an envelope — an HTML error page from an intercepting proxy, a
+		// load balancer's own JSON — reaches here having failed, so refusing it is
+		// the whole point: callers that discard the body (rotation cleanup) would
+		// otherwise read it as success and silently leave a live key in place.
+		if status != http.StatusOK {
+			return nil, fmt.Errorf("alicloud %s returned HTTP %d with an unrecognised body: %s",
+				params.Get("Action"), status, alicloudBodyPreview(respBody))
+		}
+
 		return respBody, nil
 	}
 
@@ -478,6 +542,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	mgmtSecret := credential.GetString(d.credSource.Config, "access_key_secret", "")
 	userName := credential.GetString(d.credSource.Config, "management_user_name", "")
 	activationDelay := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultAlicloudActivationDelay)
+	ramEndpoint := d.endpointLocked("ram_endpoint", DefaultAlicloudRAMEndpoint)
 	configSnapshot := make(map[string]string, len(d.credSource.Config))
 	for k, v := range d.credSource.Config {
 		configSnapshot[k] = v
@@ -500,7 +565,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	listParams.Set("Format", "JSON")
 	listParams.Set("UserName", userName)
 
-	listBody, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), listParams, mgmtID, mgmtSecret, "")
+	listBody, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, listParams, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("RAM ListAccessKeys failed: %w", err)
 	}
@@ -530,7 +595,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 		del.Set("Format", "JSON")
 		del.Set("UserName", userName)
 		del.Set(ramParamUserAccessKeyID, k.AccessKeyID)
-		if _, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), del, mgmtID, mgmtSecret, ""); err != nil {
+		if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
 			return nil, nil, 0, fmt.Errorf("failed to delete orphaned access key %s: %w", truncateID(k.AccessKeyID, 8), err)
 		}
 	}
@@ -542,7 +607,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	createParams.Set("Format", "JSON")
 	createParams.Set("UserName", userName)
 
-	createBody, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), createParams, mgmtID, mgmtSecret, "")
+	createBody, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, createParams, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("RAM CreateAccessKey failed: %w", err)
 	}
@@ -608,7 +673,7 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 		return nil
 	}
 
-	mgmtID, mgmtSecret := d.mgmtAccessKey()
+	ramEndpoint, mgmtID, mgmtSecret := d.ramCallConfig()
 	if mgmtID == "" || mgmtSecret == "" {
 		return fmt.Errorf("management access keys are required to clean up old key")
 	}
@@ -628,7 +693,7 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	inactivate.Set(ramParamUserAccessKeyID, oldKeyID)
 	inactivate.Set("Status", "Inactive")
 
-	if _, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), inactivate, mgmtID, mgmtSecret, ""); err != nil {
+	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, inactivate, mgmtID, mgmtSecret, ""); err != nil {
 		return fmt.Errorf("RAM UpdateAccessKey (Inactive) failed: %w", err)
 	}
 	d.logger.Info("disabled old management access key",
@@ -644,7 +709,7 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	del.Set("UserName", userName)
 	del.Set(ramParamUserAccessKeyID, oldKeyID)
 
-	if _, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), del, mgmtID, mgmtSecret, ""); err != nil {
+	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
 		return fmt.Errorf("RAM DeleteAccessKey (old management key) failed: %w", err)
 	}
 

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -3,11 +3,13 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stephnangue/warden/credential"
@@ -499,6 +501,113 @@ func TestAlicloudDriver_CallSignedJSON_StopsAtMaxAttempts(t *testing.T) {
 	assert.Contains(t, err.Error(), "Throttling")
 }
 
+// 400/403/404 are marked OK statuses only so Alicloud error envelopes arrive as
+// readable bodies. A 4xx whose body is not an envelope — an intercepting proxy's
+// HTML error page, a load balancer's own JSON — must still fail. It used to be
+// read as success, which let CleanupRotation report that it had deleted a key it
+// had not touched.
+func TestAlicloudDriver_CallSignedJSON_NonEnvelope4xxIsAnError(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantInErr   string
+	}{
+		{
+			name:        "html error page from a proxy",
+			status:      http.StatusForbidden,
+			contentType: "text/html",
+			body:        "<html>\n<head><title>403 Forbidden</title></head>\n<body>denied</body>\n</html>",
+			wantInErr:   "403 Forbidden",
+		},
+		{
+			name:        "json without a Code field",
+			status:      http.StatusBadRequest,
+			contentType: "application/json",
+			body:        `{"message":"malformed request"}`,
+			wantInErr:   "malformed request",
+		},
+		{
+			name:        "empty body",
+			status:      http.StatusNotFound,
+			contentType: "text/plain",
+			body:        "",
+			wantInErr:   "<empty>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hits := 0
+			sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer sts.Close()
+
+			f := &AlicloudDriverFactory{}
+			d, _ := f.Create(map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "mgmt-secret",
+				"sts_endpoint":      sts.URL,
+			}, createAlicloudTestLogger())
+
+			err := d.(*AlicloudDriver).VerifySpec(context.Background(), &credential.CredSpec{
+				Config: map[string]string{
+					"mint_method": "assume_role",
+					"role_arn":    "acs:ram::123:role/proxied",
+				},
+			})
+			require.Error(t, err, "a non-envelope %d must not be treated as success", tc.status)
+			assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", tc.status))
+			assert.Contains(t, err.Error(), tc.wantInErr, "the body should be quoted back for triage")
+			assert.Equal(t, 1, hits, "a non-envelope 4xx is not transient and must not be retried")
+		})
+	}
+}
+
+// The body excerpt is collapsed onto one line so a multi-line HTML error page
+// cannot break the error across a dozen log lines, and bounded so it cannot
+// flood them either.
+func TestAlicloudBodyPreview(t *testing.T) {
+	assert.Equal(t, "<empty>", alicloudBodyPreview(nil))
+	assert.Equal(t, "<empty>", alicloudBodyPreview([]byte("")))
+	assert.Equal(t, "a b c", alicloudBodyPreview([]byte("a\n  b\t\nc\n")))
+
+	long := alicloudBodyPreview([]byte(strings.Repeat("x", alicloudBodyPreviewLen*2)))
+	assert.Equal(t, strings.Repeat("x", alicloudBodyPreviewLen)+"...", long)
+}
+
+// The typed envelope error lets callers branch on the upstream Code instead of
+// matching substrings. Rotation cleanup relies on this to treat an
+// already-deleted key as success.
+func TestAlicloudErrorHasCodePrefix(t *testing.T) {
+	notExist := alicloudErrorFromEnvelope(alicloudErrorEnvelope{
+		Code: "EntityNotExist.User.AccessKey", Message: "gone", RequestId: "req-1",
+	})
+
+	assert.True(t, alicloudErrorHasCodePrefix(notExist, "EntityNotExist"))
+	assert.True(t, alicloudErrorHasCodePrefix(notExist, "EntityNotExist.User"))
+	assert.True(t, alicloudErrorHasCodePrefix(notExist, "EntityNotExist.User.AccessKey"))
+	assert.False(t, alicloudErrorHasCodePrefix(notExist, "NoPermission"))
+
+	// The dotted boundary keeps a prefix from matching a longer sibling code.
+	assert.False(t, alicloudErrorHasCodePrefix(
+		alicloudErrorFromEnvelope(alicloudErrorEnvelope{Code: "EntityNotExistent"}), "EntityNotExist"))
+
+	// It survives wrapping, and a plain error is simply not a match.
+	assert.True(t, alicloudErrorHasCodePrefix(fmt.Errorf("cleanup: %w", notExist), "EntityNotExist"))
+	assert.False(t, alicloudErrorHasCodePrefix(errors.New("EntityNotExist.User"), "EntityNotExist"))
+
+	// Formatting is unchanged from the untyped version operators are used to.
+	assert.Equal(t, "EntityNotExist.User.AccessKey: gone (RequestId=req-1)", notExist.Error())
+	assert.Equal(t, "NoPermission: denied",
+		alicloudErrorFromEnvelope(alicloudErrorEnvelope{Code: "NoPermission", Message: "denied"}).Error())
+}
+
 // --- Rotation ---
 
 func TestAlicloudDriver_SupportsRotation(t *testing.T) {
@@ -630,7 +739,7 @@ func TestAlicloudDriver_Rotation_HappyPath(t *testing.T) {
 
 	// Commit: swap to the new config
 	require.NoError(t, drv.CommitRotation(context.Background(), newConfig))
-	mgmtID, _ := drv.mgmtAccessKey()
+	_, mgmtID, _ := drv.ramCallConfig()
 	assert.Equal(t, "LTAI-rotated-1", mgmtID)
 
 	// Cleanup: two-step — UpdateAccessKey(Inactive) then DeleteAccessKey on the old key.
@@ -725,6 +834,104 @@ func TestAlicloudDriver_Rotation_CleanupRefusesCurrentKey(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "currently active")
+}
+
+// The defect this PR fixes, at the level it actually bites. CleanupRotation
+// discards the response body, so when a non-envelope 4xx was classified as
+// success both steps reported done, no PendingCleanup was persisted, nothing
+// retried, and the old privileged key stayed live forever.
+func TestAlicloudDriver_Rotation_CleanupFailsOnInterceptedResponse(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<html><body>blocked by policy</body></html>"))
+	}))
+	defer srv.Close()
+
+	f := &AlicloudDriverFactory{}
+	d, _ := f.Create(map[string]string{
+		"access_key_id":        "LTAI-new",
+		"access_key_secret":    "new-secret",
+		"management_user_name": "warden-management",
+		"ram_endpoint":         srv.URL,
+	}, createAlicloudTestLogger())
+
+	err := d.(*AlicloudDriver).CleanupRotation(context.Background(), map[string]string{
+		"access_key_id":        "LTAI-old",
+		"management_user_name": "warden-management",
+	})
+
+	require.Error(t, err, "an intercepted RAM response must not read as a completed cleanup")
+	assert.Contains(t, err.Error(), "UpdateAccessKey")
+	assert.Contains(t, err.Error(), "blocked by policy")
+	assert.Equal(t, 1, hits, "cleanup must stop at the failed Inactive step, not go on to delete")
+}
+
+// CommitRotation replaces the whole Config map while mints are reading it, so
+// every accessor must hold configMu. Run under -race: before the endpoint
+// accessors took the read lock this reported a data race on credSource.Config.
+//
+// It also pins the pairing. stsCallConfig returns the endpoint and the key from
+// one snapshot, so a mint can never sign with one config's key against another
+// config's address — which is what reading them through separate accessors
+// allowed.
+func TestAlicloudDriver_ConfigAccessIsRaceFree(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.minted",
+				"AccessKeySecret": "minted-secret",
+				"SecurityToken":   "minted-token",
+				"Expiration":      "2099-01-01T00:00:00Z",
+			},
+		})
+	}))
+	defer sts.Close()
+
+	f := &AlicloudDriverFactory{}
+	d, _ := f.Create(map[string]string{
+		"access_key_id":        "LTAI-gen-0",
+		"access_key_secret":    "secret-0",
+		"management_user_name": "warden-management",
+		"sts_endpoint":         sts.URL,
+	}, createAlicloudTestLogger())
+	drv := d.(*AlicloudDriver)
+
+	spec := &credential.CredSpec{Config: map[string]string{
+		"mint_method": "assume_role",
+		"role_arn":    "acs:ram::123:role/concurrent",
+	}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_, _, _, _, err := drv.MintCredential(context.Background(), spec)
+				assert.NoError(t, err)
+				drv.SupportsRotation()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for gen := 1; gen <= 40; gen++ {
+			require.NoError(t, drv.CommitRotation(context.Background(), map[string]string{
+				"access_key_id":        fmt.Sprintf("LTAI-gen-%d", gen),
+				"access_key_secret":    fmt.Sprintf("secret-%d", gen),
+				"management_user_name": "warden-management",
+				"sts_endpoint":         sts.URL,
+			}))
+		}
+	}()
+
+	wg.Wait()
 }
 
 // --- ACS3 signing helper ---


### PR DESCRIPTION
**PR 1 of 5 in a defect series on the Alicloud driver.** Stacked: #536 → #537 → #538 → #539 build on this.

`callSignedJSON` marks 400/403/404 as OK statuses so Alicloud error envelopes arrive as readable bodies rather than being dropped as transport errors. It then classified the result by parsing the body for a top-level `Code`, and **never looked at the status again**.

A 4xx whose body is not an envelope therefore read as success: an intercepting proxy's HTML error page, a load balancer's own JSON. That is worst in `CleanupRotation`, which discards the body entirely — both `UpdateAccessKey(Inactive)` and `DeleteAccessKey` reported done, no pending cleanup was persisted, nothing retried, and **the old privileged management key stayed live indefinitely**.

## What changed

Consult the status after envelope classification: a non-200 that did not parse as an envelope is an error, quoting a bounded single-line excerpt of the body for triage. The 4xx statuses stay listed — the point of listing them is to get the body back, not to accept the outcome. This mirrors what the OAuth2 token path already does at `oauth_token.go:71`.

Also makes the envelope error **typed**, so callers can branch on the upstream `Code` instead of matching substrings of a formatted message, with a helper matching a code family. The message format is unchanged. PR #536 needs this to recognise `EntityNotExist.*`.

## Also: a data race on `credSource.Config`

`CommitRotation` replaces the whole map under the write lock while `stsEndpoint()` and `ramEndpoint()` read it with no lock at all. Both are gone, replaced by `stsCallConfig`/`ramCallConfig` returning the endpoint and the key pair from **one** snapshot — reading them through separate accessors also let a rotation land in between and sign with one config's key against another config's address.

## Verification

Confirmed the race test genuinely catches it: removed the read lock, ran under `-race`, got `DATA RACE`; restored, clean. Sibling check came back clean — four other drivers list `StatusNotFound` as OK, but all are DELETE/revoke paths where 404 legitimately means "already gone".