### PR TITLE
feat(alicloud): mint STS credentials keyless over workload identity federation

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1156,8 +1156,8 @@ const authMethodOIDCFederation = "oidc_federation"
 
 // isFederationSource reports whether a source authenticates by presenting a
 // caller's identity assertion. Every such driver — aws, azure, gcp, hvault,
-// kubernetes — spells it the same way, so one predicate covers them all and covers
-// a new one the day it lands.
+// kubernetes, alicloud — spells it the same way, so one predicate covers them all
+// and covers a new one the day it lands.
 //
 // This is narrower than "holds no secret", which also describes a chained source
 // or spec (secret_spec), whose secret lives in the spec it references. Those are

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -1908,6 +1908,7 @@ func TestCredentialConfigStore_FederationSourceRejectsRotationPeriod(t *testing.
 		credential.SourceTypeGCP,
 		credential.SourceTypeVault,
 		credential.SourceTypeKubernetes,
+		credential.SourceTypeAlicloud,
 	}
 
 	for _, sourceType := range federationTypes {

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -43,10 +43,26 @@ const (
 	ramParamUserAccessKeyID = "UserAccessKeyId"
 )
 
+// alicloudAuthMethodStatic and alicloudAuthMethodOIDCFederation select how the
+// source authenticates. static (default) signs every call with a long-lived RAM
+// access key pair held in config; oidc_federation holds no key at all and mints
+// only by presenting the caller's identity assertion to STS AssumeRoleWithOIDC.
+// An empty auth_method means static, so records written before federation existed
+// keep working.
+const (
+	alicloudAuthMethodStatic         = "static"
+	alicloudAuthMethodOIDCFederation = "oidc_federation"
+)
+
+// alicloudTimestampFormat is the ISO 8601 form Alibaba's RPC common Timestamp
+// parameter takes: UTC, second precision, literal Z.
+const alicloudTimestampFormat = "2006-01-02T15:04:05Z"
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*AlicloudDriver)(nil)
 var _ credential.SpecVerifier = (*AlicloudDriver)(nil)
 var _ credential.Rotatable = (*AlicloudDriver)(nil)
+var _ credential.ExchangeMinter = (*AlicloudDriver)(nil)
 
 // AlicloudDriver mints credentials from Alibaba Cloud STS.
 //
@@ -84,7 +100,20 @@ func (f *AlicloudDriverFactory) Type() string {
 
 // ValidateConfig validates Alicloud source configuration.
 func (f *AlicloudDriverFactory) ValidateConfig(config map[string]string) error {
-	return credential.ValidateSchema(config,
+	if err := credential.ValidateSchema(config,
+		credential.StringField("auth_method").
+			OneOf(alicloudAuthMethodStatic, alicloudAuthMethodOIDCFederation).
+			Describe("How the source authenticates: 'static' (RAM access key pair) or 'oidc_federation' (keyless, exchanges the caller's identity assertion via STS AssumeRoleWithOIDC)").
+			Example(alicloudAuthMethodStatic),
+
+		credential.StringField("oidc_provider_arn").
+			Describe("RAM OIDC provider ARN that trusts Warden's issuer (required for auth_method=oidc_federation)").
+			Example("acs:ram::123456789012:oidc-provider/warden"),
+
+		credential.StringField("audience").
+			Describe("Assertion audience; must match a client_id registered on the RAM OIDC provider (auth_method=oidc_federation)").
+			Example("https://warden.example.com"),
+
 		credential.StringField("access_key_id").
 			Describe("Management access key ID (usually starts with LTAI)").
 			Example("LTAIxxxxxxxxxxxxxxxx"),
@@ -117,7 +146,45 @@ func (f *AlicloudDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
-	)
+	); err != nil {
+		return err
+	}
+
+	// Cross-field rules per auth_method. Each mode rejects the other's fields, so a
+	// half-converted source fails at write rather than behaving as the mode the
+	// operator did not intend.
+	//
+	// Present-but-empty is validated as static, not skipped. GetString returns a
+	// stored "" rather than the default, and the schema pass above skips empty
+	// values too — so a switch that only matched the two named modes would let a
+	// source through carrying neither a key pair nor a federation config, and it is
+	// static that such a source then behaves as.
+	switch credential.GetString(config, "auth_method", alicloudAuthMethodStatic) {
+	case "", alicloudAuthMethodStatic:
+		// oidc_provider_arn and audience seed only the federation exchange; on a
+		// static source they would be silently ignored, so reject rather than
+		// mislead. Note the static path deliberately does not require a key pair
+		// here — the schema has never marked one required, and tightening that is
+		// a separate change.
+		for _, k := range []string{"oidc_provider_arn", "audience"} {
+			if config[k] != "" {
+				return fmt.Errorf("field '%s' is only valid for auth_method=%s", k, alicloudAuthMethodOIDCFederation)
+			}
+		}
+	case alicloudAuthMethodOIDCFederation:
+		if credential.GetString(config, "oidc_provider_arn", "") == "" {
+			return fmt.Errorf("oidc_provider_arn is required for auth_method=%s", alicloudAuthMethodOIDCFederation)
+		}
+		// A federation source holds no key of its own, so it has nothing to rotate
+		// and no RAM user to rotate as — ram_endpoint included, which only the
+		// rotation calls ever read.
+		for _, k := range []string{"access_key_id", "access_key_secret", "management_user_name", "activation_delay", "ram_endpoint"} {
+			if config[k] != "" {
+				return fmt.Errorf("field '%s' must not be set for auth_method=%s", k, alicloudAuthMethodOIDCFederation)
+			}
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns source config keys that should be masked.
@@ -186,8 +253,35 @@ func (d *AlicloudDriver) endpointLocked(key, fallback string) string {
 	return strings.TrimRight(credential.GetString(d.credSource.Config, key, fallback), "/")
 }
 
+// getAuthMethod returns the source's configured auth_method, normalising both an
+// absent key and a stored empty string to static — the former so a record written
+// before federation existed keeps its old behaviour, the latter because GetString
+// hands back a stored "" rather than the default. It reads under configMu because
+// CommitRotation swaps the whole config map.
+func (d *AlicloudDriver) getAuthMethod() string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	if method := credential.GetString(d.credSource.Config, "auth_method", alicloudAuthMethodStatic); method != "" {
+		return method
+	}
+	return alicloudAuthMethodStatic
+}
+
+// federationConfig returns the STS endpoint and the OIDC provider ARN from one
+// config snapshot, for the same reason stsCallConfig pairs its two reads.
+func (d *AlicloudDriver) federationConfig() (endpoint, providerARN string) {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.endpointLocked("sts_endpoint", DefaultAlicloudSTSEndpoint),
+		credential.GetString(d.credSource.Config, "oidc_provider_arn", "")
+}
+
 // MintCredential returns Alicloud credentials for the given spec.
 func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: a source with auth_method=%s mints only from a caller assertion: set subject_token_source (warden_identity or agent_identity) on the spec", alicloudAuthMethodOIDCFederation)
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "assume_role":
@@ -197,18 +291,46 @@ func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.Cr
 	}
 }
 
-// mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
-func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
-	if mgmtID == "" || mgmtSecret == "" {
-		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
+// MintCredentialWithExchange mints STS session credentials over workload identity
+// federation: the caller's identity assertion is exchanged at STS for a session on
+// the spec's RAM role, so the source stores no key of its own and ActionTrail
+// records the identity behind each request rather than one shared RAM user.
+//
+// The subject token is trusted at the source — either an assertion Warden minted
+// and signed, or the agent's own verified inbound JWT — so it is forwarded to STS
+// as-is. STS validates it against the OIDC provider's registered issuer and
+// client_ids, and the role's trust policy decides what it may assume.
+func (d *AlicloudDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() != alicloudAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: workload identity federation requires auth_method=%s on the source", alicloudAuthMethodOIDCFederation)
+	}
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: no subject token in exchange inputs")
 	}
 
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	if mintMethod != "assume_role" {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: mint_method %q is not supported over auth_method=%s (supported: assume_role)", mintMethod, alicloudAuthMethodOIDCFederation)
+	}
+	return d.assumeRoleWithOIDC(ctx, spec, inputs.SubjectToken)
+}
+
+// alicloudAssumeRoleParams is the spec-derived half of an assume-role call, shared
+// by the static and federated paths so the two cannot drift on defaults or clamps.
+type alicloudAssumeRoleParams struct {
+	RoleARN     string
+	SessionName string
+	Duration    time.Duration
+	Policy      string
+}
+
+// resolveAssumeRoleParams reads and normalises the spec's assume-role settings.
+func resolveAssumeRoleParams(spec *credential.CredSpec) (*alicloudAssumeRoleParams, error) {
 	roleARN := credential.GetString(spec.Config, "role_arn", "")
 	if roleARN == "" {
-		return nil, nil, 0, "", fmt.Errorf("role_arn is required for assume_role")
+		return nil, fmt.Errorf("role_arn is required for assume_role")
 	}
-	sessionName := credential.GetString(spec.Config, "role_session_name", "warden-session")
+
 	duration := credential.GetDuration(spec.Config, "duration_seconds", time.Hour)
 	if duration < alicloudMinSTSDuration {
 		duration = alicloudMinSTSDuration
@@ -217,22 +339,98 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		duration = alicloudMaxSTSDuration
 	}
 
+	return &alicloudAssumeRoleParams{
+		RoleARN:     roleARN,
+		SessionName: credential.GetString(spec.Config, "role_session_name", "warden-session"),
+		Duration:    duration,
+		Policy:      credential.GetString(spec.Config, "policy", ""),
+	}, nil
+}
+
+// mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
+func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
+	if mgmtID == "" || mgmtSecret == "" {
+		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
+	}
+
+	ar, err := resolveAssumeRoleParams(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	params := url.Values{}
 	params.Set("Action", "AssumeRole")
 	params.Set("Version", alicloudSTSVersion)
 	params.Set("Format", "JSON")
-	params.Set("RoleArn", roleARN)
-	params.Set("RoleSessionName", sessionName)
-	params.Set("DurationSeconds", fmt.Sprintf("%d", int(duration.Seconds())))
-	if p := credential.GetString(spec.Config, "policy", ""); p != "" {
-		params.Set("Policy", p)
+	params.Set("RoleArn", ar.RoleARN)
+	params.Set("RoleSessionName", ar.SessionName)
+	params.Set("DurationSeconds", fmt.Sprintf("%d", int(ar.Duration.Seconds())))
+	if ar.Policy != "" {
+		params.Set("Policy", ar.Policy)
 	}
 
 	respBody, err := d.callSignedJSON(ctx, http.MethodPost, stsEndpoint, params, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed: %w", err)
 	}
+	return d.credentialsFromSTSResponse(respBody, ar)
+}
 
+// assumeRoleWithOIDC exchanges the caller's assertion for STS session credentials.
+//
+// The call is unsigned: AssumeRoleWithOIDC authenticates by the OIDC token itself,
+// and Alibaba documents that it takes no Signature or AccessKeyId. That is what
+// lets a source holding no key make it at all.
+//
+// The assertion travels in the POST form body, never the query string. A query
+// parameter would be printed back by *url.Error on any transport failure — the
+// full URL, token and all — into operator-visible errors and logs, and into every
+// proxy and load-balancer access log on the path. Alibaba's own RRSA credential
+// provider splits the request the same way, with Action/Version/Format in the
+// query and the token in the body.
+func (d *AlicloudDriver) assumeRoleWithOIDC(ctx context.Context, spec *credential.CredSpec, assertion string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	stsEndpoint, providerARN := d.federationConfig()
+	if providerARN == "" {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: oidc_provider_arn is required on the source for auth_method=%s", alicloudAuthMethodOIDCFederation)
+	}
+
+	ar, err := resolveAssumeRoleParams(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	// Action/Version/Format/Timestamp are the RPC common parameters and stay in the
+	// query, exactly as Alibaba's own RRSA client sends them. Timestamp is part of
+	// that convention rather than something the body could carry, and nothing local
+	// can prove STS tolerates its absence — an httptest stub accepts whatever it is
+	// given — so it is sent rather than assumed optional.
+	query := url.Values{}
+	query.Set("Action", "AssumeRoleWithOIDC")
+	query.Set("Version", alicloudSTSVersion)
+	query.Set("Format", "JSON")
+	query.Set("Timestamp", time.Now().UTC().Format(alicloudTimestampFormat))
+
+	body := url.Values{}
+	body.Set("RoleArn", ar.RoleARN)
+	body.Set("OIDCProviderArn", providerARN)
+	body.Set("OIDCToken", assertion)
+	body.Set("RoleSessionName", ar.SessionName)
+	body.Set("DurationSeconds", fmt.Sprintf("%d", int(ar.Duration.Seconds())))
+	if ar.Policy != "" {
+		body.Set("Policy", ar.Policy)
+	}
+
+	respBody, err := d.callAnonymousJSON(ctx, stsEndpoint, query, body)
+	if err != nil {
+		return nil, nil, 0, "", d.mapFederationError(err, ar.RoleARN, providerARN)
+	}
+	return d.credentialsFromSTSResponse(respBody, ar)
+}
+
+// credentialsFromSTSResponse parses an assume-role response into the mint tuple.
+// Both assume-role paths return the same Credentials block, so they share this.
+func (d *AlicloudDriver) credentialsFromSTSResponse(respBody []byte, ar *alicloudAssumeRoleParams) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	var resp struct {
 		Credentials struct {
 			AccessKeyID     string `json:"AccessKeyId"`
@@ -248,22 +446,49 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		return nil, nil, 0, "", fmt.Errorf("STS returned empty credentials")
 	}
 
-	leaseTTL, err := d.stsLeaseTTL(resp.Credentials.Expiration, duration)
+	leaseTTL, err := d.stsLeaseTTL(resp.Credentials.Expiration, ar.Duration)
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
 
 	d.logger.Info("issued STS temporary credentials",
 		logger.String("access_key", truncateID(resp.Credentials.AccessKeyID, 8)),
-		logger.String("role_arn", roleARN),
+		logger.String("role_arn", ar.RoleARN),
 		logger.String("expires", resp.Credentials.Expiration),
 	)
+
+	metadata := map[string]interface{}{
+		"role_arn":     ar.RoleARN,
+		"session_name": ar.SessionName,
+		"expiration":   resp.Credentials.Expiration,
+	}
 
 	return map[string]interface{}{
 		"access_key_id":     resp.Credentials.AccessKeyID,
 		"access_key_secret": resp.Credentials.AccessKeySecret,
 		"security_token":    resp.Credentials.SecurityToken,
-	}, nil, leaseTTL, "", nil // STS tokens are self-expiring; no leaseID
+	}, metadata, leaseTTL, "", nil // STS tokens are self-expiring; no leaseID
+}
+
+// mapFederationError adds triage guidance to the STS error codes that mean the
+// trust relationship is misconfigured, since the raw envelope names none of the
+// three things an operator has to check.
+func (d *AlicloudDriver) mapFederationError(err error, roleARN, providerARN string) error {
+	switch {
+	case alicloudErrorHasCodePrefix(err, "AuthenticationFail"),
+		alicloudErrorHasCodePrefix(err, "InvalidParameter.OIDCProviderArn"),
+		alicloudErrorHasCodePrefix(err, "IDPNotFound"):
+		return fmt.Errorf("STS AssumeRoleWithOIDC rejected the assertion for provider %s: %w "+
+			"(check that the RAM OIDC provider trusts Warden's issuer URL, that the assertion's "+
+			"audience matches one of its registered client_ids, and that the trust policy on %s "+
+			"admits the assertion's subject)", providerARN, err, roleARN)
+	case alicloudErrorHasCodePrefix(err, "NoPermission"),
+		alicloudErrorHasCodePrefix(err, "EntityNotExist.Role"):
+		return fmt.Errorf("STS AssumeRoleWithOIDC could not assume %s: %w "+
+			"(check the role exists and its trust policy admits this OIDC provider)", roleARN, err)
+	default:
+		return fmt.Errorf("STS AssumeRoleWithOIDC failed: %w", err)
+	}
 }
 
 // stsLeaseTTL converts the Expiration STS reports into a lease TTL.
@@ -325,6 +550,19 @@ const alicloudVerifyTimeout = 10 * time.Second
 // STS validates the management key; a valid signature followed by any RAM
 // role resolution error validates the role_arn. A single call covers both.
 func (d *AlicloudDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	// A federation source has no ambient credential to dry-run with — assertions
+	// are per caller, per request — so a misconfigured role surfaces at the first
+	// mint instead.
+	//
+	// This guard is defence in depth and nothing more: VerifySpec runs only inside
+	// the spec-create test-mint, which is skipped for every exchange spec, and a
+	// non-exchange spec on a keyless source is already refused by MintCredential
+	// before reaching here. Do not add config checks below expecting them to fire
+	// on a federated source.
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return nil
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "assume_role":
@@ -458,11 +696,55 @@ func (d *AlicloudDriver) callSignedJSON(
 	params url.Values,
 	mgmtID, mgmtSecret, securityToken string,
 ) ([]byte, error) {
+	return d.callJSON(ctx, method, endpoint, params, nil, func(req *http.Request) error {
+		// Re-sign every attempt so x-acs-date and x-acs-signature-nonce advance,
+		// staying inside ACS3's 15-minute skew window.
+		if err := signACS3(req, mgmtID, mgmtSecret, securityToken, nil); err != nil {
+			return fmt.Errorf("sign request: %w", err)
+		}
+		return nil
+	})
+}
+
+// callAnonymousJSON sends an unsigned RPC call, carrying its parameters in a
+// form-encoded POST body rather than the query string.
+//
+// STS AssumeRoleWithOIDC is the only call that takes this path. It authenticates
+// by the OIDC token it carries, so Alibaba documents that it needs no Signature
+// and no AccessKeyId — which is what a keyless source relies on, having neither.
+//
+// The body matters as much as the missing signature. httputil wraps a transport
+// failure around *url.Error, whose message prints the whole URL; a token in the
+// query string would land in operator-visible errors, in server logs, and in the
+// access log of every proxy on the path. Only Action/Version/Format stay in the
+// query, matching how Alibaba's own RRSA client splits the request.
+func (d *AlicloudDriver) callAnonymousJSON(
+	ctx context.Context,
+	endpoint string,
+	query, body url.Values,
+) ([]byte, error) {
+	return d.callJSON(ctx, http.MethodPost, endpoint, query, body, nil)
+}
+
+// callJSON owns the retry loop, backoff, and envelope classification shared by
+// the signed and anonymous paths. sign is nil for an anonymous call; body is nil
+// for a query-only one.
+func (d *AlicloudDriver) callJSON(
+	ctx context.Context,
+	method, endpoint string,
+	query, body url.Values,
+	sign func(*http.Request) error,
+) ([]byte, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
 	}
-	u.RawQuery = params.Encode()
+	u.RawQuery = query.Encode()
+
+	var encodedBody []byte
+	if body != nil {
+		encodedBody = []byte(body.Encode())
+	}
 
 	var lastErr error
 	for attempt := 0; attempt < alicloudMaxRetryAttempts; attempt++ {
@@ -477,25 +759,30 @@ func (d *AlicloudDriver) callSignedJSON(
 			}
 		}
 
-		// Re-sign every attempt so x-acs-date and x-acs-signature-nonce
-		// advance, staying inside ACS3's 15-minute skew window.
-		req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(nil))
+		// Rebuilt each attempt so the signer, if any, produces fresh date and
+		// nonce headers.
+		req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(encodedBody))
 		if err != nil {
 			return nil, err
 		}
 		req.Host = u.Host
 		// x-acs-action and x-acs-version are required in the signed headers for V3;
 		// mirror the Action and Version query params into them.
-		if action := params.Get("Action"); action != "" {
+		if action := query.Get("Action"); action != "" {
 			req.Header.Set("x-acs-action", action)
 		}
-		if version := params.Get("Version"); version != "" {
+		if version := query.Get("Version"); version != "" {
 			req.Header.Set("x-acs-version", version)
 		}
 		req.Header.Set("Accept", "application/json")
+		if encodedBody != nil {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
 
-		if err := signACS3(req, mgmtID, mgmtSecret, securityToken, nil); err != nil {
-			return nil, fmt.Errorf("sign request: %w", err)
+		if sign != nil {
+			if err := sign(req); err != nil {
+				return nil, err
+			}
 		}
 
 		headers := make(map[string]string, len(req.Header))
@@ -514,6 +801,7 @@ func (d *AlicloudDriver) callSignedJSON(
 			Method:  method,
 			URL:     u.String(),
 			Headers: headers,
+			Body:    encodedBody,
 			OKStatuses: []int{
 				http.StatusOK,
 				http.StatusBadRequest,
@@ -553,7 +841,7 @@ func (d *AlicloudDriver) callSignedJSON(
 		// otherwise read it as success and silently leave a live key in place.
 		if status != http.StatusOK {
 			return nil, fmt.Errorf("alicloud %s returned HTTP %d with an unrecognised body: %s",
-				params.Get("Action"), status, alicloudBodyPreview(respBody))
+				query.Get("Action"), status, alicloudBodyPreview(respBody))
 		}
 
 		return respBody, nil
@@ -568,6 +856,14 @@ func (d *AlicloudDriver) callSignedJSON(
 // management access key: an existing access_key_id + access_key_secret plus
 // management_user_name identifying which RAM user owns the key.
 func (d *AlicloudDriver) SupportsRotation() bool {
+	// A federation source holds no key, so there is nothing to rotate.
+	// ValidateConfig already keeps the key fields off such a source, which would
+	// make the check below false anyway; stating it here keeps the invariant
+	// independent of that.
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return false
+	}
+
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
 	return credential.GetString(d.credSource.Config, "access_key_id", "") != "" &&
@@ -693,6 +989,10 @@ func (d *AlicloudDriver) makeRoomForNewKey(
 // cleanup config (with the old access_key_id), and the activation delay to let
 // RAM eventual consistency propagate.
 func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return nil, nil, 0, fmt.Errorf("alicloud: a source with auth_method=%s holds no key to rotate", alicloudAuthMethodOIDCFederation)
+	}
+
 	d.configMu.RLock()
 	mgmtID := credential.GetString(d.credSource.Config, "access_key_id", "")
 	mgmtSecret := credential.GetString(d.credSource.Config, "access_key_secret", "")

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -67,6 +68,382 @@ func TestAlicloudDriverFactory_ValidateConfig(t *testing.T) {
 			"sts_endpoint":      "https://sts.aliyuncs.com",
 			"ram_endpoint":      "https://ram.aliyuncs.com",
 		}))
+	})
+}
+
+// --- Keyless (auth_method=oidc_federation) ---
+
+func TestAlicloudDriverFactory_ValidateConfig_AuthMethod(t *testing.T) {
+	f := &AlicloudDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr string
+	}{
+		{
+			name: "federation with a provider arn",
+			config: map[string]string{
+				"auth_method":       "oidc_federation",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+				"audience":          "https://warden.example.com",
+			},
+		},
+		{
+			name:    "federation without a provider arn",
+			config:  map[string]string{"auth_method": "oidc_federation"},
+			wantErr: "oidc_provider_arn is required",
+		},
+		{
+			name: "unknown auth_method",
+			config: map[string]string{
+				"auth_method": "instance_role",
+			},
+			wantErr: "auth_method",
+		},
+		{
+			// The static source's fields are exactly what federation removes, so
+			// carrying either is a half-converted source.
+			name: "federation carrying a key pair",
+			config: map[string]string{
+				"auth_method":       "oidc_federation",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+				"access_key_id":     "LTAI-mgmt",
+			},
+			wantErr: "access_key_id",
+		},
+		{
+			name: "federation carrying rotation config",
+			config: map[string]string{
+				"auth_method":          "oidc_federation",
+				"oidc_provider_arn":    "acs:ram::123456789012:oidc-provider/warden",
+				"management_user_name": "warden-management",
+			},
+			wantErr: "management_user_name",
+		},
+		{
+			// ram_endpoint is read only by the rotation calls, which federation
+			// forecloses.
+			name: "federation carrying a ram endpoint",
+			config: map[string]string{
+				"auth_method":       "oidc_federation",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+				"ram_endpoint":      "https://ram.aliyuncs.com",
+			},
+			wantErr: "ram_endpoint",
+		},
+		{
+			name: "static carrying a provider arn",
+			config: map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "secret",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+			},
+			wantErr: "oidc_provider_arn",
+		},
+		{
+			name: "static carrying an audience",
+			config: map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "secret",
+				"audience":          "https://warden.example.com",
+			},
+			wantErr: "audience",
+		},
+		{
+			// A stored empty auth_method is validated as static, not skipped —
+			// GetString hands back the stored "" rather than the default.
+			name: "explicit empty auth_method is treated as static",
+			config: map[string]string{
+				"auth_method":       "",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+			},
+			wantErr: "oidc_provider_arn",
+		},
+		{
+			// Unchanged from before federation existed: nothing is required.
+			name:   "empty config is still valid",
+			config: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := f.ValidateConfig(tt.config)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// newFederationDriver builds a keyless driver pointed at an STS stub.
+func newAlicloudFederationDriver(t *testing.T, stsURL string) *AlicloudDriver {
+	t.Helper()
+	f := &AlicloudDriverFactory{}
+	d, err := f.Create(map[string]string{
+		"auth_method":       "oidc_federation",
+		"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+		"audience":          "https://warden.example.com",
+		"sts_endpoint":      stsURL,
+	}, createAlicloudTestLogger())
+	require.NoError(t, err)
+	return d.(*AlicloudDriver)
+}
+
+func federationSpec() *credential.CredSpec {
+	return &credential.CredSpec{
+		Name: "prod",
+		Config: map[string]string{
+			"mint_method":      "assume_role",
+			"role_arn":         "acs:ram::123456789012:role/warden-prod",
+			"duration_seconds": "1800s",
+		},
+	}
+}
+
+// A keyless source has no key to sign with and no ambient identity, so the
+// non-exchange path must fail closed rather than fall back to anything. This is
+// also what makes the spec-create test-mint reject a non-exchange spec on such a
+// source.
+func TestAlicloudDriver_Federation_MintCredentialFailsClosed(t *testing.T) {
+	drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+
+	_, _, _, _, err := drv.MintCredential(context.Background(), federationSpec())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject_token_source")
+}
+
+func TestAlicloudDriver_Federation_MintWithExchange(t *testing.T) {
+	const assertion = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qifq.payload.signature"
+
+	var gotQuery url.Values
+	var gotForm url.Values
+	var gotAuth, gotRawQuery, gotContentType string
+
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		gotQuery = r.URL.Query()
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		require.NoError(t, r.ParseForm())
+		gotForm = r.PostForm
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.federated",
+				"AccessKeySecret": "federated-secret",
+				"SecurityToken":   "federated-token",
+				"Expiration":      time.Now().Add(1800 * time.Second).UTC().Format(time.RFC3339),
+			},
+		})
+	}))
+	defer sts.Close()
+
+	drv := newAlicloudFederationDriver(t, sts.URL)
+	raw, metadata, ttl, leaseID, err := drv.MintCredentialWithExchange(
+		context.Background(), federationSpec(),
+		&credential.ExchangeInputs{SubjectToken: assertion})
+	require.NoError(t, err)
+
+	// The RPC common parameters identify the call and stay in the query, as
+	// Alibaba's own RRSA client sends them — Timestamp included, which is part of
+	// that convention and which no stub can prove optional.
+	assert.Equal(t, "AssumeRoleWithOIDC", gotQuery.Get("Action"))
+	assert.Equal(t, alicloudSTSVersion, gotQuery.Get("Version"))
+	assert.Equal(t, "JSON", gotQuery.Get("Format"))
+	stamp, tsErr := time.Parse(alicloudTimestampFormat, gotQuery.Get("Timestamp"))
+	require.NoError(t, tsErr, "Timestamp must be ISO 8601 UTC")
+	assert.WithinDuration(t, time.Now(), stamp, time.Minute)
+
+	// The exchange parameters travel in the form body.
+	assert.Equal(t, "application/x-www-form-urlencoded", gotContentType)
+	assert.Equal(t, assertion, gotForm.Get("OIDCToken"))
+	assert.Equal(t, "acs:ram::123456789012:oidc-provider/warden", gotForm.Get("OIDCProviderArn"))
+	assert.Equal(t, "acs:ram::123456789012:role/warden-prod", gotForm.Get("RoleArn"))
+	assert.Equal(t, "1800", gotForm.Get("DurationSeconds"))
+
+	// The two load-bearing negatives. AssumeRoleWithOIDC is anonymous, and the
+	// assertion must never reach the URL — *url.Error prints the whole thing on
+	// any transport failure.
+	assert.Empty(t, gotAuth, "AssumeRoleWithOIDC is an anonymous call")
+	assert.NotContains(t, gotRawQuery, assertion, "the assertion must not be in the query string")
+	assert.NotContains(t, gotRawQuery, "OIDCToken")
+
+	assert.Equal(t, "STS.federated", raw["access_key_id"])
+	assert.Equal(t, "federated-secret", raw["access_key_secret"])
+	assert.Equal(t, "federated-token", raw["security_token"])
+	assert.Equal(t, "acs:ram::123456789012:role/warden-prod", metadata["role_arn"])
+	assert.InDelta(t, 1800, ttl.Seconds(), 5)
+	assert.Empty(t, leaseID, "STS sessions are self-expiring")
+}
+
+// Pins the body-not-query decision against a future refactor: point the driver at
+// a dead port so client.Do fails, and check the assertion is not in the error.
+// With the token in the query string, *url.Error would print it verbatim.
+func TestAlicloudDriver_Federation_TransportErrorDoesNotLeakAssertion(t *testing.T) {
+	const assertion = "eyJhbGciOiJSUzI1NiJ9.super-secret-payload.signature"
+
+	// A listener closed immediately gives us an address nothing answers on.
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := closed.URL
+	closed.Close()
+
+	drv := newAlicloudFederationDriver(t, deadURL)
+	_, _, _, _, err := drv.MintCredentialWithExchange(
+		context.Background(), federationSpec(),
+		&credential.ExchangeInputs{SubjectToken: assertion})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), assertion,
+		"a transport error must not print the caller's assertion")
+	assert.NotContains(t, err.Error(), "super-secret-payload")
+}
+
+func TestAlicloudDriver_Federation_ExchangeRejections(t *testing.T) {
+	t.Run("rejected on a static source", func(t *testing.T) {
+		f := &AlicloudDriverFactory{}
+		d, _ := f.Create(map[string]string{
+			"access_key_id":     "LTAI-mgmt",
+			"access_key_secret": "secret",
+		}, createAlicloudTestLogger())
+
+		_, _, _, _, err := d.(*AlicloudDriver).MintCredentialWithExchange(
+			context.Background(), federationSpec(),
+			&credential.ExchangeInputs{SubjectToken: "assertion"})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "oidc_federation")
+	})
+
+	t.Run("rejected with no subject token", func(t *testing.T) {
+		drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+
+		_, _, _, _, err := drv.MintCredentialWithExchange(context.Background(), federationSpec(), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+
+		_, _, _, _, err = drv.MintCredentialWithExchange(
+			context.Background(), federationSpec(), &credential.ExchangeInputs{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+	})
+
+	t.Run("rejected for an unsupported mint_method", func(t *testing.T) {
+		drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+		spec := federationSpec()
+		spec.Config["mint_method"] = "dynamic_keys"
+
+		_, _, _, _, err := drv.MintCredentialWithExchange(
+			context.Background(), spec, &credential.ExchangeInputs{SubjectToken: "assertion"})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assume_role")
+	})
+}
+
+// The three things most likely to be misconfigured are the issuer trust, the
+// audience, and the role's trust policy; the raw envelope names none of them.
+func TestAlicloudDriver_Federation_ErrorMappingNamesTheTrustChain(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Code":      "AuthenticationFail.OIDCToken.Invalid",
+			"Message":   "The OIDC token is invalid.",
+			"RequestId": "req-oidc",
+		})
+	}))
+	defer sts.Close()
+
+	drv := newAlicloudFederationDriver(t, sts.URL)
+	_, _, _, _, err := drv.MintCredentialWithExchange(
+		context.Background(), federationSpec(),
+		&credential.ExchangeInputs{SubjectToken: "assertion"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AuthenticationFail.OIDCToken.Invalid", "the upstream code survives")
+	assert.Contains(t, err.Error(), "issuer")
+	assert.Contains(t, err.Error(), "client_ids")
+	assert.Contains(t, err.Error(), "trust policy")
+}
+
+// A federation source holds no key, so there is nothing to rotate and no RAM user
+// to rotate as.
+func TestAlicloudDriver_Federation_RotationRefused(t *testing.T) {
+	drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+
+	assert.False(t, drv.SupportsRotation())
+
+	_, _, _, err := drv.PrepareRotation(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no key to rotate")
+}
+
+// VerifySpec has no ambient credential to dry-run with under federation. The
+// guard is unreachable in practice — the spec-create test-mint is skipped for
+// exchange specs — but it must not attempt a network call if it is ever reached.
+func TestAlicloudDriver_Federation_VerifySpecMakesNoCall(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("VerifySpec must not call STS on a federation source")
+	}))
+	defer sts.Close()
+
+	drv := newAlicloudFederationDriver(t, sts.URL)
+	assert.NoError(t, drv.VerifySpec(context.Background(), federationSpec()))
+}
+
+func TestAlicloudAssertionClaims(t *testing.T) {
+	federationSource := map[string]string{
+		"auth_method":       "oidc_federation",
+		"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+		"audience":          "https://warden.example.com",
+	}
+
+	t.Run("audience comes from the source", func(t *testing.T) {
+		aud, ok := DeriveAssertionAudience(credential.SourceTypeAlicloud, federationSource, nil)
+		assert.True(t, ok)
+		assert.Equal(t, "https://warden.example.com", aud)
+	})
+
+	t.Run("no audience without one configured", func(t *testing.T) {
+		// Alibaba matches aud against the provider's registered client_ids, which
+		// the operator chooses, so there is no default to fall back to. Returning
+		// false is what makes spec-create demand assertion_audience.
+		_, ok := DeriveAssertionAudience(credential.SourceTypeAlicloud, map[string]string{
+			"auth_method":       "oidc_federation",
+			"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+		}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("a static source derives no audience", func(t *testing.T) {
+		_, ok := DeriveAssertionAudience(credential.SourceTypeAlicloud, map[string]string{
+			"access_key_id": "LTAI-mgmt",
+			"audience":      "https://warden.example.com",
+		}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("resource is the role arn", func(t *testing.T) {
+		res, ok := DeriveAssertionResource(credential.SourceTypeAlicloud, federationSource, map[string]string{
+			"mint_method": "assume_role",
+			"role_arn":    "acs:ram::123456789012:role/warden-prod",
+		})
+		assert.True(t, ok)
+		assert.Equal(t, "alicloud-ram:acs:ram::123456789012:role/warden-prod", res)
+	})
+
+	t.Run("no resource without a role arn", func(t *testing.T) {
+		_, ok := DeriveAssertionResource(credential.SourceTypeAlicloud, federationSource, map[string]string{
+			"mint_method": "assume_role",
+		})
+		assert.False(t, ok)
 	})
 }
 

--- a/credential/drivers/assertion_claims.go
+++ b/credential/drivers/assertion_claims.go
@@ -35,6 +35,8 @@ func DeriveAssertionResource(sourceType string, sourceCfg, specCfg map[string]st
 		return vaultAssertionResource(sourceCfg, specCfg)
 	case credential.SourceTypeKubernetes:
 		return kubernetesAssertionResource(specCfg)
+	case credential.SourceTypeAlicloud:
+		return alicloudAssertionResource(specCfg)
 	default:
 		return "", false
 	}
@@ -63,9 +65,46 @@ func DeriveAssertionAudience(sourceType string, sourceCfg, specCfg map[string]st
 		return vaultAssertionAudience(sourceCfg)
 	case credential.SourceTypeKubernetes:
 		return kubernetesAssertionAudience(sourceCfg)
+	case credential.SourceTypeAlicloud:
+		return alicloudAssertionAudience(sourceCfg)
 	default:
 		return "", false
 	}
+}
+
+// alicloudAssertionAudience derives the warden_identity assertion audience for a
+// keyless Alicloud source: the source's explicit `audience`, or ("", false) when
+// unset. There is no conventional default — unlike AWS, which accepts
+// sts.amazonaws.com, Alibaba matches the assertion's aud against the client_ids
+// registered on the RAM OIDC provider, which the operator chooses — so an unset
+// audience forces the spec to set assertion_audience (the spec-create gate
+// enforces this, and mint fails closed otherwise).
+//
+// Gated on auth_method=oidc_federation: only a keyless source federates, so a
+// static source supplies no derived audience even if a stored config record
+// somehow carries one.
+func alicloudAssertionAudience(sourceCfg map[string]string) (string, bool) {
+	if credential.GetString(sourceCfg, "auth_method", alicloudAuthMethodStatic) != alicloudAuthMethodOIDCFederation {
+		return "", false
+	}
+	if aud := credential.GetString(sourceCfg, "audience", ""); aud != "" {
+		return aud, true
+	}
+	return "", false
+}
+
+// alicloudAssertionResource reports the RAM role a federation spec assumes, for
+// the warden_resource claim. Pure: reads spec config only, no network or driver
+// state. The driver has a single mint path, so unlike the multi-engine sources
+// there is no mint_method to dispatch on.
+//
+// The provider prefix is human-readable sugar on an opaque value — never parse it
+// back, since a role ARN contains ':' itself.
+func alicloudAssertionResource(specCfg map[string]string) (string, bool) {
+	if arn := credential.GetString(specCfg, "role_arn", ""); arn != "" {
+		return "alicloud-ram:" + arn, true
+	}
+	return "", false
 }
 
 // kubernetesAssertionAudience derives the warden_identity assertion audience for a

--- a/credential/drivers/registry_test.go
+++ b/credential/drivers/registry_test.go
@@ -12,7 +12,8 @@ func TestRegisterBuiltinDrivers(t *testing.T) {
 	err := RegisterBuiltinDrivers(registry)
 	require.NoError(t, err)
 
-	// Verify all expected drivers are registered
+	// Every builtin driver, not a subset — an under-enumerated list reads as
+	// "all registered" while silently skipping whatever was added last.
 	expectedTypes := []string{
 		credential.SourceTypeLocal,
 		credential.SourceTypeVault,
@@ -23,6 +24,15 @@ func TestRegisterBuiltinDrivers(t *testing.T) {
 		credential.SourceTypeGitHub,
 		credential.SourceTypeAPIKey,
 		credential.SourceTypeOAuth2,
+		credential.SourceTypeAlicloud,
+		credential.SourceTypeElastic,
+		credential.SourceTypeGrafana,
+		credential.SourceTypeHoneycomb,
+		credential.SourceTypeIBM,
+		credential.SourceTypeKubernetes,
+		credential.SourceTypeOVH,
+		credential.SourceTypeScaleway,
+		credential.SourceTypeTokenExchange,
 	}
 	for _, typeName := range expectedTypes {
 		factory, err := registry.GetFactory(typeName)


### PR DESCRIPTION
**PR 4 of 5.** Stacked on #537 — this PR's diff is the top commit only.

The alicloud source was the last cloud source that could only authenticate with a long-lived RAM access key pair held in its config. It can now run keyless like aws, azure, gcp, hvault and kubernetes: `auth_method=oidc_federation` holds no key at all and mints by presenting the caller's identity assertion to STS `AssumeRoleWithOIDC`, so ActionTrail records the identity behind each request rather than one shared RAM user, and there is no management key to store, rotate, or leak.

## Two externally-verified properties the design rests on

Both confirmed against Alibaba's documentation and their own RRSA credential provider rather than assumed:

**The call is anonymous.** Alibaba states it takes no `Signature`, `SignatureMethod`, `SignatureVersion` or `AccessKeyId`, because the OIDC token authenticates it. That is what lets a source holding no key make it at all, and why the transport grew an unsigned path rather than reusing the ACS3 signer, which hard-errors on empty credentials. The signed path is unchanged: with no body it still hashes an empty one.

**The parameters go in the POST form body.** This is a redaction requirement, not a style choice: `httputil` wraps a transport failure around `*url.Error`, whose message prints the entire URL. With the assertion in the query string, a single connection refused puts the caller's signed identity into operator-visible errors, server logs, and the access log of every proxy on the path — **verified by moving the token to the query and watching the regression test print it**. Only the RPC common parameters (`Action`, `Version`, `Format`, `Timestamp`) stay in the query, matching Alibaba's client field for field.

## Configuration

Follows the other keyless drivers. `oidc_provider_arn` names the trust relationship and lives on the source, like GCP's `workload_identity_provider`. `mint_method` stays `assume_role` — federation changes how the source authenticates, not what it produces — so `alicloud_keys` is untouched and existing specs keep working. Each mode rejects the other's fields, so a half-converted source fails at write; an empty `auth_method` is validated as static, since that is what such a source behaves as.

**The assertion audience has no default.** Alibaba matches `aud` against the `client_ids` registered on the RAM OIDC provider, which the operator chooses, so unlike AWS there is no conventional value to fall back to. `alicloudAssertionAudience` returns false when unset, which makes spec creation demand an explicit `assertion_audience` instead of minting a token STS will reject.

Federated STS errors are mapped to name the three things that are actually misconfigured — issuer trust, the provider's `client_ids`, and the role's trust policy — since the raw envelope names none of them.

## One behaviour change outside the feature

Sharing the response parser between the two mint methods means a **static** `assume_role` mint now returns `role_arn`, `session_name` and `expiration` as metadata where it previously returned none. This reaches audit records and `Credential.Metadata`, and matches what the AWS federated path already reports.

## Note for operators

Converting an existing static source is **delete-and-recreate**: the update path merges config, so a stored `access_key_secret` cannot be cleared.

Also completes two under-enumerated test lists rather than adding one row: `registry_test.go` asserted "all expected drivers" while naming 9 of 18, and the cross-type federation `rotation_period` test claimed to cover "every federation-capable source type" while naming 5 of 6.