### PR TITLE
fix(credential): scope chained secret modifiers to the reference they describe

### DIFF
--- a/credential/chaining.go
+++ b/credential/chaining.go
@@ -17,6 +17,11 @@ const (
 	// ConfigSecretField names which key of the referenced credential's Data carries
 	// the single secret value. Optional: a single-key payload auto-detects, and a
 	// typed referenced credential can fall back to its primary field.
+	//
+	// It modifies a reference rather than standing alone, so a source-level value
+	// applies only while it still describes the payload being fetched: not when the
+	// source names a secret_spec and a spec on it overrides that with a different
+	// one. See sourceModifiersApply.
 	ConfigSecretField = "secret_field"
 
 	// MaxSecretChainDepth bounds chaining: a referenced secret-spec may not itself
@@ -32,6 +37,11 @@ const (
 	// rotation-sensitive referenced secret such as a single-use refresh token). When
 	// set, the fetched material is shared across a caller's requests (per agent
 	// identity, and per user when the referenced fetch is user-scoped) for the TTL.
+	//
+	// Like ConfigSecretField it modifies a reference: a caching policy is chosen for
+	// one secret's rotation profile, so a source-level value does not carry onto a
+	// spec that overrode the source's secret_spec with a different one. See
+	// sourceModifiersApply.
 	ConfigSecretCacheTTL = "secret_cache_ttl"
 )
 

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -902,6 +902,166 @@ func TestChaining_CacheTTLSpecOptOut(t *testing.T) {
 	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(), "spec-level 0 opts out of source TTL")
 }
 
+// --- Source modifiers describe the source's own reference ---
+//
+// secret_field and secret_cache_ttl are not peers of secret_spec: they say how to
+// read and cache one payload. A source that chains a secret of its own has written
+// them for THAT payload, so a spec that overrides the reference must not inherit
+// them — the field would name a key its payload lacks, and the TTL would cache a
+// secret whose owner never opted in.
+
+func TestChaining_SourceSecretFieldNotInheritedAcrossReferences(t *testing.T) {
+	env := newChainingEnv(t)
+
+	// A second secret spec, with a differently-shaped payload from the source's.
+	env.store.AddSource(&CredSource{Name: "secretsource2", Type: "secretsrc", Config: map[string]string{}})
+	env.store.AddSpec(&CredSpec{Name: "other-secret-spec", Type: TypeVaultToken, Source: "secretsource2",
+		Config: map[string]string{}})
+	env.secretDriver.mintFunc = func(_ context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		if spec.Name == "other-secret-spec" {
+			return map[string]interface{}{"token": "OTHER-SECRET"}, nil, 0, "", nil
+		}
+		return map[string]interface{}{"private_key": "PEM", "app_id": "42"}, nil, 0, "", nil
+	}
+
+	// The source chains a multi-key payload and needs secret_field to pick from it.
+	env.store.AddSource(&CredSource{Name: "consumersource-chained", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretField: "private_key"}})
+	// The spec overrides the reference with a payload that has no private_key.
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretSpec: "other-secret-spec"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, "private_key", env.consumerDriver.lastMaterial.Field,
+		"the source's field describes the source's payload, not this spec's")
+	assert.Equal(t, "OTHER-SECRET", env.consumerDriver.lastMaterial.Secret(),
+		"resolution falls through to single-key auto-detect on the spec's own payload")
+}
+
+// TestChaining_InheritedFieldOnMultiKeyPayloadIsTheReportedSymptom covers the shape
+// operators actually hit: the spec's payload has several keys, so auto-detect cannot
+// rescue an inherited field that names none of them. Before the fix the consumer was
+// handed Field="private_key" against a payload without it — the "secret_field is
+// empty or absent" report, citing a field the spec's operator never set.
+func TestChaining_InheritedFieldOnMultiKeyPayloadIsTheReportedSymptom(t *testing.T) {
+	env := newChainingEnv(t)
+
+	env.store.AddSource(&CredSource{Name: "secretsource2", Type: "secretsrc", Config: map[string]string{}})
+	env.store.AddSpec(&CredSpec{Name: "other-secret-spec", Type: TypeVaultToken, Source: "secretsource2",
+		Config: map[string]string{}})
+	env.secretDriver.mintFunc = func(_ context.Context, spec *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		if spec.Name == "other-secret-spec" {
+			return map[string]interface{}{"token": "T", "expires": "later"}, nil, 0, "", nil
+		}
+		return map[string]interface{}{"private_key": "PEM", "app_id": "42"}, nil, 0, "", nil
+	}
+
+	env.store.AddSource(&CredSource{Name: "consumersource-chained", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretField: "private_key"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretSpec: "other-secret-spec"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, env.consumerDriver.lastMaterial.Field,
+		"no field resolves: the source's names another payload's key, and a multi-key payload cannot auto-detect")
+	assert.Equal(t, "T", env.consumerDriver.lastMaterial.Data["token"],
+		"the whole payload still reaches the consumer to read by name")
+}
+
+// TestChaining_SourceModifiersApplyWhenSpecRestatesTheReference: restating the
+// source's reference names the same payload, so the source's modifiers still
+// describe it. A redundant but truthful config must not lose them.
+func TestChaining_SourceModifiersApplyWhenSpecRestatesTheReference(t *testing.T) {
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"alpha": "A", "beta": "B"}, nil, 0, "", nil
+	}
+	env.store.AddSource(&CredSource{Name: "consumersource-chained", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretField: "beta", ConfigSecretCacheTTL: "30m"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "B", env.consumerDriver.lastMaterial.Secret(), "the source's field still selects")
+
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), env.secretDriver.mintCalls.Load(), "the source's TTL still caches")
+}
+
+func TestChaining_SourceSecretFieldStillInheritedAsADefault(t *testing.T) {
+	// A source with no reference of its own has no rival payload: its secret_field
+	// can only be a default for whatever its specs reference, so it still applies.
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"alpha": "A", "beta": "B"}, nil, 0, "", nil
+	}
+	env.store.AddSource(&CredSource{Name: "consumersource-field", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretField: "beta"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource-field",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "B", env.consumerDriver.lastMaterial.Secret())
+}
+
+func TestChaining_SourceCacheTTLNotInheritedAcrossReferences(t *testing.T) {
+	env := newChainingEnv(t)
+	env.store.AddSource(&CredSource{Name: "secretsource2", Type: "secretsrc", Config: map[string]string{}})
+	env.store.AddSpec(&CredSpec{Name: "other-secret-spec", Type: TypeVaultToken, Source: "secretsource2",
+		Config: map[string]string{}})
+
+	// The source caches its own chained secret for 30m. Two specs override the
+	// reference; their payload must not inherit that policy.
+	env.store.AddSource(&CredSource{Name: "consumersource-chained", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretSpec: "other-secret-spec"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretSpec: "other-secret-spec"}})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"the spec's payload is fetched per mint — the documented default — not cached under the source's policy")
+}
+
+func TestChaining_SpecFieldStillOverridesForASourceReference(t *testing.T) {
+	// The coherent case: the source names the payload, the spec refines which key to
+	// read out of it. Both concern the same payload, so this keeps working.
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"alpha": "A", "beta": "B"}, nil, 0, "", nil
+	}
+	env.store.AddSource(&CredSource{Name: "consumersource-chained", Type: "consumersrc",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretField: "alpha"}})
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource-chained",
+		Config: map[string]string{ConfigSecretField: "beta"}})
+
+	ctx := createNamespaceContext()
+	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "B", env.consumerDriver.lastMaterial.Secret())
+}
+
 // TestChaining_CacheIsolatesPerRole: one principal authenticating under two roles
 // must not share a cached secret, even though everything else about its identity
 // matches.

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -687,18 +687,51 @@ func (m *Manager) fetchUncached(ctx context.Context, caller Caller, secretRef st
 	return credB.Data, credB.Type, false, "", nil
 }
 
-// secretCacheTTL resolves ConfigSecretCacheTTL spec-then-source (matching how
-// secret_spec / secret_field resolve). Returns 0 (no caching) when unset. A spec-level
-// value is authoritative by PRESENCE, so an explicit spec-level "0" opts out of a
-// source-level TTL (e.g. a rotation-sensitive consumer under a source that caches).
+// secretCacheTTL resolves ConfigSecretCacheTTL spec-then-source. Returns 0 (no
+// caching) when unset. A spec-level value is authoritative by PRESENCE, so an
+// explicit spec-level "0" opts out of a source-level TTL (e.g. a rotation-sensitive
+// consumer under a source that caches).
+//
+// The source-level value does NOT apply when the spec overrode a reference the
+// source had of its own: see sourceModifiersApply. A caching policy is chosen for
+// one secret's rotation profile, so inheriting it across a different reference
+// caches one payload under a policy picked for another, silently opting the spec
+// into caching it never asked for.
 func (m *Manager) secretCacheTTL(ctx context.Context, spec *CredSpec) time.Duration {
 	if _, ok := spec.Config[ConfigSecretCacheTTL]; ok {
 		return GetDuration(spec.Config, ConfigSecretCacheTTL, 0)
 	}
 	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil {
+		if !sourceModifiersApply(spec, src) {
+			return 0
+		}
 		return GetDuration(src.Config, ConfigSecretCacheTTL, 0)
 	}
 	return 0
+}
+
+// sourceModifiersApply reports whether a source's secret_field / secret_cache_ttl
+// describe the payload actually being fetched for this spec.
+//
+// Two separate questions decide a chained fetch: which payload is fetched (whoever
+// set secret_spec, spec-level winning — see secretSpecRef) and how to read and cache
+// it. The modifiers only mean anything against the payload they were written for.
+//
+// A source that sets no secret_spec of its own has no payload of its own, so its
+// modifiers can only be defaults for whatever its specs reference — apply them. A
+// spec that restates the source's reference names the same payload, so they still
+// describe it — apply them there too, rather than punishing a redundant but
+// truthful config.
+//
+// What is left is the case they cannot survive: the source names a reference AND
+// the spec overrides it with a DIFFERENT one. Then the source's field names a key
+// the spec's payload does not contain, which consuming drivers report as
+// "secret_field %q is empty or absent" citing a field the spec's operator never
+// set, and its TTL caches a secret whose owner never opted in.
+func sourceModifiersApply(spec *CredSpec, src *CredSource) bool {
+	return spec.Config[ConfigSecretSpec] == "" ||
+		src.Config[ConfigSecretSpec] == "" ||
+		spec.Config[ConfigSecretSpec] == src.Config[ConfigSecretSpec]
 }
 
 // invalidateChainedSecret evicts a cached secret and forgets any in-flight singleflight
@@ -925,15 +958,20 @@ func copyStringMap(in map[string]string) map[string]string {
 }
 
 // resolveSecretField selects which key of the referenced credential's Data carries
-// the single secret: an explicit secret_field (spec-level then source-level), else a
-// single-key payload, else the referenced type's primary field. Returns "" when it
-// cannot determine one — a multi-secret consumer reads Data directly and ignores it;
-// a single-secret consumer surfaces the "set secret_field" error at use.
+// the single secret: an explicit secret_field (spec-level, then source-level when the
+// source's modifiers still describe the payload in play), else a single-key payload,
+// else the referenced type's primary field. Returns "" when it cannot determine one —
+// a multi-secret consumer reads Data directly and ignores it; a single-secret consumer
+// surfaces the "set secret_field" error at use.
+//
+// A spec refining the field for a source-level reference is the coherent case and
+// still works: both concern the same payload. See sourceModifiersApply for the one
+// case that does not.
 func (m *Manager) resolveSecretField(ctx context.Context, spec *CredSpec, credB *Credential) string {
 	if f := spec.Config[ConfigSecretField]; f != "" {
 		return f
 	}
-	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil {
+	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil && sourceModifiersApply(spec, src) {
 		if f := src.Config[ConfigSecretField]; f != "" {
 			return f
 		}


### PR DESCRIPTION
Found while designing chained credentials for the Scaleway driver, but it is a live bug in shared chaining infrastructure today, independent of that work.

## The bug

`secret_spec`, `secret_field` and `secret_cache_ttl` all resolved spec-then-source independently, as if the three were peers — the doc comment on `secretCacheTTL` said so explicitly ("matching how secret_spec / secret_field resolve").

They are not peers. `secret_spec` names **which payload is fetched**; the other two say **how to read and cache it**. A field name or a caching policy only means anything against the payload it was written for.

So a source that chains a secret of its own, plus a spec on it that overrides the reference with a *different* one, ended up describing two different payloads with one set of modifiers:

- the source's `secret_field` named a key the spec's payload does not contain, which consuming drivers report as `secret_field "x" is empty or absent` — citing a field the spec's operator never set;
- the source's `secret_cache_ttl` cached the spec's secret under a policy chosen for the source's, silently opting it into caching when the documented default for an unset value is *none*.

Reachable today for `github` and `static_apikey` — the two chained drivers that permit a spec-level `secret_spec`, since the switch in `credential_config_store.go` rejects it only for `token_exchange`, `gitlab` and `oauth2`.

## The fix

Apply the source's modifiers only while they still describe the payload in play. Exactly one of four combinations changes:

| `secret_spec` on | `secret_field` on | before | after |
|---|---|---|---|
| source | source | source's | unchanged |
| source | spec | spec's | unchanged |
| spec | spec | spec's | unchanged |
| **spec** | **source** | **source's** — names a key in a payload this spec never fetched | none: falls through to auto-detect, then the driver's conventional key |

A source that sets no `secret_spec` of its own has no rival payload, so its modifiers stay defaults for whatever its specs reference — the documented behaviour, and what an existing test already pins. A spec that *restates* the source's reference names the same payload, so they still apply there too.

## Migration

One shape changes: a spec that overrides the source's reference with a different one and leaned on the source's field or TTL now needs its own. That only worked by coincidence, when two unrelated payloads happened to share a key name.

## Verification

`go build ./...`, `go vet ./credential/...`, `go test -race ./credential/...`, `go test ./core/...` clean. Full e2e suite green against a live cluster — `credential` and `fullchain` carry the gitlab/github/oauth2/token_exchange chained rows this touches.

New tests assert both directions: the source's field and TTL are *not* inherited across a differing reference (including the multi-key payload where auto-detect cannot rescue it — the actual reported symptom), and *are* still applied as defaults, when the spec restates the reference, and when a spec refines the field for a source-level reference.
