### PR TITLE
feat(credential): select fields and pin revisions on static secret reads

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -912,6 +912,14 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				return logical.ErrBadRequestf("invalid config for type '%s': %s", spec.Type, err.Error())
 			}
 
+			// The stored-secret selection keys span several credential types but
+			// hinge on the mint method, so they are checked once here rather than
+			// repeated per type. Both fail open where they are ignored, which is
+			// what makes silence the wrong answer.
+			if err := credential.ValidateSecretSelection(spec.Config, source.Type); err != nil {
+				return logical.ErrBadRequestf("invalid config for type '%s': %s", spec.Type, err.Error())
+			}
+
 			// A credential field the source will not carry is dead config: the
 			// spec mints without it and the provider takes its fallback branch,
 			// which looks like a working mount rather than a misconfigured one.

--- a/credential/carriage.go
+++ b/credential/carriage.go
@@ -105,6 +105,7 @@ var reservedSpecConfigKeys = map[string]struct{}{
 	"role_arn":        {},
 	"version_stage":   {},
 	"version_id":      {},
+	"secret_version":  {},
 	"credential_type": {},
 	"json_key_map":    {},
 }

--- a/credential/carriage_test.go
+++ b/credential/carriage_test.go
@@ -227,7 +227,7 @@ func TestIsReservedSpecConfigKey(t *testing.T) {
 		ConfigAssertionAudience, ConfigAssertionMetadataClaims,
 		ConfigAssertionUserClaims, ConfigAssertionAlgorithm, ConfigAssertionResource,
 		"mint_method", "kv2_mount", "secret_path", "secret_id", "role_arn",
-		"version_stage", "version_id", "credential_type", "json_key_map",
+		"version_stage", "version_id", "secret_version", "credential_type", "json_key_map",
 		RawAdjunctFieldsKey, RawRotatedRefreshTokenKey, "__anything",
 	}
 	for _, k := range reserved {

--- a/credential/config_helpers.go
+++ b/credential/config_helpers.go
@@ -138,3 +138,108 @@ func ValidateRequired(config map[string]string, requiredKeys ...string) error {
 	}
 	return nil
 }
+
+// ApplyKeyMap projects a fetched secret payload through the operator's
+// "srcKey=destKey" selection, given as a comma-separated list. Each pair copies one
+// source key into the result under its destination name; a pair whose source key is
+// absent from the payload is skipped.
+//
+// The projection is deliberately exclusive: keys the spec does not name are dropped,
+// so a spec vends exactly the fields its operator selected and nothing else that
+// happens to be stored alongside them at the same path. An empty keyMapStr means no
+// selection was configured, and the payload passes through untouched.
+func ApplyKeyMap(data map[string]interface{}, keyMapStr string) map[string]interface{} {
+	if keyMapStr == "" {
+		return data
+	}
+	result := make(map[string]interface{})
+	for _, pair := range strings.Split(keyMapStr, ",") {
+		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(parts) == 2 {
+			srcKey := strings.TrimSpace(parts[0])
+			destKey := strings.TrimSpace(parts[1])
+			if val, ok := data[srcKey]; ok {
+				result[destKey] = val
+			}
+		}
+	}
+	return result
+}
+
+// The two selection keys read a secret someone else wrote, but they do not apply to
+// the same set of mint methods, so each carries its own list. Every mint method
+// absent from a list builds its payload itself, and the key would be inert there.
+var (
+	// json_key_map projects a multi-field payload, so it applies wherever a fetch
+	// returns a whole document to pick from.
+	mintMethodsHonoringKeyMap = map[string]map[string]struct{}{
+		SourceTypeVault: {"static_aws": {}, "static_apikey": {}, "kv2_read": {}},
+		SourceTypeAWS:   {"secrets_manager": {}},
+	}
+
+	// secret_version pins a revision, which each store spells its own way: a
+	// number for KV v2, an opaque identifier for Key Vault. A store that spells it
+	// differently again (version_id / version_stage on Secrets Manager) is absent
+	// here, so pinning there keeps using its own keys.
+	mintMethodsHonoringSecretVersion = map[string]map[string]struct{}{
+		SourceTypeVault: {"static_aws": {}, "static_apikey": {}, "kv2_read": {}},
+		SourceTypeAzure: {"key_vault_secret": {}},
+	}
+)
+
+// ValidateSecretSelection rejects the stored-secret selection keys on a spec whose
+// mint method does not read a stored secret. Both keys fail open by nature — an
+// ignored json_key_map vends the unprojected payload, and an ignored secret_version
+// vends the current revision — so a spec setting them on the wrong mint method looks
+// filtered or pinned while being neither. Rejecting at write time is the only point
+// that sees the mint method and its source together.
+//
+// secret_version is narrower than json_key_map: a store with its own version
+// addressing spells it differently (version_id / version_stage), so secret_version
+// is accepted only where a numbered read applies.
+func ValidateSecretSelection(config map[string]string, sourceType string) error {
+	mintMethod := config["mint_method"]
+
+	if keyMap := config["json_key_map"]; keyMap != "" {
+		if _, ok := mintMethodsHonoringKeyMap[sourceType][mintMethod]; !ok {
+			return fmt.Errorf("'json_key_map' selects fields of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, and secrets_manager on an aws source", mintMethod)
+		}
+		if err := validateKeyMapSyntax(keyMap); err != nil {
+			return err
+		}
+	}
+
+	if _, ok := mintMethodsHonoringSecretVersion[sourceType][mintMethod]; !ok && config["secret_version"] != "" {
+		return fmt.Errorf("'secret_version' pins a revision of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, and key_vault_secret on an azure source", mintMethod)
+	}
+
+	return nil
+}
+
+// validateKeyMapSyntax checks that every pair names both a source and a
+// destination. ApplyKeyMap skips a pair it cannot split, which would otherwise
+// narrow the selection silently: the spec writes fine, mints fine, and vends a
+// payload missing the field the operator meant to select. A duplicated destination
+// is rejected for the same reason — one of the two sources would vanish with no
+// indication which.
+func validateKeyMapSyntax(keyMapStr string) error {
+	seen := make(map[string]struct{})
+	for _, pair := range strings.Split(keyMapStr, ",") {
+		trimmed := strings.TrimSpace(pair)
+		if trimmed == "" {
+			return fmt.Errorf("'json_key_map' has an empty entry; each one must read 'srcKey=destKey'")
+		}
+
+		srcKey, destKey, split := strings.Cut(trimmed, "=")
+		srcKey, destKey = strings.TrimSpace(srcKey), strings.TrimSpace(destKey)
+		if !split || srcKey == "" || destKey == "" {
+			return fmt.Errorf("'json_key_map' entry %q must read 'srcKey=destKey' with both names set", trimmed)
+		}
+
+		if _, dup := seen[destKey]; dup {
+			return fmt.Errorf("'json_key_map' maps more than one field to '%s'; only one of them would be vended", destKey)
+		}
+		seen[destKey] = struct{}{}
+	}
+	return nil
+}

--- a/credential/config_helpers_test.go
+++ b/credential/config_helpers_test.go
@@ -8,6 +8,204 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestApplyKeyMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		keyMap   string
+		expected map[string]interface{}
+	}{
+		{
+			name: "basic remapping",
+			data: map[string]interface{}{
+				"accessKeyId": "AKIA123",
+				"secretKey":   "secret123",
+			},
+			keyMap: "accessKeyId=access_key_id,secretKey=secret_access_key",
+			expected: map[string]interface{}{
+				"access_key_id":     "AKIA123",
+				"secret_access_key": "secret123",
+			},
+		},
+		{
+			name: "missing source key",
+			data: map[string]interface{}{
+				"accessKeyId": "AKIA123",
+			},
+			keyMap: "accessKeyId=access_key_id,missing=other",
+			expected: map[string]interface{}{
+				"access_key_id": "AKIA123",
+			},
+		},
+		{
+			name: "whitespace handling",
+			data: map[string]interface{}{
+				"key1": "val1",
+			},
+			keyMap: " key1 = mapped_key1 ",
+			expected: map[string]interface{}{
+				"mapped_key1": "val1",
+			},
+		},
+		{
+			// The selection is a disclosure boundary: what it does not name, it
+			// does not vend.
+			name: "unnamed keys are dropped",
+			data: map[string]interface{}{
+				"api_key":     "sk-abc",
+				"admin_token": "root-secret",
+				"note":        "internal",
+			},
+			keyMap:   "api_key=api_key",
+			expected: map[string]interface{}{"api_key": "sk-abc"},
+		},
+		{
+			name: "no selection passes the payload through untouched",
+			data: map[string]interface{}{
+				"api_key": "sk-abc",
+				"note":    "internal",
+			},
+			keyMap: "",
+			expected: map[string]interface{}{
+				"api_key": "sk-abc",
+				"note":    "internal",
+			},
+		},
+		{
+			name:     "no pair matches yields an empty payload",
+			data:     map[string]interface{}{"api_key": "sk-abc"},
+			keyMap:   "typo=api_key",
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ApplyKeyMap(tt.data, tt.keyMap))
+		})
+	}
+}
+
+func TestValidateSecretSelection(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     map[string]string
+		sourceType string
+		wantErr    string
+	}{
+		{
+			name:       "json_key_map on a KV read",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": "token=api_key"},
+			sourceType: SourceTypeVault,
+		},
+		{
+			name:       "json_key_map on a Secrets Manager read",
+			config:     map[string]string{"mint_method": "secrets_manager", "json_key_map": "token=api_key"},
+			sourceType: SourceTypeAWS,
+		},
+		{
+			name:       "secret_version on a KV read",
+			config:     map[string]string{"mint_method": "static_aws", "secret_version": "3"},
+			sourceType: SourceTypeVault,
+		},
+		{
+			// secret_version predates this check on the Key Vault fetch, where it
+			// is an opaque identifier rather than a number. Rejecting it there
+			// would break every pinned Key Vault spec already written.
+			name:       "secret_version on a Key Vault read",
+			config:     map[string]string{"mint_method": "key_vault_secret", "secret_version": "abc123def456"},
+			sourceType: SourceTypeAzure,
+		},
+		{
+			// The Key Vault fetch returns one secret, not a document to pick from.
+			name:       "json_key_map on a Key Vault read",
+			config:     map[string]string{"mint_method": "key_vault_secret", "json_key_map": "a=b"},
+			sourceType: SourceTypeAzure,
+			wantErr:    "'json_key_map' selects fields of a stored secret",
+		},
+		{
+			name:       "neither key set is always fine",
+			config:     map[string]string{"mint_method": "dynamic_gcp"},
+			sourceType: SourceTypeVault,
+		},
+		{
+			name:       "json_key_map on a mint method that builds its own payload",
+			config:     map[string]string{"mint_method": "dynamic_aws", "json_key_map": "a=b"},
+			sourceType: SourceTypeVault,
+			wantErr:    "'json_key_map' selects fields of a stored secret",
+		},
+		{
+			name:       "json_key_map on an STS mint",
+			config:     map[string]string{"mint_method": "sts_assume_role", "json_key_map": "a=b"},
+			sourceType: SourceTypeAWS,
+			wantErr:    "'json_key_map' selects fields of a stored secret",
+		},
+		{
+			// Secrets Manager addresses revisions as version_id / version_stage,
+			// so a numbered version there would silently do nothing.
+			name:       "secret_version on a Secrets Manager read",
+			config:     map[string]string{"mint_method": "secrets_manager", "secret_version": "3"},
+			sourceType: SourceTypeAWS,
+			wantErr:    "'secret_version' pins a revision",
+		},
+		{
+			name:       "secret_version on a dynamic mint",
+			config:     map[string]string{"mint_method": "dynamic_ibm", "secret_version": "3"},
+			sourceType: SourceTypeVault,
+			wantErr:    "'secret_version' pins a revision",
+		},
+		{
+			// ApplyKeyMap skips a pair it cannot split, so without this check the
+			// spec would write, mint, and quietly omit organization_id.
+			name:       "key map entry missing its separator",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": "token=api_key,org_id:organization_id"},
+			sourceType: SourceTypeVault,
+			wantErr:    "must read 'srcKey=destKey'",
+		},
+		{
+			name:       "key map entry with an empty destination",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": "token="},
+			sourceType: SourceTypeVault,
+			wantErr:    "must read 'srcKey=destKey'",
+		},
+		{
+			name:       "key map entry with an empty source",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": "=api_key"},
+			sourceType: SourceTypeVault,
+			wantErr:    "must read 'srcKey=destKey'",
+		},
+		{
+			name:       "key map with a trailing comma",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": "token=api_key,"},
+			sourceType: SourceTypeVault,
+			wantErr:    "empty entry",
+		},
+		{
+			name:       "key map with a duplicated destination",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": "token=api_key,pat=api_key"},
+			sourceType: SourceTypeVault,
+			wantErr:    "more than one field to 'api_key'",
+		},
+		{
+			name:       "well-formed multi-pair key map with padding",
+			config:     map[string]string{"mint_method": "kv2_read", "json_key_map": " token = api_key , org_id = organization_id "},
+			sourceType: SourceTypeVault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSecretSelection(tt.config, tt.sourceType)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestGetString(t *testing.T) {
 	cfg := map[string]string{"key": "value"}
 	assert.Equal(t, "value", GetString(cfg, "key", "default"))

--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -696,11 +696,8 @@ func (d *AWSDriver) fetchSecret(ctx context.Context, sm *secretsmanager.Client, 
 		return nil, nil, 0, "", fmt.Errorf("failed to parse secret JSON: %w", err)
 	}
 
-	// Apply json_key_map if provided (remap keys)
-	jsonKeyMap := credential.GetString(spec.Config, "json_key_map", "")
-	if jsonKeyMap != "" {
-		secretData = applyKeyMap(secretData, jsonKeyMap)
-	}
+	// Project through the spec's field selection, when it declares one.
+	secretData = credential.ApplyKeyMap(secretData, credential.GetString(spec.Config, "json_key_map", ""))
 
 	if d.logger != nil {
 		d.logger.Debug("fetched secret from AWS Secrets Manager",
@@ -721,23 +718,6 @@ func accountIDFromARN(arn string) string {
 		return ""
 	}
 	return parts[4]
-}
-
-// applyKeyMap remaps keys in data according to a comma-separated "srcKey=destKey" map
-func applyKeyMap(data map[string]interface{}, keyMapStr string) map[string]interface{} {
-	result := make(map[string]interface{})
-	pairs := strings.Split(keyMapStr, ",")
-	for _, pair := range pairs {
-		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
-		if len(parts) == 2 {
-			srcKey := strings.TrimSpace(parts[0])
-			destKey := strings.TrimSpace(parts[1])
-			if val, ok := data[srcKey]; ok {
-				result[destKey] = val
-			}
-		}
-	}
-	return result
 }
 
 // mintViaRDSIAMToken generates a short-lived IAM authentication token for RDS.

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -210,55 +210,6 @@ func TestAWSDriver_SupportsRotation(t *testing.T) {
 	}
 }
 
-func TestApplyKeyMap(t *testing.T) {
-	tests := []struct {
-		name     string
-		data     map[string]interface{}
-		keyMap   string
-		expected map[string]interface{}
-	}{
-		{
-			name: "basic remapping",
-			data: map[string]interface{}{
-				"accessKeyId": "AKIA123",
-				"secretKey":   "secret123",
-			},
-			keyMap: "accessKeyId=access_key_id,secretKey=secret_access_key",
-			expected: map[string]interface{}{
-				"access_key_id":     "AKIA123",
-				"secret_access_key": "secret123",
-			},
-		},
-		{
-			name: "missing source key",
-			data: map[string]interface{}{
-				"accessKeyId": "AKIA123",
-			},
-			keyMap: "accessKeyId=access_key_id,missing=other",
-			expected: map[string]interface{}{
-				"access_key_id": "AKIA123",
-			},
-		},
-		{
-			name: "whitespace handling",
-			data: map[string]interface{}{
-				"key1": "val1",
-			},
-			keyMap: " key1 = mapped_key1 ",
-			expected: map[string]interface{}{
-				"mapped_key1": "val1",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := applyKeyMap(tt.data, tt.keyMap)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestAccountIDFromARN(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -703,12 +703,32 @@ func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Clien
 		return nil, nil, 0, "", err
 	}
 
-	secret, err := client.KVv2(kv2Mount).Get(ctx, secretPath)
+	// A spec may pin a numbered revision; without one it reads the current revision.
+	// Pinning does not follow rotation — a pinned spec keeps vending the revision it
+	// names until an operator moves it.
+	kv := client.KVv2(kv2Mount)
+	secretVersion := credential.GetInt(spec.Config, "secret_version", 0)
+
+	var secret *api.KVSecret
+	if secretVersion > 0 {
+		secret, err = kv.GetVersion(ctx, secretPath, secretVersion)
+	} else {
+		secret, err = kv.Get(ctx, secretPath)
+	}
 	if err != nil {
+		if secretVersion > 0 {
+			return nil, nil, 0, "", fmt.Errorf("failed to read version %d of KV secret: %w", secretVersion, err)
+		}
 		return nil, nil, 0, "", fmt.Errorf("failed to read KV secret: %w", err)
 	}
 
 	if secret == nil || secret.Data == nil {
+		// A deleted revision still answers, carrying its metadata and no data. The
+		// path is fine in that case, so blaming the path would send the operator
+		// looking in the wrong place.
+		if secretVersion > 0 {
+			return nil, nil, 0, "", fmt.Errorf("version %d of the secret at path '%s' on mount '%s' holds no data (the revision may have been deleted)", secretVersion, secretPath, kv2Mount)
+		}
 		return nil, nil, 0, "", fmt.Errorf("no secret found at path '%s' on mount '%s'", secretPath, kv2Mount)
 	}
 
@@ -717,11 +737,17 @@ func (d *VaultDriver) fetchStaticKVSecret(ctx context.Context, client *api.Clien
 			logger.String("spec", spec.Name),
 			logger.String("mount", kv2Mount),
 			logger.String("path", secretPath),
+			logger.Int("secret_version", secretVersion),
 		)
 	}
 
+	// Project through the spec's field selection, when it declares one. A stored
+	// secret may hold more keys than this spec should vend, and their names are
+	// chosen by whoever wrote the secret rather than by the credential type.
+	data := credential.ApplyKeyMap(secret.Data, credential.GetString(spec.Config, "json_key_map", ""))
+
 	// Return raw data (static, no lease)
-	return secret.Data, nil, 0, "", nil
+	return data, nil, 0, "", nil
 }
 
 // fetchDynamicAWSCreds fetches dynamic AWS credentials from Vault AWS engine

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -1303,3 +1303,194 @@ func TestResolveSecretPath_UntemplatedIsByteIdentical(t *testing.T) {
 		})
 	}
 }
+
+// staticKVServer serves one multi-key secret, recording the version query the driver
+// sent so a pinned read can be told apart from a current-revision one.
+func staticKVServer(t *testing.T, gotVersion *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/auth/jwt/login":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"auth": map[string]interface{}{"client_token": "hvs.childtoken", "accessor": "acc-123", "lease_duration": 900},
+			})
+		case "/v1/secret/data/team/shared":
+			*gotVersion = r.URL.Query().Get("version")
+			if *gotVersion == "99" {
+				// A destroyed or never-written revision comes back as a 404 with
+				// no body, which the client surfaces as "secret not found".
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"errors": []string{}})
+				return
+			}
+			if *gotVersion == "42" {
+				// A soft-deleted revision answers 200 with its metadata and a null
+				// data block, so the read succeeds and carries nothing.
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": nil,
+						"metadata": map[string]interface{}{
+							"version":       42,
+							"deletion_time": "2026-01-02T03:04:05Z",
+						},
+					},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"token":       "sk-abc123",
+						"accessKeyId": "AKIA123",
+						"admin_token": "root-secret",
+					},
+					"metadata": map[string]interface{}{"version": 1},
+				},
+			})
+		case "/v1/auth/token/revoke-self":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+}
+
+// A static KV read projects through json_key_map: the spec selects which of the
+// stored secret's fields it vends and renames them to what the credential type
+// expects. Fields the spec does not name are not vended at all. The same body backs
+// static_aws, static_apikey and kv2_read, so all three are covered here.
+func TestVaultDriver_StaticKVSecret_JSONKeyMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		mintMethod string
+		keyMap     string
+		expected   map[string]interface{}
+	}{
+		{
+			name:       "kv2_read selects one field out of a shared path",
+			mintMethod: "kv2_read",
+			keyMap:     "token=slack_token",
+			expected:   map[string]interface{}{"slack_token": "sk-abc123"},
+		},
+		{
+			name:       "static_apikey renames into the type's primary field",
+			mintMethod: "static_apikey",
+			keyMap:     "token=api_key",
+			expected:   map[string]interface{}{"api_key": "sk-abc123"},
+		},
+		{
+			name:       "static_aws renames into the type's fields",
+			mintMethod: "static_aws",
+			keyMap:     "accessKeyId=access_key_id,token=secret_access_key",
+			expected:   map[string]interface{}{"access_key_id": "AKIA123", "secret_access_key": "sk-abc123"},
+		},
+		{
+			name:       "no selection vends the stored payload verbatim",
+			mintMethod: "kv2_read",
+			keyMap:     "",
+			expected: map[string]interface{}{
+				"token":       "sk-abc123",
+				"accessKeyId": "AKIA123",
+				"admin_token": "root-secret",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotVersion string
+			srv := staticKVServer(t, &gotVersion)
+			defer srv.Close()
+
+			driver := federationDriver(t, srv.URL)
+			spec := &credential.CredSpec{
+				Name: "kv-mapped",
+				Config: map[string]string{
+					"mint_method":  tt.mintMethod,
+					"kv2_mount":    "secret",
+					"secret_path":  "team/shared",
+					"json_key_map": tt.keyMap,
+				},
+			}
+
+			rawData, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(), spec, verifiedInputs())
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, rawData)
+			// Unpinned specs read the current revision.
+			assert.Empty(t, gotVersion)
+		})
+	}
+}
+
+// A spec may pin a numbered revision of the stored secret; without one it reads the
+// current revision.
+func TestVaultDriver_StaticKVSecret_Version(t *testing.T) {
+	t.Run("pinned revision is requested", func(t *testing.T) {
+		var gotVersion string
+		srv := staticKVServer(t, &gotVersion)
+		defer srv.Close()
+
+		driver := federationDriver(t, srv.URL)
+		spec := &credential.CredSpec{
+			Name: "kv-pinned",
+			Config: map[string]string{
+				"mint_method":    "kv2_read",
+				"kv2_mount":      "secret",
+				"secret_path":    "team/shared",
+				"secret_version": "3",
+			},
+		}
+
+		rawData, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(), spec, verifiedInputs())
+		require.NoError(t, err)
+		assert.Equal(t, "3", gotVersion)
+		assert.Equal(t, "sk-abc123", rawData["token"])
+	})
+
+	t.Run("a missing revision surfaces the error", func(t *testing.T) {
+		var gotVersion string
+		srv := staticKVServer(t, &gotVersion)
+		defer srv.Close()
+
+		driver := federationDriver(t, srv.URL)
+		spec := &credential.CredSpec{
+			Name: "kv-pinned",
+			Config: map[string]string{
+				"mint_method":    "kv2_read",
+				"kv2_mount":      "secret",
+				"secret_path":    "team/shared",
+				"secret_version": "99",
+			},
+		}
+
+		_, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(), spec, verifiedInputs())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "version 99")
+	})
+
+	// A soft-deleted revision reads back successfully with no data, so the failure
+	// has to name the revision — the path it was read from is fine, and pointing at
+	// the path sends the operator looking in the wrong place.
+	t.Run("a soft-deleted revision names the revision, not the path", func(t *testing.T) {
+		var gotVersion string
+		srv := staticKVServer(t, &gotVersion)
+		defer srv.Close()
+
+		driver := federationDriver(t, srv.URL)
+		spec := &credential.CredSpec{
+			Name: "kv-pinned",
+			Config: map[string]string{
+				"mint_method":    "kv2_read",
+				"kv2_mount":      "secret",
+				"secret_path":    "team/shared",
+				"secret_version": "42",
+			},
+		}
+
+		_, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(), spec, verifiedInputs())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "version 42")
+		assert.Contains(t, err.Error(), "deleted")
+	})
+}

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -123,6 +123,17 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 			Describe("Specific Secrets Manager version ID (optional)").
 			Example("uuid-version-id"),
 
+		// Field selection over the stored secret, shared by the KV read
+		// (static_apikey) and the Secrets Manager read.
+		credential.StringField("json_key_map").
+			Describe("Comma-separated 'srcKey=destKey' selection of the stored secret's fields; unnamed keys are not vended. Use it when the stored key is not named api_key").
+			Example("token=api_key"),
+
+		credential.IntField("secret_version").
+			Min(1).
+			Describe("Pin a numbered revision of the KV secret (static_apikey only); omit to read the current one. A pinned spec does not follow rotation").
+			Example("3"),
+
 		// Credential chaining (apikey source): source the api_key from another cred spec
 		// instead of storing it inline, making the spec keyless.
 		credential.StringField(credential.ConfigSecretSpec).

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -92,6 +92,17 @@ func (t *AWSIAMAccessKeysCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("version_id").
 			Describe("Specific version ID to retrieve (optional)").
 			Example("uuid-version-id"),
+
+		// Field selection over the stored secret, shared by the KV read
+		// (static_aws) and the Secrets Manager read.
+		credential.StringField("json_key_map").
+			Describe("Comma-separated 'srcKey=destKey' selection of the stored secret's fields; unnamed keys are not vended. Use it when the stored keys are not named access_key_id / secret_access_key").
+			Example("accessKeyId=access_key_id,secretKey=secret_access_key"),
+
+		credential.IntField("secret_version").
+			Min(1).
+			Describe("Pin a numbered revision of the KV secret (static_aws only); omit to read the current one. A pinned spec does not follow rotation").
+			Example("3"),
 	}
 }
 

--- a/credential/types/key_value.go
+++ b/credential/types/key_value.go
@@ -40,7 +40,7 @@ func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("mint_method").
 			OneOf("kv2_read").
-			Describe("Mint method (kv2_read reads a Vault KV v2 secret verbatim)").
+			Describe("Mint method (kv2_read reads a Vault KV v2 secret)").
 			Example("kv2_read"),
 
 		credential.StringField("kv2_mount").
@@ -50,6 +50,15 @@ func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("secret_path").
 			Describe("Path to the secret within the KV v2 mount").
 			Example("github/ci"),
+
+		credential.StringField("json_key_map").
+			Describe("Comma-separated 'srcKey=destKey' selection of the stored secret's fields; unnamed keys are not vended. Omit to vend the payload verbatim").
+			Example("token=api_key"),
+
+		credential.IntField("secret_version").
+			Min(1).
+			Describe("Pin a numbered revision of the secret; omit to read the current one. A pinned spec does not follow rotation").
+			Example("3"),
 	}
 }
 

--- a/credential/types/key_value_test.go
+++ b/credential/types/key_value_test.go
@@ -35,6 +35,29 @@ func TestKeyValueCredType_ValidateConfig(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "valid kv2_read with a field selection and a pinned version",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci", "json_key_map": "token=api_key", "secret_version": "3"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
+		},
+		{
+			// GetInt falls back to its default on an unparseable value, so a
+			// typo'd version would silently read the current revision. The
+			// schema is what stops it reaching the driver.
+			name:       "non-numeric version",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci", "secret_version": "latest"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "secret_version",
+		},
+		{
+			name:       "version below the first revision",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci", "secret_version": "0"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "secret_version",
+		},
+		{
 			name:       "unsupported source type",
 			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
 			sourceType: credential.SourceTypeAWS,

--- a/provider/sdk/httpproxy/transport.go
+++ b/provider/sdk/httpproxy/transport.go
@@ -70,8 +70,10 @@ func NewTransportWithTLS(caData string, skipVerify bool) (*http.Transport, error
 
 	t.TLSClientConfig = tlsConfig
 
-	// Configure HTTP/2 after TLSClientConfig is set so the h2 wiring
-	// (NextProtos, internal state) binds to the correct tls.Config.
+	// Configure HTTP/2 after TLSClientConfig is set so the h2 wiring binds to the
+	// correct tls.Config. How that wiring is recorded depends on the compiling
+	// toolchain — a protocol set on the transport, or an ALPN entry on the TLS
+	// config — so read it back through a helper rather than by field.
 	if err := http2.ConfigureTransport(t); err != nil {
 		log.Printf("Failed to configure HTTP/2 for httpproxy TLS transport: %v", err)
 	}

--- a/provider/sdk/httpproxy/transport_test.go
+++ b/provider/sdk/httpproxy/transport_test.go
@@ -9,12 +9,29 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"math/big"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// assertHTTP2Enabled checks that HTTP/2 survived the TLS customization, whichever
+// mechanism the compiling toolchain records it with. From Go 1.27 the http2 helper
+// delegates to the standard library's native HTTP/2 and flips Transport.Protocols;
+// before that it prepended "h2" to the TLS config's NextProtos. Which one applies is
+// decided by the installed toolchain's release tags, not by the module's go
+// directive, so asserting either alone makes the test pass or fail by toolchain.
+func assertHTTP2Enabled(t *testing.T, transport *http.Transport) {
+	t.Helper()
+
+	if transport.Protocols != nil && transport.Protocols.HTTP2() {
+		return
+	}
+	assert.Contains(t, transport.TLSClientConfig.NextProtos, "h2",
+		"HTTP/2 enabled through neither Transport.Protocols nor TLSClientConfig.NextProtos")
+}
 
 // generateTestCACert creates a self-signed CA certificate for testing and
 // returns its PEM-encoded bytes.
@@ -58,7 +75,7 @@ func TestNewTransportWithTLS_ValidCAData(t *testing.T) {
 	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
 	// Verify HTTP/2 is properly configured after TLS customization
-	assert.Contains(t, transport.TLSClientConfig.NextProtos, "h2")
+	assertHTTP2Enabled(t, transport)
 }
 
 func TestNewTransportWithTLS_InvalidBase64(t *testing.T) {


### PR DESCRIPTION
## What

Gives a spec reading a stored secret two things it did not have on the hvault source: a say in **which fields it vends and under what names** (`json_key_map`), and a way to **pin a numbered revision** (`secret_version`).

`json_key_map` previously existed only on the Secrets Manager path. `kv2_read` felt the gap most — its `key_value` type deliberately refuses the shared token base so it can carry an arbitrary payload, and copies every string key through verbatim, leaving it the one mint method with neither field selection nor renaming.

## How

- `applyKeyMap` moves out of the aws driver into `credential.ApplyKeyMap`.
- It runs on the shared static KV read, covering `static_aws`, `static_apikey` and `kv2_read` across **both** the direct and the federated dispatch path — one call site, since both routes share `fetchStaticKVSecret`.
- `secret_version` routes the read through a numbered fetch when set, the current revision otherwise.
- Both keys are declared in the schemas that accept them and refused at write time on mint methods that would ignore them, checked once centrally rather than repeated across seven types.

Fields the spec does not name are dropped rather than renamed around — the selection is the list of what a spec vends.

## Notes for review

**`secret_version` was already taken.** It names the Key Vault revision on an azure source. A single allowlist would have rejected every existing pinned Key Vault spec on its next write, so the two keys carry separate lists: `json_key_map` covers the Vault static-KV methods plus `secrets_manager`, `secret_version` covers the Vault static-KV methods plus `key_vault_secret`. Regression tests pin both. Note the key is a string on Key Vault and an integer here — each store spells revisions its own way.

**Pinning does not follow rotation.** A pinned spec keeps serving the revision it names; it reproduces a known state rather than running one. Worth a caveat in the docs.

**A deleted revision still answers**, carrying metadata and no data, so the read succeeds and yields nothing. The failure names the revision rather than the path, which is intact.

**Behaviour change worth flagging:** on the Vault static-KV path `json_key_map` goes from inert to load-bearing. Undeclared keys were never rejected, so a pre-existing spec that set it with pairs not matching its secret would flip from "worked, ignored the key" to "projects to empty, fails every mint". No such spec should exist given the key was only ever documented for AWS. Relatedly, `UpdateSpec` re-validates on every write, so a stored spec carrying either key on a now-disallowed mint method returns 400 on an unrelated edit. Enforcing only on create is a one-line alternative if that trade reads wrong.

## Second commit

An unrelated pre-existing test failure: `TestNewTransportWithTLS_ValidCAData` asserted `NextProtos` contained `h2`. From Go 1.27 the http2 helper delegates to the standard library's native HTTP/2 and records it on the transport's protocol set, leaving the ALPN list alone. File selection follows the installed toolchain's release tags, not the module's go directive, so the same source passed on one machine and failed on another. The transport was always correct; the test named a mechanism.

## Testing

`go build ./...`, `go vet`, and the full `go test ./...` suite pass. New coverage: the projection across all three mint methods, verbatim pass-through with no selection, pinned reads, a missing revision, a soft-deleted revision, key-map syntax rejection (missing separator, empty source or destination, trailing comma, duplicate destination), and the Azure regression cases.

Docs are deferred to the pre-release doc pass — `vault.md` still describes `kv2_read` as returning the verbatim payload, which is now conditional.
