### PR TITLE
fix(ibm): contain rotation orphans, and close three gaps this stack opened

### DIFF
--- a/credential/drivers/ibm_driver.go
+++ b/credential/drivers/ibm_driver.go
@@ -26,6 +26,26 @@ const ibmMaxResponseBodySize = 1 << 20 // 1MB
 // defaultIBMIAMEndpoint is the default IBM Cloud IAM endpoint
 const defaultIBMIAMEndpoint = "https://iam.cloud.ibm.com"
 
+// ibmRotationDescriptionPrefix stamps an API key created by rotation. The id of
+// the key it replaces is appended, so the stamp names one lineage rather than
+// every key Warden ever made: a key created by rotating from K is stamped with K,
+// so the key currently in use — stamped with *its* predecessor — can never match,
+// and neither can a sibling source's key, whose lineage starts somewhere else.
+// That scoping is what makes the sweep safe to run at all.
+const ibmRotationDescriptionPrefix = "Managed by Warden credential rotation, replacing "
+
+// ibmLegacyRotationDescription is the description every rotated key carried before
+// the lineage stamp existed. Such a key names no lineage, so it cannot be matched
+// by a stamp — and a sweep that only matched stamps could therefore never reclaim
+// a single orphan that predated this scheme, which is most of them on any cluster
+// that has been rotating. It is Warden's own constant and was never applied to
+// anything but a rotation key, so matching it is as safe as matching a stamp: the
+// live key is excluded by id either way.
+const ibmLegacyRotationDescription = "Managed by Warden credential rotation"
+
+// ibmListPageSize bounds one page of the API key listing the sweep walks.
+const ibmListPageSize = 100
+
 // defaultIBMAccessKeysChainTTL bounds how long a served COS pair stays cached when
 // the spec sets no secret_cache_ttl. The pair has no expiry of its own, so this is
 // only how long Warden goes before walking the chain again to see whether the
@@ -37,6 +57,7 @@ var _ credential.SourceDriver = (*IBMDriver)(nil)
 var _ credential.Rotatable = (*IBMDriver)(nil)
 var _ credential.SpecVerifier = (*IBMDriver)(nil)
 var _ credential.ChainedSecretMinter = (*IBMDriver)(nil)
+var _ credential.RotationConfigValidator = (*IBMDriverFactory)(nil)
 
 // IBMDriver mints credentials from IBM Cloud services.
 // It exchanges an IBM Cloud API key for IAM bearer tokens.
@@ -179,6 +200,29 @@ func (f *IBMDriverFactory) ValidateConfig(config map[string]string) error {
 // SensitiveConfigFields returns the list of config keys that should be masked in output
 func (f *IBMDriverFactory) SensitiveConfigFields() []string {
 	return []string{"api_key", "ca_data"}
+}
+
+// ValidateRotationConfig rejects a rotation_period on a source that could never
+// rotate, so the operator hears about it at write time rather than never.
+//
+// It mirrors SupportsRotation exactly, from the config map instead of live driver
+// state. The two must stay in step: anything SupportsRotation requires and this
+// does not becomes a source that is accepted and then fails every cycle forever.
+//
+// This became necessary when api_key stopped being Required(): a source holding
+// neither a key nor a reference is now a legitimate shape (it serves only
+// access_keys specs), and nothing else would have caught a rotation_period on it.
+// The chained case is refused by the store, but it is checked here too so the two
+// halves of "cannot rotate" are stated in one place.
+func (f *IBMDriverFactory) ValidateRotationConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") != "" {
+		return fmt.Errorf("rotation does not apply to a chained source (%s is set); the referenced spec's owner rotates the api key",
+			credential.ConfigSecretSpec)
+	}
+	if credential.GetString(config, "api_key", "") == "" {
+		return fmt.Errorf("rotating an ibm source requires api_key; a source that holds none serves only access_keys specs and the rotation manager could never complete a cycle")
+	}
+	return nil
 }
 
 // InferCredentialType infers the credential type from the spec's mint_method.
@@ -490,21 +534,26 @@ func (d *IBMDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) e
 // Rotatable Interface Implementation (Source API Key Rotation)
 // ============================================================================
 
-// SupportsRotation returns true if this driver can rotate its source API key.
-// Rotation requires the API key's IAM identity to have permission to create/delete API keys.
+// SupportsRotation returns true if this driver has a source API key to rotate.
+//
+// It reports on configuration, not on whether discovery has already succeeded. It
+// used to require a discovered iamID, which made one transient failure at driver
+// creation permanent: nothing re-ran discovery, so the manager retried to
+// MaxRotateAttempts, parked the entry, and came back to the same answer for the
+// life of the instance. PrepareRotation re-probes instead — it has a context to do
+// it with, which this method does not.
+//
+// Whether the identity may actually create keys is still IBM's to say, and it says
+// so at PrepareRotation. A permission error there is a clearer report than "source
+// configuration does not support rotation" anyway.
 func (d *IBMDriver) SupportsRotation() bool {
 	// The key lives at its source of truth, and whoever owns the referenced spec
-	// rotates it there. On a chained source iamID is never discovered, so this would
-	// be false anyway — stating it keeps the invariant independent of discovery.
-	// Taken before authMu: isChained acquires configMu, and the driver's established
-	// order is authMu then configMu, never the reverse.
+	// rotates it there. Taken before authMu: isChained acquires configMu, and the
+	// driver's established order is authMu then configMu, never the reverse.
 	if d.isChained() {
 		return false
 	}
-
-	d.authMu.Lock()
-	defer d.authMu.Unlock()
-	return d.iamID != ""
+	return d.getAPIKey() != ""
 }
 
 // PrepareRotation creates a new API key for the same IAM identity.
@@ -520,8 +569,18 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 
-	if d.iamID == "" {
-		return nil, nil, 0, fmt.Errorf("cannot rotate: IAM identity not discovered")
+	// Discovery is best-effort at creation time, so a blip there leaves the identity
+	// unknown. Re-probe here rather than refusing forever: this is the first point
+	// after creation that both needs the identity and has a context to fetch it with.
+	// Both ids are required: iamID names the identity the replacement is created
+	// for, and apiKeyID is what cleanup deletes and what the sweep must never touch.
+	if d.iamID == "" || d.apiKeyID == "" {
+		if err := d.discoverAPIKeyDetailsLocked(ctx); err != nil {
+			return nil, nil, 0, fmt.Errorf("cannot rotate: IAM identity not discovered: %w", err)
+		}
+		if d.iamID == "" || d.apiKeyID == "" {
+			return nil, nil, 0, fmt.Errorf("cannot rotate: IBM did not report both an iam_id and an api key id")
+		}
 	}
 
 	// Get IAM token using current API key
@@ -530,13 +589,18 @@ func (d *IBMDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 		return nil, nil, 0, fmt.Errorf("failed to get IAM token for rotation: %w", err)
 	}
 
-	// Create new API key for the same IAM identity
-	newAPIKey, newAPIKeyID, err := d.createAPIKey(ctx, iamToken)
+	oldAPIKeyID := d.apiKeyID
+
+	// Reclaim before creating, so a key this source lost track of on an earlier
+	// attempt is gone before another is made. The key in use is excluded by id.
+	d.sweepOrphanedRotationKeys(ctx, iamToken)
+
+	// Create new API key for the same IAM identity, stamped with the key it
+	// replaces so an operator reading the IBM console can see the lineage.
+	newAPIKey, newAPIKeyID, err := d.createAPIKey(ctx, iamToken, ibmRotationDescriptionPrefix+oldAPIKeyID)
 	if err != nil {
 		return nil, nil, 0, err
 	}
-
-	oldAPIKeyID := d.apiKeyID
 
 	// Build new config
 	newConfig := d.configSnapshot()
@@ -615,7 +679,11 @@ func (d *IBMDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 		return fmt.Errorf("failed to get IAM token for cleanup: %w", err)
 	}
 
-	if err := d.deleteAPIKey(ctx, iamToken, oldAPIKeyID); err != nil {
+	// A key that is already gone is the goal state, not a failure. Without this the
+	// cleanup retries daily for a week before being abandoned with an error, for a
+	// key nobody can find — which is what a delete that succeeded and then lost its
+	// response, or a crash between the delete and the record removal, looks like.
+	if err := d.deleteAPIKey(ctx, iamToken, oldAPIKeyID); err != nil && !isIBMNotFound(err) {
 		return fmt.Errorf("failed to delete old API key: %w", err)
 	}
 
@@ -816,15 +884,16 @@ func (d *IBMDriver) discoverAPIKeyDetailsLocked(ctx context.Context) error {
 	return nil
 }
 
-// createAPIKey creates a new API key for the same IAM identity.
+// createAPIKey creates a new API key for the same IAM identity, stamped with the
+// lineage the sweep scopes on.
 // Caller must hold authMu (PrepareRotation).
-func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, string, error) {
+func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken, stamp string) (string, string, error) {
 	iamEndpoint := d.getIAMEndpoint()
 	accountID := d.accountIDLocked()
 
 	reqBody, err := json.Marshal(map[string]interface{}{
 		"name":        fmt.Sprintf("warden-rotated-%d", time.Now().Unix()),
-		"description": "Managed by Warden credential rotation",
+		"description": stamp,
 		"iam_id":      d.iamID,
 		"account_id":  accountID,
 	})
@@ -841,7 +910,7 @@ func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, 
 			"Content-Type":  "application/json",
 			"Accept":        "application/json",
 		},
-	}, defaultIBMRetryConfig())
+	}, ibmCreateRetryConfig())
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create new API key: %w", err)
 	}
@@ -859,6 +928,166 @@ func (d *IBMDriver) createAPIKey(ctx context.Context, iamToken string) (string, 
 	}
 
 	return createResp.Apikey, createResp.ID, nil
+}
+
+// isIBMRotationKey reports whether a key's description marks it as one this
+// driver's rotation created — either stamped with a lineage, or carrying the flat
+// description used before lineages existed.
+//
+// Deliberately not an exact-stamp match. Matching only the current lineage reads
+// as the safer choice, but it reclaims almost nothing: a key is orphaned precisely
+// when its rotation was abandoned, and the next rotation stamps a different
+// lineage, so the orphan's stamp is never asked for again. Every pre-lineage
+// orphan is missed for the same reason. What actually bounds the damage is the
+// caller's exclusion of the key in use, plus the listing being scoped to this
+// source's own IAM identity.
+//
+// The one case this widening does not cover safely is two sources sharing an IAM
+// identity while both rotate — there, each would sweep the other's key. That
+// configuration is already fatal without any sweep, since either source's cleanup
+// deletes the key the other is holding; this makes it fail sooner rather than
+// introducing a new way to fail.
+func isIBMRotationKey(description string) bool {
+	return description == ibmLegacyRotationDescription ||
+		strings.HasPrefix(description, ibmRotationDescriptionPrefix)
+}
+
+// sweepOrphanedRotationKeys deletes API keys this source's rotation created and
+// then lost track of — a retried create, a crash before the staged entry was
+// persisted, or a rotation abandoned after its replacement was already made.
+//
+// Failures are logged and swallowed. A rotation that works must not be failed
+// because tidying up after a previous one did not.
+// Caller must hold authMu (PrepareRotation).
+func (d *IBMDriver) sweepOrphanedRotationKeys(ctx context.Context, iamToken string) {
+	iamEndpoint := d.getIAMEndpoint()
+
+	query := url.Values{}
+	query.Set("iam_id", d.iamID)
+	query.Set("pagesize", fmt.Sprintf("%d", ibmListPageSize))
+	if accountID := d.accountIDLocked(); accountID != "" {
+		query.Set("account_id", accountID)
+	}
+
+	headers := map[string]string{
+		"Authorization": "Bearer " + iamToken,
+		"Accept":        "application/json",
+	}
+
+	for pageToken := ""; ; {
+		if pageToken != "" {
+			query.Set("pagetoken", pageToken)
+		}
+
+		respBody, _, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
+			Method:  "GET",
+			URL:     iamEndpoint + "/v1/apikeys?" + query.Encode(),
+			Headers: headers,
+		}, defaultIBMRetryConfig())
+		if err != nil {
+			if d.logger != nil {
+				d.logger.Warn("could not list API keys to sweep orphaned rotation keys", logger.Err(err))
+			}
+			return
+		}
+
+		var list struct {
+			Apikeys []struct {
+				ID          string `json:"id"`
+				Description string `json:"description"`
+			} `json:"apikeys"`
+			Next string `json:"next"`
+		}
+		if err := json.Unmarshal(respBody, &list); err != nil {
+			if d.logger != nil {
+				d.logger.Warn("could not parse API key listing while sweeping orphaned rotation keys", logger.Err(err))
+			}
+			return
+		}
+
+		for _, key := range list.Apikeys {
+			// Excluding the key in use is the guard that matters, and it is checked by
+			// id rather than by description: an empty or unexpected description must
+			// never be able to make the live key look sweepable, since deleting it
+			// would lock the source out of IBM entirely.
+			if key.ID == "" || key.ID == d.apiKeyID || !isIBMRotationKey(key.Description) {
+				continue
+			}
+			if d.logger != nil {
+				d.logger.Warn("deleting an orphaned API key from a previous rotation attempt",
+					logger.String("api_key_id", truncateID(key.ID, 8)),
+				)
+			}
+			if err := d.deleteAPIKey(ctx, iamToken, key.ID); err != nil && !isIBMNotFound(err) {
+				if d.logger != nil {
+					d.logger.Warn("could not delete an orphaned API key",
+						logger.String("api_key_id", truncateID(key.ID, 8)),
+						logger.Err(err),
+					)
+				}
+			}
+		}
+
+		// IBM returns `next` as a link, not a bare token. Absent means this was the
+		// last page, which is the only signal needed to stop.
+		if list.Next == "" {
+			return
+		}
+		token := ibmPageTokenFromLink(list.Next)
+		if token == "" || token == pageToken {
+			// An unparseable or repeating link would loop forever; stop instead of
+			// sweeping the same page until the context dies.
+			return
+		}
+		pageToken = token
+	}
+}
+
+// ibmPageTokenFromLink extracts the pagetoken query parameter from the `next` link
+// IBM returns, which is a full URL rather than the bare token the next request
+// needs.
+func ibmPageTokenFromLink(link string) string {
+	parsed, err := url.Parse(link)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get("pagetoken")
+}
+
+// isIBMNotFound reports whether a failed delete means the key is already gone, as
+// opposed to the request never having reached a key endpoint at all.
+//
+// Both answer 404. Accepting the status alone would make a mis-set iam_endpoint
+// indistinguishable from a successful cleanup, so a live key would be reported as
+// deleted. IBM names the resource error in the body; a bare routing 404 carries no
+// such marker.
+func isIBMNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, `"code":"not_found"`) || strings.Contains(msg, `"code": "not_found"`)
+}
+
+// ibmCreateRetryConfig does not retry at all.
+//
+// Creating an API key is not idempotent, and an IBM API key carries no expiry, so
+// a request IBM committed but did not acknowledge leaves a fully privileged key
+// alive forever with nothing tracking it. Narrowing RetryableStatuses is not
+// enough: ExecuteWithRetry retries a transport error before it ever looks at that
+// list (helper/httputil/retry.go), and a connection reset or a timeout reading the
+// response is the likeliest way to lose an acknowledgement for a request that
+// arrived. MaxAttempts=1 is the only setting that makes the create happen once.
+//
+// The cost is that a genuine 429 now fails the rotation instead of backing off.
+// That is the right trade: the manager retries the whole cycle on its own
+// schedule, and a rotation deferred to the next attempt is cheaper than a key
+// nobody can find.
+func ibmCreateRetryConfig() httputil.HTTPRetryConfig {
+	cfg := defaultIBMRetryConfig()
+	cfg.MaxAttempts = 1
+	cfg.RetryableStatuses = nil
+	return cfg
 }
 
 // deleteAPIKey deletes an API key by ID

--- a/credential/drivers/ibm_driver_test.go
+++ b/credential/drivers/ibm_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -136,22 +137,29 @@ func TestIBMDriver_Revoke_NoOp(t *testing.T) {
 }
 
 func TestIBMDriver_SupportsRotation(t *testing.T) {
-	// The factory always sets credSource, so these mirror a real driver rather than
-	// a bare struct: SupportsRotation now reads config to see whether the source
-	// chains its key.
-	inline := func(iamID string) *IBMDriver {
+	// SupportsRotation reports on configuration, not on whether discovery has run:
+	// a source holding a key can rotate, and PrepareRotation re-probes the identity
+	// if it has to. The factory always sets credSource, so these mirror a real
+	// driver rather than a bare struct.
+	withConfig := func(cfg map[string]string, iamID string) *IBMDriver {
 		return &IBMDriver{
-			credSource: &credential.CredSource{Type: credential.SourceTypeIBM, Config: map[string]string{}},
+			credSource: &credential.CredSource{Type: credential.SourceTypeIBM, Config: cfg},
 			iamID:      iamID,
 		}
 	}
 
-	t.Run("true when iamID is set", func(t *testing.T) {
-		assert.True(t, inline("iam-1234").SupportsRotation())
+	t.Run("true when the source holds a key", func(t *testing.T) {
+		assert.True(t, withConfig(map[string]string{"api_key": "k"}, "iam-1234").SupportsRotation())
 	})
 
-	t.Run("false when iamID is empty", func(t *testing.T) {
-		assert.False(t, inline("").SupportsRotation())
+	// The point of the change: a blip during discovery at creation time must not
+	// disable rotation for the life of the driver instance.
+	t.Run("true even before discovery has run", func(t *testing.T) {
+		assert.True(t, withConfig(map[string]string{"api_key": "k"}, "").SupportsRotation())
+	})
+
+	t.Run("false when the source holds no key", func(t *testing.T) {
+		assert.False(t, withConfig(map[string]string{}, "iam-1234").SupportsRotation())
 	})
 
 	// The key lives at its source of truth; whoever owns the referenced spec rotates
@@ -486,11 +494,36 @@ func TestIBMDriver_PrepareRotation(t *testing.T) {
 	assert.Equal(t, DefaultIBMActivationDelay, activateAfter)
 }
 
-func TestIBMDriver_PrepareRotation_NoIAMID(t *testing.T) {
-	d := &IBMDriver{
-		credSource: &credential.CredSource{Type: credential.SourceTypeIBM, Config: map[string]string{}},
-		iamID:      "",
-	}
+// Discovery is best-effort at creation time, so a blip there used to disable
+// rotation for the life of the driver instance — nothing ever re-ran it. Rotation
+// re-probes instead, which is the first point after creation that both needs the
+// identity and has a context to fetch it with.
+func TestIBMDriver_PrepareRotation_ReprobesDiscovery(t *testing.T) {
+	srv := newIBMMockServer(t)
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.iamID = "" // as if discovery had failed at Create
+	d.apiKeyID = ""
+
+	newConfig, _, _, err := d.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+	assert.NotEmpty(t, newConfig["api_key"])
+	assert.Equal(t, "iam-ServiceId-abcdef", d.iamID, "the identity was recovered, not assumed")
+}
+
+// When the re-probe itself fails, the error says so rather than reporting the
+// source as unrotatable — the manager can then surface a cause an operator can act on.
+func TestIBMDriver_PrepareRotation_ReportsFailedReprobe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.iamID = ""
+	d.tokenCache.Clear()
+
 	_, _, _, err := d.PrepareRotation(context.TODO())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "IAM identity not discovered")
@@ -1117,9 +1150,12 @@ func TestIBMDriver_MintCredential_FailsClosedWhenChained(t *testing.T) {
 // creation takes, so an unskipped probe would refuse a keyless source at write and
 // fail every mint after.
 func TestIBMDriverFactory_Create_SkipsProbeWithoutKey(t *testing.T) {
-	var hits int
+	// Atomic because the write happens on the httptest handler goroutine: the
+	// socket hop carries no happens-before edge the race detector recognises, and
+	// this counter is read precisely when the guard under test has regressed.
+	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits++
+		atomic.AddInt32(&hits, 1)
 		http.Error(w, "no source should reach me", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
@@ -1136,20 +1172,20 @@ func TestIBMDriverFactory_Create_SkipsProbeWithoutKey(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			hits = 0
+			atomic.StoreInt32(&hits, 0)
 			log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
 			d, err := f.Create(config, log)
 			require.NoError(t, err)
 			require.NotNil(t, d)
-			assert.Zero(t, hits, "Create must make no upstream call without a stored key")
+			assert.Zero(t, atomic.LoadInt32(&hits), "Create must make no upstream call without a stored key")
 		})
 	}
 }
 
 func TestIBMDriver_VerifySpec_ChainedSourceNeedsNoAPIKey(t *testing.T) {
-	var hits int
+	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits++
+		atomic.AddInt32(&hits, 1)
 		http.Error(w, "no verification should reach me", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
@@ -1157,7 +1193,7 @@ func TestIBMDriver_VerifySpec_ChainedSourceNeedsNoAPIKey(t *testing.T) {
 	t.Run("chained source verifies without a call", func(t *testing.T) {
 		d := newChainedIBMDriver(t, srv.URL)
 		require.NoError(t, d.VerifySpec(context.TODO(), bearerSpec()))
-		assert.Zero(t, hits)
+		assert.Zero(t, atomic.LoadInt32(&hits))
 	})
 
 	// The schema no longer demands api_key, so this is where its absence lands --
@@ -1176,4 +1212,218 @@ func TestIBMDriver_VerifySpec_ChainedSourceNeedsNoAPIKey(t *testing.T) {
 		assert.Contains(t, err.Error(), "api_key")
 		assert.Contains(t, err.Error(), credential.ConfigSecretSpec)
 	})
+}
+
+// ============================================================================
+// Rotation: orphan containment
+// ============================================================================
+
+// Creating an API key is not idempotent, and an IBM key carries no expiry, so a
+// retried create leaves a fully privileged credential live on the tenant with
+// nothing tracking it. Narrowing the retryable statuses is not enough — the retry
+// helper retries transport errors before it consults that list — so the create
+// must not retry at all.
+func TestIBMCreateRetryConfig_DoesNotRetryAtAll(t *testing.T) {
+	cfg := ibmCreateRetryConfig()
+	assert.Equal(t, 1, cfg.MaxAttempts, "a committed-but-unacknowledged create must not be repeated")
+	assert.Empty(t, cfg.RetryableStatuses)
+
+	// The shared config still carries the 5xx wildcard and multiple attempts, which
+	// is correct for the idempotent calls that use it — this pins that they differ.
+	assert.Contains(t, defaultIBMRetryConfig().RetryableStatuses, 500)
+	assert.Greater(t, defaultIBMRetryConfig().MaxAttempts, 1)
+}
+
+// A 502 answered after IBM committed the key must produce one key, not two: the
+// create is attempted exactly once, and the error surfaces.
+func TestIBMDriver_CreateAPIKey_IsAttemptedOnce(t *testing.T) {
+	var creates int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/identity/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/apikeys" {
+			atomic.AddInt32(&creates, 1)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		http.Error(w, "unexpected", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.authMu.Lock()
+	_, _, err := d.createAPIKey(context.TODO(), "iam-token", ibmRotationDescriptionPrefix+"ApiKey-old")
+	d.authMu.Unlock()
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&creates),
+		"a 5xx must not be retried: IBM may already have committed the key")
+}
+
+func TestIsIBMNotFound(t *testing.T) {
+	// IBM names the resource error in the body.
+	assert.True(t, isIBMNotFound(fmt.Errorf(`status 404: {"errors":[{"code":"not_found"}]}`)))
+	assert.True(t, isIBMNotFound(fmt.Errorf(`status 404: {"errors":[{"code": "not_found"}]}`)))
+
+	// A bare routing 404 carries no such marker. Treating it as success would make
+	// a mis-set iam_endpoint indistinguishable from a completed cleanup, so a live
+	// key would be reported as deleted.
+	assert.False(t, isIBMNotFound(fmt.Errorf("status 404: 404 page not found")))
+	assert.False(t, isIBMNotFound(nil))
+}
+
+// A key that is already gone is the goal state. Without this the pending cleanup
+// retries daily for a week and is then abandoned with an error, for a key nobody
+// can find.
+func TestIBMDriver_CleanupRotation_ToleratesAlreadyDeleted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/identity/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+			return
+		}
+		if r.Method == http.MethodDelete {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"not_found","message":"API key not found"}]}`))
+			return
+		}
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	require.NoError(t, d.CleanupRotation(context.TODO(), map[string]string{"api_key_id": "ApiKey-gone"}))
+}
+
+// A routing 404 is still a failure: it means the request never reached a key
+// endpoint, so the key it names may well be alive.
+func TestIBMDriver_CleanupRotation_RoutingNotFoundStillFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/identity/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	err := d.CleanupRotation(context.TODO(), map[string]string{"api_key_id": "ApiKey-maybe-alive"})
+	require.Error(t, err)
+}
+
+// The sweep reclaims every key this source's rotation created and lost track of —
+// not just the current lineage. Matching only the current stamp reclaimed almost
+// nothing: an orphan exists precisely because its rotation was abandoned, and the
+// next rotation stamps a different lineage, so the orphan's own stamp is never
+// asked for again. Keys predating the lineage scheme were unreachable for the same
+// reason. What bounds the damage is the live-key exclusion, checked by id.
+func TestIBMDriver_SweepOrphanedRotationKeys_ReclaimsAbandonedLineages(t *testing.T) {
+	var deleted []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/apikeys":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"apikeys": []map[string]string{
+				// This lineage's orphan — a retried or crashed create.
+				{"id": "ApiKey-orphan", "description": ibmRotationDescriptionPrefix + "ApiKey-12345"},
+				// An abandoned lineage: the key left live when an activation failed
+				// after its replacement was staged. Previously unreachable forever.
+				{"id": "ApiKey-abandoned", "description": ibmRotationDescriptionPrefix + "ApiKey-older"},
+				// Created before lineage stamps existed. Also previously unreachable.
+				{"id": "ApiKey-legacy", "description": ibmLegacyRotationDescription},
+				// The live key. Excluded by id, whatever its description says.
+				{"id": "ApiKey-12345", "description": ibmRotationDescriptionPrefix + "ApiKey-ancestor"},
+				// Not ours: no Warden rotation ever created it.
+				{"id": "ApiKey-human", "description": "created by a person"},
+				{"id": "ApiKey-blank", "description": ""},
+			}})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			deleted = append(deleted, strings.TrimPrefix(r.URL.Path, "/v1/apikeys/"))
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.authMu.Lock()
+	d.sweepOrphanedRotationKeys(context.TODO(), "iam-token")
+	d.authMu.Unlock()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.ElementsMatch(t, []string{"ApiKey-orphan", "ApiKey-abandoned", "ApiKey-legacy"}, deleted,
+		"every rotation key this source lost track of, and nothing it did not create")
+	assert.NotContains(t, deleted, "ApiKey-12345", "the live key must never be swept")
+}
+
+func TestIsIBMRotationKey(t *testing.T) {
+	assert.True(t, isIBMRotationKey(ibmRotationDescriptionPrefix+"ApiKey-abc"))
+	assert.True(t, isIBMRotationKey(ibmLegacyRotationDescription))
+	assert.False(t, isIBMRotationKey("created by a person"))
+	assert.False(t, isIBMRotationKey(""))
+}
+
+// Tidying up after a previous rotation must never fail the one that works.
+func TestIBMDriver_SweepOrphanedRotationKeys_SwallowsFailures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "listing is down", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	// The assertion is that this returns at all rather than panicking or blocking.
+	d.sweepOrphanedRotationKeys(context.TODO(), "iam-token")
+}
+
+func TestIBMPageTokenFromLink(t *testing.T) {
+	assert.Equal(t, "abc123",
+		ibmPageTokenFromLink("https://iam.cloud.ibm.com/v1/apikeys?pagesize=100&pagetoken=abc123"))
+	assert.Empty(t, ibmPageTokenFromLink("https://iam.cloud.ibm.com/v1/apikeys?pagesize=100"))
+	assert.Empty(t, ibmPageTokenFromLink("://not a url"))
+}
+
+// A rotation stamps the key it creates with the key it replaces, which is what
+// gives the next sweep a lineage to scope on.
+func TestIBMDriver_PrepareRotation_StampsTheReplacedKey(t *testing.T) {
+	var gotDescription string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/identity/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/apikeys":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"apikeys": []map[string]string{}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/apikeys":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			gotDescription, _ = body["description"].(string)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ApiKey-new", "apikey": "new-key"})
+		default:
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	d := newTestIBMDriver(t, srv.URL)
+	_, cleanupConfig, _, err := d.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+
+	assert.Equal(t, ibmRotationDescriptionPrefix+"ApiKey-12345", gotDescription,
+		"the new key must name the one it replaces, so a later sweep can scope on it")
+	assert.Equal(t, "ApiKey-12345", cleanupConfig["api_key_id"])
 }

--- a/credential/types/ibmcloud_keys.go
+++ b/credential/types/ibmcloud_keys.go
@@ -40,8 +40,8 @@ func (t *IBMCloudKeysCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("eyJraWQiOiIyMDI..."),
 
 		credential.StringField("mint_method").
-			OneOf("access_keys", "dynamic_ibm").
-			Describe("Mint method for credential minting; omit on an ibm source for a bearer-only spec").
+			OneOf("iam_token", "access_keys", "dynamic_ibm").
+			Describe("Mint method for credential minting; 'iam_token' (or omitted) on an ibm source is the bearer-only API-mode spec").
 			Example("access_keys"),
 
 		// Dynamic IBM fields (for Vault IBM secrets engine)
@@ -86,11 +86,15 @@ func (t *IBMCloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 		}
 	case credential.SourceTypeIBM:
 		switch config["mint_method"] {
-		case "":
+		case "", "iam_token":
 			// Bearer-only: the IAM token minted from the source, which is the
-			// gateway's API mode. An inline COS pair was only ever consumed by
-			// iam_with_cos, and that method existed to serve a standing secret
-			// out of spec config.
+			// gateway's API mode. iam_token is accepted explicitly as well as by
+			// omission — the driver's own errors name it, and a spec that must be
+			// typed ibmcloud_keys for the gateway to accept it should be able to
+			// say which method it uses rather than relying on a silent default.
+			//
+			// An inline COS pair was only ever consumed by iam_with_cos, and that
+			// method existed to serve a standing secret out of spec config.
 			for _, key := range []string{"access_key_id", "secret_access_key"} {
 				if config[key] != "" {
 					return fmt.Errorf("'%s' must be omitted; a COS pair is served by an access_keys spec from its %s, never stored inline",
@@ -126,7 +130,7 @@ func (t *IBMCloudKeysCredType) ValidateConfig(config map[string]string, sourceTy
 			}
 
 		default:
-			return fmt.Errorf("'mint_method' must be 'access_keys' for ibm source (or omitted for a bearer-only spec), got: %s", config["mint_method"])
+			return fmt.Errorf("'mint_method' must be 'iam_token' or 'access_keys' for ibm source (iam_token may be omitted), got: %s", config["mint_method"])
 		}
 	}
 

--- a/e2e/fullchain/ibmcloud_chaining_test.go
+++ b/e2e/fullchain/ibmcloud_chaining_test.go
@@ -36,7 +36,7 @@ const (
 	// json_key_map drops what it does not name.
 	ibmChainedAPIKey         = "e2e-ibm-chained-api-key"
 	ibmChainedStoredField    = "ibmcloud_api_key"
-	ibmChainedUnrelatedField = "unrelated_field"
+	ibmChainedUnrelatedValue = "must-not-be-vended"
 
 	// Written to secret/data/e2e/ibm-cos-hmac by setup.sh. Both halves, because
 	// for access_keys the pair IS the credential.
@@ -210,11 +210,15 @@ func TestIBMCloudChaining_SourceFetchesTheAPIKeyPerRequest(t *testing.T) {
 				}
 			}
 
-			// json_key_map drops what it does not name, so the companion field
-			// sharing that Vault path must never have reached the driver — which is
-			// what makes a shared secret path safe to reference.
-			if strings.Contains(strings.Join(keys, ","), ibmChainedUnrelatedField) {
-				t.Errorf("an unnamed field of the referenced secret reached the grant: %v", keys)
+			// The companion value sharing that Vault path must never be what the
+			// grant spent. json_key_map drops what it does not name, so the driver
+			// never sees it — but the projection is also what makes the mint work at
+			// all here, since the key is stored under neither conventional name.
+			// Asserting on the value, not the field name: the name never travels.
+			for _, k := range keys {
+				if k == ibmChainedUnrelatedValue {
+					t.Errorf("the companion value from the referenced secret was spent as the api key")
+				}
 			}
 		})
 	}
@@ -253,10 +257,22 @@ func setupIBMAccessKeysChain(t *testing.T, subj scalewaySubject) {
 		"create the spec-chained access_keys spec")
 }
 
-// TestIBMCloudChaining_AccessKeysServesThePairAndCallsNothing pins the property
-// that makes access_keys worth having: the pair is served from elsewhere, and IBM
-// is not contacted at all — nothing is created, so nothing is left behind.
-func TestIBMCloudChaining_AccessKeysServesThePairAndCallsNothing(t *testing.T) {
+// TestIBMCloudChaining_AccessKeysSpecWritesWithoutTouchingIBM covers what this
+// suite can reach: an access_keys spec and its grant-free source are accepted, and
+// standing the pair up costs no IBM call.
+//
+// It deliberately does NOT claim to exercise the serving path. An earlier version
+// did, on the reasoning that "the store test-mints it" — it does not: a chained
+// spec is excluded from both the test-mint and VerifySpec, so spec creation runs
+// schema and placement validation only, and the zero-call assertion below is
+// nearly free. Driving a real COS request needs the gateway's S3 leg pointed at a
+// local listener, and this provider exposes only cos_endpoint_type, whose three
+// values all resolve to real IBM hostnames — provider/ovh solves the same problem
+// with an s3_url host override, which is what makes its S3 rows possible. So
+// mintAccessKeysFromSecret and ExtractS3Credentials are covered by unit tests on
+// each side, agreeing on access_key_id and secret_access_key, but nothing checks
+// that agreement on a live request.
+func TestIBMCloudChaining_AccessKeysSpecWritesWithoutTouchingIBM(t *testing.T) {
 	ensureEnv(t)
 
 	for _, subj := range scalewaySubjects {
@@ -264,12 +280,8 @@ func TestIBMCloudChaining_AccessKeysServesThePairAndCallsNothing(t *testing.T) {
 			ibmResetGrantKeys()
 			setupIBMAccessKeysChain(t, subj)
 
-			// Creating the spec is itself the assertion here: the store test-mints it,
-			// so a spec that writes successfully is one whose chain resolved and whose
-			// pair the driver accepted. What this row adds is the negative — that
-			// reaching the pair took no IBM call whatsoever.
 			if keys := ibmObservedGrantKeys(); len(keys) != 0 {
-				t.Errorf("the IAM stub was called %d time(s) for an access_keys spec, want 0: %v", len(keys), keys)
+				t.Errorf("the IAM stub was called %d time(s) standing up an access_keys spec, want 0: %v", len(keys), keys)
 			}
 		})
 	}

--- a/provider/ibmcloud/provider.go
+++ b/provider/ibmcloud/provider.go
@@ -289,13 +289,18 @@ Credential type: ibmcloud_keys (at least one mode required)
   - secret_access_key: COS HMAC secret access key for Object Storage (COS mode)
 
 Two credential source types are supported:
-- ibm (mint_method omitted): IAM token minted from the source API key, for API mode
+- ibm (iam_token): IAM token minted from the source API key, for API mode
 - ibm (access_keys): the COS HMAC pair a referenced spec yields, for COS mode
 - hvault (dynamic_ibm): Dynamic API key from Vault IBM engine + IAM token exchange + static COS HMAC
 
-A spec serves one mode, so a role fronting both API and COS traffic needs one spec
-of each. The COS pair is never stored on the spec: access_keys names a secret_spec
-that yields it, and nothing here creates or deletes a pair at IBM.
+Specs for this mount must be typed ibmcloud_keys explicitly. A spec created without
+a type is inferred from its mint_method, and iam_token infers oauth_bearer_token —
+which this mount refuses at request time, after the spec has written successfully.
+
+A spec serves one mode, and a role binds one spec, so serving both API and COS
+traffic takes two roles, one per spec. The COS pair is never stored on the spec:
+access_keys names a secret_spec that yields it, and nothing here creates or deletes
+a pair at IBM.
 
 Configuration:
 - ibmcloud_url: Egress base. Left unset, API mode connects to the host named in the


### PR DESCRIPTION
Rotation could leave fully privileged IBM API keys alive with nothing tracking them, and an IBM API key carries no expiry, so an orphan outlives everything.

**Creates no longer retry.** Creating a key is not idempotent, and the retry helper retries a transport error *before* it consults `RetryableStatuses` — so a connection reset or a timeout reading the response, the likeliest way to lose an acknowledgement for a request that arrived, produced up to three live keys of which Warden learned one. Narrowing the statuses is not sufficient; `MaxAttempts=1` is. A rate-limited create now fails the rotation rather than backing off, which is the right trade: the manager retries the whole cycle on its own schedule, and a deferred rotation is cheaper than a key nobody can find.

**Keys already lost are reclaimed** by a sweep matching any key this rotation scheme created — stamped with a lineage, or carrying the flat description used before lineages existed — and excluding the key in use *by id* rather than by description, so a missing or unexpected description cannot make the live key look sweepable.

Scoping the sweep to a single lineage reads as safer but reclaims almost nothing: a key is orphaned precisely when its rotation was abandoned, so its own stamp is never asked for again, and every pre-lineage orphan is missed for the same reason. Keys are still stamped, now for the operator reading the IBM console. The listing is scoped to this source's IAM identity; two sources sharing an identity while both rotate would sweep each other — a configuration already fatal without any sweep, since either one's cleanup deletes the key the other holds. **That is the trade-off most worth a second opinion.**

**Cleanup tolerates an IBM-marked `not_found` delete.** A bare routing 404 still fails, so a mis-set `iam_endpoint` cannot pass as a completed cleanup.

**A transient discovery failure no longer disables rotation for the driver's lifetime.** `SupportsRotation` reports on configuration; `PrepareRotation` re-probes, since it has a context.

### Three gaps earlier PRs in this stack opened

- **`RotationConfigValidator`** — needed the moment `api_key` stopped being required (#557): a source holding neither a key nor a reference is a legitimate shape, and nothing else would have caught a `rotation_period` on it before the manager began failing every cycle forever.
- **`mint_method=iam_token` accepted on `ibmcloud_keys`** — the bearer-only shape #556 documents infers `oauth_bearer_token` when the type is omitted, which the gateway then refuses at request time *after* the spec wrote successfully. The provider help now says so, and says serving both modes takes two **roles**, since a role binds one spec.
- **The e2e `access_keys` row no longer claims to drive the serving path** — it rested on the store test-minting the spec, which it does not: a chained spec is excluded from both the test-mint and `VerifySpec`. The real gap (no local listener for the S3 leg) is recorded rather than papered over.

Stacked on #558.