### PR TITLE
deps: upgrade Go from 1.26.0 to 1.26.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions — use cases, documentation, code, bug reports, and fe
 
 ## Prerequisites
 
-- **Go 1.26.1 or later** — [Download Go](https://go.dev/dl/)
+- **Go 1.26.7 or later** — [Download Go](https://go.dev/dl/)
 - **Docker and Docker Compose** — [Install Docker](https://docs.docker.com/get-docker/)
 - **Make** — Pre-installed on macOS/Linux
 - **Git** — [Install Git](https://git-scm.com/downloads)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.7-alpine AS builder
 
 # Install build dependencies in a single layer
 RUN apk add --no-cache git gcc musl-dev

--- a/deploy/Dockerfile.smoke
+++ b/deploy/Dockerfile.smoke
@@ -6,7 +6,7 @@
 #
 # Base / WORKDIR / ENTRYPOINT match Dockerfile.goreleaser so the
 # chart exercises the same surface as the production image.
-FROM golang:1.26-bookworm AS build
+FROM golang:1.26.7-bookworm AS build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stephnangue/warden
 
-go 1.26.0
+go 1.26.7
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1


### PR DESCRIPTION
## Why

`go.mod` pinned an explicit patch (`go 1.26.0`), and all three CI/release jobs resolve their toolchain with `setup-go`'s `go-version-file: go.mod`. Per setup-go's documented behavior, *"If a patch version is specified, that specific patch version will be used"* — so the unit job, the e2e job, and the goreleaser release build all compiled with exactly **go1.26.0**, released 2026-02-10.

Upstream has since shipped go1.26.1 through go1.26.7, carrying **six rounds of security fixes** to `crypto/tls`, `crypto/x509`, `net/http`, `net/url`, `encoding/asn1`, `html/template`, and the `go` command — the exact surface a credential broker terminating TLS, validating x509 chains, and proxying HTTP depends on.

## What

| File | Change |
| --- | --- |
| `go.mod` | `go 1.26.0` → `go 1.26.7` |
| `deploy/Dockerfile` | `golang:1.26.1-alpine` → `golang:1.26.7-alpine` |
| `deploy/Dockerfile.smoke` | `golang:1.26-bookworm` → `golang:1.26.7-bookworm` |
| `CONTRIBUTING.md` | `Go 1.26.1 or later` → `Go 1.26.7 or later` |

The build images and the contributor prerequisite had drifted to 1.26.1 and 1.26; this realigns all four on one version.

No workflow changes are needed — all three `setup-go` steps read `go.mod` and pick the new patch up automatically. `deploy/Dockerfile.goreleaser*` are distroless runtime images with no Go toolchain, and `.goreleaser.yaml` inherits whatever `setup-go` installs.

Keeping the **explicit patch** (rather than a bare `go 1.26`) preserves reproducible release builds, matches the convention set by #48, and makes the version a hard floor: a stale toolchain now fails the build instead of silently producing a binary with known CVEs. Confirmed — `GOTOOLCHAIN=go1.26.0 go vet ./...` is refused with `go.mod requires go >= 1.26.7`.

## Verification

All runs pinned with `GOTOOLCHAIN=go1.26.7` to match exactly what CI installs:

- `go build` — OK
- `go test -race -count=1 ./...` — exit 0, **66 packages ok, 0 FAIL**
- `make test-e2e` — exit 0, **20 packages ok, 0 FAIL**, clean teardown

No code or test changes were required.

## Follow-ups (not in this PR)

- **Go 1.27** is deliberately deferred. go1.27.0 shipped 2026-08-19 and there is still no go1.27.1; Go 1.26 keeps receiving security patches until 1.28 (~Feb 2027), so there is no support-window pressure. 1.27 also switches `encoding/json` to the v2 implementation at the toolchain level, which wants its own PR and its own e2e run.
- **Pre-existing `copylocks` findings**, unrelated to this change: `api/client.go:967`, `:1020`, `:1074` and `core/token_store.go:667`, `:701`, `:1502`, `:1619` (assignments copying a struct containing a `sync.RWMutex`). CI does not surface them because it runs only `go test -race`, whose implicit vet subset excludes `copylocks`.
- **`CHANGELOG.md` is untouched**, matching how #48 was handled — the `### Infrastructure` entry belongs in the pre-release doc pass.
