### PR TITLE
fix(core): follow a rotation period when it changes, and stop churning drivers

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -353,7 +354,8 @@ func (s *CredentialConfigStore) UpdateSpec(ctx context.Context, spec *credential
 
 	// Check if spec exists
 	cacheKey := s.buildSpecCacheKey(ns.UUID, spec.Name)
-	if _, err := s.loadSpec(ns.UUID, spec.Name); err != nil {
+	existing, err := s.loadSpec(ns.UUID, spec.Name)
+	if err != nil {
 		return ErrSpecNotFound
 	}
 
@@ -366,12 +368,51 @@ func (s *CredentialConfigStore) UpdateSpec(ctx context.Context, spec *credential
 	s.specsByID.Set(cacheKey, spec, 1)
 	s.specsByID.Wait()
 
+	// Same reconciliation the source path does, for the same reason: the spec
+	// update API has always carried rotation_period, so a period could be changed
+	// or cleared in place while the manager kept the schedule it was given at
+	// create.
+	s.reconcileSpecRotation(ctx, spec, existing.RotationPeriod)
+
 	s.logger.Debug("updated credential spec",
 		logger.String("namespace", ns.UUID),
 		logger.String("spec_name", spec.Name),
 	)
 
 	return nil
+}
+
+// reconcileSpecRotation brings the rotation manager in line with a spec's
+// persisted rotation period.
+//
+// A changed period re-registers rather than editing in place: RotationManager's
+// UpdateRotationPeriod addresses entries by the source key, so it cannot reach a
+// spec entry at all, and register replaces an existing entry outright — which
+// reschedules the next action from now, so a shortened period does not wait out
+// the old one.
+//
+// Failures are logged, not returned: the spec is already persisted.
+func (s *CredentialConfigStore) reconcileSpecRotation(ctx context.Context, spec *credential.CredSpec, oldPeriod time.Duration) {
+	if s.rotationManager == nil {
+		return
+	}
+
+	switch {
+	case spec.RotationPeriod <= 0 && oldPeriod > 0:
+		if err := s.rotationManager.UnregisterSpec(ctx, spec.Name); err != nil {
+			s.logger.Warn("failed to unregister spec from rotation after update",
+				logger.String("spec_name", spec.Name), logger.Err(err))
+		} else {
+			s.logger.Info("rotation disabled for spec",
+				logger.String("spec_name", spec.Name))
+		}
+
+	case spec.RotationPeriod > 0 && spec.RotationPeriod != oldPeriod:
+		if err := s.rotationManager.RegisterSpec(ctx, spec.Name, spec.Source, spec.RotationPeriod); err != nil {
+			s.logger.Warn("failed to re-register spec for rotation after update",
+				logger.String("spec_name", spec.Name), logger.Err(err))
+		}
+	}
 }
 
 // DeleteSpec removes a spec by name
@@ -629,13 +670,23 @@ func (s *CredentialConfigStore) UpdateSource(ctx context.Context, source *creden
 		return err
 	}
 
-	// Close old driver instance since config has changed
-	// This ensures the driver will be recreated with the new config on next use
-	if err := s.core.credentialManager.CloseDriver(ctx, source.Name); err != nil {
-		s.logger.Warn("failed to close driver during source update",
-			logger.String("source_name", source.Name),
-			logger.Err(err))
-		// Continue with update even if driver cleanup fails
+	// Close the old driver instance only when the config it was built from actually
+	// changed, so it is rebuilt from the new one on next use.
+	//
+	// Config is the only field a driver reads: Name keys it, Type is immutable
+	// (refused above), and RotationPeriod is the manager's state, not the driver's.
+	// So an update that touches only the rotation period leaves every driver input
+	// identical, and tearing the instance down would discard live state — cached
+	// tokens, discovered identity, pooled connections — to rebuild something byte
+	// for byte the same. That case stopped being hypothetical when the update path
+	// began accepting a rotation period on its own.
+	if !maps.Equal(existing.Config, source.Config) {
+		if err := s.core.credentialManager.CloseDriver(ctx, source.Name); err != nil {
+			s.logger.Warn("failed to close driver during source update",
+				logger.String("source_name", source.Name),
+				logger.Err(err))
+			// Continue with update even if driver cleanup fails
+		}
 	}
 
 	// Persist to storage
@@ -647,12 +698,64 @@ func (s *CredentialConfigStore) UpdateSource(ctx context.Context, source *creden
 	s.sourcesByID.Set(cacheKey, source, 1)
 	s.sourcesByID.Wait()
 
+	// Reconcile the rotation schedule with what was just persisted. Until this
+	// existed the manager was told about a source only at create and delete, so a
+	// period changed in place kept firing on the old schedule and a period cleared
+	// in place kept firing at all — the config said one thing and the manager did
+	// another, with nothing to reveal the disagreement.
+	s.reconcileSourceRotation(ctx, source, existing.RotationPeriod)
+
 	s.logger.Debug("updated credential source",
 		logger.String("namespace", ns.UUID),
 		logger.String("source_name", source.Name),
 	)
 
 	return nil
+}
+
+// reconcileSourceRotation brings the rotation manager in line with a source's
+// persisted rotation period.
+//
+// Enrolment eligibility is re-evaluated, not assumed: a source that gains a
+// secret_spec, or is otherwise converted to holding no secret of its own, must
+// leave the schedule even if its period were somehow still set — validateSource
+// refuses that combination, so in practice the period arrives as zero and the
+// unregister below is what actually removes the entry.
+//
+// Failures are logged, not returned: the source is already persisted, and failing
+// the update here would report an error for a write that happened.
+func (s *CredentialConfigStore) reconcileSourceRotation(ctx context.Context, source *credential.CredSource, oldPeriod time.Duration) {
+	if s.rotationManager == nil {
+		return
+	}
+
+	eligible := source.RotationPeriod > 0 &&
+		!isFederationSource(source.Config) &&
+		source.Config[credential.ConfigSecretSpec] == ""
+
+	switch {
+	case !eligible && oldPeriod > 0:
+		if err := s.rotationManager.UnregisterSource(ctx, source.Name); err != nil {
+			s.logger.Warn("failed to unregister source from rotation after update",
+				logger.String("source_name", source.Name), logger.Err(err))
+		} else {
+			s.logger.Info("rotation disabled for source",
+				logger.String("source_name", source.Name))
+		}
+
+	case eligible && oldPeriod <= 0:
+		if err := s.rotationManager.RegisterSource(ctx, source.Name, source.Type, source.RotationPeriod); err != nil {
+			s.logger.Warn("failed to register source for rotation after update",
+				logger.String("source_name", source.Name), logger.Err(err))
+		}
+
+	case eligible && source.RotationPeriod != oldPeriod:
+		// Reschedules from now, so a shortened period does not wait out the old one.
+		if err := s.rotationManager.UpdateRotationPeriod(ctx, source.Name, source.RotationPeriod); err != nil {
+			s.logger.Warn("failed to update rotation period after source update",
+				logger.String("source_name", source.Name), logger.Err(err))
+		}
+	}
 }
 
 // DeleteSource removes a source by name

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2585,3 +2585,128 @@ func TestCredentialConfigStore_IBMAccessKeysNeedsItsOwnReference(t *testing.T) {
 		assert.Contains(t, err.Error(), "rotation_period")
 	})
 }
+
+// A driver is built from its source's Config and nothing else — Name keys it, Type
+// is immutable, and RotationPeriod belongs to the manager. So an update that leaves
+// Config alone must leave the instance alone: rebuilding it would discard cached
+// tokens, discovered identity and pooled connections to produce something
+// identical. This matters now that a rotation period can be updated on its own.
+func TestCredentialConfigStore_UpdateSourceClosesDriverOnlyOnConfigChange(t *testing.T) {
+	core := createTestCore(t)
+	store := core.credConfigStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	src := &credential.CredSource{
+		Name: "driver-src", Type: "local",
+		Config:         map[string]string{"key": "v1"},
+		RotationPeriod: 48 * time.Hour,
+	}
+	require.NoError(t, store.CreateSource(ctx, src))
+
+	first, err := core.credentialManager.GetOrCreateDriver(ctx, "driver-src")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	// Rotation period only: same config, so the instance must survive.
+	src.RotationPeriod = 26 * time.Hour
+	require.NoError(t, store.UpdateSource(ctx, src))
+
+	afterPeriodChange, err := core.credentialManager.GetOrCreateDriver(ctx, "driver-src")
+	require.NoError(t, err)
+	assert.Same(t, first, afterPeriodChange,
+		"an update that changes no driver input must not tear the driver down")
+
+	// Config changed: the instance must be rebuilt from it.
+	src.Config = map[string]string{"key": "v2"}
+	require.NoError(t, store.UpdateSource(ctx, src))
+
+	afterConfigChange, err := core.credentialManager.GetOrCreateDriver(ctx, "driver-src")
+	require.NoError(t, err)
+	assert.NotSame(t, first, afterConfigChange,
+		"a changed config must produce a driver built from it")
+}
+
+// The rotation manager used to learn about a source or spec only at create and
+// delete. A period changed in place therefore kept firing on the old schedule, and
+// a period cleared in place kept firing at all — the stored config said one thing
+// and the manager did another, with nothing to surface the disagreement.
+func TestCredentialConfigStore_RotationScheduleFollowsUpdates(t *testing.T) {
+	// The lighter store harness builds a Core with no credential manager, and
+	// UpdateSource closes the source's driver — so this needs the full one.
+	core := createTestCore(t)
+	store := core.credConfigStore
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	rm := NewRotationManager(core, core.logger.WithSubsystem("rotation"), nil)
+	rm.Start()
+	defer rm.Stop()
+	store.rotationManager = rm
+
+	ns, err := store.getNamespaceFromContext(ctx)
+	require.NoError(t, err)
+
+	t.Run("source", func(t *testing.T) {
+		src := &credential.CredSource{
+			Name: "rot-src", Type: "local",
+			Config:         map[string]string{"key": "v"},
+			RotationPeriod: 48 * time.Hour,
+		}
+		require.NoError(t, store.CreateSource(ctx, src))
+
+		entry := rm.GetEntry(ns.UUID, "rot-src")
+		require.NotNil(t, entry, "create must enrol a source that carries a period")
+		require.Equal(t, 48*time.Hour, entry.RotationPeriod)
+		firstAction := entry.NextAction
+
+		// Shortening must bring the next rotation forward rather than waiting out
+		// the period the entry was created with.
+		src.RotationPeriod = 26 * time.Hour
+		require.NoError(t, store.UpdateSource(ctx, src))
+
+		entry = rm.GetEntry(ns.UUID, "rot-src")
+		require.NotNil(t, entry)
+		assert.Equal(t, 26*time.Hour, entry.RotationPeriod)
+		assert.True(t, entry.NextAction.Before(firstAction),
+			"a shortened period must reschedule from now")
+
+		// Clearing it must remove the entry, not leave one firing on a period the
+		// source no longer carries.
+		src.RotationPeriod = 0
+		require.NoError(t, store.UpdateSource(ctx, src))
+		assert.Nil(t, rm.GetEntry(ns.UUID, "rot-src"),
+			"a source with no rotation period must not stay enrolled")
+
+		// And setting one again must re-enrol it.
+		src.RotationPeriod = 30 * time.Hour
+		require.NoError(t, store.UpdateSource(ctx, src))
+		assert.NotNil(t, rm.GetEntry(ns.UUID, "rot-src"))
+	})
+
+	// Specs reached this state through the API long before sources could: the spec
+	// update handler has always carried rotation_period.
+	t.Run("spec", func(t *testing.T) {
+		specEntry := func() *RotationEntry {
+			if v, ok := rm.entries.Load(buildSpecKey(ns.UUID, "rot-spec")); ok {
+				return v.(*RotationEntry)
+			}
+			return nil
+		}
+
+		spec := &credential.CredSpec{
+			Name: "rot-spec", Type: credential.TypeAPIKey, Source: "rot-src",
+			Config:         map[string]string{"api_key": "v"},
+			RotationPeriod: 48 * time.Hour,
+		}
+		require.NoError(t, store.CreateSpec(ctx, spec))
+		require.NotNil(t, specEntry(), "create must enrol a spec that carries a period")
+
+		spec.RotationPeriod = 26 * time.Hour
+		require.NoError(t, store.UpdateSpec(ctx, spec))
+		require.NotNil(t, specEntry())
+		assert.Equal(t, 26*time.Hour, specEntry().RotationPeriod)
+
+		spec.RotationPeriod = 0
+		require.NoError(t, store.UpdateSpec(ctx, spec))
+		assert.Nil(t, specEntry(), "a spec with no rotation period must not stay enrolled")
+	})
+}

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -427,16 +427,29 @@ func (b *SystemBackend) handleCredentialSourceUpdate(ctx context.Context, req *l
 		}
 	}
 
-	// Create updated source for validation and persistence. RotationPeriod
-	// is preserved from the existing entry — the typed UpdateCredentialSource
-	// API only carries Config, so dropping it here would (1) fail hvault
-	// validation (rotation_period required) on every update, and (2)
-	// silently strip rotation config from non-hvault sources too.
+	// RotationPeriod is preserved from the existing entry unless the caller names
+	// it. Preserving on absence is what keeps an ordinary config-only update from
+	// (1) failing hvault validation, which requires a rotation_period, and (2)
+	// silently stripping rotation config from every other source type.
+	//
+	// Honouring it when supplied is what makes a rotating source convertible. A
+	// source that holds no secret of its own is refused a rotation_period, so
+	// moving a keyed source onto a referenced spec means clearing the period in the
+	// same write — and with no way to express that, the conversion was impossible
+	// in place and delete-and-recreate is blocked while specs reference the source.
+	rotationPeriod := existingSource.RotationPeriod
+	if raw, ok := d.GetOk("rotation_period"); ok {
+		if seconds, isInt := raw.(int); isInt {
+			rotationPeriod = time.Duration(seconds) * time.Second
+		}
+	}
+
+	// Create updated source for validation and persistence.
 	updatedSource := &credential.CredSource{
 		Name:           existingSource.Name,
 		Type:           existingSource.Type,
 		Config:         mergedConfig,
-		RotationPeriod: existingSource.RotationPeriod,
+		RotationPeriod: rotationPeriod,
 	}
 
 	// Update via credential config store (validates and tests connection before persisting)

--- a/core/sys_credentials_test.go
+++ b/core/sys_credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
@@ -171,6 +172,69 @@ func TestSystemBackend_HandleCredentialSourceUpdate(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Data["message"], "Successfully updated")
+}
+
+// A config-only update must not disturb the rotation period — that is what lets an
+// ordinary edit leave rotation alone — but a caller that names it must be able to
+// change it, including to zero. Without the second half, a rotating source can
+// never be converted to draw its secret from a referenced spec: such a source is
+// refused a rotation_period, and delete-and-recreate is blocked while specs
+// reference it.
+func TestSystemBackend_HandleCredentialSourceUpdate_RotationPeriod(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+	schema := backend.pathCredentials()[0].Fields
+
+	createRaw := map[string]interface{}{
+		"name":   "rotating-source",
+		"type":   "local",
+		"config": map[string]interface{}{"key": "value1"},
+		// Above DefaultMinCredSourceRotationPeriod; a shorter one is refused, and the
+		// handler reports that as a response rather than an error.
+		"rotation_period": int(48 * time.Hour / time.Second),
+	}
+	req := createTestRequest(logical.CreateOperation, "cred/sources/rotating-source", createRaw)
+	createResp, err := backend.handleCredentialSourceCreate(ctx, req, createFieldData(schema, createRaw))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode, "create failed: %v", createResp.Data)
+
+	readBack := func(t *testing.T) time.Duration {
+		t.Helper()
+		src, err := backend.core.credConfigStore.GetSource(ctx, "rotating-source")
+		require.NoError(t, err)
+		return src.RotationPeriod
+	}
+	require.Equal(t, 48*time.Hour, readBack(t))
+
+	t.Run("absent leaves it alone", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"name":   "rotating-source",
+			"config": map[string]interface{}{"key": "value2"},
+		}
+		_, err := backend.handleCredentialSourceUpdate(ctx, req, createFieldData(schema, raw))
+		require.NoError(t, err)
+		assert.Equal(t, 48*time.Hour, readBack(t))
+	})
+
+	t.Run("supplied changes it", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"name":            "rotating-source",
+			"rotation_period": int(72 * time.Hour / time.Second),
+		}
+		_, err := backend.handleCredentialSourceUpdate(ctx, req, createFieldData(schema, raw))
+		require.NoError(t, err)
+		assert.Equal(t, 72*time.Hour, readBack(t))
+	})
+
+	// The case the chaining migration needs.
+	t.Run("zero clears it", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"name":            "rotating-source",
+			"rotation_period": 0,
+		}
+		_, err := backend.handleCredentialSourceUpdate(ctx, req, createFieldData(schema, raw))
+		require.NoError(t, err)
+		assert.Zero(t, readBack(t))
+	})
 }
 
 func TestSystemBackend_HandleCredentialSourceDelete(t *testing.T) {

--- a/e2e/rotation/rotation_test.go
+++ b/e2e/rotation/rotation_test.go
@@ -3,6 +3,7 @@
 package rotation
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -297,6 +298,93 @@ func TestRotationPeriodUpdateOnExistingSource(t *testing.T) {
 	}
 
 	cleanupSource(t, port, "e2e-rot-upd2")
+}
+
+// TestRotationScheduleFollowsInPlaceUpdate drives the schedule, not just the
+// stored config: a rotation period changed or cleared through the update API must
+// reach the rotation manager.
+//
+// The two neighbouring rows named for updating a period both delete and recreate
+// the source, because updating one in place was not possible — the update handler
+// preserved whatever period the source was created with. Nothing therefore covered
+// the manager's side of an update, which is where the schedule actually lives.
+//
+// next_rotation is the observable: the source read reports it only while an entry
+// is registered, so its disappearance is the assertion that clearing the period
+// unregistered the entry rather than leaving one firing on a period the source no
+// longer carries.
+func TestRotationScheduleFollowsInPlaceUpdate(t *testing.T) {
+	port := h.GetLeaderPort(t)
+	const name = "e2e-rot-inplace"
+	cleanupSource(t, port, name)
+	t.Cleanup(func() { cleanupSource(t, port, name) })
+
+	// POST creates and refuses an existing name; PUT is the update verb. The two
+	// neighbouring rows never needed the distinction, having only ever created.
+	mustWrite := func(method, what, body string) {
+		t.Helper()
+		status, resp := h.APIRequest(t, method, "sys/cred/sources/"+name, port, body)
+		if status != 200 && status != 201 && status != 204 {
+			t.Fatalf("%s: status %d: %s", what, status, string(resp))
+		}
+	}
+
+	// Returns the stored period and the scheduled next rotation, the latter empty
+	// when the source is not enrolled.
+	read := func(t *testing.T) (float64, string) {
+		t.Helper()
+		status, body := h.APIRequest(t, "GET", "sys/cred/sources/"+name, port, "")
+		if status != 200 {
+			t.Fatalf("read: status %d: %s", status, string(body))
+		}
+		data := h.ParseJSON(t, body)
+		period, _ := h.JSONPath(data, "data.rotation_period").(float64)
+		next, _ := h.JSONPath(data, "data.next_rotation").(string)
+		return period, next
+	}
+
+	// A local source, not the hvault one the rest of this file uses: hvault is
+	// required to carry a rotation_period, so clearing one is refused before it
+	// could reach the manager. Enrolment does not depend on the type — any source
+	// with a period is registered — so this covers the same lifecycle.
+	const body = `{"type":"local","rotation_period":%d,"config":{"key":"value"}}`
+
+	mustWrite("POST", "create", fmt.Sprintf(body, 300))
+	period, firstNext := read(t)
+	if period != 300 {
+		t.Fatalf("rotation_period = %v, want 300 after create", period)
+	}
+	if firstNext == "" {
+		t.Fatal("no next_rotation after create: the source was never enrolled")
+	}
+
+	// Change it in place. The config is untouched, so this is the case that used to
+	// leave the manager on the period the source was created with.
+	mustWrite("PUT", "update period", fmt.Sprintf(body, 600))
+
+	period, secondNext := read(t)
+	if period != 600 {
+		t.Fatalf("rotation_period = %v, want 600 after update", period)
+	}
+	if secondNext == "" {
+		t.Fatal("no next_rotation after updating the period: the entry was dropped")
+	}
+	// Rescheduled from now against a longer period, so the next action must move
+	// later. Comparing the strings is enough: both are RFC3339 in UTC.
+	if secondNext <= firstNext {
+		t.Errorf("next_rotation did not move for a lengthened period: %s then %s", firstNext, secondNext)
+	}
+
+	// Clear it. The entry must go, not linger on the old schedule.
+	mustWrite("PUT", "clear period", fmt.Sprintf(body, 0))
+
+	period, clearedNext := read(t)
+	if period != 0 {
+		t.Fatalf("rotation_period = %v, want 0 after clearing", period)
+	}
+	if clearedNext != "" {
+		t.Errorf("next_rotation still reported after clearing the period (%s): the entry is still enrolled", clearedNext)
+	}
 }
 
 // TestDeleteSourceWithRotation verifies a rotating source can be deleted (T-045).


### PR DESCRIPTION
The rotation manager was told about a source or spec at create and at delete, and nowhere else. A period changed in place therefore kept firing on the schedule the entry was created with, and a period cleared in place kept firing at all: the stored config said one thing and the manager did another, with nothing to reveal the disagreement. `RotationManager.UpdateRotationPeriod` already existed for exactly this and **had no caller outside its own tests**.

**For specs this was reachable through the API all along** — the spec update handler has always carried `rotation_period`. For sources it was latent, because the update handler preserved whatever period the source was created with, and it becomes reachable here: an update that *names* a `rotation_period` is honoured, including a zero. Absence still preserves, which keeps an ordinary config-only edit from failing hvault validation or silently stripping rotation from every other type.

That was needed to convert a rotating source to draw its secret from a referenced spec: such a source is refused a `rotation_period`, so it must be cleared in the same write, and delete-and-recreate is blocked while specs reference it.

**`UpdateSource` now closes the driver only when its config actually changed.** Config is the only field a driver reads — `Name` keys it, `Type` is immutable, `RotationPeriod` belongs to the manager — so an update touching only the period left every driver input identical while tearing the instance down, discarding cached tokens, discovered identity and pooled connections to rebuild something byte for byte the same. Harmless while every update carried a config; not once a period could be updated alone.

### On the tests

The two existing e2e rows named for updating a period both **delete and recreate**, and neither ever issued a `PUT` — a fossil of the gap rather than an oversight. The new row asserts the *schedule*, not the stored config: a source read reports `next_rotation` only while an entry is registered, so its disappearance is what proves clearing the period unregistered the entry.

Verified against a cluster rebuilt **without** the reconciliation, where it fails on both counts:

```
next_rotation did not move for a lengthened period: …19:19:43 then …19:19:43
next_rotation still reported after clearing the period: the entry is still enrolled
```

### Open question, deliberately not decided here

A lengthened period currently reschedules from now. That treats the period as a cadence; it is arguably a **max-age policy**, in which case the anchor should be `LastRotation + newPeriod`. The argument for changing it: reschedule-from-now can be **starved** — an operator who touches the period on a 30-day policy every few days never rotates, and nothing surfaces that the secret is aging. Left as a follow-up because it needs a floor plus jitter to avoid a thundering herd, and deserves its own tests.

Stacked on #559.