### PR TITLE
test(e2e): drive both ovh mint methods, both gateway modes, and both chain levels

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1081,9 +1081,12 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		// An access_keys spec's credential is the key pair the referenced spec
 		// yields, so the reference has to be its own. Reached by a source-level one
 		// it would be handed whatever that source authenticates with — a client
-		// credential, not this pair. (A spec that names its own is not here:
-		// chainedRef would be that one, and the type validator has already refused
-		// it any inline pair.)
+		// credential, not this pair.
+		//
+		// The type validator refuses this shape first, since it requires every
+		// access_keys spec to name a reference. This is the layer that holds when
+		// the type registry is unavailable and credType is nil, which is also why
+		// the store's own tests are what exercise it.
 		if source.Type == credential.SourceTypeOVH &&
 			spec.Config[credential.ConfigSecretSpec] == "" &&
 			credential.GetString(spec.Config, "mint_method", "") == "access_keys" {

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2342,6 +2342,7 @@ func TestCredentialConfigStore_OAuth2Chaining(t *testing.T) {
 // source. The factory keeps the record because Create hands out a fresh driver.
 type leasingDriverFactory struct {
 	leaseID   string
+	mintErr   error
 	verifyErr error
 	revoked   []string
 }
@@ -2360,7 +2361,7 @@ type leasingDriver struct{ factory *leasingDriverFactory }
 
 func (d *leasingDriver) Type() string { return "leasing_driver" }
 func (d *leasingDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	return map[string]interface{}{"token": "minted"}, nil, time.Hour, d.factory.leaseID, nil
+	return map[string]interface{}{"token": "minted"}, nil, time.Hour, d.factory.leaseID, d.factory.mintErr
 }
 func (d *leasingDriver) Revoke(ctx context.Context, leaseID string) error {
 	d.factory.revoked = append(d.factory.revoked, leaseID)
@@ -2423,6 +2424,19 @@ func TestCredentialConfigStore_ValidateSpec_ReleasesTestMintLease(t *testing.T) 
 		require.NoError(t, store.UpdateSpec(ctx, s))
 		assert.Equal(t, []string{"lease-update", "lease-update"}, factory.revoked,
 			"a spec edit test-mints again, so it must release again")
+	})
+
+	t.Run("released when the mint reports a lease and then fails", func(t *testing.T) {
+		// A driver that created the credential and then failed still leaves it at
+		// the source. Reading the lease before the error is what makes that
+		// recoverable, so the order is deliberate rather than incidental.
+		factory := &leasingDriverFactory{leaseID: "lease-partial", mintErr: fmt.Errorf("upstream hung up mid-mint")}
+		store, ctx := setup(t, factory)
+
+		err := store.CreateSpec(ctx, spec("partial"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential test failed")
+		assert.Equal(t, []string{"lease-partial"}, factory.revoked)
 	})
 
 	t.Run("nothing to release when the mint issues no lease", func(t *testing.T) {

--- a/credential/drivers/ovh_driver.go
+++ b/credential/drivers/ovh_driver.go
@@ -294,6 +294,15 @@ func (d *OVHDriver) mintOAuth2TokenFromSecret(ctx context.Context, material cred
 			credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
 	}
 
+	// secret_field names the secret, so pointing it at the id is a misconfiguration
+	// with a confusing failure: the id would be posted as the secret, the endpoint
+	// would answer invalid_client, and that reads on this path as a stale secret —
+	// evicting a good cached credential and retrying to no purpose.
+	if material.Field == "client_id" {
+		return nil, nil, 0, "", fmt.Errorf("ovh: %s must name the client secret, not 'client_id'; the id is read by name alongside it",
+			credential.ConfigSecretField)
+	}
+
 	// The id travels with its secret. secret_field names the secret alone, so the
 	// id is read by convention — and there is nowhere to fall back to, since a
 	// chained source is refused an inline one.
@@ -390,7 +399,11 @@ func (d *OVHDriver) fetchOAuth2Token(ctx context.Context, chained *ovhChainedAut
 		clientID, clientSecret = d.getClientCredentials()
 	}
 	if clientID == "" || clientSecret == "" {
-		return "", 0, fmt.Errorf("client_id and client_secret are required on source config")
+		// The message VerifySpec would give never reaches an operator: spec
+		// validation test-mints first and reports whatever that returns. So the
+		// alternative is named here, where it is actually read.
+		return "", 0, fmt.Errorf("client_id and client_secret are required on source config, or a %s naming a spec that yields them",
+			credential.ConfigSecretSpec)
 	}
 
 	formData := url.Values{
@@ -485,7 +498,11 @@ func (d *OVHDriver) mintOAuth2Token(ctx context.Context, chained *ovhChainedAuth
 // to release, and the credential type marks these non-revocable.
 func (d *OVHDriver) Revoke(_ context.Context, leaseID string) error {
 	if leaseID != "" {
-		d.logger.Debug("ignoring revocation for an OVH lease this driver no longer issues",
+		// Not Debug: a lease this driver did not issue predates the removal of the
+		// methods that created object-storage keys. Those keys have no expiry, so
+		// this is an orphan someone has to delete by hand — and the lease id names
+		// the project, user and key they need.
+		d.logger.Warn("cannot revoke a lease from a mint method this driver no longer has; if it names an object-storage key, that key persists until deleted manually",
 			logger.String("lease_id", leaseID))
 	}
 	return nil

--- a/credential/drivers/ovh_driver_test.go
+++ b/credential/drivers/ovh_driver_test.go
@@ -634,6 +634,21 @@ func TestOVHDriver_MintFromSecret_SecretFieldResolution(t *testing.T) {
 		})
 	}
 
+	// The pair authenticates together, so a field pointing at the id is a
+	// misconfiguration whose failure would otherwise read as a stale secret and
+	// cost a pointless evict-and-retry.
+	t.Run("a field naming the id is refused rather than spent", func(t *testing.T) {
+		driver := ovhChainedDriver(t, "https://unused")
+
+		_, _, _, _, err := driver.MintFromSecret(context.Background(), spec, credential.SecretMaterial{
+			Field: "client_id",
+			Data:  map[string]string{"client_id": "fetched-id", "client_secret": "fetched-secret"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must name the client secret")
+		assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+	})
+
 	// A field that resolved to nothing is a misconfigured secret_field. Falling
 	// back would silently authenticate with some other value from the payload.
 	t.Run("a resolved-but-empty field does not fall back", func(t *testing.T) {

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -46,13 +46,15 @@ import (
 // ibmcloud's source needs the IAM stub's URL, which is not known until the stub
 // is listening. Keeping all four together makes the reason legible. kubernetes
 // joins there for the same reason — its keyless source names the recording
-// upstream as its API server, so it cannot be described until that is up.
+// upstream as its API server, so it cannot be described until that is up. ovh
+// too: its mount names the S3 listener, which the S3 rows need to exist before
+// the mount config is written.
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
 	mcpAWSEnv, mcpAWSWrongCredEnv, atlassianEnv, honeycombEnv,
 	prometheusEnv, prometheusBasicEnv,
-	scalewayEnv, cloudflareEnv, ovhEnv,
+	scalewayEnv, cloudflareEnv,
 	vaultEnv,
 }
 
@@ -83,6 +85,9 @@ func TestMain(m *testing.M) {
 	if ibmIAMStub != nil {
 		ibmIAMStub.Close()
 	}
+	if ovhS3 != nil {
+		ovhS3.Close()
+	}
 	os.Exit(code)
 }
 
@@ -104,6 +109,13 @@ func ensureEnv(t *testing.T) {
 		// server, so like ibmcloud its env cannot be built until the listener is up.
 		kubernetesEnv = buildKubernetesEnv(upstream.URL)
 		allEnvs = append(allEnvs, kubernetesEnv)
+
+		// ovh's mount names the S3 listener in s3_url. The S3 leg always forwards
+		// over https and would otherwise address a real public host, so without
+		// this the object-storage half of a dual-mode gateway is unreachable.
+		ovhS3 = startOVHS3Upstream()
+		ovhEnv = buildOVHEnv(ovhS3.URL)
+		allEnvs = append(allEnvs, ovhEnv)
 
 		// vault's source is the one that authenticates against something real: it
 		// verifies its AppRole role and logs in while being created, so the role

--- a/e2e/fullchain/ovh_test.go
+++ b/e2e/fullchain/ovh_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,12 +43,17 @@ const ovhClientSecret = "agent-secret"
 
 const (
 	// Written to secret/data/e2e/ovh-client-credential by setup.sh, and the pair
-	// a chained source performs its grant with. Hydra validates it, so the
-	// chained row passes only if these values reached the driver from Vault —
+	// a chained source performs its grant with. Hydra validates it, so the chained
+	// row passes only if these values reached the driver from the secret store —
 	// unlike every other chained row here, whose secret is spent on a stand-in
 	// that would accept anything.
-	ovhChainedClientID     = "e2e-agent"
-	ovhChainedClientSecret = "agent-secret"
+	//
+	// A client of its own, deliberately. Seeded with e2e-agent — which every
+	// other source in this suite holds inline — a routing regression that fell
+	// back to one of them would present an identical credential and the row could
+	// not tell the difference. The minted token names this client instead.
+	ovhChainedClientID     = "e2e-ovh-chain"
+	ovhChainedClientSecret = "ovh-chain-secret"
 
 	// Written to secret/data/e2e/ovh-access-keys by setup.sh. Both halves,
 	// because for access_keys the pair IS the credential.
@@ -396,9 +403,15 @@ func TestOVH_OAuth2TokenChainMintsWithVaultHeldClientCredential(t *testing.T) {
 			setupOVHClientCredChain(t, subj)
 			upstream.Reset()
 
+			// Captured once: these helpers perform a fresh grant on every call, so
+			// comparing against a second call would compare against a token that
+			// was never sent — an assertion that can never fail.
+			userJWT := h.FullChainUserJWT(t)
+			agentJWT := h.GetDefaultJWT(t)
+
 			status, body, _ := h.ChainRequest(t, leaderPort, ovhEnv, h.ChainOpts{
-				AgentToken: h.GetDefaultJWT(t),
-				Bearer:     h.FullChainUserJWT(t),
+				AgentToken: agentJWT,
+				Bearer:     userJWT,
 				Role:       ovhChainAgentRole,
 				Path:       "me",
 			})
@@ -415,8 +428,23 @@ func TestOVH_OAuth2TokenChainMintsWithVaultHeldClientCredential(t *testing.T) {
 			if !ok || !strings.HasPrefix(token, "ey") {
 				t.Fatalf("upstream Authorization did not carry a minted JWT: %q", token)
 			}
-			if token == h.FullChainUserJWT(t) || token == ovhChainedClientSecret {
-				t.Error("something other than a minted token reached the upstream")
+			for what, value := range map[string]string{
+				"the user's own bearer": userJWT,
+				"the agent's own token": agentJWT,
+				"the client secret":     ovhChainedClientSecret,
+			} {
+				if token == value {
+					t.Errorf("%s reached the upstream instead of a minted credential", what)
+				}
+			}
+
+			// The claim is what makes this row load-bearing. A 200 alone proves
+			// only that SOME valid client credential was spent, and every other
+			// source here holds one inline — so a regression that routed to one of
+			// them would look identical. This client exists nowhere but the secret
+			// store, so its name in the token is proof the chain ran.
+			if got := ovhJWTClientID(t, token); got != ovhChainedClientID {
+				t.Errorf("the minted token was granted to %q, want %q — the credential did not come from the chain", got, ovhChainedClientID)
 			}
 
 			// And the source really holds nothing: the create-time refusal is
@@ -448,7 +476,8 @@ func TestOVH_AccessKeysChainReSignsWithTheVaultHeldPair(t *testing.T) {
 			upstream.Reset()
 			ovhS3.Reset()
 
-			req := signOVHS3Request(t, h.GetDefaultJWT(t), ovhAccessAgentRole, ovhS3SignedTestPath, false)
+			agentJWT := h.GetDefaultJWT(t)
+			req := signOVHS3Request(t, agentJWT, ovhAccessAgentRole, ovhS3SignedTestPath, false)
 			status, body := sendOVHS3Request(t, req)
 			if status != 200 {
 				t.Fatalf("status %d, body %s", status, body)
@@ -467,8 +496,9 @@ func TestOVH_AccessKeysChainReSignsWithTheVaultHeldPair(t *testing.T) {
 				t.Errorf("re-signed with some other access key: %q", authz)
 			}
 			// The caller's own token was the inbound SigV4 credential; it must not
-			// have been passed along as the outbound one.
-			if strings.Contains(authz, h.GetDefaultJWT(t)) {
+			// have been passed along as the outbound one. Compared against the
+			// token actually sent — these helpers mint a fresh one per call.
+			if strings.Contains(authz, agentJWT) {
 				t.Error("the caller's token was forwarded as the S3 credential")
 			}
 			// The secret half is what the signature is computed with and must
@@ -507,6 +537,11 @@ func TestOVH_S3SignatureIsVerifiedBeforeAnythingIsSpent(t *testing.T) {
 	status, body := sendOVHS3Request(t, req)
 	if status != http.StatusForbidden {
 		t.Fatalf("status %d, want 403 (body: %s)", status, body)
+	}
+	// Named, because a policy denial or a missing role is also a 403 and would
+	// let this pass with the verification never having run.
+	if !strings.Contains(body, "Signature") {
+		t.Errorf("403 body %q does not name the signature; this may be some other refusal", body)
 	}
 	if n := len(ovhS3.Requests()); n != 0 {
 		t.Errorf("a request with a bad signature reached the S3 upstream %d times", n)
@@ -637,4 +672,35 @@ func TestOVH_ChainedConfigRefusals(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ovhJWTClientID reads the client the token was granted to.
+//
+// Hydra puts the granting client in client_id on a client_credentials token, and
+// repeats it as sub. Either identifies the service account, which is what the
+// chained row needs: the 200 proves a valid credential was spent, and this
+// proves it was the one held in the secret store rather than one sitting inline
+// on some other source.
+func ovhJWTClientID(t *testing.T, token string) string {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token is not a JWT (%d segments)", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode the token payload: %v", err)
+	}
+	var claims struct {
+		ClientID string `json:"client_id"`
+		Sub      string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("parse the token claims: %v", err)
+	}
+	if claims.ClientID != "" {
+		return claims.ClientID
+	}
+	return claims.Sub
 }

--- a/e2e/fullchain/ovh_test.go
+++ b/e2e/fullchain/ovh_test.go
@@ -3,9 +3,21 @@
 package fullchain
 
 import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
 
@@ -19,22 +31,274 @@ import (
 // deployment's service-account tokens need not come from ovh.com. Without that
 // override the regional endpoint map is the only answer and every mint would
 // call the vendor for real.
+//
+// It is also the only provider here whose two mint methods differ in whether
+// they call anything at all. oauth2_token performs the grant; access_keys serves
+// an object-storage pair held elsewhere and calls nothing, which is what makes
+// the S3 rows below assertable against a listener of their own.
 
 const ovhClientSecret = "agent-secret"
 
-var ovhEnv = h.ProviderEnv{
-	Mount:      "fc-ovh",
-	Type:       "ovh",
-	URLKey:     "ovh_url",
-	CredType:   "ovh_keys",
-	SourceType: "ovh",
-	SourceConfig: map[string]string{
-		"client_id":       "e2e-agent",
-		"client_secret":   ovhClientSecret,
-		"token_url":       h.HydraIssuer + "/oauth2/token",
-		"tls_skip_verify": "true",
-	},
-	CredConfig: map[string]string{"mint_method": "oauth2_token"},
+const (
+	// Written to secret/data/e2e/ovh-client-credential by setup.sh, and the pair
+	// a chained source performs its grant with. Hydra validates it, so the
+	// chained row passes only if these values reached the driver from Vault —
+	// unlike every other chained row here, whose secret is spent on a stand-in
+	// that would accept anything.
+	ovhChainedClientID     = "e2e-agent"
+	ovhChainedClientSecret = "agent-secret"
+
+	// Written to secret/data/e2e/ovh-access-keys by setup.sh. Both halves,
+	// because for access_keys the pair IS the credential.
+	ovhChainedAccessKey = "E2EOVHACCESSKEY00000"
+	ovhChainedSecretKey = "e2e-ovh-access-not-a-real-secret"
+
+	// Test-local, the sources included, for the reason gitlab_test.go gives: a
+	// killed run skips t.Cleanup, and a spec left hanging off a shared source
+	// would block that source from being deleted, failing the next run's setup
+	// before it reaches the cleanup that would have cleared it.
+	ovhClientCredSpec   = "fc-ovh-client-from-vault"
+	ovhChainSource      = "fc-ovh-keyless-src"
+	ovhChainSpec        = "fc-ovh-chain-cred"
+	ovhChainAgentRole   = "fc-ovh-chain-agent"
+	ovhPairSecretSpec   = "fc-ovh-pair-from-vault"
+	ovhAccessSource     = "fc-ovh-access-src"
+	ovhAccessSpec       = "fc-ovh-access-cred"
+	ovhAccessAgentRole  = "fc-ovh-access-agent"
+	ovhS3Region         = "gra"
+	ovhS3SignedTestPath = "/fc-ovh-bucket/probe.txt"
+)
+
+// ovhMustWrite is the local provisioning helper the chained rows share.
+func ovhMustWrite(t *testing.T, method, path, body, what string) {
+	t.Helper()
+	switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+	case 200, 201, 204:
+	default:
+		t.Fatalf("%s (status %d): %s", what, status, resp)
+	}
+}
+
+// ovhS3Upstream stands in for OVH Object Storage.
+//
+// It is a listener of its own, and a TLS one, for two reasons the shared
+// recording upstream cannot satisfy: the S3 leg always forwards over https, and
+// a row whose point is that access_keys calls nothing needs somewhere for
+// "nothing" to be observable — pointed at one listener, zero mint calls could
+// never be told apart from the proxied request itself.
+type ovhS3Upstream struct {
+	*httptest.Server
+	mu   sync.Mutex
+	reqs []*http.Request
+}
+
+func startOVHS3Upstream() *ovhS3Upstream {
+	up := &ovhS3Upstream{}
+	up.Server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up.mu.Lock()
+		up.reqs = append(up.reqs, r.Clone(context.Background()))
+		up.mu.Unlock()
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><ListBucketResult></ListBucketResult>`))
+	}))
+	return up
+}
+
+func (u *ovhS3Upstream) Requests() []*http.Request {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]*http.Request(nil), u.reqs...)
+}
+
+func (u *ovhS3Upstream) Reset() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.reqs = nil
+}
+
+func (u *ovhS3Upstream) Last(t *testing.T) *http.Request {
+	t.Helper()
+	reqs := u.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("the S3 upstream received no request")
+	}
+	return reqs[len(reqs)-1]
+}
+
+// Both are built in ensureEnv: the mount names the S3 listener, which does not
+// exist until it is listening.
+var (
+	ovhS3  *ovhS3Upstream
+	ovhEnv h.ProviderEnv
+)
+
+// buildOVHEnv names the S3 listener, which is not known until it is up — the
+// same reason kubernetes and ibmcloud build their envs in ensureEnv.
+func buildOVHEnv(s3URL string) h.ProviderEnv {
+	return h.ProviderEnv{
+		Mount:      "fc-ovh",
+		Type:       "ovh",
+		URLKey:     "ovh_url",
+		CredType:   "ovh_keys",
+		SourceType: "ovh",
+		SourceConfig: map[string]string{
+			"client_id":       "e2e-agent",
+			"client_secret":   ovhClientSecret,
+			"token_url":       h.HydraIssuer + "/oauth2/token",
+			"tls_skip_verify": "true",
+		},
+		// s3_url exists so an operator whose traffic leaves through a private
+		// gateway can name it; here it is what makes the S3 leg reachable at all,
+		// since the region otherwise resolves to a real public host.
+		ExtraConfig: map[string]any{
+			"s3_url":          s3URL,
+			"tls_skip_verify": true,
+		},
+		CredConfig: map[string]string{"mint_method": "oauth2_token"},
+	}
+}
+
+// ovhReferencedSpec creates the key_value spec a chain points at. It mirrors
+// scalewayReferencedSpec and takes the same subject matrix: the store refuses an
+// unpinned reference, and the two ways of pinning it federate differently.
+func ovhReferencedSpec(t *testing.T, name, secretPath string, subj scalewaySubject) {
+	t.Helper()
+	ovhMustWrite(t, "POST", "sys/cred/specs/"+name, fmt.Sprintf(`{
+		"type":"key_value","source":%q,"config":{
+			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":%q,
+			"subject_token_source":%q}}`, subj.source, secretPath, subj.name),
+		"create the referenced secret spec "+name)
+}
+
+// setupOVHClientCredChain builds the SOURCE-level chain: a source holding
+// neither half of its service account, and an oauth2_token spec that inherits
+// the chain from it.
+func setupOVHClientCredChain(t *testing.T, subj scalewaySubject) {
+	t.Helper()
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+ovhChainAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+ovhChainSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+ovhChainSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+ovhClientCredSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	ovhReferencedSpec(t, ovhClientCredSpec, "e2e/ovh-client-credential", subj)
+
+	// Neither client_id nor client_secret: validation refuses a source that keeps
+	// either while also naming a chain, because the two authenticate as a pair.
+	//
+	// secret_field is set because the payload holds two keys, so nothing could
+	// pick between them — the id is read by name beside whatever the field names.
+	ovhMustWrite(t, "POST", "sys/cred/sources/"+ovhChainSource, fmt.Sprintf(`{
+		"type":"ovh","config":{
+			"token_url":%q,"tls_skip_verify":"true",
+			"secret_spec":%q,"secret_field":"client_secret"}}`,
+		h.HydraIssuer+"/oauth2/token", ovhClientCredSpec),
+		"create the keyless ovh source")
+
+	// Ordinary: it inherits the chain from its source and carries no chaining
+	// config of its own, which is what source-level chaining means.
+	ovhMustWrite(t, "POST", "sys/cred/specs/"+ovhChainSpec, `{
+		"type":"ovh_keys","source":"`+ovhChainSource+`","config":{
+			"mint_method":"oauth2_token"}}`,
+		"create the chained oauth2_token spec")
+
+	ovhMustWrite(t, "POST", "auth/jwt/role/"+ovhChainAgentRole, `{
+		"token_policies":["`+ovhEnv.Policy()+`"],"cred_spec_name":"`+ovhChainSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the chained agent role")
+}
+
+// setupOVHAccessKeysChain builds the SPEC-level chain. The source holds nothing
+// at all — not even a chain — because for access_keys the reference belongs to
+// the spec whose credential it yields, and the source performs no grant.
+func setupOVHAccessKeysChain(t *testing.T, subj scalewaySubject) {
+	t.Helper()
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+ovhAccessAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+ovhAccessSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+ovhAccessSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+ovhPairSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	ovhReferencedSpec(t, ovhPairSecretSpec, "e2e/ovh-access-keys", subj)
+
+	// No service account: a source serving only access_keys specs never performs
+	// the grant, so it is not asked for one.
+	ovhMustWrite(t, "POST", "sys/cred/sources/"+ovhAccessSource,
+		`{"type":"ovh","config":{"ovh_endpoint":"ovh-eu"}}`,
+		"create the grant-free ovh source")
+
+	// No secret_field: it names a single secret, and a pair is not one — both
+	// halves are read by name, and the spec is refused a field for that reason.
+	ovhMustWrite(t, "POST", "sys/cred/specs/"+ovhAccessSpec, `{
+		"type":"ovh_keys","source":"`+ovhAccessSource+`","config":{
+			"mint_method":"access_keys","secret_spec":"`+ovhPairSecretSpec+`"}}`,
+		"create the spec-chained access_keys spec")
+
+	ovhMustWrite(t, "POST", "auth/jwt/role/"+ovhAccessAgentRole, `{
+		"token_policies":["`+ovhEnv.Policy()+`"],"cred_spec_name":"`+ovhAccessSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the chained access_keys agent role")
+}
+
+// signOVHS3Request signs a gateway request the way an S3 client authenticating
+// to Warden does: the caller's own token is both halves of the SigV4 credential,
+// because verification reconstructs the secret from the access key id it reads
+// off the wire. Warden verifies that signature, then re-signs with the real
+// provider keys before forwarding.
+func signOVHS3Request(t *testing.T, token, role, path string, tamper bool) *http.Request {
+	t.Helper()
+
+	url := fmt.Sprintf("%s/v1/%s/gateway%s", h.NodeURL(leaderPort), ovhEnv.Mount, path)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build the S3 request: %v", err)
+	}
+	// Signed rather than added afterwards: Warden verifies over the headers as
+	// they arrive, so a role added after signing would break the signature.
+	req.Header.Set("X-Warden-Role", role)
+
+	empty := sha256.Sum256(nil)
+	creds := awssdk.Credentials{AccessKeyID: token, SecretAccessKey: token}
+	signer := v4.NewSigner(func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true })
+	if err := signer.SignHTTP(context.Background(), creds, req, hex.EncodeToString(empty[:]), "s3", ovhS3Region, time.Now()); err != nil {
+		t.Fatalf("sign the S3 request: %v", err)
+	}
+
+	if tamper {
+		// Change the signature and nothing else, so the request stays
+		// well-formed and only verification can reject it.
+		authz := req.Header.Get("Authorization")
+		idx := strings.LastIndex(authz, "Signature=")
+		if idx < 0 {
+			t.Fatalf("signed Authorization has no Signature component: %q", authz)
+		}
+		req.Header.Set("Authorization", authz[:idx]+"Signature=00000000000000000000000000000000000000000000000000000000000000ff")
+	}
+	return req
+}
+
+func sendOVHS3Request(t *testing.T, req *http.Request) (int, string) {
+	t.Helper()
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("send the S3 request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
 }
 
 // TestOVH_MintedTokenReachesUpstream drives the whole chain including the
@@ -79,5 +343,298 @@ func TestOVH_MintedTokenReachesUpstream(t *testing.T) {
 	}
 	if got.Path != "/me" {
 		t.Errorf("upstream path = %q, want /me", got.Path)
+	}
+}
+
+// TestOVH_AgentTokenChannelDisplacesTheUserBearer is the row the dual-mode SDK
+// used to get wrong: it never read X-Warden-Agent-Token, so a request that
+// separated the two principals had the user's bearer taken as the agent.
+//
+// ovh injects into Authorization rather than a native header, so the assertion
+// is displacement rather than absence — the user's JWT arrived there and must
+// not still be there.
+func TestOVH_AgentTokenChannelDisplacesTheUserBearer(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, ovhEnv)
+
+	userJWT := h.FullChainUserJWT(t)
+	status, body, _ := h.ChainRequest(t, leaderPort, ovhEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     userJWT,
+		Role:       ovhEnv.JWTAgentRole(),
+		Path:       "me",
+	})
+
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+
+	token, ok := strings.CutPrefix(upstream.Last(t).Header.Get("Authorization"), "Bearer ")
+	if !ok || token == "" {
+		t.Fatal("upstream received no Bearer credential")
+	}
+	if token == userJWT {
+		t.Error("the user's bearer survived to the upstream instead of the minted credential")
+	}
+}
+
+// TestOVH_OAuth2TokenChainMintsWithVaultHeldClientCredential is the source-level
+// half: the service account is not in the source at all, it is fetched per
+// request as the calling agent and spent on the grant.
+//
+// This row is stronger than the other chained rows in this package. Elsewhere
+// the chained secret is spent against a stand-in that would accept any value, so
+// the assertion has to inspect the mint call. Here Hydra checks the pair, so a
+// 200 with a real JWT on the wire is itself proof that what came out of Vault
+// was the genuine client credential.
+func TestOVH_OAuth2TokenChainMintsWithVaultHeldClientCredential(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, ovhEnv)
+
+	for _, subj := range scalewaySubjects {
+		t.Run(subj.name, func(t *testing.T) {
+			setupOVHClientCredChain(t, subj)
+			upstream.Reset()
+
+			status, body, _ := h.ChainRequest(t, leaderPort, ovhEnv, h.ChainOpts{
+				AgentToken: h.GetDefaultJWT(t),
+				Bearer:     h.FullChainUserJWT(t),
+				Role:       ovhChainAgentRole,
+				Path:       "me",
+			})
+			if status != 200 {
+				t.Fatalf("status %d, body %s", status, string(body))
+			}
+
+			// One call: the grant goes to Hydra, not to the upstream.
+			if n := len(upstream.Requests()); n != 1 {
+				t.Errorf("upstream calls = %d, want 1 (the grant is Hydra's)", n)
+			}
+
+			token, ok := strings.CutPrefix(upstream.Last(t).Header.Get("Authorization"), "Bearer ")
+			if !ok || !strings.HasPrefix(token, "ey") {
+				t.Fatalf("upstream Authorization did not carry a minted JWT: %q", token)
+			}
+			if token == h.FullChainUserJWT(t) || token == ovhChainedClientSecret {
+				t.Error("something other than a minted token reached the upstream")
+			}
+
+			// And the source really holds nothing: the create-time refusal is
+			// pinned below, this is the state that refusal produces.
+			_, srcBody := h.APIRequest(t, "GET", "sys/cred/sources/"+ovhChainSource, leaderPort, "")
+			for _, half := range []string{ovhChainedClientID, ovhChainedClientSecret} {
+				if strings.Contains(string(srcBody), half) {
+					t.Errorf("the source stores %q, which it is supposed to fetch: %s", half, srcBody)
+				}
+			}
+		})
+	}
+}
+
+// TestOVH_AccessKeysChainReSignsWithTheVaultHeldPair is the spec-level half, and
+// the only row in this package that follows a credential all the way through the
+// S3 leg.
+//
+// Its point is doubled. The pair exists only in Vault, so seeing it in the
+// outgoing signature proves the chain ran; and access_keys mints by serving that
+// pair rather than asking OVH for one, so the API upstream must stay untouched.
+func TestOVH_AccessKeysChainReSignsWithTheVaultHeldPair(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, ovhEnv)
+
+	for _, subj := range scalewaySubjects {
+		t.Run(subj.name, func(t *testing.T) {
+			setupOVHAccessKeysChain(t, subj)
+			upstream.Reset()
+			ovhS3.Reset()
+
+			req := signOVHS3Request(t, h.GetDefaultJWT(t), ovhAccessAgentRole, ovhS3SignedTestPath, false)
+			status, body := sendOVHS3Request(t, req)
+			if status != 200 {
+				t.Fatalf("status %d, body %s", status, body)
+			}
+
+			got := ovhS3.Last(t)
+			authz := got.Header.Get("Authorization")
+			if !strings.HasPrefix(authz, "AWS4-HMAC-SHA256 ") {
+				t.Fatalf("the S3 upstream was not addressed with a SigV4 signature: %q", authz)
+			}
+			// The re-signed credential names the access key. Its secret half never
+			// appears on the wire — it is what the signature is computed with — so
+			// the access key is what an assertion can reach, and it exists nowhere
+			// but Vault.
+			if !strings.Contains(authz, "Credential="+ovhChainedAccessKey+"/") {
+				t.Errorf("re-signed with some other access key: %q", authz)
+			}
+			// The caller's own token was the inbound SigV4 credential; it must not
+			// have been passed along as the outbound one.
+			if strings.Contains(authz, h.GetDefaultJWT(t)) {
+				t.Error("the caller's token was forwarded as the S3 credential")
+			}
+			// The secret half is what the signature is computed with and must
+			// never travel: SigV4 exists so that it does not.
+			for name, values := range got.Header {
+				for _, v := range values {
+					if strings.Contains(v, ovhChainedSecretKey) {
+						t.Errorf("the secret key travelled in header %s", name)
+					}
+				}
+			}
+			if got.URL.Path != ovhS3SignedTestPath {
+				t.Errorf("S3 upstream path = %q, want %q", got.URL.Path, ovhS3SignedTestPath)
+			}
+
+			// access_keys serves a pair that already exists. Any call to the OVH
+			// API would mean something tried to create one.
+			if n := len(upstream.Requests()); n != 0 {
+				t.Errorf("the OVH API was called %d times; access_keys must call nothing", n)
+			}
+		})
+	}
+}
+
+// TestOVH_S3SignatureIsVerifiedBeforeAnythingIsSpent pins the negative half of
+// the S3 leg: a request Warden cannot verify never reaches a credential, so no
+// mint happens and nothing leaves.
+func TestOVH_S3SignatureIsVerifiedBeforeAnythingIsSpent(t *testing.T) {
+	ensureEnv(t)
+	useJWTAgentLeg(t, ovhEnv)
+	setupOVHAccessKeysChain(t, scalewaySubjects[0])
+	upstream.Reset()
+	ovhS3.Reset()
+
+	req := signOVHS3Request(t, h.GetDefaultJWT(t), ovhAccessAgentRole, ovhS3SignedTestPath, true)
+	status, body := sendOVHS3Request(t, req)
+	if status != http.StatusForbidden {
+		t.Fatalf("status %d, want 403 (body: %s)", status, body)
+	}
+	if n := len(ovhS3.Requests()); n != 0 {
+		t.Errorf("a request with a bad signature reached the S3 upstream %d times", n)
+	}
+	if n := len(upstream.Requests()); n != 0 {
+		t.Errorf("a request with a bad signature reached the API upstream %d times", n)
+	}
+}
+
+// TestOVH_ChainedConfigRefusals pins the shapes a chained ovh configuration must
+// not take, at the point they are written rather than at first use.
+//
+// Each row exercises a different layer running in the real server: the driver
+// factory, the store's cross-object guard, and the credential type. The last is
+// the one the store's own unit tests cannot reach, since their Core is built
+// without a type registry.
+func TestOVH_ChainedConfigRefusals(t *testing.T) {
+	ensureEnv(t)
+	setupOVHClientCredChain(t, scalewaySubjects[0])
+
+	sources := []struct {
+		name   string
+		id     string
+		body   string
+		errMsg string
+	}{
+		{
+			// Keeping the secret would leave a source that reads as keyless while
+			// storing the very secret chaining removes.
+			name: "an inline client_secret kept alongside the chain",
+			id:   "inline-client-secret",
+			body: fmt.Sprintf(`{"type":"ovh","config":{
+				"token_url":%q,"tls_skip_verify":"true","secret_spec":%q,
+				"client_secret":"left-behind"}}`,
+				h.HydraIssuer+"/oauth2/token", ovhClientCredSpec),
+			errMsg: "client_secret must be omitted when secret_spec is set",
+		},
+		{
+			// And the id, because the pair authenticates together: an id here
+			// beside a fetched secret would name one service account while
+			// presenting another's.
+			name: "an inline client_id kept alongside the chain",
+			id:   "inline-client-id",
+			body: fmt.Sprintf(`{"type":"ovh","config":{
+				"token_url":%q,"tls_skip_verify":"true","secret_spec":%q,
+				"client_id":"some-other-account"}}`,
+				h.HydraIssuer+"/oauth2/token", ovhClientCredSpec),
+			errMsg: "client_id must be omitted when secret_spec is set",
+		},
+	}
+	for _, tt := range sources {
+		t.Run(tt.name, func(t *testing.T) {
+			name := "fc-ovh-refused-" + tt.id
+			t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/sources/"+name, leaderPort, "") })
+
+			status, body := h.APIRequest(t, "POST", "sys/cred/sources/"+name, leaderPort, tt.body)
+			if status < 400 {
+				t.Fatalf("got status %d, want a failure (body: %s)", status, body)
+			}
+			if !strings.Contains(string(body), tt.errMsg) {
+				t.Errorf("error should mention %q, got: %s", tt.errMsg, body)
+			}
+		})
+	}
+
+	// id names the spec, rather than the description doing it: a description
+	// reads better with an apostrophe in it, and a spec path does not survive one.
+	specs := []struct {
+		name   string
+		id     string
+		body   string
+		errMsg string
+	}{
+		{
+			// Nothing mints the pair, so without a reference there is none to
+			// serve — and inheriting the source's would hand this spec the client
+			// credential, which is not its credential either. The store carries a
+			// guard for the second reading, but the type validator refuses the
+			// shape outright and is what fires here; the store's is what holds
+			// when the type registry is unavailable.
+			name: "an access_keys spec naming no reference",
+			id:   "access-without-reference",
+			body: `{"type":"ovh_keys","source":"` + ovhChainSource + `","config":{
+				"mint_method":"access_keys"}}`,
+			errMsg: "'access_keys' requires 'secret_spec'",
+		},
+		{
+			// The client credential authenticates the source's own calls, and the
+			// driver factory only ever sees source config — a reference parked on
+			// the spec would slip past the checks that gate a chained source.
+			name: "a spec-level reference on oauth2_token",
+			id:   "token-spec-level-reference",
+			body: `{"type":"ovh_keys","source":"` + ovhChainSource + `","config":{
+				"mint_method":"oauth2_token","secret_spec":"` + ovhClientCredSpec + `"}}`,
+			errMsg: "belongs on the source",
+		},
+		{
+			// Removed outright: it created an object-storage pair that outlived
+			// every lease, with nothing able to delete it afterwards.
+			name: "the removed dynamic_s3 mint method",
+			id:   "removed-dynamic-s3",
+			body: `{"type":"ovh_keys","source":"` + ovhChainSource + `","config":{
+				"mint_method":"dynamic_s3","project_id":"p","user_id":"u"}}`,
+			errMsg: "mint_method",
+		},
+		{
+			// A pair parked in spec config is the standing secret access_keys
+			// exists to avoid, and nothing here would ever rotate it.
+			name: "an access_keys spec carrying an inline pair",
+			id:   "access-inline-pair",
+			body: `{"type":"ovh_keys","source":"` + ovhChainSource + `","config":{
+				"mint_method":"access_keys","secret_spec":"` + ovhPairSecretSpec + `",
+				"access_key":"E2EOVHINLINEKEY00000","secret_key":"e2e-ovh-inline-not-a-real-secret"}}`,
+			errMsg: "must be omitted for access_keys",
+		},
+	}
+	for _, tt := range specs {
+		t.Run(tt.name, func(t *testing.T) {
+			name := "fc-ovh-spec-refused-" + tt.id
+			t.Cleanup(func() { h.APIRequest(t, "DELETE", "sys/cred/specs/"+name, leaderPort, "") })
+
+			status, body := h.APIRequest(t, "POST", "sys/cred/specs/"+name, leaderPort, tt.body)
+			if status < 400 {
+				t.Fatalf("got status %d, want a failure (body: %s)", status, body)
+			}
+			if !strings.Contains(string(body), tt.errMsg) {
+				t.Errorf("error should mention %q, got: %s", tt.errMsg, body)
+			}
+		})
 	}
 }

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -368,6 +368,24 @@ vault_api POST "secret/data/e2e/scaleway-mgmt-key" \
 vault_api POST "secret/data/e2e/scaleway-static-pair" \
   '{"data":{"access_key":"SCWE2ECHAINEDPAIR000","secret_key":"e2e-scw-chained-pair-not-a-real-secret"}}'
 
+# The OAuth2 client credential a keyless ovh source performs its grant with.
+# Both halves, because they authenticate as a pair — a chained source is refused
+# an inline client_id precisely so an id cannot name one service account while
+# the secret beside it belongs to another.
+#
+# These are the real Hydra e2e-agent client values, so the chained mint performs
+# a REAL grant against a validating token endpoint: the row passes only if the
+# pair fetched from here satisfies Hydra. Every other chained row in this suite
+# spends its secret against a stand-in.
+vault_api POST "secret/data/e2e/ovh-client-credential" \
+  '{"data":{"client_id":"e2e-agent","client_secret":"agent-secret"}}'
+
+# An object-storage key pair for ovh's access_keys method, which serves a pair
+# held elsewhere and calls OVH for nothing. Like the scaleway pair above this is
+# a SPEC-level chain, for the same reason: the pair IS the credential.
+vault_api POST "secret/data/e2e/ovh-access-keys" \
+  '{"data":{"access_key":"E2EOVHACCESSKEY00000","secret_key":"e2e-ovh-access-not-a-real-secret"}}'
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -373,12 +373,16 @@ vault_api POST "secret/data/e2e/scaleway-static-pair" \
 # an inline client_id precisely so an id cannot name one service account while
 # the secret beside it belongs to another.
 #
-# These are the real Hydra e2e-agent client values, so the chained mint performs
-# a REAL grant against a validating token endpoint: the row passes only if the
-# pair fetched from here satisfies Hydra. Every other chained row in this suite
-# spends its secret against a stand-in.
+# A real Hydra client, so the chained mint performs a REAL grant against a
+# validating token endpoint: the row passes only if the pair fetched from here
+# satisfies Hydra. Every other chained row in this suite spends its secret
+# against a stand-in that would accept anything.
+#
+# Deliberately NOT e2e-agent, which every other source in the suite holds
+# inline: the minted token carries this client's id, so the row can tell the
+# chain from a routing regression that fell back to an inline credential.
 vault_api POST "secret/data/e2e/ovh-client-credential" \
-  '{"data":{"client_id":"e2e-agent","client_secret":"agent-secret"}}'
+  '{"data":{"client_id":"e2e-ovh-chain","client_secret":"ovh-chain-secret"}}'
 
 # An object-storage key pair for ovh's access_keys method, which serves a pair
 # held elsewhere and calls OVH for nothing. Like the scaleway pair above this is
@@ -453,6 +457,17 @@ curl -s -X POST "$HYDRA_ADMIN/admin/clients" \
   -H "Content-Type: application/json" \
   -d '{"client_id":"e2e-ephemeral","client_name":"E2E Ephemeral","client_secret":"ephemeral-secret","grant_types":["client_credentials"],"response_types":[],"scope":"api:read api:write","token_endpoint_auth_method":"client_secret_post","client_credentials_grant_access_token_lifespan":"2s"}' \
   >/dev/null 2>&1 && echo "  [OK] e2e-ephemeral (2s TTL)" || echo "  [SKIP] e2e-ephemeral (already exists?)"
+
+# A client of its own for the ovh chained row, so that row can prove WHICH
+# credential was spent. The chained source fetches its service account from the
+# secret store; every other source in this suite holds e2e-agent inline, so a
+# chain seeded with e2e-agent would look identical to a routing regression that
+# fell back to one of them. This client exists nowhere but the secret store, and
+# the minted token names it in its client_id claim.
+curl -s -X POST "$HYDRA_ADMIN/admin/clients" \
+  -H "Content-Type: application/json" \
+  -d '{"client_id":"e2e-ovh-chain","client_name":"E2E OVH Chained Service Account","client_secret":"ovh-chain-secret","grant_types":["client_credentials"],"response_types":[],"scope":"api:read api:write","token_endpoint_auth_method":"client_secret_post"}' \
+  >/dev/null 2>&1 && echo "  [OK] e2e-ovh-chain" || echo "  [SKIP] e2e-ovh-chain (already exists?)"
 
 # Verify JWT issuance works
 echo "  Verifying JWT issuance..."

--- a/provider/ovh/provider.go
+++ b/provider/ovh/provider.go
@@ -2,9 +2,12 @@ package ovh
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/provider/sdk/dualgateway"
 )
 
@@ -25,9 +28,42 @@ var Spec = &dualgateway.ProviderSpec{
 		CredentialField:   "api_token",
 	},
 
-	S3Endpoint: func(_ map[string]any, region string) string {
+	ExtraConfigKeys: []string{"s3_url"},
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		"s3_url": {
+			Type:        framework.TypeString,
+			Description: "Override the Object Storage host the region would resolve to, for a private egress gateway fronting it. Host or URL; the S3 leg is always https.",
+		},
+	},
+	OnConfigParsed: func(config map[string]any) map[string]any {
+		return map[string]any{
+			"s3_host": s3Host(framework.GetConfigString(config, "s3_url", "")),
+		}
+	},
+	S3Endpoint: func(state map[string]any, region string) string {
+		// The same reason ovh_url exists on the API side: an operator whose
+		// traffic leaves through a private gateway needs to name it. Without
+		// this the region is the only answer and the S3 leg always addresses
+		// the public host.
+		if host, _ := state["s3_host"].(string); host != "" {
+			return host
+		}
 		return fmt.Sprintf("s3.%s.io.cloud.ovh.net", region)
 	},
+}
+
+// s3Host reduces an operator-set s3_url to the host S3Endpoint must return.
+// A URL is accepted because that is what the API-side key takes and operators
+// will write one either way; the scheme is dropped rather than honoured, since
+// the S3 leg re-signs and forwards over https regardless.
+func s3Host(configured string) string {
+	if configured == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(configured); err == nil && parsed.Host != "" {
+		return parsed.Host
+	}
+	return strings.TrimSuffix(configured, "/")
 }
 
 // Factory creates a new OVH provider backend.
@@ -41,7 +77,8 @@ The provider auto-detects the request type based on the Authorization header:
 - Standard API requests: injects Authorization: Bearer header with the API
   token and forwards to the configured ovh_url (default: https://eu.api.ovh.com/1.0)
 - S3 Object Storage requests (AWS SigV4): verifies the incoming signature, re-signs
-  with real OVH S3 credentials, and forwards to s3.{region}.io.cloud.ovh.net
+  with real OVH S3 credentials, and forwards to s3.{region}.io.cloud.ovh.net,
+  or to s3_url when one is set
 
 The gateway path format is:
   /ovh/gateway/{api-path}
@@ -92,6 +129,7 @@ Regional API endpoints and their matching OAuth2 token URLs:
 
 Configuration:
 - ovh_url: OVH API base URL (default: https://eu.api.ovh.com/1.0)
+- s3_url: Object Storage host override (default: s3.{region}.io.cloud.ovh.net)
 - max_body_size: Maximum request body size (default: 10MB, max: 100MB)
 - timeout: Request timeout duration (default: 30s)
 - auto_auth_path: Auth mount path for implicit authentication (e.g., 'auth/jwt/')

--- a/provider/ovh/provider.go
+++ b/provider/ovh/provider.go
@@ -35,9 +35,24 @@ var Spec = &dualgateway.ProviderSpec{
 			Description: "Override the Object Storage host the region would resolve to, for a private egress gateway fronting it. Host or URL; the S3 leg is always https.",
 		},
 	},
+	ValidateExtraConfig: func(config map[string]any) error {
+		// Nothing else checks this key, so a typo would be stored happily and
+		// surface much later as a per-request failure against a nonsense host.
+		configured := framework.GetConfigString(config, "s3_url", "")
+		if configured == "" {
+			return nil
+		}
+		host := s3Host(configured)
+		if host == "" || strings.ContainsAny(host, "/?#") {
+			return fmt.Errorf("s3_url must name a host, optionally with a port: %q", configured)
+		}
+		return nil
+	},
+	// Keyed as the operator wrote it, so a config read reports something the
+	// config write would accept. A host is itself a valid s3_url.
 	OnConfigParsed: func(config map[string]any) map[string]any {
 		return map[string]any{
-			"s3_host": s3Host(framework.GetConfigString(config, "s3_url", "")),
+			"s3_url": s3Host(framework.GetConfigString(config, "s3_url", "")),
 		}
 	},
 	S3Endpoint: func(state map[string]any, region string) string {
@@ -45,7 +60,7 @@ var Spec = &dualgateway.ProviderSpec{
 		// traffic leaves through a private gateway needs to name it. Without
 		// this the region is the only answer and the S3 leg always addresses
 		// the public host.
-		if host, _ := state["s3_host"].(string); host != "" {
+		if host, _ := state["s3_url"].(string); host != "" {
 			return host
 		}
 		return fmt.Sprintf("s3.%s.io.cloud.ovh.net", region)

--- a/provider/ovh/provider_test.go
+++ b/provider/ovh/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The S3 leg forces https and addresses a host, so an override is reduced to
@@ -23,6 +24,43 @@ func TestS3Host(t *testing.T) {
 			assert.Equal(t, tc.want, s3Host(tc.configured))
 		})
 	}
+}
+
+// Nothing else checks this key, so a value that cannot be a host has to be
+// refused here or it is stored and only fails per request, much later.
+func TestValidateExtraConfig(t *testing.T) {
+	for name, tc := range map[string]struct {
+		configured string
+		wantErr    bool
+	}{
+		"unset":               {"", false},
+		"bare host":           {"s3.egress.internal", false},
+		"host and port":       {"127.0.0.1:8443", false},
+		"full URL":            {"https://s3.egress.internal", false},
+		"scheme with no host": {"https://", true},
+		"host with a path":    {"s3.egress.internal/v1", true},
+		"query string":        {"s3.egress.internal?x=1", true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := Spec.ValidateExtraConfig(map[string]any{"s3_url": tc.configured})
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// A config read echoes the state map back, so the key has to be one the write
+// path would accept — otherwise a mount's configuration cannot round-trip.
+func TestOnConfigParsedRoundTrips(t *testing.T) {
+	state := Spec.OnConfigParsed(map[string]any{"s3_url": "https://s3.egress.internal/"})
+	host, ok := state["s3_url"].(string)
+	require.True(t, ok, "config read must report s3_url, the key an operator writes")
+	assert.Equal(t, "s3.egress.internal", host)
+	assert.NoError(t, Spec.ValidateExtraConfig(map[string]any{"s3_url": host}),
+		"what a read reports must be writable again")
 }
 
 func TestS3Endpoint(t *testing.T) {

--- a/provider/ovh/provider_test.go
+++ b/provider/ovh/provider_test.go
@@ -1,0 +1,44 @@
+package ovh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The S3 leg forces https and addresses a host, so an override is reduced to
+// one. Operators write the API-side key as a URL, so this accepts either rather
+// than making the two keys behave differently.
+func TestS3Host(t *testing.T) {
+	for name, tc := range map[string]struct{ configured, want string }{
+		"unset":           {"", ""},
+		"bare host":       {"s3.egress.internal", "s3.egress.internal"},
+		"host and port":   {"127.0.0.1:8443", "127.0.0.1:8443"},
+		"https URL":       {"https://s3.egress.internal", "s3.egress.internal"},
+		"URL with a path": {"https://s3.egress.internal/v1/", "s3.egress.internal"},
+		"http URL":        {"http://127.0.0.1:8443", "127.0.0.1:8443"},
+		"trailing slash":  {"s3.egress.internal/", "s3.egress.internal"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, s3Host(tc.configured))
+		})
+	}
+}
+
+func TestS3Endpoint(t *testing.T) {
+	t.Run("the region names the public host", func(t *testing.T) {
+		assert.Equal(t, "s3.gra.io.cloud.ovh.net", Spec.S3Endpoint(map[string]any{}, "gra"))
+	})
+
+	// An operator whose traffic leaves through a private gateway names it, and
+	// the region stops deciding where the request goes.
+	t.Run("an override wins over the region", func(t *testing.T) {
+		state := Spec.OnConfigParsed(map[string]any{"s3_url": "https://s3.egress.internal"})
+		assert.Equal(t, "s3.egress.internal", Spec.S3Endpoint(state, "gra"))
+	})
+
+	t.Run("no override leaves the region deciding", func(t *testing.T) {
+		state := Spec.OnConfigParsed(map[string]any{})
+		assert.Equal(t, "s3.gra.io.cloud.ovh.net", Spec.S3Endpoint(state, "gra"))
+	})
+}

--- a/provider/sdk/dualgateway/config.go
+++ b/provider/sdk/dualgateway/config.go
@@ -45,6 +45,12 @@ func validateConfig(spec *ProviderSpec, config map[string]any) error {
 		}
 	}
 
+	if spec.ValidateExtraConfig != nil {
+		if err := spec.ValidateExtraConfig(config); err != nil {
+			return err
+		}
+	}
+
 	if err := framework.ValidateCommonConfig(config); err != nil {
 		return err
 	}

--- a/provider/sdk/dualgateway/spec.go
+++ b/provider/sdk/dualgateway/spec.go
@@ -91,7 +91,18 @@ type ProviderSpec struct {
 	// OnConfigParsed is called after standard config parsing to extract
 	// provider-specific fields. Returns a state map stored on the backend.
 	// If nil, no extra state is maintained.
+	//
+	// Keys returned here are echoed back by a config read, so name them as the
+	// operator wrote them: a read that reports a key the write path would refuse
+	// leaves no way to round-trip a mount's configuration.
 	OnConfigParsed func(config map[string]any) map[string]any
+
+	// ValidateExtraConfig checks the values behind ExtraConfigKeys at write time.
+	// The standard validation covers only the keys every provider shares, so
+	// without this an extra key is accepted with any content at all and a typo
+	// surfaces as a per-request failure long afterwards. If nil, extra keys are
+	// accepted as written.
+	ValidateExtraConfig func(config map[string]any) error
 
 	// --- Optional Credential Extraction Overrides ---
 


### PR DESCRIPTION
The ovh suite was one row: a bearer token minted through an `oauth2_token` spec, asserted by hand. It covered one of the mint methods, one of the two gateway modes, and none of the chaining — so the object-storage half of a dual-mode gateway had never been driven end to end by anything.

## What the rows now cover

- **The `oauth2_token` chain** fetches its service account from the secret store and performs a *real* grant. Hydra validates the pair, so unlike every other chained row in this package — whose secret is spent on a stand-in that would accept anything — the row exercises a validating token endpoint.
- **The `access_keys` chain** follows a pair all the way through the S3 leg and asserts it in the outgoing signature, while asserting the OVH API was called zero times, which is the whole claim of that mint method.
- Both run under **both subject modes**, so each secret is fetched and spent once with the agent's own JWT forwarded as the subject and once with an assertion Warden signed itself.
- A tampered signature is refused before any credential is spent, and six configuration shapes are refused at write time rather than at first use.

## The one product change

Reaching the S3 leg needed `s3_url`. The region resolved to a real public host with no way to name anything else, so that leg could not be pointed at a listener and had no coverage at all. It is the same private-egress configuration `ovh_url` already provides on the API side, and the mechanism r2 uses for `account_id`.

The dual-gateway spec also gains a `ValidateExtraConfig` hook: the shared validation covers only the keys every provider has, so without it an extra key is accepted with any content at all and a typo surfaces as a per-request failure much later. Nil-able and additive; the other providers are unaffected.

## Review follow-ups included here

This branch also carries the fixes from a review of the whole stack. They touch files owned by the earlier PRs, so **the earlier three read as they were originally written** — if you would rather each PR stand alone, say so and I will distribute these into their owning branches.

Two of them were in the new tests, and both were the kind that pass while proving nothing:

- `GetJWT` performs a fresh grant on every call, so two negative assertions compared the credential that reached the upstream against a token that was never sent. A leak of the user's bearer would have passed. Both now compare against what actually travelled.
- The chained row could not tell the chain from a routing regression: its secret was seeded as `e2e-agent`/`agent-secret`, which every other source in the suite holds inline and Hydra accepts from anyone. The chain now has a Hydra client of its own, existing nowhere but the secret store, and the row decodes the minted token and asserts the claim naming it. Verified by reseeding with the old shared value and confirming the row fails.

The rest: the tampered-signature row accepted any 403 (a policy denial would have passed it); `s3_url` had no validation at all and its parsed state was keyed so a config read reported something the write path refuses; an orphaned-lease log was `Debug`, hiding what the release notes ask operators to clean up; a `secret_field` naming `client_id` would post the id as the secret and read as a stale credential; and the missing-service-account error now names the chaining alternative, because `VerifySpec`'s version of that message is unreachable — spec validation test-mints first.

## Testing

Full e2e suite green across all 20 packages on a clean cluster. Unit tests green.

One pre-existing failure, `TestNewTransportWithTLS_ValidCAData` in `provider/sdk/httpproxy`, also fails on `main` and is unrelated.

---

Fourth of four stacked PRs. Based on #550.
