### PR TITLE
feat(remotesign): share one compact-JWS path between local and remote keys

### DIFF
--- a/credential/drivers/jwt_sign.go
+++ b/credential/drivers/jwt_sign.go
@@ -1,46 +1,30 @@
 package drivers
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
+
+	"github.com/stephnangue/warden/internal/remotesign"
 )
 
-// signRS256JWT signs the given header and claims as a compact RS256 JWS. It is
-// the general-purpose counterpart to the GitHub App JWT signer, used to build
-// RFC 7523 client-assertion JWTs for private_key_jwt client authentication.
+// signRS256JWT signs the given header and claims as a compact RS256 JWS with a key held
+// in this process. It is the general-purpose counterpart to the GitHub App JWT signer,
+// used to build RFC 7523 client-assertion JWTs for private_key_jwt client
+// authentication.
+//
+// The encoding and signing are delegated so that a key held here and a key held
+// elsewhere produce their assertions through one code path rather than two that can
+// drift apart: an *rsa.PrivateKey is already a crypto.Signer whose Sign, handed a plain
+// crypto.Hash, is PKCS#1 v1.5 — the same bytes this produced when it did the work
+// inline. There is no context to bind, because signing with a local key makes no call.
 func signRS256JWT(key *rsa.PrivateKey, header map[string]string, claims map[string]interface{}) (string, error) {
 	if key == nil {
 		return "", fmt.Errorf("private key not configured")
 	}
-	if header == nil {
-		header = map[string]string{}
-	}
-	header["alg"] = "RS256"
-	if header["typ"] == "" {
-		header["typ"] = "JWT"
-	}
-
-	headerJSON, err := json.Marshal(header)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal JWT header: %w", err)
-	}
-	claimsJSON, err := json.Marshal(claims)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal JWT claims: %w", err)
-	}
-
-	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
-	h := rsaSHA256Hash()
-	h.Write([]byte(signingInput))
-	signature, err := rsa.SignPKCS1v15(nil, key, rsaSHA256HashType(), h.Sum(nil))
-	if err != nil {
-		return "", fmt.Errorf("failed to sign JWT: %w", err)
-	}
-	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+	return remotesign.SignCompactJWS(context.Background(), key, "RS256", header, claims)
 }
 
 // newJTI returns a random token identifier for a client assertion.

--- a/credential/drivers/jwt_sign_test.go
+++ b/credential/drivers/jwt_sign_test.go
@@ -1,0 +1,102 @@
+package drivers
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignRS256JWT_ByteIdenticalToInlineSigning pins the one property that matters when
+// signing moves behind a shared helper: the bytes on the wire do not change. It rebuilds
+// the assertion the way this function did when it signed inline — marshal, base64url,
+// SHA-256, PKCS#1 v1.5 — and requires an exact match, so a future change to the shared
+// path that alters header handling or encoding fails here rather than at an
+// authorization server that rejects the assertion.
+func TestSignRS256JWT_ByteIdenticalToInlineSigning(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	header := map[string]string{"kid": "key-1"}
+	claims := map[string]interface{}{
+		"iss": "client-abc",
+		"sub": "client-abc",
+		"aud": "https://idp.example.com/token",
+		"jti": "fixed-jti",
+		"iat": 1700000000,
+		"exp": 1700000300,
+	}
+
+	got, err := signRS256JWT(key, header, claims)
+	require.NoError(t, err)
+
+	// The previous inline implementation, reproduced verbatim.
+	expHeader := map[string]string{"kid": "key-1", "alg": "RS256", "typ": "JWT"}
+	headerJSON, err := json.Marshal(expHeader)
+	require.NoError(t, err)
+	claimsJSON, err := json.Marshal(claims)
+	require.NoError(t, err)
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+	h := rsaSHA256Hash()
+	h.Write([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(nil, key, rsaSHA256HashType(), h.Sum(nil))
+	require.NoError(t, err)
+	want := signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+
+	assert.Equal(t, want, got)
+}
+
+// TestSignRS256JWT_VerifiesAndSetsHeader covers the assertion an authorization server
+// actually checks: a valid RS256 signature over the signing input, with alg and typ
+// present and the caller's kid preserved.
+func TestSignRS256JWT_VerifiesAndSetsHeader(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	token, err := signRS256JWT(key, map[string]string{"kid": "abc"}, map[string]interface{}{"iss": "c1"})
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	var hdr map[string]string
+	require.NoError(t, json.Unmarshal(headerJSON, &hdr))
+	assert.Equal(t, "RS256", hdr["alg"])
+	assert.Equal(t, "JWT", hdr["typ"])
+	assert.Equal(t, "abc", hdr["kid"])
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	h := crypto.SHA256.New()
+	h.Write([]byte(parts[0] + "." + parts[1]))
+	assert.NoError(t, rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, h.Sum(nil), sig))
+}
+
+// TestSignRS256JWT_DoesNotMutateCallerHeader: the helper sets alg and typ on a copy. A
+// caller reusing one header map across assertions would otherwise be handing in a map
+// that already carries the previous call's values.
+func TestSignRS256JWT_DoesNotMutateCallerHeader(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	header := map[string]string{"kid": "abc"}
+	_, err = signRS256JWT(key, header, map[string]interface{}{"iss": "c1"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"kid": "abc"}, header)
+}
+
+// TestSignRS256JWT_NilKey fails closed rather than emitting an unsigned assertion.
+func TestSignRS256JWT_NilKey(t *testing.T) {
+	_, err := signRS256JWT(nil, nil, map[string]interface{}{"iss": "c1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private key not configured")
+}

--- a/internal/remotesign/backend.go
+++ b/internal/remotesign/backend.go
@@ -15,6 +15,7 @@ package remotesign
 import (
 	"context"
 	"crypto"
+	"crypto/elliptic"
 	"errors"
 	"io"
 	"time"
@@ -68,17 +69,18 @@ type Backend interface {
 // from the core alg table by value (these are standard wire constants) to keep
 // this package free of a core import.
 type algParams struct {
-	transitKeyType string      // transit key type, e.g. "rsa-2048"
-	hashName       string      // transit hash_algorithm, e.g. "sha2-256"
-	hash           crypto.Hash // the digest the caller must have used
-	isRSA          bool
+	transitKeyType string         // transit key type, e.g. "rsa-2048"
+	hashName       string         // transit hash_algorithm, e.g. "sha2-256"
+	hash           crypto.Hash    // the digest the caller must have used
+	isRSA          bool           //
+	curve          elliptic.Curve // nil for RSA; the curve whose width an ES* signature is padded to
 }
 
 var algParamsByAlg = map[string]algParams{
 	"RS256": {transitKeyType: "rsa-2048", hashName: "sha2-256", hash: crypto.SHA256, isRSA: true},
 	"RS384": {transitKeyType: "rsa-3072", hashName: "sha2-384", hash: crypto.SHA384, isRSA: true},
-	"ES256": {transitKeyType: "ecdsa-p256", hashName: "sha2-256", hash: crypto.SHA256, isRSA: false},
-	"ES384": {transitKeyType: "ecdsa-p384", hashName: "sha2-384", hash: crypto.SHA384, isRSA: false},
+	"ES256": {transitKeyType: "ecdsa-p256", hashName: "sha2-256", hash: crypto.SHA256, isRSA: false, curve: elliptic.P256()},
+	"ES384": {transitKeyType: "ecdsa-p384", hashName: "sha2-384", hash: crypto.SHA384, isRSA: false, curve: elliptic.P384()},
 }
 
 // Signer adapts one (Backend, KeyRef) pair to crypto.Signer, so it drops into the

--- a/internal/remotesign/jws.go
+++ b/internal/remotesign/jws.go
@@ -1,0 +1,111 @@
+package remotesign
+
+import (
+	"context"
+	"crypto"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// SignCompactJWS signs header and claims as a compact JWS with the given JWS alg.
+//
+// It is written against crypto.Signer alone, so the same call serves a private key
+// held in this process and one held in a KMS: the caller picks which by choosing the
+// signer. That is the point of the helper — a caller that supports both should not
+// have two signing paths that can drift apart in header handling or encoding.
+//
+// The alg header is always set from alg (never taken from the caller's map), so the
+// header cannot disagree with the key and hash actually used.
+func SignCompactJWS(ctx context.Context, signer crypto.Signer, alg string, header map[string]string, claims map[string]interface{}) (string, error) {
+	if signer == nil {
+		return "", errors.New("remotesign: no signer")
+	}
+	p, ok := algParamsByAlg[alg]
+	if !ok {
+		return "", fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
+	}
+
+	// Copy rather than mutate: the caller's map may be reused across signatures, and
+	// silently writing alg/typ into it would make this call order-dependent.
+	hdr := make(map[string]string, len(header)+2)
+	for k, v := range header {
+		hdr[k] = v
+	}
+	hdr["alg"] = alg
+	if hdr["typ"] == "" {
+		hdr["typ"] = "JWT"
+	}
+
+	headerJSON, err := json.Marshal(hdr)
+	if err != nil {
+		return "", fmt.Errorf("remotesign: marshal JWS header: %w", err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("remotesign: marshal JWS claims: %w", err)
+	}
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+	h := p.hash.New()
+	h.Write([]byte(signingInput))
+	digest := h.Sum(nil)
+
+	// Bind the request context when the signer supports it. For a remote signer Sign
+	// is a network call, so without this it would run unbounded regardless of the
+	// caller's deadline; a local key has no such method and is unaffected.
+	if b, ok := signer.(interface {
+		WithContext(context.Context) crypto.Signer
+	}); ok && ctx != nil {
+		signer = b.WithContext(ctx)
+	}
+
+	// crypto.Signer.Sign takes the already-hashed digest and returns, for RSA, PKCS#1
+	// v1.5 bytes (opts is a plain crypto.Hash, not *rsa.PSSOptions) and, for ECDSA, an
+	// ASN.1 SEQUENCE{r,s}.
+	sig, err := signer.Sign(rand.Reader, digest, p.hash)
+	if err != nil {
+		return "", fmt.Errorf("remotesign: sign: %w", err)
+	}
+	if p.curve != nil {
+		sig, err = ecSigASN1ToJWS(sig, p.curve)
+		if err != nil {
+			return "", err
+		}
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// ecSigASN1ToJWS converts the ASN.1 SEQUENCE{r,s} that crypto.Signer produces for
+// ECDSA into the fixed-width R‖S concatenation JWS requires. The two encodings are
+// not interchangeable: a DER signature placed on the wire as-is is well-formed bytes
+// that no verifier accepts.
+func ecSigASN1ToJWS(der []byte, curve elliptic.Curve) ([]byte, error) {
+	var parsed struct{ R, S *big.Int }
+	rest, err := asn1.Unmarshal(der, &parsed)
+	if err != nil {
+		return nil, fmt.Errorf("remotesign: parse ECDSA signature: %w", err)
+	}
+	if len(rest) != 0 {
+		return nil, errors.New("remotesign: trailing bytes after ECDSA signature")
+	}
+	if parsed.R == nil || parsed.S == nil || parsed.R.Sign() <= 0 || parsed.S.Sign() <= 0 {
+		return nil, errors.New("remotesign: invalid ECDSA signature scalars")
+	}
+	n := (curve.Params().BitSize + 7) / 8
+	return append(ecCoord(parsed.R, n), ecCoord(parsed.S, n)...), nil
+}
+
+// ecCoord renders an ECDSA signature scalar as a fixed byteLen-wide big-endian slice —
+// the width JWS requires, left-padded with zeros.
+func ecCoord(n *big.Int, byteLen int) []byte {
+	b := make([]byte, byteLen)
+	n.FillBytes(b)
+	return b
+}

--- a/internal/remotesign/jws_test.go
+++ b/internal/remotesign/jws_test.go
@@ -1,0 +1,140 @@
+package remotesign
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignCompactJWS_RS256Verifies(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	token, err := SignCompactJWS(context.Background(), key, "RS256",
+		map[string]string{"kid": "k1"}, map[string]interface{}{"iss": "me"})
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	h := crypto.SHA256.New()
+	h.Write([]byte(parts[0] + "." + parts[1]))
+	require.NoError(t, rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, h.Sum(nil), sig))
+}
+
+// TestSignCompactJWS_ES256IsFixedWidthRS is the case a naive implementation gets wrong:
+// crypto.Signer returns an ASN.1 SEQUENCE{r,s} for ECDSA, but JWS requires the
+// fixed-width R‖S concatenation. Emitting the DER form produces well-formed bytes that
+// no verifier accepts, so assert both the width and that ecdsa.Verify agrees.
+func TestSignCompactJWS_ES256IsFixedWidthRS(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	token, err := SignCompactJWS(context.Background(), key, "ES256", nil, map[string]interface{}{"iss": "me"})
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	require.Len(t, sig, 64, "ES256 signature is two 32-byte scalars, not DER")
+
+	h := crypto.SHA256.New()
+	h.Write([]byte(parts[0] + "." + parts[1]))
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	assert.True(t, ecdsa.Verify(&key.PublicKey, h.Sum(nil), r, s))
+}
+
+func TestSignCompactJWS_ES384IsFixedWidthRS(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+
+	token, err := SignCompactJWS(context.Background(), key, "ES384", nil, map[string]interface{}{"iss": "me"})
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	require.Len(t, sig, 96, "ES384 signature is two 48-byte scalars")
+}
+
+// TestSignCompactJWS_AlgHeaderComesFromTheAlgArgument: a header that disagreed with the
+// key and hash actually used would be a signature no verifier can check, so the caller
+// does not get to set alg.
+func TestSignCompactJWS_AlgHeaderComesFromTheAlgArgument(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	token, err := SignCompactJWS(context.Background(), key, "RS256",
+		map[string]string{"alg": "ES256", "typ": "custom+jwt"}, map[string]interface{}{"iss": "me"})
+	require.NoError(t, err)
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(strings.Split(token, ".")[0])
+	require.NoError(t, err)
+	var hdr map[string]string
+	require.NoError(t, json.Unmarshal(headerJSON, &hdr))
+	assert.Equal(t, "RS256", hdr["alg"], "alg is taken from the argument, not the caller's header")
+	assert.Equal(t, "custom+jwt", hdr["typ"], "an explicit typ is preserved")
+}
+
+func TestSignCompactJWS_Rejects(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	_, err = SignCompactJWS(context.Background(), key, "PS256", nil, map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported signing algorithm")
+
+	_, err = SignCompactJWS(context.Background(), nil, "RS256", nil, map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no signer")
+}
+
+// ctxSigner records whether the shared path bound the caller's context before signing,
+// which is what bounds a remote signer's network call.
+type ctxSigner struct {
+	crypto.Signer
+	bound    context.Context
+	signedAt *context.Context // set to `bound` at Sign time, so the test sees what signed
+}
+
+func (s *ctxSigner) WithContext(ctx context.Context) crypto.Signer {
+	cp := *s
+	cp.bound = ctx
+	return &cp
+}
+
+func (s *ctxSigner) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	*s.signedAt = s.bound
+	return s.Signer.Sign(r, digest, opts)
+}
+
+func TestSignCompactJWS_BindsContextWhenSignerSupportsIt(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+	var signedAt context.Context
+
+	_, err = SignCompactJWS(ctx, &ctxSigner{Signer: key, signedAt: &signedAt}, "RS256", nil,
+		map[string]interface{}{"iss": "me"})
+	require.NoError(t, err)
+	require.NotNil(t, signedAt, "a signer exposing WithContext is bound before signing")
+	assert.Equal(t, "marker", signedAt.Value(ctxKey{}), "it receives the caller's own context")
+}

--- a/internal/remotesign/transit.go
+++ b/internal/remotesign/transit.go
@@ -18,8 +18,9 @@ import (
 	"github.com/stephnangue/warden/logger"
 )
 
-// backendTypeTransit is the persisted discriminator for the transit backend.
-const backendTypeTransit = "transit"
+// BackendTypeTransit is the persisted discriminator for the transit backend, and the
+// value a consumer matches on to decide which backend a chained payload describes.
+const BackendTypeTransit = "transit"
 
 // TransitConfig configures a transit-backed remote signer. It mirrors the fields
 // of the `signer "transit"` HCL stanza.
@@ -105,6 +106,30 @@ func NewTransitBackend(cfg TransitConfig, log *logger.GatedLogger) (*TransitBack
 	return b, nil
 }
 
+// NewTransitClientBackend wraps an already-authenticated client instead of building
+// one. It starts no token renewal and holds no goroutine, so a caller may build one
+// per request and discard it: the token's lifetime belongs to whoever obtained it, and
+// renewing a short-lived per-request token would be both useless and a leak. Close is
+// therefore a no-op here.
+//
+// The returned backend has no key-name prefix, so it serves only the operations that
+// take an explicit key name — Sign, PublicKey, NamedKeyInfo. EnsureKey and NewVersion
+// derive a name from an algorithm and report that they are unavailable.
+func NewTransitClientBackend(client *api.Client, mountPath string, timeout time.Duration, log *logger.GatedLogger) (*TransitBackend, error) {
+	if client == nil {
+		return nil, fmt.Errorf("remotesign: a transit client is required")
+	}
+	if strings.TrimSpace(mountPath) == "" {
+		return nil, fmt.Errorf("remotesign: transit mount_path is required")
+	}
+	return &TransitBackend{
+		client:    client,
+		mountPath: strings.Trim(mountPath, "/"),
+		timeout:   timeout,
+		log:       log,
+	}, nil
+}
+
 // startRenewal keeps a renewable token alive for the life of the backend, mirroring
 // the transit auto-seal wrapper. A non-renewable or short-lived static token simply
 // runs without a watcher; signing fails closed once it expires.
@@ -147,7 +172,7 @@ func (b *TransitBackend) startRenewal(disable bool) {
 	go watcher.Start()
 }
 
-func (b *TransitBackend) Type() string { return backendTypeTransit }
+func (b *TransitBackend) Type() string { return BackendTypeTransit }
 
 // Close stops token renewal.
 func (b *TransitBackend) Close() {
@@ -157,8 +182,13 @@ func (b *TransitBackend) Close() {
 }
 
 // keyNameFor derives the transit key name for a JWS alg, e.g. "warden-oidc-rs256".
-func (b *TransitBackend) keyNameFor(alg string) string {
-	return b.keyNamePrefix + "-" + strings.ToLower(alg)
+// A backend built around an existing client has no prefix and addresses keys by
+// explicit name, so deriving one is refused rather than producing "-rs256".
+func (b *TransitBackend) keyNameFor(alg string) (string, error) {
+	if b.keyNamePrefix == "" {
+		return "", fmt.Errorf("remotesign: this backend has no key name prefix and addresses keys by explicit name; cannot derive a key name for %s", alg)
+	}
+	return b.keyNamePrefix + "-" + strings.ToLower(alg), nil
 }
 
 // EnsureKey creates alg's key if absent (idempotent) and returns its latest version.
@@ -167,7 +197,10 @@ func (b *TransitBackend) EnsureKey(ctx context.Context, alg string) (KeyInfo, er
 	if !ok {
 		return KeyInfo{}, fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
 	}
-	name := b.keyNameFor(alg)
+	name, err := b.keyNameFor(alg)
+	if err != nil {
+		return KeyInfo{}, err
+	}
 	ctx, cancel := b.withTimeout(ctx)
 	defer cancel()
 	if _, err := b.client.Logical().WriteWithContext(ctx, b.keysPath(name), map[string]interface{}{
@@ -183,7 +216,10 @@ func (b *TransitBackend) NewVersion(ctx context.Context, alg string) (KeyInfo, e
 	if _, ok := algParamsByAlg[alg]; !ok {
 		return KeyInfo{}, fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
 	}
-	name := b.keyNameFor(alg)
+	name, err := b.keyNameFor(alg)
+	if err != nil {
+		return KeyInfo{}, err
+	}
 	ctx, cancel := b.withTimeout(ctx)
 	defer cancel()
 	if _, err := b.client.Logical().WriteWithContext(ctx, b.keysPath(name)+"/rotate", nil); err != nil {
@@ -221,6 +257,75 @@ func validateTransitKey(kd *transitKeyData, name, alg string) error {
 	}
 	if kd.Exportable {
 		return fmt.Errorf("remotesign: transit key %q is exportable; the OIDC issuer key must be non-exportable (recreate with exportable=false)", name)
+	}
+	return nil
+}
+
+// NamedKeyInfo reads a key by explicit name and returns the requested version, or the
+// latest when version is 0. Unlike latestKeyInfo it applies the relaxed compatibility
+// rules below, because the key was provisioned by an operator rather than created by
+// this package.
+//
+// Resolving "latest" to a concrete number here is deliberate: a caller that carries the
+// resolved version forward keeps signing with the version it validated, instead of
+// whatever is newest whenever the signature is eventually produced.
+func (b *TransitBackend) NamedKeyInfo(ctx context.Context, name, alg string, version int) (KeyInfo, error) {
+	if strings.TrimSpace(name) == "" {
+		return KeyInfo{}, fmt.Errorf("remotesign: a key name is required")
+	}
+	if version < 0 {
+		return KeyInfo{}, fmt.Errorf("remotesign: key version must be 0 (latest) or positive, got %d", version)
+	}
+	ctx, cancel := b.withTimeout(ctx)
+	defer cancel()
+	kd, err := b.readKey(ctx, name)
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	if err := validateKeyForAlg(kd, name, alg); err != nil {
+		return KeyInfo{}, err
+	}
+	want := version
+	if want == 0 {
+		want = kd.LatestVersion
+	}
+	pub, err := kd.publicKeyForVersion(want)
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	created, err := kd.creationTimeForVersion(want)
+	if err != nil {
+		return KeyInfo{}, err
+	}
+	return KeyInfo{
+		Ref:       KeyRef{KeyName: name, Version: want, Alg: alg},
+		Public:    pub,
+		CreatedAt: created,
+	}, nil
+}
+
+// validateKeyForAlg checks that an operator-provisioned key can sign alg. It is looser
+// than validateTransitKey, which pins an exact key type because this package created
+// that key: an RSA key of any supported size signs any RS* algorithm, so refusing
+// rsa-4096 for RS256 would reject a legitimate — indeed stronger — key. Curves stay
+// exact, since an ES256 signature only verifies against P-256.
+//
+// Non-exportability is enforced on both paths. It is the entire premise of asking a
+// remote service to sign rather than fetching the key.
+func validateKeyForAlg(kd *transitKeyData, name, alg string) error {
+	p, ok := algParamsByAlg[alg]
+	if !ok {
+		return fmt.Errorf("remotesign: unsupported signing algorithm %q", alg)
+	}
+	if p.isRSA {
+		if !strings.HasPrefix(kd.Type, "rsa-") {
+			return fmt.Errorf("remotesign: key %q has type %q and cannot sign %s; an RSA key is required", name, kd.Type, alg)
+		}
+	} else if kd.Type != p.transitKeyType {
+		return fmt.Errorf("remotesign: key %q has type %q, expected %q for %s", name, kd.Type, p.transitKeyType, alg)
+	}
+	if kd.Exportable {
+		return fmt.Errorf("remotesign: key %q is exportable; a remotely signed key must be non-exportable (recreate it with exportable=false)", name)
 	}
 	return nil
 }
@@ -281,7 +386,10 @@ func (b *TransitBackend) Sign(ctx context.Context, ref KeyRef, digest []byte, op
 
 // latestKeyInfo reads alg's key, validates it, and returns its latest version.
 func (b *TransitBackend) latestKeyInfo(ctx context.Context, alg string) (KeyInfo, error) {
-	name := b.keyNameFor(alg)
+	name, err := b.keyNameFor(alg)
+	if err != nil {
+		return KeyInfo{}, err
+	}
 	kd, err := b.readKey(ctx, name)
 	if err != nil {
 		return KeyInfo{}, err

--- a/internal/remotesign/transit_test.go
+++ b/internal/remotesign/transit_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -399,4 +400,128 @@ func TestSigner_RoutesToBackend(t *testing.T) {
 	sig, err := s.Sign(rand.Reader, digest[:], crypto.SHA256)
 	require.NoError(t, err)
 	require.NoError(t, rsa.VerifyPKCS1v15(info.Public.(*rsa.PublicKey), crypto.SHA256, digest[:], sig))
+}
+
+// newClientTestBackend builds the client-injected backend the credential drivers use:
+// an existing client, no key-name prefix, no renewal.
+func newClientTestBackend(t *testing.T, f *fakeTransit) *TransitBackend {
+	t.Helper()
+	srv := httptest.NewServer(f.handler())
+	t.Cleanup(srv.Close)
+	cfg := api.DefaultConfig()
+	cfg.Address = srv.URL
+	c, err := api.NewClient(cfg)
+	require.NoError(t, err)
+	c.SetToken("test-token")
+	b, err := NewTransitClientBackend(c, "transit", 5*time.Second, nil)
+	require.NoError(t, err)
+	t.Cleanup(b.Close)
+	return b
+}
+
+// TestTransitClientBackend_NoRenewalRequest is the property that makes this constructor
+// safe to call per request: it must not renew. The wrapped token is short-lived and
+// owned by whoever obtained it, so a renew here would be a wasted round trip and would
+// leave a watcher goroutine behind on every mint.
+func TestTransitClientBackend_NoRenewalRequest(t *testing.T) {
+	f := newFakeTransit(t)
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		f.handler().ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := api.DefaultConfig()
+	cfg.Address = srv.URL
+	c, err := api.NewClient(cfg)
+	require.NoError(t, err)
+	c.SetToken("test-token")
+
+	b, err := NewTransitClientBackend(c, "transit", 5*time.Second, nil)
+	require.NoError(t, err)
+	assert.Nil(t, b.watcher, "no lifetime watcher, so no goroutine to leak")
+	b.Close() // safe with a nil watcher
+	for _, p := range paths {
+		assert.NotContains(t, p, "auth/token/renew-self", "construction issues no renewal request")
+	}
+}
+
+func TestTransitClientBackend_RequiresClientAndMount(t *testing.T) {
+	_, err := NewTransitClientBackend(nil, "transit", 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client is required")
+
+	c, err := api.NewClient(api.DefaultConfig())
+	require.NoError(t, err)
+	_, err = NewTransitClientBackend(c, "  ", 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mount_path is required")
+}
+
+// TestTransitClientBackend_PrefixlessOpsRefused: without a prefix there is no algorithm
+// -> key-name mapping, so the deriving operations must say so rather than address a key
+// literally named "-rs256".
+func TestTransitClientBackend_PrefixlessOpsRefused(t *testing.T) {
+	f := newFakeTransit(t)
+	b := newClientTestBackend(t, f)
+
+	_, err := b.EnsureKey(context.Background(), "RS256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit name")
+
+	_, err = b.NewVersion(context.Background(), "RS256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit name")
+}
+
+// TestNamedKeyInfo_ResolvesLatestAndPinned: version 0 resolves to a concrete latest, and
+// an explicit version is honoured. Resolving to a number is what lets a caller keep
+// signing with the version it validated instead of whatever is newest later.
+func TestNamedKeyInfo_ResolvesLatestAndPinned(t *testing.T) {
+	f := newFakeTransit(t)
+	f.keys["client-assertion"] = &fakeKey{keyType: "rsa-2048",
+		versions: []crypto.Signer{genKey(t, "rsa-2048"), genKey(t, "rsa-2048")}}
+	b := newClientTestBackend(t, f)
+
+	latest, err := b.NamedKeyInfo(context.Background(), "client-assertion", "RS256", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, latest.Ref.Version, "0 resolves to the concrete latest version")
+	assert.Equal(t, "client-assertion", latest.Ref.KeyName)
+	assert.NotNil(t, latest.Public)
+
+	pinned, err := b.NamedKeyInfo(context.Background(), "client-assertion", "RS256", 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, pinned.Ref.Version)
+
+	_, err = b.NamedKeyInfo(context.Background(), "client-assertion", "RS256", 99)
+	require.Error(t, err, "a version that does not exist is refused at validation time")
+
+	_, err = b.NamedKeyInfo(context.Background(), "", "RS256", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key name is required")
+}
+
+// TestNamedKeyInfo_RelaxedRSASizeButExactCurve: the operator provisions this key, so any
+// RSA size may sign any RS* alg — refusing rsa-4096 for RS256 would reject a stronger
+// key for no reason. Curves stay exact, since ES256 only verifies against P-256.
+func TestNamedKeyInfo_RelaxedRSASizeButExactCurve(t *testing.T) {
+	f := newFakeTransit(t)
+	// A larger RSA key than the alg's nominal type, signing RS256.
+	f.keys["big-rsa"] = &fakeKey{keyType: "rsa-3072", versions: []crypto.Signer{genKey(t, "rsa-3072")}}
+	f.keys["p384"] = &fakeKey{keyType: "ecdsa-p384", versions: []crypto.Signer{genKey(t, "ecdsa-p384")}}
+	f.keys["exportable"] = &fakeKey{keyType: "rsa-2048", exportable: true,
+		versions: []crypto.Signer{genKey(t, "rsa-2048")}}
+	b := newClientTestBackend(t, f)
+
+	_, err := b.NamedKeyInfo(context.Background(), "big-rsa", "RS256", 0)
+	require.NoError(t, err, "any RSA size signs any RS* alg")
+
+	_, err = b.NamedKeyInfo(context.Background(), "p384", "ES256", 0)
+	require.Error(t, err, "the curve must match the alg exactly")
+	assert.Contains(t, err.Error(), "expected")
+
+	_, err = b.NamedKeyInfo(context.Background(), "exportable", "RS256", 0)
+	require.Error(t, err, "non-exportability is the premise of remote signing")
+	assert.Contains(t, err.Error(), "exportable")
 }


### PR DESCRIPTION
**3 of 6.** Stacked on #563.

Adds `SignCompactJWS`, written against `crypto.Signer` alone, so a key held in this process and a key held in a KMS produce their assertions through the same code instead of two paths that can drift apart in header handling or encoding. It carries the ES\* conversion from the ASN.1 `SEQUENCE{r,s}` that `crypto.Signer` returns to the fixed-width `R‖S` that JWS requires — bytes that are well-formed either way, but that only verify in one of them.

`signRS256JWT` now delegates to it. A test pins the output byte-identical to the previous inline implementation, since the observable contract is what an authorization server accepts.

Also prepares the transit backend for callers that address keys by name:

- `NewTransitClientBackend` wraps an existing client, starts no renewal and holds no goroutine, so it can be built per request and discarded.
- `NamedKeyInfo` reads a key by explicit name and resolves version 0 to a concrete latest, so a caller keeps signing with the version it validated.
- Key/alg compatibility is relaxed for operator-provisioned keys: any RSA size signs any RS\* alg. Curves stay exact, and non-exportability is still enforced.

No behaviour change for the issuer: it keeps its own strict validation and its prefix-derived key names.
