### PR TITLE
test(e2e): drive the keyless alicloud source through a real assertion exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,17 @@ temp/
 
 # E2E generated certs
 e2e/loadbalancer/certs/
+
+# E2E cluster runtime state. All of it is produced by e2e/setup.sh and is local
+# to one machine: a built binary, the cluster's root token, node PIDs, and the
+# API listener's TLS material.
+#
+# The certs matter beyond tidiness. *.key is ignored above but *.crt was not, so
+# committing this directory publishes a certificate without its key — and
+# setup.sh skips generation when it finds server.crt, leaving a fresh checkout
+# with a cert it has no key for and a listener that cannot start.
+e2e/.bin/
+e2e/.certs/
+e2e/.logs/
+e2e/.pids/
+e2e/.root_token

--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1156,8 +1156,8 @@ const authMethodOIDCFederation = "oidc_federation"
 
 // isFederationSource reports whether a source authenticates by presenting a
 // caller's identity assertion. Every such driver — aws, azure, gcp, hvault,
-// kubernetes — spells it the same way, so one predicate covers them all and covers
-// a new one the day it lands.
+// kubernetes, alicloud — spells it the same way, so one predicate covers them all
+// and covers a new one the day it lands.
 //
 // This is narrower than "holds no secret", which also describes a chained source
 // or spec (secret_spec), whose secret lives in the spec it references. Those are

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -1908,6 +1908,7 @@ func TestCredentialConfigStore_FederationSourceRejectsRotationPeriod(t *testing.
 		credential.SourceTypeGCP,
 		credential.SourceTypeVault,
 		credential.SourceTypeKubernetes,
+		credential.SourceTypeAlicloud,
 	}
 
 	for _, sourceType := range federationTypes {

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -67,8 +68,9 @@ type AlicloudDriver struct {
 	logger     *logger.GatedLogger
 	httpClient *http.Client
 
-	// configMu protects credSource.Config against concurrent reads and writes
-	// (for future rotation support).
+	// configMu protects credSource.Config against concurrent reads and writes:
+	// CommitRotation replaces the whole map while mint and rotation calls are
+	// reading it. Every accessor of credSource.Config must hold it.
 	configMu sync.RWMutex
 }
 
@@ -158,25 +160,30 @@ func (d *AlicloudDriver) Cleanup(_ context.Context) error {
 	return nil
 }
 
-func (d *AlicloudDriver) mgmtAccessKey() (string, string) {
+// stsCallConfig returns the STS endpoint and the management key pair from a
+// single config snapshot. Endpoint and credentials are read together rather than
+// through separate accessors so a rotation committing between two reads cannot
+// pair one config's key with another config's address.
+func (d *AlicloudDriver) stsCallConfig() (endpoint, keyID, keySecret string) {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
-	return credential.GetString(d.credSource.Config, "access_key_id", ""),
+	return d.endpointLocked("sts_endpoint", DefaultAlicloudSTSEndpoint),
+		credential.GetString(d.credSource.Config, "access_key_id", ""),
 		credential.GetString(d.credSource.Config, "access_key_secret", "")
 }
 
-func (d *AlicloudDriver) stsEndpoint() string {
-	return strings.TrimRight(
-		credential.GetString(d.credSource.Config, "sts_endpoint", DefaultAlicloudSTSEndpoint),
-		"/",
-	)
+// ramCallConfig is stsCallConfig for the RAM management API.
+func (d *AlicloudDriver) ramCallConfig() (endpoint, keyID, keySecret string) {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.endpointLocked("ram_endpoint", DefaultAlicloudRAMEndpoint),
+		credential.GetString(d.credSource.Config, "access_key_id", ""),
+		credential.GetString(d.credSource.Config, "access_key_secret", "")
 }
 
-func (d *AlicloudDriver) ramEndpoint() string {
-	return strings.TrimRight(
-		credential.GetString(d.credSource.Config, "ram_endpoint", DefaultAlicloudRAMEndpoint),
-		"/",
-	)
+// endpointLocked reads and normalises one endpoint key. Caller must hold configMu.
+func (d *AlicloudDriver) endpointLocked(key, fallback string) string {
+	return strings.TrimRight(credential.GetString(d.credSource.Config, key, fallback), "/")
 }
 
 // MintCredential returns Alicloud credentials for the given spec.
@@ -192,7 +199,7 @@ func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.Cr
 
 // mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
 func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	mgmtID, mgmtSecret := d.mgmtAccessKey()
+	stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
 	if mgmtID == "" || mgmtSecret == "" {
 		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
 	}
@@ -221,7 +228,7 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		params.Set("Policy", p)
 	}
 
-	respBody, err := d.callSignedJSON(ctx, http.MethodPost, d.stsEndpoint(), params, mgmtID, mgmtSecret, "")
+	respBody, err := d.callSignedJSON(ctx, http.MethodPost, stsEndpoint, params, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed: %w", err)
 	}
@@ -281,7 +288,7 @@ func (d *AlicloudDriver) VerifySpec(ctx context.Context, spec *credential.CredSp
 		if roleARN == "" {
 			return fmt.Errorf("role_arn is required for assume_role")
 		}
-		mgmtID, mgmtSecret := d.mgmtAccessKey()
+		stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
 		if mgmtID == "" || mgmtSecret == "" {
 			return fmt.Errorf("source must have management access_key_id/access_key_secret for assume_role")
 		}
@@ -297,7 +304,7 @@ func (d *AlicloudDriver) VerifySpec(ctx context.Context, spec *credential.CredSp
 		params.Set("RoleSessionName", "warden-verify")
 		params.Set("DurationSeconds", fmt.Sprintf("%d", int(alicloudMinSTSDuration.Seconds())))
 
-		if _, err := d.callSignedJSON(verifyCtx, http.MethodPost, d.stsEndpoint(), params, mgmtID, mgmtSecret, ""); err != nil {
+		if _, err := d.callSignedJSON(verifyCtx, http.MethodPost, stsEndpoint, params, mgmtID, mgmtSecret, ""); err != nil {
 			return fmt.Errorf("alicloud pre-flight AssumeRole failed: %w", err)
 		}
 		return nil
@@ -337,13 +344,59 @@ func parseAlicloudEnvelope(body []byte) (alicloudErrorEnvelope, bool) {
 	return env, env.Code != ""
 }
 
-// alicloudErrorFromEnvelope wraps an Alicloud error envelope into a Go error
+// alicloudAPIError carries a parsed error envelope so callers can branch on the
+// upstream Code rather than matching substrings of a formatted message. Rotation
+// cleanup, for instance, treats an already-deleted key (EntityNotExist.*) as
+// success while still failing on anything else.
+type alicloudAPIError struct {
+	alicloudErrorEnvelope
+}
+
+// Error formats Code, Message, and RequestId for operator triage.
+func (e *alicloudAPIError) Error() string {
+	if e.RequestId != "" {
+		return fmt.Sprintf("%s: %s (RequestId=%s)", e.Code, e.Message, e.RequestId)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// alicloudErrorFromEnvelope wraps an Alicloud error envelope into a typed error
 // whose message carries Code, Message, and RequestId for operator triage.
 func alicloudErrorFromEnvelope(env alicloudErrorEnvelope) error {
-	if env.RequestId != "" {
-		return fmt.Errorf("%s: %s (RequestId=%s)", env.Code, env.Message, env.RequestId)
+	return &alicloudAPIError{alicloudErrorEnvelope: env}
+}
+
+// alicloudBodyPreviewLen bounds how much of an unrecognised response body is
+// quoted back in an error. Enough to tell an HTML error page from a JSON one and
+// read the first line of either, short enough not to flood a log line.
+const alicloudBodyPreviewLen = 256
+
+// alicloudBodyPreview renders an unrecognised response body as a single-line
+// excerpt for an error message. Whitespace is collapsed because the bodies this
+// is reached for are typically multi-line HTML, which would otherwise break the
+// error across a dozen log lines.
+func alicloudBodyPreview(body []byte) string {
+	if len(body) == 0 {
+		return "<empty>"
 	}
-	return fmt.Errorf("%s: %s", env.Code, env.Message)
+	preview := strings.Join(strings.Fields(string(body)), " ")
+	if len(preview) > alicloudBodyPreviewLen {
+		preview = preview[:alicloudBodyPreviewLen] + "..."
+	}
+	return preview
+}
+
+// alicloudErrorHasCodePrefix reports whether err carries an Alicloud error
+// envelope whose Code equals prefix or begins with prefix + ".". Alicloud groups
+// related codes that way (EntityNotExist.User, EntityNotExist.User.AccessKey),
+// so matching the family is the useful test; the dotted form keeps
+// "EntityNotExist" from also matching a hypothetical "EntityNotExistent".
+func alicloudErrorHasCodePrefix(err error, prefix string) bool {
+	var apiErr *alicloudAPIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.Code == prefix || strings.HasPrefix(apiErr.Code, prefix+".")
 }
 
 // callSignedJSON builds and sends an ACS3-signed request to an Alicloud
@@ -448,6 +501,17 @@ func (d *AlicloudDriver) callSignedJSON(
 			return nil, alicloudErrorFromEnvelope(env)
 		}
 
+		// The 4xx statuses above are marked OK only to get their bodies back for
+		// envelope classification, never to accept the outcome. A 4xx whose body
+		// is not an envelope — an HTML error page from an intercepting proxy, a
+		// load balancer's own JSON — reaches here having failed, so refusing it is
+		// the whole point: callers that discard the body (rotation cleanup) would
+		// otherwise read it as success and silently leave a live key in place.
+		if status != http.StatusOK {
+			return nil, fmt.Errorf("alicloud %s returned HTTP %d with an unrecognised body: %s",
+				params.Get("Action"), status, alicloudBodyPreview(respBody))
+		}
+
 		return respBody, nil
 	}
 
@@ -478,6 +542,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	mgmtSecret := credential.GetString(d.credSource.Config, "access_key_secret", "")
 	userName := credential.GetString(d.credSource.Config, "management_user_name", "")
 	activationDelay := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultAlicloudActivationDelay)
+	ramEndpoint := d.endpointLocked("ram_endpoint", DefaultAlicloudRAMEndpoint)
 	configSnapshot := make(map[string]string, len(d.credSource.Config))
 	for k, v := range d.credSource.Config {
 		configSnapshot[k] = v
@@ -500,7 +565,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	listParams.Set("Format", "JSON")
 	listParams.Set("UserName", userName)
 
-	listBody, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), listParams, mgmtID, mgmtSecret, "")
+	listBody, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, listParams, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("RAM ListAccessKeys failed: %w", err)
 	}
@@ -530,7 +595,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 		del.Set("Format", "JSON")
 		del.Set("UserName", userName)
 		del.Set(ramParamUserAccessKeyID, k.AccessKeyID)
-		if _, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), del, mgmtID, mgmtSecret, ""); err != nil {
+		if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
 			return nil, nil, 0, fmt.Errorf("failed to delete orphaned access key %s: %w", truncateID(k.AccessKeyID, 8), err)
 		}
 	}
@@ -542,7 +607,7 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	createParams.Set("Format", "JSON")
 	createParams.Set("UserName", userName)
 
-	createBody, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), createParams, mgmtID, mgmtSecret, "")
+	createBody, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, createParams, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("RAM CreateAccessKey failed: %w", err)
 	}
@@ -608,7 +673,7 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 		return nil
 	}
 
-	mgmtID, mgmtSecret := d.mgmtAccessKey()
+	ramEndpoint, mgmtID, mgmtSecret := d.ramCallConfig()
 	if mgmtID == "" || mgmtSecret == "" {
 		return fmt.Errorf("management access keys are required to clean up old key")
 	}
@@ -628,7 +693,7 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	inactivate.Set(ramParamUserAccessKeyID, oldKeyID)
 	inactivate.Set("Status", "Inactive")
 
-	if _, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), inactivate, mgmtID, mgmtSecret, ""); err != nil {
+	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, inactivate, mgmtID, mgmtSecret, ""); err != nil {
 		return fmt.Errorf("RAM UpdateAccessKey (Inactive) failed: %w", err)
 	}
 	d.logger.Info("disabled old management access key",
@@ -644,7 +709,7 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	del.Set("UserName", userName)
 	del.Set(ramParamUserAccessKeyID, oldKeyID)
 
-	if _, err := d.callSignedJSON(ctx, http.MethodPost, d.ramEndpoint(), del, mgmtID, mgmtSecret, ""); err != nil {
+	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
 		return fmt.Errorf("RAM DeleteAccessKey (old management key) failed: %w", err)
 	}
 

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -531,11 +531,123 @@ func (d *AlicloudDriver) SupportsRotation() bool {
 		credential.GetString(d.credSource.Config, "management_user_name", "") != ""
 }
 
+// alicloudAccessKey is one entry of a RAM ListAccessKeys response.
+type alicloudAccessKey struct {
+	AccessKeyID string `json:"AccessKeyId"`
+	Status      string `json:"Status"`
+}
+
+// alicloudAccessKeyInactive is the RAM status of a disabled access key. A key
+// Warden left behind mid-cleanup carries it, because CleanupRotation always
+// deactivates before deleting.
+const alicloudAccessKeyInactive = "Inactive"
+
+// alicloudCodeEntityNotExist is the RAM error-code family for a subject that is
+// not there — EntityNotExist.User, EntityNotExist.User.AccessKey, and so on.
+const alicloudCodeEntityNotExist = "EntityNotExist"
+
+// alicloudMaxRAMKeysPerUser is the number of access keys RAM allows one user to
+// hold. Rotation needs a free slot to create the new key in, which is the only
+// reason it ever removes an existing one.
+const alicloudMaxRAMKeysPerUser = 2
+
+// makeRoomForNewKey frees a slot so CreateAccessKey can succeed, and does so
+// without destroying a key it cannot attribute to Warden.
+//
+// It acts only when the user is at the cap, removes at most one key per attempt,
+// and deletes only a key that is already Inactive — the state Warden's own
+// interrupted cleanup leaves behind, since CleanupRotation deactivates before it
+// deletes. An Active key that is not the current one is deactivated instead, and
+// the attempt stops with an error; the retry finds it Inactive and reclaims the
+// slot. The rotation manager retries a failed prepare on an exponential backoff
+// starting around twenty seconds, so that detour costs one short retry, not a
+// rotation period.
+//
+// It exists because rotation must still be able to heal itself. Two paths leave
+// an Active key of Warden's own behind — a crash between CreateAccessKey and the
+// staged-rotation persist, and a staged activation exhausting its attempts, after
+// which the manager resets to idle and prepares afresh — so refusing to touch
+// Active keys at all would wedge rotation permanently once either happened.
+// Deactivating a genuine third-party key is disruptive but reversible; deleting
+// one is not, which is the trade this makes.
+func (d *AlicloudDriver) makeRoomForNewKey(
+	ctx context.Context,
+	ramEndpoint, mgmtID, mgmtSecret, userName string,
+	keys []alicloudAccessKey,
+) error {
+	if len(keys) < alicloudMaxRAMKeysPerUser {
+		return nil
+	}
+
+	// The current key must be among the user's own. If it is not, the source is
+	// pointed at the wrong management_user_name (or the key belongs to another
+	// user), and every key listed here belongs to someone else — so touch none of
+	// them and say why.
+	var candidate *alicloudAccessKey
+	currentFound := false
+	for i := range keys {
+		switch {
+		case keys[i].AccessKeyID == mgmtID:
+			currentFound = true
+		case candidate == nil:
+			candidate = &keys[i]
+		}
+	}
+	if !currentFound {
+		return fmt.Errorf(
+			"RAM user %q holds %d access keys, none of them the configured access_key_id %s: "+
+				"refusing to remove a key this source does not own (check management_user_name)",
+			userName, len(keys), truncateID(mgmtID, 8))
+	}
+	if candidate == nil {
+		return nil
+	}
+
+	if candidate.Status == alicloudAccessKeyInactive {
+		d.logger.Warn("deleting inactive orphaned RAM access key from an interrupted rotation",
+			logger.String("orphaned_key_id", truncateID(candidate.AccessKeyID, 8)),
+			logger.String("ram_user", userName),
+		)
+		del := url.Values{}
+		del.Set("Action", "DeleteAccessKey")
+		del.Set("Version", alicloudRAMVersion)
+		del.Set("Format", "JSON")
+		del.Set("UserName", userName)
+		del.Set(ramParamUserAccessKeyID, candidate.AccessKeyID)
+		if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
+			return fmt.Errorf("failed to delete orphaned access key %s: %w", truncateID(candidate.AccessKeyID, 8), err)
+		}
+		return nil
+	}
+
+	d.logger.Warn("deactivating an active non-current RAM access key to free a rotation slot; "+
+		"it will be deleted on the next rotation attempt",
+		logger.String("key_id", truncateID(candidate.AccessKeyID, 8)),
+		logger.String("ram_user", userName),
+	)
+	inactivate := url.Values{}
+	inactivate.Set("Action", "UpdateAccessKey")
+	inactivate.Set("Version", alicloudRAMVersion)
+	inactivate.Set("Format", "JSON")
+	inactivate.Set("UserName", userName)
+	inactivate.Set(ramParamUserAccessKeyID, candidate.AccessKeyID)
+	inactivate.Set("Status", alicloudAccessKeyInactive)
+	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, inactivate, mgmtID, mgmtSecret, ""); err != nil {
+		return fmt.Errorf("failed to deactivate non-current access key %s: %w", truncateID(candidate.AccessKeyID, 8), err)
+	}
+
+	return fmt.Errorf(
+		"RAM user %q is at the %d-key limit and the non-current key %s was still active; "+
+			"it has been deactivated and will be removed on the next rotation attempt. "+
+			"If it is not Warden's, reactivate it and give this source a dedicated RAM user",
+		userName, alicloudMaxRAMKeysPerUser, truncateID(candidate.AccessKeyID, 8))
+}
+
 // PrepareRotation creates a new RAM access key for the configured management
-// user while the existing key remains valid. Before creating, it deletes any
-// orphaned keys from previous failed rotations (RAM allows at most 2 keys per
-// user). Returns the new config, a cleanup config (with the old access_key_id),
-// and the activation delay to let RAM eventual consistency propagate.
+// user while the existing key remains valid. If the user is at RAM's two-key
+// limit it first frees a slot (see makeRoomForNewKey). Returns the new config, a
+// cleanup config (with the old access_key_id), and the activation delay to let
+// RAM eventual consistency propagate.
 func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
 	d.configMu.RLock()
 	mgmtID := credential.GetString(d.credSource.Config, "access_key_id", "")
@@ -556,9 +668,8 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 		return nil, nil, 0, fmt.Errorf("management_user_name is required for rotation")
 	}
 
-	// Step 1: clean up orphaned keys from previous failed rotations.
-	// RAM users can hold at most 2 access keys; if there are already 2, remove
-	// any that aren't our current management key before creating the new one.
+	// Step 1: list the user's keys, so a slot can be freed if the RAM two-key
+	// limit would otherwise make CreateAccessKey fail.
 	listParams := url.Values{}
 	listParams.Set("Action", "ListAccessKeys")
 	listParams.Set("Version", alicloudRAMVersion)
@@ -571,33 +682,15 @@ func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string
 	}
 	var listResp struct {
 		AccessKeys struct {
-			AccessKey []struct {
-				AccessKeyID string `json:"AccessKeyId"`
-				Status      string `json:"Status"`
-			} `json:"AccessKey"`
+			AccessKey []alicloudAccessKey `json:"AccessKey"`
 		} `json:"AccessKeys"`
 	}
 	if err := json.Unmarshal(listBody, &listResp); err != nil {
 		return nil, nil, 0, fmt.Errorf("parse ListAccessKeys response: %w", err)
 	}
 
-	for _, k := range listResp.AccessKeys.AccessKey {
-		if k.AccessKeyID == mgmtID {
-			continue
-		}
-		d.logger.Warn("deleting orphaned RAM access key from previous failed rotation",
-			logger.String("orphaned_key_id", truncateID(k.AccessKeyID, 8)),
-			logger.String("ram_user", userName),
-		)
-		del := url.Values{}
-		del.Set("Action", "DeleteAccessKey")
-		del.Set("Version", alicloudRAMVersion)
-		del.Set("Format", "JSON")
-		del.Set("UserName", userName)
-		del.Set(ramParamUserAccessKeyID, k.AccessKeyID)
-		if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
-			return nil, nil, 0, fmt.Errorf("failed to delete orphaned access key %s: %w", truncateID(k.AccessKeyID, 8), err)
-		}
+	if err := d.makeRoomForNewKey(ctx, ramEndpoint, mgmtID, mgmtSecret, userName, listResp.AccessKeys.AccessKey); err != nil {
+		return nil, nil, 0, err
 	}
 
 	// Step 2: create a new access key for the same user.
@@ -691,9 +784,22 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	inactivate.Set("Format", "JSON")
 	inactivate.Set("UserName", userName)
 	inactivate.Set(ramParamUserAccessKeyID, oldKeyID)
-	inactivate.Set("Status", "Inactive")
+	inactivate.Set("Status", alicloudAccessKeyInactive)
 
 	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, inactivate, mgmtID, mgmtSecret, ""); err != nil {
+		// A key that is already gone is the outcome this is working towards, so
+		// it is success, not failure. Cleanup is retried for days after a failure,
+		// and the next rotation's slot-freeing sweep can delete the very key a
+		// pending cleanup is still chasing — without this, those retries would
+		// fail daily and eventually log an abandonment for a key that no longer
+		// exists.
+		if alicloudErrorHasCodePrefix(err, alicloudCodeEntityNotExist) {
+			d.logger.Info("old management access key was already removed; cleanup is complete",
+				logger.String("old_key_id", truncateID(oldKeyID, 8)),
+				logger.String("ram_user", userName),
+			)
+			return nil
+		}
 		return fmt.Errorf("RAM UpdateAccessKey (Inactive) failed: %w", err)
 	}
 	d.logger.Info("disabled old management access key",
@@ -710,7 +816,10 @@ func (d *AlicloudDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 	del.Set(ramParamUserAccessKeyID, oldKeyID)
 
 	if _, err := d.callSignedJSON(ctx, http.MethodPost, ramEndpoint, del, mgmtID, mgmtSecret, ""); err != nil {
-		return fmt.Errorf("RAM DeleteAccessKey (old management key) failed: %w", err)
+		// Same reasoning as the Inactive step: deleted is deleted, whoever did it.
+		if !alicloudErrorHasCodePrefix(err, alicloudCodeEntityNotExist) {
+			return fmt.Errorf("RAM DeleteAccessKey (old management key) failed: %w", err)
+		}
 	}
 
 	d.logger.Info("deleted old management access key after rotation",

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -43,10 +43,26 @@ const (
 	ramParamUserAccessKeyID = "UserAccessKeyId"
 )
 
+// alicloudAuthMethodStatic and alicloudAuthMethodOIDCFederation select how the
+// source authenticates. static (default) signs every call with a long-lived RAM
+// access key pair held in config; oidc_federation holds no key at all and mints
+// only by presenting the caller's identity assertion to STS AssumeRoleWithOIDC.
+// An empty auth_method means static, so records written before federation existed
+// keep working.
+const (
+	alicloudAuthMethodStatic         = "static"
+	alicloudAuthMethodOIDCFederation = "oidc_federation"
+)
+
+// alicloudTimestampFormat is the ISO 8601 form Alibaba's RPC common Timestamp
+// parameter takes: UTC, second precision, literal Z.
+const alicloudTimestampFormat = "2006-01-02T15:04:05Z"
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*AlicloudDriver)(nil)
 var _ credential.SpecVerifier = (*AlicloudDriver)(nil)
 var _ credential.Rotatable = (*AlicloudDriver)(nil)
+var _ credential.ExchangeMinter = (*AlicloudDriver)(nil)
 
 // AlicloudDriver mints credentials from Alibaba Cloud STS.
 //
@@ -84,7 +100,20 @@ func (f *AlicloudDriverFactory) Type() string {
 
 // ValidateConfig validates Alicloud source configuration.
 func (f *AlicloudDriverFactory) ValidateConfig(config map[string]string) error {
-	return credential.ValidateSchema(config,
+	if err := credential.ValidateSchema(config,
+		credential.StringField("auth_method").
+			OneOf(alicloudAuthMethodStatic, alicloudAuthMethodOIDCFederation).
+			Describe("How the source authenticates: 'static' (RAM access key pair) or 'oidc_federation' (keyless, exchanges the caller's identity assertion via STS AssumeRoleWithOIDC)").
+			Example(alicloudAuthMethodStatic),
+
+		credential.StringField("oidc_provider_arn").
+			Describe("RAM OIDC provider ARN that trusts Warden's issuer (required for auth_method=oidc_federation)").
+			Example("acs:ram::123456789012:oidc-provider/warden"),
+
+		credential.StringField("audience").
+			Describe("Assertion audience; must match a client_id registered on the RAM OIDC provider (auth_method=oidc_federation)").
+			Example("https://warden.example.com"),
+
 		credential.StringField("access_key_id").
 			Describe("Management access key ID (usually starts with LTAI)").
 			Example("LTAIxxxxxxxxxxxxxxxx"),
@@ -117,7 +146,45 @@ func (f *AlicloudDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
-	)
+	); err != nil {
+		return err
+	}
+
+	// Cross-field rules per auth_method. Each mode rejects the other's fields, so a
+	// half-converted source fails at write rather than behaving as the mode the
+	// operator did not intend.
+	//
+	// Present-but-empty is validated as static, not skipped. GetString returns a
+	// stored "" rather than the default, and the schema pass above skips empty
+	// values too — so a switch that only matched the two named modes would let a
+	// source through carrying neither a key pair nor a federation config, and it is
+	// static that such a source then behaves as.
+	switch credential.GetString(config, "auth_method", alicloudAuthMethodStatic) {
+	case "", alicloudAuthMethodStatic:
+		// oidc_provider_arn and audience seed only the federation exchange; on a
+		// static source they would be silently ignored, so reject rather than
+		// mislead. Note the static path deliberately does not require a key pair
+		// here — the schema has never marked one required, and tightening that is
+		// a separate change.
+		for _, k := range []string{"oidc_provider_arn", "audience"} {
+			if config[k] != "" {
+				return fmt.Errorf("field '%s' is only valid for auth_method=%s", k, alicloudAuthMethodOIDCFederation)
+			}
+		}
+	case alicloudAuthMethodOIDCFederation:
+		if credential.GetString(config, "oidc_provider_arn", "") == "" {
+			return fmt.Errorf("oidc_provider_arn is required for auth_method=%s", alicloudAuthMethodOIDCFederation)
+		}
+		// A federation source holds no key of its own, so it has nothing to rotate
+		// and no RAM user to rotate as — ram_endpoint included, which only the
+		// rotation calls ever read.
+		for _, k := range []string{"access_key_id", "access_key_secret", "management_user_name", "activation_delay", "ram_endpoint"} {
+			if config[k] != "" {
+				return fmt.Errorf("field '%s' must not be set for auth_method=%s", k, alicloudAuthMethodOIDCFederation)
+			}
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns source config keys that should be masked.
@@ -186,8 +253,35 @@ func (d *AlicloudDriver) endpointLocked(key, fallback string) string {
 	return strings.TrimRight(credential.GetString(d.credSource.Config, key, fallback), "/")
 }
 
+// getAuthMethod returns the source's configured auth_method, normalising both an
+// absent key and a stored empty string to static — the former so a record written
+// before federation existed keeps its old behaviour, the latter because GetString
+// hands back a stored "" rather than the default. It reads under configMu because
+// CommitRotation swaps the whole config map.
+func (d *AlicloudDriver) getAuthMethod() string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	if method := credential.GetString(d.credSource.Config, "auth_method", alicloudAuthMethodStatic); method != "" {
+		return method
+	}
+	return alicloudAuthMethodStatic
+}
+
+// federationConfig returns the STS endpoint and the OIDC provider ARN from one
+// config snapshot, for the same reason stsCallConfig pairs its two reads.
+func (d *AlicloudDriver) federationConfig() (endpoint, providerARN string) {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.endpointLocked("sts_endpoint", DefaultAlicloudSTSEndpoint),
+		credential.GetString(d.credSource.Config, "oidc_provider_arn", "")
+}
+
 // MintCredential returns Alicloud credentials for the given spec.
 func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: a source with auth_method=%s mints only from a caller assertion: set subject_token_source (warden_identity or agent_identity) on the spec", alicloudAuthMethodOIDCFederation)
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "assume_role":
@@ -197,18 +291,46 @@ func (d *AlicloudDriver) MintCredential(ctx context.Context, spec *credential.Cr
 	}
 }
 
-// mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
-func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
-	if mgmtID == "" || mgmtSecret == "" {
-		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
+// MintCredentialWithExchange mints STS session credentials over workload identity
+// federation: the caller's identity assertion is exchanged at STS for a session on
+// the spec's RAM role, so the source stores no key of its own and ActionTrail
+// records the identity behind each request rather than one shared RAM user.
+//
+// The subject token is trusted at the source — either an assertion Warden minted
+// and signed, or the agent's own verified inbound JWT — so it is forwarded to STS
+// as-is. STS validates it against the OIDC provider's registered issuer and
+// client_ids, and the role's trust policy decides what it may assume.
+func (d *AlicloudDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if d.getAuthMethod() != alicloudAuthMethodOIDCFederation {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: workload identity federation requires auth_method=%s on the source", alicloudAuthMethodOIDCFederation)
+	}
+	if inputs == nil || inputs.SubjectToken == "" {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: no subject token in exchange inputs")
 	}
 
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	if mintMethod != "assume_role" {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: mint_method %q is not supported over auth_method=%s (supported: assume_role)", mintMethod, alicloudAuthMethodOIDCFederation)
+	}
+	return d.assumeRoleWithOIDC(ctx, spec, inputs.SubjectToken)
+}
+
+// alicloudAssumeRoleParams is the spec-derived half of an assume-role call, shared
+// by the static and federated paths so the two cannot drift on defaults or clamps.
+type alicloudAssumeRoleParams struct {
+	RoleARN     string
+	SessionName string
+	Duration    time.Duration
+	Policy      string
+}
+
+// resolveAssumeRoleParams reads and normalises the spec's assume-role settings.
+func resolveAssumeRoleParams(spec *credential.CredSpec) (*alicloudAssumeRoleParams, error) {
 	roleARN := credential.GetString(spec.Config, "role_arn", "")
 	if roleARN == "" {
-		return nil, nil, 0, "", fmt.Errorf("role_arn is required for assume_role")
+		return nil, fmt.Errorf("role_arn is required for assume_role")
 	}
-	sessionName := credential.GetString(spec.Config, "role_session_name", "warden-session")
+
 	duration := credential.GetDuration(spec.Config, "duration_seconds", time.Hour)
 	if duration < alicloudMinSTSDuration {
 		duration = alicloudMinSTSDuration
@@ -217,22 +339,98 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		duration = alicloudMaxSTSDuration
 	}
 
+	return &alicloudAssumeRoleParams{
+		RoleARN:     roleARN,
+		SessionName: credential.GetString(spec.Config, "role_session_name", "warden-session"),
+		Duration:    duration,
+		Policy:      credential.GetString(spec.Config, "policy", ""),
+	}, nil
+}
+
+// mintAssumeRole calls STS AssumeRole to obtain temporary credentials.
+func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	stsEndpoint, mgmtID, mgmtSecret := d.stsCallConfig()
+	if mgmtID == "" || mgmtSecret == "" {
+		return nil, nil, 0, "", fmt.Errorf("source access_key_id and access_key_secret are required for assume_role")
+	}
+
+	ar, err := resolveAssumeRoleParams(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	params := url.Values{}
 	params.Set("Action", "AssumeRole")
 	params.Set("Version", alicloudSTSVersion)
 	params.Set("Format", "JSON")
-	params.Set("RoleArn", roleARN)
-	params.Set("RoleSessionName", sessionName)
-	params.Set("DurationSeconds", fmt.Sprintf("%d", int(duration.Seconds())))
-	if p := credential.GetString(spec.Config, "policy", ""); p != "" {
-		params.Set("Policy", p)
+	params.Set("RoleArn", ar.RoleARN)
+	params.Set("RoleSessionName", ar.SessionName)
+	params.Set("DurationSeconds", fmt.Sprintf("%d", int(ar.Duration.Seconds())))
+	if ar.Policy != "" {
+		params.Set("Policy", ar.Policy)
 	}
 
 	respBody, err := d.callSignedJSON(ctx, http.MethodPost, stsEndpoint, params, mgmtID, mgmtSecret, "")
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed: %w", err)
 	}
+	return d.credentialsFromSTSResponse(respBody, ar)
+}
 
+// assumeRoleWithOIDC exchanges the caller's assertion for STS session credentials.
+//
+// The call is unsigned: AssumeRoleWithOIDC authenticates by the OIDC token itself,
+// and Alibaba documents that it takes no Signature or AccessKeyId. That is what
+// lets a source holding no key make it at all.
+//
+// The assertion travels in the POST form body, never the query string. A query
+// parameter would be printed back by *url.Error on any transport failure — the
+// full URL, token and all — into operator-visible errors and logs, and into every
+// proxy and load-balancer access log on the path. Alibaba's own RRSA credential
+// provider splits the request the same way, with Action/Version/Format in the
+// query and the token in the body.
+func (d *AlicloudDriver) assumeRoleWithOIDC(ctx context.Context, spec *credential.CredSpec, assertion string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	stsEndpoint, providerARN := d.federationConfig()
+	if providerARN == "" {
+		return nil, nil, 0, "", fmt.Errorf("alicloud: oidc_provider_arn is required on the source for auth_method=%s", alicloudAuthMethodOIDCFederation)
+	}
+
+	ar, err := resolveAssumeRoleParams(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	// Action/Version/Format/Timestamp are the RPC common parameters and stay in the
+	// query, exactly as Alibaba's own RRSA client sends them. Timestamp is part of
+	// that convention rather than something the body could carry, and nothing local
+	// can prove STS tolerates its absence — an httptest stub accepts whatever it is
+	// given — so it is sent rather than assumed optional.
+	query := url.Values{}
+	query.Set("Action", "AssumeRoleWithOIDC")
+	query.Set("Version", alicloudSTSVersion)
+	query.Set("Format", "JSON")
+	query.Set("Timestamp", time.Now().UTC().Format(alicloudTimestampFormat))
+
+	body := url.Values{}
+	body.Set("RoleArn", ar.RoleARN)
+	body.Set("OIDCProviderArn", providerARN)
+	body.Set("OIDCToken", assertion)
+	body.Set("RoleSessionName", ar.SessionName)
+	body.Set("DurationSeconds", fmt.Sprintf("%d", int(ar.Duration.Seconds())))
+	if ar.Policy != "" {
+		body.Set("Policy", ar.Policy)
+	}
+
+	respBody, err := d.callAnonymousJSON(ctx, stsEndpoint, query, body)
+	if err != nil {
+		return nil, nil, 0, "", d.mapFederationError(err, ar.RoleARN, providerARN)
+	}
+	return d.credentialsFromSTSResponse(respBody, ar)
+}
+
+// credentialsFromSTSResponse parses an assume-role response into the mint tuple.
+// Both assume-role paths return the same Credentials block, so they share this.
+func (d *AlicloudDriver) credentialsFromSTSResponse(respBody []byte, ar *alicloudAssumeRoleParams) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	var resp struct {
 		Credentials struct {
 			AccessKeyID     string `json:"AccessKeyId"`
@@ -248,22 +446,49 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		return nil, nil, 0, "", fmt.Errorf("STS returned empty credentials")
 	}
 
-	leaseTTL, err := d.stsLeaseTTL(resp.Credentials.Expiration, duration)
+	leaseTTL, err := d.stsLeaseTTL(resp.Credentials.Expiration, ar.Duration)
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
 
 	d.logger.Info("issued STS temporary credentials",
 		logger.String("access_key", truncateID(resp.Credentials.AccessKeyID, 8)),
-		logger.String("role_arn", roleARN),
+		logger.String("role_arn", ar.RoleARN),
 		logger.String("expires", resp.Credentials.Expiration),
 	)
+
+	metadata := map[string]interface{}{
+		"role_arn":     ar.RoleARN,
+		"session_name": ar.SessionName,
+		"expiration":   resp.Credentials.Expiration,
+	}
 
 	return map[string]interface{}{
 		"access_key_id":     resp.Credentials.AccessKeyID,
 		"access_key_secret": resp.Credentials.AccessKeySecret,
 		"security_token":    resp.Credentials.SecurityToken,
-	}, nil, leaseTTL, "", nil // STS tokens are self-expiring; no leaseID
+	}, metadata, leaseTTL, "", nil // STS tokens are self-expiring; no leaseID
+}
+
+// mapFederationError adds triage guidance to the STS error codes that mean the
+// trust relationship is misconfigured, since the raw envelope names none of the
+// three things an operator has to check.
+func (d *AlicloudDriver) mapFederationError(err error, roleARN, providerARN string) error {
+	switch {
+	case alicloudErrorHasCodePrefix(err, "AuthenticationFail"),
+		alicloudErrorHasCodePrefix(err, "InvalidParameter.OIDCProviderArn"),
+		alicloudErrorHasCodePrefix(err, "IDPNotFound"):
+		return fmt.Errorf("STS AssumeRoleWithOIDC rejected the assertion for provider %s: %w "+
+			"(check that the RAM OIDC provider trusts Warden's issuer URL, that the assertion's "+
+			"audience matches one of its registered client_ids, and that the trust policy on %s "+
+			"admits the assertion's subject)", providerARN, err, roleARN)
+	case alicloudErrorHasCodePrefix(err, "NoPermission"),
+		alicloudErrorHasCodePrefix(err, "EntityNotExist.Role"):
+		return fmt.Errorf("STS AssumeRoleWithOIDC could not assume %s: %w "+
+			"(check the role exists and its trust policy admits this OIDC provider)", roleARN, err)
+	default:
+		return fmt.Errorf("STS AssumeRoleWithOIDC failed: %w", err)
+	}
 }
 
 // stsLeaseTTL converts the Expiration STS reports into a lease TTL.
@@ -325,6 +550,19 @@ const alicloudVerifyTimeout = 10 * time.Second
 // STS validates the management key; a valid signature followed by any RAM
 // role resolution error validates the role_arn. A single call covers both.
 func (d *AlicloudDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	// A federation source has no ambient credential to dry-run with — assertions
+	// are per caller, per request — so a misconfigured role surfaces at the first
+	// mint instead.
+	//
+	// This guard is defence in depth and nothing more: VerifySpec runs only inside
+	// the spec-create test-mint, which is skipped for every exchange spec, and a
+	// non-exchange spec on a keyless source is already refused by MintCredential
+	// before reaching here. Do not add config checks below expecting them to fire
+	// on a federated source.
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return nil
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "assume_role":
@@ -458,11 +696,55 @@ func (d *AlicloudDriver) callSignedJSON(
 	params url.Values,
 	mgmtID, mgmtSecret, securityToken string,
 ) ([]byte, error) {
+	return d.callJSON(ctx, method, endpoint, params, nil, func(req *http.Request) error {
+		// Re-sign every attempt so x-acs-date and x-acs-signature-nonce advance,
+		// staying inside ACS3's 15-minute skew window.
+		if err := signACS3(req, mgmtID, mgmtSecret, securityToken, nil); err != nil {
+			return fmt.Errorf("sign request: %w", err)
+		}
+		return nil
+	})
+}
+
+// callAnonymousJSON sends an unsigned RPC call, carrying its parameters in a
+// form-encoded POST body rather than the query string.
+//
+// STS AssumeRoleWithOIDC is the only call that takes this path. It authenticates
+// by the OIDC token it carries, so Alibaba documents that it needs no Signature
+// and no AccessKeyId — which is what a keyless source relies on, having neither.
+//
+// The body matters as much as the missing signature. httputil wraps a transport
+// failure around *url.Error, whose message prints the whole URL; a token in the
+// query string would land in operator-visible errors, in server logs, and in the
+// access log of every proxy on the path. Only Action/Version/Format stay in the
+// query, matching how Alibaba's own RRSA client splits the request.
+func (d *AlicloudDriver) callAnonymousJSON(
+	ctx context.Context,
+	endpoint string,
+	query, body url.Values,
+) ([]byte, error) {
+	return d.callJSON(ctx, http.MethodPost, endpoint, query, body, nil)
+}
+
+// callJSON owns the retry loop, backoff, and envelope classification shared by
+// the signed and anonymous paths. sign is nil for an anonymous call; body is nil
+// for a query-only one.
+func (d *AlicloudDriver) callJSON(
+	ctx context.Context,
+	method, endpoint string,
+	query, body url.Values,
+	sign func(*http.Request) error,
+) ([]byte, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
 	}
-	u.RawQuery = params.Encode()
+	u.RawQuery = query.Encode()
+
+	var encodedBody []byte
+	if body != nil {
+		encodedBody = []byte(body.Encode())
+	}
 
 	var lastErr error
 	for attempt := 0; attempt < alicloudMaxRetryAttempts; attempt++ {
@@ -477,25 +759,30 @@ func (d *AlicloudDriver) callSignedJSON(
 			}
 		}
 
-		// Re-sign every attempt so x-acs-date and x-acs-signature-nonce
-		// advance, staying inside ACS3's 15-minute skew window.
-		req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(nil))
+		// Rebuilt each attempt so the signer, if any, produces fresh date and
+		// nonce headers.
+		req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(encodedBody))
 		if err != nil {
 			return nil, err
 		}
 		req.Host = u.Host
 		// x-acs-action and x-acs-version are required in the signed headers for V3;
 		// mirror the Action and Version query params into them.
-		if action := params.Get("Action"); action != "" {
+		if action := query.Get("Action"); action != "" {
 			req.Header.Set("x-acs-action", action)
 		}
-		if version := params.Get("Version"); version != "" {
+		if version := query.Get("Version"); version != "" {
 			req.Header.Set("x-acs-version", version)
 		}
 		req.Header.Set("Accept", "application/json")
+		if encodedBody != nil {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
 
-		if err := signACS3(req, mgmtID, mgmtSecret, securityToken, nil); err != nil {
-			return nil, fmt.Errorf("sign request: %w", err)
+		if sign != nil {
+			if err := sign(req); err != nil {
+				return nil, err
+			}
 		}
 
 		headers := make(map[string]string, len(req.Header))
@@ -514,6 +801,7 @@ func (d *AlicloudDriver) callSignedJSON(
 			Method:  method,
 			URL:     u.String(),
 			Headers: headers,
+			Body:    encodedBody,
 			OKStatuses: []int{
 				http.StatusOK,
 				http.StatusBadRequest,
@@ -553,7 +841,7 @@ func (d *AlicloudDriver) callSignedJSON(
 		// otherwise read it as success and silently leave a live key in place.
 		if status != http.StatusOK {
 			return nil, fmt.Errorf("alicloud %s returned HTTP %d with an unrecognised body: %s",
-				params.Get("Action"), status, alicloudBodyPreview(respBody))
+				query.Get("Action"), status, alicloudBodyPreview(respBody))
 		}
 
 		return respBody, nil
@@ -568,6 +856,14 @@ func (d *AlicloudDriver) callSignedJSON(
 // management access key: an existing access_key_id + access_key_secret plus
 // management_user_name identifying which RAM user owns the key.
 func (d *AlicloudDriver) SupportsRotation() bool {
+	// A federation source holds no key, so there is nothing to rotate.
+	// ValidateConfig already keeps the key fields off such a source, which would
+	// make the check below false anyway; stating it here keeps the invariant
+	// independent of that.
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return false
+	}
+
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
 	return credential.GetString(d.credSource.Config, "access_key_id", "") != "" &&
@@ -693,6 +989,10 @@ func (d *AlicloudDriver) makeRoomForNewKey(
 // cleanup config (with the old access_key_id), and the activation delay to let
 // RAM eventual consistency propagate.
 func (d *AlicloudDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	if d.getAuthMethod() == alicloudAuthMethodOIDCFederation {
+		return nil, nil, 0, fmt.Errorf("alicloud: a source with auth_method=%s holds no key to rotate", alicloudAuthMethodOIDCFederation)
+	}
+
 	d.configMu.RLock()
 	mgmtID := credential.GetString(d.credSource.Config, "access_key_id", "")
 	mgmtSecret := credential.GetString(d.credSource.Config, "access_key_secret", "")

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -248,6 +248,11 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		return nil, nil, 0, "", fmt.Errorf("STS returned empty credentials")
 	}
 
+	leaseTTL, err := d.stsLeaseTTL(resp.Credentials.Expiration, duration)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	d.logger.Info("issued STS temporary credentials",
 		logger.String("access_key", truncateID(resp.Credentials.AccessKeyID, 8)),
 		logger.String("role_arn", roleARN),
@@ -258,7 +263,46 @@ func (d *AlicloudDriver) mintAssumeRole(ctx context.Context, spec *credential.Cr
 		"access_key_id":     resp.Credentials.AccessKeyID,
 		"access_key_secret": resp.Credentials.AccessKeySecret,
 		"security_token":    resp.Credentials.SecurityToken,
-	}, nil, duration, "", nil // STS tokens are self-expiring; no leaseID
+	}, nil, leaseTTL, "", nil // STS tokens are self-expiring; no leaseID
+}
+
+// stsLeaseTTL converts the Expiration STS reports into a lease TTL.
+//
+// The requested duration alone is the wrong answer: it is measured before the
+// round trip, so the lease outlives the credential by however long the call took,
+// and it ignores an expiry STS shortened for its own reasons. The credential is
+// cached for its whole lease, so an over-long lease means a cache hit near the
+// end hands out a token that dies mid-request. The aws, gcp, ibm, elastic and
+// github drivers all derive their TTL from the server's expiry for this reason.
+//
+// The reported expiry is also capped at the requested duration, because it is
+// only as trustworthy as the agreement between two clocks. A local clock running
+// behind Alibaba's would otherwise reintroduce the very over-long lease this
+// exists to prevent, just bounded by skew rather than by round-trip time. STS
+// never issues longer than asked, so a longer expiry means skew, not generosity.
+//
+// An unparseable Expiration falls back to the requested duration: a usable
+// credential should not be thrown away over a timestamp format, and the fallback
+// is no worse than the behaviour this replaces. An expiry already in the past is
+// a different matter — there is no usable credential to return.
+func (d *AlicloudDriver) stsLeaseTTL(expiration string, requested time.Duration) (time.Duration, error) {
+	expiry, err := time.Parse(time.RFC3339, expiration)
+	if err != nil {
+		d.logger.Warn("STS returned an Expiration that is not RFC3339; falling back to the requested duration",
+			logger.String("expiration", expiration),
+			logger.String("requested", requested.String()),
+		)
+		return requested, nil
+	}
+
+	ttl := time.Until(expiry)
+	if ttl <= 0 {
+		return 0, fmt.Errorf("STS returned credentials that already expired at %s", expiration)
+	}
+	if ttl > requested {
+		return requested, nil
+	}
+	return ttl, nil
 }
 
 // Revoke is a no-op: the driver's only supported mint method (assume_role)

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/logger"
@@ -126,6 +127,7 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 	var receivedAuth string
 	var receivedRoleArn string
 
+	expiry := time.Now().Add(1800 * time.Second).UTC().Format(time.RFC3339)
 	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAction = r.URL.Query().Get("Action")
 		receivedRoleArn = r.URL.Query().Get("RoleArn")
@@ -136,7 +138,7 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 				"AccessKeyId":     "STS.tempid",
 				"AccessKeySecret": "tempsecret",
 				"SecurityToken":   "tempstsToken",
-				"Expiration":      "2099-01-01T00:00:00Z",
+				"Expiration":      expiry,
 			},
 		})
 	}))
@@ -164,7 +166,10 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 	assert.Equal(t, "STS.tempid", raw["access_key_id"])
 	assert.Equal(t, "tempsecret", raw["access_key_secret"])
 	assert.Equal(t, "tempstsToken", raw["security_token"])
-	assert.Equal(t, 1800, int(ttl.Seconds()), "ttl should match duration_seconds")
+	// Derived from the Expiration STS reported, so it is at most the requested
+	// 1800s — never more, whatever the round trip cost.
+	assert.InDelta(t, 1800, ttl.Seconds(), 5, "ttl should track the reported expiry")
+	assert.LessOrEqual(t, ttl, 1800*time.Second)
 	assert.Equal(t, "", leaseID, "STS has no leaseID")
 
 	// Verify the request was signed with ACS3 and had the right params
@@ -172,6 +177,87 @@ func TestAlicloudDriver_MintAssumeRole(t *testing.T) {
 	assert.Equal(t, "acs:ram::123:role/ops", receivedRoleArn)
 	assert.True(t, strings.HasPrefix(receivedAuth, "ACS3-HMAC-SHA256"), "must be ACS3 signed: %q", receivedAuth)
 	assert.Contains(t, receivedAuth, "Credential=LTAI-mgmt")
+}
+
+// mintWithExpiration mints one credential against an STS stub that reports the
+// given Expiration verbatim, and returns the resulting lease TTL.
+func mintWithExpiration(t *testing.T, expiration, durationSeconds string) (time.Duration, error) {
+	t.Helper()
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.tempid",
+				"AccessKeySecret": "tempsecret",
+				"SecurityToken":   "tempstsToken",
+				"Expiration":      expiration,
+			},
+		})
+	}))
+	t.Cleanup(sts.Close)
+
+	f := &AlicloudDriverFactory{}
+	d, err := f.Create(map[string]string{
+		"access_key_id":     "LTAI-mgmt",
+		"access_key_secret": "mgmt-secret",
+		"sts_endpoint":      sts.URL,
+	}, createAlicloudTestLogger())
+	require.NoError(t, err)
+
+	_, _, ttl, _, err := d.MintCredential(context.Background(), &credential.CredSpec{
+		Config: map[string]string{
+			"mint_method":      "assume_role",
+			"role_arn":         "acs:ram::123:role/ops",
+			"duration_seconds": durationSeconds,
+		},
+	})
+	return ttl, err
+}
+
+// The lease must follow the credential, not the request. STS is free to issue a
+// shorter session than was asked for; caching for the requested duration would
+// then serve a dead token to whoever hits the cache near the end.
+func TestAlicloudDriver_MintAssumeRole_TTLFollowsServerExpiry(t *testing.T) {
+	shortened := time.Now().Add(600 * time.Second).UTC().Format(time.RFC3339)
+
+	ttl, err := mintWithExpiration(t, shortened, "3600s")
+
+	require.NoError(t, err)
+	assert.InDelta(t, 600, ttl.Seconds(), 5, "the reported expiry wins over the requested duration")
+}
+
+// The reported expiry is only as good as the agreement between two clocks. A
+// local clock running behind Alibaba's reports a remaining lifetime longer than
+// was ever requested, which would reintroduce the over-long lease this fix
+// exists to prevent — so the requested duration is the ceiling. STS never issues
+// longer than asked, so a longer expiry means skew, not generosity.
+func TestAlicloudDriver_MintAssumeRole_TTLCappedAtRequestedDuration(t *testing.T) {
+	skewed := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+
+	ttl, err := mintWithExpiration(t, skewed, "1800s")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1800*time.Second, ttl, "an expiry beyond the requested duration must be capped")
+}
+
+// A credential that is usable should not be discarded over a timestamp format,
+// so an unparseable Expiration falls back to the requested duration — no worse
+// than the behaviour this replaced.
+func TestAlicloudDriver_MintAssumeRole_UnparseableExpiryFallsBack(t *testing.T) {
+	ttl, err := mintWithExpiration(t, "not-a-timestamp", "1800s")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1800*time.Second, ttl)
+}
+
+// An expiry already in the past leaves nothing usable to hand back.
+func TestAlicloudDriver_MintAssumeRole_ExpiredCredentialIsRejected(t *testing.T) {
+	past := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+
+	_, err := mintWithExpiration(t, past, "1800s")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already expired")
 }
 
 func TestAlicloudDriver_MintAssumeRole_MissingRoleArn(t *testing.T) {
@@ -1130,4 +1216,36 @@ func TestSignACS3_KnownAnswer(t *testing.T) {
 		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		r.Header.Get("x-acs-content-sha256"),
 	)
+}
+
+// ACS3 sorts by parameter name only. A repeated name keeps the order it arrived
+// in, because that is the order the server signs; sorting the values would
+// compute a canonical string the server does not derive. This matches the
+// identical helper in provider/alicloud/signature.go.
+func TestACS3CanonicalQuery(t *testing.T) {
+	got, err := acs3CanonicalQuery("b=2&a=1&c=hello%20world")
+	require.NoError(t, err)
+	assert.Equal(t, "a=1&b=2&c=hello%20world", got)
+
+	got, err = acs3CanonicalQuery("k=b&k=a&j=1")
+	require.NoError(t, err)
+	assert.Equal(t, "j=1&k=b&k=a", got, "values for a repeated name keep request order")
+
+	got, err = acs3CanonicalQuery("")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// A query that will not parse must be reported, not silently rendered as empty:
+// signing an empty canonical query for a request that has one produces a
+// signature the server cannot reproduce, surfacing as a confusing remote
+// SignatureDoesNotMatch instead of the local defect.
+func TestACS3CanonicalQuery_MalformedQueryIsReported(t *testing.T) {
+	_, err := acs3CanonicalQuery("a=%zz")
+	require.Error(t, err)
+
+	r, _ := http.NewRequest("POST", "https://sts.aliyuncs.com/", nil)
+	r.URL.RawQuery = "a=%zz"
+	assert.Error(t, signACS3(r, "LTAItest", "secret", "", nil),
+		"signACS3 should surface a malformed query rather than sign an empty one")
 }

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -649,6 +649,17 @@ type ramServer struct {
 	actionSeq     []string // action names in the order received, for ordering assertions
 }
 
+// writeEntityNotExist replies as RAM does for an access key that is not there:
+// an error envelope on HTTP 404, not a bare status.
+func (s *ramServer) writeEntityNotExist(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNotFound)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"Code":      "EntityNotExist.User.AccessKey",
+		"Message":   "The specified access key does not exist.",
+		"RequestId": "req-not-exist",
+	})
+}
+
 func (s *ramServer) handle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	action := r.URL.Query().Get("Action")
@@ -688,7 +699,7 @@ func (s *ramServer) handle(w http.ResponseWriter, r *http.Request) {
 		id := r.URL.Query().Get("UserAccessKeyId")
 		status := r.URL.Query().Get("Status")
 		if _, ok := s.keys[id]; !ok {
-			http.Error(w, "no such key", http.StatusBadRequest)
+			s.writeEntityNotExist(w)
 			return
 		}
 		s.keys[id] = status
@@ -698,6 +709,10 @@ func (s *ramServer) handle(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"RequestId": "req"})
 	case "DeleteAccessKey":
 		id := r.URL.Query().Get("UserAccessKeyId")
+		if _, ok := s.keys[id]; !ok {
+			s.writeEntityNotExist(w)
+			return
+		}
 		delete(s.keys, id)
 		s.deleted = append(s.deleted, id)
 		_ = json.NewEncoder(w).Encode(map[string]any{"RequestId": "req"})
@@ -766,36 +781,120 @@ func TestAlicloudDriver_Rotation_HappyPath(t *testing.T) {
 	assert.Less(t, updateIdx, deleteIdx, "UpdateAccessKey(Inactive) must precede DeleteAccessKey")
 }
 
-func TestAlicloudDriver_Rotation_OrphanCleanup(t *testing.T) {
-	// Simulate a previous failed rotation that left an orphan key behind.
+// newRotationDriver builds a driver pointed at a ramServer, holding keyID as its
+// current management key.
+func newRotationDriver(t *testing.T, srvURL, keyID string) *AlicloudDriver {
+	t.Helper()
+	f := &AlicloudDriverFactory{}
+	d, err := f.Create(map[string]string{
+		"access_key_id":        keyID,
+		"access_key_secret":    "secret-" + keyID,
+		"management_user_name": "warden-management",
+		"ram_endpoint":         srvURL,
+	}, createAlicloudTestLogger())
+	require.NoError(t, err)
+	return d.(*AlicloudDriver)
+}
+
+// An Inactive orphan is what Warden's own interrupted cleanup leaves behind
+// (CleanupRotation deactivates before it deletes), so it can be reclaimed
+// immediately.
+func TestAlicloudDriver_Rotation_SweepsInactiveOrphanAtCap(t *testing.T) {
 	ram := &ramServer{
 		user: "warden-management",
 		keys: map[string]string{
 			"LTAI-old":    "Active",
-			"LTAI-orphan": "Active", // at the RAM two-key limit
+			"LTAI-orphan": "Inactive", // at the RAM two-key limit
 		},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
 	defer srv.Close()
 
-	f := &AlicloudDriverFactory{}
-	d, _ := f.Create(map[string]string{
-		"access_key_id":        "LTAI-old",
-		"access_key_secret":    "old-secret",
-		"management_user_name": "warden-management",
-		"ram_endpoint":         srv.URL,
-	}, createAlicloudTestLogger())
-	drv := d.(*AlicloudDriver)
-
-	newConfig, _, _, err := drv.PrepareRotation(context.Background())
+	newConfig, _, _, err := newRotationDriver(t, srv.URL, "LTAI-old").
+		PrepareRotation(context.Background())
 	require.NoError(t, err)
 
-	// Orphan should have been deleted before create
-	assert.Contains(t, ram.deleted, "LTAI-orphan")
-	// Current key must not be touched by orphan cleanup
-	assert.NotContains(t, ram.deleted, "LTAI-old")
-	// New key should have been created
+	assert.Equal(t, []string{"LTAI-orphan"}, ram.deleted)
+	assert.NotContains(t, ram.deleted, "LTAI-old", "the current key must never be swept")
 	assert.Equal(t, "LTAI-rotated-1", newConfig["access_key_id"])
+}
+
+// An Active non-current key is not one Warden can attribute to itself, so it is
+// deactivated rather than deleted and the cycle stops. The next cycle finds it
+// Inactive and reclaims the slot — rotation heals itself without ever destroying
+// a key outright.
+func TestAlicloudDriver_Rotation_DeactivatesActiveKeyThenSweepsNextCycle(t *testing.T) {
+	ram := &ramServer{
+		user: "warden-management",
+		keys: map[string]string{
+			"LTAI-old":        "Active",
+			"LTAI-breakglass": "Active", // at the cap, and not ours
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+	defer srv.Close()
+	drv := newRotationDriver(t, srv.URL, "LTAI-old")
+
+	// First cycle: deactivate, refuse to go further, create nothing.
+	_, _, _, err := drv.PrepareRotation(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deactivated")
+	assert.Equal(t, []string{"LTAI-breakglass"}, ram.deactivated)
+	assert.Empty(t, ram.deleted, "an active key must never be deleted outright")
+	assert.Empty(t, ram.created, "no key may be created while the user is at the cap")
+	assert.Equal(t, "Inactive", ram.keys["LTAI-breakglass"])
+
+	// Second cycle: the slot is now reclaimable and rotation proceeds.
+	newConfig, _, _, err := drv.PrepareRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"LTAI-breakglass"}, ram.deleted)
+	assert.Equal(t, "LTAI-rotated-1", newConfig["access_key_id"])
+}
+
+// Below the cap there is a free slot already, so nothing is swept whatever its
+// status — the only reason to remove a key is to make room.
+func TestAlicloudDriver_Rotation_BelowCapSweepsNothing(t *testing.T) {
+	for _, status := range []string{"Active", "Inactive"} {
+		t.Run("sole key is "+status, func(t *testing.T) {
+			ram := &ramServer{
+				user: "warden-management",
+				keys: map[string]string{"LTAI-old": status},
+			}
+			srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+			defer srv.Close()
+
+			_, _, _, err := newRotationDriver(t, srv.URL, "LTAI-old").
+				PrepareRotation(context.Background())
+			require.NoError(t, err)
+
+			assert.Empty(t, ram.deleted)
+			assert.Empty(t, ram.deactivated)
+			assert.Equal(t, []string{"LTAI-rotated-1"}, ram.created)
+		})
+	}
+}
+
+// If the configured key is not among the user's own, every key listed belongs to
+// someone else — most likely management_user_name is wrong. Touch none of them.
+func TestAlicloudDriver_Rotation_RefusesWhenCurrentKeyIsNotTheUsers(t *testing.T) {
+	ram := &ramServer{
+		user: "warden-management",
+		keys: map[string]string{
+			"LTAI-someone-else":   "Active",
+			"LTAI-someone-else-2": "Active",
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+	defer srv.Close()
+
+	_, _, _, err := newRotationDriver(t, srv.URL, "LTAI-not-on-this-user").
+		PrepareRotation(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "management_user_name")
+	assert.Empty(t, ram.deleted)
+	assert.Empty(t, ram.deactivated)
+	assert.Empty(t, ram.created)
 }
 
 func TestAlicloudDriver_Rotation_MissingConfig(t *testing.T) {
@@ -834,6 +933,54 @@ func TestAlicloudDriver_Rotation_CleanupRefusesCurrentKey(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "currently active")
+}
+
+// Cleanup is retried for days after a failure, and the next rotation's
+// slot-freeing sweep can delete the very key a pending cleanup is still chasing.
+// Cleaning up an already-deleted key must therefore succeed: otherwise those
+// retries fail daily until the manager logs an abandonment for a key that no
+// longer exists.
+func TestAlicloudDriver_Rotation_CleanupIsIdempotent(t *testing.T) {
+	ram := &ramServer{
+		user: "warden-management",
+		keys: map[string]string{"LTAI-new": "Active"}, // LTAI-old already gone
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ram.handle))
+	defer srv.Close()
+
+	err := newRotationDriver(t, srv.URL, "LTAI-new").
+		CleanupRotation(context.Background(), map[string]string{
+			"access_key_id":        "LTAI-old",
+			"management_user_name": "warden-management",
+		})
+
+	require.NoError(t, err, "cleaning up an already-deleted key is the outcome we wanted")
+	assert.Empty(t, ram.deleted)
+	assert.Equal(t, "Active", ram.keys["LTAI-new"], "the live key must be untouched")
+}
+
+// Idempotency must not swallow a real failure: only the not-there family counts
+// as already-done.
+func TestAlicloudDriver_Rotation_CleanupStillFailsOnOtherErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Code":      "NoPermission",
+			"Message":   "ram:UpdateAccessKey is not granted.",
+			"RequestId": "req-denied",
+		})
+	}))
+	defer srv.Close()
+
+	err := newRotationDriver(t, srv.URL, "LTAI-new").
+		CleanupRotation(context.Background(), map[string]string{
+			"access_key_id":        "LTAI-old",
+			"management_user_name": "warden-management",
+		})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NoPermission")
 }
 
 // The defect this PR fixes, at the level it actually bites. CleanupRotation

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -3,11 +3,13 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stephnangue/warden/credential"
@@ -499,6 +501,113 @@ func TestAlicloudDriver_CallSignedJSON_StopsAtMaxAttempts(t *testing.T) {
 	assert.Contains(t, err.Error(), "Throttling")
 }
 
+// 400/403/404 are marked OK statuses only so Alicloud error envelopes arrive as
+// readable bodies. A 4xx whose body is not an envelope — an intercepting proxy's
+// HTML error page, a load balancer's own JSON — must still fail. It used to be
+// read as success, which let CleanupRotation report that it had deleted a key it
+// had not touched.
+func TestAlicloudDriver_CallSignedJSON_NonEnvelope4xxIsAnError(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantInErr   string
+	}{
+		{
+			name:        "html error page from a proxy",
+			status:      http.StatusForbidden,
+			contentType: "text/html",
+			body:        "<html>\n<head><title>403 Forbidden</title></head>\n<body>denied</body>\n</html>",
+			wantInErr:   "403 Forbidden",
+		},
+		{
+			name:        "json without a Code field",
+			status:      http.StatusBadRequest,
+			contentType: "application/json",
+			body:        `{"message":"malformed request"}`,
+			wantInErr:   "malformed request",
+		},
+		{
+			name:        "empty body",
+			status:      http.StatusNotFound,
+			contentType: "text/plain",
+			body:        "",
+			wantInErr:   "<empty>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hits := 0
+			sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer sts.Close()
+
+			f := &AlicloudDriverFactory{}
+			d, _ := f.Create(map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "mgmt-secret",
+				"sts_endpoint":      sts.URL,
+			}, createAlicloudTestLogger())
+
+			err := d.(*AlicloudDriver).VerifySpec(context.Background(), &credential.CredSpec{
+				Config: map[string]string{
+					"mint_method": "assume_role",
+					"role_arn":    "acs:ram::123:role/proxied",
+				},
+			})
+			require.Error(t, err, "a non-envelope %d must not be treated as success", tc.status)
+			assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", tc.status))
+			assert.Contains(t, err.Error(), tc.wantInErr, "the body should be quoted back for triage")
+			assert.Equal(t, 1, hits, "a non-envelope 4xx is not transient and must not be retried")
+		})
+	}
+}
+
+// The body excerpt is collapsed onto one line so a multi-line HTML error page
+// cannot break the error across a dozen log lines, and bounded so it cannot
+// flood them either.
+func TestAlicloudBodyPreview(t *testing.T) {
+	assert.Equal(t, "<empty>", alicloudBodyPreview(nil))
+	assert.Equal(t, "<empty>", alicloudBodyPreview([]byte("")))
+	assert.Equal(t, "a b c", alicloudBodyPreview([]byte("a\n  b\t\nc\n")))
+
+	long := alicloudBodyPreview([]byte(strings.Repeat("x", alicloudBodyPreviewLen*2)))
+	assert.Equal(t, strings.Repeat("x", alicloudBodyPreviewLen)+"...", long)
+}
+
+// The typed envelope error lets callers branch on the upstream Code instead of
+// matching substrings. Rotation cleanup relies on this to treat an
+// already-deleted key as success.
+func TestAlicloudErrorHasCodePrefix(t *testing.T) {
+	notExist := alicloudErrorFromEnvelope(alicloudErrorEnvelope{
+		Code: "EntityNotExist.User.AccessKey", Message: "gone", RequestId: "req-1",
+	})
+
+	assert.True(t, alicloudErrorHasCodePrefix(notExist, "EntityNotExist"))
+	assert.True(t, alicloudErrorHasCodePrefix(notExist, "EntityNotExist.User"))
+	assert.True(t, alicloudErrorHasCodePrefix(notExist, "EntityNotExist.User.AccessKey"))
+	assert.False(t, alicloudErrorHasCodePrefix(notExist, "NoPermission"))
+
+	// The dotted boundary keeps a prefix from matching a longer sibling code.
+	assert.False(t, alicloudErrorHasCodePrefix(
+		alicloudErrorFromEnvelope(alicloudErrorEnvelope{Code: "EntityNotExistent"}), "EntityNotExist"))
+
+	// It survives wrapping, and a plain error is simply not a match.
+	assert.True(t, alicloudErrorHasCodePrefix(fmt.Errorf("cleanup: %w", notExist), "EntityNotExist"))
+	assert.False(t, alicloudErrorHasCodePrefix(errors.New("EntityNotExist.User"), "EntityNotExist"))
+
+	// Formatting is unchanged from the untyped version operators are used to.
+	assert.Equal(t, "EntityNotExist.User.AccessKey: gone (RequestId=req-1)", notExist.Error())
+	assert.Equal(t, "NoPermission: denied",
+		alicloudErrorFromEnvelope(alicloudErrorEnvelope{Code: "NoPermission", Message: "denied"}).Error())
+}
+
 // --- Rotation ---
 
 func TestAlicloudDriver_SupportsRotation(t *testing.T) {
@@ -630,7 +739,7 @@ func TestAlicloudDriver_Rotation_HappyPath(t *testing.T) {
 
 	// Commit: swap to the new config
 	require.NoError(t, drv.CommitRotation(context.Background(), newConfig))
-	mgmtID, _ := drv.mgmtAccessKey()
+	_, mgmtID, _ := drv.ramCallConfig()
 	assert.Equal(t, "LTAI-rotated-1", mgmtID)
 
 	// Cleanup: two-step — UpdateAccessKey(Inactive) then DeleteAccessKey on the old key.
@@ -725,6 +834,104 @@ func TestAlicloudDriver_Rotation_CleanupRefusesCurrentKey(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "currently active")
+}
+
+// The defect this PR fixes, at the level it actually bites. CleanupRotation
+// discards the response body, so when a non-envelope 4xx was classified as
+// success both steps reported done, no PendingCleanup was persisted, nothing
+// retried, and the old privileged key stayed live forever.
+func TestAlicloudDriver_Rotation_CleanupFailsOnInterceptedResponse(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<html><body>blocked by policy</body></html>"))
+	}))
+	defer srv.Close()
+
+	f := &AlicloudDriverFactory{}
+	d, _ := f.Create(map[string]string{
+		"access_key_id":        "LTAI-new",
+		"access_key_secret":    "new-secret",
+		"management_user_name": "warden-management",
+		"ram_endpoint":         srv.URL,
+	}, createAlicloudTestLogger())
+
+	err := d.(*AlicloudDriver).CleanupRotation(context.Background(), map[string]string{
+		"access_key_id":        "LTAI-old",
+		"management_user_name": "warden-management",
+	})
+
+	require.Error(t, err, "an intercepted RAM response must not read as a completed cleanup")
+	assert.Contains(t, err.Error(), "UpdateAccessKey")
+	assert.Contains(t, err.Error(), "blocked by policy")
+	assert.Equal(t, 1, hits, "cleanup must stop at the failed Inactive step, not go on to delete")
+}
+
+// CommitRotation replaces the whole Config map while mints are reading it, so
+// every accessor must hold configMu. Run under -race: before the endpoint
+// accessors took the read lock this reported a data race on credSource.Config.
+//
+// It also pins the pairing. stsCallConfig returns the endpoint and the key from
+// one snapshot, so a mint can never sign with one config's key against another
+// config's address — which is what reading them through separate accessors
+// allowed.
+func TestAlicloudDriver_ConfigAccessIsRaceFree(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.minted",
+				"AccessKeySecret": "minted-secret",
+				"SecurityToken":   "minted-token",
+				"Expiration":      "2099-01-01T00:00:00Z",
+			},
+		})
+	}))
+	defer sts.Close()
+
+	f := &AlicloudDriverFactory{}
+	d, _ := f.Create(map[string]string{
+		"access_key_id":        "LTAI-gen-0",
+		"access_key_secret":    "secret-0",
+		"management_user_name": "warden-management",
+		"sts_endpoint":         sts.URL,
+	}, createAlicloudTestLogger())
+	drv := d.(*AlicloudDriver)
+
+	spec := &credential.CredSpec{Config: map[string]string{
+		"mint_method": "assume_role",
+		"role_arn":    "acs:ram::123:role/concurrent",
+	}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_, _, _, _, err := drv.MintCredential(context.Background(), spec)
+				assert.NoError(t, err)
+				drv.SupportsRotation()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for gen := 1; gen <= 40; gen++ {
+			require.NoError(t, drv.CommitRotation(context.Background(), map[string]string{
+				"access_key_id":        fmt.Sprintf("LTAI-gen-%d", gen),
+				"access_key_secret":    fmt.Sprintf("secret-%d", gen),
+				"management_user_name": "warden-management",
+				"sts_endpoint":         sts.URL,
+			}))
+		}
+	}()
+
+	wg.Wait()
 }
 
 // --- ACS3 signing helper ---

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -67,6 +68,382 @@ func TestAlicloudDriverFactory_ValidateConfig(t *testing.T) {
 			"sts_endpoint":      "https://sts.aliyuncs.com",
 			"ram_endpoint":      "https://ram.aliyuncs.com",
 		}))
+	})
+}
+
+// --- Keyless (auth_method=oidc_federation) ---
+
+func TestAlicloudDriverFactory_ValidateConfig_AuthMethod(t *testing.T) {
+	f := &AlicloudDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr string
+	}{
+		{
+			name: "federation with a provider arn",
+			config: map[string]string{
+				"auth_method":       "oidc_federation",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+				"audience":          "https://warden.example.com",
+			},
+		},
+		{
+			name:    "federation without a provider arn",
+			config:  map[string]string{"auth_method": "oidc_federation"},
+			wantErr: "oidc_provider_arn is required",
+		},
+		{
+			name: "unknown auth_method",
+			config: map[string]string{
+				"auth_method": "instance_role",
+			},
+			wantErr: "auth_method",
+		},
+		{
+			// The static source's fields are exactly what federation removes, so
+			// carrying either is a half-converted source.
+			name: "federation carrying a key pair",
+			config: map[string]string{
+				"auth_method":       "oidc_federation",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+				"access_key_id":     "LTAI-mgmt",
+			},
+			wantErr: "access_key_id",
+		},
+		{
+			name: "federation carrying rotation config",
+			config: map[string]string{
+				"auth_method":          "oidc_federation",
+				"oidc_provider_arn":    "acs:ram::123456789012:oidc-provider/warden",
+				"management_user_name": "warden-management",
+			},
+			wantErr: "management_user_name",
+		},
+		{
+			// ram_endpoint is read only by the rotation calls, which federation
+			// forecloses.
+			name: "federation carrying a ram endpoint",
+			config: map[string]string{
+				"auth_method":       "oidc_federation",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+				"ram_endpoint":      "https://ram.aliyuncs.com",
+			},
+			wantErr: "ram_endpoint",
+		},
+		{
+			name: "static carrying a provider arn",
+			config: map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "secret",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+			},
+			wantErr: "oidc_provider_arn",
+		},
+		{
+			name: "static carrying an audience",
+			config: map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "secret",
+				"audience":          "https://warden.example.com",
+			},
+			wantErr: "audience",
+		},
+		{
+			// A stored empty auth_method is validated as static, not skipped —
+			// GetString hands back the stored "" rather than the default.
+			name: "explicit empty auth_method is treated as static",
+			config: map[string]string{
+				"auth_method":       "",
+				"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+			},
+			wantErr: "oidc_provider_arn",
+		},
+		{
+			// Unchanged from before federation existed: nothing is required.
+			name:   "empty config is still valid",
+			config: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := f.ValidateConfig(tt.config)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// newFederationDriver builds a keyless driver pointed at an STS stub.
+func newAlicloudFederationDriver(t *testing.T, stsURL string) *AlicloudDriver {
+	t.Helper()
+	f := &AlicloudDriverFactory{}
+	d, err := f.Create(map[string]string{
+		"auth_method":       "oidc_federation",
+		"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+		"audience":          "https://warden.example.com",
+		"sts_endpoint":      stsURL,
+	}, createAlicloudTestLogger())
+	require.NoError(t, err)
+	return d.(*AlicloudDriver)
+}
+
+func federationSpec() *credential.CredSpec {
+	return &credential.CredSpec{
+		Name: "prod",
+		Config: map[string]string{
+			"mint_method":      "assume_role",
+			"role_arn":         "acs:ram::123456789012:role/warden-prod",
+			"duration_seconds": "1800s",
+		},
+	}
+}
+
+// A keyless source has no key to sign with and no ambient identity, so the
+// non-exchange path must fail closed rather than fall back to anything. This is
+// also what makes the spec-create test-mint reject a non-exchange spec on such a
+// source.
+func TestAlicloudDriver_Federation_MintCredentialFailsClosed(t *testing.T) {
+	drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+
+	_, _, _, _, err := drv.MintCredential(context.Background(), federationSpec())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject_token_source")
+}
+
+func TestAlicloudDriver_Federation_MintWithExchange(t *testing.T) {
+	const assertion = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qifq.payload.signature"
+
+	var gotQuery url.Values
+	var gotForm url.Values
+	var gotAuth, gotRawQuery, gotContentType string
+
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		gotQuery = r.URL.Query()
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		require.NoError(t, r.ParseForm())
+		gotForm = r.PostForm
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.federated",
+				"AccessKeySecret": "federated-secret",
+				"SecurityToken":   "federated-token",
+				"Expiration":      time.Now().Add(1800 * time.Second).UTC().Format(time.RFC3339),
+			},
+		})
+	}))
+	defer sts.Close()
+
+	drv := newAlicloudFederationDriver(t, sts.URL)
+	raw, metadata, ttl, leaseID, err := drv.MintCredentialWithExchange(
+		context.Background(), federationSpec(),
+		&credential.ExchangeInputs{SubjectToken: assertion})
+	require.NoError(t, err)
+
+	// The RPC common parameters identify the call and stay in the query, as
+	// Alibaba's own RRSA client sends them — Timestamp included, which is part of
+	// that convention and which no stub can prove optional.
+	assert.Equal(t, "AssumeRoleWithOIDC", gotQuery.Get("Action"))
+	assert.Equal(t, alicloudSTSVersion, gotQuery.Get("Version"))
+	assert.Equal(t, "JSON", gotQuery.Get("Format"))
+	stamp, tsErr := time.Parse(alicloudTimestampFormat, gotQuery.Get("Timestamp"))
+	require.NoError(t, tsErr, "Timestamp must be ISO 8601 UTC")
+	assert.WithinDuration(t, time.Now(), stamp, time.Minute)
+
+	// The exchange parameters travel in the form body.
+	assert.Equal(t, "application/x-www-form-urlencoded", gotContentType)
+	assert.Equal(t, assertion, gotForm.Get("OIDCToken"))
+	assert.Equal(t, "acs:ram::123456789012:oidc-provider/warden", gotForm.Get("OIDCProviderArn"))
+	assert.Equal(t, "acs:ram::123456789012:role/warden-prod", gotForm.Get("RoleArn"))
+	assert.Equal(t, "1800", gotForm.Get("DurationSeconds"))
+
+	// The two load-bearing negatives. AssumeRoleWithOIDC is anonymous, and the
+	// assertion must never reach the URL — *url.Error prints the whole thing on
+	// any transport failure.
+	assert.Empty(t, gotAuth, "AssumeRoleWithOIDC is an anonymous call")
+	assert.NotContains(t, gotRawQuery, assertion, "the assertion must not be in the query string")
+	assert.NotContains(t, gotRawQuery, "OIDCToken")
+
+	assert.Equal(t, "STS.federated", raw["access_key_id"])
+	assert.Equal(t, "federated-secret", raw["access_key_secret"])
+	assert.Equal(t, "federated-token", raw["security_token"])
+	assert.Equal(t, "acs:ram::123456789012:role/warden-prod", metadata["role_arn"])
+	assert.InDelta(t, 1800, ttl.Seconds(), 5)
+	assert.Empty(t, leaseID, "STS sessions are self-expiring")
+}
+
+// Pins the body-not-query decision against a future refactor: point the driver at
+// a dead port so client.Do fails, and check the assertion is not in the error.
+// With the token in the query string, *url.Error would print it verbatim.
+func TestAlicloudDriver_Federation_TransportErrorDoesNotLeakAssertion(t *testing.T) {
+	const assertion = "eyJhbGciOiJSUzI1NiJ9.super-secret-payload.signature"
+
+	// A listener closed immediately gives us an address nothing answers on.
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := closed.URL
+	closed.Close()
+
+	drv := newAlicloudFederationDriver(t, deadURL)
+	_, _, _, _, err := drv.MintCredentialWithExchange(
+		context.Background(), federationSpec(),
+		&credential.ExchangeInputs{SubjectToken: assertion})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), assertion,
+		"a transport error must not print the caller's assertion")
+	assert.NotContains(t, err.Error(), "super-secret-payload")
+}
+
+func TestAlicloudDriver_Federation_ExchangeRejections(t *testing.T) {
+	t.Run("rejected on a static source", func(t *testing.T) {
+		f := &AlicloudDriverFactory{}
+		d, _ := f.Create(map[string]string{
+			"access_key_id":     "LTAI-mgmt",
+			"access_key_secret": "secret",
+		}, createAlicloudTestLogger())
+
+		_, _, _, _, err := d.(*AlicloudDriver).MintCredentialWithExchange(
+			context.Background(), federationSpec(),
+			&credential.ExchangeInputs{SubjectToken: "assertion"})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "oidc_federation")
+	})
+
+	t.Run("rejected with no subject token", func(t *testing.T) {
+		drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+
+		_, _, _, _, err := drv.MintCredentialWithExchange(context.Background(), federationSpec(), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+
+		_, _, _, _, err = drv.MintCredentialWithExchange(
+			context.Background(), federationSpec(), &credential.ExchangeInputs{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no subject token")
+	})
+
+	t.Run("rejected for an unsupported mint_method", func(t *testing.T) {
+		drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+		spec := federationSpec()
+		spec.Config["mint_method"] = "dynamic_keys"
+
+		_, _, _, _, err := drv.MintCredentialWithExchange(
+			context.Background(), spec, &credential.ExchangeInputs{SubjectToken: "assertion"})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assume_role")
+	})
+}
+
+// The three things most likely to be misconfigured are the issuer trust, the
+// audience, and the role's trust policy; the raw envelope names none of them.
+func TestAlicloudDriver_Federation_ErrorMappingNamesTheTrustChain(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Code":      "AuthenticationFail.OIDCToken.Invalid",
+			"Message":   "The OIDC token is invalid.",
+			"RequestId": "req-oidc",
+		})
+	}))
+	defer sts.Close()
+
+	drv := newAlicloudFederationDriver(t, sts.URL)
+	_, _, _, _, err := drv.MintCredentialWithExchange(
+		context.Background(), federationSpec(),
+		&credential.ExchangeInputs{SubjectToken: "assertion"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AuthenticationFail.OIDCToken.Invalid", "the upstream code survives")
+	assert.Contains(t, err.Error(), "issuer")
+	assert.Contains(t, err.Error(), "client_ids")
+	assert.Contains(t, err.Error(), "trust policy")
+}
+
+// A federation source holds no key, so there is nothing to rotate and no RAM user
+// to rotate as.
+func TestAlicloudDriver_Federation_RotationRefused(t *testing.T) {
+	drv := newAlicloudFederationDriver(t, "https://sts.example.invalid")
+
+	assert.False(t, drv.SupportsRotation())
+
+	_, _, _, err := drv.PrepareRotation(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no key to rotate")
+}
+
+// VerifySpec has no ambient credential to dry-run with under federation. The
+// guard is unreachable in practice — the spec-create test-mint is skipped for
+// exchange specs — but it must not attempt a network call if it is ever reached.
+func TestAlicloudDriver_Federation_VerifySpecMakesNoCall(t *testing.T) {
+	sts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("VerifySpec must not call STS on a federation source")
+	}))
+	defer sts.Close()
+
+	drv := newAlicloudFederationDriver(t, sts.URL)
+	assert.NoError(t, drv.VerifySpec(context.Background(), federationSpec()))
+}
+
+func TestAlicloudAssertionClaims(t *testing.T) {
+	federationSource := map[string]string{
+		"auth_method":       "oidc_federation",
+		"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+		"audience":          "https://warden.example.com",
+	}
+
+	t.Run("audience comes from the source", func(t *testing.T) {
+		aud, ok := DeriveAssertionAudience(credential.SourceTypeAlicloud, federationSource, nil)
+		assert.True(t, ok)
+		assert.Equal(t, "https://warden.example.com", aud)
+	})
+
+	t.Run("no audience without one configured", func(t *testing.T) {
+		// Alibaba matches aud against the provider's registered client_ids, which
+		// the operator chooses, so there is no default to fall back to. Returning
+		// false is what makes spec-create demand assertion_audience.
+		_, ok := DeriveAssertionAudience(credential.SourceTypeAlicloud, map[string]string{
+			"auth_method":       "oidc_federation",
+			"oidc_provider_arn": "acs:ram::123456789012:oidc-provider/warden",
+		}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("a static source derives no audience", func(t *testing.T) {
+		_, ok := DeriveAssertionAudience(credential.SourceTypeAlicloud, map[string]string{
+			"access_key_id": "LTAI-mgmt",
+			"audience":      "https://warden.example.com",
+		}, nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("resource is the role arn", func(t *testing.T) {
+		res, ok := DeriveAssertionResource(credential.SourceTypeAlicloud, federationSource, map[string]string{
+			"mint_method": "assume_role",
+			"role_arn":    "acs:ram::123456789012:role/warden-prod",
+		})
+		assert.True(t, ok)
+		assert.Equal(t, "alicloud-ram:acs:ram::123456789012:role/warden-prod", res)
+	})
+
+	t.Run("no resource without a role arn", func(t *testing.T) {
+		_, ok := DeriveAssertionResource(credential.SourceTypeAlicloud, federationSource, map[string]string{
+			"mint_method": "assume_role",
+		})
+		assert.False(t, ok)
 	})
 }
 

--- a/credential/drivers/alicloud_sign.go
+++ b/credential/drivers/alicloud_sign.go
@@ -66,10 +66,15 @@ func signACS3(r *http.Request, accessKeyID, accessKeySecret, securityToken strin
 		rawQuery = r.URL.RawQuery
 	}
 
+	canonicalQuery, err := acs3CanonicalQuery(rawQuery)
+	if err != nil {
+		return err
+	}
+
 	canonicalRequest := strings.Join([]string{
 		r.Method,
 		canonicalURI,
-		acs3CanonicalQuery(rawQuery),
+		canonicalQuery,
 		canonicalHdrs,
 		signedHeadersStr,
 		bodyHash,
@@ -157,13 +162,17 @@ func acs3CanonicalHeaders(r *http.Request, signed []string) (canonical, signedSt
 	return b.String(), strings.Join(normalized, ";")
 }
 
-func acs3CanonicalQuery(rawQuery string) string {
+// acs3CanonicalQuery renders rawQuery in ACS3 canonical form. A query that will
+// not parse is reported rather than rendered as empty: signing an empty query for
+// a request that has one produces a signature the server cannot reproduce, so the
+// caller would see a remote SignatureDoesNotMatch instead of the local defect.
+func acs3CanonicalQuery(rawQuery string) (string, error) {
 	if rawQuery == "" {
-		return ""
+		return "", nil
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("malformed query string: %w", err)
 	}
 	keys := make([]string, 0, len(values))
 	for k := range values {
@@ -180,7 +189,7 @@ func acs3CanonicalQuery(rawQuery string) string {
 			parts = append(parts, acs3Encode(k)+"="+acs3Encode(v))
 		}
 	}
-	return strings.Join(parts, "&")
+	return strings.Join(parts, "&"), nil
 }
 
 func acs3Encode(s string) string {

--- a/credential/drivers/assertion_claims.go
+++ b/credential/drivers/assertion_claims.go
@@ -35,6 +35,8 @@ func DeriveAssertionResource(sourceType string, sourceCfg, specCfg map[string]st
 		return vaultAssertionResource(sourceCfg, specCfg)
 	case credential.SourceTypeKubernetes:
 		return kubernetesAssertionResource(specCfg)
+	case credential.SourceTypeAlicloud:
+		return alicloudAssertionResource(specCfg)
 	default:
 		return "", false
 	}
@@ -63,9 +65,46 @@ func DeriveAssertionAudience(sourceType string, sourceCfg, specCfg map[string]st
 		return vaultAssertionAudience(sourceCfg)
 	case credential.SourceTypeKubernetes:
 		return kubernetesAssertionAudience(sourceCfg)
+	case credential.SourceTypeAlicloud:
+		return alicloudAssertionAudience(sourceCfg)
 	default:
 		return "", false
 	}
+}
+
+// alicloudAssertionAudience derives the warden_identity assertion audience for a
+// keyless Alicloud source: the source's explicit `audience`, or ("", false) when
+// unset. There is no conventional default — unlike AWS, which accepts
+// sts.amazonaws.com, Alibaba matches the assertion's aud against the client_ids
+// registered on the RAM OIDC provider, which the operator chooses — so an unset
+// audience forces the spec to set assertion_audience (the spec-create gate
+// enforces this, and mint fails closed otherwise).
+//
+// Gated on auth_method=oidc_federation: only a keyless source federates, so a
+// static source supplies no derived audience even if a stored config record
+// somehow carries one.
+func alicloudAssertionAudience(sourceCfg map[string]string) (string, bool) {
+	if credential.GetString(sourceCfg, "auth_method", alicloudAuthMethodStatic) != alicloudAuthMethodOIDCFederation {
+		return "", false
+	}
+	if aud := credential.GetString(sourceCfg, "audience", ""); aud != "" {
+		return aud, true
+	}
+	return "", false
+}
+
+// alicloudAssertionResource reports the RAM role a federation spec assumes, for
+// the warden_resource claim. Pure: reads spec config only, no network or driver
+// state. The driver has a single mint path, so unlike the multi-engine sources
+// there is no mint_method to dispatch on.
+//
+// The provider prefix is human-readable sugar on an opaque value — never parse it
+// back, since a role ARN contains ':' itself.
+func alicloudAssertionResource(specCfg map[string]string) (string, bool) {
+	if arn := credential.GetString(specCfg, "role_arn", ""); arn != "" {
+		return "alicloud-ram:" + arn, true
+	}
+	return "", false
 }
 
 // kubernetesAssertionAudience derives the warden_identity assertion audience for a

--- a/credential/drivers/registry_test.go
+++ b/credential/drivers/registry_test.go
@@ -12,7 +12,8 @@ func TestRegisterBuiltinDrivers(t *testing.T) {
 	err := RegisterBuiltinDrivers(registry)
 	require.NoError(t, err)
 
-	// Verify all expected drivers are registered
+	// Every builtin driver, not a subset — an under-enumerated list reads as
+	// "all registered" while silently skipping whatever was added last.
 	expectedTypes := []string{
 		credential.SourceTypeLocal,
 		credential.SourceTypeVault,
@@ -23,6 +24,15 @@ func TestRegisterBuiltinDrivers(t *testing.T) {
 		credential.SourceTypeGitHub,
 		credential.SourceTypeAPIKey,
 		credential.SourceTypeOAuth2,
+		credential.SourceTypeAlicloud,
+		credential.SourceTypeElastic,
+		credential.SourceTypeGrafana,
+		credential.SourceTypeHoneycomb,
+		credential.SourceTypeIBM,
+		credential.SourceTypeKubernetes,
+		credential.SourceTypeOVH,
+		credential.SourceTypeScaleway,
+		credential.SourceTypeTokenExchange,
 	}
 	for _, typeName := range expectedTypes {
 		factory, err := registry.GetFactory(typeName)

--- a/credential/types/alicloud_keys.go
+++ b/credential/types/alicloud_keys.go
@@ -41,18 +41,9 @@ func (t *AlicloudKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example(""),
 
 		credential.StringField("mint_method").
-			OneOf("static_alicloud", "assume_role").
-			Describe("Mint method for credential minting. Use static_alicloud with a hvault source, or assume_role with an alicloud source.").
+			OneOf("assume_role").
+			Describe("Mint method for credential minting. Use assume_role with an alicloud source.").
 			Example("assume_role"),
-
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_alicloud)").
-			Example("secret"),
-
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_alicloud)").
-			Example("alicloud/prod/keys"),
 
 		// STS assume_role fields
 		credential.StringField("role_arn").
@@ -75,11 +66,11 @@ func (t *AlicloudKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 // ValidateConfig validates the Config for an Alicloud credential spec
 func (t *AlicloudKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	switch sourceType {
-	case credential.SourceTypeVault, credential.SourceTypeAlicloud:
-		// Supported
-	default:
-		return fmt.Errorf("alicloud_keys credentials require a vault or alicloud source, got: %s", sourceType)
+	// A vault source is not supported: it would need a static_alicloud mint method,
+	// which the Vault driver has never implemented. It used to be accepted here and
+	// then failed at the first mint.
+	if sourceType != credential.SourceTypeAlicloud {
+		return fmt.Errorf("alicloud_keys credentials require an alicloud source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -87,25 +78,11 @@ func (t *AlicloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 		return err
 	}
 
-	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_alicloud" {
-			return fmt.Errorf("'mint_method' must be 'static_alicloud' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_alicloud")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_alicloud")
-		}
-	case credential.SourceTypeAlicloud:
-		mintMethod := config["mint_method"]
-		if mintMethod != "assume_role" {
-			return fmt.Errorf("'mint_method' must be 'assume_role' for alicloud source, got: %s", mintMethod)
-		}
-		if config["role_arn"] == "" {
-			return fmt.Errorf("'role_arn' is required for assume_role")
-		}
+	if mintMethod := config["mint_method"]; mintMethod != "assume_role" {
+		return fmt.Errorf("'mint_method' must be 'assume_role' for alicloud source, got: %s", mintMethod)
+	}
+	if config["role_arn"] == "" {
+		return fmt.Errorf("'role_arn' is required for assume_role")
 	}
 
 	return nil

--- a/credential/types/alicloud_keys_test.go
+++ b/credential/types/alicloud_keys_test.go
@@ -1,0 +1,150 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlicloudKeysCredType_Metadata(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	md := ct.Metadata()
+	assert.Equal(t, credential.TypeAlicloudKeys, md.Name)
+	assert.Equal(t, credential.CategoryCloudIAM, md.Category)
+}
+
+func TestAlicloudKeysCredType_ValidateConfig_AlicloudSource(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	tests := []struct {
+		name   string
+		config map[string]string
+		errMsg string
+	}{
+		{
+			name: "valid assume_role config",
+			config: map[string]string{
+				"mint_method": "assume_role",
+				"role_arn":    "acs:ram::123456789012:role/warden",
+			},
+		},
+		{
+			name: "valid with optional fields",
+			config: map[string]string{
+				"mint_method":       "assume_role",
+				"role_arn":          "acs:ram::123456789012:role/warden",
+				"role_session_name": "warden-session",
+				"duration_seconds":  "3600s",
+			},
+		},
+		{
+			name:   "missing mint_method",
+			config: map[string]string{"role_arn": "acs:ram::123456789012:role/warden"},
+			errMsg: "mint_method",
+		},
+		{
+			name: "missing role_arn",
+			config: map[string]string{
+				"mint_method": "assume_role",
+			},
+			errMsg: "role_arn",
+		},
+		{
+			// duration_seconds is a duration field, so a bare integer is not
+			// accepted — it needs the unit.
+			name: "duration_seconds without a unit",
+			config: map[string]string{
+				"mint_method":      "assume_role",
+				"role_arn":         "acs:ram::123456789012:role/warden",
+				"duration_seconds": "3600",
+			},
+			errMsg: "duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ct.ValidateConfig(tt.config, credential.SourceTypeAlicloud)
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// A vault source needed a static_alicloud mint method that the Vault driver never
+// implemented, so such a spec passed validation here and then failed at its first
+// mint. It is refused at create now.
+func TestAlicloudKeysCredType_ValidateConfig_VaultSourceRejected(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "static_alicloud",
+		"kv2_mount":   "secret",
+		"secret_path": "alicloud/prod/keys",
+	}, credential.SourceTypeVault)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alicloud source")
+}
+
+func TestAlicloudKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "assume_role",
+		"role_arn":    "acs:ram::123456789012:role/warden",
+	}, credential.SourceTypeAWS)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alicloud source")
+}
+
+func TestAlicloudKeysCredType_Parse(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+
+	t.Run("STS credentials with a security token", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key_id":     "STS.abc",
+			"access_key_secret": "sts-secret",
+			"security_token":    "sts-token",
+		}, nil, time.Hour, "")
+		require.NoError(t, err)
+		assert.Equal(t, credential.TypeAlicloudKeys, cred.Type)
+		assert.Equal(t, "STS.abc", cred.Data["access_key_id"])
+		assert.Equal(t, "sts-secret", cred.Data["access_key_secret"])
+		assert.Equal(t, "sts-token", cred.Data["security_token"])
+		assert.Equal(t, time.Hour, cred.LeaseTTL)
+	})
+
+	t.Run("security_token is omitted when empty", func(t *testing.T) {
+		cred, err := ct.Parse(map[string]interface{}{
+			"access_key_id":     "LTAI.abc",
+			"access_key_secret": "secret",
+		}, nil, time.Hour, "")
+		require.NoError(t, err)
+		assert.NotContains(t, cred.Data, "security_token")
+	})
+
+	t.Run("missing fields are rejected", func(t *testing.T) {
+		_, err := ct.Parse(map[string]interface{}{
+			"access_key_secret": "secret",
+		}, nil, time.Hour, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key_id")
+
+		_, err = ct.Parse(map[string]interface{}{
+			"access_key_id": "LTAI.abc",
+		}, nil, time.Hour, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access_key_secret")
+	})
+}
+
+func TestAlicloudKeysCredType_SensitiveConfigFields(t *testing.T) {
+	ct := &AlicloudKeysCredType{}
+	fields := ct.SensitiveConfigFields()
+	assert.Contains(t, fields, "access_key_secret")
+	assert.Contains(t, fields, "security_token")
+}

--- a/credential/types/cloudflare_keys.go
+++ b/credential/types/cloudflare_keys.go
@@ -40,28 +40,19 @@ func (t *CloudflareKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("v1.0-xxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
 		credential.StringField("mint_method").
-			OneOf("static_keys", "static_cloudflare").
+			OneOf("static_keys").
 			Describe("Mint method for credential minting").
 			Example("static_keys"),
-
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_cloudflare)").
-			Example("secret"),
-
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_cloudflare)").
-			Example("cloudflare/prod/keys"),
 	}
 }
 
 // ValidateConfig validates the Config for a Cloudflare credential spec
 func (t *CloudflareKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	switch sourceType {
-	case credential.SourceTypeLocal, credential.SourceTypeVault:
-		// Supported
-	default:
-		return fmt.Errorf("cloudflare_keys credentials require a local or vault source, got: %s", sourceType)
+	// A vault source is not supported: it would need a static_cloudflare mint
+	// method, which the Vault driver has never implemented. It used to be accepted
+	// here and then failed at the first mint.
+	if sourceType != credential.SourceTypeLocal {
+		return fmt.Errorf("cloudflare_keys credentials require a local source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -69,30 +60,17 @@ func (t *CloudflareKeysCredType) ValidateConfig(config map[string]string, source
 		return err
 	}
 
-	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_cloudflare" {
-			return fmt.Errorf("'mint_method' must be 'static_cloudflare' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_cloudflare")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_cloudflare")
-		}
-	default:
-		hasAPI := config["api_token"] != ""
-		hasR2 := config["access_key_id"] != "" || config["secret_access_key"] != ""
-		if !hasAPI && !hasR2 {
-			return fmt.Errorf("at least one of 'api_token' (for API) or 'access_key_id'+'secret_access_key' (for R2) is required")
-		}
-		// If R2 fields are partially set, both must be present
-		if config["access_key_id"] != "" && config["secret_access_key"] == "" {
-			return fmt.Errorf("'secret_access_key' is required when 'access_key_id' is set")
-		}
-		if config["secret_access_key"] != "" && config["access_key_id"] == "" {
-			return fmt.Errorf("'access_key_id' is required when 'secret_access_key' is set")
-		}
+	hasAPI := config["api_token"] != ""
+	hasR2 := config["access_key_id"] != "" || config["secret_access_key"] != ""
+	if !hasAPI && !hasR2 {
+		return fmt.Errorf("at least one of 'api_token' (for API) or 'access_key_id'+'secret_access_key' (for R2) is required")
+	}
+	// If R2 fields are partially set, both must be present
+	if config["access_key_id"] != "" && config["secret_access_key"] == "" {
+		return fmt.Errorf("'secret_access_key' is required when 'access_key_id' is set")
+	}
+	if config["secret_access_key"] != "" && config["access_key_id"] == "" {
+		return fmt.Errorf("'access_key_id' is required when 'secret_access_key' is set")
 	}
 
 	return nil

--- a/credential/types/cloudflare_keys_test.go
+++ b/credential/types/cloudflare_keys_test.go
@@ -88,72 +88,18 @@ func TestCloudflareKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
 	}
 }
 
-func TestCloudflareKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
+// A vault source needed a static_cloudflare mint method that the Vault driver
+// never implemented, so such a spec passed validation here and then failed at its
+// first mint. It is refused at create now.
+func TestCloudflareKeysCredType_ValidateConfig_VaultSourceRejected(t *testing.T) {
 	ct := &CloudflareKeysCredType{}
-	tests := []struct {
-		name    string
-		config  map[string]string
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name: "valid vault config",
-			config: map[string]string{
-				"mint_method": "static_cloudflare",
-				"kv2_mount":   "secret",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing mint_method",
-			config: map[string]string{
-				"kv2_mount":   "secret",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "wrong mint_method",
-			config: map[string]string{
-				"mint_method": "static_keys",
-				"kv2_mount":   "secret",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "missing kv2_mount",
-			config: map[string]string{
-				"mint_method": "static_cloudflare",
-				"secret_path": "cloudflare/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "kv2_mount",
-		},
-		{
-			name: "missing secret_path",
-			config: map[string]string{
-				"mint_method": "static_cloudflare",
-				"kv2_mount":   "secret",
-			},
-			wantErr: true,
-			errMsg:  "secret_path",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "static_cloudflare",
+		"kv2_mount":   "secret",
+		"secret_path": "cloudflare/prod/keys",
+	}, credential.SourceTypeVault)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local source")
 }
 
 func TestCloudflareKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
@@ -164,7 +110,7 @@ func TestCloudflareKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
 		"api_token":         "test-api-token",
 	}, credential.SourceTypeAWS)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "local or vault")
+	assert.Contains(t, err.Error(), "local source")
 }
 
 func TestCloudflareKeysCredType_Parse(t *testing.T) {

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -37,18 +37,9 @@ func (t *ScalewayKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
 
 		credential.StringField("mint_method").
-			OneOf("static_scaleway", "static_keys", "dynamic_keys").
+			OneOf("static_keys", "dynamic_keys").
 			Describe("Mint method for credential minting").
 			Example("static_keys"),
-
-		// Vault source fields
-		credential.StringField("kv2_mount").
-			Describe("Vault KV2 mount path (required for static_scaleway)").
-			Example("secret"),
-
-		credential.StringField("secret_path").
-			Describe("Path to secret in KV2 (required for static_scaleway)").
-			Example("scaleway/prod/keys"),
 
 		// Scaleway dynamic_keys fields
 		credential.StringField("application_id").
@@ -71,11 +62,14 @@ func (t *ScalewayKeysCredType) ConfigSchema() []*credential.FieldValidator {
 
 // ValidateConfig validates the Config for a Scaleway credential spec
 func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceType string) error {
+	// A vault source is not supported: it would need a static_scaleway mint method,
+	// which the Vault driver has never implemented. It used to be accepted here and
+	// then failed at the first mint.
 	switch sourceType {
-	case credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeScaleway:
+	case credential.SourceTypeLocal, credential.SourceTypeScaleway:
 		// Supported
 	default:
-		return fmt.Errorf("scaleway_keys credentials require a local, vault, or scaleway source, got: %s", sourceType)
+		return fmt.Errorf("scaleway_keys credentials require a local or scaleway source, got: %s", sourceType)
 	}
 
 	schema := t.ConfigSchema()
@@ -84,16 +78,6 @@ func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceTy
 	}
 
 	switch sourceType {
-	case credential.SourceTypeVault:
-		if config["mint_method"] != "static_scaleway" {
-			return fmt.Errorf("'mint_method' must be 'static_scaleway' for vault source, got: %s", config["mint_method"])
-		}
-		if config["kv2_mount"] == "" {
-			return fmt.Errorf("'kv2_mount' is required when mint_method is static_scaleway")
-		}
-		if config["secret_path"] == "" {
-			return fmt.Errorf("'secret_path' is required when mint_method is static_scaleway")
-		}
 	case credential.SourceTypeScaleway:
 		mintMethod := config["mint_method"]
 		switch mintMethod {

--- a/credential/types/scaleway_keys_test.go
+++ b/credential/types/scaleway_keys_test.go
@@ -72,72 +72,18 @@ func TestScalewayKeysCredType_ValidateConfig_LocalSource(t *testing.T) {
 	}
 }
 
-func TestScalewayKeysCredType_ValidateConfig_VaultSource(t *testing.T) {
+// A vault source needed a static_scaleway mint method that the Vault driver never
+// implemented, so such a spec passed validation here and then failed at its first
+// mint. It is refused at create now.
+func TestScalewayKeysCredType_ValidateConfig_VaultSourceRejected(t *testing.T) {
 	ct := &ScalewayKeysCredType{}
-	tests := []struct {
-		name    string
-		config  map[string]string
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name: "valid vault config",
-			config: map[string]string{
-				"mint_method": "static_scaleway",
-				"kv2_mount":   "secret",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing mint_method",
-			config: map[string]string{
-				"kv2_mount":   "secret",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "wrong mint_method",
-			config: map[string]string{
-				"mint_method": "dynamic_aws",
-				"kv2_mount":   "secret",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "mint_method",
-		},
-		{
-			name: "missing kv2_mount",
-			config: map[string]string{
-				"mint_method": "static_scaleway",
-				"secret_path": "scaleway/prod/keys",
-			},
-			wantErr: true,
-			errMsg:  "kv2_mount",
-		},
-		{
-			name: "missing secret_path",
-			config: map[string]string{
-				"mint_method": "static_scaleway",
-				"kv2_mount":   "secret",
-			},
-			wantErr: true,
-			errMsg:  "secret_path",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ct.ValidateConfig(tt.config, credential.SourceTypeVault)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+	err := ct.ValidateConfig(map[string]string{
+		"mint_method": "static_scaleway",
+		"kv2_mount":   "secret",
+		"secret_path": "scaleway/prod/keys",
+	}, credential.SourceTypeVault)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local or scaleway")
 }
 
 func TestScalewayKeysCredType_ValidateConfig_ScalewaySource(t *testing.T) {
@@ -210,7 +156,7 @@ func TestScalewayKeysCredType_ValidateConfig_UnsupportedSource(t *testing.T) {
 		"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 	}, credential.SourceTypeAWS)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "local, vault, or scaleway")
+	assert.Contains(t, err.Error(), "local or scaleway")
 }
 
 func TestScalewayKeysCredType_Parse(t *testing.T) {

--- a/e2e/credential/alicloud_keyless_test.go
+++ b/e2e/credential/alicloud_keyless_test.go
@@ -1,0 +1,400 @@
+//go:build e2e
+
+package credential
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// A keyless Alicloud source holds no RAM access key. Every mint exchanges the
+// caller's Warden-minted assertion at STS AssumeRoleWithOIDC for a session on the
+// spec's role, so what this suite has to prove is that the assertion is real, that
+// it reaches STS in the right shape, and that the credentials come back.
+//
+// The exchange is what a stub can stand in for: it is an ordinary HTTPS call to an
+// endpoint the source names, so pointing sts_endpoint at a local listener puts the
+// whole mint under test. That is the same move e2e/fullchain/ibmcloud_test.go
+// makes for IBM's IAM grant.
+//
+// It lives here rather than in e2e/fullchain for two reasons that both come from
+// the provider rather than the driver. The Alicloud gateway is agent-only by
+// design — provider/alicloud/agent_only_test.go pins that it never yields a user
+// principal — so it has no user_auth_path, while every fullchain mount is
+// configured with one. And it has no URL override key at all: it resolves its
+// target from the inbound Host, which must end in .aliyuncs.com, and then dials
+// that real public host. So the mount is set up directly here, in the agent-only
+// shape e2e/forwarding/sigv4_test.go already uses.
+//
+// The consequence is worth stating plainly: this covers the mint hop, not the
+// gateway hop. Minting runs before routing, so the exchange happens and is fully
+// observable even though the request afterwards cannot reach a local upstream.
+// Nothing here proves the minted security_token is signed correctly onto an
+// outbound request — the same gap e2e/fullchain/mcp_aws_test.go records for AWS.
+
+const (
+	alicloudSourceName = "e2e-alicloud-keyless"
+	alicloudSpecName   = "e2e-alicloud-federated"
+	alicloudPolicyName = "e2e-alicloud-gateway"
+	alicloudJWTRole    = "e2e-alicloud-federated"
+	alicloudMount      = "e2e-alicloud"
+
+	// Deliberately not shaped like real Alibaba identifiers, so a secret scanner
+	// has nothing to catch. Do not "correct" these to look real.
+	alicloudRoleARN     = "acs:ram::100000000000001:role/e2e-not-a-real-role"
+	alicloudProviderARN = "acs:ram::100000000000001:oidc-provider/e2e-not-a-real-provider"
+
+	// The audience an operator registers as a client_id on the RAM OIDC provider.
+	// There is no conventional default for Alibaba, which is why the source has to
+	// carry one.
+	alicloudAudience = "https://warden.e2e.example.com"
+
+	// What e2e/setup.sh configures the issuer with. The assertion's iss is pinned
+	// to exactly this.
+	alicloudIssuerURL = "https://127.0.0.1:8000"
+)
+
+// alicloudSTSExchange is one recorded AssumeRoleWithOIDC call.
+type alicloudSTSExchange struct {
+	Query    url.Values
+	Form     url.Values
+	AuthHdr  string
+	RawQuery string
+}
+
+// alicloudSTSStub stands in for Alibaba STS. It records what the driver sent and
+// answers with canned session credentials.
+type alicloudSTSStub struct {
+	*httptest.Server
+
+	mu        sync.Mutex
+	exchanges []alicloudSTSExchange
+}
+
+func startAlicloudSTSStub(t *testing.T) *alicloudSTSStub {
+	t.Helper()
+	stub := &alicloudSTSStub{}
+	stub.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// ParseForm reads the body, so capture the raw query first.
+		rawQuery := r.URL.RawQuery
+		query := r.URL.Query()
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+
+		stub.mu.Lock()
+		stub.exchanges = append(stub.exchanges, alicloudSTSExchange{
+			Query:    query,
+			Form:     r.PostForm,
+			AuthHdr:  r.Header.Get("Authorization"),
+			RawQuery: rawQuery,
+		})
+		stub.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"RequestId": "e2e-sts-request",
+			"Credentials": map[string]any{
+				"AccessKeyId":     "STS.e2e-not-a-real-session-key",
+				"AccessKeySecret": "e2e-not-a-real-session-secret",
+				"SecurityToken":   "e2e-not-a-real-security-token",
+				"Expiration":      time.Now().Add(time.Hour).UTC().Format("2006-01-02T15:04:05Z"),
+			},
+		})
+	}))
+	t.Cleanup(stub.Close)
+	return stub
+}
+
+func (s *alicloudSTSStub) Exchanges() []alicloudSTSExchange {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]alicloudSTSExchange(nil), s.exchanges...)
+}
+
+// mustWrite performs one setup write, accepting 409 so a rerun against a cluster
+// that still holds the previous run's objects is idempotent.
+func mustWrite(t *testing.T, port int, path, body, what string) {
+	t.Helper()
+	status, resp := h.APIRequest(t, "POST", path, port, body)
+	switch status {
+	case 200, 201, 204, 409:
+	default:
+		t.Fatalf("%s: status %d: %s", what, status, string(resp))
+	}
+}
+
+// setupAlicloudKeyless provisions the keyless source, an exchange spec, the policy
+// and JWT role that bind it, and the agent-only mount.
+//
+// Cleanup is registered before anything is created, so a failure partway through
+// does not leave objects behind for the next run to trip over.
+func setupAlicloudKeyless(t *testing.T, port int, stsURL string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		leader := h.GetLeaderPort(t)
+		h.APIRequest(t, "DELETE", "sys/providers/"+alicloudMount, leader, "")
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+alicloudJWTRole, leader, "")
+		h.APIRequest(t, "DELETE", "sys/policies/cbp/"+alicloudPolicyName, leader, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+alicloudSpecName, leader, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+alicloudSourceName, leader, "")
+	})
+
+	// The source carries no access_key_id and no access_key_secret — that is the
+	// whole point. tls_skip_verify is what permits the stub's http:// endpoint.
+	mustWrite(t, port, "sys/cred/sources/"+alicloudSourceName, mustJSON(t, map[string]any{
+		"type": "alicloud",
+		"config": map[string]string{
+			"auth_method":       "oidc_federation",
+			"oidc_provider_arn": alicloudProviderARN,
+			"audience":          alicloudAudience,
+			"sts_endpoint":      stsURL,
+			"tls_skip_verify":   "true",
+		},
+	}), "create keyless alicloud source")
+
+	// subject_token_source lives in the spec's config, alongside the mint
+	// settings — that is what marks the spec as an exchange spec and skips the
+	// create-time test-mint a keyless source could never satisfy.
+	mustWrite(t, port, "sys/cred/specs/"+alicloudSpecName, mustJSON(t, map[string]any{
+		"type":   "alicloud_keys",
+		"source": alicloudSourceName,
+		"config": map[string]string{
+			"subject_token_source": "warden_identity",
+			"mint_method":          "assume_role",
+			"role_arn":             alicloudRoleARN,
+			"duration_seconds":     "3600s",
+		},
+	}), "create federated alicloud spec")
+
+	mustWrite(t, port, "sys/policies/cbp/"+alicloudPolicyName, mustJSON(t, map[string]any{
+		"policy": fmt.Sprintf("path %q {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n}", alicloudMount+"/gateway*"),
+	}), "create alicloud gateway policy")
+
+	mustWrite(t, port, "auth/jwt/role/"+alicloudJWTRole, mustJSON(t, map[string]any{
+		"token_policies": []string{alicloudPolicyName},
+		"user_claim":     "sub",
+		"cred_spec_name": alicloudSpecName,
+		"token_ttl":      3600,
+	}), "create alicloud JWT role")
+
+	mustWrite(t, port, "sys/providers/"+alicloudMount, `{"type":"alicloud"}`, "mount alicloud provider")
+
+	// Agent-only: the provider yields no user principal by design, so there is no
+	// user leg to configure.
+	status, body := h.APIRequest(t, "POST", alicloudMount+"/config", port, mustJSON(t, map[string]any{
+		"auto_auth_path": "auth/jwt/",
+		"default_role":   alicloudJWTRole,
+	}))
+	if status != 200 && status != 201 && status != 204 {
+		t.Fatalf("configure alicloud provider: status %d: %s", status, string(body))
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestAlicloudKeyless_MintsFromAWardenAssertion drives one gateway request and
+// checks what the exchange carried.
+//
+// The gateway request does not complete, and does not need to: minting runs before
+// routing, so the exchange has already happened by the time the request is refused.
+// It is refused for carrying no ACS3 or SigV4 signature — a signed request would
+// only get as far as host resolution, which will not dial a local listener either.
+// Either way the mint is what this observes.
+func TestAlicloudKeyless_MintsFromAWardenAssertion(t *testing.T) {
+	leader := h.GetLeaderPort(t)
+	sts := startAlicloudSTSStub(t)
+	setupAlicloudKeyless(t, leader, sts.URL)
+
+	jwt := h.GetDefaultJWT(t)
+	// The Alicloud gateway is agent-only and takes its caller identity the way an
+	// ACS3 client would carry a session token: a JWT in x-acs-security-token is
+	// transparent mode, and the role comes from the mount's default_role. A plain
+	// Authorization: Bearer is not a credential this provider recognises — it
+	// yields a 401 before anything mints.
+	//
+	// The Host is the one a real client would send, since the provider resolves its
+	// upstream target from it. This request never gets that far: the gateway
+	// dispatch refuses anything without an ACS3 or SigV4 signature before host
+	// resolution runs. It is set anyway so the request is the shape a client sends
+	// rather than one that only happens to work.
+	status, body := h.DoRequest(t, "POST",
+		h.NodeURL(leader)+"/v1/"+alicloudMount+"/gateway/?Action=DescribeRegions&Version=2014-05-26",
+		map[string]string{
+			"x-acs-security-token": jwt,
+			"Host":                 "ecs.cn-hangzhou.aliyuncs.com",
+		}, "")
+	// Recorded rather than asserted: the outcome of the hop after the mint is not
+	// what this test is about, and pinning it would make the test fail for reasons
+	// that have nothing to do with federation. It is still the first thing to read
+	// if the exchange below did not happen.
+	t.Logf("gateway request returned %d: %s", status, string(body))
+
+	exchanges := sts.Exchanges()
+	if len(exchanges) != 1 {
+		t.Fatalf("STS saw %d exchanges, want exactly 1", len(exchanges))
+	}
+	ex := exchanges[0]
+
+	// The RPC common parameters identify the call and stay in the query.
+	if got := ex.Query.Get("Action"); got != "AssumeRoleWithOIDC" {
+		t.Errorf("Action = %q, want AssumeRoleWithOIDC", got)
+	}
+	if got := ex.Query.Get("Version"); got != "2015-04-01" {
+		t.Errorf("Version = %q, want 2015-04-01", got)
+	}
+	if ex.Query.Get("Timestamp") == "" {
+		t.Error("Timestamp is missing from the query")
+	}
+
+	// The exchange parameters travel in the form body.
+	if got := ex.Form.Get("RoleArn"); got != alicloudRoleARN {
+		t.Errorf("RoleArn = %q, want %q", got, alicloudRoleARN)
+	}
+	if got := ex.Form.Get("OIDCProviderArn"); got != alicloudProviderARN {
+		t.Errorf("OIDCProviderArn = %q, want %q", got, alicloudProviderARN)
+	}
+	if got := ex.Form.Get("DurationSeconds"); got != "3600" {
+		t.Errorf("DurationSeconds = %q, want 3600", got)
+	}
+
+	assertion := ex.Form.Get("OIDCToken")
+	if assertion == "" {
+		t.Fatal("OIDCToken is missing from the request body")
+	}
+
+	// The two properties the driver's design turns on. AssumeRoleWithOIDC is
+	// anonymous, and the assertion must never reach the URL — a transport failure
+	// prints the whole URL into logs, so a token in the query leaks on every
+	// timeout.
+	if ex.AuthHdr != "" {
+		t.Errorf("AssumeRoleWithOIDC carried an Authorization header: %q", ex.AuthHdr)
+	}
+	if strings.Contains(ex.RawQuery, "OIDCToken") || strings.Contains(ex.RawQuery, assertion) {
+		t.Errorf("the assertion appeared in the query string: %q", ex.RawQuery)
+	}
+
+	// The assertion is checked the way STS would: against the issuer's published
+	// JWKS, signature first.
+	claims := h.VerifyAssertion(t, leader, assertion)
+
+	if got := claims["iss"]; got != alicloudIssuerURL {
+		t.Errorf("iss = %v, want %q", got, alicloudIssuerURL)
+	}
+	if got := claims["aud"]; got != alicloudAudience {
+		t.Errorf("aud = %v, want %q — it must match a client_id on the RAM OIDC provider", got, alicloudAudience)
+	}
+	sub, _ := claims["sub"].(string)
+	if !strings.HasPrefix(sub, "wid:") {
+		t.Errorf("sub = %q, want a wid: composite subject", sub)
+	}
+	if got := claims["warden_resource"]; got != "alicloud-ram:"+alicloudRoleARN {
+		t.Errorf("warden_resource = %v, want the role the exchange targets", got)
+	}
+	exp, ok := claims["exp"].(float64)
+	if !ok || time.Unix(int64(exp), 0).Before(time.Now()) {
+		t.Errorf("exp = %v, want a time in the future", claims["exp"])
+	}
+}
+
+// A keyless source mints only from a caller assertion, so a spec that does not ask
+// for one has no way to mint. The spec-create test-mint is what catches it.
+func TestAlicloudKeyless_NonExchangeSpecIsRefusedAtCreate(t *testing.T) {
+	leader := h.GetLeaderPort(t)
+	sts := startAlicloudSTSStub(t)
+	setupAlicloudKeyless(t, leader, sts.URL)
+
+	const name = "e2e-alicloud-non-exchange"
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/specs/"+name, h.GetLeaderPort(t), "") })
+
+	status, body := h.APIRequest(t, "POST", "sys/cred/specs/"+name, leader, mustJSON(t, map[string]any{
+		"type":   "alicloud_keys",
+		"source": alicloudSourceName,
+		"config": map[string]string{
+			"mint_method": "assume_role",
+			"role_arn":    alicloudRoleARN,
+		},
+	}))
+
+	if status == 200 || status == 201 {
+		t.Fatalf("a non-exchange spec on a keyless source was accepted (status %d)", status)
+	}
+	if !strings.Contains(string(body), "subject_token_source") {
+		t.Errorf("refusal should name subject_token_source, got: %s", string(body))
+	}
+}
+
+// A federated source holds no secret of its own, so a rotation_period could never
+// be honoured — the manager would retry, park the entry as failed, and come back
+// hourly for the life of the source. Refusing at create is what keeps that entry
+// from existing.
+func TestAlicloudKeyless_RotationPeriodRefusedOnKeylessSource(t *testing.T) {
+	leader := h.GetLeaderPort(t)
+	sts := startAlicloudSTSStub(t)
+
+	const name = "e2e-alicloud-rotating"
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, h.GetLeaderPort(t), "") })
+
+	status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leader, mustJSON(t, map[string]any{
+		"type":            "alicloud",
+		"rotation_period": 86400,
+		"config": map[string]string{
+			"auth_method":       "oidc_federation",
+			"oidc_provider_arn": alicloudProviderARN,
+			"audience":          alicloudAudience,
+			"sts_endpoint":      sts.URL,
+			"tls_skip_verify":   "true",
+		},
+	}))
+
+	if status == 200 || status == 201 {
+		t.Fatalf("a keyless source was accepted with a rotation_period (status %d)", status)
+	}
+	if !strings.Contains(string(body), "rotation_period") {
+		t.Errorf("refusal should name rotation_period, got: %s", string(body))
+	}
+}
+
+// The static and keyless shapes are mutually exclusive: a source carrying both is
+// half-converted, and which half wins would be silent.
+func TestAlicloudKeyless_MixedConfigIsRefused(t *testing.T) {
+	leader := h.GetLeaderPort(t)
+
+	const name = "e2e-alicloud-mixed"
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, h.GetLeaderPort(t), "") })
+
+	status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leader, mustJSON(t, map[string]any{
+		"type": "alicloud",
+		"config": map[string]string{
+			"auth_method":       "oidc_federation",
+			"oidc_provider_arn": alicloudProviderARN,
+			"access_key_id":     "LTAI-e2e-not-a-real-key",
+			"access_key_secret": "e2e-not-a-real-secret",
+		},
+	}))
+
+	if status == 200 || status == 201 {
+		t.Fatalf("a source carrying both a key pair and federation config was accepted (status %d)", status)
+	}
+	if !strings.Contains(string(body), "access_key_id") {
+		t.Errorf("refusal should name the offending field, got: %s", string(body))
+	}
+}

--- a/e2e/fullchain/kubernetes_test.go
+++ b/e2e/fullchain/kubernetes_test.go
@@ -3,15 +3,8 @@
 package fullchain
 
 import (
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rsa"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net/http"
 	"strings"
 	"testing"
@@ -389,135 +382,10 @@ func bearerOf(t *testing.T, header string) string {
 // verifyAssertion checks a Warden-minted assertion against the issuer's published
 // JWKS and returns its claims — the same two steps a cluster's JWT authenticator
 // takes, which is why this is worth doing here rather than decoding and trusting.
+//
+// The mechanics moved to e2e/helpers once a second federation source needed them;
+// this stays as the package's one-argument form.
 func verifyAssertion(t *testing.T, token string) map[string]any {
 	t.Helper()
-
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		t.Fatalf("assertion is not a three-part JWT (%d parts)", len(parts))
-	}
-
-	var header struct {
-		Alg string `json:"alg"`
-		Kid string `json:"kid"`
-	}
-	if err := json.Unmarshal(decodeSegment(t, parts[0]), &header); err != nil {
-		t.Fatalf("parse assertion header: %v", err)
-	}
-
-	key := jwksKey(t, header.Kid, header.Alg)
-	signed := parts[0] + "." + parts[1]
-	verifySignature(t, header.Alg, key, signed, decodeSegment(t, parts[2]))
-
-	var claims map[string]any
-	if err := json.Unmarshal(decodeSegment(t, parts[1]), &claims); err != nil {
-		t.Fatalf("parse assertion claims: %v", err)
-	}
-	return claims
-}
-
-func decodeSegment(t *testing.T, segment string) []byte {
-	t.Helper()
-	decoded, err := base64.RawURLEncoding.DecodeString(segment)
-	if err != nil {
-		t.Fatalf("decode JWT segment: %v", err)
-	}
-	return decoded
-}
-
-// jwksKey fetches the issuer's published JWKS and rebuilds the key the assertion
-// names. Going through the published document rather than any internal handle is
-// the point: it is what a cluster would fetch.
-func jwksKey(t *testing.T, kid, alg string) any {
-	t.Helper()
-
-	status, body := h.DoRequest(t, "GET", h.NodeURL(leaderPort)+"/oidc/jwks", nil, "")
-	if status != 200 {
-		t.Fatalf("GET /oidc/jwks = %d: %s", status, body)
-	}
-
-	var doc struct {
-		Keys []struct {
-			Kid string `json:"kid"`
-			Alg string `json:"alg"`
-			Kty string `json:"kty"`
-			N   string `json:"n"`
-			E   string `json:"e"`
-			Crv string `json:"crv"`
-			X   string `json:"x"`
-			Y   string `json:"y"`
-		} `json:"keys"`
-	}
-	if err := json.Unmarshal(body, &doc); err != nil {
-		t.Fatalf("parse jwks: %v (%s)", err, body)
-	}
-
-	for _, k := range doc.Keys {
-		if k.Kid != kid {
-			continue
-		}
-		switch k.Kty {
-		case "RSA":
-			return &rsa.PublicKey{
-				N: new(big.Int).SetBytes(decodeSegment(t, k.N)),
-				E: int(new(big.Int).SetBytes(decodeSegment(t, k.E)).Int64()),
-			}
-		case "EC":
-			return &ecdsa.PublicKey{
-				Curve: ecCurve(t, k.Crv),
-				X:     new(big.Int).SetBytes(decodeSegment(t, k.X)),
-				Y:     new(big.Int).SetBytes(decodeSegment(t, k.Y)),
-			}
-		default:
-			t.Fatalf("jwk %s has unsupported kty %q", kid, k.Kty)
-		}
-	}
-
-	t.Fatalf("assertion names kid %q (alg %s), which the published JWKS does not carry", kid, alg)
-	return nil
-}
-
-func ecCurve(t *testing.T, crv string) elliptic.Curve {
-	t.Helper()
-	if crv != "P-256" {
-		t.Fatalf("unsupported EC curve %q", crv)
-	}
-	return elliptic.P256()
-}
-
-// verifySignature checks the assertion's signature with the published key. A
-// cluster that could not do this would reject the token, so a row that skipped it
-// could pass on an assertion no cluster would accept.
-func verifySignature(t *testing.T, alg string, key any, signed string, sig []byte) {
-	t.Helper()
-
-	digest := sha256.Sum256([]byte(signed))
-
-	switch alg {
-	case "RS256":
-		pub, ok := key.(*rsa.PublicKey)
-		if !ok {
-			t.Fatalf("alg RS256 but the JWKS key is %T", key)
-		}
-		if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], sig); err != nil {
-			t.Fatalf("assertion signature does not verify against the published JWKS: %v", err)
-		}
-	case "ES256":
-		pub, ok := key.(*ecdsa.PublicKey)
-		if !ok {
-			t.Fatalf("alg ES256 but the JWKS key is %T", key)
-		}
-		// JWS packs ES256 as r||s fixed-width, not as the ASN.1 form ecdsa.Verify
-		// would take.
-		if len(sig) != 64 {
-			t.Fatalf("ES256 signature is %d bytes, want 64", len(sig))
-		}
-		r := new(big.Int).SetBytes(sig[:32])
-		s := new(big.Int).SetBytes(sig[32:])
-		if !ecdsa.Verify(pub, digest[:], r, s) {
-			t.Fatal("assertion signature does not verify against the published JWKS")
-		}
-	default:
-		t.Fatalf("unsupported assertion alg %q", alg)
-	}
+	return h.VerifyAssertion(t, leaderPort, token)
 }

--- a/e2e/helpers/assertion_helpers.go
+++ b/e2e/helpers/assertion_helpers.go
@@ -1,0 +1,166 @@
+//go:build e2e
+
+package helpers
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// Verifying a Warden-minted identity assertion the way an upstream would: fetch
+// the issuer's published JWKS, rebuild the key the token names, and check the
+// signature before reading a single claim.
+//
+// These live here rather than beside one suite's tests because more than one
+// federation source is worth driving end to end, and each would otherwise carry
+// its own copy of the same JOSE handling. There is no JOSE dependency in the
+// tree; this is stdlib throughout, which is why it is worth writing once.
+
+// VerifyAssertion checks a Warden-minted assertion against the issuer's published
+// JWKS and returns its claims.
+//
+// The signature check is not decoration. An upstream that could not verify the
+// token would reject it, so a test that decoded the claims without verifying
+// could pass on an assertion no real cluster would accept.
+//
+// leaderPort names the node to fetch the JWKS from. The document is public, so
+// any node serves it.
+func VerifyAssertion(t *testing.T, leaderPort int, token string) map[string]any {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("assertion is not a three-part JWT (%d parts)", len(parts))
+	}
+
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(DecodeJWTSegment(t, parts[0]), &header); err != nil {
+		t.Fatalf("parse assertion header: %v", err)
+	}
+
+	key := jwksKey(t, leaderPort, header.Kid, header.Alg)
+	signed := parts[0] + "." + parts[1]
+	verifyAssertionSignature(t, header.Alg, key, signed, DecodeJWTSegment(t, parts[2]))
+
+	var claims map[string]any
+	if err := json.Unmarshal(DecodeJWTSegment(t, parts[1]), &claims); err != nil {
+		t.Fatalf("parse assertion claims: %v", err)
+	}
+	return claims
+}
+
+// DecodeJWTSegment decodes one base64url JWT segment.
+func DecodeJWTSegment(t *testing.T, segment string) []byte {
+	t.Helper()
+	decoded, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		t.Fatalf("decode JWT segment: %v", err)
+	}
+	return decoded
+}
+
+// jwksKey fetches the issuer's published JWKS and rebuilds the key the assertion
+// names. Going through the published document rather than any internal handle is
+// the point: it is what a cluster would fetch.
+func jwksKey(t *testing.T, leaderPort int, kid, alg string) any {
+	t.Helper()
+
+	status, body := DoRequest(t, "GET", NodeURL(leaderPort)+"/oidc/jwks", nil, "")
+	if status != 200 {
+		t.Fatalf("GET /oidc/jwks = %d: %s", status, body)
+	}
+
+	var doc struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+			Alg string `json:"alg"`
+			Kty string `json:"kty"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+			Crv string `json:"crv"`
+			X   string `json:"x"`
+			Y   string `json:"y"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("parse jwks: %v (%s)", err, body)
+	}
+
+	for _, k := range doc.Keys {
+		if k.Kid != kid {
+			continue
+		}
+		switch k.Kty {
+		case "RSA":
+			return &rsa.PublicKey{
+				N: new(big.Int).SetBytes(DecodeJWTSegment(t, k.N)),
+				E: int(new(big.Int).SetBytes(DecodeJWTSegment(t, k.E)).Int64()),
+			}
+		case "EC":
+			return &ecdsa.PublicKey{
+				Curve: ecCurve(t, k.Crv),
+				X:     new(big.Int).SetBytes(DecodeJWTSegment(t, k.X)),
+				Y:     new(big.Int).SetBytes(DecodeJWTSegment(t, k.Y)),
+			}
+		default:
+			t.Fatalf("jwk %s has unsupported kty %q", kid, k.Kty)
+		}
+	}
+
+	t.Fatalf("assertion names kid %q (alg %s), which the published JWKS does not carry", kid, alg)
+	return nil
+}
+
+func ecCurve(t *testing.T, crv string) elliptic.Curve {
+	t.Helper()
+	if crv != "P-256" {
+		t.Fatalf("unsupported EC curve %q", crv)
+	}
+	return elliptic.P256()
+}
+
+// verifyAssertionSignature checks the assertion's signature with the published key.
+func verifyAssertionSignature(t *testing.T, alg string, key any, signed string, sig []byte) {
+	t.Helper()
+
+	digest := sha256.Sum256([]byte(signed))
+
+	switch alg {
+	case "RS256":
+		pub, ok := key.(*rsa.PublicKey)
+		if !ok {
+			t.Fatalf("alg RS256 but the JWKS key is %T", key)
+		}
+		if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], sig); err != nil {
+			t.Fatalf("assertion signature does not verify against the published JWKS: %v", err)
+		}
+	case "ES256":
+		pub, ok := key.(*ecdsa.PublicKey)
+		if !ok {
+			t.Fatalf("alg ES256 but the JWKS key is %T", key)
+		}
+		// JWS packs ES256 as r||s fixed-width, not as the ASN.1 form ecdsa.Verify
+		// would take.
+		if len(sig) != 64 {
+			t.Fatalf("ES256 signature is %d bytes, want 64", len(sig))
+		}
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		if !ecdsa.Verify(pub, digest[:], r, s) {
+			t.Fatal("assertion signature does not verify against the published JWKS")
+		}
+	default:
+		t.Fatalf("unsupported assertion alg %q", alg)
+	}
+}

--- a/provider/alicloud/signature.go
+++ b/provider/alicloud/signature.go
@@ -127,15 +127,19 @@ func generateNonce() (string, error) {
 }
 
 // canonicalQueryString builds the canonical query string per ACS3 rules:
-// parameters sorted by key (then value), keys and values percent-encoded with
-// unreserved characters preserved, '=' appended for keys with empty values.
-func canonicalQueryString(rawQuery string) string {
+// parameters sorted by name, keys and values percent-encoded with unreserved
+// characters preserved, '=' appended for keys with empty values.
+// A query that will not parse is reported rather than rendered as empty: an
+// empty canonical query for a request that has one yields a signature neither
+// side can reproduce, surfacing as a remote SignatureDoesNotMatch on the signing
+// path and an unexplained rejection on the verifying one.
+func canonicalQueryString(rawQuery string) (string, error) {
 	if rawQuery == "" {
-		return ""
+		return "", nil
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("malformed query string: %w", err)
 	}
 
 	keys := make([]string, 0, len(values))
@@ -146,13 +150,17 @@ func canonicalQueryString(rawQuery string) string {
 
 	var parts []string
 	for _, k := range keys {
-		vs := values[k]
-		sort.Strings(vs)
-		for _, v := range vs {
+		// Sorted by name only. ACS3 has no notion of a repeated parameter — an
+		// array is flattened into indexed names (InstanceId.1, InstanceId.2), so
+		// every name is distinct and ordering values would never come up. A
+		// request that does repeat a name is signed by Alibaba in the order it
+		// arrived, so sorting the values here would compute a different string
+		// from the one the server derives and the signature would be rejected.
+		for _, v := range values[k] {
 			parts = append(parts, acs3Encode(k)+"="+acs3Encode(v))
 		}
 	}
-	return strings.Join(parts, "&")
+	return strings.Join(parts, "&"), nil
 }
 
 // acs3Encode percent-encodes s per ACS3 rules: unreserved characters stay as-is,
@@ -286,10 +294,15 @@ func SignACS3(r *http.Request, accessKeyID, accessKeySecret, securityToken strin
 		rawQuery = r.URL.RawQuery
 	}
 
+	canonicalQuery, err := canonicalQueryString(rawQuery)
+	if err != nil {
+		return err
+	}
+
 	canonicalRequest := strings.Join([]string{
 		r.Method,
 		canonicalURI,
-		canonicalQueryString(rawQuery),
+		canonicalQuery,
 		canonicalHdrs,
 		signedHeadersStr,
 		hashSHA256(body),
@@ -336,10 +349,15 @@ func VerifyACS3(r *http.Request, accessKeySecret string, body []byte) (bool, err
 		return false, fmt.Errorf("body hash does not match x-acs-content-sha256 header")
 	}
 
+	canonicalQuery, err := canonicalQueryString(rawQuery)
+	if err != nil {
+		return false, err
+	}
+
 	canonicalRequest := strings.Join([]string{
 		r.Method,
 		canonicalURI,
-		canonicalQueryString(rawQuery),
+		canonicalQuery,
 		canonicalHdrs,
 		signedHeadersStr,
 		contentHash,

--- a/provider/alicloud/signature_test.go
+++ b/provider/alicloud/signature_test.go
@@ -134,13 +134,50 @@ func TestSignWithSecurityToken(t *testing.T) {
 
 func TestCanonicalQueryString(t *testing.T) {
 	// Canonical form sorts keys and percent-encodes values.
-	got := canonicalQueryString("b=2&a=1&c=hello%20world")
+	got, err := canonicalQueryString("b=2&a=1&c=hello%20world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "a=1&b=2&c=hello%20world"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
-	if got := canonicalQueryString(""); got != "" {
+
+	got, err = canonicalQueryString("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
 		t.Errorf("empty query should produce empty canonical, got %q", got)
+	}
+}
+
+// ACS3 sorts by parameter name only; a repeated name keeps the order it arrived
+// in, because that is the order the server signs. Sorting the values would
+// compute a canonical string the server does not derive.
+func TestCanonicalQueryString_RepeatedNameKeepsRequestOrder(t *testing.T) {
+	got, err := canonicalQueryString("k=b&k=a&j=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "j=1&k=b&k=a"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// A query that will not parse must be reported, not silently rendered as empty:
+// signing an empty canonical query for a request that has one produces a
+// signature the server cannot reproduce.
+func TestCanonicalQueryString_MalformedQueryIsReported(t *testing.T) {
+	if _, err := canonicalQueryString("a=%zz"); err == nil {
+		t.Errorf("expected an error for a malformed query")
+	}
+
+	r := httptest.NewRequest("GET", "https://sts.aliyuncs.com/", nil)
+	r.URL.RawQuery = "a=%zz"
+	if err := SignACS3(r, "LTAI-test-id", "test-secret", "", nil); err == nil {
+		t.Errorf("SignACS3 should surface a malformed query rather than sign an empty one")
 	}
 }
 

--- a/provider/cloudflare/provider.go
+++ b/provider/cloudflare/provider.go
@@ -118,9 +118,8 @@ Credential type: cloudflare_keys (at least one mode required)
   - access_key_id: R2 access key ID for Object Storage (R2 mode)
   - secret_access_key: R2 secret access key for Object Storage (R2 mode)
 
-Two credential source types are supported:
+One credential source type is supported:
 - local (static_keys): Static credentials stored on the spec
-- hvault (static_cloudflare): Keys fetched from a Vault/OpenBao KV v2 secret
 
 Configuration:
 - cloudflare_url: Cloudflare API base URL (default: https://api.cloudflare.com/client/v4)

--- a/provider/scaleway/provider.go
+++ b/provider/scaleway/provider.go
@@ -66,12 +66,11 @@ S3 Object Storage:
 
   Supported S3 regions: fr-par, nl-ams, pl-waw, it-mil
 
-Three credential source types are supported:
+Two credential source types are supported:
 - scaleway (static_keys): Static API keys stored on the spec
 - scaleway (dynamic_keys): Ephemeral API keys minted via the IAM API
   (POST /iam/v1alpha1/api-keys) with automatic revocation on lease expiry.
   The management key supports automatic rotation.
-- hvault (static_scaleway): Keys fetched from a Vault/OpenBao KV v2 secret
 
 Configuration:
 - scaleway_url: Scaleway API base URL (default: https://api.scaleway.com)


### PR DESCRIPTION
**PR 5 of 5.** Stacked on #538 — this PR's diff is the top two commits only.

A keyless Alicloud source holds no RAM access key: every mint exchanges the caller's Warden-minted assertion at STS `AssumeRoleWithOIDC` for a session on the spec's role. This covers that exchange **end to end against a live cluster** — source and spec created through the API, a real assertion minted by the issuer, and the request the driver actually sends.

The exchange is what a stub can stand in for: it is an ordinary HTTPS call to an endpoint the source names, so pointing `sts_endpoint` at a local listener puts the whole mint under test — the same move `ibmcloud_test.go` makes for IBM's IAM grant.

## What it pins that unit tests cannot

That the assertion Warden mints **verifies against the issuer's published JWKS**, and carries the `iss`, `aud`, `wid:` subject and `warden_resource` claims STS would be matching against. Plus the two properties the driver's design turns on: no `Authorization` header, since `AssumeRoleWithOIDC` is anonymous, and no assertion anywhere in the query string.

## Where it lives, and why not fullchain

Because of the **provider**, not the driver. The Alicloud gateway is agent-only by design — `agent_only_test.go` pins that it never yields a user principal — so it has no `user_auth_path`, while every fullchain mount is configured with one. And it has no URL override key: it resolves its target from the inbound Host, which must end `.aliyuncs.com`. So the mount is set up directly, in the agent-only shape `e2e/forwarding/sigv4_test.go` uses, and caller identity arrives as a JWT in `x-acs-security-token`.

## Known gap, stated rather than implied

**This covers the mint hop, not the gateway hop.** Minting runs before routing, so the exchange happens and is fully observable even though the request afterwards is refused. Nothing here proves the minted `security_token` is signed onto an outbound request — the same gap `mcp_aws_test.go` records for AWS. That path does have unit coverage in `provider/alicloud/handler_test.go`.

## Also

The assertion verifier **moves** from `e2e/fullchain/kubernetes_test.go` to `e2e/helpers` now that a second federation source needs it. A move, not a rewrite; `kubernetes_test.go` keeps its one-argument form and its rows still pass.

The second commit corrects a comment about what the request's `Host` does — it is set because the provider resolves its target from it, but this request is refused at signature dispatch before host resolution runs. Related helper fix in #533.

## Verification

All four rows pass against a live 3-node cluster; full e2e suite 20 packages, 0 failures.