### PR TITLE
fix(chaining): bound a cached secret to the lifetime it was minted with

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1585,8 +1585,10 @@ func (s *CredentialConfigStore) CheckSpecReferences(ctx context.Context, specNam
 //
 // It deliberately does NOT assert the referenced spec is leaseless here: that would
 // need per-type mint-method introspection this layer lacks, and the authoritative
-// guard is at mint time — issueChained revokes and fails closed if a referenced spec
-// ever returns a lease (including after a config-drift edit this check couldn't see).
+// guard is at mint time — the chaining path revokes and fails closed if a referenced
+// spec ever returns a lease (including after a config-drift edit this check couldn't
+// see). A referenced credential with a lifetime but no lease is permitted; it orphans
+// nothing, and the chaining cache bounds its entry to that lifetime.
 func (s *CredentialConfigStore) validateSecretSpecRef(ctx context.Context, ref string) error {
 	refSpec, err := s.GetSpec(ctx, ref)
 	if err != nil {

--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -297,7 +297,89 @@ func TestChaining_LeaselessBackstop(t *testing.T) {
 	ctx := createNamespaceContext()
 	_, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "static/leaseless")
+	assert.Contains(t, err.Error(), "leaseless")
+}
+
+// TestChaining_TTLWithoutLeaseAccepted: a referenced secret-spec may report a lifetime of
+// its own so long as it holds no lease. The backstop above exists because the chaining
+// path skips expiration registration and would orphan a lease; a lifetime WITHOUT a lease
+// id has nothing to orphan — nothing downstream must be told to release it, the material
+// just stops being valid — so refusing it would rule out an entire class of referenced
+// spec for no benefit.
+func TestChaining_TTLWithoutLeaseAccepted(t *testing.T) {
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"token": "THE-SECRET"}, nil, time.Hour, "", nil
+	}
+	env.store.AddSpec(&CredSpec{Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: map[string]string{ConfigSecretSpec: "secret-spec"}})
+
+	ctx := createNamespaceContext()
+	cred, err := env.manager.IssueCredential(ctx, chainCaller("tokA"), "consumer", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "consumer-token:THE-SECRET", cred.Data["token"])
+}
+
+// TestChaining_CacheEntryClampedToReferencedTTL: a cached payload never outlives the
+// credential it was minted from. Holding it for the full secret_cache_ttl would keep
+// vending material that already stopped being valid, and the consumer would not find out
+// until the downstream refused it — one failed mint per entry for the rest of the window.
+func TestChaining_CacheEntryClampedToReferencedTTL(t *testing.T) {
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"token": "THE-SECRET"}, nil, 100 * time.Millisecond, "", nil
+	}
+	// A cache TTL far longer than the referenced credential's own lifetime.
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "30m"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.secretDriver.mintCalls.Load())
+
+	// Past the referenced credential's lifetime but far inside secret_cache_ttl: the
+	// entry is gone, so the second consumer re-fetches instead of being served a
+	// payload the source has already expired.
+	time.Sleep(200 * time.Millisecond)
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"entry expired with the referenced credential, not with secret_cache_ttl")
+}
+
+// TestChaining_CacheEntryKeepsShorterConfiguredTTL is the other direction: the clamp
+// takes the SHORTER of the two, so a long-lived referenced credential does not pin the
+// entry to its own lifetime and override a shorter secret_cache_ttl.
+//
+// The configured TTL is the short one here and the entry is read after it has passed, so
+// the row fails if the clamp ever took the max — or the referenced lifetime — instead.
+// Asserting a hit at t=0 would have passed under all three.
+func TestChaining_CacheEntryKeepsShorterConfiguredTTL(t *testing.T) {
+	env := newChainingEnv(t)
+	env.secretDriver.mintFunc = func(_ context.Context, _ *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+		return map[string]interface{}{"token": "THE-SECRET"}, nil, time.Hour, "", nil
+	}
+	cfg := map[string]string{ConfigSecretSpec: "secret-spec", ConfigSecretCacheTTL: "100ms"}
+	env.store.AddSpec(&CredSpec{Name: "consumer1", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+	env.store.AddSpec(&CredSpec{Name: "consumer2", Type: TypeVaultToken, Source: "consumersource", Config: cfg})
+
+	ctx := createNamespaceContext()
+	caller := chainCaller("tokA")
+
+	_, err := env.manager.IssueCredential(ctx, caller, "consumer1", nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), env.secretDriver.mintCalls.Load())
+
+	// Past the configured TTL but far inside the referenced credential's own hour.
+	time.Sleep(200 * time.Millisecond)
+	_, err = env.manager.IssueCredential(ctx, caller, "consumer2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), env.secretDriver.mintCalls.Load(),
+		"the shorter configured TTL governs; a long referenced lifetime must not extend the entry")
 }
 
 // TestChaining_SecretFieldSelection covers multi-key payloads: an explicit

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -115,8 +115,9 @@ type ExpirationRegistrar interface {
 // chainedSecret is the cached payload of a referenced secret-spec: the minted
 // credential's Data plus its Type. Type is retained because resolveSecretField uses it
 // for the PrimaryFieldProvider fallback, so a cache hit resolves the secret_field
-// identically to a fresh fetch. It never contains a lease (the referenced spec is
-// static/leaseless) and is held in memory only, never persisted.
+// identically to a fresh fetch. It never contains a lease (a referenced spec that
+// returns one is refused) and is held in memory only, never persisted. When the
+// referenced credential has a lifetime of its own, the entry is bounded by it.
 type chainedSecret struct {
 	Data map[string]string
 	Type string
@@ -553,7 +554,7 @@ func (m *Manager) buildSecretMaterial(ctx context.Context, spec *CredSpec, data 
 // credential. The caller owns the one-hop depth guard and building inputsB (via
 // caller.ResolveInputs); this function materializes any lazily-minted subject/actor
 // tokens, mints via the non-caching internal path (so the fetched secret is never
-// cached), and enforces that the referenced credential is static/leaseless.
+// cached), and enforces that the referenced credential holds no lease.
 func (m *Manager) fetchChainedSecret(ctx context.Context, caller Caller, secretRef string, inputsB *ExchangeInputs) (*Credential, error) {
 	// Materialize any lazily-minted subject/actor tokens here: the referenced spec is
 	// minted via the non-caching internal path, which — unlike the caching wrapper —
@@ -582,26 +583,26 @@ func (m *Manager) fetchChainedSecret(ctx context.Context, caller Caller, secretR
 		return nil, fmt.Errorf("secret_spec %q: %w", secretRef, err)
 	}
 
-	// A referenced secret-spec must be static/leaseless: this path skips expiration
-	// registration, so a leased credential would orphan its lease. The create-time
-	// guard forbids this; fail closed (best-effort revoke) if config drift produced
-	// one anyway.
-	if credB.LeaseID != "" || credB.LeaseTTL > 0 {
-		if credB.LeaseID != "" {
-			// Best-effort revoke on a fresh context (the request ctx may be near its
-			// issuance deadline); log rather than drop the outcome.
-			revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			if drv, derr := m.driverCoordinator.GetOrCreateDriver(ctx, credB.SourceName); derr == nil {
-				if rerr := drv.Revoke(revokeCtx, credB.LeaseID); rerr != nil {
-					m.log.Warn("failed to revoke orphaned lease from a leased secret_spec",
-						logger.String("secret_spec", secretRef),
-						logger.String("lease_id", credB.LeaseID),
-						logger.Err(rerr))
-				}
+	// A referenced secret-spec must hold no lease: this path skips expiration
+	// registration, so a leased credential would orphan its lease. A lifetime WITHOUT a
+	// lease id orphans nothing — nothing downstream has to be told to release it, the
+	// material simply stops being valid — so it is allowed through, and the caller
+	// bounds any cache entry to it. The create-time guard forbids a lease; fail closed
+	// (best-effort revoke) if config drift produced one anyway.
+	if credB.LeaseID != "" {
+		// Best-effort revoke on a fresh context (the request ctx may be near its
+		// issuance deadline); log rather than drop the outcome.
+		revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if drv, derr := m.driverCoordinator.GetOrCreateDriver(ctx, credB.SourceName); derr == nil {
+			if rerr := drv.Revoke(revokeCtx, credB.LeaseID); rerr != nil {
+				m.log.Warn("failed to revoke orphaned lease from a leased secret_spec",
+					logger.String("secret_spec", secretRef),
+					logger.String("lease_id", credB.LeaseID),
+					logger.Err(rerr))
 			}
-			cancel()
 		}
-		return nil, fmt.Errorf("secret_spec %q must reference a static/leaseless credential, but it returned a lease", secretRef)
+		cancel()
+		return nil, fmt.Errorf("secret_spec %q must reference a leaseless credential, but it returned a lease", secretRef)
 	}
 
 	return credB, nil
@@ -613,7 +614,8 @@ func (m *Manager) fetchChainedSecret(ctx context.Context, caller Caller, secretR
 // caller retries on a downstream rejection only when a stale cached value could be the
 // cause). key is the cache key (empty when caching is disabled), for invalidation on
 // retry. A ttl <= 0, or a context without a namespace, disables caching and fetches
-// directly — the behaviour-preserving default.
+// directly — the behaviour-preserving default. An entry never outlives the referenced
+// credential: a lifetime reported by the fetch caps the configured ttl.
 func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, spec *CredSpec, secretRef string, inputsB *ExchangeInputs) (data map[string]string, typ string, fromCache bool, key string, err error) {
 	ttl := m.secretCacheTTL(ctx, spec)
 	if ttl <= 0 {
@@ -665,7 +667,15 @@ func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, s
 			return nil, e
 		}
 		cs := chainedSecret{Data: credB.Data, Type: credB.Type}
-		m.secretCache.SetWithTTL(key, cs, 1, ttl)
+		// A referenced credential carrying its own lifetime bounds the entry. Holding it
+		// for the full secret_cache_ttl would keep vending material that already stopped
+		// being valid, and the consumer would not discover that until the downstream
+		// refused it — one failed mint per entry, for the rest of the window.
+		entryTTL := ttl
+		if credB.LeaseTTL > 0 && credB.LeaseTTL < entryTTL {
+			entryTTL = credB.LeaseTTL
+		}
+		m.secretCache.SetWithTTL(key, cs, 1, entryTTL)
 		m.secretCache.Wait() // Ristretto sets are async; shrink the window vs a concurrent Del.
 		return cs, nil
 	})


### PR DESCRIPTION
**1 of 6.** Base of a stack adding KMS-held client-assertion keys. Reviewable on its own; the rest build on it.

The chained-secret path refused any referenced credential reporting a lifetime, not just a leased one. The guard exists because this path skips expiration registration, so a lease would be orphaned — but a lifetime without a lease id has nothing to orphan: no handle has to be released, the material simply stops being valid.

Narrows the guard to a lease id, and caps the cache entry at the shorter of `secret_cache_ttl` and the referenced credential's own lifetime. Without the cap, a payload cached for an hour behind a ten-minute credential would keep being vended long after it stopped working, and nothing would notice until the downstream refused it — one failed mint per entry, for the rest of the window.

No behaviour change for existing chained drivers: a referenced spec could not report a lifetime before this, so no entry changes its lifetime.

## Verification

Unit tests cover both clamp directions and the retained lease refusal. The full e2e suite passes, including all eight existing chaining suites — this touches machinery every chained driver runs through, so those are the real regression surface.
