### PR TITLE
fix(scaleway): derive lease TTL from the server, and stop rotation orphaning keys

### DIFF
--- a/credential/drivers/scaleway_driver.go
+++ b/credential/drivers/scaleway_driver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,17 @@ import (
 
 const scalewayMaxResponseBodySize = 1 << 20 // 1MB
 const scalewayMaxRetryAttempts = 3
+
+// scalewayRotationDescriptionPrefix stamps a management key created by rotation.
+// The key it replaces is appended, so the stamp names one lineage rather than
+// "some Warden rotated this": two sources rotating keys for the same bearer would
+// otherwise be indistinguishable, and the orphan sweep below would delete a
+// sibling's live key. A key created by rotating from K is never itself stamped
+// with K, so the sweep can never reach the key currently in use.
+const scalewayRotationDescriptionPrefix = "warden-management-key-rotated-from-"
+
+// scalewayListPageSize bounds one page of the IAM key listing used by the sweep.
+const scalewayListPageSize = 100
 
 // DefaultScalewayIAMPath is the default IAM API path prefix.
 // Currently v1alpha1 — update this when Scaleway promotes the API to stable.
@@ -73,8 +85,12 @@ func (f *ScalewayDriverFactory) ValidateConfig(config map[string]string) error {
 
 		credential.StringField("management_access_key").
 			Custom(func(v string) error {
+				// The value is deliberately not echoed. When the fields are swapped —
+				// the case this check exists to catch — this one holds the secret key,
+				// and a validation error travels to API clients and logs where field
+				// masking cannot reach it.
 				if v != "" && !strings.HasPrefix(v, "SCW") {
-					return fmt.Errorf("management_access_key must start with SCW, got: %s (did you swap access_key and secret_key?)", v)
+					return fmt.Errorf("management_access_key must start with SCW (did you swap access_key and secret_key?)")
 				}
 				return nil
 			}).
@@ -103,6 +119,10 @@ func (f *ScalewayDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
+
+		credential.DurationField("activation_delay").
+			Describe("Overlap before a rotated management key becomes active (default: 30s)").
+			Example("30s"),
 	)
 }
 
@@ -140,9 +160,50 @@ func (d *ScalewayDriver) Type() string {
 	return credential.SourceTypeScaleway
 }
 
-// getScalewayURL returns the Scaleway API base URL from source config.
-// Thread-safe: scaleway_url is never modified by rotation.
-func (d *ScalewayDriver) getScalewayURL() string {
+// scalewayRetryConfig retries rate limiting and transient server errors. Safe for
+// reads and deletes, which are idempotent.
+func scalewayRetryConfig() httputil.HTTPRetryConfig {
+	return httputil.HTTPRetryConfig{
+		MaxAttempts:       scalewayMaxRetryAttempts,
+		MaxBodySize:       scalewayMaxResponseBodySize,
+		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+		BaseBackoff:       1 * time.Second,
+		JitterPercent:     20,
+	}
+}
+
+// scalewayCreateRetryConfig retries rate limiting only.
+//
+// Creating an API key is not idempotent, and the retry helper treats 500 in the
+// list as "every 5xx". A proxy answering 502 after Scaleway already committed the
+// key turns one request into two live keys, and only one of them is ever returned
+// to us: for a mint the orphan self-expires, but a rotation key carries no expiry
+// and would outlive everything. 429 stays because a rate-limited request was
+// never processed.
+func scalewayCreateRetryConfig() httputil.HTTPRetryConfig {
+	cfg := scalewayRetryConfig()
+	cfg.RetryableStatuses = []int{http.StatusTooManyRequests}
+	return cfg
+}
+
+// isScalewayNotFound reports whether a failed delete means the key is already
+// gone, as opposed to the request never having reached a key endpoint at all.
+//
+// Both answer 404. Accepting the status alone — as this driver used to — makes a
+// mistyped iam_api_path indistinguishable from a successful cleanup, so a live
+// key gets reported as deleted. Scaleway names the resource error in the body;
+// a bare routing 404 carries no such marker.
+func isScalewayNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), `"type":"not_found"`) ||
+		strings.Contains(err.Error(), `"type": "not_found"`)
+}
+
+// getScalewayURLLocked returns the Scaleway API base URL from source config.
+// Caller must hold configMu (read or write).
+func (d *ScalewayDriver) getScalewayURLLocked() string {
 	return strings.TrimRight(credential.GetString(d.credSource.Config, "scaleway_url", "https://api.scaleway.com"), "/")
 }
 
@@ -152,20 +213,41 @@ func (d *ScalewayDriver) getManagementSecretKeyLocked() string {
 	return credential.GetString(d.credSource.Config, "management_secret_key", "")
 }
 
-// getIAMAPIPath returns the IAM API path prefix from source config.
+// getIAMAPIPathLocked returns the IAM API path prefix from source config.
 // Defaults to DefaultScalewayIAMPath (/iam/v1alpha1).
-func (d *ScalewayDriver) getIAMAPIPath() string {
+// Caller must hold configMu (read or write).
+func (d *ScalewayDriver) getIAMAPIPathLocked() string {
 	return credential.GetString(d.credSource.Config, "iam_api_path", DefaultScalewayIAMPath)
 }
 
 // iamURL builds a full IAM API URL for the given subpath (e.g., "/api-keys").
+//
+// It takes the read lock even though neither value it reads is rewritten by
+// rotation: what rotation replaces is the config map itself, so reading any key
+// from it without the lock races the swap. Callers must not already hold
+// configMu — read locks are not re-entrant, and a writer queued between two
+// acquisitions on one goroutine would deadlock.
 func (d *ScalewayDriver) iamURL(subpath string) string {
-	return d.getScalewayURL() + d.getIAMAPIPath() + subpath
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.getScalewayURLLocked() + d.getIAMAPIPathLocked() + subpath
+}
+
+// iamKeyURL builds the URL for one API key, escaping the identifier. The id
+// reaches Revoke replayed from a stored lease, so a value carrying "/" or "?"
+// would otherwise retarget an authenticated DELETE at another IAM resource.
+func (d *ScalewayDriver) iamKeyURL(accessKey string) string {
+	return d.iamURL("/api-keys/" + url.PathEscape(accessKey))
 }
 
 // MintCredential returns Scaleway credentials for the given spec.
+//
+// mint_method is not defaulted: the credential type refuses to create a spec
+// without an explicit one, so a default here could only ever be reached by a
+// config that bypassed validation, and silently minting static keys for it would
+// be the wrong answer.
 func (d *ScalewayDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	mintMethod := credential.GetString(spec.Config, "mint_method", "static_keys")
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "static_keys":
 		return d.mintStaticCredential(spec)
@@ -210,6 +292,9 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 	}
 
 	ttl := credential.GetDuration(spec.Config, "ttl", 1*time.Hour)
+	if ttl <= 0 {
+		return nil, nil, 0, "", fmt.Errorf("ttl must be positive for dynamic_keys mint method, got %s", ttl)
+	}
 	description := credential.GetString(spec.Config, "description", fmt.Sprintf("warden-%s", spec.Name))
 	defaultProjectID := credential.GetString(spec.Config, "default_project_id", "")
 
@@ -230,14 +315,6 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 
 	apiURL := d.iamURL("/api-keys")
 
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       scalewayMaxRetryAttempts,
-		MaxBodySize:       scalewayMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
-
 	httpReq := httputil.HTTPRequest{
 		Method: http.MethodPost,
 		URL:    apiURL,
@@ -249,7 +326,7 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		},
 	}
 
-	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, scalewayCreateRetryConfig())
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to create Scaleway API key: %w", err)
 	}
@@ -271,10 +348,16 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		return nil, nil, 0, "", fmt.Errorf("Scaleway API returned empty access_key or secret_key")
 	}
 
+	leaseTTL, err := d.leaseTTLFromExpiry(resp.ExpiresAt, ttl)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	d.logger.Info("created dynamic Scaleway API key",
 		logger.String("access_key", truncateID(resp.AccessKey, 8)),
 		logger.String("spec", spec.Name),
 		logger.String("expires_at", resp.ExpiresAt),
+		logger.String("lease_ttl", leaseTTL.String()),
 	)
 
 	rawData := map[string]interface{}{
@@ -283,7 +366,52 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 	}
 
 	// LeaseID is the access_key — used by Revoke to delete the key
-	return rawData, nil, ttl, resp.AccessKey, nil
+	return rawData, nil, leaseTTL, resp.AccessKey, nil
+}
+
+// leaseTTLFromExpiry converts the expires_at Scaleway reports into a lease TTL.
+//
+// The requested duration alone is the wrong answer. It is measured before the
+// round trip, so the lease outlives the key by however long the call took —
+// including up to two backoff waits on a retry. It also ignores an expiry the
+// organization shortened for its own reasons: a credential-duration policy can
+// cap a key well below what was asked, and the credential is cached for its whole
+// lease, so an over-long lease means later hits hand out a key that is already
+// dead.
+//
+// The reported expiry is capped at the requested duration, because it is only as
+// trustworthy as the agreement between two clocks. A local clock running behind
+// Scaleway's would otherwise reintroduce the very over-long lease this exists to
+// prevent, bounded by skew rather than by round-trip time.
+//
+// An unparseable expiry falls back to the requested duration: a usable key should
+// not be thrown away over a timestamp format. An expiry already in the past is a
+// different matter — there is no usable key to return.
+func (d *ScalewayDriver) leaseTTLFromExpiry(expiresAt string, requested time.Duration) (time.Duration, error) {
+	if expiresAt == "" {
+		d.logger.Warn("Scaleway returned no expires_at; falling back to the requested duration",
+			logger.String("requested", requested.String()),
+		)
+		return requested, nil
+	}
+
+	expiry, err := time.Parse(time.RFC3339, expiresAt)
+	if err != nil {
+		d.logger.Warn("Scaleway returned an expires_at that is not RFC3339; falling back to the requested duration",
+			logger.String("expires_at", expiresAt),
+			logger.String("requested", requested.String()),
+		)
+		return requested, nil
+	}
+
+	ttl := time.Until(expiry)
+	if ttl <= 0 {
+		return 0, fmt.Errorf("Scaleway returned an API key that already expired at %s", expiresAt)
+	}
+	if ttl > requested {
+		return requested, nil
+	}
+	return ttl, nil
 }
 
 // Revoke deletes a dynamically created API key via DELETE /iam/v1alpha1/api-keys/{access_key}.
@@ -302,29 +430,36 @@ func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
 		return fmt.Errorf("management_secret_key is required to revoke Scaleway API keys")
 	}
 
-	apiURL := d.iamURL("/api-keys/" + leaseID)
-
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       scalewayMaxRetryAttempts,
-		MaxBodySize:       scalewayMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
-
 	httpReq := httputil.HTTPRequest{
 		Method: http.MethodDelete,
-		URL:    apiURL,
+		URL:    d.iamKeyURL(leaseID),
 		Headers: map[string]string{
 			"X-Auth-Token": managementKey,
 			"Accept":       "application/json",
 		},
-		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
+		OKStatuses: []int{http.StatusNoContent, http.StatusOK},
 	}
 
-	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, scalewayRetryConfig())
 	if err != nil {
-		return fmt.Errorf("failed to revoke Scaleway API key %s: %w", leaseID, err)
+		if isScalewayNotFound(err) {
+			d.logger.Info("dynamic Scaleway API key was already gone",
+				logger.String("access_key", truncateID(leaseID, 8)),
+			)
+			return nil
+		}
+		// A bare 404 is not a revocation. It is almost always a misconfigured
+		// iam_api_path, and returning an error would send the expiration manager
+		// into backoff and then a daily retry for a request that can never
+		// succeed. Say so loudly and let the key expire on its own.
+		if status == http.StatusNotFound {
+			d.logger.Warn("Scaleway returned 404 with no not_found marker; the key was NOT revoked and will live until it expires — check iam_api_path",
+				logger.String("access_key", truncateID(leaseID, 8)),
+				logger.String("url", d.iamKeyURL(leaseID)),
+			)
+			return nil
+		}
+		return fmt.Errorf("failed to revoke Scaleway API key %s: %w", truncateID(leaseID, 8), err)
 	}
 
 	d.logger.Info("revoked dynamic Scaleway API key",
@@ -370,19 +505,12 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 		return nil, nil, 0, fmt.Errorf("management_access_key is required for rotation")
 	}
 
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       scalewayMaxRetryAttempts,
-		MaxBodySize:       scalewayMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
+	retryConfig := scalewayRetryConfig()
 
 	// Look up the current key to find its bearer (application_id or user_id)
-	getURL := d.iamURL("/api-keys/" + managementAccessKey)
 	getReq := httputil.HTTPRequest{
 		Method:  http.MethodGet,
-		URL:     getURL,
+		URL:     d.iamKeyURL(managementAccessKey),
 		Headers: map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
 	}
 
@@ -399,16 +527,26 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 		return nil, nil, 0, fmt.Errorf("failed to parse key info: %w", err)
 	}
 
+	if keyInfo.ApplicationID == "" && keyInfo.UserID == "" {
+		return nil, nil, 0, fmt.Errorf("current management key has no application_id or user_id")
+	}
+
+	// Every key this rotation creates is stamped with the key it replaces, so the
+	// stamp names one lineage. Sweeping it before creating anything reclaims keys
+	// left behind by an earlier attempt at this same rotation — a retried create,
+	// or a crash before the staged entry was persisted — which are invisible to
+	// Warden and, unlike a minted key, never expire.
+	stamp := scalewayRotationDescriptionPrefix + managementAccessKey
+	d.sweepOrphanedRotationKeys(ctx, managementKey, keyInfo.ApplicationID, keyInfo.UserID, stamp)
+
 	// Create a new management key for the same bearer
 	createBody := map[string]interface{}{
-		"description": "warden-management-key-rotated",
+		"description": stamp,
 	}
 	if keyInfo.ApplicationID != "" {
 		createBody["application_id"] = keyInfo.ApplicationID
-	} else if keyInfo.UserID != "" {
-		createBody["user_id"] = keyInfo.UserID
 	} else {
-		return nil, nil, 0, fmt.Errorf("current management key has no application_id or user_id")
+		createBody["user_id"] = keyInfo.UserID
 	}
 
 	bodyJSON, err := json.Marshal(createBody)
@@ -416,15 +554,14 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 		return nil, nil, 0, fmt.Errorf("failed to marshal create request: %w", err)
 	}
 
-	createURL := d.iamURL("/api-keys")
 	createReq := httputil.HTTPRequest{
 		Method:  http.MethodPost,
-		URL:     createURL,
+		URL:     d.iamURL("/api-keys"),
 		Body:    bodyJSON,
 		Headers: map[string]string{"X-Auth-Token": managementKey, "Content-Type": "application/json", "Accept": "application/json"},
 	}
 
-	respBody, _, err = httputil.ExecuteWithRetry(ctx, d.httpClient, createReq, retryConfig)
+	respBody, _, err = httputil.ExecuteWithRetry(ctx, d.httpClient, createReq, scalewayCreateRetryConfig())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to create new management key: %w", err)
 	}
@@ -455,8 +592,89 @@ func (d *ScalewayDriver) PrepareRotation(ctx context.Context) (map[string]string
 		logger.String("new_access_key", truncateID(newKey.AccessKey, 8)),
 	)
 
-	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultScalewayActivationDelay)
+	// Read from the snapshot taken under the lock above, not from the live map:
+	// two network round trips have happened since, and a concurrent CommitRotation
+	// may have replaced the map in the meantime.
+	activateAfter := credential.GetDuration(configSnapshot, "activation_delay", DefaultScalewayActivationDelay)
 	return newConfig, cleanupConfig, activateAfter, nil
+}
+
+// sweepOrphanedRotationKeys deletes management keys left behind by an earlier
+// attempt at this same rotation.
+//
+// Scoped by exact description, which encodes the key being replaced. A key
+// created by rotating from K is stamped with K, so the key currently in use —
+// stamped with *its* predecessor — can never match, and neither can a sibling
+// source's key, whose lineage starts somewhere else. That scoping is the whole
+// safety argument: a sweep keyed on "some Warden rotated this" would delete
+// another source's live credential.
+//
+// Failures are logged and swallowed. A rotation that works must not be failed
+// because tidying up after a previous one did not.
+func (d *ScalewayDriver) sweepOrphanedRotationKeys(ctx context.Context, managementKey, applicationID, userID, stamp string) {
+	bearer := url.Values{}
+	if applicationID != "" {
+		bearer.Set("application_id", applicationID)
+	} else {
+		bearer.Set("user_id", userID)
+	}
+	bearer.Set("page_size", fmt.Sprintf("%d", scalewayListPageSize))
+
+	for page := 1; ; page++ {
+		bearer.Set("page", fmt.Sprintf("%d", page))
+		listReq := httputil.HTTPRequest{
+			Method:  http.MethodGet,
+			URL:     d.iamURL("/api-keys") + "?" + bearer.Encode(),
+			Headers: map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
+		}
+
+		respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, listReq, scalewayRetryConfig())
+		if err != nil {
+			d.logger.Warn("could not list API keys to sweep orphaned rotation keys",
+				logger.Err(err),
+			)
+			return
+		}
+
+		var list struct {
+			APIKeys []struct {
+				AccessKey   string `json:"access_key"`
+				Description string `json:"description"`
+			} `json:"api_keys"`
+			TotalCount int `json:"total_count"`
+		}
+		if err := json.Unmarshal(respBody, &list); err != nil {
+			d.logger.Warn("could not parse API key listing while sweeping orphaned rotation keys",
+				logger.Err(err),
+			)
+			return
+		}
+
+		for _, key := range list.APIKeys {
+			if key.Description != stamp || key.AccessKey == "" {
+				continue
+			}
+			d.logger.Warn("deleting an orphaned management key from a previous rotation attempt",
+				logger.String("access_key", truncateID(key.AccessKey, 8)),
+			)
+			delReq := httputil.HTTPRequest{
+				Method:     http.MethodDelete,
+				URL:        d.iamKeyURL(key.AccessKey),
+				Headers:    map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
+				OKStatuses: []int{http.StatusNoContent, http.StatusOK},
+			}
+			if _, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, delReq, scalewayRetryConfig()); err != nil && !isScalewayNotFound(err) {
+				d.logger.Warn("could not delete an orphaned management key",
+					logger.Err(err),
+					logger.String("access_key", truncateID(key.AccessKey, 8)),
+				)
+			}
+		}
+
+		if len(list.APIKeys) < scalewayListPageSize || page*scalewayListPageSize >= list.TotalCount {
+			return
+		}
+	}
 }
 
 // CommitRotation activates the new management key in driver state.
@@ -488,24 +706,25 @@ func (d *ScalewayDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 		return fmt.Errorf("management_secret_key is required to clean up old key")
 	}
 
-	deleteURL := d.iamURL("/api-keys/" + oldAccessKey)
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       scalewayMaxRetryAttempts,
-		MaxBodySize:       scalewayMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
-
 	deleteReq := httputil.HTTPRequest{
 		Method:     http.MethodDelete,
-		URL:        deleteURL,
+		URL:        d.iamKeyURL(oldAccessKey),
 		Headers:    map[string]string{"X-Auth-Token": managementKey, "Accept": "application/json"},
-		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
+		OKStatuses: []int{http.StatusNoContent, http.StatusOK},
 	}
 
-	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, deleteReq, retryConfig)
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, deleteReq, scalewayRetryConfig())
 	if err != nil {
+		// Already gone is the outcome this wanted. Anything else — including a bare
+		// 404 from a mistyped iam_api_path — is returned rather than swallowed: the
+		// old management key carries no expiry, so reporting a failed delete as
+		// success would leave a fully privileged credential alive indefinitely.
+		if isScalewayNotFound(err) {
+			d.logger.Info("old management key was already gone",
+				logger.String("access_key", truncateID(oldAccessKey, 8)),
+			)
+			return nil
+		}
 		d.logger.Warn("failed to delete old management key during cleanup",
 			logger.Err(err),
 			logger.String("access_key", truncateID(oldAccessKey, 8)),
@@ -522,7 +741,7 @@ func (d *ScalewayDriver) CleanupRotation(ctx context.Context, cleanupConfig map[
 
 // VerifySpec validates that the spec's credentials are functional.
 func (d *ScalewayDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
-	mintMethod := credential.GetString(spec.Config, "mint_method", "static_keys")
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	switch mintMethod {
 	case "static_keys":
@@ -547,26 +766,16 @@ func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.
 	}
 
 	// Verify the key works by calling a lightweight IAM endpoint
-	apiURL := d.iamURL("/api-keys/" + accessKey)
-
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       scalewayMaxRetryAttempts,
-		MaxBodySize:       scalewayMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
-
 	httpReq := httputil.HTTPRequest{
 		Method: http.MethodGet,
-		URL:    apiURL,
+		URL:    d.iamKeyURL(accessKey),
 		Headers: map[string]string{
 			"X-Auth-Token": secretKey,
 			"Accept":       "application/json",
 		},
 	}
 
-	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	_, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, scalewayRetryConfig())
 	if err != nil {
 		return fmt.Errorf("Scaleway API key verification failed: %w", err)
 	}

--- a/credential/drivers/scaleway_driver_test.go
+++ b/credential/drivers/scaleway_driver_test.go
@@ -3,9 +3,12 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,7 +117,10 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 		assert.Empty(t, leaseID)
 	})
 
-	t.Run("default mint_method is static_keys", func(t *testing.T) {
+	t.Run("mint_method is not defaulted", func(t *testing.T) {
+		// The credential type refuses a spec without an explicit mint_method, so an
+		// empty one here means validation was bypassed. Minting static keys anyway
+		// would guess at what the operator meant.
 		spec := &credential.CredSpec{
 			Name: "test-spec",
 			Config: map[string]string{
@@ -123,9 +129,9 @@ func TestScalewayDriver_MintStaticCredential(t *testing.T) {
 			},
 		}
 
-		rawData, _, _, _, err := driver.MintCredential(context.Background(), spec)
-		require.NoError(t, err)
-		assert.Equal(t, "SCWXXXXXXXXXXXXXXXXX", rawData["access_key"])
+		_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected static_keys or dynamic_keys")
 	})
 
 	t.Run("missing access_key", func(t *testing.T) {
@@ -229,8 +235,112 @@ func TestScalewayDriver_MintDynamicCredential(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "SCWNEWKEYXXXXXXXXXX", rawData["access_key"])
 	assert.Equal(t, "new-uuid-secret-key", rawData["secret_key"])
-	assert.Equal(t, 2*time.Hour, ttl)
+	// The lease follows the server's expires_at, which the stub echoes back — so it
+	// lands just under the requested 2h by the round-trip time, never above it.
+	assert.LessOrEqual(t, ttl, 2*time.Hour)
+	assert.Greater(t, ttl, 2*time.Hour-time.Minute)
 	assert.Equal(t, "SCWNEWKEYXXXXXXXXXX", leaseID) // leaseID = access_key
+}
+
+func TestScalewayDriver_MintDynamicCredential_LeaseFollowsServerExpiry(t *testing.T) {
+	// An organization credential-duration policy can cap a key well below what was
+	// asked for. The lease has to follow the key, not the request: it bounds how
+	// long the credential is served from cache, and a lease outliving its key means
+	// later requests are handed something already dead.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_key": "SCWCLAMPEDKEYXXXXXX",
+			"secret_key": "clamped-secret",
+			"expires_at": time.Now().Add(15 * time.Minute).UTC().Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"tls_skip_verify":       "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{
+		Name: "clamped-spec",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+			"ttl":            "24h",
+		},
+	}
+
+	_, _, ttl, _, err := driver.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Less(t, ttl, 16*time.Minute, "lease must follow the clamped expires_at, not the requested 24h")
+	assert.Greater(t, ttl, 14*time.Minute)
+}
+
+func TestScalewayDriver_MintDynamicCredential_UnparseableExpiryFallsBack(t *testing.T) {
+	// A usable key is not thrown away over a timestamp format.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_key": "SCWWEIRDEXPIRYXXXXX",
+			"secret_key": "weird-secret",
+			"expires_at": "next tuesday",
+		})
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"tls_skip_verify":       "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+
+	_, _, ttl, _, err := driver.MintCredential(context.Background(), &credential.CredSpec{
+		Name: "weird-spec",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+			"ttl":            "30m",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, ttl)
+}
+
+func TestScalewayDriver_MintDynamicCredential_AlreadyExpiredIsAnError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_key": "SCWDEADKEYXXXXXXXXX",
+			"secret_key": "dead-secret",
+			"expires_at": time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"tls_skip_verify":       "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+
+	_, _, _, _, err = driver.MintCredential(context.Background(), &credential.CredSpec{
+		Name: "dead-spec",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+			"ttl":            "1h",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already expired")
 }
 
 func TestScalewayDriver_MintDynamicCredential_MissingManagementKey(t *testing.T) {
@@ -493,11 +603,22 @@ func TestScalewayDriver_PrepareRotation(t *testing.T) {
 				"application_id": "app-mgmt-123",
 			})
 
+		// The orphan sweep lists the bearer's keys before creating anything.
+		case r.Method == http.MethodGet && r.URL.Path == "/iam/v1alpha1/api-keys":
+			assert.Equal(t, "app-mgmt-123", r.URL.Query().Get("application_id"))
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"api_keys":    []interface{}{},
+				"total_count": 0,
+			})
+
 		case r.Method == http.MethodPost && r.URL.Path == "/iam/v1alpha1/api-keys":
 			var body map[string]interface{}
 			json.NewDecoder(r.Body).Decode(&body)
 			assert.Equal(t, "app-mgmt-123", body["application_id"])
-			assert.Equal(t, "warden-management-key-rotated", body["description"])
+			// The stamp names the key being replaced, so two sources rotating for the
+			// same bearer produce distinguishable lineages.
+			assert.Equal(t, "warden-management-key-rotated-from-SCWOLDMGMTKEY", body["description"])
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]string{
@@ -684,7 +805,7 @@ func TestScalewayDriver_GetScalewayURL(t *testing.T) {
 		d := &ScalewayDriver{
 			credSource: &credential.CredSource{Config: map[string]string{}},
 		}
-		assert.Equal(t, "https://api.scaleway.com", d.getScalewayURL())
+		assert.Equal(t, "https://api.scaleway.com", d.getScalewayURLLocked())
 	})
 
 	t.Run("custom URL", func(t *testing.T) {
@@ -693,6 +814,208 @@ func TestScalewayDriver_GetScalewayURL(t *testing.T) {
 				"scaleway_url": "https://api.fr-par.scaleway.com/",
 			}},
 		}
-		assert.Equal(t, "https://api.fr-par.scaleway.com", d.getScalewayURL())
+		assert.Equal(t, "https://api.fr-par.scaleway.com", d.getScalewayURLLocked())
 	})
+}
+
+// --- Defect regression tests ---
+
+func TestScalewayDriverFactory_ValidateConfig_DoesNotEchoSwappedSecret(t *testing.T) {
+	// The swap this check catches puts the SECRET key in management_access_key.
+	// Echoing the offending value would leak it into API responses and logs, where
+	// SensitiveConfigFields cannot mask it.
+	f := &ScalewayDriverFactory{}
+	secret := "11111111-2222-3333-4444-555555555555"
+
+	err := f.ValidateConfig(map[string]string{"management_access_key": secret})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.Contains(t, err.Error(), "did you swap")
+}
+
+func TestScalewayDriverFactory_ValidateConfig_ActivationDelay(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+
+	require.NoError(t, f.ValidateConfig(map[string]string{"activation_delay": "2m"}))
+
+	// Previously undeclared, so a typo passed validation and was then silently
+	// swallowed by GetDuration, leaving the operator with the 30s default.
+	err := f.ValidateConfig(map[string]string{"activation_delay": "30sec"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "activation_delay")
+}
+
+func TestScalewayDriver_Revoke_NotFoundBodyIsSuccessBareIsNot(t *testing.T) {
+	t.Run("not_found body means already gone", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"type":"not_found","message":"api key not found"}`))
+		}))
+		defer server.Close()
+
+		f := &ScalewayDriverFactory{}
+		driver, err := f.Create(map[string]string{
+			"scaleway_url":          server.URL,
+			"management_secret_key": "mgmt-secret-key",
+			"tls_skip_verify":       "true",
+		}, createScalewayTestLogger())
+		require.NoError(t, err)
+
+		require.NoError(t, driver.Revoke(context.Background(), "SCWGONEKEYXXXXXXXXX"))
+	})
+
+	t.Run("bare 404 does not claim revocation", func(t *testing.T) {
+		// What a mistyped iam_api_path produces. Revoke still returns nil — an error
+		// would send the expiration manager into backoff and then a daily retry for a
+		// request that can never succeed — but it must not log success.
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "404 page not found", http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		f := &ScalewayDriverFactory{}
+		driver, err := f.Create(map[string]string{
+			"scaleway_url":          server.URL,
+			"management_secret_key": "mgmt-secret-key",
+			"tls_skip_verify":       "true",
+		}, createScalewayTestLogger())
+		require.NoError(t, err)
+
+		require.NoError(t, driver.Revoke(context.Background(), "SCWLIVEKEYXXXXXXXXX"))
+	})
+}
+
+func TestScalewayDriver_CleanupRotation_BareNotFoundIsAnError(t *testing.T) {
+	// The old management key carries no expiry, so reporting a failed delete as
+	// success would leave a fully privileged credential alive indefinitely.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"tls_skip_verify":       "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+
+	err = driver.(*ScalewayDriver).CleanupRotation(context.Background(),
+		map[string]string{"access_key": "SCWOLDMGMTKEY"})
+	require.Error(t, err)
+}
+
+func TestScalewayDriver_PrepareRotation_SweepsOnlyItsOwnLineage(t *testing.T) {
+	// The sweep must reclaim orphans from a previous attempt at THIS rotation while
+	// leaving alone an operator's own key and a sibling Warden source's key, which
+	// is stamped from a different predecessor. Deleting the latter would be the
+	// delete-a-key-you-do-not-own bug re-aimed at another Warden.
+	var deleted []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/iam/v1alpha1/api-keys/SCWOLDMGMTKEY":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_key":     "SCWOLDMGMTKEY",
+				"application_id": "app-mgmt-123",
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/iam/v1alpha1/api-keys":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"api_keys": []map[string]string{
+					{"access_key": "SCWORPHANKEY", "description": "warden-management-key-rotated-from-SCWOLDMGMTKEY"},
+					{"access_key": "SCWSIBLINGKEY", "description": "warden-management-key-rotated-from-SCWOTHERKEY"},
+					{"access_key": "SCWOPERATORKEY", "description": "ops-terraform"},
+					{"access_key": "SCWOLDMGMTKEY", "description": "warden-management-key-rotated-from-SCWANCESTOR"},
+				},
+				"total_count": 4,
+			})
+
+		case r.Method == http.MethodDelete:
+			deleted = append(deleted, strings.TrimPrefix(r.URL.Path, "/iam/v1alpha1/api-keys/"))
+			w.WriteHeader(http.StatusNoContent)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/iam/v1alpha1/api-keys":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_key": "SCWNEWMGMTKEY",
+				"secret_key": "new-mgmt-secret",
+			})
+
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "old-mgmt-secret",
+		"management_access_key": "SCWOLDMGMTKEY",
+		"tls_skip_verify":       "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+
+	_, _, _, err = driver.(*ScalewayDriver).PrepareRotation(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"SCWORPHANKEY"}, deleted,
+		"only this lineage's orphan may be deleted — not a sibling source's key, an operator key, or the key in use")
+}
+
+func TestScalewayDriver_MintConcurrentWithCommitRotation(t *testing.T) {
+	// Rotation replaces the whole config map, so every read of it — including the
+	// ones behind iamURL, for keys rotation never rewrites — has to hold the lock.
+	// Meaningful under -race.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_key": "SCWRACEKEYXXXXXXXXX",
+			"secret_key": "race-secret",
+			"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":          server.URL,
+		"management_secret_key": "mgmt-secret-key",
+		"management_access_key": "SCWMGMTKEY",
+		"tls_skip_verify":       "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+	scw := driver.(*ScalewayDriver)
+
+	spec := &credential.CredSpec{
+		Name:   "race-spec",
+		Config: map[string]string{"mint_method": "dynamic_keys", "application_id": "app-123", "ttl": "1h"},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _, _, _ = scw.MintCredential(context.Background(), spec)
+			_ = scw.SupportsRotation()
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_ = scw.CommitRotation(context.Background(), map[string]string{
+				"scaleway_url":          server.URL,
+				"management_secret_key": fmt.Sprintf("rotated-secret-%d", n),
+				"management_access_key": fmt.Sprintf("SCWROTATED%d", n),
+				"tls_skip_verify":       "true",
+			})
+		}(i)
+	}
+	wg.Wait()
 }

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stephnangue/warden/helper"
 )
 
+// scalewayMaxDescriptionLength bounds the description sent when minting a key.
+// Enforced here rather than left to the API so an over-long value — which the
+// default "warden-<spec name>" can reach on its own — is refused at spec create
+// instead of failing every mint.
+const scalewayMaxDescriptionLength = 200
+
 // ScalewayKeysCredType handles Scaleway API key credentials.
 // A single key pair serves both the standard API (secret_key as X-Auth-Token)
 // and S3 Object Storage (access_key + secret_key for SigV4 signing).
@@ -51,10 +57,29 @@ func (t *ScalewayKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
 
 		credential.StringField("description").
+			Custom(func(v string) error {
+				if len(v) > scalewayMaxDescriptionLength {
+					return fmt.Errorf("description must be at most %d characters, got %d", scalewayMaxDescriptionLength, len(v))
+				}
+				return nil
+			}).
 			Describe("Description for dynamically created keys (max 200 chars)").
 			Example("warden-managed-key"),
 
 		credential.DurationField("ttl").
+			Custom(func(v string) error {
+				// DurationField only checks that the value parses, so "0s" and "-1h"
+				// reach the mint and produce a key that is born expired — with a lease
+				// TTL of 0, which makes it unrevocable and so never cleaned up.
+				d, err := time.ParseDuration(v)
+				if err != nil {
+					return nil // the field's own parse check reports this
+				}
+				if d <= 0 {
+					return fmt.Errorf("ttl must be positive, got %s", v)
+				}
+				return nil
+			}).
 			Describe("TTL for dynamically created keys (default: 1h)").
 			Example("1h"),
 	}


### PR DESCRIPTION
Found while designing keyless support for this driver. Five defects, two of them high severity; the keyless work depends on this landing first, so it ships on its own.

## The two that matter

**Lease TTL ignored the server.** The TTL was the locally requested duration, measured *before* the round trip and ignoring any expiry Scaleway shortened for its own reasons. An organization credential-duration policy can cap a key well below what was asked, and the credential is cached for its whole lease — so a `ttl=24h` spec clamped to 1h served a dead key for 23 hours and never re-minted. This is the bug `28ca65d` fixed in alicloud; the TTL now comes from the returned `expires_at`, capped at the requested duration against clock skew.

**Rotation orphaned non-expiring management keys.** The replacement key was stamped with a description shared by every Warden source, and nothing ever reclaimed keys left behind by a failed attempt. Those keys carry no expiry, so a retried create — or a crash before the staged entry was persisted — left a permanent, fully privileged credential invisible to Warden.

The fix stamps each key with the one it replaces, so the stamp names one lineage, and sweeps that lineage before creating. A key created by rotating from K is never itself stamped with K, so the sweep cannot reach the key in use — nor a sibling source's, whose lineage starts elsewhere. Sweeping on the shared description would have been `4c1ef67` re-aimed at another Warden.

Creating a key is also not idempotent, and the retry helper treats `500` in the list as *every* 5xx, so a proxy answering 502 after the key was committed turned one request into two live keys. The create paths now retry rate limiting only.

## The rest

- Stop echoing the offending value when the access and secret keys are swapped — precisely the case where it holds the secret, and a validation error reaches API clients and logs where field masking cannot follow.
- Take the config lock for every read of the config map: rotation replaces the *map*, not the individual keys, so reads of values rotation never rewrites were still racing the swap.
- Read `activation_delay` from the snapshot taken under that lock, not from the live map two round trips later.
- Treat a 404 carrying a `not_found` marker as an already-deleted key and a bare 404 as the routing failure it usually is, instead of reporting an undeleted key as revoked.
- Escape identifiers interpolated into request paths.
- Declare `activation_delay` in the schema, so a malformed value is refused rather than silently defaulted.
- Reject a non-positive `ttl` and an over-long `description`.
- Stop defaulting an absent `mint_method` to `static_keys`, which the credential type refuses to create in the first place.

## Verification

`go build ./...`, `go vet ./credential/...`, `go test -race ./credential/...`, `go test ./core/...` all clean. Full e2e suite green against a live cluster (20 packages).

New tests cover: a clamped `expires_at`, an unparseable one, an already-expired one, the swapped-key error not containing its input, `Revoke`/`CleanupRotation` 404 handling, a malformed `activation_delay`, `MintCredential` concurrent with `CommitRotation` under `-race`, and — the load-bearing one — that the sweep deletes only its own lineage's orphan while leaving a sibling source's key, an operator's key, and the key in use alone.