### PR TITLE
fix(credential): release the test-mint lease, and stop guessing an hour of token life

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -835,6 +835,33 @@ func (s *CredentialConfigStore) ValidateSpec(ctx context.Context, spec *credenti
 	return s.validateSpec(ctx, spec, false)
 }
 
+// revokeValidationLease releases the credential a create-time test-mint produced
+// at the source.
+//
+// Best effort, and deliberately not fatal: a spec that validated should not be
+// refused because the cleanup call failed. But the attempt has to be made and its
+// failure has to be visible, because nothing else in the system knows this lease
+// exists — it never reaches the expiration manager, so this is its only chance to
+// go back.
+//
+// Runs on a fresh context: the request's own may already be cancelled by the time
+// the deferred call fires.
+func (s *CredentialConfigStore) revokeValidationLease(driver credential.SourceDriver, leaseID, sourceName string) {
+	revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := driver.Revoke(revokeCtx, leaseID); err != nil {
+		s.logger.Warn("failed to release the credential minted to validate a spec; it may still exist at the source",
+			logger.String("lease_id", leaseID),
+			logger.String("source", sourceName),
+			logger.Err(err))
+		return
+	}
+	s.logger.Debug("released the credential minted to validate a spec",
+		logger.String("lease_id", leaseID),
+		logger.String("source", sourceName))
+}
+
 // validateSpec validates a spec. When skipVerification is true the test-mint and
 // SpecVerifier checks are skipped — used by the connect seal and refresh-token
 // write-back, which already hold a known-good token and must not re-mint it.
@@ -1128,8 +1155,23 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				}
 
 				if runTestMint {
-					if _, _, _, _, err := driver.MintCredential(ctx, testSpec); err != nil {
-						return logical.ErrBadRequestf("credential test failed for spec type '%s': %s", spec.Type, err.Error())
+					_, _, _, leaseID, mintErr := driver.MintCredential(ctx, testSpec)
+					// A test-mint that reaches the source creates a real credential
+					// there. Nothing downstream registers this lease with the expiration
+					// manager — it is not cached, not leased, never revoked — so without
+					// this release it is abandoned at the source. Where the source's
+					// credentials carry no expiry of their own, that is a permanent,
+					// fully privileged credential nobody tracks, one per spec write.
+					//
+					// Deferred rather than released inline: verification below can fail
+					// too, and this lease must go back either way. Registered after the
+					// Cleanup above so it runs first, while the client still has
+					// connections to use.
+					if leaseID != "" {
+						defer s.revokeValidationLease(driver, leaseID, spec.Source)
+					}
+					if mintErr != nil {
+						return logical.ErrBadRequestf("credential test failed for spec type '%s': %s", spec.Type, mintErr.Error())
 					}
 
 					// Run additional verification if the driver supports it.

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2336,3 +2336,100 @@ func TestCredentialConfigStore_OAuth2Chaining(t *testing.T) {
 		assert.Contains(t, err.Error(), key+" must be omitted when the source sets secret_spec")
 	}
 }
+
+// leasingDriver mints a credential that carries a lease, so tests can observe
+// what becomes of the credential a spec's validation test-mint creates at the
+// source. The factory keeps the record because Create hands out a fresh driver.
+type leasingDriverFactory struct {
+	leaseID   string
+	verifyErr error
+	revoked   []string
+}
+
+func (f *leasingDriverFactory) Type() string { return "leasing_driver" }
+func (f *leasingDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
+	return &leasingDriver{factory: f}, nil
+}
+func (f *leasingDriverFactory) ValidateConfig(config map[string]string) error { return nil }
+func (f *leasingDriverFactory) SensitiveConfigFields() []string               { return nil }
+func (f *leasingDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
+	return "leasing_cred", nil
+}
+
+type leasingDriver struct{ factory *leasingDriverFactory }
+
+func (d *leasingDriver) Type() string { return "leasing_driver" }
+func (d *leasingDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return map[string]interface{}{"token": "minted"}, nil, time.Hour, d.factory.leaseID, nil
+}
+func (d *leasingDriver) Revoke(ctx context.Context, leaseID string) error {
+	d.factory.revoked = append(d.factory.revoked, leaseID)
+	return nil
+}
+func (d *leasingDriver) Cleanup(ctx context.Context) error { return nil }
+func (d *leasingDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
+	return d.factory.verifyErr
+}
+
+// TestCredentialConfigStore_ValidateSpec_ReleasesTestMintLease covers the
+// credential a spec write creates at the source just to prove the spec works.
+// Nothing downstream knows that lease exists — it is never cached and never
+// registered with the expiration manager — so validation is its only chance to go
+// back. A source whose credentials carry no expiry of their own would otherwise
+// accumulate one live, fully privileged credential per spec write.
+func TestCredentialConfigStore_ValidateSpec_ReleasesTestMintLease(t *testing.T) {
+	setup := func(t *testing.T, factory *leasingDriverFactory) (*CredentialConfigStore, context.Context) {
+		t.Helper()
+		store, ctx := setupTestCredentialConfigStore(t)
+		store.core.credentialDriverRegistry = credential.NewDriverRegistry(nil)
+		require.NoError(t, store.core.credentialDriverRegistry.RegisterFactory(factory))
+		store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+		require.NoError(t, store.core.credentialTypeRegistry.Register(&testCredentialType{typeName: "leasing_cred"}))
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "leasing-src", Type: "leasing_driver"}))
+		return store, ctx
+	}
+
+	spec := func(name string) *credential.CredSpec {
+		return &credential.CredSpec{Name: name, Type: "leasing_cred", Source: "leasing-src"}
+	}
+
+	t.Run("released after the spec validates", func(t *testing.T) {
+		factory := &leasingDriverFactory{leaseID: "lease-validate"}
+		store, ctx := setup(t, factory)
+
+		require.NoError(t, store.CreateSpec(ctx, spec("ok")))
+		assert.Equal(t, []string{"lease-validate"}, factory.revoked)
+	})
+
+	t.Run("released when verification fails after the mint", func(t *testing.T) {
+		factory := &leasingDriverFactory{leaseID: "lease-verify", verifyErr: fmt.Errorf("upstream says no")}
+		store, ctx := setup(t, factory)
+
+		err := store.CreateSpec(ctx, spec("bad"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential verification failed")
+		// The spec is refused, but the credential it minted still exists at the
+		// source — the failure is exactly when abandoning it would be easiest.
+		assert.Equal(t, []string{"lease-verify"}, factory.revoked)
+	})
+
+	t.Run("released again on every update", func(t *testing.T) {
+		factory := &leasingDriverFactory{leaseID: "lease-update"}
+		store, ctx := setup(t, factory)
+
+		s := spec("churn")
+		require.NoError(t, store.CreateSpec(ctx, s))
+		s.Config = map[string]string{"changed": "yes"}
+		require.NoError(t, store.UpdateSpec(ctx, s))
+		assert.Equal(t, []string{"lease-update", "lease-update"}, factory.revoked,
+			"a spec edit test-mints again, so it must release again")
+	})
+
+	t.Run("nothing to release when the mint issues no lease", func(t *testing.T) {
+		factory := &leasingDriverFactory{leaseID: ""}
+		store, ctx := setup(t, factory)
+
+		require.NoError(t, store.CreateSpec(ctx, spec("leaseless")))
+		assert.Empty(t, factory.revoked)
+	})
+}

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -18,6 +18,12 @@ import (
 const ovhMaxResponseBodySize = 1 << 20 // 1MB
 const ovhMaxRetryAttempts = 3
 
+// ovhFallbackTokenTTL bounds a token whose lifetime the endpoint declined to
+// state. The lease decides how long the bearer keeps being served from cache, so
+// a generous guess hands out a token that expired long ago, while a short one
+// costs only another mint.
+const ovhFallbackTokenTTL = 5 * time.Minute
+
 // ovhEndpoint holds the resolved API and OAuth2 token URLs for a region.
 type ovhEndpoint struct {
 	apiURL   string
@@ -285,7 +291,14 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 
 	tokenTTL := time.Duration(tokenResp.ExpiresIn) * time.Second
 	if tokenTTL <= 0 {
-		tokenTTL = 1 * time.Hour // fallback if expires_in is missing
+		// Nothing here knows how long the token is actually good for, and the
+		// credential is served from cache for the whole lease. Fall back to a span
+		// short enough that a wrong guess is corrected by a re-mint rather than by
+		// an agent presenting a dead bearer.
+		d.logger.Warn("OAuth2 token response carried no usable expires_in; bounding the lease at the fallback lifetime",
+			logger.String("fallback", ovhFallbackTokenTTL.String()),
+		)
+		tokenTTL = ovhFallbackTokenTTL
 	}
 
 	return tokenResp.AccessToken, tokenTTL, nil

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -627,7 +627,7 @@ func TestOVHDriver_MintOAuth2Token_MissingExpiresIn(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": "valid-token",
 			"token_type":   "Bearer",
-			// no expires_in — should fall back to 1h
+			// no expires_in — the lease is bounded by the fallback instead
 		})
 	}))
 	defer server.Close()
@@ -641,7 +641,11 @@ func TestOVHDriver_MintOAuth2Token_MissingExpiresIn(t *testing.T) {
 	rawData, _, ttl, _, err := driver.MintCredential(context.Background(), spec)
 	require.NoError(t, err)
 	assert.Equal(t, "valid-token", rawData["api_token"])
-	assert.Equal(t, 1*time.Hour, ttl) // fallback TTL
+	// A token of unstated lifetime is served for a short span, not an assumed
+	// hour: the credential is cached for the whole lease, so guessing long hands
+	// out a bearer that is already dead.
+	assert.Equal(t, ovhFallbackTokenTTL, ttl)
+	assert.Less(t, ttl, 1*time.Hour)
 }
 
 func TestOVHDriver_MintDynamicS3_EmptySecret(t *testing.T) {


### PR DESCRIPTION
Two ways a credential outlived what anyone was tracking.

## The test-mint abandoned a real credential on every spec write

Validating a spec test-mints it against the source, then dropped every return value but the error. That mint creates a real credential upstream, and nothing downstream ever learned of it: not cached, not registered with the expiration manager, never revoked. For a source whose credentials carry no expiry of their own, each `cred spec write` — create *or* update — left one live, fully privileged credential behind.

The fix captures the lease and releases it, deferred so it goes back whether the spec validates or verification rejects it afterwards, on a fresh context because the request's own may already be cancelled.

This is a core fix, so it repairs every driver. Grafana was the worst case: its mint creates a service account per call, so every spec write orphaned a live one.

## A token of unstated lifetime was served as good for an hour

The OVH driver invented an hour when the endpoint stated no `expires_in`. The lease decides how long that bearer keeps being served from cache, so a token really good for fifteen minutes was handed out as valid for forty-five more. Bounded at five minutes now, and logged: guessing short costs a re-mint, guessing long serves a corpse.

## Testing

`go test ./credential/... ./core/...` green. The new store tests cover release after a successful validation, release when verification fails afterwards, release again on every update, release when the mint reports a lease and then fails, and nothing to release when the mint issues none. Reverting the store change makes them fail.

Full e2e suite green (20 packages).

---

First of four stacked PRs making the OVH source keyless. The rest build on this branch.
