### PR TITLE
fix(core): guard rotation entry writes, and refuse a period that cannot be honoured

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1247,6 +1247,20 @@ func (s *CredentialConfigStore) validateSource(ctx context.Context, source *cred
 				return logical.ErrBadRequestf("invalid config for source type '%s': %s", source.Type, err.Error())
 			}
 
+			// A rotation_period the driver could never honour is worse than one
+			// that is refused: the manager retries, parks the entry as failed,
+			// comes back after FailedMinAge and repeats for the life of the
+			// source, all of it only in the server log. Factories opt in to this
+			// check; see credential.RotationConfigValidator for why
+			// SupportsRotation cannot be consulted here instead.
+			if source.RotationPeriod > 0 {
+				if rv, ok := factory.(credential.RotationConfigValidator); ok {
+					if err := rv.ValidateRotationConfig(source.Config); err != nil {
+						return logical.ErrBadRequestf("rotation_period cannot be honoured for source type '%s': %s", source.Type, err.Error())
+					}
+				}
+			}
+
 			// Test connection by creating a temporary driver instance
 			// This validates credentials and connectivity (e.g., Vault authentication)
 			// Skipped during rotation where new credentials may not yet be propagated

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -1964,6 +1964,97 @@ func TestCredentialConfigStore_FederationRotationGateRunsOnUpdate(t *testing.T) 
 	require.NoError(t, store.validateSource(ctx, updated, false))
 }
 
+// unrotatableFactory opts in to RotationConfigValidator and refuses unless the
+// config names a management user, mirroring how a real driver reports that it has
+// nothing to rotate with.
+type unrotatableFactory struct{ sourceType string }
+
+func (f *unrotatableFactory) Type() string { return f.sourceType }
+func (f *unrotatableFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	return &testDriver{}, nil
+}
+func (f *unrotatableFactory) ValidateConfig(config map[string]string) error { return nil }
+func (f *unrotatableFactory) SensitiveConfigFields() []string               { return nil }
+func (f *unrotatableFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return credential.TypeAPIKey, nil
+}
+func (f *unrotatableFactory) ValidateRotationConfig(config map[string]string) error {
+	if config["management_user_name"] == "" {
+		return fmt.Errorf("management_user_name is required")
+	}
+	return nil
+}
+
+// A rotation_period the driver can never honour is refused at write time.
+//
+// Accepted, it produces no error an operator ever sees: the manager finds
+// SupportsRotation false, retries to MaxRotateAttempts, parks the entry as failed,
+// returns after FailedMinAge and repeats for the life of the source, entirely in
+// the server log.
+//
+// The check is opt-in per factory, because SupportsRotation cannot be consulted at
+// config time — some implementations probe the upstream to answer, and others
+// answer false for configurations that are required to carry a rotation_period
+// anyway.
+func TestCredentialConfigStore_UnrotatableSourceRejectsRotationPeriod(t *testing.T) {
+	newStore := func(t *testing.T) (*CredentialConfigStore, context.Context) {
+		store, ctx := setupTestCredentialConfigStore(t)
+		store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+		require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(
+			&unrotatableFactory{sourceType: credential.SourceTypeAlicloud}))
+		return store, ctx
+	}
+
+	t.Run("refused when the config cannot rotate", func(t *testing.T) {
+		store, ctx := newStore(t)
+		err := store.CreateSource(ctx, &credential.CredSource{
+			Name:           "unrotatable",
+			Type:           credential.SourceTypeAlicloud,
+			Config:         map[string]string{"access_key_id": "LTAI-mgmt"},
+			RotationPeriod: 48 * time.Hour,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period cannot be honoured")
+		assert.Contains(t, err.Error(), "management_user_name")
+	})
+
+	t.Run("allowed once the config can rotate", func(t *testing.T) {
+		store, ctx := newStore(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "rotatable",
+			Type: credential.SourceTypeAlicloud,
+			Config: map[string]string{
+				"access_key_id":        "LTAI-mgmt",
+				"management_user_name": "warden-management",
+			},
+			RotationPeriod: 48 * time.Hour,
+		}))
+	})
+
+	t.Run("not consulted without a rotation_period", func(t *testing.T) {
+		store, ctx := newStore(t)
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name:   "no-rotation",
+			Type:   credential.SourceTypeAlicloud,
+			Config: map[string]string{"access_key_id": "LTAI-mgmt"},
+		}))
+	})
+
+	// The gate lives in the shared validator, so an edit cannot slip a
+	// rotation_period past what create would have refused.
+	t.Run("runs on update too", func(t *testing.T) {
+		store, ctx := newStore(t)
+		err := store.validateSource(ctx, &credential.CredSource{
+			Name:           "unrotatable",
+			Type:           credential.SourceTypeAlicloud,
+			Config:         map[string]string{"access_key_id": "LTAI-mgmt"},
+			RotationPeriod: 48 * time.Hour,
+		}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period cannot be honoured")
+	})
+}
+
 // TestCredentialConfigStore_ChainedSpecRejectsRotationPeriod covers the spec half
 // of the same rule.
 //

--- a/core/rotation.go
+++ b/core/rotation.go
@@ -132,6 +132,28 @@ func (e *RotationEntry) clearStagedFields() {
 	e.PreparedAt = time.Time{}
 }
 
+// stagedRotation is the outcome of a slow-path prepare: credentials generated
+// upstream and waiting to be activated.
+//
+// It is returned from the prepare step rather than written straight onto the
+// entry so that every write to an entry's staged fields happens under e.mu, in
+// the job that owns the transition. Writing them from the prepare step would
+// race the tick loop's readers and persistEntry's marshal of the whole struct.
+type stagedRotation struct {
+	NewConfig       map[string]string
+	CleanupConfig   map[string]string
+	ActivationDelay time.Duration
+	PreparedAt      time.Time
+}
+
+// applyStaged copies a completed prepare onto the entry. Caller must hold e.mu.
+func (e *RotationEntry) applyStaged(s *stagedRotation) {
+	e.NewConfig = s.NewConfig
+	e.CleanupConfig = s.CleanupConfig
+	e.ActivationDelay = s.ActivationDelay
+	e.PreparedAt = s.PreparedAt
+}
+
 // GetState returns the entry's current state in a thread-safe manner.
 func (e *RotationEntry) GetState() EntryState {
 	e.mu.Lock()
@@ -400,8 +422,10 @@ func (m *RotationManager) register(entry *RotationEntry) error {
 
 	// Replace existing entry if present
 	if existing, loaded := m.entries.Load(key); loaded {
+		// The entry being replaced is live: a worker may be mutating its state
+		// right now, so read it through the accessor rather than off the field.
 		old := existing.(*RotationEntry)
-		if old.State == StateFailed {
+		if old.GetState() == StateFailed {
 			atomic.AddInt64(&m.failedCount, -1)
 		}
 		m.entries.Store(key, entry)
@@ -548,20 +572,29 @@ func (m *RotationManager) UpdateRotationPeriod(ctx context.Context, sourceName s
 		return fmt.Errorf("source %s is not registered for rotation", sourceName)
 	}
 
+	// Take the entry's lock: the schedule fields are written by worker goroutines
+	// too, and persistEntry marshals every field of the struct, so an unlocked
+	// update here races both those writes and its own persist.
 	entry := existing.(*RotationEntry)
+	entry.mu.Lock()
 	entry.RotationPeriod = newPeriod
 	entry.NextAction = time.Now().Add(newPeriod)
+	nextAction := entry.NextAction
 
+	var persistErr error
 	if m.storage != nil {
-		if err := m.persistEntry(entry); err != nil {
-			return fmt.Errorf("failed to persist updated rotation entry: %w", err)
-		}
+		persistErr = m.persistEntryIfCurrent(entry)
+	}
+	entry.mu.Unlock()
+
+	if persistErr != nil {
+		return fmt.Errorf("failed to persist updated rotation entry: %w", persistErr)
 	}
 
 	m.log.Info("updated rotation period",
 		logger.String("source", sourceName),
 		logger.String("new_period", newPeriod.String()),
-		logger.Time("next_rotation", entry.NextAction))
+		logger.Time("next_rotation", nextAction))
 
 	return nil
 }
@@ -591,6 +624,27 @@ func (m *RotationManager) persistEntry(entry *RotationEntry) error {
 	})
 }
 
+// persistEntryIfCurrent persists entry unless it has been superseded in the
+// registry, in which case it does nothing.
+//
+// register() replaces the map value for a key while a job may still be running
+// against the entry it replaced, and both entries map to the same storage path.
+// Without this check, the in-flight job's completion would write the superseded
+// entry's state over the live one's record — invisible until a restart restored
+// the stale copy.
+//
+// Only the job paths use it. register() itself persists before storing, by
+// design, so its own write must not be filtered out.
+func (m *RotationManager) persistEntryIfCurrent(entry *RotationEntry) error {
+	key := m.buildEntryKey(entry)
+	if current, ok := m.entries.Load(key); ok && current.(*RotationEntry) != entry {
+		m.log.Debug("skipping persist for a superseded rotation entry",
+			logger.String("key", key))
+		return nil
+	}
+	return m.persistEntry(entry)
+}
+
 // deleteEntry removes an entry from storage
 func (m *RotationManager) deleteEntry(entry *RotationEntry) error {
 	return m.storage.Delete(context.Background(), m.entryStoragePath(entry))
@@ -603,70 +657,71 @@ func (m *RotationManager) deleteEntry(entry *RotationEntry) error {
 // prepareSource creates new credentials and either activates them immediately (fast path)
 // or returns staged data for deferred activation (slow path).
 //
-// Returns (newConfig, cleanupConfig, activateAfter, error).
-// activateAfter == 0 means fast path (already activated inline).
-func (m *RotationManager) prepareSource(entry *RotationEntry) (activateAfter time.Duration, err error) {
+// A nil *stagedRotation means the fast path: activation already happened inline.
+// The staged data is returned rather than written onto the entry here, so the
+// caller can apply it under the entry's lock — see stagedRotation.
+func (m *RotationManager) prepareSource(entry *RotationEntry) (staged *stagedRotation, err error) {
 	ctx, cancel := context.WithTimeout(m.quitCtx, StageTimeout)
 	defer cancel()
 
 	ns, err := m.getNamespaceFromEntry(ctx, entry)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get namespace for entry: %w", err)
+		return nil, fmt.Errorf("failed to get namespace for entry: %w", err)
 	}
 	ctx = namespace.ContextWithNamespace(ctx, ns)
 
 	if m.core == nil || m.core.credConfigStore == nil {
-		return 0, fmt.Errorf("credential config store not available")
+		return nil, fmt.Errorf("credential config store not available")
 	}
 
 	source, err := m.core.credConfigStore.GetSource(ctx, entry.SourceName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get source %s: %w", entry.SourceName, err)
+		return nil, fmt.Errorf("failed to get source %s: %w", entry.SourceName, err)
 	}
 
 	if m.core.credentialManager == nil {
-		return 0, fmt.Errorf("credential manager not available")
+		return nil, fmt.Errorf("credential manager not available")
 	}
 
 	driver, err := m.core.credentialManager.GetOrCreateDriver(ctx, entry.SourceName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get driver for source %s: %w", entry.SourceName, err)
+		return nil, fmt.Errorf("failed to get driver for source %s: %w", entry.SourceName, err)
 	}
 
 	rotatable, ok := driver.(credential.Rotatable)
 	if !ok {
-		return 0, fmt.Errorf("driver for source %s does not support rotation", entry.SourceName)
+		return nil, fmt.Errorf("driver for source %s does not support rotation", entry.SourceName)
 	}
 
 	if !rotatable.SupportsRotation() {
-		return 0, fmt.Errorf("source %s configuration does not support rotation", entry.SourceName)
+		return nil, fmt.Errorf("source %s configuration does not support rotation", entry.SourceName)
 	}
 
 	// PREPARE: Generate new credentials (old still valid)
 	newConfig, cleanupConfig, delay, err := rotatable.PrepareRotation(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("prepare rotation failed for source %s: %w", entry.SourceName, err)
+		return nil, fmt.Errorf("prepare rotation failed for source %s: %w", entry.SourceName, err)
 	}
 
 	// Fast path: immediate activation
 	if delay == 0 {
 		if err := m.activateSourceInline(ctx, entry, source, rotatable, newConfig, cleanupConfig); err != nil {
-			return 0, err
+			return nil, err
 		}
-		return 0, nil
+		return nil, nil
 	}
 
-	// Slow path: populate staged fields on the entry
-	entry.NewConfig = newConfig
-	entry.CleanupConfig = cleanupConfig
-	entry.ActivationDelay = delay
-	entry.PreparedAt = time.Now()
-
+	// Slow path: hand the staged data back for the caller to apply under the lock.
 	m.log.Debug("prepared source rotation, activation scheduled",
 		logger.String("source", entry.SourceName),
 		logger.String("activate_after", delay.String()))
 
-	return delay, nil
+	return &stagedRotation{
+		NewConfig:       newConfig,
+		CleanupConfig:   cleanupConfig,
+		ActivationDelay: delay,
+		PreparedAt:      time.Now(),
+	}, nil
 }
 
 // activateSourceInline runs persist + commit + cleanup synchronously (fast path for activateAfter == 0).
@@ -744,69 +799,72 @@ func (m *RotationManager) activateSource(entry *RotationEntry) error {
 	return nil
 }
 
-// prepareSpec creates new spec credentials and either activates immediately or returns staged data.
-func (m *RotationManager) prepareSpec(entry *RotationEntry) (activateAfter time.Duration, err error) {
+// prepareSpec creates new spec credentials and either activates immediately or returns
+// staged data. A nil *stagedRotation means activation already happened inline. As in
+// prepareSource, the staged data is returned rather than written onto the entry so the
+// caller can apply it under the entry's lock.
+func (m *RotationManager) prepareSpec(entry *RotationEntry) (staged *stagedRotation, err error) {
 	ctx, cancel := context.WithTimeout(m.quitCtx, StageTimeout)
 	defer cancel()
 
 	ns, err := m.getNamespaceFromEntry(ctx, entry)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get namespace for entry: %w", err)
+		return nil, fmt.Errorf("failed to get namespace for entry: %w", err)
 	}
 	ctx = namespace.ContextWithNamespace(ctx, ns)
 
 	if m.core == nil || m.core.credConfigStore == nil {
-		return 0, fmt.Errorf("credential config store not available")
+		return nil, fmt.Errorf("credential config store not available")
 	}
 
 	spec, err := m.core.credConfigStore.GetSpec(ctx, entry.SpecName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get spec %s: %w", entry.SpecName, err)
+		return nil, fmt.Errorf("failed to get spec %s: %w", entry.SpecName, err)
 	}
 
 	if m.core.credentialManager == nil {
-		return 0, fmt.Errorf("credential manager not available")
+		return nil, fmt.Errorf("credential manager not available")
 	}
 
 	driver, err := m.core.credentialManager.GetOrCreateDriver(ctx, entry.SourceName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get driver for source %s: %w", entry.SourceName, err)
+		return nil, fmt.Errorf("failed to get driver for source %s: %w", entry.SourceName, err)
 	}
 
 	specRotatable, ok := driver.(credential.SpecRotatable)
 	if !ok {
-		return 0, fmt.Errorf("driver for source %s does not support spec rotation", entry.SourceName)
+		return nil, fmt.Errorf("driver for source %s does not support spec rotation", entry.SourceName)
 	}
 
 	if !specRotatable.SupportsSpecRotation() {
-		return 0, fmt.Errorf("source %s configuration does not support spec rotation", entry.SourceName)
+		return nil, fmt.Errorf("source %s configuration does not support spec rotation", entry.SourceName)
 	}
 
 	// PREPARE
 	newConfig, cleanupConfig, delay, err := specRotatable.PrepareSpecRotation(ctx, spec)
 	if err != nil {
-		return 0, fmt.Errorf("prepare spec rotation failed for spec %s: %w", entry.SpecName, err)
+		return nil, fmt.Errorf("prepare spec rotation failed for spec %s: %w", entry.SpecName, err)
 	}
 
 	// Fast path
 	if delay == 0 {
 		if err := m.activateSpecInline(ctx, entry, spec, specRotatable, newConfig, cleanupConfig); err != nil {
-			return 0, err
+			return nil, err
 		}
-		return 0, nil
+		return nil, nil
 	}
 
-	// Slow path: populate staged fields
-	entry.NewConfig = newConfig
-	entry.CleanupConfig = cleanupConfig
-	entry.ActivationDelay = delay
-	entry.PreparedAt = time.Now()
-
+	// Slow path: hand the staged data back for the caller to apply under the lock.
 	m.log.Info("prepared spec rotation, activation scheduled",
 		logger.String("spec", entry.SpecName),
 		logger.String("activate_after", delay.String()))
 
-	return delay, nil
+	return &stagedRotation{
+		NewConfig:       newConfig,
+		CleanupConfig:   cleanupConfig,
+		ActivationDelay: delay,
+		PreparedAt:      time.Now(),
+	}, nil
 }
 
 // activateSpecInline runs persist + commit + cleanup synchronously (fast path).

--- a/core/rotation_jobs.go
+++ b/core/rotation_jobs.go
@@ -28,15 +28,17 @@ func (j *prepareJob) Execute() error {
 	m := j.manager
 	entry := j.entry
 
-	var activateAfter time.Duration
+	var staged *stagedRotation
 	var err error
 
-	// Business logic — no lock held (these do I/O)
+	// Business logic — no lock held (these do I/O). They return the staged data
+	// rather than writing it onto the entry, so every write below happens under
+	// the lock the tick loop and persistEntry read against.
 	switch entry.EntryType {
 	case EntryTypeSpec:
-		activateAfter, err = m.prepareSpec(entry)
+		staged, err = m.prepareSpec(entry)
 	default:
-		activateAfter, err = m.prepareSource(entry)
+		staged, err = m.prepareSource(entry)
 	}
 
 	if err != nil {
@@ -46,7 +48,7 @@ func (j *prepareJob) Execute() error {
 	now := time.Now()
 
 	entry.mu.Lock()
-	if activateAfter == 0 {
+	if staged == nil {
 		// Fast path: activation already done inline by prepareSource/prepareSpec
 		entry.State = StateIdle
 		entry.LastRotation = now
@@ -56,8 +58,9 @@ func (j *prepareJob) Execute() error {
 		entry.clearStagedFields()
 	} else {
 		// Slow path: staged for deferred activation
+		entry.applyStaged(staged)
 		entry.State = StateStaged
-		entry.NextAction = now.Add(jitterDuration(activateAfter, 0.10))
+		entry.NextAction = now.Add(jitterDuration(staged.ActivationDelay, 0.10))
 		entry.Attempts = 0
 		entry.LastError = ""
 	}
@@ -66,7 +69,7 @@ func (j *prepareJob) Execute() error {
 	state := entry.State
 
 	if m.storage != nil {
-		if err := m.persistEntry(entry); err != nil {
+		if err := m.persistEntryIfCurrent(entry); err != nil {
 			m.log.Error("failed to persist entry after prepare",
 				logger.String("key", j.key),
 				logger.Err(err))
@@ -145,7 +148,7 @@ func (j *prepareJob) OnFailure(err error) {
 	}
 
 	if m.storage != nil {
-		if err := m.persistEntry(entry); err != nil {
+		if err := m.persistEntryIfCurrent(entry); err != nil {
 			m.log.Error("failed to persist entry after prepare failure",
 				logger.String("key", j.key),
 				logger.Err(err))
@@ -197,7 +200,7 @@ func (j *activateJob) Execute() error {
 	nextAction := entry.NextAction
 
 	if m.storage != nil {
-		if err := m.persistEntry(entry); err != nil {
+		if err := m.persistEntryIfCurrent(entry); err != nil {
 			m.log.Error("failed to persist entry after activation",
 				logger.String("key", j.key),
 				logger.Err(err))
@@ -262,7 +265,7 @@ func (j *activateJob) OnFailure(err error) {
 	}
 
 	if m.storage != nil {
-		if err := m.persistEntry(entry); err != nil {
+		if err := m.persistEntryIfCurrent(entry); err != nil {
 			m.log.Error("failed to persist entry after activation failure",
 				logger.String("key", j.key),
 				logger.Err(err))

--- a/core/rotation_test.go
+++ b/core/rotation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -943,4 +944,72 @@ func TestRotation_FailedStateHasNextAction(t *testing.T) {
 	assert.True(t, entry.NextAction.After(before),
 		"NextAction should be in the future for failed entry")
 	assert.Equal(t, StateFailed, entry.State)
+}
+
+// An entry is shared: worker goroutines mutate its state while the tick loop reads
+// it and persistEntry marshals every field. UpdateRotationPeriod used to write
+// RotationPeriod and NextAction, then marshal the whole struct, holding no lock at
+// all. Run under -race: this reports on the unguarded version and is quiet on the
+// guarded one.
+func TestRotationManager_UpdateRotationPeriodIsRaceFree(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	rm := NewRotationManager(nil, log.WithSubsystem("rotation"), nil)
+	rm.Start()
+	defer rm.Stop()
+
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	require.NoError(t, rm.RegisterSource(ctx, "racy-source", "vault", 1*time.Hour))
+
+	key := buildRotationKey(namespace.RootNamespace.UUID, "racy-source")
+	val, _ := rm.entries.Load(key)
+	entry := val.(*RotationEntry)
+
+	var wg sync.WaitGroup
+
+	// Writer: the config path an operator drives by updating a source.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			assert.NoError(t, rm.UpdateRotationPeriod(ctx, "racy-source", time.Duration(i+1)*time.Minute))
+		}
+	}()
+
+	// Writers: what a rotation job does to the same entry as it completes.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				entry.mu.Lock()
+				entry.State = StateStaged
+				entry.Attempts++
+				entry.applyStaged(&stagedRotation{
+					NewConfig:       map[string]string{"access_key_id": "rotated"},
+					CleanupConfig:   map[string]string{"access_key_id": "old"},
+					ActivationDelay: time.Minute,
+					PreparedAt:      time.Now(),
+				})
+				entry.clearStagedFields()
+				entry.State = StateIdle
+				entry.mu.Unlock()
+			}
+		}()
+	}
+
+	// Readers: what the tick loop does on every pass.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = entry.GetState()
+				_ = entry.GetNextAction()
+				_ = entry.GetAttempts()
+				_ = entry.GetNewConfig()
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/credential/drivers/alicloud_driver.go
+++ b/credential/drivers/alicloud_driver.go
@@ -63,6 +63,7 @@ var _ credential.SourceDriver = (*AlicloudDriver)(nil)
 var _ credential.SpecVerifier = (*AlicloudDriver)(nil)
 var _ credential.Rotatable = (*AlicloudDriver)(nil)
 var _ credential.ExchangeMinter = (*AlicloudDriver)(nil)
+var _ credential.RotationConfigValidator = (*AlicloudDriverFactory)(nil)
 
 // AlicloudDriver mints credentials from Alibaba Cloud STS.
 //
@@ -851,6 +852,26 @@ func (d *AlicloudDriver) callJSON(
 }
 
 // --- Rotatable interface (management key rotation) ---
+
+// ValidateRotationConfig rejects a rotation_period on a source that could never
+// rotate, so the operator hears about it at write time rather than never.
+//
+// It mirrors SupportsRotation exactly, from the config map instead of live driver
+// state. The two must stay in step: anything SupportsRotation requires and this
+// does not becomes a source that is accepted and then fails every cycle forever.
+func (f *AlicloudDriverFactory) ValidateRotationConfig(config map[string]string) error {
+	var missing []string
+	for _, key := range []string{"access_key_id", "access_key_secret", "management_user_name"} {
+		if credential.GetString(config, key, "") == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("rotating an alicloud source requires %s; without them the rotation manager can never complete a cycle",
+			strings.Join(missing, ", "))
+	}
+	return nil
+}
 
 // SupportsRotation returns true if the source has enough config to rotate the
 // management access key: an existing access_key_id + access_key_secret plus

--- a/credential/drivers/alicloud_driver_test.go
+++ b/credential/drivers/alicloud_driver_test.go
@@ -447,6 +447,65 @@ func TestAlicloudAssertionClaims(t *testing.T) {
 	})
 }
 
+// A rotation_period the driver could never honour is refused at write time.
+// Accepting it means the manager retries, parks the entry as failed, comes back
+// after FailedMinAge and repeats for the life of the source, all of it visible
+// only in the server log.
+//
+// The rules must match SupportsRotation exactly — anything required there but not
+// here is a source that is accepted and then fails every cycle forever — so the
+// same configs are asserted against both.
+func TestAlicloudDriverFactory_ValidateRotationConfig(t *testing.T) {
+	f := &AlicloudDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr string
+	}{
+		{
+			name: "complete rotation config",
+			config: map[string]string{
+				"access_key_id":        "LTAI-mgmt",
+				"access_key_secret":    "secret",
+				"management_user_name": "warden-management",
+			},
+		},
+		{
+			name: "missing management_user_name",
+			config: map[string]string{
+				"access_key_id":     "LTAI-mgmt",
+				"access_key_secret": "secret",
+			},
+			wantErr: "management_user_name",
+		},
+		{
+			name:    "missing everything",
+			config:  map[string]string{},
+			wantErr: "access_key_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := f.ValidateRotationConfig(tt.config)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+
+			// The config-time check and the live check must agree, or a source
+			// slips past one and stalls on the other.
+			d, createErr := f.Create(tt.config, createAlicloudTestLogger())
+			require.NoError(t, createErr)
+			assert.Equal(t, err == nil, d.(*AlicloudDriver).SupportsRotation(),
+				"ValidateRotationConfig and SupportsRotation must agree")
+		})
+	}
+}
+
 func TestAlicloudDriverFactory_Create(t *testing.T) {
 	f := &AlicloudDriverFactory{}
 	log := createAlicloudTestLogger()

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -100,6 +100,32 @@ type SpecVerifier interface {
 	VerifySpec(ctx context.Context, spec *CredSpec) error
 }
 
+// RotationConfigValidator is an optional interface for driver factories that can
+// tell, from source config alone, that a source will never be able to rotate.
+//
+// It exists because a source accepted with a rotation_period its driver cannot
+// honour does not fail loudly — it fails on a schedule, forever. Every cycle the
+// manager finds SupportsRotation false, errors, retries to MaxRotateAttempts,
+// parks the entry as failed, comes back after FailedMinAge and repeats, visible
+// only in server logs and never to the operator who created the source.
+//
+// SupportsRotation cannot serve this purpose at config time. It is a method on a
+// live driver, and some implementations probe the upstream to answer (Azure asks
+// Microsoft Graph whether it holds the permissions), which is not something a
+// config write should do. Others answer false for configurations that are
+// perfectly valid and required to carry a rotation_period anyway — a token-auth
+// hvault source is the standing example.
+//
+// So this is opt-in per factory and must be pure: read the config map, return an
+// error naming the missing key, touch nothing else. A factory that does not
+// implement it is simply not checked. Drivers whose SupportsRotation is already
+// pure config inspection can adopt it as the need arises.
+type RotationConfigValidator interface {
+	// ValidateRotationConfig returns an error if a rotation_period on this config
+	// could never be honoured. It is called only when a rotation_period is set.
+	ValidateRotationConfig(config map[string]string) error
+}
+
 // Rotatable is an optional interface for drivers that support credential rotation.
 // Credential sources can implement this to allow periodic rotation of their
 // authentication credentials (e.g., Vault AppRole secret_id, AWS IAM keys).


### PR DESCRIPTION
**Rebased onto `main` now that #535–#539 have merged.** The conflict flagged below is resolved: both interface assertions coexist on the alicloud factory, and the two tests that had been inserted at the same point are now separate functions. Verified after rebase — `go test -race ./...` clean, and the full `e2e/rotation` suite passes against a binary built from this branch, including `TestUpdateRotationPeriod`, the failover and full-restart rows, and `TestCleanupRetryPersistence`.

One interaction worth knowing, new since the keyless work merged: a keyless source carrying a `rotation_period` now matches two rules. The federation check (`credential_config_store.go:1216`) runs before the new factory check (`:1257`), so such a source still gets the specific "does not apply to a federated credential source" message rather than a confusing "requires access_key_id".

---


## Unsynchronised entry writes

A `RotationEntry` is shared: worker goroutines mutate its state while the tick loop reads it and `persistEntry` marshals every field. Three places wrote to one without holding its mutex.

`UpdateRotationPeriod` set `RotationPeriod` and `NextAction` and then persisted — a marshal of the whole struct — under **no lock at all**. Locking it alone would not have closed the race, because `prepareSource` and `prepareSpec` also wrote the staged fields unlocked; only the job that followed them took the lock. Taking the mutex in `UpdateRotationPeriod` would have made its marshal race *those* writes instead.

So the prepare step now **returns** the staged data rather than writing it onto the entry, and the job applies it under the lock alongside the state transition it belongs with. A nil return means the fast path, where activation already happened inline. `register()` also read a live entry's `State` off the field while replacing it; that goes through the accessor.

While there: a job holds its entry pointer across the whole run, but `register()` can replace the map value underneath it, and both entries persist to the same storage key — so an in-flight job's completion could write the superseded entry's state over the live one's record, invisible until a restart restored the stale copy. The job paths now persist only if their entry is still the registered one.

## A rotation_period that can never be honoured

`validateSource` refuses one on a chained or federated source, but nothing stopped an alicloud source with a `rotation_period` and no `management_user_name`. Its driver reports `SupportsRotation` false forever, so every cycle errors, retries to `MaxRotateAttempts`, parks the entry as failed, returns after `FailedMinAge` and repeats **for the life of the source** — all of it in the server log, none of it to the operator who wrote the config. The docs claim such a source is skipped; it is not.

**Consulting `SupportsRotation` at config time does not work.** It is a method on a live driver, and Azure's answers by asking Microsoft Graph whether it holds the permissions, which is not something a config write should do. Vault's returns false for token auth, a configuration `validateSource` separately *requires* to carry a `rotation_period` — a blanket check would make those sources uncreatable.

Instead a factory can opt in to `RotationConfigValidator`, a pure config-map predicate consulted only when a `rotation_period` is set. Alicloud implements it, mirroring its `SupportsRotation`; a test asserts the two agree, since anything required by one and not the other is a source that is accepted and then stalls forever.

## Verification

`go test ./core/... -race`; the race test reproduces the defect when the lock is removed.