### PR TITLE
feat(ovh): fetch the OAuth2 client credential per request instead of storing one

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1036,6 +1036,14 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				return logical.ErrBadRequestf("for a gitlab source, set secret_spec on the source (the chained secret — a personal access token, or an OAuth application secret — authenticates the source), not on the spec")
 			case credential.SourceTypeOAuth2:
 				return logical.ErrBadRequestf("for an oauth2 source, set secret_spec on the source (the chained client credential authenticates the source), not on the spec")
+			case credential.SourceTypeOVH:
+				// ovh chains at both levels, and the level says which secret is
+				// meant: an access_keys spec's own reference is the key pair it
+				// serves, while the client credential the grant is made with is a
+				// source concern like the others above.
+				if credential.GetString(spec.Config, "mint_method", "") != "access_keys" {
+					return logical.ErrBadRequestf("for an ovh source, set secret_spec on the source (the chained client credential authenticates the source's own OAuth2 calls), not on the spec; a spec-level reference is for access_keys, whose credential is the referenced pair itself")
+				}
 			}
 		}
 		// An oauth2 source that chains its client credential resolves the pair per mint,

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2489,6 +2489,18 @@ func TestCredentialConfigStore_OVHChaining(t *testing.T) {
 		}))
 	})
 
+	t.Run("an oauth2_token spec may not carry a reference of its own", func(t *testing.T) {
+		// The grant runs with the source's service account, so a reference here
+		// would describe a secret this spec never spends — and would slip past the
+		// source-level checks that gate which sources may chain at all.
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ovh-token-chained", Type: credential.TypeOVHKeys, Source: "ovh-src",
+			Config: map[string]string{"mint_method": "oauth2_token", credential.ConfigSecretSpec: "ovh-client-cred"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set secret_spec on the source")
+	})
+
 	t.Run("a chained spec cannot also carry a rotation period", func(t *testing.T) {
 		err := store.CreateSpec(ctx, &credential.CredSpec{
 			Name: "ovh-s3-rotating", Type: credential.TypeOVHKeys, Source: "ovh-src",

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -69,6 +69,18 @@ type OVHDriver struct {
 	configMu sync.RWMutex
 }
 
+// ovhChainedAuth carries the client credential fetched through credential
+// chaining, for a source that stores none of its own.
+//
+// Both halves travel together. An id kept in config beside a secret fetched from
+// the chain would name one service account while presenting another's secret,
+// which the token endpoint answers with invalid_client — and which this path
+// would then misread as a stale secret and retry, fruitlessly, every time.
+type ovhChainedAuth struct {
+	clientID     string
+	clientSecret string
+}
+
 // OVHDriverFactory creates OVHDriver instances.
 type OVHDriverFactory struct{}
 
@@ -79,12 +91,16 @@ func (f *OVHDriverFactory) Type() string {
 
 // ValidateConfig validates OVH source configuration.
 func (f *OVHDriverFactory) ValidateConfig(config map[string]string) error {
+	if err := validateOVHChainedConfig(config); err != nil {
+		return err
+	}
 	return credential.ValidateSchema(config,
 		// Required for oauth2_token specs and refused nowhere else: a source
 		// serving only access_keys specs never performs the grant, so demanding a
-		// service account it will not use would be config kept for nothing. The
-		// spec-level check in VerifySpec is what actually holds an oauth2_token
-		// spec to a source that can mint for it.
+		// service account it will not use would be config kept for nothing, and a
+		// chained source is refused one outright. The spec-level check in
+		// VerifySpec is what actually holds an oauth2_token spec to a source that
+		// can mint for it.
 		credential.StringField("client_id").
 			Describe("OAuth2 service account client ID (required for oauth2_token specs)").
 			Example("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
@@ -111,7 +127,38 @@ func (f *OVHDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
+
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Cred spec yielding the OAuth2 client credential (client_id and client_secret), instead of storing one here").
+			Example("ovh-client-cred"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Field of the referenced credential holding the client secret; the client id travels beside it under 'client_id'").
+			Example("client_secret"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("How long to reuse the fetched client credential before re-fetching (default: no caching)").
+			Example("30m"),
 	)
+}
+
+// validateOVHChainedConfig rejects source config that contradicts chaining.
+//
+// A chained source holds neither half of the client credential: the secret
+// because keeping it would leave a source that reads as keyless while storing
+// the very secret chaining removes, and the id because the pair authenticates
+// together — see ovhChainedAuth for what a mismatched one costs.
+func validateOVHChainedConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") == "" {
+		return nil
+	}
+	for _, key := range []string{"client_id", "client_secret"} {
+		if credential.GetString(config, key, "") != "" {
+			return fmt.Errorf("%s must be omitted when %s is set; the referenced spec supplies the whole client credential",
+				key, credential.ConfigSecretSpec)
+		}
+	}
+	return nil
 }
 
 // validateOVHEndpointOverride checks a URL an operator has substituted for the
@@ -185,10 +232,12 @@ func (d *OVHDriver) Type() string {
 
 // MintCredential returns OVH credentials for the given spec.
 func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	// An access_keys spec is served from fetched secret material, which arrives
-	// through MintFromSecret. Reaching here means the spec named a reference the
-	// minting layer did not route on, and there is no pair to hand back.
-	if spec.Config[credential.ConfigSecretSpec] != "" {
+	// Both chaining shapes are served from fetched secret material, which arrives
+	// through MintFromSecret: an access_keys spec's own reference to its pair, and
+	// a source-level reference to the client credential this grant needs. Reaching
+	// here with either means the minting layer did not route on it, and there is
+	// nothing held here to fall back to.
+	if spec.Config[credential.ConfigSecretSpec] != "" || d.isChained() {
 		return nil, nil, 0, "", fmt.Errorf("ovh: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
 			credential.ConfigSecretSpec)
 	}
@@ -196,7 +245,7 @@ func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 	switch mintMethod {
 	case "oauth2_token":
-		return d.mintOAuth2Token(ctx)
+		return d.mintOAuth2Token(ctx, nil)
 	case "access_keys":
 		return nil, nil, 0, "", fmt.Errorf("ovh: an access_keys spec must set %s naming a spec that yields its access_key and secret_key; the pair is served from that material, never minted here",
 			credential.ConfigSecretSpec)
@@ -205,17 +254,65 @@ func (d *OVHDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	}
 }
 
-// MintFromSecret serves the object-storage key pair the referenced spec yielded.
+// MintFromSecret mints from secret material fetched through credential chaining.
+// What the material means depends on the mint method, so each arm reads it
+// differently: oauth2_token receives the client credential the grant is made
+// with, access_keys receives the key pair itself.
+func (d *OVHDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+	switch mintMethod {
+	case "oauth2_token":
+		return d.mintOAuth2TokenFromSecret(ctx, material)
+	case "access_keys":
+		return d.mintAccessKeysFromSecret(spec, material)
+	default:
+		// mint_method is validated at spec create, so reaching here means config
+		// drifted. The material's meaning is defined by the method, so with an
+		// unknown one there is no safe way to spend it.
+		return nil, nil, 0, "", fmt.Errorf("ovh: credential chaining supports mint_method=oauth2_token or access_keys, got %q", mintMethod)
+	}
+}
+
+// mintOAuth2TokenFromSecret performs the grant with a client credential fetched
+// through the chain, for a source that stores none.
+func (d *OVHDriver) mintOAuth2TokenFromSecret(ctx context.Context, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	secret := material.Secret()
+	// Fall back to conventional names ONLY when no field was resolved. A field
+	// that resolved to nothing is a misconfigured secret_field — say so, rather
+	// than silently authenticating with some other value from the payload.
+	if secret == "" && material.Field == "" {
+		if secret = material.Data["client_secret"]; secret == "" {
+			secret = material.Data["secret"]
+		}
+	}
+	if secret == "" {
+		if material.Field != "" {
+			return nil, nil, 0, "", fmt.Errorf("ovh: %s %q is empty or absent in the fetched secret material: %w",
+				credential.ConfigSecretField, material.Field, credential.ErrChainedSecretIncomplete)
+		}
+		return nil, nil, 0, "", fmt.Errorf("ovh: no client secret in fetched secret material (set %s, or store it under 'client_secret'): %w",
+			credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
+	}
+
+	// The id travels with its secret. secret_field names the secret alone, so the
+	// id is read by convention — and there is nowhere to fall back to, since a
+	// chained source is refused an inline one.
+	clientID := material.Data["client_id"]
+	if clientID == "" {
+		return nil, nil, 0, "", fmt.Errorf("ovh: no client id in fetched secret material (store it under 'client_id' alongside the secret): %w",
+			credential.ErrChainedSecretIncomplete)
+	}
+
+	return d.mintOAuth2Token(ctx, &ovhChainedAuth{clientID: clientID, clientSecret: secret})
+}
+
+// mintAccessKeysFromSecret serves the object-storage key pair the referenced spec
+// yielded.
 //
 // It makes no request: the pair already exists, so there is nothing to create and
 // nothing to revoke. That is the whole reason this method exists in place of one
 // that asks OVH for a fresh pair — see the type comment.
-func (d *OVHDriver) MintFromSecret(_ context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	mintMethod := credential.GetString(spec.Config, "mint_method", "")
-	if mintMethod != "access_keys" {
-		return nil, nil, 0, "", fmt.Errorf("ovh: credential chaining supports mint_method=access_keys only, got %q", mintMethod)
-	}
-
+func (d *OVHDriver) mintAccessKeysFromSecret(spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	// The spec must name the reference itself. A source-level one would describe
 	// whatever that source authenticates with, not this credential.
 	//
@@ -270,9 +367,28 @@ func (d *OVHDriver) getClientCredentials() (clientID, clientSecret string) {
 	return
 }
 
-// fetchOAuth2Token performs the OAuth2 client_credentials exchange and returns the access token and TTL.
-func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, ttl time.Duration, err error) {
-	clientID, clientSecret := d.getClientCredentials()
+// isChainedLocked reports whether this source fetches its client credential
+// through a reference rather than holding one. The caller must hold configMu.
+func (d *OVHDriver) isChainedLocked() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
+func (d *OVHDriver) isChained() bool {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.isChainedLocked()
+}
+
+// fetchOAuth2Token performs the OAuth2 client_credentials exchange and returns
+// the access token and TTL. A chained client credential is passed in; a nil one
+// means the source holds its own.
+func (d *OVHDriver) fetchOAuth2Token(ctx context.Context, chained *ovhChainedAuth) (accessToken string, ttl time.Duration, err error) {
+	var clientID, clientSecret string
+	if chained != nil {
+		clientID, clientSecret = chained.clientID, chained.clientSecret
+	} else {
+		clientID, clientSecret = d.getClientCredentials()
+	}
 	if clientID == "" || clientSecret == "" {
 		return "", 0, fmt.Errorf("client_id and client_secret are required on source config")
 	}
@@ -301,8 +417,17 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 		},
 	}
 
-	respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
 	if err != nil {
+		// On the chained path an authentication refusal marks the fetched pair as
+		// possibly stale, so the minting layer evicts a cached copy and retries once
+		// with a fresh fetch. RFC 6749 section 5.2 reports invalid_client as 400 or
+		// 401, and the fetched credential is the only thing that varies per mint
+		// here — so a refusal is about the credential or about nothing.
+		if chained != nil && (status == http.StatusBadRequest || status == http.StatusUnauthorized || status == http.StatusForbidden) {
+			return "", 0, fmt.Errorf("ovh: OAuth2 token endpoint rejected the chained client credential: %w (%w)",
+				credential.ErrChainedSecretRejected, err)
+		}
 		return "", 0, fmt.Errorf("OAuth2 token request failed: %w", err)
 	}
 
@@ -335,8 +460,8 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context) (accessToken string, t
 }
 
 // mintOAuth2Token mints a bearer token via the OAuth2 client_credentials grant.
-func (d *OVHDriver) mintOAuth2Token(ctx context.Context) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	token, ttl, err := d.fetchOAuth2Token(ctx)
+func (d *OVHDriver) mintOAuth2Token(ctx context.Context, chained *ovhChainedAuth) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	token, ttl, err := d.fetchOAuth2Token(ctx, chained)
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
@@ -380,10 +505,16 @@ func (d *OVHDriver) VerifySpec(_ context.Context, spec *credential.CredSpec) err
 	case "oauth2_token":
 		// The grant runs with the source's service account, which the source
 		// schema no longer demands — a source serving only access_keys specs has
-		// no use for one. This is where that requirement actually lands.
+		// no use for one. This is where that requirement actually lands, unless
+		// the source fetches its client credential per request, in which case
+		// there is nothing to check until one is fetched.
+		if d.isChained() {
+			return nil
+		}
 		clientID, clientSecret := d.getClientCredentials()
 		if clientID == "" || clientSecret == "" {
-			return fmt.Errorf("an oauth2_token spec needs client_id and client_secret on its source")
+			return fmt.Errorf("an oauth2_token spec needs client_id and client_secret on its source, or a %s naming a spec that yields them",
+				credential.ConfigSecretSpec)
 		}
 		return nil
 	case "access_keys":

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -3,9 +3,11 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -485,18 +487,21 @@ func TestOVHDriver_MintFromSecret_IncompletePair(t *testing.T) {
 	}
 }
 
-func TestOVHDriver_MintFromSecret_RefusesOtherMintMethods(t *testing.T) {
+// mint_method is validated at spec create, so an unknown one here means config
+// drifted. The material's meaning is defined by the method, so there is no safe
+// way to spend it.
+func TestOVHDriver_MintFromSecret_RefusesUnknownMintMethod(t *testing.T) {
 	driver := createOVHTestDriver(t, "https://unused", nil)
 
-	spec := &credential.CredSpec{Name: "api-spec", Config: map[string]string{
-		"mint_method":               "oauth2_token",
+	spec := &credential.CredSpec{Name: "drifted", Config: map[string]string{
+		"mint_method":               "dynamic_s3",
 		credential.ConfigSecretSpec: "ovh-pair",
 	}}
 	_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
 		Data: map[string]string{"access_key": "a", "secret_key": "b"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "access_keys")
+	assert.Contains(t, err.Error(), "dynamic_s3")
 }
 
 // Routing is the minting layer's job; if a chained spec ever reaches the direct
@@ -519,4 +524,199 @@ func TestOVHDriver_MintCredential_FailsClosedForAccessKeys(t *testing.T) {
 		require.Error(t, err)
 	}
 	assert.Zero(t, calls)
+}
+
+// --- chained client credential tests ---
+
+// ovhChainedTokenServer answers the grant, recording the credential presented.
+func ovhChainedTokenServer(t *testing.T, status int) (*httptest.Server, *url.Values) {
+	t.Helper()
+	posted := &url.Values{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		*posted = r.PostForm
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "chained-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}))
+	}))
+	t.Cleanup(server.Close)
+	return server, posted
+}
+
+func ovhChainedDriver(t *testing.T, serverURL string) *OVHDriver {
+	t.Helper()
+	// A chained source holds neither half, so both are cleared.
+	return createOVHTestDriver(t, serverURL, map[string]string{
+		"client_id":                 "",
+		"client_secret":             "",
+		credential.ConfigSecretSpec: "ovh-client-cred",
+	})
+}
+
+func TestOVHDriverFactory_ValidateConfig_Chaining(t *testing.T) {
+	f := &OVHDriverFactory{}
+
+	t.Run("a chained source holds neither half", func(t *testing.T) {
+		assert.NoError(t, f.ValidateConfig(map[string]string{
+			credential.ConfigSecretSpec:  "ovh-client-cred",
+			credential.ConfigSecretField: "client_secret",
+		}))
+	})
+
+	// Keeping either half would leave a source that reads as keyless while storing
+	// the secret chaining removes, or that names one service account while
+	// presenting another's secret.
+	for _, key := range []string{"client_id", "client_secret"} {
+		t.Run("refuses an inline "+key, func(t *testing.T) {
+			err := f.ValidateConfig(map[string]string{
+				credential.ConfigSecretSpec: "ovh-client-cred",
+				key:                         "left-behind",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), key+" must be omitted")
+		})
+	}
+}
+
+func TestOVHDriver_MintFromSecret_OAuth2Token(t *testing.T) {
+	server, posted := ovhChainedTokenServer(t, http.StatusOK)
+	driver := ovhChainedDriver(t, server.URL)
+	spec := &credential.CredSpec{Name: "api-spec", Config: map[string]string{"mint_method": "oauth2_token"}}
+
+	rawData, _, ttl, leaseID, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+		Data: map[string]string{"client_id": "fetched-id", "client_secret": "fetched-secret"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "chained-token", rawData["api_token"])
+	assert.Equal(t, time.Hour, ttl)
+	assert.Empty(t, leaseID)
+
+	// The grant is made with the fetched pair, not with anything held here.
+	assert.Equal(t, "fetched-id", posted.Get("client_id"))
+	assert.Equal(t, "fetched-secret", posted.Get("client_secret"))
+}
+
+func TestOVHDriver_MintFromSecret_SecretFieldResolution(t *testing.T) {
+	spec := &credential.CredSpec{Name: "api-spec", Config: map[string]string{"mint_method": "oauth2_token"}}
+
+	t.Run("a resolved field wins over the conventional names", func(t *testing.T) {
+		server, posted := ovhChainedTokenServer(t, http.StatusOK)
+		driver := ovhChainedDriver(t, server.URL)
+
+		_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+			Field: "app_secret",
+			Data: map[string]string{
+				"client_id": "fetched-id", "app_secret": "chosen", "client_secret": "ignored",
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "chosen", posted.Get("client_secret"))
+	})
+
+	for name, data := range map[string]map[string]string{
+		"client_secret": {"client_id": "fetched-id", "client_secret": "by-convention"},
+		"secret":        {"client_id": "fetched-id", "secret": "by-convention"},
+	} {
+		t.Run("falls back to "+name+" when no field resolved", func(t *testing.T) {
+			server, posted := ovhChainedTokenServer(t, http.StatusOK)
+			driver := ovhChainedDriver(t, server.URL)
+
+			_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{Data: data})
+			require.NoError(t, err)
+			assert.Equal(t, "by-convention", posted.Get("client_secret"))
+		})
+	}
+
+	// A field that resolved to nothing is a misconfigured secret_field. Falling
+	// back would silently authenticate with some other value from the payload.
+	t.Run("a resolved-but-empty field does not fall back", func(t *testing.T) {
+		driver := ovhChainedDriver(t, "https://unused")
+
+		_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+			Field: "app_secret",
+			Data:  map[string]string{"client_id": "fetched-id", "client_secret": "not-this-one"},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		assert.Contains(t, err.Error(), "app_secret")
+	})
+}
+
+// The id travels with its secret, and a chained source is refused an inline one,
+// so there is nowhere to fall back to.
+func TestOVHDriver_MintFromSecret_MissingClientID(t *testing.T) {
+	driver := ovhChainedDriver(t, "https://unused")
+	spec := &credential.CredSpec{Name: "api-spec", Config: map[string]string{"mint_method": "oauth2_token"}}
+
+	_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+		Data: map[string]string{"client_secret": "fetched-secret"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+	assert.Contains(t, err.Error(), "client id")
+}
+
+// A refusal from the token endpoint marks the fetched pair as possibly stale, so
+// the minting layer can evict a cached copy and fetch again. Only on the chained
+// path: with a credential held in config there is nothing to re-fetch.
+func TestOVHDriver_MintFromSecret_RejectionIsRetryable(t *testing.T) {
+	spec := &credential.CredSpec{Name: "api-spec", Config: map[string]string{"mint_method": "oauth2_token"}}
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("chained mint carries the sentinel on %d", status), func(t *testing.T) {
+			server, _ := ovhChainedTokenServer(t, status)
+			driver := ovhChainedDriver(t, server.URL)
+
+			_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+				Data: map[string]string{"client_id": "fetched-id", "client_secret": "stale"},
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+		})
+
+		t.Run(fmt.Sprintf("direct mint does not, on %d", status), func(t *testing.T) {
+			server, _ := ovhChainedTokenServer(t, status)
+			driver := createOVHTestDriver(t, server.URL, nil)
+
+			_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+		})
+	}
+}
+
+// Routing is the minting layer's job. A chained source reaching the direct path
+// has no credential held here to fall back to, so it must refuse rather than mint
+// with an empty one.
+func TestOVHDriver_MintCredential_FailsClosedWhenChained(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := ovhChainedDriver(t, server.URL)
+	_, _, _, _, err := driver.MintCredential(context.Background(), &credential.CredSpec{
+		Name: "api-spec", Config: map[string]string{"mint_method": "oauth2_token"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+	assert.Zero(t, calls)
+}
+
+// A chained source has no service account to check until one is fetched.
+func TestOVHDriver_VerifySpec_ChainedSourceNeedsNoServiceAccount(t *testing.T) {
+	driver := ovhChainedDriver(t, "https://unused")
+	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
+		Name: "api-spec", Config: map[string]string{"mint_method": "oauth2_token"},
+	})
+	assert.NoError(t, err)
 }

--- a/provider/ovh/provider.go
+++ b/provider/ovh/provider.go
@@ -81,7 +81,9 @@ Credential source: ovh
   Storage needs one spec of each.
 
   Source config: client_id, client_secret (both required only for oauth2_token
-  specs), ovh_endpoint (ovh-eu/ovh-ca/ovh-us), token_url.
+  specs), ovh_endpoint (ovh-eu/ovh-ca/ovh-us), token_url. Set secret_spec
+  instead of the pair to fetch the service account per request, so the source
+  stores no credential of its own.
 
 Regional API endpoints and their matching OAuth2 token URLs:
 - EU:  ovh_url=https://eu.api.ovh.com/1.0   token_url=https://www.ovh.com/auth/oauth2/token


### PR DESCRIPTION
An ovh source held a service account in its config: a client id and secret, read on every mint, masked on read, rotated by nobody. This removes it.

OVH's token endpoint accepts only `client_credentials` — there is no assertion grant to federate against — so the way to stop storing the credential is to fetch it when it is needed. A source can now set `secret_spec` naming a spec that yields the pair; Warden mints that spec as the calling agent and hands the result to the grant. The credential exists in memory for the length of one request and is never written to the barrier.

## Both halves, never one

An id kept in config beside a fetched secret would name one service account while presenting another's, which the token endpoint reports as `invalid_client` — indistinguishable from a stale secret, so the minting layer would evict a perfectly good cached credential and retry, every time. Refusing either half inline removes that failure mode rather than documenting it. Same rule gitlab and oauth2 already apply.

## Retryable rejections

A 400, 401 or 403 from the grant now carries `ErrChainedSecretRejected`, but only on the chained path: there the fetched credential is the one thing that varies per mint, so a refusal is about the credential or about nothing, and the retry that follows is worth making. With a credential held in config there is nothing to re-fetch and the sentinel would buy a pointless second attempt.

## Two chaining levels

ovh now chains at both, and the level says which secret is meant: a source-level reference is the client credential the grant is made with, a spec-level one is the key pair an `access_keys` spec serves. Putting a reference on the wrong one is refused with the placement named, rather than quietly fetching a secret the spec cannot spend.

## Usage

```sh
warden cred spec create ovh-client-cred -json '{
  "type": "key_value",
  "source": "secrets-fed",
  "config": {
    "mint_method": "kv2_read",
    "kv2_mount": "secret",
    "secret_path": "infra/ovh-service-account",
    "subject_token_source": "warden_identity"
  }
}'

# No client_id, no client_secret.
warden cred source create ovh-keyless -json '{
  "type": "ovh",
  "config": {
    "ovh_endpoint": "ovh-eu",
    "secret_spec": "ovh-client-cred",
    "secret_field": "client_secret",
    "secret_cache_ttl": "30m"
  }
}'

warden cred spec create ovh-api-token -json '{
  "type": "ovh_keys",
  "source": "ovh-keyless",
  "config": { "mint_method": "oauth2_token" }
}'
```

`subject_token_source` (`warden_identity` or `agent_identity`) is required on the referenced spec.

## Testing

`go test ./credential/... ./core/...` green; full e2e suite green. The e2e coverage lands in the next PR, where the chain is driven against a real OAuth2 issuer under both subject modes.

---

Third of four stacked PRs. Based on #549.
