### PR TITLE
feat(hvault): mint a scoped signing capability instead of handing out a key

### DIFF
--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -251,6 +251,10 @@ func (f *VaultDriverFactory) InferCredentialType(specConfig map[string]string) (
 		return credential.TypeOAuthBearerToken, nil
 	case "vault_token", "":
 		return credential.TypeVaultToken, nil
+	case mintMethodTransitSigner:
+		// A multi-field payload with no single primary field, which is what makes a
+		// consumer read it by name rather than having one value picked out for it.
+		return credential.TypeKeyValue, nil
 	default:
 		return "", fmt.Errorf("cannot infer credential type for mint_method %q", mintMethod)
 	}
@@ -373,8 +377,15 @@ func (d *VaultDriver) MintCredential(ctx context.Context, spec *credential.CredS
 		// credential_name here fails closed in resolveClaimTemplate (nothing to
 		// satisfy {{user.…}} or {{agent.…}} with).
 		return d.fetchOAuth2Creds(ctx, d.vault, spec, nil, nil)
+	case mintMethodTransitSigner:
+		// Refused rather than served from the shared source session: the capability is
+		// minted as the caller so it can be pinned to a narrow per-caller role, and the
+		// signing key stays reachable by nothing that outlives the request.
+		return nil, nil, 0, "", fmt.Errorf(
+			"vault: mint_method=%s requires auth_method=%s on the source and subject_token_source on the spec, so the capability is minted as the caller",
+			mintMethodTransitSigner, vaultAuthMethodOIDCFederation)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'kv2_read', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for Vault driver; supported: 'static_aws', 'static_apikey', 'kv2_read', 'dynamic_aws', 'dynamic_gcp', 'dynamic_ibm', 'vault_token', 'oauth2', 'transit_signer'", mintMethod)
 	}
 }
 
@@ -400,14 +411,22 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 	if inputs == nil || inputs.SubjectToken == "" {
 		return nil, nil, 0, "", fmt.Errorf("vault: no subject token in exchange inputs")
 	}
+	mintMethod := credential.GetString(spec.Config, "mint_method", "")
+
+	// Checked BEFORE logging in, not inside the mint: the login is what obtains the
+	// token, so a check that ran afterwards would already have minted one under
+	// whatever role the source names — the broad token this requirement exists to
+	// prevent — and only then refused to use it.
+	if err := validateTransitSignerSpec(mintMethod, spec); err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	// Exchange the assertion for a per-request Vault token on an isolated client.
 	client, loginAuth, err := d.loginViaJWT(ctx, spec, inputs.SubjectToken)
 	if err != nil {
 		return nil, nil, 0, "", err
 	}
 	loginTTL := time.Duration(loginAuth.LeaseDuration) * time.Second
-
-	mintMethod := credential.GetString(spec.Config, "mint_method", "")
 
 	// The JWT-login token itself is the credential — never revoke it here.
 	if mintMethod == "vault_token" {
@@ -443,6 +462,12 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 		return rawData, metadata, loginTTL, "", nil
 	}
 
+	// Like vault_token, the login token is itself the credential — it carries the
+	// capability — so this returns before the revoke-on-exit paths below.
+	if mintMethod == mintMethodTransitSigner {
+		return d.mintTransitSigner(ctx, client, spec, loginAuth, loginTTL, inputs.UserClaims, inputs.AgentClaims)
+	}
+
 	// Downstream engines: broker with the per-request login token.
 	var (
 		rawData  map[string]interface{}
@@ -464,7 +489,7 @@ func (d *VaultDriver) MintCredentialWithExchange(ctx context.Context, spec *cred
 	case "oauth2":
 		rawData, metadata, leaseTTL, _, err = d.fetchOAuth2Creds(ctx, client, spec, inputs.UserClaims, inputs.AgentClaims)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("vault: mint_method %q is not supported over auth_method=%s (supported: vault_token, static_aws, static_apikey, kv2_read, dynamic_aws, dynamic_gcp, dynamic_ibm, oauth2)", mintMethod, vaultAuthMethodOIDCFederation)
+		return nil, nil, 0, "", fmt.Errorf("vault: mint_method %q is not supported over auth_method=%s (supported: vault_token, transit_signer, static_aws, static_apikey, kv2_read, dynamic_aws, dynamic_gcp, dynamic_ibm, oauth2)", mintMethod, vaultAuthMethodOIDCFederation)
 	}
 	if err != nil {
 		return nil, nil, 0, "", err

--- a/credential/drivers/vault_transit_signer.go
+++ b/credential/drivers/vault_transit_signer.go
@@ -1,0 +1,246 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/internal/remotesign"
+	"github.com/stephnangue/warden/logger"
+)
+
+// mintMethodTransitSigner mints a scoped signing capability rather than a secret: a
+// short-lived token that may do nothing but sign with one named key, plus the
+// coordinates naming that key. A consumer chains it and asks the store to sign, so the
+// private key is read by nobody — including Warden.
+const mintMethodTransitSigner = "transit_signer"
+
+// defaultTransitMount is the conventional mount path for a transit engine.
+const defaultTransitMount = "transit"
+
+// defaultSigningAlg is the algorithm assumed when a spec names none. RS256 is the one
+// algorithm essentially every authorization server accepts for client assertions.
+const defaultSigningAlg = "RS256"
+
+// transitSignerPayloadPrefix marks spec-config keys carried verbatim into the minted
+// payload. What travels there means something only to the consumer — the OAuth client
+// the key is registered to, a key id an authorization server selects on — so this
+// driver copies it without interpreting it, rather than growing config keys for a
+// protocol it does not speak.
+const transitSignerPayloadPrefix = "payload."
+
+// mintTransitSigner builds the signing capability. The login token IS the credential,
+// as with a plain token mint, so it is never revoked here: the consumer needs it live
+// for as long as it holds the material.
+//
+// Every coordinate is resolved and checked now, against the real key, so a
+// misconfiguration surfaces here naming the key and its actual type — rather than much
+// later as an assertion the authorization server rejects for reasons it will not
+// explain.
+func (d *VaultDriver) mintTransitSigner(
+	ctx context.Context,
+	client *api.Client,
+	spec *credential.CredSpec,
+	loginAuth *api.SecretAuth,
+	loginTTL time.Duration,
+	userClaims, agentClaims map[string]string,
+) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	keyName, err := resolveClaimTemplate(credential.GetString(spec.Config, "transit_key", ""),
+		userClaims, agentClaims, "transit_key")
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	if keyName == "" {
+		return nil, nil, 0, "", fmt.Errorf("vault: transit_key is required for mint_method=%s", mintMethodTransitSigner)
+	}
+	mount := credential.GetString(spec.Config, "transit_mount", defaultTransitMount)
+	alg := credential.GetString(spec.Config, "signing_alg", defaultSigningAlg)
+
+	version, err := transitSignerVersion(spec.Config)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	// Timeout 0 inherits this request's deadline, which is the right bound: the
+	// capability is being minted for this mint and nothing else.
+	backend, err := remotesign.NewTransitClientBackend(client, mount, 0, d.logger)
+	if err != nil {
+		return nil, nil, 0, "", fmt.Errorf("vault: %w", err)
+	}
+	defer backend.Close()
+
+	// Reads the key, checks it can sign alg, checks it is non-exportable, and resolves
+	// "latest" to a concrete number.
+	info, err := backend.NamedKeyInfo(ctx, keyName, alg, version)
+	if err != nil {
+		return nil, nil, 0, "", fmt.Errorf("vault: signing key %q is unusable for %s: %w", keyName, alg, err)
+	}
+
+	payload, err := transitSignerPayloadFields(spec.Config, userClaims, agentClaims)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	if payload["client_id"] == "" {
+		return nil, nil, 0, "", fmt.Errorf(
+			"vault: mint_method=%s requires %sclient_id on the spec: the consumer names the client its assertion is for, and this driver only carries that name",
+			mintMethodTransitSigner, transitSignerPayloadPrefix)
+	}
+
+	// A key id the operator did not set is derived from the key and the exact version
+	// that will sign, so it always names the public half the authorization server has
+	// to hold. Derived after resolution, so a templated key yields a per-caller id.
+	if payload["kid"] == "" {
+		payload["kid"] = fmt.Sprintf("%s-v%d", info.Ref.KeyName, info.Ref.Version)
+	}
+
+	if loginTTL <= 0 {
+		// A role issuing a token with no expiry: give the cache layer a positive
+		// lifetime rather than a zero, which would read as "static" and never refresh.
+		loginTTL = 1 * time.Hour
+	}
+	if spec.MaxTTL > 0 && loginTTL > spec.MaxTTL {
+		loginTTL = spec.MaxTTL
+	}
+
+	rawData := map[string]interface{}{
+		"kms_backend":         remotesign.BackendTypeTransit,
+		"vault_token":         loginAuth.ClientToken,
+		"vault_address":       credential.GetString(d.credSource.Config, "vault_address", ""),
+		"transit_mount":       mount,
+		"transit_key":         info.Ref.KeyName,
+		"transit_key_version": strconv.Itoa(info.Ref.Version),
+		"signing_alg":         alg,
+		// Lets the consumer skip a round trip it already knows will fail, and tell a
+		// spent capability apart from a broken one.
+		"token_expires_at": time.Now().Add(loginTTL).UTC().Format(time.RFC3339),
+	}
+	if ns := credential.GetString(d.credSource.Config, "vault_namespace", ""); ns != "" {
+		rawData["vault_namespace"] = ns
+	}
+	for k, v := range payload {
+		rawData[k] = v
+	}
+
+	// Warden cannot prove the role's policy is as narrow as it should be: a policy is a
+	// name here, and enforcing what is behind it belongs to the store. Recording what
+	// the login actually granted at least makes a too-broad role visible in an audit
+	// log rather than nowhere at all.
+	// A token issued without an accessor is not tracked in the store and cannot be
+	// revoked or renewed — the cheap, self-expiring shape this capability wants, since
+	// it is minted per request and deliberately never revoked. One issued WITH an
+	// accessor is persisted instead, so every mint becomes a storage write the store
+	// must later clean up.
+	//
+	// This is recorded rather than enforced. What actually bounds the capability is the
+	// role's policy, not the token's shape: with only sign and key-read granted, a
+	// tracked token is no more useful to a thief than an untracked one. The cost is
+	// operational, so it is the operator's to weigh — but not silently.
+	//
+	// Every value is a string: credential metadata is flattened to strings on parse, so
+	// a slice or a number here fails the mint outright rather than being coerced.
+	batch := loginAuth.Accessor == ""
+	metadata := map[string]interface{}{
+		"role":                d.effectiveJWTRole(spec),
+		"policies":            strings.Join(loginAuth.Policies, ","),
+		"transit_key":         info.Ref.KeyName,
+		"transit_key_version": strconv.Itoa(info.Ref.Version),
+		"tracked_token":       strconv.FormatBool(!batch),
+	}
+	if loginAuth.Accessor != "" {
+		metadata["accessor"] = loginAuth.Accessor
+	}
+
+	if d.logger != nil {
+		if !batch {
+			d.logger.Warn("signing capability minted as a tracked token",
+				logger.String("spec", spec.Name),
+				logger.String("jwt_role", d.effectiveJWTRole(spec)),
+				logger.String("detail", "this capability is minted per request and never revoked, so each one is a stored token left to expire; token_type=batch on the role avoids the write"),
+			)
+		}
+		d.logger.Debug("minted a scoped signing capability",
+			logger.String("spec", spec.Name),
+			logger.String("jwt_role", d.effectiveJWTRole(spec)),
+			logger.String("transit_key", info.Ref.KeyName),
+			logger.Int("key_version", info.Ref.Version),
+			logger.Bool("batch_token", batch),
+			logger.String("ttl", loginTTL.String()),
+		)
+	}
+
+	return rawData, metadata, loginTTL, "", nil
+}
+
+// transitSignerVersion reads an optional pinned key version. Absent means "resolve the
+// latest at mint time"; either way the resolved number is what travels, never "latest",
+// so a held capability keeps signing with the version it was checked against instead of
+// whatever happens to be newest when it eventually signs.
+func transitSignerVersion(config map[string]string) (int, error) {
+	raw := strings.TrimSpace(credential.GetString(config, "transit_key_version", ""))
+	if raw == "" {
+		return 0, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 1 {
+		return 0, fmt.Errorf("vault: transit_key_version must be a positive integer, got %q", raw)
+	}
+	return v, nil
+}
+
+// validateTransitSignerSpec checks what must hold before a login is attempted. It is a
+// no-op for every other mint method.
+//
+// The capability's entire value is that it can do nothing but sign. Inheriting the
+// source's role would hand the consumer whatever that role grants — quietly, and with
+// broader reach than the key material this replaces, which would make the feature worse
+// than storing the key. So the narrow role is required on the spec, and required here,
+// before the login that would otherwise have already obtained the broad token.
+func validateTransitSignerSpec(mintMethod string, spec *credential.CredSpec) error {
+	if mintMethod != mintMethodTransitSigner {
+		return nil
+	}
+	if credential.GetString(spec.Config, "jwt_role", "") == "" {
+		return fmt.Errorf(
+			"vault: mint_method=%s requires a spec-level jwt_role naming a role whose policy grants only signing with the key; inheriting the source's role would mint a broader capability than the key it replaces",
+			mintMethodTransitSigner)
+	}
+	return nil
+}
+
+// transitSignerCoordinates are the payload names this driver writes itself. The
+// passthrough bag may not use them: stripped of its prefix, payload.vault_token would
+// land on the same key as the capability's real token and, being merged second, would
+// replace it — sending the capability somewhere else, or spending a token that is not
+// the one this mint obtained.
+var transitSignerCoordinates = map[string]struct{}{
+	"kms_backend": {}, "vault_token": {}, "vault_address": {}, "vault_namespace": {},
+	"transit_mount": {}, "transit_key": {}, "transit_key_version": {},
+	"signing_alg": {}, "token_expires_at": {},
+}
+
+// transitSignerPayloadFields collects the payload.* passthrough bag with its prefix
+// stripped. Values may be claim-templated, so one spec can front a different client and
+// a different key per caller.
+//
+// A name the driver writes itself is refused rather than dropped: silently ignoring it
+// would leave an operator with a spec that reads as though it set something.
+func transitSignerPayloadFields(config map[string]string, userClaims, agentClaims map[string]string) (map[string]string, error) {
+	out := map[string]string{}
+	for k, v := range credential.GetPrefixed(config, transitSignerPayloadPrefix) {
+		if _, reserved := transitSignerCoordinates[k]; reserved {
+			return nil, fmt.Errorf(
+				"vault: %s%s is not allowed: %q is part of the signing capability this mint writes, and carrying one here would replace it",
+				transitSignerPayloadPrefix, k, k)
+		}
+		resolved, err := resolveClaimTemplate(v, userClaims, agentClaims, transitSignerPayloadPrefix+k)
+		if err != nil {
+			return nil, err
+		}
+		out[k] = resolved
+	}
+	return out, nil
+}

--- a/credential/drivers/vault_transit_signer_test.go
+++ b/credential/drivers/vault_transit_signer_test.go
@@ -1,0 +1,352 @@
+package drivers
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signerKey is one key the fake store holds, with a public half a read returns.
+type signerKey struct {
+	keyType    string
+	exportable bool
+	versions   int
+}
+
+// transitSignerServer stands in for the store: a JWT login plus a transit key read. It
+// records the login body and the token presented on the key read, which is how the
+// tests check that the capability was minted under the spec's narrow role and used with
+// the token that role issued.
+type transitSignerServer struct {
+	keys           map[string]signerKey
+	loginBody      map[string]interface{}
+	keyReadToken   string
+	keyReadPath    string
+	loginTTLSecond int
+	// suppressAccessor models a role issuing untracked (batch) tokens, which carry no
+	// accessor because the store never persists them.
+	suppressAccessor bool
+}
+
+func newTransitSignerServer(t *testing.T, keys map[string]signerKey) (*transitSignerServer, string) {
+	t.Helper()
+	s := &transitSignerServer{keys: keys, loginTTLSecond: 900}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/auth/jwt/login" {
+			_ = json.NewDecoder(r.Body).Decode(&s.loginBody)
+			auth := map[string]interface{}{
+				"client_token":   "hvs.capability",
+				"accessor":       "acc-9",
+				"lease_duration": s.loginTTLSecond,
+				"policies":       []string{"default", "warden-tx-signer"},
+			}
+			if s.suppressAccessor {
+				delete(auth, "accessor")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"auth": auth})
+			return
+		}
+		if name, ok := trimPrefixOK(r.URL.Path, "/v1/transit/keys/"); ok {
+			s.keyReadToken = r.Header.Get("X-Vault-Token")
+			s.keyReadPath = r.URL.Path
+			k, found := s.keys[name]
+			if !found {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"errors": []string{"no such key"}})
+				return
+			}
+			versions := map[string]interface{}{}
+			for i := 1; i <= k.versions; i++ {
+				versions[strconv.Itoa(i)] = map[string]interface{}{
+					"public_key":    testPubPEM(t, k.keyType),
+					"creation_time": time.Now().UTC().Format(time.RFC3339Nano),
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+				"type":           k.keyType,
+				"exportable":     k.exportable,
+				"latest_version": k.versions,
+				"keys":           versions,
+			}})
+			return
+		}
+		http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return s, srv.URL
+}
+
+func trimPrefixOK(s, prefix string) (string, bool) {
+	if len(s) > len(prefix) && s[:len(prefix)] == prefix {
+		return s[len(prefix):], true
+	}
+	return "", false
+}
+
+func testPubPEM(t *testing.T, keyType string) string {
+	t.Helper()
+	var pub interface{}
+	switch keyType {
+	case "ecdsa-p256":
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub = &k.PublicKey
+	case "ecdsa-p384":
+		k, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		require.NoError(t, err)
+		pub = &k.PublicKey
+	default:
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		pub = &k.PublicKey
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func transitSignerSpec(cfg map[string]string) *credential.CredSpec {
+	base := map[string]string{
+		"mint_method":       "transit_signer",
+		"jwt_role":          "warden-transit-signer",
+		"transit_key":       "client-assertion",
+		"payload.client_id": "warden-gateway",
+	}
+	for k, v := range cfg {
+		if v == "" {
+			delete(base, k)
+			continue
+		}
+		base[k] = v
+	}
+	return &credential.CredSpec{Name: "signer", Config: base}
+}
+
+func TestTransitSigner_MintsScopedCapability(t *testing.T) {
+	srv, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 3},
+	})
+	driver := federationDriver(t, url)
+
+	rawData, metadata, ttl, leaseID, err := driver.MintCredentialWithExchange(
+		context.TODO(), transitSignerSpec(nil), verifiedInputs())
+	require.NoError(t, err)
+
+	// The capability is minted under the SPEC's narrow role, not the source's broad
+	// one — the whole security argument for the feature.
+	assert.Equal(t, "warden-transit-signer", srv.loginBody["role"])
+	assert.Equal(t, "hvs.capability", srv.keyReadToken, "the key is read with the token that role issued")
+
+	assert.Equal(t, "transit", rawData["kms_backend"])
+	assert.Equal(t, "hvs.capability", rawData["vault_token"])
+	assert.Equal(t, url, rawData["vault_address"])
+	assert.Equal(t, "transit", rawData["transit_mount"])
+	assert.Equal(t, "client-assertion", rawData["transit_key"])
+	assert.Equal(t, "RS256", rawData["signing_alg"])
+	assert.Equal(t, "warden-gateway", rawData["client_id"], "payload.* travels unprefixed")
+
+	// "Latest" is resolved to a concrete number here, so the held capability keeps
+	// signing with the version that was validated rather than whatever is newest when
+	// it eventually signs.
+	assert.Equal(t, "3", rawData["transit_key_version"])
+	assert.Equal(t, "client-assertion-v3", rawData["kid"], "kid names the exact version that will sign")
+	assert.NotEmpty(t, rawData["token_expires_at"])
+
+	assert.Equal(t, 900*time.Second, ttl, "the capability lives exactly as long as its token")
+	assert.Empty(t, leaseID, "nothing to revoke: the token expires on its own")
+
+	// What the role actually granted is recorded, since Warden cannot prove the policy
+	// behind the name is as narrow as it should be.
+	assert.Equal(t, "warden-transit-signer", metadata["role"])
+	// Strings throughout: credential metadata is flattened to strings on parse, so a
+	// slice or a number here would fail the mint rather than be coerced.
+	assert.Equal(t, "default,warden-tx-signer", metadata["policies"])
+	assert.Equal(t, "3", metadata["transit_key_version"])
+}
+
+// TestTransitSigner_RequiresSpecLevelRole is the guard that keeps the feature from
+// being worse than what it replaces: inheriting the source's broad role would mint a
+// capability with more reach than the private key it removes.
+func TestTransitSigner_RequiresSpecLevelRole(t *testing.T) {
+	_, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 1},
+	})
+	driver := federationDriver(t, url)
+
+	_, _, _, _, err := driver.MintCredentialWithExchange(
+		context.TODO(), transitSignerSpec(map[string]string{"jwt_role": ""}), verifiedInputs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec-level jwt_role")
+	assert.Contains(t, err.Error(), "broader capability")
+}
+
+func TestTransitSigner_PinnedVersionAndExplicitKid(t *testing.T) {
+	_, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 4},
+	})
+	driver := federationDriver(t, url)
+
+	rawData, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(),
+		transitSignerSpec(map[string]string{"transit_key_version": "2", "payload.kid": "operator-chosen"}),
+		verifiedInputs())
+	require.NoError(t, err)
+	assert.Equal(t, "2", rawData["transit_key_version"])
+	assert.Equal(t, "operator-chosen", rawData["kid"], "an explicit kid wins over the derived one")
+}
+
+func TestTransitSigner_RejectsUnusableKeys(t *testing.T) {
+	_, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 2},
+		"exportable-key":   {keyType: "rsa-2048", versions: 1, exportable: true},
+		"ec-key":           {keyType: "ecdsa-p384", versions: 1},
+	})
+	driver := federationDriver(t, url)
+
+	cases := []struct {
+		name   string
+		cfg    map[string]string
+		errMsg string
+	}{
+		{"unknown key", map[string]string{"transit_key": "nope"}, "unusable"},
+		{"exportable key", map[string]string{"transit_key": "exportable-key"}, "exportable"},
+		{"curve does not match alg", map[string]string{"transit_key": "ec-key", "signing_alg": "ES256"}, "expected"},
+		{"version beyond latest", map[string]string{"transit_key_version": "9"}, "unusable"},
+		{"non-numeric version", map[string]string{"transit_key_version": "latest"}, "positive integer"},
+		{"missing client id", map[string]string{"payload.client_id": ""}, "payload.client_id"},
+		{"missing key name", map[string]string{"transit_key": ""}, "transit_key is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, err := driver.MintCredentialWithExchange(
+				context.TODO(), transitSignerSpec(tc.cfg), verifiedInputs())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
+// TestTransitSigner_TemplatedPerCaller: one source and one spec front a different client
+// and a different non-exportable key per agent.
+func TestTransitSigner_TemplatedPerCaller(t *testing.T) {
+	_, url := newTransitSignerServer(t, map[string]signerKey{
+		"tx-agent-7": {keyType: "rsa-2048", versions: 1},
+	})
+	driver := federationDriver(t, url)
+
+	inputs := verifiedInputs()
+	inputs.AgentClaims = map[string]string{"sub": "agent-7"}
+
+	rawData, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(),
+		transitSignerSpec(map[string]string{
+			"transit_key":       "tx-{{agent.sub}}",
+			"payload.client_id": "client-{{agent.sub}}",
+		}), inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "tx-agent-7", rawData["transit_key"])
+	assert.Equal(t, "client-agent-7", rawData["client_id"])
+	assert.Equal(t, "tx-agent-7-v1", rawData["kid"], "a templated key yields a per-caller kid")
+}
+
+// TestTransitSigner_RefusedOffTheExchangePath: the capability is minted as the caller so
+// it can be pinned to a narrow per-caller role. Served from the shared source session it
+// would be neither.
+func TestTransitSigner_RefusedOffTheExchangePath(t *testing.T) {
+	_, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 1},
+	})
+	driver := federationDriver(t, url)
+
+	_, _, _, _, err := driver.MintCredential(context.TODO(), transitSignerSpec(nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "oidc_federation")
+}
+
+func TestTransitSigner_InfersKeyValueType(t *testing.T) {
+	f := &VaultDriverFactory{}
+	typ, err := f.InferCredentialType(map[string]string{"mint_method": "transit_signer"})
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeKeyValue, typ)
+}
+
+// TestTransitSigner_RecordsWhetherTheTokenIsTracked: an accessor means the store
+// persisted the token, so each mint leaves one behind to expire. Warden records that
+// rather than refusing it — the role's policy, not the token's shape, is what bounds
+// the capability — but it must not pass unnoticed.
+func TestTransitSigner_RecordsWhetherTheTokenIsTracked(t *testing.T) {
+	keys := map[string]signerKey{"client-assertion": {keyType: "rsa-2048", versions: 1}}
+
+	t.Run("untracked token", func(t *testing.T) {
+		srv, url := newTransitSignerServer(t, keys)
+		srv.suppressAccessor = true
+		driver := federationDriver(t, url)
+
+		_, metadata, _, _, err := driver.MintCredentialWithExchange(
+			context.TODO(), transitSignerSpec(nil), verifiedInputs())
+		require.NoError(t, err)
+		assert.Equal(t, "false", metadata["tracked_token"])
+		assert.NotContains(t, metadata, "accessor", "an untracked token has none to record")
+	})
+
+	t.Run("tracked token still mints", func(t *testing.T) {
+		_, url := newTransitSignerServer(t, keys)
+		driver := federationDriver(t, url)
+
+		_, metadata, _, _, err := driver.MintCredentialWithExchange(
+			context.TODO(), transitSignerSpec(nil), verifiedInputs())
+		require.NoError(t, err, "a tracked token is an operational cost, not an error")
+		assert.Equal(t, "true", metadata["tracked_token"])
+		assert.Equal(t, "acc-9", metadata["accessor"])
+	})
+}
+
+// TestTransitSigner_RejectsReservedPayloadNames: the bag is merged into the payload
+// after the coordinates are written, so a name the driver owns would replace the real
+// one — pointing the consumer at another address, or handing it a token this mint never
+// obtained. Refused rather than dropped, so the spec cannot read as though it took.
+func TestTransitSigner_RejectsReservedPayloadNames(t *testing.T) {
+	_, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 1},
+	})
+	driver := federationDriver(t, url)
+
+	for _, key := range []string{"vault_token", "vault_address", "kms_backend", "transit_key", "transit_key_version", "signing_alg", "token_expires_at"} {
+		t.Run(key, func(t *testing.T) {
+			_, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(),
+				transitSignerSpec(map[string]string{"payload." + key: "attacker-supplied"}), verifiedInputs())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "payload."+key)
+			assert.Contains(t, err.Error(), "would replace it")
+		})
+	}
+}
+
+// TestTransitSigner_RoleCheckedBeforeLogin: the requirement exists to stop a broad token
+// ever being minted, so it has to run before the login that would mint one. A check that
+// ran inside the mint would refuse the capability only after obtaining it.
+func TestTransitSigner_RoleCheckedBeforeLogin(t *testing.T) {
+	srv, url := newTransitSignerServer(t, map[string]signerKey{
+		"client-assertion": {keyType: "rsa-2048", versions: 1},
+	})
+	driver := federationDriver(t, url)
+
+	_, _, _, _, err := driver.MintCredentialWithExchange(context.TODO(),
+		transitSignerSpec(map[string]string{"jwt_role": ""}), verifiedInputs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec-level jwt_role")
+	assert.Nil(t, srv.loginBody, "no login was attempted, so no token was minted under the source's broad role")
+}

--- a/credential/types/key_value.go
+++ b/credential/types/key_value.go
@@ -39,8 +39,8 @@ func (t *KeyValueCredType) Metadata() credential.TypeMetadata {
 func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("mint_method").
-			OneOf("kv2_read").
-			Describe("Mint method (kv2_read reads a Vault KV v2 secret)").
+			OneOf("kv2_read", "transit_signer").
+			Describe("Mint method (kv2_read reads a Vault KV v2 secret; transit_signer mints a scoped signing capability)").
 			Example("kv2_read"),
 
 		credential.StringField("kv2_mount").
@@ -73,14 +73,31 @@ func (t *KeyValueCredType) ValidateConfig(config map[string]string, sourceType s
 		return err
 	}
 
-	if config["mint_method"] != "kv2_read" {
-		return fmt.Errorf("'mint_method' must be 'kv2_read' for a key_value credential, got: %s", config["mint_method"])
-	}
-	if config["kv2_mount"] == "" {
-		return fmt.Errorf("'kv2_mount' is required for mint_method=kv2_read")
-	}
-	if config["secret_path"] == "" {
-		return fmt.Errorf("'secret_path' is required for mint_method=kv2_read")
+	// Both mint methods produce a multi-field payload with no primary field, which is
+	// what this type exists to carry. What they need from the config differs entirely,
+	// so each states its own requirements; the driver checks the rest against the
+	// store, where a locator can actually be resolved.
+	switch config["mint_method"] {
+	case "kv2_read":
+		if config["kv2_mount"] == "" {
+			return fmt.Errorf("'kv2_mount' is required for mint_method=kv2_read")
+		}
+		if config["secret_path"] == "" {
+			return fmt.Errorf("'secret_path' is required for mint_method=kv2_read")
+		}
+	case "transit_signer":
+		if config["transit_key"] == "" {
+			return fmt.Errorf("'transit_key' is required for mint_method=transit_signer")
+		}
+		// Checked here as well as at mint time so the mistake surfaces when the spec is
+		// written, rather than on the first request that needs it. A spec without its
+		// own role would otherwise inherit the source's, which is the one thing this
+		// mint method must never do.
+		if config["jwt_role"] == "" {
+			return fmt.Errorf("'jwt_role' is required for mint_method=transit_signer: it must name a role whose policy grants only signing with the key, and inheriting the source's role would grant more")
+		}
+	default:
+		return fmt.Errorf("'mint_method' must be 'kv2_read' or 'transit_signer' for a key_value credential, got: %s", config["mint_method"])
 	}
 
 	return nil

--- a/credential/types/key_value_test.go
+++ b/credential/types/key_value_test.go
@@ -29,6 +29,38 @@ func TestKeyValueCredType_ValidateConfig(t *testing.T) {
 		errMsg     string
 	}{
 		{
+			// The narrow role is mandatory: without its own, the spec would inherit the
+			// source's, which is the one thing this mint method must not do.
+			name:       "transit_signer without a role",
+			config:     map[string]string{"mint_method": "transit_signer", "transit_key": "k"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "'jwt_role' is required",
+		},
+		{
+			// transit_signer produces the same multi-field, no-primary-field payload
+			// this type exists to carry, but needs none of the kv2 locators.
+			name:       "valid transit_signer",
+			config:     map[string]string{"mint_method": "transit_signer", "transit_key": "client-assertion", "jwt_role": "warden-transit-signer"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
+		},
+		{
+			name:       "transit_signer without a key",
+			config:     map[string]string{"mint_method": "transit_signer", "jwt_role": "r"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "'transit_key' is required",
+		},
+		{
+			// The kv2 locators belong to kv2_read alone; requiring them of every mint
+			// method is what kept transit_signer from being expressible at all.
+			name:       "transit_signer needs no kv2 locators",
+			config:     map[string]string{"mint_method": "transit_signer", "transit_key": "k", "jwt_role": "r", "kv2_mount": "", "secret_path": ""},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    false,
+		},
+		{
 			name:       "valid kv2_read",
 			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
 			sourceType: credential.SourceTypeVault,


### PR DESCRIPTION
**4 of 6.** Stacked on #564.

Adds `mint_method=transit_signer`. It mints a capability rather than a secret: a short-lived token that can do nothing but sign with one named key, plus the coordinates naming that key. A consumer chains it and asks the store to sign, so the private key is read by nobody — Warden included.

Available only over the exchange path, so the capability is minted as the caller and can be pinned to a narrow per-caller role. A spec-level `jwt_role` is mandatory here, unlike everywhere else it is optional: inheriting the source's role would quietly mint a token with more reach than the key material this replaces, which is the one outcome that would make the feature worse than doing nothing. It is checked before the login, and again at spec-write time, so the mistake cannot mint a broad token on its way to being refused.

The key is read and checked at mint — right type for the algorithm, non-exportable, version present — so a misconfiguration surfaces naming the key and its actual type, rather than later as an assertion an authorization server rejects without saying why. "Latest" is resolved to a concrete version and that number is what travels.

Two things Warden cannot enforce are recorded instead of ignored: the policies the login actually granted, and whether the token is tracked by the store. A tracked token still works — the policy, not the token's shape, is what bounds the capability — but each mint then leaves a stored token behind to expire.

Consumer-facing values (the OAuth client the key belongs to, an optional kid) travel in a `payload.*` passthrough bag copied verbatim. They mean nothing to this driver, and naming them in its config would put another protocol's vocabulary in a store driver. Names the driver writes itself are refused in the bag, since merging happens second and would otherwise replace the real coordinates. Values are claim-templatable, so one source and one spec can front a different client and a different key per agent.
