### PR TITLE
fix(alicloud): stop rotation from deleting keys it does not own

### DIFF
--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -531,11 +531,123 @@ func (d *AlicloudDriver) SupportsRotation() bool {
 		credential.GetString(d.credSource.Config, "management_user_name", "") != ""
 }
 
+// alicloudAccessKey is one entry of a RAM ListAccessKeys response.
+type alicloudAccessKey struct {
+	AccessKeyID string `json:"AccessKeyId"`
+	Status      string `json:"Status"`
+}
+
+// alicloudAccessKeyInactive is the RAM status of a disabled access key. A key
+// Warden left behind mid-cleanup carries it, because CleanupRotation always
+// deactivates before deleting.
+const alicloudAccessKeyInactive = "Inactive"
+
+// alicloudCodeEntityNotExist is the RAM error-code family for a subject that is
+// not there — EntityNotExist.User, EntityNotExist.User.AccessKey, and so on.
+const alicloudCodeEntityNotExist = "EntityNotExist"
+
+// alicloudMaxRAMKeysPerUser is the number of access keys RAM allows one user to
+// hold. Rotation needs a free slot to create the new key in, which is the only
+// reason it ever removes an existing one.
+const alicloudMaxRAMKeysPerUser = 2
+
+// makeRoomForNewKey frees a slot so CreateAccessKey can succeed, and does so
+// without destroying a key it cannot attribute to Warden.
+//
+// It acts only when the user is at the cap, removes at most one key per attempt,
+// and deletes only a key that is already Inactive — the state Warden's own
+// interrupted cleanup leaves behind, since CleanupRotation deactivates before it
+// deletes. An Active key that is not the current one is deactivated instead, and
+// the attempt stops with an error; the retry finds it Inactive and reclaims the
+// slot. The rotation manager retries a failed prepare on an exponential backoff
+// starting around twenty seconds, so that detour costs one short retry, not a
+// rotation period.
+//
+// It exists because rotation must still be able to heal itself. Two paths leave
+// an Active key of Warden's own behind — a crash between CreateAccessKey and the
+// staged-rotation persist, and a staged activation exhausting its attempts, after
+// which the manager resets to idle and prepares afresh — so refusing to touch
+// Active keys at all would wedge rotation permanently once either happened.
+// Deactivating a genuine third-party key is disruptive but reversible; deleting
+// one is not, which is the trade this makes.
+func (d *AlicloudDriver) makeRoomForNewKey(
+	ctx context.Context,
+	ramEndpoint, mgmtID, mgmtSecret, userName string,
+	keys []alicloudAccessKey,
+) error {
+	if len(keys) < alicloudMaxRAMKeysPerUser {
+		return nil
+	}
+
+	// The current key must be among the user's own. If it is not, the source is
+	// pointed at the wrong management_user_name (or the key belongs to another
+	// user), and every key listed here belongs to someone else — so touch none of
+	// them and say why.
+	var candidate *alicloudAccessKey
+	currentFound := false
+	for i := range keys {
+		switch {
+		case keys[i].AccessKeyID == mgmtID:
+			currentFound = true
+		case candidate == nil:
+			candidate = &keys[i]
+		}
+	}
+	if !currentFound {
+		return fmt.Errorf(
+			"RAM user %q holds %d access keys, none of them the configured access_key_id %s: "+
+				"refusing to remove a key this source does not own (check management_user_name)",
+			userName, len(keys), truncateID(mgmtID, 8))
+	}
+	if candidate == nil {
+		return nil
+	}
+
+	if candidate.Status == alicloudAccessKeyInactive {
+		d.logger.Warn("deleting inactive orphaned RAM access key from an interrupted rotation",
+			logger.String("orphaned_key_id", truncateID(candidate.AccessKeyID, 8)),
+			logger.String("ram_user", userName),
+		)
+		del := url.Values{}
+		del.Set("Action", "DeleteAccessKey")
+		del.Set("Version", alicloudRAMVersion)
+		del.Set("Format", "JSON")
+		del.Set("UserName", userName)
+		del.Set(ramParamUserAccessKeyID, candidate.AccessKeyID)
+		if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
+			return fmt.Errorf("failed to delete orphaned access key %s: %w", truncateID(candidate.AccessKeyID, 8), err)
+		}
+		return nil
+	}
+
+	d.logger.Warn("deactivating an active non-current RAM access key to free a rotation slot; "+
+		"it will be deleted on the next rotation attempt",
+		logger.String("key_id", truncateID(candidate.AccessKeyID, 8)),
+		logger.String("ram_user", userName),
+	)
+	inactivate := url.Values{}
+	inactivate.Set("Action", "UpdateAccessKey")
+	inactivate.Set("Version", alicloudRAMVersion)
+	inactivate.Set("Format", "JSON")
+	inactivate.Set("UserName", userName)
+	inactivate.Set(ramParamUserAccessKeyID, candidate.AccessKeyID)
+	inactivate.Set("Status", alicloudAccessKeyInactive)
+	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, inactivate, mgmtID, mgmtSecret, ""); err != nil {
+		return fmt.Errorf("failed to deactivate non-current access key %s: %w", truncateID(candidate.AccessKeyID, 8), err)
+	}
+
+	return fmt.Errorf(
+		"RAM user %q is at the %d-key limit and the non-current key %s was still active; "+
+			"it has been deactivated and will be removed on the next rotation attempt. "+
+			"If it is not Warden's, reactivate it and give this source a dedicated RAM user",
+		userName, alicloudMaxRAMKeysPerUser, truncateID(candidate.AccessKeyID, 8))
+}
+
 // PrepareRotation creates a new RAM access key for the configured management
-// user while the existing key remains valid. Before creating, it deletes any
-// orphaned keys from previous failed rotations (RAM allows at most 2 keys per
-// user). Returns the new config, a cleanup config (with the old access_key_id),
-// and the activation delay to let RAM eventual consistency propagate.
+// user while the existing key remains valid. If the user is at RAM's two-key
+// limit it first frees a slot (see makeRoomForNewKey). Returns the new config, a
+// cleanup config (with the old access_key_id), and the activation delay to let
+// RAM eventual consistency propagate.
 func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
 	d.configMu.RLock()
 	mgmtID := credential.GetString(d.credSource.Config, "access_key_id", "")
@@ -556,9 +668,8 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 		return nil, nil, 0, fmt.Errorf("management_user_name is required for rotation")
 	}
 
-	// Step 1: clean up orphaned keys from previous failed rotations.
-	// RAM users can hold at most 2 access keys; if there are already 2, remove
-	// any that aren't our current management key before creating the new one.
+	// Step 1: list the user's keys, so a slot can be freed if the RAM two-key
+	// limit would otherwise make CreateAccessKey fail.
 	listParams := url.Values{}
 	listParams.Set("Action", "ListAccessKeys")
 	listParams.Set("Version", alicloudRAMVersion)
@@ -571,33 +682,15 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	}
 	var listResp struct {
 		AccessKeys struct {
-			AccessKey []struct {
-				AccessKeyID string `json:"AccessKeyId"`
-				Status      string `json:"Status"`
-			} `json:"AccessKey"`
+			AccessKey []alicloudAccessKey `json:"AccessKey"`
 		} `json:"AccessKeys"`
 	}
 	if err := json.Unmarshal(listBody, &listResp); err != nil {
 		return nil, nil, 0, fmt.Errorf("parse ListAccessKeys response: %w", err)
 	}
 
-	for _, k := range listResp.AccessKeys.AccessKey {
-		if k.AccessKeyID == mgmtID {
-			continue
-		}
-		d.logger.Warn("deleting orphaned RAM access key from previous failed rotation",
-			logger.String("orphaned_key_id", truncateID(k.AccessKeyID, 8)),
-			logger.String("ram_user", userName),
-		)
-		del := url.Values{}
-		del.Set("Action", "DeleteAccessKey")
-		del.Set("Version", alicloudRAMVersion)
-		del.Set("Format", "JSON")
-		del.Set("UserName", userName)
-		del.Set(ramParamUserAccessKeyID, k.AccessKeyID)
-		if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
-			return nil, nil, 0, fmt.Errorf("failed to delete orphaned access key %s: %w", truncateID(k.AccessKeyID, 8), err)
-		}
+	if err := d.makeRoomForNewKey(ctx, ramEndpoint, mgmtID, mgmtSecret, userName, listResp.AccessKeys.AccessKey); err != nil {
+		return nil, nil, 0, err
 	}
 
 	// Step 2: create a new access key for the same user.
@@ -691,9 +784,22 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	inactivate.Set("Format", "JSON")
 	inactivate.Set("UserName", userName)
 	inactivate.Set(ramParamUserAccessKeyID, oldKeyID)
-	inactivate.Set("Status", "Inactive")
+	inactivate.Set("Status", alicloudAccessKeyInactive)
 
 	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, inactivate, mgmtID, mgmtSecret, ""); err != nil {
+		// A key that is already gone is the outcome this is working towards, so
+		// it is success, not failure. Cleanup is retried for days after a failure,
+		// and the next rotation's slot-freeing sweep can delete the very key a
+		// pending cleanup is still chasing — without this, those retries would
+		// fail daily and eventually log an abandonment for a key that no longer
+		// exists.
+		if alicloudErrorHasCodePrefix(err, alicloudCodeEntityNotExist) {
+			d.logger.Info("old management access key was already removed; cleanup is complete",
+				logger.String("old_key_id", truncateID(oldKeyID, 8)),
+				logger.String("ram_user", userName),
+			)
+			return nil
+		}
 		return fmt.Errorf("RAM UpdateAccessKey (Inactive) failed: %w", err)
 	}
 	d.logger.Info("disabled old management access key",
@@ -710,7 +816,10 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	del.Set(ramParamUserAccessKeyID, oldKeyID)
 
 	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
-		return fmt.Errorf("RAM DeleteAccessKey (old management key) failed: %w", err)
+		// Same reasoning as the Inactive step: deleted is deleted, whoever did it.
+		if !alicloudErrorHasCodePrefix(err, alicloudCodeEntityNotExist) {
+			return fmt.Errorf("RAM DeleteAccessKey (old management key) failed: %w", err)
+		}
 	}
 
 	d.logger.Info("deleted old management access key after rotation",

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -649,6 +649,17 @@ type ramServer struct {
 	actionSeq     []string // action names in the order received, for ordering assertions
 }
 
+// writeEntityNotExist replies as RAM does for an access key that is not there:
+// an error envelope on HTTP 404, not a bare status.
+func (s *ramServer) writeEntityNotExist(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNotFound)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"Code":      "EntityNotExist.User.AccessKey",
+		"Message":   "The specified access key does not exist.",
+		"RequestId": "req-not-exist",
+	})
+}
+
 func (s *ramServer) handle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	action := r.URL.Query().Get("Action")
@@ -688,7 +699,7 @@ func (s *ramServer) handle(w http.ResponseWriter, r *http.Request) {
 		id := r.URL.Query().Get("UserAccessKeyId")
 		status := r.URL.Query().Get("Status")
 		if _, ok := s.keys[id]; !ok {
-			http.Error(w, "no such key", http.StatusBadRequest)
+			s.writeEntityNotExist(w)
 			return
 		}
 		s.keys[id] = status
@@ -698,6 +709,10 @@ func (s *ramServer) handle(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"RequestId": "req"})
 	case "DeleteAccessKey":
 		id := r.URL.Query().Get("UserAccessKeyId")
+		if _, ok := s.keys[id]; !ok {
+			s.writeEntityNotExist(w)
+			return
+		}
 		delete(s.keys, id)
 		s.deleted = append(s.deleted, id)
 		_ = json.NewEncoder(w).Encode(map[string]any{"RequestId": "req"})
@@ -766,36 +781,120 @@ func TestAlicloudDriver_Rotation_HappyPath(t *testing.T) {
 	assert.Less(t, updateIdx, deleteIdx, "UpdateAccessKey(Inactive) must precede DeleteAccessKey")
 }
 
-func TestAlicloudDriver_Rotation_OrphanCleanup(t *testing.T) {
-	// Simulate a previous failed rotation that left an orphan key behind.
+// newRotationDriver builds a driver pointed at a ramServer, holding keyID as its
+// current management key.
+func newRotationDriver(t *testing.T, srvURL, keyID string) *AlicloudDriver {
+	t.Helper()
+	f := &AlicloudDriverFactory{}
+	d, err := f.Create(map[string]string{
+		"access_key_id":        keyID,
+		"access_key_secret":    "secret-" + keyID,
+		"management_user_name": "warden-management",
+		"ram_endpoint":         srvURL,
+	}, createAlicloudTestLogger())
+	require.NoError(t, err)
+	return d.(*AlicloudDriver)
+}
+
+// An Inactive orphan is what Warden's own interrupted cleanup leaves behind
+// (CleanupRotation deactivates before it deletes), so it can be reclaimed
+// immediately.
+func TestAlicloudDriver_Rotation_SweepsInactiveOrphanAtCap(t *testing.T) {
 	ram := &ramServer{
 		user: "warden-management",
 		keys: map[string]string{
 			"LTAI-old":    "Active",
-			"LTAI-orphan": "Active", // at the RAM two-key limit
+			"LTAI-orphan": "Inactive", // at the RAM two-key limit
 		},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
 	defer srv.Close()
 
-	f := &AlicloudDriverFactory{}
-	d, _ := f.Create(map[string]string{
-		"access_key_id":        "LTAI-old",
-		"access_key_secret":    "old-secret",
-		"management_user_name": "warden-management",
-		"ram_endpoint":         srv.URL,
-	}, createAlicloudTestLogger())
-	drv := d.(*AlicloudDriver)
-
-	newConfig, _, _, err := drv.PrepareRotation(context.Background())
+	newConfig, _, _, err := newRotationDriver(t, srv.URL, "LTAI-old").
+		PrepareRotation(context.Background())
 	require.NoError(t, err)
 
-	// Orphan should have been deleted before create
-	assert.Contains(t, ram.deleted, "LTAI-orphan")
-	// Current key must not be touched by orphan cleanup
-	assert.NotContains(t, ram.deleted, "LTAI-old")
-	// New key should have been created
+	assert.Equal(t, []string{"LTAI-orphan"}, ram.deleted)
+	assert.NotContains(t, ram.deleted, "LTAI-old", "the current key must never be swept")
 	assert.Equal(t, "LTAI-rotated-1", newConfig["access_key_id"])
+}
+
+// An Active non-current key is not one Warden can attribute to itself, so it is
+// deactivated rather than deleted and the cycle stops. The next cycle finds it
+// Inactive and reclaims the slot — rotation heals itself without ever destroying
+// a key outright.
+func TestAlicloudDriver_Rotation_DeactivatesActiveKeyThenSweepsNextCycle(t *testing.T) {
+	ram := &ramServer{
+		user: "warden-management",
+		keys: map[string]string{
+			"LTAI-old":        "Active",
+			"LTAI-breakglass": "Active", // at the cap, and not ours
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+	defer srv.Close()
+	drv := newRotationDriver(t, srv.URL, "LTAI-old")
+
+	// First cycle: deactivate, refuse to go further, create nothing.
+	_, _, _, err := drv.PrepareRotation(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deactivated")
+	assert.Equal(t, []string{"LTAI-breakglass"}, ram.deactivated)
+	assert.Empty(t, ram.deleted, "an active key must never be deleted outright")
+	assert.Empty(t, ram.created, "no key may be created while the user is at the cap")
+	assert.Equal(t, "Inactive", ram.keys["LTAI-breakglass"])
+
+	// Second cycle: the slot is now reclaimable and rotation proceeds.
+	newConfig, _, _, err := drv.PrepareRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"LTAI-breakglass"}, ram.deleted)
+	assert.Equal(t, "LTAI-rotated-1", newConfig["access_key_id"])
+}
+
+// Below the cap there is a free slot already, so nothing is swept whatever its
+// status — the only reason to remove a key is to make room.
+func TestAlicloudDriver_Rotation_BelowCapSweepsNothing(t *testing.T) {
+	for _, status := range []string{"Active", "Inactive"} {
+		t.Run("sole key is "+status, func(t *testing.T) {
+			ram := &ramServer{
+				user: "warden-management",
+				keys: map[string]string{"LTAI-old": status},
+			}
+			srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+			defer srv.Close()
+
+			_, _, _, err := newRotationDriver(t, srv.URL, "LTAI-old").
+				PrepareRotation(context.Background())
+			require.NoError(t, err)
+
+			assert.Empty(t, ram.deleted)
+			assert.Empty(t, ram.deactivated)
+			assert.Equal(t, []string{"LTAI-rotated-1"}, ram.created)
+		})
+	}
+}
+
+// If the configured key is not among the user's own, every key listed belongs to
+// someone else — most likely management_user_name is wrong. Touch none of them.
+func TestAlicloudDriver_Rotation_RefusesWhenCurrentKeyIsNotTheUsers(t *testing.T) {
+	ram := &ramServer{
+		user: "warden-management",
+		keys: map[string]string{
+			"LTAI-someone-else":   "Active",
+			"LTAI-someone-else-2": "Active",
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+	defer srv.Close()
+
+	_, _, _, err := newRotationDriver(t, srv.URL, "LTAI-not-on-this-user").
+		PrepareRotation(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "management_user_name")
+	assert.Empty(t, ram.deleted)
+	assert.Empty(t, ram.deactivated)
+	assert.Empty(t, ram.created)
 }
 
 func TestAlicloudDriver_Rotation_MissingConfig(t *testing.T) {
@@ -834,6 +933,54 @@ func TestAlicloudDriver_Rotation_CleanupRefusesCurrentKey(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "currently active")
+}
+
+// Cleanup is retried for days after a failure, and the next rotation's
+// slot-freeing sweep can delete the very key a pending cleanup is still chasing.
+// Cleaning up an already-deleted key must therefore succeed: otherwise those
+// retries fail daily until the manager logs an abandonment for a key that no
+// longer exists.
+func TestAlicloudDriver_Rotation_CleanupIsIdempotent(t *testing.T) {
+	ram := &ramServer{
+		user: "warden-management",
+		keys: map[string]string{"LTAI-new": "Active"}, // LTAI-old already gone
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+	defer srv.Close()
+
+	err := newRotationDriver(t, srv.URL, "LTAI-new").
+		CleanupRotation(context.Background(), map[string]string{
+			"access_key_id":        "LTAI-old",
+			"management_user_name": "warden-management",
+		})
+
+	require.NoError(t, err, "cleaning up an already-deleted key is the outcome we wanted")
+	assert.Empty(t, ram.deleted)
+	assert.Equal(t, "Active", ram.keys["LTAI-new"], "the live key must be untouched")
+}
+
+// Idempotency must not swallow a real failure: only the not-there family counts
+// as already-done.
+func TestAlicloudDriver_Rotation_CleanupStillFailsOnOtherErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Code":      "NoPermission",
+			"Message":   "ram:UpdateAccessKey is not granted.",
+			"RequestId": "req-denied",
+		})
+	}))
+	defer srv.Close()
+
+	err := newRotationDriver(t, srv.URL, "LTAI-new").
+		CleanupRotation(context.Background(), map[string]string{
+			"access_key_id":        "LTAI-old",
+			"management_user_name": "warden-management",
+		})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NoPermission")
 }
 
 // The defect this PR fixes, at the level it actually bites. CleanupRotation


### PR DESCRIPTION
**PR 2 of 5.** Stacked on #535 — review that first; this PR's diff is the top commit only.

`PrepareRotation` frees a slot before creating the new management key, because RAM caps a user at two. The sweep was meant to remove a key left behind by an interrupted rotation, and its comment says so — *"if there are already 2, remove any that aren't our current management key"* — but the loop had **neither the count check nor a stop after the first deletion**. It deleted every non-current key on the user, on every rotation. An operator break-glass key, or a second source sharing `management_user_name`, was destroyed the first time rotation ran, with only a warning in the log.

The AWS driver, which this was copied from, gates on the key count and breaks after one. This is a regression against the sibling, not a novel design gap.

## What changed

Restore both guards, and go further: delete only a key that is already **Inactive**, which is the state Warden's own interrupted cleanup leaves behind since `CleanupRotation` deactivates before it deletes.

An **Active** non-current key is deactivated instead, and the attempt stops with an error naming it. The retry — the manager backs off ~20s and tries again — finds it Inactive and reclaims the slot.

Refusing to touch Active keys outright would have been safer still, but two paths leave an Active key of Warden's own behind (a crash between `CreateAccessKey` and the staged persist; a staged activation exhausting its attempts, after which the manager prepares afresh), so a strict rule would **wedge rotation permanently** once either happened. Deactivating a third-party key is disruptive but reversible; deleting one is not.

Also refuses to sweep anything when the configured `access_key_id` is not among the user's own keys — every key listed then belongs to someone else, and the likely cause is a wrong `management_user_name`.

## Also: cleanup idempotency

A pending cleanup is retried for days, and the next rotation's sweep can delete the very key it is still chasing; `EntityNotExist.*` then failed every retry until the manager logged an abandonment for a key that no longer existed. Treat that family as success on both steps — deleted is deleted. Other failures, `NoPermission` included, still fail.

## Verification

The old orphan-cleanup test encoded the unsafe behaviour and is replaced by four covering the Inactive sweep, the deactivate-then-reclaim two-step, below-the-cap doing nothing, and the not-our-user refusal — plus two for idempotency, including one asserting `NoPermission` still fails so it does not swallow real errors.