### PR TITLE
feat(ibm): fetch the IAM api key per request instead of storing one

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1052,6 +1052,13 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				if credential.GetString(spec.Config, "mint_method", "") != "access_keys" {
 					return logical.ErrBadRequestf("for an ovh source, set secret_spec on the source (the chained client credential authenticates the source's own OAuth2 calls), not on the spec; a spec-level reference is for access_keys, whose credential is the referenced pair itself")
 				}
+			case credential.SourceTypeIBM:
+				// ibm chains at both levels too: an access_keys spec's own reference
+				// is the COS pair it serves, while the api key the IAM token grant is
+				// made with is a source concern like the others above.
+				if credential.GetString(spec.Config, "mint_method", "") != "access_keys" {
+					return logical.ErrBadRequestf("for an ibm source, set secret_spec on the source (the chained api key authenticates the source's own IAM token grant), not on the spec; a spec-level reference is for access_keys, whose credential is the referenced pair itself")
+				}
 			}
 		}
 		// An oauth2 source that chains its client credential resolves the pair per mint,
@@ -1252,6 +1259,10 @@ const authMethodOIDCFederation = "oidc_federation"
 // caller's identity assertion. Every such driver — aws, azure, gcp, hvault,
 // kubernetes, alicloud — spells it the same way, so one predicate covers them all
 // and covers a new one the day it lands.
+//
+// Not every keyless source federates: ibm, ovh and scaleway have no assertion grant
+// to exchange against, so they remove their stored secret by chaining instead and
+// are gated by the secret_spec rules rather than by this predicate.
 //
 // This is narrower than "holds no secret", which also describes a chained source
 // or spec (secret_spec), whose secret lives in the spec it references. Those are

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2561,4 +2561,27 @@ func TestCredentialConfigStore_IBMAccessKeysNeedsItsOwnReference(t *testing.T) {
 		Name: "ibm-cos-own", Type: credential.TypeIBMCloudKeys, Source: "ibm-src",
 		Config: map[string]string{"mint_method": "access_keys", credential.ConfigSecretSpec: "ibm-cos-pair"},
 	}))
+
+	// The other direction: a bearer spec's api key is a source concern, so a
+	// reference parked on the spec describes a secret it never spends.
+	t.Run("a bearer spec may not carry a reference of its own", func(t *testing.T) {
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "ibm-bearer-chained", Type: credential.TypeIBMCloudKeys, Source: "ibm-src",
+			Config: map[string]string{credential.ConfigSecretSpec: "ibm-api-key"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set secret_spec on the source")
+	})
+
+	// A chained source holds no secret of its own to rotate; that passes to whoever
+	// owns the referenced spec.
+	t.Run("a chained source may not carry a rotation period", func(t *testing.T) {
+		err := store.CreateSource(ctx, &credential.CredSource{
+			Name: "ibm-rotating", Type: credential.SourceTypeIBM,
+			Config:         map[string]string{credential.ConfigSecretSpec: "ibm-api-key"},
+			RotationPeriod: time.Hour,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period")
+	})
 }

--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -92,17 +92,64 @@ func (f *IBMDriverFactory) Type() string {
 	return credential.SourceTypeIBM
 }
 
+// validateIBMChainedConfig rejects source config that contradicts chaining.
+//
+// A chained source stores no api key: keeping one would leave a source that reads
+// as keyless while storing the very secret chaining exists to remove. account_id
+// and activation_delay go for a different reason — their only consumer is rotation
+// (the account a replacement key is created in, and how long to overlap it), which
+// a chained source hands to whoever owns the referenced spec, so leaving them is
+// dead config describing a job this source no longer does.
+func validateIBMChainedConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") == "" {
+		return nil
+	}
+	for _, key := range []string{"api_key", "account_id", "activation_delay"} {
+		if credential.GetString(config, key, "") != "" {
+			return fmt.Errorf("%s must be omitted when %s is set; the api key is supplied by the referenced spec, and rotation belongs to whoever owns it",
+				key, credential.ConfigSecretSpec)
+		}
+	}
+	return nil
+}
+
 // ValidateConfig validates IBM Cloud driver configuration using declarative schema
 func (f *IBMDriverFactory) ValidateConfig(config map[string]string) error {
+	if err := validateIBMChainedConfig(config); err != nil {
+		return err
+	}
+
 	return credential.ValidateSchema(config,
+		// Not Required(): a source serving only access_keys specs never performs the
+		// grant, so demanding a key it will not use would be config kept for nothing,
+		// and a chained source is refused one outright. VerifySpec is what actually
+		// holds an iam_token spec to a source that can mint for it.
 		credential.StringField("api_key").
-			Required().
-			Describe("IBM Cloud API key").
+			Describe("IBM Cloud API key (required for iam_token specs, unless the source sets secret_spec)").
 			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
 		credential.StringField("account_id").
 			Describe("IBM Cloud account ID (optional, discovered from API key if omitted)").
 			Example("abcdef1234567890abcdef1234567890"),
+
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Cred spec yielding the IAM api key, instead of storing one here").
+			Example("ibm-api-key"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Field of the referenced credential holding the api key (defaults: 'api_key', then 'apikey')").
+			Example("api_key"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("How long to reuse the fetched api key before re-fetching (default: no caching)").
+			Example("30m"),
+
+		// Read by PrepareRotation but never declared until now, so a typo'd duration
+		// was silently replaced by the default. The chained validator refuses it by
+		// name, which makes it a key that has to be documented.
+		credential.DurationField("activation_delay").
+			Describe("Overlap before a rotated api key becomes active (default: 2m)").
+			Example("2m"),
 
 		credential.StringField("iam_endpoint").
 			Custom(func(v string) error {
@@ -164,6 +211,17 @@ func (f *IBMDriverFactory) Create(config map[string]string, log *logger.GatedLog
 	}
 	driver.httpClient = httpClient
 
+	// A source without a stored key has nothing to probe and nothing to discover: a
+	// chained source fetches its key per request, as the caller — and there is no
+	// caller here — while a source serving only access_keys specs never performs the
+	// grant at all. Both checks below exist to catch a bad stored key early; with no
+	// stored key they could only refuse config that is absent on purpose. This
+	// matters twice over, since Create is both the store's source connection test
+	// and the path every lazy driver creation takes.
+	if credential.GetString(config, "api_key", "") == "" {
+		return driver, nil
+	}
+
 	// Validate source credentials by acquiring a token
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -191,6 +249,14 @@ func (f *IBMDriverFactory) Create(config map[string]string, log *logger.GatedLog
 
 // MintCredential mints credentials based on the spec's mint_method.
 func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A chained spec or source mints through MintFromSecret, which the minting layer
+	// routes it to. Reaching here means the routing was bypassed, so fail closed
+	// rather than falling back to a key this source may not even hold.
+	if spec.Config[credential.ConfigSecretSpec] != "" || d.isChained() {
+		return nil, nil, 0, "", fmt.Errorf("ibm: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
+			credential.ConfigSecretSpec)
+	}
+
 	mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token")
 
 	switch mintMethod {
@@ -209,6 +275,14 @@ func (d *IBMDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 
 // mintIAMToken exchanges the source API key for an IAM bearer token
 func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// The schema no longer demands a key, so this is where its absence is reported.
+	// Naming the alternative matters: "api_key is empty" from the exchange helper
+	// tells an operator nothing about the reference they could have set instead.
+	if d.getAPIKey() == "" {
+		return nil, nil, 0, "", fmt.Errorf("api_key is required on source config, or a %s naming a spec that yields it",
+			credential.ConfigSecretSpec)
+	}
+
 	token, expiry, err := d.getIAMToken(ctx)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
@@ -231,20 +305,94 @@ func (d *IBMDriver) mintIAMToken(ctx context.Context, spec *credential.CredSpec)
 }
 
 // MintFromSecret mints from secret material fetched through credential chaining.
-// access_keys receives the COS HMAC pair itself, which it serves unchanged: no
-// request is made to IBM, nothing is created, and there is nothing to revoke.
-func (d *IBMDriver) MintFromSecret(_ context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	if mintMethod := credential.GetString(spec.Config, "mint_method", ""); mintMethod != "access_keys" {
-		return nil, nil, 0, "", fmt.Errorf("ibm: credential chaining supports mint_method=access_keys, got %q", mintMethod)
+// What the material means depends on the mint method, so each arm reads it
+// differently: iam_token receives the api key the token grant is made with,
+// access_keys receives the COS HMAC pair itself.
+func (d *IBMDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	switch mintMethod := credential.GetString(spec.Config, "mint_method", ""); mintMethod {
+	case "iam_token", "":
+		return d.mintIAMTokenFromSecret(ctx, spec, material)
+	case "access_keys":
+		return d.mintAccessKeysFromSecret(spec, material)
+	default:
+		// mint_method is validated at spec create, so reaching here means config
+		// drifted. The material's meaning is defined by the method, so with an
+		// unknown one there is no safe way to spend it.
+		return nil, nil, 0, "", fmt.Errorf("ibm: credential chaining supports mint_method=iam_token or access_keys, got %q", mintMethod)
+	}
+}
+
+// mintIAMTokenFromSecret performs the apikey grant with an api key fetched through
+// the chain, for a source that stores none.
+//
+// It deliberately does NOT call getIAMToken. That cache files every bearer under
+// one fixed key, which is right when a single stored key mints every token — but a
+// fetched key is resolved per caller, and the referenced spec may legitimately hand
+// different callers different keys, so the shared slot would serve one caller's IAM
+// token to another. Per-caller reuse lives where it is safe: the minting layer
+// caches the finished credential per session token, and the fetched key per agent
+// identity.
+func (d *IBMDriver) mintIAMTokenFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	apiKey := material.Secret()
+
+	// Fall back to conventional names ONLY when no field was resolved. A field that
+	// resolved to nothing is a misconfigured secret_field — say so, rather than
+	// silently authenticating with some other value from the payload.
+	if apiKey == "" && material.Field == "" {
+		if apiKey = material.Data["api_key"]; apiKey == "" {
+			apiKey = material.Data["apikey"]
+		}
+	}
+	if apiKey == "" {
+		if material.Field != "" {
+			return nil, nil, 0, "", fmt.Errorf("ibm: %s %q is empty or absent in the fetched secret material: %w",
+				credential.ConfigSecretField, material.Field, credential.ErrChainedSecretIncomplete)
+		}
+		return nil, nil, 0, "", fmt.Errorf("ibm: no api key in fetched secret material (set %s, or store it under 'api_key'): %w",
+			credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
 	}
 
-	// The spec must name the reference itself. Routed here by a source-level one,
-	// the material would be whatever the source authenticates with, not this
-	// credential. Spec create refuses that combination, but a source converted to
-	// chaining afterwards is not re-validated against the specs already bound to
-	// it, so this is the guard that actually holds.
+	token, expiry, status, err := exchangeIBMAPIKeyForIAMTokenWithStatus(ctx, d.httpClient, apiKey, d.getIAMEndpoint(), d.logger)
+	if err != nil {
+		// On the chained path an authentication refusal marks the fetched key as
+		// possibly stale, so the minting layer evicts a cached copy and retries once
+		// with a fresh fetch. IBM answers a bad, deleted or locked api key with 400
+		// and a BXNIM error envelope, and the key is the only thing in this request
+		// that varies per mint — the grant type is a constant — so a refusal is about
+		// the credential or about nothing. Throttling and outages were already
+		// retried and arrive with other statuses, unmapped: an IBM outage is not a
+		// stale key, and a 404 is a mis-set iam_endpoint.
+		switch status {
+		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+			return nil, nil, 0, "", fmt.Errorf("ibm: IAM token endpoint rejected the chained api key: %w (%w)",
+				credential.ErrChainedSecretRejected, err)
+		}
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire IBM IAM token: %w", err)
+	}
+
+	ttl := time.Until(expiry)
+	if d.logger != nil {
+		d.logger.Debug("minted IBM IAM bearer token from fetched secret material",
+			logger.String("spec", spec.Name),
+			logger.String("ttl", ttl.String()),
+		)
+	}
+
+	// No leaseID — IAM tokens expire naturally and cannot be revoked
+	return map[string]interface{}{"access_token": token}, nil, ttl, "", nil
+}
+
+// mintAccessKeysFromSecret serves the COS HMAC pair a referenced spec yields: no
+// request is made to IBM, nothing is created, and there is nothing to revoke.
+func (d *IBMDriver) mintAccessKeysFromSecret(spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// The spec must name the reference itself. Routed here by a source-level one, the
+	// material would be the api key that source authenticates with, not this
+	// credential — and an operator's referenced payload may well carry both. Spec
+	// create refuses that combination, but a source converted to chaining afterwards
+	// is not re-validated against the specs already bound to it, so this is the guard
+	// that actually holds.
 	if spec.Config[credential.ConfigSecretSpec] == "" {
-		return nil, nil, 0, "", fmt.Errorf("ibm: an access_keys spec must set its own %s naming a spec that yields its access_key_id and secret_access_key",
+		return nil, nil, 0, "", fmt.Errorf("ibm: an access_keys spec must set its own %s naming a spec that yields its access_key_id and secret_access_key; this source's chained secret is its IAM api key, not this credential",
 			credential.ConfigSecretSpec)
 	}
 
@@ -306,6 +454,17 @@ func (d *IBMDriver) Cleanup(ctx context.Context) error {
 func (d *IBMDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
 	switch mintMethod := credential.GetString(spec.Config, "mint_method", "iam_token"); mintMethod {
 	case "iam_token":
+		// The grant runs with the source's api key, which the source schema no longer
+		// demands — a source serving only access_keys specs has no use for one. This
+		// is where that requirement actually lands, unless the source fetches its key
+		// per request, in which case there is nothing to check until one is fetched.
+		if d.isChained() {
+			return nil
+		}
+		if d.getAPIKey() == "" {
+			return fmt.Errorf("an iam_token spec needs api_key on its source, or a %s naming a spec that yields it",
+				credential.ConfigSecretSpec)
+		}
 		// Verify the source API key can mint an IAM token
 		if _, _, err := d.getIAMToken(ctx); err != nil {
 			return fmt.Errorf("IBM spec verification failed: %w", err)
@@ -334,6 +493,15 @@ func (d *IBMDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) e
 // SupportsRotation returns true if this driver can rotate its source API key.
 // Rotation requires the API key's IAM identity to have permission to create/delete API keys.
 func (d *IBMDriver) SupportsRotation() bool {
+	// The key lives at its source of truth, and whoever owns the referenced spec
+	// rotates it there. On a chained source iamID is never discovered, so this would
+	// be false anyway — stating it keeps the invariant independent of discovery.
+	// Taken before authMu: isChained acquires configMu, and the driver's established
+	// order is authMu then configMu, never the reverse.
+	if d.isChained() {
+		return false
+	}
+
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 	return d.iamID != ""
@@ -342,6 +510,13 @@ func (d *IBMDriver) SupportsRotation() bool {
 // PrepareRotation creates a new API key for the same IAM identity.
 // Returns activateAfter to allow time for IBM Cloud propagation.
 func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	// Same ordering note as SupportsRotation: configMu is taken before authMu here,
+	// never nested inside it.
+	if d.isChained() {
+		return nil, nil, 0, fmt.Errorf("rotation does not apply to a chained source (%s is set); the referenced spec's owner rotates the api key",
+			credential.ConfigSecretSpec)
+	}
+
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 
@@ -534,6 +709,23 @@ func (d *IBMDriver) configSnapshot() map[string]string {
 		snapshot[k] = v
 	}
 	return snapshot
+}
+
+// isChainedLocked reports whether this source draws its api key from a referenced
+// cred spec rather than holding one inline.
+// Caller must hold configMu (read or write).
+func (d *IBMDriver) isChainedLocked() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
+// isChained is isChainedLocked for callers holding no lock. Read locks are not
+// re-entrant — a writer queued between two acquisitions on one goroutine
+// deadlocks — so anything already inside a configMu block must call the Locked
+// form instead.
+func (d *IBMDriver) isChained() bool {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.isChainedLocked()
 }
 
 // swapConfig publishes a config and retires every token the previous one minted, as one

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -35,10 +35,11 @@ func TestIBMDriverFactory_SensitiveConfigFields(t *testing.T) {
 func TestIBMDriverFactory_ValidateConfig(t *testing.T) {
 	f := &IBMDriverFactory{}
 
-	t.Run("missing api_key", func(t *testing.T) {
-		err := f.ValidateConfig(map[string]string{})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "api_key")
+	// The schema no longer demands api_key: a source serving only access_keys specs
+	// never performs the grant, and a chained source is refused one outright. An
+	// iam_token spec still needs it, which VerifySpec and the mint path enforce.
+	t.Run("api_key is not required at source level", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{}))
 	})
 
 	t.Run("valid minimal config", func(t *testing.T) {
@@ -135,14 +136,40 @@ func TestIBMDriver_Revoke_NoOp(t *testing.T) {
 }
 
 func TestIBMDriver_SupportsRotation(t *testing.T) {
+	// The factory always sets credSource, so these mirror a real driver rather than
+	// a bare struct: SupportsRotation now reads config to see whether the source
+	// chains its key.
+	inline := func(iamID string) *IBMDriver {
+		return &IBMDriver{
+			credSource: &credential.CredSource{Type: credential.SourceTypeIBM, Config: map[string]string{}},
+			iamID:      iamID,
+		}
+	}
+
 	t.Run("true when iamID is set", func(t *testing.T) {
-		d := &IBMDriver{iamID: "iam-1234"}
-		assert.True(t, d.SupportsRotation())
+		assert.True(t, inline("iam-1234").SupportsRotation())
 	})
 
 	t.Run("false when iamID is empty", func(t *testing.T) {
-		d := &IBMDriver{}
+		assert.False(t, inline("").SupportsRotation())
+	})
+
+	// The key lives at its source of truth; whoever owns the referenced spec rotates
+	// it there. Asserted with iamID set, so it is the chaining that decides and not
+	// merely the absence of discovery.
+	t.Run("false when the source chains its key", func(t *testing.T) {
+		d := &IBMDriver{
+			credSource: &credential.CredSource{
+				Type:   credential.SourceTypeIBM,
+				Config: map[string]string{credential.ConfigSecretSpec: "ibm-api-key"},
+			},
+			iamID: "iam-1234",
+		}
 		assert.False(t, d.SupportsRotation())
+
+		_, _, _, err := d.PrepareRotation(context.TODO())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
 	})
 }
 
@@ -460,7 +487,10 @@ func TestIBMDriver_PrepareRotation(t *testing.T) {
 }
 
 func TestIBMDriver_PrepareRotation_NoIAMID(t *testing.T) {
-	d := &IBMDriver{iamID: ""}
+	d := &IBMDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeIBM, Config: map[string]string{}},
+		iamID:      "",
+	}
 	_, _, _, err := d.PrepareRotation(context.TODO())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "IAM identity not discovered")
@@ -660,16 +690,19 @@ func TestIBMDriver_MintFromSecret_RequiresSpecOwnReference(t *testing.T) {
 	assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
 }
 
-func TestIBMDriver_MintFromSecret_RefusesOtherMintMethods(t *testing.T) {
+// mint_method is validated at spec create, so an unknown one here means config
+// drifted. The material's meaning is defined by the method, so with an unknown one
+// there is no safe way to spend it.
+func TestIBMDriver_MintFromSecret_RefusesUnknownMintMethod(t *testing.T) {
 	srv := newIBMMockServer(t)
 	defer srv.Close()
 
 	d := newTestIBMDriver(t, srv.URL)
 
-	spec := &credential.CredSpec{Name: "test-spec", Config: map[string]string{"mint_method": "iam_token"}}
+	spec := &credential.CredSpec{Name: "test-spec", Config: map[string]string{"mint_method": "iam_with_cos"}}
 	_, _, _, _, err := d.MintFromSecret(context.TODO(), spec, credential.SecretMaterial{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "access_keys")
+	assert.Contains(t, err.Error(), "iam_with_cos")
 }
 
 // An access_keys spec reaching the direct mint path named no reference; nothing
@@ -864,4 +897,283 @@ func TestIBMDriver_TokenFromRetiredKeyIsNeverServed(t *testing.T) {
 	cached, _, ok := d.tokenCache.Get("iam", 30*time.Second)
 	require.True(t, ok)
 	assert.NotEqual(t, "test-iam-token-test-key", cached, "the retired key's token must never reach the cache")
+}
+
+// ============================================================================
+// Source-level chaining: the api key is fetched per request, not stored
+// ============================================================================
+
+// newChainedIBMDriver builds a driver for a source that holds no api key of its
+// own, which is what a chained source looks like once Create has skipped the probe.
+func newChainedIBMDriver(t *testing.T, serverURL string) *IBMDriver {
+	t.Helper()
+	return &IBMDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeIBM,
+			Config: map[string]string{
+				"iam_endpoint":              serverURL,
+				credential.ConfigSecretSpec: "ibm-api-key",
+			},
+		},
+		tokenCache: NewTokenCache(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func bearerSpec() *credential.CredSpec {
+	return &credential.CredSpec{Name: "test-spec", Config: map[string]string{"mint_method": "iam_token"}}
+}
+
+// A chained source keeps none of the config that describes a key it does not hold,
+// nor the rotation settings for a job it no longer does.
+func TestIBMDriverFactory_ValidateConfig_Chaining(t *testing.T) {
+	f := &IBMDriverFactory{}
+
+	t.Run("a reference alone is valid", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			credential.ConfigSecretSpec: "ibm-api-key",
+		}))
+	})
+
+	for _, key := range []string{"api_key", "account_id", "activation_delay"} {
+		t.Run(key+" is refused beside a reference", func(t *testing.T) {
+			err := f.ValidateConfig(map[string]string{
+				credential.ConfigSecretSpec: "ibm-api-key",
+				key:                         "some-value",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), key)
+			assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+		})
+	}
+}
+
+func TestIBMDriver_MintFromSecret_IAMToken(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newChainedIBMDriver(t, srv.URL)
+
+	material := credential.SecretMaterial{Data: map[string]string{"api_key": "fetched-key"}}
+
+	rawData, _, ttl, leaseID, err := d.MintFromSecret(context.TODO(), bearerSpec(), material)
+	require.NoError(t, err)
+
+	// The mock derives its token from the key it was given, so this proves the
+	// fetched key reached the grant rather than anything held on the source.
+	assert.Equal(t, "test-iam-token-fetched-key", rawData["access_token"])
+	assert.True(t, ttl > 0)
+	assert.Empty(t, leaseID, "IAM tokens expire naturally and cannot be revoked")
+}
+
+func TestIBMDriver_MintFromSecret_SecretFieldResolution(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newChainedIBMDriver(t, srv.URL)
+
+	t.Run("a resolved field wins over the conventional names", func(t *testing.T) {
+		material := credential.SecretMaterial{
+			Field: "ibm_key",
+			Data:  map[string]string{"ibm_key": "field-key", "api_key": "conventional-key"},
+		}
+		rawData, _, _, _, err := d.MintFromSecret(context.TODO(), bearerSpec(), material)
+		require.NoError(t, err)
+		assert.Equal(t, "test-iam-token-field-key", rawData["access_token"])
+	})
+
+	// A field that resolved to nothing is a misconfigured secret_field. Falling back
+	// would authenticate with some other value from the payload, so it is named.
+	t.Run("a resolved-but-empty field errors instead of falling back", func(t *testing.T) {
+		material := credential.SecretMaterial{
+			Field: "ibm_key",
+			Data:  map[string]string{"api_key": "conventional-key"},
+		}
+		_, _, _, _, err := d.MintFromSecret(context.TODO(), bearerSpec(), material)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		assert.Contains(t, err.Error(), "ibm_key")
+	})
+
+	t.Run("api_key then apikey when no field is set", func(t *testing.T) {
+		for name, want := range map[string]string{"api_key": "a", "apikey": "b"} {
+			material := credential.SecretMaterial{Data: map[string]string{name: want}}
+			rawData, _, _, _, err := d.MintFromSecret(context.TODO(), bearerSpec(), material)
+			require.NoError(t, err)
+			assert.Equal(t, "test-iam-token-"+want, rawData["access_token"])
+		}
+	})
+
+	t.Run("neither present is incomplete", func(t *testing.T) {
+		material := credential.SecretMaterial{Data: map[string]string{"unrelated": "x"}}
+		_, _, _, _, err := d.MintFromSecret(context.TODO(), bearerSpec(), material)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+	})
+}
+
+// On the chained path the fetched key is the one thing that varies per mint, so an
+// authentication refusal is worth telling the minting layer about: it evicts the
+// cached secret and retries once with a fresh fetch.
+func TestIBMDriver_MintFromSecret_RejectionIsRetryable(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newChainedIBMDriver(t, srv.URL)
+
+	material := credential.SecretMaterial{Data: map[string]string{"api_key": "invalid-key"}}
+	_, _, _, _, err := d.MintFromSecret(context.TODO(), bearerSpec(), material)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+// An inline source maps nothing: there is nothing to re-fetch, so the sentinel
+// would only buy a pointless second attempt.
+func TestIBMDriver_MintCredential_InlineRejectionIsNotRetryable(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.credSource.Config["api_key"] = "invalid-key"
+	d.tokenCache.Clear()
+
+	_, _, _, _, err := d.MintCredential(context.TODO(), bearerSpec())
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected)
+}
+
+// The driver's token cache files every bearer under one fixed key, which is right
+// when a single stored key mints every token. A fetched key is resolved per caller
+// and the referenced spec may hand different callers different keys, so routing the
+// chained mint through that cache would serve one caller's IAM token to another --
+// an authorization bypass at IBM's end, where every action would be attributed to
+// whoever minted first. This pins that the chained path never touches it.
+func TestIBMDriver_ChainedMintBypassesTokenCache(t *testing.T) {
+	var exchanges int
+	var mu sync.Mutex
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		mu.Lock()
+		exchanges++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-iam-token-" + r.FormValue("apikey"),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	d := newChainedIBMDriver(t, srv.URL)
+
+	mintAs := func(key string) string {
+		rawData, _, _, _, err := d.MintFromSecret(context.TODO(),
+			bearerSpec(), credential.SecretMaterial{Data: map[string]string{"api_key": key}})
+		require.NoError(t, err)
+		return rawData["access_token"].(string)
+	}
+
+	tokenA := mintAs("key-of-caller-A")
+	tokenB := mintAs("key-of-caller-B")
+
+	assert.Equal(t, "test-iam-token-key-of-caller-A", tokenA)
+	assert.Equal(t, "test-iam-token-key-of-caller-B", tokenB)
+	assert.NotEqual(t, tokenA, tokenB, "caller B must not be served caller A's token")
+	assert.Equal(t, 2, exchanges, "each caller's key is exchanged on its own")
+
+	// Nothing was filed under the shared slot, so no later inline path could serve
+	// a token minted from someone's fetched key either.
+	_, _, ok := d.tokenCache.Get("iam", 0)
+	assert.False(t, ok, "the chained path must not populate the shared token cache")
+}
+
+// A chained spec or source mints through MintFromSecret. Reaching MintCredential
+// means the routing was bypassed, so it fails closed rather than falling back to a
+// key this source may not even hold.
+func TestIBMDriver_MintCredential_FailsClosedWhenChained(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	t.Run("source-level reference", func(t *testing.T) {
+		d := newChainedIBMDriver(t, srv.URL)
+		_, _, _, _, err := d.MintCredential(context.TODO(), bearerSpec())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+	})
+
+	t.Run("spec-level reference", func(t *testing.T) {
+		d := newTestIBMDriver(t, srv.URL)
+		spec := bearerSpec()
+		spec.Config[credential.ConfigSecretSpec] = "ibm-api-key"
+		_, _, _, _, err := d.MintCredential(context.TODO(), spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+	})
+}
+
+// Create is both the store's source connection test and the path every lazy driver
+// creation takes, so an unskipped probe would refuse a keyless source at write and
+// fail every mint after.
+func TestIBMDriverFactory_Create_SkipsProbeWithoutKey(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "no source should reach me", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := &IBMDriverFactory{}
+
+	for name, config := range map[string]map[string]string{
+		"chained source": {
+			"iam_endpoint":              srv.URL,
+			credential.ConfigSecretSpec: "ibm-api-key",
+		},
+		"source serving only access_keys specs": {
+			"iam_endpoint": srv.URL,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hits = 0
+			log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+			d, err := f.Create(config, log)
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			assert.Zero(t, hits, "Create must make no upstream call without a stored key")
+		})
+	}
+}
+
+func TestIBMDriver_VerifySpec_ChainedSourceNeedsNoAPIKey(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "no verification should reach me", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Run("chained source verifies without a call", func(t *testing.T) {
+		d := newChainedIBMDriver(t, srv.URL)
+		require.NoError(t, d.VerifySpec(context.TODO(), bearerSpec()))
+		assert.Zero(t, hits)
+	})
+
+	// The schema no longer demands api_key, so this is where its absence lands --
+	// naming the reference an operator could have set instead.
+	t.Run("an unchained source without a key names both alternatives", func(t *testing.T) {
+		d := &IBMDriver{
+			credSource: &credential.CredSource{
+				Type:   credential.SourceTypeIBM,
+				Config: map[string]string{"iam_endpoint": srv.URL},
+			},
+			tokenCache: NewTokenCache(),
+			httpClient: &http.Client{Timeout: 5 * time.Second},
+		}
+		err := d.VerifySpec(context.TODO(), bearerSpec())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api_key")
+		assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
+	})
 }

--- a/credential/drivers/ibm_iam.go
+++ b/credential/drivers/ibm_iam.go
@@ -35,8 +35,19 @@ type ibmIAMTokenResponse struct {
 // (custom CA, skip verify) should pass a client built via BuildHTTPClient. log may be
 // nil; it carries the one case worth reporting, a response that stated no lifetime.
 func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, apiKey, iamEndpoint string, log *logger.GatedLogger) (string, time.Time, error) {
+	token, expiry, _, err := exchangeIBMAPIKeyForIAMTokenWithStatus(ctx, httpClient, apiKey, iamEndpoint, log)
+	return token, expiry, err
+}
+
+// exchangeIBMAPIKeyForIAMTokenWithStatus is exchangeIBMAPIKeyForIAMToken plus the
+// HTTP status the endpoint answered with, which ExecuteWithRetry reports even on
+// error. Only the chained mint path reads it: there the fetched key is the one
+// thing that varies per request, so an authentication refusal is worth telling the
+// minting layer about. A key held in config has nothing to re-fetch, so every other
+// caller uses the wrapper above.
+func exchangeIBMAPIKeyForIAMTokenWithStatus(ctx context.Context, httpClient *http.Client, apiKey, iamEndpoint string, log *logger.GatedLogger) (string, time.Time, int, error) {
 	if apiKey == "" {
-		return "", time.Time{}, fmt.Errorf("api_key is empty")
+		return "", time.Time{}, 0, fmt.Errorf("api_key is empty")
 	}
 	if iamEndpoint == "" {
 		iamEndpoint = defaultIBMIAMEndpoint
@@ -50,7 +61,7 @@ func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, 
 		"apikey":     {apiKey},
 	}
 
-	respBody, _, err := httputil.ExecuteWithRetry(ctx, httpClient, httputil.HTTPRequest{
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, httpClient, httputil.HTTPRequest{
 		Method: "POST",
 		URL:    iamEndpoint + "/identity/token",
 		Body:   []byte(form.Encode()),
@@ -60,15 +71,15 @@ func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, 
 		},
 	}, defaultIBMRetryConfig())
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("IBM IAM token request failed: %w", err)
+		return "", time.Time{}, status, fmt.Errorf("IBM IAM token request failed: %w", err)
 	}
 
 	var tokenResp ibmIAMTokenResponse
 	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
-		return "", time.Time{}, fmt.Errorf("failed to decode IAM token response: %w", err)
+		return "", time.Time{}, status, fmt.Errorf("failed to decode IAM token response: %w", err)
 	}
 	if tokenResp.AccessToken == "" {
-		return "", time.Time{}, fmt.Errorf("IAM token response missing access_token")
+		return "", time.Time{}, status, fmt.Errorf("IAM token response missing access_token")
 	}
 
 	// Compute expiry from either expiration (Unix timestamp) or expires_in (seconds)
@@ -91,5 +102,5 @@ func exchangeIBMAPIKeyForIAMToken(ctx context.Context, httpClient *http.Client, 
 		expiry = time.Now().Add(ibmFallbackTokenTTL)
 	}
 
-	return tokenResp.AccessToken, expiry, nil
+	return tokenResp.AccessToken, expiry, status, nil
 }

--- a/credential/types/ibmcloud_keys.go
+++ b/credential/types/ibmcloud_keys.go
@@ -97,6 +97,12 @@ func (t *IBMCloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 						key, credential.ConfigSecretSpec)
 				}
 			}
+			// The grant runs with the source's api key, so a reference here would
+			// describe a secret this spec never spends. On an ibm source a
+			// spec-level reference means access_keys and nothing else.
+			if config[credential.ConfigSecretSpec] != "" {
+				return fmt.Errorf("for a bearer-only spec, '%s' belongs on the source: the chained api key authenticates the source's own IAM token grant; a spec-level reference is for access_keys", credential.ConfigSecretSpec)
+			}
 
 		case "access_keys":
 			// The pair is the credential itself, so the spec must name where it

--- a/credential/types/oauth_bearer_token.go
+++ b/credential/types/oauth_bearer_token.go
@@ -146,6 +146,12 @@ func (t *OAuthBearerTokenCredType) ValidateConfig(config map[string]string, sour
 		if mm := config["mint_method"]; mm != "" && mm != "iam_token" {
 			return fmt.Errorf("'mint_method' must be 'iam_token' for ibm source, got: %s", mm)
 		}
+		// The grant runs with the source's api key, so a reference parked here would
+		// describe a secret this spec never spends — and would slip past the
+		// source-level checks that gate which sources may chain at all.
+		if config[credential.ConfigSecretSpec] != "" {
+			return fmt.Errorf("for an ibm source, '%s' belongs on the source: the chained api key authenticates the source's own IAM token grant, not this spec", credential.ConfigSecretSpec)
+		}
 	case credential.SourceTypeTokenExchange:
 		// The token_exchange driver is exchange-only: it mints solely from a
 		// caller-derived subject. A spec that opts out (subject_token_source absent


### PR DESCRIPTION
IBM Cloud IAM trusts no external OIDC issuer — trusted profiles federate only IBM-managed compute, and the token endpoint's only usable machine grant exchanges an api key — so the assertion-based keyless path the other cloud drivers take has nothing to exchange against. Verified three ways: IBM's live discovery document lists neither `jwt-bearer` nor `token-exchange`; `IBM/platform-services-go-sdk`'s `iamidentityv1` (816 KB) has zero matches for `oidc`; and trusted-profile claim rules are only `Profile-SAML` or `Profile-CR` over six IBM compute types.

What is achievable is removing the key from Warden. A source can now set `secret_spec` naming a spec that yields the api key; Warden mints that spec as the calling agent and hands the result to the grant. The key exists in memory for one request and is never written to the barrier.

ibm now chains at **both levels**, and the level says which secret is meant: a source-level reference is the api key the grant is made with, a spec-level one is the COS pair an `access_keys` spec serves. This is the same shape ovh reached in #550.

### The part most worth reviewing

**The chained mint bypasses the driver's token cache.** That cache files every bearer under one fixed key, which is right when one stored key mints every token. But a fetched key is resolved *per caller* — the chained-secret cache is keyed on agent identity precisely so one agent is never served another's fetched secret — so the shared slot would serve one caller's IAM token to another. That is an authorization bypass at IBM's end, where every policy decision and audit line would attribute one caller's actions to another. There is a named regression test for it.

Per-caller reuse still happens where it is safe: the minting layer caches the finished credential per session token, and the fetched key per agent identity.

### Honest ceiling

Chaining removes the *stored* key; it does not give per-caller identity at IBM. Every caller's bearer carries the same IBM identity unless the referenced spec resolves different keys per caller. The per-caller property is on the fetch, which is audited and authorized per agent — not on IBM's side. That is the same ceiling scaleway accepted in #545.

Also: a chained source is refused an inline `api_key`, `account_id` and `activation_delay`; rotation is refused outright; and `Create`'s eager probe and discovery are skipped for any source without a stored key, which also admits a source serving only `access_keys` specs.

Stacked on #556.