### PR TITLE
feat(ibm)!: serve COS keys from a referenced spec, and stop reading them inline

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1100,6 +1100,15 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 			credential.GetString(spec.Config, "mint_method", "") == "access_keys" {
 			return logical.ErrBadRequestf("an access_keys spec must set its own secret_spec naming a spec that yields its access_key and secret_key; the source's chained secret (%q) is a client credential, not this pair", chainedRef)
 		}
+		// The same rule for ibm, whose access_keys spec serves a COS HMAC pair. A
+		// source-level reference on an ibm source describes the api key its own IAM
+		// token grant is made with, so routing this spec by it would mint from the
+		// wrong secret entirely.
+		if source.Type == credential.SourceTypeIBM &&
+			spec.Config[credential.ConfigSecretSpec] == "" &&
+			credential.GetString(spec.Config, "mint_method", "") == "access_keys" {
+			return logical.ErrBadRequestf("an access_keys spec must set its own secret_spec naming a spec that yields its access_key_id and secret_access_key; the source's chained secret (%q) is its IAM api key, not this pair", chainedRef)
+		}
 		// A chained consumer's identity normally flows through the referenced secret-spec,
 		// so its own subject/actor exchange config would be dead — reject that confusing
 		// combination. The token_exchange driver is the exception: it is itself an

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2525,3 +2525,40 @@ func TestCredentialConfigStore_OVHChaining(t *testing.T) {
 		assert.Contains(t, err.Error(), "rotation_period")
 	})
 }
+
+// The same placement rule on an ibm source, whose access_keys spec serves a COS
+// HMAC pair. This is the layer that holds when the type registry is unavailable
+// and credType is nil, which is why the store's own test exercises it.
+func TestCredentialConfigStore_IBMAccessKeysNeedsItsOwnReference(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+
+	for _, name := range []string{"ibm-api-key", "ibm-cos-pair"} {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: name, Type: "vault_token", Source: "src",
+			Config: map[string]string{"subject_token_source": "warden_identity", "assertion_audience": "vault"},
+		}))
+	}
+
+	// A source whose own secret is chained: its reference describes the api key
+	// the IAM token grant is made with, not any spec's credential.
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "ibm-src", Type: credential.SourceTypeIBM,
+		Config: map[string]string{credential.ConfigSecretSpec: "ibm-api-key"},
+	}))
+
+	// Inheriting that reference would hand this spec the api key, which is not the
+	// pair it describes — it would mint from the wrong secret entirely.
+	err := store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "ibm-cos-inheriting", Type: credential.TypeIBMCloudKeys, Source: "ibm-src",
+		Config: map[string]string{"mint_method": "access_keys"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set its own secret_spec")
+
+	// Naming its own reference is fine on the very same source.
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "ibm-cos-own", Type: credential.TypeIBMCloudKeys, Source: "ibm-src",
+		Config: map[string]string{"mint_method": "access_keys", credential.ConfigSecretSpec: "ibm-cos-pair"},
+	}))
+}

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -26,10 +26,17 @@ const ibmMaxResponseBodySize = 1 << 20 // 1MB
 // defaultIBMIAMEndpoint is the default IBM Cloud IAM endpoint
 const defaultIBMIAMEndpoint = "https://iam.cloud.ibm.com"
 
+// defaultIBMAccessKeysChainTTL bounds how long a served COS pair stays cached when
+// the spec sets no secret_cache_ttl. The pair has no expiry of its own, so this is
+// only how long Warden goes before walking the chain again to see whether the
+// referenced spec now yields a different one.
+const defaultIBMAccessKeysChainTTL = 30 * time.Minute
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*IBMDriver)(nil)
 var _ credential.Rotatable = (*IBMDriver)(nil)
 var _ credential.SpecVerifier = (*IBMDriver)(nil)
+var _ credential.ChainedSecretMinter = (*IBMDriver)(nil)
 
 // IBMDriver mints credentials from IBM Cloud services.
 // It exchanges an IBM Cloud API key for IAM bearer tokens.
@@ -133,7 +140,7 @@ func (f *IBMDriverFactory) InferCredentialType(specConfig map[string]string) (st
 	switch mintMethod {
 	case "iam_token", "":
 		return credential.TypeOAuthBearerToken, nil
-	case "iam_with_cos":
+	case "access_keys":
 		return credential.TypeIBMCloudKeys, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
@@ -189,10 +196,14 @@ func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	switch mintMethod {
 	case "iam_token":
 		return d.mintIAMToken(ctx, spec)
-	case "iam_with_cos":
-		return d.mintIAMWithCOS(ctx, spec)
+	case "access_keys":
+		// Reached only when the spec named no reference: a chained spec is routed
+		// to MintFromSecret instead. Without one there is no pair to serve, and
+		// nothing here creates one.
+		return nil, nil, 0, "", fmt.Errorf("ibm: an access_keys spec must set %s naming a spec that yields its access_key_id and secret_access_key; the pair is served from that material, never minted here",
+			credential.ConfigSecretSpec)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for IBM driver; use 'iam_token' or 'iam_with_cos'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for IBM driver; use 'iam_token' or 'access_keys'", mintMethod)
 	}
 }
 
@@ -219,36 +230,55 @@ func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec)
 	return rawData, nil, ttl, "", nil
 }
 
-// mintIAMWithCOS mints an IAM bearer token and combines it with static COS HMAC keys from spec config.
-func (d *IBMDriver) mintIAMWithCOS(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	token, expiry, err := d.getIAMToken(ctx)
-	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
+// MintFromSecret mints from secret material fetched through credential chaining.
+// access_keys receives the COS HMAC pair itself, which it serves unchanged: no
+// request is made to IBM, nothing is created, and there is nothing to revoke.
+func (d *IBMDriver) MintFromSecret(_ context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	if mintMethod := credential.GetString(spec.Config, "mint_method", ""); mintMethod != "access_keys" {
+		return nil, nil, 0, "", fmt.Errorf("ibm: credential chaining supports mint_method=access_keys, got %q", mintMethod)
 	}
 
-	ttl := time.Until(expiry)
-	rawData := map[string]interface{}{
-		"access_token": token,
+	// The spec must name the reference itself. Routed here by a source-level one,
+	// the material would be whatever the source authenticates with, not this
+	// credential. Spec create refuses that combination, but a source converted to
+	// chaining afterwards is not re-validated against the specs already bound to
+	// it, so this is the guard that actually holds.
+	if spec.Config[credential.ConfigSecretSpec] == "" {
+		return nil, nil, 0, "", fmt.Errorf("ibm: an access_keys spec must set its own %s naming a spec that yields its access_key_id and secret_access_key",
+			credential.ConfigSecretSpec)
 	}
 
-	// Add optional COS HMAC keys from spec config (API-only mode is valid)
-	accessKeyID := credential.GetString(spec.Config, "access_key_id", "")
-	secretAccessKey := credential.GetString(spec.Config, "secret_access_key", "")
-	if accessKeyID != "" && secretAccessKey != "" {
-		rawData["access_key_id"] = accessKeyID
-		rawData["secret_access_key"] = secretAccessKey
+	// Both halves are read by name, from IBM's own spelling for them — the
+	// cos_hmac_keys fields of a service credential — so a pair stored from IBM's
+	// export is read unrenamed. A payload using other names is projected by the
+	// referenced spec's json_key_map, which is where that belongs.
+	accessKeyID := material.Data["access_key_id"]
+	secretAccessKey := material.Data["secret_access_key"]
+	if accessKeyID == "" || secretAccessKey == "" {
+		return nil, nil, 0, "", fmt.Errorf("ibm: fetched secret material must hold both 'access_key_id' and 'secret_access_key' for access_keys: %w",
+			credential.ErrChainedSecretIncomplete)
+	}
+
+	// Advisory TTL, no lease id: nothing was created, so nothing is revocable.
+	// Making no request, this path can never be told the pair was rotated, so
+	// without a TTL the credential would sit in cache for the caller's whole
+	// session. The TTL only forces the chain to be walked again.
+	ttl := credential.GetDuration(spec.Config, credential.ConfigSecretCacheTTL, 0)
+	if ttl <= 0 {
+		ttl = defaultIBMAccessKeysChainTTL
 	}
 
 	if d.logger != nil {
-		hasCOS := accessKeyID != "" && secretAccessKey != ""
-		d.logger.Debug("minted IBM Cloud keys (IAM token + COS HMAC)",
+		d.logger.Debug("served IBM COS keys from fetched secret material",
 			logger.String("spec", spec.Name),
 			logger.String("ttl", ttl.String()),
-			logger.Bool("has_cos", hasCOS),
 		)
 	}
 
-	return rawData, nil, ttl, "", nil
+	return map[string]interface{}{
+		"access_key_id":     accessKeyID,
+		"secret_access_key": secretAccessKey,
+	}, nil, ttl, "", nil
 }
 
 // Revoke is a no-op for IBM credentials (IAM tokens expire naturally)
@@ -271,20 +301,30 @@ func (d *IBMDriver) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-// VerifySpec validates that an IBM spec's configuration is functional by performing
-// a lightweight IAM token exchange. Called during spec creation/update only.
+// VerifySpec validates that an IBM spec's configuration is functional. Called
+// during spec creation/update only.
 func (d *IBMDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
-	mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token")
-	if mintMethod != "iam_token" {
+	switch mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token"); mintMethod {
+	case "iam_token":
+		// Verify the source API key can mint an IAM token
+		if _, _, err := d.getIAMToken(ctx); err != nil {
+			return fmt.Errorf("IBM spec verification failed: %w", err)
+		}
 		return nil
-	}
 
-	// Verify the source API key can mint an IAM token
-	_, _, err := d.getIAMToken(ctx)
-	if err != nil {
-		return fmt.Errorf("IBM spec verification failed: %w", err)
+	case "access_keys":
+		// Reached only if the spec named no reference; a chained spec skips
+		// verification entirely. Without one there is no pair to serve, and this
+		// path makes no request, so there is nothing else to check.
+		if spec.Config[credential.ConfigSecretSpec] == "" {
+			return fmt.Errorf("an access_keys spec must set %s naming a spec that yields its access_key_id and secret_access_key",
+				credential.ConfigSecretSpec)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported mint_method: %s (expected iam_token or access_keys)", mintMethod)
 	}
-	return nil
 }
 
 // ============================================================================

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -82,10 +82,15 @@ func TestIBMDriverFactory_InferCredentialType(t *testing.T) {
 		assert.Equal(t, credential.TypeOAuthBearerToken, ct)
 	})
 
-	t.Run("iam_with_cos", func(t *testing.T) {
-		ct, err := f.InferCredentialType(map[string]string{"mint_method": "iam_with_cos"})
+	t.Run("access_keys", func(t *testing.T) {
+		ct, err := f.InferCredentialType(map[string]string{"mint_method": "access_keys"})
 		require.NoError(t, err)
 		assert.Equal(t, credential.TypeIBMCloudKeys, ct)
+	})
+
+	t.Run("iam_with_cos is gone", func(t *testing.T) {
+		_, err := f.InferCredentialType(map[string]string{"mint_method": "iam_with_cos"})
+		require.Error(t, err)
 	})
 
 	t.Run("unsupported mint method", func(t *testing.T) {
@@ -561,75 +566,135 @@ func TestIBMDriver_VerifySpec(t *testing.T) {
 }
 
 // ============================================================================
-// iam_with_cos Mint Method Tests
+// access_keys Mint Method Tests
 // ============================================================================
 
-func TestIBMDriver_MintIAMWithCOS_DualMode(t *testing.T) {
+func accessKeysSpec(secretSpec string) *credential.CredSpec {
+	cfg := map[string]string{"mint_method": "access_keys"}
+	if secretSpec != "" {
+		cfg[credential.ConfigSecretSpec] = secretSpec
+	}
+	return &credential.CredSpec{Name: "test-spec", Config: cfg}
+}
+
+func TestIBMDriver_MintFromSecret_ServesThePair(t *testing.T) {
 	srv := newIBMMockServer(t)
 	defer srv.Close()
 
 	d := newTestIBMDriver(t, srv.URL)
 
-	spec := &credential.CredSpec{
-		Name: "test-spec",
-		Config: map[string]string{
-			"mint_method":       "iam_with_cos",
-			"access_key_id":     "cos-access-key",
-			"secret_access_key": "cos-secret-key",
-		},
-	}
+	material := credential.SecretMaterial{Data: map[string]string{
+		"access_key_id":     "cos-access-key",
+		"secret_access_key": "cos-secret-key",
+	}}
 
-	rawData, _, ttl, leaseID, err := d.MintCredential(context.TODO(), spec)
+	rawData, _, ttl, leaseID, err := d.MintFromSecret(context.TODO(), accessKeysSpec("cos-pair"), material)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, rawData["access_token"])
 	assert.Equal(t, "cos-access-key", rawData["access_key_id"])
 	assert.Equal(t, "cos-secret-key", rawData["secret_access_key"])
-	assert.True(t, ttl > 0)
-	assert.Empty(t, leaseID, "IAM tokens should have no lease ID")
+	// The bearer half is gone: a spec serves one mode, and this one is COS.
+	assert.NotContains(t, rawData, "access_token")
+	assert.Equal(t, defaultIBMAccessKeysChainTTL, ttl)
+	assert.Empty(t, leaseID, "nothing was created, so nothing is revocable")
 }
 
-func TestIBMDriver_MintIAMWithCOS_APIOnly(t *testing.T) {
+func TestIBMDriver_MintFromSecret_HonoursSecretCacheTTL(t *testing.T) {
 	srv := newIBMMockServer(t)
 	defer srv.Close()
 
 	d := newTestIBMDriver(t, srv.URL)
 
-	spec := &credential.CredSpec{
-		Name: "test-spec",
-		Config: map[string]string{
-			"mint_method": "iam_with_cos",
-		},
-	}
+	spec := accessKeysSpec("cos-pair")
+	spec.Config[credential.ConfigSecretCacheTTL] = "5m"
 
-	rawData, _, _, _, err := d.MintCredential(context.TODO(), spec)
+	material := credential.SecretMaterial{Data: map[string]string{
+		"access_key_id":     "ak",
+		"secret_access_key": "sk",
+	}}
+
+	_, _, ttl, _, err := d.MintFromSecret(context.TODO(), spec, material)
 	require.NoError(t, err)
-
-	assert.NotEmpty(t, rawData["access_token"])
-	_, hasAK := rawData["access_key_id"]
-	_, hasSK := rawData["secret_access_key"]
-	assert.False(t, hasAK, "COS keys should be absent when not configured")
-	assert.False(t, hasSK, "COS keys should be absent when not configured")
+	assert.Equal(t, 5*time.Minute, ttl)
 }
 
-func TestIBMDriver_MintIAMWithCOS_InvalidKey(t *testing.T) {
+// Half a pair is refused rather than served: the gateway's COS leg needs both, and
+// silently dropping one would surface as an opaque SigV4 failure at the provider.
+func TestIBMDriver_MintFromSecret_RequiresBothHalves(t *testing.T) {
 	srv := newIBMMockServer(t)
 	defer srv.Close()
 
 	d := newTestIBMDriver(t, srv.URL)
-	d.credSource.Config["api_key"] = "invalid-key"
-	d.tokenCache.Clear()
 
-	spec := &credential.CredSpec{
-		Name: "test-spec",
-		Config: map[string]string{
-			"mint_method": "iam_with_cos",
-		},
+	for _, tc := range []struct {
+		name string
+		data map[string]string
+	}{
+		{"missing secret_access_key", map[string]string{"access_key_id": "ak"}},
+		{"missing access_key_id", map[string]string{"secret_access_key": "sk"}},
+		{"empty payload", map[string]string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, err := d.MintFromSecret(context.TODO(), accessKeysSpec("cos-pair"), credential.SecretMaterial{Data: tc.data})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		})
 	}
+}
 
+// The guard that holds once a source is converted to chaining with specs already
+// bound to it: the store cannot re-validate those, so the driver refuses again.
+func TestIBMDriver_MintFromSecret_RequiresSpecOwnReference(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	material := credential.SecretMaterial{Data: map[string]string{
+		"access_key_id":     "ak",
+		"secret_access_key": "sk",
+	}}
+
+	_, _, _, _, err := d.MintFromSecret(context.TODO(), accessKeysSpec(""), material)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+}
+
+func TestIBMDriver_MintFromSecret_RefusesOtherMintMethods(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	spec := &credential.CredSpec{Name: "test-spec", Config: map[string]string{"mint_method": "iam_token"}}
+	_, _, _, _, err := d.MintFromSecret(context.TODO(), spec, credential.SecretMaterial{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access_keys")
+}
+
+// An access_keys spec reaching the direct mint path named no reference; nothing
+// here creates a pair, so it fails closed naming what is missing.
+func TestIBMDriver_MintCredential_AccessKeysRefusedWithoutChain(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	_, _, _, _, err := d.MintCredential(context.TODO(), accessKeysSpec(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+}
+
+func TestIBMDriver_MintCredential_IAMWithCOSNowUnsupported(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+
+	spec := &credential.CredSpec{Name: "test-spec", Config: map[string]string{"mint_method": "iam_with_cos"}}
 	_, _, _, _, err := d.MintCredential(context.TODO(), spec)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to acquire IBM IAM token")
+	assert.Contains(t, err.Error(), "unsupported mint_method")
 }
 
 // ============================================================================

--- a/credential/types/ibmcloud_keys.go
+++ b/credential/types/ibmcloud_keys.go
@@ -40,9 +40,9 @@ func (t *IBMCloudKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("eyJraWQiOiIyMDI..."),
 
 		credential.StringField("mint_method").
-			OneOf("iam_with_cos", "dynamic_ibm").
-			Describe("Mint method for credential minting").
-			Example("iam_with_cos"),
+			OneOf("access_keys", "dynamic_ibm").
+			Describe("Mint method for credential minting; omit on an ibm source for a bearer-only spec").
+			Example("access_keys"),
 
 		// Dynamic IBM fields (for Vault IBM secrets engine)
 		credential.StringField("ibm_mount").
@@ -85,15 +85,42 @@ func (t *IBMCloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 			return fmt.Errorf("'role_name' is required when mint_method is dynamic_ibm")
 		}
 	case credential.SourceTypeIBM:
-		if config["mint_method"] != "iam_with_cos" && config["mint_method"] != "" {
-			return fmt.Errorf("'mint_method' must be 'iam_with_cos' for ibm source, got: %s", config["mint_method"])
-		}
-		// COS HMAC keys are optional — API-only mode is valid
-		if config["access_key_id"] != "" && config["secret_access_key"] == "" {
-			return fmt.Errorf("'secret_access_key' is required when 'access_key_id' is set")
-		}
-		if config["secret_access_key"] != "" && config["access_key_id"] == "" {
-			return fmt.Errorf("'access_key_id' is required when 'secret_access_key' is set")
+		switch config["mint_method"] {
+		case "":
+			// Bearer-only: the IAM token minted from the source, which is the
+			// gateway's API mode. An inline COS pair was only ever consumed by
+			// iam_with_cos, and that method existed to serve a standing secret
+			// out of spec config.
+			for _, key := range []string{"access_key_id", "secret_access_key"} {
+				if config[key] != "" {
+					return fmt.Errorf("'%s' must be omitted; a COS pair is served by an access_keys spec from its %s, never stored inline",
+						key, credential.ConfigSecretSpec)
+				}
+			}
+
+		case "access_keys":
+			// The pair is the credential itself, so the spec must name where it
+			// comes from. Nothing mints it: this method exists precisely so that
+			// no key pair is stored here or created at IBM.
+			if config[credential.ConfigSecretSpec] == "" {
+				return fmt.Errorf("'access_keys' requires '%s' naming a spec that yields its access_key_id and secret_access_key", credential.ConfigSecretSpec)
+			}
+			// Refuse an inline pair rather than quietly preferring one over the
+			// other: a pair sitting in spec config is the standing secret this
+			// method exists to avoid, and nothing here would ever rotate it.
+			for _, key := range []string{"access_key_id", "secret_access_key"} {
+				if config[key] != "" {
+					return fmt.Errorf("'%s' must be omitted for access_keys; the referenced spec supplies the whole pair", key)
+				}
+			}
+			// secret_field selects a single secret, and a pair is not one. Both
+			// halves are read by name, so a field here could only mislead.
+			if config[credential.ConfigSecretField] != "" {
+				return fmt.Errorf("'%s' does not apply to access_keys: the referenced credential must hold both 'access_key_id' and 'secret_access_key', read by name", credential.ConfigSecretField)
+			}
+
+		default:
+			return fmt.Errorf("'mint_method' must be 'access_keys' for ibm source (or omitted for a bearer-only spec), got: %s", config["mint_method"])
 		}
 	}
 

--- a/credential/types/ibmcloud_keys_test.go
+++ b/credential/types/ibmcloud_keys_test.go
@@ -99,28 +99,57 @@ func TestIBMCloudKeysCredType_ValidateConfig_IBMSource(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid iam_with_cos",
+			name: "valid access_keys with a reference",
 			config: map[string]string{
-				"mint_method":       "iam_with_cos",
-				"access_key_id":     "cos-key",
-				"secret_access_key": "cos-secret",
+				"mint_method":               "access_keys",
+				credential.ConfigSecretSpec: "cos-pair",
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid iam_with_cos API-only",
-			config: map[string]string{
-				"mint_method": "iam_with_cos",
-			},
+			name:    "bearer-only spec (mint_method omitted)",
+			config:  map[string]string{},
 			wantErr: false,
 		},
 		{
-			name: "default mint_method for ibm source",
+			name: "access_keys without a reference",
+			config: map[string]string{
+				"mint_method": "access_keys",
+			},
+			wantErr: true,
+			errMsg:  credential.ConfigSecretSpec,
+		},
+		{
+			// The pair sitting in spec config is the standing secret this method
+			// exists to remove, so it is refused rather than quietly preferred.
+			name: "access_keys with an inline pair",
+			config: map[string]string{
+				"mint_method":               "access_keys",
+				credential.ConfigSecretSpec: "cos-pair",
+				"access_key_id":             "cos-key",
+				"secret_access_key":         "cos-secret",
+			},
+			wantErr: true,
+			errMsg:  "must be omitted for access_keys",
+		},
+		{
+			name: "access_keys with secret_field",
+			config: map[string]string{
+				"mint_method":                "access_keys",
+				credential.ConfigSecretSpec:  "cos-pair",
+				credential.ConfigSecretField: "whole_pair",
+			},
+			wantErr: true,
+			errMsg:  "does not apply to access_keys",
+		},
+		{
+			name: "bearer-only spec refuses an inline pair",
 			config: map[string]string{
 				"access_key_id":     "cos-key",
 				"secret_access_key": "cos-secret",
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "never stored inline",
 		},
 		{
 			name: "wrong mint_method for ibm source",
@@ -131,13 +160,12 @@ func TestIBMCloudKeysCredType_ValidateConfig_IBMSource(t *testing.T) {
 			errMsg:  "mint_method",
 		},
 		{
-			name: "partial COS - missing secret_access_key",
+			name: "iam_with_cos is refused on the next write",
 			config: map[string]string{
-				"mint_method":   "iam_with_cos",
-				"access_key_id": "cos-key",
+				"mint_method": "iam_with_cos",
 			},
 			wantErr: true,
-			errMsg:  "secret_access_key",
+			errMsg:  "mint_method",
 		},
 	}
 	for _, tt := range tests {

--- a/e2e/fullchain/ibmcloud_test.go
+++ b/e2e/fullchain/ibmcloud_test.go
@@ -77,7 +77,10 @@ func buildIBMCloudEnv(iamURL string) h.ProviderEnv {
 			"iam_endpoint":    iamURL,
 			"tls_skip_verify": "true",
 		},
-		CredConfig: map[string]string{"mint_method": "iam_with_cos"},
+		// Bearer-only: mint_method omitted is the gateway's API mode, which is all
+		// these rows drive. The COS half is a separate spec now — access_keys, whose
+		// pair comes from a referenced spec rather than from config.
+		CredConfig: map[string]string{},
 	}
 }
 

--- a/provider/ibmcloud/provider.go
+++ b/provider/ibmcloud/provider.go
@@ -289,8 +289,13 @@ Credential type: ibmcloud_keys (at least one mode required)
   - secret_access_key: COS HMAC secret access key for Object Storage (COS mode)
 
 Two credential source types are supported:
-- ibm (iam_with_cos): IAM token minted from source API key + static COS HMAC keys
+- ibm (mint_method omitted): IAM token minted from the source API key, for API mode
+- ibm (access_keys): the COS HMAC pair a referenced spec yields, for COS mode
 - hvault (dynamic_ibm): Dynamic API key from Vault IBM engine + IAM token exchange + static COS HMAC
+
+A spec serves one mode, so a role fronting both API and COS traffic needs one spec
+of each. The COS pair is never stored on the spec: access_keys names a secret_spec
+that yields it, and nothing here creates or deletes a pair at IBM.
 
 Configuration:
 - ibmcloud_url: Egress base. Left unset, API mode connects to the host named in the


### PR DESCRIPTION
> **Breaking.** `iam_with_cos` is removed. Specs using it are refused on the next write and fail on the next mint.

`iam_with_cos` read `access_key_id`/`secret_access_key` straight out of spec config: a standing, never-rotated secret sitting in Warden, stapled to a freshly minted IAM token. The pair half was already optional — a spec without one behaved as a plain bearer mint, and a spec with only half had both halves silently dropped — so the method's only distinct behaviour was the inline pair, and that is the part chaining exists to remove.

`access_keys` names a spec that yields the pair and serves it. Nothing is created at IBM, nothing is revoked, no lease is handed out. The field names are IBM's own — the `cos_hmac_keys` fields of a service credential — so a pair stored from IBM's export is read unrenamed, and a payload using other names is projected by the referenced spec's `json_key_map`.

Placement is enforced at three layers, as with ovh and scaleway: the credential type refuses an `access_keys` spec without its own `secret_spec`, the store refuses one that would inherit a source-level reference, and the driver refuses again at mint — which is the guard that holds once a source is converted with specs already bound to it.

**Migration.** A role that relied on one `iam_with_cos` credential serving *both* API and COS traffic must be split. Because a role binds one spec, that means one role per mode, not one spec per mode — the provider help is corrected to say so in a later PR in this stack.

The gateway is unchanged: it already routes per request by signature and reads one field set per mode. What changes is only where the pair lives.

Stacked on #555.