### PR TITLE
docs: make per-request role assertion the landing page's lead, and answer grant-vs-authority in the roles doc

### DIFF
--- a/site/src/content/docs/concepts/roles.md
+++ b/site/src/content/docs/concepts/roles.md
@@ -2,27 +2,80 @@
 title: "Roles"
 ---
 
-A **role** is a named, reusable definition — set once by an operator on an
-[auth method](/concepts/authentication/#auth-methods) — that projects a specific slice
-of capability onto a caller. The closest analogy is a **database view**: it
-stores no authority of its own and holds no data. It is a saved definition that
-Warden **resolves on each request** into a concrete grant — *who may assume it*
-(the identity binding), *what it may do* (its [policies](/concepts/policies/)), and
-*what credential it is handed* (the [credential spec](/concepts/credentials/) Warden
-mints). And just as many views can sit over the same tables, each exposing a
-different subset of columns and rows, many roles can sit over the same provider backend,
-each exposing a different subset of its actions.
+A **role** is something a caller **asserts**, not something it holds. An operator
+defines it once on an [auth method](/concepts/authentication/#auth-methods); a caller
+then names it on an individual request — *"I am acting as `read-repo` for this
+call"* — and Warden decides, on that request, whether the assertion holds. Nothing
+is handed over and nothing is kept. What the assertion produces — a token carrying
+the role's [policies](/concepts/policies/), and the credential Warden mints from its
+[credential spec](/concepts/credentials/) — lives for that one request and no longer.
+
+A role definition has two halves. It is a **predicate** — *who may assume it*, the
+identity binding — and a **projection** — *what they may do*, and *what credential
+they are handed*. Warden evaluates both fresh on every request.
 
 This is what lets one workload hold a single identity credential yet act with **least
-privilege**: it borrows exactly the authority of whichever role it names for the
-task at hand, and nothing more.
+privilege**: it borrows exactly the authority of whichever role it names for the task
+at hand, for exactly one call, and nothing more.
+
+## Grant, Authority, or Neither?
+
+Both words get used loosely for roles, and neither one fits. Being precise about it
+explains most of what follows.
+
+An **authority** is a power a principal *holds*. A role holds nothing — it is a
+definition sitting in storage, not a capability sitting on a caller.
+
+A **grant** is a conferral that has *already happened*, to a named principal, and
+that persists until it is revoked. A role is not that either: it matches nobody
+until a request arrives carrying a credential that satisfies its binding.
+
+So a role is **neither**. It is the definition that turns a verified identity into a
+grant — and the grant is the *output*: the token and the minted credential, alive for
+the length of one request.
+
+The contrast with a cloud STS is exact, and worth holding on to. `AssumeRole` also
+resolves a role definition against an identity, but what comes back is a **held
+grant** — session credentials the caller carries for an hour, everywhere it goes,
+until they expire. In Warden the assumption never converts into something the caller
+holds.
+
+> **A role is asserted, not held. The grant is what the assertion produces, and it
+> lasts one request.**
+
+## Roles Are Per-Request
+
+Because a role is resolved on each request, authority is never fixed onto a
+connection or a session. This is the property the rest of this page builds on.
+
+**The role is supplied on every request.** For transparent callers there is no
+login and no session in which a role is set once; the role travels with each
+individual request (via the `X-Warden-Role` header, the request path, or a query
+parameter — see [Selecting a Role](#selecting-a-role)). The role is a property of
+the request, not of the connection.
+
+**Authorization happens per request, at runtime.** Warden authorizes each request
+independently against the role it names. Internally it derives a transparent
+token's identifier by hashing *credential + mount + role* together, so a request
+that names a different role resolves to a different token with different policies.
+
+**Clients can change role mid-session.** The same workload, holding the same
+credential, can present one role on one request and a different role on the next.
+This is exactly what the worked example below relies on: an agent operates under a
+least-privilege role for routine work and names a higher-privilege role only for
+the specific step that genuinely needs it, narrowing the blast radius of any
+single action without re-authenticating.
 
 ## A Role Is a View Over Your Infrastructure
 
-Calling a role "an identity" is the common shorthand, but it's misleading: an
-identity is something you *hold*, whereas a role holds nothing — like a database
-view, it is resolved fresh on every request. That is why the view analogy fits
-better, and it is worth making precise:
+Calling a role "an identity" is the common shorthand, and it misleads for the reason
+above: an identity is something you *hold*. The sharper analogy for a definition that
+holds nothing and is resolved fresh on every use is a **database view**. A view stores
+no data; it is a saved definition the database evaluates against the base tables on
+each query. And just as many views can sit over the same tables, each exposing a
+different subset of columns and rows, many roles can sit over the same provider
+backend, each exposing a different subset of its actions. The parallel runs closer
+than it first looks:
 
 | A database view… | A Warden role… |
 |------------------|----------------|
@@ -161,6 +214,15 @@ separate, isolated routes from one agent, sharing no authority. There is no
 ambient, pre-granted authority sitting on the connection waiting to be reused, so
 there is nothing to move laterally *into*.
 
+**Nothing accrues on the session for an attacker to lift.** Elsewhere, assuming a
+role produces session credentials that sit in the agent's process until they expire —
+an artifact that can be stolen and replayed for as long as it stays valid. Warden
+hands the caller no such artifact: the credential it mints is injected upstream and
+never reaches the agent, and a transparent caller never logs in at all — it presents
+the identity it already had, names a role, and Warden resolves the pair itself on
+each request. There is no assumed-role session to lift, because assuming a role here
+produces nothing that outlives the call.
+
 **A hallucinated — or injected — action can't do damage: the model can't call
 what its role doesn't grant.** Because `tools/list` is filtered to the role's
 allowed set, a destructive tool the model might invent — `delete_repo`, say — or
@@ -187,29 +249,6 @@ a subtask, the trail reads as a per-task ledger: which role searched the repo,
 which pushed, which messaged Slack — each under its own scoped credential. When
 something goes wrong, you know precisely which task did it and with what
 authority.
-
-## Roles Are Per-Request
-
-Because a role is resolved on each request — like a view evaluated fresh on each
-query — authority is never fixed onto a connection or a session.
-
-**The role is supplied on every request.** For transparent callers there is no
-login and no session in which a role is set once; the role travels with each
-individual request (via the `X-Warden-Role` header, the request path, or a query
-parameter — see [Selecting a Role](#selecting-a-role)). The role is a property of
-the request, not of the connection.
-
-**Authorization happens per request, at runtime.** Warden authorizes each request
-independently against the role it names. Internally it derives a transparent
-token's identifier by hashing *credential + mount + role* together, so a request
-that names a different role resolves to a different token with different policies.
-
-**Clients can change role mid-session.** The same workload, holding the same
-credential, can present one role on one request and a different role on the next.
-This is exactly what the worked example above relies on: an agent operates under a
-least-privilege role for routine work and names a higher-privilege role only for
-the specific step that genuinely needs it, narrowing the blast radius of any
-single action without re-authenticating.
 
 ## Where Roles Live
 
@@ -251,7 +290,9 @@ warden role list -o ndjson | jq -r .name
 
 ## Common Fields
 
-Every role, regardless of auth method, shares the same grant fields:
+Every role, regardless of auth method, shares the same definition fields. Nothing
+here is conferred at write time; this is what the assertion resolves to when a
+request names the role:
 
 | Field | Meaning |
 |-------|---------|
@@ -365,7 +406,7 @@ automatically.
 
 - [Authentication](/concepts/authentication/) — how a credential is proven before a role
   is applied.
-- [Policies](/concepts/policies/) — what a role grants.
+- [Policies](/concepts/policies/) — what a role projects onto the caller.
 - [MCP](/concepts/mcp/) — how a role's policy filters a provider's `tools/list` and gates
   each `tools/call`.
 - [Providers](/concepts/providers/) — the upstreams a role reaches.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -70,6 +70,10 @@ const nav = [
               <a class="btn btn-primary" href="/concepts/">Get started</a>
               <a class="btn btn-on-dark" href={github}>View on GitHub</a>
             </div>
+            <p class="hero-note">
+              No session-scoped access. Your agent names a role on every single request, and
+              Warden authorizes every one.
+            </p>
           </div>
 
           <div class="hero-visual">
@@ -252,50 +256,54 @@ const nav = [
 
             <article class="pillar">
               <div class="pillar-copy">
-                <p class="pillar-tag">Beyond a single access level</p>
-                <h3>Let one agent assume the right role for each task</h3>
+                <p class="pillar-tag">A role per request, not per session</p>
+                <h3>The role is asserted on every call — never held</h3>
                 <p>
-                  Hand an agent one access level and it carries the same broad permissions
-                  everywhere. Warden breaks access into roles — named, least-privilege slices,
-                  each scoped to a single task, that the agent assumes one at a time. It reads a
-                  repo under one role, pushes under another, posts to Slack under a third, and
-                  each role exposes only the tools its policy allows — the rest aren't just blocked,
-                  they're also invisible. No other gateway models agent access this way.
+                  Assuming a role elsewhere means holding one: cloud STS hands back session
+                  credentials good for an hour, and until they expire the agent carries that
+                  authority everywhere it goes. Warden hands over nothing. The agent names a
+                  role on each individual request — reading a repo under one, pushing under
+                  another, posting to Slack under a third, down the same connection without
+                  re-authenticating — and Warden re-verifies its identity, re-resolves that
+                  role's policy, and mints a fresh credential for that one call. Nothing
+                  accumulates on the session, so there is no assumed role sitting there to
+                  steal or wander around inside. And each role exposes only the tools its
+                  policy allows — the rest aren't just blocked, they're invisible.
                 </p>
                 <a class="pillar-link" href="/concepts/roles/">How roles work <span class="arw" aria-hidden="true">→</span></a>
               </div>
               <div class="pillar-visual">
-                <svg viewBox="0 0 320 190" role="img" aria-label="The read-repo role allows search_repos and read_file but not push; the push-repo role allows push but not search_repos or read_file — each role scopes a different set of tools.">
-                  <text x="160" y="18" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10" letter-spacing="0.5">TOOLS ARE SCOPED TO ROLES</text>
-                  <g font-family="sans-serif">
-                    <!-- read-repo: reads allowed, push not -->
-                    <rect x="14" y="38" width="142" height="140" rx="11" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
-                    <text x="85" y="60" text-anchor="middle" fill="#1a2233" font-size="12" font-weight="600">read-repo</text>
-                    <line x1="26" y1="70" x2="144" y2="70" stroke="#e6e8ee" stroke-width="1.2" />
-                    <circle cx="34" cy="92" r="7" fill="#0b1020" />
-                    <path d="M31 92 l2 2 l4 -5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-                    <text x="48" y="96" fill="#1a2233" font-size="10.5">search_repos</text>
-                    <circle cx="34" cy="120" r="7" fill="#0b1020" />
-                    <path d="M31 120 l2 2 l4 -5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-                    <text x="48" y="124" fill="#1a2233" font-size="10.5">read_file</text>
-                    <circle cx="34" cy="148" r="7" fill="#e01e1e" />
-                    <path d="M31 145 l6 6 M37 145 l-6 6" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" />
-                    <text x="48" y="152" fill="#b6bccb" font-size="10.5">push</text>
-
-                    <!-- push-repo: push allowed, reads not -->
-                    <rect x="164" y="38" width="142" height="140" rx="11" fill="#fff" stroke="#cbd2e0" stroke-width="1.4" />
-                    <text x="235" y="60" text-anchor="middle" fill="#1a2233" font-size="12" font-weight="600">push-repo</text>
-                    <line x1="176" y1="70" x2="294" y2="70" stroke="#e6e8ee" stroke-width="1.2" />
-                    <circle cx="184" cy="92" r="7" fill="#e01e1e" />
-                    <path d="M181 89 l6 6 M187 89 l-6 6" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" />
-                    <text x="198" y="96" fill="#b6bccb" font-size="10.5">search_repos</text>
-                    <circle cx="184" cy="120" r="7" fill="#e01e1e" />
-                    <path d="M181 117 l6 6 M187 117 l-6 6" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" />
-                    <text x="198" y="124" fill="#b6bccb" font-size="10.5">read_file</text>
-                    <circle cx="184" cy="148" r="7" fill="#0b1020" />
-                    <path d="M181 148 l2 2 l4 -5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-                    <text x="198" y="152" fill="#1a2233" font-size="10.5">push</text>
+                <svg viewBox="0 0 320 190" role="img" aria-label="Three consecutive requests travel down one connection under one identity; each names a different role — read-repo, then push-repo, then send-message — and each is re-authorized on its own and handed its own fresh credential.">
+                  <text x="160" y="16" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10" letter-spacing="0.5">SAME CONNECTION · SAME IDENTITY</text>
+                  <line x1="26" y1="34" x2="26" y2="162" stroke="#0b1020" stroke-width="2" stroke-linecap="round" />
+                  <g stroke="#cbd2e0" stroke-width="1.5">
+                    <line x1="26" y1="55" x2="44" y2="55" />
+                    <line x1="26" y1="99" x2="44" y2="99" />
+                    <line x1="26" y1="143" x2="44" y2="143" />
                   </g>
+                  <g font-family="sans-serif">
+                    <rect x="44" y="36" width="262" height="38" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
+                    <circle cx="66" cy="55" r="10" fill="#0b1020" />
+                    <text x="66" y="59" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">1</text>
+                    <text x="86" y="59" fill="#1a2233" font-size="12" font-weight="600">read-repo</text>
+                    <circle cx="284" cy="55" r="8" fill="#0b1020" />
+                    <path d="M280 55 l3 3 l5 -6" stroke="#fff" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+
+                    <rect x="44" y="80" width="262" height="38" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
+                    <circle cx="66" cy="99" r="10" fill="#0b1020" />
+                    <text x="66" y="103" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">2</text>
+                    <text x="86" y="103" fill="#1a2233" font-size="12" font-weight="600">push-repo</text>
+                    <circle cx="284" cy="99" r="8" fill="#0b1020" />
+                    <path d="M280 99 l3 3 l5 -6" stroke="#fff" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+
+                    <rect x="44" y="124" width="262" height="38" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
+                    <circle cx="66" cy="143" r="10" fill="#0b1020" />
+                    <text x="66" y="147" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">3</text>
+                    <text x="86" y="147" fill="#1a2233" font-size="12" font-weight="600">send-message</text>
+                    <circle cx="284" cy="143" r="8" fill="#0b1020" />
+                    <path d="M280 143 l3 3 l5 -6" stroke="#fff" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+                  </g>
+                  <text x="160" y="180" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="9">each request re-authorized · its own fresh credential · nothing carried over</text>
                 </svg>
               </div>
             </article>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,22 +62,20 @@ const nav = [
           <div>
             <h1>The secure gateway for the AI agent era</h1>
             <p class="sub">
-              Manage what your AI agents can reach and stop credentials from ever landing in
-              their hands, with identity-based access for every MCP server, cloud, code host,
-              database, and SaaS your agents now touch.
+              Decide what every AI agent may do, call by call, across every MCP server, cloud,
+              code host, database, and SaaS it touches.
             </p>
             <div class="hero-actions">
               <a class="btn btn-primary" href="/concepts/">Get started</a>
               <a class="btn btn-on-dark" href={github}>View on GitHub</a>
             </div>
             <p class="hero-note">
-              No session-scoped access. Your agent names a role on every single request, and
-              Warden authorizes every one.
+              Your agent names a role on every request, and Warden authorizes every one.
             </p>
           </div>
 
           <div class="hero-visual">
-            <svg class="flow" viewBox="0 0 340 366" role="img" aria-label="An AI agent presents its own identity and the identity of the user it acts for to Warden, which authenticates them, authorizes the call, mints a fresh short-lived credential, and proxies the request to upstream systems.">
+            <svg class="flow" viewBox="0 0 340 366" role="img" aria-label="On each request an AI agent asserts a role, presenting its own identity and the identity of the user it acts for to Warden, which authenticates them, authorizes the call, mints a fresh short-lived credential, and proxies the request to upstream systems.">
               <defs>
                 <marker id="ar" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
                   <path d="M0 0 L10 5 L0 10 z" fill="#cdd4e6" />
@@ -85,7 +83,7 @@ const nav = [
               </defs>
               <rect class="box" x="60" y="14" width="220" height="72" rx="12" />
               <text class="t" x="170" y="46">AI Agent</text>
-              <text class="s" x="170" y="66">presents agent + user identity</text>
+              <text class="s" x="170" y="66">assert a role per request</text>
 
               <line class="line" x1="170" y1="90" x2="170" y2="142" marker-end="url(#ar)" />
               <text class="e" x="150" y="120" style="text-anchor:end">agent identity</text>
@@ -127,12 +125,11 @@ const nav = [
                 <p>
                   A short-lived token is still a secret in the agent's environment — just one
                   that expires. Warden removes it. The agent holds no upstream key: it presents
-                  only identities — its own, and (when it acts for someone) the user's — and Warden
-                  authenticates them, mints a scoped credential, and injects it on the way through.
-                  Jailbroken or prompt-injected, it has nothing to exfiltrate, because it never held
-                  anything. And in its keyless modes the gateway is no honeypot in its place:
-                  federation lets Warden hold no standing secret, and chaining fetches what it needs
-                  from an external vault per request — so there is no key-trove to breach.
+                  only identities — its own, and the user's when it acts for someone — and
+                  Warden mints a scoped credential and injects it on the way through.
+                  Jailbroken or prompt-injected, it has nothing to exfiltrate. Nor does the
+                  gateway become the honeypot: federation leaves Warden no standing secret, and
+                  chaining fetches each credential from an external vault per request.
                 </p>
                 <a class="pillar-link" href="/concepts/credentials/">How credentials work <span class="arw" aria-hidden="true">→</span></a>
               </div>
@@ -157,24 +154,70 @@ const nav = [
                 </svg>
               </div>
             </article>
-
             <article class="pillar">
               <div class="pillar-copy">
-                <p class="pillar-tag">Beyond a shared service identity</p>
+                <p class="pillar-tag">A role per request, not per session</p>
+                <h3>The role is asserted on every call — never held</h3>
+                <p>
+                  Assuming a role elsewhere means holding one: cloud STS hands back session
+                  credentials good for an hour, carried everywhere until they expire. Warden
+                  hands over nothing. The agent names a role on each request — reading a repo
+                  under one, pushing under another — and every call is re-authorized against
+                  that role's policy, with its own freshly minted credential. Nothing
+                  accumulates on the session; there is no assumed role to steal, and each role
+                  shows the agent only the tools it allows.
+                </p>
+                <a class="pillar-link" href="/concepts/roles/">How roles work <span class="arw" aria-hidden="true">→</span></a>
+              </div>
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="A table of three consecutive requests on the same connection. Request 1 asserts the role read-repo, request 2 asserts push-repo, request 3 asserts send-message, and Warden mints a new credential for each one.">
+                  <g font-family="sans-serif" font-weight="700" font-size="7.5" fill="#5b6478" letter-spacing="0.5" text-anchor="middle">
+                    <text x="44" y="24">REQUEST</text>
+                    <text x="135" y="24">ROLE ASSERTED</text>
+                    <text x="248" y="24">WARDEN MINTS</text>
+                  </g>
+                  <g font-family="sans-serif">
+                    <rect x="14" y="36" width="292" height="36" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
+                    <circle cx="44" cy="54" r="11" fill="#0b1020" />
+                    <text x="44" y="58" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">1</text>
+                    <text x="135" y="58" text-anchor="middle" fill="#1a2233" font-size="11.5" font-weight="600">read-repo</text>
+                    <rect x="200" y="44" width="96" height="20" rx="10" fill="#fff" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="248" y="58" text-anchor="middle" fill="#1a2233" font-size="9">a new credential</text>
+
+                    <rect x="14" y="78" width="292" height="36" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
+                    <circle cx="44" cy="96" r="11" fill="#0b1020" />
+                    <text x="44" y="100" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">2</text>
+                    <text x="135" y="100" text-anchor="middle" fill="#1a2233" font-size="11.5" font-weight="600">push-repo</text>
+                    <rect x="200" y="86" width="96" height="20" rx="10" fill="#fff" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="248" y="100" text-anchor="middle" fill="#1a2233" font-size="9">a new credential</text>
+
+                    <rect x="14" y="120" width="292" height="36" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
+                    <circle cx="44" cy="138" r="11" fill="#0b1020" />
+                    <text x="44" y="142" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">3</text>
+                    <text x="135" y="142" text-anchor="middle" fill="#1a2233" font-size="11.5" font-weight="600">send-message</text>
+                    <rect x="200" y="128" width="96" height="20" rx="10" fill="#fff" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="248" y="142" text-anchor="middle" fill="#1a2233" font-size="9">a new credential</text>
+                  </g>
+                  <text x="160" y="171" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="8.5">each one authorized on its own · nothing carried over to the next</text>
+                </svg>
+              </div>
+            </article>
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">From impersonation to delegation</p>
                 <h3>One agent — and every user is still themselves</h3>
                 <p>
                   An agent often acts for many people at once. Warden carries each person's
                   verified identity alongside the agent's, so the upstream authorizes the real
-                  human — with their own scope — and every action is attributed to them, not a
-                  shared service account. One agent connects to every system; the person behind
-                  each request is never collapsed into it. It works even for systems with no
-                  built-in way to act on someone's behalf, and scales to a whole fleet of users
-                  without a role per person.
+                  human — the agent acting for them, not as them — and every action is
+                  attributed to the person, not to a shared service account.
+                  It works even where the upstream has no built-in way to act on someone's
+                  behalf, and scales to thousands of users without a role for each one.
                 </p>
-                <a class="pillar-link" href="/use-cases/per-user-access/">See per-user access <span class="arw" aria-hidden="true">→</span></a>
+                <a class="pillar-link" href="/concepts/delegation/">How delegation works <span class="arw" aria-hidden="true">→</span></a>
               </div>
               <div class="pillar-visual">
-                <svg viewBox="0 0 320 190" role="img" aria-label="Three users each keep their own identity; a single agent carries each identity through Warden to every system, where each user is authorized and audited as themselves.">
+                <svg viewBox="0 0 320 190" role="img" aria-label="Three users each keep their own identity. One agent carries its own identity together with each user's out to every system, so a request names both the agent and the person it acts for, and each user is authorized and audited as themselves.">
                   <!-- users converge into the agent -->
                   <line x1="35" y1="44" x2="112" y2="86" stroke="#cbd2e0" stroke-width="1.6" />
                   <line x1="35" y1="95" x2="112" y2="95" stroke="#cbd2e0" stroke-width="1.6" />
@@ -205,118 +248,34 @@ const nav = [
                     <text x="22" y="152" text-anchor="middle">C</text>
                   </g>
                   <text x="22" y="176" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="8" letter-spacing="0.5">USERS</text>
-                  <!-- the same identities, carried through the one agent -->
+                  <!-- both principals travel: the agent's own identity beside each user's -->
                   <g font-family="sans-serif" font-weight="700" font-size="8" fill="#1a2233">
-                    <circle cx="206" cy="78" r="8" fill="#fff" stroke="#1a2233" stroke-width="1.3" />
-                    <text x="206" y="81" text-anchor="middle">A</text>
-                    <circle cx="206" cy="95" r="8" fill="#fff" stroke="#1a2233" stroke-width="1.3" />
-                    <text x="206" y="98" text-anchor="middle">B</text>
-                    <circle cx="206" cy="112" r="8" fill="#fff" stroke="#1a2233" stroke-width="1.3" />
-                    <text x="206" y="115" text-anchor="middle">C</text>
+                    <circle cx="191" cy="78" r="5.5" fill="#0b1020" />
+                    <circle cx="210" cy="78" r="8" fill="#fff" stroke="#1a2233" stroke-width="1.3" />
+                    <text x="210" y="81" text-anchor="middle">A</text>
+                    <circle cx="191" cy="95" r="5.5" fill="#0b1020" />
+                    <circle cx="210" cy="95" r="8" fill="#fff" stroke="#1a2233" stroke-width="1.3" />
+                    <text x="210" y="98" text-anchor="middle">B</text>
+                    <circle cx="191" cy="112" r="5.5" fill="#0b1020" />
+                    <circle cx="210" cy="112" r="8" fill="#fff" stroke="#1a2233" stroke-width="1.3" />
+                    <text x="210" y="115" text-anchor="middle">C</text>
                   </g>
+                  <text x="201" y="134" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="7.5">agent + user</text>
                   <text x="280" y="155" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="8">authorized &amp; audited</text>
                   <text x="280" y="166" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="8">as the real user</text>
                 </svg>
               </div>
             </article>
-
             <article class="pillar">
               <div class="pillar-copy">
-                <p class="pillar-tag">Beyond static API specs</p>
-                <h3>Agents discover exactly what they can call</h3>
-                <p>
-                  An MCP server advertises its tools; a plain REST API just hands over a
-                  sprawling spec and leaves the agent to guess. Warden gives every non-MCP
-                  system the same treatment — the agent asks what it can do and gets back only
-                  the endpoints its policy allows, each with a schema scoped to the arguments it
-                  may pass. Fewer failed calls, and no ten-thousand-line spec stuffed into the
-                  context window.
-                </p>
-                <a class="pillar-link" href="/concepts/discovery-and-skills/">How discovery works <span class="arw" aria-hidden="true">→</span></a>
-              </div>
-              <div class="pillar-visual">
-                <svg viewBox="0 0 320 190" role="img" aria-label="A discovery response lists only the endpoints the agent may call, each with a schema scoped to the arguments it may pass; disallowed endpoints stay hidden.">
-                  <rect x="24" y="16" width="272" height="158" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.5" />
-                  <text x="44" y="42" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10.5" letter-spacing="0.6">DISCOVER · what can I use?</text>
-                  <line x1="44" y1="52" x2="276" y2="52" stroke="#e6e8ee" stroke-width="1.3" />
-                  <g font-family="sans-serif" font-size="12">
-                    <rect x="44" y="64" width="232" height="28" rx="7" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
-                    <text x="56" y="82" fill="#1a2233">POST /deploy</text>
-                    <text x="264" y="82" text-anchor="end" fill="#e01e1e" font-size="10.5">{"{ env, region }"}</text>
-                    <rect x="44" y="100" width="232" height="28" rx="7" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
-                    <text x="56" y="118" fill="#1a2233">GET /logs</text>
-                    <text x="264" y="118" text-anchor="end" fill="#e01e1e" font-size="10.5">{"{ service }"}</text>
-                    <rect x="44" y="136" width="232" height="28" rx="7" fill="#fff" stroke="#e6e8ee" stroke-width="1.2" stroke-dasharray="4 4" />
-                    <text x="56" y="154" fill="#b6bccb">DELETE /records</text>
-                    <text x="264" y="154" text-anchor="end" fill="#b6bccb" font-size="10.5">not exposed</text>
-                  </g>
-                </svg>
-              </div>
-            </article>
-
-            <article class="pillar">
-              <div class="pillar-copy">
-                <p class="pillar-tag">A role per request, not per session</p>
-                <h3>The role is asserted on every call — never held</h3>
-                <p>
-                  Assuming a role elsewhere means holding one: cloud STS hands back session
-                  credentials good for an hour, and until they expire the agent carries that
-                  authority everywhere it goes. Warden hands over nothing. The agent names a
-                  role on each individual request — reading a repo under one, pushing under
-                  another, posting to Slack under a third, down the same connection without
-                  re-authenticating — and Warden re-verifies its identity, re-resolves that
-                  role's policy, and mints a fresh credential for that one call. Nothing
-                  accumulates on the session, so there is no assumed role sitting there to
-                  steal or wander around inside. And each role exposes only the tools its
-                  policy allows — the rest aren't just blocked, they're invisible.
-                </p>
-                <a class="pillar-link" href="/concepts/roles/">How roles work <span class="arw" aria-hidden="true">→</span></a>
-              </div>
-              <div class="pillar-visual">
-                <svg viewBox="0 0 320 190" role="img" aria-label="Three consecutive requests travel down one connection under one identity; each names a different role — read-repo, then push-repo, then send-message — and each is re-authorized on its own and handed its own fresh credential.">
-                  <text x="160" y="16" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10" letter-spacing="0.5">SAME CONNECTION · SAME IDENTITY</text>
-                  <line x1="26" y1="34" x2="26" y2="162" stroke="#0b1020" stroke-width="2" stroke-linecap="round" />
-                  <g stroke="#cbd2e0" stroke-width="1.5">
-                    <line x1="26" y1="55" x2="44" y2="55" />
-                    <line x1="26" y1="99" x2="44" y2="99" />
-                    <line x1="26" y1="143" x2="44" y2="143" />
-                  </g>
-                  <g font-family="sans-serif">
-                    <rect x="44" y="36" width="262" height="38" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
-                    <circle cx="66" cy="55" r="10" fill="#0b1020" />
-                    <text x="66" y="59" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">1</text>
-                    <text x="86" y="59" fill="#1a2233" font-size="12" font-weight="600">read-repo</text>
-                    <circle cx="284" cy="55" r="8" fill="#0b1020" />
-                    <path d="M280 55 l3 3 l5 -6" stroke="#fff" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-
-                    <rect x="44" y="80" width="262" height="38" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
-                    <circle cx="66" cy="99" r="10" fill="#0b1020" />
-                    <text x="66" y="103" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">2</text>
-                    <text x="86" y="103" fill="#1a2233" font-size="12" font-weight="600">push-repo</text>
-                    <circle cx="284" cy="99" r="8" fill="#0b1020" />
-                    <path d="M280 99 l3 3 l5 -6" stroke="#fff" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-
-                    <rect x="44" y="124" width="262" height="38" rx="9" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.3" />
-                    <circle cx="66" cy="143" r="10" fill="#0b1020" />
-                    <text x="66" y="147" text-anchor="middle" fill="#fff" font-weight="700" font-size="11">3</text>
-                    <text x="86" y="147" fill="#1a2233" font-size="12" font-weight="600">send-message</text>
-                    <circle cx="284" cy="143" r="8" fill="#0b1020" />
-                    <path d="M280 143 l3 3 l5 -6" stroke="#fff" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-                  </g>
-                  <text x="160" y="180" text-anchor="middle" fill="#5b6478" font-family="sans-serif" font-size="9">each request re-authorized · its own fresh credential · nothing carried over</text>
-                </svg>
-              </div>
-            </article>
-
-            <article class="pillar">
-              <div class="pillar-copy">
-                <p class="pillar-tag">Beyond scope-based access</p>
+                <p class="pillar-tag">A scope only opens the door</p>
                 <h3>Authorize every call, down to the argument</h3>
                 <p>
-                  OAuth scopes and IAM roles hand out broad, session-wide access, then trust the
-                  agent to stay inside it. Warden decides each call as it happens — which action,
-                  which tool, which arguments, and on whose behalf it acts. Least privilege on
-                  every request, never a coarse grant the agent can wander around inside.
+                  A scope that grants write access to repositories names a category of action,
+                  not the action itself, and then trusts the agent to stay inside it. Warden
+                  decides the call instead: which tool, with which arguments, against which
+                  resource. Deploying to staging goes through; the same tool aimed at production
+                  does not — a line drawn at the gateway, not asked of the model.
                 </p>
                 <a class="pillar-link" href="/concepts/policies/">How policies work <span class="arw" aria-hidden="true">→</span></a>
               </div>
@@ -338,6 +297,39 @@ const nav = [
                     <path d="M60 129 l8 8 M68 129 l-8 8" stroke="#fff" stroke-width="1.8" fill="none" stroke-linecap="round" />
                     <text x="84" y="137" fill="#1a2233">env = "production"</text>
                     <text x="266" y="137" text-anchor="end" fill="#e01e1e" font-size="10.5">blocked</text>
+                  </g>
+                </svg>
+              </div>
+            </article>
+            <article class="pillar">
+              <div class="pillar-copy">
+                <p class="pillar-tag">Discovery for every system</p>
+                <h3>Agents discover exactly what they can call</h3>
+                <p>
+                  An MCP server can tell an agent what tools it offers. A REST API can't: it
+                  hands over a sprawling spec and leaves the agent to guess which parts it may
+                  touch. Warden answers the question for both — the agent asks what it can do
+                  here and gets back a short, typed list of exactly the calls it may make, each
+                  schema narrowed to the arguments it may pass. Fewer failed calls, and no
+                  ten-thousand-line spec stuffed into the context window.
+                </p>
+                <a class="pillar-link" href="/concepts/discovery-and-skills/">How discovery works <span class="arw" aria-hidden="true">→</span></a>
+              </div>
+              <div class="pillar-visual">
+                <svg viewBox="0 0 320 190" role="img" aria-label="A discovery response lists only the endpoints the agent may call, each with a schema scoped to the arguments it may pass; disallowed endpoints stay hidden.">
+                  <rect x="24" y="16" width="272" height="158" rx="12" fill="#fff" stroke="#cbd2e0" stroke-width="1.5" />
+                  <text x="44" y="42" fill="#5b6478" font-family="sans-serif" font-weight="700" font-size="10.5" letter-spacing="0.6">DISCOVER · what can I use?</text>
+                  <line x1="44" y1="52" x2="276" y2="52" stroke="#e6e8ee" stroke-width="1.3" />
+                  <g font-family="sans-serif" font-size="12">
+                    <rect x="44" y="64" width="232" height="28" rx="7" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="56" y="82" fill="#1a2233">POST /deploy</text>
+                    <text x="264" y="82" text-anchor="end" fill="#e01e1e" font-size="10.5">{"{ env, region }"}</text>
+                    <rect x="44" y="100" width="232" height="28" rx="7" fill="#f6f7f9" stroke="#cbd2e0" stroke-width="1.2" />
+                    <text x="56" y="118" fill="#1a2233">GET /logs</text>
+                    <text x="264" y="118" text-anchor="end" fill="#e01e1e" font-size="10.5">{"{ service }"}</text>
+                    <rect x="44" y="136" width="232" height="28" rx="7" fill="#fff" stroke="#e6e8ee" stroke-width="1.2" stroke-dasharray="4 4" />
+                    <text x="56" y="154" fill="#b6bccb">DELETE /records</text>
+                    <text x="264" y="154" text-anchor="end" fill="#b6bccb" font-size="10.5">not exposed</text>
                   </g>
                 </svg>
               </div>


### PR DESCRIPTION
Per-request role assertion is one of Warden's main advantages and it appeared nowhere on the landing page. This makes it the lead, then fixes the roles concept page it links into.

## Landing page

**The roles pillar now leads with per-request assertion.** It previously sold tool filtering, which is a consequence of the mechanism rather than the mechanism itself. New eyebrow, headline, and copy contrasting a cloud STS session credential you hold for an hour against a role named per call. Its diagram is replaced with a three-row table — request, role asserted, credential minted.

**Each pillar now owns one idea.** Roles, scopes, and discovery all opened on the same session-versus-request contrast, and roles and discovery both claimed a policy-filtered tool list, so a reader met the same point three times. Roles keep timing, scopes keep granularity, discovery keeps what a caller can see. Copy lengths drop from 70–120 words to 64–86.

**Eyebrows retitled.** Three of five shared a "Beyond X" template that named a category to surpass rather than making a claim.

| | Before | After |
|---|---|---|
| 1 | Keyless by design | *unchanged* |
| 2 | Beyond a single access level | A role per request, not per session |
| 3 | Beyond a shared service identity | From impersonation to delegation |
| 4 | Beyond scope-based access | A scope only opens the door |
| 5 | Beyond static API specs | Discovery for every system |

**The per-user pillar was illustrating the wrong thing.** Only the user's badge reached the upstream, which is the picture of impersonation, not delegation. Both principals now travel together, and the pillar points at the delegation concept page that draws the same distinction rather than at a use-case page.

**The hero** opened on managing "what your AI agents can reach" — the coarse framing `use-cases/runtime-authorization` argues against, since reaching a system says nothing about what you may do in it. It now leads on the call-by-call decision. The credential line is dropped as the mechanism rather than the claim; the keyless pillar makes that case with nuance a hero cannot carry. A note under the CTAs states the role-per-request point, and the diagram's agent box says `assert a role per request`.

## Roles concept page

**Answers grant-vs-authority head-on.** The page opened by calling a role a definition that "stores no authority", then described its "grant fields" and told readers policies are "what a role grants". A new section says it outright: a role is neither, because an authority is held and a grant has already been conferred, whereas a role matches nobody until a request satisfies its binding. The grant is the output and it lasts one request — contrasted with an STS `AssumeRole`, which does hand back a grant the caller holds.

**Restructured** so the differentiator is not five sections down. The intro leads with *asserted, not held*; "Roles Are Per-Request" moves ahead of the worked example. The database-view analogy stays and now introduces itself where it is used. Adds the benefit that follows from having no session artifact to steal, and drops the two spots where the old grant vocabulary contradicted the opening.

All existing anchors (`#roles-are-per-request`, `#selecting-a-role`, `#discovery-what-roles-can-i-assume`) still resolve — no heading was renamed or removed.

## Verification

`npm run build` passes, 155 pages. Reviewed against a local dev server throughout. Docs only; no Go code touched.
