### PR TITLE
feat(token_exchange): authenticate with a client key Warden never holds

### DIFF
--- a/credential/drivers/token_exchange_driver.go
+++ b/credential/drivers/token_exchange_driver.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/helper"
+	"github.com/stephnangue/warden/internal/remotesign"
 	"github.com/stephnangue/warden/logger"
 )
 
@@ -37,11 +40,17 @@ func TokenExchangeSupportsActor(sourceCfg map[string]string) bool {
 }
 
 // Client-authentication methods selected by the source's `client_auth` config.
-// private_key_jwt is added in a later change; the secret methods ship here.
+//
+// kms_private_key_jwt puts the same assertion on the wire as private_key_jwt — the
+// authorization server cannot tell them apart — but the key is held in a KMS and Warden
+// never sees it. It is a separate method rather than a modifier because the two are
+// configured from opposite ends: one takes a key, the other takes a reference to a
+// capability, and nothing an operator sets for one is meaningful for the other.
 const (
-	clientAuthSecretBasic   = "client_secret_basic"
-	clientAuthSecretPost    = "client_secret_post"
-	clientAuthPrivateKeyJWT = "private_key_jwt"
+	clientAuthSecretBasic      = "client_secret_basic"
+	clientAuthSecretPost       = "client_secret_post"
+	clientAuthPrivateKeyJWT    = "private_key_jwt"
+	clientAuthKMSPrivateKeyJWT = "kms_private_key_jwt"
 )
 
 // clientAssertionType is the RFC 7523 client-assertion type for private_key_jwt.
@@ -73,6 +82,29 @@ type tokenExchangeChainedAuth struct {
 	clientID string
 	secret   string
 	kid      string
+	// kms is set instead of secret when the referenced spec minted a signing
+	// capability rather than a key. The two are mutually exclusive: one carries the
+	// key, the other carries permission to use a key it will never see.
+	kms *kmsSignerMaterial
+}
+
+// kmsSignerMaterial is a signing capability fetched through chaining: which key, which
+// version, where it lives, and a token that may sign with it. It holds no key material —
+// that absence is the entire point of the method.
+type kmsSignerMaterial struct {
+	backend    string
+	token      string
+	address    string
+	namespace  string
+	mount      string
+	keyName    string
+	keyVersion int
+	alg        string
+	kid        string
+	// expiresAt is the capability token's expiry, when the producer reported one. It
+	// lets a spent capability be recognised without spending a round trip discovering
+	// it, and told apart from a broken one.
+	expiresAt time.Time
 }
 
 // TokenExchangeDriver exchanges a caller-derived identity (a subject token, and
@@ -84,6 +116,10 @@ type TokenExchangeDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
 	httpClient *http.Client
+	// kmsClients pools one token-less base client per signing backend address, cloned
+	// per assertion so the capability token never touches a shared client. In practice
+	// it holds a single entry.
+	kmsClients sync.Map
 }
 
 // TokenExchangeDriverFactory creates TokenExchangeDriver instances.
@@ -121,8 +157,8 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 			Example("https://auth.resourceapp.example.com/oauth2/token"),
 
 		credential.StringField("client_auth").
-			OneOf(clientAuthSecretBasic, clientAuthSecretPost, clientAuthPrivateKeyJWT).
-			Describe("How Warden authenticates to the token endpoint").
+			OneOf(clientAuthSecretBasic, clientAuthSecretPost, clientAuthPrivateKeyJWT, clientAuthKMSPrivateKeyJWT).
+			Describe("How Warden authenticates to the token endpoint; kms_private_key_jwt signs the same assertion with a key held in a KMS, reached through secret_spec").
 			Example("client_secret_post"),
 
 		credential.StringField("client_id").
@@ -227,6 +263,27 @@ func (f *TokenExchangeDriverFactory) ValidateConfig(config map[string]string) er
 		}
 		if credential.GetString(config, "private_key", "") == "" {
 			return fmt.Errorf("private_key (or secret_spec) is required for client_auth=private_key_jwt")
+		}
+	case clientAuthKMSPrivateKeyJWT:
+		// The signing capability IS the referenced material, so there is no inline
+		// form of this method: without secret_spec there is nothing to sign with.
+		if !chained {
+			return fmt.Errorf("client_auth=%s requires secret_spec naming the spec that mints the signing capability", clientAuthKMSPrivateKeyJWT)
+		}
+		// Same rule as private_key_jwt, and for the same reason: everything naming the
+		// client travels with the key it belongs to.
+		if err := rejectInlineClientCredential(config, "private_key", "client_assertion_kid"); err != nil {
+			return err
+		}
+		// The payload is read by fixed field names, so a field selector would either be
+		// ignored or point at one coordinate as though it were the secret.
+		if credential.GetString(config, credential.ConfigSecretField, "") != "" {
+			return fmt.Errorf("secret_field must be omitted for client_auth=%s; the referenced payload is read by its own field names", clientAuthKMSPrivateKeyJWT)
+		}
+		// The algorithm is a property of the key, checked against it when the capability
+		// is minted. Naming it again here could only ever disagree.
+		if credential.GetString(config, "client_assertion_alg", "") != "" {
+			return fmt.Errorf("client_assertion_alg must be omitted for client_auth=%s; the algorithm travels with the key in the referenced payload", clientAuthKMSPrivateKeyJWT)
 		}
 	}
 
@@ -340,8 +397,19 @@ func tokenExchangeChainedAuthFromMaterial(cfg map[string]string, material creden
 
 	secret := material.Secret()
 	var kid string
+	var kms *kmsSignerMaterial
 
 	switch credential.GetString(cfg, "client_auth", clientAuthSecretPost) {
+	case clientAuthKMSPrivateKeyJWT:
+		// Nothing secret is selected here: the payload is a set of coordinates read by
+		// name, so material.Field plays no part. Clear whatever the generic selector
+		// picked out — leaving a coordinate sitting in the secret slot would present it
+		// as key material to anything that later reads the struct.
+		secret = ""
+		var err error
+		if kms, err = kmsSignerFromMaterial(material); err != nil {
+			return nil, err
+		}
 	case clientAuthSecretPost, clientAuthSecretBasic, "":
 		if secret == "" && material.Field == "" {
 			secret = material.Data["client_secret"]
@@ -373,8 +441,8 @@ func tokenExchangeChainedAuthFromMaterial(cfg map[string]string, material creden
 	default:
 		// A source-config error, not a payload one: refetching cannot change the answer,
 		// so this must not carry the sentinel that asks the manager to try again.
-		return nil, fmt.Errorf("token_exchange: credential chaining supports client_auth=%s, %s or %s, got %q",
-			clientAuthSecretPost, clientAuthSecretBasic, clientAuthPrivateKeyJWT,
+		return nil, fmt.Errorf("token_exchange: credential chaining supports client_auth=%s, %s, %s or %s, got %q",
+			clientAuthSecretPost, clientAuthSecretBasic, clientAuthPrivateKeyJWT, clientAuthKMSPrivateKeyJWT,
 			credential.GetString(cfg, "client_auth", ""))
 	}
 
@@ -383,7 +451,68 @@ func tokenExchangeChainedAuthFromMaterial(cfg map[string]string, material creden
 		return nil, fmt.Errorf("token_exchange: no client id in fetched secret material (store it under 'client_id' alongside the secret): %w", credential.ErrChainedSecretIncomplete)
 	}
 
-	return &tokenExchangeChainedAuth{clientID: clientID, secret: secret, kid: kid}, nil
+	return &tokenExchangeChainedAuth{clientID: clientID, secret: secret, kid: kid, kms: kms}, nil
+}
+
+// kmsSignerFromMaterial reads a signing capability out of the referenced payload. Every
+// coordinate is required and read by its own name — the producer writes them all
+// together, so any one missing means a payload written by something else, or by an
+// older version of the producer.
+//
+// Those failures carry ErrChainedSecretIncomplete so a cached payload predating a field
+// is refetched once, rather than failing every mint for the rest of its cache window.
+func kmsSignerFromMaterial(material credential.SecretMaterial) (*kmsSignerMaterial, error) {
+	need := func(key string) (string, error) {
+		if v := material.Data[key]; v != "" {
+			return v, nil
+		}
+		return "", fmt.Errorf("token_exchange: the fetched signing capability has no %q: %w", key, credential.ErrChainedSecretIncomplete)
+	}
+
+	backend, err := need("kms_backend")
+	if err != nil {
+		return nil, err
+	}
+	if backend != remotesign.BackendTypeTransit {
+		// A backend this build cannot drive. Not a payload-freshness problem — refetching
+		// yields the same answer — so it must not ask the manager to retry.
+		return nil, fmt.Errorf("token_exchange: unsupported signing backend %q in the fetched capability", backend)
+	}
+
+	m := &kmsSignerMaterial{backend: backend, namespace: material.Data["vault_namespace"], kid: material.Data["kid"]}
+	for _, f := range []struct {
+		key string
+		dst *string
+	}{
+		{"vault_token", &m.token},
+		{"vault_address", &m.address},
+		{"transit_mount", &m.mount},
+		{"transit_key", &m.keyName},
+		{"signing_alg", &m.alg},
+	} {
+		if *f.dst, err = need(f.key); err != nil {
+			return nil, err
+		}
+	}
+
+	rawVersion, err := need("transit_key_version")
+	if err != nil {
+		return nil, err
+	}
+	// The producer always writes a concrete version, so an unusable one means a stale or
+	// foreign payload — something a refetch can fix.
+	if m.keyVersion, err = strconv.Atoi(rawVersion); err != nil || m.keyVersion < 1 {
+		return nil, fmt.Errorf("token_exchange: the fetched signing capability has an unusable key version %q: %w", rawVersion, credential.ErrChainedSecretIncomplete)
+	}
+
+	// Optional: without it the expiry preflight is simply skipped, and a spent
+	// capability is discovered by the store refusing to sign with it instead.
+	if raw := material.Data["token_expires_at"]; raw != "" {
+		if ts, perr := time.Parse(time.RFC3339, raw); perr == nil {
+			m.expiresAt = ts
+		}
+	}
+	return m, nil
 }
 
 // mintExchange runs the exchange for the configured grant. chained, when non-nil,
@@ -433,7 +562,7 @@ func (d *TokenExchangeDriver) exchangeOnce(ctx context.Context, spec *credential
 	}
 	tokenURL := credential.GetString(d.credSource.Config, "token_url", "")
 	headers := map[string]string{}
-	if err := d.applyClientAuth(form, headers, tokenURL, chained); err != nil {
+	if err := d.applyClientAuth(ctx, form, headers, tokenURL, chained); err != nil {
 		return nil, err
 	}
 	resp, err := postOAuthTokenForm(ctx, d.httpClient, tokenURL, form, headers)
@@ -477,7 +606,7 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 		leg1.Set(k, v)
 	}
 	h1 := map[string]string{}
-	if err := d.applyClientAuth(leg1, h1, idpURL, chained); err != nil {
+	if err := d.applyClientAuth(ctx, leg1, h1, idpURL, chained); err != nil {
 		return nil, err
 	}
 	jag, err := postOAuthTokenForm(ctx, d.httpClient, idpURL, leg1, h1)
@@ -504,7 +633,7 @@ func (d *TokenExchangeDriver) mintIDJAG(ctx context.Context, spec *credential.Cr
 	// leg 2 (the resource-AS redemption), not leg 1 (which mints the ID-JAG).
 	d.addResources(leg2, spec)
 	h2 := map[string]string{}
-	if err := d.applyClientAuth(leg2, h2, resURL, chained); err != nil {
+	if err := d.applyClientAuth(ctx, leg2, h2, resURL, chained); err != nil {
 		return nil, err
 	}
 	final, err := postOAuthTokenForm(ctx, d.httpClient, resURL, leg2, h2)
@@ -565,7 +694,7 @@ func (d *TokenExchangeDriver) buildExchangeForm(spec *credential.CredSpec, input
 // Both halves move together: an id from config beside a secret from the chain would
 // name one client while presenting another's, which the token endpoint answers with
 // invalid_client.
-func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[string]string, tokenEndpoint string, chained *tokenExchangeChainedAuth) error {
+func (d *TokenExchangeDriver) applyClientAuth(ctx context.Context, form url.Values, headers map[string]string, tokenEndpoint string, chained *tokenExchangeChainedAuth) error {
 	cfg := d.credSource.Config
 	clientID := credential.GetString(cfg, "client_id", "")
 	clientSecret := credential.GetString(cfg, "client_secret", "")
@@ -582,8 +711,10 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 		// RFC 6749 §2.3.1: client id/secret are form-urlencoded, then Basic-encoded.
 		creds := url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)
 		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))
-	case clientAuthPrivateKeyJWT:
-		assertion, err := d.buildClientAssertion(clientID, tokenEndpoint, chained)
+	case clientAuthPrivateKeyJWT, clientAuthKMSPrivateKeyJWT:
+		// One case for both: the assertion, and everything the endpoint sees, is
+		// identical. Only where the signature comes from differs.
+		assertion, err := d.buildClientAssertion(ctx, clientID, tokenEndpoint, chained)
 		if err != nil {
 			return err
 		}
@@ -602,7 +733,28 @@ func (d *TokenExchangeDriver) applyClientAuth(form url.Values, headers map[strin
 // credential chaining in place of the source-configured ones; clientID is then the
 // chained id its caller already substituted, so the assertion names the client whose key
 // signs it, under the key id that key was stored beside.
-func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint string, chained *tokenExchangeChainedAuth) (string, error) {
+func (d *TokenExchangeDriver) buildClientAssertion(ctx context.Context, clientID, tokenEndpoint string, chained *tokenExchangeChainedAuth) (string, error) {
+	jti, err := newJTI()
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss": clientID,
+		"sub": clientID,
+		"aud": tokenEndpoint,
+		"jti": jti,
+		"iat": now.Unix(),
+		"exp": now.Add(clientAssertionTTL).Unix(),
+	}
+
+	// A chained signing capability signs the very same claims elsewhere. Built here
+	// rather than in the remote path so the two methods cannot drift into producing
+	// different assertions.
+	if chained != nil && chained.kms != nil {
+		return d.signAssertionWithCapability(ctx, chained.kms, claims)
+	}
+
 	pemKey := credential.GetString(d.credSource.Config, "private_key", "")
 	kid := credential.GetString(d.credSource.Config, "client_assertion_kid", "")
 	if chained != nil {
@@ -612,22 +764,9 @@ func (d *TokenExchangeDriver) buildClientAssertion(clientID, tokenEndpoint strin
 	if err != nil {
 		return "", fmt.Errorf("token_exchange: invalid private_key: %w", err)
 	}
-	jti, err := newJTI()
-	if err != nil {
-		return "", err
-	}
-	now := time.Now()
 	header := map[string]string{}
 	if kid != "" {
 		header["kid"] = kid
-	}
-	claims := map[string]interface{}{
-		"iss": clientID,
-		"sub": clientID,
-		"aud": tokenEndpoint,
-		"jti": jti,
-		"iat": now.Unix(),
-		"exp": now.Add(clientAssertionTTL).Unix(),
 	}
 	assertion, err := signRS256JWT(key, header, claims)
 	if err != nil {
@@ -764,9 +903,11 @@ func classifyExchangeError(err error) error {
 func chainedClientAuthError(err error, chained bool) error {
 	// The rejection test itself is shared with the oauth2 driver
 	// (isChainedClientAuthRejection); here it covers client_secret_post's 400,
-	// client_secret_basic's 401, and a rejected private_key_jwt assertion. Keep the
-	// underlying error (the IdP's code / description) in the chain alongside the sentinel
-	// for legible diagnostics.
+	// client_secret_basic's 401, and a rejected assertion under either private_key_jwt
+	// method. For a KMS-held key that last case is how an authorization server holding
+	// only the previous public key recovers: the eviction re-mints the capability, which
+	// resolves the current key version. Keep the underlying error (the IdP's code /
+	// description) in the chain alongside the sentinel for legible diagnostics.
 	if chained && isChainedClientAuthRejection(err) {
 		return fmt.Errorf("token_exchange: client authentication rejected: %w (%w)", credential.ErrChainedSecretRejected, err)
 	}

--- a/credential/drivers/token_exchange_kms.go
+++ b/credential/drivers/token_exchange_kms.go
@@ -1,0 +1,116 @@
+package drivers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/internal/remotesign"
+)
+
+// kmsCapabilitySkew is how far ahead of a capability's expiry it is treated as already
+// spent. Building and sending an assertion is not instantaneous, and a capability that
+// expires mid-flight fails at the token endpoint as an opaque client-auth error rather
+// than as the expiry it is.
+const kmsCapabilitySkew = 10 * time.Second
+
+// signAssertionWithCapability signs the client assertion with a key the capability
+// names but Warden cannot read.
+//
+// Errors are mapped deliberately. Anything meaning "this capability is spent" carries
+// ErrChainedSecretRejected, so the minting layer discards the cached one and mints a
+// fresh capability — the same self-healing a rotated secret gets. Anything meaning "the
+// KMS is unreachable" carries no sentinel at all: a refetch cannot mend a network, and
+// evicting a perfectly good capability would turn a blip into a stampede.
+func (d *TokenExchangeDriver) signAssertionWithCapability(ctx context.Context, m *kmsSignerMaterial, claims map[string]interface{}) (string, error) {
+	// Cheaper than discovering the same thing from a refused signature, and it keeps a
+	// spent capability distinguishable from a broken one.
+	if !m.expiresAt.IsZero() && time.Now().Add(kmsCapabilitySkew).After(m.expiresAt) {
+		return "", fmt.Errorf("token_exchange: the fetched signing capability expired at %s: %w",
+			m.expiresAt.Format(time.RFC3339), credential.ErrChainedSecretRejected)
+	}
+
+	client, err := d.kmsClient(m)
+	if err != nil {
+		return "", err
+	}
+	backend, err := remotesign.NewTransitClientBackend(client, m.mount, 0, d.logger)
+	if err != nil {
+		return "", fmt.Errorf("token_exchange: %w", err)
+	}
+	defer backend.Close()
+
+	header := map[string]string{}
+	if m.kid != "" {
+		header["kid"] = m.kid
+	}
+	signer := remotesign.NewSigner(backend,
+		remotesign.KeyRef{KeyName: m.keyName, Version: m.keyVersion, Alg: m.alg}, nil, 0)
+
+	assertion, err := remotesign.SignCompactJWS(ctx, signer, m.alg, header, claims)
+	if err != nil {
+		return "", classifyCapabilitySignError(err)
+	}
+	return assertion, nil
+}
+
+// classifyCapabilitySignError decides whether a failed signature should cost the
+// capability its place in the cache.
+func classifyCapabilitySignError(err error) error {
+	var respErr *api.ResponseError
+	if errors.As(err, &respErr) {
+		switch respErr.StatusCode {
+		case http.StatusForbidden, http.StatusUnauthorized:
+			// The token was rejected: expired, or revoked under us. A fresh capability
+			// is exactly the fix.
+			return fmt.Errorf("token_exchange: the signing capability was refused: %w", credential.ErrChainedSecretRejected)
+		case http.StatusBadRequest:
+			// Most often the pinned version has fallen below the key's minimum after a
+			// rotation, which re-minting resolves by picking up the new version. A
+			// genuine configuration fault fails the same way on the retry and surfaces
+			// then — one extra fetch, and the manager retries only once.
+			return fmt.Errorf("token_exchange: the signing request was refused (%w): %w", err, credential.ErrChainedSecretRejected)
+		}
+	}
+	// Unreachable, timed out, or the KMS itself is unwell. The capability is probably
+	// fine; refetching would not help and would evict something still usable.
+	return fmt.Errorf("token_exchange: failed to sign the client assertion remotely: %w", err)
+}
+
+// kmsClient returns a client for the capability's address, cloned from a pooled base so
+// the connection pool is shared while the token stays per-request. The token must never
+// land on a shared client: concurrent mints hold different capabilities, and one
+// overwriting another's token would sign with the wrong key or none.
+func (d *TokenExchangeDriver) kmsClient(m *kmsSignerMaterial) (*api.Client, error) {
+	key := m.address + "\x00" + m.namespace
+	base, ok := d.kmsClients.Load(key)
+	if !ok {
+		cfg := api.DefaultConfig()
+		cfg.Address = m.address
+		// DefaultConfig reads the process environment, and two of the values it picks
+		// up would redirect this client away from the capability it is about to spend.
+		// An agent address is preferred over Address when the request is built, so a
+		// stray one would send the token somewhere the payload never named; a namespace
+		// would scope the signing call to a tenant the capability was not minted for.
+		// Both are cleared unconditionally — the payload is the only authority here.
+		cfg.AgentAddress = ""
+		built, err := api.NewClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("token_exchange: cannot reach the signing backend at %q: %w", m.address, err)
+		}
+		built.SetToken("")
+		built.SetNamespace(m.namespace)
+		base, _ = d.kmsClients.LoadOrStore(key, built)
+	}
+
+	client, err := base.(*api.Client).CloneWithHeaders()
+	if err != nil {
+		return nil, fmt.Errorf("token_exchange: cannot prepare a signing client: %w", err)
+	}
+	client.SetToken(m.token)
+	return client, nil
+}

--- a/credential/drivers/token_exchange_kms_test.go
+++ b/credential/drivers/token_exchange_kms_test.go
@@ -1,0 +1,602 @@
+package drivers
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSigningBackend stands in for the KMS: it reads a key and signs a prehashed
+// digest with a key it holds, so an assertion it signs actually verifies.
+type fakeSigningBackend struct {
+	key           *rsa.PrivateKey
+	signCalls     int
+	signBody      map[string]interface{}
+	signPath      string
+	tokenSeen     string
+	namespaceSeen string
+	statusCode    int // when non-zero, the sign call fails with this status
+}
+
+func newFakeSigningBackend(t *testing.T) (*fakeSigningBackend, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	f := &fakeSigningBackend{key: key}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/transit/sign/") {
+			f.signCalls++
+			f.signPath = r.URL.Path
+			f.tokenSeen = r.Header.Get("X-Vault-Token")
+			f.namespaceSeen = r.Header.Get("X-Vault-Namespace")
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&f.signBody))
+			if f.statusCode != 0 {
+				w.WriteHeader(f.statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"errors": []string{"refused"}})
+				return
+			}
+			digest, err := base64.StdEncoding.DecodeString(f.signBody["input"].(string))
+			require.NoError(t, err)
+			sig, err := rsa.SignPKCS1v15(rand.Reader, f.key, crypto.SHA256, digest)
+			require.NoError(t, err)
+			verInt := signedKeyVersion(f.signBody)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+				"signature":   "vault:v" + strconv.Itoa(verInt) + ":" + base64.StdEncoding.EncodeToString(sig),
+				"key_version": verInt,
+			}})
+			return
+		}
+		http.Error(w, "unexpected "+r.URL.Path, http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return f, srv.URL
+}
+
+// signedKeyVersion reads the version the sign request pinned. JSON numbers decode as
+// float64 here, so the fake must not assume otherwise.
+func signedKeyVersion(body map[string]interface{}) int {
+	switch v := body["key_version"].(type) {
+	case float64:
+		return int(v)
+	case json.Number:
+		n, _ := strconv.Atoi(v.String())
+		return n
+	}
+	return 0
+}
+
+func (f *fakeSigningBackend) pubPEM(t *testing.T) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(&f.key.PublicKey)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+// capabilityMaterial is the payload the transit_signer mint method produces.
+func capabilityMaterial(addr string, over map[string]string) credential.SecretMaterial {
+	data := map[string]string{
+		"kms_backend":         "transit",
+		"vault_token":         "hvs.capability",
+		"vault_address":       addr,
+		"transit_mount":       "transit",
+		"transit_key":         "client-assertion",
+		"transit_key_version": "2",
+		"signing_alg":         "RS256",
+		"kid":                 "client-assertion-v2",
+		"client_id":           "warden-gateway",
+		"token_expires_at":    time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339),
+	}
+	for k, v := range over {
+		if v == "" {
+			delete(data, k)
+			continue
+		}
+		data[k] = v
+	}
+	return credential.SecretMaterial{Data: data}
+}
+
+func kmsSourceConfig(tokenURL string) map[string]string {
+	return map[string]string{
+		"token_url":   tokenURL,
+		"grant":       tokenExchangeGrantRFC8693,
+		"client_auth": clientAuthKMSPrivateKeyJWT,
+		"secret_spec": "idp-client-signer",
+	}
+}
+
+// TestKMSAssertion_SignsRemotelyAndVerifies is the whole feature end to end: the
+// assertion the authorization server receives is signed by a key this process never
+// held, and it verifies against that key's public half.
+func TestKMSAssertion_SignsRemotelyAndVerifies(t *testing.T) {
+	kms, kmsURL := newFakeSigningBackend(t)
+
+	var gotAssertion, gotClientID, gotAssertionType string
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotAssertion = r.Form.Get("client_assertion")
+		gotClientID = r.Form.Get("client_id")
+		gotAssertionType = r.Form.Get("client_assertion_type")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "downstream", "token_type": "Bearer", "expires_in": 1800,
+		})
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(kmsSourceConfig(sts.URL), sts.Client())
+	spec := &credential.CredSpec{Name: "s", Config: map[string]string{}}
+
+	data, _, _, _, err := d.MintCredentialWithExchangeFromSecret(context.Background(), spec,
+		subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u1"})),
+		capabilityMaterial(kmsURL, nil))
+	require.NoError(t, err)
+	assert.Equal(t, "downstream", data["api_key"])
+
+	// The signing request pinned the exact version and asked for the encoding the
+	// crypto.Signer contract expects.
+	assert.Equal(t, 1, kms.signCalls)
+	assert.Equal(t, "/v1/transit/sign/client-assertion", kms.signPath)
+	assert.Equal(t, "hvs.capability", kms.tokenSeen)
+	assert.Equal(t, true, kms.signBody["prehashed"])
+	assert.Equal(t, "pkcs1v15", kms.signBody["signature_algorithm"])
+	assert.Equal(t, "sha2-256", kms.signBody["hash_algorithm"])
+	assert.Equal(t, 2, signedKeyVersion(kms.signBody), "the sign request pinned the exact version")
+
+	// What the endpoint saw is an ordinary private_key_jwt assertion.
+	assert.Equal(t, "warden-gateway", gotClientID)
+	assert.Equal(t, clientAssertionType, gotAssertionType)
+
+	parts := strings.Split(gotAssertion, ".")
+	require.Len(t, parts, 3)
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	var hdr map[string]string
+	require.NoError(t, json.Unmarshal(headerJSON, &hdr))
+	assert.Equal(t, "RS256", hdr["alg"])
+	assert.Equal(t, "client-assertion-v2", hdr["kid"], "the kid names the version that signed")
+
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]interface{}
+	require.NoError(t, json.Unmarshal(claimsJSON, &claims))
+	assert.Equal(t, "warden-gateway", claims["iss"])
+	assert.Equal(t, "warden-gateway", claims["sub"])
+	assert.Equal(t, sts.URL, claims["aud"])
+	assert.NotEmpty(t, claims["jti"])
+
+	// The signature verifies against the key the KMS holds — which is the only proof
+	// that the remote path produced a usable assertion rather than plausible bytes.
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	h := crypto.SHA256.New()
+	h.Write([]byte(parts[0] + "." + parts[1]))
+	require.NoError(t, rsa.VerifyPKCS1v15(&kms.key.PublicKey, crypto.SHA256, h.Sum(nil), sig))
+	_ = kms.pubPEM(t)
+}
+
+// TestKMSAssertion_ExpiredCapabilitySkipsTheRoundTrip: a spent capability is recognised
+// from what it already carries, and asks for a fresh one, without spending a call to
+// find out.
+func TestKMSAssertion_ExpiredCapabilitySkipsTheRoundTrip(t *testing.T) {
+	kms, kmsURL := newFakeSigningBackend(t)
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "should not be reached", http.StatusInternalServerError)
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(kmsSourceConfig(sts.URL), sts.Client())
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(context.Background(),
+		&credential.CredSpec{Name: "s", Config: map[string]string{}},
+		subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u1"})),
+		capabilityMaterial(kmsURL, map[string]string{
+			"token_expires_at": time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected, "a spent capability is replaced, not retried")
+	assert.Equal(t, 0, kms.signCalls, "no signing request is made for a capability known to be spent")
+}
+
+func TestKMSAssertion_SignFailureMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		sentinel bool
+	}{
+		{"token refused", http.StatusForbidden, true},
+		{"unauthorized", http.StatusUnauthorized, true},
+		{"version fenced after rotation", http.StatusBadRequest, true},
+		{"backend unwell", http.StatusInternalServerError, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kms, kmsURL := newFakeSigningBackend(t)
+			kms.statusCode = tc.status
+			sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "unreached", http.StatusInternalServerError)
+			}))
+			defer sts.Close()
+
+			d := newExchangeDriver(kmsSourceConfig(sts.URL), sts.Client())
+			_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(context.Background(),
+				&credential.CredSpec{Name: "s", Config: map[string]string{}},
+				subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u1"})),
+				capabilityMaterial(kmsURL, nil))
+			require.Error(t, err)
+			if tc.sentinel {
+				assert.ErrorIs(t, err, credential.ErrChainedSecretRejected,
+					"a refused capability should be replaced")
+			} else {
+				assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected,
+					"refetching cannot mend an unreachable backend, and must not evict a good capability")
+			}
+		})
+	}
+}
+
+func TestKMSAssertion_MaterialExtraction(t *testing.T) {
+	cases := []struct {
+		name       string
+		over       map[string]string
+		errMsg     string
+		incomplete bool
+	}{
+		{"missing token", map[string]string{"vault_token": ""}, "vault_token", true},
+		{"missing address", map[string]string{"vault_address": ""}, "vault_address", true},
+		{"missing mount", map[string]string{"transit_mount": ""}, "transit_mount", true},
+		{"missing key", map[string]string{"transit_key": ""}, "transit_key", true},
+		{"missing alg", map[string]string{"signing_alg": ""}, "signing_alg", true},
+		{"missing version", map[string]string{"transit_key_version": ""}, "transit_key_version", true},
+		{"missing backend", map[string]string{"kms_backend": ""}, "kms_backend", true},
+		{"zero version", map[string]string{"transit_key_version": "0"}, "unusable key version", true},
+		{"non-numeric version", map[string]string{"transit_key_version": "latest"}, "unusable key version", true},
+		{"unknown backend", map[string]string{"kms_backend": "cloudkms"}, "unsupported signing backend", false},
+		{"missing client id", map[string]string{"client_id": ""}, "no client id", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tokenExchangeChainedAuthFromMaterial(
+				map[string]string{"client_auth": clientAuthKMSPrivateKeyJWT},
+				capabilityMaterial("http://kms.example", tc.over))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+			if tc.incomplete {
+				// A payload that could become complete — refetching may fix it.
+				assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+			} else {
+				// A build that cannot drive this backend. Refetching yields the same
+				// answer, so it must not ask the manager to try again.
+				assert.NotErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+			}
+		})
+	}
+}
+
+// TestKMSAssertion_IgnoresSecretField: the payload is read by fixed names, so a stray
+// field selector must not be mistaken for "this one is the secret".
+func TestKMSAssertion_IgnoresSecretField(t *testing.T) {
+	material := capabilityMaterial("http://kms.example", nil)
+	material.Field = "transit_key"
+
+	auth, err := tokenExchangeChainedAuthFromMaterial(
+		map[string]string{"client_auth": clientAuthKMSPrivateKeyJWT}, material)
+	require.NoError(t, err)
+	require.NotNil(t, auth.kms)
+	assert.Equal(t, "client-assertion", auth.kms.keyName)
+	assert.Empty(t, auth.secret, "no key material travels with a capability")
+}
+
+func TestKMSAssertion_ValidateConfig(t *testing.T) {
+	f := &TokenExchangeDriverFactory{}
+	base := func(over map[string]string) map[string]string {
+		cfg := map[string]string{
+			"token_url":   "https://idp.example.com/token",
+			"client_auth": clientAuthKMSPrivateKeyJWT,
+			"secret_spec": "idp-client-signer",
+		}
+		for k, v := range over {
+			if v == "" {
+				delete(cfg, k)
+				continue
+			}
+			cfg[k] = v
+		}
+		return cfg
+	}
+
+	require.NoError(t, f.ValidateConfig(base(nil)))
+
+	// A real key: the schema parses private_key before the client_auth arm runs, so a
+	// junk value would be rejected for the wrong reason and prove nothing.
+	pemKey := func() string {
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		return string(pem.EncodeToMemory(&pem.Block{
+			Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}))
+	}()
+
+	cases := []struct {
+		name   string
+		cfg    map[string]string
+		errMsg string
+	}{
+		{"no secret_spec", base(map[string]string{"secret_spec": ""}), "requires secret_spec"},
+		{"inline client_id", base(map[string]string{"client_id": "x"}), "must be omitted"},
+		{"inline private_key", base(map[string]string{"private_key": pemKey}), "must be omitted"},
+		{"inline kid", base(map[string]string{"client_assertion_kid": "k"}), "must be omitted"},
+		{"secret_field", base(map[string]string{"secret_field": "f"}), "secret_field must be omitted"},
+		{"assertion alg", base(map[string]string{"client_assertion_alg": "RS256"}), "client_assertion_alg must be omitted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := f.ValidateConfig(tc.cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
+// multiKeySigningBackend signs for several named keys and records which capability
+// token arrived against which key on every request.
+type multiKeySigningBackend struct {
+	mu     sync.Mutex
+	keys   map[string]*rsa.PrivateKey
+	paired map[string]string // key name -> the token that signed for it
+	mixed  []string          // any request whose token did not belong to its key
+}
+
+func newMultiKeySigningBackend(t *testing.T, keyNames []string, tokenFor map[string]string) (*multiKeySigningBackend, string) {
+	t.Helper()
+	b := &multiKeySigningBackend{keys: map[string]*rsa.PrivateKey{}, paired: map[string]string{}}
+	for _, name := range keyNames {
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		b.keys[name] = k
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		name := strings.TrimPrefix(r.URL.Path, "/v1/transit/sign/")
+		token := r.Header.Get("X-Vault-Token")
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+
+		b.mu.Lock()
+		b.paired[name] = token
+		if want, ok := tokenFor[name]; ok && token != want {
+			// The whole point of the row: a token that belongs to a different
+			// capability arrived against this key.
+			b.mixed = append(b.mixed, fmt.Sprintf("key %s signed with token %q, want %q", name, token, want))
+		}
+		key := b.keys[name]
+		b.mu.Unlock()
+
+		if key == nil {
+			http.Error(w, "no such key", http.StatusNotFound)
+			return
+		}
+		digest, err := base64.StdEncoding.DecodeString(body["input"].(string))
+		if err != nil {
+			http.Error(w, "bad input", http.StatusBadRequest)
+			return
+		}
+		sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest)
+		if err != nil {
+			http.Error(w, "sign failed", http.StatusInternalServerError)
+			return
+		}
+		ver := signedKeyVersion(body)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+			"signature":   "vault:v" + strconv.Itoa(ver) + ":" + base64.StdEncoding.EncodeToString(sig),
+			"key_version": ver,
+		}})
+	}))
+	t.Cleanup(srv.Close)
+	return b, srv.URL
+}
+
+// TestKMSAssertion_ConcurrentSigningKeepsCapabilitiesApart pins the isolation the client
+// pool depends on. One driver fronts many callers, and the base client for a given
+// address is shared between them; only the per-assertion clone carries a token. If that
+// clone were ever dropped — or the token set on the shared client — concurrent mints
+// holding different capabilities would cross, and an assertion would be signed with the
+// wrong key or refused outright.
+//
+// Each capability names its own key and carries its own token, so a crossing is directly
+// observable at the backend rather than inferred.
+func TestKMSAssertion_ConcurrentSigningKeepsCapabilitiesApart(t *testing.T) {
+	const n = 24
+	keyNames := make([]string, n)
+	tokenFor := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		keyNames[i] = fmt.Sprintf("key-%02d", i)
+		tokenFor[keyNames[i]] = fmt.Sprintf("hvs.token-%02d", i)
+	}
+	backend, url := newMultiKeySigningBackend(t, keyNames, tokenFor)
+
+	// One driver, one pooled base client for this address — the shared state under test.
+	d := newExchangeDriver(kmsSourceConfig("https://idp.example.com/token"), http.DefaultClient)
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	assertions := make([]string, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			auth, err := tokenExchangeChainedAuthFromMaterial(
+				map[string]string{"client_auth": clientAuthKMSPrivateKeyJWT},
+				capabilityMaterial(url, map[string]string{
+					"transit_key":         keyNames[i],
+					"vault_token":         tokenFor[keyNames[i]],
+					"transit_key_version": "1",
+				}))
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			<-start // release them together, so the clones genuinely overlap
+			assertions[i], errs[i] = d.signAssertionWithCapability(
+				context.Background(), auth.kms, map[string]interface{}{"iss": "c", "sub": "c"})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "capability %d failed to sign", i)
+		require.NotEmpty(t, assertions[i])
+	}
+
+	backend.mu.Lock()
+	mixed := append([]string(nil), backend.mixed...)
+	paired := len(backend.paired)
+	backend.mu.Unlock()
+
+	assert.Empty(t, mixed, "a capability's token reached another capability's key")
+	assert.Equal(t, n, paired, "every capability signed with its own key")
+
+	// And each assertion verifies against the key its own capability named — the proof
+	// that the right key signed, not merely that the right token was presented.
+	for i, a := range assertions {
+		parts := strings.Split(a, ".")
+		require.Len(t, parts, 3)
+		sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+		require.NoError(t, err)
+		h := crypto.SHA256.New()
+		h.Write([]byte(parts[0] + "." + parts[1]))
+		assert.NoError(t, rsa.VerifyPKCS1v15(&backend.keys[keyNames[i]].PublicKey, crypto.SHA256, h.Sum(nil), sig),
+			"assertion %d was not signed by the key its capability named", i)
+	}
+}
+
+// TestKMSAssertion_IgnoresAmbientEnvironment: the client that spends a capability must
+// talk to the address the payload names and nowhere else. The API client's defaults read
+// the process environment, and an agent address there is preferred over the configured
+// one when the request is built — so an operator-set VAULT_AGENT_ADDR would otherwise
+// divert a live capability token to whatever is listening there.
+func TestKMSAssertion_IgnoresAmbientEnvironment(t *testing.T) {
+	// A port nothing is listening on: if the client honoured it, the signing call would
+	// fail to connect rather than reach the fake backend.
+	t.Setenv("VAULT_AGENT_ADDR", "http://127.0.0.1:1")
+	t.Setenv("VAULT_NAMESPACE", "someone-elses-tenant")
+	t.Setenv("VAULT_TOKEN", "env-operator-token")
+
+	kms, kmsURL := newFakeSigningBackend(t)
+	sts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"downstream","token_type":"Bearer","expires_in":1800}`))
+	}))
+	defer sts.Close()
+
+	d := newExchangeDriver(kmsSourceConfig(sts.URL), sts.Client())
+	_, _, _, _, err := d.MintCredentialWithExchangeFromSecret(context.Background(),
+		&credential.CredSpec{Name: "s", Config: map[string]string{}},
+		subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u1"})),
+		capabilityMaterial(kmsURL, nil))
+	require.NoError(t, err, "the signing call must reach the payload's address, not an ambient agent")
+	assert.Equal(t, 1, kms.signCalls)
+	assert.Equal(t, "hvs.capability", kms.tokenSeen,
+		"the capability's own token signed, not one inherited from the environment")
+	assert.Empty(t, kms.namespaceSeen,
+		"the payload named no namespace, so none is sent")
+}
+
+// TestKMSAssertion_IDJAGSignsBothLegs: an ID-JAG exchange authenticates twice, at two
+// different endpoints, inside one mint. Both legs must present an assertion signed by
+// the capability, and each must be bound to the endpoint that receives it — an assertion
+// replayed from leg 1 to leg 2 carries the wrong audience and a correct authorization
+// server rejects it.
+//
+// Both legs share buildClientAssertion, so this guards against a future change that
+// hoists the assertion out of the per-leg path and reuses one across both.
+func TestKMSAssertion_IDJAGSignsBothLegs(t *testing.T) {
+	kms, kmsURL := newFakeSigningBackend(t)
+
+	var (
+		mu      sync.Mutex
+		byAud   = map[string]string{} // aud claim -> the assertion that carried it
+		clients []string
+	)
+	recordLeg := func(t *testing.T, r *http.Request) {
+		t.Helper()
+		require.NoError(t, r.ParseForm())
+		assertion := r.Form.Get("client_assertion")
+		parts := strings.Split(assertion, ".")
+		require.Len(t, parts, 3, "each leg must carry a signed assertion")
+		claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+		require.NoError(t, err)
+		var claims map[string]interface{}
+		require.NoError(t, json.Unmarshal(claimsJSON, &claims))
+		aud, _ := claims["aud"].(string)
+		mu.Lock()
+		byAud[aud] = assertion
+		clients = append(clients, r.Form.Get("client_id"))
+		mu.Unlock()
+	}
+
+	resSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recordLeg(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "final-access", "expires_in": 600})
+	}))
+	defer resSrv.Close()
+
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recordLeg(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "the-id-jag", "issued_token_type": tokenTypeIDJAG, "expires_in": 300})
+	}))
+	defer idpSrv.Close()
+
+	d := newExchangeDriver(map[string]string{
+		"token_url":          idpSrv.URL,
+		"resource_token_url": resSrv.URL,
+		"grant":              tokenExchangeGrantIDJAG,
+		"client_auth":        clientAuthKMSPrivateKeyJWT,
+		"secret_spec":        "idp-client-signer",
+	}, &http.Client{})
+	spec := &credential.CredSpec{Config: map[string]string{"audience": "https://resource-as.example.com"}}
+
+	rawData, _, _, _, err := d.MintCredentialWithExchangeFromSecret(context.Background(), spec,
+		subjectInputs(makeUnsignedJWT(map[string]interface{}{"sub": "u1"})),
+		capabilityMaterial(kmsURL, nil))
+	require.NoError(t, err)
+	assert.Equal(t, "final-access", rawData["api_key"])
+
+	// One signature per leg: neither is reused, and neither leg went unauthenticated.
+	assert.Equal(t, 2, kms.signCalls, "each leg signs its own assertion")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, byAud, 2, "the two assertions carried different audiences")
+	assert.Contains(t, byAud, idpSrv.URL, "leg 1's assertion is bound to the home endpoint")
+	assert.Contains(t, byAud, resSrv.URL, "leg 2's assertion is bound to the resource endpoint")
+	assert.NotEqual(t, byAud[idpSrv.URL], byAud[resSrv.URL], "an assertion must not be replayed across legs")
+	assert.Equal(t, []string{"warden-gateway", "warden-gateway"}, clients, "both legs name the client the payload carries")
+}


### PR DESCRIPTION
**5 of 6.** Stacked on #565.

Adds `client_auth=kms_private_key_jwt`. It puts the same RFC 7523 assertion on the wire as `private_key_jwt` — the authorization server cannot tell them apart — but the key stays in a KMS and this process never sees it. The signing capability arrives through `secret_spec`, so there is no inline form of the method.

It is a separate `client_auth` value rather than a modifier on the existing one because the two are configured from opposite ends. One takes a key; the other takes a reference to permission to use a key. Nothing an operator sets for one means anything for the other, so they get their own validation arm and the `private_key_jwt` arm is untouched.

Claims are built once and signed either locally or remotely, so the two methods cannot drift into producing different assertions. Both legs of an ID-JAG exchange sign through the same path, each bound to its own endpoint.

Failures are mapped by what a retry could actually fix. A refused or expired capability carries `ErrChainedSecretRejected` so the minting layer discards it and mints a fresh one — which is also how an authorization server that has moved to a new key version recovers. An unreachable KMS carries no sentinel: refetching cannot mend a network, and evicting a working capability would turn a blip into a stampede.

The capability token is set on a per-assertion clone of a pooled client, never on a shared one, and the client is built without inheriting an address or namespace from the process environment — the payload is the only authority for where a capability is spent.

## Verification

Includes a 24-way concurrency test proving capabilities cannot cross between simultaneous mints; it fails (17 of 24 crossing) if the per-assertion clone is removed.
