### PR TITLE
fix(alicloud): correct lease TTL, canonical query, and dead mint methods

### DIFF
--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -248,6 +248,11 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		return nil, nil, 0, "", fmt.Errorf("STS returned empty credentials")
 	}
 
+	leaseTTL, err := d.stsLeaseTTL(resp.Credentials.Expiration, duration)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	d.logger.Info("issued STS temporary credentials",
 		logger.String("access_key", truncateID(resp.Credentials.AccessKeyID, 8)),
 		logger.String("role_arn", roleARN),
@@ -258,7 +263,46 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		"access_key_id":     resp.Credentials.AccessKeyID,
 		"access_key_secret": resp.Credentials.AccessKeySecret,
 		"security_token":    resp.Credentials.SecurityToken,
-	}, nil, duration, "", nil // STS tokens are self-expiring; no leaseID
+	}, nil, leaseTTL, "", nil // STS tokens are self-expiring; no leaseID
+}
+
+// stsLeaseTTL converts the Expiration STS reports into a lease TTL.
+//
+// The requested duration alone is the wrong answer: it is measured before the
+// round trip, so the lease outlives the credential by however long the call took,
+// and it ignores an expiry STS shortened for its own reasons. The credential is
+// cached for its whole lease, so an over-long lease means a cache hit near the
+// end hands out a token that dies mid-request. The aws, gcp, ibm, elastic and
+// github drivers all derive their TTL from the server's expiry for this reason.
+//
+// The reported expiry is also capped at the requested duration, because it is
+// only as trustworthy as the agreement between two clocks. A local clock running
+// behind Alibaba's would otherwise reintroduce the very over-long lease this
+// exists to prevent, just bounded by skew rather than by round-trip time. STS
+// never issues longer than asked, so a longer expiry means skew, not generosity.
+//
+// An unparseable Expiration falls back to the requested duration: a usable
+// credential should not be thrown away over a timestamp format, and the fallback
+// is no worse than the behaviour this replaces. An expiry already in the past is
+// a different matter — there is no usable credential to return.
+func (d *AlicloudDriver) stsLeaseTTL(expiration string, requested time.Duration) (time.Duration, error) {
+	expiry, err := time.Parse(time.RFC3339, expiration)
+	if err != nil {
+		d.logger.Warn("STS returned an Expiration that is not RFC3339; falling back to the requested duration",
+			logger.String("expiration", expiration),
+			logger.String("requested", requested.String()),
+		)
+		return requested, nil
+	}
+
+	ttl := time.Until(expiry)
+	if ttl <= 0 {
+		return 0, fmt.Errorf("STS returned credentials that already expired at %s", expiration)
+	}
+	if ttl > requested {
+		return requested, nil
+	}
+	return ttl, nil
 }
 
 // Revoke is a no-op: the driver's only supported mint method (assume_role)

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/logger"
@@ -126,6 +127,7 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 	var receivedAuth string
 	var receivedRoleArn string
 
+	expiry := time.Now().Add(1800 * time.Second).UTC().Format(time.RFC3339)
 	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAction = r.URL.Query().Get("Action")
 		receivedRoleArn = r.URL.Query().Get("RoleArn")
@@ -136,7 +138,7 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 				"AccessKeyId":     "STS.tempid",
 				"AccessKeySecret": "tempsecret",
 				"SecurityToken":   "tempstsToken",
-				"Expiration":      "2099-01-01T00:00:00Z",
+				"Expiration":      expiry,
 			},
 		})
 	}))
@@ -164,7 +166,10 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 	assert.Equal(t, "STS.tempid", raw["access_key_id"])
 	assert.Equal(t, "tempsecret", raw["access_key_secret"])
 	assert.Equal(t, "tempstsToken", raw["security_token"])
-	assert.Equal(t, 1800, int(ttl.Seconds()), "ttl should match duration_seconds")
+	// Derived from the Expiration STS reported, so it is at most the requested
+	// 1800s — never more, whatever the round trip cost.
+	assert.InDelta(t, 1800, ttl.Seconds(), 5, "ttl should track the reported expiry")
+	assert.LessOrEqual(t, ttl, 1800*time.Second)
 	assert.Equal(t, "", leaseID, "STS has no leaseID")
 
 	// Verify the request was signed with ACS3 and had the right params
@@ -172,6 +177,87 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 	assert.Equal(t, "acs:ram::123:role/ops", receivedRoleArn)
 	assert.True(t, strings.HasPrefix(receivedAuth, "ACS3-HMAC-SHA256"), "must be ACS3 signed: %q", receivedAuth)
 	assert.Contains(t, receivedAuth, "Credential=LTAI-mgmt")
+}
+
+// mintWithExpiration mints one credential against an STS stub that reports the
+// given Expiration verbatim, and returns the resulting lease TTL.
+func mintWithExpiration(t *testing.T, expiration, durationSeconds string) (time.Duration, error) {
+	t.Helper()
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.tempid",
+				"AccessKeySecret": "tempsecret",
+				"SecurityToken":   "tempstsToken",
+				"Expiration":      expiration,
+			},
+		})
+	}))
+	t.Cleanup(sts.Close)
+
+	f := &AlicloudDriverFactory{}
+	d, err := f.Create(map[string]string{
+		"access_key_id":     "LTAI-mgmt",
+		"access_key_secret": "mgmt-secret",
+		"sts_endpoint":      sts.URL,
+	}, createAlicloudTestLogger())
+	require.NoError(t, err)
+
+	_, _, ttl, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+		Config: map[string]string{
+			"mint_method":      "assume_role",
+			"role_arn":         "acs:ram::123:role/ops",
+			"duration_seconds": durationSeconds,
+		},
+	})
+	return ttl, err
+}
+
+// The lease must follow the credential, not the request. STS is free to issue a
+// shorter session than was asked for; caching for the requested duration would
+// then serve a dead token to whoever hits the cache near the end.
+func TestAlicloudDriver_MintAssumeRole_TTLFollowsServerExpiry(t *testing.T) {
+	shortened := time.Now().Add(600 * time.Second).UTC().Format(time.RFC3339)
+
+	ttl, err := mintWithExpiration(t, shortened, "3600s")
+
+	require.NoError(t, err)
+	assert.InDelta(t, 600, ttl.Seconds(), 5, "the reported expiry wins over the requested duration")
+}
+
+// The reported expiry is only as good as the agreement between two clocks. A
+// local clock running behind Alibaba's reports a remaining lifetime longer than
+// was ever requested, which would reintroduce the over-long lease this fix
+// exists to prevent — so the requested duration is the ceiling. STS never issues
+// longer than asked, so a longer expiry means skew, not generosity.
+func TestAlicloudDriver_MintAssumeRole_TTLCappedAtRequestedDuration(t *testing.T) {
+	skewed := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+
+	ttl, err := mintWithExpiration(t, skewed, "1800s")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1800*time.Second, ttl, "an expiry beyond the requested duration must be capped")
+}
+
+// A credential that is usable should not be discarded over a timestamp format,
+// so an unparseable Expiration falls back to the requested duration — no worse
+// than the behaviour this replaced.
+func TestAlicloudDriver_MintAssumeRole_UnparseableExpiryFallsBack(t *testing.T) {
+	ttl, err := mintWithExpiration(t, "not-a-timestamp", "1800s")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1800*time.Second, ttl)
+}
+
+// An expiry already in the past leaves nothing usable to hand back.
+func TestAlicloudDriver_MintAssumeRole_ExpiredCredentialIsRejected(t *testing.T) {
+	past := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+
+	_, err := mintWithExpiration(t, past, "1800s")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already expired")
 }
 
 func TestAlicloudDriver_MintAssumeRole_MissingRoleArn(t *testing.T) {
@@ -1130,4 +1216,36 @@ func TestSignACS3_KnownAnswer(t *testing.T) {
 		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		r.Header.Get("x-acs-content-sha256"),
 	)
+}
+
+// ACS3 sorts by parameter name only. A repeated name keeps the order it arrived
+// in, because that is the order the server signs; sorting the values would
+// compute a canonical string the server does not derive. This matches the
+// identical helper in provider/alicloud/signature.go.
+func TestACS3CanonicalQuery(t *testing.T) {
+	got, err := acs3CanonicalQuery("b=2&a=1&c=hello%20world")
+	require.NoError(t, err)
+	assert.Equal(t, "a=1&b=2&c=hello%20world", got)
+
+	got, err = acs3CanonicalQuery("k=b&k=a&j=1")
+	require.NoError(t, err)
+	assert.Equal(t, "j=1&k=b&k=a", got, "values for a repeated name keep request order")
+
+	got, err = acs3CanonicalQuery("")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// A query that will not parse must be reported, not silently rendered as empty:
+// signing an empty canonical query for a request that has one produces a
+// signature the server cannot reproduce, surfacing as a confusing remote
+// SignatureDoesNotMatch instead of the local defect.
+func TestACS3CanonicalQuery_MalformedQueryIsReported(t *testing.T) {
+	_, err := acs3CanonicalQuery("a=%zz")
+	require.Error(t, err)
+
+	r, _ := http.NewRequest("POST", "https://sts.aliyuncs.com/", nil)
+	r.URL.RawQuery = "a=%zz"
+	assert.Error(t, signACS3(r, "LTAItest", "secret", "", nil),
+		"signACS3 should surface a malformed query rather than sign an empty one")
 }

--- a/credential/drivers/alicloud_sign.go
+++ b/credential/drivers/alicloud_sign.go
@@ -66,10 +66,15 @@ func signACS3(r *http.Request, accessKeyID, accessKeySecret, securityToken strin
 		rawQuery = r.URL.RawQuery
 	}
 
+	canonicalQuery, err := acs3CanonicalQuery(rawQuery)
+	if err != nil {
+		return err
+	}
+
 	canonicalRequest := strings.Join([]string{
 		r.Method,
 		canonicalURI,
-		acs3CanonicalQuery(rawQuery),
+		canonicalQuery,
 		canonicalHdrs,
 		signedHeadersStr,
 		bodyHash,
@@ -157,13 +162,17 @@ func acs3CanonicalHeaders(r *http.Request, signed []string) (canonical, signedSt
 	return b.String(), strings.Join(normalized, ";")
 }
 
-func acs3CanonicalQuery(rawQuery string) string {
+// acs3CanonicalQuery renders rawQuery in ACS3 canonical form. A query that will
+// not parse is reported rather than rendered as empty: signing an empty query for
+// a request that has one produces a signature the server cannot reproduce, so the
+// caller would see a remote SignatureDoesNotMatch instead of the local defect.
+func acs3CanonicalQuery(rawQuery string) (string, error) {
 	if rawQuery == "" {
-		return ""
+		return "", nil
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("malformed query string: %w", err)
 	}
 	keys := make([]string, 0, len(values))
 	for k := range values {
@@ -180,7 +189,7 @@ func acs3CanonicalQuery(rawQuery string) string {
 			parts = append(parts, acs3Encode(k)+"="+acs3Encode(v))
 		}
 	}
-	return strings.Join(parts, "&")
+	return strings.Join(parts, "&"), nil
 }
 
 func acs3Encode(s string) string {

--- a/credential/types/alicloud_keys.go
+++ b/credential/types/alicloud_keys.go
@@ -41,18 +41,9 @@ func (t *AlicloudKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example(""),
 
 		credential.StringField("mint_method").
-			OneOf("static_alicloud", "assume_role").
-			Describe("Mint method for credential minting. Use static_alicloud with a hvault source, or assume_role with an alicloud source.").
+			OneOf("assume_role").
+			Describe("Mint method for credential minting. Use assume_role with an alicloud source.").
 			Example("assume_role"),
-
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_alicloud)").
-			Example("secret"),
-
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_alicloud)").
-			Example("alicloud/prod/keys"),
 
 		// STS assume_role fields
 		credential.StringField("role_arn").
@@ -75,11 +66,11 @@ func (t *AlicloudKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 // ValidateConfig validates the Config for an Alicloud credential spec
 func (t *AlicloudKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	switch sourceType {
-	case credential.SourceTypeVault, credential.SourceTypeAlicloud:
-		// Supported
-	default:
-		return fmt.Errorf("alicloud_keys credentials require a vault or alicloud source, got: %s", sourceType)
+	// A vault source is not supported: it would need a static_alicloud mint method,
+	// which the Vault driver has never implemented. It used to be accepted here and
+	// then failed at the first mint.
+	if sourceType != credential.SourceTypeAlicloud {
+		return fmt.Errorf("alicloud_keys credentials require an alicloud source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -87,25 +78,11 @@ func (t *AlicloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 		return err
 	}
 
-	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_alicloud" {
-			return fmt.Errorf("'mint_method' must be 'static_alicloud' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_alicloud")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_alicloud")
-		}
-	case credential.SourceTypeAlicloud:
-		mintMethod := config["mint_method"]
-		if mintMethod != "assume_role" {
-			return fmt.Errorf("'mint_method' must be 'assume_role' for alicloud source, got: %s", mintMethod)
-		}
-		if config["role_arn"] == "" {
-			return fmt.Errorf("'role_arn' is required for assume_role")
-		}
+	if mintMethod := config["mint_method"]; mintMethod != "assume_role" {
+		return fmt.Errorf("'mint_method' must be 'assume_role' for alicloud source, got: %s", mintMethod)
+	}
+	if config["role_arn"] == "" {
+		return fmt.Errorf("'role_arn' is required for assume_role")
 	}
 
 	return nil

--- a/credential/types/alicloud_keys_test.go
+++ b/credential/types/alicloud_keys_test.go
@@ -1,0 +1,150 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlicloudKeysCredType_Metadata(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	md := ct.Metadata()
+	assert.Equal(t, credential.TypeAlicloudKeys, md.Name)
+	assert.Equal(t, credential.CategoryCloudIAM, md.Category)
+}
+
+func TestAlicloudKeysCredType_ValidateConfig_AlicloudSource(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	tests := []struct {
+		name   string
+		config map[string]string
+		errMsg string
+	}{
+		{
+			name: "valid assume_role config",
+			config: map[string]string{
+				"mint_method": "assume_role",
+				"role_arn":    "acs:ram::123456789012:role/warden",
+			},
+		},
+		{
+			name: "valid with optional fields",
+			config: map[string]string{
+				"mint_method":       "assume_role",
+				"role_arn":          "acs:ram::123456789012:role/warden",
+				"role_session_name": "warden-session",
+				"duration_seconds":  "3600s",
+			},
+		},
+		{
+			name:   "missing mint_method",
+			config: map[string]string{"role_arn": "acs:ram::123456789012:role/warden"},
+			errMsg: "mint_method",
+		},
+		{
+			name: "missing role_arn",
+			config: map[string]string{
+				"mint_method": "assume_role",
+			},
+			errMsg: "role_arn",
+		},
+		{
+			// duration_seconds is a duration field, so a bare integer is not
+			// accepted — it needs the unit.
+			name: "duration_seconds without a unit",
+			config: map[string]string{
+				"mint_method":      "assume_role",
+				"role_arn":         "acs:ram::123456789012:role/warden",
+				"duration_seconds": "3600",
+			},
+			errMsg: "duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeAlicloud)
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// A vault source needed a static_alicloud mint method that the Vault driver never
+// implemented, so such a spec passed validation here and then failed at its first
+// mint. It is refused at create now.
+func TestAlicloudKeysCredType_ValidateConfig_VaultSourceRejected(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "static_alicloud",
+		"kv2_mount":   "secret",
+		"secret_path": "alicloud/prod/keys",
+	}, credential.SourceTypeVault)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alicloud source")
+}
+
+func TestAlicloudKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "assume_role",
+		"role_arn":    "acs:ram::123456789012:role/warden",
+	}, credential.SourceTypeAWS)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alicloud source")
+}
+
+func TestAlicloudKeysCredType_Parse(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+
+	t.Run("STS credentials with a security token", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key_id":     "STS.abc",
+			"access_key_secret": "sts-secret",
+			"security_token":    "sts-token",
+		}, nil, time.Hour, "")
+		require.NoError(t, err)
+		assert.Equal(t, credential.TypeAlicloudKeys, cred.Type)
+		assert.Equal(t, "STS.abc", cred.Data["access_key_id"])
+		assert.Equal(t, "sts-secret", cred.Data["access_key_secret"])
+		assert.Equal(t, "sts-token", cred.Data["security_token"])
+		assert.Equal(t, time.Hour, cred.LeaseTTL)
+	})
+
+	t.Run("security_token is omitted when empty", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key_id":     "LTAI.abc",
+			"access_key_secret": "secret",
+		}, nil, time.Hour, "")
+		require.NoError(t, err)
+		assert.NotContains(t, cred.Data, "security_token")
+	})
+
+	t.Run("missing fields are rejected", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{
+			"access_key_secret": "secret",
+		}, nil, time.Hour, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key_id")
+
+		_, err = ct.Parse(map[string]interface{}{
+			"access_key_id": "LTAI.abc",
+		}, nil, time.Hour, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key_secret")
+	})
+}
+
+func TestAlicloudKeysCredType_SensitiveConfigFields(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	fields := ct.SensitiveConfigFields()
+	assert.Contains(t, fields, "access_key_secret")
+	assert.Contains(t, fields, "security_token")
+}

--- a/credential/types/cloudflare_keys.go
+++ b/credential/types/cloudflare_keys.go
@@ -40,28 +40,19 @@ func (t *CloudflareKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("v1.0-xxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
 		credential.StringField("mint_method").
-			OneOf("static_keys", "static_cloudflare").
+			OneOf("static_keys").
 			Describe("Mint method for credential minting").
 			Example("static_keys"),
-
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_cloudflare)").
-			Example("secret"),
-
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_cloudflare)").
-			Example("cloudflare/prod/keys"),
 	}
 }
 
 // ValidateConfig validates the Config for a Cloudflare credential spec
 func (t *CloudflareKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	switch sourceType {
-	case credential.SourceTypeLocal, credential.SourceTypeVault:
-		// Supported
-	default:
-		return fmt.Errorf("cloudflare_keys credentials require a local or vault source, got: %s", sourceType)
+	// A vault source is not supported: it would need a static_cloudflare mint
+	// method, which the Vault driver has never implemented. It used to be accepted
+	// here and then failed at the first mint.
+	if sourceType != credential.SourceTypeLocal {
+		return fmt.Errorf("cloudflare_keys credentials require a local source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -69,30 +60,17 @@ func (t *CloudflareKeysCredType) ValidateConfig(config map[string]string, source
 		return err
 	}
 
-	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_cloudflare" {
-			return fmt.Errorf("'mint_method' must be 'static_cloudflare' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_cloudflare")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_cloudflare")
-		}
-	default:
-		hasAPI := config["api_token"] != ""
-		hasR2 := config["access_key_id"] != "" || config["secret_access_key"] != ""
-		if !hasAPI && !hasR2 {
-			return fmt.Errorf("at least one of 'api_token' (for API) or 'access_key_id'+'secret_access_key' (for R2) is required")
-		}
-		// If R2 fields are partially set, both must be present
-		if config["access_key_id"] != "" && config["secret_access_key"] == "" {
-			return fmt.Errorf("'secret_access_key' is required when 'access_key_id' is set")
-		}
-		if config["secret_access_key"] != "" && config["access_key_id"] == "" {
-			return fmt.Errorf("'access_key_id' is required when 'secret_access_key' is set")
-		}
+	hasAPI := config["api_token"] != ""
+	hasR2 := config["access_key_id"] != "" || config["secret_access_key"] != ""
+	if !hasAPI && !hasR2 {
+		return fmt.Errorf("at least one of 'api_token' (for API) or 'access_key_id'+'secret_access_key' (for R2) is required")
+	}
+	// If R2 fields are partially set, both must be present
+	if config["access_key_id"] != "" && config["secret_access_key"] == "" {
+		return fmt.Errorf("'secret_access_key' is required when 'access_key_id' is set")
+	}
+	if config["secret_access_key"] != "" && config["access_key_id"] == "" {
+		return fmt.Errorf("'access_key_id' is required when 'secret_access_key' is set")
 	}
 
 	return nil

--- a/credential/types/cloudflare_keys_test.go
+++ b/credential/types/cloudflare_keys_test.go
@@ -88,72 +88,18 @@ func TestCloudflareKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
 	}
 }
 
-func TestCloudflareKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
+// A vault source needed a static_cloudflare mint method that the Vault driver
+// never implemented, so such a spec passed validation here and then failed at its
+// first mint. It is refused at create now.
+func TestCloudflareKeysCredType_ValidateConfig_VaultSourceRejected(t *testing.T) {
 	ct := &CloudflareKeysCredType{}
-	tests := []struct {
-		name    string
-		config  map[string]string
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name: "valid vault config",
-			config: map[string]string{
-				"mint_method": "static_cloudflare",
-				"kv2_mount":   "secret",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing mint_method",
-			config: map[string]string{
-				"kv2_mount":   "secret",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "wrong mint_method",
-			config: map[string]string{
-				"mint_method": "static_keys",
-				"kv2_mount":   "secret",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "missing kv2_mount",
-			config: map[string]string{
-				"mint_method": "static_cloudflare",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "kv2_mount",
-		},
-		{
-			name: "missing secret_path",
-			config: map[string]string{
-				"mint_method": "static_cloudflare",
-				"kv2_mount":   "secret",
-			},
-			wantErr: true,
-			errMsg:  "secret_path",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "static_cloudflare",
+		"kv2_mount":   "secret",
+		"secret_path": "cloudflare/prod/keys",
+	}, credential.SourceTypeVault)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local source")
 }
 
 func TestCloudflareKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
@@ -164,7 +110,7 @@ func TestCloudflareKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
 		"api_token":         "test-api-token",
 	}, credential.SourceTypeAWS)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "local or vault")
+	assert.Contains(t, err.Error(), "local source")
 }
 
 func TestCloudflareKeysCredType_Parse(t *testing.T) {

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -37,18 +37,9 @@ func (t *ScalewayKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
 
 		credential.StringField("mint_method").
-			OneOf("static_scaleway", "static_keys", "dynamic_keys").
+			OneOf("static_keys", "dynamic_keys").
 			Describe("Mint method for credential minting").
 			Example("static_keys"),
-
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_scaleway)").
-			Example("secret"),
-
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_scaleway)").
-			Example("scaleway/prod/keys"),
 
 		// Scaleway dynamic_keys fields
 		credential.StringField("application_id").
@@ -71,11 +62,14 @@ func (t *ScalewayKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 // ValidateConfig validates the Config for a Scaleway credential spec
 func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	// A vault source is not supported: it would need a static_scaleway mint method,
+	// which the Vault driver has never implemented. It used to be accepted here and
+	// then failed at the first mint.
 	switch sourceType {
-	case credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeScaleway:
+	case credential.SourceTypeLocal, credential.SourceTypeScaleway:
 		// Supported
 	default:
-		return fmt.Errorf("scaleway_keys credentials require a local, vault, or scaleway source, got: %s", sourceType)
+		return fmt.Errorf("scaleway_keys credentials require a local or scaleway source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -84,16 +78,6 @@ func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceTy
 	}
 
 	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_scaleway" {
-			return fmt.Errorf("'mint_method' must be 'static_scaleway' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_scaleway")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_scaleway")
-		}
 	case credential.SourceTypeScaleway:
 		mintMethod := config["mint_method"]
 		switch mintMethod {

--- a/credential/types/scaleway_keys_test.go
+++ b/credential/types/scaleway_keys_test.go
@@ -72,72 +72,18 @@ func TestScalewayKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
 	}
 }
 
-func TestScalewayKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
+// A vault source needed a static_scaleway mint method that the Vault driver never
+// implemented, so such a spec passed validation here and then failed at its first
+// mint. It is refused at create now.
+func TestScalewayKeysCredType_ValidateConfig_VaultSourceRejected(t *testing.T) {
 	ct := &ScalewayKeysCredType{}
-	tests := []struct {
-		name    string
-		config  map[string]string
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name: "valid vault config",
-			config: map[string]string{
-				"mint_method": "static_scaleway",
-				"kv2_mount":   "secret",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing mint_method",
-			config: map[string]string{
-				"kv2_mount":   "secret",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "wrong mint_method",
-			config: map[string]string{
-				"mint_method": "dynamic_aws",
-				"kv2_mount":   "secret",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "missing kv2_mount",
-			config: map[string]string{
-				"mint_method": "static_scaleway",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "kv2_mount",
-		},
-		{
-			name: "missing secret_path",
-			config: map[string]string{
-				"mint_method": "static_scaleway",
-				"kv2_mount":   "secret",
-			},
-			wantErr: true,
-			errMsg:  "secret_path",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "static_scaleway",
+		"kv2_mount":   "secret",
+		"secret_path": "scaleway/prod/keys",
+	}, credential.SourceTypeVault)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local or scaleway")
 }
 
 func TestScalewayKeysCredType_ValidateConfig_ScalewaySource(t *testing.T) {
@@ -210,7 +156,7 @@ func TestScalewayKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
 		"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 	}, credential.SourceTypeAWS)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "local, vault, or scaleway")
+	assert.Contains(t, err.Error(), "local or scaleway")
 }
 
 func TestScalewayKeysCredType_Parse(t *testing.T) {

--- a/provider/alicloud/signature.go
+++ b/provider/alicloud/signature.go
@@ -127,15 +127,19 @@ func generateNonce() (string, error) {
 }
 
 // canonicalQueryString builds the canonical query string per ACS3 rules:
-// parameters sorted by key (then value), keys and values percent-encoded with
-// unreserved characters preserved, '=' appended for keys with empty values.
-func canonicalQueryString(rawQuery string) string {
+// parameters sorted by name, keys and values percent-encoded with unreserved
+// characters preserved, '=' appended for keys with empty values.
+// A query that will not parse is reported rather than rendered as empty: an
+// empty canonical query for a request that has one yields a signature neither
+// side can reproduce, surfacing as a remote SignatureDoesNotMatch on the signing
+// path and an unexplained rejection on the verifying one.
+func canonicalQueryString(rawQuery string) (string, error) {
 	if rawQuery == "" {
-		return ""
+		return "", nil
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("malformed query string: %w", err)
 	}
 
 	keys := make([]string, 0, len(values))
@@ -146,13 +150,17 @@ func canonicalQueryString(rawQuery string) string {
 
 	var parts []string
 	for _, k := range keys {
-		vs := values[k]
-		sort.Strings(vs)
-		for _, v := range vs {
+		// Sorted by name only. ACS3 has no notion of a repeated parameter — an
+		// array is flattened into indexed names (InstanceId.1, InstanceId.2), so
+		// every name is distinct and ordering values would never come up. A
+		// request that does repeat a name is signed by Alibaba in the order it
+		// arrived, so sorting the values here would compute a different string
+		// from the one the server derives and the signature would be rejected.
+		for _, v := range values[k] {
 			parts = append(parts, acs3Encode(k)+"="+acs3Encode(v))
 		}
 	}
-	return strings.Join(parts, "&")
+	return strings.Join(parts, "&"), nil
 }
 
 // acs3Encode percent-encodes s per ACS3 rules: unreserved characters stay as-is,
@@ -286,10 +294,15 @@ func SignACS3(r *http.Request, accessKeyID, accessKeySecret, securityToken strin
 		rawQuery = r.URL.RawQuery
 	}
 
+	canonicalQuery, err := canonicalQueryString(rawQuery)
+	if err != nil {
+		return err
+	}
+
 	canonicalRequest := strings.Join([]string{
 		r.Method,
 		canonicalURI,
-		canonicalQueryString(rawQuery),
+		canonicalQuery,
 		canonicalHdrs,
 		signedHeadersStr,
 		hashSHA256(body),
@@ -336,10 +349,15 @@ func VerifyACS3(r *http.Request, accessKeySecret string, body []byte) (bool, err
 		return false, fmt.Errorf("body hash does not match x-acs-content-sha256 header")
 	}
 
+	canonicalQuery, err := canonicalQueryString(rawQuery)
+	if err != nil {
+		return false, err
+	}
+
 	canonicalRequest := strings.Join([]string{
 		r.Method,
 		canonicalURI,
-		canonicalQueryString(rawQuery),
+		canonicalQuery,
 		canonicalHdrs,
 		signedHeadersStr,
 		contentHash,

--- a/provider/alicloud/signature_test.go
+++ b/provider/alicloud/signature_test.go
@@ -134,13 +134,50 @@ func TestSignWithSecurityToken(t *testing.T) {
 
 func TestCanonicalQueryString(t *testing.T) {
 	// Canonical form sorts keys and percent-encodes values.
-	got := canonicalQueryString("b=2&a=1&c=hello%20world")
+	got, err := canonicalQueryString("b=2&a=1&c=hello%20world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "a=1&b=2&c=hello%20world"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
-	if got := canonicalQueryString(""); got != "" {
+
+	got, err = canonicalQueryString("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
 		t.Errorf("empty query should produce empty canonical, got %q", got)
+	}
+}
+
+// ACS3 sorts by parameter name only; a repeated name keeps the order it arrived
+// in, because that is the order the server signs. Sorting the values would
+// compute a canonical string the server does not derive.
+func TestCanonicalQueryString_RepeatedNameKeepsRequestOrder(t *testing.T) {
+	got, err := canonicalQueryString("k=b&k=a&j=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "j=1&k=b&k=a"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// A query that will not parse must be reported, not silently rendered as empty:
+// signing an empty canonical query for a request that has one produces a
+// signature the server cannot reproduce.
+func TestCanonicalQueryString_MalformedQueryIsReported(t *testing.T) {
+	if _, err := canonicalQueryString("a=%zz"); err == nil {
+		t.Errorf("expected an error for a malformed query")
+	}
+
+	r := httptest.NewRequest("GET", "https://sts.aliyuncs.com/", nil)
+	r.URL.RawQuery = "a=%zz"
+	if err := SignACS3(r, "LTAI-test-id", "test-secret", "", nil); err == nil {
+		t.Errorf("SignACS3 should surface a malformed query rather than sign an empty one")
 	}
 }
 

--- a/provider/cloudflare/provider.go
+++ b/provider/cloudflare/provider.go
@@ -118,9 +118,8 @@ Credential type: cloudflare_keys (at least one mode required)
   - access_key_id: R2 access key ID for Object Storage (R2 mode)
   - secret_access_key: R2 secret access key for Object Storage (R2 mode)
 
-Two credential source types are supported:
+One credential source type is supported:
 - local (static_keys): Static credentials stored on the spec
-- hvault (static_cloudflare): Keys fetched from a Vault/OpenBao KV v2 secret
 
 Configuration:
 - cloudflare_url: Cloudflare API base URL (default: https://api.cloudflare.com/client/v4)

--- a/provider/scaleway/provider.go
+++ b/provider/scaleway/provider.go
@@ -66,12 +66,11 @@ S3 Object Storage:
 
   Supported S3 regions: fr-par, nl-ams, pl-waw, it-mil
 
-Three credential source types are supported:
+Two credential source types are supported:
 - scaleway (static_keys): Static API keys stored on the spec
 - scaleway (dynamic_keys): Ephemeral API keys minted via the IAM API
   (POST /iam/v1alpha1/api-keys) with automatic revocation on lease expiry.
   The management key supports automatic rotation.
-- hvault (static_scaleway): Keys fetched from a Vault/OpenBao KV v2 secret
 
 Configuration:
 - scaleway_url: Scaleway API base URL (default: https://api.scaleway.com)


### PR DESCRIPTION
**PR 3 of 5.** Stacked on #536 — this PR's diff is the top commit only. Three unrelated correctness fixes in the alicloud credential path.

## Lease TTL

`mintAssumeRole` returned the *requested* duration, measured before the HTTP round trip, and only logged the `Expiration` STS reported. The credential is cached for its whole lease, so the lease outlived the credential by however long the call took, and an expiry STS shortened for its own reasons was ignored entirely — a cache hit near the end handed out a dead token. Derive the TTL from the reported expiry, as the aws, gcp, ibm, elastic and github drivers already do.

The reported expiry is **capped at the requested duration**: it is only as trustworthy as the agreement between two clocks, and a local clock running behind Alibaba's would otherwise reintroduce the same over-long lease, bounded by skew instead of round-trip time.

## Canonical query

The driver's ACS3 signer and the provider's copy disagreed on repeated parameter names: the driver kept request order, the provider sorted the values. Alibaba's v3 signature specification **sorts by parameter name only** — arrays are flattened into indexed names, so a name is never repeated in a well-formed request, and one that is repeated is signed in arrival order.

The driver was right; the provider now matches it. **Note the direction**: changing the driver instead would have altered live outbound signing to fix a comment. This is wire-visible on the gateway's verify path, but only for a client that had matched the old sorted-value behaviour, which no official Alibaba SDK can produce.

Both copies also swallowed a `url.ParseQuery` failure into an empty canonical query, turning a malformed local query into a remote `SignatureDoesNotMatch`. Both now report it.

## Dead mint methods

`mint_method=static_alicloud` was in the `alicloud_keys` schema and required for a `hvault` source, but the Vault driver has never implemented it in either `InferCredentialType` or `MintCredential`: such a spec passed validation and failed at its first mint. It has never worked, so remove it rather than build it.

`static_cloudflare` and `static_scaleway` are the **same defect** in `cloudflare_keys` and `scaleway_keys`, so they go too, along with the vault-source branches that existed only to serve them and the provider help text advertising them. Existing persisted specs are unaffected at load; they simply can no longer be created or updated, having never been able to mint.

## Also

Adds `credential/types/alicloud_keys_test.go`, which did not exist. One case pins that `duration_seconds` needs a unit — the docs currently show a bare `3600`, which the duration field rejects.