### PR TITLE
fix(ibm): stop mutating the shared source config, and bound the token-life guess

### DIFF
--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -47,8 +47,9 @@ type IBMDriver struct {
 	// HTTP client for IBM Cloud API calls
 	httpClient *http.Client
 
-	// authMu serializes rotation and protects iamID/apiKeyID. It is held across the
-	// upstream calls a rotation makes, which can run to minutes under retry.
+	// authMu serializes rotation and protects iamID/apiKeyID/discoveredAccountID. It
+	// is held across the upstream calls a rotation makes, which can run to minutes
+	// under retry.
 	authMu sync.Mutex
 
 	// configMu guards credSource.Config, which CommitRotation replaces wholesale.
@@ -66,6 +67,14 @@ type IBMDriver struct {
 	// Used for cleanup during rotation
 	// Protected by authMu
 	apiKeyID string
+
+	// discoveredAccountID is the account the source API key belongs to, learned from
+	// discovery when the operator did not configure one. It is held here rather than
+	// written back into credSource.Config because that map is not the driver's own:
+	// the factory is handed the config store's map by reference, and the store serves
+	// that same map to readers who take no driver lock. Writing to it raced them.
+	// Protected by authMu
+	discoveredAccountID string
 }
 
 // IBMDriverFactory creates IBMDriver instances
@@ -445,7 +454,7 @@ func (d *IBMDriver) getIAMToken(ctx context.Context) (string, time.Time, error) 
 
 // acquireIAMToken exchanges the source API key for an IAM bearer token.
 func (d *IBMDriver) acquireIAMToken(ctx context.Context) (string, time.Time, error) {
-	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, d.getAPIKey(), d.getIAMEndpoint())
+	return exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, d.getAPIKey(), d.getIAMEndpoint(), d.logger)
 }
 
 // Config accessors — single source of truth is credSource.Config, read under configMu
@@ -458,11 +467,20 @@ func (d *IBMDriver) getAPIKey() string {
 	return credential.GetString(d.credSource.Config, "api_key", "")
 }
 
-// getAccountID reads the configured or discovered account id.
-func (d *IBMDriver) getAccountID() string {
+// accountIDLocked reports the account a rotated key should be created in: the
+// operator-configured one, or else the one discovery learned. Caller must hold
+// authMu, which guards discoveredAccountID. Taking configMu underneath it follows
+// the order the rest of the driver already uses (discoverAPIKeyDetailsLocked reads
+// the api key the same way), so the two never nest the other way round.
+func (d *IBMDriver) accountIDLocked() string {
 	d.configMu.RLock()
-	defer d.configMu.RUnlock()
-	return credential.GetString(d.credSource.Config, "account_id", "")
+	configured := credential.GetString(d.credSource.Config, "account_id", "")
+	d.configMu.RUnlock()
+
+	if configured != "" {
+		return configured
+	}
+	return d.discoveredAccountID
 }
 
 // configSnapshot copies the source config, so a caller reading several keys sees one
@@ -476,19 +494,6 @@ func (d *IBMDriver) configSnapshot() map[string]string {
 		snapshot[k] = v
 	}
 	return snapshot
-}
-
-// setAccountIDIfUnset records an account id learned from discovery, leaving an
-// operator-configured one alone.
-func (d *IBMDriver) setAccountIDIfUnset(accountID string) {
-	if accountID == "" {
-		return
-	}
-	d.configMu.Lock()
-	defer d.configMu.Unlock()
-	if credential.GetString(d.credSource.Config, "account_id", "") == "" {
-		d.credSource.Config["account_id"] = accountID
-	}
 }
 
 // swapConfig publishes a config and retires every token the previous one minted, as one
@@ -565,8 +570,9 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 	d.iamID = detailsResp.IamID
 	d.apiKeyID = detailsResp.ID
 
-	// Set account_id from discovery if not already configured
-	d.setAccountIDIfUnset(detailsResp.AccountID)
+	// Record the account discovery reported. An operator-configured account_id still
+	// wins at read time, so this is stored unconditionally rather than only when unset.
+	d.discoveredAccountID = detailsResp.AccountID
 
 	if d.logger != nil {
 		d.logger.Trace("discovered IBM API key details",
@@ -582,7 +588,7 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 // Caller must hold authMu (PrepareRotation).
 func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, string, error) {
 	iamEndpoint := d.getIAMEndpoint()
-	accountID := d.getAccountID()
+	accountID := d.accountIDLocked()
 
 	reqBody, err := json.Marshal(map[string]interface{}{
 		"name":        fmt.Sprintf("warden-rotated-%d", time.Now().Unix()),

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -402,7 +402,41 @@ func TestIBMDriver_DiscoverAPIKeyDetails(t *testing.T) {
 
 	assert.Equal(t, "iam-ServiceId-abcdef", d.iamID)
 	assert.Equal(t, "ApiKey-12345", d.apiKeyID)
-	assert.Equal(t, "acc-123456", d.credSource.Config["account_id"])
+	assert.Equal(t, "acc-123456", d.discoveredAccountID)
+
+	// The discovered account is held on the driver, never written back into the
+	// config map. That map belongs to the config store, which hands the same
+	// instance to readers taking no driver lock, so a write here raced them.
+	assert.NotContains(t, d.credSource.Config, "account_id",
+		"discovery must not mutate the source config map")
+}
+
+// An operator-configured account wins over whatever discovery reports, which is
+// what the removed write-back used to express by only filling an unset key.
+func TestIBMDriver_AccountID_ConfiguredWinsOverDiscovered(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := &IBMDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeIBM,
+			Config: map[string]string{
+				"api_key":      "test-key",
+				"iam_endpoint": srv.URL,
+				"account_id":   "acc-operator",
+			},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	require.NoError(t, d.discoverAPIKeyDetails(context.TODO()))
+
+	assert.Equal(t, "acc-123456", d.discoveredAccountID, "discovery still records what it saw")
+
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	assert.Equal(t, "acc-operator", d.accountIDLocked())
 }
 
 func TestIBMDriver_PrepareRotation(t *testing.T) {

--- a/credential/drivers/ibm_iam.go
+++ b/credential/drivers/ibm_iam.go
@@ -9,7 +9,14 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/helper/httputil"
+	"github.com/stephnangue/warden/logger"
 )
+
+// ibmFallbackTokenTTL bounds a token whose lifetime the endpoint declined to state.
+// The lease decides how long the bearer keeps being served from cache, so a generous
+// guess hands out a token that expired long ago, while a short one costs only another
+// mint.
+const ibmFallbackTokenTTL = 5 * time.Minute
 
 // ibmIAMTokenResponse represents the IBM Cloud IAM token endpoint response.
 type ibmIAMTokenResponse struct {
@@ -25,8 +32,9 @@ type ibmIAMTokenResponse struct {
 // dynamic API keys).
 //
 // If httpClient is nil, http.DefaultClient is used. Callers that need TLS configuration
-// (custom CA, skip verify) should pass a client built via BuildHTTPClient.
-func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, apiKey, iamEndpoint string) (string, time.Time, error) {
+// (custom CA, skip verify) should pass a client built via BuildHTTPClient. log may be
+// nil; it carries the one case worth reporting, a response that stated no lifetime.
+func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, apiKey, iamEndpoint string, log *logger.GatedLogger) (string, time.Time, error) {
 	if apiKey == "" {
 		return "", time.Time{}, fmt.Errorf("api_key is empty")
 	}
@@ -65,12 +73,22 @@ func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, 
 
 	// Compute expiry from either expiration (Unix timestamp) or expires_in (seconds)
 	var expiry time.Time
-	if tokenResp.Expiration > 0 {
+	switch {
+	case tokenResp.Expiration > 0:
 		expiry = time.Unix(tokenResp.Expiration, 0)
-	} else if tokenResp.ExpiresIn > 0 {
+	case tokenResp.ExpiresIn > 0:
 		expiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
-	} else {
-		expiry = time.Now().Add(1 * time.Hour) // IBM IAM tokens have ~1h TTL
+	default:
+		// Nothing here knows how long the token is actually good for, and the
+		// credential is served from cache for the whole lease. Fall back to a span
+		// short enough that a wrong guess is corrected by a re-mint rather than by
+		// an agent presenting a dead bearer.
+		if log != nil {
+			log.Warn("IAM token response carried no usable expiry; bounding the lease at the fallback lifetime",
+				logger.String("fallback", ibmFallbackTokenTTL.String()),
+			)
+		}
+		expiry = time.Now().Add(ibmFallbackTokenTTL)
 	}
 
 	return tokenResp.AccessToken, expiry, nil

--- a/credential/drivers/ibm_iam_test.go
+++ b/credential/drivers/ibm_iam_test.go
@@ -32,14 +32,14 @@ func TestExchangeIBMAPIKeyForIAMToken_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	token, expiry, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "my-api-key", srv.URL)
+	token, expiry, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "my-api-key", srv.URL, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "token-abc", token)
 	assert.True(t, expiry.After(time.Now()))
 }
 
 func TestExchangeIBMAPIKeyForIAMToken_EmptyAPIKey(t *testing.T) {
-	_, _, err := exchangeIBMAPIKeyForIAMToken(context.Background(), nil, "", "https://iam.cloud.ibm.com")
+	_, _, err := exchangeIBMAPIKeyForIAMToken(context.Background(), nil, "", "https://iam.cloud.ibm.com", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key is empty")
 }
@@ -52,7 +52,7 @@ func TestExchangeIBMAPIKeyForIAMToken_EmptyEndpointUsesDefault(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
-	_, _, err := exchangeIBMAPIKeyForIAMToken(ctx, &http.Client{Timeout: 10 * time.Millisecond}, "some-key", "")
+	_, _, err := exchangeIBMAPIKeyForIAMToken(ctx, &http.Client{Timeout: 10 * time.Millisecond}, "some-key", "", nil)
 	require.Error(t, err)
 	// Either context deadline or DNS/connect error is acceptable — we just want to confirm
 	// it attempted to call the default endpoint rather than failing early.
@@ -69,7 +69,7 @@ func TestExchangeIBMAPIKeyForIAMToken_MissingAccessToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL)
+	_, _, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing access_token")
 }
@@ -86,14 +86,18 @@ func TestExchangeIBMAPIKeyForIAMToken_ExpiresInFallback(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, expiry, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL)
+	_, expiry, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL, nil)
 	require.NoError(t, err)
 	remaining := time.Until(expiry)
 	assert.True(t, remaining > 30*time.Second && remaining <= 61*time.Second,
 		"expiry should be ~60s from now, got %s", remaining)
 }
 
-func TestExchangeIBMAPIKeyForIAMToken_NoExpiryInfoFallbackTo1h(t *testing.T) {
+// A response stating no lifetime is bounded at the short fallback, not guessed
+// generously. The lease is what decides how long the bearer keeps being served, so
+// an hour-long guess against a token good for minutes hands out a dead credential
+// for the rest of the lease; a short one costs a re-mint and nothing else.
+func TestExchangeIBMAPIKeyForIAMToken_NoExpiryInfoBoundsAtFallback(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -103,11 +107,11 @@ func TestExchangeIBMAPIKeyForIAMToken_NoExpiryInfoFallbackTo1h(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, expiry, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL)
+	_, expiry, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL, nil)
 	require.NoError(t, err)
 	remaining := time.Until(expiry)
-	assert.True(t, remaining > 50*time.Minute && remaining <= 61*time.Minute,
-		"expiry should fall back to ~1h, got %s", remaining)
+	assert.True(t, remaining > ibmFallbackTokenTTL-time.Minute && remaining <= ibmFallbackTokenTTL,
+		"expiry should be bounded at %s, got %s", ibmFallbackTokenTTL, remaining)
 }
 
 func TestExchangeIBMAPIKeyForIAMToken_InvalidJSON(t *testing.T) {
@@ -117,7 +121,7 @@ func TestExchangeIBMAPIKeyForIAMToken_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL)
+	_, _, err := exchangeIBMAPIKeyForIAMToken(context.Background(), srv.Client(), "key", srv.URL, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decode IAM token response")
 }

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -1013,7 +1013,7 @@ func (d *VaultDriver) fetchDynamicIBMCreds(ctx context.Context, client *api.Clie
 	// that Warden can't use. Use a fresh context for revocation so it still fires
 	// if the caller's context is already canceled.
 	iamEndpoint := credential.GetString(spec.Config, "iam_endpoint", defaultIBMIAMEndpoint)
-	accessToken, tokenExpiry, err := exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, apiKey, iamEndpoint)
+	accessToken, tokenExpiry, err := exchangeIBMAPIKeyForIAMToken(ctx, d.httpClient, apiKey, iamEndpoint, d.logger)
 	if err != nil {
 		if secret.LeaseID != "" {
 			revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
Two live bugs in the IBM driver, independent of everything else in this stack.

**A process crash.** Discovery wrote the account id it learned back into `credSource.Config`. That map is not the driver's own: the registry hands the factory the config store's map by reference, and the store serves that same instance to readers who take no driver lock — a source read, and the per-request identity path. The write was guarded by `configMu`, which none of them hold, so an ibm source configured without `account_id` — the case the schema documents, since it is discovered when omitted — could crash the process on a concurrent map read and write. It also left the cache holding a value that was never persisted, so the account id appeared in an API read and vanished on restart.

The account id now lives on the driver beside `iamID` and `apiKeyID`, which is what the other two discovered values already do. An operator-configured account still wins; only the write goes away.

**A token served past its life.** A response stating no lifetime was assumed good for an hour. The lease decides how long the bearer keeps being served from cache, so a token good for minutes was handed out dead for the rest of it — and the guess reached the vault driver's dynamic ibm path too, where it capped a longer Vault lease. Bounded at five minutes with a log, matching the ovh path.

**Note for review:** `TestIBMDriver_DiscoverAPIKeyDetails` was asserting the buggy write-back. It now asserts that discovery must *not* touch the config map, so a reintroduction fails deterministically.

Verified: `go build ./...`, `go vet`, `./credential/... ./core/... ./provider/...`, and `-race` on the IBM driver tests.

First of six stacked PRs.