### PR TITLE
refactor: move the remote-signing backend out of core

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -25,13 +25,13 @@ import (
 	"github.com/stephnangue/warden/api"
 	"github.com/stephnangue/warden/audit"
 	"github.com/stephnangue/warden/config"
-	"github.com/stephnangue/warden/core/oidcsign"
 	"github.com/stephnangue/warden/core/seal"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/credential/drivers"
 	"github.com/stephnangue/warden/credential/types"
 	"github.com/stephnangue/warden/internal/locking"
 	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/internal/remotesign"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 	phy "github.com/stephnangue/warden/physical"
@@ -236,7 +236,7 @@ type Core struct {
 	// lazily on the active serving path in setupOIDCIssuer and closed in
 	// stopOIDCIssuer, so a standby holds no idle KMS token. Guarded by oidcSetupMu.
 	// oidcSignTimeout is its per-call timeout.
-	oidcSignBackend oidcsign.Backend
+	oidcSignBackend remotesign.Backend
 	oidcSignTimeout time.Duration
 
 	// oidcRotationCancel stops the active node's signing-key rotation loop, and
@@ -888,7 +888,7 @@ func parseConfigBool(s string) bool {
 // is configured (the default: in-process keys). A construction failure is a
 // config error (bad TLS/address); transit being unreachable is not detected here.
 // Called under oidcSetupMu.
-func (c *Core) ensureOIDCSignBackend() (oidcsign.Backend, time.Duration, error) {
+func (c *Core) ensureOIDCSignBackend() (remotesign.Backend, time.Duration, error) {
 	if c.oidcSignBackend != nil {
 		return c.oidcSignBackend, c.oidcSignTimeout, nil
 	}
@@ -909,7 +909,7 @@ func (c *Core) ensureOIDCSignBackend() (oidcsign.Backend, time.Duration, error) 
 	if prefix == "" {
 		prefix = defaultOIDCKeyNamePrefix
 	}
-	backend, err := oidcsign.NewTransitBackend(oidcsign.TransitConfig{
+	backend, err := remotesign.NewTransitBackend(remotesign.TransitConfig{
 		Address:        s.Address,
 		Token:          s.Token,
 		MountPath:      s.MountPath,
@@ -1012,7 +1012,7 @@ func (c *Core) setupOIDCIssuer(ctx context.Context, standby, configWrite bool) e
 	// external signer when the `signer` stanza is configured; a standby uses no
 	// backend (it holds no KMS token) and reconstructs any remote keys as
 	// verification-only.
-	var backend oidcsign.Backend
+	var backend remotesign.Backend
 	var signTimeout time.Duration
 	if !standby {
 		b, to, berr := c.ensureOIDCSignBackend()

--- a/core/oidc_issuer_storage.go
+++ b/core/oidc_issuer_storage.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
-	"github.com/stephnangue/warden/core/oidcsign"
+	"github.com/stephnangue/warden/internal/remotesign"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -66,8 +66,8 @@ func toStored(sk *signingKey) (storedSigningKey, error) {
 	out := storedSigningKey{Kid: sk.kid, Alg: sk.alg, CreatedAt: sk.createdAt, RetiredAt: sk.retiredAt}
 	// A KMS-backed key has no exportable private material — persist only its handle
 	// and cached public key.
-	if rs, ok := sk.key.(*oidcsign.Signer); ok {
-		pemStr, err := oidcsign.MarshalPublicKeyPEM(rs.Public())
+	if rs, ok := sk.key.(*remotesign.Signer); ok {
+		pemStr, err := remotesign.MarshalPublicKeyPEM(rs.Public())
 		if err != nil {
 			return storedSigningKey{}, fmt.Errorf("oidc issuer: %w", err)
 		}
@@ -94,9 +94,9 @@ func toStored(sk *signingKey) (storedSigningKey, error) {
 // the JWKS. The verification-only case arises on the active node after a
 // remote->local cutover (the signer stanza was removed, so backend is nil) or for
 // retired keys left behind by a previously-configured backend. backend may be nil.
-func fromStored(s storedSigningKey, backend oidcsign.Backend, timeout time.Duration) (*signingKey, error) {
+func fromStored(s storedSigningKey, backend remotesign.Backend, timeout time.Duration) (*signingKey, error) {
 	if s.Remote != nil {
-		pub, err := oidcsign.ParsePublicKeyPEM(s.Remote.PublicKeyPEM)
+		pub, err := remotesign.ParsePublicKeyPEM(s.Remote.PublicKeyPEM)
 		if err != nil {
 			return nil, fmt.Errorf("oidc issuer: %w", err)
 		}
@@ -109,12 +109,12 @@ func fromStored(s storedSigningKey, backend oidcsign.Backend, timeout time.Durat
 		if kid != s.Kid {
 			return nil, fmt.Errorf("oidc issuer: stored remote key kid mismatch (stored %q, computed %q)", s.Kid, kid)
 		}
-		ref := oidcsign.KeyRef{KeyName: s.Remote.KeyName, Version: s.Remote.KeyVersion, Alg: s.Alg}
+		ref := remotesign.KeyRef{KeyName: s.Remote.KeyName, Version: s.Remote.KeyVersion, Alg: s.Alg}
 		var signer crypto.Signer
 		if backend != nil && backend.Type() == s.Remote.Backend {
-			signer = oidcsign.NewSigner(backend, ref, pub, timeout)
+			signer = remotesign.NewSigner(backend, ref, pub, timeout)
 		} else {
-			signer = oidcsign.NewVerifyingSigner(s.Remote.Backend, ref, pub)
+			signer = remotesign.NewVerifyingSigner(s.Remote.Backend, ref, pub)
 		}
 		return &signingKey{key: signer, alg: s.Alg, kid: s.Kid, createdAt: s.CreatedAt, retiredAt: s.RetiredAt}, nil
 	}
@@ -184,7 +184,7 @@ func persistKeySet(ctx context.Context, storage sdklogical.Storage, keysets map[
 // when none has been persisted yet, so the caller can decide to generate the keys.
 // backend (and its per-call timeout) reconstructs signing-capable remote keys; pass
 // nil to reconstruct any remote keys as verification-only.
-func loadKeySet(ctx context.Context, storage sdklogical.Storage, backend oidcsign.Backend, timeout time.Duration, log *logger.GatedLogger) (map[string]*algKeyset, error) {
+func loadKeySet(ctx context.Context, storage sdklogical.Storage, backend remotesign.Backend, timeout time.Duration, log *logger.GatedLogger) (map[string]*algKeyset, error) {
 	entry, err := storage.Get(ctx, oidcKeySetPath)
 	if err != nil {
 		return nil, fmt.Errorf("oidc issuer: read keyset: %w", err)

--- a/core/oidc_signing_backend.go
+++ b/core/oidc_signing_backend.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stephnangue/warden/core/oidcsign"
+	"github.com/stephnangue/warden/internal/remotesign"
 )
 
 // oidcKeySource abstracts where the issuer's signing keys come from: local
@@ -51,7 +51,7 @@ func (localKeySource) remote() bool { return false }
 // active/next/retired model maps onto KMS key versions, and the private key never
 // enters Warden. active/next are two distinct versions of the alg's key.
 type remoteKeySource struct {
-	backend oidcsign.Backend
+	backend remotesign.Backend
 	timeout time.Duration
 }
 
@@ -91,12 +91,12 @@ func (r remoteKeySource) remote() bool { return true }
 // is the RFC 7638 thumbprint of the public key — identical to a local key's kid
 // and stable across restarts — and createdAt is the KMS-side creation time, so the
 // rotation scheduler's anchor survives restarts.
-func (r remoteKeySource) newRemoteSigningKey(info oidcsign.KeyInfo) (*signingKey, error) {
+func (r remoteKeySource) newRemoteSigningKey(info remotesign.KeyInfo) (*signingKey, error) {
 	kid, err := signingKeyID(info.Public)
 	if err != nil {
 		return nil, err
 	}
-	signer := oidcsign.NewSigner(r.backend, info.Ref, info.Public, r.timeout)
+	signer := remotesign.NewSigner(r.backend, info.Ref, info.Public, r.timeout)
 	return &signingKey{key: signer, alg: info.Ref.Alg, kid: kid, createdAt: info.CreatedAt}, nil
 }
 
@@ -105,7 +105,7 @@ func isRemoteSigningKey(sk *signingKey) bool {
 	if sk == nil {
 		return false
 	}
-	_, ok := sk.key.(*oidcsign.Signer)
+	_, ok := sk.key.(*remotesign.Signer)
 	return ok
 }
 
@@ -131,7 +131,7 @@ func oidcKeySetSourceMismatch(keysets map[string]*algKeyset, wantRemote bool) bo
 // sign (a different or removed backend left it verification-only) must go too, so
 // adding a second backend type later cannot silently install an unusable key.
 func oidcActiveKeyNeedsCutover(active *signingKey, wantRemote bool) bool {
-	rs, isRemote := active.key.(*oidcsign.Signer)
+	rs, isRemote := active.key.(*remotesign.Signer)
 	if !wantRemote {
 		return isRemote
 	}

--- a/core/oidc_signing_backend_test.go
+++ b/core/oidc_signing_backend_test.go
@@ -15,13 +15,13 @@ import (
 
 	"github.com/hashicorp/cap/jwt"
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
-	"github.com/stephnangue/warden/core/oidcsign"
+	"github.com/stephnangue/warden/internal/remotesign"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeSignBackend is an in-memory oidcsign.Backend for tests: it holds a real
+// fakeSignBackend is an in-memory remotesign.Backend for tests: it holds a real
 // RSA/ECDSA key per alg version and signs by delegating to the underlying
 // crypto.Signer, so its output matches the crypto.Signer contract exactly (RSA
 // PKCS#1 v1.5, ECDSA ASN.1 DER) and minted assertions verify against the JWKS.
@@ -55,21 +55,21 @@ func genForAlg(t *testing.T, alg string) crypto.Signer {
 
 func (f *fakeSignBackend) Type() string { return "transit" }
 
-func (f *fakeSignBackend) infoLocked(alg string) oidcsign.KeyInfo {
+func (f *fakeSignBackend) infoLocked(alg string) remotesign.KeyInfo {
 	vers := f.versions[alg]
 	ver := len(vers)
-	return oidcsign.KeyInfo{
-		Ref:       oidcsign.KeyRef{KeyName: "fake-" + alg, Version: ver, Alg: alg},
+	return remotesign.KeyInfo{
+		Ref:       remotesign.KeyRef{KeyName: "fake-" + alg, Version: ver, Alg: alg},
 		Public:    vers[ver-1].Public(),
 		CreatedAt: time.Now().Add(time.Duration(ver) * time.Second),
 	}
 }
 
-func (f *fakeSignBackend) EnsureKey(_ context.Context, alg string) (oidcsign.KeyInfo, error) {
+func (f *fakeSignBackend) EnsureKey(_ context.Context, alg string) (remotesign.KeyInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.opErr != nil {
-		return oidcsign.KeyInfo{}, f.opErr
+		return remotesign.KeyInfo{}, f.opErr
 	}
 	if len(f.versions[alg]) == 0 {
 		f.versions[alg] = []crypto.Signer{genForAlg(f.t, alg)}
@@ -77,23 +77,23 @@ func (f *fakeSignBackend) EnsureKey(_ context.Context, alg string) (oidcsign.Key
 	return f.infoLocked(alg), nil
 }
 
-func (f *fakeSignBackend) NewVersion(_ context.Context, alg string) (oidcsign.KeyInfo, error) {
+func (f *fakeSignBackend) NewVersion(_ context.Context, alg string) (remotesign.KeyInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.opErr != nil {
-		return oidcsign.KeyInfo{}, f.opErr
+		return remotesign.KeyInfo{}, f.opErr
 	}
 	f.versions[alg] = append(f.versions[alg], genForAlg(f.t, alg))
 	return f.infoLocked(alg), nil
 }
 
-func (f *fakeSignBackend) PublicKey(_ context.Context, ref oidcsign.KeyRef) (crypto.PublicKey, error) {
+func (f *fakeSignBackend) PublicKey(_ context.Context, ref remotesign.KeyRef) (crypto.PublicKey, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.versions[ref.Alg][ref.Version-1].Public(), nil
 }
 
-func (f *fakeSignBackend) Sign(_ context.Context, ref oidcsign.KeyRef, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+func (f *fakeSignBackend) Sign(_ context.Context, ref remotesign.KeyRef, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	f.mu.Lock()
 	signer := f.versions[ref.Alg][ref.Version-1]
 	f.mu.Unlock()
@@ -131,7 +131,7 @@ func TestStorageV4_RemoteRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	kid, err := signingKeyID(info.Public)
 	require.NoError(t, err)
-	sk := &signingKey{key: oidcsign.NewSigner(fake, info.Ref, info.Public, time.Second), alg: oidcAlgRS256, kid: kid, createdAt: info.CreatedAt}
+	sk := &signingKey{key: remotesign.NewSigner(fake, info.Ref, info.Public, time.Second), alg: oidcAlgRS256, kid: kid, createdAt: info.CreatedAt}
 
 	stored, err := toStored(sk)
 	require.NoError(t, err)
@@ -144,13 +144,13 @@ func TestStorageV4_RemoteRoundTrip(t *testing.T) {
 	back, err := fromStored(stored, fake, time.Second)
 	require.NoError(t, err)
 	assert.Equal(t, kid, back.kid)
-	rs := back.key.(*oidcsign.Signer)
+	rs := back.key.(*remotesign.Signer)
 	assert.True(t, rs.CanSign())
 
 	// With no backend -> verification-only (fails closed on Sign) but same public key/kid.
 	vonly, err := fromStored(stored, nil, 0)
 	require.NoError(t, err)
-	assert.False(t, vonly.key.(*oidcsign.Signer).CanSign())
+	assert.False(t, vonly.key.(*remotesign.Signer).CanSign())
 	assert.Equal(t, kid, vonly.kid)
 
 	// A tampered kid is rejected (the kid is a pure function of the public key).
@@ -194,9 +194,9 @@ func TestOIDCActiveKeyNeedsCutover(t *testing.T) {
 	require.NoError(t, err)
 
 	local := mustGen(t, oidcAlgRS256)
-	remoteSigning := &signingKey{key: oidcsign.NewSigner(fake, info.Ref, info.Public, time.Second)}
+	remoteSigning := &signingKey{key: remotesign.NewSigner(fake, info.Ref, info.Public, time.Second)}
 	// A remote key whose backend is absent/different — reconstructed verify-only.
-	remoteVerifyOnly := &signingKey{key: oidcsign.NewVerifyingSigner("transit", info.Ref, info.Public)}
+	remoteVerifyOnly := &signingKey{key: remotesign.NewVerifyingSigner("transit", info.Ref, info.Public)}
 
 	// Local config: only remote keys need to go.
 	assert.False(t, oidcActiveKeyNeedsCutover(local, false))
@@ -213,7 +213,7 @@ func TestOIDCActiveKeyNeedsCutover(t *testing.T) {
 
 // setupRemoteIssuer enables the issuer and installs the fake backend on core, then
 // runs an active setup. Returns the storage view for assertions.
-func setupRemoteIssuer(t *testing.T, core *Core, fake oidcsign.Backend) {
+func setupRemoteIssuer(t *testing.T, core *Core, fake remotesign.Backend) {
 	t.Helper()
 	ctx := context.Background()
 	storage := NewBarrierView(core.barrier, oidcIssuerStorePrefix)

--- a/core/sys_oidc_issuer.go
+++ b/core/sys_oidc_issuer.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stephnangue/warden/core/oidcsign"
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/internal/remotesign"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
@@ -230,7 +230,7 @@ func (b *SystemBackend) signerSummary() map[string]any {
 			if ks == nil || ks.active == nil {
 				continue
 			}
-			if rs, ok := ks.active.key.(*oidcsign.Signer); ok {
+			if rs, ok := ks.active.key.(*remotesign.Signer); ok {
 				out["mode"] = "external_kms"
 				out["backend"] = rs.BackendType()
 				break

--- a/internal/remotesign/backend.go
+++ b/internal/remotesign/backend.go
@@ -1,14 +1,16 @@
-// Package oidcsign provides remote signing backends for the OIDC issuer's
-// signing keys, so an operator can hold the private key in an external KMS (e.g.
-// an OpenBao/Vault transit engine) where it never leaves the KMS. Warden keeps
-// only a handle plus the public key and asks the KMS to sign each assertion.
+// Package remotesign provides signing backends whose private key is held in an
+// external KMS and never leaves it. Warden keeps only a handle plus the public
+// key, and asks the KMS to sign each digest.
 //
-// The package has no dependency on the core package: a Backend produces a
-// crypto.Signer (Signer) that drops into the issuer's signingKey.key seam, and
-// signing/verification flow through the standard crypto.Signer / crypto.PublicKey
-// interfaces. Cloud KMS and PKCS#11/HSM backends can be added by implementing
-// Backend without touching the issuer.
-package oidcsign
+// A Backend produces a crypto.Signer (Signer), so remote signing substitutes
+// wherever a caller already holds one — the OIDC issuer's signing key today —
+// and signing and verification flow through the standard crypto.Signer /
+// crypto.PublicKey interfaces. Cloud KMS and PKCS#11/HSM backends can be added by
+// implementing Backend without touching any caller.
+//
+// The package deliberately depends on no other Warden package beyond logging, so
+// callers in any layer can use it without inverting their dependencies.
+package remotesign
 
 import (
 	"context"
@@ -22,7 +24,7 @@ import (
 // rotated out-of-band (e.g. an HSM referenced by label): NewVersion is not a
 // programmatic operation there, and the caller degrades to operator-managed
 // rotation. The transit backend supports rotation and never returns this.
-var ErrRotationUnsupported = errors.New("oidcsign: backend does not support programmatic key rotation")
+var ErrRotationUnsupported = errors.New("remotesign: backend does not support programmatic key rotation")
 
 // KeyRef names one immutable key version in the backend. Alg is carried so a
 // stateless Sign call can select the signing parameters (hash, and PKCS#1 v1.5
@@ -128,7 +130,7 @@ func (s *Signer) CanSign() bool { return s.backend != nil }
 // timeout bounded further by any context bound via WithContext.
 func (s *Signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	if s.backend == nil {
-		return nil, errors.New("oidcsign: no signing backend for this key (verification-only)")
+		return nil, errors.New("remotesign: no signing backend for this key (verification-only)")
 	}
 	ctx := s.ctx
 	if ctx == nil {

--- a/internal/remotesign/transit.go
+++ b/internal/remotesign/transit.go
@@ -1,4 +1,4 @@
-package oidcsign
+package remotesign
 
 import (
 	"context"
@@ -40,7 +40,7 @@ type TransitConfig struct {
 	TLSSkipVerify bool
 }
 
-// TransitBackend signs OIDC assertions via an OpenBao/Vault transit engine, where
+// TransitBackend signs via a transit secrets engine, where
 // the private key is created non-exportable and never leaves the KMS.
 type TransitBackend struct {
 	client        *api.Client
@@ -58,10 +58,10 @@ var _ Backend = (*TransitBackend)(nil)
 // transit being unreachable is not detected until a key operation. log may be nil.
 func NewTransitBackend(cfg TransitConfig, log *logger.GatedLogger) (*TransitBackend, error) {
 	if strings.TrimSpace(cfg.MountPath) == "" {
-		return nil, fmt.Errorf("oidcsign: transit mount_path is required")
+		return nil, fmt.Errorf("remotesign: transit mount_path is required")
 	}
 	if strings.TrimSpace(cfg.KeyNamePrefix) == "" {
-		return nil, fmt.Errorf("oidcsign: transit key_name_prefix is required")
+		return nil, fmt.Errorf("remotesign: transit key_name_prefix is required")
 	}
 
 	apiCfg := api.DefaultConfig()
@@ -79,13 +79,13 @@ func NewTransitBackend(cfg TransitConfig, log *logger.GatedLogger) (*TransitBack
 			Insecure:      cfg.TLSSkipVerify,
 		}
 		if err := apiCfg.ConfigureTLS(tls); err != nil {
-			return nil, fmt.Errorf("oidcsign: configure transit TLS: %w", err)
+			return nil, fmt.Errorf("remotesign: configure transit TLS: %w", err)
 		}
 	}
 
 	client, err := api.NewClient(apiCfg)
 	if err != nil {
-		return nil, fmt.Errorf("oidcsign: create transit client: %w", err)
+		return nil, fmt.Errorf("remotesign: create transit client: %w", err)
 	}
 	if cfg.Token != "" {
 		client.SetToken(cfg.Token)
@@ -123,12 +123,12 @@ func (b *TransitBackend) startRenewal(disable bool) {
 	defer cancel()
 	secret, err := b.client.Auth().Token().RenewTokenAsSelfWithContext(ctx, b.client.Token(), 0)
 	if err != nil {
-		b.logInfo("oidcsign: transit token not renewable, disabling renewal", logger.Err(err))
+		b.logInfo("remotesign: transit token not renewable, disabling renewal", logger.Err(err))
 		return
 	}
 	watcher, err := b.client.NewLifetimeWatcher(&api.LifetimeWatcherInput{Secret: secret})
 	if err != nil {
-		b.logInfo("oidcsign: failed to start transit token renewal", logger.Err(err))
+		b.logInfo("remotesign: failed to start transit token renewal", logger.Err(err))
 		return
 	}
 	b.watcher = watcher
@@ -137,7 +137,7 @@ func (b *TransitBackend) startRenewal(disable bool) {
 			select {
 			case err := <-watcher.DoneCh():
 				if err != nil {
-					b.logError("oidcsign: transit token renewal stopped", logger.Err(err))
+					b.logError("remotesign: transit token renewal stopped", logger.Err(err))
 				}
 				return
 			case <-watcher.RenewCh():
@@ -165,7 +165,7 @@ func (b *TransitBackend) keyNameFor(alg string) string {
 func (b *TransitBackend) EnsureKey(ctx context.Context, alg string) (KeyInfo, error) {
 	p, ok := algParamsByAlg[alg]
 	if !ok {
-		return KeyInfo{}, fmt.Errorf("oidcsign: unsupported signing algorithm %q", alg)
+		return KeyInfo{}, fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
 	}
 	name := b.keyNameFor(alg)
 	ctx, cancel := b.withTimeout(ctx)
@@ -173,7 +173,7 @@ func (b *TransitBackend) EnsureKey(ctx context.Context, alg string) (KeyInfo, er
 	if _, err := b.client.Logical().WriteWithContext(ctx, b.keysPath(name), map[string]interface{}{
 		"type": p.transitKeyType,
 	}); err != nil {
-		return KeyInfo{}, fmt.Errorf("oidcsign: ensure transit key %q: %w", name, err)
+		return KeyInfo{}, fmt.Errorf("remotesign: ensure transit key %q: %w", name, err)
 	}
 	return b.latestKeyInfo(ctx, alg)
 }
@@ -181,13 +181,13 @@ func (b *TransitBackend) EnsureKey(ctx context.Context, alg string) (KeyInfo, er
 // NewVersion rotates alg's key and returns the new latest version.
 func (b *TransitBackend) NewVersion(ctx context.Context, alg string) (KeyInfo, error) {
 	if _, ok := algParamsByAlg[alg]; !ok {
-		return KeyInfo{}, fmt.Errorf("oidcsign: unsupported signing algorithm %q", alg)
+		return KeyInfo{}, fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
 	}
 	name := b.keyNameFor(alg)
 	ctx, cancel := b.withTimeout(ctx)
 	defer cancel()
 	if _, err := b.client.Logical().WriteWithContext(ctx, b.keysPath(name)+"/rotate", nil); err != nil {
-		return KeyInfo{}, fmt.Errorf("oidcsign: rotate transit key %q: %w", name, err)
+		return KeyInfo{}, fmt.Errorf("remotesign: rotate transit key %q: %w", name, err)
 	}
 	return b.latestKeyInfo(ctx, alg)
 }
@@ -214,13 +214,13 @@ func (b *TransitBackend) PublicKey(ctx context.Context, ref KeyRef) (crypto.Publ
 func validateTransitKey(kd *transitKeyData, name, alg string) error {
 	p, ok := algParamsByAlg[alg]
 	if !ok {
-		return fmt.Errorf("oidcsign: unsupported signing algorithm %q", alg)
+		return fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
 	}
 	if kd.Type != p.transitKeyType {
-		return fmt.Errorf("oidcsign: transit key %q has type %q, expected %q for %s", name, kd.Type, p.transitKeyType, alg)
+		return fmt.Errorf("remotesign: transit key %q has type %q, expected %q for %s", name, kd.Type, p.transitKeyType, alg)
 	}
 	if kd.Exportable {
-		return fmt.Errorf("oidcsign: transit key %q is exportable; the OIDC issuer key must be non-exportable (recreate with exportable=false)", name)
+		return fmt.Errorf("remotesign: transit key %q is exportable; the OIDC issuer key must be non-exportable (recreate with exportable=false)", name)
 	}
 	return nil
 }
@@ -230,25 +230,25 @@ func validateTransitKey(kd *transitKeyData, name, alg string) error {
 // requested in ASN.1 form, matching the crypto.Signer contract.
 func (b *TransitBackend) Sign(ctx context.Context, ref KeyRef, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	if _, ok := opts.(*rsa.PSSOptions); ok {
-		return nil, fmt.Errorf("oidcsign: RSA-PSS is not supported by the transit signer")
+		return nil, fmt.Errorf("remotesign: RSA-PSS is not supported by the transit signer")
 	}
 	p, ok := algParamsByAlg[ref.Alg]
 	if !ok {
-		return nil, fmt.Errorf("oidcsign: unsupported signing algorithm %q", ref.Alg)
+		return nil, fmt.Errorf("remotesign: unsupported signing algorithm %q", ref.Alg)
 	}
 	if ref.Version < 1 {
 		// A zero version resolves to "latest" server-side, so refuse it up front
 		// rather than sign with the wrong (pre-published next) key.
-		return nil, fmt.Errorf("oidcsign: key version must be >= 1, got %d", ref.Version)
+		return nil, fmt.Errorf("remotesign: key version must be >= 1, got %d", ref.Version)
 	}
 	// Guard the digest against an alg/hash mismatch. For ECDSA transit signs
 	// whatever prehashed bytes arrive, so a wrong-hash digest would produce a
 	// well-formed but permanently unverifiable signature — fail fast instead.
 	if opts.HashFunc() != p.hash {
-		return nil, fmt.Errorf("oidcsign: %s requires a %v digest, got %v", ref.Alg, p.hash, opts.HashFunc())
+		return nil, fmt.Errorf("remotesign: %s requires a %v digest, got %v", ref.Alg, p.hash, opts.HashFunc())
 	}
 	if len(digest) != p.hash.Size() {
-		return nil, fmt.Errorf("oidcsign: %s digest must be %d bytes, got %d", ref.Alg, p.hash.Size(), len(digest))
+		return nil, fmt.Errorf("remotesign: %s digest must be %d bytes, got %d", ref.Alg, p.hash.Size(), len(digest))
 	}
 
 	data := map[string]interface{}{
@@ -265,15 +265,15 @@ func (b *TransitBackend) Sign(ctx context.Context, ref KeyRef, digest []byte, op
 	defer cancel()
 	secret, err := b.client.Logical().WriteWithContext(ctx, b.signPath(ref.KeyName), data)
 	if err != nil {
-		return nil, fmt.Errorf("oidcsign: transit sign %q: %w", ref.KeyName, err)
+		return nil, fmt.Errorf("remotesign: transit sign %q: %w", ref.KeyName, err)
 	}
 	if secret == nil || secret.Data == nil {
-		return nil, fmt.Errorf("oidcsign: transit sign %q returned no data", ref.KeyName)
+		return nil, fmt.Errorf("remotesign: transit sign %q returned no data", ref.KeyName)
 	}
 	// The response's key_version is the authoritative, template-independent proof
 	// of which version signed; verify it pinned to the version we asked for.
 	if signedVer, err := asInt(secret.Data["key_version"]); err == nil && signedVer != ref.Version {
-		return nil, fmt.Errorf("oidcsign: transit signed with key version %d, expected %d", signedVer, ref.Version)
+		return nil, fmt.Errorf("remotesign: transit signed with key version %d, expected %d", signedVer, ref.Version)
 	}
 	raw, _ := secret.Data["signature"].(string)
 	return decodeTransitSignature(raw)
@@ -343,17 +343,17 @@ type transitKeyVersion struct {
 func (b *TransitBackend) readKey(ctx context.Context, name string) (*transitKeyData, error) {
 	secret, err := b.client.Logical().ReadWithContext(ctx, b.keysPath(name))
 	if err != nil {
-		return nil, fmt.Errorf("oidcsign: read transit key %q: %w", name, err)
+		return nil, fmt.Errorf("remotesign: read transit key %q: %w", name, err)
 	}
 	if secret == nil || secret.Data == nil {
-		return nil, fmt.Errorf("oidcsign: transit key %q not found", name)
+		return nil, fmt.Errorf("remotesign: transit key %q not found", name)
 	}
 	kd := &transitKeyData{}
 	kd.Type, _ = secret.Data["type"].(string)
 	kd.Exportable, _ = secret.Data["exportable"].(bool)
 	lv, err := asInt(secret.Data["latest_version"])
 	if err != nil {
-		return nil, fmt.Errorf("oidcsign: transit key %q: bad latest_version: %w", name, err)
+		return nil, fmt.Errorf("remotesign: transit key %q: bad latest_version: %w", name, err)
 	}
 	kd.LatestVersion = lv
 	// Re-marshal the versions map through JSON to decode into typed structs. This
@@ -371,7 +371,7 @@ func (b *TransitBackend) readKey(ctx context.Context, name string) (*transitKeyD
 func (kd *transitKeyData) versionEntry(version int) (transitKeyVersion, error) {
 	v, ok := kd.Keys[strconv.Itoa(version)]
 	if !ok {
-		return transitKeyVersion{}, fmt.Errorf("oidcsign: transit key has no version %d", version)
+		return transitKeyVersion{}, fmt.Errorf("remotesign: transit key has no version %d", version)
 	}
 	return v, nil
 }
@@ -391,7 +391,7 @@ func (kd *transitKeyData) creationTimeForVersion(version int) (time.Time, error)
 	}
 	t, err := time.Parse(time.RFC3339Nano, v.CreationTime)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("oidcsign: parse transit key creation_time %q: %w", v.CreationTime, err)
+		return time.Time{}, fmt.Errorf("remotesign: parse transit key creation_time %q: %w", v.CreationTime, err)
 	}
 	return t, nil
 }
@@ -399,21 +399,21 @@ func (kd *transitKeyData) creationTimeForVersion(version int) (time.Time, error)
 // ParsePublicKeyPEM decodes a PKIX PEM public key and ensures it is RSA or ECDSA.
 func ParsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
 	if pemStr == "" {
-		return nil, fmt.Errorf("oidcsign: empty public key")
+		return nil, fmt.Errorf("remotesign: empty public key")
 	}
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
-		return nil, fmt.Errorf("oidcsign: public key is not valid PEM")
+		return nil, fmt.Errorf("remotesign: public key is not valid PEM")
 	}
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("oidcsign: parse public key: %w", err)
+		return nil, fmt.Errorf("remotesign: parse public key: %w", err)
 	}
 	switch pub.(type) {
 	case *rsa.PublicKey, *ecdsa.PublicKey:
 		return pub, nil
 	default:
-		return nil, fmt.Errorf("oidcsign: unsupported public key type %T", pub)
+		return nil, fmt.Errorf("remotesign: unsupported public key type %T", pub)
 	}
 }
 
@@ -422,7 +422,7 @@ func ParsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
 func MarshalPublicKeyPEM(pub crypto.PublicKey) (string, error) {
 	der, err := x509.MarshalPKIXPublicKey(pub)
 	if err != nil {
-		return "", fmt.Errorf("oidcsign: marshal public key: %w", err)
+		return "", fmt.Errorf("remotesign: marshal public key: %w", err)
 	}
 	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})), nil
 }
@@ -435,18 +435,18 @@ func MarshalPublicKeyPEM(pub crypto.PublicKey) (string, error) {
 // uses standard base64.
 func decodeTransitSignature(sig string) ([]byte, error) {
 	if sig == "" {
-		return nil, fmt.Errorf("oidcsign: transit returned an empty signature")
+		return nil, fmt.Errorf("remotesign: transit returned an empty signature")
 	}
 	i := strings.LastIndex(sig, ":")
 	if i < 0 || i == len(sig)-1 {
-		return nil, fmt.Errorf("oidcsign: malformed transit signature")
+		return nil, fmt.Errorf("remotesign: malformed transit signature")
 	}
 	raw, err := base64.StdEncoding.DecodeString(sig[i+1:])
 	if err != nil {
-		return nil, fmt.Errorf("oidcsign: decode transit signature: %w", err)
+		return nil, fmt.Errorf("remotesign: decode transit signature: %w", err)
 	}
 	if len(raw) == 0 {
-		return nil, fmt.Errorf("oidcsign: transit returned an empty signature payload")
+		return nil, fmt.Errorf("remotesign: transit returned an empty signature payload")
 	}
 	return raw, nil
 }

--- a/internal/remotesign/transit_test.go
+++ b/internal/remotesign/transit_test.go
@@ -1,4 +1,4 @@
-package oidcsign
+package remotesign
 
 import (
 	"context"


### PR DESCRIPTION
**2 of 6.** Stacked on #562.

Pure move, no behaviour change. The remote-signing package holds no dependency on `core` and is about to gain a second caller in the credential drivers, which cannot import `core` without inverting the dependency.

`core/oidcsign` becomes `internal/remotesign`, and the rename drops the now-wrong framing: the package signs digests for whoever holds a `crypto.Signer`, and "oidcsign" named only its first caller.

The persisted `transit` backend discriminator is a string constant and is untouched, so stored issuer keys still round-trip.

## Verification

Import churn only. The issuer suites pass unchanged — that they do is the whole review.
