### PR TITLE
feat(ovh)!: serve object-storage keys from a referenced spec, and stop creating them

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1070,6 +1070,17 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 			credential.GetString(spec.Config, "mint_method", "") == "static_keys" {
 			return logical.ErrBadRequestf("a static_keys spec on a chained scaleway source (secret_spec %q) must set its own secret_spec naming a spec that yields its access_key and secret_key; the source's chained secret is a management key, not this credential", chainedRef)
 		}
+		// An access_keys spec's credential is the key pair the referenced spec
+		// yields, so the reference has to be its own. Reached by a source-level one
+		// it would be handed whatever that source authenticates with — a client
+		// credential, not this pair. (A spec that names its own is not here:
+		// chainedRef would be that one, and the type validator has already refused
+		// it any inline pair.)
+		if source.Type == credential.SourceTypeOVH &&
+			spec.Config[credential.ConfigSecretSpec] == "" &&
+			credential.GetString(spec.Config, "mint_method", "") == "access_keys" {
+			return logical.ErrBadRequestf("an access_keys spec must set its own secret_spec naming a spec that yields its access_key and secret_key; the source's chained secret (%q) is a client credential, not this pair", chainedRef)
+		}
 		// A chained consumer's identity normally flows through the referenced secret-spec,
 		// so its own subject/actor exchange config would be dead — reject that confusing
 		// combination. The token_exchange driver is the exception: it is itself an

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2433,3 +2433,69 @@ func TestCredentialConfigStore_ValidateSpec_ReleasesTestMintLease(t *testing.T) 
 		assert.Empty(t, factory.revoked)
 	})
 }
+
+// An OVH source and its specs chain at different levels, and the level is what
+// says which secret is meant. The source's reference, when it has one, describes
+// the service account it performs the grant with; an access_keys spec's reference
+// describes the object-storage pair that IS its credential. Getting that wrong
+// would serve a caller the wrong secret entirely, so the placement is enforced
+// rather than inferred.
+func TestCredentialConfigStore_OVHChaining(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	for _, name := range []string{"ovh-client-cred", "ovh-pair"} {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: name, Type: "vault_token", Source: "src",
+			Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+		}))
+	}
+
+	// A source that only ever serves access_keys specs performs no grant, so it
+	// needs no service account and no chain of its own.
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "ovh-src", Type: credential.SourceTypeOVH,
+		Config: map[string]string{"ovh_endpoint": "ovh-eu"},
+	}))
+
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "ovh-s3", Type: credential.TypeOVHKeys, Source: "ovh-src",
+		Config: map[string]string{"mint_method": "access_keys", credential.ConfigSecretSpec: "ovh-pair"},
+	}))
+
+	// The referenced spec is now load-bearing for a live spec and cannot be
+	// deleted out from under it.
+	require.ErrorIs(t, store.DeleteSpec(ctx, "ovh-pair"), ErrSpecInUse)
+
+	t.Run("an access_keys spec may not ride a source-level reference", func(t *testing.T) {
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "ovh-keyless", Type: credential.SourceTypeOVH,
+			Config: map[string]string{credential.ConfigSecretSpec: "ovh-client-cred"},
+		}))
+
+		// Inheriting the source's chain would hand this spec the client credential,
+		// which is not the pair it describes.
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ovh-s3-inheriting", Type: credential.TypeOVHKeys, Source: "ovh-keyless",
+			Config: map[string]string{"mint_method": "access_keys"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must set its own secret_spec")
+
+		// Naming its own reference is fine on the very same source.
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ovh-s3-own", Type: credential.TypeOVHKeys, Source: "ovh-keyless",
+			Config: map[string]string{"mint_method": "access_keys", credential.ConfigSecretSpec: "ovh-pair"},
+		}))
+	})
+
+	t.Run("a chained spec cannot also carry a rotation period", func(t *testing.T) {
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ovh-s3-rotating", Type: credential.TypeOVHKeys, Source: "ovh-src",
+			Config:         map[string]string{"mint_method": "access_keys", credential.ConfigSecretSpec: "ovh-pair"},
+			RotationPeriod: time.Hour,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period")
+	})
+}

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -18,43 +18,51 @@ import (
 const ovhMaxResponseBodySize = 1 << 20 // 1MB
 const ovhMaxRetryAttempts = 3
 
+// defaultOVHAccessKeysChainTTL bounds how long a served key pair stays cached
+// when the spec sets no secret_cache_ttl of its own. The pair itself does not
+// expire; this is only how often the chain is walked again to notice that the
+// referenced spec now yields a different one.
+const defaultOVHAccessKeysChainTTL = 30 * time.Minute
+
 // ovhFallbackTokenTTL bounds a token whose lifetime the endpoint declined to
 // state. The lease decides how long the bearer keeps being served from cache, so
 // a generous guess hands out a token that expired long ago, while a short one
 // costs only another mint.
 const ovhFallbackTokenTTL = 5 * time.Minute
 
-// ovhEndpoint holds the resolved API and OAuth2 token URLs for a region.
-type ovhEndpoint struct {
-	apiURL   string
-	tokenURL string
-}
-
-// ovhEndpoints maps endpoint names to their API and token URLs.
-var ovhEndpoints = map[string]ovhEndpoint{
-	"ovh-eu": {apiURL: "https://eu.api.ovh.com/1.0", tokenURL: "https://www.ovh.com/auth/oauth2/token"},
-	"ovh-ca": {apiURL: "https://ca.api.ovh.com/1.0", tokenURL: "https://ca.ovh.com/auth/oauth2/token"},
-	"ovh-us": {apiURL: "https://api.us.ovhcloud.com/1.0", tokenURL: "https://us.ovhcloud.com/auth/oauth2/token"},
+// ovhEndpoints maps a regional endpoint name to the OAuth2 token URL it stands
+// for. The regional API base URL used to live here too; nothing asks the OVH API
+// for anything any more, so the region now selects only where the grant is made.
+var ovhEndpoints = map[string]string{
+	"ovh-eu": "https://www.ovh.com/auth/oauth2/token",
+	"ovh-ca": "https://ca.ovh.com/auth/oauth2/token",
+	"ovh-us": "https://us.ovhcloud.com/auth/oauth2/token",
 }
 
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*OVHDriver)(nil)
 var _ credential.SpecVerifier = (*OVHDriver)(nil)
+var _ credential.ChainedSecretMinter = (*OVHDriver)(nil)
 
-// OVHDriver mints credentials from OVHcloud APIs.
+// OVHDriver mints credentials for OVHcloud APIs.
 //
-// Two mint methods are supported (configured per-spec via mint_method):
-//   - oauth2_token: Mints a bearer token via OAuth2 client_credentials grant (~1h TTL)
-//   - dynamic_s3: Creates S3 credentials via the OVH cloud API (static, revocable)
-//   - oauth2_token_and_s3: Mints both a bearer token and S3 credentials
+// Two mint methods are supported, configured per-spec via mint_method:
+//   - oauth2_token: a bearer token from the OAuth2 client_credentials grant,
+//     using the service account in the source config.
+//   - access_keys: the object-storage key pair a referenced spec yields. The
+//     spec names that reference itself; the pair reaches this driver as fetched
+//     secret material and no request is made to OVH at all.
 //
-// The source config holds an OAuth2 service account (client_id + client_secret)
-// and optionally default project_id + user_id for S3 credential management.
+// This driver creates nothing upstream and hands out no leases. Object-storage
+// keys have no expiry of their own, so a credential that created one would have
+// to be deleted again to be safe — and the only moment revocation runs, lease
+// expiry, has neither a caller to fetch a secret as nor a stored one to use.
+// Serving a pair that already exists sidesteps that entirely: there is nothing
+// to revoke because nothing was created.
 type OVHDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
 	httpClient *http.Client
-	apiURL     string // resolved API base URL
 	tokenURL   string // resolved OAuth2 token URL
 
 	// configMu protects credSource.Config reads during potential future rotation.
@@ -72,14 +80,17 @@ func (f *OVHDriverFactory) Type() string {
 // ValidateConfig validates OVH source configuration.
 func (f *OVHDriverFactory) ValidateConfig(config map[string]string) error {
 	return credential.ValidateSchema(config,
+		// Required for oauth2_token specs and refused nowhere else: a source
+		// serving only access_keys specs never performs the grant, so demanding a
+		// service account it will not use would be config kept for nothing. The
+		// spec-level check in VerifySpec is what actually holds an oauth2_token
+		// spec to a source that can mint for it.
 		credential.StringField("client_id").
-			Required().
-			Describe("OAuth2 service account client ID").
+			Describe("OAuth2 service account client ID (required for oauth2_token specs)").
 			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
 
 		credential.StringField("client_secret").
-			Required().
-			Describe("OAuth2 service account client secret").
+			Describe("OAuth2 service account client secret (required for oauth2_token specs)").
 			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
 		credential.StringField("ovh_endpoint").
@@ -87,23 +98,10 @@ func (f *OVHDriverFactory) ValidateConfig(config map[string]string) error {
 			Describe("OVH regional endpoint (default: ovh-eu)").
 			Example("ovh-eu"),
 
-		credential.StringField("api_url").
-			Custom(validateOVHEndpointOverride(config)).
-			Describe("Override the API base URL the endpoint would resolve to. For a private egress gateway fronting the OVH API, or a test double.").
-			Example("https://ovh-gateway.internal/1.0"),
-
 		credential.StringField("token_url").
 			Custom(validateOVHEndpointOverride(config)).
 			Describe("Override the OAuth2 token URL the endpoint would resolve to. Set it to the token endpoint of whatever issues the service account's tokens.").
 			Example("https://ovh-gateway.internal/auth/oauth2/token"),
-
-		credential.StringField("project_id").
-			Describe("Default Public Cloud project ID for S3 credential management").
-			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
-
-		credential.StringField("user_id").
-			Describe("Default Public Cloud user ID for S3 credential management").
-			Example("12345"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -116,11 +114,10 @@ func (f *OVHDriverFactory) ValidateConfig(config map[string]string) error {
 	)
 }
 
-// validateOVHEndpointOverride checks a URL an operator has substituted for one
-// of the regional defaults. The client secret is posted to token_url and the
-// bearer it returns is used against api_url, so plaintext is only permitted
-// alongside the same tls_skip_verify a caller must already have set to mean it
-// — matching how the IBM source gates iam_endpoint.
+// validateOVHEndpointOverride checks a URL an operator has substituted for the
+// regional default. The client secret is posted to token_url, so plaintext is
+// only permitted alongside the same tls_skip_verify a caller must already have
+// set to mean it — matching how the IBM source gates iam_endpoint.
 func validateOVHEndpointOverride(config map[string]string) func(string) error {
 	return func(v string) error {
 		if v == "" {
@@ -154,18 +151,14 @@ func (f *OVHDriverFactory) InferCredentialType(_ map[string]string) (string, err
 // Create instantiates a new OVHDriver.
 func (f *OVHDriverFactory) Create(config map[string]string, log *logger.GatedLogger) (credential.SourceDriver, error) {
 	endpointName := credential.GetString(config, "ovh_endpoint", "ovh-eu")
-	ep, ok := ovhEndpoints[endpointName]
+	regionTokenURL, ok := ovhEndpoints[endpointName]
 	if !ok {
 		return nil, fmt.Errorf("unknown ovh_endpoint: %s (expected ovh-eu, ovh-ca, or ovh-us)", endpointName)
 	}
 
-	// The regional endpoint is a shorthand for two URLs, and either can be
-	// pointed elsewhere: a private egress gateway fronting the OVH API, or a
-	// deployment whose service-account tokens are issued by something other
-	// than ovh.com. Overriding one leaves the other on the regional default,
-	// since the two are reached independently.
-	apiURL := credential.GetString(config, "api_url", ep.apiURL)
-	tokenURL := credential.GetString(config, "token_url", ep.tokenURL)
+	// The regional default can be pointed elsewhere: a deployment whose
+	// service-account tokens are issued by something other than ovh.com.
+	tokenURL := credential.GetString(config, "token_url", regionTokenURL)
 
 	httpClient, err := BuildHTTPClient(config, 30*time.Second)
 	if err != nil {
@@ -179,7 +172,6 @@ func (f *OVHDriverFactory) Create(config map[string]string, log *logger.GatedLog
 		},
 		logger:     log.WithSubsystem(credential.SourceTypeOVH),
 		httpClient: httpClient,
-		apiURL:     apiURL,
 		tokenURL:   tokenURL,
 	}
 
@@ -193,17 +185,80 @@ func (d *OVHDriver) Type() string {
 
 // MintCredential returns OVH credentials for the given spec.
 func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// An access_keys spec is served from fetched secret material, which arrives
+	// through MintFromSecret. Reaching here means the spec named a reference the
+	// minting layer did not route on, and there is no pair to hand back.
+	if spec.Config[credential.ConfigSecretSpec] != "" {
+		return nil, nil, 0, "", fmt.Errorf("ovh: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
+			credential.ConfigSecretSpec)
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "oauth2_token":
 		return d.mintOAuth2Token(ctx)
-	case "dynamic_s3":
-		return d.mintDynamicS3(ctx, spec)
-	case "oauth2_token_and_s3":
-		return d.mintOAuth2TokenAndS3(ctx, spec)
+	case "access_keys":
+		return nil, nil, 0, "", fmt.Errorf("ovh: an access_keys spec must set %s naming a spec that yields its access_key and secret_key; the pair is served from that material, never minted here",
+			credential.ConfigSecretSpec)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected oauth2_token, dynamic_s3, or oauth2_token_and_s3)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method: %s (expected oauth2_token or access_keys)", mintMethod)
 	}
+}
+
+// MintFromSecret serves the object-storage key pair the referenced spec yielded.
+//
+// It makes no request: the pair already exists, so there is nothing to create and
+// nothing to revoke. That is the whole reason this method exists in place of one
+// that asks OVH for a fresh pair — see the type comment.
+func (d *OVHDriver) MintFromSecret(_ context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	if mintMethod != "access_keys" {
+		return nil, nil, 0, "", fmt.Errorf("ovh: credential chaining supports mint_method=access_keys only, got %q", mintMethod)
+	}
+
+	// The spec must name the reference itself. A source-level one would describe
+	// whatever that source authenticates with, not this credential.
+	//
+	// Spec create refuses that combination, but a source converted to chaining
+	// afterwards is not re-validated against the specs already bound to it, so this
+	// is the guard that actually holds.
+	if spec.Config[credential.ConfigSecretSpec] == "" {
+		return nil, nil, 0, "", fmt.Errorf("ovh: an access_keys spec must set its own %s naming a spec that yields its access_key and secret_key",
+			credential.ConfigSecretSpec)
+	}
+
+	// Both halves are read by name. secret_field selects a single secret and a pair
+	// is not one, so the spec is refused that field at create and there is nothing
+	// here for a resolved field to mean.
+	accessKey := material.Data["access_key"]
+	secretKey := material.Data["secret_key"]
+	if accessKey == "" || secretKey == "" {
+		return nil, nil, 0, "", fmt.Errorf("ovh: fetched secret material must hold both 'access_key' and 'secret_key' for access_keys: %w",
+			credential.ErrChainedSecretIncomplete)
+	}
+
+	// The TTL is advisory. Nothing about this mint can discover that the pair was
+	// rotated upstream — it makes no request, so it never sees a rejection — and a
+	// zero TTL would pin the credential in cache for the caller's whole session.
+	// With no lease id the credential is not revocable, so this only forces the
+	// chain to be walked again.
+	ttl := credential.GetDuration(spec.Config, credential.ConfigSecretCacheTTL, 0)
+	if ttl <= 0 {
+		ttl = defaultOVHAccessKeysChainTTL
+	}
+
+	d.logger.Info("served OVH access keys from fetched secret material",
+		logger.String("access_key", truncateID(accessKey, 8)),
+		logger.String("spec", spec.Name),
+		logger.String("ttl", ttl.String()),
+	)
+
+	rawData := map[string]interface{}{
+		"access_key": accessKey,
+		"secret_key": secretKey,
+	}
+
+	return rawData, nil, ttl, "", nil
 }
 
 // getClientCredentials reads client_id and client_secret from source config under RLock.
@@ -213,31 +268,6 @@ func (d *OVHDriver) getClientCredentials() (clientID, clientSecret string) {
 	clientID = credential.GetString(d.credSource.Config, "client_id", "")
 	clientSecret = credential.GetString(d.credSource.Config, "client_secret", "")
 	return
-}
-
-// resolveProjectAndUser resolves project_id and user_id from spec config, falling back to source config.
-func (d *OVHDriver) resolveProjectAndUser(spec *credential.CredSpec) (projectID, userID string, err error) {
-	projectID = credential.GetString(spec.Config, "project_id", "")
-	if projectID == "" {
-		d.configMu.RLock()
-		projectID = credential.GetString(d.credSource.Config, "project_id", "")
-		d.configMu.RUnlock()
-	}
-	if projectID == "" {
-		return "", "", fmt.Errorf("project_id is required for S3 credential management (set on source or spec)")
-	}
-
-	userID = credential.GetString(spec.Config, "user_id", "")
-	if userID == "" {
-		d.configMu.RLock()
-		userID = credential.GetString(d.credSource.Config, "user_id", "")
-		d.configMu.RUnlock()
-	}
-	if userID == "" {
-		return "", "", fmt.Errorf("user_id is required for S3 credential management (set on source or spec)")
-	}
-
-	return projectID, userID, nil
 }
 
 // fetchOAuth2Token performs the OAuth2 client_credentials exchange and returns the access token and TTL.
@@ -322,174 +352,17 @@ func (d *OVHDriver) mintOAuth2Token(ctx context.Context) (map[string]interface{}
 	return rawData, nil, ttl, "", nil // No leaseID — token expires naturally
 }
 
-// s3CredentialResult holds the result of an S3 credential creation call.
-type s3CredentialResult struct {
-	accessKey string
-	secretKey string
-	leaseID   string // projectId/userId/accessKeyId — used for revocation
-}
-
-// createS3Credentials creates S3 credentials via the OVH cloud API.
-// The token must be a valid OAuth2 bearer token for API auth.
-func (d *OVHDriver) createS3Credentials(ctx context.Context, token, projectID, userID string) (*s3CredentialResult, error) {
-	apiURL := fmt.Sprintf("%s/cloud/project/%s/user/%s/s3Credentials", d.apiURL, projectID, userID)
-
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       ovhMaxRetryAttempts,
-		MaxBodySize:       ovhMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
+// Revoke is a no-op: no mint method here issues a lease.
+//
+// A bearer token expires on its own, and an access_keys pair was never created by
+// this driver — it belongs to whoever owns the referenced spec, and deleting it
+// would revoke a credential this source only borrowed. So there is never a handle
+// to release, and the credential type marks these non-revocable.
+func (d *OVHDriver) Revoke(_ context.Context, leaseID string) error {
+	if leaseID != "" {
+		d.logger.Debug("ignoring revocation for an OVH lease this driver no longer issues",
+			logger.String("lease_id", leaseID))
 	}
-
-	httpReq := httputil.HTTPRequest{
-		Method: http.MethodPost,
-		URL:    apiURL,
-		Headers: map[string]string{
-			"Authorization": "Bearer " + token,
-			"Content-Type":  "application/json",
-			"Accept":        "application/json",
-		},
-	}
-
-	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OVH S3 credentials: %w", err)
-	}
-
-	var s3Resp struct {
-		Access string `json:"access"`
-		Secret string `json:"secret"`
-	}
-	if err := json.Unmarshal(respBody, &s3Resp); err != nil {
-		return nil, fmt.Errorf("failed to parse S3 credentials response: %w", err)
-	}
-
-	if s3Resp.Access == "" || s3Resp.Secret == "" {
-		return nil, fmt.Errorf("OVH API returned empty S3 access or secret key")
-	}
-
-	return &s3CredentialResult{
-		accessKey: s3Resp.Access,
-		secretKey: s3Resp.Secret,
-		leaseID:   fmt.Sprintf("%s/%s/%s", projectID, userID, s3Resp.Access),
-	}, nil
-}
-
-// mintDynamicS3 creates S3 credentials via the OVH cloud API.
-// The TTL is derived from the OAuth2 token used for API auth — S3 keys are
-// revoked and re-created when the credential lease expires (~1h).
-func (d *OVHDriver) mintDynamicS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	token, tokenTTL, err := d.fetchOAuth2Token(ctx)
-	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to get OAuth2 token for S3 credential creation: %w", err)
-	}
-
-	projectID, userID, err := d.resolveProjectAndUser(spec)
-	if err != nil {
-		return nil, nil, 0, "", err
-	}
-
-	s3, err := d.createS3Credentials(ctx, token, projectID, userID)
-	if err != nil {
-		return nil, nil, 0, "", err
-	}
-
-	d.logger.Info("created dynamic OVH S3 credentials",
-		logger.String("access_key", truncateID(s3.accessKey, 8)),
-		logger.String("spec", spec.Name),
-		logger.String("ttl", tokenTTL.String()),
-	)
-
-	rawData := map[string]interface{}{
-		"access_key": s3.accessKey,
-		"secret_key": s3.secretKey,
-	}
-
-	return rawData, nil, tokenTTL, s3.leaseID, nil
-}
-
-// mintOAuth2TokenAndS3 mints both a bearer token and S3 credentials.
-func (d *OVHDriver) mintOAuth2TokenAndS3(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	token, tokenTTL, err := d.fetchOAuth2Token(ctx)
-	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to mint OAuth2 token for dual-mode credential: %w", err)
-	}
-
-	projectID, userID, err := d.resolveProjectAndUser(spec)
-	if err != nil {
-		return nil, nil, 0, "", err
-	}
-
-	s3, err := d.createS3Credentials(ctx, token, projectID, userID)
-	if err != nil {
-		return nil, nil, 0, "", err
-	}
-
-	d.logger.Info("minted OVH dual-mode credentials (OAuth2 token + S3)",
-		logger.String("access_key", truncateID(s3.accessKey, 8)),
-		logger.String("token_ttl", tokenTTL.String()),
-		logger.String("spec", spec.Name),
-	)
-
-	rawData := map[string]interface{}{
-		"api_token":  token,
-		"access_key": s3.accessKey,
-		"secret_key": s3.secretKey,
-	}
-
-	// TTL = token TTL (shorter-lived governs refresh; S3 keys are revoked on refresh)
-	return rawData, nil, tokenTTL, s3.leaseID, nil
-}
-
-// Revoke deletes dynamically created S3 credentials.
-// The leaseID format is: projectId/userId/accessKeyId
-func (d *OVHDriver) Revoke(ctx context.Context, leaseID string) error {
-	if leaseID == "" {
-		return nil
-	}
-
-	parts := strings.SplitN(leaseID, "/", 3)
-	if len(parts) != 3 {
-		return fmt.Errorf("invalid OVH lease ID format: %s (expected projectId/userId/accessKeyId)", leaseID)
-	}
-	projectID, userID, accessKeyID := parts[0], parts[1], parts[2]
-
-	// Mint a fresh token for API auth
-	token, _, err := d.fetchOAuth2Token(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get OAuth2 token for S3 credential revocation: %w", err)
-	}
-
-	apiURL := fmt.Sprintf("%s/cloud/project/%s/user/%s/s3Credentials/%s", d.apiURL, projectID, userID, accessKeyID)
-
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       ovhMaxRetryAttempts,
-		MaxBodySize:       ovhMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500, 503},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
-
-	httpReq := httputil.HTTPRequest{
-		Method: http.MethodDelete,
-		URL:    apiURL,
-		Headers: map[string]string{
-			"Authorization": "Bearer " + token,
-			"Accept":        "application/json",
-		},
-		OKStatuses: []int{http.StatusNoContent, http.StatusOK, http.StatusNotFound},
-	}
-
-	_, _, err = httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
-	if err != nil {
-		return fmt.Errorf("failed to revoke OVH S3 credentials %s: %w", accessKeyID, err)
-	}
-
-	d.logger.Info("revoked OVH S3 credentials",
-		logger.String("access_key", truncateID(accessKeyID, 8)),
-	)
-
 	return nil
 }
 
@@ -505,12 +378,22 @@ func (d *OVHDriver) VerifySpec(_ context.Context, spec *credential.CredSpec) err
 
 	switch mintMethod {
 	case "oauth2_token":
-		// No extra config needed — uses source's client_id/secret
+		// The grant runs with the source's service account, which the source
+		// schema no longer demands — a source serving only access_keys specs has
+		// no use for one. This is where that requirement actually lands.
+		clientID, clientSecret := d.getClientCredentials()
+		if clientID == "" || clientSecret == "" {
+			return fmt.Errorf("an oauth2_token spec needs client_id and client_secret on its source")
+		}
 		return nil
-	case "dynamic_s3", "oauth2_token_and_s3":
-		_, _, err := d.resolveProjectAndUser(spec)
-		return err
+	case "access_keys":
+		// Reached only if the spec named no reference; a chained spec skips
+		// verification entirely. Without one there is no pair to serve.
+		if spec.Config[credential.ConfigSecretSpec] == "" {
+			return fmt.Errorf("an access_keys spec must set %s naming a spec that yields its access_key and secret_key", credential.ConfigSecretSpec)
+		}
+		return nil
 	default:
-		return fmt.Errorf("unsupported mint_method: %s (expected oauth2_token, dynamic_s3, or oauth2_token_and_s3)", mintMethod)
+		return fmt.Errorf("unsupported mint_method: %s (expected oauth2_token or access_keys)", mintMethod)
 	}
 }

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -29,7 +29,7 @@ func createOVHTestLogger() *logger.GatedLogger {
 }
 
 // createOVHTestDriver creates an OVHDriver pointing at a test server.
-// The driver's apiURL and tokenURL are overridden to point at the test server.
+// The driver's tokenURL is overridden to point at the test server.
 func createOVHTestDriver(t *testing.T, serverURL string, extraConfig map[string]string) *OVHDriver {
 	t.Helper()
 
@@ -55,7 +55,6 @@ func createOVHTestDriver(t *testing.T, serverURL string, extraConfig map[string]
 		},
 		logger:     log.WithSubsystem(credential.SourceTypeOVH),
 		httpClient: httpClient,
-		apiURL:     serverURL,
 		tokenURL:   serverURL + "/auth/oauth2/token",
 	}
 
@@ -88,30 +87,11 @@ func TestOVHDriverFactory_ValidateConfig(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("valid config with S3 fields", func(t *testing.T) {
-		err := f.ValidateConfig(map[string]string{
-			"client_id":     "test-id",
-			"client_secret": "test-secret",
-			"project_id":    "proj-123",
-			"user_id":       "user-456",
-		})
-		assert.NoError(t, err)
-	})
-
-	t.Run("missing client_id", func(t *testing.T) {
-		err := f.ValidateConfig(map[string]string{
-			"client_secret": "test-secret",
-		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "client_id")
-	})
-
-	t.Run("missing client_secret", func(t *testing.T) {
-		err := f.ValidateConfig(map[string]string{
-			"client_id": "test-id",
-		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "client_secret")
+	// A source serving only access_keys specs never performs the grant, so the
+	// service account is not demanded here. VerifySpec is what refuses an
+	// oauth2_token spec on a source that has none.
+	t.Run("a source with no service account is accepted", func(t *testing.T) {
+		assert.NoError(t, f.ValidateConfig(map[string]string{"ovh_endpoint": "ovh-eu"}))
 	})
 
 	t.Run("invalid endpoint", func(t *testing.T) {
@@ -152,9 +132,7 @@ func TestOVHDriverFactory_Create(t *testing.T) {
 			"client_secret": "test-secret",
 		}, log)
 		require.NoError(t, err)
-		ovhDriver := driver.(*OVHDriver)
-		assert.Equal(t, "https://eu.api.ovh.com/1.0", ovhDriver.apiURL)
-		assert.Equal(t, "https://www.ovh.com/auth/oauth2/token", ovhDriver.tokenURL)
+		assert.Equal(t, "https://www.ovh.com/auth/oauth2/token", driver.(*OVHDriver).tokenURL)
 	})
 
 	t.Run("ovh-us endpoint", func(t *testing.T) {
@@ -164,9 +142,7 @@ func TestOVHDriverFactory_Create(t *testing.T) {
 			"ovh_endpoint":  "ovh-us",
 		}, log)
 		require.NoError(t, err)
-		ovhDriver := driver.(*OVHDriver)
-		assert.Equal(t, "https://api.us.ovhcloud.com/1.0", ovhDriver.apiURL)
-		assert.Equal(t, "https://us.ovhcloud.com/auth/oauth2/token", ovhDriver.tokenURL)
+		assert.Equal(t, "https://us.ovhcloud.com/auth/oauth2/token", driver.(*OVHDriver).tokenURL)
 	})
 
 	t.Run("unknown endpoint", func(t *testing.T) {
@@ -179,45 +155,28 @@ func TestOVHDriverFactory_Create(t *testing.T) {
 		assert.Contains(t, err.Error(), "unknown ovh_endpoint")
 	})
 
-	// The regional endpoint is shorthand for two URLs reached independently, so
-	// overriding one must leave the other on its regional default — a source
-	// whose tokens come from elsewhere still talks to the regional API.
-	t.Run("token_url override leaves api_url regional", func(t *testing.T) {
+	// The grant is the only request this driver makes, so a deployment whose
+	// service-account tokens come from somewhere other than ovh.com points
+	// token_url there and the region stops mattering.
+	t.Run("token_url override replaces the regional default", func(t *testing.T) {
 		driver, err := f.Create(map[string]string{
 			"client_id":     "test-id",
 			"client_secret": "test-secret",
 			"token_url":     "https://issuer.internal/oauth2/token",
 		}, log)
 		require.NoError(t, err)
-		ovhDriver := driver.(*OVHDriver)
-		assert.Equal(t, "https://issuer.internal/oauth2/token", ovhDriver.tokenURL)
-		assert.Equal(t, "https://eu.api.ovh.com/1.0", ovhDriver.apiURL)
+		assert.Equal(t, "https://issuer.internal/oauth2/token", driver.(*OVHDriver).tokenURL)
 	})
 
-	t.Run("api_url override leaves token_url regional", func(t *testing.T) {
-		driver, err := f.Create(map[string]string{
-			"client_id":     "test-id",
-			"client_secret": "test-secret",
-			"api_url":       "https://egress.internal/1.0",
-		}, log)
-		require.NoError(t, err)
-		ovhDriver := driver.(*OVHDriver)
-		assert.Equal(t, "https://egress.internal/1.0", ovhDriver.apiURL)
-		assert.Equal(t, "https://www.ovh.com/auth/oauth2/token", ovhDriver.tokenURL)
-	})
-
-	t.Run("overrides compose with a non-default endpoint", func(t *testing.T) {
+	t.Run("an override wins over a non-default endpoint", func(t *testing.T) {
 		driver, err := f.Create(map[string]string{
 			"client_id":     "test-id",
 			"client_secret": "test-secret",
 			"ovh_endpoint":  "ovh-us",
-			"api_url":       "https://egress.internal/1.0",
 			"token_url":     "https://issuer.internal/oauth2/token",
 		}, log)
 		require.NoError(t, err)
-		ovhDriver := driver.(*OVHDriver)
-		assert.Equal(t, "https://egress.internal/1.0", ovhDriver.apiURL)
-		assert.Equal(t, "https://issuer.internal/oauth2/token", ovhDriver.tokenURL)
+		assert.Equal(t, "https://issuer.internal/oauth2/token", driver.(*OVHDriver).tokenURL)
 	})
 }
 
@@ -286,194 +245,7 @@ func TestOVHDriver_MintOAuth2Token_EmptyResponse(t *testing.T) {
 
 // --- Dynamic S3 credential tests ---
 
-func TestOVHDriver_MintDynamicS3(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "temp-token",
-				"token_type":   "Bearer",
-				"expires_in":   3599,
-			})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/proj-123/user/user-456/s3Credentials":
-			assert.Equal(t, "Bearer temp-token", r.Header.Get("Authorization"))
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access": "s3-access-key-123",
-				"secret": "s3-secret-key-456",
-			})
-
-		default:
-			http.Error(w, "not found", http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "user-456",
-	})
-
-	spec := &credential.CredSpec{
-		Name: "s3-spec",
-		Config: map[string]string{
-			"mint_method": "dynamic_s3",
-		},
-	}
-
-	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
-	require.NoError(t, err)
-	assert.Equal(t, "s3-access-key-123", rawData["access_key"])
-	assert.Equal(t, "s3-secret-key-456", rawData["secret_key"])
-	assert.Equal(t, 3599*time.Second, ttl) // TTL from OAuth2 token
-	assert.Equal(t, "proj-123/user-456/s3-access-key-123", leaseID)
-}
-
-func TestOVHDriver_MintDynamicS3_SpecOverridesSource(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "temp-token",
-				"token_type":   "Bearer",
-				"expires_in":   3599,
-			})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/spec-proj/user/spec-user/s3Credentials":
-			// Spec-level project_id and user_id should be used
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access": "s3-key",
-				"secret": "s3-secret",
-			})
-
-		default:
-			http.Error(w, "unexpected: "+r.URL.Path, http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "source-proj",
-		"user_id":    "source-user",
-	})
-
-	spec := &credential.CredSpec{
-		Name: "s3-spec",
-		Config: map[string]string{
-			"mint_method": "dynamic_s3",
-			"project_id":  "spec-proj",
-			"user_id":     "spec-user",
-		},
-	}
-
-	rawData, _, _, leaseID, err := driver.MintCredential(context.Background(), spec)
-	require.NoError(t, err)
-	assert.Equal(t, "s3-key", rawData["access_key"])
-	assert.Equal(t, "spec-proj/spec-user/s3-key", leaseID)
-}
-
-func TestOVHDriver_MintDynamicS3_MissingProjectID(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token": "temp-token",
-			"expires_in":   3599,
-		})
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, nil) // No project_id on source
-
-	spec := &credential.CredSpec{
-		Name: "s3-spec",
-		Config: map[string]string{
-			"mint_method": "dynamic_s3",
-			// No project_id on spec either
-			"user_id": "user-123",
-		},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "project_id")
-}
-
-func TestOVHDriver_MintDynamicS3_MissingUserID(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token": "temp-token",
-			"expires_in":   3599,
-		})
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-	})
-
-	spec := &credential.CredSpec{
-		Name: "s3-spec",
-		Config: map[string]string{
-			"mint_method": "dynamic_s3",
-		},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "user_id")
-}
-
 // --- Dual mode (oauth2_token_and_s3) tests ---
-
-func TestOVHDriver_MintOAuth2TokenAndS3(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "dual-token",
-				"token_type":   "Bearer",
-				"expires_in":   3599,
-			})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/proj-123/user/user-456/s3Credentials":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access": "dual-s3-key",
-				"secret": "dual-s3-secret",
-			})
-
-		default:
-			http.Error(w, "not found", http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "user-456",
-	})
-
-	spec := &credential.CredSpec{
-		Name: "dual-spec",
-		Config: map[string]string{
-			"mint_method": "oauth2_token_and_s3",
-		},
-	}
-
-	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
-	require.NoError(t, err)
-	assert.Equal(t, "dual-token", rawData["api_token"])
-	assert.Equal(t, "dual-s3-key", rawData["access_key"])
-	assert.Equal(t, "dual-s3-secret", rawData["secret_key"])
-	assert.Equal(t, 3599*time.Second, ttl) // Token TTL governs refresh
-	assert.Equal(t, "proj-123/user-456/dual-s3-key", leaseID)
-}
 
 // --- Unsupported mint method ---
 
@@ -494,61 +266,32 @@ func TestOVHDriver_MintCredential_UnsupportedMethod(t *testing.T) {
 
 // --- Revoke tests ---
 
-func TestOVHDriver_Revoke(t *testing.T) {
-	var deletedPath string
-	tokenCalled := false
-
+// No mint method issues a lease any more, so revocation has nothing to release.
+// A lease id from before that change is ignored rather than erroring: erroring
+// would only send the expiration manager into a retry ladder for a request that
+// can never succeed.
+func TestOVHDriver_Revoke_IsNoOp(t *testing.T) {
+	calls := 0
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
-			tokenCalled = true
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "revoke-token",
-				"expires_in":   3599,
-			})
-
-		case r.Method == http.MethodDelete:
-			assert.Equal(t, "Bearer revoke-token", r.Header.Get("Authorization"))
-			deletedPath = r.URL.Path
-			w.WriteHeader(http.StatusNoContent)
-
-		default:
-			http.Error(w, "not found", http.StatusNotFound)
-		}
+		calls++
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	driver := createOVHTestDriver(t, server.URL, nil)
 
-	err := driver.Revoke(context.Background(), "proj-123/user-456/s3-key-789")
-	require.NoError(t, err)
-	assert.True(t, tokenCalled)
-	assert.Equal(t, "/cloud/project/proj-123/user/user-456/s3Credentials/s3-key-789", deletedPath)
-}
-
-func TestOVHDriver_Revoke_EmptyLeaseID(t *testing.T) {
-	driver := createOVHTestDriver(t, "https://unused", nil)
-	err := driver.Revoke(context.Background(), "")
-	assert.NoError(t, err)
-}
-
-func TestOVHDriver_Revoke_InvalidLeaseID(t *testing.T) {
-	driver := createOVHTestDriver(t, "https://unused", nil)
-	err := driver.Revoke(context.Background(), "invalid-format")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid OVH lease ID format")
+	for _, leaseID := range []string{"", "proj-123/user-456/s3-key-789", "not-a-lease-shape"} {
+		assert.NoError(t, driver.Revoke(context.Background(), leaseID), "leaseID %q", leaseID)
+	}
+	assert.Zero(t, calls, "revocation must not reach the network")
 }
 
 // --- VerifySpec tests ---
 
 func TestOVHDriver_VerifySpec(t *testing.T) {
-	driver := createOVHTestDriver(t, "https://unused", map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "user-456",
-	})
+	driver := createOVHTestDriver(t, "https://unused", nil)
 
-	t.Run("oauth2_token - no extra config needed", func(t *testing.T) {
+	t.Run("oauth2_token - the source's service account suffices", func(t *testing.T) {
 		err := driver.VerifySpec(context.Background(), &credential.CredSpec{
 			Name:   "api-spec",
 			Config: map[string]string{"mint_method": "oauth2_token"},
@@ -556,22 +299,28 @@ func TestOVHDriver_VerifySpec(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("dynamic_s3 - source has project_id and user_id", func(t *testing.T) {
-		err := driver.VerifySpec(context.Background(), &credential.CredSpec{
-			Name:   "s3-spec",
-			Config: map[string]string{"mint_method": "dynamic_s3"},
+	// The source schema no longer demands a service account, so this is where an
+	// oauth2_token spec on a source without one is caught.
+	t.Run("oauth2_token - refused on a source with no service account", func(t *testing.T) {
+		bare := createOVHTestDriver(t, "https://unused", map[string]string{
+			"client_id":     "",
+			"client_secret": "",
 		})
-		assert.NoError(t, err)
-	})
-
-	t.Run("dynamic_s3 - missing project_id", func(t *testing.T) {
-		driverNoProject := createOVHTestDriver(t, "https://unused", nil)
-		err := driverNoProject.VerifySpec(context.Background(), &credential.CredSpec{
-			Name:   "s3-spec",
-			Config: map[string]string{"mint_method": "dynamic_s3"},
+		err := bare.VerifySpec(context.Background(), &credential.CredSpec{
+			Name:   "api-spec",
+			Config: map[string]string{"mint_method": "oauth2_token"},
 		})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "project_id")
+		assert.Contains(t, err.Error(), "client_id and client_secret")
+	})
+
+	t.Run("access_keys - refused without a reference to serve", func(t *testing.T) {
+		err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+			Name:   "s3-spec",
+			Config: map[string]string{"mint_method": "access_keys"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
 	})
 
 	t.Run("unsupported mint_method", func(t *testing.T) {
@@ -648,147 +397,126 @@ func TestOVHDriver_MintOAuth2Token_MissingExpiresIn(t *testing.T) {
 	assert.Less(t, ttl, 1*time.Hour)
 }
 
-func TestOVHDriver_MintDynamicS3_EmptySecret(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/auth/oauth2/token":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "temp-token",
-				"expires_in":   3599,
-			})
-		default:
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access": "s3-key",
-				"secret": "", // empty secret
-			})
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "user-456",
-	})
-
-	spec := &credential.CredSpec{
-		Name:   "s3-spec",
-		Config: map[string]string{"mint_method": "dynamic_s3"},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty S3 access or secret key")
-}
-
-func TestOVHDriver_MintDynamicS3_APIError(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/auth/oauth2/token":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "temp-token",
-				"expires_in":   3599,
-			})
-		default:
-			http.Error(w, `{"message":"User not found"}`, http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "bad-user",
-	})
-
-	spec := &credential.CredSpec{
-		Name:   "s3-spec",
-		Config: map[string]string{"mint_method": "dynamic_s3"},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create OVH S3 credentials")
-}
-
-func TestOVHDriver_MintOAuth2TokenAndS3_CallCount(t *testing.T) {
-	var tokenCalls, s3Calls int
-
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/auth/oauth2/token":
-			tokenCalls++
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "counted-token",
-				"expires_in":   3599,
-			})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/cloud/project/proj-123/user/user-456/s3Credentials":
-			s3Calls++
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access": "counted-key",
-				"secret": "counted-secret",
-			})
-
-		default:
-			http.Error(w, "unexpected", http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "user-456",
-	})
-
-	spec := &credential.CredSpec{
-		Name:   "dual-spec",
-		Config: map[string]string{"mint_method": "oauth2_token_and_s3"},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.NoError(t, err)
-	assert.Equal(t, 1, tokenCalls, "should make exactly 1 token call")
-	assert.Equal(t, 1, s3Calls, "should make exactly 1 S3 credential call")
-}
-
-func TestOVHDriver_MintOAuth2TokenAndS3_S3APIError(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/auth/oauth2/token":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token": "good-token",
-				"expires_in":   3599,
-			})
-		default:
-			http.Error(w, `{"message":"Forbidden"}`, http.StatusForbidden)
-		}
-	}))
-	defer server.Close()
-
-	driver := createOVHTestDriver(t, server.URL, map[string]string{
-		"project_id": "proj-123",
-		"user_id":    "user-456",
-	})
-
-	spec := &credential.CredSpec{
-		Name:   "dual-spec",
-		Config: map[string]string{"mint_method": "oauth2_token_and_s3"},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create OVH S3 credentials")
-}
-
 // --- Cleanup test ---
 
 func TestOVHDriver_Cleanup(t *testing.T) {
 	driver := createOVHTestDriver(t, "https://unused", nil)
 	err := driver.Cleanup(context.Background())
 	assert.NoError(t, err)
+}
+
+// --- access_keys (chained) tests ---
+
+func ovhAccessKeysSpec(secretSpec string) *credential.CredSpec {
+	cfg := map[string]string{"mint_method": "access_keys"}
+	if secretSpec != "" {
+		cfg[credential.ConfigSecretSpec] = secretSpec
+	}
+	return &credential.CredSpec{Name: "s3-spec", Config: cfg}
+}
+
+// The pair is served straight from the fetched material. The point of the method
+// is that OVH is never asked for anything, so the test fails if any request is
+// made — the driver is pointed at a server that would record one.
+func TestOVHDriver_MintFromSecret_AccessKeys(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+	material := credential.SecretMaterial{Data: map[string]string{
+		"access_key": "held-access",
+		"secret_key": "held-secret",
+	}}
+
+	rawData, _, ttl, leaseID, err := driver.MintFromSecret(context.Background(), ovhAccessKeysSpec("ovh-pair"), material)
+	require.NoError(t, err)
+	assert.Equal(t, "held-access", rawData["access_key"])
+	assert.Equal(t, "held-secret", rawData["secret_key"])
+	assert.Zero(t, calls, "serving a pair that already exists must make no request")
+
+	// No lease: nothing was created here, so there is no handle to release and
+	// nothing for the expiration manager to try to revoke.
+	assert.Empty(t, leaseID)
+	assert.Equal(t, defaultOVHAccessKeysChainTTL, ttl)
+
+	t.Run("the spec's secret_cache_ttl bounds how long the pair is reused", func(t *testing.T) {
+		spec := ovhAccessKeysSpec("ovh-pair")
+		spec.Config[credential.ConfigSecretCacheTTL] = "2m"
+		_, _, ttl, _, err := driver.MintFromSecret(context.Background(), spec, material)
+		require.NoError(t, err)
+		assert.Equal(t, 2*time.Minute, ttl)
+	})
+}
+
+// A source-level reference describes whatever that source authenticates with, not
+// this credential. Spec create refuses the combination, but converting a source
+// afterwards does not re-validate the specs already bound to it — so this guard
+// is the one that actually holds.
+func TestOVHDriver_MintFromSecret_RequiresOwnSecretSpec(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), ovhAccessKeysSpec(""), credential.SecretMaterial{
+		Data: map[string]string{"access_key": "a", "secret_key": "b"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+}
+
+func TestOVHDriver_MintFromSecret_IncompletePair(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+
+	for name, data := range map[string]map[string]string{
+		"no secret_key": {"access_key": "a"},
+		"no access_key": {"secret_key": "b"},
+		"neither":       {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, _, _, err := driver.MintFromSecret(context.Background(), ovhAccessKeysSpec("ovh-pair"),
+				credential.SecretMaterial{Data: data})
+			require.Error(t, err)
+			// The sentinel is what lets the minting layer evict a cached copy and
+			// fetch again, rather than serving half a credential.
+			assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		})
+	}
+}
+
+func TestOVHDriver_MintFromSecret_RefusesOtherMintMethods(t *testing.T) {
+	driver := createOVHTestDriver(t, "https://unused", nil)
+
+	spec := &credential.CredSpec{Name: "api-spec", Config: map[string]string{
+		"mint_method":               "oauth2_token",
+		credential.ConfigSecretSpec: "ovh-pair",
+	}}
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+		Data: map[string]string{"access_key": "a", "secret_key": "b"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access_keys")
+}
+
+// Routing is the minting layer's job; if a chained spec ever reaches the direct
+// path the driver must refuse rather than mint something else.
+func TestOVHDriver_MintCredential_FailsClosedForAccessKeys(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := createOVHTestDriver(t, server.URL, nil)
+
+	for _, spec := range []*credential.CredSpec{
+		ovhAccessKeysSpec("ovh-pair"),
+		ovhAccessKeysSpec(""),
+	} {
+		_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+		require.Error(t, err)
+	}
+	assert.Zero(t, calls)
 }

--- a/credential/types/ovh_keys.go
+++ b/credential/types/ovh_keys.go
@@ -28,18 +28,9 @@ func (t *OVHKeysCredType) Metadata() credential.TypeMetadata {
 func (t *OVHKeysCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("mint_method").
-			OneOf("oauth2_token", "dynamic_s3", "oauth2_token_and_s3").
+			OneOf("oauth2_token", "access_keys").
 			Describe("Mint method for credential minting").
 			Example("oauth2_token"),
-
-		// Per-spec overrides for S3 user targeting
-		credential.StringField("project_id").
-			Describe("Public Cloud project ID (overrides source default, required for dynamic_s3/oauth2_token_and_s3)").
-			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
-
-		credential.StringField("user_id").
-			Describe("Public Cloud user ID (overrides source default, required for dynamic_s3/oauth2_token_and_s3)").
-			Example("12345"),
 	}
 }
 
@@ -56,10 +47,37 @@ func (t *OVHKeysCredType) ValidateConfig(config map[string]string, sourceType st
 
 	mintMethod := config["mint_method"]
 	switch mintMethod {
-	case "oauth2_token", "dynamic_s3", "oauth2_token_and_s3":
-		// Valid — driver handles the rest
+	case "oauth2_token":
+		// The grant runs with the source's service account, so a reference parked
+		// here would describe a secret this spec never spends — and would slip past
+		// the source-level checks that gate which sources may chain at all.
+		if config[credential.ConfigSecretSpec] != "" {
+			return fmt.Errorf("for an oauth2_token spec, '%s' belongs on the source: the client credential authenticates the source's own OAuth2 calls, not this spec", credential.ConfigSecretSpec)
+		}
+
+	case "access_keys":
+		// The pair is the credential itself, so the spec must name where it comes
+		// from. Nothing mints it: this method exists precisely so that no key pair
+		// is created — and therefore left behind — on OVH's side.
+		if config[credential.ConfigSecretSpec] == "" {
+			return fmt.Errorf("'access_keys' requires '%s' naming a spec that yields its access_key and secret_key", credential.ConfigSecretSpec)
+		}
+		// Refuse an inline pair rather than quietly preferring one over the other:
+		// a key pair sitting in spec config is the standing secret this method
+		// exists to avoid, and nothing here would ever rotate it.
+		for _, key := range []string{"access_key", "secret_key"} {
+			if config[key] != "" {
+				return fmt.Errorf("'%s' must be omitted for access_keys; the referenced spec supplies the whole pair", key)
+			}
+		}
+		// secret_field selects a single secret, and a pair is not one. Both halves
+		// are read by name, so a field here could only be misleading.
+		if config[credential.ConfigSecretField] != "" {
+			return fmt.Errorf("'%s' does not apply to access_keys: the referenced credential must hold both 'access_key' and 'secret_key', read by name", credential.ConfigSecretField)
+		}
+
 	default:
-		return fmt.Errorf("'mint_method' must be 'oauth2_token', 'dynamic_s3', or 'oauth2_token_and_s3', got: %s", mintMethod)
+		return fmt.Errorf("'mint_method' must be 'oauth2_token' or 'access_keys', got: %s", mintMethod)
 	}
 
 	return nil
@@ -108,8 +126,9 @@ func (t *OVHKeysCredType) Parse(rawData, metadata map[string]interface{}, leaseT
 		LeaseID:  leaseID,
 		IssuedAt: time.Now(),
 		// Revoking means releasing a lease at the source, which needs a handle to
-		// release. The OVH driver's bare OAuth2-token path returns no leaseID; the
-		// S3 paths carry one.
+		// release. No OVH mint method returns one: a bearer token expires on its
+		// own, and an access_keys pair was never created here to be deleted. The
+		// condition stays because the field is what the rest of the system reads.
 		Revocable: leaseTTL > 0 && leaseID != "",
 		Data:      data,
 		Metadata:  meta,

--- a/credential/types/ovh_keys_test.go
+++ b/credential/types/ovh_keys_test.go
@@ -34,18 +34,8 @@ func TestOVHKeysCredType_ValidateConfig_OVHSource(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "valid: dynamic_s3",
-			config:  map[string]string{"mint_method": "dynamic_s3"},
-			wantErr: false,
-		},
-		{
-			name:    "valid: oauth2_token_and_s3",
-			config:  map[string]string{"mint_method": "oauth2_token_and_s3"},
-			wantErr: false,
-		},
-		{
-			name:    "valid: dynamic_s3 with project_id and user_id overrides",
-			config:  map[string]string{"mint_method": "dynamic_s3", "project_id": "proj-123", "user_id": "user-456"},
+			name:    "valid: access_keys naming the spec that yields its pair",
+			config:  map[string]string{"mint_method": "access_keys", credential.ConfigSecretSpec: "ovh-pair"},
 			wantErr: false,
 		},
 		{
@@ -59,6 +49,57 @@ func TestOVHKeysCredType_ValidateConfig_OVHSource(t *testing.T) {
 			config:  map[string]string{"mint_method": "static_keys"},
 			wantErr: true,
 			errMsg:  "mint_method",
+		},
+		{
+			// Removed: it created an object-storage pair that outlived every lease.
+			name:    "invalid: dynamic_s3 is no longer a mint method",
+			config:  map[string]string{"mint_method": "dynamic_s3"},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			name:    "invalid: oauth2_token_and_s3 is no longer a mint method",
+			config:  map[string]string{"mint_method": "oauth2_token_and_s3"},
+			wantErr: true,
+			errMsg:  "mint_method",
+		},
+		{
+			// Nothing mints the pair, so without a reference there is none to serve.
+			name:    "invalid: access_keys without a reference",
+			config:  map[string]string{"mint_method": "access_keys"},
+			wantErr: true,
+			errMsg:  credential.ConfigSecretSpec,
+		},
+		{
+			// A pair parked in spec config is the standing secret this method exists
+			// to avoid, and nothing here would ever rotate it.
+			name: "invalid: access_keys with an inline pair",
+			config: map[string]string{
+				"mint_method": "access_keys", credential.ConfigSecretSpec: "ovh-pair",
+				"access_key": "a", "secret_key": "b",
+			},
+			wantErr: true,
+			errMsg:  "must be omitted for access_keys",
+		},
+		{
+			// secret_field selects one secret, and a pair is not one.
+			name: "invalid: access_keys with a secret_field",
+			config: map[string]string{
+				"mint_method": "access_keys", credential.ConfigSecretSpec: "ovh-pair",
+				credential.ConfigSecretField: "secret_key",
+			},
+			wantErr: true,
+			errMsg:  "does not apply to access_keys",
+		},
+		{
+			// The grant runs with the source's service account, so a reference here
+			// would describe a secret this spec never spends.
+			name: "invalid: oauth2_token with a spec-level reference",
+			config: map[string]string{
+				"mint_method": "oauth2_token", credential.ConfigSecretSpec: "ovh-client-cred",
+			},
+			wantErr: true,
+			errMsg:  "belongs on the source",
 		},
 	}
 	for _, tt := range tests {

--- a/credential/types/revocable_test.go
+++ b/credential/types/revocable_test.go
@@ -55,8 +55,10 @@ func TestRevocableRequiresLeaseID(t *testing.T) {
 			leaseID:   "ibm/creds/role/abc123",
 		},
 		{
-			// The OVH driver's bare OAuth2-token path returns no leaseID; its S3
-			// paths carry one.
+			// No OVH mint path returns a leaseID: a bearer token expires on its own,
+			// and an access_keys pair was never created here to be deleted. The row
+			// still passes a leaseID so the invariant is asserted rather than left
+			// to whichever paths happen to exist.
 			name:      "ovh_keys",
 			reachable: true,
 			credType:  &OVHKeysCredType{},

--- a/provider/ovh/provider.go
+++ b/provider/ovh/provider.go
@@ -69,17 +69,19 @@ Credential type: ovh_keys
   - access_key: S3 access key for Object Storage
   - secret_key: S3 secret key for Object Storage
 
-Credential source: ovh (OAuth2 service account)
-  Warden automatically mints bearer tokens via client_credentials grant
-  (~1h TTL, auto-refreshed) and creates S3 credentials on demand.
-
+Credential source: ovh
   Mint methods:
-  - oauth2_token: Mints API bearer tokens only
-  - dynamic_s3: Creates S3 access_key + secret_key (~1h TTL, revocable)
-  - oauth2_token_and_s3: Both API token + S3 credentials
+  - oauth2_token: Mints an API bearer token via the client_credentials grant,
+    using the service account in the source config (auto-refreshed).
+  - access_keys: Serves the Object Storage access_key + secret_key a referenced
+    spec yields. The spec sets secret_spec naming that reference; the pair is
+    read from it per request and nothing is created at OVH.
 
-  Source config: client_id, client_secret, ovh_endpoint (ovh-eu/ovh-ca/ovh-us),
-  project_id, user_id (for S3). project_id and user_id can be overridden per-spec.
+  A spec serves one mode, so a role fronting both the REST API and Object
+  Storage needs one spec of each.
+
+  Source config: client_id, client_secret (both required only for oauth2_token
+  specs), ovh_endpoint (ovh-eu/ovh-ca/ovh-us), token_url.
 
 Regional API endpoints and their matching OAuth2 token URLs:
 - EU:  ovh_url=https://eu.api.ovh.com/1.0   token_url=https://www.ovh.com/auth/oauth2/token


### PR DESCRIPTION
> **Breaking.** The `dynamic_s3` and `oauth2_token_and_s3` mint methods are removed. Specs using them are refused on the next write and fail on the next mint. Replace them with `access_keys`.

## Why remove them

OVH object-storage credentials have no expiry of their own: once created, only a delete removes them. That put the driver in a position it could not hold. A credential minted for a lease has to be deleted when the lease ends, but the moment revocation runs is the moment nothing is available to authorise it — there is no caller left to fetch a secret as, and a keyless source stores none. Any path that created a pair was one restart, one misrouted delete, or one converted source away from leaving a fully privileged credential live on the tenant with nothing tracking it.

## What replaces them

`access_keys` names a spec that yields an `access_key` and a `secret_key`, and serves that pair. No request is made to OVH, nothing is created, and there is nothing to revoke — the problem is removed rather than mitigated. The pair lives wherever the referenced spec reads it from, so it is not in Warden's config either.

This is the same shape Scaleway's `static_keys` already has.

## Where the reference sits

The level says which secret is meant, so it is enforced at three layers rather than inferred:

- the credential type refuses an `access_keys` spec without a reference, and an `oauth2_token` spec with one;
- the store refuses an `access_keys` spec that would inherit a source-level reference describing a client credential;
- the driver refuses it again at mint — the guard that actually holds once a source is converted with specs already bound to it.

## Consequences

`Revoke` is a no-op and the driver hands out no leases. **Credentials minted before this change keep their lease IDs and will not be deleted** — drain them before upgrading, or remove them from the OVH console. Their TTL was the OAuth2 token TTL, so they are at most about an hour old at upgrade. This is the one silent part of the removal; everything else fails loudly.

Also drops `api_url` and the regional API base URLs. Nothing calls the OVH API any more, so the region now selects only where the grant is made, and a config key that is silently ignored is worse than no key at all.

## Not included

- Docs (`site/src/content/docs/credential-drivers/ovh.md`, `provider-backends/ovh.md`, the capability matrix) — deferred to the release doc-prep pass, along with a CHANGELOG entry carrying migration instructions.
- The Terraform harness in `provider/ovh/e2e_test/` is now stale: its README creates a spec with `mint_method=oauth2_token_and_s3`, and `main.tf` routes both the REST and S3 provider blocks through one role. With dual mode gone that needs two specs and two roles. It runs against a real tenant, so it is left for someone who can execute it.

## Testing

`go test ./credential/... ./core/... ./provider/...` green; full e2e suite green.

---

Second of four stacked PRs. Based on #548.
