### PR TITLE
feat(scaleway): mint from chained secrets, so no Scaleway key sits in config

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1030,6 +1030,19 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				}
 			}
 		}
+		// A scaleway source chains the management key that authorises creating fresh
+		// pairs, which is a dynamic_keys concern. A static_keys spec on it does not
+		// use that key at all — its credential is a pair of its own — so source-level
+		// routing would hand it the management payload and mint from the wrong secret.
+		// Such a spec must name its own reference. (A spec that already does is not
+		// here: chainedRef would be its own, and the type validator has already
+		// refused it any inline pair.)
+		if source.Type == credential.SourceTypeScaleway &&
+			source.Config[credential.ConfigSecretSpec] != "" &&
+			spec.Config[credential.ConfigSecretSpec] == "" &&
+			credential.GetString(spec.Config, "mint_method", "") == "static_keys" {
+			return logical.ErrBadRequestf("a static_keys spec on a chained scaleway source (secret_spec %q) must set its own secret_spec naming a spec that yields its access_key and secret_key; the source's chained secret is a management key, not this credential", chainedRef)
+		}
 		// A chained consumer's identity normally flows through the referenced secret-spec,
 		// so its own subject/actor exchange config would be dead — reject that confusing
 		// combination. The token_exchange driver is the exception: it is itself an

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2191,6 +2191,79 @@ func TestCredentialConfigStore_GitLabChaining(t *testing.T) {
 	assert.Contains(t, err.Error(), "set secret_spec on the source")
 }
 
+// TestCredentialConfigStore_ScalewayChaining covers a source type where the two mint
+// methods chain different secrets at different levels: dynamic_keys chains the
+// management key on the SOURCE (it authenticates the source's IAM calls), while
+// static_keys chains the credential pair on the SPEC (it is that spec's credential
+// and authenticates nothing of the source's).
+func TestCredentialConfigStore_ScalewayChaining(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	for _, name := range []string{"scw-mgmt", "scw-pair"} {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: name, Type: "vault_token", Source: "src",
+			Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+		}))
+	}
+
+	// A chained scaleway source carries no management key of its own.
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "scw-keyless", Type: credential.SourceTypeScaleway,
+		Config: map[string]string{credential.ConfigSecretSpec: "scw-mgmt"},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "scw-inline", Type: credential.SourceTypeScaleway,
+		Config: map[string]string{"management_secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"},
+	}))
+
+	// dynamic_keys inherits the source's chain and needs no config of its own.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "scw-dynamic", Type: credential.TypeScalewayKeys, Source: "scw-keyless",
+		Config: map[string]string{"mint_method": "dynamic_keys", "application_id": "app-1"},
+	}))
+
+	// A static_keys spec names its own reference, and may sit on the same source.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "scw-static", Type: credential.TypeScalewayKeys, Source: "scw-keyless",
+		Config: map[string]string{"mint_method": "static_keys", credential.ConfigSecretSpec: "scw-pair"},
+	}))
+
+	// Source-level routing would hand a static_keys spec the management payload,
+	// which is not its credential.
+	err := store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "scw-static-inheriting", Type: credential.TypeScalewayKeys, Source: "scw-keyless",
+		Config: map[string]string{
+			"mint_method": "static_keys",
+			"access_key":  "SCWXXXXXXXXXXXXXXXXX",
+			"secret_key":  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set its own secret_spec")
+
+	// The rest of the matrix — a spec-level secret_spec on dynamic_keys, an inline
+	// pair or a secret_field alongside a chained static_keys spec — is owned by
+	// ScalewayKeysCredType.ValidateConfig, which sees everything it needs in spec
+	// config. It is covered in credential/types/scaleway_keys_test.go, and cannot be
+	// exercised here: this harness builds a Core with no credentialTypeRegistry, so
+	// the type validator never runs.
+
+	// Rotation belongs to whoever owns the referenced secret.
+	rotating := &credential.CredSource{
+		Name: "scw-rotating", Type: credential.SourceTypeScaleway,
+		Config: map[string]string{credential.ConfigSecretSpec: "scw-mgmt"},
+	}
+	rotating.RotationPeriod = 24 * time.Hour
+	err = store.CreateSource(ctx, rotating)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation_period does not apply to a chained source")
+
+	// A source that reads as keyless must not still store the key chaining removes.
+	// That rule belongs to the driver factory, which this harness has no registry
+	// for; it is covered by TestScalewayDriverFactory_ValidateConfig_Chaining.
+}
+
 // TestCredentialConfigStore_OAuth2Chaining covers the guards on an oauth2 source that
 // fetches its whole client credential per mint: chaining is a source concern, the pair
 // must not be half-configured, and the consent flow cannot reach chained material.

--- a/credential/drivers/scaleway_driver.go
+++ b/credential/drivers/scaleway_driver.go
@@ -38,10 +38,23 @@ const DefaultScalewayIAMPath = "/iam/v1alpha1"
 // delay guards against any internal propagation across regions.
 const DefaultScalewayActivationDelay = 30 * time.Second
 
+// defaultScalewayStaticChainTTL bounds how long a chained static pair is served
+// before the chain is walked again. The static mint makes no API call, so it never
+// sees a rejection and can never be told its pair went stale; without a lease TTL
+// the credential would be cached for the caller's whole session.
+const defaultScalewayStaticChainTTL = 30 * time.Minute
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*ScalewayDriver)(nil)
 var _ credential.SpecVerifier = (*ScalewayDriver)(nil)
 var _ credential.Rotatable = (*ScalewayDriver)(nil)
+var _ credential.ChainedSecretMinter = (*ScalewayDriver)(nil)
+
+// scalewayChainedAuth carries the management secret key fetched through credential
+// chaining, for a source that stores none of its own.
+type scalewayChainedAuth struct {
+	secretKey string
+}
 
 // ScalewayDriver mints credentials from Scaleway IAM.
 //
@@ -72,6 +85,9 @@ func (f *ScalewayDriverFactory) Type() string {
 
 // ValidateConfig validates Scaleway source configuration.
 func (f *ScalewayDriverFactory) ValidateConfig(config map[string]string) error {
+	if err := validateChainedConfig(config); err != nil {
+		return err
+	}
 	return credential.ValidateSchema(config,
 		credential.StringField("scaleway_url").
 			Custom(func(v string) error {
@@ -123,7 +139,39 @@ func (f *ScalewayDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.DurationField("activation_delay").
 			Describe("Overlap before a rotated management key becomes active (default: 30s)").
 			Example("30s"),
+
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Cred spec yielding the management secret key, instead of storing one here").
+			Example("scw-mgmt-key"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Field of the referenced credential holding the management secret key").
+			Example("management_secret_key"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("How long to reuse the fetched secret before re-fetching (default: no caching)").
+			Example("30m"),
 	)
+}
+
+// validateChainedConfig rejects source config that contradicts credential chaining.
+//
+// A source that keeps its management key while claiming to fetch one reads as
+// keyless but still stores the very secret chaining exists to remove. The rotation
+// keys go with it for a different reason: their only consumer is rotation, which a
+// chained source hands to whoever owns the referenced spec, so leaving them is dead
+// config that describes a job this source no longer does.
+func validateChainedConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") == "" {
+		return nil
+	}
+	for _, key := range []string{"management_secret_key", "management_access_key", "activation_delay"} {
+		if credential.GetString(config, key, "") != "" {
+			return fmt.Errorf("%s must be omitted when %s is set; the key is supplied by the referenced spec, and rotation belongs to whoever owns it",
+				key, credential.ConfigSecretSpec)
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns source config keys that should be masked.
@@ -213,6 +261,23 @@ func (d *ScalewayDriver) getManagementSecretKeyLocked() string {
 	return credential.GetString(d.credSource.Config, "management_secret_key", "")
 }
 
+// isChainedLocked reports whether this source draws its management key from another
+// cred spec rather than holding one inline.
+// Caller must hold configMu (read or write).
+func (d *ScalewayDriver) isChainedLocked() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
+// isChained is isChainedLocked for callers holding no lock. Read locks are not
+// re-entrant — a writer queued between two acquisitions on one goroutine
+// deadlocks — so anything already inside a configMu block must call the Locked
+// form instead.
+func (d *ScalewayDriver) isChained() bool {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.isChainedLocked()
+}
+
 // getIAMAPIPathLocked returns the IAM API path prefix from source config.
 // Defaults to DefaultScalewayIAMPath (/iam/v1alpha1).
 // Caller must hold configMu (read or write).
@@ -247,15 +312,114 @@ func (d *ScalewayDriver) iamKeyURL(accessKey string) string {
 // config that bypassed validation, and silently minting static keys for it would
 // be the wrong answer.
 func (d *ScalewayDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A chained spec mints through MintFromSecret, which the minting layer routes it
+	// to. Arriving here means that routing was bypassed, so fail rather than fall
+	// through to inline material this source or spec does not have.
+	if spec.Config[credential.ConfigSecretSpec] != "" || d.isChained() {
+		return nil, nil, 0, "", fmt.Errorf("scaleway: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
+			credential.ConfigSecretSpec)
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "static_keys":
 		return d.mintStaticCredential(spec)
 	case "dynamic_keys":
-		return d.mintDynamicCredential(ctx, spec)
+		return d.mintDynamicCredential(ctx, spec, nil)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected static_keys or dynamic_keys)", mintMethod)
 	}
+}
+
+// MintFromSecret mints from secret material fetched via credential chaining. What
+// the material means depends on the mint method, so each arm reads it differently:
+// dynamic_keys receives the management key that authorises creating a fresh pair,
+// static_keys receives the pair itself.
+func (d *ScalewayDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	switch mintMethod {
+	case "dynamic_keys":
+		key := material.Secret()
+		// Fall back to a conventional name ONLY when no field was resolved. A field
+		// that resolved to nothing is a misconfigured secret_field — say so, rather
+		// than silently authenticating with some other value from the payload.
+		if key == "" && material.Field == "" {
+			if key = material.Data["management_secret_key"]; key == "" {
+				key = material.Data["secret_key"]
+			}
+		}
+		if key == "" {
+			if material.Field != "" {
+				return nil, nil, 0, "", fmt.Errorf("scaleway: %s %q is empty or absent in the fetched secret material: %w",
+					credential.ConfigSecretField, material.Field, credential.ErrChainedSecretIncomplete)
+			}
+			return nil, nil, 0, "", fmt.Errorf("scaleway: no management secret key in fetched secret material (set %s, or store it under 'management_secret_key'): %w",
+				credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
+		}
+		return d.mintDynamicCredential(ctx, spec, &scalewayChainedAuth{secretKey: key})
+
+	case "static_keys":
+		return d.mintStaticFromSecret(spec, material)
+
+	default:
+		// mint_method is validated at spec create, so reaching here means config
+		// drifted. The material's meaning is defined by the method, so with an
+		// unknown one there is no safe way to spend it.
+		return nil, nil, 0, "", fmt.Errorf("scaleway: credential chaining supports mint_method=dynamic_keys or static_keys, got %q", mintMethod)
+	}
+}
+
+// mintStaticFromSecret returns the pair the referenced spec yielded.
+//
+// Both halves are read by name: secret_field selects a single secret and a pair is
+// not one, so the spec is refused it at create and a source-level value does not
+// reach a spec that named its own reference. There is nothing here for a resolved
+// field to mean.
+//
+// Unlike the inline static path this reports a lease TTL. Nothing about this mint
+// can discover that the pair was rotated upstream — it makes no request, so it never
+// sees a rejection — and a zero TTL would pin the credential in cache for the
+// caller's whole session. The TTL is advisory only: with no lease id the credential
+// is not revocable, so it just forces the chain to be walked again.
+func (d *ScalewayDriver) mintStaticFromSecret(spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// The spec must name the reference itself. Routed here by a SOURCE-level one,
+	// the material would be the management key — whose payload is also a Scaleway
+	// pair — and this would hand the caller a credential that can create and delete
+	// API keys, in place of the scoped one the spec describes.
+	//
+	// Spec create refuses that combination, but a source converted to chaining
+	// afterwards is not re-validated against the specs already bound to it, so this
+	// is the guard that actually holds.
+	if spec.Config[credential.ConfigSecretSpec] == "" {
+		return nil, nil, 0, "", fmt.Errorf("scaleway: a static_keys spec must set its own %s naming a spec that yields its access_key and secret_key; this source's chained secret is a management key, not this credential",
+			credential.ConfigSecretSpec)
+	}
+
+	accessKey := material.Data["access_key"]
+	secretKey := material.Data["secret_key"]
+	if accessKey == "" || secretKey == "" {
+		return nil, nil, 0, "", fmt.Errorf("scaleway: fetched secret material must hold both 'access_key' and 'secret_key' for static_keys: %w",
+			credential.ErrChainedSecretIncomplete)
+	}
+
+	// Track the spec's own secret_cache_ttl where it has one, so an operator who
+	// tightened reuse of the fetched pair gets a matching bound here.
+	//
+	// This deliberately does not consult the source: the minting layer may still
+	// apply a source-level TTL to the fetch (when the source has no reference of its
+	// own, or names the same one), so the two can differ, and the effective staleness
+	// is the larger — plus, since a re-mint at expiry can be served cached material,
+	// the two compose rather than cancel.
+	ttl := credential.GetDuration(spec.Config, credential.ConfigSecretCacheTTL, 0)
+	if ttl <= 0 {
+		ttl = defaultScalewayStaticChainTTL
+	}
+
+	rawData := map[string]interface{}{
+		"access_key": accessKey,
+		"secret_key": secretKey,
+	}
+	return rawData, nil, ttl, "", nil
 }
 
 // mintStaticCredential reads access_key and secret_key from spec config.
@@ -278,10 +442,16 @@ func (d *ScalewayDriver) mintStaticCredential(spec *credential.CredSpec) (map[st
 }
 
 // mintDynamicCredential creates a new API key via the Scaleway IAM API.
-func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	d.configMu.RLock()
-	managementKey := d.getManagementSecretKeyLocked()
-	d.configMu.RUnlock()
+// chained is nil for an inline source and set for one fetching its key per mint.
+func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *credential.CredSpec, chained *scalewayChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	managementKey := ""
+	if chained != nil {
+		managementKey = chained.secretKey
+	} else {
+		d.configMu.RLock()
+		managementKey = d.getManagementSecretKeyLocked()
+		d.configMu.RUnlock()
+	}
 	if managementKey == "" {
 		return nil, nil, 0, "", fmt.Errorf("management_secret_key is required on source for dynamic_keys mint method")
 	}
@@ -326,8 +496,15 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		},
 	}
 
-	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, scalewayCreateRetryConfig())
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, scalewayCreateRetryConfig())
 	if err != nil {
+		// On the chained path, mark an authentication rejection so the minting layer
+		// treats a cached secret as stale, evicts it and retries once with a fresh
+		// fetch. Without this a key rotated at its source would fail every request
+		// until the cache entry aged out on its own.
+		if chained != nil && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+			return nil, nil, 0, "", fmt.Errorf("scaleway: failed to create API key: %w (%w)", credential.ErrChainedSecretRejected, err)
+		}
 		return nil, nil, 0, "", fmt.Errorf("failed to create Scaleway API key: %w", err)
 	}
 
@@ -365,8 +542,19 @@ func (d *ScalewayDriver) mintDynamicCredential(ctx context.Context, spec *creden
 		"secret_key": resp.SecretKey,
 	}
 
-	// LeaseID is the access_key — used by Revoke to delete the key
-	return rawData, nil, leaseTTL, resp.AccessKey, nil
+	// LeaseID is the access_key — used by Revoke to delete the key.
+	//
+	// A chained mint hands out none. Revocation runs at lease expiry with only a
+	// lease id, no caller and no way to walk the chain again, so a source holding no
+	// key of its own cannot honour a lease it issued. The key still dies on its own
+	// expires_at, which the lease TTL above already tracks; what is given up is
+	// deleting it early — including at session end, which an inline source does do.
+	// Keep chained spec ttl short.
+	leaseID := resp.AccessKey
+	if chained != nil {
+		leaseID = ""
+	}
+	return rawData, nil, leaseTTL, leaseID, nil
 }
 
 // leaseTTLFromExpiry converts the expires_at Scaleway reports into a lease TTL.
@@ -425,7 +613,21 @@ func (d *ScalewayDriver) Revoke(ctx context.Context, leaseID string) error {
 
 	d.configMu.RLock()
 	managementKey := d.getManagementSecretKeyLocked()
+	chained := d.isChainedLocked()
 	d.configMu.RUnlock()
+
+	// A lease on a chained source predates its conversion: chained mints hand out
+	// none. There is no key here to authorise the delete and no caller to walk the
+	// chain with, and that will never change — so returning an error would only
+	// send the expiration manager into backoff and then a daily retry, forever, for
+	// a request that cannot succeed. The key carries its own expires_at.
+	if chained {
+		d.logger.Warn("cannot revoke a lease issued before this source began chaining its management key; the key will live until it expires",
+			logger.String("access_key", truncateID(leaseID, 8)),
+		)
+		return nil
+	}
+
 	if managementKey == "" {
 		return fmt.Errorf("management_secret_key is required to revoke Scaleway API keys")
 	}
@@ -482,6 +684,13 @@ func (d *ScalewayDriver) Cleanup(_ context.Context) error {
 func (d *ScalewayDriver) SupportsRotation() bool {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
+	// isChainedLocked, not isChained: the read lock is already held for the whole
+	// body and read locks are not re-entrant.
+	if d.isChainedLocked() {
+		// The key lives at its source of truth, and whoever owns the referenced spec
+		// rotates it there.
+		return false
+	}
 	return d.getManagementSecretKeyLocked() != "" &&
 		credential.GetString(d.credSource.Config, "management_access_key", "") != ""
 }
@@ -755,6 +964,13 @@ func (d *ScalewayDriver) VerifySpec(ctx context.Context, spec *credential.CredSp
 
 // verifyStaticKeys verifies that the static access_key exists via the IAM API.
 func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.CredSpec) error {
+	// A chained spec holds no pair to verify — it is fetched per mint, as the
+	// caller, and there is no caller here. Reporting "no secret_key configured"
+	// would describe config that is absent on purpose.
+	if spec.Config[credential.ConfigSecretSpec] != "" {
+		return nil
+	}
+
 	secretKey := credential.GetString(spec.Config, "secret_key", "")
 	if secretKey == "" {
 		return fmt.Errorf("no secret_key configured in spec")
@@ -787,8 +1003,12 @@ func (d *ScalewayDriver) verifyStaticKeys(ctx context.Context, spec *credential.
 func (d *ScalewayDriver) verifyDynamicConfig(spec *credential.CredSpec) error {
 	d.configMu.RLock()
 	hasKey := d.getManagementSecretKeyLocked() != ""
+	chained := d.isChainedLocked()
 	d.configMu.RUnlock()
-	if !hasKey {
+
+	// A chained source holds no management key on purpose; it is fetched per mint,
+	// as the caller. Demanding one here would report correct config as broken.
+	if !chained && !hasKey {
 		return fmt.Errorf("management_secret_key is required on source for dynamic_keys mint method")
 	}
 	if credential.GetString(spec.Config, "application_id", "") == "" {

--- a/credential/drivers/scaleway_driver_test.go
+++ b/credential/drivers/scaleway_driver_test.go
@@ -818,6 +818,310 @@ func TestScalewayDriver_GetScalewayURL(t *testing.T) {
 	})
 }
 
+// --- Credential chaining ---
+
+func newChainedScalewayDriver(t *testing.T, serverURL string) *ScalewayDriver {
+	t.Helper()
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"scaleway_url":    serverURL,
+		"secret_spec":     "scw-mgmt-key",
+		"secret_field":    "management_secret_key",
+		"tls_skip_verify": "true",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+	return driver.(*ScalewayDriver)
+}
+
+func chainedDynamicKeysSpec() *credential.CredSpec {
+	return &credential.CredSpec{
+		Name: "chained-dynamic",
+		Config: map[string]string{
+			"mint_method":    "dynamic_keys",
+			"application_id": "app-123",
+			"ttl":            "1h",
+		},
+	}
+}
+
+func chainedStaticKeysSpec() *credential.CredSpec {
+	return &credential.CredSpec{
+		Name:   "chained-static",
+		Config: map[string]string{"mint_method": "static_keys", "secret_spec": "scw-pair"},
+	}
+}
+
+func TestScalewayDriverFactory_ValidateConfig_Chaining(t *testing.T) {
+	f := &ScalewayDriverFactory{}
+
+	t.Run("minimal chained config", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"secret_spec":      "scw-mgmt-key",
+			"secret_field":     "management_secret_key",
+			"secret_cache_ttl": "30m",
+		}))
+	})
+
+	// A source that keeps its key while claiming to fetch one reads as keyless but
+	// still stores the very secret chaining exists to remove. The rotation keys go
+	// with it: their only consumer is rotation, which a chained source hands away.
+	for _, key := range []string{"management_secret_key", "management_access_key", "activation_delay"} {
+		t.Run("chained rejects "+key, func(t *testing.T) {
+			cfg := map[string]string{"secret_spec": "scw-mgmt-key"}
+			switch key {
+			case "management_access_key":
+				cfg[key] = "SCWXXXXXXXXXXXXXXXXX"
+			case "activation_delay":
+				cfg[key] = "2m"
+			default:
+				cfg[key] = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+			}
+			err := f.ValidateConfig(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), key)
+		})
+	}
+
+	t.Run("non-chained config still accepts management keys", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"management_access_key": "SCWXXXXXXXXXXXXXXXXX",
+			"management_secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			"activation_delay":      "2m",
+		}))
+	})
+}
+
+func TestScalewayDriver_MintCredential_FailsClosedWhenChained(t *testing.T) {
+	t.Run("source-level", func(t *testing.T) {
+		d := newChainedScalewayDriver(t, "https://api.scaleway.com")
+		_, _, _, _, err := d.MintCredential(context.Background(), chainedDynamicKeysSpec())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret_spec")
+	})
+
+	t.Run("spec-level", func(t *testing.T) {
+		f := &ScalewayDriverFactory{}
+		driver, err := f.Create(map[string]string{}, createScalewayTestLogger())
+		require.NoError(t, err)
+		_, _, _, _, err = driver.MintCredential(context.Background(), chainedStaticKeysSpec())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret_spec")
+	})
+}
+
+func TestScalewayDriver_MintFromSecret_DynamicKeys(t *testing.T) {
+	cases := []struct {
+		name     string
+		material credential.SecretMaterial
+	}{
+		{"resolved field", credential.SecretMaterial{
+			Data:  map[string]string{"management_secret_key": "FETCHED-MGMT"},
+			Field: "management_secret_key",
+		}},
+		{"conventional management_secret_key", credential.SecretMaterial{
+			Data: map[string]string{"management_secret_key": "FETCHED-MGMT", "note": "x"},
+		}},
+		{"conventional secret_key", credential.SecretMaterial{
+			Data: map[string]string{"secret_key": "FETCHED-MGMT", "note": "x"},
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotToken string
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotToken = r.Header.Get("X-Auth-Token")
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"access_key": "SCWCHAINEDKEYXXXXXX",
+					"secret_key": "chained-minted-secret",
+					"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				})
+			}))
+			defer server.Close()
+
+			d := newChainedScalewayDriver(t, server.URL)
+			rawData, _, ttl, leaseID, err := d.MintFromSecret(context.Background(), chainedDynamicKeysSpec(), tc.material)
+			require.NoError(t, err)
+
+			assert.Equal(t, "FETCHED-MGMT", gotToken, "the fetched key authenticates the mint")
+			assert.Equal(t, "SCWCHAINEDKEYXXXXXX", rawData["access_key"])
+			assert.Greater(t, ttl, time.Duration(0))
+			assert.Empty(t, leaseID, "a chained source cannot honour a lease it has no key to revoke with")
+		})
+	}
+}
+
+func TestScalewayDriver_MintFromSecret_StaticKeys(t *testing.T) {
+	// The static path spends the material directly; it must not call Scaleway at all.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("static_keys must not call the Scaleway API")
+	}))
+	defer server.Close()
+
+	d := newChainedScalewayDriver(t, server.URL)
+	material := credential.SecretMaterial{
+		Data: map[string]string{"access_key": "SCWFETCHEDPAIRXXXXX", "secret_key": "fetched-pair-secret"},
+		// A resolved field has no meaning for a pair; it must not derail the read.
+		Field: "management_secret_key",
+	}
+
+	rawData, _, ttl, leaseID, err := d.MintFromSecret(context.Background(), chainedStaticKeysSpec(), material)
+	require.NoError(t, err)
+	assert.Equal(t, "SCWFETCHEDPAIRXXXXX", rawData["access_key"])
+	assert.Equal(t, "fetched-pair-secret", rawData["secret_key"])
+	assert.Empty(t, leaseID)
+	assert.Equal(t, defaultScalewayStaticChainTTL, ttl,
+		"a positive TTL bounds staleness: this path can never learn the pair was rotated")
+}
+
+func TestScalewayDriver_MintFromSecret_StaticKeys_RefusesSourceLevelRouting(t *testing.T) {
+	// Converting a source to chaining does not re-validate the specs already bound
+	// to it, so an inline static_keys spec can end up routed by the SOURCE's
+	// reference. Its material is then the management key — whose payload is also a
+	// Scaleway pair — and minting from it would hand the caller a credential that
+	// can create and delete API keys, in place of the scoped one the spec describes.
+	d := newChainedScalewayDriver(t, "https://api.scaleway.com")
+
+	inlineSpec := &credential.CredSpec{
+		Name: "pre-conversion",
+		Config: map[string]string{
+			"mint_method": "static_keys",
+			"access_key":  "SCWSPECOWNKEYXXXXXX",
+			"secret_key":  "spec-own-secret",
+		},
+	}
+	managementPayload := credential.SecretMaterial{
+		Data: map[string]string{"access_key": "SCWMANAGEMENTKEYXXX", "secret_key": "management-secret"},
+	}
+
+	_, _, _, _, err := d.MintFromSecret(context.Background(), inlineSpec, managementPayload)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set its own secret_spec")
+}
+
+func TestScalewayDriver_MintFromSecret_StaticKeys_TTLFollowsCacheTTL(t *testing.T) {
+	d := newChainedScalewayDriver(t, "https://api.scaleway.com")
+	spec := chainedStaticKeysSpec()
+	spec.Config["secret_cache_ttl"] = "5m"
+
+	_, _, ttl, _, err := d.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+		Data: map[string]string{"access_key": "SCWPAIRXXXXXXXXXXXX", "secret_key": "s"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, ttl)
+
+	// "0" opts out of caching, not out of a staleness bound: taking it literally
+	// would restore the session-long pin this TTL exists to prevent.
+	spec.Config["secret_cache_ttl"] = "0"
+	_, _, ttl, _, err = d.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+		Data: map[string]string{"access_key": "SCWPAIRXXXXXXXXXXXX", "secret_key": "s"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, defaultScalewayStaticChainTTL, ttl)
+}
+
+func TestScalewayDriver_MintFromSecret_IncompleteMaterial(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("must not reach the Scaleway API with unusable material")
+	}))
+	defer server.Close()
+	d := newChainedScalewayDriver(t, server.URL)
+
+	t.Run("dynamic: resolved field is empty", func(t *testing.T) {
+		_, _, _, _, err := d.MintFromSecret(context.Background(), chainedDynamicKeysSpec(),
+			credential.SecretMaterial{Data: map[string]string{"other": "x"}, Field: "management_secret_key"})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		assert.Contains(t, err.Error(), "management_secret_key")
+	})
+
+	t.Run("dynamic: no field and no conventional key", func(t *testing.T) {
+		_, _, _, _, err := d.MintFromSecret(context.Background(), chainedDynamicKeysSpec(),
+			credential.SecretMaterial{Data: map[string]string{"other": "x", "more": "y"}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+	})
+
+	for _, tc := range []struct {
+		name string
+		data map[string]string
+	}{
+		{"missing access_key", map[string]string{"secret_key": "s"}},
+		{"missing secret_key", map[string]string{"access_key": "SCWXXXXXXXXXXXXXXXXX"}},
+		{"missing both", map[string]string{"unrelated": "x"}},
+	} {
+		t.Run("static: "+tc.name, func(t *testing.T) {
+			_, _, _, _, err := d.MintFromSecret(context.Background(), chainedStaticKeysSpec(),
+				credential.SecretMaterial{Data: tc.data})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		})
+	}
+
+	t.Run("unknown mint_method", func(t *testing.T) {
+		_, _, _, _, err := d.MintFromSecret(context.Background(),
+			&credential.CredSpec{Name: "drifted", Config: map[string]string{"mint_method": "wat"}},
+			credential.SecretMaterial{Data: map[string]string{"secret_key": "s"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dynamic_keys or static_keys")
+	})
+}
+
+func TestScalewayDriver_MintFromSecret_RejectionIsRetryable(t *testing.T) {
+	// A key rotated at its source must be recoverable: the minting layer evicts the
+	// cached secret and retries once, but only if the driver says it was rejected.
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, `{"type":"denied_authentication"}`, status)
+			}))
+			defer server.Close()
+
+			d := newChainedScalewayDriver(t, server.URL)
+			_, _, _, _, err := d.MintFromSecret(context.Background(), chainedDynamicKeysSpec(),
+				credential.SecretMaterial{Data: map[string]string{"management_secret_key": "STALE"}})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+		})
+	}
+
+	t.Run("other failures are not retryable", func(t *testing.T) {
+		// Re-fetching an identical secret cannot help, so it must not be tried.
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"type":"not_found"}`, http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		d := newChainedScalewayDriver(t, server.URL)
+		_, _, _, _, err := d.MintFromSecret(context.Background(), chainedDynamicKeysSpec(),
+			credential.SecretMaterial{Data: map[string]string{"management_secret_key": "FINE"}})
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+	})
+}
+
+func TestScalewayDriver_ChainedSourceOwnsNoRotation(t *testing.T) {
+	d := newChainedScalewayDriver(t, "https://api.scaleway.com")
+	assert.False(t, d.SupportsRotation(), "the referenced spec's owner rotates the key at its source of truth")
+
+	// A lease predating the conversion can never be revoked, and saying so with an
+	// error would only make the expiration manager retry it daily, forever.
+	require.NoError(t, d.Revoke(context.Background(), "SCWPRECONVERSIONKEY"))
+}
+
+func TestScalewayDriver_NonChainedSourceStillRotates(t *testing.T) {
+	// A plain source that merely hosts a spec-chained static spec keeps its own
+	// management key, and keeps rotating it.
+	f := &ScalewayDriverFactory{}
+	driver, err := f.Create(map[string]string{
+		"management_secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+		"management_access_key": "SCWXXXXXXXXXXXXXXXXX",
+	}, createScalewayTestLogger())
+	require.NoError(t, err)
+	assert.True(t, driver.(*ScalewayDriver).SupportsRotation())
+}
+
 // --- Defect regression tests ---
 
 func TestScalewayDriverFactory_ValidateConfig_DoesNotEchoSwappedSecret(t *testing.T) {

--- a/credential/types/scaleway_keys.go
+++ b/credential/types/scaleway_keys.go
@@ -104,16 +104,43 @@ func (t *ScalewayKeysCredType) ValidateConfig(config map[string]string, sourceTy
 
 	switch sourceType {
 	case credential.SourceTypeScaleway:
+		chained := config[credential.ConfigSecretSpec] != ""
 		mintMethod := config["mint_method"]
 		switch mintMethod {
 		case "static_keys":
-			if config["access_key"] == "" {
-				return fmt.Errorf("'access_key' is required for static_keys")
+			// The pair either lives here or is fetched from a referenced spec — never
+			// both. A half left behind would be presented against the other half
+			// fetched from the chain.
+			if chained {
+				for _, key := range []string{"access_key", "secret_key"} {
+					if config[key] != "" {
+						return fmt.Errorf("'%s' must be omitted when '%s' is set; the referenced spec supplies the whole pair",
+							key, credential.ConfigSecretSpec)
+					}
+				}
+				// secret_field names one secret, and a pair is not one: both halves are
+				// read by name. Anything set here was set deliberately and does nothing.
+				if config[credential.ConfigSecretField] != "" {
+					return fmt.Errorf("'%s' does not apply to static_keys: the credential is a pair, read from the referenced payload's 'access_key' and 'secret_key' by name",
+						credential.ConfigSecretField)
+				}
+				break
 			}
-			if config["secret_key"] == "" {
-				return fmt.Errorf("'secret_key' is required for static_keys")
+			// Naming both remedies matters: on a chained source the missing-pair error
+			// would otherwise send an operator to add inline keys that the rule above
+			// then rejects.
+			if config["access_key"] == "" || config["secret_key"] == "" {
+				return fmt.Errorf("static_keys needs 'access_key' and 'secret_key', or a '%s' naming a spec that yields them",
+					credential.ConfigSecretSpec)
 			}
 		case "dynamic_keys":
+			// The management key authenticates the SOURCE's calls to the IAM API, and
+			// the driver factory only ever sees source config — a reference parked on
+			// the spec would slip past the checks that gate a chained source.
+			if chained {
+				return fmt.Errorf("for dynamic_keys, set '%s' on the source: the chained management key authenticates the source, not this spec",
+					credential.ConfigSecretSpec)
+			}
 			if config["application_id"] == "" {
 				return fmt.Errorf("'application_id' is required for dynamic_keys")
 			}
@@ -156,10 +183,11 @@ func (t *ScalewayKeysCredType) Parse(rawData, metadata map[string]interface{}, l
 		LeaseID:  leaseID,
 		IssuedAt: time.Now(),
 		// Revoking means releasing a lease at the source, which needs a handle to
-		// release. Scaleway's static path returns no TTL and its dynamic path
-		// returns a leaseID, so the second condition changes nothing today — it
-		// states the invariant rather than leaving the next mint path to
-		// rediscover it.
+		// release. Both conditions are load-bearing: a chained mint reports a TTL
+		// bounding how long its material may be reused, but hands out no leaseID —
+		// it has no key of its own to authorise a delete with, and no caller at
+		// expiry to fetch one. Registering such a credential for revocation would
+		// schedule a call that can only fail.
 		Revocable: leaseTTL > 0 && leaseID != "",
 		Data: map[string]string{
 			"access_key": accessKey,

--- a/credential/types/scaleway_keys_test.go
+++ b/credential/types/scaleway_keys_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -120,6 +121,29 @@ func TestScalewayKeysCredType_ValidateConfig_ScalewaySource(t *testing.T) {
 			errMsg:  "application_id",
 		},
 		{
+			// A non-positive ttl parses, so it used to reach the mint and produce a
+			// key born expired — with a lease TTL of 0, making it unrevocable and so
+			// never cleaned up.
+			name: "dynamic_keys rejects a non-positive ttl",
+			config: map[string]string{
+				"mint_method":    "dynamic_keys",
+				"application_id": "app-123",
+				"ttl":            "0s",
+			},
+			wantErr: true,
+			errMsg:  "ttl must be positive",
+		},
+		{
+			name: "dynamic_keys rejects an over-long description",
+			config: map[string]string{
+				"mint_method":    "dynamic_keys",
+				"application_id": "app-123",
+				"description":    strings.Repeat("x", scalewayMaxDescriptionLength+1),
+			},
+			wantErr: true,
+			errMsg:  "at most 200 characters",
+		},
+		{
 			name: "missing mint_method",
 			config: map[string]string{
 				"access_key": "SCWXXXXXXXXXXXXXXXXX",
@@ -134,6 +158,71 @@ func TestScalewayKeysCredType_ValidateConfig_ScalewaySource(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "mint_method",
+		},
+
+		// --- Credential chaining ---
+		{
+			name: "chained static_keys carries no pair",
+			config: map[string]string{
+				"mint_method": "static_keys",
+				"secret_spec": "scw-pair",
+			},
+			wantErr: false,
+		},
+		{
+			name: "chained static_keys rejects an inline access_key",
+			config: map[string]string{
+				"mint_method": "static_keys",
+				"secret_spec": "scw-pair",
+				"access_key":  "SCWXXXXXXXXXXXXXXXXX",
+			},
+			wantErr: true,
+			errMsg:  "'access_key' must be omitted",
+		},
+		{
+			name: "chained static_keys rejects an inline secret_key",
+			config: map[string]string{
+				"mint_method": "static_keys",
+				"secret_spec": "scw-pair",
+				"secret_key":  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			wantErr: true,
+			errMsg:  "'secret_key' must be omitted",
+		},
+		{
+			// secret_field names one secret and a pair is not one, so anything set
+			// here was set deliberately and would do nothing.
+			name: "chained static_keys rejects secret_field",
+			config: map[string]string{
+				"mint_method":  "static_keys",
+				"secret_spec":  "scw-pair",
+				"secret_field": "secret_key",
+			},
+			wantErr: true,
+			errMsg:  "does not apply to static_keys",
+		},
+		{
+			// Naming both remedies is the point: on a chained source, an error that
+			// only asked for inline keys would send an operator to add config the
+			// next rule rejects.
+			name: "static_keys with neither a pair nor a reference names both remedies",
+			config: map[string]string{
+				"mint_method": "static_keys",
+			},
+			wantErr: true,
+			errMsg:  "or a 'secret_spec' naming a spec that yields them",
+		},
+		{
+			// The management key authenticates the SOURCE's IAM calls, and the driver
+			// factory only ever sees source config.
+			name: "dynamic_keys rejects a spec-level secret_spec",
+			config: map[string]string{
+				"mint_method":    "dynamic_keys",
+				"application_id": "app-123",
+				"secret_spec":    "scw-mgmt-key",
+			},
+			wantErr: true,
+			errMsg:  "set 'secret_spec' on the source",
 		},
 	}
 	for _, tt := range tests {
@@ -188,6 +277,19 @@ func TestScalewayKeysCredType_Parse(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			// What a chained mint returns: a TTL bounding how long the fetched
+			// material may be reused, but no lease — nothing here can be revoked,
+			// and registering it for revocation would schedule a call that must fail.
+			name: "TTL without a lease is not revocable",
+			rawData: map[string]interface{}{
+				"access_key": "SCWXXXXXXXXXXXXXXXXX",
+				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			},
+			leaseTTL: 30 * time.Minute,
+			leaseID:  "",
+			wantErr:  false,
+		},
+		{
 			name: "missing access_key",
 			rawData: map[string]interface{}{
 				"secret_key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -233,7 +335,10 @@ func TestScalewayKeysCredType_Parse(t *testing.T) {
 				assert.Equal(t, tt.rawData["secret_key"], cred.Data["secret_key"])
 				assert.Equal(t, tt.leaseTTL, cred.LeaseTTL)
 				assert.Equal(t, tt.leaseID, cred.LeaseID)
-				if tt.leaseTTL > 0 {
+				// Both halves matter: a chained mint reports a TTL bounding reuse of
+				// its material but hands out no leaseID, having no key of its own to
+				// revoke with.
+				if tt.leaseTTL > 0 && tt.leaseID != "" {
 					assert.True(t, cred.Revocable)
 				} else {
 					assert.False(t, cred.Revocable)


### PR DESCRIPTION
Stacked on #544 (base), and contains a merge of #543. Land #543 and #544 first; the diff here shows that merge commit alongside this PR's own work.

## Why this shape

Scaleway has **no workload identity federation** — no STS, no token exchange, no OIDC provider, no assume-role. Research against Scaleway's docs, the IAM API reference, the full IAM changelog and `scaleway-sdk-go` at HEAD found none of it; the IAM API is `v1alpha1` and authenticates with a static key pair in a header, and that is the whole model. Scaleway's "identity federation" page is SAML/OAuth2 SSO for human console login.

So the `auth_method=oidc_federation` path that aws/azure/gcp/alicloud/hvault/kubernetes take has nothing to exchange against, and cannot be ported. What *is* achievable is removing the key from Warden, through the credential-chaining infrastructure that already exists.

## The split

Both mint methods now source their secret through chaining, each at the level that owns it:

| `mint_method` | secret today | chains at | what the chain supplies |
|---|---|---|---|
| `dynamic_keys` | `management_secret_key` in **source** config | the **source** | the management key → driver POSTs `/iam/v1alpha1/api-keys` for a fresh short-lived pair |
| `static_keys` | `access_key` + `secret_key` in **spec** config | the **spec** | the pair itself → returned directly, no API call |

The management key authenticates the source's own IAM calls, which is what makes chaining a source concern — the same reasoning the store already applies to `token_exchange`, `gitlab` and `oauth2`. The static pair authenticates nothing of the source's: it *is* the spec's credential, handed to the caller. A source-level reference would also hand every spec on the mount the same pair, which is not what a mount is for.

Split that way the two compose: one chained source serves its `dynamic_keys` specs while a `static_keys` spec beside them names its own reference.

`static_keys` matters more than it first looks — `dynamic_keys` needs the management key to hold IAM key-creation rights, which many Scaleway API keys do not have. For those operators it is the only route to a mount with nothing at rest in Warden. It is the weaker mode (a shared long-lived pair, no per-lease isolation) and the docs should say so.

## Two things worth review attention

**A privilege-escalation path, guarded twice.** A `static_keys` spec routed by a *source-level* reference would receive the management key — whose payload is also a Scaleway pair — and hand the caller a credential that can create and delete API keys. It is refused at spec create, and again at mint, because the second guard is the one that holds: converting a source to chaining does not re-validate the specs already bound to it.

**The static arm reports a lease TTL where the inline path reports none.** Making no request, it can never be told its pair was rotated, so the evict-and-retry that protects the dynamic arm is unreachable for it — and with `leaseTTL == 0` the credential would sit in cache for the caller's whole *session*. The TTL is advisory (no lease id, so nothing revocable) and only forces the chain to be walked again. Note the bound compounds: a re-mint at expiry can be served cached material, so worst-case staleness is `advisory TTL + secret_cache_ttl`.

## What is given up

Chained dynamic mints hand out no lease id either — revocation runs at expiry with no caller and no key to authorise the delete. The key still dies on its `expires_at`, but early revocation goes, **including at session end**, which an inline source does perform. A `ttl: 24h` spec under 1h sessions goes from "key dies with the session" to 23 extra hours of live key. Keep chained spec `ttl` short.

Rotation is refused on a chained source and passes to whoever owns the referenced spec. A lease predating such a conversion is unrevocable by construction, so `Revoke` says so and returns rather than sending the expiration manager into a daily retry it can never satisfy.

## Verification

`go build ./...`, `go vet ./credential/...`, `go test -race ./credential/...`, `go test ./core/...` clean. Full e2e suite green against a live cluster. End-to-end coverage is in the follow-up PR.

Docs are deferred to the pre-release doc-prep pass, per convention: the `scaleway.md` chained-mode section, the staleness bounds, and the session-end revocation change.
